### PR TITLE
Set runtime agent cancellation source earlier to prevent unexpected errors on dispose

### DIFF
--- a/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
@@ -18,7 +18,7 @@ public partial class WolverineRuntime : IAgentRuntime
     private bool _agentsAreDisabled;
     private Task? _healthCheckLoop;
 
-    private CancellationTokenSource _agentCancellation;
+    private readonly CancellationTokenSource _agentCancellation;
 
     public NodeAgentController? NodeController { get; private set; }
 

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -43,8 +43,6 @@ public partial class WolverineRuntime
             Handlers.AddMessageHandler(typeof(IAgentCommand), new AgentCommandHandler(this));
             Storage.Initialize(this);
 
-            _agentCancellation = CancellationTokenSource.CreateLinkedTokenSource(Cancellation);
-
             // This MUST be done before the messaging transports are started up
             _hasStarted = true; // Have to do this before you can use MessageBus
             await startAgentsAsync();

--- a/src/Wolverine/Runtime/WolverineRuntime.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.cs
@@ -58,6 +58,7 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IHostedService
         _container = container;
 
         Cancellation = DurabilitySettings.Cancellation;
+        _agentCancellation = CancellationTokenSource.CreateLinkedTokenSource(Cancellation);
 
         Tracker = new WolverineTracker(Logger);
 


### PR DESCRIPTION
If you start a wolverine app with persistence configured, but the db not running, then the app will eventually close. There is meant to be an error here but it gets covered up by null reference exceptions relating to cancellation tokens.  This should fix that.

Setting the cancellation token source in the constructor next to the `Cancellation` token that it is based on.