### PR TITLE
Fixed blocking tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,4 +35,4 @@ jobs:
 
 
     - name: Test
-      run: dotnet run -p build/build.csproj -- ci
+      run: dotnet run -p build/build.csproj -- full

--- a/build/build.cs
+++ b/build/build.cs
@@ -175,7 +175,7 @@ namespace build
 
         private static void RunCurrentProject(string args)
         {
-            Run("dotnet", $"run  --framework net6.0 --no-build --no-restore -- {args}");
+            Run("dotnet", $"run  --framework net7.0 --no-build --no-restore -- {args}");
         }
 
         private static void CopyFilesRecursively(string sourcePath, string targetPath)
@@ -235,7 +235,7 @@ namespace build
                 ? $"src/Testing/{projectName}/{projectName}.csproj"
                 : $"src/{string.Join('/', paths.SkipLast(1))}/{projectName}/{projectName}.csproj";
             
-            Run("dotnet", $"test --no-build --no-restore " + path);
+            Run("dotnet", $"test --no-build --no-restore {path} --logger \"console;verbosity=detailed\"");
         }
 
         private static string GetEnvironmentVariable(string variableName)

--- a/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
+++ b/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
+++ b/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
@@ -25,4 +25,8 @@
         <ProjectReference Include="..\Wolverine.FluentValidation\Wolverine.FluentValidation.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
 </Project>

--- a/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
+++ b/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Extensions/Wolverine.MemoryPack.Tests/Wolverine.MemoryPack.Tests.csproj
+++ b/src/Extensions/Wolverine.MemoryPack.Tests/Wolverine.MemoryPack.Tests.csproj
@@ -16,4 +16,8 @@
       <ProjectReference Include="..\Wolverine.MemoryPack\Wolverine.MemoryPack.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
 </Project>

--- a/src/Extensions/Wolverine.MemoryPack.Tests/Wolverine.MemoryPack.Tests.csproj
+++ b/src/Extensions/Wolverine.MemoryPack.Tests/Wolverine.MemoryPack.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/Extensions/Wolverine.MemoryPack.Tests/Wolverine.MemoryPack.Tests.csproj
+++ b/src/Extensions/Wolverine.MemoryPack.Tests/Wolverine.MemoryPack.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/Persistence/PersistenceTests/EFCore/EfCoreCompilationScenarios.cs
+++ b/src/Persistence/PersistenceTests/EFCore/EfCoreCompilationScenarios.cs
@@ -25,13 +25,14 @@ public class EfCoreCompilationScenarios
     [Fact]
     public async Task ef_context_is_scoped_and_options_are_singleton()
     {
-        using var host = WolverineHost.For(opts =>
+        var host = WolverineHost.For(opts =>
         {
             // Default of both is scoped
             opts.Services.AddDbContext<SampleDbContext>(optionsLifetime: ServiceLifetime.Singleton);
         });
 
         await host.Services.GetRequiredService<IMessageBus>().InvokeAsync(new CreateItem { Name = "foo" });
+        await host.StopAsync();
     }
 
 

--- a/src/Persistence/PersistenceTests/EFCore/EfCoreCompilationScenarios.cs
+++ b/src/Persistence/PersistenceTests/EFCore/EfCoreCompilationScenarios.cs
@@ -25,7 +25,7 @@ public class EfCoreCompilationScenarios
     [Fact]
     public async Task ef_context_is_scoped_and_options_are_singleton()
     {
-        var host = WolverineHost.For(opts =>
+        var host = await WolverineHost.ForAsync(opts =>
         {
             // Default of both is scoped
             opts.Services.AddDbContext<SampleDbContext>(optionsLifetime: ServiceLifetime.Singleton);

--- a/src/Persistence/PersistenceTests/Marten/DurableTcpTransportCompliance.cs
+++ b/src/Persistence/PersistenceTests/Marten/DurableTcpTransportCompliance.cs
@@ -44,10 +44,9 @@ public class DurableTcpTransportFixture : TransportComplianceFixture, IAsyncLife
         });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        Dispose();
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 }
 

--- a/src/Persistence/PersistenceTests/PersistenceTests.csproj
+++ b/src/Persistence/PersistenceTests/PersistenceTests.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-
         <IsPackable>false</IsPackable>
 
         <LangVersion>10</LangVersion>

--- a/src/Persistence/PersistenceTests/PersistenceTests.csproj
+++ b/src/Persistence/PersistenceTests/PersistenceTests.csproj
@@ -32,4 +32,8 @@
         </Compile>
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
 </Project>

--- a/src/Persistence/PersistenceTests/PersistenceTests.csproj
+++ b/src/Persistence/PersistenceTests/PersistenceTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
 
         <LangVersion>10</LangVersion>

--- a/src/Persistence/PersistenceTests/Postgresql/LocalPostgresqlBackedTransportCompliance.cs
+++ b/src/Persistence/PersistenceTests/Postgresql/LocalPostgresqlBackedTransportCompliance.cs
@@ -18,10 +18,9 @@ public class LocalPostgresqlBackedFixture : TransportComplianceFixture, IAsyncLi
         return TheOnlyAppIs(opts => { opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString); });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        Dispose();
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 }
 

--- a/src/Persistence/PersistenceTests/application_of_transaction_middleware.cs
+++ b/src/Persistence/PersistenceTests/application_of_transaction_middleware.cs
@@ -50,9 +50,10 @@ public class application_of_transaction_middleware : IAsyncLifetime
         theContainer = _host.Services.ShouldBeOfType<Container>();
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        return _host.StopAsync();
+        await _host.StopAsync();
+        await theContainer.DisposeAsync();
     }
 
     [Theory]

--- a/src/Persistence/PersistenceTests/durability_with_local.cs
+++ b/src/Persistence/PersistenceTests/durability_with_local.cs
@@ -23,7 +23,7 @@ public class durability_with_local : PostgresqlContext
     [Fact]
     public async Task should_recover_persisted_messages()
     {
-        var host1 = WolverineHost.For(opts => opts.ConfigureDurableSender(true, true));
+        var host1 = await WolverineHost.ForAsync(opts => opts.ConfigureDurableSender(true, true));
         await host1.SendAsync(new ReceivedMessage());
 
         var counts = await host1.Get<IMessageStore>().Admin.FetchCountsAsync();
@@ -31,7 +31,6 @@ public class durability_with_local : PostgresqlContext
         await host1.StopAsync();
 
         counts.Incoming.ShouldBe(1);
-        await host1.StopAsync();
 
         // Don't use WolverineHost here because you need the existing persisted state!!!!
         var host2 = await Host.CreateDefaultBuilder().UseWolverine(opts => opts.ConfigureDurableSender(true, false))

--- a/src/Persistence/PersistenceTests/durability_with_local.cs
+++ b/src/Persistence/PersistenceTests/durability_with_local.cs
@@ -35,8 +35,8 @@ public class durability_with_local : PostgresqlContext
         }
 
         // Don't use WolverineHost here because you need the existing persisted state!!!!
-        using (var host1 = Host.CreateDefaultBuilder().UseWolverine(opts => opts.ConfigureDurableSender(true, false))
-                   .Start())
+        using (var host1 = await Host.CreateDefaultBuilder().UseWolverine(opts => opts.ConfigureDurableSender(true, false))
+                   .StartAsync())
         {
             var counts = await host1.Get<IMessageStore>().Admin.FetchCountsAsync();
 

--- a/src/Testing/CircuitBreakingTests/CircuitBreakingTests.csproj
+++ b/src/Testing/CircuitBreakingTests/CircuitBreakingTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Testing/CircuitBreakingTests/CircuitBreakingTests.csproj
+++ b/src/Testing/CircuitBreakingTests/CircuitBreakingTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Testing/CircuitBreakingTests/CircuitBreakingTests.csproj
+++ b/src/Testing/CircuitBreakingTests/CircuitBreakingTests.csproj
@@ -35,4 +35,7 @@
         </Compile>
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
 </Project>

--- a/src/Testing/CoreTests/Acceptance/executing_with_middleware.cs
+++ b/src/Testing/CoreTests/Acceptance/executing_with_middleware.cs
@@ -33,7 +33,9 @@ public class executing_with_middleware
         await host.InvokeMessageAndWaitAsync(message);
 
         foreach (var action in recorder.Actions) _output.WriteLine($"\"{action}\"");
-
+        
+        await host.StopAsync();
+        
         return recorder.Actions;
     }
 

--- a/src/Testing/CoreTests/CoreTests.csproj
+++ b/src/Testing/CoreTests/CoreTests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-
         <IsPackable>false</IsPackable>
 
         <LangVersion>10</LangVersion>

--- a/src/Testing/CoreTests/CoreTests.csproj
+++ b/src/Testing/CoreTests/CoreTests.csproj
@@ -20,4 +20,7 @@
         <ProjectReference Include="..\TestingSupport\TestingSupport.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
 </Project>

--- a/src/Testing/CoreTests/CoreTests.csproj
+++ b/src/Testing/CoreTests/CoreTests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        
         <IsPackable>false</IsPackable>
 
         <LangVersion>10</LangVersion>

--- a/src/Testing/CoreTests/CoreTests.csproj
+++ b/src/Testing/CoreTests/CoreTests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        
         <IsPackable>false</IsPackable>
 
         <LangVersion>10</LangVersion>

--- a/src/Testing/CoreTests/Transports/Tcp/LightweightTcpTransportCompliance.cs
+++ b/src/Testing/CoreTests/Transports/Tcp/LightweightTcpTransportCompliance.cs
@@ -20,9 +20,9 @@ public class LightweightTcpFixture : TransportComplianceFixture, IAsyncLifetime
         await ReceiverIs(opts => { opts.ListenAtPort(OutboundAddress.Port); });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 }
 

--- a/src/Testing/OpenTelemetry/TracingTests/TracingTests.csproj
+++ b/src/Testing/OpenTelemetry/TracingTests/TracingTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Testing/OpenTelemetry/TracingTests/TracingTests.csproj
+++ b/src/Testing/OpenTelemetry/TracingTests/TracingTests.csproj
@@ -37,4 +37,7 @@
         </Compile>
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
 </Project>

--- a/src/Testing/OpenTelemetry/TracingTests/TracingTests.csproj
+++ b/src/Testing/OpenTelemetry/TracingTests/TracingTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Testing/PolicyTests/PolicyTests/PolicyTests.csproj
+++ b/src/Testing/PolicyTests/PolicyTests/PolicyTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Testing/PolicyTests/PolicyTests/PolicyTests.csproj
+++ b/src/Testing/PolicyTests/PolicyTests/PolicyTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Testing/PolicyTests/PolicyTests/PolicyTests.csproj
+++ b/src/Testing/PolicyTests/PolicyTests/PolicyTests.csproj
@@ -34,4 +34,7 @@
         </Compile>
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
 </Project>

--- a/src/Testing/ScheduledJobTests/ScheduledJobTests.csproj
+++ b/src/Testing/ScheduledJobTests/ScheduledJobTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Testing/ScheduledJobTests/ScheduledJobTests.csproj
+++ b/src/Testing/ScheduledJobTests/ScheduledJobTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Testing/ScheduledJobTests/ScheduledJobTests.csproj
+++ b/src/Testing/ScheduledJobTests/ScheduledJobTests.csproj
@@ -35,4 +35,8 @@
         </Compile>
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
 </Project>

--- a/src/Testing/TestingSupport/WolverineHost.cs
+++ b/src/Testing/TestingSupport/WolverineHost.cs
@@ -48,6 +48,13 @@ public static class WolverineHost
         return bootstrap(options);
     }
 
+    public static Task<IHost> ForAsync(Action<WolverineOptions> configure)
+    {
+        var options = new WolverineOptions();
+        configure(options);
+        return bootstrapAsync(options);
+    }
+    
     private static IHost bootstrap(WolverineOptions options)
     {
         return Host.CreateDefaultBuilder()
@@ -57,6 +64,14 @@ public static class WolverineHost
             .Start();
     }
 
+    private static Task<IHost> bootstrapAsync(WolverineOptions options)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(options, (c, o) => { })
+            .UseResourceSetupOnStartup(StartupAction.ResetState)
+            //.ConfigureLogging(x => x.ClearProviders())
+            .StartAsync();
+    }
 
     /// <summary>
     ///     Shortcut to create a new empty WebHostBuilder with Wolverine's default

--- a/src/Transports/Wolverine.AmazonSqs.Tests/BufferedSendingAndReceivingCompliance.cs
+++ b/src/Transports/Wolverine.AmazonSqs.Tests/BufferedSendingAndReceivingCompliance.cs
@@ -29,9 +29,9 @@ public class BufferedComplianceFixture : TransportComplianceFixture, IAsyncLifet
         });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 }
 

--- a/src/Transports/Wolverine.AmazonSqs.Tests/DurableSendingAndReceivingCompliance.cs
+++ b/src/Transports/Wolverine.AmazonSqs.Tests/DurableSendingAndReceivingCompliance.cs
@@ -48,9 +48,9 @@ public class DurableComplianceFixture : TransportComplianceFixture, IAsyncLifeti
         });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 
     [Collection("acceptance")]

--- a/src/Transports/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
+++ b/src/Transports/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Transports/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
+++ b/src/Transports/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -33,4 +32,7 @@
         </Compile>
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
 </Project>

--- a/src/Transports/Wolverine.AmazonSqs.Tests/sending_compliance_with_prefixes.cs
+++ b/src/Transports/Wolverine.AmazonSqs.Tests/sending_compliance_with_prefixes.cs
@@ -35,9 +35,9 @@ public class PrefixedComplianceFixture : TransportComplianceFixture, IAsyncLifet
         });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 }
 

--- a/src/Transports/Wolverine.AzureServiceBus.Tests/BufferedSendingAndReceivingCompliance.cs
+++ b/src/Transports/Wolverine.AzureServiceBus.Tests/BufferedSendingAndReceivingCompliance.cs
@@ -32,9 +32,9 @@ public class BufferedComplianceFixture : TransportComplianceFixture, IAsyncLifet
         });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 }
 

--- a/src/Transports/Wolverine.AzureServiceBus.Tests/DurableSendingAndReceivingCompliance.cs
+++ b/src/Transports/Wolverine.AzureServiceBus.Tests/DurableSendingAndReceivingCompliance.cs
@@ -54,9 +54,9 @@ public class DurableComplianceFixture : TransportComplianceFixture, IAsyncLifeti
         });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 
     [Collection("acceptance")]

--- a/src/Transports/Wolverine.AzureServiceBus.Tests/Wolverine.AzureServiceBus.Tests.csproj
+++ b/src/Transports/Wolverine.AzureServiceBus.Tests/Wolverine.AzureServiceBus.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>
@@ -32,4 +31,7 @@
         </Compile>
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
 </Project>

--- a/src/Transports/Wolverine.AzureServiceBus.Tests/Wolverine.AzureServiceBus.Tests.csproj
+++ b/src/Transports/Wolverine.AzureServiceBus.Tests/Wolverine.AzureServiceBus.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/src/Transports/Wolverine.Pulsar.Tests/InlinePulsarTransportComplianceTests.cs
+++ b/src/Transports/Wolverine.Pulsar.Tests/InlinePulsarTransportComplianceTests.cs
@@ -34,9 +34,9 @@ public class InlinePulsarTransportFixture : TransportComplianceFixture, IAsyncLi
         });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 
     public override void BeforeEach()

--- a/src/Transports/Wolverine.Pulsar.Tests/PulsarTransportComplianceTests.cs
+++ b/src/Transports/Wolverine.Pulsar.Tests/PulsarTransportComplianceTests.cs
@@ -33,9 +33,9 @@ public class PulsarTransportFixture : TransportComplianceFixture, IAsyncLifetime
         });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 
     public override void BeforeEach()

--- a/src/Transports/Wolverine.Pulsar.Tests/Wolverine.Pulsar.Tests.csproj
+++ b/src/Transports/Wolverine.Pulsar.Tests/Wolverine.Pulsar.Tests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-
         <IsPackable>false</IsPackable>
 
         <RootNamespace>Jasper.Pulsar.Tests</RootNamespace>
@@ -24,6 +22,10 @@
     <ItemGroup>
         <ProjectReference Include="..\Wolverine.Pulsar\Wolverine.Pulsar.csproj"/>
         <ProjectReference Include="..\..\Testing\TestingSupport\TestingSupport.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
 </Project>

--- a/src/Transports/Wolverine.Pulsar.Tests/Wolverine.Pulsar.Tests.csproj
+++ b/src/Transports/Wolverine.Pulsar.Tests/Wolverine.Pulsar.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
 
         <RootNamespace>Jasper.Pulsar.Tests</RootNamespace>

--- a/src/Transports/Wolverine.RabbitMQ.Tests/InlineRabbitMqTransportComplianceTests.cs
+++ b/src/Transports/Wolverine.RabbitMQ.Tests/InlineRabbitMqTransportComplianceTests.cs
@@ -35,9 +35,9 @@ public class InlineRabbitMqTransportFixture : TransportComplianceFixture, IAsync
         });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 }
 

--- a/src/Transports/Wolverine.RabbitMQ.Tests/RabbitMqTransportComplianceTests.cs
+++ b/src/Transports/Wolverine.RabbitMQ.Tests/RabbitMqTransportComplianceTests.cs
@@ -35,9 +35,9 @@ public class RabbitMqTransportFixture : TransportComplianceFixture, IAsyncLifeti
         });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 }
 

--- a/src/Transports/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
+++ b/src/Transports/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/src/Transports/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
+++ b/src/Transports/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
@@ -28,4 +28,7 @@
         </Compile>
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
 </Project>

--- a/src/Transports/Wolverine.RabbitMQ.Tests/sending_compliance_with_prefixes.cs
+++ b/src/Transports/Wolverine.RabbitMQ.Tests/sending_compliance_with_prefixes.cs
@@ -38,9 +38,9 @@ public class PrefixedComplianceFixture : TransportComplianceFixture, IAsyncLifet
         });
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        return Task.CompletedTask;
+        await DisposeAsync();
     }
 }
 

--- a/xunit.runner.json
+++ b/xunit.runner.json
@@ -1,0 +1,5 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": true,
+  "longRunningTestSeconds": 60
+}


### PR DESCRIPTION
* Fixed test runner - TargetFramework in *Tests.csproj was preventing test run due to conflict with TargetFrameworks from Directory.Build.props
* Where it is appropriate calling async dispose instead of dispose 
* Created `xunit.runner.json` with `longRunningTestSeconds` set to 60 seconds - reporting tests that are running 60 seconds as long-running
