### PR TITLE
Always leverage SQL transactions in EF Core transactional middleware

### DIFF
--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -87,10 +87,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
         
         var dbType = DetermineDbContextType(chain, container);
 
-        if (chain.RequiresOutbox())
-        {
-            chain.Middleware.Insert(0, new EnrollDbContextInTransaction(dbType));
-        }
+        chain.Middleware.Insert(0, new EnrollDbContextInTransaction(dbType));
 
         var saveChangesAsync =
             dbType.GetMethod(nameof(DbContext.SaveChangesAsync), new[] { typeof(CancellationToken) });
@@ -242,7 +239,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
             if (_envelopeTransaction != null)
             {
                 writer.WriteComment(
-                    "If we have separate context for outbox and application, the we need to manually commit the transaction");
+                    "If we have separate context for outbox and application, then we need to manually commit the transaction");
                 writer.Write(
                     $"if ({_envelopeTransaction.Usage} is Wolverine.EntityFrameworkCore.Internals.RawDatabaseEnvelopeTransaction rawTx) {{ await rawTx.CommitAsync(); }}");
             }


### PR DESCRIPTION
This will allow message handlers to call `DbContext.SaveChangesAsync()` at any point during the transaction. This is helpful when you need to get the auto-generated entity ID before committing the entire transaction. Previously, the codegen would only leverage SQL transactions when the chain required an outbox.