### PR TITLE
Separates postgre transport and message storage schemas

### DIFF
--- a/src/Persistence/Wolverine.Marten/MartenIntegration.cs
+++ b/src/Persistence/Wolverine.Marten/MartenIntegration.cs
@@ -39,11 +39,13 @@ internal class MartenIntegration : IWolverineExtension, IEventForwarding
         options.Policies.ForwardHandledTypes(new EventWrapperForwarder());
 
         var transport = options.Transports.GetOrCreate<PostgresqlTransport>();
-        transport.SchemaName = TransportSchemaName;
+        transport.TransportSchemaName = TransportSchemaName;
+        transport.MessageStorageSchemaName = MessageStorageSchemaName;
     }
 
     internal MartenEventRouter EventRouter { get; } = new();
     public string TransportSchemaName { get; set; } = "wolverine_queues";
+    public string MessageStorageSchemaName { get; set; } = "public";
 
     EventForwardingTransform<T> IEventForwarding.SubscribeToEvent<T>()
     {

--- a/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
@@ -74,7 +74,8 @@ public static class WolverineOptionsMartenExtensions
 
         expression.Services.AddSingleton<IWolverineExtension>(new MartenIntegration
         {
-            TransportSchemaName = transportSchemaName ?? schemaName ?? "wolverine_queues"
+            TransportSchemaName = transportSchemaName ?? schemaName ?? "wolverine_queues",
+            MessageStorageSchemaName = schemaName ?? "public"
         });
 
         expression.Services.AddSingleton<OutboxedSessionFactory>();

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlConfigurationExtensions.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlConfigurationExtensions.cs
@@ -68,7 +68,8 @@ public static class PostgresqlConfigurationExtensions
     /// <returns></returns>
     public static PostgresqlPersistenceExpression UsePostgresqlPersistenceAndTransport(this WolverineOptions options,
         string connectionString,
-        string? schema = null)
+        string? schema = null,
+        string? transportSchema = null)
     {
         var extension = new PostgresqlBackedPersistence
         {
@@ -109,9 +110,15 @@ public static class PostgresqlConfigurationExtensions
         });
 
         var transport = options.Transports.GetOrCreate<PostgresqlTransport>();
+        
         if (schema.IsNotEmpty())
         {
-            transport.SchemaName = schema;
+            transport.TransportSchemaName = schema;
+            transport.MessageStorageSchemaName = schema;
+        }
+        if (transportSchema.IsNotEmpty())
+        {
+            transport.TransportSchemaName = transportSchema;
         }
 
         options.Transports.Add(transport);

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueueListener.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueueListener.cs
@@ -44,7 +44,7 @@ internal class PostgresqlQueueListener : IListener
 
         _queueTableName = _queue.QueueTable.Identifier.QualifiedName;
         _scheduledTableName = _queue.ScheduledTable.Identifier.QualifiedName;
-        _schemaName = _queue.Parent.SchemaName;
+        _schemaName = _queue.Parent.MessageStorageSchemaName;
 
         _tryPopMessagesDirectlySql = $@"
 WITH message AS (

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueueSender.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueueSender.cs
@@ -39,7 +39,7 @@ internal class PostgresqlQueueSender : IPostgresqlQueueSender
 
         Destination = PostgresqlQueue.ToUri(queue.Name, databaseName);
 
-        _schemaName = queue.Parent.SchemaName;
+        _schemaName = queue.Parent.TransportSchemaName;
         _moveFromOutgoingToQueueSql = $@"
 INSERT into {queue.QueueTable.Identifier} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.KeepUntil}) 
 SELECT {DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.DeliverBy} 

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
@@ -22,7 +22,12 @@ public class PostgresqlTransport : BrokerTransport<PostgresqlQueue>, ITransportC
     /// <summary>
     /// Schema name for the queue and scheduled message tables
     /// </summary>
-    public string SchemaName { get; set; } = "wolverine_queues";
+    public string TransportSchemaName { get; set; } = "wolverine_queues";
+    
+    /// <summary>
+    /// Schema name for the message storage tables
+    /// </summary>
+    public string MessageStorageSchemaName { get; set; } = "public";
 
     public async ValueTask ConfigureAsync(IWolverineRuntime runtime)
     {

--- a/src/Persistence/Wolverine.Postgresql/Transport/QueueTable.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/QueueTable.cs
@@ -7,7 +7,7 @@ namespace Wolverine.Postgresql.Transport;
 internal class QueueTable : Table
 {
     public QueueTable(PostgresqlTransport parent, string tableName) : base(
-        new DbObjectName(parent.SchemaName, tableName))
+        new DbObjectName(parent.TransportSchemaName, tableName))
     {
         AddColumn<Guid>(DatabaseConstants.Id).AsPrimaryKey();
         AddColumn(DatabaseConstants.Body, "bytea").NotNull();

--- a/src/Persistence/Wolverine.Postgresql/Transport/ScheduledMessageTable.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/ScheduledMessageTable.cs
@@ -7,7 +7,7 @@ namespace Wolverine.Postgresql.Transport;
 internal class ScheduledMessageTable : Table
 {
     public ScheduledMessageTable(PostgresqlTransport settings, string tableName) : base(
-        new DbObjectName(settings.SchemaName, tableName))
+        new DbObjectName(settings.TransportSchemaName, tableName))
     {
         AddColumn<Guid>(DatabaseConstants.Id).AsPrimaryKey();
         AddColumn(DatabaseConstants.Body, "bytea").NotNull();


### PR DESCRIPTION
The problem is better explained in the issue it fixes https://github.com/JasperFx/wolverine/issues/868 

But the solution i got was to store the transport and message storage schemas into 2 different fields. That way you are able to configure them separately via the wolverine integration. 

I also added an extra parameter to the use postgresql transport option to be able to configure it through that as well.

I would appreciate if anyone could double check the changes. 