### PR TITLE
Fix otlp docs

### DIFF
--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -209,18 +209,19 @@ code sample:
 <a id='snippet-sample_enabling_open_telemetry'></a>
 ```cs
 // builder.Services is an IServiceCollection object
-builder.Services.AddOpenTelemetryTracing(x =>
-{
-    x.SetResourceBuilder(ResourceBuilder
-            .CreateDefault()
-            .AddService("OtelWebApi")) // <-- sets service name
-        .AddJaegerExporter()
-        .AddAspNetCoreInstrumentation()
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resources => resources.AddService("OtelWebApi")) // <-- sets service name
+    .WithTracing(tracing =>
+    {
+        tracing
+            .AddOtlpExporter() // <-- Add otlp exporter that by default outputs to the Jaeger default port
+            .AddAspNetCoreInstrumentation()
+            
+            // This is absolutely necessary to collect the Wolverine
+            // open telemetry tracing information in your application
+            .AddSource("Wolverine");
+    });
 
-        // This is absolutely necessary to collect the Wolverine
-        // open telemetry tracing information in your application
-        .AddSource("Wolverine");
-});
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/OpenTelemetry/OtelWebApi/Program.cs#L36-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_open_telemetry' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->


### PR DESCRIPTION
Fixes a this section in the docs about setting up Open Telemetry https://wolverine.netlify.app/guide/logging.html#open-telemetry It used an outdated version of .NET OpenTelemetry packages that has the deprecated `AddOpenTelemetryTracing` method that was removed in version 1.4.0 https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md#140