### PR TITLE
use char instead of string where possible

### DIFF
--- a/src/Http/Wolverine.Http/HttpChain.Codegen.cs
+++ b/src/Http/Wolverine.Http/HttpChain.Codegen.cs
@@ -146,6 +146,6 @@ public partial class HttpChain
     {
         var parts = RoutePattern.RawText.Replace("{", "").Replace("*", "").Replace("}", "").Split('/').Select(x => x.Split(':').First());
 
-        return _httpMethods.Select(x => x.ToUpper()).Concat(parts).Join("_").Replace("-", "_").Replace("__", "_");
+        return _httpMethods.Select(x => x.ToUpper()).Concat(parts).Join("_").Replace('-', '_').Replace("__", "_");
     }
 }

--- a/src/Testing/CoreTests/Transports/BrokerTransportTests.cs
+++ b/src/Testing/CoreTests/Transports/BrokerTransportTests.cs
@@ -48,7 +48,7 @@ public class FakeTransport : BrokerTransport<FakeEndpoint>
 
     public override string SanitizeIdentifier(string identifier)
     {
-        return identifier.Replace("#", ".");
+        return identifier.Replace('#', '.');
     }
 
     protected override IEnumerable<FakeEndpoint> endpoints()

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/conventional_listener_discovery.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/conventional_listener_discovery.cs
@@ -21,7 +21,7 @@ public class conventional_listener_discovery : ConventionalRoutingContext
                 return null; // should not be routed
             }
 
-            return t.ToMessageTypeName().Replace(".", "-");
+            return t.ToMessageTypeName().Replace('.', '-');
         }));
 
         AssertNoRoutes<PublishedMessage>();
@@ -80,7 +80,7 @@ public class conventional_listener_discovery : ConventionalRoutingContext
                 return null; // should not be routed
             }
 
-            return t.ToMessageTypeName().Replace(".", "-");
+            return t.ToMessageTypeName().Replace('.', '-');
         }));
 
         var uri = "sqs://routed".ToUri();

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
@@ -13,7 +13,7 @@ public class AmazonSqsTransport : BrokerTransport<AmazonSqsQueue>
 {
     public const string DeadLetterQueueName = "wolverine-dead-letter-queue";
 
-    public const string Separator = "-";
+    public const char Separator = '-';
 
     public AmazonSqsTransport() : base("sqs", "Amazon SQS")
     {
@@ -50,13 +50,13 @@ public class AmazonSqsTransport : BrokerTransport<AmazonSqsQueue>
             var prefix = identifier[..suffixIndex];
             var suffix = identifier[suffixIndex..];
 
-            prefix = prefix.Replace(".", Separator);
+            prefix = prefix.Replace('.', Separator);
 
             return prefix + suffix;
         }
 
         // ".fifo" suffix not found
-        return identifier.Replace(".", Separator);
+        return identifier.Replace('.', Separator);
     }
 
     public override string SanitizeIdentifier(string identifier)

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/conventional_listener_discovery.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/conventional_listener_discovery.cs
@@ -22,7 +22,7 @@ public class conventional_listener_discovery : ConventionalRoutingContext
                 return null; // should not be routed
             }
 
-            return t.ToMessageTypeName().Replace(".", "-");
+            return t.ToMessageTypeName().Replace('.', '-');
         }));
 
         AssertNoRoutes<PublishedMessage>();
@@ -81,7 +81,7 @@ public class conventional_listener_discovery : ConventionalRoutingContext
                 return null; // should not be routed
             }
 
-            return t.ToMessageTypeName().Replace(".", "-");
+            return t.ToMessageTypeName().Replace('.', '-');
         }));
 
         var uri = "sqs://routed".ToUri();

--- a/src/Wolverine/Configuration/Chain.cs
+++ b/src/Wolverine/Configuration/Chain.cs
@@ -63,7 +63,7 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
     public void Audit(MemberInfo member, string? heading = null)
     {
         AuditedMembers.Add(new AuditedMember(member, heading ?? member.Name,
-            member.Name.SplitPascalCase().Replace(" ", ".").ToLowerInvariant()));
+            member.Name.SplitPascalCase().Replace(' ', '.').ToLowerInvariant()));
     }
 
     private bool isConfigureMethod(MethodInfo method)

--- a/src/Wolverine/Tracking/Diagnostics.cs
+++ b/src/Wolverine/Tracking/Diagnostics.cs
@@ -54,7 +54,7 @@ internal class Grid<T>
             column.WriteLine(writer, item);
         }
 
-        writer.WriteLine("|");
+        writer.WriteLine('|');
     }
 
     private void writeHeaderRow(StringWriter writer)
@@ -64,8 +64,7 @@ internal class Grid<T>
             column.WriteHeader(writer);
         }
 
-        writer.Write("|");
-        writer.WriteLine();
+        writer.WriteLine('|');
     }
 
     private static void writeSolidLine(StringWriter writer, int totalWidth)

--- a/src/Wolverine/Transports/Local/LocalTransport.cs
+++ b/src/Wolverine/Transports/Local/LocalTransport.cs
@@ -15,7 +15,7 @@ internal class LocalTransport : TransportBase<LocalQueue>, ILocalMessageRoutingC
     private readonly Cache<string, LocalQueue> _queues;
 
     private Action<Type, IListenerConfiguration> _customization = (_, _) => { };
-    private Func<Type, string> _determineName = t => t.ToMessageTypeName().Replace("+", ".");
+    private Func<Type, string> _determineName = t => t.ToMessageTypeName().Replace('+', '.');
 
 
     public LocalTransport() : base(TransportConstants.Local, "Local (In Memory)")

--- a/src/Wolverine/Util/WolverineMessageNaming.cs
+++ b/src/Wolverine/Util/WolverineMessageNaming.cs
@@ -78,7 +78,7 @@ internal class FullTypeNaming : IMessageTypeNaming
             parts.Insert(0, messageType.DeclaringType!.Name);
         }
 
-        messageTypeName = string.Join("_", parts).Replace(",", "_");
+        messageTypeName = string.Join("_", parts).Replace(',', '_');
         return true;
     }
 }


### PR DESCRIPTION
this is very minor perf tweak. `String.Replace(String,String)` internally checks if both strings r 1 char, and then calls the char overload. so this just avoids that check.