### PR TITLE
Fix body params in GET request when using complex query string

### DIFF
--- a/src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
@@ -27,8 +27,7 @@ internal class FromQueryAttributeUsage : IParameterStrategy
         if (parameter.ParameterType.IsTypeOrNullableOf<TimeOnly>()) return false;
         if (parameter.ParameterType.IsTypeOrNullableOf<TimeSpan>()) return false;
         if (parameter.ParameterType.IsTypeOrNullableOf<Guid>()) return false;
-        
-        chain.RequestType = parameter.ParameterType;
+
         variable = new QueryStringBindingFrame(parameter.ParameterType, chain).Variable;
         return true;
     }


### PR DESCRIPTION
Now in GET request the `[FromQuery]` complex object is duplicated in the body.

![image](https://github.com/user-attachments/assets/045f2fca-825d-4e89-8866-c989f615c803)

I removed `chain.RequestType = parameter.ParameterType;` but i'm not sure if it is used for something else. In that case maybe a solution is creating something similar to `public bool IsFormData { get; internal set; }` in HttpChain.cs
