### PR TITLE
Support IFormFile binding on complex [FromForm] models

### DIFF
--- a/src/Http/Wolverine.Http.Tests/from_form_file_binding.cs
+++ b/src/Http/Wolverine.Http.Tests/from_form_file_binding.cs
@@ -1,0 +1,50 @@
+using System.Net.Http;
+using Shouldly;
+
+namespace Wolverine.Http.Tests;
+
+public class from_form_file_binding : IntegrationContext
+{
+    public from_form_file_binding(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task bind_single_file_on_complex_model()
+    {
+        var content = new MultipartFormDataContent();
+        content.Add(new StringContent("test-name"), "Name");
+        content.Add(new ByteArrayContent(new byte[] { 1, 2, 3 }), "File", "test.txt");
+
+        var response = await Host.Server.CreateClient().PostAsync("/api/fromform-file", content);
+        var text = await response.Content.ReadAsStringAsync();
+        response.EnsureSuccessStatusCode();
+        text.ShouldBe("test-name|test.txt|3");
+    }
+
+    [Fact]
+    public async Task bind_file_collection_on_complex_model()
+    {
+        var content = new MultipartFormDataContent();
+        content.Add(new StringContent("test-name"), "Name");
+        content.Add(new ByteArrayContent(new byte[] { 1, 2, 3 }), "Files", "file1.txt");
+        content.Add(new ByteArrayContent(new byte[] { 4, 5 }), "Files", "file2.txt");
+
+        var response = await Host.Server.CreateClient().PostAsync("/api/fromform-files", content);
+        response.EnsureSuccessStatusCode();
+        var text = await response.Content.ReadAsStringAsync();
+        text.ShouldBe("test-name|2");
+    }
+
+    [Fact]
+    public async Task bind_file_on_complex_model_when_no_file_sent()
+    {
+        var content = new MultipartFormDataContent();
+        content.Add(new StringContent("test-name"), "Name");
+
+        var response = await Host.Server.CreateClient().PostAsync("/api/fromform-file", content);
+        response.EnsureSuccessStatusCode();
+        var text = await response.Content.ReadAsStringAsync();
+        text.ShouldBe("test-name||");
+    }
+}

--- a/src/Http/Wolverine.Http/CodeGen/FromFileStrategy.cs
+++ b/src/Http/Wolverine.Http/CodeGen/FromFileStrategy.cs
@@ -107,3 +107,77 @@ internal class FromFileValues : SyncFrame
         Next?.GenerateCode(method, writer);
     }
 }
+
+internal class FormFilePropertyFrame : SyncFrame, IReadHttpFrame
+{
+    private string? _property;
+    private readonly string _formName;
+
+    public FormFilePropertyFrame(string formName)
+    {
+        _formName = formName;
+        Variable = new HttpElementVariable(typeof(IFormFile), formName.SanitizeFormNameForVariable(), this);
+    }
+
+    public HttpElementVariable Variable { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (Mode == AssignMode.WriteToProperty && _property != null)
+        {
+            writer.Write(
+                $"{_property} = {nameof(HttpHandler.ReadFormFileByName)}(httpContext, \"{_formName}\");");
+        }
+        else
+        {
+            writer.Write(
+                $"var {Variable.Usage} = {nameof(HttpHandler.ReadFormFileByName)}(httpContext, \"{_formName}\");");
+        }
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public void AssignToProperty(string usage)
+    {
+        _property = usage;
+        Mode = AssignMode.WriteToProperty;
+    }
+
+    public AssignMode Mode { get; private set; } = AssignMode.WriteToVariable;
+}
+
+internal class FormFileCollectionPropertyFrame : SyncFrame, IReadHttpFrame
+{
+    private string? _property;
+
+    public FormFileCollectionPropertyFrame()
+    {
+        Variable = new HttpElementVariable(typeof(IFormFileCollection), "files", this);
+    }
+
+    public HttpElementVariable Variable { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (Mode == AssignMode.WriteToProperty && _property != null)
+        {
+            writer.Write(
+                $"{_property} = {nameof(HttpHandler.ReadManyFormFileValues)}(httpContext);");
+        }
+        else
+        {
+            writer.Write(
+                $"var {Variable.Usage} = {nameof(HttpHandler.ReadManyFormFileValues)}(httpContext);");
+        }
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public void AssignToProperty(string usage)
+    {
+        _property = usage;
+        Mode = AssignMode.WriteToProperty;
+    }
+
+    public AssignMode Mode { get; private set; } = AssignMode.WriteToVariable;
+}

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -376,7 +376,7 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
         if (HasRequestType)
         {
             if(IsFormData){
-                Metadata.Accepts(RequestType, true, "application/x-www-form-urlencoded");
+                Metadata.Accepts(RequestType, true, "application/x-www-form-urlencoded", "multipart/form-data");
             }else{
                 Metadata.Accepts(RequestType, false, "application/json");
             }

--- a/src/Http/Wolverine.Http/HttpHandler.cs
+++ b/src/Http/Wolverine.Http/HttpHandler.cs
@@ -89,6 +89,11 @@ public abstract class HttpHandler
         return context.Request.Form.Files.SingleOrDefault();
     }
 
+    public static IFormFile? ReadFormFileByName(HttpContext context, string name)
+    {
+        return context.Request.Form.Files.GetFile(name);
+    }
+
     public static IFormFileCollection? ReadManyFormFileValues(HttpContext context)
     {
         return context.Request.Form.Files;

--- a/src/Http/WolverineWebApi/Forms/FormEndpoints.cs
+++ b/src/Http/WolverineWebApi/Forms/FormEndpoints.cs
@@ -99,6 +99,30 @@ public static class FromFormEndpoints{
     [WolverinePost("/api/fromformbigquery")]
     public static BigQuery Post([FromForm] BigQuery query) => query;
     #endregion
+
+    [WolverinePost("/api/fromform-file")]
+    public static string PostWithFile([FromForm] FormWithFile form)
+    {
+        return $"{form.Name}|{form.File?.FileName}|{form.File?.Length}";
+    }
+
+    [WolverinePost("/api/fromform-files")]
+    public static string PostWithFiles([FromForm] FormWithFiles form)
+    {
+        return $"{form.Name}|{form.Files?.Count}";
+    }
+}
+
+public class FormWithFile
+{
+    public string Name { get; set; }
+    public IFormFile? File { get; set; }
+}
+
+public class FormWithFiles
+{
+    public string Name { get; set; }
+    public IFormFileCollection? Files { get; set; }
 }
 
 #region sample_using_as_parameters_binding


### PR DESCRIPTION
## Summary
- **Fixes #1705**: `IFormFile` and `IFormFileCollection` properties on complex models annotated with `[FromForm]` are now automatically bound from multipart form data
- Previously, only direct method parameters of type `IFormFile`/`IFormFileCollection` were supported via `FromFileStrategy`. The `FormBindingFrame` that handles complex model property binding called `TryFindOrCreateFormValue()` for each property, which had no handling for file types — silently skipping them
- Added `ReadFormFileByName` helper to `HttpHandler` that reads a form file by field name via `IFormFileCollection.GetFile()`
- Added `FormFilePropertyFrame` and `FormFileCollectionPropertyFrame` code generation frames for property-level file binding
- Updated `FormBindingFrame` to detect `IFormFile`/`IFormFileCollection` in both constructor parameters and settable properties
- Also accepts `multipart/form-data` content type on all form data endpoints alongside `application/x-www-form-urlencoded`

## Test plan
- [x] New test: `bind_single_file_on_complex_model` — verifies `IFormFile` property is bound with correct filename and length
- [x] New test: `bind_file_collection_on_complex_model` — verifies `IFormFileCollection` property is bound with correct file count
- [x] New test: `bind_file_on_complex_model_when_no_file_sent` — verifies `IFormFile` property is null when no file is sent
- [x] All existing `from_form_binding` tests pass (11 passed, 2 skipped due to pre-existing Alba limitation)
- [x] Full HTTP test suite: 463 passed, 4 pre-existing failures unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)