### PR TITLE
Making the tracked session catch and complete on no handlers / routes…

### DIFF
--- a/src/Testing/CoreTests/Tracking/when_determining_if_the_session_is_done.cs
+++ b/src/Testing/CoreTests/Tracking/when_determining_if_the_session_is_done.cs
@@ -165,3 +165,4 @@ public class when_determining_if_the_session_is_done : IDisposable
         session.Status.ShouldBe(TrackingStatus.Completed);
     }
 }
+

--- a/src/Wolverine/Tracking/EnvelopeHistory.cs
+++ b/src/Wolverine/Tracking/EnvelopeHistory.cs
@@ -154,8 +154,10 @@ internal class EnvelopeHistory
 
             case MessageEventType.NoHandlers:
             case MessageEventType.NoRoutes:
+                record.IsComplete = true;
+                break;
+            
             case MessageEventType.Requeued:
-
                 break;
 
             default:


### PR DESCRIPTION
… when you are using tracking w/ external transports & across hosts. Closes GH-1632