### PR TITLE
Make IdentityAttribute bypass convention for determining aggregate ID

### DIFF
--- a/src/Persistence/MartenTests/AggregateHandlerAttributeTests.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerAttributeTests.cs
@@ -81,6 +81,13 @@ public class AggregateHandlerAttributeTests
     }
 
     [Fact]
+    public void determine_aggregate_id_with_identity_attribute_bypass()
+    {
+        AggregateHandlerAttribute.DetermineAggregateIdMember(typeof(Invoice), typeof(AggregateIdConventionBypassingCommand))
+            .Name.ShouldBe(nameof(AggregateIdConventionBypassingCommand.StreamId));
+    }
+
+    [Fact]
     public void cannot_determine_aggregate_id()
     {
         Should.Throw<InvalidOperationException>(() =>
@@ -95,6 +102,8 @@ public class Invoice
     public Guid Id { get; set; }
     public int Version { get; set; }
 }
+
+public record AggregateIdConventionBypassingCommand(Guid Id, [property: Identity] Guid StreamId);
 
 public record BadCommand(Guid XId);
 

--- a/src/Persistence/Wolverine.Marten/AggregateHandlerAttribute.cs
+++ b/src/Persistence/Wolverine.Marten/AggregateHandlerAttribute.cs
@@ -223,8 +223,9 @@ public class AggregateHandlerAttribute : ModifyChainAttribute
     internal static MemberInfo DetermineAggregateIdMember(Type aggregateType, Type commandType)
     {
         var conventionalMemberName = $"{aggregateType.Name}Id";
-        var member = commandType.GetMembers().FirstOrDefault(x =>
-            x.HasAttribute<IdentityAttribute>() || x.Name.EqualsIgnoreCase(conventionalMemberName) || x.Name.EqualsIgnoreCase("Id"));
+        var member = commandType.GetMembers().FirstOrDefault(x => x.HasAttribute<IdentityAttribute>())
+                     ?? commandType.GetMembers().FirstOrDefault(x =>
+                         x.Name.EqualsIgnoreCase(conventionalMemberName) || x.Name.EqualsIgnoreCase("Id"));
 
         if (member == null)
         {


### PR DESCRIPTION
Assuming it was a bug