### PR TITLE
Fixed broken document links.

### DIFF
--- a/docs/guide/basics.md
+++ b/docs/guide/basics.md
@@ -66,10 +66,10 @@ The diagram above should just say "Message Handler" as Wolverine makes no struct
 ## Terminology
 
 * *Message* -- Typically just a .NET class or C# record that can be easily serialized. See [messages and serialization](/guide/messages) for more information
-* *Message Handler* -- A method or function that "knows" how to process an incoming message. See [Message Handlers](/guide/handlers/) for more information
+* *Message Handler* -- A method or function that "knows" how to process an incoming message. See [Message Handlers](/guide/durability/) for more information
 * *Transport* -- This refers to the support within Wolverine for external messaging infrastructure tools like Rabbit MQ or Pulsar
 * *Endpoint* -- A Wolverine connection to some sort of external resource like a Rabbit MQ exchange or an Amazon SQS queue. The [Async API](https://www.asyncapi.com/) specification refers to this as a *channel*, and Wolverine may very well change its nomenclature in the future to be consistent with Async API
 * *Sending Agent* -- You won't use this directly in your own code, but Wolverine's internal adapters to publish outgoing messages to transport endpoints
 * *Listening Agent* -- Again, an internal detail of Wolverine that receives messages from external transport endpoints, and mediates between the transports and executing the message handlers
-* *Message Store* -- Database storage for Wolverine's [inbox/outbox persistent messaging](/guide/persistence/)
+* *Message Store* -- Database storage for Wolverine's [inbox/outbox persistent messaging](/guide/durability/)
 * *Durability Agent* -- An internal subsystem in Wolverine that runs in a background service to interact with the message store for Wolverine's [transactional inbox/outbox](https://microservices.io/patterns/data/transactional-outbox.html) functionality

--- a/docs/guide/durability/index.md
+++ b/docs/guide/durability/index.md
@@ -2,7 +2,7 @@
 
 See the blog post [Transactional Outbox/Inbox with Wolverine and why you care](https://jeremydmiller.com/2022/12/15/transactional-outbox-inbox-with-wolverine-and-why-you-care/) for more context.
 
-One of Wolverine's most important features is durable message persistence using your application's database for reliable "[store and forward](https://en.wikipedia.org/wiki/Store_and_forward)" queueing with all possible Wolverine transport options, including the [lightweight TCP transport](/transports/tcp) and external transports like the [Rabbit MQ transport](/guide/messaging/transports/rabbitmq).
+One of Wolverine's most important features is durable message persistence using your application's database for reliable "[store and forward](https://en.wikipedia.org/wiki/Store_and_forward)" queueing with all possible Wolverine transport options, including the [lightweight TCP transport](/guide/messaging/transports/tcp) and external transports like the [Rabbit MQ transport](/guide/messaging/transports/rabbitmq).
 
 It's a chaotic world out when high volume systems need to interact with other systems. Your system may fail, other systems may be down,
 there's network hiccups, occasional failures -- and you still need your systems to get to a consistent state without messages just
@@ -67,8 +67,8 @@ storage and processed when the system is restarted. Wolverine does this through 
 [IHostedService](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-6.0&tabs=visual-studio) runtime that is automatically registered in your system through the `UseWolverine()` extension method.
 
 ::: tip
-At the moment, Wolverine only supports Postgresql or Sql Server as the underlying database and either [Marten](/marten) or
-[Entity Framework Core](/efcore) as the application persistence framework.
+At the moment, Wolverine only supports Postgresql or Sql Server as the underlying database and either [Marten](/guide/durability/marten) or
+[Entity Framework Core](/guide/durability/efcore) as the application persistence framework.
 :::
 
 There are four things you need to enable for the transactional outbox (and inbox for incoming messages):

--- a/docs/guide/durability/marten.md
+++ b/docs/guide/durability/marten.md
@@ -54,9 +54,9 @@ For more information, see [durable messaging](/guide/durability/) and the [sampl
 
 Using the `IntegrateWithWolverine()` extension method behind your call to `AddMarten()` will:
 
-* Register the necessary [inbox and outbox](/guide/persistence/) database tables with [Marten's database schema management](https://martendb.io/schema/migrations.html)
+* Register the necessary [inbox and outbox](/guide/durability/) database tables with [Marten's database schema management](https://martendb.io/schema/migrations.html)
 * Adds Wolverine's "DurabilityAgent" to your .NET application for the inbox and outbox
-* Makes Marten the active [saga storage](/guide/persistence/sagas) for Wolverine
+* Makes Marten the active [saga storage](/guide/durability/sagas) for Wolverine
 * Adds transactional middleware using Marten to your Wolverine application
 
 
@@ -315,7 +315,7 @@ using var host = await Host.CreateDefaultBuilder()
 
 On the flip side of using Wolverine's "outbox" support for outgoing messages, you can also choose to use the same message persistence for incoming messages such that
 incoming messages are first persisted to the application's underlying Postgresql database before being processed. While
-you *could* use this with external message brokers like Rabbit MQ, it's more likely this will be valuable for Wolverine's [local queues](/guide/in-memory-bus).
+you *could* use this with external message brokers like Rabbit MQ, it's more likely this will be valuable for Wolverine's [local queues](/guide/messaging/transports/local).
 
 Back to the sample Marten + Wolverine integration from this page:
 
@@ -377,7 +377,7 @@ app.MapPost("/orders/create2", (CreateOrder command, IMessageBus bus)
 
 ## Saga Storage
 
-Marten is an easy option for [persistent sagas](/guide/persistence/sagas) with Wolverine. Yet again, to opt into using Marten as your saga storage mechanism in Wolverine, you
+Marten is an easy option for [persistent sagas](/guide/durability/sagas) with Wolverine. Yet again, to opt into using Marten as your saga storage mechanism in Wolverine, you
 just need to add the `IntegrateWithWolverine()` option to your Marten configuration as shown in the [Getting Started](#getting-started) section above.
 
 When using the Wolverine + Marten integration, your stateful saga classes should be valid Marten document types that inherit from Wolverine's `Saga` type, which generally means being a public class with a valid
@@ -469,7 +469,7 @@ public record MarkItemReady(Guid OrderId, string ItemName, int Version);
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/OrderEventSourcingSample/Order.cs#L64-L69' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemready' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-In the code above we're also utilizing Wolverine's [outbox messaging](/guide/persistence/) support to both order and guarantee the delivery of a `ShipOrder` message when
+In the code above we're also utilizing Wolverine's [outbox messaging](/guide/durability/) support to both order and guarantee the delivery of a `ShipOrder` message when
 the Marten transaction
 
 Before getting into Wolverine middleware strategies, let's first build out an MVC controller method for the command above:
@@ -657,7 +657,7 @@ public static void Handle(OrderEventSourcingSample.MarkItemReady command, IEvent
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/OrderEventSourcingSample/Alternatives/Signatures.cs#L25-L54' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemreadyhandler_with_explicit_stream' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Just as in other Wolverine [message handlers](/guide/messages/handlers), you can use
+Just as in other Wolverine [message handlers](/guide/handlers/), you can use
 additional method arguments for registered services ("method injection"), the `CancellationToken`
 for the message, and the message `Envelope` if you need access to message metadata.
 

--- a/docs/guide/durability/sagas.md
+++ b/docs/guide/durability/sagas.md
@@ -73,7 +73,7 @@ public class Order : Saga
 A few explanatory notes on this code before we move on to detailed documentation:
 
 * Wolverine leans a bit on type and naming conventions to discover message handlers and to “know” how to call these message handlers. Some folks will definitely not like the magic, but this approach leads to substantially less code and arguably complexity compared to existing .Net tools
-* Wolverine supports the idea of [scheduled messages](/guide/messaging/scheduled), and the new `TimeoutMessage` base class we used up there is just a shorthand way to utilize that support for “saga timeout” conditions
+* Wolverine supports the idea of [scheduled messages](/guide/messaging/message-bus.html#scheduling-message-delivery-or-execution), and the new `TimeoutMessage` base class we used up there is just a shorthand way to utilize that support for “saga timeout” conditions
 * Wolverine generally tries to adapt to your application code rather that using mandatory adapter interfaces
 * Subclassing `Saga` is meaningful first as this tells Wolverine "hey, this stateful type should be treated as a saga" for [handler discovery](/guide/handlers/discovery), but also for communicating
   to Wolverine that a logical saga is complete and should be deleted

--- a/docs/guide/handlers/index.md
+++ b/docs/guide/handlers/index.md
@@ -45,9 +45,9 @@ public static async Task publish_command(IMessageBus bus)
 Between the call to `IMessageBus.PublishAsync()` and `MyMessageHandler.Handle(MyMessage)` there's a couple things
 going on:
 
-1. Wolverine's built in, [automatic handler discovery](/discovery) has to find the candidate message handler methods
+1. Wolverine's built in, [automatic handler discovery](/guide/handlers/discovery) has to find the candidate message handler methods
    and correlate them by message type
-2. Wolverine's [runtime message processing](/runtime) builds some connective code at runtime to relay the
+2. Wolverine's [runtime message processing](/guide/runtime) builds some connective code at runtime to relay the
    messages passed into `IMessageBus` to the right message handler methods
 
 Before diving into the exact rules for message handlers, here are some valid handler methods:
@@ -283,7 +283,7 @@ So, what can be injected as an argument to your message handler?
 
 ## Cascading Messages from Actions
 
-See [Cascading Messages](/cascade) for more details on this feature.
+See [Cascading Messages](/guide/handlers/cascading) for more details on this feature.
 
 ## Using the Message Envelope
 

--- a/docs/guide/messaging/transports/local.md
+++ b/docs/guide/messaging/transports/local.md
@@ -19,10 +19,10 @@ Some things to know about the local queues:
 
 * Local worker queues can be durable, meaning that the enqueued messages are persisted first so that they aren't lost if the application is shut down before they're processed. More on that below.
 * You can use any number of named local queues, and they don't even have to be declared upfront (might want to be careful with that though)
-* Local worker queues utilize Wolverine's [error handling](/guide/messages/error-handling) policies to selectively handle any detected exceptions from the [message handlers](/guide/messages/handlers).
+* Local worker queues utilize Wolverine's [error handling](/guide/handlers/error-handling) policies to selectively handle any detected exceptions from the [message handlers](/guide/handlers/).
 * You can control the priority and parallelization of each individual local queue
 * Message types can be routed to particular queues
-* [Cascading messages](/guide/messages/handlers.html#cascading-messages-from-actions) can be used with the local queues
+* [Cascading messages](/guide/handlers/cascading) can be used with the local queues
 * The local queues can be used like any other message transport and be the target of routing rules
 
 
@@ -54,10 +54,10 @@ public ValueTask EnqueueToQueue(IMessageContext bus)
 ## Scheduling Local Execution
 
 :::tip
-If you need the command scheduling to be persistent or be persisted across service restarts, you'll need to enable the [message persistence](/guide/persistence/) within Wolverine.
+If you need the command scheduling to be persistent or be persisted across service restarts, you'll need to enable the [message persistence](/guide/durability/) within Wolverine.
 :::
 
-The "scheduled execution" feature can be used with local execution within the same application. See [Scheduled Messages](/guide/scheduled) for more information. Use the `IMessageBus.ScheduleAsync()` extension methods like this:
+The "scheduled execution" feature can be used with local execution within the same application. See [Scheduled Messages](/guide/messaging/message-bus.html#scheduling-message-delivery-or-execution) for more information. Use the `IMessageBus.ScheduleAsync()` extension methods like this:
 
 <!-- snippet: sample_schedule_job_locally -->
 <a id='snippet-sample_schedule_job_locally'></a>
@@ -210,7 +210,7 @@ using var host = await Host.CreateDefaultBuilder()
 <!-- endSnippet -->
 
 
-See [Persistent Messaging](http://localhost:5050/guide/persistence/) for more information.
+See [Durable Inbox and Outbox Messaging](/guide/durability/) for more information.
 
 
 ## Configuring Parallelization and Execution Properties

--- a/docs/guide/messaging/transports/rabbitmq.md
+++ b/docs/guide/messaging/transports/rabbitmq.md
@@ -55,7 +55,7 @@ See the [Rabbit MQ .NET Client documentation](https://www.rabbitmq.com/dotnet-ap
 
 ## Interoperability with Mass Transit
 
-Wolverine can interoperate bi-directionally with [MassTransit](https://masstransit-project.com/) using [Rabbit MQ](/guides/messaging/transports/masstransit).
+Wolverine can interoperate bi-directionally with [MassTransit](https://masstransit-project.com/) using [RabbitMQ](http://www.rabbitmq.com/).
 At this point, the interoperability is **only** functional if MassTransit is using its standard "envelope" serialization
 approach (i.e., **not** using raw JSON serialization).
 
@@ -126,16 +126,16 @@ using var host = await Host.CreateDefaultBuilder()
 <!-- endSnippet -->
 
 With the defaults from above, for each message that the application can handle
-(as determined by the discovered [message handlers](/guide/messages/discovery)) the conventional routing will:
+(as determined by the discovered [message handlers](/guide/handlers/discovery)) the conventional routing will:
 
-1. A durable queue using Wolverine's [message type name logic](/guide/messages/#message-type-name-or-alias)
+1. A durable queue using Wolverine's [message type name logic](/guide/messages.html#message-type-name-or-alias)
 2. A listening endpoint to the queue above configured with a single, inline listener and **without and enrollment in the durable outbox**
 
 Likewise, for every outgoing message type, the routing convention will *on demand at runtime*:
 
 1. Declare a fanout exchange named with the Wolverine message type alias name (usually the full name of the message type)
 2. Create the exchange if auto provisioning is enabled if the exchange does not already exist
-3. Create a [subscription rule](/guide/messaging/configuration) for that message type to the new exchange within the system
+3. Create a [subscription rule](/guide/messaging/subscriptions) for that message type to the new exchange within the system
 
 Of course, you may want your own slightly different behavior, so there's plenty of hooks to customize the
 Rabbit MQ routing conventions as shown below:
@@ -396,7 +396,7 @@ await publisher.SendAsync(new Message1());
 <!-- endSnippet -->
 
 You will be sending that message to the "topics-exchange" with a topic name derived from
-the message type. By default that topic name will be Wolverine's [message type alias](/guide/messages/#message-type-name-or-alias).
+the message type. By default that topic name will be Wolverine's [message type alias](/guide/messages.html#message-type-name-or-alias).
 Unless explicitly overridden, that alias is the full type name of the message type.
 
 That topic name derivation can be overridden explicitly by placing the `[Topic]` attribute

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -156,7 +156,7 @@ with extraneous `return Task.Completed;` code like you'd have to with other .NET
 As I mentioned earlier, we want our API to create an email whenever a new issue is created. In
 this case I'm opting to have that email generation and email sending happen in a second
 message handler that will run after the initial command. You might also notice that the `CreateIssueHandler.Handle()` method returns an `IssueCreated` event.
-When Wolverine sees that a handler creates what we call a [cascading message](TODO -- link here!), Wolverine will
+When Wolverine sees that a handler creates what we call a [cascading message](/guide/handlers/cascading), Wolverine will
 publish the `IssueCreated` event to an in memory
 queue after the initial message handler succeeds. The advantage of doing this is allowing the
 slower email generation and sending process to happen in background processes instead of holding up
@@ -205,4 +205,4 @@ years before the ASP.NET team got around to it:-)*
 
 This page introduced the basic usage of Wolverine, how to wire Wolverine
 into .NET applications, and some rudimentary `Handler` usage. There's much more
-of course, so learn more about [Handlers and Messages](/guide/messages/).
+of course, so learn more about [Handlers and Messages](/guide/handlers/).

--- a/docs/tutorials/mediator.md
+++ b/docs/tutorials/mediator.md
@@ -17,7 +17,7 @@ endpoint that can accept an input that will create and persist a new `Item`, whi
 * [MVC Core](https://docs.microsoft.com/en-us/aspnet/core/mvc/overview?view=aspnetcore-6.0) as the Web API framework, but I'm mostly
   using the newer Minimal API feature for this
 * Wolverine as our mediator of course!
-* Sql Server as the backing database store, using [Wolverine's Sql Server message persistence](/guide/persistence/sqlserver)
+* Sql Server as the backing database store, using [Wolverine's Sql Server message persistence](/guide/durability/#using-sql-server-for-message-storage)
 * [EF Core](https://docs.microsoft.com/en-us/ef/core/) as the persistence mechanism
 
 First off, let's start a new project with the `dotnet new webapi` template. Next, we'll add some configuration
@@ -118,17 +118,18 @@ There isn't much to this code -- and that's the entire point! When Wolverine reg
 a .NET Core application, it adds the `IMessageBus` service to the underlying system IoC container
 so it can be injected into controller classes or Minimal API endpoint as shown above.The `IMessageBus.InvokeAsync(message)`
 method takes the message passed in, finds the correct execution path for the message type, and
-executes the correct Wolverine handler(s) as well as any of the registered [Wolverine middleware](/guide/messages/middleware).
+executes the correct Wolverine handler(s) as well as any of the registered [Wolverine middleware](/guide/handlers/middleware).
 
 ::: tip
-This execution happens inline, but will use the *RetryNow* error handling capabilities. See [Wolverine's error handling](/guide/messages/error-handling) for more information.
+This execution happens inline, but will use the *RetryNow* error handling capabilities. See [Wolverine's error handling](/guide/handlers/error-handling) for more information.
 :::
 
 See also:
 
-* [Cascading messages from actions](/guide/messages/handlers.html#cascading-messages-from-actions) for a better explanation of how the `ItemCreated`
+* [Cascading messages from actions](/guide/handlers/cascading) for a better explanation of how the `ItemCreated`
   event message is automatically published if the handler success.
-* [Messages and message handlers](/guide/messages/) for the details of how to write Wolverine message handlers and how they
+* [Messages](/guide/messages) for the details of messages themselves including versioning, serialization, and forwarding.
+* [Message handlers](/guide/handlers/) for the details of how to write Wolverine message handlers and how they
   are discovered
 
 As a contrast, here's what the same functionality looks like if you write all the functionality out


### PR DESCRIPTION
Crawled the site + vitepress's link checker to fix some broken links within the documentation. 

There were a few places that linked to concepts that are now spread across multiple parts and I made some judgement calls on where those should go. 

There are still 3 places within the app that reference pages no longer there and am an sure where to point them. 

1. On the [getting started](https://wolverine.netlify.app/tutorials/getting-started.html) page, the link to "a local message bus" points to what used to be a command-bus.md page that no longer exists. Not sure whether to link this to the [local transports ](https://wolverine.netlify.app/guide/messaging/transports/local.html)section.
2. On the [getting started](https://wolverine.netlify.app/tutorials/getting-started.html) page, the link to "See Also: Wolverine as a Command Bus" points to an in-memory-bus.md page that no longer exists. Again, feels like it should go to the local transports section, but not sure. 
3. On the [Marten ](https://wolverine.netlify.app/guide/durability/marten.html) integration page, the link to "command bus" is pointing to a in-memory-bus.md page that no longer exists. A link to the local transports is already in this documentation, so not sure where to point.

Note: This is my first ever contribution to an open source project and as such have no clue what the hell I'm doing. Feel free to comment/advise as necessary. 