### PR TITLE
Fixed issue where the sticky multi-tenanted agent family for postgres…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>2.11.0</Version>
+        <Version>2.11.1</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
@@ -139,6 +139,11 @@ public class PostgresqlTransport : BrokerTransport<PostgresqlQueue>, ITransportC
 
     IEnumerable<IAgentFamily> IAgentFamilySource.BuildAgentFamilySources(IWolverineRuntime runtime)
     {
+        if (runtime.Storage is not MultiTenantedMessageDatabase)
+        {
+            yield break;
+        }
+        
         if (Queues.Any(x => x is { IsListener: true, ListenerScope: ListenerScope.Exclusive }))
             yield return new StickyPostgresqlQueueListenerAgentFamily(runtime);
     }


### PR DESCRIPTION
… was used incorrectly. Bumps to 2.11.1