### PR TITLE
Support native scheduling in batch mode.

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Transport/HttpScheduledMessageTests.cs
+++ b/src/Http/Wolverine.Http.Tests/Transport/HttpScheduledMessageTests.cs
@@ -1,0 +1,141 @@
+using System.Text.Json;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Http.Transport;
+using Wolverine.Transports;
+
+namespace Wolverine.Http.Tests.Transport;
+
+public class Tenant
+{
+    public const string Id = "AwesomeTenant";
+}
+
+public class HttpScheduledMessageTests
+{
+    private IWolverineHttpTransportClient _transportClient =
+        Substitute.For<IWolverineHttpTransportClient>();
+    private async Task<IHost> CreateHostAsync()
+    {
+        var streamKey = $"scheduled-test-{Guid.NewGuid():N}";
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "ScheduledTestService";
+                opts.Services.AddSingleton<ScheduledMessageTracker>();
+                opts.Services
+                    .AddSingleton<IWolverineHttpTransportClient,
+                        TestWolverineHttpTransportClient>();
+                // Fast polling for tests
+                opts.Durability.ScheduledJobFirstExecution = 50.Milliseconds();
+                opts.Durability.ScheduledJobPollingTime = 100.Milliseconds();
+
+                var transport = new HttpTransport();
+                opts.Transports.Add(transport);
+                opts.PublishAllMessages().ToHttpEndpoint(
+                        "https://localhost:5000/wolverine/scheduled-test-endpoint",
+                        true,
+                        false)
+                    .BufferedInMemory();
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task should_delay_execution_of_scheduled_message()
+    {
+        using var host = await CreateHostAsync();
+        var tracker =
+            host.Services.GetRequiredService<ScheduledMessageTracker>();
+        var tenantId = Guid.NewGuid().ToString();
+        var bus = host.MessageBus();
+        bus.TenantId = Tenant.Id;
+        var count = 5;
+        var i = count;
+        while (i-- > 0)
+        {
+            var command = new ScheduledTestCommand(Guid.NewGuid().ToString());
+            var scheduledTime = DateTimeOffset.UtcNow.AddSeconds(3);
+
+            var startTime = DateTimeOffset.UtcNow;
+            await bus.ScheduleAsync(command, scheduledTime);
+        }
+
+        await Task.Delay(500); // some delay for batching
+        tracker.ReceivedMessages.Count.ShouldBe(count);
+    }
+}
+
+public class TestWolverineHttpTransportClient : IWolverineHttpTransportClient
+{
+    private readonly ScheduledMessageTracker _tracker;
+    public TestWolverineHttpTransportClient(ScheduledMessageTracker tracker)
+    {
+        _tracker = tracker;
+    }
+    public Task SendBatchAsync(string uri, OutgoingMessageBatch batch)
+    {
+        foreach (var envelope in batch.Messages)
+        {
+            if (envelope.ScheduledTime.HasValue)
+            {
+                Assert.Equal(envelope.TenantId, Tenant.Id);
+                _tracker.RecordExecution(envelope.Id.ToString());
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task SendAsync(
+        string uri,
+        Envelope envelope,
+        JsonSerializerOptions? options = null)
+    {
+        if (envelope.ScheduledTime.HasValue)
+        {
+            _tracker.RecordExecution(envelope.Id.ToString());
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+public record ScheduledTestCommand(string Id);
+
+public class ScheduledMessageTracker
+{
+    private readonly List<string> _receivedMessages = new();
+    private readonly Dictionary<string, DateTimeOffset> _executionTimes = new();
+    private readonly object _lock = new();
+
+    public IReadOnlyList<string> ReceivedMessages
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _receivedMessages.ToList();
+            }
+        }
+    }
+
+    public void RecordExecution(string messageId)
+    {
+        lock (_lock)
+        {
+            _receivedMessages.Add(messageId);
+            _executionTimes[messageId] = DateTimeOffset.UtcNow;
+        }
+    }
+
+    public DateTimeOffset GetExecutionTime(string messageId)
+    {
+        lock (_lock)
+        {
+            return _executionTimes[messageId];
+        }
+    }
+}

--- a/src/Http/Wolverine.Http/Transport/HttpEndpoint.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpEndpoint.cs
@@ -31,10 +31,11 @@ public class HttpEndpoint : Endpoint
         return Mode == EndpointMode.Inline
             ? new InlineHttpSender(this, runtime, runtime.Services)
             : new BatchedSender(
-                this,
-                new HttpSenderProtocol(this, runtime.Services),
-                runtime.Cancellation,
-                runtime.LoggerFactory.CreateLogger<HttpSenderProtocol>());
+                    this,
+                    new HttpSenderProtocol(this, runtime.Services),
+                    runtime.Cancellation,
+                    runtime.LoggerFactory.CreateLogger<HttpSenderProtocol>())
+                { SupportsNativeScheduledSend = SupportsNativeScheduledSend };
     }
 
     public override IDictionary<string, object> DescribeProperties()

--- a/src/Transports/Redis/Wolverine.Redis.Tests/RedisSenderProtocolTests.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/RedisSenderProtocolTests.cs
@@ -1,0 +1,401 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using StackExchange.Redis;
+using Wolverine.Redis.Internal;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Serialization;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Wolverine.Util;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Wolverine.Redis.Tests;
+
+/// <summary>
+/// Unit tests for RedisSenderProtocol verifying native scheduling behavior.
+/// These tests verify that:
+/// 1. Immediate messages are sent directly to Redis streams
+/// 2. Scheduled messages are stored in Redis sorted sets for later execution
+/// 3. The scheduling happens at the transport level (no in-memory job scheduling)
+/// </summary>
+[Collection("RedisSenderProtocolTests")]
+public class RedisSenderProtocolTests : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private IHost? _host;
+    private IWolverineRuntime? _runtime;
+    private RedisTransport? _transport;
+    private IDatabase? _database;
+    private string _streamKey = "";
+
+    public RedisSenderProtocolTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _streamKey = $"sender-protocol-test-{Guid.NewGuid():N}";
+        
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "SenderProtocolTestService";
+                opts.UseRedisTransport("localhost:6379").AutoProvision();
+            }).StartAsync();
+
+        _runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+        _transport = _runtime.Options.Transports.GetOrCreate<RedisTransport>();
+        _database = _transport.GetDatabase(database: 0);
+        
+        // Clean up any existing data
+        await _database.KeyDeleteAsync(_streamKey);
+        await _database.KeyDeleteAsync($"{_streamKey}:scheduled");
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_database != null)
+        {
+            await _database.KeyDeleteAsync(_streamKey);
+            await _database.KeyDeleteAsync($"{_streamKey}:scheduled");
+        }
+        
+        if (_host != null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+    }
+
+    [Fact]
+    public void implements_native_scheduling_interface()
+    {
+        // Verify the protocol implements ISenderProtocolWithNativeScheduling
+        typeof(ISenderProtocolWithNativeScheduling).IsAssignableFrom(typeof(RedisSenderProtocol))
+            .ShouldBeTrue("RedisSenderProtocol should implement ISenderProtocolWithNativeScheduling");
+        
+        _output.WriteLine("✓ RedisSenderProtocol implements ISenderProtocolWithNativeScheduling");
+        _output.WriteLine("  This marker interface tells Wolverine that native scheduling is supported");
+    }
+
+    [Fact]
+    public async Task sends_immediate_message_to_redis_stream()
+    {
+        // Arrange
+        var endpoint = _transport!.StreamEndpoint(_streamKey);
+        endpoint.EnvelopeMapper = new RedisEnvelopeMapper(endpoint);
+        
+        var protocol = new RedisSenderProtocol(_transport, endpoint);
+        var callback = Substitute.For<ISenderCallback>();
+        
+        var message = new SenderProtocolTestMessage("test-immediate");
+        var envelope = CreateEnvelope(message);
+        // No ScheduledTime = immediate message
+        
+        var batch = new OutgoingMessageBatch(endpoint.Uri, new[] { envelope });
+
+        // Act
+        await protocol.SendBatchAsync(callback, batch);
+
+        // Assert
+        var streamLength = await _database!.StreamLengthAsync(_streamKey);
+        streamLength.ShouldBe(1, "Immediate message should be in stream");
+        
+        var scheduledCount = await _database.SortedSetLengthAsync($"{_streamKey}:scheduled");
+        scheduledCount.ShouldBe(0, "Immediate message should NOT be in scheduled set");
+        
+        await callback.Received(1).MarkSuccessfulAsync(batch);
+        
+        _output.WriteLine("✓ Immediate message sent directly to Redis stream");
+    }
+
+    [Fact]
+    public async Task sends_scheduled_message_to_sorted_set()
+    {
+        // Arrange
+        var endpoint = _transport!.StreamEndpoint(_streamKey);
+        endpoint.EnvelopeMapper = new RedisEnvelopeMapper(endpoint);
+        
+        var protocol = new RedisSenderProtocol(_transport, endpoint);
+        var callback = Substitute.For<ISenderCallback>();
+        
+        var message = new SenderProtocolTestMessage("test-scheduled");
+        var scheduledTime = DateTimeOffset.UtcNow.AddMinutes(5);
+        var envelope = CreateEnvelope(message);
+        envelope.ScheduledTime = scheduledTime;
+        
+        var batch = new OutgoingMessageBatch(endpoint.Uri, new[] { envelope });
+
+        // Act
+        await protocol.SendBatchAsync(callback, batch);
+
+        // Assert
+        var streamLength = await _database!.StreamLengthAsync(_streamKey);
+        streamLength.ShouldBe(0, "Scheduled message should NOT be in stream");
+        
+        var scheduledCount = await _database.SortedSetLengthAsync($"{_streamKey}:scheduled");
+        scheduledCount.ShouldBe(1, "Scheduled message should be in scheduled set");
+        
+        // Verify the score matches the scheduled time
+        var entries = await _database.SortedSetRangeByScoreWithScoresAsync($"{_streamKey}:scheduled");
+        entries.Length.ShouldBe(1);
+        var expectedScore = scheduledTime.ToUnixTimeMilliseconds();
+        Math.Abs(entries[0].Score - expectedScore).ShouldBeLessThan(1000, "Score should match scheduled time");
+        
+        await callback.Received(1).MarkSuccessfulAsync(batch);
+        
+        _output.WriteLine("✓ Scheduled message stored in Redis sorted set with correct score");
+        _output.WriteLine($"  Scheduled for: {scheduledTime}");
+        _output.WriteLine($"  Score: {entries[0].Score} (expected: {expectedScore})");
+    }
+
+    [Fact]
+    public async Task sends_mixed_batch_to_appropriate_destinations()
+    {
+        // Arrange
+        var endpoint = _transport!.StreamEndpoint(_streamKey);
+        endpoint.EnvelopeMapper = new RedisEnvelopeMapper(endpoint);
+        
+        var protocol = new RedisSenderProtocol(_transport, endpoint);
+        var callback = Substitute.For<ISenderCallback>();
+        
+        var immediateMessage = new SenderProtocolTestMessage("immediate");
+        var scheduledMessage = new SenderProtocolTestMessage("scheduled");
+        
+        var immediateEnvelope = CreateEnvelope(immediateMessage);
+        var scheduledEnvelope = CreateEnvelope(scheduledMessage);
+        scheduledEnvelope.ScheduledTime = DateTimeOffset.UtcNow.AddMinutes(10);
+        
+        var batch = new OutgoingMessageBatch(endpoint.Uri, new[] { immediateEnvelope, scheduledEnvelope });
+
+        // Act
+        await protocol.SendBatchAsync(callback, batch);
+
+        // Assert
+        var streamLength = await _database!.StreamLengthAsync(_streamKey);
+        streamLength.ShouldBe(1, "Only immediate message should be in stream");
+        
+        var scheduledCount = await _database.SortedSetLengthAsync($"{_streamKey}:scheduled");
+        scheduledCount.ShouldBe(1, "Only scheduled message should be in scheduled set");
+        
+        await callback.Received(1).MarkSuccessfulAsync(batch);
+        
+        _output.WriteLine("✓ Mixed batch: immediate → stream, scheduled → sorted set");
+    }
+
+    [Fact]
+    public async Task treats_past_scheduled_time_as_immediate()
+    {
+        // Arrange
+        var endpoint = _transport!.StreamEndpoint(_streamKey);
+        endpoint.EnvelopeMapper = new RedisEnvelopeMapper(endpoint);
+        
+        var protocol = new RedisSenderProtocol(_transport, endpoint);
+        var callback = Substitute.For<ISenderCallback>();
+        
+        var message = new SenderProtocolTestMessage("past-scheduled");
+        var pastTime = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var envelope = CreateEnvelope(message);
+        envelope.ScheduledTime = pastTime;
+        
+        var batch = new OutgoingMessageBatch(endpoint.Uri, new[] { envelope });
+
+        // Act
+        await protocol.SendBatchAsync(callback, batch);
+
+        // Assert - past scheduled time should go to stream (immediate)
+        var streamLength = await _database!.StreamLengthAsync(_streamKey);
+        streamLength.ShouldBe(1, "Past-scheduled message should be in stream (treated as immediate)");
+        
+        var scheduledCount = await _database.SortedSetLengthAsync($"{_streamKey}:scheduled");
+        scheduledCount.ShouldBe(0, "Past-scheduled message should NOT be in scheduled set");
+        
+        await callback.Received(1).MarkSuccessfulAsync(batch);
+        
+        _output.WriteLine("✓ Past scheduled time treated as immediate - sent to stream");
+    }
+
+    [Fact]
+    public async Task sends_multiple_immediate_messages_in_batch()
+    {
+        // Arrange
+        var endpoint = _transport!.StreamEndpoint(_streamKey);
+        endpoint.EnvelopeMapper = new RedisEnvelopeMapper(endpoint);
+        
+        var protocol = new RedisSenderProtocol(_transport, endpoint);
+        var callback = Substitute.For<ISenderCallback>();
+        
+        var envelopes = Enumerable.Range(0, 5)
+            .Select(i => CreateEnvelope(new SenderProtocolTestMessage($"msg-{i}")))
+            .ToArray();
+        
+        var batch = new OutgoingMessageBatch(endpoint.Uri, envelopes);
+
+        // Act
+        await protocol.SendBatchAsync(callback, batch);
+
+        // Assert
+        var streamLength = await _database!.StreamLengthAsync(_streamKey);
+        streamLength.ShouldBe(5, "All immediate messages should be in stream");
+        
+        await callback.Received(1).MarkSuccessfulAsync(batch);
+        
+        _output.WriteLine("✓ Multiple immediate messages sent to stream");
+    }
+
+    [Fact]
+    public async Task sends_multiple_scheduled_messages_in_batch()
+    {
+        // Arrange
+        var endpoint = _transport!.StreamEndpoint(_streamKey);
+        endpoint.EnvelopeMapper = new RedisEnvelopeMapper(endpoint);
+        
+        var protocol = new RedisSenderProtocol(_transport, endpoint);
+        var callback = Substitute.For<ISenderCallback>();
+        
+        var baseTime = DateTimeOffset.UtcNow;
+        var envelopes = Enumerable.Range(0, 5).Select(i =>
+        {
+            var env = CreateEnvelope(new SenderProtocolTestMessage($"scheduled-{i}"));
+            env.ScheduledTime = baseTime.AddMinutes(i + 1);
+            return env;
+        }).ToArray();
+        
+        var batch = new OutgoingMessageBatch(endpoint.Uri, envelopes);
+
+        // Act
+        await protocol.SendBatchAsync(callback, batch);
+
+        // Assert
+        var scheduledCount = await _database!.SortedSetLengthAsync($"{_streamKey}:scheduled");
+        scheduledCount.ShouldBe(5, "All scheduled messages should be in sorted set");
+        
+        var streamLength = await _database.StreamLengthAsync(_streamKey);
+        streamLength.ShouldBe(0, "No messages should be in stream");
+        
+        await callback.Received(1).MarkSuccessfulAsync(batch);
+        
+        _output.WriteLine("✓ Multiple scheduled messages stored in sorted set");
+    }
+
+    [Fact]
+    public async Task uses_correct_score_for_scheduled_time()
+    {
+        // Arrange
+        var endpoint = _transport!.StreamEndpoint(_streamKey);
+        endpoint.EnvelopeMapper = new RedisEnvelopeMapper(endpoint);
+        
+        var protocol = new RedisSenderProtocol(_transport, endpoint);
+        var callback = Substitute.For<ISenderCallback>();
+        
+        var scheduledTime = new DateTimeOffset(2030, 6, 15, 10, 30, 0, TimeSpan.Zero);
+        var expectedScore = scheduledTime.ToUnixTimeMilliseconds();
+        
+        var envelope = CreateEnvelope(new SenderProtocolTestMessage("score-test"));
+        envelope.ScheduledTime = scheduledTime;
+        
+        var batch = new OutgoingMessageBatch(endpoint.Uri, new[] { envelope });
+
+        // Act
+        await protocol.SendBatchAsync(callback, batch);
+
+        // Assert
+        var entries = await _database!.SortedSetRangeByScoreWithScoresAsync($"{_streamKey}:scheduled");
+        entries.Length.ShouldBe(1);
+        entries[0].Score.ShouldBe(expectedScore, "Score should exactly match scheduled time in milliseconds");
+        
+        _output.WriteLine("✓ Correct score used for scheduled time");
+        _output.WriteLine($"  Expected: {expectedScore}, Actual: {entries[0].Score}");
+    }
+
+    [Fact]
+    public async Task scheduled_message_can_be_deserialized()
+    {
+        // Arrange - verify the serialized message can be deserialized back
+        var endpoint = _transport!.StreamEndpoint(_streamKey);
+        endpoint.EnvelopeMapper = new RedisEnvelopeMapper(endpoint);
+        
+        var protocol = new RedisSenderProtocol(_transport, endpoint);
+        var callback = Substitute.For<ISenderCallback>();
+        
+        var originalId = Guid.NewGuid();
+        var scheduledTime = DateTimeOffset.UtcNow.AddMinutes(5);
+        var envelope = CreateEnvelope(new SenderProtocolTestMessage("deserialize-test"));
+        envelope.Id = originalId;
+        envelope.ScheduledTime = scheduledTime;
+        
+        var batch = new OutgoingMessageBatch(endpoint.Uri, new[] { envelope });
+
+        // Act
+        await protocol.SendBatchAsync(callback, batch);
+
+        // Assert - read back and deserialize
+        var entries = await _database!.SortedSetRangeByScoreAsync($"{_streamKey}:scheduled");
+        entries.Length.ShouldBe(1);
+        
+        var deserializedEnvelope = EnvelopeSerializer.Deserialize((byte[])entries[0]!);
+        deserializedEnvelope.Id.ShouldBe(originalId);
+        deserializedEnvelope.ScheduledTime.ShouldNotBeNull();
+        Math.Abs((deserializedEnvelope.ScheduledTime!.Value - scheduledTime).TotalSeconds).ShouldBeLessThan(1);
+        
+        _output.WriteLine("✓ Scheduled message can be deserialized correctly");
+        _output.WriteLine($"  Original ID: {originalId}");
+        _output.WriteLine($"  Deserialized ID: {deserializedEnvelope.Id}");
+    }
+
+    [Fact]
+    public void dispose_does_not_throw()
+    {
+        // Arrange
+        var endpoint = _transport!.StreamEndpoint(_streamKey);
+        endpoint.EnvelopeMapper = new RedisEnvelopeMapper(endpoint);
+        var protocol = new RedisSenderProtocol(_transport, endpoint);
+        
+        // Act & Assert - Dispose should not throw
+        Should.NotThrow(() => protocol.Dispose());
+        
+        _output.WriteLine("✓ Dispose completes without throwing");
+    }
+
+    [Fact]
+    public async Task marks_callback_successful_after_send()
+    {
+        // Arrange
+        var endpoint = _transport!.StreamEndpoint(_streamKey);
+        endpoint.EnvelopeMapper = new RedisEnvelopeMapper(endpoint);
+        
+        var protocol = new RedisSenderProtocol(_transport, endpoint);
+        var callback = Substitute.For<ISenderCallback>();
+        
+        var envelope = CreateEnvelope(new SenderProtocolTestMessage("callback-test"));
+        var batch = new OutgoingMessageBatch(endpoint.Uri, new[] { envelope });
+
+        // Act
+        await protocol.SendBatchAsync(callback, batch);
+
+        // Assert
+        await callback.Received(1).MarkSuccessfulAsync(batch);
+        await callback.DidNotReceive().MarkProcessingFailureAsync(Arg.Any<OutgoingMessageBatch>(), Arg.Any<Exception>());
+        
+        _output.WriteLine("✓ Callback marked successful after successful send");
+    }
+
+    private Envelope CreateEnvelope(SenderProtocolTestMessage message)
+    {
+        var serializer = _runtime!.Options.DefaultSerializer;
+        return new Envelope(message)
+        {
+            Id = Guid.NewGuid(),
+            MessageType = typeof(SenderProtocolTestMessage).ToMessageTypeName(),
+            Data = serializer.WriteMessage(message),
+            ContentType = serializer.ContentType
+        };
+    }
+}
+
+public record SenderProtocolTestMessage(string Id);

--- a/src/Transports/Redis/Wolverine.Redis.Tests/ScheduledMessageTests.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/ScheduledMessageTests.cs
@@ -25,8 +25,8 @@ public class ScheduledMessageTests
                 opts.Durability.ScheduledJobPollingTime = 100.Milliseconds();
                 
                 opts.UseRedisTransport("localhost:6379").AutoProvision();
-                
-                opts.PublishAllMessages().ToRedisStream(streamKey).SendInline();
+
+                opts.PublishAllMessages().ToRedisStream(streamKey);
                 opts.ListenToRedisStream(streamKey, "scheduled-test-group")
                     .StartFromBeginning();
                     
@@ -118,7 +118,7 @@ public class ScheduledMessageTests
                 
                 opts.UseRedisTransport("localhost:6379").AutoProvision();
                 
-                opts.PublishAllMessages().ToRedisStream(streamKey).SendInline();
+                opts.PublishAllMessages().ToRedisStream(streamKey);
                 opts.ListenToRedisStream(streamKey, "scheduled-test-group")
                     .StartFromBeginning();
                     

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisSenderProtocol.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisSenderProtocol.cs
@@ -5,7 +5,7 @@ using Wolverine.Transports.Sending;
 
 namespace Wolverine.Redis.Internal;
 
-public class RedisSenderProtocol : ISenderProtocol, IDisposable
+public class RedisSenderProtocol : ISenderProtocolWithNativeScheduling, IDisposable
 {
     private readonly RedisTransport _transport;
     private readonly RedisStreamEndpoint _endpoint;


### PR DESCRIPTION
Redis and Http transport was doing in memory scheduling for buffered mode. The PR enhances to send messages out for something else to take the responsibility of sending messages at scheduled time if the transport supports native scheduling.