### PR TITLE
Add [NonTransactional] attribute to opt out of auto-applied transactions

### DIFF
--- a/docs/guide/durability/efcore/transactional-middleware.md
+++ b/docs/guide/durability/efcore/transactional-middleware.md
@@ -71,6 +71,28 @@ public static ItemCreated Handle(
 When using the transactional middleware around a message handler, the `DbContext` is used to persist
 the outgoing messages as part of Wolverine's outbox support.
 
+### Opting Out with [NonTransactional]
+
+When using `AutoApplyTransactions()`, you can opt specific handlers or HTTP endpoints out of
+transactional middleware by decorating them with the `[NonTransactional]` attribute:
+
+```cs
+using Wolverine.Attributes;
+
+public static class MyHandler
+{
+    // This handler will NOT have transactional middleware applied
+    // even when AutoApplyTransactions() is enabled
+    [NonTransactional]
+    public static void Handle(MyCommand command, MyDbContext db)
+    {
+        // You're managing the DbContext yourself here
+    }
+}
+```
+
+The `[NonTransactional]` attribute can be placed on individual handler methods or on the handler class to opt out all methods in that class.
+
 ## Eager vs Lightweight Transactions <Badge type="tip" text="5.15" />
 
 By default, the EF Core middleware will run in `Eager` mode meaning that Wolverine

--- a/docs/guide/durability/marten/transactional-middleware.md
+++ b/docs/guide/durability/marten/transactional-middleware.md
@@ -33,6 +33,66 @@ With this enabled, Wolverine will automatically use the Marten
 transactional middleware for handlers that have a dependency on `IDocumentSession` (meaning the method takes in `IDocumentSession` or has
 some dependency that itself depends on `IDocumentSession`) as long as the `IntegrateWithWolverine()` call was used in application bootstrapping.
 
+### Opting Out with [NonTransactional]
+
+When using `AutoApplyTransactions()`, there may be specific handlers or HTTP endpoints where you want to explicitly opt out of
+transactional middleware even though they use `IDocumentSession`. You can do this with the `[NonTransactional]` attribute:
+
+```cs
+using Wolverine.Attributes;
+
+public static class MySpecialHandler
+{
+    // This handler will NOT have transactional middleware applied
+    // even when AutoApplyTransactions() is enabled
+    [NonTransactional]
+    public static void Handle(MyCommand command, IDocumentSession session)
+    {
+        // You're managing the session yourself here
+    }
+}
+```
+
+The `[NonTransactional]` attribute can be placed on individual handler methods or on the handler class itself to opt out all methods:
+
+```cs
+using Wolverine.Attributes;
+
+// No methods in this handler class will have
+// transactional middleware applied
+[NonTransactional]
+public static class NonTransactionalHandlers
+{
+    public static void Handle(CommandA command, IDocumentSession session)
+    {
+        // ...
+    }
+
+    public static void Handle(CommandB command, IDocumentSession session)
+    {
+        // ...
+    }
+}
+```
+
+This also works for Wolverine HTTP endpoints:
+
+```cs
+using Wolverine.Attributes;
+using Wolverine.Http;
+
+public static class MyEndpoints
+{
+    // This endpoint will NOT use transactional middleware
+    [NonTransactional]
+    [WolverinePost("/my-non-transactional-endpoint")]
+    public static string Post(IDocumentSession session)
+    {
+        return "not transactional";
+    }
+}
+```
+
 In the previous section we saw an example of incorporating Wolverine's outbox with Marten transactions. We also wrote a fair amount of code to do so that could easily feel
 repetitive over time. Using Wolverine's transactional middleware support for Marten, the long hand handler above can become this equivalent:
 

--- a/src/Http/Wolverine.Http.Tests/non_transactional_attribute_http_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/non_transactional_attribute_http_tests.cs
@@ -1,0 +1,27 @@
+using Shouldly;
+
+namespace Wolverine.Http.Tests;
+
+public class non_transactional_attribute_http_tests : IntegrationContext
+{
+    public non_transactional_attribute_http_tests(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public void endpoint_with_non_transactional_attribute_should_not_be_transactional()
+    {
+        var chain = HttpChains.ChainFor("POST", "/non-transactional");
+        chain.ShouldNotBeNull();
+        chain.IsTransactional.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void endpoint_without_non_transactional_should_still_be_transactional()
+    {
+        // The /middleware-messages/{name} endpoint uses [Transactional] explicitly
+        var chain = HttpChains.ChainFor("POST", "/middleware-messages/{name}");
+        chain.ShouldNotBeNull();
+        chain.IsTransactional.ShouldBeTrue();
+    }
+}

--- a/src/Http/WolverineWebApi/NonTransactionalEndpoint.cs
+++ b/src/Http/WolverineWebApi/NonTransactionalEndpoint.cs
@@ -1,0 +1,15 @@
+using Marten;
+using Wolverine.Attributes;
+using Wolverine.Http;
+
+namespace WolverineWebApi;
+
+public static class NonTransactionalEndpoint
+{
+    [NonTransactional]
+    [WolverinePost("/non-transactional")]
+    public static string Post(IDocumentSession session)
+    {
+        return "not transactional";
+    }
+}

--- a/src/Persistence/MartenTests/non_transactional_attribute_opt_out.cs
+++ b/src/Persistence/MartenTests/non_transactional_attribute_opt_out.cs
@@ -1,0 +1,108 @@
+using IntegrationTests;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Marten;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+
+namespace MartenTests;
+
+public class non_transactional_attribute_opt_out : PostgresqlContext
+{
+    [Fact]
+    public async Task handler_with_non_transactional_attribute_should_not_be_transactional()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(Servers.PostgresConnectionString)
+                    .IntegrateWithWolverine();
+
+                opts.Policies.AutoApplyTransactions();
+            }).StartAsync();
+
+        var runtime = host.GetRuntime();
+
+        // A handler that uses IDocumentSession but is decorated with [NonTransactional]
+        // should NOT have transactional middleware applied
+        runtime.Handlers.ChainFor<NonTransactionalCommand>()
+            .IsTransactional.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task handler_without_non_transactional_attribute_should_still_be_transactional()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(Servers.PostgresConnectionString)
+                    .IntegrateWithWolverine();
+
+                opts.Policies.AutoApplyTransactions();
+            }).StartAsync();
+
+        var runtime = host.GetRuntime();
+
+        // A normal handler that uses IDocumentSession should still get
+        // transactional middleware from AutoApplyTransactions
+        runtime.Handlers.ChainFor<TransactionalCommand>()
+            .IsTransactional.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task non_transactional_attribute_on_handler_class_should_opt_out()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(Servers.PostgresConnectionString)
+                    .IntegrateWithWolverine();
+
+                opts.Policies.AutoApplyTransactions();
+            }).StartAsync();
+
+        var runtime = host.GetRuntime();
+
+        // [NonTransactional] on the handler class should also opt out
+        runtime.Handlers.ChainFor<NonTransactionalClassCommand>()
+            .IsTransactional.ShouldBeFalse();
+    }
+}
+
+public record NonTransactionalCommand(Guid Id);
+public record TransactionalCommand(Guid Id);
+public record NonTransactionalClassCommand(Guid Id);
+
+public static class NonTransactionalCommandHandler
+{
+    [NonTransactional]
+    public static void Handle(NonTransactionalCommand command, IDocumentSession session)
+    {
+        session.Store(new NonTransactionalDoc { Id = command.Id });
+    }
+}
+
+public static class TransactionalCommandHandler
+{
+    public static void Handle(TransactionalCommand command, IDocumentSession session)
+    {
+        session.Store(new NonTransactionalDoc { Id = command.Id });
+    }
+}
+
+[NonTransactional]
+public static class NonTransactionalClassCommandHandler
+{
+    public static void Handle(NonTransactionalClassCommand command, IDocumentSession session)
+    {
+        session.Store(new NonTransactionalDoc { Id = command.Id });
+    }
+}
+
+public class NonTransactionalDoc
+{
+    public Guid Id { get; set; }
+}

--- a/src/Wolverine/Attributes/NonTransactionalAttribute.cs
+++ b/src/Wolverine/Attributes/NonTransactionalAttribute.cs
@@ -1,0 +1,8 @@
+namespace Wolverine.Attributes;
+
+/// <summary>
+///     Explicitly opts out a handler or HTTP endpoint from having transactional
+///     middleware applied automatically by <c>AutoApplyTransactions()</c>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class NonTransactionalAttribute : Attribute;

--- a/src/Wolverine/Persistence/AutoApplyTransactions.cs
+++ b/src/Wolverine/Persistence/AutoApplyTransactions.cs
@@ -16,7 +16,7 @@ internal class AutoApplyTransactions : IChainPolicy
             return;
         }
 
-        foreach (var chain in chains.Where(x => !x.HasAttribute<TransactionalAttribute>()))
+        foreach (var chain in chains.Where(x => !x.HasAttribute<TransactionalAttribute>() && !x.HasAttribute<NonTransactionalAttribute>()))
         {
             if (Idempotency.HasValue)
             {


### PR DESCRIPTION
## Summary
- Adds a new `[NonTransactional]` attribute that allows handlers and HTTP endpoints to explicitly opt out of transactional middleware when using `AutoApplyTransactions()`
- The attribute can be placed on individual handler methods or on the handler class itself
- Works for both message handlers and Wolverine HTTP endpoints

Closes #2180

## Test plan
- [x] MartenTests: `[NonTransactional]` on handler method prevents transactional middleware
- [x] MartenTests: `[NonTransactional]` on handler class prevents transactional middleware
- [x] MartenTests: Normal handlers still get transactional middleware with `AutoApplyTransactions()`
- [x] Wolverine.Http.Tests: `[NonTransactional]` on HTTP endpoint prevents transactional middleware
- [x] Wolverine.Http.Tests: Full test suite passes (474 passed, 10 skipped, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)