### PR TITLE
Bug 926 also fix OpenAPI generation

### DIFF
--- a/src/Http/Wolverine.Http/CodeGen/FromFileStrategy.cs
+++ b/src/Http/Wolverine.Http/CodeGen/FromFileStrategy.cs
@@ -17,14 +17,13 @@ public class FromFileStrategy : IParameterStrategy
     {
         if (parameter.ParameterType == typeof(IFormFile))
         {
-            chain.FileParameters.Add(parameter);
-
             var existing = chain.ChainVariables.FirstOrDefault(x => x.VariableType == typeof(IFormFile));
             if (existing != null)
             {
                 variable = existing;
                 return true;
             }
+            chain.FileParameters.Add(parameter);
 
             var frame = new FromFileValue(parameter);
             chain.Middleware.Add(frame);
@@ -36,14 +35,14 @@ public class FromFileStrategy : IParameterStrategy
 
         if (parameter.ParameterType == typeof(IFormFileCollection))
         {
-            chain.FileParameters.Add(parameter);
-
             var existing = chain.ChainVariables.FirstOrDefault(x => x.VariableType == typeof(IFormFileCollection));
             if (existing != null)
             {
                 variable = existing;
                 return true;
             }
+ 
+            chain.FileParameters.Add(parameter);
 
             var frame = new FromFileValues(parameter);
             chain.Middleware.Add(frame);

--- a/src/Http/WolverineWebApi/FileUploadEndpoint.cs
+++ b/src/Http/WolverineWebApi/FileUploadEndpoint.cs
@@ -1,4 +1,5 @@
 using Wolverine;
+using Wolverine.Attributes;
 using Wolverine.Http;
 
 namespace WolverineWebApi;
@@ -34,6 +35,28 @@ public static class Bug748Endpoint
     public static (SomeSideEffect, OutgoingMessages) Upload(IFormFile file)
     {
         return (new SomeSideEffect(), []);
+    }
+}
+
+public static class Bug928Endpoint
+{
+    [Middleware(typeof(Bug928MiddleWare.FileLengthValidationMiddleware))]
+    [WolverinePost("/upload/middleware")]
+    public static Task HandleAsync(IFormFile file)
+    {
+        // Process file
+        return Task.CompletedTask;
+    }
+}
+
+public static class Bug928MiddleWare
+{
+    public static class FileLengthValidationMiddleware
+    {
+        public static void Before(IFormFile file)
+        {
+            // todo, return ProblemDetail if validation fails
+        }
     }
 }
 


### PR DESCRIPTION
Noticed after the fix of bug [926](https://github.com/JasperFx/wolverine/issues/926) that the code generation works fine but the OpenAPI generation is broken. 
Based on the tests this change should fix it. 