### PR TITLE
Add TenantId support to CloudEvents and update related tests

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Internal/Generated/WolverineHandlers/GET_todo_id.cs
+++ b/src/Http/Wolverine.Http.Tests/Internal/Generated/WolverineHandlers/GET_todo_id.cs
@@ -14,14 +14,14 @@ namespace Internal.Generated.WolverineHandlers
     public sealed class GET_todo_id : Wolverine.Http.HttpHandler
     {
         private readonly Wolverine.Http.WolverineHttpOptions _wolverineHttpOptions;
-        private readonly Wolverine.Runtime.IWolverineRuntime _wolverineRuntime;
         private readonly Wolverine.Marten.Publishing.OutboxedSessionFactory _outboxedSessionFactory;
+        private readonly Wolverine.Runtime.IWolverineRuntime _wolverineRuntime;
 
-        public GET_todo_id(Wolverine.Http.WolverineHttpOptions wolverineHttpOptions, Wolverine.Runtime.IWolverineRuntime wolverineRuntime, Wolverine.Marten.Publishing.OutboxedSessionFactory outboxedSessionFactory) : base(wolverineHttpOptions)
+        public GET_todo_id(Wolverine.Http.WolverineHttpOptions wolverineHttpOptions, Wolverine.Marten.Publishing.OutboxedSessionFactory outboxedSessionFactory, Wolverine.Runtime.IWolverineRuntime wolverineRuntime) : base(wolverineHttpOptions)
         {
             _wolverineHttpOptions = wolverineHttpOptions;
-            _wolverineRuntime = wolverineRuntime;
             _outboxedSessionFactory = outboxedSessionFactory;
+            _wolverineRuntime = wolverineRuntime;
         }
 
 

--- a/src/Http/Wolverine.Http.Tests/Internal/Generated/WolverineHandlers/POST_todo_create.cs
+++ b/src/Http/Wolverine.Http.Tests/Internal/Generated/WolverineHandlers/POST_todo_create.cs
@@ -14,14 +14,14 @@ namespace Internal.Generated.WolverineHandlers
     public sealed class POST_todo_create : Wolverine.Http.HttpHandler
     {
         private readonly Wolverine.Http.WolverineHttpOptions _wolverineHttpOptions;
-        private readonly Wolverine.Runtime.IWolverineRuntime _wolverineRuntime;
         private readonly Wolverine.Marten.Publishing.OutboxedSessionFactory _outboxedSessionFactory;
+        private readonly Wolverine.Runtime.IWolverineRuntime _wolverineRuntime;
 
-        public POST_todo_create(Wolverine.Http.WolverineHttpOptions wolverineHttpOptions, Wolverine.Runtime.IWolverineRuntime wolverineRuntime, Wolverine.Marten.Publishing.OutboxedSessionFactory outboxedSessionFactory) : base(wolverineHttpOptions)
+        public POST_todo_create(Wolverine.Http.WolverineHttpOptions wolverineHttpOptions, Wolverine.Marten.Publishing.OutboxedSessionFactory outboxedSessionFactory, Wolverine.Runtime.IWolverineRuntime wolverineRuntime) : base(wolverineHttpOptions)
         {
             _wolverineHttpOptions = wolverineHttpOptions;
-            _wolverineRuntime = wolverineRuntime;
             _outboxedSessionFactory = outboxedSessionFactory;
+            _wolverineRuntime = wolverineRuntime;
         }
 
 
@@ -40,11 +40,11 @@ namespace Internal.Generated.WolverineHandlers
                 return;
             }
 
+            var tenantIdentifier = new JasperFx.MultiTenancy.TenantId(tenantId);
             var messageContext = new Wolverine.Runtime.MessageContext(_wolverineRuntime);
             messageContext.TenantId = tenantId;
             // Building the Marten session using the detected tenant id
             await using var documentSession = _outboxedSessionFactory.OpenSession(messageContext, tenantId);
-            var tenantIdentifier = new JasperFx.MultiTenancy.TenantId(tenantId);
             // Reading the request body via JSON deserialization
             var (command, jsonContinue) = await ReadJsonAsync<Wolverine.Http.Tests.MultiTenancy.CreateTodo>(httpContext);
             if (jsonContinue == Wolverine.HandlerContinuation.Stop) return;

--- a/src/Http/Wolverine.Http.Tests/Transport/CloudEventsHttpTransportTests.cs
+++ b/src/Http/Wolverine.Http.Tests/Transport/CloudEventsHttpTransportTests.cs
@@ -35,6 +35,7 @@ public class CloudEventsHttpTransportTests
         var envelope = new Envelope
         {
             Id = Guid.NewGuid(),
+            TenantId =  "greattenantId",
             MessageType = "TestMessage",
             Message = message,
             Data = Encoding.UTF8.GetBytes("{\"name\":\"test\"}"),
@@ -58,6 +59,7 @@ public class CloudEventsHttpTransportTests
         content.ShouldContain("type");
         content.ShouldContain("source");
         content.ShouldContain("id");
+        content.ShouldContain("tenantid");
     }
 
     [Fact]
@@ -72,6 +74,7 @@ public class CloudEventsHttpTransportTests
         var envelope = new Envelope
         {
             Id = envelopeId,
+            TenantId = "greattenantId",
             MessageType = "MyApp.TestCommand",
             Message = message,
             Data = Encoding.UTF8.GetBytes("{\"value\":42}"),
@@ -94,6 +97,7 @@ public class CloudEventsHttpTransportTests
         ce.Type.ShouldBe("Wolverine.Http.Tests.Transport.CloudEventsTestCommand");
         ce.Source.ShouldBe("test-service");
         ce.Id.ToString().ShouldBe(envelopeId.ToString());
+        ce.TenantId.ShouldBe("greattenantId");
         ce.DataContentType.ShouldStartWith("application/json");
     }
 

--- a/src/Wolverine/Runtime/Interop/CloudEventsMapper.cs
+++ b/src/Wolverine/Runtime/Interop/CloudEventsMapper.cs
@@ -26,6 +26,7 @@ internal class CloudEventsEnvelope
     {
         if (envelope.Message is null) throw new ArgumentNullException(nameof(envelope), "Message is null");
         
+        TenantId = envelope.TenantId;
         Data = envelope.Message;
         
         // Doesn't always apply in Wolverine, so ¯\_(ツ)_/¯
@@ -45,6 +46,9 @@ internal class CloudEventsEnvelope
     
     [JsonPropertyName("topic")]
     public string Topic { get; set; }
+    
+    [JsonPropertyName("tenantid")]
+    public string TenantId { get; set; }
     
     [JsonPropertyName("traceid")]
     public string TraceId { get; set; }
@@ -121,6 +125,11 @@ public class CloudEventsMapper : IUnwrapsMetadataMessageSerializer
                 MapIncoming(envelope, node["Message"]);
                 return;
             }
+        }
+
+        if (node.TryGetValue<string>("tenantid", out var tenantid))
+        {
+            envelope.TenantId = tenantid;
         }
 
         if (node.TryGetValue<string>("traceid", out var traceId))


### PR DESCRIPTION
This pull request adds support for handling the `TenantId` property in Cloud Events envelopes. The changes enhance multi-tenancy support by including `TenantId` in both outgoing and incoming Cloud Events on http transport.