### PR TITLE
Fix semaphore leak in RabbitMqChannelAgent.EnsureInitiated()

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
@@ -44,6 +44,7 @@ internal abstract class RabbitMqChannelAgent : IAsyncDisposable
         
         if (Channel is not null)
         {
+            Locker.Release();
             return;
         }
 


### PR DESCRIPTION
## Summary
  Fix a deadlock caused by a semaphore not being released in `EnsureInitiated()` when the channel was already initialized by a concurrent call.

  ## Problem
  When multiple concurrent `PublishAsync` calls hit a cold (uninitialized) sender:
  1. All calls pass the first `Channel is not null` check
  2. First call acquires the semaphore, initializes the channel, releases semaphore 
  3. Second call acquires the semaphore, sees channel is now initialized, **returns without releasing the semaphore** 
  4. Remaining calls wait forever on the semaphore

  ## Reproduction
  ```csharp
  await app.StartAsync();
  var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();

  // This deadlocks - only ~2 of 5 messages complete
  var tasks = Enumerable.Range(1, 5)
      .Select(id => bus.PublishAsync(id).AsTask())
      .ToArray();
  await Task.WhenAll(tasks);