### PR TITLE
Only set empty body status code if it wasn't set by the handler already

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Bugs/Bug_766_status_code_overwritten.cs
+++ b/src/Http/Wolverine.Http.Tests/Bugs/Bug_766_status_code_overwritten.cs
@@ -1,0 +1,98 @@
+using Alba;
+using IntegrationTests;
+using Marten;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Wolverine.Marten;
+
+namespace Wolverine.Http.Tests.Bugs
+{
+    public class Bug_766_status_code_overwritten
+    {
+        [Theory]
+        [InlineData(400)]
+        [InlineData(404)]
+        [InlineData(500)]
+        public async Task status_code_should_not_be_overwritten_when_set_by_handler(int code)
+        {
+            var builder = WebApplication.CreateBuilder([]);
+
+            // config
+            builder.Services.AddMarten(opts =>
+            {
+                // Establish the connection string to your Marten database
+                opts.Connection(Servers.PostgresConnectionString);
+                opts.DatabaseSchemaName = "myapp";
+
+                // Specify that we want to use STJ as our serializer
+                opts.UseSystemTextJsonForSerialization();
+
+                opts.Policies.AllDocumentsSoftDeleted();
+                opts.Policies.AllDocumentsAreMultiTenanted();
+
+                opts.DisableNpgsqlLogging = true;
+            }).IntegrateWithWolverine().UseLightweightSessions();
+
+            builder.Host.UseWolverine(opts => opts.Discovery.IncludeAssembly(GetType().Assembly));
+
+            builder.Services.AddWolverineHttp();
+
+            // This is using Alba, which uses WebApplicationFactory under the covers
+            await using var host = await AlbaHost.For(builder, app =>
+            {
+                app.MapWolverineEndpoints();
+            });
+
+            await host.Scenario(x =>
+            {
+                x.Get.Url($"/status/{code}");
+                x.StatusCodeShouldBe(code);
+            });
+        }
+
+        [Fact]
+        public async Task status_code_should_be_204_when_no_body_and_default_status_code()
+        {
+            var builder = WebApplication.CreateBuilder([]);
+
+            // config
+            builder.Services.AddMarten(opts =>
+            {
+                // Establish the connection string to your Marten database
+                opts.Connection(Servers.PostgresConnectionString);
+                opts.DatabaseSchemaName = "myapp";
+
+                // Specify that we want to use STJ as our serializer
+                opts.UseSystemTextJsonForSerialization();
+
+                opts.Policies.AllDocumentsSoftDeleted();
+                opts.Policies.AllDocumentsAreMultiTenanted();
+
+                opts.DisableNpgsqlLogging = true;
+            }).IntegrateWithWolverine().UseLightweightSessions();
+
+            builder.Host.UseWolverine(opts => opts.Discovery.IncludeAssembly(GetType().Assembly));
+
+            builder.Services.AddWolverineHttp();
+
+            // This is using Alba, which uses WebApplicationFactory under the covers
+            await using var host = await AlbaHost.For(builder, app =>
+            {
+                app.MapWolverineEndpoints();
+            });
+
+            await host.Scenario(x =>
+            {
+                x.Get.Url($"/status/{200}");
+                x.StatusCodeShouldBe(204);
+            });
+        }
+    }
+
+    public static class StatusCodeEndpoints
+    {
+        [EmptyResponse]
+        [WolverineGet("/status/{code}")]
+        public static void SetStatusCode(int code, HttpContext httpContext) => httpContext.Response.StatusCode = code;
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/Bugs/Bug_766_status_code_overwritten.cs
+++ b/src/Http/Wolverine.Http.Tests/Bugs/Bug_766_status_code_overwritten.cs
@@ -23,14 +23,6 @@ namespace Wolverine.Http.Tests.Bugs
                 // Establish the connection string to your Marten database
                 opts.Connection(Servers.PostgresConnectionString);
                 opts.DatabaseSchemaName = "myapp";
-
-                // Specify that we want to use STJ as our serializer
-                opts.UseSystemTextJsonForSerialization();
-
-                opts.Policies.AllDocumentsSoftDeleted();
-                opts.Policies.AllDocumentsAreMultiTenanted();
-
-                opts.DisableNpgsqlLogging = true;
             }).IntegrateWithWolverine().UseLightweightSessions();
 
             builder.Host.UseWolverine(opts => opts.Discovery.IncludeAssembly(GetType().Assembly));
@@ -61,14 +53,6 @@ namespace Wolverine.Http.Tests.Bugs
                 // Establish the connection string to your Marten database
                 opts.Connection(Servers.PostgresConnectionString);
                 opts.DatabaseSchemaName = "myapp";
-
-                // Specify that we want to use STJ as our serializer
-                opts.UseSystemTextJsonForSerialization();
-
-                opts.Policies.AllDocumentsSoftDeleted();
-                opts.Policies.AllDocumentsAreMultiTenanted();
-
-                opts.DisableNpgsqlLogging = true;
             }).IntegrateWithWolverine().UseLightweightSessions();
 
             builder.Host.UseWolverine(opts => opts.Discovery.IncludeAssembly(GetType().Assembly));

--- a/src/Http/Wolverine.Http/Resources/EmptyBody204Policy.cs
+++ b/src/Http/Wolverine.Http/Resources/EmptyBody204Policy.cs
@@ -27,7 +27,8 @@ internal class WriteEmptyBodyStatusCode : SyncFrame
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
         writer.WriteComment("Wolverine automatically sets the status code to 204 for empty responses");
-        writer.Write($"if (!{_context!.Usage}.{nameof(HttpContext.Response)}.{nameof(HttpResponse.HasStarted)}) {_context!.Usage}.{nameof(HttpContext.Response)}.{nameof(HttpResponse.StatusCode)} = 204;");
+        // Only change the status code if it wasn't already set by the user's handler (default is 200).
+        writer.Write($"if ({_context!.Usage}.{nameof(HttpContext.Response)} is {{ {nameof(HttpResponse.HasStarted)}: false, {nameof(HttpResponse.StatusCode)}: 200 }}) {_context!.Usage}.{nameof(HttpContext.Response)}.{nameof(HttpResponse.StatusCode)} = 204;");
         Next?.GenerateCode(method, writer);
     }
 


### PR DESCRIPTION
This PR fixes #766. It modifies the `EmptyBody204Policy` policy to check if the `HttpResponse` status code is the default in addition to checking `HasStarted`. Only if both conditions are met does it set the status code to 204.