### PR TITLE
Add support for Azure ServiceBus subscription filter

### DIFF
--- a/docs/guide/messaging/transports/azureservicebus/topics.md
+++ b/docs/guide/messaging/transports/azureservicebus/topics.md
@@ -47,5 +47,24 @@ that work, Wolverine tries to build out a queue called `wolverine.response.[Your
 requeues from subscription listening. If your Wolverine application doesn't have permissions to create queues at runtime,
 you may want to build that queue manually or forgo using "Requeue" as an error handling technique.
 
+## Topic Filters
 
+If Wolverine is provisioning the subscriptions for you, you can customize the subscription filter being created.
 
+<!-- snippet: sample_configuring_azure_service_bus_subscription_filter -->
+<a id='snippet-sample_configuring_azure_service_bus_subscription_filter'></a>
+```cs
+opts.ListenToAzureServiceBusSubscription(
+    "subscription1",
+    configureSubscriptionRule: rule =>
+    {
+        rule.Filter = new SqlRuleFilter("NOT EXISTS(user.ignore) OR user.ignore NOT LIKE 'true'");
+    })
+    .FromTopic("topic1");
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L166-L174' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_azure_service_bus_subscription_filter' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The default filter if not customized is a simple `1=1` (always true) filter.
+
+For more information regarding subscription filters, see the [Azure Service Bus documentation](https://learn.microsoft.com/en-us/azure/service-bus-messaging/topic-filters).

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/send_and_receive_with_topics_and_subscriptions_with_custom_rule.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/send_and_receive_with_topics_and_subscriptions_with_custom_rule.cs
@@ -1,0 +1,66 @@
+using Azure.Messaging.ServiceBus.Administration;
+using Shouldly;
+using TestingSupport.Compliance;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+public class TopicsWithCustomRuleComplianceFixture()
+    : TransportComplianceFixture(new Uri("asb://topic/topic1"), 120), IAsyncLifetime
+{
+    public async Task InitializeAsync()
+    {
+        await SenderIs(opts =>
+        {
+            opts.UseAzureServiceBusTesting()
+                .AutoProvision();
+        });
+
+        await ReceiverIs(opts =>
+        {
+            opts.UseAzureServiceBusTesting()
+                .AutoProvision();
+
+            opts.ListenToAzureServiceBusSubscription(
+                    "subscription1", 
+                    configureSubscriptionRule: rule =>
+                    {
+                        rule.Filter = new SqlRuleFilter("NOT EXISTS(user.ignore) OR user.ignore NOT LIKE 'true'");
+                    })
+                .FromTopic("topic1");
+        });
+    }
+
+    public Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+}
+
+[Collection("acceptance")]
+public class TopicAndSubscriptionWithCustomRuleSendingAndReceivingCompliance : TransportCompliance<TopicsWithCustomRuleComplianceFixture>
+{
+    [Fact]
+    public async Task ignores_message_not_matching_the_filter()
+    {
+        /*
+         * Please note that this test may take a while to run,
+         * as it will wait for a message to be processed by the receiver
+         * but there should none be incoming because of the subscription
+         * filter.
+         */
+
+        var session = await theSender.TrackActivity(Fixture.DefaultTimeout)
+            .AlsoTrack(theReceiver)
+            .DoNotAssertOnExceptionsDetected()
+            .ExecuteAndWaitAsync(
+                c => c.EndpointFor(theOutboundAddress).SendAsync(
+                    new Message1(),
+                    new DeliveryOptions()
+                        .WithHeader("ignore", "true")));
+        
+        var record = session.FindEnvelopesWithMessageType<Message1>(MessageEventType.MessageSucceeded).SingleOrDefault();
+        record.ShouldBeNull();
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusSubscriptionListenerConfiguration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusSubscriptionListenerConfiguration.cs
@@ -39,6 +39,18 @@ public class AzureServiceBusSubscriptionListenerConfiguration : ListenerConfigur
         add(e => configure(e.Options));
         return this;
     }
+
+    /// <summary>
+    ///     Configure the underlying Azure Service Bus Subscription rule. This is only applicable when
+    ///     Wolverine is creating the Subscription.
+    /// </summary>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public AzureServiceBusSubscriptionListenerConfiguration ConfigureSubscriptionRule(Action<CreateRuleOptions> configure)
+    {
+        add(e => configure(e.RuleOptions));
+        return this;
+    }
     
     /// <summary>
     ///     Configure the underlying Azure Service Bus Subscription. This is only applicable when

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AsyncPageableExtensions.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AsyncPageableExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Azure;
+
+namespace Wolverine.AzureServiceBus.Internal;
+
+internal static class AsyncPageableExtensions
+{
+    public static async ValueTask<List<T>> ToListAsync<T>(this AsyncPageable<T> source)
+        where T : notnull
+    {
+        var list = new List<T>();
+
+        await foreach (var item in source)
+        {
+            list.Add(item);
+        }
+
+        return list;
+    }
+}


### PR DESCRIPTION
This pull request adds support for subscription filter when using Azure ServiceBus transport.

When configuring to listen to a Azure ServiceBus subscription it's now possible to customize the filter
```
opts.ListenToAzureServiceBusSubscription(
    "<subscriptionName>",
    configureSubscriptionRule: rule =>
    {
        rule.Filter = new SqlRuleFilter("NOT EXISTS(user.ignore) OR user.ignore NOT LIKE 'true'");
    })
    .FromTopic("<topicName>");
```
If you don't customize a rule, the same default `1=1` filter rule is created as before.

For more information regarding subscription filters see https://learn.microsoft.com/en-us/azure/service-bus-messaging/topic-filters

Please note, the filter rule is only created if Wolverine creates the subscription (`AutoProvision = true`) and any other configured filter rule will be deleted so that the subscription matches the configuration.

Resolves #574