### PR TITLE
Fix EntityAttribute codegen for value type identities (GH-2207)

### DIFF
--- a/src/Wolverine/Persistence/ThrowRequiredDataMissingExceptionFrame.cs
+++ b/src/Wolverine/Persistence/ThrowRequiredDataMissingExceptionFrame.cs
@@ -32,7 +32,11 @@ internal class ThrowRequiredDataMissingExceptionFrame : SyncFrame
         }
         else if (Message.Contains("{Id}"))
         {
-            writer.Write($"throw new {typeof(RequiredDataMissingException).FullNameInCode()}(\"{Message}\".Replace(\"{{Id}}\", {Identity.Usage}?.ToString() ?? \"\"));");
+            var toStringExpression = Identity.VariableType.IsValueType
+                ? $"{Identity.Usage}.ToString()"
+                : $"{Identity.Usage}?.ToString() ?? \"\"";
+
+            writer.Write($"throw new {typeof(RequiredDataMissingException).FullNameInCode()}(\"{Message}\".Replace(\"{{Id}}\", {toStringExpression}));");
         }
         else
         {


### PR DESCRIPTION
## Summary
- `ThrowRequiredDataMissingExceptionFrame` unconditionally generated `identity?.ToString()` with the null-conditional operator, which is invalid C# for value types like `Guid`, `int`, `long` — causing a CS0023 compile error
- Now checks `Identity.VariableType.IsValueType` to emit `.ToString()` for value types and `?.ToString() ?? ""` for reference types
- Regression was introduced in #2147 (v5.15.0)

## Test plan
- [x] 3 new tests in MartenTests for `[Entity(OnMissing = OnMissing.ThrowException)]` with Guid identity
- [x] Full MartenTests: 331 passed, 2 failed (pre-existing durability flakes)
- [x] Full Wolverine.Http.Tests: 497 passed, 1 failed (pre-existing Bug_2182), 10 skipped — no regressions

Closes #2207

🤖 Generated with [Claude Code](https://claude.com/claude-code)