### PR TITLE
fix: Use per-queue DLX exchange overrides and add regression coverage

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/DeadLetterQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/DeadLetterQueue.cs
@@ -63,6 +63,17 @@ public class DeadLetterQueue
 
     public Action<RabbitMqExchange>? ConfigureExchange { get; set; }
 
+    public DeadLetterQueue Clone()
+    {
+        return new DeadLetterQueue(QueueName, Mode)
+        {
+            ExchangeName = ExchangeName,
+            BindingName = BindingName,
+            ConfigureQueue = ConfigureQueue,
+            ConfigureExchange = ConfigureExchange
+        };
+    }
+
     protected bool Equals(DeadLetterQueue other)
     {
         return _queueName == other._queueName && ExchangeName == other.ExchangeName;

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -43,7 +43,7 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
 
         if (QueueName != _parent.DeadLetterQueue.QueueName)
         {
-            DeadLetterQueue = _parent.DeadLetterQueue;
+            DeadLetterQueue = _parent.DeadLetterQueue.Clone();
         }
     }
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
@@ -179,7 +179,7 @@ public class RabbitMqListenerConfiguration : InteroperableListenerConfiguration<
     {
         add(e =>
         {
-            e.DeadLetterQueue = dlq;
+            e.DeadLetterQueue = dlq.Clone();
         });
 
         return this;


### PR DESCRIPTION
fix: Use per-queue DLX exchange overrides

Per-queue RabbitMQ DLX overrides were ignored because the transport and queues shared the same DeadLetterQueue instance. When a per-queue override was applied, later uses of the shared instance (or transport default) overwrote the queue’s exchange name, so the queue was declared with the transport’s default DLX instead of the specified per queue DLX.

- Ensure RabbitMQ queues get independent DLQ instances (cloned) so per-queue overrides aren’t overwritten by transport defaults.
- Keep per-queue x-dead-letter-exchange values intact during queue declaration.
- Add regression tests for default+override DLX scenarios and queue declaration arguments.

Closes #1864 