### PR TITLE
fixed transaction being not committed problem when using EF Core

### DIFF
--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/RawDatabaseEnvelopeTransaction.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/RawDatabaseEnvelopeTransaction.cs
@@ -101,4 +101,14 @@ public class RawDatabaseEnvelopeTransaction : IEnvelopeTransaction
 
         return ValueTask.CompletedTask;
     }
+    
+    public ValueTask CommitAsync()
+    {
+        if (DbContext.Database.CurrentTransaction != null)
+        {
+            return new ValueTask(DbContext.Database.CurrentTransaction.CommitAsync());
+        }
+
+        return ValueTask.CompletedTask;
+    }
 }

--- a/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
@@ -49,7 +49,7 @@ public static class WolverineEntityCoreExtensions
         return dbContext.Model.FindAnnotation(WolverineEntityCoreExtensions.WolverineEnabled) != null;
     }
 
-    internal static IEnvelopeTransaction BuildTransaction(this DbContext dbContext, MessageContext context)
+    public static IEnvelopeTransaction BuildTransaction(this DbContext dbContext, MessageContext context)
     {
         return dbContext.IsWolverineEnabled() 
             ? new MappedEnvelopeTransaction(dbContext, context) 

--- a/src/Samples/EFCoreSample/ItemService.Tests/end_to_end.cs
+++ b/src/Samples/EFCoreSample/ItemService.Tests/end_to_end.cs
@@ -30,7 +30,7 @@ public class end_to_end
         using var nested = host.Services.As<IContainer>().GetNestedContainer();
         var context = nested.GetInstance<ItemsDbContext>();
 
-        var item = context.Items.FirstOrDefaultAsync(x => x.Name == name);
+        var item = await context.Items.FirstOrDefaultAsync(x => x.Name == name);
         item.ShouldNotBeNull();
     }
 

--- a/src/Samples/EFCoreSample/ItemService.Tests/end_to_end_for_dbcontext_not_integrated_with_outbox.cs
+++ b/src/Samples/EFCoreSample/ItemService.Tests/end_to_end_for_dbcontext_not_integrated_with_outbox.cs
@@ -1,0 +1,35 @@
+using Alba;
+using JasperFx.Core.Reflection;
+using Lamar;
+using Microsoft.EntityFrameworkCore;
+using Oakton;
+using Shouldly;
+using Wolverine.Tracking;
+
+namespace ItemService.Tests;
+
+public class end_to_end_for_dbcontext_not_integrated_with_outbox
+{
+    public end_to_end_for_dbcontext_not_integrated_with_outbox()
+    {
+        OaktonEnvironment.AutoStartHost = true;
+    }
+    
+    [Fact]
+    public async Task run_through_the_handler()
+    {
+        using var host = await AlbaHost.For<Program>();
+
+        var name = Guid.NewGuid().ToString();
+        var tracked = await host.InvokeMessageAndWaitAsync(new CreateItemWithDbContextNotIntegratedWithOutboxCommand { Name = name });
+        tracked.FindSingleTrackedMessageOfType<ItemCreatedInDbContextNotIntegratedWithOutbox>()
+            .ShouldNotBeNull();
+        
+        
+        using var nested = host.Services.As<IContainer>().GetNestedContainer();
+        var context = nested.GetInstance<ItemsDbContext>();
+
+        var item = await context.Items.FirstOrDefaultAsync(x => x.Name == name);
+        item.ShouldNotBeNull();
+    }
+}

--- a/src/Samples/EFCoreSample/ItemService/CreateItemCommandHandler.cs
+++ b/src/Samples/EFCoreSample/ItemService/CreateItemCommandHandler.cs
@@ -1,9 +1,12 @@
+using Wolverine.Attributes;
+
 namespace ItemService;
 
 public static class CreateItemCommandHandler
 {
     #region sample_handler_using_efcore
 
+    [Transactional]
     public static ItemCreated Handle(
         // This would be the message
         CreateItemCommand command,

--- a/src/Samples/EFCoreSample/ItemService/CreateItemWithDbContextNotIntegratedWithOutboxCommandHandler.cs
+++ b/src/Samples/EFCoreSample/ItemService/CreateItemWithDbContextNotIntegratedWithOutboxCommandHandler.cs
@@ -1,0 +1,52 @@
+using Wolverine.Attributes;
+
+namespace ItemService;
+
+public class CreateItemWithDbContextNotIntegratedWithOutboxCommand
+{
+    public string Name { get; set; }
+}
+
+public class ItemCreatedInDbContextNotIntegratedWithOutbox
+{
+    public Guid Id { get; set; }
+}
+
+public class CreateItemWithDbContextNotIntegratedWithOutboxCommandHandler
+{
+    [Transactional]
+    public static ItemCreatedInDbContextNotIntegratedWithOutbox Handle(
+        // This would be the message
+        CreateItemWithDbContextNotIntegratedWithOutboxCommand command,
+
+        // Any other arguments are assumed
+        // to be service dependencies
+        ItemsDbContextWithoutOutbox db)
+    {
+        // Create a new Item entity
+        var item = new Item
+        {
+            Name = command.Name
+        };
+
+        // Add the item to the current
+        // DbContext unit of work
+        db.Items.Add(item);
+
+        // This event being returned
+        // by the handler will be automatically sent
+        // out as a "cascading" message
+        return new ItemCreatedInDbContextNotIntegratedWithOutbox
+        {
+            Id = item.Id
+        };
+    }
+}
+
+public class ItemCreatedInDbContextNotIntegratedWithOutboxHandler
+{
+    public void Handle(ItemCreatedInDbContextNotIntegratedWithOutbox @event)
+    {
+        Console.WriteLine("You created a new item with id " + @event.Id);
+    }
+}

--- a/src/Samples/EFCoreSample/ItemService/ItemsDbContext.cs
+++ b/src/Samples/EFCoreSample/ItemService/ItemsDbContext.cs
@@ -25,3 +25,30 @@ public class ItemsDbContext : DbContext
 }
 
 #endregion
+
+
+#region sample_ItemsDbContext_NotIntegratedWithOutbox
+
+public class ItemsDbContextWithoutOutbox : DbContext
+{
+    public ItemsDbContextWithoutOutbox(DbContextOptions<ItemsDbContextWithoutOutbox> options) : base(options)
+    {
+    }
+
+    public DbSet<Item> Items { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // Your normal EF Core mapping
+        modelBuilder.Entity<Item>(map =>
+        {
+            map.ToTable("items");
+            map.HasKey(x => x.Id);
+            map.Property(x => x.Name);
+        });
+    }
+}
+
+#endregion
+
+ 

--- a/src/Samples/EFCoreSample/ItemService/Program.cs
+++ b/src/Samples/EFCoreSample/ItemService/Program.cs
@@ -21,6 +21,14 @@ builder.Services.AddDbContextWithWolverineIntegration<ItemsDbContext>(
 
 #endregion
 
+#region registration_of_db_context_not_integrated_with_outbox
+
+// Add DbContext that is not integrated with outbox
+builder.Services.AddDbContext<ItemsDbContextWithoutOutbox>(
+    x => x.UseSqlServer(connectionString));
+
+#endregion
+
 #region sample_registering_efcore_middleware
 
 builder.Host.UseWolverine(opts =>
@@ -66,6 +74,8 @@ if (app.Environment.IsDevelopment())
 app.MapControllers();
 
 app.MapPost("/items/create", (CreateItemCommand command, IMessageBus bus) => bus.InvokeAsync(command));
+
+app.MapPost("/items/createWithDbContextNotIntegratedWithOutbox", (CreateItemWithDbContextNotIntegratedWithOutboxCommand command, IMessageBus bus) => bus.InvokeAsync(command));
 
 #region sample_using_oakton_for_command_line_parsing
 


### PR DESCRIPTION
The wrong transaction envelope was used when using EF Core integration, it is fixed by changing generated code so it checks if DbContext is integrated with outbox or not. For DbContext integrated with outbox DbContext will handle the transaction by itself, so a call to SaveChangesAsnc is enough to save user data and messages together in one transaction. If DbContext is not integrated with outbox, then we need to use RawDatabaseEnvelopeTransaction that will start transaction, share it with both user db context and outbox db context and finally commit it.