### PR TITLE
Add Azure SignalR to SignalR transport

### DIFF
--- a/docs/guide/messaging/transports/signalr.md
+++ b/docs/guide/messaging/transports/signalr.md
@@ -46,6 +46,26 @@ builder.UseWolverine(opts =>
         // for the WolverineHub
         o.ClientTimeoutInterval = 10.Seconds();
     });
+
+    // Instead of self-hosting, it's also possible to
+    // use Azure SignalR. Only one of the two SignalR
+    // registrations are necessary. Both register the
+    // required services in DI
+    opts.UseAzureSignalR(hub =>
+    {
+        // Optionally configure the SignalR HubOptions
+        // for the WolverineHub
+        hub.ClientTimeoutInterval = 10.Seconds();
+    }, service =>
+    {
+        // And optionally configure the Azure SignalR
+        // options for the connection.
+        service.ApplicationName = "wolverine";
+
+        // You probably want one of these from your
+        // configuration somehow
+        service.ConnectionString = "Endpoint=https://myresource.service.signalr.net;AccessKey=...;Version=1.0;";
+    });
     
     // Using explicit routing to send specific
     // messages to SignalR
@@ -59,7 +79,7 @@ builder.UseWolverine(opts =>
     });
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/WolverineChat/Program.cs#L12-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_signalr_on_server_side' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/WolverineChat/Program.cs#L12-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_signalr_on_server_side' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 That handles the Wolverine configuration and the SignalR service registrations, but you will also need to map
@@ -84,7 +104,7 @@ app.MapWolverineSignalRHub("/api/messages");
 
 return await app.RunJasperFxCommands(args);
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/WolverineChat/Program.cs#L43-L61' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_map_wolverine_signalrhub' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/WolverineChat/Program.cs#L63-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_map_wolverine_signalrhub' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Messages and Serialization

--- a/src/Samples/WolverineChat/Program.cs
+++ b/src/Samples/WolverineChat/Program.cs
@@ -23,6 +23,26 @@ builder.UseWolverine(opts =>
         // for the WolverineHub
         o.ClientTimeoutInterval = 10.Seconds();
     });
+
+    // Instead of self-hosting, it's also possible to
+    // use Azure SignalR. Only one of the two SignalR
+    // registrations are necessary. Both register the
+    // required services in DI
+    opts.UseAzureSignalR(hub =>
+    {
+        // Optionally configure the SignalR HubOptions
+        // for the WolverineHub
+        hub.ClientTimeoutInterval = 10.Seconds();
+    }, service =>
+    {
+        // And optionally configure the Azure SignalR
+        // options for the connection.
+        service.ApplicationName = "wolverine";
+
+        // You probably want one of these from your
+        // configuration somehow
+        service.ConnectionString = "Endpoint=https://myresource.service.signalr.net;AccessKey=...;Version=1.0;";
+    });
     
     // Using explicit routing to send specific
     // messages to SignalR

--- a/src/Transports/SignalR/Wolverine.SignalR/SignalRWolverineExtensions.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/SignalRWolverineExtensions.cs
@@ -70,6 +70,28 @@ public static class SignalRWolverineExtensions
     }
 
     /// <summary>
+    /// Adds the WolverineHub to this application for Azure SignalR message processing
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="configureHub">Optionally configure the SignalR HubOptions for Wolverine</param>
+    /// <param name="configureSignalR">Optionally configure the Azure SignalR options for Wolverine</param>
+    /// <returns></returns>
+    public static SignalRListenerConfiguration UseAzureSignalR(this WolverineOptions options, Action<HubOptions>? configureHub = null, Action<Microsoft.Azure.SignalR.ServiceOptions>? configureSignalR = null)
+    {
+        configureHub ??= _ => { };
+        configureSignalR ??= _ => { };
+
+        options.Services.AddSignalR(configureHub).AddAzureSignalR(configureSignalR);
+
+        var transport = options.SignalRTransport();
+
+        options.Services.AddSingleton<SignalRTransport>(s =>
+            s.GetRequiredService<IWolverineRuntime>().Options.Transports.GetOrCreate<SignalRTransport>());
+
+        return new SignalRListenerConfiguration(transport);
+    }
+
+    /// <summary>
     /// Syntactical shortcut to register the WolverineHub SignalR Hub for sending
     /// messages to this server. Equivalent to MapHub<WolverineHub>(route).
     /// </summary>

--- a/src/Transports/SignalR/Wolverine.SignalR/Wolverine.SignalR.csproj
+++ b/src/Transports/SignalR/Wolverine.SignalR/Wolverine.SignalR.csproj
@@ -17,5 +17,6 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.8" />
+      <PackageReference Include="Microsoft.Azure.SignalR" Version="1.32.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Since there's almost no difference between the two I just added the `Microsoft.Azure.SignalR` nuget directly to `Wolverine.SignalR`. If you'd rather have a separate package that extends `Wolverine.SignalR`, just say the word (and should it then be Wolverine.AzureSignalR, or Wolverine.SignalR.Azure?)

I haven't added any automated tests, since I'm a bit unsure how to test SignalR properly. None of the existing SignalR-tests have broken. Some manual testing shows that messages gets sent correctly between clients.