### PR TITLE
Fix OpenTelemetry docs

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -106,17 +106,16 @@ return await Host.CreateDefaultBuilder(args)
         opts.PublishMessage<RabbitMessage2>().ToRabbitQueue(MessagingConstants.Subscriber2Queue);
 
         // Add Open Telemetry tracing
-        opts.Services.AddOpenTelemetryTracing(builder =>
-        {
-            builder
-                .SetResourceBuilder(ResourceBuilder
-                    .CreateDefault()
-                    .AddService("Subscriber1"))
-                .AddJaegerExporter()
-
-                // Add Wolverine as a source
-                .AddSource("Wolverine");
-        });
+        opts.Services.AddOpenTelemetry()
+            .ConfigureResource(resources => resources.AddService("Subscriber1")) // <-- sets service name
+            .WithTracing(tracing =>
+            {
+                tracing
+                    .AddOtlpExporter() // <-- Add otlp exporter that by default outputs to the Jaeger default port
+                    
+                    // Add Wolverine as a source
+                    .AddSource("Wolverine");
+            });
     })
 
     // Executing with Oakton as the command line parser to unlock

--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -209,18 +209,18 @@ code sample:
 <a id='snippet-sample_enabling_open_telemetry'></a>
 ```cs
 // builder.Services is an IServiceCollection object
-builder.Services.AddOpenTelemetryTracing(x =>
-{
-    x.SetResourceBuilder(ResourceBuilder
-            .CreateDefault()
-            .AddService("OtelWebApi")) // <-- sets service name
-        .AddJaegerExporter()
-        .AddAspNetCoreInstrumentation()
-
-        // This is absolutely necessary to collect the Wolverine
-        // open telemetry tracing information in your application
-        .AddSource("Wolverine");
-});
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resources => resources.AddService("OtelWebApi")) // <-- sets service name
+    .WithTracing(tracing =>
+    {
+        tracing
+            .AddOtlpExporter() // <-- Add otlp exporter that by default outputs to the Jaeger default port
+            .AddAspNetCoreInstrumentation()
+            
+            // This is absolutely necessary to collect the Wolverine
+            // open telemetry tracing information in your application
+            .AddSource("Wolverine");
+    });
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/OpenTelemetry/OtelWebApi/Program.cs#L36-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_open_telemetry' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->


### PR DESCRIPTION
This fix was already applied in https://github.com/JasperFx/wolverine/pull/735 but got overriden with https://github.com/JasperFx/wolverine/commit/bc6f501a61798cfa2a6b487830e0decea785c5ab . I guess this was done by accident since `AddOpenTelemetryTracing` is deprecated.

Full credit to @woksin for the initial fix!