### PR TITLE
Fixes broken Rabbit exchange checks.

### DIFF
--- a/src/Transports/Wolverine.RabbitMQ.Tests/StatefulResourceSmokeTests.cs
+++ b/src/Transports/Wolverine.RabbitMQ.Tests/StatefulResourceSmokeTests.cs
@@ -34,7 +34,13 @@ public class StatefulResourceSmokeTests
 
                 opts.PublishMessage<SRMessage3>()
                     .ToRabbitQueue("sr" + starting++);
+
+                PublishMessageToRabbitExchange<SRMessage4>(opts, "sr" + starting++);
             });
+
+        void PublishMessageToRabbitExchange<TMessage>(WolverineOptions opts, string queueName)
+            => opts.PublishMessage<TMessage>()
+                .ToRabbitExchange(queueName, exchange => exchange.BindQueue(queueName));
     }
 
     [Fact]

--- a/src/Transports/Wolverine.RabbitMQ.Tests/end_to_end.cs
+++ b/src/Transports/Wolverine.RabbitMQ.Tests/end_to_end.cs
@@ -340,7 +340,7 @@ public class end_to_end
     [Fact]
     public async Task use_fan_out_exchange()
     {
-        var exchangeName = "fanout";
+        var exchangeName = "fanout1";
         var queueName1 = RabbitTesting.NextQueueName() + "e23";
         var queueName2 = RabbitTesting.NextQueueName() + "e23";
         var queueName3 = RabbitTesting.NextQueueName() + "e23";

--- a/src/Transports/Wolverine.RabbitMQ/Internal/RabbitMqExchange.cs
+++ b/src/Transports/Wolverine.RabbitMQ/Internal/RabbitMqExchange.cs
@@ -131,10 +131,10 @@ public class RabbitMqExchange : RabbitMqEndpoint, IRabbitMqExchange
     public override ValueTask<bool> CheckAsync()
     {
         using var channel = _parent.ListeningConnection.CreateModel();
-        var exchangeTypeName = ExchangeType.ToString().ToLower();
+        var exchangeName = Name.ToLower();
         try
         {
-            channel.ExchangeDeclarePassive(exchangeTypeName);
+            channel.ExchangeDeclarePassive(exchangeName);
             return ValueTask.FromResult(true);
         }
         catch (Exception)


### PR DESCRIPTION
Fixes https://github.com/JasperFx/wolverine/issues/367.

Adds test coverage for `RabbitMqExchange` environment checks.

Changes `exchangeName` in Rabbit MQ `end_to_end.use_fan_out_exchange()` test from `"fanout"` to `"fanout1"` to avoid future collisions with the `fanout` exchange type.

Modifies `RabbitMqExchange` to reference exchanges by name rather than by type.