### PR TITLE
Improve Mapper Extensibility

### DIFF
--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelopeMapper.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelopeMapper.cs
@@ -5,7 +5,7 @@ using Wolverine.Transports;
 
 namespace Wolverine.AzureServiceBus.Internal;
 
-internal class AzureServiceBusEnvelopeMapper : EnvelopeMapper<ServiceBusReceivedMessage, ServiceBusMessage>, IAzureServiceBusEnvelopeMapper
+public class AzureServiceBusEnvelopeMapper : EnvelopeMapper<ServiceBusReceivedMessage, ServiceBusMessage>, IAzureServiceBusEnvelopeMapper
 {
     public AzureServiceBusEnvelopeMapper(Endpoint endpoint, IWolverineRuntime runtime) : base(endpoint)
     {

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaEnvelopeMapper.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaEnvelopeMapper.cs
@@ -5,11 +5,10 @@ using Wolverine.Transports;
 
 namespace Wolverine.Kafka.Internals;
 
-internal class KafkaEnvelopeMapper : EnvelopeMapper<Message<string, byte[]>, Message<string, byte[]>>, IKafkaEnvelopeMapper
+public class KafkaEnvelopeMapper : EnvelopeMapper<Message<string, byte[]>, Message<string, byte[]>>, IKafkaEnvelopeMapper
 {
     public KafkaEnvelopeMapper(Endpoint endpoint) : base(endpoint)
     {
-
     }
 
     protected override void writeOutgoingHeader(Message<string, byte[]> outgoing, string key, string value)

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttEnvelopeMapper.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttEnvelopeMapper.cs
@@ -105,6 +105,7 @@ internal class MqttEnvelopeMapper : IMqttEnvelopeMapper
         envelope.Data = incoming.PayloadSegment.ToArray();
 
         envelope.MessageType = _topic.MessageTypeName;
+        envelope.TopicName = incoming.Topic;
 
         foreach (var property in incoming.UserProperties)
         {

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttEnvelopeMapper.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttEnvelopeMapper.cs
@@ -5,7 +5,7 @@ using Wolverine.Runtime.Serialization;
 
 namespace Wolverine.MQTT.Internals;
 
-internal class MqttEnvelopeMapper : IMqttEnvelopeMapper
+public class MqttEnvelopeMapper : IMqttEnvelopeMapper
 {
     private readonly MqttTopic _topic;
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelopeMapper.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelopeMapper.cs
@@ -14,7 +14,7 @@ namespace Wolverine.RabbitMQ.Internal;
 /// </summary>
 public interface IRabbitMqEnvelopeMapper : IEnvelopeMapper<IReadOnlyBasicProperties, IBasicProperties>;
 
-internal class RabbitMqEnvelopeMapper : EnvelopeMapper<IReadOnlyBasicProperties, IBasicProperties>, IRabbitMqEnvelopeMapper
+public class RabbitMqEnvelopeMapper : EnvelopeMapper<IReadOnlyBasicProperties, IBasicProperties>, IRabbitMqEnvelopeMapper
 {
     public RabbitMqEnvelopeMapper(Endpoint endpoint, IWolverineRuntime runtime) : base(endpoint)
     {

--- a/src/Wolverine/Configuration/ListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/ListenerConfiguration.cs
@@ -222,6 +222,18 @@ public class ListenerConfiguration<TSelf, TEndpoint> : DelayedEndpointConfigurat
         add(e => e.MessageType = messageType);
         return this.As<TSelf>();
     }
+    
+    /// <summary>
+    ///     Apply a custom configuration to the underlying endpoint for
+    ///     interoperability with non-Wolverine systems.
+    /// </summary>
+    /// <param name="configure">The action to configure the endpoint for interop.</param>
+    /// <returns>The current listener configuration instance.</returns>
+    public TSelf UseInterop(Action<TEndpoint> configure)
+    {
+        add(configure);
+        return this.As<TSelf>();
+    }
 }
 
 public enum ProcessingOrder

--- a/src/Wolverine/Configuration/SubscriberConfiguration.cs
+++ b/src/Wolverine/Configuration/SubscriberConfiguration.cs
@@ -150,6 +150,18 @@ public class SubscriberConfiguration<T, TEndpoint> : DelayedEndpointConfiguratio
         add(e => e.OutgoingRules.Add(rule));
         return this.As<T>();
     }
+    
+    /// <summary>
+    ///     Apply a custom configuration to the underlying endpoint for
+    ///     interoperability with non-Wolverine systems.
+    /// </summary>
+    /// <param name="configure">The action to configure the endpoint for interop.</param>
+    /// <returns>The current subscriber configuration instance.</returns>
+    public T UseInterop(Action<TEndpoint> configure)
+    {
+        add(configure);
+        return this.As<T>();
+    }
 }
 
 internal class SubscriberConfiguration : SubscriberConfiguration<ISubscriberConfiguration, Endpoint>,

--- a/src/Wolverine/Transports/EnvelopeMapper.cs
+++ b/src/Wolverine/Transports/EnvelopeMapper.cs
@@ -24,10 +24,11 @@ public interface IEnvelopeMapper<TIncoming, TOutgoing> : IOutgoingMapper<TOutgoi
 
 public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIncoming, TOutgoing>
 {
-    private const string DateTimeOffsetFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
+    /// <summary>yyyy-MM-dd HH:mm:ss:ffffff Z</summary>
+    private const string _dateTimeOffsetFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
     private readonly Endpoint _endpoint;
 
-    private readonly Dictionary<PropertyInfo, string> _envelopeToHeader = new();
+    private readonly Lazy<Dictionary<PropertyInfo, string>> _envelopeToHeader;
 
     private readonly Dictionary<PropertyInfo, Action<Envelope, TOutgoing>> _envelopeToOutgoing = new();
 
@@ -35,71 +36,132 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
     private readonly Lazy<Action<Envelope, TIncoming>> _mapIncoming;
     private readonly Lazy<Action<Envelope, TOutgoing>> _mapOutgoing;
 
+    /// <summary>
+    ///     Map the headers and properties of an incoming message to an Envelope.
+    /// </summary>
+    protected Action<Envelope, TIncoming> mapIncoming => _mapIncoming.Value;
+    
+    /// <summary>
+    ///     Map the headers and properties of an Envelope to an outgoing message.
+    /// </summary>
+    protected Action<Envelope, TOutgoing> mapOutgoing => _mapOutgoing.Value;
+
     public EnvelopeMapper(Endpoint endpoint)
     {
         _endpoint = endpoint;
 
         _mapIncoming = new Lazy<Action<Envelope, TIncoming>>(compileIncoming);
         _mapOutgoing = new Lazy<Action<Envelope, TOutgoing>>(compileOutgoing);
-
-        MapPropertyToHeader(x => x.CorrelationId!, EnvelopeConstants.CorrelationIdKey);
-        MapPropertyToHeader(x => x.SagaId!, EnvelopeConstants.SagaIdKey);
-        MapPropertyToHeader(x => x.Id, EnvelopeConstants.IdKey);
-        MapPropertyToHeader(x => x.ConversationId, EnvelopeConstants.ConversationIdKey);
-        MapPropertyToHeader(x => x.ParentId!, EnvelopeConstants.ParentIdKey);
-        MapPropertyToHeader(x => x.ContentType!, EnvelopeConstants.ContentTypeKey);
-        MapPropertyToHeader(x => x.Source!, EnvelopeConstants.SourceKey);
-        MapPropertyToHeader(x => x.ReplyRequested!, EnvelopeConstants.ReplyRequestedKey);
-        MapPropertyToHeader(x => x.ReplyUri!, EnvelopeConstants.ReplyUriKey);
-        MapPropertyToHeader(x => x.ScheduledTime!, EnvelopeConstants.ExecutionTimeKey);
-
-        MapPropertyToHeader(x => x.SentAt, EnvelopeConstants.SentAtKey);
-
-        MapPropertyToHeader(x => x.AckRequested, EnvelopeConstants.AckRequestedKey);
-        MapPropertyToHeader(x => x.IsResponse, EnvelopeConstants.IsResponseKey);
-        MapPropertyToHeader(x => x.MessageType!, EnvelopeConstants.MessageTypeKey);
-        MapPropertyToHeader(x => x.AcceptedContentTypes, EnvelopeConstants.AcceptedContentTypesKey);
-
-        MapPropertyToHeader(x => x.TenantId!, EnvelopeConstants.TenantIdKey);
-
-        MapPropertyToHeader(x => x.DeliverBy!, EnvelopeConstants.DeliverByKey);
-
-        MapPropertyToHeader(x => x.Attempts, EnvelopeConstants.AttemptsKey);
+        
+        _envelopeToHeader = new Lazy<Dictionary<PropertyInfo, string>>(initializePropertiesToHeaders);
     }
 
+    /// <summary>
+    ///     Map the properties on the Envelope to headers.
+    /// </summary>
+    protected virtual Dictionary<PropertyInfo, string> initializePropertiesToHeaders()
+    {
+        return new Dictionary<PropertyInfo, string>
+        {
+            { getProperty(x => x.CorrelationId!), EnvelopeConstants.CorrelationIdKey },
+            { getProperty(x => x.SagaId!), EnvelopeConstants.SagaIdKey },
+            { getProperty(x => x.Id), EnvelopeConstants.IdKey },
+            { getProperty(x => x.ConversationId), EnvelopeConstants.ConversationIdKey },
+            { getProperty(x => x.ParentId!), EnvelopeConstants.ParentIdKey },
+            { getProperty(x => x.ContentType!), EnvelopeConstants.ContentTypeKey },
+            { getProperty(x => x.Source!), EnvelopeConstants.SourceKey },
+            { getProperty(x => x.ReplyRequested!), EnvelopeConstants.ReplyRequestedKey },
+            { getProperty(x => x.ReplyUri!), EnvelopeConstants.ReplyUriKey },
+            { getProperty(x => x.ScheduledTime!), EnvelopeConstants.ExecutionTimeKey },
+            
+            { getProperty(x => x.SentAt), EnvelopeConstants.SentAtKey },
+            
+            { getProperty(x => x.AckRequested), EnvelopeConstants.AckRequestedKey },
+            { getProperty(x => x.IsResponse), EnvelopeConstants.IsResponseKey },
+            { getProperty(x => x.MessageType!), EnvelopeConstants.MessageTypeKey },
+            { getProperty(x => x.AcceptedContentTypes), EnvelopeConstants.AcceptedContentTypesKey },
+            
+            { getProperty(x => x.TenantId!), EnvelopeConstants.TenantIdKey },
+            
+            { getProperty(x => x.DeliverBy!), EnvelopeConstants.DeliverByKey },
+            
+            { getProperty(x => x.Attempts), EnvelopeConstants.AttemptsKey }
+        };
+    }
+
+    /// <summary>
+    ///     Get a property from the Envelope by an expression, for use in <see cref="initializePropertiesToHeaders"/>.
+    /// </summary>
+    /// <param name="property">The expression to get the property from.</param>
+    /// <returns>The <see cref="PropertyInfo"/> for the specified property.</returns>
+    protected PropertyInfo getProperty(Expression<Func<Envelope, object>> property)
+    {
+        return ReflectionHelper.GetProperty(property);
+    }
+
+    /// <summary>
+    ///    Get all headers that are mapped from the Envelope to the outgoing message.
+    /// </summary>
+    /// <returns>The header keys.</returns>
     public IEnumerable<string> AllHeaders()
     {
-        return _envelopeToHeader.Values;
+        return _envelopeToHeader.Value.Values;
     }
 
-    public void MapIncomingToEnvelope(Envelope envelope, TIncoming incoming)
+    /// <summary>
+    ///     Map the incoming message to an Envelope.
+    ///     By default, this will map incoming headers and properties to the Envelope
+    ///     using <see cref="mapIncoming"/>, and set the serializer based on the content type of the incoming message.
+    ///
+    ///     If no matching serializer is found on the Endpoint, the default serializer
+    ///     from the Endpoint configuration will be used.
+    /// </summary>
+    /// <param name="envelope">The envelope to map to.</param>
+    /// <param name="incoming">The incoming message to map from.</param>
+    public virtual void MapIncomingToEnvelope(Envelope envelope, TIncoming incoming)
     {
-        _mapIncoming.Value(envelope, incoming);
+        mapIncoming(envelope, incoming);
 
         var contentType = envelope.ContentType;
         var serializer = _endpoint.TryFindSerializer(contentType) ?? _endpoint.DefaultSerializer;
         envelope.Serializer = serializer;
     }
 
-    public void MapEnvelopeToOutgoing(Envelope envelope, TOutgoing outgoing)
+    /// <summary>
+    ///     Map the Envelope to an outgoing message.
+    ///     By default, this will map outgoing headers and properties to the outgoing message
+    ///     using <see cref="mapOutgoing"/>, and set the <see cref="TransportConstants.ProtocolVersion"/> header.
+    /// </summary>
+    /// <param name="envelope">The envelope to map from.</param>
+    /// <param name="outgoing">The outgoing message to map to.</param>
+    public virtual void MapEnvelopeToOutgoing(Envelope envelope, TOutgoing outgoing)
     {
-
-        _mapOutgoing.Value(envelope, outgoing);
+        mapOutgoing(envelope, outgoing);
         writeOutgoingHeader(outgoing, TransportConstants.ProtocolVersion, "1.0"); // fancier later
     }
 
     /// <summary>
-    ///     This endpoint will assume that any unidentified incoming message types
-    ///     are the supplied message type. This is meant primarily for interaction
-    ///     with incoming messages from MassTransit
+    ///     Configure the EnvelopeMapper to assume that all unidentified messages are
+    ///     of the specified message type.
+    /// 
+    ///     This is meant primarily for interaction with incoming messages from MassTransit.
     /// </summary>
-    /// <param name="messageType"></param>
+    /// <param name="messageType">The message type to assume for unidentified messages.</param>
     public void ReceivesMessage(Type messageType)
     {
         _incomingToEnvelope[ReflectionHelper.GetProperty<Envelope>(x => x.MessageType!)] =
             (e, _) => e.MessageType = messageType.ToMessageTypeName();
     }
 
+    /// <summary>
+    ///     Map a property on the Envelope with custom read and write actions.
+    ///
+    ///     The properties are mapped <b>after</b> the headers are written, so
+    ///     you can use the headers in your custom logic if needed.
+    /// </summary>
+    /// <param name="property">The property on the Envelope to map.</param>
+    /// <param name="readFromIncoming">The action to read the property value from the incoming message.</param>
+    /// <param name="writeToOutgoing">The action to write the property value to the outgoing message.</param>
     public void MapProperty(Expression<Func<Envelope, object>> property, Action<Envelope, TIncoming> readFromIncoming,
         Action<Envelope, TOutgoing> writeToOutgoing)
     {
@@ -108,6 +170,15 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         _envelopeToOutgoing[prop] = writeToOutgoing;
     }
 
+    /// <summary>
+    ///     Map a property on the Envelope to the outgoing message with a custom write action.
+    ///
+    ///     This is useful when you need to write complex types or perform custom logic.
+    ///     The properties are mapped <b>after</b> the headers are written, so 
+    ///     you can use the headers in your custom logic if needed.
+    /// </summary>
+    /// <param name="property">The property on the Envelope to map.</param>
+    /// <param name="writeToOutgoing">The action to write the property value to the outgoing message.</param>
     public void MapOutgoingProperty(Expression<Func<Envelope, object>> property,
         Action<Envelope, TOutgoing> writeToOutgoing)
     {
@@ -115,10 +186,15 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         _envelopeToOutgoing[prop] = writeToOutgoing;
     }
 
+    /// <summary>
+    ///     Map a property on the Envelope to a header key.
+    /// </summary>
+    /// <param name="property">The property on the Envelope to map.</param>
+    /// <param name="headerKey">The header key to map the property to.</param>
     public void MapPropertyToHeader(Expression<Func<Envelope, object>> property, string headerKey)
     {
         var prop = ReflectionHelper.GetProperty(property);
-        _envelopeToHeader[prop] = headerKey;
+        _envelopeToHeader.Value[prop] = headerKey;
     }
 
     private Action<Envelope, TIncoming> compileIncoming()
@@ -148,7 +224,7 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
             writeHeaders
         };
 
-        foreach (var pair in _envelopeToHeader.Where(x => !_envelopeToOutgoing.ContainsKey(x.Key)))
+        foreach (var pair in _envelopeToHeader.Value.Where(x => !_envelopeToOutgoing.ContainsKey(x.Key)))
         {
             var getMethod = getString!;
             if (pair.Key.PropertyType == typeof(Uri))
@@ -231,7 +307,7 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
             writeHeaders
         };
 
-        var headers = _envelopeToHeader.Where(x => !_incomingToEnvelope.ContainsKey(x.Key));
+        var headers = _envelopeToHeader.Value.Where(x => !_incomingToEnvelope.ContainsKey(x.Key));
         foreach (var pair in headers)
         {
             var setMethod = setString!;
@@ -287,36 +363,74 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         return lambda.CompileFast();
     }
 
+    /// <summary>
+    ///     Write any "other" headers from the envelope to the outgoing message.
+    ///
+    ///     This is specifically for custom headers that are included with messages
+    ///     that are not recognized or processed by Wolverine itself.
+    /// </summary>
+    /// <param name="outgoing">The outgoing message to write headers to.</param>
+    /// <param name="envelope">The envelope containing the headers.</param>
     protected void writeOutgoingOtherHeaders(TOutgoing outgoing, Envelope envelope)
     {
-        var reserved = _envelopeToHeader.Values.ToArray();
+        var reserved = _envelopeToHeader.Value.Values.ToArray();
 
         foreach (var header in envelope.Headers.Where(x => !reserved.Contains(x.Key)))
             writeOutgoingHeader(outgoing, header.Key, header.Value!);
     }
 
+    /// <summary>
+    ///     Write a header to the outgoing message.
+    /// </summary>
+    /// <param name="outgoing">The outgoing message.</param>
+    /// <param name="key">The key of the header to write.</param>
+    /// <param name="value">The value of the header to write.</param>
     protected abstract void writeOutgoingHeader(TOutgoing outgoing, string key, string value);
+    
+    /// <summary>
+    ///     Try to read a header from the incoming message.
+    /// </summary>
+    /// <param name="incoming">The incoming message.</param>
+    /// <param name="key">The key of the header to read.</param>
+    /// <param name="value">The value of the header if it exists, otherwise null.</param>
+    /// <returns>A flag indicating whether the header was found.</returns>
     protected abstract bool tryReadIncomingHeader(TIncoming incoming, string key, out string? value);
 
     /// <summary>
-    ///     This is strictly for "other" headers that are passed along that are not
-    ///     used by Wolverine
+    ///     Write any "other" headers from the incoming message to the envelope.
+    /// 
+    ///     This is specifically for custom headers that are included with messages
+    ///     but are not recognized or processed by Wolverine itself.
     /// </summary>
-    /// <param name="incoming"></param>
-    /// <param name="envelope"></param>
+    /// <param name="incoming">The incoming message.</param>
+    /// <param name="envelope">The envelope to write the headers to.</param>
     protected virtual void writeIncomingHeaders(TIncoming incoming, Envelope envelope)
     {
         // nothing
     }
 
-    protected string[] readStringArray(TIncoming incoming, string key)
+    /// <summary>
+    ///     Read a header value as a string array.
+    ///     By default, this will split the header value by commas.
+    /// </summary>
+    /// <param name="incoming">The incoming message.</param>
+    /// <param name="key">The key of the header to read.</param>
+    /// <returns>The string array value of the header, or an empty array if the header is not present.</returns>
+    protected virtual string[] readStringArray(TIncoming incoming, string key)
     {
         return tryReadIncomingHeader(incoming, key, out var value)
             ? value!.Split(',')
             : [];
     }
 
-    protected int readInt(TIncoming incoming, string key)
+    /// <summary>
+    ///     Read a header value as an integer.
+    ///     By default, this will return 0 if the header is not present or cannot be parsed.
+    /// </summary>
+    /// <param name="incoming">The incoming message.</param>
+    /// <param name="key">The key of the header to read.</param>
+    /// <returns>The integer value of the header, or 0 if the header is not present or cannot be parsed.</returns>
+    protected virtual int readInt(TIncoming incoming, string key)
     {
         if (tryReadIncomingHeader(incoming, key, out var raw))
         {
@@ -326,24 +440,44 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
             }
         }
 
-        return default;
+        return 0;
     }
 
-    protected string? readString(TIncoming incoming, string key)
+    /// <summary>
+    ///     Read a header value as a string.
+    /// </summary>
+    /// <param name="incoming">The incoming message.</param>
+    /// <param name="key">The key of the header to read.</param>
+    /// <returns>The string value of the header, or null if the header is not present.</returns>
+    protected virtual string? readString(TIncoming incoming, string key)
     {
         return tryReadIncomingHeader(incoming, key, out var value)
             ? value
             : null;
     }
 
-    protected Uri? readUri(TIncoming incoming, string key)
+    /// <summary>
+    ///     Read a header value as a Uri.
+    /// </summary>
+    /// <param name="incoming">The incoming message.</param>
+    /// <param name="key">The key of the header to read.</param>
+    /// <returns>The Uri value of the header, or null if the header is not present or cannot be parsed.</returns>
+    protected virtual Uri? readUri(TIncoming incoming, string key)
     {
         return tryReadIncomingHeader(incoming, key, out var value)
             ? new Uri(value!)
             : null;
     }
 
-    protected void writeStringArray(TOutgoing outgoing, string key, string[]? value)
+    /// <summary>
+    ///     Write a string array as a header value.
+    ///     By default, this will join the array elements with commas.
+     ///    If the value is null, no header will be written.
+    /// </summary>
+    /// <param name="outgoing">The outgoing message.</param>
+    /// <param name="key">The key of the header to write.</param>
+    /// <param name="value">The string array value to write.</param>
+    protected virtual void writeStringArray(TOutgoing outgoing, string key, string[]? value)
     {
         if (value != null)
         {
@@ -351,7 +485,15 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         }
     }
 
-    protected void writeUri(TOutgoing outgoing, string key, Uri? value)
+    /// <summary>
+    ///     Write a Uri as a header value.
+    ///     By default, this will write the header value as the string representation of the Uri.
+    ///     If the value is null, no header will be written.
+    /// </summary>
+    /// <param name="outgoing">The outgoing message.</param>
+    /// <param name="key">The key of the header to write.</param>
+    /// <param name="value">The Uri value to write.</param>
+    protected virtual void writeUri(TOutgoing outgoing, string key, Uri? value)
     {
         if (value != null)
         {
@@ -359,7 +501,13 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         }
     }
 
-    protected void writeString(TOutgoing outgoing, string key, string? value)
+    /// <summary>
+    ///     Write a string as a header value.
+    /// </summary>
+    /// <param name="outgoing">The outgoing message.</param>
+    /// <param name="key">The key of the header to write.</param>
+    /// <param name="value">The string value to write.</param>
+    protected virtual void writeString(TOutgoing outgoing, string key, string? value)
     {
         if (value != null)
         {
@@ -367,12 +515,27 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         }
     }
 
-    protected void writeInt(TOutgoing outgoing, string key, int value)
+    /// <summary>
+    ///     Write an integer as a header value.
+    ///     By default, this will write the header value as a string representation of the integer.
+    /// </summary>
+    /// <param name="outgoing">The outgoing message.</param>
+    /// <param name="key">The key of the header to write.</param>
+    /// <param name="value">The integer value to write.</param>
+    protected virtual void writeInt(TOutgoing outgoing, string key, int value)
     {
         writeOutgoingHeader(outgoing, key, value.ToString());
     }
 
-    protected void writeGuid(TOutgoing outgoing, string key, Guid value)
+    /// <summary>
+    ///     Write a Guid as a header value.
+    ///     By default, this will write the header value as a string representation of the Guid.
+    ///     If the Guid is empty, no header will be written.
+    /// </summary>
+    /// <param name="outgoing">The outgoing message.</param>
+    /// <param name="key">The key of the header to write.</param>
+    /// <param name="value">The Guid value to write.</param>
+    protected virtual void writeGuid(TOutgoing outgoing, string key, Guid value)
     {
         if (value != Guid.Empty)
         {
@@ -380,7 +543,15 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         }
     }
 
-    protected void writeBoolean(TOutgoing outgoing, string key, bool value)
+    /// <summary>
+    ///     Write a boolean as a header value.
+    ///     By default, this will write the header value as "true" if the boolean is true.
+    ///     Otherwise, no header will be written.
+    /// </summary>
+    /// <param name="outgoing">The outgoing message.</param>
+    /// <param name="key">The key of the header to write.</param>
+    /// <param name="value">The boolean value to write.</param>
+    protected virtual void writeBoolean(TOutgoing outgoing, string key, bool value)
     {
         if (value)
         {
@@ -388,20 +559,52 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         }
     }
 
-    protected void writeNullableDateTimeOffset(TOutgoing outgoing, string key, DateTimeOffset? value)
+    /// <summary>
+    ///     Write a DateTimeOffset as a header value.
+    ///     By default, this will write the header value as a string in
+    ///     the format "<inheritdoc cref="_dateTimeOffsetFormat"/>".
+    ///     If the value is null, no header will be written.
+    ///
+    ///     Note: The DateTimeOffset is converted to UTC before writing, so <b>the offset is not preserved</b>.
+    /// </summary>
+    /// <param name="outgoing">The outgoing message.</param>
+    /// <param name="key">The key of the header to write.</param>
+    /// <param name="value">The DateTimeOffset value to write.</param>
+    protected virtual void writeNullableDateTimeOffset(TOutgoing outgoing, string key, DateTimeOffset? value)
     {
         if (value.HasValue)
         {
-            writeOutgoingHeader(outgoing, key, value.Value.ToUniversalTime().ToString(DateTimeOffsetFormat));
+            writeOutgoingHeader(outgoing, key, value.Value.ToUniversalTime().ToString(_dateTimeOffsetFormat));
         }
     }
 
-    protected void writeDateTimeOffset(TOutgoing outgoing, string key, DateTimeOffset value)
+    /// <summary>
+    ///     Write a DateTimeOffset as a header value.
+    ///     By default, this will write the header value as a string in
+    ///     the format "<inheritdoc cref="_dateTimeOffsetFormat"/>".
+    /// 
+    ///     Note: The DateTimeOffset is converted to UTC before writing, so <b>the offset is not preserved</b>.
+    /// </summary>
+    /// <param name="outgoing">The outgoing message.</param>
+    /// <param name="key">The key of the header to write.</param>
+    /// <param name="value">The DateTimeOffset value to write.</param>
+    protected virtual void writeDateTimeOffset(TOutgoing outgoing, string key, DateTimeOffset value)
     {
-        writeOutgoingHeader(outgoing, key, value.ToUniversalTime().ToString(DateTimeOffsetFormat));
+        writeOutgoingHeader(outgoing, key, value.ToUniversalTime().ToString(_dateTimeOffsetFormat));
     }
 
-    protected Guid readGuid(TIncoming incoming, string key)
+    /// <summary>
+    ///     Read a header value as a Guid.
+    ///     By default, this will return <see cref="Guid.Empty"/> if the header is
+    ///     not present or cannot be parsed.
+    /// </summary>
+    /// <param name="incoming">The incoming message.</param>
+    /// <param name="key">The key of the header to read.</param>
+    /// <returns>
+    ///     The Guid value of the header, or <see cref="Guid.Empty"/> if the header is
+    ///     not present or cannot be parsed.
+    /// </returns>
+    protected virtual Guid readGuid(TIncoming incoming, string key)
     {
         if (tryReadIncomingHeader(incoming, key, out var raw))
         {
@@ -414,7 +617,16 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         return Guid.Empty;
     }
 
-    protected bool readBoolean(TIncoming incoming, string key)
+    /// <summary>
+    ///     Read a header value as a boolean.
+    ///     By default, this will return false if the header is not present or cannot be parsed.
+    /// </summary>
+    /// <param name="incoming">The incoming message.</param>
+    /// <param name="key">The key of the header to read.</param>
+    /// <returns>
+    ///     The boolean value of the header, or false if the header is not present or cannot be parsed.
+    /// </returns>
+    protected virtual bool readBoolean(TIncoming incoming, string key)
     {
         if (tryReadIncomingHeader(incoming, key, out var raw))
         {
@@ -427,11 +639,22 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         return false;
     }
 
-    protected DateTimeOffset readDateTimeOffset(TIncoming incoming, string key)
+    /// <summary>
+    ///     Read a header value as a DateTimeOffset.
+    ///     By default, this will return the default value if the header is not present or
+    ///     cannot be parsed from the expected format "<inheritdoc cref="_dateTimeOffsetFormat"/>".
+    /// </summary>
+    /// <param name="incoming">The incoming message.</param>
+    /// <param name="key">The key of the header to read.</param>
+    /// <returns>
+    ///     The DateTimeOffset value of the header, or default(DateTimeOffset) if
+    ///     the header is not present or cannot be parsed.
+    /// </returns>
+    protected virtual DateTimeOffset readDateTimeOffset(TIncoming incoming, string key)
     {
         if (tryReadIncomingHeader(incoming, key, out var raw))
         {
-            if (DateTimeOffset.TryParseExact(raw, DateTimeOffsetFormat, null, DateTimeStyles.AssumeUniversal,  out var flag))
+            if (DateTimeOffset.TryParseExact(raw, _dateTimeOffsetFormat, null, DateTimeStyles.AssumeUniversal,  out var flag))
             {
                 return flag;
             }
@@ -440,11 +663,21 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         return default;
     }
 
-    protected DateTimeOffset? readNullableDateTimeOffset(TIncoming incoming, string key)
+    /// <summary>
+    ///     Read a header value as a nullable DateTimeOffset.
+    ///     By default, this will return null if the header is not present or
+    ///     cannot be parsed from the expected format "<inheritdoc cref="_dateTimeOffsetFormat"/>".
+    /// </summary>
+    /// <param name="incoming">The incoming message.</param>
+    /// <param name="key">The key of the header to read.</param>
+    /// <returns>
+    ///     The nullable DateTimeOffset value of the header, or null if the header is not present or cannot be parsed.
+    /// </returns>
+    protected virtual DateTimeOffset? readNullableDateTimeOffset(TIncoming incoming, string key)
     {
         if (tryReadIncomingHeader(incoming, key, out var raw))
         {
-            if (DateTimeOffset.TryParseExact(raw, DateTimeOffsetFormat, null, DateTimeStyles.AssumeUniversal,
+            if (DateTimeOffset.TryParseExact(raw, _dateTimeOffsetFormat, null, DateTimeStyles.AssumeUniversal,
                     out var flag))
             {
                 return flag;


### PR DESCRIPTION
**Overview**
As part of migrating a production system to Wolverine, we encountered scenarios where we need to process mixed message formats through a single listener, particularly with Kafka and MQTT. This PR introduces targeted enhancements to support such use cases without breaking existing behavior.

**Changes**
- Allow full configuration of the endpoint during interop setup.
  - Note that previous methods similar to `UseInterop` were not removed to avoid breaking changes - it might be duplicated for some configurations.
- MQTT topic name is now added to incoming envelopes.
- Several base methods in EnvelopeMapper are now virtual, allowing selective overrides.
- Internal mappers were made public so they can be extended or wrapped without copying internal logic.

**Motivation**
- We need to handle versioned messages in Kafka using a single listener.
- Additionally, MQTT messages must be validated based on the topic they were received on.

These changes allow us to plug in custom logic without having to fork or duplicate Wolverine internals.

**Example**
```csharp
public abstract class VersionedKafkaEnvelopeMapper
    : IEnvelopeMapper<Message<string, string>, Message<string, string>>
{
    /// <summary>
    /// The mappers for different versions of Kafka messages.
    /// If messages without a version header are received, a mapper with the key "" will be used.
    /// </summary>
    protected abstract Dictionary<string, IKafkaEnvelopeMapper> Mappers { get; }
    
    public void MapEnvelopeToOutgoing(Envelope envelope, Message<string, string> outgoing)
    {
        var version = envelope.Headers["version"] ?? string.Empty;

        if (!Mappers.TryGetValue(version, out var mapper))
            throw new NotSupportedException("Unsupported Kafka message version: " + version);
        
        mapper.MapEnvelopeToOutgoing(envelope, outgoing);
        outgoing.Headers.Add("version", Encoding.Default.GetBytes(version));
    }

    public void MapIncomingToEnvelope(Envelope envelope, Message<string, string> incoming)
    {
        var version = string.Empty;
        if (incoming.Headers.TryGetLastBytes("version", out var versionBytes))
        {
            version = Encoding.Default.GetString(versionBytes);
        }
        
        if (!Mappers.TryGetValue(version, out var mapper))
            throw new NotSupportedException("Unsupported Kafka message version: " + version);
        
        mapper.MapIncomingToEnvelope(envelope, incoming);
    }

    public IEnumerable<string> AllHeaders()
    {
        return Mappers.SelectMany(x => x.Value.AllHeaders()).ToHashSet();
    }
}

public class MyKafkaEnvelopeMapper(Endpoint endpoint) : VersionedKafkaEnvelopeMapper
{
    protected override Dictionary<string, IKafkaEnvelopeMapper> Mappers { get; } = new()
    {
        { string.Empty, new LegacyKafkaEnvelopeMapper(endpoint) },
        { "v1", new KafkaEnvelopeMapper(endpoint) },
    };
}
```