### PR TITLE
Fix some usages of HttpChain.RequestType after filling it with System.Void as default value

### DIFF
--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -174,7 +174,7 @@ public partial class HttpChain
 
     private void fillRequestType(ApiDescription apiDescription)
     {
-        if (RequestType != null)
+        if (HasRequestType)
         {
             var parameterDescription = new ApiParameterDescription
             {

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -250,7 +250,7 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
     public override Type? InputType()
     {
-        return RequestType;
+        return HasRequestType ? RequestType : null;
     }
 
     public override string ToString()
@@ -279,7 +279,7 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
             .WithMetadata(new HttpMethodMetadata(_httpMethods));
             //.WithMetadata(Method.Method);
 
-        if (RequestType != null)
+        if (HasRequestType)
         {
             Metadata.Accepts(RequestType, false, "application/json");
         }
@@ -434,5 +434,7 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
     string IEndpointSummaryMetadata.Summary => ToString();
 
     public List<ParameterInfo> FileParameters { get; } = [];
+    
+    [MemberNotNullWhen(true, nameof(RequestType))]
     public bool HasRequestType => RequestType != null && RequestType != typeof(void);
 }


### PR DESCRIPTION
I noticed that [this change](https://github.com/JasperFx/wolverine/blob/844cd97810a391b3cff882e27dbc8d2d680dfce5/src/Http/Wolverine.Http/HttpChain.cs#L178-L180) lead to some changes in the OpenAPI generation (see my change in `HttpChain.ApiDescription`).
It leads to endpoints without a request having a "made up" request with type `System.Void`, which in turn trips up Swashbuckle.

To me, it seems like that wasn't the intention with the `RequestType ??= typeof(void)` so I made these adjustments.

I also checked the other usages of the `RequestType` property and tried to adjust them if needed.