### PR TITLE
Binary producer/consumer for kafka

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
@@ -6,7 +6,7 @@ using Wolverine.Util;
 
 namespace Wolverine.Kafka;
 
-public interface IKafkaEnvelopeMapper : IEnvelopeMapper<Message<string, string>, Message<string, string>>;
+public interface IKafkaEnvelopeMapper : IEnvelopeMapper<Message<string, byte[]>, Message<string, byte[]>>;
 
 /// <summary>
 /// Option to publish or receive raw JSON from or to Kafka topics
@@ -23,17 +23,17 @@ internal class JsonOnlyMapper : IKafkaEnvelopeMapper
         _messageTypeName = topic.MessageType?.ToMessageTypeName();
     }
 
-    public void MapEnvelopeToOutgoing(Envelope envelope, Message<string, string> outgoing)
+    public void MapEnvelopeToOutgoing(Envelope envelope, Message<string, byte[]> outgoing)
     {
         outgoing.Key = envelope.GroupId;
 
         if (envelope.Data != null && envelope.Data.Any())
         {
-            outgoing.Value = Encoding.Default.GetString(envelope.Data);
+            outgoing.Value = envelope.Data;
         }
         else if (envelope.Message != null)
         {
-            outgoing.Value = JsonSerializer.Serialize(envelope.Message, _options);
+            outgoing.Value = Encoding.Default.GetBytes(JsonSerializer.Serialize(envelope.Message, _options));
         }
         else
         {
@@ -42,9 +42,9 @@ internal class JsonOnlyMapper : IKafkaEnvelopeMapper
         }
     }
 
-    public void MapIncomingToEnvelope(Envelope envelope, Message<string, string> incoming)
+    public void MapIncomingToEnvelope(Envelope envelope, Message<string, byte[]> incoming)
     {
-        envelope.Data = Encoding.Default.GetBytes(incoming.Value);
+        envelope.Data = incoming.Value;
         envelope.MessageType = _messageTypeName;
     }
 

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/InlineKafkaSender.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/InlineKafkaSender.cs
@@ -6,7 +6,7 @@ namespace Wolverine.Kafka.Internals;
 public class InlineKafkaSender : ISender, IDisposable
 {
     private readonly KafkaTopic _topic;
-    private readonly IProducer<string,string> _producer;
+    private readonly IProducer<string, byte[]> _producer;
 
     public InlineKafkaSender(KafkaTopic topic)
     {

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaEnvelopeMapper.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaEnvelopeMapper.cs
@@ -5,19 +5,19 @@ using Wolverine.Transports;
 
 namespace Wolverine.Kafka.Internals;
 
-internal class KafkaEnvelopeMapper : EnvelopeMapper<Message<string, string>, Message<string, string>>, IKafkaEnvelopeMapper
+internal class KafkaEnvelopeMapper : EnvelopeMapper<Message<string, byte[]>, Message<string, byte[]>>, IKafkaEnvelopeMapper
 {
     public KafkaEnvelopeMapper(Endpoint endpoint) : base(endpoint)
     {
 
     }
 
-    protected override void writeOutgoingHeader(Message<string, string> outgoing, string key, string value)
+    protected override void writeOutgoingHeader(Message<string, byte[]> outgoing, string key, string value)
     {
         outgoing.Headers.Add(key, Encoding.Default.GetBytes(value));
     }
 
-    protected override bool tryReadIncomingHeader(Message<string, string> incoming, string key, out string value)
+    protected override bool tryReadIncomingHeader(Message<string, byte[]> incoming, string key, out string value)
     {
         if (incoming.Headers.TryGetLastBytes(key, out var bytes))
         {

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -9,7 +9,7 @@ namespace Wolverine.Kafka.Internals;
 
 public class KafkaListener : IListener, IDisposable
 {
-    private readonly IConsumer<string,string> _consumer;
+    private readonly IConsumer<string, byte[]> _consumer;
     private CancellationTokenSource _cancellation = new();
     private readonly Task _runner;
     private readonly IReceiver _receiver;
@@ -17,7 +17,7 @@ public class KafkaListener : IListener, IDisposable
     private readonly QualityOfService _qualityOfService;
 
     public KafkaListener(KafkaTopic topic, ConsumerConfig config,
-        IConsumer<string, string> consumer, IReceiver receiver,
+        IConsumer<string, byte[]> consumer, IReceiver receiver,
         ILogger<KafkaListener> logger)
     {
         Address = topic.Uri;

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -12,10 +12,10 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
     public Cache<string, KafkaTopic> Topics { get; }
 
     public ProducerConfig ProducerConfig { get; } = new();
-    public Action<ProducerBuilder<string, string>> ConfigureProducerBuilders { get; internal set; } = _ => {};
+    public Action<ProducerBuilder<string, byte[]>> ConfigureProducerBuilders { get; internal set; } = _ => {};
 
     public ConsumerConfig ConsumerConfig { get; } = new();
-    public Action<ConsumerBuilder<string, string>> ConfigureConsumerBuilders { get; internal set; } = _ => {};
+    public Action<ConsumerBuilder<string, byte[]>> ConfigureConsumerBuilders { get; internal set; } = _ => {};
 
     public AdminClientConfig AdminClientConfig { get; } = new();
     public Action<AdminClientBuilder> ConfigureAdminClientBuilders { get; internal set; } = _ => {};
@@ -76,16 +76,16 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
         yield break;
     }
 
-    internal IProducer<string, string> CreateProducer(ProducerConfig? config)
+    internal IProducer<string, byte[]> CreateProducer(ProducerConfig? config)
     {
-        var producerBuilder = new ProducerBuilder<string, string>(config ?? ProducerConfig);
+        var producerBuilder = new ProducerBuilder<string, byte[]>(config ?? ProducerConfig);
         ConfigureProducerBuilders(producerBuilder);
         return producerBuilder.Build();
     }
 
-    internal IConsumer<string, string> CreateConsumer(ConsumerConfig? config)
+    internal IConsumer<string, byte[]> CreateConsumer(ConsumerConfig? config)
     {
-        var consumerBuilder = new ConsumerBuilder<string, string>(config ?? ConsumerConfig);
+        var consumerBuilder = new ConsumerBuilder<string, byte[]>(config ?? ConsumerConfig);
         ConfigureConsumerBuilders(consumerBuilder);
         return consumerBuilder.Build();
     }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaSenderProtocol.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaSenderProtocol.cs
@@ -7,7 +7,7 @@ namespace Wolverine.Kafka;
 public class KafkaSenderProtocol : ISenderProtocol, IDisposable
 {
     private readonly KafkaTopic _topic;
-    private readonly IProducer<string,string> _producer;
+    private readonly IProducer<string, byte[]> _producer;
 
     public KafkaSenderProtocol(KafkaTopic topic)
     {

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -1,6 +1,7 @@
 using Confluent.Kafka;
 using Confluent.Kafka.Admin;
 using Microsoft.Extensions.Logging;
+using System.Text;
 using Wolverine.Configuration;
 using Wolverine.Kafka.Internals;
 using Wolverine.Runtime;
@@ -70,10 +71,10 @@ public class KafkaTopic : Endpoint, IBrokerEndpoint
         try
         {
             using var client = Parent.CreateProducer(ProducerConfig);
-            await client.ProduceAsync(TopicName, new Message<string, string>
+            await client.ProduceAsync(TopicName, new Message<string, byte[]>
             {
                 Key = "ping",
-                Value = "ping"
+                Value = Encoding.Default.GetBytes("ping")
             });
 
 

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
@@ -44,7 +44,7 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     /// </summary>
     /// <param name="configure"></param>
     /// <returns></returns>
-    public KafkaTransportExpression ConfigureProducerBuilders(Action<ProducerBuilder<string, string>> configure)
+    public KafkaTransportExpression ConfigureProducerBuilders(Action<ProducerBuilder<string, byte[]>> configure)
     {
         _transport.ConfigureProducerBuilders = configure;
         return this;
@@ -67,7 +67,7 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     /// </summary>
     /// <param name="configure"></param>
     /// <returns></returns>
-    public KafkaTransportExpression ConfigureConsumerBuilders(Action<ConsumerBuilder<string, string>> configure)
+    public KafkaTransportExpression ConfigureConsumerBuilders(Action<ConsumerBuilder<string, byte[]>> configure)
     {
         _transport.ConfigureConsumerBuilders = configure;
         return this;

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExtensions.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExtensions.cs
@@ -110,12 +110,12 @@ public static class KafkaTransportExtensions
         return new KafkaSubscriberConfiguration(topic);
     }
 
-    internal static Envelope CreateEnvelope(this IKafkaEnvelopeMapper mapper, string topicName, Message<string, string> message)
+    internal static Envelope CreateEnvelope(this IKafkaEnvelopeMapper mapper, string topicName, Message<string, byte[]> message)
     {
         var envelope = new Envelope
         {
             PartitionKey = message.Key,
-            Data = Encoding.Default.GetBytes(message.Value),
+            Data = message.Value,
             TopicName = topicName
         };
 
@@ -126,12 +126,12 @@ public static class KafkaTransportExtensions
         return envelope;
     }
 
-    internal static Message<string, string> CreateMessage(this IKafkaEnvelopeMapper mapper, Envelope envelope)
+    internal static Message<string, byte[]> CreateMessage(this IKafkaEnvelopeMapper mapper, Envelope envelope)
     {
-        var message = new Message<string, string>
+        var message = new Message<string, byte[]>
         {
             Key = !string.IsNullOrEmpty(envelope.PartitionKey) ? envelope.PartitionKey : envelope.Id.ToString(),
-            Value = Encoding.Default.GetString(envelope.Data),
+            Value = envelope.Data,
             Headers = new Headers()
         };
 


### PR DESCRIPTION
Why we need this change - in current implementation Wolverine is serializing message using IMessageSerializer to bytes but in kafka ProducerBuilder<string, string> is used to we are transforming this to string with Encoding.Default.GetString and inside IProducer<string, string>.ProduceAsync() another method is used to change this to bytes again with Encoding.Default.GetBytes (https://github.com/confluentinc/confluent-kafka-dotnet/blob/3f10fc8f829e7540e135fe8fe343371f1d4f5f2b/src/Confluent.Kafka/Serializers.cs#L42). So there is additional overhead that could be simplified by using ProducerBuilder<string, byte[]>.
Additionally in our case we implemented custom serializer using confluent avro and during tests we saw that Encoding.Default is not enough and byte array we get when deserializing are different. After investigation we find out that bytes produced by avro can't be change to UTF8 - it works only when we changed woverine code to Encoding.Unicode.