### PR TITLE
Add support for routing messages based on attribute decoration

### DIFF
--- a/src/Testing/CoreTests/Runtime/Green/Messages.cs
+++ b/src/Testing/CoreTests/Runtime/Green/Messages.cs
@@ -5,3 +5,5 @@ public class GreenMessage1;
 public class GreenMessage2;
 
 public class GreenMessage3;
+
+public class GreenAttribute : Attribute;

--- a/src/Testing/CoreTests/Runtime/Red/Messages.cs
+++ b/src/Testing/CoreTests/Runtime/Red/Messages.cs
@@ -1,7 +1,16 @@
 namespace CoreTests.Runtime.Red;
 
+[Red]
 public class RedMessage1;
 
+[Crimson]
 public class RedMessage2;
 
+[Burgundy]
 public class RedMessage3;
+
+public class RedAttribute : Attribute;
+
+public class CrimsonAttribute : RedAttribute;
+
+public class BurgundyAttribute : RedAttribute;

--- a/src/Testing/CoreTests/Runtime/SubscriptionTester.cs
+++ b/src/Testing/CoreTests/Runtime/SubscriptionTester.cs
@@ -46,6 +46,17 @@ public class SubscriptionTester
     }
 
     [Fact]
+    public void description_of_attribute_rule()
+    {
+        var rule = new Subscription
+        {
+            BaseOrAttributeType = typeof(RandomClassAttribute),
+            Scope = RoutingScope.Attribute
+        };
+        rule.ToString().ShouldBe("Message type is decorated with 'CoreTests.Runtime.RandomClassAttribute' or a derived type");
+    }
+
+    [Fact]
     public void description_of_all_types()
     {
         var rule = Subscription.All();
@@ -86,6 +97,20 @@ public class SubscriptionTester
     }
 
     [Fact]
+    public void negative_attribute_test()
+    {
+        var rule = new Subscription
+        {
+            Scope = RoutingScope.Attribute,
+            BaseOrAttributeType = typeof(GreenAttribute)
+        };
+
+        rule.Matches(typeof(GreenMessage1)).ShouldBeFalse();
+        rule.Matches(typeof(GreenMessage2)).ShouldBeFalse();
+        rule.Matches(typeof(GreenMessage3)).ShouldBeFalse();
+    }
+
+    [Fact]
     public void positive_namespace_test()
     {
         var rule = new Subscription
@@ -98,6 +123,23 @@ public class SubscriptionTester
         rule.Matches(typeof(RedMessage2)).ShouldBeTrue();
         rule.Matches(typeof(RedMessage3)).ShouldBeTrue();
     }
+
+    [Fact]
+    public void positive_attribute_test()
+    {
+        var rule = new Subscription
+        {
+            Scope = RoutingScope.Attribute,
+            BaseOrAttributeType = typeof(RedAttribute)
+        };
+
+        rule.Matches(typeof(RedMessage1)).ShouldBeTrue();
+        rule.Matches(typeof(RedMessage2)).ShouldBeTrue();
+        rule.Matches(typeof(RedMessage3)).ShouldBeTrue();
+    }
 }
 
+[RandomClass]
 public class RandomClass;
+
+public class RandomClassAttribute : Attribute;

--- a/src/Wolverine/Configuration/PublishingExpression.cs
+++ b/src/Wolverine/Configuration/PublishingExpression.cs
@@ -160,6 +160,35 @@ public class PublishingExpression : IPublishToExpression
         return MessagesFromAssembly(typeof(T).Assembly);
     }
 
+    /// <summary>
+    ///	    Create a publishing rule for all messages decorated with the specified attribute type or a derived type
+    /// </summary>
+    /// <param name="attributeType"></param>
+    /// <returns></returns>
+    public PublishingExpression MessagesDecoratedWith(Type attributeType)
+    {
+        AutoAddSubscriptions = true;
+
+        _subscriptions.Add(new Subscription()
+        {
+            Scope = RoutingScope.Attribute,
+            BaseOrAttributeType = attributeType,
+        });
+
+        return this;
+    }
+
+    /// <summary>
+    ///	    Create a publishing rule for all messages decorated with the attribute of type T or a derived type
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public PublishingExpression MessagesDecoratedWith<T>()
+        where T : Attribute
+    {
+        return MessagesDecoratedWith(typeof(T));
+    }
+
     internal void AttachSubscriptions()
     {
         if (!_endpoints.Any())
@@ -182,6 +211,6 @@ public class PublishingExpression : IPublishToExpression
     /// <typeparam name="T"></typeparam>
     public void MessagesImplementing<T>()
     {
-        _subscriptions.Add(new Subscription { BaseType = typeof(T), Scope = RoutingScope.Implements });
+        _subscriptions.Add(new Subscription { BaseOrAttributeType = typeof(T), Scope = RoutingScope.Implements });
     }
 }

--- a/src/Wolverine/Runtime/Routing/RoutingScope.cs
+++ b/src/Wolverine/Runtime/Routing/RoutingScope.cs
@@ -7,5 +7,6 @@ public enum RoutingScope
     Type,
     TypeName,
     All,
-    Implements
+    Implements,
+    Attribute
 }

--- a/src/Wolverine/Runtime/Routing/Subscription.cs
+++ b/src/Wolverine/Runtime/Routing/Subscription.cs
@@ -43,7 +43,10 @@ public class Subscription
     /// </summary>
     public string Match { get; init; } = string.Empty;
 
-    public Type? BaseType { get; init; }
+    /// <summary>
+    ///     A base type if matching on implementation or an attribute type if matching on decoration
+    /// </summary>
+    public Type? BaseOrAttributeType { get; init; }
 
     /// <summary>
     ///     Create a subscription for a specific message type
@@ -80,7 +83,8 @@ public class Subscription
             RoutingScope.Type => type.Name.EqualsIgnoreCase(Match) || type.FullName!.EqualsIgnoreCase(Match) ||
                                  type.ToMessageTypeName().EqualsIgnoreCase(Match),
             RoutingScope.TypeName => type.ToMessageTypeName().EqualsIgnoreCase(Match),
-            RoutingScope.Implements => type.CanBeCastTo(BaseType!),
+            RoutingScope.Implements => type.CanBeCastTo(BaseOrAttributeType!),
+            RoutingScope.Attribute => type.IsDefined(BaseOrAttributeType!, inherit: false),
             _ => !type.CanBeCastTo<IAgentCommand>()
         };
     }
@@ -140,6 +144,9 @@ public class Subscription
 
             case RoutingScope.TypeName:
                 return $"Message name is '{Match}'";
+
+            case RoutingScope.Attribute:
+                return $"Message type is decorated with '{BaseOrAttributeType?.FullName}' or a derived type";
         }
 
         throw new ArgumentOutOfRangeException();

--- a/src/Wolverine/Transports/Local/LocalTransport.cs
+++ b/src/Wolverine/Transports/Local/LocalTransport.cs
@@ -36,7 +36,7 @@ internal class LocalTransport : TransportBase<LocalQueue>, ILocalMessageRoutingC
         var agentQueue = _queues[TransportConstants.Agents];
         agentQueue.TelemetryEnabled = false;
         agentQueue.Subscriptions.Add(new Subscription
-            { Scope = RoutingScope.Implements, BaseType = typeof(IAgentCommand) });
+            { Scope = RoutingScope.Implements, BaseOrAttributeType = typeof(IAgentCommand) });
         agentQueue.ExecutionOptions.MaxDegreeOfParallelism = 20;
         agentQueue.Role = EndpointRole.System;
         agentQueue.Mode = EndpointMode.BufferedInMemory;


### PR DESCRIPTION
Closes #1149

I've run the CoreTests unit tests on .NET 7.0/8.0/9.0. All pass.

Otherwise let me know if you want anything altered.