### PR TITLE
Issue #135 - Ability to mark persisted dead letter messages as replayable

### DIFF
--- a/src/Persistence/PersistenceTests/Postgresql/PostgresqlMessageStoreTests.cs
+++ b/src/Persistence/PersistenceTests/Postgresql/PostgresqlMessageStoreTests.cs
@@ -14,6 +14,7 @@ using PersistenceTests.Marten;
 using PersistenceTests.Marten.Persistence;
 using Shouldly;
 using TestingSupport;
+using Weasel.Core;
 using Wolverine;
 using Wolverine.Marten;
 using Wolverine.Persistence.Durability;
@@ -199,6 +200,72 @@ public class PostgresqlMessageStoreTests : PostgresqlContext, IDisposable, IAsyn
         var counts = await thePersistence.Admin.FetchCountsAsync();
 
         counts.Incoming.ShouldBe(0);
+        counts.Scheduled.ShouldBe(0);
+        counts.Handled.ShouldBe(0);
+    }
+    
+    [Fact]
+    public async Task move_replayable_error_messages_to_incoming()
+    {
+        /*
+         * Going to start with two error messages in dead letter queue
+         * Mark one as Replayable
+         * Run the DurabilityAction
+         * Replayable message should be moved back to Inbox
+         */
+        
+        var unReplayableEnvelope = ObjectMother.Envelope();
+        var replayableEnvelope = ObjectMother.Envelope();
+        await thePersistence.StoreIncomingAsync(unReplayableEnvelope);
+        await thePersistence.StoreIncomingAsync(replayableEnvelope);
+
+        var ex = new DivideByZeroException("Kaboom!");
+        await thePersistence.MoveToDeadLetterStorageAsync(unReplayableEnvelope, ex);
+        await thePersistence.MoveToDeadLetterStorageAsync(replayableEnvelope, ex);
+
+        var settings = theHost.Services.GetRequiredService<PostgresqlSettings>();
+
+        // make one of the messages replayable
+        
+        var updateErrorMessageAsReplayable = $"update {settings.SchemaName}.{DatabaseConstants.DeadLetterTable} set {DatabaseConstants.Replayable} = true " +
+                                             $"where {DatabaseConstants.Id} = '{replayableEnvelope.Id}'";
+        
+        await settings
+            .CreateCommand(updateErrorMessageAsReplayable)
+            .ExecuteOnce();
+        
+        // verify message was updated to make it replayable
+        await using var conn = settings.CreateConnection();
+        await conn.OpenAsync();
+        
+        var replayableErrorMessagesCountAfterMakingReplayable = (long) (await conn.CreateCommand(
+                $"select count(*) from {settings.SchemaName}.{DatabaseConstants.DeadLetterTable} where {DatabaseConstants.Replayable} = true")
+            .ExecuteScalarAsync())!;
+        
+        await conn.CloseAsync();
+        
+        await thePersistence.Session.BeginAsync();
+
+        // run the action
+        await new MoveReplayableErrorMessagesToIncoming()
+            .MoveReplayableErrorMessagesToIncomingAsync(thePersistence.Session, settings);
+
+        await thePersistence.Session.CommitAsync();
+
+        // verify un replayable message still exists
+        await conn.OpenAsync();
+        
+        var errorMessagesCountAfterDurabilityAction = (long) (await conn.CreateCommand(
+                $"select count(*) from {settings.SchemaName}.{DatabaseConstants.DeadLetterTable}")
+            .ExecuteScalarAsync())!;
+
+        await conn.CloseAsync();
+        
+        var counts = await thePersistence.Admin.FetchCountsAsync();
+
+        replayableErrorMessagesCountAfterMakingReplayable.ShouldBe(1);
+        errorMessagesCountAfterDurabilityAction.ShouldBe(1);
+        counts.Incoming.ShouldBe(1);
         counts.Scheduled.ShouldBe(0);
         counts.Handled.ShouldBe(0);
     }

--- a/src/Persistence/Wolverine.Postgresql/Schema/DeadLettersTable.cs
+++ b/src/Persistence/Wolverine.Postgresql/Schema/DeadLettersTable.cs
@@ -22,5 +22,6 @@ internal class DeadLettersTable : Table
         AddColumn<string>(DatabaseConstants.ExceptionMessage);
 
         AddColumn<DateTimeOffset>(DatabaseConstants.SentAt);
+        AddColumn<bool>(DatabaseConstants.Replayable);
     }
 }

--- a/src/Persistence/Wolverine.RDBMS/DatabaseConstants.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabaseConstants.cs
@@ -16,6 +16,7 @@ public static class DatabaseConstants
 
     public const string ExceptionType = "exception_type";
     public const string ExceptionMessage = "exception_message";
+    public const string Replayable = "replayable";
 
     public const string OutgoingTable = "wolverine_outgoing_envelopes";
     public const string IncomingTable = "wolverine_incoming_envelopes";
@@ -33,5 +34,5 @@ public static class DatabaseConstants
         $"{Body}, {Id}, {OwnerId}, {Destination}, {DeliverBy}, {Attempts}, {MessageType}";
 
     public static readonly string DeadLetterFields =
-        $"{Id}, {ExecutionTime}, {Body}, {MessageType}, {Source}, {ExceptionType}, {ExceptionMessage}, {SentAt}";
+        $"{Id}, {ExecutionTime}, {Body}, {MessageType}, {ReceivedAt}, {Source}, {ExceptionType}, {ExceptionMessage}, {SentAt}, {Replayable}";
 }

--- a/src/Persistence/Wolverine.RDBMS/DatabasePersistence.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabasePersistence.cs
@@ -120,10 +120,12 @@ public static class DatabasePersistence
             list.Add(builder.AddParameter(error.Envelope.ScheduledTime));
             list.Add(builder.AddParameter(EnvelopeSerializer.Serialize(error.Envelope)));
             list.Add(builder.AddParameter(error.Envelope.MessageType));
+            list.Add(builder.AddParameter(error.Envelope.Destination?.ToString()));
             list.Add(builder.AddParameter(error.Envelope.Source));
             list.Add(builder.AddParameter(error.ExceptionType));
             list.Add(builder.AddParameter(error.ExceptionMessage));
             list.Add(builder.AddParameter(error.Envelope.SentAt.ToUniversalTime()));
+            list.Add(builder.AddParameter(false));
 
             var parameterList = list.Select(x => $"@{x.ParameterName}").Join(", ");
 

--- a/src/Persistence/Wolverine.RDBMS/Durability/MoveReplayableErrorMessagesToIncoming.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/MoveReplayableErrorMessagesToIncoming.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading.Tasks;
+using Weasel.Core;
+using Wolverine.Persistence.Durability;
+using Wolverine.Transports;
+
+namespace Wolverine.RDBMS.Durability;
+
+public class MoveReplayableErrorMessagesToIncoming : IDurabilityAction
+{
+    public string Description => "Moving Replayable Error Envelopes from DeadLetterTable to IncomingTable";
+
+    public Task ExecuteAsync(IMessageDatabase database, IDurabilityAgent agent,
+        IDurableStorageSession session)
+    {
+        return session.WithinTransactionAsync(() => MoveReplayableErrorMessagesToIncomingAsync(session, database.Settings));
+    }
+    
+    public Task MoveReplayableErrorMessagesToIncomingAsync(IDurableStorageSession session, DatabaseSettings databaseSettings)
+    {
+        if (session.Transaction == null)
+        {
+            throw new InvalidOperationException("No current transaction");
+        }
+        
+        var insertIntoIncomingSql = $"insert into {databaseSettings.SchemaName}.{DatabaseConstants.IncomingTable} ({DatabaseConstants.IncomingFields})" +
+                                    $" select {DatabaseConstants.Body}, {DatabaseConstants.Id}, '{EnvelopeStatus.Incoming}', 0, null, 0, {DatabaseConstants.MessageType}, {DatabaseConstants.ReceivedAt} " +
+                                    $"from {databaseSettings.SchemaName}.{DatabaseConstants.DeadLetterTable} " +
+                                    $"where {DatabaseConstants.Replayable} = @replayable";
+
+        var removeFromDeadLetterSql = $"; delete from {databaseSettings.SchemaName}.{DatabaseConstants.DeadLetterTable} where {DatabaseConstants.Replayable} = @replayable";
+        
+        var removeFromDeadLetterSqlAndInsertIntoIncomingSql  = $"{insertIntoIncomingSql}; {removeFromDeadLetterSql}";
+        
+        return session.CreateCommand(removeFromDeadLetterSqlAndInsertIntoIncomingSql)
+            .With("replayable", true)
+            .ExecuteNonQueryAsync(session.Cancellation);
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Schema/DeadLettersTable.cs
+++ b/src/Persistence/Wolverine.SqlServer/Schema/DeadLettersTable.cs
@@ -22,5 +22,6 @@ internal class DeadLettersTable : Table
         AddColumn(DatabaseConstants.ExceptionMessage, "varchar(max)");
 
         AddColumn<DateTimeOffset>(DatabaseConstants.SentAt);
+        AddColumn<bool>(DatabaseConstants.Replayable);
     }
 }


### PR DESCRIPTION
This PR is for the following:

- Issue #135 
- Resolves the issue where `received_at` in the dead letter queue was not being tracked. Identified this issue when working on #135