### PR TITLE
Fix UseSystemTextJsonForSerialization customization

### DIFF
--- a/src/Wolverine/WolverineOptions.Serialization.cs
+++ b/src/Wolverine/WolverineOptions.Serialization.cs
@@ -87,7 +87,7 @@ public sealed partial class WolverineOptions
         configuration?.Invoke(options);
 
         var serializer = new SystemTextJsonSerializer(options);
-        _defaultSerializer ??= serializer;
+        _defaultSerializer = serializer;
 
         _serializers[serializer.ContentType] = serializer;
     }


### PR DESCRIPTION
`UseSystemTextJsonForSerialization` configuration isn't respecting any configuration passed in for Azure Service Bus (and possibly other messaging options). This is because the initial `WolverineOptions` calls over to `UseSystemTextJsonForSerialization` without any parameters, so `_defaultSerializer` gets set. Then the `??=` means it never takes the right side.

This should resolve this issue.

(I briefly looked at creating a test for this, but I wasn't sure if it might belong under configuration or serialization tests... categorization is hard)

Closes #717