### PR TITLE
Adds documentation for the SNS transport

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -156,6 +156,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                                         {text: 'Conventional Routing', link:'/guide/messaging/transports/sqs/conventional-routing'},
                                         {text: 'Interoperability', link:'/guide/messaging/transports/sqs/interoperability'}
                                     ]},
+                                {text: 'Amazon SNS', link: '/guide/messaging/transports/sns'},
                                 {text: 'TCP', link: '/guide/messaging/transports/tcp'},
                                 {text: 'Google PubSub', link: '/guide/messaging/transports/gcp-pubsub/', items: [
                                         {text: 'Publishing', link:'/guide/messaging/transports/gcp-pubsub/publishing'},
@@ -243,6 +244,3 @@ const config: UserConfig<DefaultTheme.Config> = {
 }
 
 export default withMermaid(config);
-
-
-

--- a/docs/guide/messaging/transports/sns.md
+++ b/docs/guide/messaging/transports/sns.md
@@ -1,0 +1,164 @@
+# Using Amazon SNS
+
+::: warning
+At this moment, Wolverine cannot support request/reply mechanics (`IMessageBus.InvokeAsync<T>()`).
+:::
+
+:::tip
+Due to the nature of SNS, Wolverine doesn't include any listening functionality for this transport. You may forward 
+messages to Amazon SQS and use it in conjunction with the SQS transport to listen for incoming messages.
+:::
+
+Wolverine supports [Amazon SNS](https://aws.amazon.com/sns/) as a messaging transport through the WolverineFx.AmazonSns package.
+
+## Connecting to the Broker
+
+First, if you are using the [shared AWS config and credentials files](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html), the SNS connection is just this:
+
+<!-- snippet: sample_simplistic_aws_sns_setup -->
+<a id='snippet-sample_simplistic_aws_sns_setup'></a>
+```cs
+var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        // This does depend on the server having an AWS credentials file
+        // See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html for more information
+        opts.UseAmazonSnsTransport()
+
+            // Let Wolverine create missing topics and subscriptions as necessary
+            .AutoProvision();
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L27-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_simplistic_aws_sns_setup' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+
+<!-- snippet: sample_config_aws_sns_connection -->
+<a id='snippet-sample_config_aws_sns_connection'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.UseWolverine(opts =>
+{
+    var config = builder.Configuration;
+
+    opts.UseAmazonSnsTransport(snsConfig =>
+        {
+            snsConfig.ServiceURL = config["AwsUrl"];
+            // And any other elements of the SNS AmazonSimpleNotificationServiceConfig
+            // that you may need to configure
+        })
+
+        // Let Wolverine create missing topics and subscriptions as necessary
+        .AutoProvision();
+});
+
+using var host = builder.Build();
+await host.StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L45-L66' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_config_aws_sns_connection' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+
+If you'd just like to connect to Amazon SNS running from within [LocalStack](https://localstack.cloud/) on your development box,
+there's this helper:
+
+<!-- snippet: sample_connect_to_sns_and_localstack -->
+<a id='snippet-sample_connect_to_sns_and_localstack'></a>
+```cs
+var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        // Connect to an SNS broker running locally
+        // through LocalStack
+        opts.UseAmazonSnsTransportLocally();
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L12-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_connect_to_sns_and_localstack' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+And lastly, if you want to explicitly supply an access and secret key for your credentials to SNS, you can use this syntax:
+
+<!-- snippet: sample_setting_aws_sns_credentials -->
+<a id='snippet-sample_setting_aws_sns_credentials'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.UseWolverine(opts =>
+{
+    var config = builder.Configuration;
+
+    opts.UseAmazonSnsTransport(snsConfig =>
+        {
+            snsConfig.ServiceURL = config["AwsUrl"];
+            // And any other elements of the SNS AmazonSimpleNotificationServiceConfig
+            // that you may need to configure
+        })
+
+        // And you can also add explicit AWS credentials
+        .Credentials(new BasicAWSCredentials(config["AwsAccessKey"], config["AwsSecretKey"]))
+
+        // Let Wolverine create missing topics and subscriptions as necessary
+        .AutoProvision();
+});
+
+using var host = builder.Build();
+await host.StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L71-L95' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_setting_aws_sns_credentials' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Publishing
+
+Configuring subscriptions through Amazon SNS topics is done with the `ToSnsTopic()` extension method
+shown in the example below:
+
+<!-- snippet: sample_subscriber_rules_for_sns -->
+<a id='snippet-sample_subscriber_rules_for_sns'></a>
+```cs
+var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseAmazonSnsTransport();
+
+        opts.PublishMessage<Message1>()
+            .ToSnsTopic("outbound1")
+
+            // Increase the outgoing message throughput, but at the cost
+            // of strict ordering
+            .MessageBatchMaxDegreeOfParallelism(Environment.ProcessorCount)
+            .ConfigureTopicCreation(conf =>
+            {
+                // Configure topic creation request...
+            });
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L100-L119' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_subscriber_rules_for_sns' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Topic Subscriptions
+
+Wolverine gives you the ability to automatically subscribe SQS Queues to SNS topics with it's auto-provision
+feature through the `SubscribeSqsQueue()` extension method.
+
+<!-- snippet: sample_sns_topic_subscriptions_creation -->
+<a id='snippet-sample_sns_topic_subscriptions_creation'></a>
+```cs
+var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseAmazonSnsTransport()
+            // Without this, the SubscribeSqsQueue() call does nothing
+            .AutoProvision();
+
+        opts.PublishMessage<Message1>()
+            .ToSnsTopic("outbound1")
+            // Sets a subscriptions to be
+            .SubscribeSqsQueue("queueName",
+                config =>
+                {
+                    // Configure subscription attributes
+                    config.RawMessageDelivery = true;
+                });
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L124-L144' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sns_topic_subscriptions_creation' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->

--- a/docs/guide/messaging/transports/sqs/index.md
+++ b/docs/guide/messaging/transports/sqs/index.md
@@ -1,10 +1,5 @@
 # Using Amazon SQS
 
-::: tip
-Wolverine is only supporting SQS queues for right now, but support for publishing or subscribing through [Amazon SNS](https://aws.amazon.com/sns/) will
-come shortly.
-:::
-
 ::: warning
 At this moment, Wolverine cannot support request/reply mechanics (`IMessageBus.InvokeAsync<T>()`) with Amazon SQS.
 :::
@@ -117,4 +112,3 @@ await host.StartAsync();
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs#L83-L111' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_setting_aws_credentials' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
-

--- a/docs/guide/messaging/transports/sqs/interoperability.md
+++ b/docs/guide/messaging/transports/sqs/interoperability.md
@@ -45,7 +45,7 @@ using var host = await Host.CreateDefaultBuilder()
             o => { o.PropertyNamingPolicy = JsonNamingPolicy.CamelCase; });
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs#L235-L250' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_publish_raw_json_in_sqs' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs#L272-L287' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_publish_raw_json_in_sqs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Advanced Interoperability
@@ -86,7 +86,7 @@ public class CustomSqsMapper : ISqsEnvelopeMapper
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs#L271-L303' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_custom_sqs_mapper' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs#L308-L340' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_custom_sqs_mapper' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And apply this to any or all of your SQS endpoints with the configuration fluent interface as shown in this sample:
@@ -103,5 +103,47 @@ using var host = await Host.CreateDefaultBuilder()
             .ConfigureSenders(s => s.InteropWith(new CustomSqsMapper()));
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs#L256-L267' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_apply_custom_sqs_mapping' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs#L293-L304' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_apply_custom_sqs_mapping' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Receive messages from Amazon SNS
+
+By default, Amazon SNS wraps their messages in a structured format that includes metadata.
+You can either turn this feature off in SNS or let Wolverine handle the mapping like this:
+
+<!-- snippet: sample_receive_sns_topic_metadata_in_sqs -->
+<a id='snippet-sample_receive_sns_topic_metadata_in_sqs'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseAmazonSqsTransport();
+
+        opts.ListenToSqsQueue("incoming")
+            // Interops with SNS structured metadata
+            .ReceiveSnsTopicMessage();
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs#L236-L248' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_receive_sns_topic_metadata_in_sqs' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+It's possible for the original message that was sent to SNS to be in a different format. 
+You can also specify a custom mapper to deal with the format of the original message as shown here:
+
+<!-- snippet: sample_receive_sns_topic_metadata_with_custom_mapper_in_sqs -->
+<a id='snippet-sample_receive_sns_topic_metadata_with_custom_mapper_in_sqs'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseAmazonSqsTransport();
+
+        opts.ListenToSqsQueue("incoming")
+            // Interops with SNS structured metadata
+            .ReceiveSnsTopicMessage(
+                // Sets inner mapper for original message
+                new RawJsonSqsEnvelopeMapper(typeof(Message1), new JsonSerializerOptions()));
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs#L253-L267' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_receive_sns_topic_metadata_with_custom_mapper_in_sqs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs
@@ -1,0 +1,145 @@
+﻿using Amazon.Runtime;
+using Microsoft.Extensions.Hosting;
+using Wolverine.ComplianceTests.Compliance;
+
+namespace Wolverine.AmazonSns.Tests.Samples;
+
+public class Bootstrapping
+{
+    public async Task for_local_development()
+    {
+        #region sample_connect_to_sns_and_localstack
+
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Connect to an SNS broker running locally
+                // through LocalStack
+                opts.UseAmazonSnsTransportLocally();
+            }).StartAsync();
+
+        #endregion
+    }
+
+    public async Task connect_to_broker()
+    {
+        #region sample_simplistic_aws_sns_setup
+
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // This does depend on the server having an AWS credentials file
+                // See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html for more information
+                opts.UseAmazonSnsTransport()
+
+                    // Let Wolverine create missing topics and subscriptions as necessary
+                    .AutoProvision();
+            }).StartAsync();
+
+        #endregion
+    }
+    
+    public async Task connect_with_customization()
+    {
+        #region sample_config_aws_sns_connection
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            var config = builder.Configuration;
+
+            opts.UseAmazonSnsTransport(snsConfig =>
+                {
+                    snsConfig.ServiceURL = config["AwsUrl"];
+                    // And any other elements of the SNS AmazonSimpleNotificationServiceConfig
+                    // that you may need to configure
+                })
+
+                // Let Wolverine create missing topics and subscriptions as necessary
+                .AutoProvision();
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        #endregion
+    }
+    
+    public async Task setting_credentials()
+    {
+        #region sample_setting_aws_sns_credentials
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            var config = builder.Configuration;
+
+            opts.UseAmazonSnsTransport(snsConfig =>
+                {
+                    snsConfig.ServiceURL = config["AwsUrl"];
+                    // And any other elements of the SNS AmazonSimpleNotificationServiceConfig
+                    // that you may need to configure
+                })
+
+                // And you can also add explicit AWS credentials
+                .Credentials(new BasicAWSCredentials(config["AwsAccessKey"], config["AwsSecretKey"]))
+
+                // Let Wolverine create missing topics and subscriptions as necessary
+                .AutoProvision();
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        #endregion
+    }
+    
+    public async Task publishing()
+    {
+        #region sample_subscriber_rules_for_sns
+
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAmazonSnsTransport();
+
+                opts.PublishMessage<Message1>()
+                    .ToSnsTopic("outbound1")
+
+                    // Increase the outgoing message throughput, but at the cost
+                    // of strict ordering
+                    .MessageBatchMaxDegreeOfParallelism(Environment.ProcessorCount)
+                    .ConfigureTopicCreation(conf =>
+                    {
+                        // Configure topic creation request...
+                    });
+            }).StartAsync();
+
+        #endregion
+    }
+    
+    public async Task topic_subscriptions()
+    {
+        #region sample_sns_topic_subscriptions_creation
+
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAmazonSnsTransport()
+                    // Without this, the SubscribeSqsQueue() call does nothing
+                    .AutoProvision();
+
+                opts.PublishMessage<Message1>()
+                    .ToSnsTopic("outbound1")
+                    // Sets a subscriptions to be
+                    .SubscribeSqsQueue("queueName",
+                        config =>
+                        {
+                            // Configure subscription attributes
+                            config.RawMessageDelivery = true;
+                        });
+            }).StartAsync();
+
+        #endregion
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs
@@ -229,6 +229,43 @@ public class Bootstrapping
 
         #endregion
     }
+    
+    
+    public async Task receive_sns_topic_metadata()
+    {
+        #region sample_receive_sns_topic_metadata_in_sqs
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAmazonSqsTransport();
+
+                opts.ListenToSqsQueue("incoming")
+                    // Interops with SNS structured metadata
+                    .ReceiveSnsTopicMessage();
+            }).StartAsync();
+
+        #endregion
+    }
+    
+    public async Task receive_sns_topic_metadata_with_custom_mapper()
+    {
+        #region sample_receive_sns_topic_metadata_with_custom_mapper_in_sqs
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAmazonSqsTransport();
+
+                opts.ListenToSqsQueue("incoming")
+                    // Interops with SNS structured metadata
+                    .ReceiveSnsTopicMessage(
+                        // Sets inner mapper for original message
+                        new RawJsonSqsEnvelopeMapper(typeof(Message1), new JsonSerializerOptions()));
+            }).StartAsync();
+
+        #endregion
+    }
 
     public async Task publish_raw_json()
     {


### PR DESCRIPTION
Adds documentation for the new SNS transport.

I also removed the message at the top of the SQS transport saying that SNS support was coming soon and added a setup example for the new SNS mapper in the SQS transport.