### PR TITLE
Fix remaining messages in the outbox when the transportation connection isn't stable

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
@@ -36,7 +36,7 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
         string routingKey, IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body,
         CancellationToken cancellationToken = new())
     {
-        if (_latched || _cancellation.IsCancellationRequested)
+        if (_latched || _cancellation.IsCancellationRequested || !_listener.IsConnected)
         {
             await _listener.Channel!.BasicRejectAsync(deliveryTag, true, _cancellation);
             return;

--- a/src/Wolverine/Transports/Sending/CircuitWatcher.cs
+++ b/src/Wolverine/Transports/Sending/CircuitWatcher.cs
@@ -34,10 +34,9 @@ internal class CircuitWatcher : IDisposable
 
     private async Task pingUntilConnectedAsync()
     {
-        while (!_cancellation.IsCancellationRequested)
+        using var timer=new PeriodicTimer(_senderCircuit.RetryInterval);
+        while (await timer.WaitForNextTickAsync(_cancellation))
         {
-            await Task.Delay(_senderCircuit.RetryInterval, _cancellation);
-
             try
             {
                 var pinged = await _senderCircuit.TryToResumeAsync(_cancellation);

--- a/src/Wolverine/Transports/Sending/SendingAgent.cs
+++ b/src/Wolverine/Transports/Sending/SendingAgent.cs
@@ -17,6 +17,7 @@ public abstract class SendingAgent : ISendingAgent, ISenderCallback, ISenderCirc
     protected readonly DurabilitySettings _settings;
     private CircuitWatcher? _circuitWatcher;
     private int _failureCount;
+    private readonly SemaphoreSlim _failureCountLock = new SemaphoreSlim(1, 1);
 
 
     public SendingAgent(ILogger logger, IMessageTracker messageLogger, ISender sender, DurabilitySettings settings,
@@ -106,17 +107,14 @@ public abstract class SendingAgent : ISendingAgent, ISenderCallback, ISenderCirc
 
     TimeSpan ISenderCircuit.RetryInterval => Endpoint.PingIntervalForCircuitResume;
 
-    Task ISenderCircuit.ResumeAsync(CancellationToken cancellationToken)
+    async Task ISenderCircuit.ResumeAsync(CancellationToken cancellationToken)
     {
         using var activity = WolverineTracing.ActivitySource.StartActivity(WolverineTracing.SendingResumed);
         activity?.SetTag(WolverineTracing.EndpointAddress, Endpoint.Uri);
-        
-        _circuitWatcher?.SafeDispose();
-        _circuitWatcher = null;
 
-        Unlatch();
+        await MarkSuccessAsync();
 
-        return executeWithRetriesAsync(() => afterRestartingAsync(_sender));
+        await executeWithRetriesAsync(() => afterRestartingAsync(_sender));
     }
 
     public Endpoint Endpoint { get; }
@@ -263,35 +261,48 @@ public abstract class SendingAgent : ISendingAgent, ISenderCallback, ISenderCirc
             return;
         }
 
-        _failureCount++;
-
-        if (_failureCount >= Endpoint.FailuresBeforeCircuitBreaks)
+        await _failureCountLock.WaitAsync();
+        try
         {
-            using var activity = WolverineTracing.ActivitySource.StartActivity(WolverineTracing.SendingPaused);
-            activity?.SetTag(WolverineTracing.StopReason, WolverineTracing.TooManySenderFailures);
-            activity?.SetTag(WolverineTracing.EndpointAddress, Endpoint.Uri);
-            
-            await LatchAndDrainAsync();
-            await EnqueueForRetryAsync(batch);
+            _failureCount++;
 
-            _circuitWatcher = new CircuitWatcher(this, _settings.Cancellation);
+            if (_failureCount >= Endpoint.FailuresBeforeCircuitBreaks)
+            {
+                using var activity = WolverineTracing.ActivitySource.StartActivity(WolverineTracing.SendingPaused);
+                activity?.SetTag(WolverineTracing.StopReason, WolverineTracing.TooManySenderFailures);
+                activity?.SetTag(WolverineTracing.EndpointAddress, Endpoint.Uri);
+
+                await LatchAndDrainAsync();
+                await EnqueueForRetryAsync(batch);
+
+                _circuitWatcher ??= new CircuitWatcher(this, _settings.Cancellation);
+                return;
+            }
         }
-        else
+        finally
         {
-            foreach (var envelope in batch.Messages) await _sending.PostAsync(envelope);
+            _failureCountLock.Release();
         }
+
+        foreach (var envelope in batch.Messages) await _sending.PostAsync(envelope);
     }
 
     public abstract Task EnqueueForRetryAsync(OutgoingMessageBatch batch);
 
-    public Task MarkSuccessAsync()
+    public async Task MarkSuccessAsync()
     {
-        _failureCount = 0;
-        Unlatch();
-        _circuitWatcher?.SafeDispose();
-        _circuitWatcher = null;
-
-        return Task.CompletedTask;
+        await _failureCountLock.WaitAsync();
+        try
+        {
+            _failureCount = 0;
+            Unlatch();
+            _circuitWatcher?.SafeDispose();
+            _circuitWatcher = null;
+        }
+        finally
+        {
+            _failureCountLock.Release();
+        }
     }
 
     public Task MarkProcessingFailureAsync(Envelope outgoing, Exception? exception)


### PR DESCRIPTION
To fix the reported problems in this issue: #1430

Fixed issues:
- Reset failure count after reconnecting and modifying it thread-safe in the sending agent (to ensure latching exactly after `FailuresBeforeCircuitBreaks` retries and reset after reconnecting).
- Make the in-memory queue thread-safe in durable outboxes.
- Fix issue in `RabbitMqChannelAgent` connection state management (rely on the RabbitMQ.Client connection recovery feature and recreate channels only after reconnecting).

Other improvements:
- Use PeriodicTimer in `CircuitWatcher` instead of using the `while` loop in
- Ensure RabbitMQ channels and consumptions will be recovered after connection recovery by creating a new channel and re-consumption.