### PR TITLE
feat(sqs): allow requesting MessageAttributes on ReceiveMessage (interop-only)

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/AmazonSqsQueueTests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/AmazonSqsQueueTests.cs
@@ -66,7 +66,8 @@ public class AmazonSqsQueueTests
         {
             MaxNumberOfMessages = 8,
             VisibilityTimeout = 3,
-            WaitTimeSeconds = 11
+            WaitTimeSeconds = 11,
+            MessageAttributeNames = ["All"],
         };
 
         var request = new ReceiveMessageRequest();
@@ -76,6 +77,39 @@ public class AmazonSqsQueueTests
         request.VisibilityTimeout.ShouldBe(endpoint.VisibilityTimeout);
         request.MaxNumberOfMessages.ShouldBe(endpoint.MaxNumberOfMessages);
         request.WaitTimeSeconds.ShouldBe(endpoint.WaitTimeSeconds);
+        request.MessageAttributeNames.ShouldBe(endpoint.MessageAttributeNames);
+    }
+
+    [Fact]
+    public void default_message_attribute_names_is_null_on_endpoint()
+    {
+        new AmazonSqsQueue("foo", new AmazonSqsTransport())
+            .MessageAttributeNames.ShouldBeNull();
+    }
+
+    [Fact]
+    public void configure_request_does_not_set_message_attribute_names_when_null()
+    {
+        var endpoint = new AmazonSqsQueue("foo", new AmazonSqsTransport());
+        var request = new ReceiveMessageRequest();
+
+        endpoint.ConfigureRequest(request);
+
+        request.MessageAttributeNames.ShouldBeNull();
+    }
+
+    [Fact]
+    public void configure_request_does_not_set_when_empty_list()
+    {
+        var endpoint = new AmazonSqsQueue("foo", new AmazonSqsTransport())
+        {
+            MessageAttributeNames = []
+        };
+        var request = new ReceiveMessageRequest();
+
+        endpoint.ConfigureRequest(request);
+
+        request.MessageAttributeNames.ShouldBeNull();
     }
 }
 

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -90,6 +90,13 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue
     /// </summary>
     public string? DeadLetterQueueName { get; set; } = AmazonSqsTransport.DeadLetterQueueName;
 
+    /// <summary>
+    ///     Optional list of message attribute names to request in ReceiveMessage.
+    ///     Use "All" to retrieve all message attributes. If null or empty, nothing is requested.
+    ///     (Attention: this is different from <see cref="ReceiveMessageRequest.MessageSystemAttributeNames"/>.)
+    /// </summary>
+    public List<string>? MessageAttributeNames { get; set; }
+
     public async ValueTask<bool> CheckAsync()
     {
         var response = await _parent.Client!.GetQueueUrlAsync(QueueName);
@@ -299,6 +306,11 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue
         request.WaitTimeSeconds = WaitTimeSeconds;
         request.MaxNumberOfMessages = MaxNumberOfMessages;
         request.VisibilityTimeout = VisibilityTimeout;
+
+        if (MessageAttributeNames is { Count: > 0 })
+        {
+            request.MessageAttributeNames = MessageAttributeNames;
+        }
     }
 
     public async Task TeardownAsync(IAmazonSQS client, CancellationToken token)


### PR DESCRIPTION
## Summary
Enable **opt-in** retrieval of Amazon SQS **user-defined message attributes** on receive, **without changing default mappers**. By design, this PR is **interop-only**: attributes are requested from SQS when configured, and are available to custom `ISqsEnvelopeMapper` implementations. Built-in mappers remain unchanged.

## Motivation
Amazon SQS only returns user-defined message attributes when explicitly requested (`ReceiveMessageRequest.MessageAttributeNames`). The transport currently never sets this field, so consumers cannot read those attributes. This PR forwards configured names to the receive request to support interoperability scenarios that rely on custom mappers.

## What changed
- Added `AmazonSqsQueue.MessageAttributeNames` (optional).
- In `ConfigureRequest`, apply `MessageAttributeNames` only when the list is non-empty.
- Default behavior remains unchanged (no attributes requested unless configured).
- No changes to `RawJsonSqsEnvelopeMapper` or `DefaultSqsEnvelopeMapper`.

## How to use
```csharp
// Request All user-defined message attributes:
queue.MessageAttributeNames = new List<string> { "All" };

// Or request specific attributes:
queue.MessageAttributeNames = new List<string> { "retailerId", "commId" };
```
> [!NOTE]
> The mapping of attributes received for the `Envelope` (headers/metadata) is handled by your custom `ISqsEnvelopeMapper`.

## Notes

- If `MessageAttributeNames` is `null` or empty, **no** attributes are requested (current default).
- Using `"All"` requests all **user-defined** message attributes.
- This setting affects **receive** only (`ReceiveMessageRequest.MessageAttributeNames`); sending attributes remains unchanged and is handled by the SQS envelope mapper.
- Requesting many attributes (or `"All"`) can increase the response payload size; use only when needed.
- System attributes (`ReceiveMessageRequest.MessageSystemAttributeNames`) are out of scope for this change.

## Tests

- `configure_request`
- `default_message_attribute_names_is_null_on_endpoint`
- `configure_request_does_not_set_message_attribute_names_when_null`
- `configure_request_does_not_set_when_empty_list`

## Backward compatibility

No breaking changes. If not configured, behavior is identical to current versions.

## Documentation
Short note in the SQS transport docs explaining `MessageAttributeNames` and the "All" keyword. 
[AWS Documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html)