### PR TITLE
Copy-Paste error in KafkaTransportExpression's method name

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs
@@ -43,9 +43,9 @@ public class DocumentationSamples
                         // are only exposed from the builder
                     })
                     
-                    .ConfigureAdminConsumerBuilders(builder =>
+                    .ConfigureAdminClientBuilders(builder =>
                     {
-                        // configure admin consumer builders
+                        // configure admin client builders
                     });
 
                 // Just publish all messages to Kafka topics

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
@@ -88,7 +88,7 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     /// </summary>
     /// <param name="configure"></param>
     /// <returns></returns>
-    public KafkaTransportExpression ConfigureAdminConsumerBuilders(Action<AdminClientBuilder> configure)
+    public KafkaTransportExpression ConfigureAdminClientBuilders(Action<AdminClientBuilder> configure)
     {
         _transport.ConfigureAdminClientBuilders = configure;
         return this;


### PR DESCRIPTION
Follow-up on #1346

Sorry for the oversight. I was doing it on Friday night after a tough week at work.