### PR TITLE
Minor documentation updates

### DIFF
--- a/src/Http/Wolverine.Http.Tests/DocumentationSamples.cs
+++ b/src/Http/Wolverine.Http.Tests/DocumentationSamples.cs
@@ -30,7 +30,7 @@ public class ConditionalRedirectHandler
 {
     #region sample_conditional_IResult_return
 
-    [WolverineGet("/choose/color")]
+    [WolverinePost("/choose/color")]
     public IResult Redirect(GoToColor request)
     {
         switch (request.Color)


### PR DESCRIPTION
Don't use WolverineGet on methods with a request payload - reduce confusion.