### PR TITLE
Publishing a message without a handler doesn't add it to the tracked session

### DIFF
--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -419,6 +419,11 @@ that is tracked.
 Note that you'll probably *mostly* *invoke* messages in these tests, but there are additional extension
 methods on `IHost` for other `IMessageBus` operations.
 
+:::info
+The Tracked Session includes only messages sent, published, or scheduled during the tracked session.
+Messages sent before the tracked session are not included in the tracked session.
+:::
+
 Finally, there are some more advanced options in tracked sessions you may find useful as 
 shown below:
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -472,6 +472,12 @@ public async Task using_tracked_sessions_advanced(IHost otherWolverineSystem)
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/TestingSupportSamples.cs#L134-L175' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_tracked_session_usage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+The samples shown above inlcude `Sent` message records, but there are more properties available in the `TrackedSession` object.
+In accordance with the `MessageEventType` enum, you can access these properties on the `TrackedSession` object:
+
+<!-- snippet: sample_record_collections -->
+<!-- endSnippet -->
+
 Let's consider we're testing a Wolverine application which publishes a message, when a change to a watched folder is detected. The part we want to test is that a message is actually published when a file is added to the watched folder. We can use the `TrackActivity` method to start a tracked session and then use the `ExecuteAndWaitAsync` method to wait for the message to be published when the file change has happened.
 
 <!-- snippet: sample_send_message_on_file_change -->

--- a/src/Testing/CoreTests/Tracking/When_session_is_tracked_for_published_message_without_handler.cs
+++ b/src/Testing/CoreTests/Tracking/When_session_is_tracked_for_published_message_without_handler.cs
@@ -1,0 +1,79 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Tracking;
+using Xunit;
+using Xunit.Abstractions;
+
+public record FileAdded(string FileName);
+
+public class RandomFileChangeForPublish
+{
+    private readonly IMessageBus _messageBus;
+
+    public RandomFileChangeForPublish(
+        IMessageBus messageBus
+    ) => _messageBus = messageBus;
+
+    public async Task SimulateRandomFileChange()
+    {
+        await Task.Delay(
+            TimeSpan.FromMilliseconds(
+                new Random().Next(100, 1000)
+            )
+        );
+        var randomFileName = Path.GetRandomFileName();
+        await _messageBus.PublishAsync(new FileAdded(randomFileName));
+    }
+}
+
+
+public class When_session_is_tracked_for_published_message_without_handler : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+    private IHost _host;
+
+    public When_session_is_tracked_for_published_message_without_handler(
+        ITestOutputHelper testOutputHelper
+    ) => _testOutputHelper = testOutputHelper;
+
+    public async Task InitializeAsync()
+    {
+        var hostBuilder = Host.CreateDefaultBuilder();
+        hostBuilder.ConfigureServices(
+            services => { services.AddSingleton<RandomFileChangeForPublish>(); }
+        );
+        hostBuilder.UseWolverine();
+
+        _host = await hostBuilder.StartAsync();
+    }
+
+    [Fact]
+    public async Task should_be_included_in_sent_record_collection()
+    {
+        var randomEventEmitter = _host.Services.GetRequiredService<RandomFileChangeForPublish>();
+
+        var session = await _host
+            .TrackActivity()
+            .Timeout(2.Seconds())
+            .ExecuteAndWaitAsync(
+                (Func<IMessageContext, Task>)(
+                    async (
+                        _
+                    ) => await randomEventEmitter.SimulateRandomFileChange()
+                )
+            );
+
+
+        session.Sent.AllMessages()
+            .Count()
+            .ShouldBe(1);
+
+        session.Sent.AllMessages()
+            .First()
+            .ShouldBeOfType<FileAdded>();
+    }
+
+
+    public async Task DisposeAsync() => await _host.StopAsync();
+}

--- a/src/Testing/CoreTests/Tracking/When_session_is_tracked_for_published_message_without_handler.cs
+++ b/src/Testing/CoreTests/Tracking/When_session_is_tracked_for_published_message_without_handler.cs
@@ -65,11 +65,11 @@ public class When_session_is_tracked_for_published_message_without_handler : IAs
             );
 
 
-        session.Sent.AllMessages()
+        session.NoRoutes.AllMessages()
             .Count()
             .ShouldBe(1);
 
-        session.Sent.AllMessages()
+        session.NoRoutes.AllMessages()
             .First()
             .ShouldBeOfType<FileAdded>();
     }

--- a/src/Wolverine/Tracking/ITrackedSession.cs
+++ b/src/Wolverine/Tracking/ITrackedSession.cs
@@ -13,6 +13,11 @@ public interface ITrackedSession
     ///     Records of all messages received during the tracked session
     /// </summary>
     RecordCollection Received { get; }
+    
+    /// <summary>
+    ///    Records of all messages received during the tracked session that were not routed
+    /// </summary>
+    RecordCollection NoRoutes { get; }
 
     /// <summary>
     ///     Records of all messages sent during the tracked session. This will include messages

--- a/src/Wolverine/Tracking/ITrackedSession.cs
+++ b/src/Wolverine/Tracking/ITrackedSession.cs
@@ -15,20 +15,56 @@ public interface ITrackedSession
     RecordCollection Received { get; }
     
     /// <summary>
-    ///    Records of all messages received during the tracked session that were not routed
-    /// </summary>
-    RecordCollection NoRoutes { get; }
-
-    /// <summary>
     ///     Records of all messages sent during the tracked session. This will include messages
     ///     published to local queues
     /// </summary>
     RecordCollection Sent { get; }
 
     /// <summary>
+    ///     Records of all messages that were executed during the tracked session
+    /// </summary>
+    RecordCollection ExecutionStarted { get; }
+
+    /// <summary>
+    ///     Records of all messages that were successfully executed during the tracked session
+    /// </summary>
+    RecordCollection ExecutionFinished { get; }
+    
+    /// <summary>
+    ///   Records of all messages that successfully completed their processing
+    /// </summary>
+    RecordCollection MessageSucceeded { get; }
+    
+    /// <summary>
+    ///     Records of all messages that failed during processing
+    /// </summary>
+    RecordCollection MessageFailed { get; }
+
+    /// <summary>
+    ///    Records of all messages which have no handlers
+    /// </summary>
+    RecordCollection NoHandlers { get; }
+    
+    /// <summary>
+    ///    Records of all messages received during the tracked session that were not routed
+    /// </summary>
+    RecordCollection NoRoutes { get; }
+
+    /// <summary>
+    ///    Records of all messages that were moved to the error queue
+    /// </summary>
+    RecordCollection MovedToErrorQueue { get; }
+    
+    /// <summary>
+    ///     Records of all messages that were requeued
+    /// </summary>
+    RecordCollection Requeued { get; }
+    
+    /// <summary>
     ///     Message processing records for messages that were executed. Note that this includes message
     ///     executions that failed and additional attempts as a separate record in the case of retries
     /// </summary>
+    [Obsolete("Use ExecutionFinished instead")]
     RecordCollection Executed { get; }
 
     /// <summary>

--- a/src/Wolverine/Tracking/MessageEventType.cs
+++ b/src/Wolverine/Tracking/MessageEventType.cs
@@ -1,5 +1,6 @@
 namespace Wolverine.Tracking;
 
+#region sample_record_collections
 public enum MessageEventType
 {
     Received,
@@ -13,3 +14,4 @@ public enum MessageEventType
     MovedToErrorQueue,
     Requeued
 }
+#endregion

--- a/src/Wolverine/Tracking/TrackedSession.cs
+++ b/src/Wolverine/Tracking/TrackedSession.cs
@@ -150,9 +150,14 @@ internal class TrackedSession : ITrackedSession
 
     public RecordCollection Received => new(MessageEventType.Received, this);
     public RecordCollection Sent => new(MessageEventType.Sent, this);
+    public RecordCollection ExecutionStarted => new(MessageEventType.ExecutionStarted, this);
+    public RecordCollection ExecutionFinished => new(MessageEventType.ExecutionFinished, this);
+    public RecordCollection MessageSucceeded => new(MessageEventType.MessageSucceeded, this);
+    public RecordCollection MessageFailed => new(MessageEventType.MessageFailed, this);
+    public RecordCollection NoHandlers => new(MessageEventType.NoHandlers, this);
     public RecordCollection NoRoutes => new(MessageEventType.NoRoutes, this);
-
-
+    public RecordCollection MovedToErrorQueue => new(MessageEventType.MovedToErrorQueue, this);
+    public RecordCollection Requeued => new(MessageEventType.Requeued, this);
     public RecordCollection Executed => new(MessageEventType.ExecutionFinished, this);
 
     public void WatchOther(IHost host)

--- a/src/Wolverine/Tracking/TrackedSession.cs
+++ b/src/Wolverine/Tracking/TrackedSession.cs
@@ -150,6 +150,7 @@ internal class TrackedSession : ITrackedSession
 
     public RecordCollection Received => new(MessageEventType.Received, this);
     public RecordCollection Sent => new(MessageEventType.Sent, this);
+    public RecordCollection NoRoutes => new(MessageEventType.NoRoutes, this);
 
 
     public RecordCollection Executed => new(MessageEventType.ExecutionFinished, this);


### PR DESCRIPTION
This PR exposes all states of messages represented via `MessageEventType` as record collections on `ITrackedSession` and it's `TrackedSession` implementation.

It also extends the related docs.

The property `Executed` is obsoleted in favor of two new properties `ExecutionStarted` and `ExecutionFinished` where the latter is replacing the existing `Executed` collection.