### PR TITLE
Update documentation on [Entity] attribute usage

### DIFF
--- a/docs/guide/durability/efcore/operations.md
+++ b/docs/guide/durability/efcore/operations.md
@@ -141,4 +141,7 @@ public static class TodoHandler
 
 Wolverine also supports the usage of the `[Entity]` attribute to load entity data by its identity with EF Core. As you'd 
 expect, Wolverine can "find" the right EF Core `DbContext` type for the entity type through IoC service registrations. 
+The loaded EF core entity does not included related entities. 
 
+For more information on the usage of this attribute see 
+[Automatically loading entities to method parameters](/guide/handlers/persistence#automatically-loading-entities-to-method-parameters).


### PR DESCRIPTION
Add link to the documentation for the [Entity] attribute.

Currently if you search Entity on the docs, this EF core docs come up first, rather than the actual page, and I've had to search that one out a few times, so figured this will be a thing for other people.

<img width="692" height="177" alt="image" src="https://github.com/user-attachments/assets/df3843b6-2d5b-4b45-a96e-f6226adb929e" />

Whilst doing this, I've clarified that the loaded EF Core entity does not include related entities.