### PR TITLE
fix: NRE during disposal of stubbed MqttTransport

### DIFF
--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTransport.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTransport.cs
@@ -122,7 +122,15 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        await Client.StopAsync();
+        try
+        {
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if (Client is not null)
+                await Client.StopAsync();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
     }
 
     internal async ValueTask SubscribeToTopicAsync(string topicName, MqttListener listener, MqttTopic mqttTopic)


### PR DESCRIPTION
When external transports are disabled, the current implementation of `MqttTransport` would throw a `NullReferenceException` upon disposal. This PR aims at fixing that.

Minimal reproduction of issue:

```
using Wolverine;
using Wolverine.MQTT;

var host = Host.CreateDefaultBuilder()
    .UseWolverine(opts =>
    {
        opts.UseMqttWithLocalBroker();
        opts.StubAllExternalTransports();
    });

var app = host.Build();

await app.StartAsync();

app.Dispose();

```