### PR TITLE
Preliminary work on the external table transport for incoming messages

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -162,7 +162,8 @@ const config: UserConfig<DefaultTheme.Config> = {
                                 {text: 'Sql Server', link: '/guide/messaging/transports/sqlserver'},
                                 {text: 'PostgreSQL', link: '/guide/messaging/transports/postgresql'},
                                 {text: 'MQTT', link: '/guide/messaging/transports/mqtt'},
-                                {text: 'Kafka', link: '/guide/messaging/transports/kafka'}
+                                {text: 'Kafka', link: '/guide/messaging/transports/kafka'},
+                                {text: 'External Database Tables', link: '/guide/messaging/transports/external-tables'}
                             ]
                         },
                         {text: 'Endpoint Specific Operations', link: '/guide/messaging/endpoint-operations'},

--- a/docs/guide/messaging/transports/external-tables.md
+++ b/docs/guide/messaging/transports/external-tables.md
@@ -1,0 +1,92 @@
+# Externally Controlled Database Tables <Badge type="tip" text="3.5" />
+
+Let's say that you'd like to publish messages to a Wolverine application from an existing system where it's not feasible
+to either utilize Wolverine, and that system does not currently have any kind of messaging capability. And of course, you
+want the messaging to Wolverine to be robust through some sort of transactional outbox, but you certainly don't want to 
+have to build custom infrastructure to manage that. 
+
+Wolverine provides a capability to scrape an externally controlled database table for incoming messages in a reliable way.
+Assuming that you are using one of the relational database options for persisting messages already like [PostgreSQL](/guide/durability/postgresql) 
+or [Sql Server](/guide/durability/sqlserver), you can tell Wolverine to poll a table *in the same database as the message 
+store* for incoming messages like this:
+
+<!-- snippet: sample_configuring_external_database_messaging -->
+<a id='snippet-sample_configuring_external_database_messaging'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.UseWolverine(opts =>
+{
+    opts.UsePostgresqlPersistenceAndTransport(builder.Configuration.GetConnectionString("postgres"));
+
+    // Or
+    // opts.UseSqlServerPersistenceAndTransport(builder.Configuration.GetConnectionString("sqlserver"));
+    
+    // Or
+    // opts.Services
+    //     .AddMarten(builder.Configuration.GetConnectionString("postgres"))
+    //     .IntegrateWithWolverine();
+    
+    // Directing Wolverine to "listen" for messages in an externally controlled table
+    // You have to explicitly tell Wolverine about the schema name and table name
+    opts.ListenForMessagesFromExternalDatabaseTable("exports", "messaging", table =>
+        {
+            // The primary key column for this table, default is "id"
+            table.IdColumnName = "id";
+
+            // What column has the actual JSON data? Default is "json"
+            table.JsonBodyColumnName = "body";
+
+            // Optionally tell Wolverine that the message type name is this
+            // column. 
+            table.MessageTypeColumnName = "message_type";
+
+            // Add a column for the current time when a message was inserted
+            // Strictly for diagnostics
+            table.TimestampColumnName = "added";
+
+            // How often should Wolverine poll this table? Default is 10 seconds
+            table.PollingInterval = 1.Seconds();
+
+            // Maximum number of messages that each node should try to pull in at 
+            // any one time. Default is 100
+            table.MessageBatchSize = 50;
+
+            // Is Wolverine allowed to try to apply automatic database migrations for this
+            // table at startup time? Default is true.
+            // Also overridden by WolverineOptions.AutoBuildMessageStorageOnStartup
+            table.AllowWolverineControl = true;
+
+            // Wolverine uses a database advisory lock so that only one node at a time
+            // can ever be polling for messages at any one time. Default is 12000
+            // It might release contention to vary the advisory lock if you have multiple
+            // incoming tables or applications targeting the same database
+            table.AdvisoryLock = 12001;
+            
+            // Tell Wolverine what the default message type is coming from this
+            // table to aid in deserialization
+            table.MessageType = typeof(ExternalMessage);
+            
+            
+        })
+        
+        // Just showing that you have all the normal options for configuring and
+        // fine tuning the behavior of a message listening endpoint here
+        .Sequential();
+});
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PostgresqlTests/Transport/external_message_tables.cs#L160-L223' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_external_database_messaging' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+So a couple things to know:
+
+* The external table has to have a single primary key table that uses `Guid` as the .NET type. So `uuid` for PostgreSQL or 
+  `uniqueidentifier` for Sql Server
+* There must be a single column that holds the incoming message as JSON. For Sql Server this is `varbinary(max)` and `JSONB` for PostgreSQL
+* If there is a column mapped for the message type, Wolverine is using its message type naming to determine the actual .NET
+  message type. See [Message Type Name or Alias](/guide/messages.html#message-type-name-or-alias) for information about how to use this
+  or even add custom type mapping to synchronize between the upstream system and your Wolverine using system
+* If the upstream system is not sending a message type name, you will be limited to only accepting a single message type, and you will
+  have to tell Wolverine the default message type as shown above in the code sample. This is common in interop with non-Wolverine systems
+* All "external table" endpoints in Wolverine are "durable" endpoints, and the incoming messages get moved to the incoming envelope
+  tables
+* Likewise, the dead letter queueing for these messages is done with the typical database message store

--- a/src/Persistence/PostgresqlTests/Transport/external_message_tables.cs
+++ b/src/Persistence/PostgresqlTests/Transport/external_message_tables.cs
@@ -1,0 +1,246 @@
+using System.Diagnostics;
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Marten;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables;
+using Wolverine;
+using Wolverine.ComplianceTests.Compliance;
+using Wolverine.Marten;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.RDBMS.Transport;
+using Wolverine.Tracking;
+
+namespace PostgresqlTests.Transport;
+
+public class external_message_tables : IAsyncLifetime
+{
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync("external");
+    }
+    
+    public Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task can_create_basic_table()
+    {
+        var definition = new ExternalMessageTable(new DbObjectName("external", "incoming1"))
+        {
+            MessageType = typeof(Message1)
+        };
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UsePostgresqlPersistenceAndTransport(Servers.PostgresConnectionString, "external");
+            }).StartAsync();
+
+        var storage = host.Services.GetRequiredService<IMessageStore>()
+            .As<PostgresqlMessageStore>();
+
+        var table = storage.AddExternalMessageTable(definition).ShouldBeOfType<Table>();
+        table.Columns.Select(x => x.Name).ShouldBe(new string[]{"id", "body", "timestamp"});
+        table.Columns.Select(x => x.Type).ShouldBe(new string[]{"uuid", "jsonb", "timestamp with time zone"});
+        table.PrimaryKeyColumns.Single().ShouldBe("id");
+        
+
+        using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        await table.MigrateAsync(conn);
+
+        var delta = await table.FindDeltaAsync(conn);
+        
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        
+    }
+    
+    [Fact]
+    public async Task can_create_basic_table_with_message_type()
+    {
+        var definition = new ExternalMessageTable(new DbObjectName("external", "incoming1"))
+        {
+            MessageType = typeof(Message1),
+            MessageTypeColumnName = "message_type"
+        };
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UsePostgresqlPersistenceAndTransport(Servers.PostgresConnectionString, "external");
+            }).StartAsync();
+
+        var storage = host.Services.GetRequiredService<IMessageStore>()
+            .As<PostgresqlMessageStore>();
+
+        var table = storage.AddExternalMessageTable(definition).ShouldBeOfType<Table>();
+        table.Columns.Select(x => x.Name).ShouldBe(new string[]{"id", "body", "timestamp", "message_type"});
+        table.Columns.Select(x => x.Type).ShouldBe(new string[]{"uuid", "jsonb", "timestamp with time zone", "varchar"});
+        table.PrimaryKeyColumns.Single().ShouldBe("id");
+        
+
+        using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        await table.MigrateAsync(conn);
+
+        var delta = await table.FindDeltaAsync(conn);
+        
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        
+    }
+    
+    [Fact]
+    public async Task end_to_end_default_message_type()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UsePostgresqlPersistenceAndTransport(Servers.PostgresConnectionString, "external");
+
+                opts.ListenForMessagesFromExternalDatabaseTable("external", "incoming1", table =>
+                {
+                    table.MessageType = typeof(Message1);
+                    table.PollingInterval = 1.Seconds();
+                });
+
+            }).StartAsync();
+
+        var tracked = await host.TrackActivity().Timeout(1.Minutes()).WaitForMessageToBeReceivedAt<Message1>(host).ExecuteAndWaitAsync(
+            _ => host.SendMessageThroughExternalTable("external.incoming1", new Message1()));
+
+        var envelope = tracked.Received.SingleEnvelope<Message1>();
+        envelope.Destination.ShouldBe(new Uri("external-table://external.incoming1/"));
+    }
+    
+        
+    [Fact]
+    public async Task end_to_end_default_variable_message_types()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UsePostgresqlPersistenceAndTransport(Servers.PostgresConnectionString, "external");
+
+                opts.ListenForMessagesFromExternalDatabaseTable("external", "incoming1", table =>
+                {
+                    table.MessageTypeColumnName = "message_type";
+                    table.PollingInterval = 1.Seconds();
+                });
+
+            }).StartAsync();
+
+        var tracked = await host.TrackActivity().Timeout(1.Minutes()).WaitForMessageToBeReceivedAt<Message2>(host).ExecuteAndWaitAsync(
+            _ => host.SendMessageThroughExternalTable("external.incoming1", new Message2()));
+
+        var envelope = tracked.Received.SingleEnvelope<Message2>();
+        envelope.Destination.ShouldBe(new Uri("external-table://external.incoming1/"));
+    }
+
+}
+
+public static class Bootstrapping
+{
+    public static void Configure()
+    {
+        #region sample_configuring_external_database_messaging
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            opts.UsePostgresqlPersistenceAndTransport(builder.Configuration.GetConnectionString("postgres"));
+
+            // Or
+            // opts.UseSqlServerPersistenceAndTransport(builder.Configuration.GetConnectionString("sqlserver"));
+            
+            // Or
+            // opts.Services
+            //     .AddMarten(builder.Configuration.GetConnectionString("postgres"))
+            //     .IntegrateWithWolverine();
+            
+            // Directing Wolverine to "listen" for messages in an externally controlled table
+            // You have to explicitly tell Wolverine about the schema name and table name
+            opts.ListenForMessagesFromExternalDatabaseTable("exports", "messaging", table =>
+                {
+                    // The primary key column for this table, default is "id"
+                    table.IdColumnName = "id";
+
+                    // What column has the actual JSON data? Default is "json"
+                    table.JsonBodyColumnName = "body";
+
+                    // Optionally tell Wolverine that the message type name is this
+                    // column. 
+                    table.MessageTypeColumnName = "message_type";
+
+                    // Add a column for the current time when a message was inserted
+                    // Strictly for diagnostics
+                    table.TimestampColumnName = "added";
+
+                    // How often should Wolverine poll this table? Default is 10 seconds
+                    table.PollingInterval = 1.Seconds();
+
+                    // Maximum number of messages that each node should try to pull in at 
+                    // any one time. Default is 100
+                    table.MessageBatchSize = 50;
+
+                    // Is Wolverine allowed to try to apply automatic database migrations for this
+                    // table at startup time? Default is true.
+                    // Also overridden by WolverineOptions.AutoBuildMessageStorageOnStartup
+                    table.AllowWolverineControl = true;
+
+                    // Wolverine uses a database advisory lock so that only one node at a time
+                    // can ever be polling for messages at any one time. Default is 12000
+                    // It might release contention to vary the advisory lock if you have multiple
+                    // incoming tables or applications targeting the same database
+                    table.AdvisoryLock = 12001;
+                    
+                    // Tell Wolverine what the default message type is coming from this
+                    // table to aid in deserialization
+                    table.MessageType = typeof(ExternalMessage);
+                    
+                    
+                })
+                
+                // Just showing that you have all the normal options for configuring and
+                // fine tuning the behavior of a message listening endpoint here
+                .Sequential();
+        });
+
+        #endregion
+    }
+}
+
+public class ExternalMessage;
+
+public static class Message1Handler
+{
+    public static void Handle(Message1 message)
+    {
+        Debug.WriteLine("Got a Message1");
+    }
+    
+    public static void Handle(Message2 message)
+    {
+        Debug.WriteLine("Got a Message2");
+    }
+    
+    public static void Handle(Message3 message)
+    {
+        Debug.WriteLine("Got a Message3");
+    }
+    
+}

--- a/src/Persistence/SqlServerTests/Transport/external_message_tables.cs
+++ b/src/Persistence/SqlServerTests/Transport/external_message_tables.cs
@@ -1,0 +1,171 @@
+using System.Diagnostics;
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Spectre.Console;
+using Weasel.Core;
+using Weasel.SqlServer;
+using Wolverine;
+using Wolverine.ComplianceTests.Compliance;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS.Transport;
+using Wolverine.SqlServer;
+using Wolverine.SqlServer.Persistence;
+using Wolverine.Tracking;
+using Table = Weasel.SqlServer.Tables.Table;
+
+namespace SqlServerTests.Transport;
+
+public class external_message_tables : IAsyncLifetime
+{
+    public async Task InitializeAsync()
+    {
+        await using var conn = new SqlConnection(Servers.SqlServerConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync("outside");
+    }
+    
+    public Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task can_create_basic_table()
+    {
+        var definition = new ExternalMessageTable( new DbObjectName("outside", "incoming1"))
+        {
+            MessageType = typeof(Message1)
+        };
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseSqlServerPersistenceAndTransport(Servers.SqlServerConnectionString, "outside");
+            }).StartAsync();
+
+        var storage = host.Services.GetRequiredService<IMessageStore>()
+            .As<SqlServerMessageStore>();
+
+        var table = storage.AddExternalMessageTable(definition).ShouldBeOfType<Table>();
+        table.Columns.Select(x => x.Name).ShouldBe(new string[]{"id", "body", "timestamp"});
+        table.Columns.Select(x => x.Type).ShouldBe(new string[]{"uniqueidentifier", "varbinary(max)", "datetimeoffset"});
+        table.PrimaryKeyColumns.Single().ShouldBe("id");
+        
+
+        using var conn = new SqlConnection(Servers.SqlServerConnectionString);
+        await conn.OpenAsync();
+
+        await table.MigrateAsync(conn);
+
+        var delta = await table.FindDeltaAsync(conn);
+        
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        
+    }
+    
+    [Fact]
+    public async Task can_create_basic_table_with_message_type()
+    {
+        var definition = new ExternalMessageTable(new DbObjectName("outside", "incoming1"))
+        {
+            MessageType = typeof(Message1),
+            MessageTypeColumnName = "message_type"
+        };
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseSqlServerPersistenceAndTransport(Servers.SqlServerConnectionString, "outside");
+            }).StartAsync();
+
+        var storage = host.Services.GetRequiredService<IMessageStore>()
+            .As<SqlServerMessageStore>();
+
+        var table = storage.AddExternalMessageTable(definition).ShouldBeOfType<Table>();
+        table.Columns.Select(x => x.Name).ShouldBe(new string[]{"id", "body", "timestamp", "message_type"});
+        table.Columns.Select(x => x.Type).ShouldBe(new string[]{"uniqueidentifier", "varbinary(max)", "datetimeoffset", "varchar(250)"});
+        table.PrimaryKeyColumns.Single().ShouldBe("id");
+        
+
+        using var conn = new SqlConnection(Servers.SqlServerConnectionString);
+        await conn.OpenAsync();
+
+        await table.MigrateAsync(conn);
+
+        var delta = await table.FindDeltaAsync(conn);
+        
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        
+    }
+
+    [Fact]
+    public async Task end_to_end_default_message_type()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseSqlServerPersistenceAndTransport(Servers.SqlServerConnectionString, "outside");
+
+                opts.ListenForMessagesFromExternalDatabaseTable("outside", "incoming1", table =>
+                {
+                    table.MessageType = typeof(Message1);
+                    table.PollingInterval = 1.Seconds();
+                });
+
+            }).StartAsync();
+
+        var tracked = await host.TrackActivity().Timeout(1.Minutes()).WaitForMessageToBeReceivedAt<Message1>(host).ExecuteAndWaitAsync(
+            _ => host.SendMessageThroughExternalTable("outside.incoming1", new Message1()));
+
+        var envelope = tracked.Received.SingleEnvelope<Message1>();
+        envelope.Destination.ShouldBe(new Uri("external-table://outside.incoming1/"));
+    }
+    
+    [Fact]
+    public async Task end_to_end_default_variable_message_types()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseSqlServerPersistenceAndTransport(Servers.SqlServerConnectionString, "outside");
+
+                opts.ListenForMessagesFromExternalDatabaseTable("outgoing", "incoming1", table =>
+                {
+                    table.MessageTypeColumnName = "message_type";
+                    table.PollingInterval = 1.Seconds();
+                });
+
+            }).StartAsync();
+
+        var tracked = await host.TrackActivity().Timeout(1.Minutes()).WaitForMessageToBeReceivedAt<Message2>(host).ExecuteAndWaitAsync(
+            _ => host.SendMessageThroughExternalTable("outgoing.incoming1", new Message2()));
+
+        var envelope = tracked.Received.SingleEnvelope<Message2>();
+        envelope.Destination.ShouldBe(new Uri("external-table://outgoing.incoming1/"));
+    }
+
+}
+
+public static class Message1Handler
+{
+    public static void Handle(Message1 message)
+    {
+        Debug.WriteLine("Got a Message1");
+    }
+    
+    public static void Handle(Message2 message)
+    {
+        Debug.WriteLine("Got a Message2");
+    }
+    
+    public static void Handle(Message3 message)
+    {
+        Debug.WriteLine("Got a Message3");
+    }
+    
+}

--- a/src/Persistence/Wolverine.Postgresql/Wolverine.Postgresql.csproj
+++ b/src/Persistence/Wolverine.Postgresql/Wolverine.Postgresql.csproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="Npgsql" Version="8.0.6" />
-        <PackageReference Include="Weasel.Postgresql" Version="7.12.0" />
+        <PackageReference Include="Weasel.Postgresql" Version="7.12.4" />
     </ItemGroup>
 
     <Import Project="../../../Analysis.Build.props"/>

--- a/src/Persistence/Wolverine.RDBMS/IMessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/IMessageDatabase.cs
@@ -4,7 +4,10 @@ using Weasel.Core;
 using Wolverine.Logging;
 using Wolverine.Persistence.Durability;
 using Wolverine.RDBMS.Polling;
+using Wolverine.RDBMS.Transport;
+using Wolverine.Runtime;
 using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
 using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
 
 namespace Wolverine.RDBMS;
@@ -41,4 +44,13 @@ public interface IMessageDatabase : IMessageStore
     void Enqueue(IDatabaseOperation operation);
     
     IAdvisoryLock AdvisoryLock { get; }
+
+    Task PollForMessagesFromExternalTablesAsync(IListener listener,
+        IWolverineRuntime settings, ExternalMessageTable externalTable,
+        IReceiver receiver,
+        CancellationToken token);
+
+    Task MigrateExternalMessageTable(ExternalMessageTable messageTable);
+
+    Task PublishMessageToExternalTableAsync(ExternalMessageTable table, string messageTypeName, byte[] json, CancellationToken token);
 }

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Polling.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Polling.cs
@@ -1,0 +1,70 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Weasel.Core;
+using Wolverine.RDBMS.Transport;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.RDBMS;
+
+public abstract partial class MessageDatabase<T>
+{
+    public abstract Task MigrateExternalMessageTable(ExternalMessageTable definition);
+    
+    public async Task PollForMessagesFromExternalTablesAsync(IListener listener,
+        IWolverineRuntime runtime,
+        ExternalMessageTable externalTable, IReceiver receiver,
+        CancellationToken token)
+    {
+        await using var conn = CreateConnection();
+        await conn.OpenAsync(token);
+
+        if (await TryAttainLockAsync(externalTable.AdvisoryLock, conn, token))
+        {
+            var command = buildFetchSql(conn, externalTable.TableName, externalTable.Columns().ToArray(),
+                externalTable.MessageBatchSize);
+
+            await using var reader = await command.ExecuteReaderAsync(token);
+            var envelopes = await externalTable.ReadAllAsync(reader, token);
+
+            await reader.CloseAsync();
+            
+            if (envelopes.Any())
+            {
+                // Important to make every envelope as being owned by the
+                // current node
+                foreach (var envelope in envelopes)
+                {
+                    envelope.Status = EnvelopeStatus.Incoming;
+                    envelope.OwnerId = runtime.DurabilitySettings.AssignedNodeNumber;
+                }
+
+                var tx = await conn.BeginTransactionAsync(token);
+                await StoreIncomingAsync(tx, envelopes);
+
+                await deleteMany(tx, envelopes.Select(x => x.Id).ToArray(), externalTable.TableName,
+                    externalTable.IdColumnName);
+                await tx.CommitAsync(token);
+
+                await receiver.ReceivedAsync(listener, envelopes);
+            }
+        }
+
+        await conn.CloseAsync();
+    }
+
+
+    public abstract ISchemaObject AddExternalMessageTable(ExternalMessageTable definition);
+
+    protected abstract Task deleteMany(DbTransaction tx, Guid[] ids, DbObjectName tableName, string mapperIdColumnName);
+
+    protected abstract Task<bool> TryAttainLockAsync(int lockId, T connection, CancellationToken token);
+
+    protected abstract DbCommand buildFetchSql(T conn, DbObjectName tableName, string[] columnNames, int maxRecords);
+
+    public abstract Task PublishMessageToExternalTableAsync(ExternalMessageTable table, string messageTypeName,
+        byte[] json,
+        CancellationToken token);
+    
+
+}

--- a/src/Persistence/Wolverine.RDBMS/Transport/ExternalDbTransport.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/ExternalDbTransport.cs
@@ -1,0 +1,40 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Weasel.Core;
+using Wolverine.Transports;
+
+namespace Wolverine.RDBMS.Transport;
+
+public class ExternalDbTransport : TransportBase<ExternalMessageTable>
+{
+    public static readonly string ProtocolName = "external-table";
+
+    public LightweightCache<DbObjectName, ExternalMessageTable> Tables { get; }
+
+    public ExternalDbTransport() : base(ProtocolName, "External Database Tables")
+    {
+        Tables = new LightweightCache<DbObjectName, ExternalMessageTable>(name =>
+            new ExternalMessageTable(name));
+    }
+
+    protected override IEnumerable<ExternalMessageTable> endpoints()
+    {
+        return Tables;
+    }
+
+    protected override ExternalMessageTable findEndpointByUri(Uri uri)
+    {
+        if (uri.Scheme != Protocol)
+        {
+            throw new ArgumentOutOfRangeException(nameof(uri));
+        }
+        
+        var existing =  Tables.Where(x => x.Uri.OriginalString == uri.OriginalString).FirstOrDefault();
+        if (existing != null) return existing;
+
+        var tableName = uri.OriginalString.Split("//")[1].TrimEnd('/');
+        var parts = tableName.Split(".");
+        var dbObjectName = new DbObjectName(parts[0], parts[1]);
+        return Tables[dbObjectName];
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/Transport/ExternalDbTransportExtensions.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/ExternalDbTransportExtensions.cs
@@ -1,0 +1,105 @@
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Weasel.Core;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Util;
+
+namespace Wolverine.RDBMS.Transport;
+
+public static class ExternalDbTransportExtensions
+{
+    /// <summary>
+    /// Testing helper to publish a message to an externally controlled message table
+    /// </summary>
+    /// <param name="host"></param>
+    /// <param name="qualifiedTableName"></param>
+    /// <param name="message"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    public static Task SendMessageThroughExternalTable(this IHost host, string qualifiedTableName, object message,
+        CancellationToken token = default)
+    {
+        return host.Services.GetRequiredService<IWolverineRuntime>()
+            .SendMessageThroughExternalTable(qualifiedTableName, message, token);
+    }
+    
+    /// <summary>
+    /// Testing helper to publish a message to an externally controlled message table
+    /// </summary>
+    /// <param name="runtime"></param>
+    /// <param name="qualifiedTableName"></param>
+    /// <param name="message"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public static async Task SendMessageThroughExternalTable(this IWolverineRuntime runtime, string qualifiedTableName,
+        object message, CancellationToken token = default)
+    {
+        if (qualifiedTableName == null)
+        {
+            throw new ArgumentNullException(nameof(qualifiedTableName));
+        }
+
+        if (message == null)
+        {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var serializer = runtime.Options.FindSerializer("application/json");
+        var json = serializer.WriteMessage(message);
+        var database = runtime.Storage.As<IMessageDatabase>();
+        var messageTypeName = message.GetType().ToMessageTypeName();
+
+        var transport = runtime.Options.ExternalDbTransport();
+        var table = transport.Tables.FirstOrDefault(x =>
+            x.TableName.QualifiedName.EqualsIgnoreCase(qualifiedTableName));
+
+        if (table == null)
+        {
+            throw new ArgumentOutOfRangeException(nameof(qualifiedTableName), $"Unknown external table '{qualifiedTableName}'");
+        }
+
+        if (table.AllowWolverineControl)
+        {
+            await database.MigrateExternalMessageTable(table);
+        }
+
+        await database.PublishMessageToExternalTableAsync(table, messageTypeName, json, token);
+    }
+    
+    /// <summary>
+    ///     Quick access to the Rabbit MQ Transport within this application.
+    ///     This is for advanced usage
+    /// </summary>
+    /// <param name="endpoints"></param>
+    /// <returns></returns>
+    internal static ExternalDbTransport ExternalDbTransport(this WolverineOptions endpoints)
+    {
+        var transports = endpoints.As<WolverineOptions>().Transports;
+
+        return transports.GetOrCreate<ExternalDbTransport>();
+    }
+
+    /// <summary>
+    /// Register a message listener to an external database table that conforms to Wolverine's specification
+    /// for incoming messages
+    /// </summary>
+    /// <param name="endpoints"></param>
+    /// <param name="schemaName">The database schema name for the external table</param>
+    /// <param name="tableName">The database table name for the external table</param>
+    /// <param name="configure">Optional configuration of the external table for Wolverine's polling of this table</param>
+    /// <returns></returns>
+    public static ListenerConfiguration ListenForMessagesFromExternalDatabaseTable(this WolverineOptions endpoints, string schemaName, string tableName,
+        Action<IExternalMessageTable>? configure = null)
+    {
+        var transport = endpoints.ExternalDbTransport();
+        var table = transport.Tables[new DbObjectName(schemaName, tableName)];
+        configure?.Invoke(table);
+
+        return new ListenerConfiguration(table);
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/Transport/ExternalMessageTable.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/ExternalMessageTable.cs
@@ -1,0 +1,99 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Weasel.Core;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Wolverine.Util;
+
+namespace Wolverine.RDBMS.Transport;
+
+public class ExternalMessageTable : Endpoint, IExternalMessageTable
+{
+    public ExternalMessageTable(DbObjectName tableName) : base(new Uri($"{ExternalDbTransport.ProtocolName}://{tableName.QualifiedName.ToLowerInvariant()}"), EndpointRole.Application)
+    {
+        IsListener = true;
+        TableName = tableName;
+    }
+
+    protected override bool supportsMode(EndpointMode mode)
+    {
+        return mode == EndpointMode.Durable;
+    }
+
+    public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+    {
+        var database = runtime.Storage as IMessageDatabase;
+        if (database == null)
+        {
+            throw new InvalidOperationException(
+                "The external table transport option can only be used in combination with a relational database message storage option, but the message store is " +
+                runtime.Storage);
+        }
+
+        return new ValueTask<IListener>(new ExternalMessageTableListener(this, runtime, receiver));
+    }
+
+    protected override ISender CreateSender(IWolverineRuntime runtime)
+    {
+        throw new NotSupportedException();
+    }
+
+    public TimeSpan PollingInterval { get; set; } = 10.Seconds();
+
+    public DbObjectName TableName { get; init; }
+    public string IdColumnName { get; set; } = "id";
+    public string JsonBodyColumnName { get; set; } = "body";
+    public string MessageTypeColumnName { get; set; } = null;
+    public string TimestampColumnName { get; set; } = "timestamp";
+
+    public bool AllowWolverineControl { get; set; } = true;
+
+    public int AdvisoryLock { get; set; } = 12000;
+
+    public IEnumerable<string> Columns()
+    {
+        yield return IdColumnName;
+        yield return JsonBodyColumnName;
+
+        if (MessageTypeColumnName.IsNotEmpty())
+        {
+            yield return MessageTypeColumnName;
+        }
+    }
+
+    public async Task<Envelope[]> ReadAllAsync(DbDataReader reader, CancellationToken token)
+    {
+        var envelopes = new List<Envelope>();
+
+        while (await reader.ReadAsync(token))
+        {
+            var id = await reader.GetFieldValueAsync<Guid>(0, token);
+            var json = await reader.GetFieldValueAsync<byte[]>(1, token);
+
+            var envelope = new Envelope
+            {
+                Id = id,
+                Data = json
+            };
+
+            if (MessageTypeColumnName.IsEmpty())
+            {
+                envelope.MessageType = MessageType?.ToMessageTypeName();
+            }
+            else
+            {
+                var messageTypeName = await reader.GetFieldValueAsync<string>(2, token);
+                envelope.MessageType = messageTypeName.IsEmpty() ? MessageType?.ToMessageTypeName() : messageTypeName;
+            }
+            
+            envelopes.Add(envelope);
+        }
+
+
+        return envelopes.ToArray();
+    }
+
+
+}

--- a/src/Persistence/Wolverine.RDBMS/Transport/ExternalMessageTableListener.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/ExternalMessageTableListener.cs
@@ -1,0 +1,98 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+
+namespace Wolverine.RDBMS.Transport;
+
+internal class ExternalMessageTableListener : IListener
+{
+    private readonly ExternalMessageTable _messageTable;
+    private readonly IMessageDatabase _database;
+    private readonly WolverineOptions _runtimeOptions;
+    private readonly CancellationTokenSource _cancellation;
+    private readonly Task _task;
+    private readonly IWolverineRuntime _runtime;
+    private readonly ILogger<ExternalMessageTableListener> _logger;
+
+    public ExternalMessageTableListener(ExternalMessageTable messageTable, IWolverineRuntime runtime, IReceiver receiver)
+    {
+        var database = runtime.Storage as IMessageDatabase;
+
+        _messageTable = messageTable;
+        _database = database ?? throw new InvalidOperationException(
+            "The external table transport option can only be used in combination with a relational database message storage option, but the message store is " +
+            runtime.Storage);
+        _runtimeOptions = runtime.Options;
+        _runtime = runtime;
+
+        _logger = runtime.LoggerFactory.CreateLogger<ExternalMessageTableListener>();
+
+        Address = messageTable.Uri;
+
+        if (receiver is DurableReceiver durable)
+        {
+            durable.ShouldPersistBeforeProcessing = false;
+        }
+
+        _cancellation = CancellationTokenSource.CreateLinkedTokenSource(_runtimeOptions.Durability.Cancellation);
+
+        _task = Task.Run(async () =>
+        {
+            // Wait a random amount to try to avoid contesting for the shared lock
+            await Task.Delay(Random.Shared.Next(0, 2000), _cancellation.Token);
+
+            if (_runtimeOptions.AutoBuildMessageStorageOnStartup && _messageTable.AllowWolverineControl)
+            {
+                try
+                {
+                    await _database.MigrateExternalMessageTable(_messageTable);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Error trying to migrate external message table {Table}", _messageTable.TableName.QualifiedName);
+                }
+            }
+            
+            while (!_cancellation.Token.IsCancellationRequested)
+            {
+                try
+                {
+                    await _database.PollForMessagesFromExternalTablesAsync(this, _runtime, _messageTable,
+                        receiver, _cancellation.Token);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Error trying to poll for messages from external table {Table}", _messageTable.TableName.QualifiedName);
+                }
+
+                await Task.Delay(_messageTable.PollingInterval, _cancellation.Token);
+            }
+        }, _cancellation.Token);
+    }
+
+    public ValueTask CompleteAsync(Envelope envelope)
+    {
+        return new ValueTask();
+    }
+
+    public ValueTask DeferAsync(Envelope envelope)
+    {
+        return new ValueTask();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _cancellation.Cancel();
+
+        _task.SafeDispose();
+        return ValueTask.CompletedTask;
+    }
+
+    public Uri Address { get; }
+    public ValueTask StopAsync()
+    {
+        return DisposeAsync();
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/Transport/IExternalMessageTable.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/IExternalMessageTable.cs
@@ -1,0 +1,56 @@
+namespace Wolverine.RDBMS.Transport;
+
+public interface IExternalMessageTable
+{
+    TimeSpan PollingInterval { get; set; }
+    
+    /// <summary>
+    /// What is the column name for the primary key of the external table? At this point, this
+    /// must be a Guid value. Default is "id"
+    /// </summary>
+    string IdColumnName { get; set; }
+    
+    /// <summary>
+    /// What is the column name for the column that holds the actual JSON data? Default is "json"
+    /// </summary>
+    string JsonBodyColumnName { get; set; }
+    
+    /// <summary>
+    /// What is the column name for the message type name? Only use this if you expect to receive
+    /// more than one type of message from this table. If null or empty, Wolverine will omit this column.
+    /// Default is null. If not null though, make sure you use the MessageTypeMapping
+    /// </summary>
+    string MessageTypeColumnName { get; set; }
+
+    /// <summary>
+    /// What is the column name for an informational timestamp column? If it's null, Wolverine
+    /// will omit this column. The default is "timestamp"
+    /// </summary>
+    string TimestampColumnName { get; set; }
+    
+    /// <summary>
+    /// Should Wolverine try to automatically execute database migrations for this table
+    /// on startup? Default is true. 
+    /// </summary>
+    bool AllowWolverineControl { get; set; }
+    
+    /// <summary>
+    /// If you are not sending message type information in your external table, set this
+    /// so that Wolverine "knows" what type the incoming message should be deserialized to
+    /// </summary>
+    Type? MessageType { get; set; }
+    
+    /// <summary>
+    /// How many messages at a time should the application pull in from the database?
+    /// Default is 100
+    /// </summary>
+    int MessageBatchSize { get; set; }
+    
+    /// <summary>
+    /// Wolverine uses an advisory lock against the database so that only one node
+    /// at a time can be pulling in messages from the external tables. The default
+    /// is 12000. You may want to change this to prevent collisions between applications
+    /// accessing the same database. 
+    /// </summary>
+    int AdvisoryLock { get; set; }
+}

--- a/src/Persistence/Wolverine.RDBMS/Wolverine.RDBMS.csproj
+++ b/src/Persistence/Wolverine.RDBMS/Wolverine.RDBMS.csproj
@@ -15,8 +15,8 @@
 
     <ItemGroup>
         <PackageReference Include="System.Data.Common" Version="4.3.0"/>
-        <PackageReference Include="Weasel.CommandLine" Version="7.12.0"/>
-        <PackageReference Include="Weasel.Core" Version="7.12.0"/>
+        <PackageReference Include="Weasel.CommandLine" Version="7.12.4"/>
+        <PackageReference Include="Weasel.Core" Version="7.12.4"/>
     </ItemGroup>
 
     <Import Project="../../../Analysis.Build.props"/>

--- a/src/Persistence/Wolverine.SqlServer/Wolverine.SqlServer.csproj
+++ b/src/Persistence/Wolverine.SqlServer/Wolverine.SqlServer.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Weasel.SqlServer" Version="7.12.0"/>
+        <PackageReference Include="Weasel.SqlServer" Version="7.12.4"/>
     </ItemGroup>
 
     <Import Project="../../../Analysis.Build.props"/>

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -31,7 +31,6 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
 
     // These members are for draining
     private bool _latched;
-    private readonly bool _shouldPersistBeforeProcessing;
 
     public DurableReceiver(Endpoint endpoint, IWolverineRuntime runtime, IHandlerPipeline pipeline)
     {
@@ -42,7 +41,7 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
 
         Uri = endpoint.Uri;
 
-        _shouldPersistBeforeProcessing = !(endpoint is IDatabaseBackedEndpoint);
+        ShouldPersistBeforeProcessing = !(endpoint is IDatabaseBackedEndpoint);
 
         endpoint.ExecutionOptions.CancellationToken = _settings.Cancellation;
 
@@ -123,6 +122,8 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
             _deadLetterSender = dlq;
         }
     }
+
+    public bool ShouldPersistBeforeProcessing { get; set; }
 
     public Uri Uri { get; }
 
@@ -329,7 +330,7 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
             return;
         }
 
-        if (_shouldPersistBeforeProcessing && !envelope.IsFromLocalDurableQueue())
+        if (ShouldPersistBeforeProcessing && !envelope.IsFromLocalDurableQueue())
         {
             try
             {
@@ -402,7 +403,7 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
         }
 
         var batchSucceeded = false;
-        if (_shouldPersistBeforeProcessing)
+        if (ShouldPersistBeforeProcessing)
         {
             try
             {


### PR DESCRIPTION
First cut at spiking in the external message tables

Some initial tests for creating a table for the external message tables

Pulled out IExternalMessageTable, adjusted Endpoint implementation of ExternalMessageTable

Added the extension methods for registering external message tables