### PR TITLE
Add Pulsar configuration to unsubscribe on close

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -72,8 +72,6 @@ builder.UseWolverine(opts =>
     {
         var pulsarUri = builder.Configuration.GetValue<Uri>("pulsar");
         c.ServiceUrl(pulsarUri);
-        
-        
     });
 
     // Listen for incoming messages from a Pulsar topic
@@ -86,12 +84,37 @@ builder.UseWolverine(opts =>
         
         // And all the normal Wolverine options...
         .Sequential();
+
+    // Disable requeue for all Pulsar endpoints
+    opts.DisablePulsarRequeue();
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Pulsar/Wolverine.Pulsar.Tests/DocumentationSamples.cs#L47-L72' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_requeue_for_pulsar' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Pulsar/Wolverine.Pulsar.Tests/DocumentationSamples.cs#L47-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_requeue_for_pulsar' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-
-
 If you have an application that has receive only access to a subscription but not permissions to publish to Pulsar,
-you cannot use the Wolverine "Requeue" error handling policy. 
+you cannot use the Wolverine "Requeue" error handling policy.
+
+### Subscription behavior when closing connection
+
+By default, the Pulsar transport will automatically close the subscription when the endpoints is being stopped.
+If the subscription is created for you, and should be kept after application shut down, you can change this behavior.
+
+<!-- snippet: sample_pulsar_unsubscribe_on_close -->
+<a id='snippet-sample_pulsar_unsubscribe_on_close'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.UseWolverine(opts =>
+{
+    opts.UsePulsar(c =>
+    {
+        var pulsarUri = builder.Configuration.GetValue<Uri>("pulsar");
+        c.ServiceUrl(pulsarUri);
+    });
+
+    // Disable unsubscribe on close for all Pulsar endpoints
+    opts.UnsubscribePulsarOnClose(PulsarUnsubscribeOnClose.Disabled);
+});
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Pulsar/Wolverine.Pulsar.Tests/DocumentationSamples.cs#L78-L93' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pulsar_unsubscribe_on_close' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/DocumentationSamples.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/DocumentationSamples.cs
@@ -53,8 +53,6 @@ public static class DocumentationSamples
             {
                 var pulsarUri = builder.Configuration.GetValue<Uri>("pulsar");
                 c.ServiceUrl(pulsarUri);
-                
-                
             });
 
             // Listen for incoming messages from a Pulsar topic
@@ -67,6 +65,29 @@ public static class DocumentationSamples
                 
                 // And all the normal Wolverine options...
                 .Sequential();
+
+            // Disable requeue for all Pulsar endpoints
+            opts.DisablePulsarRequeue();
+        });
+
+        #endregion
+    }
+
+    public static async Task policy_configuration()
+    {
+        #region sample_pulsar_unsubscribe_on_close
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            opts.UsePulsar(c =>
+            {
+                var pulsarUri = builder.Configuration.GetValue<Uri>("pulsar");
+                c.ServiceUrl(pulsarUri);
+            });
+
+            // Disable unsubscribe on close for all Pulsar endpoints
+            opts.UnsubscribePulsarOnClose(PulsarUnsubscribeOnClose.Disabled);
         });
 
         #endregion

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarListenerTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarListenerTests.cs
@@ -1,0 +1,73 @@
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+public class PulsarListenerTests
+{
+    [Fact]
+    public async Task UnsubscribeOnClose()
+    {
+        var host = await Host.CreateDefaultBuilder().UseWolverine(opts =>
+        {
+            opts.UsePulsar();
+            opts.UnsubscribePulsarOnClose(PulsarUnsubscribeOnClose.Enabled);
+
+            var topic = "persistent://public/default/test";
+            opts.PublishMessage<PulsarListenerTestMessage>().ToPulsarTopic(topic);
+            opts.ListenToPulsarTopic(topic).SubscriptionName("test");
+        }).StartAsync();
+
+        await host.Services.GetRequiredService<IMessageBus>().PublishAsync(new PulsarListenerTestMessage());
+
+        await host.StopAsync();
+
+        var subscriptionExists = await SubscriptionExists();
+
+        subscriptionExists.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task KeepSubscriptionOnClose()
+    {
+        var host = await Host.CreateDefaultBuilder().UseWolverine(opts =>
+        {
+            opts.UsePulsar();
+            opts.UnsubscribePulsarOnClose(PulsarUnsubscribeOnClose.Disabled);
+
+            var topic = "persistent://public/default/test";
+            opts.PublishMessage<PulsarListenerTestMessage>().ToPulsarTopic(topic);
+            opts.ListenToPulsarTopic(topic).SubscriptionName("test");
+        }).StartAsync();
+
+        await host.Services.GetRequiredService<IMessageBus>()!.PublishAsync(new PulsarListenerTestMessage());
+
+        await host.StopAsync();
+
+        var subscriptionExists = await SubscriptionExists();
+
+        subscriptionExists.ShouldBeTrue();
+    }
+
+    private async Task<bool> SubscriptionExists()
+    {
+        using var httpClient = new HttpClient();
+        var response =
+            await httpClient.GetAsync("http://localhost:8080/admin/v2/persistent/public/default/test/subscriptions");
+        var subscriptions = await response.Content.ReadFromJsonAsync<JsonValue[]>();
+        return subscriptions != null && subscriptions.Length != 0;
+    }
+}
+
+public class PulsarListenerTestMessage;
+
+public static class PulsarListenerTestMessageHandler
+{
+    public static void Handle(PulsarListenerTestMessage message)
+    {
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/endpoint_configuration.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/endpoint_configuration.cs
@@ -1,0 +1,56 @@
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+public class endpoint_configuration : IDisposable
+{
+    private readonly IHost _host;
+    private readonly IWolverineRuntime theRuntime;
+
+    public endpoint_configuration()
+    {
+        _host = Host.CreateDefaultBuilder().UseWolverine(opts =>
+        {
+            opts.UsePulsar();
+            opts.DisablePulsarRequeue();
+            opts.UnsubscribePulsarOnClose(PulsarUnsubscribeOnClose.Disabled);
+
+            opts.ListenToPulsarTopic("one");
+        }).Build();
+
+        var theOptions = _host.Get<WolverineOptions>();
+        theRuntime = _host.Get<IWolverineRuntime>();
+
+        foreach (var endpoint in theOptions.Transports.AllEndpoints())
+        {
+            endpoint.Compile(theRuntime);
+        }
+    }
+
+    public void Dispose()
+    {
+        _host.Dispose();
+    }
+
+    [Fact]
+    public void requeue_disabled()
+    {
+        var uri = PulsarEndpoint.UriFor("one");
+        var endpoint = theRuntime.Endpoints.EndpointFor(uri)?.As<PulsarEndpoint>();
+
+        endpoint.EnableRequeue.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void unsubscribe_on_close_disabled()
+    {
+        var uri = PulsarEndpoint.UriFor("one");
+        var endpoint = theRuntime.Endpoints.EndpointFor(uri)?.As<PulsarEndpoint>();
+
+        endpoint.UnsubscribeOnClose.ShouldBeFalse();
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/listener_configuration.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/listener_configuration.cs
@@ -1,0 +1,25 @@
+using JasperFx.Core.Reflection;
+using Shouldly;
+using Wolverine.Configuration;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+public class listener_configuration
+{
+    [Fact]
+    public void disable_requeue()
+    {
+        var transport = new PulsarTransport();
+        var endpoint = new PulsarEndpoint(new Uri("pulsar://persistent/default/test/test"), transport);
+        var listenerConfiguration = new PulsarListenerConfiguration(endpoint);
+
+        listenerConfiguration.DisableRequeue();
+
+        endpoint.EnableRequeue.ShouldBeTrue();
+
+        listenerConfiguration.As<IDelayedEndpointConfiguration>().Apply();
+
+        endpoint.EnableRequeue.ShouldBeFalse();
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEnableRequeuePolicy.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEnableRequeuePolicy.cs
@@ -1,0 +1,25 @@
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+
+namespace Wolverine.Pulsar;
+
+/// <summary>
+/// Applies the specified requeue policy to all Pulsar endpoints.
+/// </summary>
+/// <param name="enableRequeue"></param>
+public class PulsarEnableRequeuePolicy(PulsarRequeue enableRequeue) : IEndpointPolicy
+{
+    public void Apply(Endpoint endpoint, IWolverineRuntime runtime)
+    {
+        if (endpoint is PulsarEndpoint e)
+        {
+            e.EnableRequeue = enableRequeue == PulsarRequeue.Enabled;
+        }
+    }
+}
+
+public enum PulsarRequeue
+{
+    Enabled,
+    Disabled,
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -28,6 +28,7 @@ public class PulsarEndpoint : Endpoint
     public string SubscriptionName { get; internal set; } = "Wolverine";
     public SubscriptionType SubscriptionType { get; internal set; } = SubscriptionType.Exclusive;
     public bool EnableRequeue { get; internal set; } = true;
+    public bool UnsubscribeOnClose { get; internal set; } = true;
 
     public static Uri UriFor(bool persistent, string tenant, string @namespace, string topicName)
     {

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -73,6 +73,29 @@ public static class PulsarTransportExtensions
         endpoint.IsListener = true;
         return new PulsarListenerConfiguration(endpoint);
     }
+
+    /// <summary>
+    ///     Set the specified unsubscribe on close setting for all Pulsar endpoints.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="unsubscribeOnClose"></param>
+    /// <returns></returns>
+    public static IPolicies UnsubscribePulsarOnClose(this IPolicies policies, PulsarUnsubscribeOnClose unsubscribeOnClose)
+    {
+        policies.Add(new PulsarUnsubscribeOnClosePolicy(unsubscribeOnClose));
+        return policies;
+    }
+
+    /// <summary>
+    ///     Disable the possibility of requeueing messages for all Pulsar endpoints.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public static IPolicies DisablePulsarRequeue(this IPolicies policies)
+    {
+        policies.Add(new PulsarEnableRequeuePolicy(PulsarRequeue.Disabled));
+        return policies;
+    }
 }
 
 public class PulsarListenerConfiguration : ListenerConfiguration<PulsarListenerConfiguration, PulsarEndpoint>
@@ -95,7 +118,7 @@ public class PulsarListenerConfiguration : ListenerConfiguration<PulsarListenerC
 
         return this;
     }
-    
+
     /// <summary>
     /// Override the Pulsar subscription type for just this topic
     /// </summary>

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -131,13 +131,27 @@ public class PulsarListenerConfiguration : ListenerConfiguration<PulsarListenerC
     /// <summary>
     ///     Disable the possibility of requeueing messages
     /// </summary>
-    /// <param name="enableRequeue"></param>
     /// <returns></returns>
     public PulsarListenerConfiguration DisableRequeue()
     {
         add(e =>
         {
             e.EnableRequeue = false;
+        });
+
+        return this;
+    }
+
+    /// <summary>
+    ///     Set whether the subscription should be unsubscribed when the listener is closed.
+    /// </summary>
+    /// <param name="unsubscribeOnClose"></param>
+    /// <returns></returns>
+    public PulsarListenerConfiguration UnsubscribeOnClose(bool unsubscribeOnClose)
+    {
+        add(e =>
+        {
+            e.UnsubscribeOnClose = unsubscribeOnClose;
         });
 
         return this;

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarUnsubscribeOnClosePolicy.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarUnsubscribeOnClosePolicy.cs
@@ -1,0 +1,25 @@
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+
+namespace Wolverine.Pulsar;
+
+/// <summary>
+/// Applies the specified unsubscribe on close policy to all Pulsar endpoints.
+/// </summary>
+/// <param name="unsubscribeOnClose"></param>
+public class PulsarUnsubscribeOnClosePolicy(PulsarUnsubscribeOnClose unsubscribeOnClose) : IEndpointPolicy
+{
+    public void Apply(Endpoint endpoint, IWolverineRuntime runtime)
+    {
+        if (endpoint is PulsarEndpoint e)
+        {
+            e.UnsubscribeOnClose = unsubscribeOnClose == PulsarUnsubscribeOnClose.Enabled;
+        }
+    }
+}
+
+public enum PulsarUnsubscribeOnClose
+{
+    Enabled,
+    Disabled,
+}


### PR DESCRIPTION
This PR adds an `UnsubscribeOnClose(bool)` to `PulsarTransportExtension` to set whether the Pulsar listener should unsubscribe when it's closed.

The default is `true` to keep the current behavior.

Ideally, I would prefer this (and enable requeue) to default to false and be opt-in, but that would be a breaking change.

### Motivation
We have a setup where subscriptions are created by an external system, and due to access rights limitations, our consumer can't create subscriptions but can delete them.
So we need a way to have the subscription outlive the listener.