### PR TITLE
Fix a typo

### DIFF
--- a/docs/guide/handlers/error-handling.md
+++ b/docs/guide/handlers/error-handling.md
@@ -16,7 +16,7 @@ Error handling rules in Wolverine are defined by three things:
 2. Exception matching
 3. One or more actions (retry the message? discard it? move it to an error queue?)
 
-### What do do on an error?
+### What to do on an error?
 
 | Action               | Description                                                                                                                              |
 |----------------------|------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Fix a typo in the documentation