### PR TITLE
Add the tenant ID to the current request activity

### DIFF
--- a/src/Http/Wolverine.Http.Tests/multi_tenancy_detection_and_integration.cs
+++ b/src/Http/Wolverine.Http.Tests/multi_tenancy_detection_and_integration.cs
@@ -360,25 +360,6 @@ public class multi_tenancy_detection_and_integration : IAsyncDisposable, IDispos
         activity.ShouldNotBeNull();
         activity.Tags.ShouldContain(x => x.Key == "tenant.id" && x.Value == "green");
     }
-
-    public class DiagnosticObserver : IObserver<KeyValuePair<string, object?>>
-    {
-        private readonly List<KeyValuePair<string, object?>> _diagnosticEvents;
-
-        public DiagnosticObserver(List<KeyValuePair<string, object?>> diagnosticEvents)
-        {
-            _diagnosticEvents = diagnosticEvents;
-        }
-
-        public void OnCompleted() { }
-
-        public void OnError(Exception error) { }
-
-        public void OnNext(KeyValuePair<string, object?> value)
-        {
-            _diagnosticEvents.Add(value);
-        }
-    }
 }
 
 public static class TenantedEndpoints

--- a/src/Http/Wolverine.Http.Tests/multi_tenancy_detection_and_integration.cs
+++ b/src/Http/Wolverine.Http.Tests/multi_tenancy_detection_and_integration.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Security.Claims;
 using Alba;
 using Alba.Security;

--- a/src/Http/Wolverine.Http/HttpHandler.cs
+++ b/src/Http/Wolverine.Http/HttpHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using JasperFx.Core;
@@ -24,9 +25,15 @@ public abstract class HttpHandler
         _jsonOptions = wolverineHttpOptions.JsonSerializerOptions.Value;
     }
 
-    public ValueTask<string?> TryDetectTenantId(HttpContext httpContext)
+    public async ValueTask<string?> TryDetectTenantId(HttpContext httpContext)
     {
-        return _options.TryDetectTenantId(httpContext);
+        var tenantId = await _options.TryDetectTenantId(httpContext);
+        if (tenantId != null)
+        {
+            Activity.Current?.SetTag(MetricsConstants.TenantIdKey, tenantId);
+        }
+
+        return tenantId;
     }
 
     public Task WriteTenantIdNotFound(HttpContext context)


### PR DESCRIPTION
Whenever a tenant ID is successfully detected in the `TryDetectTenantId(HttpContext httpContext)` it now is added as a tag to the current activity.

The message handler did already tag it, HTTP endpoints were missing it.