### PR TITLE
docs: fix some typos

### DIFF
--- a/docs/guide/codegen.md
+++ b/docs/guide/codegen.md
@@ -73,7 +73,7 @@ project.
 
 At production time, if there is any issue whatsoever with resource utilization, the Wolverine team
 recommends using the `Static` mode where all types are assumed to be pre-generated into what Wolverine
-thinks is the application assembly (more on this in the trouble shooting guide below).
+thinks is the application assembly (more on this in the troubleshooting guide below).
 
 ::: tip
 Most of the facilities shown here will require the [Oakton command line integration](./command-line).

--- a/docs/guide/durability/efcore.md
+++ b/docs/guide/durability/efcore.md
@@ -133,7 +133,7 @@ That registration will:
    allowing Wolverine to utilize the command batching from EF Core for the message storage
 2. Sets the `optionsLifetime` to `Singleton` scoped. This allows Wolverine to optimize the construction of your `DbContext`
    objects at runtime when the configuration options do not vary by scope
-3. Automatically registers the EF Core support for Wolverine transactional middlware and stateful saga support
+3. Automatically registers the EF Core support for Wolverine transactional middleware and stateful saga support
 
 The AddDbContextWithWolverineIntegration has an additional last default parameter wolverineDatabaseSchema. It lets you control the name of a database schema where
 Wolverine database table will be placed. The default value is null and creates Wolverine tables in the default schema.

--- a/docs/guide/handlers/discovery.md
+++ b/docs/guide/handlers/discovery.md
@@ -12,7 +12,7 @@ you could also explicitly add handler types programmatically.
 ## Troubleshooting Handler Discovery
 
 It's an imperfect world and sometimes Wolverine isn't finding handler methods for some reason or another -- or
-seems to be using types and methods you'd rather it didn't. Not to fear, there's some diagnostic tools
+seems to be using types and methods you'd rather it didn't. Not to fear, there are some diagnostic tools
 to help Wolverine explain what's going on.
 
 Directly on `WolverineOptions` itself is a diagnostic method named `DescribeHandlerMatch` that will give

--- a/docs/guide/http/endpoints.md
+++ b/docs/guide/http/endpoints.md
@@ -50,7 +50,7 @@ It's actually possible to create custom conventions for how Wolverine resolves m
 using the `IParameterStrategy` plugin interface explained later in this page.
 :::
 
-First off, every endpoint method must be a `public` method on a `public` type to accomodate the runtime code generation.
+First off, every endpoint method must be a `public` method on a `public` type to accommodate the runtime code generation.
 After that, you have quite a bit of flexibility. 
 
 In terms of what the legal parameters to your endpoint method, Wolverine uses these rules *in order of precedence*

--- a/docs/guide/http/policies.md
+++ b/docs/guide/http/policies.md
@@ -1,6 +1,6 @@
 ## HTTP Policies
 
-Custom policies can be created for HTTP endpoints through either creating your own implementation of `IHttpPolciy`
+Custom policies can be created for HTTP endpoints through either creating your own implementation of `IHttpPolicy`
 shown below:
 
 <!-- snippet: sample_IHttpPolicy -->

--- a/docs/guide/http/routing.md
+++ b/docs/guide/http/routing.md
@@ -1,7 +1,7 @@
 # Routing
 
 ::: warning
-The route argument to method name matching is case sensitive.
+The route argument to method name matching is case-sensitive.
 :::
 
 Wolverine HTTP endpoints need to be decorated with one of the `[WolverineVerb("route")]` attributes

--- a/docs/guide/messaging/message-bus.md
+++ b/docs/guide/messaging/message-bus.md
@@ -129,7 +129,7 @@ endpoint and waiting for the response. The same timeout mechanics and performanc
 
 ## Sending or Publishing Messages
 
-[Publish/Subscribe](https://docs.microsoft.com/en-us/azure/architecture/patterns/publisher-subscriber) is a messaging pattern where the senders of messages do not need to specifically know what the specific subscribers are for a given message. In this case, some kind of middleware or infrastructure is responsible for either allowing subscribers to express interest in what messages they need to receive or apply routing rules to send the published messages to the right places. Wolverine's messaging support was largely built to support the publish/subscibe messaging patterm.
+[Publish/Subscribe](https://docs.microsoft.com/en-us/azure/architecture/patterns/publisher-subscriber) is a messaging pattern where the senders of messages do not need to specifically know what the specific subscribers are for a given message. In this case, some kind of middleware or infrastructure is responsible for either allowing subscribers to express interest in what messages they need to receive or apply routing rules to send the published messages to the right places. Wolverine's messaging support was largely built to support the publish/subscribe messaging pattern.
 
 To send a message with Wolverine, use the `IMessageBus` interface or the bigger `IMessageContext` interface that
 are registered in your application's IoC container. The sample below shows the most common usage:

--- a/docs/guide/messaging/subscriptions.md
+++ b/docs/guide/messaging/subscriptions.md
@@ -18,7 +18,7 @@ public class SendingExample
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Runtime/Samples/channels.cs#L6-L17' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sending_messages_for_static_routing' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-When sending, publishing, scheduling, or invoking a message type for the first time, Wolverine runs though
+When sending, publishing, scheduling, or invoking a message type for the first time, Wolverine runs through
 a series of rules to determine what endpoint(s) subscribes to the message type. Those rules in order of precedence
 are:
 

--- a/docs/guide/messaging/transports/azureservicebus/scheduled.md
+++ b/docs/guide/messaging/transports/azureservicebus/scheduled.md
@@ -7,7 +7,7 @@ This functionality as introduced in Wolverine 1.6.0
 WolverineFx.AzureServiceBus now supports [native Azure Service Bus scheduled delivery](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-sequencing).
 There's absolutely nothing you need to do explicitly to enable this functionality. 
 
-So for message types that are routed to Azure Service Bus queues or topics, you can use this functionlity:
+So for message types that are routed to Azure Service Bus queues or topics, you can use this functionality:
 
 <!-- snippet: sample_send_delayed_message -->
 <a id='snippet-sample_send_delayed_message'></a>


### PR DESCRIPTION
I encountered a few typos/grammar while reading the docs, so I quickly fixed them to make it a bit more polished. 
While I can't contribute to the source code yet, I want to help where I can.