### PR TITLE
[WIP] Adding AWS SQS Visibility Timeout Middleware

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -177,6 +177,16 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue
 
     public bool NativeDeadLetterQueueEnabled { get; }
 
+    public AmazonSqsQueue GetQueue()
+    {
+        return _queue;
+    }
+
+    public AmazonSqsTransport GetTransport()
+    {
+        return _transport;
+    }
+
     private AmazonSqsEnvelope buildEnvelope(Message message)
     {
         var envelope = new AmazonSqsEnvelope(message);

--- a/src/Transports/AWS/Wolverine.AmazonSqs/RenewVisibilityTimeoutMiddleware.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/RenewVisibilityTimeoutMiddleware.cs
@@ -1,0 +1,103 @@
+﻿using Amazon.SQS;
+using Amazon.SQS.Model;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Wolverine.AmazonSqs.Internal;
+
+namespace Wolverine.AmazonSqs;
+
+public class RenewVisibilityTimeoutMiddleware
+{
+    private readonly CancellationTokenSource _activeTokenSource;
+    private readonly Guid _envelopeId;
+    private readonly ILogger _logger;
+    //  SQS Max Visibility Tiemout is 12 hours - https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
+    private readonly TimeSpan _maxVisibilityTimeout = TimeSpan.FromHours(12);
+    private readonly string? _messageType;
+    private readonly int _queueVisibilityTimeout = 30;
+    private readonly string? _queueUrl;
+    private readonly string _receiptHandle;
+    private readonly Task _renewVisibilityTimeoutTask;
+    private readonly DateTime _startedAt;
+    private readonly AmazonSqsTransport _transport;
+
+    public RenewVisibilityTimeoutMiddleware(Envelope envelope, ILogger logger)
+    {
+        if (envelope is AmazonSqsEnvelope { Listener: SqsListener listener } sqsEnvelope)
+        {
+            _transport = listener.GetTransport();
+            _receiptHandle = sqsEnvelope.SqsMessage.ReceiptHandle;
+            _startedAt = DateTime.UtcNow;
+            
+            var queue = listener.GetQueue();
+            _queueVisibilityTimeout = Math.Min( _queueVisibilityTimeout, queue.VisibilityTimeout);
+            _queueUrl = queue.QueueUrl;
+        }
+
+        _envelopeId = envelope.Id;
+        _messageType = envelope.MessageType;
+        _logger = logger;
+        _activeTokenSource = new CancellationTokenSource();
+        _renewVisibilityTimeoutTask = Task.Run(RenewVisibilityTimeout);
+    }
+
+    private async Task RenewVisibilityTimeout()
+    {
+        if (_queueUrl is null) return;
+        
+        var delay = TimeSpan.FromSeconds(_queueVisibilityTimeout * 0.7);
+
+        while (!_activeTokenSource.IsCancellationRequested)
+            try
+            {
+                if (delay > TimeSpan.Zero)
+                    await Task.Delay(delay, _activeTokenSource.Token)
+                        .ContinueWith(t => t, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously,
+                            TaskScheduler.Default).ConfigureAwait(false);
+
+                if (_activeTokenSource.IsCancellationRequested)
+                    break;
+
+                await _transport.Client!.ChangeMessageVisibilityAsync(_queueUrl, _receiptHandle,
+                    _queueVisibilityTimeout);
+
+                if (DateTime.UtcNow - _startedAt.AddSeconds(_queueVisibilityTimeout) >= _maxVisibilityTimeout)
+                    break;
+            }
+            catch (MessageNotInflightException exception)
+            {
+                _logger.LogWarning(exception,
+                    "Envelope ({EnvelopeId} / {MessageType} / {ReceiptHandle}) no longer in flight", _envelopeId,
+                    _messageType, _receiptHandle);
+
+                break;
+            }
+            catch (ReceiptHandleIsInvalidException exception)
+            {
+                //  If the endpoint is Durable or Buffered this might happen
+                _logger.LogWarning(exception,
+                    "Envelope ({EnvelopeId} / {MessageType} / {ReceiptHandle}) receipt handle is invalid", _envelopeId,
+                    _messageType, _receiptHandle);
+
+                break;
+            }
+            catch (AmazonSQSException exception)
+            {
+                //  If the endpoint is Durable or Buffered this might happen with localstack
+                _logger.LogError(exception,
+                    "Error extending envelope ({EnvelopeId} / {MessageType} / {ReceiptHandle}) visibility timeout to {VisibilityTimeout} seconds ({ElapsedTime})",
+                    _envelopeId, _messageType, _receiptHandle, _queueVisibilityTimeout, DateTime.UtcNow - _startedAt);
+                break;
+            }
+            catch (Exception)
+            {
+                break;
+            }
+    }
+
+    public void Finally()
+    {
+        _activeTokenSource.Cancel();
+        _renewVisibilityTimeoutTask.SafeDispose();
+    }
+}


### PR DESCRIPTION
## Description
So basically in some cases when the Message Handler takes more time than the one set in Visibility Timeout to handle the message, it make the message to go back in the queue and started being handled twice.
Some common cases for the Message Handler to slow down could be:
- Database is slow
- Third party is slow

Having this change will allow us to have a visibility timeout lower than the 120 seconds by default from Wolverine. Which leads to some benefits as not worrying about slower messages and allowing the message to be quicker reprocessed from the queue.

## Questions
I have some questions regarding this change:
- Is the middleware the better approach to handle it?
- If we keep it as a middleware should we handle it as a queue configuration?
- Is there any difference in using the middleware constructor instead of "Before"?
- Is it ok to access the Queue and Transport with the SqsListener exposing them?
- I'm not entirely sure how this will behave with the Durable/Buffered queue. I know that when we try to call "ChangeMessageVisibilityAsync", we'll get an exception back which will be handled and will stop trying to renew it. But is that ok? Is there any other behavior that I should be worried of?

## Missing
I still need to add tests, but I want to be sure of how the implementation should be done before implementing it.

PS: I tested it both in my AWS Account and Localstack

### References
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html