### PR TITLE
Produce validation problems metadata for OpenAPI in FluentValidation middleware

### DIFF
--- a/src/Http/Wolverine.Http.FluentValidation/Internals/HttpChainFluentValidationPolicy.cs
+++ b/src/Http/Wolverine.Http.FluentValidation/Internals/HttpChainFluentValidationPolicy.cs
@@ -25,7 +25,7 @@ internal class HttpChainFluentValidationPolicy : IHttpPolicy
 
         if (registered.Count() == 1)
         {
-            chain.Metadata.ProducesProblem(400);
+            chain.Metadata.ProducesValidationProblem(400);
 
             var method =
                 typeof(FluentValidationHttpExecutor).GetMethod(nameof(FluentValidationHttpExecutor.ExecuteOne))!
@@ -41,7 +41,7 @@ internal class HttpChainFluentValidationPolicy : IHttpPolicy
         }
         else if (registered.Count() > 1)
         {
-            chain.Metadata.ProducesProblem(400);
+            chain.Metadata.ProducesValidationProblem(400);
 
             var method =
                 typeof(FluentValidationHttpExecutor).GetMethod(nameof(FluentValidationHttpExecutor.ExecuteMany))!


### PR DESCRIPTION
Produce `HttpValidationProblemDetails` metadata for OpenAPI in FluentValidation middleware instead of generic `ProblemDetails`