### PR TITLE
Fix dependency lifetime issue in PingPong sample projects

### DIFF
--- a/src/Samples/PingPong/Pinger/Worker.cs
+++ b/src/Samples/PingPong/Pinger/Worker.cs
@@ -8,23 +8,25 @@ namespace Pinger;
 public class Worker : BackgroundService
 {
     private readonly ILogger<Worker> _logger;
-    private readonly IMessageBus _bus;
+    private readonly IServiceProvider _serviceProvider;
 
-    public Worker(ILogger<Worker> logger, IMessageBus bus)
+    public Worker(ILogger<Worker> logger, IServiceProvider serviceProvider)
     {
         _logger = logger;
-        _bus = bus;
+        _serviceProvider = serviceProvider;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var pingNumber = 1;
 
+        await using var scope= _serviceProvider.CreateAsyncScope();
+        var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
         while (!stoppingToken.IsCancellationRequested)
         {
             await Task.Delay(1000, stoppingToken);
             _logger.LogInformation("Sending Ping #{Number}", pingNumber);
-            await _bus.PublishAsync(new Ping { Number = pingNumber });
+            await bus.PublishAsync(new Ping { Number = pingNumber });
             pingNumber++;
         }
     }

--- a/src/Samples/PingPong/Ponger/Program.cs
+++ b/src/Samples/PingPong/Ponger/Program.cs
@@ -8,6 +8,8 @@ using Wolverine.Transports.Tcp;
 return await Host.CreateDefaultBuilder(args)
     .UseWolverine(opts =>
     {
+        opts.ApplicationAssembly = typeof(Program).Assembly;
+
         // Using Wolverine's built in TCP transport
         opts.ListenAtPort(5581);
     })

--- a/src/Samples/PingPongWithRabbitMq/Pinger/Program.cs
+++ b/src/Samples/PingPongWithRabbitMq/Pinger/Program.cs
@@ -9,9 +9,10 @@ using Wolverine.RabbitMQ;
 return await Host.CreateDefaultBuilder(args)
     .UseWolverine(opts =>
     {
+        opts.ApplicationAssembly = typeof(Program).Assembly;
+
         // Listen for messages coming into the pongs queue
-        opts
-            .ListenToRabbitQueue("pongs");
+        opts.ListenToRabbitQueue("pongs");
 
         // Publish messages to the pings queue
         opts.PublishMessage<PingMessage>().ToRabbitExchange("pings");

--- a/src/Samples/PingPongWithRabbitMq/Pinger/Properties/launchSettings.json
+++ b/src/Samples/PingPongWithRabbitMq/Pinger/Properties/launchSettings.json
@@ -1,30 +1,10 @@
 ﻿{
-  "$schema": "https://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:64643",
-      "sslPort": 44397
-    }
-  },
   "profiles": {
-    "Pinger": {
+    "PingerWithRabbitMQ": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7295;http://localhost:5295",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "DOTNET_ENVIRONMENT": "Development"
       }
     }
   }

--- a/src/Samples/PingPongWithRabbitMq/Ponger/Properties/launchSettings.json
+++ b/src/Samples/PingPongWithRabbitMq/Ponger/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "profiles": {
-    "Ponger": {
+    "PongerWithRabbitMQ": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "environmentVariables": {


### PR DESCRIPTION
Issues:
- `IMessageBus` is registered with the scoped lifetime. But it is used in the background services as a constructor parameter. Only the singleton dependencies can be injected directly into the background services.
- It seems that setting `options.ApplicationAssembly` is required. Without it, the message handlers are not found in the consumer applications.