### PR TITLE
Update event-sourcing.md (nuke unnecessary code + grammatical touch-ups)

### DIFF
--- a/docs/guide/durability/marten/event-sourcing.md
+++ b/docs/guide/durability/marten/event-sourcing.md
@@ -161,10 +161,6 @@ public static IEnumerable<object> Handle(MarkItemReady command, Order order)
 {
     if (order.Items.TryGetValue(command.ItemName, out var item))
     {
-        // Not doing this in a purist way here, but just
-        // trying to illustrate the Wolverine mechanics
-        item.Ready = true;
-
         // Mark that this item is ready
         yield return new ItemReady(command.ItemName);
     }


### PR DESCRIPTION
1. unnecessary/misleading `item.Ready = true;`
2. some light Grammarly touch-ups

Hi,

I was reading the doc, and a few things stood out to me (and to Grammarly as soon as I started editing the file).

Thanks a lot for your great OSS!