### PR TITLE
Limit message discovery on assemblies

### DIFF
--- a/src/Wolverine/Configuration/HandlerDiscovery.cs
+++ b/src/Wolverine/Configuration/HandlerDiscovery.cs
@@ -30,6 +30,9 @@ public sealed partial class HandlerDiscovery
         specifyHandlerDiscovery();
 
         _messageQuery.Excludes.IsStatic();
+        _messageQuery.Excludes.WithCondition(
+            $"Not implements {typeof(IMessage).FullNameInCode()} nor has attribute {typeof(WolverineMessageAttribute).FullNameInCode()}",
+            x => !x.CanBeCastTo<IMessage>() && !x.HasAttribute<WolverineMessageAttribute>());
         _messageQuery.Includes.Implements<IMessage>();
         _messageQuery.Includes.WithAttribute<WolverineMessageAttribute>();
         _messageQuery.Excludes.IsNotPublic();


### PR DESCRIPTION
_Only_ accept types that either implement the IMessage interface or has the attribute WolverineMessageAttribute as message types when performing message discovery by type scanning assemblies. This solves the issue where [the "Wolverine Message Routing" table outputted by the `describe` command is erroneously populated with nonsense entries](https://discord.com/channels/1074998995086225460/1074999099855753317/1243161152649957438).

**NOTE**: The `finding_message_types` test suite is green, but I have no idea if the test cases there cover all message types intended to be discovered.