### PR TITLE
Update AWS SQS FIFO queue to allow for setting MessageGroupId and Mes…

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -167,7 +167,15 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue
 
         var body = _mapper.BuildMessageBody(envelope);
         var request = new SendMessageRequest(QueueUrl, body);
-        
+        if (envelope.GroupId.IsNotEmpty())
+        {
+            request.MessageGroupId = envelope.GroupId;
+        }
+        if (envelope.DeduplicationId.IsNotEmpty())
+        {
+            request.MessageDeduplicationId = envelope.DeduplicationId;
+        }
+
         foreach (var attribute in _mapper.ToAttributes(envelope))
             request.MessageAttributes.Add(attribute.Key, attribute.Value);
 

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSenderProtocol.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSenderProtocol.cs
@@ -1,6 +1,7 @@
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using Microsoft.Extensions.Logging;
+using JasperFx.Core;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Serialization;
 using Wolverine.Transports;
@@ -53,7 +54,15 @@ internal class OutgoingSqsBatch
             try
             {
                 var entry = new SendMessageBatchRequestEntry(envelope.Id.ToString(), queue.Mapper.BuildMessageBody(envelope));
-
+                if (envelope.GroupId.IsNotEmpty())
+                {
+                    entry.MessageGroupId = envelope.GroupId;
+                }
+                if (envelope.DeduplicationId.IsNotEmpty())
+                {
+                    entry.MessageDeduplicationId = envelope.DeduplicationId;
+                }
+				
                 entries.Add(entry);
                 _envelopes.Add(entry.Id, envelope);
             }

--- a/src/Wolverine/DeliveryOptions.cs
+++ b/src/Wolverine/DeliveryOptions.cs
@@ -125,14 +125,24 @@ public class DeliveryOptions
         if (GroupId.IsNotEmpty())
         {
             envelope.GroupId = GroupId;
+        }        
+        
+        if (DeduplicationId.IsNotEmpty())
+        {
+            envelope.DeduplicationId = DeduplicationId;
         }
     }
-    
+
     /// <summary>
     /// Application defined message group identifier. Part of AMQP 1.0 spec as the "group-id" property. Session identifier
-    /// for Azure Service Bus
+    /// for Azure Service Bus. MessageGroupId for Amazon SQS FIFO Queue
     /// </summary>
     public string? GroupId { get; set; }
+
+    /// <summary>
+    /// MessageDeduplicationId for Amazon SQS FIFO Queue
+    /// </summary>
+    public string? DeduplicationId { get; set; }
 
     /// <summary>
     ///     Add a header key/value pair to the outgoing message

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -240,9 +240,14 @@ public partial class Envelope
     
     /// <summary>
     /// Application defined message group identifier. Part of AMQP 1.0 spec as the "group-id" property. Session identifier
-    /// for Azure Service Bus
+    /// for Azure Service Bus.  MessageGroupId for Amazon SQS FIFO Queue
     /// </summary>
     public string? GroupId { get; set; }
+
+    /// <summary>
+    /// MessageDeduplicationId for Amazon SQS FIFO Queue
+    /// </summary>
+    public string? DeduplicationId { get; set; }
 
     /// <summary>
     ///     Schedule this envelope to be sent or executed


### PR DESCRIPTION
Update AWS SQS FIFO queue to allow for setting MessageGroupId and MessageDeduplicationId.  MessageGroupId is required for SQS FIFO queue objects.