### PR TITLE
DisableConventionalDiscovery is under `Discovery`

### DIFF
--- a/docs/guide/handlers/discovery.md
+++ b/docs/guide/handlers/discovery.md
@@ -220,7 +220,7 @@ using var host = await Host.CreateDefaultBuilder()
     .UseWolverine(opts =>
     {
         // No automatic discovery of handlers
-        opts.DisableConventionalDiscovery();
+        opts.Discovery.DisableConventionalDiscovery();
     }).StartAsync();
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/HandlerExamples.cs#L227-L236' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_explicithandlerdiscovery' title='Start of snippet'>anchor</a></sup>


### PR DESCRIPTION
I followed the instructions to configure Wolverine and it seems like there's a typo. 