### PR TITLE
Bump System.Text.RegularExpressions to 4.3.1

### DIFF
--- a/src/Persistence/Wolverine.RDBMS/Wolverine.RDBMS.csproj
+++ b/src/Persistence/Wolverine.RDBMS/Wolverine.RDBMS.csproj
@@ -13,6 +13,15 @@
         <ProjectReference Include="..\..\Wolverine\Wolverine.csproj"/>
     </ItemGroup>
 
+    <ItemGroup Label="Patch security vulnerabilities">
+        <!--
+            warning NU1903:
+            Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability,
+            https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+        -->
+        <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    </ItemGroup>
+
     <ItemGroup>
         <PackageReference Include="System.Data.Common" Version="4.3.0"/>
         <PackageReference Include="Weasel.CommandLine" Version="7.12.0"/>


### PR DESCRIPTION
Currently, when using Wolverine, `dotnet build` emits the following warning:

```
warning NU1903:
Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability,
https://github.com/advisories/GHSA-cmhx-cq75-c4mj    
```

See https://github.com/advisories/GHSA-cmhx-cq75-c4mj for details.

Using the following command

```
dotnet nuget why System.Text.RegularExpressions
```

I was able to trace it to the following graph:

```
Project '<masked>' has the following dependency graph(s) for 'System.Text.RegularExpressions':

  [net9.0]
   │
   ├─ <masked> (v1.0.0)
   │  └─ WolverineFx.Marten (v3.5.0)
   │     └─ WolverineFx.Postgresql (v3.5.0)
   │        └─ WolverineFx.RDBMS (v3.5.0)
   │           └─ System.Data.Common (v4.3.0)
   │              └─ System.Text.RegularExpressions (v4.3.0)
   ...
```

I checked the https://www.nuget.org/packages/System.Data.Common but it does not have a patched version after v4.3.0.

So the only option I can see is to reference it directly in `WolverineFx.RDBMS`.

I hope you find this valuable enough and meeting the repository standards.