### PR TITLE
Centralize DLQ constants into DeadLetterQueueConstants

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
@@ -11,7 +11,7 @@ namespace Wolverine.AmazonSqs.Internal;
 
 public class AmazonSqsTransport : BrokerTransport<AmazonSqsQueue>
 {
-    public const string DeadLetterQueueName = "wolverine-dead-letter-queue";
+    public const string DeadLetterQueueName = DeadLetterQueueConstants.DefaultQueueName;
 
     public const char Separator = '-';
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
@@ -22,7 +22,7 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
 
     public readonly List<AzureServiceBusSubscription> Subscriptions = new();
     private string _hostName;
-    public const string DeadLetterQueueName = "wolverine-dead-letter-queue";
+    public const string DeadLetterQueueName = DeadLetterQueueConstants.DefaultQueueName;
 
     public AzureServiceBusTransport() : this(ProtocolName)
     {

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -154,10 +154,10 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
             var message = await _endpoint.EnvelopeMapper!.CreateMessage(envelope);
 
             message.Headers ??= new Headers();
-            message.Headers.Add("exception-type", Encoding.UTF8.GetBytes(exception.GetType().FullName ?? "Unknown"));
-            message.Headers.Add("exception-message", Encoding.UTF8.GetBytes(exception.Message));
-            message.Headers.Add("exception-stack", Encoding.UTF8.GetBytes(exception.StackTrace ?? ""));
-            message.Headers.Add("failed-at", Encoding.UTF8.GetBytes(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()));
+            message.Headers.Add(DeadLetterQueueConstants.ExceptionTypeHeader, Encoding.UTF8.GetBytes(exception.GetType().FullName ?? "Unknown"));
+            message.Headers.Add(DeadLetterQueueConstants.ExceptionMessageHeader, Encoding.UTF8.GetBytes(exception.Message));
+            message.Headers.Add(DeadLetterQueueConstants.ExceptionStackHeader, Encoding.UTF8.GetBytes(exception.StackTrace ?? ""));
+            message.Headers.Add(DeadLetterQueueConstants.FailedAtHeader, Encoding.UTF8.GetBytes(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()));
 
             using var producer = transport.CreateProducer(_endpoint.GetEffectiveProducerConfig());
             await producer.ProduceAsync(dlqTopicName, message);

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -41,7 +41,7 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
     /// The Kafka topic name used for native dead letter queue messages.
     /// Default is "wolverine-dead-letter-queue".
     /// </summary>
-    public string DeadLetterQueueTopicName { get; set; } = "wolverine-dead-letter-queue";
+    public string DeadLetterQueueTopicName { get; set; } = DeadLetterQueueConstants.DefaultQueueName;
 
     public KafkaUsage Usage { get; set; } = KafkaUsage.ProduceAndConsume;
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
@@ -16,7 +16,7 @@ public partial class RabbitMqTransport : BrokerTransport<RabbitMqEndpoint>, IAsy
 {
     public const string ProtocolName = "rabbitmq";
     public const string ResponseEndpointName = "RabbitMqResponses";
-    public const string DeadLetterQueueName = "wolverine-dead-letter-queue";
+    public const string DeadLetterQueueName = DeadLetterQueueConstants.DefaultQueueName;
     public const string DeadLetterQueueHeader = "x-dead-letter-exchange";
     public const string QueueTypeHeader = "x-queue-type";
 

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
@@ -66,10 +66,10 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue
             var fields = new List<NameValueEntry>
             {
                 new("envelope", serializedEnvelope),
-                new("exception-type", exception.GetType().FullName ?? "Unknown"),
-                new("exception-message", exception.Message ?? ""),
-                new("exception-stack", exception.StackTrace ?? ""),
-                new("failed-at", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()),
+                new(DeadLetterQueueConstants.ExceptionTypeHeader, exception.GetType().FullName ?? "Unknown"),
+                new(DeadLetterQueueConstants.ExceptionMessageHeader, exception.Message ?? ""),
+                new(DeadLetterQueueConstants.ExceptionStackHeader, exception.StackTrace ?? ""),
+                new(DeadLetterQueueConstants.FailedAtHeader, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()),
                 new("message-type", envelope.MessageType ?? "Unknown"),
                 new("envelope-id", envelope.Id.ToString()),
                 new("attempts", envelope.Attempts.ToString())

--- a/src/Wolverine/Transports/DeadLetterQueueConstants.cs
+++ b/src/Wolverine/Transports/DeadLetterQueueConstants.cs
@@ -1,0 +1,29 @@
+namespace Wolverine.Transports;
+
+public static class DeadLetterQueueConstants
+{
+    /// <summary>
+    /// The default queue/topic name used for dead letter queues across all transports.
+    /// </summary>
+    public const string DefaultQueueName = "wolverine-dead-letter-queue";
+
+    /// <summary>
+    /// Header key for the full type name of the exception that caused the message to fail.
+    /// </summary>
+    public const string ExceptionTypeHeader = "exception-type";
+
+    /// <summary>
+    /// Header key for the exception message.
+    /// </summary>
+    public const string ExceptionMessageHeader = "exception-message";
+
+    /// <summary>
+    /// Header key for the exception stack trace.
+    /// </summary>
+    public const string ExceptionStackHeader = "exception-stack";
+
+    /// <summary>
+    /// Header key for the Unix timestamp in milliseconds when the failure occurred.
+    /// </summary>
+    public const string FailedAtHeader = "failed-at";
+}


### PR DESCRIPTION
## Summary
- Add `DeadLetterQueueConstants` class in `Wolverine.Transports` with the shared default DLQ name (`wolverine-dead-letter-queue`) and exception header keys (`exception-type`, `exception-message`, `exception-stack`, `failed-at`)
- Update AWS SQS, Azure Service Bus, RabbitMQ, and Kafka transports to derive their DLQ name constants from the central source
- Update Kafka and Redis listeners to use header constants instead of repeated string literals

## Test plan
- [x] All transport projects compile with 0 errors
- [ ] Verify existing transport test suites still pass (no behavioral change — values are identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)