### PR TITLE
add raw json sqs envelope mapper for incoming messages

### DIFF
--- a/src/Samples/Diagnostics/DiagnosticsApp/Properties/launchSettings.json
+++ b/src/Samples/Diagnostics/DiagnosticsApp/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "DiagnosticsApp": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:55166;http://localhost:55167"
+    }
+  }
+}

--- a/src/Testing/OpenTelemetry/TracingTests/Properties/launchSettings.json
+++ b/src/Testing/OpenTelemetry/TracingTests/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "TracingTests": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:55164;http://localhost:55165"
+    }
+  }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/RawJsonSqsEnvelopeMapperTests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/RawJsonSqsEnvelopeMapperTests.cs
@@ -1,0 +1,59 @@
+﻿using System.Text.Json;
+using Amazon.SQS.Model;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Util;
+
+namespace Wolverine.AmazonSqs.Tests
+{
+    public class RawJsonSqsEnvelopeMapperTests
+    {
+        [Fact]
+        public void deserializes_json_message_with_specified_type()
+        {
+            var sut = new RawJsonSqsEnvelopeMapper(typeof(TextDetected), new JsonSerializerOptions());
+
+            string body = @"{
+	""JobId"": ""fe0ffd41549670f4190cd4c07c94141aa9cb79519a23056721857e3157cd8bf1"",
+	""Status"": ""SUCCEEDED"",
+	""API"": ""StartDocumentTextDetection"",
+	""Timestamp"": 1692958398261,
+	""DocumentLocation"": {
+		""S3ObjectName"": ""my.pdf"",
+		""S3Bucket"": ""mybucket""
+	}
+}";
+            Message nativeSqsMessage = new Message
+            {
+                Body = body,
+            };
+
+            AmazonSqsEnvelope envelope = new AmazonSqsEnvelope(nativeSqsMessage);
+
+            sut.ReadEnvelopeData(envelope, nativeSqsMessage.Body, nativeSqsMessage.MessageAttributes);
+
+            Assert.Equal(typeof(TextDetected).ToMessageTypeName(), envelope.MessageType);
+        }
+
+        public class TextDetected
+        {
+            public string JobId { get; set; } = string.Empty;
+
+            public string JobTag { get; set; } = string.Empty;
+
+            public string Status { get; set; } = string.Empty;
+
+            public DocumentLocation DocumentLocation { get; set; }
+
+            public long Timestamp { get; set; } = -1;
+
+            public string Api { get; set; } = string.Empty;
+        }
+
+        public class DocumentLocation
+        {
+            public string S3ObjectName { get; set; } = string.Empty;
+
+            public string S3Bucket { get; set; } = string.Empty;
+        }
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/receive_raw_json.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/receive_raw_json.cs
@@ -1,0 +1,89 @@
+﻿using System.Net;
+using Amazon.Runtime;
+using Amazon.SQS;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json;
+using Shouldly;
+using Wolverine.Tracking;
+
+namespace Wolverine.AmazonSqs.Tests
+{
+    public class receive_raw_json : IAsyncLifetime
+    {
+        private IHost _host;
+
+        public async Task InitializeAsync()
+        {
+            _host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts
+                        .UseAmazonSqsTransportLocally()
+                        .ConfigureListeners(listeners =>
+                        {
+                            listeners.ReceiveNativeJsonMessage(typeof(MyNativeJsonMessage));
+                        })
+                        .AutoProvision()
+                        .AutoPurgeOnStartup();
+
+                    opts.ListenToSqsQueue("receive_native_json");
+                })
+                .StartAsync();
+        }
+
+        [Fact]
+        public async Task receive_native_json_message()
+        {
+            Guid id = Guid.NewGuid();
+
+            var session = await _host.TrackActivity(2.Minutes())
+                .ExecuteAndWaitAsync(_ => SendRawJsonMessage(id, 1.Minutes()));
+
+            session.Received.SingleMessage<MyNativeJsonMessage>().Id.ShouldBe(id);
+        }
+
+        private static async Task SendRawJsonMessage(Guid id, TimeSpan timeout)
+        {
+            var credentials = new BasicAWSCredentials("ignore", "ignore");
+            var cfg = new AmazonSQSConfig
+            {
+                ServiceURL = "http://localhost:4566",
+            };
+
+            // create local sqs client
+            IAmazonSQS sqs = new AmazonSQSClient(credentials, cfg);
+
+            string queueUrl = (await sqs.GetQueueUrlAsync("receive_native_json")).QueueUrl;
+
+            var message = new MyNativeJsonMessage { Id = id };
+            string messageBody = JsonConvert.SerializeObject(message);
+
+            // send native message
+            var sendMessageResponse = await sqs.SendMessageAsync(queueUrl, messageBody);
+
+            ((int)sendMessageResponse.HttpStatusCode).ShouldBeGreaterThanOrEqualTo(200, customMessage: "Ensure Success StatusCode");
+            ((int)sendMessageResponse.HttpStatusCode).ShouldBeLessThan(300, customMessage: "Ensure Success StatusCode");
+
+            await Task.Delay(timeout);
+        }
+
+        public Task DisposeAsync()
+        {
+            return _host.StopAsync();
+        }
+    }
+
+    public class MyNativeJsonMessage
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+    }
+
+    public static class MyNativeJsonMessageHandler
+    {
+        public static void Handle(MyNativeJsonMessage message)
+        {
+            // nothing
+        }
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
@@ -1,3 +1,4 @@
+﻿using System.Text.Json;
 using Amazon.SQS.Model;
 using Wolverine.AmazonSqs.Internal;
 using Wolverine.Configuration;
@@ -72,6 +73,22 @@ public class AmazonSqsListenerConfiguration : ListenerConfiguration<AmazonSqsLis
     public AmazonSqsListenerConfiguration ConfigureQueueCreation(Action<CreateQueueRequest> configure)
     {
         add(e => configure(e.Configuration));
+        return this;
+    }
+
+    public AmazonSqsListenerConfiguration ReceiveNativeJsonMessage(
+        Type messageType,
+        Action<JsonSerializerOptions>? configure = null)
+    {
+        add(e =>
+        {
+            JsonSerializerOptions serializerOptions = new JsonSerializerOptions();
+
+            configure?.Invoke(serializerOptions);
+
+            e.Mapper = new RawJsonSqsEnvelopeMapper(messageType, serializerOptions);
+        });
+
         return this;
     }
 }

--- a/src/Transports/AWS/Wolverine.AmazonSqs/ISqsEnvelopeMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/ISqsEnvelopeMapper.cs
@@ -1,4 +1,4 @@
-using Amazon.SQS.Model;
+﻿using Amazon.SQS.Model;
 using Wolverine.Runtime.Serialization;
 using Wolverine.Transports;
 
@@ -26,7 +26,7 @@ internal class DefaultSqsEnvelopeMapper : ISqsEnvelopeMapper
     public IEnumerable<KeyValuePair<string, MessageAttributeValue>> ToAttributes(Envelope envelope)
     {
         yield return new KeyValuePair<string, MessageAttributeValue>(TransportConstants.ProtocolVersion,
-            new MessageAttributeValue { StringValue = "1.0", DataType = "String"});
+            new MessageAttributeValue { StringValue = "1.0", DataType = "String" });
     }
 
     public void ReadEnvelopeData(Envelope envelope, string messageBody,

--- a/src/Transports/AWS/Wolverine.AmazonSqs/RawJsonSqsEnvelopeMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/RawJsonSqsEnvelopeMapper.cs
@@ -1,0 +1,42 @@
+﻿using System.Text.Json;
+using Amazon.SQS.Model;
+using Wolverine.Transports;
+using Wolverine.Util;
+
+namespace Wolverine.AmazonSqs;
+
+internal class RawJsonSqsEnvelopeMapper : ISqsEnvelopeMapper
+{
+    private readonly Type _defaultMessageType;
+    private readonly JsonSerializerOptions _serializerOptions;
+
+    public RawJsonSqsEnvelopeMapper(Type defaultMessageType, JsonSerializerOptions serializerOptions)
+    {
+        _defaultMessageType = defaultMessageType;
+        _serializerOptions = serializerOptions;
+    }
+
+    public string BuildMessageBody(Envelope envelope)
+    {
+        return JsonSerializer.Serialize(
+            envelope.Message,
+            _defaultMessageType,
+            _serializerOptions);
+    }
+
+    public IEnumerable<KeyValuePair<string, MessageAttributeValue>> ToAttributes(Envelope envelope)
+    {
+        yield return new KeyValuePair<string, MessageAttributeValue>(TransportConstants.ProtocolVersion,
+            new MessageAttributeValue { StringValue = "1.0", DataType = "String" });
+    }
+
+    public void ReadEnvelopeData(Envelope envelope, string messageBody, IDictionary<string, MessageAttributeValue> attributes)
+    {
+        // assuming json serialized message
+        envelope.MessageType = _defaultMessageType.ToMessageTypeName();
+        envelope.Message = JsonSerializer.Deserialize(
+            messageBody,
+            _defaultMessageType,
+            _serializerOptions);
+    }
+}

--- a/src/Wolverine/Tracking/TrackedSessionConfiguration.cs
+++ b/src/Wolverine/Tracking/TrackedSessionConfiguration.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Wolverine.Runtime;
 using Wolverine.Runtime.RemoteInvocation;


### PR DESCRIPTION
In order to process native events published by AWS services (e.g. Amazon Textract) an simple implemenatation of the ISqsEnvelopeMapper can be configured that replaces the DefaultSqsEnvelopeMapper.