### PR TITLE
Set `BootstrapServers` in Kafka consumer specific configurations

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs
@@ -78,7 +78,8 @@ public class DocumentationSamples
                         // This will also set the Envelope.GroupId for any
                         // received messages at this topic
                         config.GroupId = "foo";
-                        
+                        config.BootstrapServers = "localhost:9092";
+
                         // Other configuration
                     });
 

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/broadcast_to_topic_rules.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/broadcast_to_topic_rules.cs
@@ -26,7 +26,11 @@ public class broadcast_to_topic_rules : IAsyncLifetime
             .UseWolverine(opts =>
             {
                 opts.UseKafka("localhost:9092").AutoProvision();
-                opts.ListenToKafkaTopic("red").ConfigureConsumer(c => c.GroupId = "crimson");
+                opts.ListenToKafkaTopic("red").ConfigureConsumer(c =>
+                {
+                    c.GroupId = "crimson";
+                    c.BootstrapServers = "localhost:9092";
+                });
                 opts.ListenToKafkaTopic("green");
                 opts.ListenToKafkaTopic("blue");
                 opts.ListenToKafkaTopic("purple");

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/configuration_precedence.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/configuration_precedence.cs
@@ -27,7 +27,11 @@ public class configuration_precedence
                 opts.ListenToKafkaTopic("General").Named("General");
                 
                 opts.ListenToKafkaTopic("ResponseMessages")
-                    .ConfigureConsumer(x => x.GroupId = "Specific").Named("Specific"); // Not working as expected
+                    .ConfigureConsumer(x =>
+                    {
+                        x.GroupId = "Specific";
+                        x.BootstrapServers = "localhost:9092";
+                    }).Named("Specific"); // Not working as expected
 
                 opts.Services.AddResourceSetupOnStartup();
             }).StartAsync();

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/configure_consumers_and_publishers.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/configure_consumers_and_publishers.cs
@@ -61,6 +61,7 @@ public class configure_consumers_and_publishers : IAsyncLifetime
                         // This will also set the Envelope.GroupId for any
                         // received messages at this topic
                         config.GroupId = "foo";
+                        config.BootstrapServers = "localhost:9092";
                         
                         // Other configuration
                     }).Named("red");


### PR DESCRIPTION
Since ConfigureConsumer() completely replaces the parent configuration, you should explicitly set BootstrapServers in the per-consumer configuration. Otherwise, my consumer didn’t work.

<img width="582" height="304" alt="Captura de pantalla 2025-08-12 a las 9 45 06" src="https://github.com/user-attachments/assets/9405eb44-7b43-4109-93a1-c5cbe013857c" />

<img width="594" height="311" alt="Captura de pantalla 2025-08-12 a las 9 45 16" src="https://github.com/user-attachments/assets/30437f9a-02a3-4d51-acd4-9185153b3302" />
