### PR TITLE
Fix FromForm Name attribute not respecting hyphens

### DIFF
--- a/src/Http/Wolverine.Http.Tests/from_form_binding.cs
+++ b/src/Http/Wolverine.Http.Tests/from_form_binding.cs
@@ -120,6 +120,18 @@ public class from_form_binding : IntegrationContext
     }
 
     [Fact]
+    public async Task from_form_respects_custom_kebab_name()
+    {
+        var result = await Host.Scenario(x => x
+            .Post.FormData(new Dictionary<string, string>
+            {
+                { "form-custom-kebab", "hello" }
+            })
+            .ToUrl("/form/kebab-name"));
+        result.ReadAsText().ShouldBe("hello");
+    }
+
+    [Fact]
     public async Task value_with_alias()
     {
         (await forForm([new("name", "Jones"), new("number", "95")])).ValueWithAlias.ShouldBeNull();

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -409,11 +409,13 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
             if (parameterType == typeof(string))
             {
                 variable = new ReadHttpFrame(BindingSource.Form, parameterType,key).Variable;
+                variable.Name = key;
                 _formValueVariables.Add(variable);
             }
             if (parameterType == typeof(string[]))
             {
                 variable = new ParsedArrayFormValue(parameterType, parameterName).Variable;
+                variable.Name = key;
                 _formValueVariables.Add(variable);
             }
 

--- a/src/Http/WolverineWebApi/Forms/FormEndpoints.cs
+++ b/src/Http/WolverineWebApi/Forms/FormEndpoints.cs
@@ -22,6 +22,12 @@ public static class FormEndpoints{
         return value ?? "";
     }
 
+    [WolverinePost("/form/kebab-name")]
+    public static string KebabFormName([FromForm(Name = "form-custom-kebab")] string value)
+    {
+        return value ?? "";
+    }
+
     [WolverinePost("/form/enum/nullable")]
     public static string UsingNullableEnumQuerystring([FromForm]Direction? direction)
     {


### PR DESCRIPTION
## Summary
- Fixed `[FromForm(Name="form-custom-kebab")]` generating code that looks up `form_custom_kebab` instead of `form-custom-kebab`
- Added `variable.Name = key` in the `string` and `string[]` branches of `TryFindOrCreateFormValue()` to match the pattern used by all other branches and by `TryFindOrCreateQuerystringValue()`
- Added test endpoint and integration test verifying hyphenated form names work correctly

## Test plan
- [x] New test `from_form_respects_custom_kebab_name` passes
- [x] All `from_form_binding` tests pass (11 passed, 2 skipped)
- [x] All `using_form_parameters` tests pass (28 passed, 8 skipped)

Closes #2064

🤖 Generated with [Claude Code](https://claude.com/claude-code)