### PR TITLE
Add regression tests for multi-tenant durability agents (GH-2085)

### DIFF
--- a/src/Persistence/PostgresqlTests/MultiTenancy/multi_tenant_durability_agents.cs
+++ b/src/Persistence/PostgresqlTests/MultiTenancy/multi_tenant_durability_agents.cs
@@ -107,7 +107,7 @@ public class multi_tenant_durability_agents : PostgresqlContext, IAsyncLifetime
         var messageId = Guid.NewGuid();
 
         // Schedule a message for the "red" tenant with a short delay
-        var bus = theHost.Services.GetRequiredService<IMessageBus>();
+        var bus = theHost.MessageBus();
         await bus.ScheduleAsync(new TenantScheduledMessage(messageId), 2.Seconds(),
             new DeliveryOptions { TenantId = "red" });
 
@@ -139,7 +139,7 @@ public class multi_tenant_durability_agents : PostgresqlContext, IAsyncLifetime
         var blueId = Guid.NewGuid();
         var mainId = Guid.NewGuid();
 
-        var bus = theHost.Services.GetRequiredService<IMessageBus>();
+        var bus = theHost.MessageBus();
 
         // Schedule messages for each tenant and the main database
         await bus.ScheduleAsync(new TenantScheduledMessage(redId), 2.Seconds(),

--- a/src/Persistence/Wolverine.Marten/Wolverine.Marten.csproj
+++ b/src/Persistence/Wolverine.Marten/Wolverine.Marten.csproj
@@ -12,7 +12,7 @@
         <ProjectReference Include="..\Wolverine.Postgresql\Wolverine.Postgresql.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Marten" Version="8.19.0" />
+      <PackageReference Include="Marten" Version="8.20.0" />
     </ItemGroup>
     <Import Project="../../../Analysis.Build.props" />
 </Project>


### PR DESCRIPTION
## Summary
- Adds regression tests verifying that durability agents, scheduled message processing, and scheduled job polling work correctly for non-master tenant databases in multi-tenant PostgreSQL setups
- All 3 tests pass on current `main`, confirming the bug reported in GH-2085 was fixed between v5.12.1 and the current codebase
- Tests serve as regression prevention going forward

## Tests added
1. **`all_tenant_durability_agents_are_started`** — verifies 3 durability agents start (main + 2 tenants)
2. **`scheduled_message_for_tenant_is_processed`** — schedules a message for a specific tenant and confirms it is handled with the correct TenantId
3. **`scheduled_messages_for_all_tenants_are_processed`** — schedules messages for both tenants and the main database, confirms all are processed correctly

## Test plan
- [x] All 3 new tests pass (`dotnet test --filter "multi_tenant_durability_agents"`)
- [x] All existing multi-tenancy tests still pass (`dotnet test --filter "MultiTenancy"`)

Closes GH-2085

🤖 Generated with [Claude Code](https://claude.com/claude-code) -- with clean up by @jeremydmiller too!