### PR TITLE
Ensure use of InvariantCulture for query binding. Closes GH-524

### DIFF
--- a/src/Http/Wolverine.Http.Tests/end_to_end.cs
+++ b/src/Http/Wolverine.Http.Tests/end_to_end.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Net.Http.Headers;
 using Alba;
 using Shouldly;
 using WolverineWebApi;
@@ -206,6 +208,19 @@ public class end_to_end : IntegrationContext
         });
 
         body.ReadAsText().ShouldBe("Name is missing");
+    }
+
+    [Fact]
+    public async Task use_decimal_querystring_hit()
+    {
+        var body = await Scenario(x =>
+        {
+            x.WithRequestHeader("Accept-Language", "fr-FR");
+            x.Get.Url("/querystring/decimal?amount=42.1");
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("Amount is 42.1");
     }
 
     #endregion

--- a/src/Http/Wolverine.Http/CodeGen/QueryStringHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/QueryStringHandling.cs
@@ -38,16 +38,19 @@ internal class ParsedQueryStringValue : SyncFrame
         var alias = Variable.VariableType.FullNameInCode();
         writer.Write($"{alias} {Variable.Usage} = default;");
 
+
         if (Variable.VariableType.IsEnum)
         {
             writer.Write($"{alias}.TryParse<{alias}>(httpContext.Request.Query[\"{Variable.Usage}\"], out {Variable.Usage});");
         }
-        else
+        else if (Variable.VariableType.IsBoolean())
         {
             writer.Write($"{alias}.TryParse(httpContext.Request.Query[\"{Variable.Usage}\"], out {Variable.Usage});");
         }
-        
-        
+        else
+        {
+            writer.Write($"{alias}.TryParse(httpContext.Request.Query[\"{Variable.Usage}\"], System.Globalization.CultureInfo.InvariantCulture, out {Variable.Usage});");
+        }
 
         Next?.GenerateCode(method, writer);
     }
@@ -75,10 +78,14 @@ internal class ParsedNullableQueryStringValue : SyncFrame
             writer.Write(
                 $"if ({_alias}.TryParse<{_innerTypeFromNullable.FullNameInCode()}>(httpContext.Request.Query[\"{Variable.Usage}\"], out var {Variable.Usage}Parsed)) {Variable.Usage} = {Variable.Usage}Parsed;");
         }
+        else if (_innerTypeFromNullable.IsBoolean())
+        {
+            writer.Write($"{_alias}.TryParse(httpContext.Request.Query[\"{Variable.Usage}\"], out {Variable.Usage});");
+        }
         else
         {
             writer.Write(
-                $"if ({_alias}.TryParse(httpContext.Request.Query[\"{Variable.Usage}\"], out var {Variable.Usage}Parsed)) {Variable.Usage} = {Variable.Usage}Parsed;");
+                $"if ({_alias}.TryParse(httpContext.Request.Query[\"{Variable.Usage}\"], System.Globalization.CultureInfo.InvariantCulture, out var {Variable.Usage}Parsed)) {Variable.Usage} = {Variable.Usage}Parsed;");
         }
 
         Next?.GenerateCode(method, writer);

--- a/src/Http/WolverineWebApi/Internal/Generated/WolverineHandlers/GET_querystring_decimal.cs
+++ b/src/Http/WolverineWebApi/Internal/Generated/WolverineHandlers/GET_querystring_decimal.cs
@@ -8,13 +8,13 @@ using WolverineWebApi;
 
 namespace Internal.Generated.WolverineHandlers
 {
-    // START: GET_querystring_int
-    public class GET_querystring_int : Wolverine.Http.HttpHandler
+    // START: GET_querystring_decimal
+    public class GET_querystring_decimal : Wolverine.Http.HttpHandler
     {
         private readonly Wolverine.Http.WolverineHttpOptions _wolverineHttpOptions;
         private readonly WolverineWebApi.Recorder _recorder;
 
-        public GET_querystring_int(Wolverine.Http.WolverineHttpOptions wolverineHttpOptions, WolverineWebApi.Recorder recorder) : base(wolverineHttpOptions)
+        public GET_querystring_decimal(Wolverine.Http.WolverineHttpOptions wolverineHttpOptions, WolverineWebApi.Recorder recorder) : base(wolverineHttpOptions)
         {
             _wolverineHttpOptions = wolverineHttpOptions;
             _recorder = recorder;
@@ -24,16 +24,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task Handle(Microsoft.AspNetCore.Http.HttpContext httpContext)
         {
-            int? age = null;
-            if (int.TryParse(httpContext.Request.Query["age"], System.Globalization.CultureInfo.InvariantCulture, out var ageParsed)) age = ageParsed;
+            System.Decimal amount = default;
+            System.Decimal.TryParse(httpContext.Request.Query["amount"], System.Globalization.CultureInfo.InvariantCulture, out amount);
             // Just saying hello in the code! Also testing the usage of attributes to customize endpoints
-            var result_of_UsingQueryStringParsing = WolverineWebApi.TestEndpoints.UsingQueryStringParsing(_recorder, age);
-            await WriteString(httpContext, result_of_UsingQueryStringParsing);
+            var result_of_UseQueryStringParsing = WolverineWebApi.TestEndpoints.UseQueryStringParsing(_recorder, amount);
+            await WriteString(httpContext, result_of_UseQueryStringParsing);
         }
 
     }
 
-    // END: GET_querystring_int
+    // END: GET_querystring_decimal
     
     
 }

--- a/src/Http/WolverineWebApi/Internal/Generated/WolverineHandlers/GET_querystring_int_nullable.cs
+++ b/src/Http/WolverineWebApi/Internal/Generated/WolverineHandlers/GET_querystring_int_nullable.cs
@@ -22,7 +22,7 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task Handle(Microsoft.AspNetCore.Http.HttpContext httpContext)
         {
             int? age = null;
-            if (int.TryParse(httpContext.Request.Query["age"], out var ageParsed)) age = ageParsed;
+            if (int.TryParse(httpContext.Request.Query["age"], System.Globalization.CultureInfo.InvariantCulture, out var ageParsed)) age = ageParsed;
             // Just saying hello in the code! Also testing the usage of attributes to customize endpoints
             var result_of_UsingQueryStringParsingNullable = WolverineWebApi.TestEndpoints.UsingQueryStringParsingNullable(age);
             await WriteString(httpContext, result_of_UsingQueryStringParsingNullable);

--- a/src/Http/WolverineWebApi/Program.cs
+++ b/src/Http/WolverineWebApi/Program.cs
@@ -66,6 +66,14 @@ builder.Host.UseWolverine(opts =>
 
 var app = builder.Build();
 
+//Force the default culture to not be en-US to ensure code is culture agnostic
+var supportedCultures = new[] { "fr-FR", "en-US" };
+var localizationOptions = new RequestLocalizationOptions().SetDefaultCulture(supportedCultures[0])
+    .AddSupportedCultures(supportedCultures)
+    .AddSupportedUICultures(supportedCultures);
+
+app.UseRequestLocalization(localizationOptions);
+
 // Configure the HTTP request pipeline.
 app.UseSwagger();
 app.UseSwaggerUI();

--- a/src/Http/WolverineWebApi/TestEndpoints.cs
+++ b/src/Http/WolverineWebApi/TestEndpoints.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Linq.Expressions;
 using Marten;
 using Wolverine.Http;
 
@@ -68,6 +70,14 @@ public static class TestEndpoints
         }
 
         return $"Age is {age}";
+    }
+
+    [WolverineGet("/querystring/decimal")]
+    public static string UseQueryStringParsing(Recorder recorder, decimal amount)
+    {
+        recorder.Actions.Add("Got through query string usage for decimal");
+
+        return string.Format(CultureInfo.InvariantCulture, "Amount is {0}", amount);
     }
 
     #region sample_simple_wolverine_http_endpoint


### PR DESCRIPTION
As mentioned in GH-524 when using aspnet cores `app.UseRequestLocalization` with a default non-us culture the query parameter binding fails to correctly bind decimal values using a period such as 10.1. 

My assumption here is that we would want to force that behaviour,  interested in whether you disagree on this point.

This is my first PR against wolverine, so using it as a learning experience. ! have committed the Generated Code, not sure whether that is appropriate or not.