### PR TITLE
Fix: compiled query resource writer assembly reference

### DIFF
--- a/src/Http/Wolverine.Http.Marten/CompiledQueryWriterPolicy.cs
+++ b/src/Http/Wolverine.Http.Marten/CompiledQueryWriterPolicy.cs
@@ -1,10 +1,11 @@
-using JasperFx.CodeGeneration;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
-using Marten;
+using JasperFx.RuntimeCompiler;
 using Marten.Linq;
-using Microsoft.AspNetCore.Http;
 using Wolverine.Http.Resources;
+using QueryableExtensions = Marten.AspNetCore.QueryableExtensions;
 
 namespace Wolverine.Http.Marten;
 
@@ -14,82 +15,65 @@ public class CompiledQueryWriterPolicy : IResourceWriterPolicy
 {
     public bool TryApply(HttpChain chain)
     {
-        bool ImplementsGenericInterface(Type type, Type assigned)
+        bool ImplementsGenericInterface(Type type, Type assigned, [NotNullWhen(true)] out Type[]? types)
         {
-            return type.GetInterfaces().Any(x =>
+            types = null;
+            var result = type.GetInterfaces().FirstOrDefault(x =>
                 x.IsGenericType && x.GetGenericTypeDefinition() == assigned);
+            if (result is null) return false;
+            types = result.GetGenericArguments();
+            return true;
         }
 
         var result = chain.Method.Creates.FirstOrDefault();
         if (result is null) return false;
-        if (ImplementsGenericInterface(result.VariableType, typeof(ICompiledListQuery<,>)))
+        // Are we dealing with a compiled query or not?
+        if (ImplementsGenericInterface(result.VariableType, typeof(ICompiledQuery<,>), out var arguments))
         {
-            chain.Postprocessors.Add(new MartenWriteArrayCodeFrame(result));
-            return true;
-        }
+            MethodInfo methodToCall;
+            
+            // Is it a compiled list query? 
+            if (ImplementsGenericInterface(result.VariableType, typeof(ICompiledListQuery<,>), out _))
+            {
+                // Cannot use GetMethod here because its ambiguous, can't use GetMethod with type parameters because of
+                // WriteArray being a generic method where binding on types passed doesn't work.
+                var method = typeof(QueryableExtensions).GetMethods().Where(x =>
+                    x is { Name: nameof(QueryableExtensions.WriteArray), IsGenericMethod: true } &&
+                    x.GetGenericArguments().Length == 2).ToArray();
+                if (method.Length != 1)
+                {
+                    throw new CodeGenerationException(method, new Exception(
+                        "Cannot find correct method for Marten.AspNetCore.QueryableExtensions.WriteArray to bind to. Incompatible Versions?"));
+                }
 
-        if (ImplementsGenericInterface(result.VariableType, typeof(ICompiledQuery<,>)))
-        {
-            chain.Postprocessors.Add(new MartenWriteJsonCodeFrame(result));
-            return true;
-        }
+                methodToCall = method[0].MakeGenericMethod(arguments);
+            }
+            else
+            {
+                var method = typeof(QueryableExtensions).GetMethod(nameof(QueryableExtensions.WriteOne));
+                if (method is null)
+                {
+                    throw new CodeGenerationException(typeof(QueryableExtensions), new Exception(
+                        "Cannot find correct method for Marten.AspNetCore.QueryableExtensions.WriteOne to bind to. Incompatible Versions?"));
+                }
 
+                methodToCall = method.MakeGenericMethod(arguments);
+            }
+
+
+            var call = new MethodCall(typeof(QueryableExtensions), methodToCall)
+                            {
+                                Arguments =
+                                {
+                                    [1] = result,
+                                    [3] = new StaticVariable(typeof(string), "\"application/json\""),
+                                    [4] = new StaticVariable(typeof(int), "200")
+                                }
+                            };
+                            chain.Postprocessors.Add(call);
+                            return true;
+        }
         return false;
     }
 }
-
-public class MartenWriteJsonCodeFrame : AsyncFrame
-{
-    private Variable? _documentSession;
-    private Variable? _httpContext;
-    private readonly Variable _compiledQuery;
-
-    public MartenWriteJsonCodeFrame(Variable variable)
-    {
-        _compiledQuery = variable;
-    }
-
-    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
-    {
-        writer.WriteComment("Run the compiled query and stream the response");
-        writer.Write($"await Marten.AspNetCore.QueryableExtensions.WriteOne({_documentSession?.Usage}, {_compiledQuery.Usage}, {_httpContext?.Usage});");
-        Next?.GenerateCode(method, writer);
-    }
-    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
-    {
-        _documentSession = chain.FindVariable(typeof(IDocumentSession));
-        yield return _documentSession;
-        _httpContext = chain.FindVariable(typeof(HttpContext));
-        yield return _httpContext;
-        foreach (var variable in base.FindVariables(chain)) yield return variable;
-    }
-}
-
-public class MartenWriteArrayCodeFrame : AsyncFrame
-{
-    private Variable? _documentSession;
-    private Variable? _httpContext;
-    private readonly Variable _compiledQuery;
-
-    public MartenWriteArrayCodeFrame(Variable variable)
-    {
-        _compiledQuery = variable;
-    }
-
-    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
-    {
-        writer.WriteComment("Run the compiled query and stream the response");
-        writer.Write($"await Marten.AspNetCore.QueryableExtensions.WriteArray({_documentSession?.Usage}, {_compiledQuery.Usage}, {_httpContext?.Usage});");
-        Next?.GenerateCode(method, writer);
-    }
-    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
-    {
-        _documentSession = chain.FindVariable(typeof(IDocumentSession));
-        yield return _documentSession;
-        _httpContext = chain.FindVariable(typeof(HttpContext));
-        yield return _httpContext;
-        foreach (var variable in base.FindVariables(chain)) yield return variable;
-    }
-}
-
 #nullable disable

--- a/src/Http/WolverineWebApi/Internal/Generated/WolverineHandlers/GET_invoices_approved.cs
+++ b/src/Http/WolverineWebApi/Internal/Generated/WolverineHandlers/GET_invoices_approved.cs
@@ -29,13 +29,12 @@ namespace Internal.Generated.WolverineHandlers
         {
             var messageContext = new Wolverine.Runtime.MessageContext(_wolverineRuntime);
             // Building the Marten session
-            await using var documentSession = _outboxedSessionFactory.OpenSession(messageContext);
+            await using var querySession = _outboxedSessionFactory.QuerySession(messageContext);
             
             // The actual HTTP request handler execution
             var approvedInvoicedCompiledQuery = WolverineWebApi.Marten.InvoicesEndpoint.GetApproved();
 
-            // Run the compiled query and stream the response
-            await Marten.AspNetCore.QueryableExtensions.WriteArray(documentSession, approvedInvoicedCompiledQuery, httpContext);
+            await Marten.AspNetCore.QueryableExtensions.WriteArray<WolverineWebApi.Marten.Invoice, System.Collections.Generic.IEnumerable<WolverineWebApi.Marten.Invoice>>(querySession, approvedInvoicedCompiledQuery, httpContext, "application/json", 200).ConfigureAwait(false);
         }
 
     }

--- a/src/Http/WolverineWebApi/Internal/Generated/WolverineHandlers/GET_invoices_compiled_id.cs
+++ b/src/Http/WolverineWebApi/Internal/Generated/WolverineHandlers/GET_invoices_compiled_id.cs
@@ -29,7 +29,7 @@ namespace Internal.Generated.WolverineHandlers
         {
             var messageContext = new Wolverine.Runtime.MessageContext(_wolverineRuntime);
             // Building the Marten session
-            await using var documentSession = _outboxedSessionFactory.OpenSession(messageContext);
+            await using var querySession = _outboxedSessionFactory.QuerySession(messageContext);
             if (!System.Guid.TryParse((string)httpContext.GetRouteValue("id"), out var id))
             {
                 httpContext.Response.StatusCode = 404;
@@ -41,8 +41,7 @@ namespace Internal.Generated.WolverineHandlers
             // The actual HTTP request handler execution
             var byIdCompiled = WolverineWebApi.Marten.InvoicesEndpoint.GetCompiled(id);
 
-            // Run the compiled query and stream the response
-            await Marten.AspNetCore.QueryableExtensions.WriteOne(documentSession, byIdCompiled, httpContext);
+            await Marten.AspNetCore.QueryableExtensions.WriteOne<WolverineWebApi.Marten.Invoice, WolverineWebApi.Marten.Invoice>(querySession, byIdCompiled, httpContext, "application/json", 200).ConfigureAwait(false);
         }
 
     }


### PR DESCRIPTION
Fixes the previously discussed missing assembly reference during code generation when using Marten CompiledQuery result writing.