### PR TITLE
Fix RabbitMQ bindings couldn't be declared for multiple tenants

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqBinding.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqBinding.cs
@@ -24,10 +24,6 @@ public class RabbitMqBinding
 
     internal async Task DeclareAsync(IChannel channel, ILogger logger)
     {
-        if (HasDeclared)
-        {
-            return;
-        }
         await channel.QueueBindAsync(_queue.EndpointName, ExchangeName, BindingKey, Arguments);
         logger.LogInformation("Declared a Rabbit Mq binding '{Key}' from exchange {Exchange} to {Queue}", BindingKey,
             ExchangeName, _queue.EndpointName);


### PR DESCRIPTION
Continuation of #1362

Fixes #1658

