### PR TITLE
Update method for disabling conventional discovery

### DIFF
--- a/docs/guide/extensions.md
+++ b/docs/guide/extensions.md
@@ -282,7 +282,7 @@ that issue, or just want a faster start up time, you can disable the automatic e
 using var host = await Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
     .UseWolverine(opts =>
     {
-        opts.DisableConventionalDiscovery();
+        opts.Discovery.DisableConventionalDiscovery();
     }, ExtensionDiscovery.ManualOnly)
     
     .StartAsync();


### PR DESCRIPTION
Documentation incorrectly describes method for disabling conventional discovery as located directly under WolverineOptions, when it is actually locataed in WolverineOptions.Discovery