### PR TITLE
Skip BeginTransactionAsync when transaction already exists on DbContext

### DIFF
--- a/src/Persistence/MartenTests/Bugs/Bug_262_test_does_not_complete_with_timeout_message.cs
+++ b/src/Persistence/MartenTests/Bugs/Bug_262_test_does_not_complete_with_timeout_message.cs
@@ -1,4 +1,5 @@
 ﻿using IntegrationTests;
+using JasperFx.Core;
 using Marten;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -39,7 +40,10 @@ public class saga_cannot_access_stream_just_persisted_in_immediate_timeout : Pos
 
         var id = Guid.NewGuid();
 
-        await host.InvokeMessageAndWaitAsync(new SomeCommand(id));
+        await host.TrackActivity()
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<SomeTimeout>(host)
+            .InvokeMessageAndWaitAsync(new SomeCommand(id));
 
         using var session = host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
 


### PR DESCRIPTION
## Summary
- Fix `EnrollDbContextInTransaction` to check `Database.CurrentTransaction == null` before calling `BeginTransactionAsync()`, preventing `InvalidOperationException` when a transaction already exists (e.g. from `EnlistInOutboxAsync` persisting outstanding messages). Closes #2107
- Fix flaky saga timeout test to use explicit activity tracking with `WaitForMessageToBeReceivedAt<SomeTimeout>`

## Test plan
- [x] EfCoreTests pass (111/112 non-multi-tenancy, 1 failure is pre-existing resource contention)
- [ ] Verify with a repro scenario using `OutgoingMessages` + `AutoApplyTransactions` + EF Core

🤖 Generated with [Claude Code](https://claude.com/claude-code)