### PR TITLE
Avoid running a query when there's nothing to do

### DIFF
--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Incoming.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Incoming.cs
@@ -16,6 +16,9 @@ public abstract partial class MessageDatabase<T>
 
     public Task ReassignIncomingAsync(int ownerId, IReadOnlyList<Envelope> incoming)
     {
+        if (incoming.Count == 0)
+            return Task.CompletedTask;
+
         var builder = ToCommandBuilder();
         foreach (var envelope in incoming)
         {


### PR DESCRIPTION
Was debugging a different problem we've been experiencing and caught an exception when it attempted to reassign incoming envelopes. It got called with 0 envelopes, built an empty SQL command and that threw an exception.

Haven't noticed any issues or logs related to this, so guessing it gets caught and handled somewhere, but feels unnecessary to open a connection when we know it won't work ahead of time.