### PR TITLE
Fix endpoints with multiple [Document] args (GH-2205)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Bugs/Bug_2205_multiple_document_args.cs
+++ b/src/Http/Wolverine.Http.Tests/Bugs/Bug_2205_multiple_document_args.cs
@@ -1,0 +1,86 @@
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using WolverineWebApi.Bugs;
+using WolverineWebApi.Marten;
+
+namespace Wolverine.Http.Tests.Bugs;
+
+public class Bug_2205_multiple_document_args(AppFixture fixture) : IntegrationContext(fixture)
+{
+    [Fact]
+    public async Task multiple_documents_should_return_both()
+    {
+        var invoiceId = Guid.NewGuid();
+        var receiptId = Guid.NewGuid();
+
+        await using var session = Store.LightweightSession();
+        session.Store(new Invoice { Id = invoiceId });
+        session.Store(new Receipt { Id = receiptId });
+        await session.SaveChangesAsync();
+
+        var result = await Scenario(x =>
+        {
+            x.Get.Url($"/bug2205/documents/{invoiceId}/{receiptId}");
+            x.StatusCodeShouldBe(200);
+        });
+
+        var text = await result.ReadAsTextAsync();
+        text.ShouldContain(invoiceId.ToString());
+        text.ShouldContain(receiptId.ToString());
+    }
+
+    [Fact]
+    public async Task multiple_documents_returns_404_when_first_missing()
+    {
+        var receiptId = Guid.NewGuid();
+
+        await using var session = Store.LightweightSession();
+        session.Store(new Receipt { Id = receiptId });
+        await session.SaveChangesAsync();
+
+        await Scenario(x =>
+        {
+            x.Get.Url($"/bug2205/documents/{Guid.NewGuid()}/{receiptId}");
+            x.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Fact]
+    public async Task multiple_documents_returns_404_when_second_missing()
+    {
+        var invoiceId = Guid.NewGuid();
+
+        await using var session = Store.LightweightSession();
+        session.Store(new Invoice { Id = invoiceId });
+        await session.SaveChangesAsync();
+
+        await Scenario(x =>
+        {
+            x.Get.Url($"/bug2205/documents/{invoiceId}/{Guid.NewGuid()}");
+            x.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Fact]
+    public async Task document_and_aggregate_should_return_both()
+    {
+        var invoiceId = Guid.NewGuid();
+        var orderId = Guid.NewGuid();
+
+        await using var session = Store.LightweightSession();
+        session.Store(new Invoice { Id = invoiceId });
+        session.Events.StartStream<Order>(orderId, new OrderCreated([new Item { Name = "Widget" }]));
+        await session.SaveChangesAsync();
+
+        var result = await Scenario(x =>
+        {
+            x.Get.Url($"/bug2205/document-and-aggregate/{invoiceId}/{orderId}");
+            x.StatusCodeShouldBe(200);
+        });
+
+        var text = await result.ReadAsTextAsync();
+        text.ShouldContain(invoiceId.ToString());
+        text.ShouldContain(orderId.ToString());
+    }
+}

--- a/src/Http/WolverineWebApi/Bugs/Bug2205_MultipleDocumentEndpoint.cs
+++ b/src/Http/WolverineWebApi/Bugs/Bug2205_MultipleDocumentEndpoint.cs
@@ -1,0 +1,34 @@
+using Wolverine.Http;
+using Wolverine.Http.Marten;
+using WolverineWebApi.Marten;
+
+namespace WolverineWebApi.Bugs;
+
+// GH-2205: Endpoints with multiple [Document] or [Aggregate] args
+// should generate valid code with all route values extracted before
+// the batch query
+
+public class Receipt
+{
+    public Guid Id { get; set; }
+    public decimal Amount { get; set; }
+}
+
+public static class Bug2205_MultipleDocumentEndpoint
+{
+    [WolverineGet("/bug2205/documents/{invoiceId}/{receiptId}")]
+    public static string GetWithMultipleDocuments(
+        [Document("invoiceId")] Invoice invoice,
+        [Document("receiptId")] Receipt receipt)
+    {
+        return $"{invoice.Id}-{receipt.Id}";
+    }
+
+    [WolverineGet("/bug2205/document-and-aggregate/{invoiceId}/{orderId}")]
+    public static string GetWithDocumentAndAggregate(
+        [Document("invoiceId")] Invoice invoice,
+        [Aggregate("orderId")] Order order)
+    {
+        return $"{invoice.Id}-{order.Id}";
+    }
+}

--- a/src/Persistence/Wolverine.Marten/Persistence/Sagas/LoadDocumentFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Persistence/Sagas/LoadDocumentFrame.cs
@@ -66,6 +66,8 @@ internal class LoadDocumentFrame : AsyncFrame, IBatchableFrame
 
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
+        yield return _sagaId;
+
         _session = chain.FindVariable(typeof(IDocumentSession));
         yield return _session;
 


### PR DESCRIPTION
## Summary
- `LoadDocumentFrame.FindVariables()` was not yielding `_sagaId`, so `MartenBatchFrame` didn't propagate the route value dependency. This caused batch query code to be emitted before route values were extracted for the 2nd+ `[Document]` parameters, producing invalid generated code.
- Added `yield return _sagaId;` to match the pattern already used by `LoadAggregateFrame`
- Added integration tests covering multiple `[Document]` params and mixed `[Document]` + `[Aggregate]` params, including 404 cases

## Test plan
- [x] 4 new integration tests pass (multiple documents, document+aggregate, 404 for missing docs)
- [x] Full Wolverine.Http.Tests suite: 497 passed, 1 failed (pre-existing Bug_2182), 10 skipped — no regressions

Closes #2205

🤖 Generated with [Claude Code](https://claude.com/claude-code)