### PR TITLE
Add support for SignalR hubs requiring authorization

### DIFF
--- a/src/Transports/SignalR/Wolverine.SignalR.Tests/custom_hub.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR.Tests/custom_hub.cs
@@ -1,5 +1,5 @@
 using JasperFx.Core;
-using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
 using Shouldly;
 using Wolverine.SignalR.Client;
@@ -10,7 +10,7 @@ namespace Wolverine.SignalR.Tests;
 
 public class custom_hub : WebSocketTestContextWithCustomHub<CustomWolverineHub>
 {
-    public static List<string> ReceivedJson = new();
+    public static List<string> ReceivedJson { get; } = new();
 
     public override async Task DisposeAsync()
     {
@@ -64,6 +64,98 @@ public class custom_hub : WebSocketTestContextWithCustomHub<CustomWolverineHub>
     }
 }
 
+public class custom_hub_with_authentication : WebSocketTestContextWithCustomHub<AuthenticatedWolverineHub>
+{
+    public static List<string> ReceivedJson { get; } = new();
+
+    public override async Task DisposeAsync()
+    {
+        ReceivedJson.Clear();
+        await base.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task client_can_receive_from_authenticated_hub()
+    {
+        var client = await StartClientHost();
+
+        var tracked = await theWebApp
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .AlsoTrack(client)
+            .Timeout(10.Seconds())
+            .SendMessageAndWaitAsync(new FromSecond("Hollywood Brown"));
+
+        var record = tracked.Received.SingleRecord<FromSecond>();
+        record.ServiceName.ShouldBe("Client");
+        record.Envelope.ShouldNotBeNull();
+        record.Envelope.Destination.ShouldBe(new Uri($"signalr-client://localhost:{Port}/messages"));
+        record.Message.ShouldBeOfType<FromSecond>()
+            .Name.ShouldBe("Hollywood Brown");
+    }
+
+    [Fact]
+    public async Task client_can_publish_using_authenticated_hub()
+    {
+        // This is an IHost that has the SignalR Client
+        // transport configured to connect to a SignalR
+        // server in the "theWebApp" IHost
+        using var client = await StartClientHost();
+
+        var tracked = await client
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .AlsoTrack(theWebApp)
+            .Timeout(10.Seconds())
+            .ExecuteAndWaitAsync(c => c.SendViaSignalRClient(clientUri, new ToSecond("Hollywood Brown")));
+
+        var record = tracked.Received.SingleRecord<ToSecond>();
+        record.ServiceName.ShouldBe("Server");
+        record.Envelope.ShouldNotBeNull();
+        record.Envelope.Destination.ShouldBe(new Uri("signalr://wolverine"));
+        record.Message.ShouldBeOfType<ToSecond>()
+            .Name.ShouldBe("Hollywood Brown");
+
+        ReceivedJson.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task client_with_invalid_token_cannot_connect()
+    {
+        // This is an IHost that has the SignalR Client
+        // transport configured to connect to a SignalR
+        // server in the "theWebApp" IHost
+        using var client = await StartClientHost(accessToken: "last-years-token");
+
+        var tracked = await client
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .AlsoTrack(theWebApp)
+            .Timeout(10.Seconds())
+            .ExecuteAndWaitAsync(c => c.SendViaSignalRClient(clientUri, new ToSecond("Hollywood Brown")));
+
+        tracked.Received.Envelopes().ShouldBeEmpty();
+        ReceivedJson.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task client_with_invalid_token_cannot_receive()
+    {
+        var client = await StartClientHost(accessToken: "last-years-token");
+
+        var tracked = await theWebApp
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .AlsoTrack(client)
+            .Timeout(100.Milliseconds())
+            .DoNotAssertOnExceptionsDetected() // We're not supposed to be able to receive, so don't throw
+            .PublishMessageAndWaitAsync(new FromSecond("Hollywood Brown"));
+
+        tracked.Received.Envelopes().ShouldBeEmpty();
+        ReceivedJson.ShouldBeEmpty();
+    }
+}
+
 public class CustomWolverineHub(SignalRTransport endpoint, ILogger<CustomWolverineHub> logger) : WolverineHub(endpoint)
 {
     public override Task OnConnectedAsync()
@@ -75,6 +167,22 @@ public class CustomWolverineHub(SignalRTransport endpoint, ILogger<CustomWolveri
     public override Task ReceiveMessage(string json)
     {
         custom_hub.ReceivedJson.Add(json);
+        return base.ReceiveMessage(json);
+    }
+}
+
+[Authorize]
+public class AuthenticatedWolverineHub(SignalRTransport endpoint, ILogger<CustomWolverineHub> logger) : WolverineHub(endpoint)
+{
+    public override Task OnConnectedAsync()
+    {
+        logger.LogInformation("Client authenticated with ID {ConnectionId}", Context.ConnectionId);
+        return base.OnConnectedAsync();
+    }
+
+    public override Task ReceiveMessage(string json)
+    {
+        custom_hub_with_authentication.ReceivedJson.Add(json);
         return base.ReceiveMessage(json);
     }
 }

--- a/src/Transports/SignalR/Wolverine.SignalR/Client/SignalRClientExtensions.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Client/SignalRClientExtensions.cs
@@ -15,9 +15,11 @@ public static class SignalRClientExtensions
     /// <param name="options"></param>
     /// <param name="url"></param>
     /// <param name="jsonOptions"></param>
+    /// <param name="accessTokenProvider">Optionally provide a token to use for authentication against the SignalR hub</param>
     /// <returns></returns>
     public static Uri UseClientToSignalR(this WolverineOptions options, string url,
-        JsonSerializerOptions? jsonOptions = null)
+        JsonSerializerOptions? jsonOptions = null,
+        Func<IServiceProvider, Func<Task<string?>>>? accessTokenProvider = null)
     {
         var transport = options.Transports.GetOrCreate<SignalRClientTransport>();
         
@@ -25,6 +27,10 @@ public static class SignalRClientExtensions
         if (jsonOptions != null)
         {
             endpoint.JsonOptions = jsonOptions;
+        }
+        if (accessTokenProvider != null)
+        {
+            endpoint.AccessTokenProvider = accessTokenProvider;
         }
 
         return endpoint.Uri;
@@ -37,9 +43,11 @@ public static class SignalRClientExtensions
     /// <param name="options"></param>
     /// <param name="port"></param>
     /// <param name="route">Default is messages. Route pattern where you have mapped the WolverineHub</param>
+    /// <param name="accessTokenProvider">Optionally provide a token to use for authentication against the SignalR hub</param>
     /// <returns></returns>
-    public static Uri UseClientToSignalR(this WolverineOptions options, int port, string route = "messages")
-        => options.UseClientToSignalR($"http://localhost:{port}/{route}");
+    public static Uri UseClientToSignalR(this WolverineOptions options, int port, string route = "messages",
+        Func<IServiceProvider, Func<Task<string?>>>? accessTokenProvider = null)
+        => options.UseClientToSignalR($"http://localhost:{port}/{route}", accessTokenProvider: accessTokenProvider);
 
     /// <summary>
     /// Send a message via a SignalR Client for the given server Uri in the format "http://localhost:[port]/[hub url]"
@@ -73,10 +81,11 @@ public static class SignalRClientExtensions
     /// <param name="publishing"></param>
     /// <param name="port"></param>
     /// <param name="relativeUrl"></param>
-    public static void ToSignalRWithClient(this IPublishToExpression publishing, int port, string relativeUrl = "messages")
+    /// <param name="accessTokenProvider">Optionally provide a token to use for authentication against the SignalR hub</param>
+    public static void ToSignalRWithClient(this IPublishToExpression publishing, int port, string relativeUrl = "messages", Func<IServiceProvider, Func<Task<string?>>>? accessTokenProvider = null)
     {
         var url = $"http://localhost:{port}/{relativeUrl}";
-        publishing.ToSignalRWithClient(url);
+        publishing.ToSignalRWithClient(url, accessTokenProvider);
     }
 
     /// <summary>
@@ -84,7 +93,8 @@ public static class SignalRClientExtensions
     /// </summary>
     /// <param name="publishing"></param>
     /// <param name="url"></param>
-    public static void ToSignalRWithClient(this IPublishToExpression publishing, string url)
+    /// <param name="accessTokenProvider">Optionally provide a token to use for authentication against the SignalR hub</param>
+    public static void ToSignalRWithClient(this IPublishToExpression publishing, string url, Func<IServiceProvider, Func<Task<string?>>>? accessTokenProvider = null)
     {
         var rawUri = new Uri(url);
         if (!rawUri.IsAbsoluteUri)
@@ -97,6 +107,11 @@ public static class SignalRClientExtensions
         var transport = transports.GetOrCreate<SignalRClientTransport>();
 
         var endpoint = transport.Clients[uri];
+        if (accessTokenProvider != null)
+        {
+            endpoint.AccessTokenProvider = accessTokenProvider;
+        }
+
         publishing.To(uri);
     }
     


### PR DESCRIPTION
Not really happy with the error handling in `SignalRClientEndpoint.BuildListenerAsync`. Since we try connecting immediately any errors prevents us from starting. The most common error will (probably) be unauthorized, so catching and logging that. But there's probably a lot better ways of handling this.

SignalR expects a `Func<Task<string?>>` as a token provider. I wrapped that so we get access to the `IServiceProvider` to get configuration or anything like that. That turns into a `Func<IServiceProvider, Func<Task<string?>>>` which isn't very pretty.

Feel free to edit or suggest improvements