### PR TITLE
Fix broken links in docs to Lamar, Marten, and Oakton

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 ::: warning
-Wolverine requires the usage of the [Lamar](https://wolverinefx.github.io/lamar) IoC container, and the call
+Wolverine requires the usage of the [Lamar](https://jasperfx.github.io/lamar) IoC container, and the call
 to `UseWolverine()` quietly replaces the built in .NET container with Lamar.
 
 Lamar was originally written specifically to support Wolverine's runtime model as well as to be a higher performance
@@ -56,7 +56,7 @@ return await app.RunOaktonCommands(args);
 
 :::tip
 The `WolverineOptions.Services` property can be used to add additional IoC service registrations with
-either the standard .NET `IServiceCollection` model or the [Lamar ServiceRegistry](https://wolverinefx.github.io/lamar/guide/ioc/registration/registry-dsl.html) syntax.
+either the standard .NET `IServiceCollection` model or the [Lamar ServiceRegistry](https://jasperfx.github.io/lamar/guide/ioc/registration/registry-dsl.html) syntax.
 :::
 
 For "headless" console applications with no user interface or HTTP service endpoints, the bootstrapping

--- a/docs/guide/handlers/index.md
+++ b/docs/guide/handlers/index.md
@@ -256,7 +256,7 @@ support for method injection in a following section.
 Similar to ASP.NET Core, Wolverine supports the concept of [method injection](https://www.martinfowler.com/articles/injection.html) in handler methods where you can just accept additional
 arguments that will be passed into your method by Wolverine when a new message is being handled.
 
-Below is an example action method that takes in a dependency on an `IDocumentSession` from [Marten](http://wolverinefx.github.io/marten):
+Below is an example action method that takes in a dependency on an `IDocumentSession` from [Marten](https://jasperfx.github.io/marten/):
 
 <!-- snippet: sample_HandlerUsingMethodInjection -->
 <a id='snippet-sample_handlerusingmethodinjection'></a>

--- a/docs/guide/messaging/transports/rabbitmq.md
+++ b/docs/guide/messaging/transports/rabbitmq.md
@@ -529,7 +529,7 @@ using var host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Wolverine.RabbitMQ.Tests/Samples.cs#L180-L190' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_autopurge_selective_queues' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Wolverine's Rabbit MQ integration also supports the [Oakton stateful resource](https://wolverinefx.github.io/oakton/guide/host/resources.html) model,
+Wolverine's Rabbit MQ integration also supports the [Oakton stateful resource](https://jasperfx.github.io/oakton/guide/host/resources.html) model,
 so you can make a generic declaration to auto-provision the Rabbit MQ objects at startup time
 (as well as any other stateful Wolverine resources like envelope storage) with the Oakton
 declarations as shown in the setup below that uses the `AddResourceSetupOnStartup()` declaration:


### PR DESCRIPTION
Some links in the docs were pointing to `wolverinefx.github.io` and returned a 404. I pointed them to `jasperfx.github.io` which works.