### PR TITLE
Add podman support for DockerUp build step.

### DIFF
--- a/build/build.cs
+++ b/build/build.cs
@@ -362,8 +362,19 @@ class Build : NukeBuild
     Target DockerUp => _ => _
         .Executes(() =>
         {
+            bool IsToolAvailable(string toolName)
+            {
+                try
+                { ToolPathResolver.GetPathExecutable(toolName);
+                  return true; }
+                catch (ArgumentException)
+                { return false; }
+            }
+
+            string toolName = new List<string> { "docker", "podman" }
+                                  .FirstOrDefault(IsToolAvailable) ?? "docker";
             ProcessTasks
-                .StartProcess("docker", "compose up -d", logOutput: false)
+                .StartProcess(toolName, "compose up -d", logOutput: false)
                 .AssertWaitForExit()
                 .AssertZeroExitCode();
             WaitForDatabaseToBeReady();


### PR DESCRIPTION
  - Previously, you weren't able to complete the DockerUp step with podman.
  - Aliases were not the solution because the StartProcess method looks for something like "absolute_path/docker.exe."
  - The GetPathExecutable method was used to define if either the docker or podman executable exists, so it supports both Windows and Linux.
  - If no tool is found, it falls back to the Docker toolName so it behaves like before and logs an error about missing Docker and not podman.