### PR TITLE
Docs: Add guidance for replacing OaktonCommandAssembly with JasperFxAssembly

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -5,8 +5,18 @@
 4.0 had very few breaking changes.
 
 * Wolverine dropped all support for .NET 6/7
-* The previous dependencies on Oakton, JasperFx.Core, and JasperFx.CodeGeneration were all combined into a single [JasperFx](https://github.com/jasperfx/jasperfx)
-  library. There are shims for any method with "Oakton" in its name, but these are marked as `[Obsolete]`. You can pretty well do a find and replace for "Oakton" to "JasperFx"
+* The previous dependencies on Oakton, JasperFx.Core, and JasperFx.CodeGeneration were all combined into a single [JasperFx](https://github.com/jasperfx/jasperfx) library. There are shims for any method with "Oakton" in its name, but these are marked as `[Obsolete]`. You can pretty well do a find and replace for "Oakton" to "JasperFx". If your Oakton command classes live in a different project than the runnable application, add this to that project's `Properties/AssemblyInfo.cs` file:
+  ```cs
+  using JasperFx;
+
+  [assembly: JasperFxAssembly]
+  ```
+  This attribute replaces the older Oakton assembly attribute:
+  ```cs
+  using Oakton;
+
+  [assembly: OaktonCommandAssembly]
+  ```
 * Internally, the full "Critter Stack" is trying to use `Uri` values to identify databases when targeting multiple databases in either a modular monolith approach or with multi-tenancy
 * Many of the internal dependencies like Marten or AWS SQS SDK Nugets were updated
 * The signature of the Kafka `IKafkaEnvelopeMapper` changed somewhat to be more efficient in message serialization


### PR DESCRIPTION
This pull request updates the migration guide for version 4.0, focusing on breaking changes and providing clearer instructions for transitioning from Oakton to JasperFx.

### Migration Instructions:

* Updated the migration guide to include instructions for replacing the older `OaktonCommandAssembly` attribute with the new `JasperFxAssembly` attribute in projects using Oakton command classes. This change ensures compatibility with the consolidated JasperFx library.