### PR TITLE
Changes name of 'parsed' variable in CodeGen to account for multiple params

### DIFF
--- a/src/Http/Wolverine.Http/CodeGen/QueryStringHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/QueryStringHandling.cs
@@ -60,7 +60,7 @@ internal class ParsedNullableQueryStringValue : SyncFrame
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
         writer.Write($"{_alias}? {Variable.Usage} = null;");
-        writer.Write($"if ({_alias}.TryParse(httpContext.Request.Query[\"{Variable.Usage}\"], out var parsed)) {Variable.Usage} = parsed;");
+        writer.Write($"if ({_alias}.TryParse(httpContext.Request.Query[\"{Variable.Usage}\"], out var {Variable.Usage}Parsed)) {Variable.Usage} = {Variable.Usage}Parsed;");
         
         Next?.GenerateCode(method, writer);
     }


### PR DESCRIPTION
If you use multiple nullable parameters like

`
    [WolverineGet("/todoitems/{id}")]
    public static Task<Todo?> GetTodo(
        int id,
        int? int1,
        int? int2,
        IQuerySession session, 
        CancellationToken cancellation) 
        => session.LoadAsync<Todo>(id, cancellation);
`

You get the error that the 'parsed' variable already exists in this context. I've changed the name of the parsed variable to include the name of the variable it is parsing to ensure that the name is not repeated. 