### PR TITLE
Transactional attribute no longer required when using EF tx

### DIFF
--- a/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
@@ -42,6 +42,8 @@ public static class WolverineEntityCoreExtensions
     public static void UseEntityFrameworkCoreTransactions(this WolverineOptions options)
     {
         options.Include<EntityFrameworkCoreBackedPersistence>();
+        
+        options.Handlers.AutoApplyTransactions();
     }
 
     internal static bool IsWolverineEnabled(this DbContext dbContext)

--- a/src/Samples/EFCoreSample/ItemService/CreateItemCommandHandler.cs
+++ b/src/Samples/EFCoreSample/ItemService/CreateItemCommandHandler.cs
@@ -1,12 +1,9 @@
-using Wolverine.Attributes;
-
 namespace ItemService;
 
 public static class CreateItemCommandHandler
 {
     #region sample_handler_using_efcore
-
-    [Transactional]
+    
     public static ItemCreated Handle(
         // This would be the message
         CreateItemCommand command,

--- a/src/Samples/EFCoreSample/ItemService/CreateItemWithDbContextNotIntegratedWithOutboxCommandHandler.cs
+++ b/src/Samples/EFCoreSample/ItemService/CreateItemWithDbContextNotIntegratedWithOutboxCommandHandler.cs
@@ -1,5 +1,3 @@
-using Wolverine.Attributes;
-
 namespace ItemService;
 
 public class CreateItemWithDbContextNotIntegratedWithOutboxCommand
@@ -14,7 +12,6 @@ public class ItemCreatedInDbContextNotIntegratedWithOutbox
 
 public class CreateItemWithDbContextNotIntegratedWithOutboxCommandHandler
 {
-    [Transactional]
     public static ItemCreatedInDbContextNotIntegratedWithOutbox Handle(
         // This would be the message
         CreateItemWithDbContextNotIntegratedWithOutboxCommand command,

--- a/src/Wolverine/Persistence/AutoApplyTransactions.cs
+++ b/src/Wolverine/Persistence/AutoApplyTransactions.cs
@@ -15,7 +15,7 @@ internal class AutoApplyTransactions : IHandlerPolicy
         var providers = rules.PersistenceProviders();
         if (!providers.Any()) return;
         
-        foreach (var chain in graph.Chains.Where(x => !x.HasAttribute<TransactionalAttribute>()))
+        foreach (var chain in graph.Chains.Where(x => x is not SagaChain && !x.HasAttribute<TransactionalAttribute>()))
         {
             var potentials = providers.Where(x => x.CanApply(chain, container)).ToArray();
             if (potentials.Length == 1)


### PR DESCRIPTION
According to the docs, the [Transactional] attribute should not be required to enroll in transactional middleware. I added a call to options.Handlers.AutoApplyTransactions() to UseEntityFrameworkCoreTransactions. I adjusted the unit tests and sample code.
I modified auto apply to skip sagas as I am not sure if it should be treated this way (if not omitted all EF Integration Saga) tests fail. 