### PR TITLE
Fix error message logging in Amazon SQS listener 

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -116,7 +116,7 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue
                     failedCount++;
                     var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();
 
-                    logger.LogError(e, "Error while trying to retrieve messages from Azure Service Bus {Uri}",
+                    logger.LogError(e, "Error while trying to retrieve messages from SQS Queue {Uri}",
                         queue.Uri);
                     await Task.Delay(pauseTime);
                 }


### PR DESCRIPTION
Fix the error message in SqsListener.cs to correctly reference the fact that it is an SQS queue and not an Azure Service Bus.
