### PR TITLE
Add invoke overloads accepting tenantId

### DIFF
--- a/src/Wolverine/Tracking/WolverineHostMessageTrackingExtensions.cs
+++ b/src/Wolverine/Tracking/WolverineHostMessageTrackingExtensions.cs
@@ -58,8 +58,9 @@ public static class WolverineHostMessageTrackingExtensions
     ///     Invoke the given message and wait until all cascading messages
     ///     have completed
     /// </summary>
-    /// <param name="runtime"></param>
-    /// <param name="action"></param>
+    /// <param name="host"></param>
+    /// <param name="message"></param>
+    /// <param name="timeoutInMilliseconds"></param>
     /// <returns></returns>
     public static Task<ITrackedSession> InvokeMessageAndWaitAsync(this IHost host, object message,
         int timeoutInMilliseconds = 5000)
@@ -71,8 +72,10 @@ public static class WolverineHostMessageTrackingExtensions
     ///     Invoke the given message and wait until all cascading messages
     ///     have completed
     /// </summary>
-    /// <param name="runtime"></param>
-    /// <param name="action"></param>
+    /// <param name="host"></param>
+    /// <param name="message"></param>
+    /// <param name="tenantId"></param>
+    /// <param name="timeoutInMilliseconds"></param>
     /// <returns></returns>
     public static Task<ITrackedSession> InvokeMessageAndWaitAsync(this IHost host, object message,
         string? tenantId = null,
@@ -89,8 +92,9 @@ public static class WolverineHostMessageTrackingExtensions
     ///     Invoke the given message with the expectation of a result T and wait until all cascading messages
     ///     have completed
     /// </summary>
-    /// <param name="runtime"></param>
-    /// <param name="action"></param>
+    /// <param name="host"></param>
+    /// <param name="message"></param>
+    /// <param name="timeoutInMilliseconds"></param>
     /// <returns></returns>
     public static async Task<(ITrackedSession, T?)> InvokeMessageAndWaitAsync<T>(this IHost host, object message,
         int timeoutInMilliseconds = 5000)
@@ -105,15 +109,21 @@ public static class WolverineHostMessageTrackingExtensions
     ///     Invoke the given message with the expectation of a result T and wait until all cascading messages
     ///     have completed
     /// </summary>
-    /// <param name="runtime"></param>
-    /// <param name="action"></param>
+    /// <param name="host"></param>
+    /// <param name="message"></param>
+    /// <param name="tenantId"></param>
+    /// <param name="timeoutInMilliseconds"></param>
     /// <returns></returns>
     public static async Task<(ITrackedSession, T?)> InvokeMessageAndWaitAsync<T>(this IHost host, object message,
         string? tenantId = null,
         int timeoutInMilliseconds = 5000)
     {
         T? returnValue = default;
-        var tracked = await host.ExecuteAndWaitAsync(async c => returnValue = await c.InvokeAsync<T>(message), timeoutInMilliseconds);
+        var tracked = await host.ExecuteAndWaitAsync(async c =>
+        {
+            c.TenantId = tenantId;
+            returnValue = await c.InvokeAsync<T>(message);
+        }, timeoutInMilliseconds);
 
         return (tracked, returnValue);
     }

--- a/src/Wolverine/Tracking/WolverineHostMessageTrackingExtensions.cs
+++ b/src/Wolverine/Tracking/WolverineHostMessageTrackingExtensions.cs
@@ -78,7 +78,7 @@ public static class WolverineHostMessageTrackingExtensions
     /// <param name="timeoutInMilliseconds"></param>
     /// <returns></returns>
     public static Task<ITrackedSession> InvokeMessageAndWaitAsync(this IHost host, object message,
-        string? tenantId = null,
+        string tenantId,
         int timeoutInMilliseconds = 5000)
     {
         return host.ExecuteAndWaitAsync(c =>
@@ -115,7 +115,7 @@ public static class WolverineHostMessageTrackingExtensions
     /// <param name="timeoutInMilliseconds"></param>
     /// <returns></returns>
     public static async Task<(ITrackedSession, T?)> InvokeMessageAndWaitAsync<T>(this IHost host, object message,
-        string? tenantId = null,
+        string tenantId,
         int timeoutInMilliseconds = 5000)
     {
         T? returnValue = default;

--- a/src/Wolverine/Tracking/WolverineHostMessageTrackingExtensions.cs
+++ b/src/Wolverine/Tracking/WolverineHostMessageTrackingExtensions.cs
@@ -66,7 +66,25 @@ public static class WolverineHostMessageTrackingExtensions
     {
         return host.ExecuteAndWaitAsync(c => c.InvokeAsync(message), timeoutInMilliseconds);
     }
-    
+
+    /// <summary>
+    ///     Invoke the given message and wait until all cascading messages
+    ///     have completed
+    /// </summary>
+    /// <param name="runtime"></param>
+    /// <param name="action"></param>
+    /// <returns></returns>
+    public static Task<ITrackedSession> InvokeMessageAndWaitAsync(this IHost host, object message,
+        string? tenantId = null,
+        int timeoutInMilliseconds = 5000)
+    {
+        return host.ExecuteAndWaitAsync(c =>
+        {
+            c.TenantId = tenantId;
+            return c.InvokeAsync(message);
+        }, timeoutInMilliseconds);
+    }
+
     /// <summary>
     ///     Invoke the given message with the expectation of a result T and wait until all cascading messages
     ///     have completed
@@ -83,6 +101,22 @@ public static class WolverineHostMessageTrackingExtensions
         return (tracked, returnValue);
     }
 
+    /// <summary>
+    ///     Invoke the given message with the expectation of a result T and wait until all cascading messages
+    ///     have completed
+    /// </summary>
+    /// <param name="runtime"></param>
+    /// <param name="action"></param>
+    /// <returns></returns>
+    public static async Task<(ITrackedSession, T?)> InvokeMessageAndWaitAsync<T>(this IHost host, object message,
+        string? tenantId = null,
+        int timeoutInMilliseconds = 5000)
+    {
+        T? returnValue = default;
+        var tracked = await host.ExecuteAndWaitAsync(async c => returnValue = await c.InvokeAsync<T>(message), timeoutInMilliseconds);
+
+        return (tracked, returnValue);
+    }
 
     /// <summary>
     ///     Executes an action and waits until the execution of all messages and all cascading messages


### PR DESCRIPTION
Adds overloads of `InvokeMessageAndWait` and `InvokeMessageAndWait` that allow passing a tenant ID to be set before `InvokeAsync` is called.