### PR TITLE
Support deleting documents by id or expression as a IMartenOp side effect

### DIFF
--- a/src/Persistence/Wolverine.Marten/IMartenOp.cs
+++ b/src/Persistence/Wolverine.Marten/IMartenOp.cs
@@ -1,4 +1,5 @@
-﻿using JasperFx.CodeGeneration;
+﻿using System.Linq.Expressions;
+using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core;
@@ -155,6 +156,93 @@ public static class MartenOps
         }
 
         return new DeleteDoc<T>(document);
+    }
+
+    /// <summary>
+    /// Return a side effect of deleting the specified document in Marten by id
+    /// </summary>
+    /// <param name="id"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static DeleteDocById<T> Delete<T>(string id) where T : notnull
+    {
+        if (id == null)
+        {
+            throw new ArgumentNullException(nameof(id));
+        }
+
+        return new DeleteDocById<T>(id);
+    }
+
+    /// <summary>
+    /// Return a side effect of deleting the specified document in Marten by id
+    /// </summary>
+    /// <param name="id"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static DeleteDocById<T> Delete<T>(Guid id) where T : notnull
+    {
+        return new DeleteDocById<T>(id);
+    }
+
+    /// <summary>
+    /// Return a side effect of deleting the specified document in Marten by id
+    /// </summary>
+    /// <param name="id"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static DeleteDocById<T> Delete<T>(int id) where T : notnull
+    {
+        return new DeleteDocById<T>(id);
+    }
+
+    /// <summary>
+    /// Return a side effect of deleting the specified document in Marten by id
+    /// </summary>
+    /// <param name="id"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static DeleteDocById<T> Delete<T>(long id) where T : notnull
+    {
+        return new DeleteDocById<T>(id);
+    }
+
+    /// <summary>
+    /// Return a side effect of deleting the specified document in Marten by id
+    /// </summary>
+    /// <param name="id"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static DeleteDocById<T> Delete<T>(object id) where T : notnull
+    {
+        if (id == null)
+        {
+            throw new ArgumentNullException(nameof(id));
+        }
+
+        return new DeleteDocById<T>(id);
+    }
+
+    /// <summary>
+    /// Return a side effect of deleting documents that match the provided filter
+    /// </summary>
+    /// <param name="expression"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static DeleteDocWhere<T> DeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
+    {
+        if (expression == null)
+        {
+            throw new ArgumentNullException(nameof(expression));
+        }
+
+        return new DeleteDocWhere<T>(expression);
     }
 
     /// <summary>
@@ -366,6 +454,53 @@ public class DeleteDoc<T> : DocumentOp where T : notnull
     public override void Execute(IDocumentSession session)
     {
         session.Delete(_document);
+    }
+}
+
+public class DeleteDocById<T> : IMartenOp where T : notnull
+{
+    private readonly object _id;
+
+    public DeleteDocById(object id)
+    {
+        _id = id;
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        switch (_id)
+        {
+            case string idAsString:
+                session.Delete<T>(idAsString);
+                break;
+            case Guid idAsGuid:
+                session.Delete<T>(idAsGuid);
+                break;
+            case long idAsLong:
+                session.Delete<T>(idAsLong);
+                break;
+            case int idAsInt:
+                session.Delete<T>(idAsInt);
+                break;
+            default:
+                session.Delete<T>(_id);
+                break;
+        }
+    }
+}
+
+public class DeleteDocWhere<T> : IMartenOp where T : notnull
+{
+    private readonly Expression<Func<T, bool>> _expression;
+
+    public DeleteDocWhere(Expression<Func<T, bool>> expression)
+    {
+        _expression = expression;
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        session.DeleteWhere(_expression);
     }
 }
 


### PR DESCRIPTION
Ran into a situation where I had a handler that only needed to delete a document by id. Felt a bit overkill to fetch the document first so adding in more deletion marten ops to cover the missing delete commands.

Supports:

`MartenOps.Delete<T>(int id)`
`MartenOps.Delete<T>(long id)`
`MartenOps.Delete<T>(Guid id)`
`MartenOps.Delete<T>(string id)`
`MartenOps.Delete<T>(object id)`
`MartenOps.DelteWhere<T>(Expression<Func<T, bool>> expression)`


