### PR TITLE
Add ability to pass arguments to the RabbitMQ consume method

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/IRabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/IRabbitMqQueue.cs
@@ -29,6 +29,11 @@ public interface IRabbitMqQueue
     IDictionary<string, object> Arguments { get; }
 
     /// <summary>
+    ///     Arguments for Rabbit MQ channel consume operations
+    /// </summary>
+    IDictionary<string, object?> ConsumerArguments { get; }
+
+    /// <summary>
     ///     Declare that Wolverine should purge the existing queue
     ///     of all existing messages on startup
     /// </summary>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -199,7 +199,7 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
 
         await Channel!.BasicQosAsync(0, Queue.PreFetchCount, false, _cancellation);
         await Channel.BasicConsumeAsync(Queue.QueueName, false,
-            _transport.ConnectionFactory?.ClientProvidedName ?? _runtime.Options.ServiceName, _consumer,
+            _transport.ConnectionFactory?.ClientProvidedName ?? _runtime.Options.ServiceName, Queue.ConsumerArguments, _consumer,
             _runtime.Cancellation);
 
         if (_transport.AutoPingListeners)

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -204,6 +204,11 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
     public IDictionary<string, object> Arguments { get; } = new Dictionary<string, object>();
 
     /// <summary>
+    ///     Arguments for Rabbit MQ channel consume operations
+    /// </summary>
+    public IDictionary<string, object?> ConsumerArguments { get; } = new Dictionary<string, object?>();
+
+    /// <summary>
     ///     Create a "time to live" limit for messages in this queue. Sets the Rabbit MQ x-message-ttl argument on a queue
     /// </summary>
     /// <param name="limit"></param>


### PR DESCRIPTION
Add ability to pass arguments to the RabbitMQ channel `BasicConsumeAsync` method. It can be used to customize stream consumption behavior. 

Example use case: `q.ConsumerArguments["x-stream-offset"] = "first";`