### PR TITLE
Update to latest Lamar for bug fixes with minimal API

### DIFF
--- a/src/Wolverine/Wolverine.csproj
+++ b/src/Wolverine/Wolverine.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FastExpressionCompiler" Version="3.3.3" />
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="10.0.0" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="10.0.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="[6.0.0,8.0.0)" />
 


### PR DESCRIPTION
It took me a very long time to try and figure out why model binding in minimal API wasn't working, but I finally figured out that it's a bug in Lamar that was fixed in 10.0.1.