### PR TITLE
Refactor HTTP transport

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Samples/ExternalHttpServer.cs
+++ b/src/Http/Wolverine.Http.Tests/Samples/ExternalHttpServer.cs
@@ -12,8 +12,14 @@ builder.UseWolverine(opts =>
     var transport = new HttpTransport();
     opts.Transports.Add(transport);
     // Publish all messages to the external http endpoint using the named http client
-    // The .SendInline() method fails, so do not use it here
+    // This will publish anarray of envelopes to the external endpoint
     opts.PublishAllMessages().ToHttpEndpoint(httpNamedClient);
+    
+    // To publish individual messages instead of batches, use this instead
+    // opts.PublishAllMessages().ToHttpEndpoint(httpNamedClient).SendInline();
+    
+    // If the httpendpoint supports native scheduled sends, use this instead
+    // opts.PublishAllMessages().ToHttpEndpoint(httpNamedClient, supportsNativeScheduledSend: true).SendInline();
 });
 builder.Services.AddWolverineHttp();
 // Configure the named http client to point to the external wolverine server
@@ -24,9 +30,12 @@ builder.Services.AddHttpClient(
         client.BaseAddress = new Uri("https://where-ever-you want-message-to-go/");
         //client.DefaultRequestHeaders.Add("Authorization", $"Bearer eyJ***");
     });
-// To handle the messages over HTTP, send them to https://where-your-app-with-message-handlers/_wolverine/batch/queue
+// To handle the array of messages over HTTP, send them to https://where-your-app-with-message-handlers/_wolverine/batch/queue
+// To handle single message over HTTP, send them to https://where-your-app-with-message-handlers/_wolverine/invoke
 // Register the WolverineHttpTransportClient for sending messages over HTTP
-builder.Services.AddScoped<WolverineHttpTransportClient>();
+builder.Services.AddScoped<IWolverineHttpTransportClient, WolverineHttpTransportClient>();
+// You can have your own implementation of IWolverineHttpTransportClient if you need custom behavior
+// builder.Services.AddScoped<IWolverineHttpTransportClient, MyWolverineHttpTransportClient>();
 var app = builder.Build();
 app.MapWolverineEndpoints();
 app.MapPost(

--- a/src/Http/Wolverine.Http.Tests/Transport/HttpEndpointTests.cs
+++ b/src/Http/Wolverine.Http.Tests/Transport/HttpEndpointTests.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Http.Transport;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace Wolverine.Http.Tests.Transport;
+
+public class HttpEndpointTests
+{
+    private readonly Uri _uri = "http://localhost:5000".ToUri();
+    private readonly HttpEndpoint _endpoint;
+
+    public HttpEndpointTests()
+    {
+        _endpoint = new HttpEndpoint(_uri, EndpointRole.Application);
+    }
+
+    private ISender InvokeCreateSender(IWolverineRuntime runtime)
+    {
+        var method = typeof(HttpEndpoint).GetMethod("CreateSender", BindingFlags.Instance | BindingFlags.NonPublic);
+        return (ISender)method.Invoke(_endpoint, new object[] { runtime });
+    }
+
+    private bool InvokeSupportsMode(EndpointMode mode)
+    {
+        var method = typeof(HttpEndpoint).GetMethod("supportsMode", BindingFlags.Instance | BindingFlags.NonPublic);
+        return (bool)method.Invoke(_endpoint, new object[] { mode });
+    }
+
+    [Fact]
+    public void constructor_sets_uri_and_role()
+    {
+        _endpoint.Uri.ShouldBe(_uri);
+        _endpoint.Role.ShouldBe(EndpointRole.Application);
+    }
+
+    [Fact]
+    public async Task build_listener_returns_nullo_listener()
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        var receiver = Substitute.For<IReceiver>();
+
+        var listener = await _endpoint.BuildListenerAsync(runtime, receiver);
+
+        listener.ShouldBeOfType<NulloListener>();
+        listener.Address.ShouldBe(_uri);
+    }
+
+    [Fact]
+    public void create_sender_inline_mode()
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Services.Returns(Substitute.For<IServiceProvider>());
+        
+        _endpoint.Mode = EndpointMode.Inline;
+
+        var sender = InvokeCreateSender(runtime);
+
+        sender.ShouldBeOfType<InlineHttpSender>();
+    }
+
+    [Fact]
+    public void create_sender_buffered_mode()
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Services.Returns(Substitute.For<IServiceProvider>());
+        runtime.LoggerFactory.Returns(NullLoggerFactory.Instance);
+        
+        _endpoint.Mode = EndpointMode.BufferedInMemory;
+
+        var sender = InvokeCreateSender(runtime);
+
+        sender.ShouldBeOfType<BatchedSender>();
+    }
+
+    [Fact]
+    public void describe_properties_returns_base_properties()
+    {
+        var properties = _endpoint.DescribeProperties();
+        properties.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void supports_all_modes()
+    {
+        InvokeSupportsMode(EndpointMode.Inline).ShouldBeTrue();
+        InvokeSupportsMode(EndpointMode.BufferedInMemory).ShouldBeTrue();
+        InvokeSupportsMode(EndpointMode.Durable).ShouldBeTrue();
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/Transport/WolverineHttpTransportClientTests.cs
+++ b/src/Http/Wolverine.Http.Tests/Transport/WolverineHttpTransportClientTests.cs
@@ -41,7 +41,7 @@ public class WolverineHttpTransportClientTests
         _handler.LastRequest.ShouldNotBeNull();
         _handler.LastRequest.Method.ShouldBe(HttpMethod.Post);
         _handler.LastRequest.RequestUri.ToString().ShouldBe(uri);
-        _handler.LastRequest.Content.Headers.ContentType.MediaType.ShouldBe(HttpTransportExecutor.EnvelopeContentType);
+        _handler.LastRequest.Content.Headers.ContentType.MediaType.ShouldBe(HttpTransport.EnvelopeContentType);
 
         var expectedData = EnvelopeSerializer.Serialize(envelope);
         _handler.LastContent.ShouldBe(expectedData);
@@ -67,7 +67,7 @@ public class WolverineHttpTransportClientTests
         _handler.LastRequest.ShouldNotBeNull();
         _handler.LastRequest.Method.ShouldBe(HttpMethod.Post);
         _handler.LastRequest.RequestUri.ToString().ShouldBe("https://target-url/");
-        _handler.LastRequest.Content.Headers.ContentType.MediaType.ShouldBe(HttpTransportExecutor.EnvelopeBatchContentType);
+        _handler.LastRequest.Content.Headers.ContentType.MediaType.ShouldBe(HttpTransport.EnvelopeBatchContentType);
 
         var expectedData = EnvelopeSerializer.Serialize(envelopes);
         _handler.LastContent.ShouldBe(expectedData);

--- a/src/Http/Wolverine.Http.Tests/Transport/http_transport_end_to_end.cs
+++ b/src/Http/Wolverine.Http.Tests/Transport/http_transport_end_to_end.cs
@@ -32,7 +32,7 @@ public class http_transport_end_to_end : IntegrationContext
 
         var (tracked, result) = await TrackedHttpCall(s =>
         {
-            s.Post.ByteArray(data).ToUrl("/_wolverine/batch/one").ContentType(HttpTransportExecutor.EnvelopeBatchContentType);
+            s.Post.ByteArray(data).ToUrl("/_wolverine/batch/one").ContentType(HttpTransport.EnvelopeBatchContentType);
         });
 
         tracked.Executed.SingleMessage<HttpMessage1>().Name.ShouldBe("one");
@@ -59,7 +59,7 @@ public class http_transport_end_to_end : IntegrationContext
         
         var (tracked, result) = await TrackedHttpCall(s =>
         {
-            s.Post.ByteArray(data).ToUrl("/_wolverine/invoke").ContentType(HttpTransportExecutor.EnvelopeContentType);
+            s.Post.ByteArray(data).ToUrl("/_wolverine/invoke").ContentType(HttpTransport.EnvelopeContentType);
         });
         
         tracked.Executed.SingleMessage<HttpMessage1>().Name.ShouldBe("Mat Cauthon");
@@ -80,8 +80,8 @@ public class http_transport_end_to_end : IntegrationContext
         
         var (tracked, result) = await TrackedHttpCall(s =>
         {
-            s.Post.ByteArray(data).ToUrl("/_wolverine/invoke").ContentType(HttpTransportExecutor.EnvelopeContentType);
-            s.ContentTypeShouldBe(HttpTransportExecutor.EnvelopeContentType);
+            s.Post.ByteArray(data).ToUrl("/_wolverine/invoke").ContentType(HttpTransport.EnvelopeContentType);
+            s.ContentTypeShouldBe(HttpTransport.EnvelopeContentType);
         });
 
         var resultData = await result.Context.Response.Body.ReadAllBytesAsync();

--- a/src/Http/Wolverine.Http/Transport/HttpEndpoint.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpEndpoint.cs
@@ -12,6 +12,7 @@ public class HttpEndpoint : Endpoint
     {
     }
 
+    internal bool SupportsNativeScheduledSend { get; set; }
     public string OutboundUri { get; set; }
 
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
@@ -21,11 +22,13 @@ public class HttpEndpoint : Endpoint
 
     protected override ISender CreateSender(IWolverineRuntime runtime)
     {
-        return new BatchedSender(
-            this, 
-            new HttpSenderProtocol(this, runtime.Services), 
-            runtime.Cancellation,
-            runtime.LoggerFactory.CreateLogger<HttpSenderProtocol>());
+        return Mode == EndpointMode.Inline
+            ? new InlineHttpSender(this, runtime, runtime.Services)
+            : new BatchedSender(
+                this,
+                new HttpSenderProtocol(this, runtime.Services),
+                runtime.Cancellation,
+                runtime.LoggerFactory.CreateLogger<HttpSenderProtocol>());
     }
 
     public override IDictionary<string, object> DescribeProperties()
@@ -35,6 +38,7 @@ public class HttpEndpoint : Endpoint
 
     protected override bool supportsMode(EndpointMode mode)
     {
-        return mode != EndpointMode.Inline;
+        return true;
     }
 }
+

--- a/src/Http/Wolverine.Http/Transport/HttpSenderProtocol.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpSenderProtocol.cs
@@ -8,7 +8,6 @@ internal class HttpSenderProtocol : ISenderProtocol
 {
     private readonly HttpEndpoint _endpoint;
     private readonly IServiceProvider _services;
-    private readonly IHttpClientFactory _clientFactory;
 
     public HttpSenderProtocol(HttpEndpoint endpoint, IServiceProvider services)
     {
@@ -19,7 +18,8 @@ internal class HttpSenderProtocol : ISenderProtocol
     public async Task SendBatchAsync(ISenderCallback callback, OutgoingMessageBatch batch)
     {
         using var scope = _services.CreateScope();
-        var client = scope.ServiceProvider.GetRequiredService<WolverineHttpTransportClient>();
+        var client = scope.ServiceProvider.GetRequiredService<IWolverineHttpTransportClient>() ??
+                     throw new InvalidOperationException("IWolverineHttpTransportClient is not registered in the service container");
         await client.SendBatchAsync(_endpoint.OutboundUri, batch);
     }
 }

--- a/src/Http/Wolverine.Http/Transport/HttpTransport.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpTransport.cs
@@ -14,6 +14,9 @@ public class HttpTransport : TransportBase<HttpEndpoint>
     {
     }
 
+    public const string EnvelopeContentType = "binary/wolverine-envelope";
+    public const string EnvelopeBatchContentType = "binary/wolverine-envelopes";
+
     protected override IEnumerable<HttpEndpoint> endpoints()
     {
         return _endpoints;

--- a/src/Http/Wolverine.Http/Transport/HttpTransportExecutor.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpTransportExecutor.cs
@@ -13,9 +13,6 @@ namespace Wolverine.Http.Transport;
 
 internal class HttpTransportExecutor
 {
-    public static readonly string EnvelopeContentType = "binary/wolverine-envelope";
-    public static readonly string EnvelopeBatchContentType = "binary/wolverine-envelopes";
-    
     private readonly WolverineRuntime _runtime;
     private readonly ILogger<HttpTransportExecutor> _logger;
 
@@ -29,7 +26,7 @@ internal class HttpTransportExecutor
     {
         if (httpContext.Request.Headers.TryGetValue("content-type", out var values))
         {
-            if (values[0] != EnvelopeBatchContentType)
+            if (values[0] != HttpTransport.EnvelopeBatchContentType)
             {
                 return Results.StatusCode(415);
             }
@@ -74,7 +71,7 @@ internal class HttpTransportExecutor
     {
         if (httpContext.Request.Headers.TryGetValue("content-type", out var values))
         {
-            if (values[0] != EnvelopeContentType)
+            if (values[0] != HttpTransport.EnvelopeContentType)
             {
                 return Results.StatusCode(415);
             }

--- a/src/Http/Wolverine.Http/Transport/HttpTransportExtensions.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpTransportExtensions.cs
@@ -33,7 +33,7 @@ public static class HttpTransportExtensions
     /// <param name="publishing"></param>
     /// <param name="url"></param>
     /// <returns></returns>
-    public static HttpTransportSubscriberConfiguration ToHttpEndpoint(this IPublishToExpression publishing, string url)
+    public static HttpTransportSubscriberConfiguration ToHttpEndpoint(this IPublishToExpression publishing, string url, bool supportsNativeScheduledSend = false)
     {
         var transports = publishing.As<PublishingExpression>().Parent.Transports;
         var transport = transports.GetOrCreate<HttpTransport>();
@@ -42,7 +42,7 @@ public static class HttpTransportExtensions
 
         // This is necessary unfortunately to hook up the subscription rules
         publishing.To(endpoint.Uri);
-
+        endpoint.SupportsNativeScheduledSend = supportsNativeScheduledSend;
         return new HttpTransportSubscriberConfiguration(endpoint);
     }
 }

--- a/src/Http/Wolverine.Http/Transport/IWolverineHttpTransportClient.cs
+++ b/src/Http/Wolverine.Http/Transport/IWolverineHttpTransportClient.cs
@@ -1,0 +1,9 @@
+using Wolverine.Transports;
+
+namespace Wolverine.Http.Transport;
+
+public interface IWolverineHttpTransportClient
+{
+    Task SendBatchAsync(string uri, OutgoingMessageBatch batch);
+    Task SendAsync(string uri, Envelope envelope);
+}

--- a/src/Http/Wolverine.Http/Transport/InlineHttpSender.cs
+++ b/src/Http/Wolverine.Http/Transport/InlineHttpSender.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Wolverine.Runtime;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.Http.Transport;
+
+internal class InlineHttpSender(HttpEndpoint endpoint, IWolverineRuntime runtime, IServiceProvider services) : ISender
+{
+    public async ValueTask SendAsync(Envelope envelope)
+    {
+        try
+        {
+            using var scope = services.CreateScope();
+            var client = scope.ServiceProvider.GetRequiredService<IWolverineHttpTransportClient>() ??
+                         throw new InvalidOperationException("IWolverineHttpTransportClient is not registered in the service container");
+            await client.SendAsync(endpoint.OutboundUri, envelope);
+        }
+        catch (Exception ex)
+        {
+            var logger = runtime.LoggerFactory.CreateLogger<InlineHttpSender>();
+            logger.LogError(
+                ex,
+                "Failed to send message {MessageId} to {Uri}",
+                envelope.Id,
+                endpoint.OutboundUri);
+        }
+    }
+
+    public bool SupportsNativeScheduledSend => endpoint.SupportsNativeScheduledSend;
+    public Uri Destination => endpoint.Uri;
+    public Task<bool> PingAsync() => Task.FromResult(true);
+
+}

--- a/src/Http/Wolverine.Http/Transport/WolverineHttpTransportClient.cs
+++ b/src/Http/Wolverine.Http/Transport/WolverineHttpTransportClient.cs
@@ -4,13 +4,13 @@ using Wolverine.Transports;
 
 namespace Wolverine.Http.Transport;
 
-public class WolverineHttpTransportClient(IHttpClientFactory clientFactory)
+public class WolverineHttpTransportClient(IHttpClientFactory clientFactory) : IWolverineHttpTransportClient
 {
     public async Task SendBatchAsync(string uri, OutgoingMessageBatch batch)
     {
         var client = clientFactory.CreateClient(uri);
         var content = new ByteArrayContent(EnvelopeSerializer.Serialize(batch.Messages));
-        content.Headers.ContentType = new MediaTypeHeaderValue(HttpTransportExecutor.EnvelopeBatchContentType);
+        content.Headers.ContentType = new MediaTypeHeaderValue(HttpTransport.EnvelopeBatchContentType);
         await client.PostAsync(client.BaseAddress, content);
     }
     
@@ -18,7 +18,7 @@ public class WolverineHttpTransportClient(IHttpClientFactory clientFactory)
     {
         var client = clientFactory.CreateClient(uri);
         var content = new ByteArrayContent(EnvelopeSerializer.Serialize(envelope));
-        content.Headers.ContentType = new MediaTypeHeaderValue(HttpTransportExecutor.EnvelopeContentType);
-        await client.PostAsync(uri, content);
+        content.Headers.ContentType = new MediaTypeHeaderValue(HttpTransport.EnvelopeContentType);
+        await client.PostAsync(client.BaseAddress, content);
     }
 }


### PR DESCRIPTION
This pull request refactors the HTTP transport layer to improve extensibility and consistency, mainly by introducing the `IWolverineHttpTransportClient` interface, consolidating content type constants, and supporting both batch and inline sending modes. It also updates tests and documentation to reflect these changes.

**Transport Client Improvements**

* Introduced the `IWolverineHttpTransportClient` interface for sending messages, allowing custom implementations and improving dependency injection flexibility. The default `WolverineHttpTransportClient` now implements this interface. [[1]](diffhunk://#diff-b1a72a4f6737bc5352571642aa1e68da991dc8a39d744715d4db81457474beeaR1-R9) [[2]](diffhunk://#diff-4220f0da44c41bcfaa20dbe333e40123840168c46583c817436c1727aaa0dd30L7-R22)
* Updated service registration to use the interface, enabling easy substitution for custom behavior.

**Content Type Consistency**

* Moved envelope content type constants (`EnvelopeContentType`, `EnvelopeBatchContentType`) to `HttpTransport`, ensuring a single source of truth and updated all usages accordingly. [[1]](diffhunk://#diff-2816ba26b7170a2db3c9942cd5b643919600e1de0d6540e0f4e7daf5efc05ddcR17-R19) [[2]](diffhunk://#diff-123cf04f43d33cf8d451e938f1ef0126c62f1f328896fa00610fc89b22c48fceL16-L18) [[3]](diffhunk://#diff-4220f0da44c41bcfaa20dbe333e40123840168c46583c817436c1727aaa0dd30L7-R22) [[4]](diffhunk://#diff-123cf04f43d33cf8d451e938f1ef0126c62f1f328896fa00610fc89b22c48fceL32-R29) [[5]](diffhunk://#diff-123cf04f43d33cf8d451e938f1ef0126c62f1f328896fa00610fc89b22c48fceL77-R74) [[6]](diffhunk://#diff-02d8940a789b47449c88043627bdc0c027a4a24546224a14d0ca94cc77f14af5L44-R44) [[7]](diffhunk://#diff-02d8940a789b47449c88043627bdc0c027a4a24546224a14d0ca94cc77f14af5L70-R70) [[8]](diffhunk://#diff-ccdb1bbc2d668c2090377c4c5bec597dc6ad9319bfff78f1460f113d642d9b23L35-R35) [[9]](diffhunk://#diff-ccdb1bbc2d668c2090377c4c5bec597dc6ad9319bfff78f1460f113d642d9b23L62-R62) [[10]](diffhunk://#diff-ccdb1bbc2d668c2090377c4c5bec597dc6ad9319bfff78f1460f113d642d9b23L83-R84)

**Endpoint and Sender Enhancements**

* Added support for inline sending mode via the new `InlineHttpSender` class, and updated `HttpEndpoint` to select the appropriate sender based on mode. [[1]](diffhunk://#diff-6856b2512575819e217b0bc9401a172e4d97594a56d37b5c50424d7313275de8R1-R34) [[2]](diffhunk://#diff-2cc0bef553bcb9a05aa37ad52be01c0d45c0dfe6fb22b739e98bb87c042ef26dL24-R27)
* Changed mode support logic in `HttpEndpoint` to allow all endpoint modes, including inline and buffered.
* Exposed `SupportsNativeScheduledSend` on `HttpEndpoint` and enabled configuration via the publishing extension method. [[1]](diffhunk://#diff-2cc0bef553bcb9a05aa37ad52be01c0d45c0dfe6fb22b739e98bb87c042ef26dR15) Fb95d5f0L13R13, [[2]](diffhunk://#diff-50e81f732665a9050cc7838d12dceeb84609badd3ba17017eacbb0772a05028fL45-R45)

**Documentation and Sample Updates**

* Improved comments in sample configuration to clarify batch vs. inline publishing and how to enable native scheduled sends. [[1]](diffhunk://#diff-7fcdd15df0bd06198db285a9c6fe7f208c2b7785ddc74097b4cc51cfbae4f4baL15-R22) [[2]](diffhunk://#diff-7fcdd15df0bd06198db285a9c6fe7f208c2b7785ddc74097b4cc51cfbae4f4baL27-R38)

**Testing Updates**

* Added comprehensive unit tests for `HttpEndpoint` covering sender creation, listener building, and mode support.
* Updated existing tests to use the new content type constants and interface-based client. [[1]](diffhunk://#diff-02d8940a789b47449c88043627bdc0c027a4a24546224a14d0ca94cc77f14af5L44-R44) [[2]](diffhunk://#diff-02d8940a789b47449c88043627bdc0c027a4a24546224a14d0ca94cc77f14af5L70-R70) [[3]](diffhunk://#diff-ccdb1bbc2d668c2090377c4c5bec597dc6ad9319bfff78f1460f113d642d9b23L35-R35) [[4]](diffhunk://#diff-ccdb1bbc2d668c2090377c4c5bec597dc6ad9319bfff78f1460f113d642d9b23L62-R62) [[5]](diffhunk://#diff-ccdb1bbc2d668c2090377c4c5bec597dc6ad9319bfff78f1460f113d642d9b23L83-R84)