### PR TITLE
docs: format container blocks

### DIFF
--- a/docs/.vitepress/cache/deps/_metadata.json
+++ b/docs/.vitepress/cache/deps/_metadata.json
@@ -1,11 +1,11 @@
 {
-  "hash": "d9310bc8",
-  "browserHash": "53be324b",
+  "hash": "9a9de62a",
+  "browserHash": "5b70765f",
   "optimized": {
     "vue": {
       "src": "../../../../node_modules/vue/dist/vue.runtime.esm-bundler.js",
       "file": "vue.js",
-      "fileHash": "b506e708",
+      "fileHash": "352a8c03",
       "needsInterop": false
     }
   },

--- a/docs/guide/handlers/discovery.md
+++ b/docs/guide/handlers/discovery.md
@@ -104,7 +104,7 @@ using var host = Host.CreateDefaultBuilder()
 
 ## Handler Type Discovery
 
-:::
+::: warning
 Wolverine does not support any kind of open generic types for message handlers and has no intentions of ever doing so.
 :::
 

--- a/docs/guide/handlers/middleware.md
+++ b/docs/guide/handlers/middleware.md
@@ -116,7 +116,7 @@ Alright, let's talk about what's happening in the code samples above:
 * Wolverine places the `Before()` method to be called in front of the actual message handler method
 * Because there is a `Finally()` method, Wolverine wraps a `try/finally` block around the code running after the `Before()` method and calls `Finally()` within that `finally` block
 
-::: 
+::: tip
 Note that the method name matching is case sensitive.
 :::
 


### PR DESCRIPTION
Before:
![image](https://github.com/JasperFx/wolverine/assets/28659384/f56ea129-32ab-4041-96dd-b03542c1ebb9)
![image](https://github.com/JasperFx/wolverine/assets/28659384/3670cd82-c87d-41e6-ad84-6ffd1ec582ed)


After:

![image](https://github.com/JasperFx/wolverine/assets/28659384/fdb27cf7-c803-4057-b53d-6a4971250f11)
![image](https://github.com/JasperFx/wolverine/assets/28659384/41138d9a-faff-4139-9e84-d4bc638b243f)
