### PR TITLE
Fix RabbitMQ not able to start in Balanced Mode

### DIFF
--- a/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
@@ -127,7 +127,6 @@ public partial class WolverineRuntime : IAgentRuntime
             case DurabilityMode.Balanced:
                 startDurableScheduledJobs();
                 startNodeAgentController();
-                await startNodeAgentWorkflowAsync();
                 break;
 
 

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -60,6 +60,10 @@ public partial class WolverineRuntime
             switch (Options.Durability.Mode)
             {
                 case DurabilityMode.Balanced:
+                    await startMessagingTransportsAsync();
+                    startInMemoryScheduledJobs();
+                    await startNodeAgentWorkflowAsync();
+                    break;
                 case DurabilityMode.Solo:
                     await startMessagingTransportsAsync();
                     startInMemoryScheduledJobs();


### PR DESCRIPTION
start node agent workflow after starting messaging transport to avoid null agent exception, when rabbit mq is used in balanced mode