### PR TITLE
Fix: return `Task.CompletedTask` when Saga not found in `TimeoutMessage` handlers

### DIFF
--- a/src/Wolverine/Persistence/Sagas/SagaChain.cs
+++ b/src/Wolverine/Persistence/Sagas/SagaChain.cs
@@ -164,7 +164,7 @@ public class SagaChain : HandlerChain
     {
         if (MessageType.CanBeCastTo<TimeoutMessage>())
         {
-            yield return new ReturnFrame();
+            yield return new ReturnFrame(new Variable(typeof(Task), $"{typeof(Task).FullNameInCode()}.{nameof(Task.CompletedTask)}"));
             yield break;
         }
 


### PR DESCRIPTION
I was trying the Saga example provided in the docs but the generation doesn't not compile because there an empty `return` instead of a `return Task.Complete`.

I'm not 100% sure that this is the correct fix.

```csharp
    // START: OrderTimeoutHandler477439855
    public class OrderTimeoutHandler477439855 : Wolverine.Runtime.Handlers.MessageHandler
    {
        private readonly Microsoft.Extensions.Logging.ILogger<SagaTest.Order> _logger;
        private readonly Wolverine.Persistence.Sagas.InMemorySagaPersistor _inMemorySagaPersistor;

        public OrderTimeoutHandler477439855(Microsoft.Extensions.Logging.ILogger<SagaTest.Order> logger, Wolverine.Persistence.Sagas.InMemorySagaPersistor inMemorySagaPersistor)
        {
            _logger = logger;
            _inMemorySagaPersistor = inMemorySagaPersistor;
        }



        public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
        {
            // The actual message body
            var orderTimeout = (SagaTest.OrderTimeout)context.Envelope.Message;

            string sagaId = context.Envelope.SagaId ?? orderTimeout.Id;
            if (string.IsNullOrEmpty(sagaId)) throw new Wolverine.Persistence.Sagas.IndeterminateSagaStateIdException(context.Envelope);
            var order = _inMemorySagaPersistor.Load<SagaTest.Order>(sagaId);
            if (order == null)
            {
                return; <-- HERE should return Task.Completed
            }

            else
            {

                // The actual message execution
                await order.Handle(orderTimeout, _logger).ConfigureAwait(false);

                // Delete the saga if completed, otherwise update it
                if (order.IsCompleted())
                {
                    _inMemorySagaPersistor.Delete<SagaTest.Order>(sagaId);
                }

                else
                {
                    _inMemorySagaPersistor.Store<SagaTest.Order>(order);
                }

                // No unit of work
            }

        }

    }

    // END: OrderTimeoutHandler477439855
```