### PR TITLE
Fix typo in codegen log output

### DIFF
--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -91,7 +91,7 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
         var logger = Container.GetInstance<ILogger<HttpGraph>>();
 
         var calls = source.FindActions();
-        logger.LogInformation("Found {Count} Wolverine HTTP endpoints in assemblys {Assemblies}", calls.Length,
+        logger.LogInformation("Found {Count} Wolverine HTTP endpoints in assemblies {Assemblies}", calls.Length,
             _options.Assemblies.Select(x => x.GetName().Name).Join(", "));
         if (calls.Length == 0)
         {


### PR DESCRIPTION
Just this typo fixed. 

<img width="1151" height="293" alt="image" src="https://github.com/user-attachments/assets/165bc75f-6c0a-4937-b3a2-a8e83e038e8d" />

