### PR TITLE
Fixes #272 - Adding MapPropertyToHeader for TenantIdKey

### DIFF
--- a/src/Wolverine/Transports/EnvelopeMapper.cs
+++ b/src/Wolverine/Transports/EnvelopeMapper.cs
@@ -68,6 +68,8 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         MapPropertyToHeader(x => x.MessageType!, EnvelopeConstants.MessageTypeKey);
         MapPropertyToHeader(x => x.AcceptedContentTypes, EnvelopeConstants.AcceptedContentTypesKey);
 
+        MapPropertyToHeader(x => x.TenantId!, EnvelopeConstants.TenantIdKey);
+
         // TODO -- could check it here, then delete it on the spot instead of mapping it!!
         MapPropertyToHeader(x => x.DeliverBy!, EnvelopeConstants.DeliverByKey);
 


### PR DESCRIPTION
This fixes an issue I found where the `tenant-id` Message attribute set in AWS SQS was being ignored