### PR TITLE
Enhance [Document] attribute with support for soft-deletes

### DIFF
--- a/docs/guide/handlers/middleware.md
+++ b/docs/guide/handlers/middleware.md
@@ -129,7 +129,7 @@ Here's the conventions:
 
 | Lifecycle                                                | Method Names                |
 |----------------------------------------------------------|-----------------------------|
-| Before the Handler(s)                                    | `Before`, `BeforeAsync`, `Load`, `LoadAsync` |
+| Before the Handler(s)                                    | `Before`, `BeforeAsync`, `Load`, `LoadAsync`, `Validate`, `ValidateAsync` |
 | After the Handler(s)                                     | `After`, `AfterAsync`, `PostProcess`, `PostProcessAsync` |
 | In `finally` blocks after the Handlers & "After" methods | `Finally`, `FinallyAsync`   |
 

--- a/docs/guide/http/marten.md
+++ b/docs/guide/http/marten.md
@@ -86,6 +86,11 @@ public static IMartenOp Increment2([Document(Required = true)] Counter counter)
 
 In the code above, if the `Counter` document does not exist, the route will stop and return a status code 404 for Not Found.
 
+:::warning
+It is recommended to use `[Document(Required = true)]` instead of the combination of `[Document][Required]`!  
+If the document is `NULL`, the former skip your `Load` / `Before` / etc. method, while the latter will still call it.
+:::
+
 However, if the document is soft-deleted your endpoint will still be executed.
 
 If you want soft-deleted documents to be treated as `NULL` for a endpoint, you can set `MaybeSoftDeleted` to `false`.  

--- a/docs/guide/http/marten.md
+++ b/docs/guide/http/marten.md
@@ -11,11 +11,6 @@ dotnet add package WolverineFx.Http.Marten
 
 ## Passing Marten Documents to Endpoint Parameters
 
-::: warning
-If you use "soft deletes" in Marten, just know that soft-deleted documents will still be found today by the `[Document]`
-attribute. This may be enhanced in the future to give you more control over the behavior later.
-:::
-
 Consider this very common use case, you have an HTTP endpoint that needs to work on a Marten document that will
 be loaded using the value of one of the route arguments as that document's identity. In a long hand way, that could
 look like this:
@@ -38,7 +33,7 @@ look like this:
         return Results.Ok(invoice);
     }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L13-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_get_invoice_longhand' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L14-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_get_invoice_longhand' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Pretty straightforward, but it's a little annoying to have to scatter in all the attributes for OpenAPI and there's definitely
@@ -54,7 +49,7 @@ public static Invoice Get([Document] Invoice invoice)
     return invoice;
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L32-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_document_attribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L33-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_document_attribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Notice that the `[Document]` attribute was able to use the "id" route parameter. By default, Wolverine is looking first
@@ -71,13 +66,13 @@ public static IMartenOp Approve([Document("number")] Invoice invoice)
     return MartenOps.Store(invoice);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L53-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_overriding_route_argument_with_document_attribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L54-L63' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_overriding_route_argument_with_document_attribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also combine the behavior of `[Document]` and `[Required]` through a single attribute like this:
 
 <!-- snippet: sample_using_Document_required -->
-<a id='snippet-sample_using_document_required'></a>
+<a id='snippet-sample_using_Document_required'></a>
 ```cs
 [WolverinePost("/api/tenants/{tenant}/counters/{id}/inc2")]
 public static IMartenOp Increment2([Document(Required = true)] Counter counter)
@@ -86,10 +81,28 @@ public static IMartenOp Increment2([Document(Required = true)] Counter counter)
     return MartenOps.Store(counter);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/Bugs/Bug_865_returning_IResult_using_Auto_codegen.cs#L118-L127' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_document_required' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/Bugs/Bug_865_returning_IResult_using_Auto_codegen.cs#L118-L127' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_Document_required' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In the code above, if the `Counter` document does not exist, the route will stop and return a status code 404 for Not Found.
+
+However, if the document is soft-deleted your endpoint will still be executed.
+
+If you want soft-deleted documents to be treated as `NULL` for a endpoint, you can set `MaybeSoftDeleted` to `false`.  
+In combination with `Required = true` that means the endpoint will return 404 for missing and soft-deleted documents.
+
+<!-- snippet: sample_using_Document_with_MaybeSoftDeleted -->
+<a id='snippet-sample_using_Document_with_MaybeSoftDeleted'></a>
+```cs
+[WolverineGet("/invoices/soft-delete/{id}")]
+public static Invoice GetSoftDeleted([Document(Required = true, MaybeSoftDeleted = false)] Invoice invoice)
+{
+    return invoice;
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L65-L71' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_Document_with_MaybeSoftDeleted' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
 
 ## Marten Aggregate Workflow 
 
@@ -227,7 +240,7 @@ public class Order
 To append a single event to an event stream from an HTTP endpoint, you can use a return value like so:
 
 <!-- snippet: sample_using_EmptyResponse -->
-<a id='snippet-sample_using_emptyresponse'></a>
+<a id='snippet-sample_using_EmptyResponse'></a>
 ```cs
 [AggregateHandler]
 [WolverinePost("/orders/ship"), EmptyResponse]
@@ -240,7 +253,7 @@ public static OrderShipped Ship(ShipOrder command, Order order)
     return new OrderShipped();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L106-L119' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_emptyresponse' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L106-L119' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_EmptyResponse' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or potentially append multiple events using the `Events` type as a return value like this sample:
@@ -302,7 +315,7 @@ public static ApprovedInvoicedCompiledQuery GetApproved()
     return new ApprovedInvoicedCompiledQuery();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L64-L70' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiled_query_return_endpoint' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L73-L79' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiled_query_return_endpoint' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 <!-- snippet: sample_compiled_query_return_query -->
@@ -316,5 +329,5 @@ public class ApprovedInvoicedCompiledQuery : ICompiledListQuery<Invoice>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L98-L108' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiled_query_return_query' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L109-L119' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiled_query_return_query' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/src/Http/Wolverine.Http.Marten/DocumentAttribute.cs
+++ b/src/Http/Wolverine.Http.Marten/DocumentAttribute.cs
@@ -30,7 +30,7 @@ public class DocumentAttribute : HttpChainParameterAttribute
 
     /// <summary>
     /// Should the absence of this document cause the endpoint to return a 404 Not Found response?
-    /// Default -- for backward compatibility -- is true
+    /// Default -- for backward compatibility -- is false.
     /// </summary>
     public bool Required { get; set; } = false;
 

--- a/src/Http/Wolverine.Http.Marten/SetVariableToNullIfSoftDeletedFrame.cs
+++ b/src/Http/Wolverine.Http.Marten/SetVariableToNullIfSoftDeletedFrame.cs
@@ -1,0 +1,56 @@
+﻿using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using Marten;
+using Marten.Storage.Metadata;
+
+namespace Wolverine.Http.Marten;
+
+internal class SetVariableToNullIfSoftDeletedFrame : SyncFrame
+{
+    private readonly Type _entityType;
+    private Variable _entity;
+    private Variable _documentSession;
+    private Variable _entityMetadata;
+
+    public SetVariableToNullIfSoftDeletedFrame(Type entityType)
+    {
+        _entityType = entityType;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment("If the document is soft deleted, set the variable to null");
+
+        if (this.IsAsync)
+        {
+            writer.Write($"var {_entityMetadata.Usage} = {_entity.Usage} != null");
+            writer.Write($"    ? await {_documentSession.Usage}.{nameof(IDocumentSession.MetadataForAsync)}({_entity.Usage}).ConfigureAwait(false)");
+            writer.Write($"    : null;");
+        }
+        else
+        {
+            writer.Write($"var {_entityMetadata.Usage} = {_entity.Usage} != null");
+            writer.Write($"    ? {_documentSession.Usage}.{nameof(IDocumentSession.MetadataFor)}({_entity.Usage})");
+            writer.Write($"    : null;");
+        }
+            
+        writer.Write($"BLOCK:if ({_entityMetadata.Usage}?.{nameof(DocumentMetadata.Deleted)} == true)");
+        writer.Write($"{_entity.Usage} = null;");
+        writer.FinishBlock();
+            
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _entity = chain.FindVariable(_entityType);
+        yield return _entity;
+
+        _documentSession = chain.FindVariable(typeof(IDocumentSession));
+        yield return _documentSession;
+
+        _entityMetadata = new Variable(typeof(DocumentMetadata), _entity.Usage + "Metadata", this);
+        yield return _entityMetadata;
+    }
+}

--- a/src/Http/Wolverine.Http.Marten/SetVariableToNullIfSoftDeletedFrame.cs
+++ b/src/Http/Wolverine.Http.Marten/SetVariableToNullIfSoftDeletedFrame.cs
@@ -6,7 +6,7 @@ using Marten.Storage.Metadata;
 
 namespace Wolverine.Http.Marten;
 
-internal class SetVariableToNullIfSoftDeletedFrame : SyncFrame
+internal class SetVariableToNullIfSoftDeletedFrame : AsyncFrame
 {
     private readonly Type _entityType;
     private Variable _entity;
@@ -22,18 +22,9 @@ internal class SetVariableToNullIfSoftDeletedFrame : SyncFrame
     {
         writer.WriteComment("If the document is soft deleted, set the variable to null");
 
-        if (this.IsAsync)
-        {
-            writer.Write($"var {_entityMetadata.Usage} = {_entity.Usage} != null");
-            writer.Write($"    ? await {_documentSession.Usage}.{nameof(IDocumentSession.MetadataForAsync)}({_entity.Usage}).ConfigureAwait(false)");
-            writer.Write($"    : null;");
-        }
-        else
-        {
-            writer.Write($"var {_entityMetadata.Usage} = {_entity.Usage} != null");
-            writer.Write($"    ? {_documentSession.Usage}.{nameof(IDocumentSession.MetadataFor)}({_entity.Usage})");
-            writer.Write($"    : null;");
-        }
+        writer.Write($"var {_entityMetadata.Usage} = {_entity.Usage} != null");
+        writer.Write($"    ? await {_documentSession.Usage}.{nameof(IDocumentSession.MetadataForAsync)}({_entity.Usage}).ConfigureAwait(false)");
+        writer.Write($"    : null;");
             
         writer.Write($"BLOCK:if ({_entityMetadata.Usage}?.{nameof(DocumentMetadata.Deleted)} == true)");
         writer.Write($"{_entity.Usage} = null;");

--- a/src/Http/Wolverine.Http.Tests/Marten/document_attribute_required_usage.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/document_attribute_required_usage.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace Wolverine.Http.Tests.Marten;
+
+public class document_attribute_required_usage(AppFixture fixture) : IntegrationContext(fixture)
+{
+    [Fact]
+    public async Task separate_attributes_call_load_method()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/document-required/separate-attributes/" + Guid.NewGuid());
+            x.StatusCodeShouldBe(404);
+        });
+
+        var problemDetails = await result.ReadAsJsonAsync<ProblemDetails>();
+        problemDetails.ShouldNotBeNull();
+        problemDetails.Title.ShouldBe("Invoice is not found");
+        problemDetails.Detail.ShouldBe("We only get here with [Document][Required]");
+    }
+    
+    [Fact]
+    public async Task document_attribute_only_does_not_call_load_method()
+    {
+        // This call gets short-circuited by DocumentAttribute.Required and thus the DocumentRequiredEndpoint.Load method is not called
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/document-required/document-attribute-only/" + Guid.NewGuid());
+            x.StatusCodeShouldBe(404);
+        });
+
+        var problemDetails = await result.ReadAsTextAsync();
+        problemDetails.ShouldBeEmpty();
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/Marten/document_attribute_usage.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/document_attribute_usage.cs
@@ -23,6 +23,24 @@ public class document_attribute_usage : IntegrationContext
     }
 
     [Fact]
+    public async Task returns_404_when_soft_deleted()
+    {
+        var invoice = new Invoice();
+        using var session = Store.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync();
+        
+        session.Delete(invoice);
+        await session.SaveChangesAsync();
+
+        await Scenario(x =>
+        {
+            x.Get.Url("/invoices/soft-delete/" + invoice.Id);
+            x.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Fact]
     public async Task default_to_id_route()
     {
         var invoice = new Invoice();

--- a/src/Http/WolverineWebApi/Marten/DocumentRequiredEndpoint.cs
+++ b/src/Http/WolverineWebApi/Marten/DocumentRequiredEndpoint.cs
@@ -1,0 +1,36 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine.Http;
+using Wolverine.Http.Marten;
+
+namespace WolverineWebApi.Marten;
+
+public class DocumentRequiredEndpoint
+{
+    public static ProblemDetails Load(Invoice? invoice)
+    {
+        if (invoice is null)
+        {
+            return new ProblemDetails
+            {
+                Title = "Invoice is not found",
+                Detail = "We only get here with [Document][Required]",
+                Status = 404,
+            };
+        }
+
+        return WolverineContinue.NoProblems;
+    }
+    
+    [WolverineGet("document-required/separate-attributes/{id}")]
+    public static Invoice SeparateAttributes([Document][Required] Invoice invoice)
+    {
+        return invoice;
+    }
+    
+    [WolverineGet("document-required/document-attribute-only/{id}")]
+    public static Invoice DocumentAttributeOnly([Document(Required = true)] Invoice invoice)
+    {
+        return invoice;
+    }
+}

--- a/src/Http/WolverineWebApi/Marten/Documents.cs
+++ b/src/Http/WolverineWebApi/Marten/Documents.cs
@@ -62,11 +62,13 @@ public class InvoicesEndpoint
 
     #endregion
 
+    #region sample_using_Document_with_MaybeSoftDeleted
     [WolverineGet("/invoices/soft-delete/{id}")]
     public static Invoice GetSoftDeleted([Document(Required = true, MaybeSoftDeleted = false)] Invoice invoice)
     {
         return invoice;
     }
+    #endregion
 
     #region sample_compiled_query_return_endpoint
     [WolverineGet("/invoices/approved")]

--- a/src/Http/WolverineWebApi/Marten/Documents.cs
+++ b/src/Http/WolverineWebApi/Marten/Documents.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using Marten;
 using Marten.Linq;
+using Marten.Metadata;
 using Microsoft.AspNetCore.Mvc;
 using Wolverine.Http;
 using Wolverine.Http.Marten;
@@ -61,6 +62,12 @@ public class InvoicesEndpoint
 
     #endregion
 
+    [WolverineGet("/invoices/soft-delete/{id}")]
+    public static Invoice GetSoftDeleted([Document(Required = true, MaybeSoftDeleted = false)] Invoice invoice)
+    {
+        return invoice;
+    }
+
     #region sample_compiled_query_return_endpoint
     [WolverineGet("/invoices/approved")]
     public static ApprovedInvoicedCompiledQuery GetApproved()
@@ -88,11 +95,13 @@ public class InvoicesEndpoint
     }
 }
 
-public class Invoice
+public class Invoice : ISoftDeleted
 {
     public Guid Id { get; set; }
     public bool Paid { get; set; }
     public bool Approved { get; set; }
+    public bool Deleted { get; set; }
+    public DateTimeOffset? DeletedAt { get; set; }
 }
 
 #region sample_compiled_query_return_query


### PR DESCRIPTION
Added DocumentAttribute.MaybeSoftDeleted flag as a way to indicate whether soft-deleted documents should be handled as NULL or not.

The naming of the property might not be the best, but it's the best succinct one I could come up with.
In the discord-discussion linked from #872 it seemed like an enum was suggested, but that would make it very long to type.
If you want to use it with `Required = true` it already gets quite long.
Updated the docs to include this new property.

Also added a test for a unexpected side-effect of using `[Document][Required]` instead of `[Document(Required = true)]`.
Added a warning for this to the docs as well.

While I was already editing some docs, I also documented the "new" before-methods introduced in #855 (they are amazing).