### PR TITLE
Improvements to the tracked sessions for failure acks and scheduled m…

### DIFF
--- a/src/Http/Wolverine.Http.Tests/IntegrationContext.cs
+++ b/src/Http/Wolverine.Http.Tests/IntegrationContext.cs
@@ -185,7 +185,7 @@ public abstract class IntegrationContext : IAsyncLifetime, IOpenApiSource
     // for message tracking to both record outgoing messages and to ensure
     // that any cascaded work spawned by the initial command is completed
     // before passing control back to the calling test
-    protected async Task<(ITrackedSession, IScenarioResult)> TrackedHttpCall(Action<Scenario> configuration)
+    protected async Task<(ITrackedSession, IScenarioResult)> TrackedHttpCall(Action<Scenario> configuration, int timeoutInMilliseconds = 5000)
     {
         IScenarioResult result = null!;
 
@@ -196,7 +196,7 @@ public abstract class IntegrationContext : IAsyncLifetime, IOpenApiSource
             // The inner part here is actually making an HTTP request
             // to the system under test with Alba
             result = await Host.Scenario(configuration);
-        });
+        }, timeoutInMilliseconds);
 
         return (tracked, result);
     }

--- a/src/Http/Wolverine.Http.Tests/using_efcore.cs
+++ b/src/Http/Wolverine.Http.Tests/using_efcore.cs
@@ -1,4 +1,5 @@
 using IntegrationTests;
+using JasperFx.Resources;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
@@ -15,6 +16,8 @@ public class using_efcore : IntegrationContext
     public using_efcore(AppFixture fixture) : base(fixture)
     {
     }
+    
+    
 
     [Fact]
     public async Task using_db_context_without_outbox()
@@ -61,6 +64,8 @@ public class using_efcore : IntegrationContext
 
     private async Task cleanItems()
     {
+        await Host.ResetResourceState();
+        
         var table = new Table("items");
         table.AddColumn<Guid>("Id").AsPrimaryKey();
         table.AddColumn<string>("Name");
@@ -74,5 +79,74 @@ public class using_efcore : IntegrationContext
             await conn.RunSqlAsync("delete from items");
             await conn.CloseAsync();
         }
+    }
+    
+    
+    [Fact]
+    public async Task using_db_context_with_outbox_schedule()
+    {
+        await cleanItems();
+
+        var command = new CreateItemCommand { Name = "Jerick McKinnon" };
+
+        var (tracked, _) = await TrackedHttpCall(x =>
+        {
+            x.Post.Json(command).ToUrl("/ef/schedule");
+            x.StatusCodeShouldBe(204);
+        }, 60000);
+
+        using var nested = Host.Services.CreateScope();
+        var context = nested.ServiceProvider.GetRequiredService<ItemsDbContext>();
+
+        var item = await context.Items.Where(x => x.Name == command.Name).FirstOrDefaultAsync();
+        item.ShouldBeNull();
+
+        var records = tracked.AllRecordsInOrder().ToArray();
+
+        var scheduledMessage = tracked.Scheduled.SingleEnvelope<ItemCreated>();
+        scheduledMessage.ScheduleDelay.ShouldNotBeNull();
+        scheduledMessage.Message.ShouldBeOfType<ItemCreated>();
+    }
+    
+    [Fact]
+    public async Task using_db_context_with_outbox_schedule2()
+    {
+        await cleanItems();
+
+        var command = new CreateItemCommand { Name = "Jerick McKinnon" };
+
+        var (tracked, _) = await TrackedHttpCall(x =>
+        {
+            x.Post.Json(command).ToUrl("/ef/schedule2");
+            x.StatusCodeShouldBe(204);
+        });
+
+        using var nested = Host.Services.CreateScope();
+        var context = nested.ServiceProvider.GetRequiredService<ItemsDbContext>();
+
+        var item = await context.Items.Where(x => x.Name == command.Name).FirstOrDefaultAsync();
+        item.ShouldBeNull();
+
+        var scheduledMessage = tracked.Scheduled.SingleEnvelope<ItemCreated>();
+        scheduledMessage.ScheduleDelay.ShouldNotBeNull();
+        scheduledMessage.Message.ShouldBeOfType<ItemCreated>();
+    }
+
+    [Fact]
+    public async Task using_db_context_with_outbox_schedule_nodb()
+    {
+        await cleanItems();
+
+        var command = new CreateItemCommand { Name = "Jerick McKinnon" };
+
+        var (tracked, _) = await TrackedHttpCall(x =>
+        {
+            x.Post.Json(command).ToUrl("/ef/schedule_nodb");
+            x.StatusCodeShouldBe(204);
+        });
+
+        var scheduledMessage = tracked.Scheduled.SingleEnvelope<ItemCreated>();
+        scheduledMessage.ScheduleDelay.ShouldNotBeNull();
+        scheduledMessage.Message.ShouldBeOfType<ItemCreated>();
     }
 }

--- a/src/Http/WolverineWebApi/EfCoreEndpoints.cs
+++ b/src/Http/WolverineWebApi/EfCoreEndpoints.cs
@@ -1,3 +1,4 @@
+using JasperFx.Core;
 using Wolverine;
 using Wolverine.Http;
 
@@ -17,5 +18,23 @@ public class EfCoreEndpoints
         var item = new Item { Name = command.Name };
         db.Items.Add(item);
         await bus.PublishAsync(new ItemCreated { Id = item.Id });
+    }
+    
+    [WolverinePost("/ef/schedule")]
+    public async Task ScheduleItem(CreateItemCommand command, ItemsDbContext db, IMessageBus bus)
+    {
+        await bus.PublishAsync(new ItemCreated { Id = Guid.NewGuid() }, new(){ ScheduleDelay = 5.Days()});
+    }
+    
+    [WolverinePost("/ef/schedule2"), EmptyResponse]
+    public static object ScheduleItem2(CreateItemCommand command)
+    {
+        return new ItemCreated { Id = Guid.NewGuid() }.DelayedFor(5.Days());
+    }
+
+    [WolverinePost("/ef/schedule_nodb")]
+    public async Task ScheduleItem_NoDb(CreateItemCommand command, IMessageBus bus)
+    {
+        await bus.PublishAsync(new ItemCreated { Id = Guid.NewGuid() }, new() { ScheduleDelay = 5.Days() });
     }
 }

--- a/src/Testing/CoreTests/Acceptance/remote_invocation.cs
+++ b/src/Testing/CoreTests/Acceptance/remote_invocation.cs
@@ -73,11 +73,6 @@ public class remote_invocation : IAsyncLifetime
         await _sender.StopAsync();
     }
 
-    /*
-
-     * Pass CancellationToken through to ReplyListener
-     */
-
     [Fact]
     public async Task request_reply_with_no_reply()
     {

--- a/src/Testing/CoreTests/Acceptance/using_ISendMyself_as_cascading_message.cs
+++ b/src/Testing/CoreTests/Acceptance/using_ISendMyself_as_cascading_message.cs
@@ -32,6 +32,8 @@ public class using_ISendMyself_as_cascading_message : IntegrationContext
         var timeout = session.FindSingleTrackedMessageOfType<DelayedResponse>();
         timeout.Id.ShouldBe(id);
 
+        var records = session.AllRecordsInOrder().ToArray();
+
         var envelope = session.FindEnvelopesWithMessageType<DelayedResponse>()
             .Distinct()
             .Single().Envelope;

--- a/src/Testing/CoreTests/Configuration/configuring_deliver_within_rules.cs
+++ b/src/Testing/CoreTests/Configuration/configuring_deliver_within_rules.cs
@@ -25,7 +25,10 @@ public class configuring_deliver_within_rules
 
         var message = new Message1();
 
-        var session = await host.SendMessageAndWaitAsync(message);
+        var session = await host.TrackActivity().SendMessageAndWaitAsync(message);
+
+        var records = session.AllRecordsInOrder().ToArray();
+        
         session.Sent.SingleEnvelope<Message1>()
             .DeliverWithin.ShouldBe(3.Seconds());
     }

--- a/src/Testing/SlowTests/tracked_session_mechanics.cs
+++ b/src/Testing/SlowTests/tracked_session_mechanics.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics;
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.Runtime.RemoteInvocation;
+using Wolverine.Tracking;
+using Wolverine.Transports.Tcp;
+using Wolverine.Util;
+using Xunit;
+
+namespace SlowTests;
+
+public class tracked_session_mechanics
+{
+    [Fact]
+    public async Task failure_acks_show_up_in_tracked_session()
+    {
+        var port1 = PortFinder.GetAvailablePort();
+        var port2 = PortFinder.GetAvailablePort();
+
+        using var sender = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.PublishAllMessages().ToPort(port2);
+                opts.ListenAtPort(port1);
+            }).StartAsync();
+        
+        using var receiver = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ListenAtPort(port2);
+            }).StartAsync();
+
+        await Should.ThrowAsync<WolverineRequestReplyException>(async () =>
+        {
+            var (tracked, response) = await sender.TrackActivity().IncludeExternalTransports().AlsoTrack(receiver)
+                .InvokeAndWaitAsync<ResponseForRequest>(new RequestResponse(false, "Something"));
+        });
+
+
+    }
+
+    [Fact]
+    public async Task deal_with_in_memory_scheduled_message()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+
+            }).StartAsync();
+
+        // Should finish cleanly
+        var tracked = await host.SendMessageAndWaitAsync(new TriggerScheduledMessage("Chiefs"));
+
+        var records = tracked.AllRecordsInOrder().ToArray();
+        
+        tracked.Sent.SingleMessage<ScheduledMessage>()
+            .Text.ShouldBe("Chiefs");
+        
+        tracked.Scheduled.SingleMessage<ScheduledMessage>()
+            .Text.ShouldBe("Chiefs");
+    }
+
+    [Fact]
+    public async Task deal_with_locally_scheduled_execution()
+    {
+        #region sample_dealing_with_locally_scheduled_messages
+
+        // In this case we're just executing everything in memory
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine");
+                opts.Policies.UseDurableInboxOnAllListeners();
+            }).StartAsync();
+
+        // Should finish cleanly
+        var tracked = await host.SendMessageAndWaitAsync(new TriggerScheduledMessage("Chiefs"));
+        
+        // Here's how you can query against the messages that were detected to be scheduled
+        tracked.Scheduled.SingleMessage<ScheduledMessage>()
+            .Text.ShouldBe("Chiefs");
+
+        // This API will try to immediately play any scheduled messages immediately
+        var replayed = await tracked.PlayScheduledMessagesAsync(10.Seconds());
+        replayed.Executed.SingleMessage<ScheduledMessage>().Text.ShouldBe("Chiefs");
+
+        #endregion
+    }
+
+    [Fact]
+    public async Task handle_scheduled_delivery_to_external_transport()
+    {
+        #region sample_handling_scheduled_delivery_to_external_transport
+
+        var port1 = PortFinder.GetAvailablePort();
+        var port2 = PortFinder.GetAvailablePort();
+
+        using var sender = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PublishMessage<ScheduledMessage>().ToPort(port2);
+                opts.ListenAtPort(port1);
+            }).StartAsync();
+        
+        using var receiver = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ListenAtPort(port2);
+            }).StartAsync();
+        
+        // Should finish cleanly
+        var tracked = await sender
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .AlsoTrack(receiver)
+            .InvokeMessageAndWaitAsync(new TriggerScheduledMessage("Broncos"));
+
+        tracked.Scheduled.SingleMessage<ScheduledMessage>()
+            .Text.ShouldBe("Broncos");
+        
+        var replayed = await tracked.PlayScheduledMessagesAsync(10.Seconds());
+        replayed.Executed.SingleMessage<ScheduledMessage>().Text.ShouldBe("Broncos");
+
+        #endregion
+    }
+}
+
+public record TriggerScheduledMessage(string Text);
+
+public record ScheduledMessage(string Text);
+
+public record TriggerResponse(bool WillReturn, string Text);
+
+public record RequestResponse(bool WillReturn, string Text);
+
+public record ResponseForRequest(string Text);
+
+public static class RequestResponseHandler
+{
+    public static async Task HandleAsync(TriggerResponse message, IMessageBus bus)
+    {
+        var final = await bus.InvokeAsync<ResponseForRequest>(new RequestResponse(message.WillReturn, message.Text));
+        final.ShouldNotBeNull();
+    }
+    
+    public static ResponseForRequest? Handle(RequestResponse msg) => msg.WillReturn ? new(msg.Text) : null;
+
+    #region sample_handlers_for_trigger_scheduled_message
+
+    public static DeliveryMessage<ScheduledMessage> Handle(TriggerScheduledMessage message)
+    {
+        // This causes a message to be scheduled for delivery in 5 minutes from now
+        return new ScheduledMessage(message.Text).DelayedFor(5.Minutes());
+    }
+
+    public static void Handle(ScheduledMessage message) => Debug.WriteLine("Got scheduled message");
+
+    #endregion
+}

--- a/src/Wolverine/Runtime/WolverineRuntime.Tracking.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Tracking.cs
@@ -53,7 +53,7 @@ public sealed partial class WolverineRuntime : IMessageTracker
     public void Sent(Envelope envelope)
     {
         _sentCounter.Add(1, envelope.ToMetricsHeaders());
-        ActiveSession?.Record(MessageEventType.Sent, envelope, _serviceName, _uniqueNodeId);
+        ActiveSession?.MaybeRecord(MessageEventType.Sent, envelope, _serviceName, _uniqueNodeId);
         _sent(Logger, envelope.CorrelationId!, envelope.GetMessageTypeName(), envelope.Id,
             envelope.Destination?.ToString() ?? string.Empty,
             null);

--- a/src/Wolverine/Tracking/EnvelopeHistory.cs
+++ b/src/Wolverine/Tracking/EnvelopeHistory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Wolverine.Transports;
 
 namespace Wolverine.Tracking;
@@ -59,10 +60,12 @@ internal class EnvelopeHistory
                     record.Envelope.MessageType == TransportConstants.ScheduledEnvelope)
                 {
                     record.IsComplete = true;
+                    record.WasScheduled = true;
                 }
 
                 if (record.Envelope.Status == EnvelopeStatus.Scheduled)
                 {
+                    record.WasScheduled = true;
                     record.IsComplete = true;
                 }
 
@@ -116,7 +119,10 @@ internal class EnvelopeHistory
             case MessageEventType.Sent:
                 if (record.Envelope.Status == EnvelopeStatus.Scheduled)
                 {
+                    record.WasScheduled = true;
                     record.IsComplete = true;
+                    
+                    record.TryUseInnerFromScheduledEnvelope();
                 }
 
                 // This can be out of order with Rabbit MQ *somehow*, so:

--- a/src/Wolverine/Tracking/ITrackedSession.cs
+++ b/src/Wolverine/Tracking/ITrackedSession.cs
@@ -19,6 +19,12 @@ public interface ITrackedSession
     ///     published to local queues
     /// </summary>
     RecordCollection Sent { get; }
+    
+    /// <summary>
+    /// Records of all message activity that were scheduled for later sending or later local execution.
+    /// Note that this collection can span records in the other collections
+    /// </summary>
+    RecordCollection Scheduled { get; }
 
     /// <summary>
     ///     Records of all messages that were executed during the tracked session
@@ -128,6 +134,13 @@ public interface ITrackedSession
     /// <param name="message"></param>
     /// <param name="condition"></param>
     void AssertCondition(string message, Func<bool> condition);
+
+    /// <summary>
+    /// Attempt to "play" any messages that were scheduled by *only* the initial IHost
+    /// </summary>
+    /// <param name="timeout"></param>
+    /// <returns></returns>
+    Task<ITrackedSession> PlayScheduledMessagesAsync(TimeSpan timeout);
 }
 
 #endregion

--- a/src/Wolverine/Tracking/MessageEventType.cs
+++ b/src/Wolverine/Tracking/MessageEventType.cs
@@ -12,6 +12,7 @@ public enum MessageEventType
     NoHandlers,
     NoRoutes,
     MovedToErrorQueue,
-    Requeued
+    Requeued,
+    Scheduled
 }
 #endregion

--- a/src/Wolverine/Tracking/RecordCollection.cs
+++ b/src/Wolverine/Tracking/RecordCollection.cs
@@ -12,7 +12,9 @@ public class RecordCollection
         _messageEventType = eventType;
         _parent = parent;
     }
-    
+
+    internal TrackedSession Parent => _parent;
+
     public EnvelopeRecord SingleRecord<T>()
     {
         var records = RecordsInOrder().Where(x => x.Message is T).ToArray();
@@ -83,7 +85,7 @@ public class RecordCollection
         return RecordsInOrder().Select(x => x.Message).Where(x => x != null)!;
     }
 
-    public IEnumerable<EnvelopeRecord> RecordsInOrder()
+    public virtual IEnumerable<EnvelopeRecord> RecordsInOrder()
     {
         return _parent.AllRecordsInOrder().Where(x => x.MessageEventType == _messageEventType);
     }
@@ -91,5 +93,17 @@ public class RecordCollection
     public IEnumerable<Envelope> Envelopes()
     {
         return RecordsInOrder().Select(x => x.Envelope);
+    }
+}
+
+public class ScheduledActivityRecordCollection : RecordCollection
+{
+    internal ScheduledActivityRecordCollection(MessageEventType eventType, TrackedSession parent) : base(eventType, parent)
+    {
+    }
+
+    public override IEnumerable<EnvelopeRecord> RecordsInOrder()
+    {
+        return Parent.AllRecordsInOrder().Where(x => x.WasScheduled || x.MessageEventType == MessageEventType.Scheduled);
     }
 }


### PR DESCRIPTION
…essages. Closes GH-1697. Closes GH-1694. Closes GH-1689. Closes GH-1688

Ability to replay scheduled messages

WIP: handling scheduled messages in tracked sessions

Adding some awareness of Failure acks to the tracked session testing support

Adding more context into Failure Ack messages to troubleshoot problems w/ request/reply scenarios. Closes GH-1689