### PR TITLE
Note to "Command Bus" broken link

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -99,7 +99,7 @@ Alright, let's talk about what we wrote up above:
 2. We registered the `UserRepository` and `IssueRepository` services
 3. We created a couple [Minimal API](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis?view=aspnetcore-6.0) endpoints
 
-See also: [Wolverine as Command Bus](/guide/in-memory-bus)
+See also: [Wolverine as Command Bus](/guide/in-memory-bus) <== BROKEN LINK
 
 The two Web API functions directly delegate to Wolverine's `IMessageBus.InvokeAsync()` method.
 In that method, Wolverine will direct the command to the correct handler and invoke that handler


### PR DESCRIPTION
I couldn't find any obvious page that corresponds to "Command Bus". Perhaps the link text should be `[Wolverine as Message Bus]` and the link should be `(https://wolverinefx.net/guide/messaging/introduction.html#getting-started-with-wolverine-as-message-bus)`.