### PR TITLE
fix: Use correct IFormFile/IFormFileCollection type in ApiDescription…

### DIFF
--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -97,7 +97,7 @@ public partial class HttpChain
                     Name = parameter.Name,
                     ParameterType = parameter.ParameterType
                 },
-                Type = typeof(IFormFile),
+                Type = parameter.ParameterType,
                 IsRequired = true
             };
 


### PR DESCRIPTION
… for FileParameters

fixes #1549 