### PR TITLE
Fixed PollForScheduledMessages in SqlServerMssageStore

### DIFF
--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -221,7 +221,7 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>
                 var reassign = conn.CreateCommand($"{_settings.SchemaName}.uspMarkIncomingOwnership", tx);
                 reassign.CommandType = CommandType.StoredProcedure;
         
-                await cmd
+                await reassign
                     .WithIdList(this, envelopes)
                     .With("owner", durabilitySettings.AssignedNodeNumber)
                     .ExecuteNonQueryAsync(_cancellation);


### PR DESCRIPTION
Hi,
There is a execution of wrong command in `PollForScheduledMessagesAsync` method.

Could you help me with test?  
It seems that instead of call `PollForScheduledMessagesAsync` I should wait when durability agent execute it in background.
I didn't figure out how to do it in a proper way.

