### PR TITLE
Tolerate trailing semicolon in RabbitMQ connection string

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Internals/ConnectionStringParserTests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Internals/ConnectionStringParserTests.cs
@@ -60,4 +60,15 @@ public class ConnectionStringParserTests
         ConnectionStringParser.Apply("virtualhost=weird", theFactory);
         theFactory.VirtualHost.ShouldBe("weird");
     }
+
+    [Theory]
+    [InlineData("host=foo;port=5673;")]
+    [InlineData("host=foo;port=5673")]
+    public void trailing_semicolon_is_optional(string connectionString)
+    {
+        ConnectionStringParser.Apply(connectionString, theFactory);
+        theFactory.HostName.ShouldBe("foo");
+        theFactory.Port.ShouldBe(5673);
+    }
+
 }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionStringParser.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionStringParser.cs
@@ -7,7 +7,7 @@ internal static class ConnectionStringParser
 {
     public static void Apply(string connectionString, ConnectionFactory factory)
     {
-        var values = connectionString.ToDelimitedArray(';');
+        var values = connectionString.ToDelimitedArray(';').Where(x => x.IsNotEmpty());
         foreach (var value in values)
         {
             var parts = value.ToDelimitedArray('=');


### PR DESCRIPTION
Usually, database connection strings contain a trailing semicolon after the last "key=value;" pair.

I'm proposing this change to respect the principle of least astonishment and keep RabbitMQ connection strings consistent with other connection strings in the application configuration. I spent some time today figuring out what's wrong; I hope it'll save other people's time in the future, too.

----

An alternative fix would be to change [JasperFx.CoreStringExtensions.ToDelimitedArray](https://github.com/JasperFx/JasperFx.Core/blob/561b4d972f6a8ca9b50b1130b6bef4386277f222/src/JasperFx.Core/StringExtensions.cs#L239) to use `StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries` as it doesn't seem that any usage in JasperFx repositories is interested in empty entries after splitting a delimited string. (See https://github.com/search?q=org%3AJasperFx+ToDelimitedArray&type=code)

Trimming entries won't be needed, too, on the [line 244](https://github.com/JasperFx/JasperFx.Core/blob/561b4d972f6a8ca9b50b1130b6bef4386277f222/src/JasperFx.Core/StringExtensions.cs#L244)

`array[i] = array[i].Trim();`

----

UPDATE: https://github.com/JasperFx/JasperFx.Core/pull/10