### PR TITLE
Query string parameters parsing to objects

### DIFF
--- a/src/Http/Wolverine.Http/CodeGen/ParsedArrayQueryStringValue.cs
+++ b/src/Http/Wolverine.Http/CodeGen/ParsedArrayQueryStringValue.cs
@@ -7,11 +7,19 @@ namespace Wolverine.Http.CodeGen;
 
 internal class ParsedArrayQueryStringValue : SyncFrame
 {
-    public ParsedArrayQueryStringValue(ParameterInfo parameter)
+    public ParsedArrayQueryStringValue(ParameterInfo parameter) : this(parameter.ParameterType, parameter.Name!)
     {
-        Variable = new QuerystringVariable(parameter.ParameterType, parameter.Name!, this);
     }
-    
+
+    public ParsedArrayQueryStringValue(PropertyInfo property) : this(property.PropertyType, property.Name!)
+    {
+    }
+
+    public ParsedArrayQueryStringValue(Type type, string name)
+    {
+        Variable = new QuerystringVariable(type, name, this);
+    }
+
     public QuerystringVariable Variable { get; }
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
@@ -27,7 +35,7 @@ internal class ParsedArrayQueryStringValue : SyncFrame
             var elementAlias = elementType.FullNameInCode();
 
             writer.Write($"var {Variable.Usage}_List = new {collectionAlias}();");
-            
+
             writer.Write($"BLOCK:foreach (var {Variable.Usage}Value in httpContext.Request.Query[\"{Variable.Usage}\"])");
 
             if (elementType.IsEnum)
@@ -47,10 +55,10 @@ internal class ParsedArrayQueryStringValue : SyncFrame
             writer.FinishBlock(); // parsing block
 
             writer.FinishBlock(); // foreach blobck
-            
+
             writer.Write($"var {Variable.Usage} = {Variable.Usage}_List.ToArray();");
         }
-        
+
         Next?.GenerateCode(method, writer);
     }
 }

--- a/src/Http/Wolverine.Http/CodeGen/QueryStringHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/QueryStringHandling.cs
@@ -36,9 +36,17 @@ internal class ReadStringQueryStringValue : SyncFrame
 
 internal class ParsedQueryStringValue : SyncFrame
 {
-    public ParsedQueryStringValue(ParameterInfo parameter)
+    public ParsedQueryStringValue(ParameterInfo parameter) : this(parameter.ParameterType, parameter.Name!)
     {
-        Variable = new QuerystringVariable(parameter.ParameterType, parameter.Name!, this);
+    }
+
+    public ParsedQueryStringValue(PropertyInfo property) : this(property.PropertyType, property.Name!)
+    {
+    }
+
+    public ParsedQueryStringValue(Type type, string name)
+    {
+        Variable = new QuerystringVariable(type, name, this);
     }
 
     public QuerystringVariable Variable { get; }
@@ -71,10 +79,18 @@ internal class ParsedNullableQueryStringValue : SyncFrame
     private readonly string _alias;
     private Type _innerTypeFromNullable;
 
-    public ParsedNullableQueryStringValue(ParameterInfo parameter)
+    public ParsedNullableQueryStringValue(ParameterInfo parameter) : this(parameter.ParameterType, parameter.Name!)
     {
-        Variable = new QuerystringVariable(parameter.ParameterType, parameter.Name!, this);
-        _innerTypeFromNullable = parameter.ParameterType.GetInnerTypeFromNullable();
+    }
+
+    public ParsedNullableQueryStringValue(PropertyInfo property) : this(property.PropertyType, property.Name!)
+    {
+    }
+
+    public ParsedNullableQueryStringValue(Type type, string name)
+    {
+        Variable = new QuerystringVariable(type, name, this);
+        _innerTypeFromNullable = type.GetInnerTypeFromNullable();
         _alias = _innerTypeFromNullable.FullNameInCode();
     }
 
@@ -107,10 +123,18 @@ internal class ParsedCollectionQueryStringValue : SyncFrame
 {
     private readonly Type _collectionElementType;
 
-    public ParsedCollectionQueryStringValue(ParameterInfo parameter)
+    public ParsedCollectionQueryStringValue(ParameterInfo parameter) : this(parameter.ParameterType, parameter.Name!)
     {
-        Variable = new QuerystringVariable(parameter.ParameterType, parameter.Name!, this);
-        _collectionElementType = GetCollectionElementType(parameter.ParameterType);
+    }
+
+    public ParsedCollectionQueryStringValue(PropertyInfo property) : this(property.PropertyType, property.Name!)
+    {
+    }
+
+    public ParsedCollectionQueryStringValue(Type type, string name)
+    {
+        Variable = new QuerystringVariable(type, name, this);
+        _collectionElementType = GetCollectionElementType(type);
     }
 
     public QuerystringVariable Variable { get; }

--- a/src/Http/Wolverine.Http/CodeGen/QueryStringObjectHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/QueryStringObjectHandling.cs
@@ -1,0 +1,218 @@
+using System.Reflection;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine.Runtime;
+
+namespace Wolverine.Http.CodeGen;
+
+internal class QueryStringObjectVariable : Variable
+{
+    public bool HasPrefix { get; set; } = false;
+    private QuerystringVariable[] _variables;
+    public string[] ArrayVariables => _variables
+        .Where(x => x.VariableType.IsArray | x.VariableType.IsAssignableTo(typeof(IEnumerable<>)))
+        .Select(x => x.Name)
+        .ToArray();
+
+    public QueryStringObjectVariable(Type variableType, QuerystringVariable[] variables) : base(variableType)
+    {
+        _variables = variables;
+    }
+
+    public QueryStringObjectVariable(Type variableType, string usage, QuerystringVariable[] variables) : base(variableType, usage)
+    {
+        _variables = variables;
+    }
+
+    public QueryStringObjectVariable(Type variableType, Frame creator, QuerystringVariable[] variables) : base(variableType, creator)
+    {
+        _variables = variables;
+    }
+
+    public QueryStringObjectVariable(Type variableType, string usage, Frame? creator, QuerystringVariable[] variables) : base(variableType, usage, creator)
+    {
+        _variables = variables;
+    }
+
+    public void SetPrefix(string? prefix = null)
+    {
+        foreach (var variable in _variables)
+        {
+            variable.Name = $"{prefix ?? Usage}.{variable.Name}";
+        }
+    }
+}
+
+internal class ReadJsonQueryString : AsyncFrame
+{
+    public ReadJsonQueryString(ParameterInfo parameter, QuerystringVariable[] variables)
+    {
+        var parameterName = parameter.Name!;
+        if (parameterName == "_")
+        {
+            parameterName = QueryStringObjectVariable.DefaultArgName(parameter.ParameterType);
+        }
+
+        Variable = new QueryStringObjectVariable(parameter.ParameterType, parameterName, this, variables);
+    }
+
+    public QueryStringObjectVariable Variable { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        var jsonContinue = $"{Variable.Usage}_continue";
+        List<string> arguments = [Variable.HasPrefix ? $"\"{Variable.Usage}\"" : "null"];
+        arguments.AddRange(Variable.ArrayVariables.Select(x => $"\"{x}\""));
+        
+        writer.WriteComment("Reading the request query strings via JSON deserialization");
+        writer.Write(
+            $"var ({Variable.Usage}, {jsonContinue}) = await ReadQueryStringJsonAsync<{Variable.VariableType.FullNameInCode()}>(httpContext, {string.Join(", ", arguments)});");
+        writer.Write(
+            $"if ({jsonContinue} == {typeof(HandlerContinuation).FullNameInCode()}.{nameof(HandlerContinuation.Stop)}) return;");
+
+        Next?.GenerateCode(method, writer);
+    }
+}
+
+internal class ReadJsonQueryStringWithNewtonsoft : MethodCall
+{
+    private static MethodInfo findMethodForType(Type parameterType)
+    {
+        return typeof(NewtonsoftHttpSerialization).GetMethod(nameof(NewtonsoftHttpSerialization.ReadFromJsonAsync))
+            .MakeGenericMethod(parameterType);
+    }
+
+    public ReadJsonQueryStringWithNewtonsoft(ParameterInfo parameter) : base(typeof(NewtonsoftHttpSerialization), findMethodForType(parameter.ParameterType))
+    {
+        var parameterName = parameter.Name!;
+        if (parameterName == "_")
+        {
+            parameterName = Variable.DefaultArgName(parameter.ParameterType);
+        }
+
+        ReturnVariable!.OverrideName(parameterName);
+
+        CommentText = "Reading the request body with JSON deserialization";
+    }
+}
+
+internal class QueryStringObjectStrategy : IParameterStrategy
+{
+    private QueryStringObjectVariable? _lastVariable;
+    private string? _lastChain;
+
+    public bool TryMatch(HttpChain chain, IServiceContainer container, ParameterInfo parameter, out Variable? variable)
+    {
+        if (parameter.GetAttribute<FromQueryAttribute>() is not null && !parameter.ParameterType.IsSimple())
+        {
+            if (_lastChain == chain.DisplayName && _lastVariable != null)
+            {
+                _lastVariable.HasPrefix = true;
+                _lastVariable.SetPrefix();
+            }
+            else
+            {
+                _lastChain = chain.DisplayName;
+                _lastVariable = null;
+            }
+
+            var properties = _lastVariable?.HasPrefix switch
+            {
+                true => GetProperties(parameter, parameter.Name),
+                _ => GetProperties(parameter)
+            };
+
+            var queryStringVariables = properties
+                .Select(x => chain.TryFindOrCreateQuerystringValue(x.Value, x.Key))
+                .Where(x => x != null)
+                .ToArray();
+
+            var queryObjectVariable = new ReadJsonQueryString(parameter, queryStringVariables!).Variable;
+            queryObjectVariable.HasPrefix = _lastVariable?.HasPrefix ?? false;
+
+            variable = Usage == JsonUsage.SystemTextJson
+                ? queryObjectVariable
+                : new ReadJsonQueryStringWithNewtonsoft(parameter).ReturnVariable!;
+
+            _lastVariable = variable as QueryStringObjectVariable;
+
+            return true;
+        }
+
+        variable = default;
+        return false;
+    }
+
+    public JsonUsage Usage { get; set; } = JsonUsage.SystemTextJson;
+
+    private Dictionary<string, Type> GetProperties(ParameterInfo parameter, string? root = null)
+    {
+        var properties = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+
+        var type = parameter.ParameterType;
+        var propertyInfos = type.GetProperties().Where(x => x.CanWrite);
+
+        foreach (var propertyInfo in propertyInfos)
+        {
+            BuildPropertyDictionary(propertyInfo, properties, root);
+        }
+
+        return properties;
+    }
+
+    private void BuildPropertyDictionary(PropertyInfo propertyInfo, Dictionary<string, Type> properties, string? root = null)
+    {
+        var type = propertyInfo.PropertyType;
+        var name = root == null ? propertyInfo.Name : $"{root}.{propertyInfo.Name}";
+        properties.Add(name, propertyInfo.PropertyType);
+
+        if (!type.IsSimple())
+        {
+            var propertyInfos = type.GetProperties().Where(x => x.CanWrite);
+
+            foreach (var prop in propertyInfos)
+            {
+                BuildPropertyDictionary(prop, properties, name);
+            }
+        }
+    }
+}
+
+internal static class QueryCollectionExtensions
+{
+    public static Dictionary<string, object> ToNestedDictionary(this IQueryCollection query, HashSet<string> isArray)
+    {
+        var result = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var kvp in query)
+        {
+            var keys = kvp.Key.Split('.');
+            AddNestedValue(result, keys, 0, isArray.Contains(kvp.Key) ? kvp.Value : kvp.Value.First());
+        }
+
+        return result;
+    }
+
+    private static void AddNestedValue(IDictionary<string, object> dict, string[] keys, int index, object value)
+    {
+        var key = keys[index];
+
+        if (index == keys.Length - 1)
+        {
+            dict[key] = value;
+            return;
+        }
+
+        if (!dict.TryGetValue(key, out var next))
+        {
+            next = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            dict[key] = next;
+        }
+
+        AddNestedValue((Dictionary<string, object>)next, keys, index + 1, value);
+    }
+}

--- a/src/Http/Wolverine.Http/CodeGen/QueryStringObjectHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/QueryStringObjectHandling.cs
@@ -38,7 +38,7 @@ internal class QueryStringObjectVariable : Variable
         _variables = variables;
     }
 
-    public void SetPrefix(string? prefix = null)
+    public void SetPrefixQueryStrings(string? prefix = null)
     {
         foreach (var variable in _variables)
         {
@@ -67,7 +67,7 @@ internal class ReadJsonQueryString : AsyncFrame
         var jsonContinue = $"{Variable.Usage}_continue";
         List<string> arguments = [Variable.HasPrefix ? $"\"{Variable.Usage}\"" : "null"];
         arguments.AddRange(Variable.ArrayVariables.Select(x => $"\"{x}\""));
-        
+
         writer.WriteComment("Reading the request query strings via JSON deserialization");
         writer.Write(
             $"var ({Variable.Usage}, {jsonContinue}) = await ReadQueryStringJsonAsync<{Variable.VariableType.FullNameInCode()}>(httpContext, {string.Join(", ", arguments)});");
@@ -112,7 +112,7 @@ internal class QueryStringObjectStrategy : IParameterStrategy
             if (_lastChain == chain.DisplayName && _lastVariable != null)
             {
                 _lastVariable.HasPrefix = true;
-                _lastVariable.SetPrefix();
+                _lastVariable.SetPrefixQueryStrings();
             }
             else
             {

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -48,6 +48,7 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
     public static readonly Variable[] HttpContextVariables =
         Variable.VariablesForProperties<HttpContext>(HttpGraph.Context);
+    public List<Variable> QueryStringObjectVariables = [];
 
     internal Variable? RequestBodyVariable { get; set; }
 

--- a/src/Http/Wolverine.Http/HttpGraph.ParameterMatching.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.ParameterMatching.cs
@@ -16,6 +16,7 @@ public partial class HttpGraph
         new RouteParameterStrategy(),
         new FromHeaderStrategy(),
         new QueryStringParameterStrategy(),
+        new QueryStringObjectStrategy(),
         new JsonBodyParameterStrategy()
     ];
 

--- a/src/Http/Wolverine.Http/HttpHandler.cs
+++ b/src/Http/Wolverine.Http/HttpHandler.cs
@@ -160,7 +160,7 @@ public abstract class HttpHandler
             var queryObject = root switch
             {
                 null => JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(dict), _jsonOptions),
-                _ => JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(dict[root]), _jsonOptions),
+                _ => dict.ContainsKey(root) ? JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(dict[root]), _jsonOptions) : JsonSerializer.Deserialize<T>("{}"),
             };
 
             return (queryObject, HandlerContinuation.Continue);


### PR DESCRIPTION
I add support to parse the Query string parameters into objects. Addressing #1289 

Example:
```csharp
[WolverineGet("/prova")]
public string GetProva([FromQuery] Person? person)
{
    ...
}

[WolverineGet("/prova_multiple")]
public string GetProvaMultiple([FromQuery] Person? person, [FromQuery] Gatto? gatto)
{
    ...
}

public record Person(string Name, int Age, string[] City, Dog Dog);

public record Gatto(string Name, int Age);

public record Dog
{
    public string Name { get; set; } = "Dog";
    public int Age { get; set; } = 42;
}
```

The Open Api generated:
![image](https://github.com/user-attachments/assets/e697d080-d3c1-49d9-952c-f0b2a2eeb286)
![image](https://github.com/user-attachments/assets/5d5864eb-af2c-4aee-bf1d-f0a5495739d8)

Not finished:
- I need to implement the parsing using Newtonsoft
- Multiple object not working properly
