### PR TITLE
Add LogDebug() to scheduled message code paths

### DIFF
--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Scheduled.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Scheduled.cs
@@ -1,4 +1,5 @@
-﻿using Weasel.Core;
+﻿using Microsoft.Extensions.Logging;
+using Weasel.Core;
 using Wolverine.Transports;
 
 namespace Wolverine.RDBMS;
@@ -9,6 +10,7 @@ public abstract partial class MessageDatabase<T>
 
     public Task ScheduleExecutionAsync(Envelope envelope)
     {
+        Logger.LogDebug("Persisting envelope {EnvelopeId} ({MessageType}) as Scheduled in database inbox at {Destination}", envelope.Id, envelope.MessageType, envelope.Destination);
         return CreateCommand(
                 $"update {SchemaName}.{DatabaseConstants.IncomingTable} set execution_time = @time, status = \'{EnvelopeStatus.Scheduled}\', attempts = @attempts, owner_id = {TransportConstants.AnyNode} where id = @id and {DatabaseConstants.ReceivedAt} = @uri;")
             .With("time", envelope.ScheduledTime!.Value)
@@ -20,6 +22,7 @@ public abstract partial class MessageDatabase<T>
 
     public Task RescheduleExistingEnvelopeForRetryAsync(Envelope envelope)
     {
+        Logger.LogDebug("Rescheduling envelope {EnvelopeId} ({MessageType}) for retry in database inbox at {Destination}", envelope.Id, envelope.MessageType, envelope.Destination);
         envelope.Status = EnvelopeStatus.Scheduled;
         envelope.OwnerId = TransportConstants.AnyNode;
 

--- a/src/Wolverine/Runtime/Routing/MessageRoute.cs
+++ b/src/Wolverine/Runtime/Routing/MessageRoute.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using ImTools;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using Microsoft.Extensions.Logging;
 using Wolverine.Attributes;
 using Wolverine.Configuration;
 using Wolverine.Runtime.Partitioning;
@@ -120,10 +121,16 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
             {
                 envelope.Status = EnvelopeStatus.Scheduled;
                 envelope.OwnerId = TransportConstants.AnyNode;
+                runtime.Logger.LogDebug("Envelope {EnvelopeId} ({MessageType}) marked as Scheduled for local execution at {Destination}", envelope.Id, envelope.MessageType, envelope.Destination);
             }
             else if (!Sender.SupportsNativeScheduledSend)
             {
+                runtime.Logger.LogDebug("Envelope {EnvelopeId} ({MessageType}) wrapped for durable scheduled send to {Destination} (transport does not support native scheduling)", envelope.Id, envelope.MessageType, envelope.Destination);
                 return envelope.ForScheduledSend(localDurableQueue);
+            }
+            else
+            {
+                runtime.Logger.LogDebug("Envelope {EnvelopeId} ({MessageType}) scheduled via native transport scheduling to {Destination}", envelope.Id, envelope.MessageType, envelope.Destination);
             }
         }
         else

--- a/src/Wolverine/Runtime/Scheduled/ScheduledSendEnvelopeHandler.cs
+++ b/src/Wolverine/Runtime/Scheduled/ScheduledSendEnvelopeHandler.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Wolverine.Runtime.Handlers;
 
 namespace Wolverine.Runtime.Scheduled;
@@ -17,6 +18,9 @@ internal class ScheduledSendEnvelopeHandler : MessageHandler
         }
 
         var scheduled = (Envelope)context.Envelope!.Message!;
+
+        context.Runtime.Logger.LogDebug("Forwarding previously scheduled envelope {EnvelopeId} ({MessageType}) for execution to {Destination}", scheduled.Id, scheduled.MessageType, scheduled.Destination);
+
         scheduled.Source = context.Runtime.Options.ServiceName;
         scheduled.ScheduledTime = null;
         scheduled.Status = EnvelopeStatus.Outgoing;

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -236,7 +236,7 @@ public partial class WolverineRuntime
     private void startInMemoryScheduledJobs()
     {
         ScheduledJobs =
-            new InMemoryScheduledJobProcessor((ILocalQueue)Endpoints.AgentForLocalQueue(TransportConstants.Replies));
+            new InMemoryScheduledJobProcessor((ILocalQueue)Endpoints.AgentForLocalQueue(TransportConstants.Replies), Logger);
 
         // Bit of a hack, but it's necessary. Came up in compliance tests
         if (Storage is NullMessageStore p)

--- a/src/Wolverine/Runtime/WolverineRuntime.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.cs
@@ -197,6 +197,7 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IHostedService
             throw new InvalidOperationException(
                 $"This action is invalid when {nameof(WolverineOptions)}.{nameof(WolverineOptions.Durability)}.{nameof(DurabilitySettings.Mode)} = {Options.Durability.Mode}");
 
+        Logger.LogDebug("Scheduling envelope {EnvelopeId} ({MessageType}) for in-memory execution at {ExecutionTime}", envelope.Id, envelope.MessageType, executionTime);
         MessageTracking.Sent(envelope);
         ScheduledJobs.Enqueue(executionTime, envelope);
     }

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -317,6 +317,7 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
 
     public Task MoveToScheduledUntilAsync(Envelope envelope, DateTimeOffset time)
     {
+        _logger.LogDebug("Moving envelope {EnvelopeId} ({MessageType}) to scheduled status until {ScheduledTime} in durable receiver", envelope.Id, envelope.MessageType, time);
         envelope.OwnerId = TransportConstants.AnyNode;
         envelope.ScheduledTime = time;
         envelope.Status = EnvelopeStatus.Scheduled;


### PR DESCRIPTION
## Summary
- Adds `LogDebug()` statements at every decision point and state transition in the scheduled message lifecycle
- Covers routing decisions (local/native/durable), in-memory scheduling, buffered/durable receivers, flush paths, reschedule paths, and database persistence
- Each log includes structured placeholders: `{EnvelopeId}`, `{MessageType}`, `{Destination}`, and context-specific values like `{ExecutionTime}`

## Test plan
- [x] `dotnet build src/Wolverine --framework net9.0` — 0 errors
- [x] `dotnet build src/Persistence/Wolverine.RDBMS --framework net9.0` — 0 errors
- [x] `dotnet test src/Testing/CoreTests --framework net9.0` — 1013 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)