### PR TITLE
Remove duplicated code snippet from "Manually adding Envelope Mapping" section

### DIFF
--- a/docs/guide/durability/efcore/outbox-and-inbox.md
+++ b/docs/guide/durability/efcore/outbox-and-inbox.md
@@ -52,33 +52,6 @@ public class SampleMappedDbContext : DbContext
 }
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests/SampleDbContext.cs#L31-L57' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_mapping_envelope_storage_to_dbcontext' title='Start of snippet'>anchor</a></sup>
-<a id='snippet-sample_mapping_envelope_storage_to_dbcontext-1'></a>
-```cs
-public class SampleMappedDbContext : DbContext
-{
-    public SampleMappedDbContext(DbContextOptions<SampleMappedDbContext> options) : base(options)
-    {
-    }
-
-    public DbSet<Item> Items { get; set; }
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        // This enables your DbContext to map the incoming and
-        // outgoing messages as part of the outbox
-        modelBuilder.MapWolverineEnvelopeStorage();
-
-        // Your normal EF Core mapping
-        modelBuilder.Entity<Item>(map =>
-        {
-            map.ToTable("items");
-            map.HasKey(x => x.Id);
-            map.Property(x => x.Name);
-        });
-    }
-}
-```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/SampleDbContext.cs#L56-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_mapping_envelope_storage_to_dbcontext-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Outbox Outside of Wolverine Handlers

--- a/src/Persistence/PersistenceTests/SampleDbContext.cs
+++ b/src/Persistence/PersistenceTests/SampleDbContext.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Wolverine.EntityFrameworkCore;
 
 namespace PersistenceTests;
 
@@ -30,53 +29,3 @@ public class Item
     public Guid Id { get; set; }
     public string Name { get; set; }
 }
-
-public class CleanDbContext : DbContext
-{
-    public CleanDbContext(DbContextOptions<CleanDbContext> options) : base(options)
-    {
-    }
-
-    public DbSet<Item> Items { get; set; }
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-
-        // Your normal EF Core mapping
-        modelBuilder.Entity<Item>(map =>
-        {
-            map.ToTable("items");
-            map.HasKey(x => x.Id);
-            map.Property(x => x.Name);
-        });
-    }
-}
-
-#region sample_mapping_envelope_storage_to_dbcontext
-
-public class SampleMappedDbContext : DbContext
-{
-    public SampleMappedDbContext(DbContextOptions<SampleMappedDbContext> options) : base(options)
-    {
-    }
-
-    public DbSet<Item> Items { get; set; }
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        // This enables your DbContext to map the incoming and
-        // outgoing messages as part of the outbox
-        modelBuilder.MapWolverineEnvelopeStorage();
-
-        // Your normal EF Core mapping
-        modelBuilder.Entity<Item>(map =>
-        {
-            map.ToTable("items");
-            map.HasKey(x => x.Id);
-            map.Property(x => x.Name);
-        });
-    }
-}
-
-#endregion


### PR DESCRIPTION
"Manually adding Envelope Mapping" section (see https://wolverinefx.net/guide/durability/efcore/outbox-and-inbox.html#manually-adding-envelope-mapping) contains 2 almost identical code snippets. The only difference is `map.ToTable("items");` vs `map.ToTable("items", "mt_items");` line. 

Technically they are different sources sharing the same region -  `sample_mapping_envelope_storage_to_dbcontext` but from documentation side they look like strange duplication.

To avoid confusion `SampleMappedDbContext` from PersistentTests project is removed. It's not actually used (as well as `CleanDbContext` there). Another `SampleMappedDbContext ` class from EfCoreTests project remains as a valid code snippet.