### PR TITLE
Add missing fluent behaviour to PublishingExpression

### DIFF
--- a/src/Wolverine/Configuration/PublishingExpression.cs
+++ b/src/Wolverine/Configuration/PublishingExpression.cs
@@ -77,7 +77,7 @@ public class PublishingExpression : IPublishToExpression
         return new LocalQueueConfiguration(settings);
     }
 
-    public void AddSubscriber(Endpoint endpoint)
+    public PublishingExpression AddSubscriber(Endpoint endpoint)
     {
         _endpoints.Add(endpoint);
 
@@ -85,6 +85,8 @@ public class PublishingExpression : IPublishToExpression
         {
             endpoint.Subscriptions.AddRange(_subscriptions);
         }
+
+        return this;
     }
 
     /// <summary>
@@ -180,8 +182,10 @@ public class PublishingExpression : IPublishToExpression
     ///     base class
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public void MessagesImplementing<T>()
+    /// <returns></returns>
+    public PublishingExpression MessagesImplementing<T>()
     {
         _subscriptions.Add(new Subscription { BaseType = typeof(T), Scope = RoutingScope.Implements });
+        return this;
     }
 }


### PR DESCRIPTION
Pretty simple, allows for declaring publishers as such:

```csharp
opts.Publish()
    .MessagesImplementing<IMarker>()
    .ToPubsub();
```