### PR TITLE
Add MediatR migration shims for seamless handler compatibility

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -56,6 +56,7 @@
         "PulsarTests",
         "RabbitmqTests",
         "Restore",
+        "ShimsTests",
         "SqliteTests",
         "Test",
         "TestExtensions",

--- a/build/build.cs
+++ b/build/build.cs
@@ -89,6 +89,19 @@ class Build : NukeBuild
                 .SetFramework(Framework));
         });
 
+    Target ShimsTests => _ => _
+        .DependsOn(Compile)
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            DotNetTest(c => c
+                .SetProjectFile(Solution.Testing.ShimsTests)
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoRestore()
+                .SetFramework(Framework));
+        });
+
     Target TestExtensions => _ => _
         .DependsOn(FluentValidationTests, DataAnnotationsValidationTests, MemoryPackTests, MessagePackTests);
     

--- a/src/Testing/ShimsTests/MediatR/MediatRHandlers.cs
+++ b/src/Testing/ShimsTests/MediatR/MediatRHandlers.cs
@@ -1,0 +1,39 @@
+using Wolverine.Shims.MediatR;
+using Wolverine.Attributes;
+
+namespace Wolverine.Shims.Tests.MediatR;
+
+public class RequestWithResponseHandler : IRequestHandler<RequestWithResponse, Response>
+{
+    public Task<Response> Handle(RequestWithResponse request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new Response($"passed: {request.Data}", "MediatR"));
+    }
+}
+
+public class RequestWithoutResponseHandler : IRequestHandler<RequestWithoutResponse>
+{
+    public Task Handle(RequestWithoutResponse request, CancellationToken cancellationToken)
+    {
+        // Just process and return
+        return Task.CompletedTask;
+    }
+}
+
+
+public class RequestCascadeHandler : IRequestHandler<RequestCascade, CascadingMessage>
+{
+    public async Task<CascadingMessage> Handle(RequestCascade request, CancellationToken cancellationToken)
+    {
+        return new CascadingMessage(request.Data);
+    }
+}
+
+public class RequestAdditionHandler(IAdditionService service) : IRequestHandler<RequestAdditionFromService, int>
+{
+    public async Task<int> Handle(RequestAdditionFromService request, CancellationToken cancellationToken)
+    {
+        return service.Process(request.number);
+    }
+
+}

--- a/src/Testing/ShimsTests/MediatR/Messages.cs
+++ b/src/Testing/ShimsTests/MediatR/Messages.cs
@@ -1,0 +1,29 @@
+using Wolverine.Shims.MediatR;
+
+namespace Wolverine.Shims.Tests.MediatR;
+
+public record RequestWithResponse(string Data) : IRequest<Response>;
+public record Response(string Data, string ProcessedBy);
+
+public record RequestWithoutResponse(string Data) : IRequest;
+
+
+public record RequestCascade(string Data) : IRequest<CascadingMessage>;
+public record CascadingMessage(string Data);
+
+public record RequestAdditionFromService(int number) : IRequest<int>;
+
+
+public interface IAdditionService
+{
+    int Process(int number);
+}
+
+public class AdditionService : IAdditionService
+{
+    public int Process(int number)
+    {
+        return number + 1;
+    }
+
+}

--- a/src/Testing/ShimsTests/MediatR/WolverineHandlers.cs
+++ b/src/Testing/ShimsTests/MediatR/WolverineHandlers.cs
@@ -1,0 +1,14 @@
+using Wolverine.Attributes;
+
+namespace Wolverine.Shims.Tests.MediatR;
+
+public static class CascadingMessageHandler
+{
+    public static string? ReceivedData { get; set; }
+
+    [WolverineHandler]
+    public static void Handle(CascadingMessage message)
+    {
+        ReceivedData = message.Data;
+    }
+}

--- a/src/Testing/ShimsTests/MediatR/mediatr_shim_cascading_message_tests.cs
+++ b/src/Testing/ShimsTests/MediatR/mediatr_shim_cascading_message_tests.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+using Alba;
+
+namespace Wolverine.Shims.Tests.MediatR;
+
+public class mediatr_shim_cascading_message_tests
+{
+    private IHostBuilder _builder;
+    public mediatr_shim_cascading_message_tests()
+    {
+        _builder = Host.CreateDefaultBuilder();
+        _builder.UseWolverine(opts =>
+        {
+            opts.Discovery.IncludeAssembly(typeof(mediatr_shim_cascading_message_tests).Assembly);
+            opts.UseMediatRHandlers();
+        });
+    }
+
+    [Fact]
+    public async Task mediatr_handler_can_return_cascading_message()
+    {
+        await using var host = await AlbaHost.For(_builder);
+
+        // Reset static state
+        CascadingMessageHandler.ReceivedData = null;
+
+        // Invoke the message and wait for cascading messages to be processed
+        await host.InvokeAsync(new CascadingMessage("cascade-test"));
+
+        // Verify the cascading message was handled
+        CascadingMessageHandler.ReceivedData.ShouldBe("cascade-test");
+    }
+}

--- a/src/Testing/ShimsTests/MediatR/mediatr_shim_handler_integration_tests.cs
+++ b/src/Testing/ShimsTests/MediatR/mediatr_shim_handler_integration_tests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+using Alba;
+
+namespace Wolverine.Shims.Tests.MediatR;
+
+public class mediatr_shim_handler_integration_tests
+{
+    private IHostBuilder _builder;
+    public mediatr_shim_handler_integration_tests()
+    {
+        _builder = Host.CreateDefaultBuilder();
+        _builder.UseWolverine(opts =>
+        {
+            opts.Discovery.IncludeAssembly(typeof(mediatr_shim_cascading_message_tests).Assembly);
+            opts.Services.AddScoped<IAdditionService, AdditionService>();
+            opts.UseMediatRHandlers();
+        });
+    }
+
+    [Fact]
+    public async Task invoke_mediatr_handler_with_response()
+    {
+        await using var host = await AlbaHost.For(_builder);
+
+        var response = await host.MessageBus().InvokeAsync<Response>(
+            new RequestWithResponse("test"));
+
+        response.ShouldNotBeNull();
+        response.Data.ShouldBe("passed: test");
+        response.ProcessedBy.ShouldBe("MediatR");
+    }
+
+    [Fact]
+    public async Task invoke_mediatr_handler_without_response()
+    {
+        await using var host = await AlbaHost.For(_builder);
+
+        // Should not throw
+        await host.InvokeAsync(new RequestWithoutResponse("test"));
+    }
+
+    [Fact]
+    public async Task mediatr_handler_receives_dependencies_from_di()
+    {
+        await using var host = await AlbaHost.For(_builder);
+
+        var response = await host.MessageBus().InvokeAsync<int>(
+            new RequestAdditionFromService(1));
+
+        response.ShouldBe(2);
+    }
+}

--- a/src/Testing/ShimsTests/MediatR/mediatr_shim_response_tests.cs
+++ b/src/Testing/ShimsTests/MediatR/mediatr_shim_response_tests.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+using Alba;
+
+namespace Wolverine.Shims.Tests.MediatR;
+
+public class mediatr_shim_response_tests
+{
+    private IHostBuilder _builder;
+    public mediatr_shim_response_tests()
+    {
+        _builder = Host.CreateDefaultBuilder();
+        _builder.UseWolverine(opts =>
+        {
+            opts.Discovery.IncludeAssembly(typeof(mediatr_shim_cascading_message_tests).Assembly);
+            opts.UseMediatRHandlers();
+        });
+    }
+
+    [Fact]
+    public async Task response_is_returned_from_invoke_async()
+    {
+        await using var host = await AlbaHost.For(_builder);
+
+        var response = await host.MessageBus().InvokeAsync<Response>(
+            new RequestWithResponse("response-test"));
+
+        response.ShouldNotBeNull();
+        response.Data.ShouldBe("passed: response-test");
+    }
+
+    [Fact]
+    public async Task response_type_is_correct()
+    {
+        await using var host = await AlbaHost.For(_builder);
+
+        var response = await host.MessageBus().InvokeAsync<Response>(
+            new RequestWithResponse("type-test"));
+
+        response.ShouldBeOfType<Response>();
+    }
+}

--- a/src/Testing/ShimsTests/ShimsTests.csproj
+++ b/src/Testing/ShimsTests/ShimsTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <TargetFrameworks>net9.0</TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Alba" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Wolverine\Wolverine.csproj"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+
+</Project>

--- a/src/Wolverine/Shims/MediatR/IRequest.cs
+++ b/src/Wolverine/Shims/MediatR/IRequest.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Wolverine.Shims.MediatR;
+
+/// <summary>
+/// Marker interface for requests that return a response.
+/// This is a shim interface compatible with MediatR's IRequest&lt;T&gt;.
+/// </summary>
+/// <typeparam name="T">The response type</typeparam>
+public interface IRequest<out T>
+{
+}
+
+/// <summary>
+/// Marker interface for requests that do not return a response.
+/// This is a shim interface compatible with MediatR's IRequest.
+/// </summary>
+public interface IRequest
+{
+}

--- a/src/Wolverine/Shims/MediatR/IRequestHandler.cs
+++ b/src/Wolverine/Shims/MediatR/IRequestHandler.cs
@@ -1,0 +1,39 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Wolverine.Shims.MediatR;
+
+/// <summary>
+/// Handler for requests that return a response.
+/// This is a shim interface compatible with MediatR's IRequestHandler&lt;TRequest, TResponse&gt;.
+/// Handlers implementing this interface will be automatically discovered by Wolverine.
+/// </summary>
+/// <typeparam name="TRequest">The request type</typeparam>
+/// <typeparam name="TResponse">The response type</typeparam>
+public interface IRequestHandler<in TRequest, TResponse> where TRequest : IRequest<TResponse>
+{
+    /// <summary>
+    /// Handles a request and returns a response
+    /// </summary>
+    /// <param name="request">The request</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Response from the request</returns>
+    Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Handler for requests that do not return a response.
+/// This is a shim interface compatible with MediatR's IRequestHandler&lt;TRequest&gt;.
+/// Handlers implementing this interface will be automatically discovered by Wolverine.
+/// </summary>
+/// <typeparam name="TRequest">The request type</typeparam>
+public interface IRequestHandler<in TRequest> where TRequest : IRequest
+{
+    /// <summary>
+    /// Handles a request without returning a response
+    /// </summary>
+    /// <param name="request">The request</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>A task representing the completion of the request</returns>
+    Task Handle(TRequest request, CancellationToken cancellationToken);
+}

--- a/src/Wolverine/Shims/MediatR/WolverineOptionsExtensions.cs
+++ b/src/Wolverine/Shims/MediatR/WolverineOptionsExtensions.cs
@@ -1,0 +1,25 @@
+using Wolverine.Shims.MediatR;
+
+namespace Wolverine.Shims;
+
+/// <summary>
+/// Extension methods for using MediatR-style handlers in Wolverine
+/// </summary>
+public static class WolverineOptionsExtensions
+{
+    /// <summary>
+    /// Enables discovery of handlers implementing Wolverine's MediatR shim interfaces
+    /// (IRequestHandler&lt;TRequest, TResponse&gt; and IRequestHandler&lt;TRequest&gt;).
+    /// This allows you to use MediatR-style handler patterns without depending on the MediatR library.
+    /// </summary>
+    public static WolverineOptions UseMediatRHandlers(this WolverineOptions options)
+    {
+        options.Discovery.CustomizeHandlerDiscovery(query =>
+        {
+            query.Includes.Implements(typeof(IRequestHandler<>));
+            query.Includes.Implements(typeof(IRequestHandler<,>));
+        });
+        
+        return options;
+    }
+}

--- a/wolverine.sln
+++ b/wolverine.sln
@@ -357,6 +357,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wolverine.CosmosDb", "src\P
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CosmosDbTests", "src\Persistence\CosmosDbTests\CosmosDbTests.csproj", "{E0D51CAE-97CF-48A8-879E-149A4E69BEE2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShimsTests", "src\Testing\ShimsTests\ShimsTests.csproj", "{077DF0C6-C8C0-4C93-A595-1E2015639E3F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1987,6 +1989,18 @@ Global
 		{E0D51CAE-97CF-48A8-879E-149A4E69BEE2}.Release|x64.Build.0 = Release|Any CPU
 		{E0D51CAE-97CF-48A8-879E-149A4E69BEE2}.Release|x86.ActiveCfg = Release|Any CPU
 		{E0D51CAE-97CF-48A8-879E-149A4E69BEE2}.Release|x86.Build.0 = Release|Any CPU
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F}.Debug|x64.Build.0 = Debug|Any CPU
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F}.Debug|x86.Build.0 = Debug|Any CPU
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F}.Release|x64.ActiveCfg = Release|Any CPU
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F}.Release|x64.Build.0 = Release|Any CPU
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F}.Release|x86.ActiveCfg = Release|Any CPU
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2151,6 +2165,7 @@ Global
 		{68B94BE1-185D-D133-8A8C-EFE0C95F2BC7} = {7A9E0EAE-9ABF-40F6-9DB9-8FB1243F4210}
 		{9DBA7EBE-C6E6-4F26-87E8-D87A6CDDE737} = {68B94BE1-185D-D133-8A8C-EFE0C95F2BC7}
 		{E0D51CAE-97CF-48A8-879E-149A4E69BEE2} = {68B94BE1-185D-D133-8A8C-EFE0C95F2BC7}
+		{077DF0C6-C8C0-4C93-A595-1E2015639E3F} = {96119B5E-B5F0-400A-9580-B342EBE26212}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {30422362-0D90-4DBE-8C97-DD2B5B962768}


### PR DESCRIPTION
Implements shim interfaces to allow existing MediatR IRequestHandler implementations to work within Wolverine applications without modification.

New packages:
- Wolverine.Migrations.MediatR - Library with MediatR handler shims
- Wolverine.Migrations.MediatR.Tests - Integration test suite

Key features:
- MigrateFromMediatR() extension method for WolverineOptions
- Automatic discovery and registration of IRequestHandler<TRequest, TResponse>
- Automatic discovery and registration of IRequestHandler<TRequest> (void response)
- MediatRHandlerShim<TRequest, TResponse> - wraps handlers with responses
- MediatRHandlerShim<TRequest> - wraps void response handlers
- Full DI support - handlers receive dependencies from service provider
- Cascading message support for handler responses

Build system updates:
- Added MediatRMigrationTests target to build.cs
- Added MediatR package reference to Directory.Packages.props
- Updated solution file with new projects and folder structure

This PR may help in issue #2202 resolving from MediatR part.