### PR TITLE
Ensure args with [NotBody] do not display within openapi.

### DIFF
--- a/src/Http/Wolverine.Http/NotBodyAttribute.cs
+++ b/src/Http/Wolverine.Http/NotBodyAttribute.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Http.Metadata;
+
 namespace Wolverine.Http;
 
 /// <summary>
@@ -6,6 +8,7 @@ namespace Wolverine.Http;
 ///     HTTP request body
 /// </summary>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
-public class NotBodyAttribute : Attribute
+public class NotBodyAttribute : Attribute, IFromServiceMetadata
 {
 }
+


### PR DESCRIPTION
While this seems like a simple change the implementation of this functionality is highly dependent on both aspnetcore ApiExplorer and swashbuckle functionality.

My understanding is that the dependency relationship between these is the following

EndpointBuilder -> Endpoint -> ApiExplorer -> Swashbuckle.

Specifically the functionality which this relies on is implemented here https://github.com/dotnet/aspnetcore/blob/b0b9f45538383bdf036bd35a84c6552d37bd6010/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs#L279C120-L287

Closes #528