### PR TITLE
Issue #145 - Allow marking dead letter messages as "Replayable" using command line

### DIFF
--- a/src/Persistence/PersistenceTests/Postgresql/PostgresqlMessageStoreTests.cs
+++ b/src/Persistence/PersistenceTests/Postgresql/PostgresqlMessageStoreTests.cs
@@ -219,30 +219,17 @@ public class PostgresqlMessageStoreTests : PostgresqlContext, IDisposable, IAsyn
         await thePersistence.StoreIncomingAsync(unReplayableEnvelope);
         await thePersistence.StoreIncomingAsync(replayableEnvelope);
 
-        var ex = new DivideByZeroException("Kaboom!");
-        await thePersistence.MoveToDeadLetterStorageAsync(unReplayableEnvelope, ex);
-        await thePersistence.MoveToDeadLetterStorageAsync(replayableEnvelope, ex);
+        var divideByZeroException = new DivideByZeroException("Kaboom!");
+        var applicationException = new ApplicationException("Kaboom!");
+        await thePersistence.MoveToDeadLetterStorageAsync(unReplayableEnvelope, divideByZeroException);
+        await thePersistence.MoveToDeadLetterStorageAsync(replayableEnvelope, applicationException);
 
         var settings = theHost.Services.GetRequiredService<PostgresqlSettings>();
 
-        // make one of the messages replayable
-        
-        var updateErrorMessageAsReplayable = $"update {settings.SchemaName}.{DatabaseConstants.DeadLetterTable} set {DatabaseConstants.Replayable} = true " +
-                                             $"where {DatabaseConstants.Id} = '{replayableEnvelope.Id}'";
-        
-        await settings
-            .CreateCommand(updateErrorMessageAsReplayable)
-            .ExecuteOnce();
-        
-        // verify message was updated to make it replayable
-        await using var conn = settings.CreateConnection();
-        await conn.OpenAsync();
-        
-        var replayableErrorMessagesCountAfterMakingReplayable = (long) (await conn.CreateCommand(
-                $"select count(*) from {settings.SchemaName}.{DatabaseConstants.DeadLetterTable} where {DatabaseConstants.Replayable} = true")
-            .ExecuteScalarAsync())!;
-        
-        await conn.CloseAsync();
+        // make one of the messages(DivideByZeroException) replayable
+        var replayableErrorMessagesCountAfterMakingReplayable = await thePersistence
+            .Admin
+            .MarkDeadLetterEnvelopesAsReplayableAsync(divideByZeroException.GetType().FullName!);
         
         await thePersistence.Session.BeginAsync();
 
@@ -252,19 +239,10 @@ public class PostgresqlMessageStoreTests : PostgresqlContext, IDisposable, IAsyn
 
         await thePersistence.Session.CommitAsync();
 
-        // verify un replayable message still exists
-        await conn.OpenAsync();
-        
-        var errorMessagesCountAfterDurabilityAction = (long) (await conn.CreateCommand(
-                $"select count(*) from {settings.SchemaName}.{DatabaseConstants.DeadLetterTable}")
-            .ExecuteScalarAsync())!;
-
-        await conn.CloseAsync();
-        
         var counts = await thePersistence.Admin.FetchCountsAsync();
 
         replayableErrorMessagesCountAfterMakingReplayable.ShouldBe(1);
-        errorMessagesCountAfterDurabilityAction.ShouldBe(1);
+        counts.DeadLetter.ShouldBe(1);
         counts.Incoming.ShouldBe(1);
         counts.Scheduled.ShouldBe(0);
         counts.Handled.ShouldBe(0);

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -108,7 +108,12 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>
             .ExecuteScalarAsync();
 
         counts.Outgoing = Convert.ToInt32(longCount);
+        
+        var deadLetterCount = await conn
+            .CreateCommand($"select count(*) from {Settings.SchemaName}.{DatabaseConstants.DeadLetterTable}")
+            .ExecuteScalarAsync();
 
+        counts.DeadLetter = Convert.ToInt32(deadLetterCount);
 
         return counts;
     }

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -95,6 +95,10 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>
         counts.Outgoing = (int)(await conn
             .CreateCommand($"select count(*) from {Settings.SchemaName}.{DatabaseConstants.OutgoingTable}")
             .ExecuteScalarAsync())!;
+        
+        counts.DeadLetter = (int)(await conn
+            .CreateCommand($"select count(*) from {Settings.SchemaName}.{DatabaseConstants.DeadLetterTable}")
+            .ExecuteScalarAsync())!;
 
         return counts;
     }

--- a/src/Wolverine/Logging/PersistedCounts.cs
+++ b/src/Wolverine/Logging/PersistedCounts.cs
@@ -21,10 +21,15 @@ public class PersistedCounts
     ///     Number of previously handled messages temporarily persisted in the durable inbox for idempotency checks
     /// </summary>
     public int Handled { get; set; }
+    
+    /// <summary>
+    ///     Number of error messages currently persisted in the dead letter
+    /// </summary>
+    public int DeadLetter { get; set; }
 
     public override string ToString()
     {
         return
-            $"{nameof(Incoming)}: {Incoming}, {nameof(Scheduled)}: {Scheduled}, {nameof(Outgoing)}: {Outgoing}, {nameof(Handled)}: {Handled}";
+            $"{nameof(Incoming)}: {Incoming}, {nameof(Scheduled)}: {Scheduled}, {nameof(Outgoing)}: {Outgoing}, {nameof(Handled)}: {Handled}, {nameof(DeadLetter)}: {DeadLetter}";
     }
 }

--- a/src/Wolverine/Persistence/Durability/IMessageStoreAdmin.cs
+++ b/src/Wolverine/Persistence/Durability/IMessageStoreAdmin.cs
@@ -14,6 +14,14 @@ public interface IMessageStoreAdmin
     Task ClearAllAsync();
 
     /// <summary>
+    ///     Marks the Envelopes in DeadLetterTable
+    ///     as replayable. DurabilityAgent will move the envelopes to IncomingTable. 
+    /// </summary>
+    /// <param name="exceptionType">Exception Type that should be marked. Default is any.</param>
+    /// <returns>Number of envelopes marked.</returns>
+    Task<int> MarkDeadLetterEnvelopesAsReplayableAsync(string exceptionType = "");
+
+    /// <summary>
     ///     Rebuilds the envelope storage and clears out any
     ///     persisted state
     /// </summary>

--- a/src/Wolverine/Persistence/Durability/NullMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/NullMessageStore.cs
@@ -240,6 +240,11 @@ internal class NullMessageStore : IMessageStore, IMessageStoreAdmin
         return Task.CompletedTask;
     }
 
+    public Task<int> MarkDeadLetterEnvelopesAsReplayableAsync(string exceptionType)
+    {
+        return Task.FromResult(0);
+    }
+
     public Task RebuildAsync()
     {
         return Task.CompletedTask;


### PR DESCRIPTION
This PR is for the following:

- Issue https://github.com/JasperFx/wolverine/issues/145
- Added command action to mark envelope(s) in dead letter as replayable, takes exception type as an argument
- Example usage: 
   -  Replay all error messages: `dotnet run -- storage replay`
   -  Replay messages with exception type 'System.ArgumentException': `dotnet run -- storage replay -t System.ArgumentException`
- Ability to count `DeadLetter` envelopes to `MessageStoreAdmin`
- Updated tests to use DeadLetter count