### PR TITLE
Docs - Fix JSON serialization link in endpoints guide

### DIFF
--- a/docs/guide/http/endpoints.md
+++ b/docs/guide/http/endpoints.md
@@ -189,7 +189,7 @@ public static OrderShipped Ship(ShipOrder command, Order order)
 
 ## JSON Handling
 
-See [JSON serialization for more information](/json)
+See [JSON serialization for more information](/guide/http/json)
 
 ## Returning Strings
 


### PR DESCRIPTION
Was giving a http 404.