### PR TITLE
Kafka Transport Improvements. Closes GH-1318. Closes GH-1358

### DIFF
--- a/docs/guide/http/querystring.md
+++ b/docs/guide/http/querystring.md
@@ -69,7 +69,7 @@ public async Task use_decimal_querystring_hit()
     body.ReadAsText().ShouldBe("Amount is 42.1");
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs#L436-L475' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_string_usage' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs#L449-L488' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_string_usage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## [FromQuery] Binding <Badge type="tip" text="3.12" />

--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -64,11 +64,30 @@ using var host = await Host.CreateDefaultBuilder()
 
         // Or explicitly make subscription rules
         opts.PublishMessage<ColorMessage>()
-            .ToKafkaTopic("colors");
+            .ToKafkaTopic("colors")
+            
+            // Override the producer configuration for just this topic
+            .ConfigureProducer(config =>
+            {
+                config.BatchSize = 100;
+                config.EnableGaplessGuarantee = true;
+                config.EnableIdempotence = true;
+            });
 
         // Listen to topics
         opts.ListenToKafkaTopic("red")
-            .ProcessInline();
+            .ProcessInline()
+            
+            // Override the consumer configuration for only this 
+            // topic
+            .ConfigureConsumer(config =>
+            {
+                // This will also set the Envelope.GroupId for any
+                // received messages at this topic
+                config.GroupId = "foo";
+                
+                // Other configuration
+            });
 
         opts.ListenToKafkaTopic("green")
             .BufferedInMemory();
@@ -79,7 +98,7 @@ using var host = await Host.CreateDefaultBuilder()
         opts.Services.AddResourceSetupOnStartup();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L10-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_with_kafka' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L11-L94' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_with_kafka' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The various `Configure*****()` methods provide quick access to the full API of the Confluent Kafka library for security
@@ -99,4 +118,67 @@ public static ValueTask publish_by_partition_key(IMessageBus bus)
 }
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/when_publishing_and_receiving_by_partition_key.cs#L13-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_publish_to_kafka_by_partition_key' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Interoperability
+
+It's a complex world out there, and it's more than likely you'll need your Wolverine application to interact with system
+that aren't also Wolverine applications. At this time, it's possible to send or receive raw JSON through Kafka and Wolverine
+by using the options shown below in test harness code:
+
+<!-- snippet: sample_raw_json_sending_and_receiving_with_kafka -->
+<a id='snippet-sample_raw_json_sending_and_receiving_with_kafka'></a>
+```cs
+_receiver = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseKafka("localhost:9092").AutoProvision();
+        opts.ListenToKafkaTopic("json")
+            
+            // You do have to tell Wolverine what the message type
+            // is that you'll receive here so that it can deserialize the 
+            // incoming data
+            .ReceiveRawJson<ColorMessage>();
+
+        opts.Services.AddResourceSetupOnStartup();
+    }).StartAsync();
+
+_sender = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseKafka("localhost:9092").AutoProvision();
+        opts.Policies.DisableConventionalLocalRouting();
+
+        opts.Services.AddResourceSetupOnStartup();
+
+        opts.PublishAllMessages().ToKafkaTopic("json")
+            
+            // Just publish the outgoing information as pure JSON
+            // and no other Wolverine metadata
+            .PublishRawJson(new JsonSerializerOptions());
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/publish_and_receive_raw_json.cs#L19-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_raw_json_sending_and_receiving_with_kafka' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Instrumentation & Diagnostics <Badge type="tip" text="3.13" />
+
+When receiving messages through Kafka and Wolverine, there are some useful elements of Kafka metadata
+on the Wolverine `Envelope` you can use for instrumentation or diagnostics as shown in this sample middleware:
+
+<!-- snippet: sample_KafkaInstrumentation_middleware -->
+<a id='snippet-sample_kafkainstrumentation_middleware'></a>
+```cs
+public static class KafkaInstrumentation
+{
+    // Just showing what data elements are available to use for 
+    // extra instrumentation when listening to Kafka topics
+    public static void Before(Envelope envelope, ILogger logger)
+    {
+        logger.LogDebug("Received message from Kafka topic {TopicName} with Offset={Offset} and GroupId={GroupId}", 
+            envelope.TopicName, envelope.Offset, envelope.GroupId);
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L98-L111' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_kafkainstrumentation_middleware' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
@@ -22,6 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\..\Persistence\Wolverine.Postgresql\Wolverine.Postgresql.csproj" />
         <ProjectReference Include="..\..\..\Testing\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj" />
         <ProjectReference Include="..\BatchMessaging\BatchMessaging.csproj" />
         <ProjectReference Include="..\Wolverine.Kafka\Wolverine.Kafka.csproj"/>

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/broadcast_to_topic_rules.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/broadcast_to_topic_rules.cs
@@ -26,7 +26,7 @@ public class broadcast_to_topic_rules : IAsyncLifetime
             .UseWolverine(opts =>
             {
                 opts.UseKafka("localhost:9092").AutoProvision();
-                opts.ListenToKafkaTopic("red");
+                opts.ListenToKafkaTopic("red").ConfigureConsumer(c => c.GroupId = "crimson");
                 opts.ListenToKafkaTopic("green");
                 opts.ListenToKafkaTopic("blue");
                 opts.ListenToKafkaTopic("purple");
@@ -43,7 +43,7 @@ public class broadcast_to_topic_rules : IAsyncLifetime
                 opts.UseKafka("localhost:9092").AutoProvision();
                 opts.Policies.DisableConventionalLocalRouting();
 
-                opts.PublishAllMessages().ToKafkaTopics();
+                opts.PublishAllMessages().ToKafkaTopics().SendInline();
 
                 opts.ServiceName = "sender";
 
@@ -61,8 +61,11 @@ public class broadcast_to_topic_rules : IAsyncLifetime
             .WaitForMessageToBeReceivedAt<RedMessage>(_receiver)
             .PublishMessageAndWaitAsync(new RedMessage("one"));
 
-        session.Received.SingleEnvelope<RedMessage>()
+        var singleEnvelope = session.Received.SingleEnvelope<RedMessage>();
+        singleEnvelope
             .Destination.ShouldBe(new Uri("kafka://topic/red"));
+        
+        singleEnvelope.GroupId.ShouldBe("crimson");
     }
 
     [Fact]

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/configure_consumers_and_publishers.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/configure_consumers_and_publishers.cs
@@ -1,0 +1,127 @@
+using Microsoft.Extensions.Hosting;
+using Oakton.Resources;
+using Shouldly;
+using Wolverine.Kafka.Internals;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Xunit.Abstractions;
+
+namespace Wolverine.Kafka.Tests;
+
+public class configure_consumers_and_publishers : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+
+    public configure_consumers_and_publishers(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private IHost _host;
+
+    public async Task InitializeAsync()
+    {
+         _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka("localhost:9092")
+                    .ConfigureConsumers(consumer =>
+                    {
+                        // GroupId will be null
+                    })
+                    .ConfigureProducers(producer =>
+                    {
+                        producer.BatchSize = 111;
+                    });
+
+                // Just publish all messages to Kafka topics
+                // based on the message type (or message attributes)
+                // This will get fancier in the near future
+                opts.PublishAllMessages().ToKafkaTopics();
+
+                // Or explicitly make subscription rules
+                opts.PublishMessage<ColorMessage>()
+                    .ToKafkaTopic("colors")
+                    
+                    // Override the producer configuration for just this topic
+                    .ConfigureProducer(config =>
+                    {
+                        config.BatchSize = 222;
+                    }).SendInline();
+
+                // Listen to topics
+                opts.ListenToKafkaTopic("red")
+                    .ProcessInline()
+                    
+                    // Override the consumer configuration for only this 
+                    // topic
+                    .ConfigureConsumer(config =>
+                    {
+                        // This will also set the Envelope.GroupId for any
+                        // received messages at this topic
+                        config.GroupId = "foo";
+                        
+                        // Other configuration
+                    }).Named("red");
+
+                opts.ListenToKafkaTopic("green")
+                    .BufferedInMemory();
+
+
+                // This will direct Wolverine to try to ensure that all
+                // referenced Kafka topics exist at application start up
+                // time
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+    }
+
+    [Fact]
+    public async Task can_receive_the_group_id_for_the_consumer_on_the_envelope()
+    {
+        Task Send(IMessageContext c) => c.EndpointFor("red").SendAsync(new RedMessage("one")).AsTask();
+        var session = await _host.ExecuteAndWaitAsync(Send);
+        
+        session.Received.SingleEnvelope<RedMessage>()
+            .GroupId.ShouldBe("foo");
+    }
+
+    [Fact]
+    public void correctly_override_consumer_configuration()
+    {
+        foreach (var listener in _host.GetRuntime().Endpoints.ActiveListeners())
+        {
+            _output.WriteLine(listener.Uri.ToString());
+        }
+        
+        var red = _host.GetRuntime().Endpoints.ActiveListeners()
+            .Single(x => x.Uri == new Uri("kafka://topic/red")).ShouldBeOfType<ListeningAgent>()
+            .Listener.ShouldBeOfType<KafkaListener>();
+        
+        red.Config.GroupId.ShouldBe("foo");
+    }
+
+    [Fact]
+    public void use_default_confsumer_config_with_no_override()
+    {
+        var green = _host.GetRuntime().Endpoints.ActiveListeners()
+            .Single(x => x.Uri.ToString().Contains("green")).ShouldBeOfType<ListeningAgent>()
+            .Listener.ShouldBeOfType<KafkaListener>();
+        
+        green.Config.GroupId.ShouldBe("Wolverine.Kafka.Tests");
+    }
+
+    [Fact]
+    public void override_producer_configuration()
+    {
+        var colors = _host.GetRuntime().Endpoints.GetOrBuildSendingAgent(new Uri("kafka://topic/colors"))
+            .ShouldBeOfType<InlineSendingAgent>().Sender.ShouldBeOfType<InlineKafkaSender>();
+        colors.Config.BatchSize.ShouldBe(222);
+    }
+
+}

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/publish_and_receive_raw_json.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/publish_and_receive_raw_json.cs
@@ -1,7 +1,12 @@
 using System.Text.Json;
+using Confluent.Kafka;
+using IntegrationTests;
+using JasperFx.Core;
 using Microsoft.Extensions.Hosting;
 using Oakton.Resources;
 using Shouldly;
+using Wolverine.Kafka.Internals;
+using Wolverine.Postgresql;
 using Wolverine.Tracking;
 
 namespace Wolverine.Kafka.Tests;
@@ -13,15 +18,27 @@ public class publish_and_receive_raw_json : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        #region sample_raw_json_sending_and_receiving_with_kafka
 
         _receiver = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
+                //opts.EnableAutomaticFailureAcks = false;
                 opts.UseKafka("localhost:9092").AutoProvision();
                 opts.ListenToKafkaTopic("json")
+                    
+                    // You do have to tell Wolverine what the message type
+                    // is that you'll receive here so that it can deserialize the 
+                    // incoming data
                     .ReceiveRawJson<ColorMessage>();
 
                 opts.Services.AddResourceSetupOnStartup();
+                
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "kafka");
+
+                opts.Services.AddResourceSetupOnStartup();
+                
+                opts.Policies.UseDurableInboxOnAllListeners();
             }).StartAsync();
 
         _sender = await Host.CreateDefaultBuilder()
@@ -32,8 +49,14 @@ public class publish_and_receive_raw_json : IAsyncLifetime
 
                 opts.Services.AddResourceSetupOnStartup();
 
-                opts.PublishAllMessages().ToKafkaTopic("json").PublishRawJson(new JsonSerializerOptions());
+                opts.PublishAllMessages().ToKafkaTopic("json")
+                    
+                    // Just publish the outgoing information as pure JSON
+                    // and no other Wolverine metadata
+                    .PublishRawJson(new JsonSerializerOptions());
             }).StartAsync();
+
+        #endregion
     }
 
     [Fact]
@@ -46,6 +69,22 @@ public class publish_and_receive_raw_json : IAsyncLifetime
 
         session.Received.SingleMessage<ColorMessage>()
             .Color.ShouldBe("yellow");
+    }
+
+    [Fact]
+    public async Task do_not_go_into_infinite_loop_with_garbage_data()
+    {
+        var transport = _sender.GetRuntime().Options.Transports.GetOrCreate<KafkaTransport>();
+        var producerBuilder = new ProducerBuilder<string, string>(transport.ProducerConfig);
+        using var producer = producerBuilder.Build();
+
+        await producer.ProduceAsync("json", new Message<string, string>
+        {
+            Value = "{garbage}"
+        });
+        producer.Flush();
+
+        await Task.Delay(2.Minutes());
     }
 
     public async Task DisposeAsync()

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/when_publishing_and_receiving_by_partition_key.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/when_publishing_and_receiving_by_partition_key.cs
@@ -77,6 +77,12 @@ public class when_publishing_and_receiving_by_partition_key : IAsyncLifetime
         singleEnvelope.Offset.ShouldBeGreaterThan(0);
     }
 
+    [Fact]
+    public async Task receive_message_with_group_id()
+    {
+
+    }
+
     public async Task DisposeAsync()
     {
         await _sender.StopAsync();

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/InlineKafkaSender.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/InlineKafkaSender.cs
@@ -12,9 +12,11 @@ public class InlineKafkaSender : ISender, IDisposable
     {
         _topic = topic;
         Destination = topic.Uri;
-        _producer = _topic.Parent.CreateProducer();
-        
+        _producer = _topic.Parent.CreateProducer(topic.ProducerConfig);
+        Config = topic.ProducerConfig ?? _topic.Parent.ProducerConfig;
     }
+
+    public ProducerConfig Config { get; }
 
     public bool SupportsNativeScheduledSend => false;
     public Uri Destination { get; }
@@ -31,11 +33,12 @@ public class InlineKafkaSender : ISender, IDisposable
         }
     }
 
-    public ValueTask SendAsync(Envelope envelope)
+    public async ValueTask SendAsync(Envelope envelope)
     {
         var message = _topic.Mapper.CreateMessage(envelope);
-        
-        return new ValueTask(_producer.ProduceAsync(envelope.TopicName ?? _topic.TopicName, message));
+
+        await _producer.ProduceAsync(envelope.TopicName ?? _topic.TopicName, message);
+        _producer.Flush();
     }
 
     public void Dispose()

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -59,16 +59,16 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
         yield break;
     }
 
-    internal IProducer<string, string> CreateProducer()
+    internal IProducer<string, string> CreateProducer(ProducerConfig? config)
     {
-        var producerBuilder = new ProducerBuilder<string, string>(ProducerConfig);
+        var producerBuilder = new ProducerBuilder<string, string>(config ?? ProducerConfig);
         ConfigureProducerBuilders(producerBuilder);
         return producerBuilder.Build();
     }
 
-    internal IConsumer<string, string> CreateConsumer()
+    internal IConsumer<string, string> CreateConsumer(ConsumerConfig? config)
     {
-        var consumerBuilder = new ConsumerBuilder<string, string>(ConsumerConfig);
+        var consumerBuilder = new ConsumerBuilder<string, string>(config ?? ConsumerConfig);
         ConfigureConsumerBuilders(consumerBuilder);
         return consumerBuilder.Build();
     }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Confluent.Kafka;
 using Wolverine.Configuration;
 
 namespace Wolverine.Kafka;
@@ -54,6 +55,24 @@ public class KafkaListenerConfiguration : ListenerConfiguration<KafkaListenerCon
             e.MessageType = messageType;
         });
 
+        return this;
+    }
+    
+    /// <summary>
+    /// Configure the consumer config for only this topic. This overrides the default
+    /// settings at the transport level
+    /// </summary>
+    /// <param name="configuration"></param>
+    /// <returns></returns>
+    public KafkaListenerConfiguration ConfigureConsumer(Action<ConsumerConfig> configuration)
+    {
+        add(topic =>
+        {
+            var config = new ConsumerConfig();
+            configuration(config);
+
+            topic.ConsumerConfig = config;
+        });
         return this;
     }
 }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaSenderProtocol.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaSenderProtocol.cs
@@ -12,7 +12,7 @@ public class KafkaSenderProtocol : ISenderProtocol, IDisposable
     public KafkaSenderProtocol(KafkaTopic topic)
     {
         _topic = topic;
-        _producer = _topic.Parent.CreateProducer();
+        _producer = _topic.Parent.CreateProducer(_topic.ProducerConfig);
     }
 
     public async Task SendBatchAsync(ISenderCallback callback, OutgoingMessageBatch batch)
@@ -24,6 +24,8 @@ public class KafkaSenderProtocol : ISenderProtocol, IDisposable
             var message = _topic.Mapper.CreateMessage(envelope);
             await _producer.ProduceAsync(envelope.TopicName ?? _topic.TopicName, message);
         }
+
+        _producer.Flush();
 
         await callback.MarkSuccessfulAsync(batch);
     }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaSubscriberConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaSubscriberConfiguration.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Confluent.Kafka;
 using Wolverine.Configuration;
 
 namespace Wolverine.Kafka;
@@ -30,6 +31,24 @@ public class KafkaSubscriberConfiguration : SubscriberConfiguration<KafkaSubscri
     public KafkaSubscriberConfiguration PublishRawJson(JsonSerializerOptions? options = null)
     {
         add(e => e.Mapper = new JsonOnlyMapper(e, options ?? new JsonSerializerOptions()));
+        return this;
+    }
+
+    /// <summary>
+    /// Configure the producer config for only this topic. This overrides the default
+    /// settings at the transport level
+    /// </summary>
+    /// <param name="configuration"></param>
+    /// <returns></returns>
+    public KafkaSubscriberConfiguration ConfigureProducer(Action<ProducerConfig> configuration)
+    {
+        add(topic =>
+        {
+            var config = new ProducerConfig();
+            configuration(config);
+
+            topic.ProducerConfig = config;
+        });
         return this;
     }
 }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
@@ -28,7 +28,8 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     }
 
     /// <summary>
-    /// Configure the Kafka message producers within the Wolverine transport
+    /// Configure the Kafka message producers within the Wolverine transport. This can be
+    /// overridden at the topic level.
     /// </summary>
     /// <param name="configure"></param>
     /// <returns></returns>
@@ -50,7 +51,8 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     }
 
     /// <summary>
-    /// Configure the Kafka message consumers within the Wolverine transport
+    /// Configure the Kafka message consumers within the Wolverine transport. This can be
+    /// overridden at the topic level.
     /// </summary>
     /// <param name="configure"></param>
     /// <returns></returns>

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExtensions.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExtensions.cs
@@ -29,6 +29,8 @@ public static class KafkaTransportExtensions
     /// <returns></returns>
     public static KafkaTransportExpression UseKafka(this WolverineOptions options, string bootstrapServers)
     {
+        // Automatic failure acks do not work with Kafka serialization failures
+        options.EnableAutomaticFailureAcks = false;
         var transport = options.KafkaTransport();
         transport.ConsumerConfig.BootstrapServers = bootstrapServers;
         transport.ProducerConfig.BootstrapServers = bootstrapServers;

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -271,7 +271,7 @@ public partial class Envelope
 
     /// <summary>
     /// Application defined message group identifier. Part of AMQP 1.0 spec as the "group-id" property. Session identifier
-    /// for Azure Service Bus.  MessageGroupId for Amazon SQS FIFO Queue
+    /// for Azure Service Bus.  MessageGroupId for Amazon SQS FIFO Queue. This is the Group Id for Kafka consumers, if there is one
     /// </summary>
     public string? GroupId { get; set; }
 

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -28,7 +28,7 @@ public interface IListeningAgent : IListenerCircuit
     ValueTask MarkAsTooBusyAndStopReceivingAsync();
 }
 
-internal class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
+public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
 {
     private readonly BackPressureAgent? _backPressureAgent;
     private readonly CircuitBreaker? _circuitBreaker;

--- a/src/Wolverine/Transports/Sending/SendingAgent.cs
+++ b/src/Wolverine/Transports/Sending/SendingAgent.cs
@@ -7,7 +7,7 @@ using Wolverine.Util.Dataflow;
 
 namespace Wolverine.Transports.Sending;
 
-internal abstract class SendingAgent : ISendingAgent, ISenderCallback, ISenderCircuit, IAsyncDisposable
+public abstract class SendingAgent : ISendingAgent, ISenderCallback, ISenderCircuit, IAsyncDisposable
 {
     private readonly ILogger _logger;
     private readonly IMessageTracker _messageLogger;
@@ -34,6 +34,8 @@ internal abstract class SendingAgent : ISendingAgent, ISenderCallback, ISenderCi
 
         _sending = new RetryBlock<Envelope>(senderDelegate, logger, _settings.Cancellation, Endpoint.ExecutionOptions);
     }
+
+    public ISender Sender => _sender;
 
     public virtual ValueTask DisposeAsync()
     {


### PR DESCRIPTION
FINALLY knocked out the infinite loop problem w/ bad data to a Kafka listener Ability to override the Kafka producer or consumer config on a topic by topic basis

Doc updates for the Kafka transport

Putting the Kafka consumer group id on the Envelope