### PR TITLE
Configure Kafka builders

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/InlineKafkaSender.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/InlineKafkaSender.cs
@@ -12,7 +12,7 @@ public class InlineKafkaSender : ISender, IDisposable
     {
         _topic = topic;
         Destination = topic.Uri;
-        _producer = new ProducerBuilder<string, string>(_topic.Parent.ProducerConfig).Build();
+        _producer = _topic.Parent.CreateProducer();
         
     }
 

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -16,11 +16,12 @@ internal class KafkaListener : IListener, IDisposable
     private readonly string? _messageTypeName;
     private readonly QualityOfService _qualityOfService;
 
-    public KafkaListener(KafkaTopic topic, ConsumerConfig config, IReceiver receiver,
+    public KafkaListener(KafkaTopic topic, ConsumerConfig config,
+        IConsumer<string, string> consumer, IReceiver receiver,
         ILogger<KafkaListener> logger)
     {
         Address = topic.Uri;
-        _consumer = new ConsumerBuilder<string, string>(config).Build();
+        _consumer = consumer;
         var mapper = topic.Mapper;
 
         _messageTypeName = topic.MessageType?.ToMessageTypeName();

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -15,6 +15,7 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
     public Action<ProducerBuilder<string, string>> ConfigureProducerBuilders { get; internal set; } = _ => {};
 
     public ConsumerConfig ConsumerConfig { get; } = new();
+    public Action<ConsumerBuilder<string, string>> ConfigureConsumerBuilders { get; internal set; } = _ => {};
 
     public AdminClientConfig AdminClientConfig { get; } = new();
 
@@ -62,5 +63,12 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
         var producerBuilder = new ProducerBuilder<string, string>(ProducerConfig);
         ConfigureProducerBuilders(producerBuilder);
         return producerBuilder.Build();
+    }
+
+    internal IConsumer<string, string> CreateConsumer()
+    {
+        var consumerBuilder = new ConsumerBuilder<string, string>(ConsumerConfig);
+        ConfigureConsumerBuilders(consumerBuilder);
+        return consumerBuilder.Build();
     }
 }

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -12,6 +12,8 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
     public Cache<string, KafkaTopic> Topics { get; }
 
     public ProducerConfig ProducerConfig { get; } = new();
+    public Action<ProducerBuilder<string, string>> ConfigureProducerBuilders { get; internal set; } = _ => {};
+
     public ConsumerConfig ConsumerConfig { get; } = new();
 
     public AdminClientConfig AdminClientConfig { get; } = new();
@@ -53,5 +55,12 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
     public override IEnumerable<PropertyColumn> DiagnosticColumns()
     {
         yield break;
+    }
+
+    internal IProducer<string, string> CreateProducer()
+    {
+        var producerBuilder = new ProducerBuilder<string, string>(ProducerConfig);
+        ConfigureProducerBuilders(producerBuilder);
+        return producerBuilder.Build();
     }
 }

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -18,6 +18,7 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
     public Action<ConsumerBuilder<string, string>> ConfigureConsumerBuilders { get; internal set; } = _ => {};
 
     public AdminClientConfig AdminClientConfig { get; } = new();
+    public Action<AdminClientBuilder> ConfigureAdminClientBuilders { get; internal set; } = _ => {};
 
     public KafkaTransport() : base("kafka", "Kafka Topics")
     {
@@ -70,5 +71,12 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
         var consumerBuilder = new ConsumerBuilder<string, string>(ConsumerConfig);
         ConfigureConsumerBuilders(consumerBuilder);
         return consumerBuilder.Build();
+    }
+
+    internal IAdminClient CreateAdminClient()
+    {
+        var adminClientBuilder = new AdminClientBuilder(AdminClientConfig);
+        ConfigureAdminClientBuilders(adminClientBuilder);
+        return adminClientBuilder.Build();
     }
 }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaSenderProtocol.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaSenderProtocol.cs
@@ -12,7 +12,7 @@ public class KafkaSenderProtocol : ISenderProtocol, IDisposable
     public KafkaSenderProtocol(KafkaTopic topic)
     {
         _topic = topic;
-        _producer = new ProducerBuilder<string, string>(_topic.Parent.ProducerConfig).Build();
+        _producer = _topic.Parent.CreateProducer();
     }
 
     public async Task SendBatchAsync(ISenderCallback callback, OutgoingMessageBatch batch)

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -41,7 +41,8 @@ public class KafkaTopic : Endpoint, IBrokerEndpoint
 
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
     {
-        var listener = new KafkaListener(this, Parent.ConsumerConfig, receiver, runtime.LoggerFactory.CreateLogger<KafkaListener>());
+        var listener = new KafkaListener(this, Parent.ConsumerConfig,
+            Parent.CreateConsumer(), receiver, runtime.LoggerFactory.CreateLogger<KafkaListener>());
         return ValueTask.FromResult((IListener)listener);
     }
 

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -78,25 +78,25 @@ public class KafkaTopic : Endpoint, IBrokerEndpoint
     public async ValueTask TeardownAsync(ILogger logger)
     {
         if (TopicName == WolverineTopicsName) return; // don't care, this is just a marker
-        using var client = new AdminClientBuilder(Parent.AdminClientConfig).Build();
-        await client.DeleteTopicsAsync(new string[] { TopicName });
+        using var adminClient = Parent.CreateAdminClient();
+        await adminClient.DeleteTopicsAsync([TopicName]);
     }
 
     public async ValueTask SetupAsync(ILogger logger)
     {
         if (TopicName == WolverineTopicsName) return; // don't care, this is just a marker
 
-        using var client = new AdminClientBuilder(Parent.AdminClientConfig).Build();
+        using var adminClient = Parent.CreateAdminClient();
 
         try
         {
-            await client.CreateTopicsAsync(new[]
-            {
+            await adminClient.CreateTopicsAsync(
+            [
                 new TopicSpecification
                 {
                     Name = TopicName
                 }
-            });
+            ]);
 
             logger.LogInformation("Created Kafka topic {Topic}", TopicName);
         }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -58,7 +58,7 @@ public class KafkaTopic : Endpoint, IBrokerEndpoint
         if (TopicName == WolverineTopicsName) return true; // don't care, this is just a marker
         try
         {
-            using var client = new ProducerBuilder<string, string>(Parent.ProducerConfig).Build();
+            using var client = Parent.CreateProducer();
             await client.ProduceAsync(TopicName, new Message<string, string>
             {
                 Key = "ping",

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
@@ -39,6 +39,17 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     }
 
     /// <summary>
+    /// Configure the Kafka message producer builders within the Wolverine transport
+    /// </summary>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public KafkaTransportExpression ConfigureProducerBuilders(Action<ProducerBuilder<string, string>> configure)
+    {
+        _transport.ConfigureProducerBuilders = configure;
+        return this;
+    }
+
+    /// <summary>
     /// Configure the Kafka message consumers within the Wolverine transport
     /// </summary>
     /// <param name="configure"></param>

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
@@ -84,6 +84,17 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     }
 
     /// <summary>
+    /// Configure the Kafka admin client builders within the Wolverine transport
+    /// </summary>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public KafkaTransportExpression ConfigureConsumerBuilders(Action<AdminClientBuilder> configure)
+    {
+        _transport.ConfigureAdminClientBuilders = configure;
+        return this;
+    }
+
+    /// <summary>
     /// Deletes and rebuilds topics on application startup
     /// </summary>
     /// <returns></returns>

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
@@ -61,6 +61,17 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     }
 
     /// <summary>
+    /// Configure the Kafka consumer builders within the Wolverine transport
+    /// </summary>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public KafkaTransportExpression ConfigureConsumerBuilders(Action<ConsumerBuilder<string, string>> configure)
+    {
+        _transport.ConfigureConsumerBuilders = configure;
+        return this;
+    }
+
+    /// <summary>
     /// Create newly used Kafka topics on endpoint activation if the topic is missing
     /// </summary>
     /// <param name="configure"></param>


### PR DESCRIPTION
### Motivation

We're using [AWS MSK](https://aws.amazon.com/msk/) (Amazon Managed Streaming for Apache Kafka), and our containerized applications authenticate via [IAM](https://aws.amazon.com/iam/) (AWS Identity and Access Management) using https://github.com/aws/aws-msk-iam-sasl-signer-net library.

As described in that repository's [Getting Started](https://github.com/aws/aws-msk-iam-sasl-signer-net?tab=readme-ov-file#getting-started) guide, specific properties on the resulting product—producer, consumer, or admin client—must be set via the corresponding builder—specifically, [Set OAuthBearerTokenRefreshHandler](https://github.com/search?q=repo%3Aconfluentinc%2Fconfluent-kafka-dotnet%20SetOAuthBearerTokenRefreshHandler&type=code).

Currently, Wolverine does not offer this capability.

In addition to the use case above, many other circumstances might require leveraging the full potential of the underlying [Confluent.Kafka](https://github.com/confluentinc/confluent-kafka-dotnet) library.

One of the baseline scenarios is troubleshooting Kafka connectivity in an environment using [SetLogHandler](https://github.com/confluentinc/confluent-kafka-dotnet/blob/6b281a85de2e4ee836f3be2435961f336a638e1b/src/Confluent.Kafka/ProducerBuilder.cs#L252) or [SetErrorHandler](https://github.com/confluentinc/confluent-kafka-dotnet/blob/6b281a85de2e4ee836f3be2435961f336a638e1b/src/Confluent.Kafka/ProducerBuilder.cs#L223).

### Proposal

I'm proposing the code I used to extend Wolverine's Kafka transport. This approach was verified in the AWS environment, and being able to customize `Confluent.Kafka`'s logging was very helpful in troubleshooting.

For e.g., I used the following values (or a subset):

- `"broker,msg,security"` for `ProducerConfig.Debug`
- "broker,admin,security"` for `AdminClientConfig.Debug`
- `"consumer,cgrp,topic,fetch,broker,security" for `ConsumerConfig.Debug`

But those would only work if `Set[Log|Error]Handler` was used on a corresponding builder.

### Notable workaround

If this does not get accepted, the workaround I used initially was to use [OutgoingMessages](https://wolverinefx.net/guide/handlers/cascading.html#using-outgoingmessages) and handle them by explicit [handlers](https://wolverinefx.net/guide/handlers/) with Producer/Client/etc. injected via DI and published to Kafka by hand.

### In closing

I tried to adhere to the existing code style and declaration order. I also used the `internal` modifier where appropriate. 

Let me know if I need to change anything.

As always, a HUGE THANK YOU for the fantastic JasperFx libraries!