### PR TITLE
Fix batching Azure ServiceBus messages to partitioned endpoints

### DIFF
--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
@@ -50,6 +50,7 @@ public abstract class AzureServiceBusEndpoint : Endpoint<IAzureServiceBusEnvelop
     public abstract ValueTask<bool> CheckAsync();
     public abstract ValueTask TeardownAsync(ILogger logger);
     public abstract ValueTask SetupAsync(ILogger logger);
+    public abstract bool IsPartitioned { get; }
 
     protected override bool supportsMode(EndpointMode mode)
     {

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
@@ -102,6 +102,8 @@ public class AzureServiceBusQueue : AzureServiceBusEndpoint, IBrokerQueue, IMass
         });
     }
 
+    public override bool IsPartitioned { get => Options.EnablePartitioning; }
+
     private async Task purgeWithSessions(ServiceBusClient client)
     {
         var cancellation = new CancellationTokenSource();

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSenderProtocol.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSenderProtocol.cs
@@ -46,6 +46,14 @@ public class AzureServiceBusSenderProtocol : ISenderProtocolWithNativeScheduling
             }
         }
 
+        if (_endpoint.IsPartitioned)
+            await sendPartitionedBatches(callback, messages, batch);
+        else
+            await sendBatches(callback, messages, batch);
+    }
+
+    private async Task sendBatches(ISenderCallback callback, List<ServiceBusMessage> messages, OutgoingMessageBatch batch)
+    {
         try
         {
             var serviceBusMessageBatch = await _sender.CreateMessageBatchAsync();
@@ -55,7 +63,7 @@ public class AzureServiceBusSenderProtocol : ISenderProtocolWithNativeScheduling
                 if (!serviceBusMessageBatch.TryAddMessage(message))
                 {
                     _logger.LogInformation("Wolverine had to break up outgoing message batches at {Uri}, you may want to reduce the MaximumMessagesToReceive configuration. No messages were lost, this is strictly informative", _endpoint.Uri);
-                    
+
                     // Send the currently full batch
                     await _sender.SendMessagesAsync(serviceBusMessageBatch, _runtime.Cancellation);
                     serviceBusMessageBatch.Dispose();
@@ -68,6 +76,55 @@ public class AzureServiceBusSenderProtocol : ISenderProtocolWithNativeScheduling
 
             // Send the final batch
             await _sender.SendMessagesAsync(serviceBusMessageBatch, _runtime.Cancellation);
+            serviceBusMessageBatch.Dispose();
+
+            await callback.MarkSuccessfulAsync(batch);
+        }
+        catch (Exception e)
+        {
+            await callback.MarkProcessingFailureAsync(batch, e);
+        }
+    }
+
+    private async Task sendPartitionedBatches(ISenderCallback callback, List<ServiceBusMessage> messages, OutgoingMessageBatch batch)
+    {
+        try
+        {
+            var serviceBusMessageBatch = await _sender.CreateMessageBatchAsync();
+
+            var groupedMessages = messages
+                .GroupBy(x => x.SessionId)
+                .ToDictionary(x => x.Key, x => x.ToList());
+
+            foreach (var (sessionId, messageGroup) in groupedMessages)
+            {
+                _logger.LogDebug("Processing batch with session id '{SessionId}'", sessionId);
+
+                foreach (var message in messageGroup)
+                {
+                    if (!serviceBusMessageBatch.TryAddMessage(message))
+                    {
+                        _logger.LogInformation("Wolverine had to break up outgoing message batches at {Uri}, you may want to reduce the MaximumMessagesToReceive configuration. No messages were lost, this is strictly informative", _endpoint.Uri);
+
+                        // Send the currently full batch
+                        await _sender.SendMessagesAsync(serviceBusMessageBatch, _runtime.Cancellation);
+                        serviceBusMessageBatch.Dispose();
+
+                        // Create a new batch and add the message to it
+                        serviceBusMessageBatch = await _sender.CreateMessageBatchAsync();
+                        serviceBusMessageBatch.TryAddMessage(message);
+                    }
+                }
+
+                await _sender.SendMessagesAsync(serviceBusMessageBatch, _runtime.Cancellation);
+                serviceBusMessageBatch = await _sender.CreateMessageBatchAsync();
+            }
+
+            // Send the final batch
+            if (serviceBusMessageBatch.Count > 0)
+            {
+                await _sender.SendMessagesAsync(serviceBusMessageBatch, _runtime.Cancellation);
+            }
             serviceBusMessageBatch.Dispose();
 
             await callback.MarkSuccessfulAsync(batch);

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
@@ -175,6 +175,8 @@ public class AzureServiceBusSubscription : AzureServiceBusEndpoint, IBrokerQueue
         _hasInitialized = true;
     }
 
+    public override bool IsPartitioned { get => Topic.IsPartitioned; }
+
     internal async ValueTask InitializeAsync(ServiceBusAdministrationClient client, ILogger logger)
     {
         if (Parent.AutoProvision)

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
@@ -116,4 +116,6 @@ public class AzureServiceBusTopic : AzureServiceBusEndpoint
 
         return subscription;
     }
+
+    public override bool IsPartitioned { get => Options.EnablePartitioning; }
 }


### PR DESCRIPTION
Fixes #2000.

I don't get the error unless partitioning is enabled on the queue or topic.

There's still a case that's not handled by this PR, and that is if we send messages with different `PartitionKey`s in the delivery options. I believe that will need another grouping and handling each partition by itself. I noticed that the PartitionKey does not get mapped by `AzureServiceBusEnvelopeMapper`, so I didn't attempt to add everything here