### PR TITLE
Use default postgres public schema when no schema is provided.

### DIFF
--- a/src/Persistence/PostgresqlTests/ConfigureWithDefaultSchema.cs
+++ b/src/Persistence/PostgresqlTests/ConfigureWithDefaultSchema.cs
@@ -1,0 +1,30 @@
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.RDBMS.Transport;
+using Wolverine.Runtime;
+
+namespace PostgresqlTests;
+
+public class ConfigureWithDefaultSchema
+{
+    [Fact]
+    public async Task should_use_public_as_default_schema()
+    {
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // no schema provided
+                opts.UsePostgresqlPersistenceAndTransport(Servers.PostgresConnectionString)
+                    .AutoProvision();
+            }).StartAsync();
+
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        runtime.Options.Transports.OfType<DatabaseControlTransport>().Single()
+            .Database.Settings.SchemaName.ShouldBe("public");
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlConfigurationExtensions.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlConfigurationExtensions.cs
@@ -78,32 +78,19 @@ public static class PostgresqlConfigurationExtensions
             }
         };
 
-        if (schema.IsNotEmpty())
-        {
-            extension.Settings.SchemaName = schema;
-        }
-        else
+        if (schema.IsEmpty())
         {
             schema = "public";
         }
 
+        extension.Settings.SchemaName = schema;
         extension.Settings.ScheduledJobLockId = $"{schema}:scheduled-jobs".GetDeterministicHashCode();
         options.Include(extension);
 
         options.Include<PostgresqlBackedPersistence>(x =>
         {
             x.Settings.ConnectionString = connectionString;
-
-            if (schema.IsNotEmpty())
-            {
-                x.Settings.SchemaName = schema;
-            }
-            else
-            {
-                schema = "public";
-
-            }
-
+            x.Settings.SchemaName = schema;
             x.Settings.ScheduledJobLockId = $"{schema}:scheduled-jobs".GetDeterministicHashCode();
         });
 


### PR DESCRIPTION
When setting up postgres using `UsePostgresqlPersistenceAndTransport` without providing a schema name then an error is thrown during startup, because the schema is empty and the table name then starts with a dot `.wolverine_node_records`: https://github.com/JasperFx/wolverine/blob/d478269/src/Persistence/Wolverine.RDBMS/Durability/PersistNodeRecord.cs#L27