### PR TITLE
add customize envelop method to local queue configuration

### DIFF
--- a/src/Wolverine/Transports/Local/LocalQueueConfiguration.cs
+++ b/src/Wolverine/Transports/Local/LocalQueueConfiguration.cs
@@ -41,4 +41,11 @@ public class LocalQueueConfiguration : ListenerConfiguration<LocalQueueConfigura
 
         return this;
     }
+
+    public LocalQueueConfiguration CustomizeOutgoing(Action<Envelope> customize)
+    {
+        add(e => e.OutgoingRules.Add(new LambdaEnvelopeRule(customize)));
+
+        return this;
+    }
 }


### PR DESCRIPTION
We require global (or at least endpoint-level) customization of envelope headers to pass some context data. For ASB transport there's `CustomizeOutgoing`, but there's non for local transport (which we use when running services locally during the development). 

This PR adds `CustomizeOutgoing` methods to local queue configuration 