### PR TITLE
Added configurable activity tracing

### DIFF
--- a/build/build.cs
+++ b/build/build.cs
@@ -151,6 +151,7 @@ namespace build
                 "./src/Extensions/Wolverine.FluentValidation",
                 "./src/Extensions/Wolverine.MemoryPack",
                 "./src/Extensions/Wolverine.MessagePack",
+                "./src/Extensions/Wolverine.OpenTelemetry",
                 "./src/Http/Wolverine.Http",
                 "./src/Http/Wolverine.Http.FluentValidation",
             };

--- a/src/Extensions/Wolverine.OpenTelemetry/OpenTelemetryInstrumentationServiceCollectionExtensions.cs
+++ b/src/Extensions/Wolverine.OpenTelemetry/OpenTelemetryInstrumentationServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Wolverine.Runtime.Tracing;
+
+namespace Wolverine.OpenTelemetry;
+
+internal static class OpenTelemetryInstrumentationServiceCollectionExtensions
+{
+    public static void AddTelemetryExtension(this IServiceCollection services, Action<WolverineTracingOptions> configure)
+    {
+        checkConfigMarker(services);
+        var telemetryExtension = new TelemetryWolverineExtension(configure);
+        services.Add(new ServiceDescriptor(typeof(IWolverineExtension), telemetryExtension));
+    }
+
+    private static void checkConfigMarker(IServiceCollection services)
+    {
+        var marker = services.FirstOrDefault(s => s.ServiceType == typeof(TelemetryExtensionConfigMarker));
+        if (marker == null)
+        {
+            services.AddSingleton(new TelemetryExtensionConfigMarker());
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "Wolverine instrumentation has already been registered and doesn't support multiple registrations.");
+    }
+}

--- a/src/Extensions/Wolverine.OpenTelemetry/OpenTelemetryInstrumentationServiceCollectionExtensions.cs
+++ b/src/Extensions/Wolverine.OpenTelemetry/OpenTelemetryInstrumentationServiceCollectionExtensions.cs
@@ -5,10 +5,10 @@ namespace Wolverine.OpenTelemetry;
 
 internal static class OpenTelemetryInstrumentationServiceCollectionExtensions
 {
-    public static void AddTelemetryExtension(this IServiceCollection services, Action<WolverineTracingOptions> configure)
+    public static void AddTelemetryExtension(this IServiceCollection services, Action<WolverineTracingOptions> configureWolverineTracingOptions)
     {
         checkConfigMarker(services);
-        var telemetryExtension = new TelemetryWolverineExtension(configure);
+        var telemetryExtension = new TelemetryWolverineExtension(configureWolverineTracingOptions);
         services.Add(new ServiceDescriptor(typeof(IWolverineExtension), telemetryExtension));
     }
 

--- a/src/Extensions/Wolverine.OpenTelemetry/TelemetryExtensionConfigMarker.cs
+++ b/src/Extensions/Wolverine.OpenTelemetry/TelemetryExtensionConfigMarker.cs
@@ -1,0 +1,3 @@
+﻿namespace Wolverine.OpenTelemetry;
+
+internal class TelemetryExtensionConfigMarker{}

--- a/src/Extensions/Wolverine.OpenTelemetry/TelemetryWolverineExtension.cs
+++ b/src/Extensions/Wolverine.OpenTelemetry/TelemetryWolverineExtension.cs
@@ -1,0 +1,17 @@
+﻿using Wolverine.Runtime.Tracing;
+
+namespace Wolverine.OpenTelemetry;
+
+internal class TelemetryWolverineExtension : IWolverineExtension
+{
+    private readonly Action<WolverineTracingOptions> _configureTelemetry;
+
+    public TelemetryWolverineExtension(Action<WolverineTracingOptions> configureTelemetry)
+    {
+        _configureTelemetry = configureTelemetry;
+    }
+    public void Configure(WolverineOptions options)
+    {
+        _configureTelemetry?.Invoke(options.Tracing);
+    }
+}

--- a/src/Extensions/Wolverine.OpenTelemetry/TelemetryWolverineExtension.cs
+++ b/src/Extensions/Wolverine.OpenTelemetry/TelemetryWolverineExtension.cs
@@ -4,14 +4,14 @@ namespace Wolverine.OpenTelemetry;
 
 internal class TelemetryWolverineExtension : IWolverineExtension
 {
-    private readonly Action<WolverineTracingOptions> _configureTelemetry;
+    private readonly Action<WolverineTracingOptions> _configureWolverineTracingOptions;
 
-    public TelemetryWolverineExtension(Action<WolverineTracingOptions> configureTelemetry)
+    public TelemetryWolverineExtension(Action<WolverineTracingOptions> configureWolverineTracingOptions)
     {
-        _configureTelemetry = configureTelemetry;
+        _configureWolverineTracingOptions = configureWolverineTracingOptions;
     }
     public void Configure(WolverineOptions options)
     {
-        _configureTelemetry?.Invoke(options.Tracing);
+        _configureWolverineTracingOptions?.Invoke(options.Tracing);
     }
 }

--- a/src/Extensions/Wolverine.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Extensions/Wolverine.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -3,15 +3,28 @@ using Wolverine.Runtime;
 using Wolverine.Runtime.Tracing;
 
 namespace Wolverine.OpenTelemetry;
-
+/// <summary>
+/// Extension methods to simplify registering of Wolverine instrumentation.
+/// </summary>
 public static class TracerProviderBuilderExtensions
 {
     private static readonly string _activitySourceName = typeof(WolverineRuntime).Assembly.GetName().Name;
+    
+    /// <summary>
+    /// Enables envelope event data collection for Wolverine
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
     public static TracerProviderBuilder AddWolverineInstrumentation(this TracerProviderBuilder builder)
-        => AddWolverineInstrumentation(builder, configure: null);
-
+        => AddWolverineInstrumentation(builder, configureWolverineTracingOptions: null);
+    /// <summary>
+    /// Enables envelope event data collection for Wolverine
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <param name="configureWolverineTracingOptions">Callback action for configuring <see cref="WolverineTracingOptions"/>.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
     public static TracerProviderBuilder AddWolverineInstrumentation(this TracerProviderBuilder builder,
-        Action<WolverineTracingOptions> configure)
+        Action<WolverineTracingOptions> configureWolverineTracingOptions)
     {
         if (builder is null)
         {
@@ -20,7 +33,7 @@ public static class TracerProviderBuilderExtensions
 
         builder.ConfigureServices(services =>
         {
-            services.AddTelemetryExtension(configure);
+            services.AddTelemetryExtension(configureWolverineTracingOptions);
         });
         return builder.AddSource(_activitySourceName);
     }

--- a/src/Extensions/Wolverine.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Extensions/Wolverine.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -1,0 +1,27 @@
+﻿using OpenTelemetry.Trace;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Tracing;
+
+namespace Wolverine.OpenTelemetry;
+
+public static class TracerProviderBuilderExtensions
+{
+    private static readonly string _activitySourceName = typeof(WolverineRuntime).Assembly.GetName().Name;
+    public static TracerProviderBuilder AddWolverineInstrumentation(this TracerProviderBuilder builder)
+        => AddWolverineInstrumentation(builder, configure: null);
+
+    public static TracerProviderBuilder AddWolverineInstrumentation(this TracerProviderBuilder builder,
+        Action<WolverineTracingOptions> configure)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder), "Must not be null");
+        }
+
+        builder.ConfigureServices(services =>
+        {
+            services.AddTelemetryExtension(configure);
+        });
+        return builder.AddSource(_activitySourceName);
+    }
+}

--- a/src/Extensions/Wolverine.OpenTelemetry/Wolverine.OpenTelemetry.csproj
+++ b/src/Extensions/Wolverine.OpenTelemetry/Wolverine.OpenTelemetry.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>OpenTelemetry Instrumentation and Extensions for Wolverine Applications</Description>
+        <DebugType>portable</DebugType>
+        <PackageId>WolverineFx.OpenTelemetry</PackageId>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Wolverine\Wolverine.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="OpenTelemetry" Version="1.6.0"/>
+    </ItemGroup>
+
+</Project>

--- a/src/Wolverine/Envelope.Internals.cs
+++ b/src/Wolverine/Envelope.Internals.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging.Abstractions;
 using Wolverine.Persistence.Durability;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Serialization;
+using Wolverine.Runtime.Tracing;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
 using Wolverine.Util;
@@ -212,7 +214,7 @@ public partial class Envelope
         _enqueued = true;
 
         if (Sender.Latched) return;
-        using var activity = WolverineTracing.StartSending(this);
+        using var activity = WolverineTracing.StartSending(this, NullLogger.Instance);
         try
         {
             await Sender.EnqueueOutgoingAsync(this);

--- a/src/Wolverine/ErrorHandling/DiscardEnvelope.cs
+++ b/src/Wolverine/ErrorHandling/DiscardEnvelope.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Tracing;
 
 namespace Wolverine.ErrorHandling;
 

--- a/src/Wolverine/ErrorHandling/MoveToErrorQueue.cs
+++ b/src/Wolverine/ErrorHandling/MoveToErrorQueue.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Tracing;
 
 namespace Wolverine.ErrorHandling;
 

--- a/src/Wolverine/ErrorHandling/NoHandlerContinuation.cs
+++ b/src/Wolverine/ErrorHandling/NoHandlerContinuation.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Tracing;
 
 namespace Wolverine.ErrorHandling;
 

--- a/src/Wolverine/ErrorHandling/PauseListenerContinuation.cs
+++ b/src/Wolverine/ErrorHandling/PauseListenerContinuation.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Tracing;
 using Wolverine.Transports;
 
 namespace Wolverine.ErrorHandling;

--- a/src/Wolverine/ErrorHandling/RequeueContinuation.cs
+++ b/src/Wolverine/ErrorHandling/RequeueContinuation.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Tracing;
 
 namespace Wolverine.ErrorHandling;
 

--- a/src/Wolverine/ErrorHandling/RetryInlineContinuation.cs
+++ b/src/Wolverine/ErrorHandling/RetryInlineContinuation.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Tracing;
 
 namespace Wolverine.ErrorHandling;
 

--- a/src/Wolverine/ErrorHandling/ScheduledRetryContinuation.cs
+++ b/src/Wolverine/ErrorHandling/ScheduledRetryContinuation.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Tracing;
 
 namespace Wolverine.ErrorHandling;
 

--- a/src/Wolverine/Persistence/Durability/DurableSendingAgent.cs
+++ b/src/Wolverine/Persistence/Durability/DurableSendingAgent.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Logging;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Tracing;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
 using Wolverine.Util.Dataflow;
@@ -125,7 +126,7 @@ internal class DurableSendingAgent : SendingAgent
 
     protected override async Task storeAndForwardAsync(Envelope envelope)
     {
-        using var activity = WolverineTracing.StartSending(envelope);
+        using var activity = WolverineTracing.StartSending(envelope, _logger);
         await _storeAndForward.PostAsync(envelope);
         activity?.Stop();
     }

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.ObjectPool;
 using Wolverine.ErrorHandling;
 using Wolverine.Logging;
 using Wolverine.Runtime.Handlers;
+using Wolverine.Runtime.Tracing;
 using Wolverine.Transports;
 
 namespace Wolverine.Runtime;
@@ -42,7 +43,7 @@ public class HandlerPipeline : IHandlerPipeline
             return Task.CompletedTask;
         }
 
-        using var activity = WolverineTracing.StartExecuting(envelope);
+        using var activity = WolverineTracing.StartExecuting(envelope, _runtime.Logger);
 
         return InvokeAsync(envelope, channel, activity);
     }

--- a/src/Wolverine/Runtime/Handlers/Executor.cs
+++ b/src/Wolverine/Runtime/Handlers/Executor.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.ObjectPool;
 using Wolverine.ErrorHandling;
 using Wolverine.Logging;
 using Wolverine.Runtime.Routing;
+using Wolverine.Runtime.Tracing;
 using Wolverine.Transports;
 using Wolverine.Util;
 
@@ -100,7 +101,7 @@ internal class Executor : IExecutor
 
     public async Task InvokeInlineAsync(Envelope envelope, CancellationToken cancellation)
     {
-        using var activity = WolverineTracing.StartExecuting(envelope);
+        using var activity = WolverineTracing.StartExecuting(envelope, _logger);
 
         _tracker.ExecutionStarted(envelope);
 

--- a/src/Wolverine/Runtime/Tracing/WolverineActivitySource.cs
+++ b/src/Wolverine/Runtime/Tracing/WolverineActivitySource.cs
@@ -7,9 +7,9 @@ internal static class WolverineActivitySource
 {
     internal static readonly AssemblyName AssemblyName = typeof(WolverineActivitySource).Assembly.GetName();
     internal static readonly string ActivitySourceName = AssemblyName.Name!;
-    internal const string SendEnvelopeActivityName = WolverineEnrichEventNames.StartSendEnvelope;
-    internal const string ReceiveEnvelopeActivityName = WolverineEnrichEventNames.StartReceivingEnvelope;
-    internal const string ExecuteEnvelopeActivityName = WolverineEnrichEventNames.StartExecutingEnvelope;
+    internal const string SendEnvelopeActivityName = "send";
+    internal const string ReceiveEnvelopeActivityName = "receive";
+    internal const string ExecuteEnvelopeActivityName = "process";
     private static readonly Version _version = AssemblyName.Version!;
     public static ActivitySource ActivitySource { get; } = new ActivitySource(ActivitySourceName, _version.ToString());
     public static WolverineTracingOptions Options { get; set; } = new WolverineTracingOptions();

--- a/src/Wolverine/Runtime/Tracing/WolverineActivitySource.cs
+++ b/src/Wolverine/Runtime/Tracing/WolverineActivitySource.cs
@@ -1,0 +1,16 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+
+namespace Wolverine.Runtime.Tracing;
+
+internal static class WolverineActivitySource
+{
+    internal static readonly AssemblyName AssemblyName = typeof(WolverineActivitySource).Assembly.GetName();
+    internal static readonly string ActivitySourceName = AssemblyName.Name!;
+    internal const string SendEnvelopeActivityName = WolverineEnrichEventNames.StartSendEnvelope;
+    internal const string ReceiveEnvelopeActivityName = WolverineEnrichEventNames.StartReceivingEnvelope;
+    internal const string ExecuteEnvelopeActivityName = WolverineEnrichEventNames.StartExecutingEnvelope;
+    private static readonly Version _version = AssemblyName.Version!;
+    public static ActivitySource ActivitySource { get; } = new ActivitySource(ActivitySourceName, _version.ToString());
+    public static WolverineTracingOptions Options { get; set; } = new WolverineTracingOptions();
+}

--- a/src/Wolverine/Runtime/Tracing/WolverineEnrichEventNames.cs
+++ b/src/Wolverine/Runtime/Tracing/WolverineEnrichEventNames.cs
@@ -2,7 +2,7 @@ namespace Wolverine.Runtime.Tracing;
 
 public static class WolverineEnrichEventNames
 {
-    public const string StartSendEnvelope = "send";
-    public const string StartReceivingEnvelope = "receive";
-    public const string StartExecutingEnvelope = "process";
+    public const string StartSendEnvelope = WolverineActivitySource.SendEnvelopeActivityName;
+    public const string StartReceivingEnvelope = WolverineActivitySource.ReceiveEnvelopeActivityName;
+    public const string StartExecutingEnvelope = WolverineActivitySource.ExecuteEnvelopeActivityName;
 }

--- a/src/Wolverine/Runtime/Tracing/WolverineEnrichEventNames.cs
+++ b/src/Wolverine/Runtime/Tracing/WolverineEnrichEventNames.cs
@@ -1,0 +1,8 @@
+namespace Wolverine.Runtime.Tracing;
+
+public static class WolverineEnrichEventNames
+{
+    public const string StartSendEnvelope = "send";
+    public const string StartReceivingEnvelope = "receive";
+    public const string StartExecutingEnvelope = "process";
+}

--- a/src/Wolverine/Runtime/Tracing/WolverineTracing.cs
+++ b/src/Wolverine/Runtime/Tracing/WolverineTracing.cs
@@ -31,10 +31,6 @@ internal static class WolverineTracing
     public const string EnvelopeRetry = "wolverine.envelope.retried";
     public const string ScheduledRetry = "wolverine.envelope.rescheduled";
 
-    internal static ActivitySource ActivitySource { get; } = new(
-        "Wolverine",
-        typeof(WolverineTracing).Assembly.GetName().Version!.ToString());
-
     public static Activity? StartSending(Envelope envelope, ILogger logger)
     {
         return StartEnvelopeActivity(WolverineActivitySource.SendEnvelopeActivityName, envelope, logger, ActivityKind.Producer);
@@ -68,8 +64,8 @@ internal static class WolverineTracing
             return null;
         }
         var activity = envelope.ParentId.IsNotEmpty()
-            ? ActivitySource.StartActivity(spanName, kind, envelope.ParentId)
-            : ActivitySource.StartActivity(spanName, kind);
+            ? WolverineActivitySource.ActivitySource.StartActivity(spanName, kind, envelope.ParentId)
+            : WolverineActivitySource.ActivitySource.StartActivity(spanName, kind);
 
         if (activity == null)
         {

--- a/src/Wolverine/Runtime/Tracing/WolverineTracing.cs
+++ b/src/Wolverine/Runtime/Tracing/WolverineTracing.cs
@@ -52,7 +52,7 @@ internal static class WolverineTracing
     {
         try
         {
-            if (WolverineActivitySource.Options.GetFilterForActivity(spanName).Invoke(envelope))
+            if (!WolverineActivitySource.Options.GetFilterForActivity(spanName).Invoke(envelope))
             {
                 logger.LogTrace("Execution of envelope {EnvelopeId} is filtered out from activity tracing", envelope.Id);
                 return null;

--- a/src/Wolverine/Runtime/Tracing/WolverineTracingOptions.cs
+++ b/src/Wolverine/Runtime/Tracing/WolverineTracingOptions.cs
@@ -17,25 +17,30 @@ public class WolverineTracingOptions
     /// </remarks>
     public Action<Activity, string, Envelope>? Enrich { get; set; }
 
-    /// <summary>
-    /// Gets or sets a Filter function to filter instrumentation for requests on a per envelope basis.
-    /// The Filter gets the <see cref="Envelope"/>, and should return a boolean.
-    /// If Filter returns <c>true</c>, the request is collected.
-    /// If Filter returns <c>false</c> or throw exception, the request is filtered out.
-    /// </summary>
+    
+    /// <inheritdoc cref="GlobalFilter"/>
+    /// <remarks>Only applies to spans generated as a result of send events</remarks>
     public Func<Envelope, bool>? SendEnvelopeFilter { get; set; }
 
-    /// <inheritdoc cref="SendEnvelopeFilter"/>
+    /// <inheritdoc cref="GlobalFilter"/>
+    /// <remarks>Only applies to spans generated as a result of receipt events</remarks>
     public Func<Envelope, bool>? ReceiveEnvelopeFilter { get; set; }
 
-    /// <inheritdoc cref="SendEnvelopeFilter"/>
+    /// <inheritdoc cref="GlobalFilter"/>
+    /// <remarks>Only applies to spans generated as a result of envelope execution events</remarks>
     public Func<Envelope, bool>? ExecuteEnvelopeFilter { get; set; }
 
     /// <summary>
-    /// Gets or sets a Filter function that will be applied to all supported Activity types
-    /// The Filter gets the <see cref="Envelope"/>, and should return a boolean.
+    /// <para>
+    /// Gets or sets a Filter function to filter instrumentation for requests on a per envelope basis.
+    /// The Filter gets the <see cref="Envelope" />, and should return a boolean.
+    /// </para>
+    /// <para>
     /// If Filter returns <c>true</c>, the request is collected.
-    /// If Filter returns <c>false</c> or throw exception, the request is filtered out.
+    /// </para>
+    /// <para>
+    /// If Filter returns <c>false</c> or throws an exception, the request is filtered out.
+    /// </para>
     /// </summary>
     public Func<Envelope, bool>? GlobalFilter { get; set; }
 

--- a/src/Wolverine/Runtime/Tracing/WolverineTracingOptions.cs
+++ b/src/Wolverine/Runtime/Tracing/WolverineTracingOptions.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics;
+
+namespace Wolverine.Runtime.Tracing;
+
+public class WolverineTracingOptions
+{
+    /// <summary>
+    /// Gets or sets an action to enrich an Activity.
+    /// </summary>
+    /// <remarks>
+    /// <para><see cref="Activity"/>: the activity being enriched.</para>
+    /// <para>string: the name of the event. Will be one of the constants in <see cref="WolverineEnrichEventNames"/>.
+    /// </para>
+    /// <para>object: the raw <see cref="Envelope"/> from which additional information can be extracted to enrich the activity.
+    /// </para>
+    /// </remarks>
+    public Action<Activity, string, Envelope>? Enrich { get; set; }
+    /// <summary>
+    /// Gets or sets a Filter function to filter instrumentation for requests on a per envelope basis.
+    /// The Filter gets the <see cref="Envelope"/>, and should return a boolean.
+    /// If Filter returns <c>true</c>, the request is collected.
+    /// If Filter returns <c>false</c> or throw exception, the request is filtered out.
+    /// </summary>
+    public Func<Envelope, bool>? SendEnvelopeFilter { get; set; }
+    /// <inheritdoc cref="SendEnvelopeFilter"/>
+    public Func<Envelope, bool>? ReceiveEnvelopeFilter { get; set; }
+    /// <inheritdoc cref="SendEnvelopeFilter"/>
+    public Func<Envelope, bool>? ExecuteEnvelopeFilter { get; set; }
+    /// <summary>
+    /// Gets or sets a Filter function that will be applied to all supported Activity types
+    /// The Filter gets the <see cref="Envelope"/>, and should return a boolean.
+    /// If Filter returns <c>true</c>, the request is collected.
+    /// If Filter returns <c>false</c> or throw exception, the request is filtered out.
+    /// </summary>
+    public Func<Envelope, bool>? GlobalFilter { get; set; }
+
+    internal WolverineTracingFilter GetFilterForActivity(string activityName)
+    {
+        Func<Envelope, bool>? activityFilter = null;
+        switch (activityName)
+        {
+            case WolverineActivitySource.SendEnvelopeActivityName:
+                activityFilter = SendEnvelopeFilter;
+                break;
+            case WolverineActivitySource.ReceiveEnvelopeActivityName:
+                activityFilter = ReceiveEnvelopeFilter;
+                break;
+            case WolverineActivitySource.ExecuteEnvelopeActivityName:
+                activityFilter = ExecuteEnvelopeFilter;
+                break;
+        }
+
+        return env => GlobalFilter?.Invoke(env) == true || activityFilter?.Invoke(env) == true;
+    }
+}
+
+internal delegate bool WolverineTracingFilter(Envelope envelope);

--- a/src/Wolverine/Runtime/Tracing/WolverineTracingOptions.cs
+++ b/src/Wolverine/Runtime/Tracing/WolverineTracingOptions.cs
@@ -57,19 +57,13 @@ public class WolverineTracingOptions
 
     internal WolverineTracingFilter GetFilterForActivity(string activityName)
     {
-        Func<Envelope, bool>? activityFilter = null;
-        switch (activityName)
+        var activityFilter = activityName switch
         {
-            case WolverineActivitySource.SendEnvelopeActivityName:
-                activityFilter = SendEnvelopeFilter;
-                break;
-            case WolverineActivitySource.ReceiveEnvelopeActivityName:
-                activityFilter = ReceiveEnvelopeFilter;
-                break;
-            case WolverineActivitySource.ExecuteEnvelopeActivityName:
-                activityFilter = ExecuteEnvelopeFilter;
-                break;
-        }
+            WolverineActivitySource.SendEnvelopeActivityName => SendEnvelopeFilter,
+            WolverineActivitySource.ReceiveEnvelopeActivityName => ReceiveEnvelopeFilter,
+            WolverineActivitySource.ExecuteEnvelopeActivityName => ExecuteEnvelopeFilter,
+            _ => null
+        };
 
         return env => filterInternalMessages(env) && 
                       GlobalFilter?.Invoke(env) != false &&

--- a/src/Wolverine/Runtime/Tracing/WolverineTracingOptions.cs
+++ b/src/Wolverine/Runtime/Tracing/WolverineTracingOptions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Wolverine.Runtime.Agents;
 
 namespace Wolverine.Runtime.Tracing;
 
@@ -15,6 +16,7 @@ public class WolverineTracingOptions
     /// </para>
     /// </remarks>
     public Action<Activity, string, Envelope>? Enrich { get; set; }
+
     /// <summary>
     /// Gets or sets a Filter function to filter instrumentation for requests on a per envelope basis.
     /// The Filter gets the <see cref="Envelope"/>, and should return a boolean.
@@ -22,10 +24,13 @@ public class WolverineTracingOptions
     /// If Filter returns <c>false</c> or throw exception, the request is filtered out.
     /// </summary>
     public Func<Envelope, bool>? SendEnvelopeFilter { get; set; }
+
     /// <inheritdoc cref="SendEnvelopeFilter"/>
     public Func<Envelope, bool>? ReceiveEnvelopeFilter { get; set; }
+
     /// <inheritdoc cref="SendEnvelopeFilter"/>
     public Func<Envelope, bool>? ExecuteEnvelopeFilter { get; set; }
+
     /// <summary>
     /// Gets or sets a Filter function that will be applied to all supported Activity types
     /// The Filter gets the <see cref="Envelope"/>, and should return a boolean.
@@ -33,6 +38,22 @@ public class WolverineTracingOptions
     /// If Filter returns <c>false</c> or throw exception, the request is filtered out.
     /// </summary>
     public Func<Envelope, bool>? GlobalFilter { get; set; }
+
+    /// <summary>
+    /// While enabled, Wolverine will not generate traces or activities for internal message types.
+    /// </summary>
+    public bool SuppressInternalMessageTypes { get; set; }
+
+    private bool filterInternalMessages(Envelope envelope)
+    {
+        if (SuppressInternalMessageTypes)
+        {
+            return envelope.Message != null &&
+                   !envelope.Message.GetType().IsAssignableTo(typeof(IInternalMessage));
+        }
+
+        return true;
+    }
 
     internal WolverineTracingFilter GetFilterForActivity(string activityName)
     {
@@ -50,7 +71,9 @@ public class WolverineTracingOptions
                 break;
         }
 
-        return env => GlobalFilter?.Invoke(env) != false && activityFilter?.Invoke(env) != false;
+        return env => filterInternalMessages(env) && 
+                      GlobalFilter?.Invoke(env) != false &&
+                      activityFilter?.Invoke(env) != false;
     }
 }
 

--- a/src/Wolverine/Runtime/Tracing/WolverineTracingOptions.cs
+++ b/src/Wolverine/Runtime/Tracing/WolverineTracingOptions.cs
@@ -50,7 +50,7 @@ public class WolverineTracingOptions
                 break;
         }
 
-        return env => GlobalFilter?.Invoke(env) == true || activityFilter?.Invoke(env) == true;
+        return env => GlobalFilter?.Invoke(env) != false && activityFilter?.Invoke(env) != false;
     }
 }
 

--- a/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Logging;
 using Wolverine.Runtime.Scheduled;
+using Wolverine.Runtime.Tracing;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
 using Wolverine.Util.Dataflow;
@@ -132,7 +133,7 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
             return;
         }
 
-        var activity = WolverineTracing.StartReceiving(envelope);
+        var activity = WolverineTracing.StartReceiving(envelope, _logger);
         _receivingBlock.Post(envelope);
         activity?.Stop();
     }

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Logging;
 using Wolverine.Persistence.Durability;
+using Wolverine.Runtime.Tracing;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
 using Wolverine.Util.Dataflow;
@@ -184,7 +185,7 @@ internal class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSc
             return;
         }
 
-        using var activity = WolverineTracing.StartReceiving(envelope);
+        using var activity = WolverineTracing.StartReceiving(envelope, _logger);
         try
         {
             var now = DateTimeOffset.UtcNow;

--- a/src/Wolverine/Runtime/WorkerQueues/InlineReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/InlineReceiver.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Wolverine.Logging;
+using Wolverine.Runtime.Tracing;
 using Wolverine.Transports;
 
 namespace Wolverine.Runtime.WorkerQueues;
@@ -37,7 +38,7 @@ internal class InlineReceiver : IReceiver
 
     public async ValueTask ReceivedAsync(IListener listener, Envelope envelope)
     {
-        using var activity = WolverineTracing.StartReceiving(envelope);
+        using var activity = WolverineTracing.StartReceiving(envelope, _logger);
 
         try
         {

--- a/src/Wolverine/Transports/Sending/BufferedSendingAgent.cs
+++ b/src/Wolverine/Transports/Sending/BufferedSendingAgent.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Logging;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Tracing;
 
 namespace Wolverine.Transports.Sending;
 
@@ -50,7 +51,7 @@ internal class BufferedSendingAgent : SendingAgent
 
     protected override async Task storeAndForwardAsync(Envelope envelope)
     {
-        using var activity = WolverineTracing.StartSending(envelope);
+        using var activity = WolverineTracing.StartSending(envelope, _logger);
         try
         {
             await _sending.PostAsync(envelope);

--- a/src/Wolverine/Transports/Sending/InlineSendingAgent.cs
+++ b/src/Wolverine/Transports/Sending/InlineSendingAgent.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Logging;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Tracing;
 using Wolverine.Util.Dataflow;
 
 namespace Wolverine.Transports.Sending;
@@ -21,7 +22,7 @@ internal class InlineSendingAgent : ISendingAgent, IDisposable
 
         _sending = new RetryBlock<Envelope>(async (e, _) =>
         {
-            using var activity = WolverineTracing.StartSending(e);
+            using var activity = WolverineTracing.StartSending(e, logger);
             try
             {
                 await _sender.SendAsync(e);

--- a/src/Wolverine/Transports/Sending/SendingAgent.cs
+++ b/src/Wolverine/Transports/Sending/SendingAgent.cs
@@ -8,10 +8,10 @@ namespace Wolverine.Transports.Sending;
 
 internal abstract class SendingAgent : ISendingAgent, ISenderCallback, ISenderCircuit, IAsyncDisposable
 {
-    private readonly ILogger _logger;
     private readonly IMessageTracker _messageLogger;
     protected readonly ISender _sender;
 
+    protected readonly ILogger _logger;
     protected readonly RetryBlock<Envelope> _sending;
     protected readonly DurabilitySettings _settings;
     private CircuitWatcher? _circuitWatcher;

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Wolverine.Configuration;
 using Wolverine.Runtime.Handlers;
 using Wolverine.Runtime.Scheduled;
+using Wolverine.Runtime.Tracing;
 using Wolverine.Transports.Local;
 
 [assembly: InternalsVisibleTo("Wolverine.Testing")]
@@ -46,7 +47,6 @@ public sealed partial class WolverineOptions
         }
 
         Durability = new DurabilitySettings { AssignedNodeNumber = UniqueNodeId.ToString().GetDeterministicHashCode() };
-
         deriveServiceName();
 
         Policies.Add<SagaPersistenceChainPolicy>();
@@ -100,6 +100,8 @@ public sealed partial class WolverineOptions
     ///     full ServiceCollection *at the time of this call*
     /// </summary>
     public ServiceRegistry Services { get; } = new();
+
+    public WolverineTracingOptions Tracing => WolverineActivitySource.Options;
 
     internal HandlerGraph HandlerGraph { get; } = new();
 

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -100,7 +100,10 @@ public sealed partial class WolverineOptions
     ///     full ServiceCollection *at the time of this call*
     /// </summary>
     public ServiceRegistry Services { get; } = new();
-
+    
+    /// <summary>
+    ///      Configure <see cref="Activity"/> tracing behavior
+    /// </summary>
     public WolverineTracingOptions Tracing => WolverineActivitySource.Options;
 
     internal HandlerGraph HandlerGraph { get; } = new();

--- a/wolverine.sln
+++ b/wolverine.sln
@@ -213,6 +213,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultiTenantedTodoWebService
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wolverine.Http.Tests.DifferentAssembly", "src\Http\Wolverine.Http.Tests.DifferentAssembly\Wolverine.Http.Tests.DifferentAssembly.csproj", "{5F51ACE8-6DFC-40CF-91C9-9CD96F77971F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wolverine.OpenTelemetry", "src\Extensions\Wolverine.OpenTelemetry\Wolverine.OpenTelemetry.csproj", "{224A915B-1B6B-4378-9C0A-DB2B863A4D17}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -538,6 +540,10 @@ Global
 		{5F51ACE8-6DFC-40CF-91C9-9CD96F77971F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5F51ACE8-6DFC-40CF-91C9-9CD96F77971F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5F51ACE8-6DFC-40CF-91C9-9CD96F77971F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{224A915B-1B6B-4378-9C0A-DB2B863A4D17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{224A915B-1B6B-4378-9C0A-DB2B863A4D17}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{224A915B-1B6B-4378-9C0A-DB2B863A4D17}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{224A915B-1B6B-4378-9C0A-DB2B863A4D17}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{24497E6A-D6B1-4C80-ABFB-57FFAD5070C4} = {96119B5E-B5F0-400A-9580-B342EBE26212}
@@ -633,5 +639,6 @@ Global
 		{9B6BD2ED-B58D-4557-B54C-EAB0268862FB} = {E426CBC2-E4AE-49B2-840E-14D54442FDAC}
 		{A4F1E33D-DA47-476A-B628-2CB8E775819E} = {E426CBC2-E4AE-49B2-840E-14D54442FDAC}
 		{5F51ACE8-6DFC-40CF-91C9-9CD96F77971F} = {4B0BC1E5-17F9-4DD0-AC93-DDC522E1BE3C}
+		{224A915B-1B6B-4378-9C0A-DB2B863A4D17} = {F429686D-BB41-4E1C-A84E-518F8A289AEF}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This pull request addresses issue #451 

It adds configuration support for Wolverine tracing, and adds an additional package for OpenTelemetry instrumentation.

- Adds configuration support for activity filtering predicates for the three supported Wolverine activity types
- Adds configuration support for global activity filtering, regardless of origin type
- Add support of enrichment of Wolverine generated activities
- Adds first class support for filtering out internal message types
- Adds additional package for OpenTelemetry instrumentation

```csharp
Host.CreateDefaultBuilder()
            .UseWolverine(options =>
            {
                // Suppress activity generation for IInternalMessage implementations
                options.Tracing.SuppressInternalMessageTypes = true; 
                options.Tracing.Enrich = (activity, eventType, envelope) =>
                {
                    // enrich the activity externally
                };
                options.Tracing.SendEnvelopeFilter = (envelope) =>
                {
                    //specify a condition in which activities shouldn't be traced for sent messages
                    return true;
                };
                options.Tracing.GlobalFilter = (envelope) =>
                {
                    //Specify a condition in which activities shouldn't be traced for any message
                    return true;
                };
            })
```

-- OR --

```csharp
Host.CreateDefaultBuilder()
            .UseWolverine()
            .ConfigureServices(services =>
            {
                services.AddOpenTelemetry()
                    .WithTracing(builder =>
                    {
                        builder
                            .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("MY SERVICE"))
                            .AddWolverineInstrumentation(options =>
                            {
                               // Suppress activity generation for IInternalMessage implementations
                                options.SuppressInternalMessageTypes = true; 
                                options.Enrich = (activity, eventType, envelope) =>
                                {
                                    // enrich the activity
                                };
                                options.SendEnvelopeFilter = (envelope) =>
                                {
                                    //specify a condition in which activities shouldn't be traced for sent messages
                                    return true;
                                };
                                options.GlobalFilter = (envelope) =>
                                {
                                    //specify a condition in which activities shouldn't be traced for any messages
                                    return true;
                                };
                            });
                    });
            });
```