### PR TITLE
fix(EntityFrameworkCore): make RawDatabaseEnvelopeTransaction public

### DIFF
--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/RawDatabaseEnvelopeTransaction.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/RawDatabaseEnvelopeTransaction.cs
@@ -13,7 +13,7 @@ namespace Wolverine.EntityFrameworkCore.Internals;
 /// <summary>
 /// Envelope transaction for raw database access for DbContexts w/o the explicit wolverine mappings
 /// </summary>
-internal class RawDatabaseEnvelopeTransaction : IEnvelopeTransaction
+public class RawDatabaseEnvelopeTransaction : IEnvelopeTransaction
 {
     private readonly DatabaseSettings _settings;
 


### PR DESCRIPTION
If is internal, the following exception is thrown while trying to find an handler.

```cs
Could not determine any valid subscribers or local handlers for message type InMemoryMediator.CreateItemCommand
Compilation failures!

CS0122: 'RawDatabaseEnvelopeTransaction' is inaccessible due to its protection level
```