### PR TITLE
Migrate to centralized NuGet package management (CPM)

### DIFF
--- a/Analysis.Build.props
+++ b/Analysis.Build.props
@@ -6,7 +6,7 @@
         <AnalysisLevel>latest</AnalysisLevel>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64" PrivateAssets="All"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="All" Condition=" '$(TargetFrawework)' == 'netstandard2.0' "/>
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="All" Condition=" '$(TargetFrawework)' == 'netstandard2.0' "/>
     </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
     </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,151 @@
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageVersion Include="Alba" Version="8.4.0" />
+        <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.2.14" />
+        <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.14" />
+        <PackageVersion Include="Azure.Identity" Version="1.17.0" />
+        <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
+        <PackageVersion Include="Confluent.Kafka" Version="2.12.0" />
+        <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+        <PackageVersion Include="DotPulsar" Version="5.1.2" />
+        <PackageVersion Include="FluentAssertions" Version="6.12.2" />
+        <PackageVersion Include="FluentValidation" Version="12.0.0" />
+        <PackageVersion Include="FSharp.Core" Version="9.0.303" />
+        <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
+        <PackageVersion Include="Google.Cloud.PubSub.V1" Version="3.24.0" />
+        <PackageVersion Include="Google.Protobuf" Version="3.31.1" />
+        <PackageVersion Include="Grpc.Core" Version="2.46.6" />
+        <PackageVersion Include="Grpc.Tools" Version="2.72.0" />
+        <PackageVersion Include="HtmlTags" Version="9.0.0" />
+        <PackageVersion Include="JasperFx" Version="1.17.2" />
+        <PackageVersion Include="JasperFx.Events" Version="1.19.1" />
+        <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.3.2" />
+        <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
+        <PackageVersion Include="Marten" Version="8.21.0" />
+        <PackageVersion Include="Marten.AspNetCore" Version="8.19.0" />
+        <PackageVersion Include="MemoryPack" Version="1.21.3" />
+        <PackageVersion Include="MessagePack" Version="3.1.3" />
+        <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+        <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.8" />
+        <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.32.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
+        <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.5" />
+        <PackageVersion Include="Microsoft.FeatureManagement" Version="3.2.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64" />
+        <PackageVersion Include="MQTTnet.Extensions.ManagedClient" Version="4.3.7.1207" />
+        <PackageVersion Include="MySqlConnector" Version="2.4.0" />
+        <PackageVersion Include="NATS.Net" Version="2.7.0" />
+        <PackageVersion Include="NewId" Version="4.0.1" />
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageVersion Include="Npgsql" Version="9.0.3" />
+        <PackageVersion Include="NSubstitute" Version="5.3.0" />
+        <PackageVersion Include="Nuke.Common" Version="9.0.4" />
+        <PackageVersion Include="NSwag.AspNetCore" Version="14.0.0" />
+        <PackageVersion Include="OpenTelemetry" Version="1.14.0" />
+        <PackageVersion Include="OpenTelemetry.Api" Version="1.14.0" />
+        <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
+        <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="1.8.0" />
+        <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
+        <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
+        <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.7.0" />
+        <PackageVersion Include="protobuf-net.BuildTools" Version="3.2.52" />
+        <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
+        <PackageVersion Include="RavenDB.Client" Version="7.0.2" />
+        <PackageVersion Include="RavenDB.DependencyInjection" Version="5.0.1" />
+        <PackageVersion Include="RavenDB.TestDriver" Version="7.0.2" />
+        <PackageVersion Include="Refit" Version="8.0.0" />
+        <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
+        <PackageVersion Include="Shouldly" Version="4.3.0" />
+        <PackageVersion Include="Spectre.Console" Version="0.53.0" />
+        <PackageVersion Include="StackExchange.Redis" Version="2.9.17" />
+        <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
+        <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="9.0.1" />
+        <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.1" />
+        <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.1" />
+        <PackageVersion Include="System.ComponentModel" Version="4.3.0" />
+        <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
+        <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
+        <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
+        <PackageVersion Include="Weasel.Core" Version="8.6.0" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="8.6.0" />
+        <PackageVersion Include="Weasel.MySql" Version="8.5.1" />
+        <PackageVersion Include="Weasel.Oracle" Version="8.6.1" />
+        <PackageVersion Include="Weasel.Postgresql" Version="8.6.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="8.6.0" />
+        <PackageVersion Include="Weasel.Sqlite" Version="8.6.0" />
+        <PackageVersion Include="xunit" Version="2.9.3" />
+        <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    </ItemGroup>
+
+    <!-- TFM-conditional Microsoft.Extensions.* for Wolverine core (version ranges for NuGet compatibility) -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+        <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="[8.0.0,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="[8.0.0,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[8.0.2,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="[8.0.1,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.1,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.1,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="[8.0.23,10.0.0)" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+        <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="[9.0.0,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="[9.0.0,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="[9.0.0,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[9.0.0,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="[9.0.0,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[9.0.0,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[9.0.0,10.0.0)" />
+        <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="[9.0.12,10.0.0)" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+        <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.2" />
+        <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0-rc.2" />
+    </ItemGroup>
+
+    <!-- TFM-conditional EF Core ecosystem -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+        <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+        <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
+    </ItemGroup>
+</Project>

--- a/WolverineWebApiFSharp/WolverineWebApiFSharp.fsproj
+++ b/WolverineWebApiFSharp/WolverineWebApiFSharp.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="FSharp.Core" Version="9.0.303" />
+      <PackageReference Update="FSharp.Core" VersionOverride="9.0.303" />
     </ItemGroup>
 
 </Project>

--- a/build/build.csproj
+++ b/build/build.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="9.0.3" />
-    <PackageReference Include="Nuke.Common" Version="9.0.4" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="Nuke.Common" />
   </ItemGroup>
 
 </Project>

--- a/src/Extensions/Wolverine.DataAnnotationsValidation.Tests/Wolverine.DataAnnotationsValidation.Tests.csproj
+++ b/src/Extensions/Wolverine.DataAnnotationsValidation.Tests/Wolverine.DataAnnotationsValidation.Tests.csproj
@@ -1,16 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.0"/>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All"/>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
+    <PackageReference Include="coverlet.collector" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
+++ b/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
@@ -5,12 +5,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
+        <PackageReference Include="coverlet.collector" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Extensions/Wolverine.FluentValidation/Wolverine.FluentValidation.csproj
+++ b/src/Extensions/Wolverine.FluentValidation/Wolverine.FluentValidation.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation" Version="12.0.0" />
+        <PackageReference Include="FluentValidation" />
     </ItemGroup>
 
 </Project>

--- a/src/Extensions/Wolverine.MemoryPack.Tests/Wolverine.MemoryPack.Tests.csproj
+++ b/src/Extensions/Wolverine.MemoryPack.Tests/Wolverine.MemoryPack.Tests.csproj
@@ -5,14 +5,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Extensions/Wolverine.MemoryPack/Wolverine.MemoryPack.csproj
+++ b/src/Extensions/Wolverine.MemoryPack/Wolverine.MemoryPack.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MemoryPack" Version="1.21.3" />
+        <PackageReference Include="MemoryPack" />
     </ItemGroup>
 
 </Project>

--- a/src/Extensions/Wolverine.MessagePack.Tests/Wolverine.MessagePack.Tests.csproj
+++ b/src/Extensions/Wolverine.MessagePack.Tests/Wolverine.MessagePack.Tests.csproj
@@ -5,14 +5,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Extensions/Wolverine.MessagePack/Wolverine.MessagePack.csproj
+++ b/src/Extensions/Wolverine.MessagePack/Wolverine.MessagePack.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MessagePack" Version="3.1.3" />
+        <PackageReference Include="MessagePack" />
     </ItemGroup>
 
 </Project>

--- a/src/Extensions/Wolverine.Protobuf.Tests/Wolverine.Protobuf.Tests.csproj
+++ b/src/Extensions/Wolverine.Protobuf.Tests/Wolverine.Protobuf.Tests.csproj
@@ -5,21 +5,21 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-		<PackageReference Include="Shouldly" Version="4.3.0" />
-		<PackageReference Include="xunit" Version="2.9.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Shouldly" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-		<PackageReference Include="Google.Protobuf" Version="3.31.1" />
-		<PackageReference Include="Grpc.Core" Version="2.46.6" />
-		<PackageReference Include="Grpc.Tools" Version="2.72.0">
+		<PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+		<PackageReference Include="Google.Protobuf" />
+		<PackageReference Include="Grpc.Core" />
+		<PackageReference Include="Grpc.Tools">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="protobuf-net.BuildTools" Version="3.2.52">
+		<PackageReference Include="protobuf-net.BuildTools">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/Extensions/Wolverine.Protobuf/Wolverine.Protobuf.csproj
+++ b/src/Extensions/Wolverine.Protobuf/Wolverine.Protobuf.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Google.Protobuf" Version="3.31.1" />
+	  <PackageReference Include="Google.Protobuf" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Http/CodeGenTarget/CodeGenTarget.csproj
+++ b/src/Http/CodeGenTarget/CodeGenTarget.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Http/CrazyStartingWebApp/CrazyStartingWebApp.csproj
+++ b/src/Http/CrazyStartingWebApp/CrazyStartingWebApp.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Http/NSwagDemonstrator/NSwagDemonstrator.csproj
+++ b/src/Http/NSwagDemonstrator/NSwagDemonstrator.csproj
@@ -19,11 +19,11 @@
             To use OpenApiGenerateDocumentsOnBuild with Wolverine, upgrade Microsoft.Extensions.ApiDescription.Server (transitive NSwag dependency).
             See also: https://github.com/RicoSuter/NSwag/issues/3403 
         -->
-        <!-- <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="8.0.1"> -->
+        <!-- <PackageReference Include="Microsoft.Extensions.ApiDescription.Server"> -->
         <!-- 	<PrivateAssets>all</PrivateAssets> -->
         <!-- 	<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets> -->
         <!-- </PackageReference> -->
-        <PackageReference Include="NSwag.AspNetCore" Version="14.0.0"/>
+        <PackageReference Include="NSwag.AspNetCore"/>
     </ItemGroup>
 
 </Project>

--- a/src/Http/OpenApiDemonstrator/OpenApiDemonstrator.csproj
+++ b/src/Http/OpenApiDemonstrator/OpenApiDemonstrator.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Http/SqlServerOutboxWebService/SqlServerOutboxWebService.csproj
+++ b/src/Http/SqlServerOutboxWebService/SqlServerOutboxWebService.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Http/StaticCodeGenDemonstrator/StaticCodeGenDemonstrator.csproj
+++ b/src/Http/StaticCodeGenDemonstrator/StaticCodeGenDemonstrator.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Http/Wolverine.AdminApi/Wolverine.AdminApi.csproj
+++ b/src/Http/Wolverine.AdminApi/Wolverine.AdminApi.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="HtmlTags" Version="9.0.0"/>
+        <PackageReference Include="HtmlTags"/>
     </ItemGroup>
 
 </Project>

--- a/src/Http/Wolverine.Http.Marten/Wolverine.Http.Marten.csproj
+++ b/src/Http/Wolverine.Http.Marten/Wolverine.Http.Marten.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\Persistence\Wolverine.Marten\Wolverine.Marten.csproj" />
         <ProjectReference Include="..\Wolverine.Http\Wolverine.Http.csproj" />
-        <PackageReference Include="Marten.AspNetCore" Version="8.19.0" />
+        <PackageReference Include="Marten.AspNetCore" />
     </ItemGroup>
 
 </Project>

--- a/src/Http/Wolverine.Http.Tests/Wolverine.Http.Tests.csproj
+++ b/src/Http/Wolverine.Http.Tests/Wolverine.Http.Tests.csproj
@@ -6,20 +6,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="8.2.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Refit" Version="8.0.0" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="8.0.0" />
-        <PackageReference Include="xunit" Version="2.9.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="Alba" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Refit" />
+        <PackageReference Include="Refit.HttpClientFactory" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>
@@ -36,14 +36,9 @@
         <Compile Remove="AlbaExtensions.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(targetframework)' == 'net8.0'">
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(targetframework)' == 'net9.0'">
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0"/>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL"/>
     </ItemGroup>
 
 </Project>

--- a/src/Http/WolverineWebApi/WolverineWebApi.csproj
+++ b/src/Http/WolverineWebApi/WolverineWebApi.csproj
@@ -3,14 +3,12 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="FSharp.Core" Version="9.0.303" />
-        <PackageReference Include="FSharp.Core" Version="9.0.202" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="StronglyTypedId" Version="1.0.0-beta08" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <PackageReference Include="StronglyTypedId" Version="1.0.0-beta08" />
+        <PackageReference Include="FSharp.Core" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="StronglyTypedId" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>
@@ -24,14 +22,9 @@
         <ProjectReference Include="..\Wolverine.Http\Wolverine.Http.csproj" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(targetframework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(targetframework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" VersionOverride="8.0.11" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Persistence/EfCoreTests/EfCoreTests.csproj
+++ b/src/Persistence/EfCoreTests/EfCoreTests.csproj
@@ -7,28 +7,23 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="8.2.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Alba" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(targetframework)' == 'net8.0'">
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(targetframework)' == 'net9.0'">
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0"/>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL"/>
     </ItemGroup>
 
 

--- a/src/Persistence/LeaderElection/MySqlTests.LeaderElection/MySqlTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/MySqlTests.LeaderElection/MySqlTests.LeaderElection.csproj
@@ -6,10 +6,10 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Persistence/LeaderElection/PostgresqlTests.LeaderElection/PostgresqlTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/PostgresqlTests.LeaderElection/PostgresqlTests.LeaderElection.csproj
@@ -6,10 +6,10 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Persistence/LeaderElection/RavenDbTests.LeaderElection/RavenDbTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/RavenDbTests.LeaderElection/RavenDbTests.LeaderElection.csproj
@@ -11,10 +11,10 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Persistence/LeaderElection/SqlServerTests.LeaderElection/SqlServerTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/SqlServerTests.LeaderElection/SqlServerTests.LeaderElection.csproj
@@ -6,10 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Persistence/MartenSubscriptionTests/MartenSubscriptionTests.csproj
+++ b/src/Persistence/MartenSubscriptionTests/MartenSubscriptionTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
@@ -8,15 +8,15 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
 
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
 
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Persistence/MartenTests/MartenTests.csproj
+++ b/src/Persistence/MartenTests/MartenTests.csproj
@@ -8,19 +8,19 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
 
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="StronglyTypedId" Version="1.0.0-beta08" />
+        <PackageReference Include="StronglyTypedId" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Persistence/MultiTenantedEfCoreWithPostgreSQL/MultiTenantedEfCoreWithPostgreSQL.csproj
+++ b/src/Persistence/MultiTenantedEfCoreWithPostgreSQL/MultiTenantedEfCoreWithPostgreSQL.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -21,14 +21,9 @@
       </Compile>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(targetframework)' == 'net8.0'">
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(targetframework)' == 'net9.0'">
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0"/>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL"/>
     </ItemGroup>
 
 </Project>

--- a/src/Persistence/MultiTenantedEfCoreWithSqlServer/MultiTenantedEfCoreWithSqlServer.csproj
+++ b/src/Persistence/MultiTenantedEfCoreWithSqlServer/MultiTenantedEfCoreWithSqlServer.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -20,14 +20,9 @@
         </Compile>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(targetframework)' == 'net8.0'">
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(targetframework)' == 'net9.0'">
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0"/>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL"/>
     </ItemGroup>
 
 </Project>

--- a/src/Persistence/MySql/MySqlTests/MySqlTests.csproj
+++ b/src/Persistence/MySql/MySqlTests/MySqlTests.csproj
@@ -6,10 +6,10 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Persistence/MySql/Wolverine.MySql/Wolverine.MySql.csproj
+++ b/src/Persistence/MySql/Wolverine.MySql/Wolverine.MySql.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
       <!-- MySqlConnector is needed as direct reference when using Weasel from source -->
-      <PackageReference Include="MySqlConnector" Version="2.4.0" />
-      <PackageReference Include="Weasel.MySql" Version="8.5.1" />
+      <PackageReference Include="MySqlConnector" />
+      <PackageReference Include="Weasel.MySql" />
     </ItemGroup>
 
     <Import Project="../../../../Analysis.Build.props" />

--- a/src/Persistence/Oracle/OracleTests/OracleTests.csproj
+++ b/src/Persistence/Oracle/OracleTests/OracleTests.csproj
@@ -6,10 +6,10 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Persistence/Oracle/Wolverine.Oracle/Wolverine.Oracle.csproj
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Wolverine.Oracle.csproj
@@ -15,8 +15,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.7.0" />
-        <PackageReference Include="Weasel.Oracle" Version="8.6.1" />
+        <PackageReference Include="Oracle.ManagedDataAccess.Core" />
+        <PackageReference Include="Weasel.Oracle" />
     </ItemGroup>
 
     <Import Project="../../../../Analysis.Build.props" />

--- a/src/Persistence/OrderEventSourcingSample/OrderEventSourcingSample.csproj
+++ b/src/Persistence/OrderEventSourcingSample/OrderEventSourcingSample.csproj
@@ -4,7 +4,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
 </Project>

--- a/src/Persistence/PausingAndRestartingListener/PausingAndRestartingListener.csproj
+++ b/src/Persistence/PausingAndRestartingListener/PausingAndRestartingListener.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Persistence/PersistenceTests/PersistenceTests.csproj
+++ b/src/Persistence/PersistenceTests/PersistenceTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
@@ -8,11 +8,11 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
 
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -30,19 +30,9 @@
 
     </ItemGroup>
 
-    <ItemGroup Condition="'$(targetframework)' == 'net8.0'">
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(targetframework)' == 'net9.0'">
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(targetframework)' == 'net10.0'">
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0-rc.2"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0"/>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Persistence/PostgresqlTests/PostgresqlTests.csproj
+++ b/src/Persistence/PostgresqlTests/PostgresqlTests.csproj
@@ -6,10 +6,10 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Persistence/RavenDbTests/RavenDbTests.csproj
+++ b/src/Persistence/RavenDbTests/RavenDbTests.csproj
@@ -11,13 +11,13 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="RavenDB.DependencyInjection" Version="5.0.1" />
-        <PackageReference Include="RavenDB.TestDriver" Version="7.0.2" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.assemblyfixture" Version="2.2.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="RavenDB.DependencyInjection" />
+        <PackageReference Include="RavenDB.TestDriver" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.assemblyfixture" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Persistence/SqlServerTests/SqlServerTests.csproj
+++ b/src/Persistence/SqlServerTests/SqlServerTests.csproj
@@ -6,17 +6,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Persistence/SqliteTests/SqliteTests.csproj
+++ b/src/Persistence/SqliteTests/SqliteTests.csproj
@@ -6,18 +6,18 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
         <ProjectReference Include="..\..\Persistence\Wolverine.RDBMS\Wolverine.RDBMS.csproj"/>
         <ProjectReference Include="..\Wolverine.Sqlite\Wolverine.Sqlite.csproj"/>
         <ProjectReference Include="..\..\Testing\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj" />

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Wolverine.EntityFrameworkCore.csproj
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Wolverine.EntityFrameworkCore.csproj
@@ -12,26 +12,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Weasel.EntityFrameworkCore" Version="8.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational"/>
+        <PackageReference Include="Weasel.EntityFrameworkCore" />
         <ProjectReference Include="..\Wolverine.RDBMS\Wolverine.RDBMS.csproj"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Persistence/Wolverine.Marten/Wolverine.Marten.csproj
+++ b/src/Persistence/Wolverine.Marten/Wolverine.Marten.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Marten-backed Persistence for Wolverine Applications</Description>
         <PackageId>WolverineFx.Marten</PackageId>
@@ -12,7 +12,7 @@
         <ProjectReference Include="..\Wolverine.Postgresql\Wolverine.Postgresql.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Marten" Version="8.21.0" />
+      <PackageReference Include="Marten" />
     </ItemGroup>
     <Import Project="../../../Analysis.Build.props" />
 </Project>

--- a/src/Persistence/Wolverine.Postgresql/Wolverine.Postgresql.csproj
+++ b/src/Persistence/Wolverine.Postgresql/Wolverine.Postgresql.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Weasel.Postgresql" Version="8.6.0" />
+      <PackageReference Include="Weasel.Postgresql" />
     </ItemGroup>
 
     <Import Project="../../../Analysis.Build.props" />

--- a/src/Persistence/Wolverine.RDBMS/Wolverine.RDBMS.csproj
+++ b/src/Persistence/Wolverine.RDBMS/Wolverine.RDBMS.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Weasel.Core" Version="8.6.0" />
+      <PackageReference Include="Weasel.Core" />
     </ItemGroup>
 
     <Import Project="../../../Analysis.Build.props" />

--- a/src/Persistence/Wolverine.RavenDb/Wolverine.RavenDb.csproj
+++ b/src/Persistence/Wolverine.RavenDb/Wolverine.RavenDb.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Description>RavenDb Saga, Message, and Outbox storage for Wolverine applications</Description>
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="RavenDB.Client" Version="7.0.2" />
+      <PackageReference Include="RavenDB.Client" />
     </ItemGroup>
 
 </Project>

--- a/src/Persistence/Wolverine.SqlServer/Wolverine.SqlServer.csproj
+++ b/src/Persistence/Wolverine.SqlServer/Wolverine.SqlServer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Sql Server-backed Persistence for Wolverine Applications</Description>
         <PackageId>WolverineFx.SqlServer</PackageId>
@@ -13,7 +13,7 @@
         <EmbeddedResource Include="Schema/*.sql" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Weasel.SqlServer" Version="8.6.0" />
+      <PackageReference Include="Weasel.SqlServer" />
     </ItemGroup>
 
     <Import Project="../../../Analysis.Build.props" />

--- a/src/Persistence/Wolverine.Sqlite/Wolverine.Sqlite.csproj
+++ b/src/Persistence/Wolverine.Sqlite/Wolverine.Sqlite.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Weasel.Sqlite" Version="8.6.0" />
+      <PackageReference Include="Weasel.Sqlite" />
     </ItemGroup>
 
     <Import Project="../../../Analysis.Build.props" />

--- a/src/Samples/CQRSWithMarten/TeleHealth.Backend/TeleHealth.Backend.csproj
+++ b/src/Samples/CQRSWithMarten/TeleHealth.Backend/TeleHealth.Backend.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/CQRSWithMarten/TeleHealth.Tests/TeleHealth.Tests.csproj
+++ b/src/Samples/CQRSWithMarten/TeleHealth.Tests/TeleHealth.Tests.csproj
@@ -6,14 +6,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Samples/CQRSWithMarten/TeleHealth.WebApi/TeleHealth.WebApi.csproj
+++ b/src/Samples/CQRSWithMarten/TeleHealth.WebApi/TeleHealth.WebApi.csproj
@@ -4,7 +4,7 @@
         
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/ChaosSender/ChaosSender.csproj
+++ b/src/Samples/ChaosSender/ChaosSender.csproj
@@ -7,8 +7,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/CommandBus/CommandBus.csproj
+++ b/src/Samples/CommandBus/CommandBus.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/Diagnostics/DiagnosticsApp/DiagnosticsApp.csproj
+++ b/src/Samples/Diagnostics/DiagnosticsApp/DiagnosticsApp.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/Diagnostics/DiagnosticsTests/DiagnosticsTests.csproj
+++ b/src/Samples/Diagnostics/DiagnosticsTests/DiagnosticsTests.csproj
@@ -5,14 +5,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="8.1.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Alba" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Samples/EFCoreSample/ItemService.Tests/ItemService.Tests.csproj
+++ b/src/Samples/EFCoreSample/ItemService.Tests/ItemService.Tests.csproj
@@ -8,20 +8,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="7.4.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Alba"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/EFCoreSample/ItemService/ItemService.csproj
+++ b/src/Samples/EFCoreSample/ItemService/ItemService.csproj
@@ -4,7 +4,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
     </ItemGroup>
 
 </Project>

--- a/src/Samples/InMemoryMediator/InMemoryMediator.csproj
+++ b/src/Samples/InMemoryMediator/InMemoryMediator.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" VersionOverride="7.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/IncidentService/IncidentService.Tests/IncidentService.Tests.csproj
+++ b/src/Samples/IncidentService/IncidentService.Tests/IncidentService.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
@@ -6,15 +6,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="8.4.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Alba" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Samples/IncidentService/IncidentService/IncidentService.csproj
+++ b/src/Samples/IncidentService/IncidentService/IncidentService.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Marten.AspNetCore" Version="8.19.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="9.0.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.1" />
+        <PackageReference Include="Marten.AspNetCore" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/KitchenSink/MartenAndRabbitEmailService/MartenAndRabbitEmailService.csproj
+++ b/src/Samples/KitchenSink/MartenAndRabbitEmailService/MartenAndRabbitEmailService.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/Middleware/AppWithMiddleware.Tests/AppWithMiddleware.Tests.csproj
+++ b/src/Samples/Middleware/AppWithMiddleware.Tests/AppWithMiddleware.Tests.csproj
@@ -5,20 +5,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="8.4.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Alba" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/Middleware/AppWithMiddleware/AppWithMiddleware.csproj
+++ b/src/Samples/Middleware/AppWithMiddleware/AppWithMiddleware.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/MultiTenantedTodoService/MultiTenantedTodoService/MultiTenantedTodoWebService.csproj
+++ b/src/Samples/MultiTenantedTodoService/MultiTenantedTodoService/MultiTenantedTodoWebService.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.5"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/MultiTenantedTodoService/MultiTenantedTodoWebService.Tests/MultiTenantedTodoWebService.Tests.csproj
+++ b/src/Samples/MultiTenantedTodoService/MultiTenantedTodoWebService.Tests/MultiTenantedTodoWebService.Tests.csproj
@@ -6,18 +6,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Alba" Version="8.4.0" />
+        <PackageReference Include="Alba" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/OrderManagement/RetailClient/RetailClient.csproj
+++ b/src/Samples/OrderManagement/RetailClient/RetailClient.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Spectre.Console" Version="0.53.0"/>
+        <PackageReference Include="Spectre.Console"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/OrderSagaSample/OrderSagaSample.csproj
+++ b/src/Samples/OrderSagaSample/OrderSagaSample.csproj
@@ -5,7 +5,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\Persistence\Wolverine.Marten\Wolverine.Marten.csproj"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/Quickstart/Quickstart.csproj
+++ b/src/Samples/Quickstart/Quickstart.csproj
@@ -4,8 +4,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/SampleTests/SampleTests/SampleTests.csproj
+++ b/src/Samples/SampleTests/SampleTests/SampleTests.csproj
@@ -1,15 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Alba" Version="6.1.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0"/>
-    <PackageReference Include="Shouldly" Version="4.0.3"/>
-    <PackageReference Include="xunit" Version="2.4.1"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
+    <PackageReference Include="Alba"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="Shouldly"/>
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.runner.visualstudio"/>
 
   </ItemGroup>
 

--- a/src/Samples/TestHarness/BankingService.Tests/BankingService.Tests.csproj
+++ b/src/Samples/TestHarness/BankingService.Tests/BankingService.Tests.csproj
@@ -5,19 +5,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="8.4.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Alba" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/TestHarness/BankingService/BankingService.csproj
+++ b/src/Samples/TestHarness/BankingService/BankingService.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.3"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/TodoWebService/TodoWebService/TodoWebService.csproj
+++ b/src/Samples/TodoWebService/TodoWebService/TodoWebService.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/TodoWebService/TodoWebServiceTests/TodoWebServiceTests.csproj
+++ b/src/Samples/TodoWebService/TodoWebServiceTests/TodoWebServiceTests.csproj
@@ -5,19 +5,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="8.4.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Alba" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/WebApiWithMarten/WebApiWithMarten.csproj
+++ b/src/Samples/WebApiWithMarten/WebApiWithMarten.csproj
@@ -6,8 +6,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
 </Project>

--- a/src/Testing/BackPressureTests/BackPressureTests.csproj
+++ b/src/Testing/BackPressureTests/BackPressureTests.csproj
@@ -1,18 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0"/>
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Testing/Benchmarks/Benchmarks.csproj
+++ b/src/Testing/Benchmarks/Benchmarks.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.1"/>
+        <PackageReference Include="BenchmarkDotNet"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Testing/CoreTests/CoreTests.csproj
+++ b/src/Testing/CoreTests/CoreTests.csproj
@@ -5,16 +5,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-        <PackageReference Include="Microsoft.FeatureManagement" Version="3.2.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0"/>
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+        <PackageReference Include="Microsoft.FeatureManagement"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Testing/MessageRoutingTests/MessageRoutingTests.csproj
+++ b/src/Testing/MessageRoutingTests/MessageRoutingTests.csproj
@@ -1,19 +1,19 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Testing/MetricsTests/MetricsTests.csproj
+++ b/src/Testing/MetricsTests/MetricsTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -8,11 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Testing/OpenTelemetry/OtelWebApi/OtelWebApi.csproj
+++ b/src/Testing/OpenTelemetry/OtelWebApi/OtelWebApi.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <PackageReference Include="OpenTelemetry" Version="1.8.0" />
-        <PackageReference Include="OpenTelemetry.Api" Version="1.8.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.8.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc8" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc8" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
+        <PackageReference Include="OpenTelemetry" />
+        <PackageReference Include="OpenTelemetry.Api" />
+        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Testing/OpenTelemetry/OtelWebApiWolverineMarten/OtelWebApiWolverineMarten.csproj
+++ b/src/Testing/OpenTelemetry/OtelWebApiWolverineMarten/OtelWebApiWolverineMarten.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
-        <PackageReference Include="OpenTelemetry" Version="1.14.0" />
-        <PackageReference Include="OpenTelemetry.Api" Version="1.14.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-        <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    </ItemGroup>
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+        <PackageReference Include="Swashbuckle.AspNetCore" VersionOverride="10.0.1" />
+        <PackageReference Include="OpenTelemetry" />
+        <PackageReference Include="OpenTelemetry.Api" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+</ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\Http\Wolverine.Http.Marten\Wolverine.Http.Marten.csproj" />

--- a/src/Testing/OpenTelemetry/Subscriber1/Subscriber1.csproj
+++ b/src/Testing/OpenTelemetry/Subscriber1/Subscriber1.csproj
@@ -5,10 +5,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry" Version="1.8.0" />
-        <PackageReference Include="OpenTelemetry.Api" Version="1.8.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc8" />
+        <PackageReference Include="OpenTelemetry" />
+        <PackageReference Include="OpenTelemetry.Api" />
+        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Testing/OpenTelemetry/Subscriber2/Subscriber2.csproj
+++ b/src/Testing/OpenTelemetry/Subscriber2/Subscriber2.csproj
@@ -5,10 +5,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry" Version="1.3.0" />
-        <PackageReference Include="OpenTelemetry.Api" Version="1.3.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc8" />
+        <PackageReference Include="OpenTelemetry" />
+        <PackageReference Include="OpenTelemetry.Api" />
+        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Testing/OpenTelemetry/TracingTests/TracingTests.csproj
+++ b/src/Testing/OpenTelemetry/TracingTests/TracingTests.csproj
@@ -6,15 +6,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="7.4.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="Shouldly" Version="4.0.3" />
-        <PackageReference Include="xunit" Version="2.8.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Alba" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Testing/PolicyTests/PolicyTests.csproj
+++ b/src/Testing/PolicyTests/PolicyTests.csproj
@@ -5,18 +5,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Testing/SlowTests/SlowTests.csproj
+++ b/src/Testing/SlowTests/SlowTests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Testing/Wolverine.ComplianceTests/Wolverine.ComplianceTests.csproj
+++ b/src/Testing/Wolverine.ComplianceTests/Wolverine.ComplianceTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Description>Compliance test harnesses for adding persistence and transport options to Wolverine</Description>
@@ -7,10 +7,10 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\Wolverine\Wolverine.csproj"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
     </ItemGroup>
 
 </Project>

--- a/src/Transports/AWS/WebAppWithSQS/WebAppWithSQS.csproj
+++ b/src/Transports/AWS/WebAppWithSQS/WebAppWithSQS.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
-        <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.5">
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="Microsoft.Extensions.ApiDescription.Server">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/Wolverine.AmazonSns.Tests.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/Wolverine.AmazonSns.Tests.csproj
@@ -1,15 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
+        <PackageReference Include="coverlet.collector" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/AWS/Wolverine.AmazonSns/Wolverine.AmazonSns.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Wolverine.AmazonSns.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <PackageId>WolverineFx.AmazonSns</PackageId>
@@ -10,8 +10,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.2.14" />
-        <PackageReference Include="AWSSDK.SQS" Version="4.0.2.14" />
+        <PackageReference Include="AWSSDK.SimpleNotificationService" />
+        <PackageReference Include="AWSSDK.SQS" />
     </ItemGroup>
 
 </Project>

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
@@ -5,11 +5,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
+        <PackageReference Include="coverlet.collector" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Wolverine.AmazonSqs.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Wolverine.AmazonSqs.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.SQS" Version="4.0.2.14" />
+        <PackageReference Include="AWSSDK.SQS" />
     </ItemGroup>
 </Project>
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Wolverine.AzureServiceBus.Tests.csproj
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Wolverine.AzureServiceBus.Tests.csproj
@@ -5,11 +5,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
+        <PackageReference Include="coverlet.collector" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Wolverine.AzureServiceBus.csproj
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Wolverine.AzureServiceBus.csproj
@@ -10,8 +10,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.17.0" />
-        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="Azure.Messaging.ServiceBus" />
 
     </ItemGroup>
 

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/Wolverine.Pubsub.Tests.csproj
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/Wolverine.Pubsub.Tests.csproj
@@ -5,11 +5,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
+        <PackageReference Include="coverlet.collector" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/GCP/Wolverine.Pubsub/Wolverine.Pubsub.csproj
+++ b/src/Transports/GCP/Wolverine.Pubsub/Wolverine.Pubsub.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Cloud.PubSub.V1" Version="3.24.0" />
+        <PackageReference Include="Google.Cloud.PubSub.V1" />
     </ItemGroup>
 
 </Project>

--- a/src/Transports/Kafka/BatchMessaging/BatchMessaging.csproj
+++ b/src/Transports/Kafka/BatchMessaging/BatchMessaging.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
@@ -6,19 +6,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Alba" Version="8.4.0" />
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="Alba" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>
@@ -32,10 +32,6 @@
         <Compile Include="..\..\..\Servers.cs">
             <Link>Servers.cs</Link>
         </Compile>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-      <PackageReference Include="Alba" Version="8.4.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Transports/Kafka/Wolverine.Kafka/Wolverine.Kafka.csproj
+++ b/src/Transports/Kafka/Wolverine.Kafka/Wolverine.Kafka.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Confluent.Kafka" Version="2.12.0" />
+        <PackageReference Include="Confluent.Kafka" />
     </ItemGroup>
 
 </Project>

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj
@@ -6,19 +6,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/MQTT/Wolverine.MQTT/Wolverine.MQTT.csproj
+++ b/src/Transports/MQTT/Wolverine.MQTT/Wolverine.MQTT.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.3.7.1207" />
+        <PackageReference Include="MQTTnet.Extensions.ManagedClient" />
     </ItemGroup>
 
 </Project>

--- a/src/Transports/NATS/Wolverine.Nats.Tests/Wolverine.Nats.Tests.csproj
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/Wolverine.Nats.Tests.csproj
@@ -6,21 +6,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="FluentAssertions" Version="6.12.2" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Meziantou.Extensions.Logging.Xunit" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/NATS/Wolverine.Nats/Wolverine.Nats.csproj
+++ b/src/Transports/NATS/Wolverine.Nats/Wolverine.Nats.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NATS.Net" Version="2.7.0" />
+        <PackageReference Include="NATS.Net" />
     </ItemGroup>
 
 </Project>

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/Wolverine.Pulsar.Tests.csproj
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/Wolverine.Pulsar.Tests.csproj
@@ -5,11 +5,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
+        <PackageReference Include="coverlet.collector" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/Pulsar/Wolverine.Pulsar/Wolverine.Pulsar.csproj
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/Wolverine.Pulsar.csproj
@@ -13,8 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotPulsar" Version="5.1.2" />
-        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.2" />
+        <PackageReference Include="DotPulsar" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" />
     </ItemGroup>
 
     <Import Project="../../../../Analysis.Build.props" />

--- a/src/Transports/RabbitMQ/ChaosTesting/ChaosTesting.csproj
+++ b/src/Transports/RabbitMQ/ChaosTesting/ChaosTesting.csproj
@@ -5,14 +5,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakingTests.csproj
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakingTests.csproj
@@ -5,14 +5,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Transports/RabbitMQ/RabbitMqBootstrapping/RabbitMqBootstrapping.csproj
+++ b/src/Transports/RabbitMQ/RabbitMqBootstrapping/RabbitMqBootstrapping.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
@@ -1,17 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Wolverine.RabbitMQ.csproj
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Wolverine.RabbitMQ.csproj
@@ -12,9 +12,8 @@
         <ProjectReference Include="..\..\..\Wolverine\Wolverine.csproj"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
-        <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    </ItemGroup>
+        <PackageReference Include="RabbitMQ.Client" />
+</ItemGroup>
 
     <Import Project="../../../../Analysis.Build.props"/>
 </Project>

--- a/src/Transports/Redis/Wolverine.Redis.Tests/Wolverine.Redis.Tests.csproj
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/Wolverine.Redis.Tests.csproj
@@ -6,16 +6,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Transports/Redis/Wolverine.Redis/Wolverine.Redis.csproj
+++ b/src/Transports/Redis/Wolverine.Redis/Wolverine.Redis.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="StackExchange.Redis" Version="2.9.17" />
+        <PackageReference Include="StackExchange.Redis" />
     </ItemGroup>
 
 </Project>

--- a/src/Transports/SignalR/Wolverine.SignalR.Tests/Wolverine.SignalR.Tests.csproj
+++ b/src/Transports/SignalR/Wolverine.SignalR.Tests/Wolverine.SignalR.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -8,16 +8,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.8" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/SignalR/Wolverine.SignalR/Wolverine.SignalR.csproj
+++ b/src/Transports/SignalR/Wolverine.SignalR/Wolverine.SignalR.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Description>SignalR Integration for Wolverine Systems</Description>
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.8" />
-      <PackageReference Include="Microsoft.Azure.SignalR" Version="1.32.0" />
+      <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+      <PackageReference Include="Microsoft.Azure.SignalR" />
     </ItemGroup>
 </Project>

--- a/src/Wolverine/Wolverine.csproj
+++ b/src/Wolverine/Wolverine.csproj
@@ -1,52 +1,27 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Build Robust Event Driven Architectures with Simpler Code</Description>
         <PackageId>WolverineFx</PackageId>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="JasperFx" Version="1.17.2" />
-        <PackageReference Include="JasperFx.Events" Version="1.19.1" />
-        <PackageReference Include="JasperFx.RuntimeCompiler" Version="4.3.2" />
-        <PackageReference Include="NewId" Version="4.0.1" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-        <PackageReference Include="System.ComponentModel" Version="4.3.0" />
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
+        <PackageReference Include="JasperFx" />
+        <PackageReference Include="JasperFx.Events" />
+        <PackageReference Include="JasperFx.RuntimeCompiler" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" />
+        <PackageReference Include="NewId" />
+        <PackageReference Include="Newtonsoft.Json" />
+        <PackageReference Include="System.ComponentModel" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+        <PackageReference Include="System.Net.NameResolution" />
+        <PackageReference Include="System.Threading.Tasks.Dataflow" />
     </ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="[9.0.0,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="[9.0.0,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[9.0.0,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[9.0.0,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[9.0.0,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="[9.0.0,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[9.0.0,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="[9.0.0,10.0.0)" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="[8.0.0,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[8.0.0,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[8.0.2,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[8.0.1,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="[8.0.1,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.1,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="[8.0.0,10.0.0)" />
-	</ItemGroup>
 
     <Import Project="../../Analysis.Build.props" />
 </Project>


### PR DESCRIPTION
## Summary
- Introduces `Directory.Packages.props` with centralized version management for all ~95 NuGet packages across 118 project files
- Strips `Version=` attributes from all `PackageReference` entries in csproj/fsproj files, with versions now governed centrally
- Uses TFM-conditional `<PackageVersion>` groups for packages that require different versions per target framework (Microsoft.Extensions.*, EF Core, Npgsql.EF, AspNetCore.OpenApi)
- Normalizes version drift (37 packages had conflicting versions across projects), upgrading test infra to latest (xunit 2.9.3, Test.Sdk 17.14.1, xunit.runner.visualstudio 2.8.2) and OpenTelemetry to 1.14.0
- Collapses now-redundant TFM-conditional `<ItemGroup>`s in Wolverine.csproj, Wolverine.EntityFrameworkCore.csproj, and several test projects
- Fixes duplicate `FSharp.Core` and `StronglyTypedId` entries in WolverineWebApi.csproj, and a redundant conditional Alba entry in Wolverine.Kafka.Tests.csproj
- Uses `VersionOverride` in 3 projects that legitimately need non-central versions (InMemoryMediator, OtelWebApiWolverineMarten, WolverineWebApi)

## Test plan
- [x] `dotnet build wolverine.sln --framework net9.0` passes with 0 errors
- [ ] CI build across all target frameworks
- [ ] Spot-check a few test suites to confirm runtime behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)