### PR TITLE
Reduce log noise

### DIFF
--- a/src/Wolverine/ExtensionLoader.cs
+++ b/src/Wolverine/ExtensionLoader.cs
@@ -42,7 +42,6 @@ internal static class ExtensionLoader
 
         if (assemblies.Length == 0)
         {
-            Console.WriteLine("No Wolverine extensions are detected");
             return;
         }
 


### PR DESCRIPTION
Removed the Console.WriteLine. In a projects with lots of tests, the logs are full with "No Wolverine extensions are detected" and this can't be controlled by log level setting of Host.