### PR TITLE
Route Parameter Variable Ordering in Marten Batch Queries

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Marten/reacting_to_read_aggregate.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/reacting_to_read_aggregate.cs
@@ -124,6 +124,8 @@ public class reacting_to_read_aggregate : IAsyncLifetime
 
 public static class LetterAggregateEndpointWithValidation
 {
+    public static void Before(Guid id) { }
+
     public static ProblemDetails Validate(LetterAggregate letters)
     {
         if (letters.ACount is 0)
@@ -142,6 +144,8 @@ public static class LetterAggregateEndpointWithValidation
 
 public static class LetterAggregateEndpoint
 {
+    public static void Load(Guid id) { }
+
     #region sample_read_aggregate_fine_grained_validation_control
 
     // Straight up 404 on missing

--- a/src/Persistence/Wolverine.Marten/Codegen/MartenQueryingFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/MartenQueryingFrame.cs
@@ -107,5 +107,17 @@ internal class MartenBatchFrame : AsyncFrame
         
         _cancellation = chain.FindVariable(typeof(CancellationToken));
         yield return _cancellation;
+
+        // This ensures those variables are declared before we try to use them in the batch enlistment code
+        foreach (var op in _operations)
+        {
+            if (op is Frame frame)
+            {
+                foreach (var variable in frame.FindVariables(chain))
+                {
+                    yield return variable;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a code generation bug where route parameters were used before they were declared when combining `[WriteAggregate]`/`[ReadAggregate]` attributes with Load/Before midleware methods.

The fix ensures `MartenBatchFrame` properly declares its dependencies on variables used by batchable frames, allowing the code generation topological sort to order frames correctly.

## Issue

When an endpoint combined:
1. A middleware method like `Load(Guid id)` or `Before(Guid id)`
2. A `[WriteAggregate]` or similar attribute

The generated code would fail with `CS0841: Cannot use local variable 'id' before it is declared` because:

- The batch query enlistment code tried to use the route parameter `id`
- But the route parameter variable was declared AFTER the batch query code
- This happened because `MartenBatchFrame` didn't declare its dependencies on route parameters

## Root Cause

The `MartenBatchFrame.FindVariables()` method only yielded `IDocumentSession` and `CancellationToken`, but not the variables that its batchable frames (like `LoadAggregateFrame`) needed.

## Solution

Adjusted `MartenBatchFrame.FindVariables()` to also enumerate and yield all variables that its enlisted batchable frames depend on.

## Test Results

reacting_to_read_aggregate was modified to add Load and Before., this cuased 3 tests to fail.   Adding the fix makes them pass, and not additional tests to fail.

## Generated Code Verification

The generated code now correctly declares the route parameter before using it in the batch query:

```csharp
// Before (broken):
var stream_letters_BatchItem = batchedQuery.Events.FetchForWriting<LetterAggregate>(id);  // ERROR: id not declared
await batchedQuery.Execute(httpContext.RequestAborted);
string id_rawValue = (string?)httpContext.GetRouteValue("id");
System.Guid id = default;

// After (correct):
string id_rawValue = (string?)httpContext.GetRouteValue("id");
System.Guid id = default;
var batchedQuery = documentSession.CreateBatchQuery();
var stream_letters_BatchItem = batchedQuery.Events.FetchForWriting<LetterAggregate>(id);  // OK: id declared
await batchedQuery.Execute(httpContext.RequestAborted);
```
