### PR TITLE
fix: api description contain invalid request type for GET requests

### DIFF
--- a/src/Http/Wolverine.Http.Tests/swashbuckle_integration.cs
+++ b/src/Http/Wolverine.Http.Tests/swashbuckle_integration.cs
@@ -53,4 +53,21 @@ public class swashbuckle_integration : IntegrationContext
         var (item, op) = FindOpenApiDocument(OperationType.Post, "/users/sign-up");
         op.Tags.ShouldContain(x => x.Name == "Users");
     }
+
+	[Fact]
+	public async Task request_body_not_required_with_primitive_query_string()
+	{
+		var endpoint = EndpointFor("/querystring/datetime");
+
+		var (item, op) = FindOpenApiDocument(OperationType.Get, "/querystring/datetime");
+		op.RequestBody.ShouldBeNull();
+	}
+
+	[Fact]
+	public async Task request_body_not_required_with_complex_query_string()
+	{
+		var endpoint = EndpointFor("/api/bigquery");
+		var (_, op) = FindOpenApiDocument(OperationType.Get, "/api/bigquery");
+		op.RequestBody.ShouldBeNull();
+	}
 }

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -222,7 +222,7 @@ public partial class HttpChain
 
     private void fillRequestType(ApiDescription apiDescription)
     {
-        if (HasRequestType && !IsFormData)
+        if (HasRequestType && !IsFormData && apiDescription.HttpMethod != "GET")
         {
             var parameterDescription = new ApiParameterDescription
             {


### PR DESCRIPTION
Tiny adjustment, the ensures that when generating the open api documentation, GET endpoints do not have request bodies and adds a couple of tests.

Currently, if the GET endpoint uses `[FromQuery] ComplexT` the type will shows up as the request body and is required.
This is incorrect, as these values are expected on the query string, not the request body.

This means that the swagger tooling can not be used to submit a request to the API and the generated JSON does not match the api specification.

In an ideal standard compliant world, the GET would support a request body (even though it's weird), but from looking at how RequestType works within the system, it would be a larger change, and from looking at some of the code, I'm not sure Wolverine supports this anyway.

+ Added test to replicate issue
+ Added fix to ensure generated API valid
+ Ran tests