### PR TITLE
Allow for parallelism configuration in BatchedSender

### DIFF
--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -116,6 +116,11 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     /// </summary>
     public int MessageBatchSize { get; set; } = 100;
     
+    /// <summary>
+    /// For endpoints that send messages in batches, this governs the maximum number
+    /// of concurrent outgoing batches 
+    /// </summary>
+    public int MessageBatchMaxDegreeOfParallelism { get; set; } = 1;
 
     /// <summary>
     ///     Mark whether or not the receiver for this listener should use

--- a/src/Wolverine/Configuration/SubscriberConfiguration.cs
+++ b/src/Wolverine/Configuration/SubscriberConfiguration.cs
@@ -68,6 +68,16 @@ public class SubscriberConfiguration<T, TEndpoint> : DelayedEndpointConfiguratio
         add(e => e.MessageBatchSize = batchSize);
         return this.As<T>();
     }
+    
+    /// <summary>
+    /// For endpoints that send messages in batches, this governs the maximum number
+    /// of concurrent outgoing batches 
+    /// </summary>
+    public T MessageBatchMaxDegreeOfParallelism(int batchMaxDegreeOfParallelism)
+    {
+        add(e => e.MessageBatchMaxDegreeOfParallelism = batchMaxDegreeOfParallelism);
+        return this.As<T>();
+    }
 
     public T DefaultSerializer(IMessageSerializer serializer)
     {

--- a/src/Wolverine/Transports/Sending/BatchedSender.cs
+++ b/src/Wolverine/Transports/Sending/BatchedSender.cs
@@ -29,7 +29,7 @@ public class BatchedSender : ISender, ISenderRequiresCallback
 
         _sender = new ActionBlock<OutgoingMessageBatch>(SendBatchAsync, new ExecutionDataflowBlockOptions
         {
-            MaxDegreeOfParallelism = 1,
+            MaxDegreeOfParallelism = destination.MessageBatchMaxDegreeOfParallelism,
             CancellationToken = _cancellation,
             BoundedCapacity = DataflowBlockOptions.Unbounded
         });


### PR DESCRIPTION
As it stands, the degree of parallelism in the action block responsible for sending batch messages to the underlying transports is capped at "1". This means only a single batch request can be in flight at any given time. By allowing the degree of parallelism in this action block to be configurable, we can push a significantly higher degree of throughput to the underlying transport in at least some cases.