### PR TITLE
Manage Sender and Listener connection separately in RMQ

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitMqTransportTests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitMqTransportTests.cs
@@ -66,4 +66,16 @@ public class RabbitMqTransportTests
     {
         theTransport.DeclareRequestReplySystemQueue.ShouldBeTrue();
     }
+
+    [Fact]
+    public void use_sender_connection_only_is_false_by_default()
+    {
+        theTransport.UseSenderConnectionOnly.ShouldBeFalse();
+    }
+    
+    [Fact]
+    public void use_listener_connection_only_is_false_by_default()
+    {
+        theTransport.UseListenerConnectionOnly.ShouldBeFalse();
+    }
 }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Samples.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Samples.cs
@@ -78,6 +78,62 @@ public class Samples
 
         #endregion
     }
+    
+    public static async Task use_listener_connection_only()
+    {
+        #region sample_disable_rabbit_mq_system_queue
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // *A* way to configure Rabbit MQ using their Uri schema
+                // documented here: https://www.rabbitmq.com/uri-spec.html
+                opts.UseRabbitMq(new Uri("amqp://localhost"))
+
+                    // Turn on listener connection only in case if you only need to listen for messages
+                    // The sender connection won't be activated in this case
+                    .UseListenerConnectionOnly();
+
+                // Set up a listener for a queue, but also
+                // fine-tune the queue characteristics if Wolverine
+                // will be governing the queue setup
+                opts.ListenToRabbitQueue("incoming2", q =>
+                {
+                    q.PurgeOnStartup = true;
+                    q.TimeToLive(5.Minutes());
+                });
+            }).StartAsync();
+
+        #endregion
+    }
+    
+    public static async Task use_sender_connection_only()
+    {
+        #region sample_disable_rabbit_mq_system_queue
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // *A* way to configure Rabbit MQ using their Uri schema
+                // documented here: https://www.rabbitmq.com/uri-spec.html
+                opts.UseRabbitMq(new Uri("amqp://localhost"))
+
+                    // Turn on sender connection only in case if you only need to send messages
+                    // The listener connection won't be created in this case
+                    .UseSenderConnectionOnly();
+
+                // Set up a listener for a queue, but also
+                // fine-tune the queue characteristics if Wolverine
+                // will be governing the queue setup
+                opts.ListenToRabbitQueue("incoming2", q =>
+                {
+                    q.PurgeOnStartup = true;
+                    q.TimeToLive(5.Minutes());
+                });
+            }).StartAsync();
+
+        #endregion
+    }
 
     public static async Task listen_to_queue()
     {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
@@ -55,6 +55,8 @@ public partial class RabbitMqTransport : BrokerTransport<RabbitMqEndpoint>, IDis
     public LightweightCache<string, RabbitMqQueue> Queues { get; }
 
     internal bool DeclareRequestReplySystemQueue { get; set; } = true;
+    internal bool UseSenderConnectionOnly { get; set; }
+    internal bool UseListenerConnectionOnly { get; set; }
 
     public void Dispose()
     {
@@ -93,13 +95,13 @@ public partial class RabbitMqTransport : BrokerTransport<RabbitMqEndpoint>, IDis
 
         ConnectionFactory.DispatchConsumersAsync = true;
 
-        if (_listenerConnection == null)
+        if (_listenerConnection == null && !UseSenderConnectionOnly)
         {
             _listenerConnection = BuildConnection();
             listenToEvents("Listener", _listenerConnection, logger);
         }
 
-        if (_sendingConnection == null)
+        if (_sendingConnection == null && !UseListenerConnectionOnly)
         {
             _sendingConnection = BuildConnection();
             listenToEvents("Sender", _sendingConnection, logger);

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransportExpression.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransportExpression.cs
@@ -127,6 +127,32 @@ public class RabbitMqTransportExpression : BrokerExpression<RabbitMqTransport, R
         return this;
     }
 
+    /// <summary>
+    /// Turn on listener connection only in case if you only need to listen for messages
+    /// The sender connection won't be activated in this case
+    /// </summary>
+    /// <returns></returns>
+    public RabbitMqTransportExpression UseListenerConnectionOnly()
+    {
+        Transport.UseListenerConnectionOnly = true;
+        Transport.UseSenderConnectionOnly = false;
+
+        return this;
+    }
+    
+    /// <summary>
+    /// Turn on sender connection only in case if you only need to send messages
+    /// The listener connection won't be created in this case
+    /// </summary>
+    /// <returns></returns>
+    public RabbitMqTransportExpression UseSenderConnectionOnly()
+    {
+        Transport.UseSenderConnectionOnly = true;
+        Transport.UseListenerConnectionOnly = false;
+
+        return this;
+    }
+
     public class BindingExpression
     {
         private readonly string _exchangeName;


### PR DESCRIPTION
Add ability to control Sender/Listener connection.
It becomes crucial when you connect to a RMQ and it creates two connections: Sender and Listener and you need only one.
In case if a service is supposed to send messages only, the Listener connection becomes a useless load that consumes additional resources, and vice-versa with the Sender connection.
In this PR I've added two methods to the `RabbitMqTransportExpression` that allow turning off Sender or Listener connection.