### PR TITLE
Reorder attribute application in HttpChain

### DIFF
--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -63,15 +63,6 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
         DisplayName = Method.ToString();
 
-        if (method.Method.TryGetAttribute<WolverineHttpMethodAttribute>(out var att))
-        {
-            MapToRoute(att.HttpMethod, att.Template, att.Order);
-            if (att.Name.IsNotEmpty())
-            {
-                DisplayName = att.Name;
-            }
-        }
-
         if (tryFindResourceType(method, out var responseType))
         {
             NoContent = false;
@@ -82,8 +73,17 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
             NoContent = true;
             ResourceType = typeof(void);
         }
-
+        
         Metadata = new RouteHandlerBuilder(new[] { this });
+        
+        if (method.Method.TryGetAttribute<WolverineHttpMethodAttribute>(out var att))
+        {
+            MapToRoute(att.HttpMethod, att.Template, att.Order);
+            if (att.Name.IsNotEmpty())
+            {
+                DisplayName = att.Name;
+            }
+        }
 
         // Apply attributes and the Configure() method if that exists too
         applyAttributesAndConfigureMethods(_parent.Rules, _parent.Container);


### PR DESCRIPTION
The attribute application code was moved below the Metadata and ResourceType definitions in HttpChain.cs. This modification ensures the Metadata and ResourceType are defined. chain.Metadata.Produces(..) calls within new Marten attributes will not longer break startup.