### PR TITLE
Add conditional in status code setting and logging service, with new …

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Marten/using_write_by_id.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/using_write_by_id.cs
@@ -1,0 +1,34 @@
+using Marten;
+using Marten.AspNetCore;
+using Microsoft.AspNetCore.Http;
+using WolverineWebApi;
+using WolverineWebApi.Marten;
+
+namespace Wolverine.Http.Tests.Marten;
+
+
+public class using_write_by_id : IntegrationContext
+{
+  public using_write_by_id(AppFixture fixture) : base(fixture)
+  {
+  }
+
+  [Fact]
+  public async Task use_marten_write_to()
+  {
+    var result = await Scenario(x =>
+    {
+      x.Post.Json(new CreateIssue("Title")).ToUrl("/issue");
+      x.StatusCodeShouldBe(201);
+    });
+
+    var issue = result.ReadAsJson<IssueCreated>();
+    
+    // This will throw a silent error, unsure how to test
+    await Scenario(x =>
+    {
+      x.Get.Url("/write-to/" + issue.Id);
+      x.StatusCodeShouldBe(200);
+    });
+  }
+}

--- a/src/Http/Wolverine.Http/Resources/EmptyBody204Policy.cs
+++ b/src/Http/Wolverine.Http/Resources/EmptyBody204Policy.cs
@@ -27,7 +27,7 @@ internal class WriteEmptyBodyStatusCode : SyncFrame
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
         writer.WriteComment("Wolverine automatically sets the status code to 204 for empty responses");
-        writer.Write($"{_context!.Usage}.{nameof(HttpContext.Response)}.{nameof(HttpResponse.StatusCode)} = 204;");
+        writer.Write($"if (!{_context!.Usage}.{nameof(HttpContext.Response)}.{nameof(HttpResponse.HasStarted)}) {_context!.Usage}.{nameof(HttpContext.Response)}.{nameof(HttpResponse.StatusCode)} = 204;");
         Next?.GenerateCode(method, writer);
     }
 

--- a/src/Http/WolverineWebApi/Program.cs
+++ b/src/Http/WolverineWebApi/Program.cs
@@ -22,6 +22,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
+builder.Services.AddLogging();
+
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/src/Http/WolverineWebApi/WriteToEndpoints.cs
+++ b/src/Http/WolverineWebApi/WriteToEndpoints.cs
@@ -1,0 +1,12 @@
+using Marten;
+using Marten.AspNetCore;
+using Wolverine.Http;
+
+namespace WolverineWebApi;
+
+public static class WriteToEndpoints
+{
+  [WolverineGet("/write-to/{id}")]
+  public static Task GetAssetCodeView(Guid id, IQuerySession session, HttpContext context)
+    => session.Json.WriteById<Issue>(id, context);
+}


### PR DESCRIPTION
…endpoint and tests

Introduced a check in EmptyBody204Policy.cs to ensure that the http response has not started before setting the status code to 204. This prevents any modifications from being attempted on a response that has already begun and can reduce unexpected behavior.

Included a logging service in the Program.cs file to allow for better tracking of application messages and help in debugging.

Two new files were added, 'using_write_by_id.cs' and 'WriteToEndpoints.cs', to create a new Marten-based endpoint ('/write-to/{id}') along with its corresponding integration test. This aims to enhance the API's functionality by allowing retrieval of issues by their unique ID.

refs #575