### PR TITLE
Fixes Weasel Dependencies in Wolverine.RDBMS

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -260,7 +260,7 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>
 
         if (_settings.IsMaster)
         {
-            var nodeTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeTableName));
+            var nodeTable = new Table(new PostgresqlObjectName(SchemaName, DatabaseConstants.NodeTableName));
             nodeTable.AddColumn<Guid>("id").AsPrimaryKey();
             nodeTable.AddColumn("node_number", "SERIAL").NotNull();
             nodeTable.AddColumn<string>("description").NotNull();
@@ -271,7 +271,7 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>
 
             yield return nodeTable;
 
-            var assignmentTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeAssignmentsTableName));
+            var assignmentTable = new Table(new PostgresqlObjectName(SchemaName, DatabaseConstants.NodeAssignmentsTableName));
             assignmentTable.AddColumn<string>("id").AsPrimaryKey();
             assignmentTable.AddColumn<Guid>("node_id")
                 .ForeignKeyTo(nodeTable.Identifier, "id", onDelete: CascadeAction.Cascade);
@@ -281,7 +281,7 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>
 
             if (_settings.CommandQueuesEnabled)
             {
-                var queueTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.ControlQueueTableName));
+                var queueTable = new Table(new PostgresqlObjectName(SchemaName, DatabaseConstants.ControlQueueTableName));
                 queueTable.AddColumn<Guid>("id").AsPrimaryKey();
                 queueTable.AddColumn<string>("message_type").NotNull();
                 queueTable.AddColumn<Guid>("node_id").NotNull();
@@ -292,7 +292,7 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>
                 yield return queueTable;
             }
             
-            var eventTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeRecordTableName));
+            var eventTable = new Table(new PostgresqlObjectName(SchemaName, DatabaseConstants.NodeRecordTableName));
             eventTable.AddColumn("id", "SERIAL").AsPrimaryKey();
             eventTable.AddColumn<int>("node_number").NotNull();
             eventTable.AddColumn<string>("event_name").NotNull();

--- a/src/Persistence/Wolverine.Postgresql/Wolverine.Postgresql.csproj
+++ b/src/Persistence/Wolverine.Postgresql/Wolverine.Postgresql.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Weasel.Postgresql" Version="6.0.1" />
+        <PackageReference Include="Weasel.Postgresql" Version="6.4.0" />
     </ItemGroup>
 
     <Import Project="../../../Analysis.Build.props" />

--- a/src/Persistence/Wolverine.RDBMS/Wolverine.RDBMS.csproj
+++ b/src/Persistence/Wolverine.RDBMS/Wolverine.RDBMS.csproj
@@ -19,7 +19,7 @@
     <ItemGroup>
         <PackageReference Include="System.Data.Common" Version="4.3.0" />
         <PackageReference Include="Weasel.CommandLine" Version="6.0.1" />
-        <PackageReference Include="Weasel.Core" Version="6.0.1" />
+        <PackageReference Include="Weasel.Core" Version="6.4.0" />
     </ItemGroup>
 
     <Import Project="../../../Analysis.Build.props" />

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -261,7 +261,7 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>
         
         if (_settings.IsMaster)
         {
-            var nodeTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeTableName));
+            var nodeTable = new Table(new SqlServerObjectName(SchemaName, DatabaseConstants.NodeTableName));
             nodeTable.AddColumn<Guid>("id").AsPrimaryKey();
             nodeTable.AddColumn<int>("node_number").AutoNumber().NotNull();
             nodeTable.AddColumn<string>("description").NotNull();
@@ -272,7 +272,7 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>
 
             yield return nodeTable;
 
-            var assignmentTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeAssignmentsTableName));
+            var assignmentTable = new Table(new SqlServerObjectName(SchemaName, DatabaseConstants.NodeAssignmentsTableName));
             assignmentTable.AddColumn<string>("id").AsPrimaryKey();
             assignmentTable.AddColumn<Guid>("node_id").ForeignKeyTo(nodeTable.Identifier, "id", onDelete:CascadeAction.Cascade);
             assignmentTable.AddColumn<DateTimeOffset>("started").DefaultValueByExpression("GETUTCDATE()").NotNull();
@@ -281,7 +281,7 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>
             
             if (_settings.CommandQueuesEnabled)
             {
-                var queueTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.ControlQueueTableName));
+                var queueTable = new Table(new SqlServerObjectName(SchemaName, DatabaseConstants.ControlQueueTableName));
                 queueTable.AddColumn<Guid>("id").AsPrimaryKey();
                 queueTable.AddColumn<string>("message_type").NotNull();
                 queueTable.AddColumn<Guid>("node_id").NotNull();
@@ -293,7 +293,7 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>
             }
             
                     
-            var eventTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeRecordTableName));
+            var eventTable = new Table(new SqlServerObjectName(SchemaName, DatabaseConstants.NodeRecordTableName));
             eventTable.AddColumn<int>("id").AutoNumber().AsPrimaryKey();
             eventTable.AddColumn<int>("node_number").NotNull();
             eventTable.AddColumn<string>("event_name").NotNull();

--- a/src/Persistence/Wolverine.SqlServer/Wolverine.SqlServer.csproj
+++ b/src/Persistence/Wolverine.SqlServer/Wolverine.SqlServer.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Weasel.SqlServer" Version="6.0.1" />
+        <PackageReference Include="Weasel.SqlServer" Version="6.4.0" />
     </ItemGroup>
 
     <Import Project="../../../Analysis.Build.props" />


### PR DESCRIPTION
This updates Weasel dependencies, and uses PostgresqlObjectName/SqlServerObjectName instead of the generic DbObjectName in the SqlServerMessageStore/PostgresqlMessageStore