### PR TITLE
added target clean to build

### DIFF
--- a/build/build.cs
+++ b/build/build.cs
@@ -30,6 +30,11 @@ namespace build
                 Run("dotnet",
                     $"build wolverine.sln --no-restore --framework net7.0");
             });
+
+            Target("clean",() =>
+            {
+                Run("dotnet", "clean wolverine.sln --framework net7.0");
+            });
             
             TestTarget("test-core", "CoreTests");
             TestTarget("test-policy", "PolicyTests");


### PR DESCRIPTION
As I had a stale version of this git repository on my machine, just pulling the newest version and trying to build resulted in some strange errors, therefore I wanted to clean out all the bin/obj directories - which I manually did.

Afterwards everything was working.

Thought maybe a clean target might be worth as well?