### PR TITLE
Add support for `IEndpointConventionBuilder.Finally` and fix status-code 200 in `PublishingEndpoint`

### DIFF
--- a/docs/guide/http/metadata.md
+++ b/docs/guide/http/metadata.md
@@ -44,13 +44,18 @@ public static void Configure(HttpChain chain)
     // a request directly to a Wolverine messaging endpoint for later processing
     chain.Metadata.Add(builder =>
     {
-        // Adding and modifying data
+        // Adding metadata
         builder.Metadata.Add(new WolverineProducesResponseTypeMetadata { StatusCode = 202, Type = null });
+    });
+    // This is run after all other metadata has been applied, even after the wolverine built-in metadata
+    // So use this if you want to change or remove some metadata
+    chain.Metadata.Finally(builder =>
+    {
         builder.RemoveStatusCodeResponse(200);
     });
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http/Runtime/PublishingEndpoint.cs#L15-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_programmatic_one_off_openapi_metadata' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http/Runtime/PublishingEndpoint.cs#L15-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_programmatic_one_off_openapi_metadata' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Swashbuckle and Wolverine

--- a/src/Http/Wolverine.Http.Tests/publishing_messages_from_http_endpoint.cs
+++ b/src/Http/Wolverine.Http.Tests/publishing_messages_from_http_endpoint.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http.Metadata;
 using Shouldly;
 using WolverineWebApi;
 
@@ -20,5 +21,17 @@ public class publishing_messages_from_http_endpoint : IntegrationContext
 
         tracked.Sent.SingleMessage<HttpMessage1>()
             .Name.ShouldBe("Glenn Frey");
+    }
+
+    [Fact]
+    public void endpoint_should_not_produce_status_code_200()
+    {
+        var endpoint = EndpointFor("/publish/message1");
+        
+        // Status-code 202 should be added in the PublishingEndpoint
+        endpoint.Metadata.FirstOrDefault(x => x is IProducesResponseTypeMetadata m && m.StatusCode == 202).ShouldNotBeNull();
+        
+        // And status-code 200 is removed
+        endpoint.Metadata.FirstOrDefault(x => x is IProducesResponseTypeMetadata m && m.StatusCode == 200).ShouldBeNull();
     }
 }

--- a/src/Http/Wolverine.Http/HttpChain.EndpointBuilder.cs
+++ b/src/Http/Wolverine.Http/HttpChain.EndpointBuilder.cs
@@ -16,6 +16,7 @@ namespace Wolverine.Http;
 public partial class HttpChain : IEndpointConventionBuilder
 {
     private readonly List<Action<EndpointBuilder>> _builderConfigurations = new();
+    private readonly List<Action<EndpointBuilder>> _finallyBuilderConfigurations = new();
 
     /// <summary>
     /// Configure ASP.Net Core endpoint metadata
@@ -26,6 +27,11 @@ public partial class HttpChain : IEndpointConventionBuilder
     public void Add(Action<EndpointBuilder> convention)
     {
         _builderConfigurations.Add(convention);
+    }
+
+    public void Finally(Action<EndpointBuilder> finallyConvention)
+    {
+        _finallyBuilderConfigurations.Add(finallyConvention);
     }
 
     private bool tryApplyAsEndpointMetadataProvider(Type? type, RouteEndpointBuilder builder)
@@ -56,6 +62,7 @@ public partial class HttpChain : IEndpointConventionBuilder
 
         establishResourceTypeMetadata(builder);
         foreach (var configuration in _builderConfigurations) configuration(builder);
+        foreach (var finallyConfiguration in _finallyBuilderConfigurations) finallyConfiguration(builder);
 
         foreach (var parameter in Method.Method.GetParameters())
         {

--- a/src/Http/Wolverine.Http/Runtime/PublishingEndpoint.cs
+++ b/src/Http/Wolverine.Http/Runtime/PublishingEndpoint.cs
@@ -20,8 +20,13 @@ public class PublishingEndpoint<T>
         // a request directly to a Wolverine messaging endpoint for later processing
         chain.Metadata.Add(builder =>
         {
-            // Adding and modifying data
+            // Adding metadata
             builder.Metadata.Add(new WolverineProducesResponseTypeMetadata { StatusCode = 202, Type = null });
+        });
+        // This is run after all other metadata has been applied, even after the wolverine built-in metadata
+        // So use this if you want to change or remove some metadata
+        chain.Metadata.Finally(builder =>
+        {
             builder.RemoveStatusCodeResponse(200);
         });
     }


### PR DESCRIPTION
During testing, the `PublishingEndpoints` still displayed the OpenAPI documentation for status-code 200, although it should have been removed in `PublishingEndpoint<T>.Configure`.

The issue seems to come from the timing of the `Configure` method; it is called before the Wolverine default metadata is added  to the builder.

Specifically, `Configure` is executed within the `HttpChain` constructor in `applyAttributesAndConfigureMethods`.
However, the default metadata is added later during endpoint construction in `establishResourceTypeMetadata`. 
Because of that, it's not possible to remove status-codes 200 or 404 in the `Configure` method because they are added afterward.

It seems that the ASP.NET Core team ran into the same problem and introduced a `IEndpointConventionBuilder.Finally` method in .NET 7 that allows metadata modifications after the standard processing.

This pull request implements this `Finally` method, and fixes the `PublishingEndpoint` class to correctly remove status-code 200.

This also allows users to remove status-code 404 if they want to.