### PR TITLE
Add support for DateOnly in query parameters

### DIFF
--- a/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs
+++ b/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs
@@ -355,6 +355,84 @@ public class using_querystring_parameters : IntegrationContext
         body.ReadAsText().ShouldBe("2025-04-05T13:37:42.0123456");
     }
 
+    [Fact]
+    public async Task using_dateonly_with_default_value()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/dateonly");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("0001-01-01");
+    }
+
+    [Fact]
+    public async Task using_dateonly_with_value()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/dateonly?value=2025-04-05");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("2025-04-05");
+    }
+
+    [Fact]
+    public async Task using_dateonly_with_invalid_value_returns_default()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/dateonly?value=-2025");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("0001-01-01");
+    }
+
+    [Fact]
+    public async Task using_nullable_dateonly_with_default_value()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/dateonly/nullable");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("Value is missing");
+    }
+
+    [Fact]
+    public async Task using_nullable_dateonly_with_value()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/dateonly?value=2025-04-05");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("2025-04-05");
+    }
+
+    [Fact]
+    public async Task using_nullable_dateonly_with_invalid_value_returns_default()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/dateonly?value=-2025");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("0001-01-01");
+    }
+
     #region sample_query_string_usage
 
     [Fact]

--- a/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs
+++ b/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs
@@ -264,6 +264,97 @@ public class using_querystring_parameters : IntegrationContext
         body.ReadAsText().ShouldBe("none");
     }
 
+    [Fact]
+    public async Task using_datetime_with_default_value()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/datetime");
+            
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("0001-01-01T00:00:00.0000000");
+    }
+
+    [Fact]
+    public async Task using_datetime_with_invalid_value_parses_to_default()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/datetime?value=-5-5-5");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("0001-01-01T00:00:00.0000000");
+    }
+
+    [Fact]
+    public async Task using_datetime_with_just_a_date()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/datetime?value=2025-04-05");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("2025-04-05T00:00:00.0000000");
+    }
+
+    [Fact]
+    public async Task using_datetime_including_time()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/datetime?value=2025-04-05T13:37:42.0123456");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("2025-04-05T13:37:42.0123456");
+    }
+
+    [Fact]
+    public async Task using_nullable_datetime_with_default_value()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/datetime/nullable");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("Value is missing");
+    }
+
+    [Fact]
+    public async Task using_nullable_datetime_with_just_a_date()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/datetime/nullable?value=2025-04-05");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("2025-04-05T00:00:00.0000000");
+    }
+
+    [Fact]
+    public async Task using_nullable_datetime_including_time()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/datetime/nullable?value=2025-04-05T13:37:42.0123456");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        body.ReadAsText().ShouldBe("2025-04-05T13:37:42.0123456");
+    }
+
     #region sample_query_string_usage
 
     [Fact]

--- a/src/Http/Wolverine.Http/CodeGen/RouteHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/RouteHandling.cs
@@ -94,7 +94,8 @@ internal class RouteParameterStrategy : IParameterStrategy
         { typeof(ulong), "ulong" },
         { typeof(Guid), typeof(Guid).FullName! },
         { typeof(DateTime), typeof(DateTime).FullName! },
-        { typeof(DateTimeOffset), typeof(DateTimeOffset).FullName! }
+        { typeof(DateTimeOffset), typeof(DateTimeOffset).FullName! },
+        { typeof(DateOnly), typeof(DateOnly).FullName! }
     };
 
     #endregion

--- a/src/Http/WolverineWebApi/QuerystringEndpoints.cs
+++ b/src/Http/WolverineWebApi/QuerystringEndpoints.cs
@@ -53,4 +53,16 @@ public static class QuerystringEndpoints
     {
         return value.HasValue ? value.Value.ToString("O") : "Value is missing";
     }
+
+    [WolverineGet("/querystring/dateonly")]
+    public static string DateOnly(DateOnly value)
+    {
+        return value.ToString("O");
+    }
+
+    [WolverineGet("/querystring/dateonly/nullable")]
+    public static string DateOnlyNullable(DateOnly? value)
+    {
+        return value.HasValue ? value.Value.ToString("O") : "Value is missing";
+    }
 }

--- a/src/Http/WolverineWebApi/QuerystringEndpoints.cs
+++ b/src/Http/WolverineWebApi/QuerystringEndpoints.cs
@@ -41,4 +41,16 @@ public static class QuerystringEndpoints
 
         return values.OrderBy(x => x).Select(x => x.ToString()).Join(",");
     }
+
+    [WolverineGet("/querystring/datetime")]
+    public static string DateTime(DateTime value)
+    {
+        return value.ToString("O");
+    }
+
+    [WolverineGet("/querystring/datetime/nullable")]
+    public static string DateTimeNullable(DateTime? value)
+    {
+        return value.HasValue ? value.Value.ToString("O") : "Value is missing";
+    }
 }


### PR DESCRIPTION
Our application, which I'm experimenting adding Wolverine to, uses a lot of `DateOnly` where we don't care about the time.

This PR adds support for getting a `DateOnly` resolved as a query parameter instead of requiring a `DateTime` which then have to be converted to `DateOnly` before being passed along.

Couldn't find any tests for `DateTime` as query parameters, so I added some of those as well