### PR TITLE
Fixes broken link for envelope in docs

### DIFF
--- a/docs/guide/handlers/cascading.md
+++ b/docs/guide/handlers/cascading.md
@@ -269,7 +269,7 @@ public class ConditionalResponseHandler
 
 ## Schedule Response Messages
 
-You may want to raise a delayed or scheduled response. In this case you will need to return an <[linkto:documentation/integration/customizing_envelopes;title=Envelope]> for the response as shown below:
+You may want to raise a delayed or scheduled response. In this case you will need to return an `Envelope` for the response as shown below:
 
 <!-- snippet: sample_DelayedResponseHandler -->
 <a id='snippet-sample_delayedresponsehandler'></a>


### PR DESCRIPTION
There was a broken link for the "Envelope" text in the Cascading Messages docs. Looking through the docs, I could not see anything obvious that it should be linking to, so I simply turned it into inline code. If there is a specific place in the docs it ought to be linking to, please let me know and I will adjust this PR.