### PR TITLE
Add test demonstrating RabbitMQ DLQ replay bug

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_ReplayDeadLetterQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_ReplayDeadLetterQueue.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using IntegrationTests;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Persistence.Durability.DeadLetterManagement;
+using Wolverine.RabbitMQ;
+using Wolverine.SqlServer;
+using Wolverine.Tracking;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Wolverine.RabbitMQ.Tests.Bugs;
+
+public class Bug_ReplayDeadLetterQueue
+{
+    private readonly ITestOutputHelper _output;
+    public Bug_ReplayDeadLetterQueue(ITestOutputHelper output) { _output = output; ReplayTestHandler.Output = output; }
+
+    [Theory]
+    [InlineData(false)] // non-durable
+    [InlineData(true)]  // durable
+    public async Task can_replay_dead_letter_message(bool useDurableInbox)
+    {
+        var queueName = $"replay-dlq-{Guid.NewGuid()}";
+        var connectionString = Servers.SqlServerConnectionString;
+
+        // Reset handler state
+        ReplayTestHandler.Reset();
+        ReplayTestHandler.FailFirst = true;
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithSqlServer(connectionString, "wolverine");
+                opts.Policies.AutoApplyTransactions();
+                opts.EnableAutomaticFailureAcks = false;
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.UseRabbitMq().DisableDeadLetterQueueing().AutoProvision().AutoPurgeOnStartup();
+                if (useDurableInbox)
+                {
+                    opts.ListenToRabbitQueue(queueName).UseDurableInbox();
+                    opts.PublishMessage<ReplayTestMessage>().ToRabbitQueue(queueName);
+                }
+                else
+                {
+                    opts.ListenToRabbitQueue(queueName);
+                    opts.PublishMessage<ReplayTestMessage>().ToRabbitQueue(queueName);
+                }
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+            }).StartAsync();
+
+        await host.ResetResourceState();
+
+        using (var scope = host.Services.CreateScope())
+        {
+            var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+            await bus.PublishAsync(new ReplayTestMessage());
+        }
+        await Task.Delay(1000);
+
+        var messageStore = host.Services.GetRequiredService<IMessageStore>();
+        var deadLetterQuery = new DeadLetterEnvelopeQueryParameters { Limit = 10 };
+        var sw = Stopwatch.StartNew();
+        Guid? deadLetterId = null;
+        while (sw.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            var deadLetterResults = await messageStore.DeadLetters.QueryDeadLetterEnvelopesAsync(deadLetterQuery);
+            if (deadLetterResults.DeadLetterEnvelopes.Any())
+            {
+                deadLetterId = deadLetterResults.DeadLetterEnvelopes.First().Id;
+                break;
+            }
+            await Task.Delay(100);
+        }
+        deadLetterId.ShouldNotBeNull("Message should be in DLQ after failure");
+
+        // Log state before replay
+        var beforeReplay = await messageStore.DeadLetters.QueryDeadLetterEnvelopesAsync(deadLetterQuery);
+        var beforeIncoming = await messageStore.Admin.AllIncomingAsync();
+        _output.WriteLine($"[BEFORE REPLAY] DLQ: {beforeReplay.DeadLetterEnvelopes.Count}, Incoming: {beforeIncoming.Count}");
+
+        // Force handler to succeed on replay (mimic Marten test)
+        ReplayTestHandler.FailFirst = false;
+
+        var tracked = await host
+            .TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .Timeout(TimeSpan.FromSeconds(10))
+            .WaitForMessageToBeReceivedAt<ReplayTestMessage>(host)
+            .ExecuteAndWaitAsync((IMessageContext _) => messageStore.DeadLetters.MarkDeadLetterEnvelopesAsReplayableAsync(new[] { deadLetterId.Value }));
+
+        // Log state after replay
+        var afterReplay = await messageStore.DeadLetters.QueryDeadLetterEnvelopesAsync(deadLetterQuery);
+        var afterIncoming = await messageStore.Admin.AllIncomingAsync();
+        _output.WriteLine($"[AFTER REPLAY] DLQ: {afterReplay.DeadLetterEnvelopes.Count}, Incoming: {afterIncoming.Count}");
+        foreach (var env in afterIncoming)
+        {
+            _output.WriteLine($"[INCOMING] Id: {env.Id}, Status: {env.Status}, OwnerId: {env.OwnerId}, ScheduledTime: {env.ScheduledTime}, Attempts: {env.Attempts}, ReceivedAt: {env.Destination}");
+        }
+
+        // Assert using the tracking result, mimicking the Marten test
+        tracked.MessageSucceeded.SingleMessage<ReplayTestMessage>()
+            .ShouldNotBeNull("ReplayTestMessage should be successfully processed after replay");
+        afterReplay.DeadLetterEnvelopes.Any(dl => dl.Id == deadLetterId).ShouldBeFalse("Message should be removed from DLQ after successful replay (this should work for both durable and non-durable queues)");
+        afterIncoming.Any(env => env.Id == deadLetterId).ShouldBeFalse("Message should not remain in Incoming after successful processing");
+    }
+}
+
+public record ReplayTestMessage;
+
+public static class ReplayTestHandler
+{
+    public static bool WasCalled = false;
+    public static bool FailFirst = true;
+    public static ITestOutputHelper? Output;
+    public static void Reset() { WasCalled = false; FailFirst = true; }
+    public static void Handle(ReplayTestMessage command)
+    {
+        var msg = $"[HANDLER] Called. FailFirst={FailFirst}";
+        if (Output != null) Output.WriteLine(msg); else Console.WriteLine(msg);
+        if (FailFirst)
+        {
+            FailFirst = false;
+            throw new DivideByZeroException("Boom.");
+        }
+        WasCalled = true;
+    }
+} 


### PR DESCRIPTION
# Bug: RabbitMQ DLQ Replay Not Working with SQL Server Persistence

## Summary

When using RabbitMQ transport with SQL Server persistence and `DeadLetterQueueMode.WolverineStorage`, replaying messages from the Dead Letter Queue (DLQ) does not work. Messages are successfully moved from the DLQ to the Incoming table, but they are never processed by the handler.

## Root Cause

The issue is in the `MarkReceived` method in `src/Wolverine/Envelope.Internals.cs` (lines 140-145). When a message is initially received by a RabbitMQ listener, the `Destination` property is set to the consumer-specific address (e.g., `rabbitmq://queue/myqueue?consumer=123`) instead of the base queue address (e.g., `rabbitmq://queue/myqueue`).

Later, when the message is moved from the DLQ back to the Incoming table via `MoveReplayableErrorMessagesToIncomingOperation`, the original `ReceivedAt` value (which contains the `?consumer=` parameter) is preserved. However, the `DurableReceiver` looks for messages with `ReceivedAt` matching the base queue address, causing a mismatch.

## Technical Details

### Current Behavior

1. Message fails processing → goes to DLQ with `ReceivedAt = "rabbitmq://queue/myqueue?consumer=123"`
2. Message is marked as replayable → moved to Incoming table with same `ReceivedAt` value
3. `DurableReceiver` queries for messages with `ReceivedAt = "rabbitmq://queue/myqueue"` (base address)
4. No match found → message sits in Incoming table unprocessed

### Expected Behavior

1. Message fails processing → goes to DLQ with `ReceivedAt = "rabbitmq://queue/myqueue"` (base address)
2. Message is marked as replayable → moved to Incoming table with same `ReceivedAt` value
3. `DurableReceiver` queries for messages with `ReceivedAt = "rabbitmq://queue/myqueue"` (base address)
4. Match found → message is processed

## Evidence

### Test Case

Created isolated test `src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_ReplayDeadLetterQueue.cs` that demonstrates the issue for both durable and non-durable RabbitMQ queues.

### Test Output

```
[HANDLER] Called. FailFirst=True
[BEFORE REPLAY] DLQ: 1, Incoming: 0
[AFTER REPLAY] DLQ: 0, Incoming: 1
[INCOMING] Id: 08ddc96c-e980-e57a-e6aa-525c34390000, Status: Incoming, OwnerId: 0, ScheduledTime: , Attempts: 0, ReceivedAt: rabbitmq://queue/replay-dlq-9600661c-0a01-4cab-9223-1e8f5942a56e?consumer=
```

The `ReceivedAt` value contains the `?consumer=` parameter, preventing the `DurableReceiver` from finding the message.

### Code Location

The bug is in `src/Wolverine/Envelope.Internals.cs`:

```csharp
internal void MarkReceived(IListener listener, DateTimeOffset now, DurabilitySettings settings)
{
    Listener = listener;

    // If this is a stream with multiple consumers, use the consumer-specific address
    if (listener is ISupportMultipleConsumers multiConsumerListener)
    {
        Destination = multiConsumerListener.ConsumerAddress; // ❌ This sets the consumer-specific address
    }
    else
    {
        Destination = listener.Address; // ✅ This sets the base address
    }
    // ...
}
```

## Proposed Fix

Modify the `MarkReceived` method to always use the base address for RabbitMQ listeners:

```csharp
internal void MarkReceived(IListener listener, DateTimeOffset now, DurabilitySettings settings)
{
    Listener = listener;

    // Always use the base address to ensure DLQ replay works correctly
    Destination = listener.Address;

    // ... rest of the method
}
```

## Impact

- **Affects**: RabbitMQ transport with SQL Server/PostgreSQL persistence and `DeadLetterQueueMode.WolverineStorage`

## Related Files

- `src/Wolverine/Envelope.Internals.cs`
- `src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs` - Defines Address vs ConsumerAddress
- `src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_ReplayDeadLetterQueue.cs` - Test case demonstrating the issue
- `src/Persistence/Wolverine.RDBMS/Durability/MoveReplayableErrorMessagesToIncomingOperation.cs` - Operation that moves messages from DLQ to Incoming

