### PR TITLE
Return the correct error message when ISideEffect is directly returned by a handler

### DIFF
--- a/src/Wolverine/ISideEffect.cs
+++ b/src/Wolverine/ISideEffect.cs
@@ -83,7 +83,7 @@ internal class SideEffectPolicy : IChainPolicy
 
     private static void applySideEffectExecution(Variable effect, IChain chain)
     {
-        if (effect.GetType() == typeof(ISideEffect))
+        if (effect.VariableType == typeof(ISideEffect))
         {
             throw new InvalidOperationException($"Return the concrete type of ISideEffect so that Wolverine can 'know' how to call into your side effect and not ISideEffect itself");
         }


### PR DESCRIPTION
The wrong type check was being done here, leading to a different, less clear method about what is going on (the one about the missing Sync/SyncAsync method). Doesn't change any behaviour for working handlers.