### PR TITLE
Allow disabling requeueing for Pulsar endpoints

### DIFF
--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -27,6 +27,7 @@ public class PulsarEndpoint : Endpoint
     public string? TopicName { get; private set; }
     public string SubscriptionName { get; internal set; } = "Wolverine";
     public SubscriptionType SubscriptionType { get; internal set; } = SubscriptionType.Exclusive;
+    public bool EnableRequeue { get; internal set; } = true;
 
     public static Uri UriFor(bool persistent, string tenant, string @namespace, string topicName)
     {

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -12,7 +12,8 @@ internal class PulsarListener : IListener
     private readonly IConsumer<ReadOnlySequence<byte>>? _consumer;
     private readonly CancellationTokenSource _localCancellation;
     private readonly Task? _receivingLoop;
-    private readonly PulsarSender _sender;
+    private readonly PulsarSender? _sender;
+    private readonly bool _enableRequeue;
 
     public PulsarListener(IWolverineRuntime runtime, PulsarEndpoint endpoint, IReceiver receiver,
         PulsarTransport transport,
@@ -27,7 +28,13 @@ internal class PulsarListener : IListener
 
         Address = endpoint.Uri;
 
-        _sender = new PulsarSender(runtime, endpoint, transport, _cancellation);
+        _enableRequeue = endpoint.EnableRequeue;
+
+        if (_enableRequeue)
+        {
+            _sender = new PulsarSender(runtime, endpoint, transport, _cancellation);
+        }
+
         var mapper = endpoint.BuildMapper(runtime);
 
         _localCancellation = new CancellationTokenSource();
@@ -71,7 +78,12 @@ internal class PulsarListener : IListener
 
     public async ValueTask DeferAsync(Envelope envelope)
     {
-        if (envelope is PulsarEnvelope e)
+        if (!_enableRequeue)
+        {
+            throw new InvalidOperationException("Requeue is not enabled for this endpoint");
+        }
+
+        if (_sender is not null && envelope is PulsarEnvelope e)
         {
             await _consumer!.Acknowledge(e.MessageData, _cancellation);
             await _sender.SendAsync(envelope);
@@ -87,7 +99,10 @@ internal class PulsarListener : IListener
             await _consumer.DisposeAsync();
         }
 
-        await _sender.DisposeAsync();
+        if (_sender != null)
+        {
+            await _sender.DisposeAsync();
+        }
 
         _receivingLoop!.Dispose();
     }
@@ -107,7 +122,12 @@ internal class PulsarListener : IListener
 
     public async Task<bool> TryRequeueAsync(Envelope envelope)
     {
-        if (envelope is PulsarEnvelope)
+        if (!_enableRequeue)
+        {
+            throw new InvalidOperationException("Requeue is not enabled for this endpoint");
+        }
+
+        if (_sender is not null && envelope is PulsarEnvelope)
         {
             await _sender.SendAsync(envelope);
             return true;

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -110,6 +110,7 @@ public class PulsarListenerConfiguration : ListenerConfiguration<PulsarListenerC
 
         return this;
     }
+
     /// <summary>
     ///     Add circuit breaker exception handling to this listener
     /// </summary>
@@ -123,6 +124,21 @@ public class PulsarListenerConfiguration : ListenerConfiguration<PulsarListenerC
             configure?.Invoke(e.CircuitBreakerOptions);
         });
 
+
+        return this;
+    }
+
+    /// <summary>
+    ///     Disable the possibility of requeueing messages
+    /// </summary>
+    /// <param name="enableRequeue"></param>
+    /// <returns></returns>
+    public PulsarListenerConfiguration DisableRequeue()
+    {
+        add(e =>
+        {
+            e.EnableRequeue = false;
+        });
 
         return this;
     }


### PR DESCRIPTION
This PR, if applied, will add a `DisableRequeue` methods on `PulsarListenerConfiguration`. The method will set a boolean in `PulsarEndpoint` that disables requeuing.

With requeuing disabled, the `PulsarEndpoint` will not create a Pulsar sender and will throw if requeueing is attempted.

Should the exception thrown be a custom exception? Should it even throw at all?

The justification is that if you only have read access to a subscription, you can't create a listener, since it also creates a sender at the same time currently.



