### PR TITLE
Added summary starting tag in IMessageBus

### DIFF
--- a/src/Wolverine/IMessageBus.cs
+++ b/src/Wolverine/IMessageBus.cs
@@ -104,7 +104,7 @@ public interface IMessageBus : ICommandBus
 {
     string? TenantId { get; set; }
 
-
+    ///<summary>
     ///     Execute the message handling for this message *right now* against the specified tenant id and wait for the completion.
     ///     If the message is handled locally, this delegates immediately
     ///     If the message is handled remotely, the message is sent and the method waits for the response


### PR DESCRIPTION
I was exploring project and noticed, that there was no open tag in summary of InvokeForTenantAsync method in IMessageBus, so the description was not displaying while using this method (I've tried it).