### PR TITLE
Pass migration logger through to Migrator

### DIFF
--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
@@ -118,7 +118,7 @@ public abstract partial class MessageDatabase<T>
 
         if (migration.Difference != SchemaPatchDifference.None)
         {
-            await Migrator.ApplyAllAsync(conn, migration, _settings.AutoCreate, ct: _cancellation);
+            await Migrator.ApplyAllAsync(conn, migration, _settings.AutoCreate, new MigrationLogger(Logger), ct: _cancellation);
         }
     }
 


### PR DESCRIPTION
When a logger isn't passed Weasel falls back to a console logger which can't be controlled externally.

We could expose the `IMigrationLogger` on the `DatabaseBase<T>` in weasel and re-use here but it's currently private so for now just newing up a new one when needed but happy for alternatives 👍 