### PR TITLE
docs: use main branch when linking to samples in source

### DIFF
--- a/docs/guide/durability/index.md
+++ b/docs/guide/durability/index.md
@@ -63,7 +63,7 @@ and slow [distributed transactions](https://en.wikipedia.org/wiki/Distributed_tr
 also includes a separate *message relay* process that will send the persisted outgoing messages in background processes (it's done by marshalling the outgoing message envelopes through [TPL Dataflow](https://docs.microsoft.com/en-us/dotnet/standard/parallel-programming/dataflow-task-parallel-library) queues if you're curious.)
 
 If any node of a Wolverine system that uses durable messaging goes down before all the messages are processed, the persisted messages will be loaded from
-storage and processed when the system is restarted. Wolverine does this through its [DurabilityAgent](https://github.com/JasperFx/wolverine/blob/master/src/Wolverine/Persistence/Durability/DurabilityAgent.cs) that will run within your application through Wolverine's
+storage and processed when the system is restarted. Wolverine does this through its [DurabilityAgent](https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/Persistence/Durability/DurabilityAgent.cs) that will run within your application through Wolverine's
 [IHostedService](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-6.0&tabs=visual-studio) runtime that is automatically registered in your system through the `UseWolverine()` extension method.
 
 ::: tip

--- a/docs/guide/durability/sagas.md
+++ b/docs/guide/durability/sagas.md
@@ -12,7 +12,7 @@ in Wolverine consists of a couple parts:
 
 ## Your First Saga
 
-*See the [OrderSagaSample](https://github.com/JasperFx/wolverine/tree/master/src/Samples/OrderSagaSample) project in GitHub for all the
+*See the [OrderSagaSample](https://github.com/JasperFx/wolverine/tree/main/src/Samples/OrderSagaSample) project in GitHub for all the
 sample code in this section.*
 
 Jumping right into an example, consider a very simple order management service that will have steps to:

--- a/docs/guide/messaging/transports/index.md
+++ b/docs/guide/messaging/transports/index.md
@@ -17,9 +17,9 @@ come in the box with Wolverine, but you'll need an add on Nuget to enable any of
 | `IListener`  | A service that helps read messages from the underlying message transport and relays those to Wolverine as Wolverine's `Envelope` structure                                                                                                                        |
 | `ISender`    | A service that helps put Wolverine `Envelope` structures out into the outgoing messaging infrastructure                                                                                                                                                        |
 
-To build a new transport, we recommend looking first at the [Wolverine.AmazonSqs](https://github.com/JasperFx/wolverine/tree/master/src/Wolverine.Pulsar) library
+To build a new transport, we recommend looking first at the [Wolverine.AmazonSqs](https://github.com/JasperFx/wolverine/tree/main/src/Wolverine.Pulsar) library
 for a sample. At a bare minimum, you'll need to implement the services above, and also add some kind of `WolverineOptions.Use[TransportName]()` extension
 method to configure the connectivity to the messaging infrastructure and add the new transport to your Wolverine application.
 
-Also note, you will definitely want to use the [SendingCompliance](https://github.com/JasperFx/wolverine/blob/master/src/TestingSupport/Compliance/SendingCompliance.cs)
+Also note, you will definitely want to use the [SendingCompliance](https://github.com/JasperFx/wolverine/blob/main/src/TestingSupport/Compliance/SendingCompliance.cs)
 tests in Wolverine to verify that your new transport meets all Wolverine requirements.

--- a/docs/guide/messaging/transports/rabbitmq.md
+++ b/docs/guide/messaging/transports/rabbitmq.md
@@ -6,7 +6,7 @@ Wolverine uses the [Rabbit MQ .NET Client](https://www.rabbitmq.com/dotnet.html)
 
 ## Installing
 
-All the code samples in this section are from the [Ping/Pong with Rabbit MQ sample project](https://github.com/JasperFx/wolverine/tree/master/src/Samples/PingPongWithRabbitMq).
+All the code samples in this section are from the [Ping/Pong with Rabbit MQ sample project](https://github.com/JasperFx/wolverine/tree/main/src/Samples/PingPongWithRabbitMq).
 
 To use [RabbitMQ](http://www.rabbitmq.com/) as a transport with Wolverine, first install the `Wolverine.RabbitMQ` library via nuget to your project. Behind the scenes, this package uses the [RabbitMQ C# Client](https://www.rabbitmq.com/dotnet.html) to both send and receive messages from RabbitMQ.
 

--- a/docs/tutorials/mediator.md
+++ b/docs/tutorials/mediator.md
@@ -1,7 +1,7 @@
 # Wolverine as Mediator
 
 ::: tip
-All of the code on this page is from [the InMemoryMediator sample project](https://github.com/JasperFx/wolverine/tree/master/src/Samples/InMemoryMediator).
+All of the code on this page is from [the InMemoryMediator sample project](https://github.com/JasperFx/wolverine/tree/main/src/Samples/InMemoryMediator).
 :::
 
 Recently there's been some renewed interest in the old [Gof Mediator pattern](https://en.wikipedia.org/wiki/Mediator_pattern) as a way to isolate

--- a/docs/tutorials/ping-pong.md
+++ b/docs/tutorials/ping-pong.md
@@ -1,6 +1,6 @@
 # Ping/Pong Messaging with TCP
 
-To show off some of the messaging, let's just build [a very simple "Ping/Pong" example](https://github.com/JasperFx/wolverine/tree/master/src/Samples/PingPong) that will exchange messages between two small .NET processes.
+To show off some of the messaging, let's just build [a very simple "Ping/Pong" example](https://github.com/JasperFx/wolverine/tree/main/src/Samples/PingPong) that will exchange messages between two small .NET processes.
 
 ![Pinger and Ponger](/ping-pong.png)
 


### PR DESCRIPTION
Prevents GitHub message "Branch not found, redirected to default branch." when opening a sample link.