### PR TITLE
Integration with Marten doc - Missing route attribute

### DIFF
--- a/src/Http/WolverineWebApi/Marten/Documents.cs
+++ b/src/Http/WolverineWebApi/Marten/Documents.cs
@@ -14,7 +14,7 @@ public class InvoicesEndpoint
     #region sample_get_invoice_longhand
 
 {
-    [WolverineGet("/invoices/longhand/id")]
+    [WolverineGet("/invoices/longhand/{id}")]
     [ProducesResponseType(404)]
     [ProducesResponseType(200, Type = typeof(Invoice))]
     public static async Task<IResult> GetInvoice(


### PR DESCRIPTION
`[WolverineGet("/invoices/longhand/id")]` is missing the route attribute.  Should be `[WolverineGet("/invoices/longhand/{id}")]`