### PR TITLE
Fix CodegenPreviewCommand TypeLoadException from Npgsql version mismatch

### DIFF
--- a/src/Http/WolverineWebApi/WolverineWebApi.csproj
+++ b/src/Http/WolverineWebApi/WolverineWebApi.csproj
@@ -24,7 +24,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" VersionOverride="8.0.11" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Remove `VersionOverride="8.0.11"` for `Npgsql.EntityFrameworkCore.PostgreSQL` in `WolverineWebApi.csproj`
- The override forced the 8.x provider on a net9.0 project using EF Core 9.0.5, causing `TypeLoadException` for `get_LockReleaseBehavior` (added in EF Core 9.0)
- Without the override, the project picks up the correct 9.0.0 version from `Directory.Packages.props`

Closes #2185

## Test plan
- [x] WolverineWebApi builds successfully with net9.0
- [x] All Wolverine.Http.Tests pass (479 passed, 10 skipped, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)