### PR TITLE
Add optional RouteUrl parameter to Wolverine endpoint attributes

### DIFF
--- a/src/Http/Wolverine.Http.Tests/routename_applies_routenamemetadata_to_route.cs
+++ b/src/Http/Wolverine.Http.Tests/routename_applies_routenamemetadata_to_route.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Routing;
+using Shouldly;
+
+namespace Wolverine.Http.Tests;
+
+public class routename_applies_routenamemetadata_to_route : IntegrationContext
+{
+    public routename_applies_routenamemetadata_to_route(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public void routename_applies_routenamemetadata()
+    {
+        var chain = HttpChains.ChainFor("POST", "/named/route");
+        chain.Endpoint.Metadata.Any(m => m is RouteNameMetadata { RouteName: "NamedRoute"}).ShouldBeTrue();
+    }
+}

--- a/src/Http/Wolverine.Http/HttpChain.EndpointBuilder.cs
+++ b/src/Http/Wolverine.Http/HttpChain.EndpointBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.RuntimeCompiler;
 using Microsoft.AspNetCore.Builder;
@@ -77,6 +78,11 @@ public partial class HttpChain : IEndpointConventionBuilder
             {
                 builder.Metadata.Add(new ProducesProblemDetailsResponseTypeMetadata());
             }
+        }
+
+        if (RouteName.IsNotEmpty())
+        {
+            builder.Metadata.Add(new RouteNameMetadata(RouteName));
         }
 
         Endpoint = (RouteEndpoint?)builder.Build();

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -98,6 +98,11 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
                 DisplayName = att.Name;
             }
 
+            if (att.RouteName.IsNotEmpty())
+            {
+                RouteName = att.RouteName;
+            }
+
             if (att.OperationId.IsNotEmpty())
             {
                 OperationId = att.OperationId;
@@ -145,8 +150,10 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
     public MethodCall Method { get; }
 
-    public string? DisplayName { get; set; }
+    public string? RouteName { get; set; }
 
+    public string? DisplayName { get; set; }
+    
     public int Order { get; set; }
 
     public IEnumerable<string> HttpMethods => _httpMethods;

--- a/src/Http/Wolverine.Http/ModifyHttpChainAttribute.cs
+++ b/src/Http/Wolverine.Http/ModifyHttpChainAttribute.cs
@@ -46,14 +46,17 @@ public abstract class HttpChainParameterAttribute : Attribute
 [AttributeUsage(AttributeTargets.Method)]
 public abstract class WolverineHttpMethodAttribute : Attribute
 {
-    protected WolverineHttpMethodAttribute(string httpMethod, string template)
+    protected WolverineHttpMethodAttribute(string httpMethod, string template, string? routeName)
     {
         HttpMethod = httpMethod;
         Template = template;
+        RouteName = routeName;
     }
 
     public string HttpMethod { get; }
     public string Template { get; }
+    
+    public string? RouteName { get; }
 
     /// <summary>
     ///     Override the routing order of this method as necessary to disambiguate routes
@@ -112,7 +115,7 @@ public class RequiresTenantAttribute : ModifyHttpChainAttribute
 /// </summary>
 public class WolverineGetAttribute : WolverineHttpMethodAttribute
 {
-    public WolverineGetAttribute([StringSyntax("Route")]string template) : base("GET", template)
+    public WolverineGetAttribute([StringSyntax("Route")]string template, string? routeName = null) : base("GET", template, routeName)
     {
     }
 }
@@ -122,7 +125,7 @@ public class WolverineGetAttribute : WolverineHttpMethodAttribute
 /// </summary>
 public class WolverinePostAttribute : WolverineHttpMethodAttribute
 {
-    public WolverinePostAttribute([StringSyntax("Route")]string template) : base("POST", template)
+    public WolverinePostAttribute([StringSyntax("Route")]string template, string? routeName = null) : base("POST", template, routeName)
     {
     }
 }
@@ -132,7 +135,7 @@ public class WolverinePostAttribute : WolverineHttpMethodAttribute
 /// </summary>
 public class WolverinePutAttribute : WolverineHttpMethodAttribute
 {
-    public WolverinePutAttribute([StringSyntax("Route")]string template) : base("PUT", template)
+    public WolverinePutAttribute([StringSyntax("Route")]string template, string? routeName = null) : base("PUT", template, routeName)
     {
     }
 }
@@ -142,7 +145,7 @@ public class WolverinePutAttribute : WolverineHttpMethodAttribute
 /// </summary>
 public class WolverineHeadAttribute : WolverineHttpMethodAttribute
 {
-    public WolverineHeadAttribute([StringSyntax("Route")]string template) : base("HEAD", template)
+    public WolverineHeadAttribute([StringSyntax("Route")]string template, string? routeName = null) : base("HEAD", template, routeName)
     {
     }
 }
@@ -152,7 +155,7 @@ public class WolverineHeadAttribute : WolverineHttpMethodAttribute
 /// </summary>
 public class WolverineDeleteAttribute : WolverineHttpMethodAttribute
 {
-    public WolverineDeleteAttribute([StringSyntax("Route")]string template) : base("DELETE", template)
+    public WolverineDeleteAttribute([StringSyntax("Route")]string template, string? routeName = null) : base("DELETE", template, routeName)
     {
     }
 }
@@ -162,7 +165,7 @@ public class WolverineDeleteAttribute : WolverineHttpMethodAttribute
 /// </summary>
 public class WolverinePatchAttribute : WolverineHttpMethodAttribute
 {
-    public WolverinePatchAttribute([StringSyntax("Route")]string template) : base("PATCH", template)
+    public WolverinePatchAttribute([StringSyntax("Route")]string template, string? routeName = null) : base("PATCH", template, routeName)
     {
     }
 }
@@ -172,7 +175,7 @@ public class WolverinePatchAttribute : WolverineHttpMethodAttribute
 /// </summary>
 public class WolverineOptionsAttribute : WolverineHttpMethodAttribute
 {
-    public WolverineOptionsAttribute([StringSyntax("Route")]string template) : base("OPTIONS", template)
+    public WolverineOptionsAttribute([StringSyntax("Route")]string template, string? routeName = null) : base("OPTIONS", template, routeName)
     {
     }
 }

--- a/src/Http/WolverineWebApi/NamedRouteEndpoint.cs
+++ b/src/Http/WolverineWebApi/NamedRouteEndpoint.cs
@@ -1,0 +1,12 @@
+using Wolverine.Http;
+
+namespace WolverineWebApi;
+
+public class NamedRouteEndpoint
+{
+    [WolverinePost("/named/route", "NamedRoute")]
+    public string Post()
+    {
+        return "Hello";
+    } 
+}


### PR DESCRIPTION
This update adds an optional second parameter to all of the Wolverine* endpoint attributes which is used to add a RouteNameMetadata instance to the endpoint definition. This allows applications to find the route path by name through the use of the IUrlHelper.RouteUrl() method.