### PR TITLE
Fix mentioning of NServiceBus in MassTransit page

### DIFF
--- a/docs/guide/messaging/masstransit.md
+++ b/docs/guide/messaging/masstransit.md
@@ -1,7 +1,7 @@
 # Interoperability with MassTransit
 
 Wolverine is the new kid on the block, and it's quite likely that many folks will already be using MassTransit for messaging.
-Fortunately, Wolverine has some ability to exchange messages with NServiceBus applications, so both tools can live and
+Fortunately, Wolverine has some ability to exchange messages with MassTransit applications, so both tools can live and
 work together.
 
 At this point, the interoperability is only built and tested for the [Rabbit MQ transport](./transports/rabbitmq.md).


### PR DESCRIPTION
Fixes a mentioning of NServiceBus instead of MassTransit in documentation for interoperability with MassTransit