### PR TITLE
Docs: fix broken link

### DIFF
--- a/docs/guide/durability/marten/sagas.md
+++ b/docs/guide/durability/marten/sagas.md
@@ -1,7 +1,7 @@
 # Marten as Saga Storage
 
 Marten is an easy option for [persistent sagas](/guide/durability/sagas) with Wolverine. Yet again, to opt into using Marten as your saga storage mechanism in Wolverine, you
-just need to add the `IntegrateWithWolverine()` option to your Marten configuration as shown in the [Getting Started](#getting-started) section above.
+just need to add the `IntegrateWithWolverine()` option to your Marten configuration as shown in the Marten Integration [Getting Started](/guide/durability/marten/#getting-started) section.
 
 When using the Wolverine + Marten integration, your stateful saga classes should be valid Marten document types that inherit from Wolverine's `Saga` type, which generally means being a public class with a valid
 Marten [identity member](https://martendb.io/documents/identity.html). Remember that your handler methods in Wolverine can accept "method injected" dependencies from your underlying


### PR DESCRIPTION
I guess the marked link here:
![image](https://github.com/user-attachments/assets/d8ca2c90-d78f-4d0b-b241-1db57199d5c6)

is intended to point to this sample:
![image](https://github.com/user-attachments/assets/c0d555f6-9fd0-4af8-9d2e-dfab4ea660b7)
 
