### PR TITLE
Docs: Remove method injection of bus in constructor injection example

### DIFF
--- a/docs/tutorials/best-practices.md
+++ b/docs/tutorials/best-practices.md
@@ -136,7 +136,7 @@ public class MyMessageHandler
         _messageBus = messageBus;
     }
     
-    public async Task HandleAsync(MyMessage message, IMessageBus messageBus)
+    public async Task HandleAsync(MyMessage message)
     {
          // handle the message..;
     }


### PR DESCRIPTION
This extra instance of IMessageBus feels like an oversight since it would lead to `_messageBus` and `messageBus` being available in the `HandleAsync` method.