### PR TITLE
docs: Users need to call AutoProvision together with AddResourceSetupOnStartup

### DIFF
--- a/docs/guide/messaging/transports/rabbitmq/object-management.md
+++ b/docs/guide/messaging/transports/rabbitmq/object-management.md
@@ -85,7 +85,11 @@ builder.Host.UseWolverine(opts =>
     // just to see things work
     opts.PublishAllMessages()
         .ToRabbitExchange("issue_events", exchange => exchange.BindQueue("issue_events"))
-        .UseDurableOutbox();
+        .UseDurableOutbox()
+        // Even when calling AddResourceSetupOnStartup(), we still
+        // need to AutoProvision to ensure any declared queues, exchanges, or
+        // bindings with the Rabbit MQ broker to be built as part of bootstrapping time
+        .AutoProvision();
 
     opts.ListenToRabbitQueue("issue_events").UseDurableInbox();
 

--- a/src/Samples/KitchenSink/MartenAndRabbitIssueService/Program.cs
+++ b/src/Samples/KitchenSink/MartenAndRabbitIssueService/Program.cs
@@ -20,7 +20,11 @@ builder.Host.UseWolverine(opts =>
     // just to see things work
     opts.PublishAllMessages()
         .ToRabbitExchange("issue_events", exchange => exchange.BindQueue("issue_events"))
-        .UseDurableOutbox();
+        .UseDurableOutbox()
+        // Even when calling AddResourceSetupOnStartup(), we still
+        // need to AutoProvision to ensure any declared queues, exchanges, or
+        // bindings with the Rabbit MQ broker to be built as part of bootstrapping time
+        .AutoProvision();
 
     opts.ListenToRabbitQueue("issue_events").UseDurableInbox();
 


### PR DESCRIPTION
The documentation had an error where it said `AddResourceSetupOnStartup` should replace the call to `AutoProvision`, but that isnt the case.

With RabbitMQ for example, at least bindings wont be created when omitting `AutoProvision`, so this should help users not get trapped in that case.

Closes: https://github.com/JasperFx/wolverine/issues/1590