### PR TITLE
fix: ensure Messages is not null

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -69,7 +69,7 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue
 
                     failedCount = 0;
 
-                    if (results.Messages.Any())
+                    if (results.Messages != null && results.Messages.Any())
                     {
                         var envelopes = new List<Envelope>(results.Messages.Count);
                         foreach (var message in results.Messages)


### PR DESCRIPTION
Ensure the Messages object is not null. Currently, an exception is being thrown while the listener is polling for new messages:

fail: Wolverine.AmazonSqs.Internal.SqsListener[0]
      Error while trying to retrieve messages from SQS Queue sqs://mp-order-test/
      System.ArgumentNullException: Value cannot be null. (Parameter 'source')
         at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
         at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source)
         at Wolverine.AmazonSqs.Internal.SqsListener.<>c__DisplayClass8_0.<<-ctor>b__2>d.MoveNext() in /home/runner/work/wolverine/wolverine/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs:line 72
Received OrderCreated event: d5fb4307-2ea8-4fe9-a651-72398f20958c, 3, 789

It does work when a message is received:

info: Messages.Orders.OrderCreated[104]
      Successfully processed message Messages.Orders.OrderCreated#08dda704-6e0a-a519-2aa0-6bd09e130000 from sqs://mp-order-test/

This will resolve #1484 