### PR TITLE
Add TransactionMiddlewareMode for EF Core middleware

### DIFF
--- a/src/Persistence/EfCoreTests/transaction_middleware_mode_tests.cs
+++ b/src/Persistence/EfCoreTests/transaction_middleware_mode_tests.cs
@@ -1,0 +1,244 @@
+using IntegrationTests;
+using JasperFx.CodeGeneration.Frames;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore.Codegen;
+using Wolverine.Persistence;
+using Wolverine.SqlServer;
+using Wolverine.Tracking;
+
+namespace EfCoreTests;
+
+[Collection("sqlserver")]
+public class transaction_middleware_mode_tests
+{
+    [Fact]
+    public async Task eager_mode_should_add_transaction_frame()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<CleanDbContext>(x =>
+                    x.UseSqlServer(Servers.SqlServerConnectionString));
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "txmode");
+                opts.UseEntityFrameworkCoreTransactions(TransactionMiddlewareMode.Eager);
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<EagerModeHandler>();
+            }).StartAsync();
+
+        var chain = host.GetRuntime().Handlers.ChainFor<EagerModeMessage>();
+
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ShouldNotBeEmpty();
+
+        chain.Postprocessors.OfType<MethodCall>()
+            .Any(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task lightweight_mode_should_not_add_transaction_frame()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<CleanDbContext>(x =>
+                    x.UseSqlServer(Servers.SqlServerConnectionString));
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "txmode");
+                opts.UseEntityFrameworkCoreTransactions(TransactionMiddlewareMode.Lightweight);
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<LightweightModeHandler>();
+            }).StartAsync();
+
+        var chain = host.GetRuntime().Handlers.ChainFor<LightweightModeMessage>();
+
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ShouldBeEmpty();
+        chain.Middleware.OfType<StartDatabaseTransactionForDbContext>().ShouldBeEmpty();
+
+        chain.Postprocessors.OfType<MethodCall>()
+            .Any(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task transactional_attribute_lightweight_overrides_eager_default()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<CleanDbContext>(x =>
+                    x.UseSqlServer(Servers.SqlServerConnectionString));
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "txmode");
+                opts.UseEntityFrameworkCoreTransactions(TransactionMiddlewareMode.Eager);
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<LightweightAttributeHandler>()
+                    .IncludeType<EagerAutoApplyHandler>();
+            }).StartAsync();
+
+        // Verify the auto-applied handler uses the Eager default
+        var eagerChain = host.GetRuntime().Handlers.ChainFor<EagerAutoApplyMessage>();
+        eagerChain.Middleware.OfType<EnrollDbContextInTransaction>().ShouldNotBeEmpty();
+
+        // Force compilation of the [Transactional] chain by triggering HandlerFor
+        host.GetRuntime().Handlers.HandlerFor<LightweightAttributeMessage>();
+        var chain = host.GetRuntime().Handlers.ChainFor<LightweightAttributeMessage>();
+
+        // The attribute overrides to Lightweight, so no transaction frame
+        chain.IsTransactional.ShouldBeTrue();
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ShouldBeEmpty();
+        chain.Middleware.OfType<StartDatabaseTransactionForDbContext>().ShouldBeEmpty();
+
+        chain.Postprocessors.OfType<MethodCall>()
+            .Any(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task transactional_attribute_eager_overrides_lightweight_default()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<CleanDbContext>(x =>
+                    x.UseSqlServer(Servers.SqlServerConnectionString));
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "txmode");
+                opts.UseEntityFrameworkCoreTransactions(TransactionMiddlewareMode.Lightweight);
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<EagerAttributeHandler>()
+                    .IncludeType<LightweightAutoApplyHandler>();
+            }).StartAsync();
+
+        // Verify the auto-applied handler uses the Lightweight default
+        var lightChain = host.GetRuntime().Handlers.ChainFor<LightweightAutoApplyMessage>();
+        lightChain.Middleware.OfType<EnrollDbContextInTransaction>().ShouldBeEmpty();
+
+        // Force compilation of the [Transactional] chain by triggering HandlerFor
+        host.GetRuntime().Handlers.HandlerFor<EagerAttributeMessage>();
+        var chain = host.GetRuntime().Handlers.ChainFor<EagerAttributeMessage>();
+
+        // The attribute overrides to Eager, so transaction frame should be present
+        chain.IsTransactional.ShouldBeTrue();
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ShouldNotBeEmpty();
+
+        chain.Postprocessors.OfType<MethodCall>()
+            .Any(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task default_mode_is_eager()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<CleanDbContext>(x =>
+                    x.UseSqlServer(Servers.SqlServerConnectionString));
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "txmode");
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<DefaultModeHandler>();
+            }).StartAsync();
+
+        var chain = host.GetRuntime().Handlers.ChainFor<DefaultModeMessage>();
+
+        // Default should be Eager
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ShouldNotBeEmpty();
+    }
+}
+
+#region test message types and handlers
+
+public record EagerModeMessage;
+
+public class EagerModeHandler
+{
+    public static void Handle(EagerModeMessage message, CleanDbContext db)
+    {
+    }
+}
+
+public record LightweightModeMessage;
+
+public class LightweightModeHandler
+{
+    public static void Handle(LightweightModeMessage message, CleanDbContext db)
+    {
+    }
+}
+
+public record LightweightAttributeMessage;
+
+public class LightweightAttributeHandler
+{
+    [Transactional(Mode = TransactionMiddlewareMode.Lightweight)]
+    public static void Handle(LightweightAttributeMessage message, CleanDbContext db)
+    {
+    }
+}
+
+public record EagerAttributeMessage;
+
+public class EagerAttributeHandler
+{
+    [Transactional(Mode = TransactionMiddlewareMode.Eager)]
+    public static void Handle(EagerAttributeMessage message, CleanDbContext db)
+    {
+    }
+}
+
+public record DefaultModeMessage;
+
+public class DefaultModeHandler
+{
+    public static void Handle(DefaultModeMessage message, CleanDbContext db)
+    {
+    }
+}
+
+public record EagerAutoApplyMessage;
+
+public class EagerAutoApplyHandler
+{
+    public static void Handle(EagerAutoApplyMessage message, CleanDbContext db)
+    {
+    }
+}
+
+public record LightweightAutoApplyMessage;
+
+public class LightweightAutoApplyHandler
+{
+    public static void Handle(LightweightAutoApplyMessage message, CleanDbContext db)
+    {
+    }
+}
+
+#endregion

--- a/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
@@ -8,9 +8,12 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Wolverine.EntityFrameworkCore.Codegen;
 using Wolverine.EntityFrameworkCore.Internals;
 using Wolverine.EntityFrameworkCore.Internals.Migrations;
+using Wolverine.Persistence;
 using Wolverine.Persistence.Durability;
+using Wolverine.Persistence.Sagas;
 using Wolverine.RDBMS;
 using Wolverine.Runtime;
 
@@ -172,10 +175,24 @@ public static class WolverineEntityCoreExtensions
 
     /// <summary>
     ///     Uses Entity Framework Core for Saga persistence and transactional
-    ///     middleware
+    ///     middleware using <see cref="TransactionMiddlewareMode.Eager"/> mode by default.
     /// </summary>
     /// <param name="options"></param>
     public static void UseEntityFrameworkCoreTransactions(this WolverineOptions options)
+    {
+        options.UseEntityFrameworkCoreTransactions(TransactionMiddlewareMode.Eager);
+    }
+
+    /// <summary>
+    ///     Uses Entity Framework Core for Saga persistence and transactional
+    ///     middleware with the specified <see cref="TransactionMiddlewareMode"/>.
+    ///     <see cref="TransactionMiddlewareMode.Eager"/> opens an explicit database transaction immediately.
+    ///     <see cref="TransactionMiddlewareMode.Lightweight"/> only relies on <c>DbContext.SaveChangesAsync()</c>
+    ///     without opening an explicit transaction.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="mode">The transaction middleware mode to use</param>
+    public static void UseEntityFrameworkCoreTransactions(this WolverineOptions options, TransactionMiddlewareMode mode)
     {
         try
         {
@@ -191,8 +208,15 @@ public static class WolverineEntityCoreExtensions
                 throw;
             }
         }
-        
+
         options.Include<EntityFrameworkCoreBackedPersistence>();
+
+        var providers = options.CodeGeneration.PersistenceProviders();
+        var efProvider = providers.OfType<EFCorePersistenceFrameProvider>().FirstOrDefault();
+        if (efProvider != null)
+        {
+            efProvider.DefaultMode = mode;
+        }
     }
 
     /// <summary>

--- a/src/Wolverine/Attributes/TransactionalAttribute.cs
+++ b/src/Wolverine/Attributes/TransactionalAttribute.cs
@@ -14,21 +14,44 @@ namespace Wolverine.Attributes;
 /// </summary>
 public class TransactionalAttribute : ModifyChainAttribute
 {
+    private bool _modeExplicitlySet;
+
     public override void Modify(IChain chain, GenerationRules rules, IServiceContainer container)
     {
         if (Idempotency.HasValue)
         {
             chain.Idempotency = Idempotency.Value;
         }
-        
+
+        if (_modeExplicitlySet)
+        {
+            chain.Tags["TransactionMiddlewareMode"] = Mode;
+        }
+
         chain.ApplyImpliedMiddlewareFromHandlers(rules);
         var transactionFrameProvider = rules.As<GenerationRules>().GetPersistenceProviders(chain, container);
         transactionFrameProvider.ApplyTransactionSupport(chain, container);
 
         chain.IsTransactional = true;
     }
-    
+
     public IdempotencyStyle? Idempotency { get; set; }
+
+    /// <summary>
+    /// Optionally override the <see cref="TransactionMiddlewareMode"/> for just this handler chain.
+    /// When set, this takes precedence over the global mode configured in
+    /// <c>UseEntityFrameworkCoreTransactions()</c>.
+    /// </summary>
+    public TransactionMiddlewareMode Mode
+    {
+        get => _mode;
+        set
+        {
+            _mode = value;
+            _modeExplicitlySet = true;
+        }
+    }
+    private TransactionMiddlewareMode _mode;
 
     public TransactionalAttribute()
     {

--- a/src/Wolverine/Persistence/TransactionMiddlewareMode.cs
+++ b/src/Wolverine/Persistence/TransactionMiddlewareMode.cs
@@ -1,0 +1,17 @@
+namespace Wolverine.Persistence;
+
+public enum TransactionMiddlewareMode
+{
+    /// <summary>
+    /// Start a native database transaction immediately when starting the message handling or HTTP request handling.
+    /// Use this for tools like EF Core that may require an explicit transaction for bulk operations
+    ///
+    /// Not supported or necessary for Marten or RavenDb
+    /// </summary>
+    Eager,
+    
+    /// <summary>
+    /// Only rely on the underlying persistence tool's version of SaveChangesAsync() for transactional boundaries
+    /// </summary>
+    Lightweight
+}


### PR DESCRIPTION
## Summary
- Adds `TransactionMiddlewareMode` enum (`Eager` / `Lightweight`) to control whether EF Core transactional middleware opens an explicit database transaction or only relies on `DbContext.SaveChangesAsync()`
- New `UseEntityFrameworkCoreTransactions(TransactionMiddlewareMode)` overload; existing no-arg version defaults to `Eager` for backwards compatibility
- `[Transactional(Mode = TransactionMiddlewareMode.Lightweight)]` attribute property allows per-handler override of the global mode

Closes #2086

## Test plan
- [x] `eager_mode_should_add_transaction_frame` — verifies Eager adds `EnrollDbContextInTransaction`
- [x] `lightweight_mode_should_not_add_transaction_frame` — verifies Lightweight skips transaction frame
- [x] `default_mode_is_eager` — verifies no-arg overload defaults to Eager
- [x] `transactional_attribute_lightweight_overrides_eager_default` — verifies attribute override from Eager→Lightweight
- [x] `transactional_attribute_eager_overrides_lightweight_default` — verifies attribute override from Lightweight→Eager
- [x] All 116/117 existing non-multi-tenancy EfCoreTests pass (1 pre-existing flaky failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)