### PR TITLE
Add failing test-case for "frame chain is being re-arranged" issue in LoadEntityFrameBlock

### DIFF
--- a/src/Http/WolverineWebApi/Bugs/FrameRearrangeEndpoint.cs
+++ b/src/Http/WolverineWebApi/Bugs/FrameRearrangeEndpoint.cs
@@ -1,0 +1,46 @@
+﻿using JasperFx.CodeGeneration;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine.Http;
+using Wolverine.Http.Marten;
+using Wolverine.Middleware;
+using Wolverine.Runtime;
+using WolverineWebApi.Marten;
+
+namespace WolverineWebApi.Bugs;
+
+public static class FrameRearrangeEndpoint
+{
+    [WolverineGet("/frame-rearrange/{id}")]
+    public static Invoice Get([Document(Required = true, MaybeSoftDeleted = false)] Invoice invoice)
+    {
+        return invoice;
+    }
+}
+
+public static class FrameRearrangeMiddleware
+{
+    public static void Before(HttpContext context)
+    {
+        // Very simplified code, but similar to what I have in production
+        var userAgents = context.Request.Headers.UserAgent;
+        if (userAgents.Any(f => f?.Contains("block-me") ?? false))
+        {
+            throw new Exception("Blocked client");
+        }
+    }
+    
+    public class HttpPolicy : IHttpPolicy
+    {
+        public void Apply(IReadOnlyList<HttpChain> chains, GenerationRules rules, IServiceContainer container)
+        {
+            // Only apply this policy to the FrameRearrangeEndpoint, but in production it's applied to all endpoints
+            foreach (var chain in chains.Where(f => f.Method.HandlerType.Name == nameof(FrameRearrangeEndpoint)))
+            {
+                var middlewarePolicy = new MiddlewarePolicy();
+                middlewarePolicy.AddType(typeof(FrameRearrangeMiddleware));
+
+                middlewarePolicy.Apply([chain], rules, container);
+            }
+        }
+    }
+}

--- a/src/Http/WolverineWebApi/Program.cs
+++ b/src/Http/WolverineWebApi/Program.cs
@@ -25,6 +25,7 @@ using Wolverine.Http.Tests.DifferentAssembly.Validation;
 using Wolverine.Http.Transport;
 using Wolverine.Marten;
 using WolverineWebApi;
+using WolverineWebApi.Bugs;
 using WolverineWebApi.Marten;
 using WolverineWebApi.Samples;
 using WolverineWebApi.Things;
@@ -264,6 +265,7 @@ app.MapWolverineEndpoints(opts =>
 
     opts.AddPolicy<StreamCollisionExceptionPolicy>();
 
+    opts.AddPolicy<FrameRearrangeMiddleware.HttpPolicy>();
 
     #region sample_adding_custom_parameter_handling
 


### PR DESCRIPTION
But my setup is different than what is "forbidden" in #1625 

I ran into this issue upgrading from 4.5 to 4.9