### PR TITLE
Add native dead letter queue support for Kafka transport

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/DeadLetterQueueTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/DeadLetterQueueTests.cs
@@ -1,0 +1,186 @@
+using System.Text;
+using Confluent.Kafka;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+using Wolverine.Kafka.Internals;
+using Wolverine.Tracking;
+using Xunit.Abstractions;
+
+namespace Wolverine.Kafka.Tests;
+
+public class DeadLetterQueueTests : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private IHost _host;
+    private readonly string _topicName;
+    private readonly string _dlqTopicName;
+
+    public DeadLetterQueueTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _topicName = $"dlq-test-{Guid.NewGuid():N}";
+        _dlqTopicName = "wolverine-dead-letter-queue";
+    }
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka("localhost:9092")
+                    .AutoProvision()
+                    .ConfigureConsumers(c => c.AutoOffsetReset = AutoOffsetReset.Earliest);
+
+                opts.ListenToKafkaTopic(_topicName)
+                    .ProcessInline()
+                    .EnableNativeDeadLetterQueue();
+
+                opts.PublishMessage<DlqTestMessage>()
+                    .ToKafkaTopic(_topicName)
+                    .SendInline();
+
+                opts.Policies.OnException<AlwaysFailException>().MoveToErrorQueue();
+
+                opts.Discovery.IncludeAssembly(GetType().Assembly);
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    private ConsumeResult<string, byte[]>? ConsumeDlqMessage(TimeSpan timeout)
+    {
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = "localhost:9092",
+            GroupId = $"dlq-verify-{Guid.NewGuid():N}",
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = true
+        };
+
+        using var consumer = new ConsumerBuilder<string, byte[]>(config).Build();
+        consumer.Subscribe(_dlqTopicName);
+
+        var deadline = DateTime.UtcNow.Add(timeout);
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                var result = consumer.Consume(TimeSpan.FromSeconds(5));
+                if (result != null) return result;
+            }
+            catch (ConsumeException)
+            {
+                // Retry on transient errors
+            }
+        }
+
+        return null;
+    }
+
+    [Fact]
+    public async Task failed_message_moves_to_dead_letter_queue()
+    {
+        var session = await _host.TrackActivity()
+            .IncludeExternalTransports()
+            .DoNotAssertOnExceptionsDetected()
+            .Timeout(30.Seconds())
+            .ExecuteAndWaitAsync(ctx => ctx.PublishAsync(new DlqTestMessage("fail-me")));
+
+        // Verify Wolverine tracked MovedToErrorQueue
+        var movedRecord = session.AllRecordsInOrder()
+            .FirstOrDefault(x => x.MessageEventType == MessageEventType.MovedToErrorQueue);
+        movedRecord.ShouldNotBeNull("Expected message to be moved to error queue");
+
+        // Consume from DLQ topic and verify message arrived
+        var result = ConsumeDlqMessage(30.Seconds());
+        result.ShouldNotBeNull("Expected message on DLQ Kafka topic");
+        result.Message.ShouldNotBeNull();
+        result.Message.Value.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task dead_letter_message_has_exception_headers()
+    {
+        await _host.TrackActivity()
+            .IncludeExternalTransports()
+            .DoNotAssertOnExceptionsDetected()
+            .Timeout(60.Seconds())
+            .WaitForMessageToBeReceivedAt<DlqTestMessage>(_host)
+            .PublishMessageAndWaitAsync(new DlqTestMessage("fail-headers"));
+
+        var result = ConsumeDlqMessage(30.Seconds());
+        result.ShouldNotBeNull("Expected message on DLQ Kafka topic");
+
+        var headers = result.Message.Headers;
+        headers.ShouldNotBeNull();
+
+        GetHeaderValue(headers, "exception-type").ShouldContain("AlwaysFailException");
+        GetHeaderValue(headers, "exception-message").ShouldNotBeNullOrEmpty();
+        GetHeaderValue(headers, "exception-stack").ShouldNotBeNullOrEmpty();
+        GetHeaderValue(headers, "failed-at").ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void native_dlq_disabled_by_default()
+    {
+        var transport = new KafkaTransport();
+        var topic = new KafkaTopic(transport, "test-topic", EndpointRole.Application);
+        topic.NativeDeadLetterQueueEnabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void default_dlq_topic_name()
+    {
+        var transport = new KafkaTransport();
+        transport.DeadLetterQueueTopicName.ShouldBe("wolverine-dead-letter-queue");
+    }
+
+    [Fact]
+    public void custom_dlq_topic_name()
+    {
+        var transport = new KafkaTransport();
+        transport.DeadLetterQueueTopicName = "my-custom-dlq";
+        transport.DeadLetterQueueTopicName.ShouldBe("my-custom-dlq");
+    }
+
+    private static string GetHeaderValue(Headers headers, string key)
+    {
+        if (headers.TryGetLastBytes(key, out var bytes))
+        {
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        return string.Empty;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_host != null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+    }
+}
+
+public record DlqTestMessage(string Id);
+
+public class AlwaysFailException : Exception
+{
+    public AlwaysFailException(string message) : base(message)
+    {
+    }
+}
+
+public static class DlqTestMessageHandler
+{
+    public static void Handle(DlqTestMessage message)
+    {
+        throw new AlwaysFailException($"Intentional failure for DLQ testing: {message.Id}");
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/dlq_compliance.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/dlq_compliance.cs
@@ -1,0 +1,53 @@
+using Confluent.Kafka;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Wolverine.ComplianceTests.Compliance;
+
+namespace Wolverine.Kafka.Tests;
+
+public class BufferedComplianceWithDlqFixture : TransportComplianceFixture, IAsyncLifetime
+{
+    public BufferedComplianceWithDlqFixture() : base(new Uri("kafka://topic/receiver"), 120)
+    {
+    }
+
+    public async Task InitializeAsync()
+    {
+        var receiverTopic = "buffered.dlq.receiver";
+        var senderTopic = "buffered.dlq.sender";
+
+        OutboundAddress = new Uri("kafka://topic/" + receiverTopic);
+
+        await ReceiverIs(opts =>
+        {
+            opts.UseKafka("localhost:9092").AutoProvision();
+
+            opts.ListenToKafkaTopic(receiverTopic)
+                .Named("receiver")
+                .BufferedInMemory()
+                .EnableNativeDeadLetterQueue();
+
+            opts.Services.AddResourceSetupOnStartup();
+        });
+
+        await SenderIs(opts =>
+        {
+            opts.UseKafka("localhost:9092")
+                .AutoProvision()
+                .ConfigureConsumers(x => x.EnableAutoCommit = false);
+
+            opts.ListenToKafkaTopic(senderTopic);
+
+            opts.PublishAllMessages().ToKafkaTopic(receiverTopic).BufferedInMemory();
+
+            opts.Services.AddResourceSetupOnStartup();
+        });
+    }
+
+    public new Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+}
+
+public class BufferedSendingAndReceivingWithDlqCompliance : TransportCompliance<BufferedComplianceWithDlqFixture>;

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Confluent.Kafka;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
@@ -7,19 +8,23 @@ using Wolverine.Util;
 
 namespace Wolverine.Kafka.Internals;
 
-public class KafkaListener : IListener, IDisposable
+public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
 {
+    private readonly KafkaTopic _endpoint;
     private readonly IConsumer<string, byte[]> _consumer;
     private CancellationTokenSource _cancellation = new();
     private readonly Task _runner;
     private readonly IReceiver _receiver;
     private readonly string? _messageTypeName;
     private readonly QualityOfService _qualityOfService;
+    private readonly ILogger _logger;
 
     public KafkaListener(KafkaTopic topic, ConsumerConfig config,
         IConsumer<string, byte[]> consumer, IReceiver receiver,
         ILogger<KafkaListener> logger)
     {
+        _endpoint = topic;
+        _logger = logger;
         Address = topic.Uri;
         _consumer = consumer;
         var mapper = topic.EnvelopeMapper;
@@ -135,6 +140,51 @@ public class KafkaListener : IListener, IDisposable
     {
         _cancellation.Cancel();
         await _runner;
+    }
+
+    public bool NativeDeadLetterQueueEnabled => _endpoint.NativeDeadLetterQueueEnabled;
+
+    public async Task MoveToErrorsAsync(Envelope envelope, Exception exception)
+    {
+        var transport = _endpoint.Parent;
+        var dlqTopicName = transport.DeadLetterQueueTopicName;
+
+        try
+        {
+            var message = await _endpoint.EnvelopeMapper!.CreateMessage(envelope);
+
+            message.Headers ??= new Headers();
+            message.Headers.Add("exception-type", Encoding.UTF8.GetBytes(exception.GetType().FullName ?? "Unknown"));
+            message.Headers.Add("exception-message", Encoding.UTF8.GetBytes(exception.Message));
+            message.Headers.Add("exception-stack", Encoding.UTF8.GetBytes(exception.StackTrace ?? ""));
+            message.Headers.Add("failed-at", Encoding.UTF8.GetBytes(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()));
+
+            using var producer = transport.CreateProducer(_endpoint.GetEffectiveProducerConfig());
+            await producer.ProduceAsync(dlqTopicName, message);
+            producer.Flush();
+
+            _logger.LogInformation(
+                "Moved envelope {EnvelopeId} to dead letter queue topic {DlqTopic}. Exception: {ExceptionType}: {ExceptionMessage}",
+                envelope.Id, dlqTopicName, exception.GetType().Name, exception.Message);
+
+            try
+            {
+                _consumer.Commit();
+            }
+            catch (Exception commitEx)
+            {
+                _logger.LogWarning(commitEx,
+                    "Error committing offset after moving envelope {EnvelopeId} to dead letter queue",
+                    envelope.Id);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to move envelope {EnvelopeId} to dead letter queue topic {DlqTopic}",
+                envelope.Id, dlqTopicName);
+            throw;
+        }
     }
 
     public void Dispose()

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -37,6 +37,12 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
         Topics = new Cache<string, KafkaTopic>(topicName => new KafkaTopic(this, topicName, EndpointRole.Application));
     }
 
+    /// <summary>
+    /// The Kafka topic name used for native dead letter queue messages.
+    /// Default is "wolverine-dead-letter-queue".
+    /// </summary>
+    public string DeadLetterQueueTopicName { get; set; } = "wolverine-dead-letter-queue";
+
     public KafkaUsage Usage { get; set; } = KafkaUsage.ProduceAndConsume;
 
     public override Uri ResourceUri
@@ -80,7 +86,19 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
 
     public override ValueTask ConnectAsync(IWolverineRuntime runtime)
     {
-        foreach (var endpoint in Topics) endpoint.Compile(runtime);
+        var needsDlqTopic = false;
+        foreach (var endpoint in Topics)
+        {
+            endpoint.Compile(runtime);
+            if (endpoint.NativeDeadLetterQueueEnabled) needsDlqTopic = true;
+        }
+
+        // Ensure the DLQ topic is registered and compiled so it gets auto-provisioned
+        if (needsDlqTopic)
+        {
+            var dlqTopic = Topics[DeadLetterQueueTopicName];
+            dlqTopic.Compile(runtime);
+        }
 
         return ValueTask.CompletedTask;
     }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -80,6 +80,31 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
     }
     
     /// <summary>
+    /// Enable native dead letter queue support for this Kafka listener.
+    /// Failed messages will be produced to the DLQ Kafka topic
+    /// (default: "wolverine-dead-letter-queue") with exception details
+    /// in Kafka headers.
+    /// </summary>
+    /// <returns></returns>
+    public KafkaListenerConfiguration EnableNativeDeadLetterQueue()
+    {
+        add(topic => topic.NativeDeadLetterQueueEnabled = true);
+        return this;
+    }
+
+    /// <summary>
+    /// Disable native dead letter queue support for this Kafka listener.
+    /// Failed messages will use Wolverine's default dead letter handling
+    /// (database persistence).
+    /// </summary>
+    /// <returns></returns>
+    public KafkaListenerConfiguration DisableNativeDeadLetterQueue()
+    {
+        add(topic => topic.NativeDeadLetterQueueEnabled = false);
+        return this;
+    }
+
+    /// <summary>
     /// Configure the consumer config for only this topic. This overrides the default
     /// settings at the transport level. This is not combinatorial with the parent configuration
     /// and overwrites all ConsumerConfig from the parent

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -50,6 +50,14 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     /// </summary>
     public ProducerConfig? ProducerConfig { get; internal set; }
 
+    /// <summary>
+    /// Enable native dead letter queue support for this endpoint.
+    /// When enabled, failed messages will be produced to the Kafka DLQ topic
+    /// instead of being moved to database-backed dead letter storage.
+    /// Default is false (opt-in).
+    /// </summary>
+    public bool NativeDeadLetterQueueEnabled { get; set; }
+
     public static string TopicNameForUri(Uri uri)
     {
         return uri.Segments.Last().Trim('/');
@@ -99,6 +107,20 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
             ? new InlineKafkaSender(this)
             : new BatchedSender(this, new KafkaSenderProtocol(this), runtime.Cancellation,
                 runtime.LoggerFactory.CreateLogger<KafkaSenderProtocol>());
+    }
+
+    public override bool TryBuildDeadLetterSender(IWolverineRuntime runtime, out ISender? deadLetterSender)
+    {
+        if (NativeDeadLetterQueueEnabled)
+        {
+            var dlqTopic = Parent.Topics[Parent.DeadLetterQueueTopicName];
+            dlqTopic.EnvelopeMapper ??= dlqTopic.BuildMapper(runtime);
+            deadLetterSender = new InlineKafkaSender(dlqTopic);
+            return true;
+        }
+
+        deadLetterSender = default;
+        return false;
     }
 
     public async ValueTask<bool> CheckAsync()

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
@@ -106,6 +106,18 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
         return this;
     }
 
+    /// <summary>
+    /// Configure the Kafka topic name used for native dead letter queue messages.
+    /// Default is "wolverine-dead-letter-queue".
+    /// </summary>
+    /// <param name="topicName">The Kafka topic name for the dead letter queue</param>
+    /// <returns></returns>
+    public KafkaTransportExpression DeadLetterQueueTopicName(string topicName)
+    {
+        _transport.DeadLetterQueueTopicName = topicName;
+        return this;
+    }
+
     protected override KafkaListenerConfiguration createListenerExpression(KafkaTopic listenerEndpoint)
     {
         return new KafkaListenerConfiguration(listenerEndpoint);


### PR DESCRIPTION
## Summary

Closes #1903

- Adds opt-in native dead letter queue (DLQ) support for the Kafka transport, routing failed messages to a configurable Kafka topic (default: `wolverine-dead-letter-queue`) with exception metadata headers (`exception-type`, `exception-message`, `exception-stack`, `failed-at`)
- Follows the existing Redis DLQ pattern: `KafkaListener` implements `ISupportDeadLetterQueue`, `KafkaTopic` overrides `TryBuildDeadLetterSender()`, fluent API via `EnableNativeDeadLetterQueue()` on listener config and `DeadLetterQueueTopicName()` on transport config
- Includes integration tests, compliance test suite, and documentation

## Test plan

- [x] 5 DLQ integration tests pass (message routing, exception headers, default disabled, default/custom topic names)
- [x] 18 DLQ compliance tests pass (`TransportCompliance<BufferedComplianceWithDlqFixture>`)
- [x] 18 existing buffered compliance tests pass (no regressions)
- [x] 18 existing inline compliance tests pass (no regressions)
- [x] All other Kafka test fixtures pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)