### PR TITLE
Decoupling the AutoCreate in Message Databases from Marten StoreOptions

### DIFF
--- a/src/Persistence/MartenTests/MultiTenancy/dynamically_spin_up_new_tenant_databases_with_autocreate.cs
+++ b/src/Persistence/MartenTests/MultiTenancy/dynamically_spin_up_new_tenant_databases_with_autocreate.cs
@@ -1,0 +1,133 @@
+﻿using IntegrationTests;
+using JasperFx.Core;
+using Marten;
+using Marten.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.RDBMS;
+
+namespace MartenTests.MultiTenancy;
+
+public class dynamically_spin_up_new_tenant_databases_with_autocreate
+{
+    [Fact]
+    public async Task add_databases_and_see_durability_agents_start()
+    {
+        var (host, store, tenantConnectionString) = await CreateHost(AutoCreate.CreateOrUpdate);
+        using (host)
+        {
+            await host.WaitUntilAssignmentsChangeTo(w =>
+            {
+                w.AgentScheme = DurabilityAgent.AgentScheme;
+
+                // 1 for the master
+                w.ExpectRunningAgents(host, 1);
+            }, 15.Seconds());
+
+            var tenancy = (MasterTableTenancy)store.Options.Tenancy;
+            await tenancy.AddDatabaseRecordAsync("tenant1", tenantConnectionString);
+
+            await host.WaitUntilAssignmentsChangeTo(w =>
+            {
+                w.AgentScheme = DurabilityAgent.AgentScheme;
+
+                // 1 for the master, 1 for the tenant databases
+                w.ExpectRunningAgents(host, 2);
+            }, 1.Minutes());
+
+            await host.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task add_databases_and_see_durability_agents_fail_to_start()
+    {
+        try
+        {
+            // This should intentionally fail because Wolverine
+            // cannot create the schema objects
+            _ = await CreateHost(AutoCreate.None);
+        }
+        catch (Exception e)
+        {
+            e.ShouldBeOfType<PostgresException>();
+            ((PostgresException)e).MessageText.ShouldBe("relation \"wolv.wolverine_nodes\" does not exist");
+        }
+    }
+
+    private static async Task<(IHost host, IDocumentStore store, string tenantConnectionString)> CreateHost(AutoCreate wolverineAutoCreate)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync("tenants");
+
+        var tenantConnectionString = await CreateDatabaseIfNotExists(conn, "tenant1");
+
+        await conn.CloseAsync();
+
+        // Setting up a Host with Multi-tenancy
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // This is too extreme for real usage, but helps tests to run faster
+                opts.Durability.NodeReassignmentPollingTime = 1.Seconds();
+
+                opts.Services.AddMarten(o =>
+                    {
+                        o.MultiTenantedDatabasesWithMasterDatabaseTable(_ =>
+                        {
+                            _.ConnectionString = Servers.PostgresConnectionString;
+                            _.SchemaName = "tenants";
+
+                            // Enable auto-creation of Master Database schema objects
+                            _.AutoCreate = AutoCreate.CreateOrUpdate;
+                        });
+
+                        // Disable auto-creation of Marten schema objects
+                        o.AutoCreateSchemaObjects = AutoCreate.None;
+                    })
+                    .IntegrateWithWolverine(
+                        "wolv",
+                        autoCreate: wolverineAutoCreate)
+
+                    // All detected changes will be applied to all
+                    // the configured tenant databases on startup
+                    .ApplyAllDatabaseChangesOnStartup();
+            })
+            .StartAsync();
+
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+
+        var tenancy = (MasterTableTenancy)store.Options.Tenancy;
+        await tenancy.ClearAllDatabaseRecordsAsync();
+
+        return (host, store, tenantConnectionString);
+    }
+
+    private static async Task<string> CreateDatabaseIfNotExists(NpgsqlConnection conn, string databaseName)
+    {
+        var builder = new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString);
+
+        var exists = await conn.DatabaseExists(databaseName);
+        if (!exists)
+        {
+            await new DatabaseSpecification().BuildDatabase(conn, databaseName);
+        }
+        else
+        {
+            // Drop Wolverine's schema because we test the creation of it
+            await conn.DropSchemaAsync("wolv");
+        }
+
+        builder.Database = databaseName;
+
+        return builder.ConnectionString;
+    }
+}

--- a/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
@@ -40,6 +40,7 @@ public static class WolverineOptionsMartenExtensions
     ///     Wolverine will try to use the master database from the Marten configuration when possible
     /// </param>
     /// <param name="transportSchemaName">Optionally configure the schema name for any PostgreSQL queues</param>
+    /// <param name="autoCreate">Optionally override whether to automatically create message database schema objects. Defaults to <see cref="StoreOptions.AutoCreateSchemaObjects"/>.</param>
     /// <returns></returns>
     public static MartenServiceCollectionExtensions.MartenConfigurationExpression IntegrateWithWolverine(
         this MartenServiceCollectionExtensions.MartenConfigurationExpression expression, 

--- a/src/Persistence/Wolverine.RDBMS/DatabaseSettings.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabaseSettings.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using Weasel.Core;
 
 namespace Wolverine.RDBMS;
 
@@ -8,6 +9,7 @@ public class DatabaseSettings
 
     public string? ConnectionString { get; set; }
     public string? SchemaName { get; set; }
+    public AutoCreate AutoCreate { get; set; } = AutoCreate.CreateOrUpdate;
 
     /// <summary>
     ///     Is this database the master database for node storage and any kind of command queueing?

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
@@ -110,7 +110,7 @@ public abstract partial class MessageDatabase<T>
 
         if (migration.Difference != SchemaPatchDifference.None)
         {
-            await Migrator.ApplyAllAsync(conn, migration, AutoCreate.CreateOrUpdate, ct: _cancellation);
+            await Migrator.ApplyAllAsync(conn, migration, _settings.AutoCreate, ct: _cancellation);
         }
     }
 

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
@@ -28,7 +28,7 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
 
     protected MessageDatabase(DatabaseSettings databaseSettings, DbDataSource dataSource, DurabilitySettings settings,
         ILogger logger, Migrator migrator, string defaultSchema) : base(new MigrationLogger(logger),
-        AutoCreate.CreateOrUpdate, migrator,
+        databaseSettings.AutoCreate, migrator,
         "WolverineEnvelopeStorage", () => (T)dataSource.CreateConnection())
     {
         _settings = databaseSettings;


### PR DESCRIPTION
With this change it's possible to have Wolverine automatically create the message storage for dynamically added tenants, irrelevant of the `AutoCreate` setting in Marten.

Previously, if one used `AutoCreateSchemaObjects = AutoCreate.None` Wolverine did start up the agents for the new tenant, but they just failed because the required schema objects for the message storage were not available.

The default remains `AutoCreate.CreateOrUpdate` (see `DatabaseSettings`) for all `MessageDatabase` implementations.
But for Marten integration, you now can specify `autoCreate: <mode>` on the call to `IntegrateWithWolverine(...)`. If not specified, it has a fallback to `StoreOptions.AutoCreateSchemaObjects`.
