### PR TITLE
Expand on Audited Members

### DIFF
--- a/src/Http/Wolverine.Http/Logging/LoggingPolicies.cs
+++ b/src/Http/Wolverine.Http/Logging/LoggingPolicies.cs
@@ -1,0 +1,39 @@
+
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using Lamar;
+using Wolverine.Configuration;
+using Wolverine.Logging;
+
+namespace Wolverine.Http.Logging;
+
+public class AuditLoggingPolicy : IHttpPolicy
+{
+    public void Apply(IReadOnlyList<HttpChain> chains, GenerationRules rules, IContainer container)
+        => new Wolverine.Logging.AuditLoggingPolicy().Apply(chains, rules, container);
+}
+
+public class AddConstantsToLoggingContextPolicy<TMessage> : IHttpPolicy
+{
+    readonly (string, object)[] _loggingConstants;
+
+    public AddConstantsToLoggingContextPolicy(params (string, object)[] loggingConstants)
+    {
+        _loggingConstants = loggingConstants;
+    }
+    public void Apply(IReadOnlyList<HttpChain> chains, GenerationRules rules, IContainer container)
+        => new Wolverine.Logging.AddConstantsToLoggingContextPolicy<TMessage>(_loggingConstants).Apply(chains, rules, container);
+}
+
+public static class WolverineHttpOptionsExtensions
+{
+    public static void AddLoggingConstantsFor<TMessage>(this WolverineHttpOptions options, params (string, object)[] kvp)
+    {
+        options.Policies.Add(new AddConstantsToLoggingContextPolicy<TMessage>(kvp));
+    }
+
+    public static void AddAuditLogging(this WolverineHttpOptions options, params (string, object)[] kvp)
+    {
+        options.Policies.Add(new AuditLoggingPolicy());
+    }
+}

--- a/src/Testing/CoreTests/Compilation/handler_with_logged_audit_members.cs
+++ b/src/Testing/CoreTests/Compilation/handler_with_logged_audit_members.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TestingSupport;
+using Wolverine.Attributes;
+using Wolverine.Logging;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreTests.Compilation;
+
+public class handler_with_logged_audit_members
+{
+    private readonly ITestOutputHelper _output;
+
+    public handler_with_logged_audit_members(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task can_compile()
+    {
+        using var host = await WolverineHost.ForAsync(o => o.AddAuditLogging());
+
+        var bus = host.Services.GetRequiredService<IMessageBus>();
+        await bus.InvokeAsync(new SomeMessage());
+
+        var graph = host.Services.GetRequiredService<HandlerGraph>();
+        var chain = graph.ChainFor<SomeMessage>();
+        
+        _output.WriteLine(chain.SourceCode);
+    }
+}
+
+public class SomeMessage
+{
+    [Audit]public Guid Id { get; set; } = Guid.NewGuid();
+    [Audit]public string SomeString { get; set; } = "test";
+}
+
+public class SomeMessageHandler
+{
+    public void Handle(SomeMessage itemCreated, ILogger logger)
+    {
+        logger.LogInformation("Some message id {Id}", itemCreated.Id);
+    }
+}

--- a/src/Wolverine/Configuration/Chain.cs
+++ b/src/Wolverine/Configuration/Chain.cs
@@ -62,8 +62,7 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
     /// <param name="heading"></param>
     public void Audit(MemberInfo member, string? heading = null)
     {
-        AuditedMembers.Add(new AuditedMember(member, heading ?? member.Name,
-            member.Name.SplitPascalCase().Replace(" ", ".").ToLowerInvariant()));
+        AuditedMembers.Add(AuditedMember.Create(member, heading));
     }
 
     private bool isConfigureMethod(MethodInfo method)
@@ -85,20 +84,9 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
 
     protected void applyAuditAttributes(Type type)
     {
-        foreach (var property in type.GetProperties())
+        foreach (var auditedMember in AuditedMember.GetAllFromType(type))
         {
-            if (property.TryGetAttribute<AuditAttribute>(out var ratt))
-            {
-                Audit(property, ratt.Heading);
-            }
-        }
-
-        foreach (var field in type.GetFields())
-        {
-            if (field.TryGetAttribute<AuditAttribute>(out var ratt))
-            {
-                Audit(field, ratt.Heading);
-            }
+            AuditedMembers.Add(auditedMember);
         }
     }
     

--- a/src/Wolverine/Logging/AuditedMember.cs
+++ b/src/Wolverine/Logging/AuditedMember.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using JasperFx.Core.Reflection;
+using Wolverine.Attributes;
 
 namespace Wolverine.Logging;
 
@@ -8,4 +10,28 @@ namespace Wolverine.Logging;
 /// </summary>
 /// <param name="Member"></param>
 /// <param name="OpenTelemetryName"></param>
-public record AuditedMember(MemberInfo Member, string MemberName, string OpenTelemetryName);
+public record AuditedMember(MemberInfo Member, string MemberName, string OpenTelemetryName)
+{
+    public static IEnumerable<AuditedMember> GetAllFromType(Type type)
+    {
+        foreach (var property in type.GetProperties())
+        {
+            if (property.TryGetAttribute<AuditAttribute>(out var att))
+            {
+                yield return Create(property, att.Heading);
+            }
+        }
+
+        foreach (var field in type.GetFields())
+        {
+            if (field.TryGetAttribute<AuditAttribute>(out var att))
+            {
+                yield return Create(field, att.Heading);
+            }
+        }
+    }
+    public static AuditedMember Create(MemberInfo member, string? heading) => new(
+            member,
+            heading ?? member.Name,
+            member.Name.ToTelemetryFriendly());
+}

--- a/src/Wolverine/Logging/LoggerBeginScopeWithAuditFrame.cs
+++ b/src/Wolverine/Logging/LoggerBeginScopeWithAuditFrame.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Lamar;
+using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
+
+namespace Wolverine.Logging;
+
+public abstract class LoggerBeginScopeWithAuditBaseFrame : SyncFrame
+{
+    private readonly Type? _inputType;
+    private readonly List<Variable> _loggers = [];
+    private readonly IEnumerable<Type> _loggerTypes;
+
+    protected LoggerBeginScopeWithAuditBaseFrame(IChain chain, IContainer container, IReadOnlyList<AuditedMember> auditedMembers, Variable? auditedVariable)
+    {
+        _loggerTypes = chain.ServiceDependencies(container, Type.EmptyTypes).Where(type => type.CanBeCastTo<ILogger>());
+        AuditedMembers = auditedMembers;
+        _inputType = chain.InputType()!;
+        AuditedVariable = auditedVariable;
+    }
+
+    protected Variable? AuditedVariable;
+    protected Variable? LoggingContext;
+    protected readonly IReadOnlyList<AuditedMember> AuditedMembers;
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        foreach (var loggerType in _loggerTypes)
+        {
+            var logger = chain.FindVariable(loggerType);
+            _loggers.Add(logger);
+            yield return logger;
+        }
+        LoggingContext = chain.FindVariable(typeof(LoggingContext));
+        if (AuditedVariable is not null || _inputType is null)
+        {
+            yield break;
+        }
+        AuditedVariable = chain.FindVariable(_inputType);
+        yield return AuditedVariable;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (AuditedMembers.Count > 0 && _loggers.Count > 0 && AuditedVariable is not null)
+        {
+            writer.WriteComment("Adding audited members to log context");
+            writer.Write($"{LoggingContext!.Usage}.{nameof(Logging.LoggingContext.AddRange)}({string.Join(", ", AuditedMembers.Select(member => $"(\"{member.MemberName}\", {AuditedVariable!.Usage}.{member.Member.Name})"))});");
+            writer.WriteComment("Beginning logging scopes for new context");
+            foreach (var logger in _loggers)
+            {
+                writer.Write(
+                    $"using var {createRandomVariable("disposable")} = {logger.Usage}.{nameof(ILogger.BeginScope)}({LoggingContext!.Usage});");
+            }
+        }
+        GenerateAdditionalCode(method, writer, _loggers);
+        Next?.GenerateCode(method, writer);
+    }
+
+    protected virtual void GenerateAdditionalCode(GeneratedMethod method, ISourceWriter writer, IEnumerable<Variable> loggerVariables)
+    {
+    }
+    static string createRandomVariable(string prefix) => $"{prefix}_{Guid.NewGuid().ToString().Replace('-', '_')}";
+}
+
+public class LoggerBeginScopeWithAuditFrame : LoggerBeginScopeWithAuditBaseFrame
+{
+    public LoggerBeginScopeWithAuditFrame(IChain chain, IContainer container)
+        : base(chain, container, chain.AuditedMembers.AsReadOnly(), null)
+    {
+    }
+}
+
+public class LoggerBeginScopeWithAuditForAggregateFrame : LoggerBeginScopeWithAuditBaseFrame
+{
+    public LoggerBeginScopeWithAuditForAggregateFrame(IChain chain, IContainer container, IReadOnlyList<AuditedMember> members, Variable variable)
+        : base(chain, container, members, variable)
+    {
+    }
+
+    protected override void GenerateAdditionalCode(GeneratedMethod method, ISourceWriter writer, IEnumerable<Variable> loggerVariables)
+    {
+        if (AuditedMembers.Count == 0)
+        {
+            return;
+        }
+        writer.WriteComment("Application-specific Open Telemetry auditing");
+        foreach (var member in AuditedMembers)
+        {
+            writer.WriteLine(
+                $"{typeof(Activity).FullNameInCode()}.{nameof(Activity.Current)}?.{nameof(Activity.SetTag)}(\"{member.OpenTelemetryName}\", {AuditedVariable!.Usage}.{member.Member.Name});");
+        }
+    }
+}

--- a/src/Wolverine/Logging/LoggingContext.cs
+++ b/src/Wolverine/Logging/LoggingContext.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Wolverine.Configuration;
+
+namespace Wolverine.Logging;
+
+public class LoggingContext : Dictionary<string, object>
+{
+    public void AddRange(params (string, object)[] kvp)
+    {
+        foreach (var (key, value) in kvp)
+        {
+            TryAdd(key, value);
+        }
+    }
+}
+
+public class LoggingContextFrame : SyncFrame
+{
+    private readonly Variable _loggingContext;
+    public LoggingContextFrame()
+    {
+        _loggingContext = Create<LoggingContext>("wolverineLoggingContext_loggingTools");
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        yield return _loggingContext;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write($"var {_loggingContext.Usage} = new {typeof(LoggingContext).FullName}();");
+        Next?.GenerateCode(method, writer);
+    }
+}
+
+public class AddConstantsToLoggingContextFrame : SyncFrame
+{
+    private readonly (string, object)[] _loggingConstants;
+    private Variable _loggingContext;
+    public AddConstantsToLoggingContextFrame(params (string, object)[] loggingConstants)
+    {
+        if (loggingConstants.Any(x => x.Item2 is not string && !x.Item2.GetType().IsNumeric()))
+        {
+            throw new ArgumentException("One or more of the constants provided is not a string or a numeric type", nameof(loggingConstants));
+        }
+        _loggingConstants = loggingConstants;
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _loggingContext = chain.FindVariable(typeof(LoggingContext));
+        yield break;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write($"{_loggingContext!.Usage}.{nameof(LoggingContext.AddRange)}({string.Join(", ", _loggingConstants.Select(kvp => $"(\"{kvp.Item1}\", {GetValue(kvp.Item2)})"))});");
+        foreach (var (key, value) in _loggingConstants)
+        {
+            writer.WriteLine(
+                $"{typeof(Activity).FullNameInCode()}.{nameof(Activity.Current)}?.{nameof(Activity.SetTag)}(\"{key.ToTelemetryFriendly()}\", {GetValue(value)});");
+        }
+        Next?.GenerateCode(method, writer);
+        return;
+
+        static string GetValue(object o) => o is string ? $"\"{o}\"" : o.ToString()!;
+    }
+}
+
+internal static class Extensions
+{
+    public static void AddMiddlewareAfterLoggingContextFrame(this IChain chain, params Frame[] frames)
+    {
+        var frameIndex = chain.Middleware.FindIndex(f => f is LoggingContextFrame);
+        if (frameIndex == -1)
+        {
+            frameIndex = 0;
+            chain.Middleware.Insert(frameIndex, new LoggingContextFrame());
+        }
+        chain.Middleware.InsertRange(frameIndex + 1, frames);
+    }
+}

--- a/src/Wolverine/Logging/LoggingPolicies.cs
+++ b/src/Wolverine/Logging/LoggingPolicies.cs
@@ -1,0 +1,54 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using Lamar;
+using Wolverine.Configuration;
+
+namespace Wolverine.Logging;
+
+public class AuditLoggingPolicy : IChainPolicy
+{
+    public void Apply(IReadOnlyList<IChain> chains, GenerationRules rules, IContainer container)
+    {
+        foreach (var chain in chains)
+        {
+            List<Frame> frames = [];
+            if (!chain.AuditedMembers.Exists(member => member.MemberName.Equals(TenantIdLogContextFrame.TenantIdContextName))
+                && !chain.Middleware.Exists(frame => frame is TenantIdLogContextFrame))
+            {
+                frames.Add(new TenantIdLogContextFrame());
+            }
+            frames.Add(new LoggerBeginScopeWithAuditFrame(chain, container));
+            chain.AddMiddlewareAfterLoggingContextFrame(frames.ToArray());
+        }
+    }
+}
+
+public class AddConstantsToLoggingContextPolicy<TMessage> : IChainPolicy
+{
+    private readonly (string, object)[] _loggingConstants;
+
+    public AddConstantsToLoggingContextPolicy(params (string, object)[] loggingConstants)
+    {
+        _loggingConstants = loggingConstants;
+    }
+    public void Apply(IReadOnlyList<IChain> chains, GenerationRules rules, IContainer container)
+    {
+        foreach (var chain in chains.Where(chain => typeof(TMessage).IsAssignableFrom(chain.InputType())))
+        {
+            chain.AddMiddlewareAfterLoggingContextFrame(new AddConstantsToLoggingContextFrame(_loggingConstants));
+        }
+    }
+}
+
+public static class WolverineOptionsExtensions
+{
+    public static void AddLoggingConstantsFor<TMessage>(this WolverineOptions options, params (string, object)[] kvp)
+    {
+        options.Policies.Add(new AddConstantsToLoggingContextPolicy<TMessage>(kvp));
+    }
+
+    public static void AddAuditLogging(this WolverineOptions options, params (string, object)[] kvp)
+    {
+        options.Policies.Add(new AuditLoggingPolicy());
+    }
+}

--- a/src/Wolverine/Logging/StringExtensions.cs
+++ b/src/Wolverine/Logging/StringExtensions.cs
@@ -1,0 +1,8 @@
+using JasperFx.Core;
+
+namespace Wolverine.Logging;
+
+internal static class StringExtensions
+{
+    internal static string ToTelemetryFriendly(this string s) => s.SplitPascalCase().Replace(' ', '.').ToLowerInvariant();
+}

--- a/src/Wolverine/Logging/TenantIdLogContextFrame.cs
+++ b/src/Wolverine/Logging/TenantIdLogContextFrame.cs
@@ -1,0 +1,26 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using Wolverine.Runtime;
+
+namespace Wolverine.Logging;
+
+public class TenantIdLogContextFrame : SyncFrame
+{
+    public const string TenantIdContextName = "TenantId";
+    private Variable _messageContext = null!;
+    private Variable _loggingContext = null!;
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _messageContext = chain.FindVariable(typeof(MessageContext));
+        yield return _messageContext;
+        _loggingContext = chain.FindVariable(typeof(LoggingContext));
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write($"{_loggingContext.Usage}.{nameof(LoggingContext.Add)}(\"{TenantIdContextName}\", {_messageContext.Usage}.{nameof(MessageContext.TenantId)} ?? \"[NotSet]\");");
+        Next?.GenerateCode(method, writer);
+    }
+}


### PR DESCRIPTION
Audit members are now also added as structured logging context to the Microsoft ILogger in message handler chain if any Audited members are present in the Chain AuditedMembers list or if the Aggregate Type has any Auditted members.