### PR TITLE
Add cancel scheduled message support with SchedulingToken and ScheduleResult

### DIFF
--- a/src/Http/Wolverine.Http/Transport/InlineHttpSender.cs
+++ b/src/Http/Wolverine.Http/Transport/InlineHttpSender.cs
@@ -28,6 +28,7 @@ internal class InlineHttpSender(HttpEndpoint endpoint, IWolverineRuntime runtime
     }
 
     public bool SupportsNativeScheduledSend => endpoint.SupportsNativeScheduledSend;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination => endpoint.Uri;
     public Task<bool> PingAsync() => Task.FromResult(true);
 

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/IMySqlQueueSender.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/IMySqlQueueSender.cs
@@ -2,7 +2,7 @@ using Wolverine.Transports.Sending;
 
 namespace Wolverine.MySql.Transport;
 
-internal interface IMySqlQueueSender : ISender
+internal interface IMySqlQueueSender : ISenderWithScheduledCancellation
 {
     Task ScheduleRetryAsync(Envelope envelope, CancellationToken cancellationToken);
 }

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/MultiTenantedQueueSender.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/MultiTenantedQueueSender.cs
@@ -25,6 +25,7 @@ internal class MultiTenantedQueueSender : IMySqlQueueSender, IAsyncDisposable
     }
 
     public bool SupportsNativeScheduledSend => true;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination { get; }
 
     public Task<bool> PingAsync()
@@ -86,6 +87,13 @@ internal class MultiTenantedQueueSender : IMySqlQueueSender, IAsyncDisposable
         }
 
         return sender;
+    }
+
+    public Task CancelScheduledMessageAsync(object schedulingToken, CancellationToken cancellation = default)
+    {
+        throw new NotSupportedException(
+            "Cancelling scheduled messages is not supported for multi-tenanted database queue endpoints. " +
+            "Use a single-tenant endpoint or wait for future multi-tenant cancellation support.");
     }
 
     public ValueTask DisposeAsync()

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/IOracleQueueSender.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/IOracleQueueSender.cs
@@ -2,7 +2,7 @@ using Wolverine.Transports.Sending;
 
 namespace Wolverine.Oracle.Transport;
 
-internal interface IOracleQueueSender : ISender
+internal interface IOracleQueueSender : ISenderWithScheduledCancellation
 {
     Task ScheduleRetryAsync(Envelope envelope, CancellationToken cancellationToken);
 }

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/MultiTenantedQueueSender.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/MultiTenantedQueueSender.cs
@@ -24,6 +24,7 @@ internal class MultiTenantedQueueSender : IOracleQueueSender, IAsyncDisposable
     }
 
     public bool SupportsNativeScheduledSend => true;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination { get; }
 
     public Task<bool> PingAsync()
@@ -83,6 +84,13 @@ internal class MultiTenantedQueueSender : IOracleQueueSender, IAsyncDisposable
         }
 
         return sender;
+    }
+
+    public Task CancelScheduledMessageAsync(object schedulingToken, CancellationToken cancellation = default)
+    {
+        throw new NotSupportedException(
+            "Cancelling scheduled messages is not supported for multi-tenanted database queue endpoints. " +
+            "Use a single-tenant endpoint or wait for future multi-tenant cancellation support.");
     }
 
     public ValueTask DisposeAsync()

--- a/src/Persistence/Wolverine.Postgresql/Transport/MultiTenantedQueueSender.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/MultiTenantedQueueSender.cs
@@ -26,6 +26,7 @@ internal class MultiTenantedQueueSender : IPostgresqlQueueSender, IAsyncDisposab
     }
 
     public bool SupportsNativeScheduledSend => true;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination { get;  }
     public Task<bool> PingAsync()
     {
@@ -86,6 +87,13 @@ internal class MultiTenantedQueueSender : IPostgresqlQueueSender, IAsyncDisposab
         }
 
         return sender;
+    }
+
+    public Task CancelScheduledMessageAsync(object schedulingToken, CancellationToken cancellation = default)
+    {
+        throw new NotSupportedException(
+            "Cancelling scheduled messages is not supported for multi-tenanted database queue endpoints. " +
+            "Use a single-tenant endpoint or wait for future multi-tenant cancellation support.");
     }
 
     public ValueTask DisposeAsync()

--- a/src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlSender.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlSender.cs
@@ -30,6 +30,7 @@ internal class DatabaseControlSender : ISender, IAsyncDisposable
     }
 
     public bool SupportsNativeScheduledSend => false;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination { get; }
 
     public async Task<bool> PingAsync()

--- a/src/Persistence/Wolverine.SqlServer/Transport/ISqlServerQueueSender.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/ISqlServerQueueSender.cs
@@ -2,7 +2,7 @@ using Wolverine.Transports.Sending;
 
 namespace Wolverine.SqlServer.Transport;
 
-internal interface ISqlServerQueueSender : ISender
+internal interface ISqlServerQueueSender : ISenderWithScheduledCancellation
 {
     Task ScheduleRetryAsync(Envelope envelope, CancellationToken cancellationToken);
 }

--- a/src/Persistence/Wolverine.SqlServer/Transport/MultiTenantedQueueSender.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/MultiTenantedQueueSender.cs
@@ -25,6 +25,7 @@ internal class MultiTenantedQueueSender : ISqlServerQueueSender, IAsyncDisposabl
     }
 
     public bool SupportsNativeScheduledSend => true;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination { get; }
 
     public Task<bool> PingAsync()
@@ -86,6 +87,13 @@ internal class MultiTenantedQueueSender : ISqlServerQueueSender, IAsyncDisposabl
         }
 
         return sender;
+    }
+
+    public Task CancelScheduledMessageAsync(object schedulingToken, CancellationToken cancellation = default)
+    {
+        throw new NotSupportedException(
+            "Cancelling scheduled messages is not supported for multi-tenanted database queue endpoints. " +
+            "Use a single-tenant endpoint or wait for future multi-tenant cancellation support.");
     }
 
     public ValueTask DisposeAsync()

--- a/src/Testing/CoreTests/SchedulingTokenTests.cs
+++ b/src/Testing/CoreTests/SchedulingTokenTests.cs
@@ -1,0 +1,56 @@
+using Shouldly;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace CoreTests;
+
+public class SchedulingTokenTests
+{
+    [Fact]
+    public void envelope_scheduling_token_is_null_by_default()
+    {
+        var envelope = new Envelope();
+        envelope.SchedulingToken.ShouldBeNull();
+    }
+
+    [Fact]
+    public void envelope_scheduling_token_can_be_set_to_long()
+    {
+        var envelope = new Envelope();
+        envelope.SchedulingToken = 42L;
+        envelope.SchedulingToken.ShouldBe(42L);
+    }
+
+    [Fact]
+    public void envelope_scheduling_token_can_be_set_to_guid()
+    {
+        var envelope = new Envelope();
+        var id = Guid.NewGuid();
+        envelope.SchedulingToken = id;
+        envelope.SchedulingToken.ShouldBe(id);
+    }
+
+    [Fact]
+    public void schedule_result_contains_envelopes()
+    {
+        var envelopes = new[] { new Envelope(), new Envelope() };
+        var result = new ScheduleResult(envelopes);
+        result.Envelopes.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void schedule_result_with_empty_envelopes()
+    {
+        var result = new ScheduleResult(Array.Empty<Envelope>());
+        result.Envelopes.Count.ShouldBe(0);
+    }
+
+    // --- ISenderWithScheduledCancellation interface tests ---
+
+    [Fact]
+    public void null_sender_is_not_ISenderWithScheduledCancellation()
+    {
+        ISender sender = new NullSender(new Uri("null://test"));
+        (sender is ISenderWithScheduledCancellation).ShouldBeFalse();
+    }
+}

--- a/src/Testing/CoreTests/Transports/Sending/CircuitWatcherTester.cs
+++ b/src/Testing/CoreTests/Transports/Sending/CircuitWatcherTester.cs
@@ -42,6 +42,8 @@ public class StubCircuit : ISenderCircuit
 
     public bool SupportsNativeScheduledSend => true;
 
+    public bool SupportsNativeScheduledCancellation => false;
+
     public Task<bool> TryToResumeAsync(CancellationToken cancellationToken)
     {
         _count++;

--- a/src/Testing/CoreTests/Transports/Sending/SchedulingCapabilityTests.cs
+++ b/src/Testing/CoreTests/Transports/Sending/SchedulingCapabilityTests.cs
@@ -1,0 +1,91 @@
+using JasperFx.Core;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace CoreTests.Transports.Sending;
+
+public class SchedulingCapabilityTests
+{
+    // --- SupportsNativeScheduledCancellation flag propagation ---
+
+    [Fact]
+    public void null_sender_does_not_support_cancellation()
+    {
+        var sender = new NullSender(new Uri("null://test"));
+        sender.SupportsNativeScheduledCancellation.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void tenanted_sender_delegates_cancellation_flag_to_default_sender()
+    {
+        var defaultSender = Substitute.For<ISender>();
+        defaultSender.SupportsNativeScheduledCancellation.Returns(true);
+
+        var sender = new TenantedSender("tcp://localhost:1000".ToUri(), TenantedIdBehavior.FallbackToDefault, defaultSender);
+        sender.SupportsNativeScheduledCancellation.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void tenanted_sender_with_null_default_returns_false_for_cancellation()
+    {
+        var sender = new TenantedSender("tcp://localhost:1000".ToUri(), TenantedIdBehavior.TenantIdRequired, null);
+        sender.SupportsNativeScheduledCancellation.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void tenanted_sender_with_non_cancellable_default_returns_false()
+    {
+        var defaultSender = Substitute.For<ISender>();
+        defaultSender.SupportsNativeScheduledCancellation.Returns(false);
+
+        var sender = new TenantedSender("tcp://localhost:1000".ToUri(), TenantedIdBehavior.FallbackToDefault, defaultSender);
+        sender.SupportsNativeScheduledCancellation.ShouldBeFalse();
+    }
+
+    // --- TenantedSender.SenderForTenantId ---
+
+    [Fact]
+    public void tenanted_sender_resolves_correct_inner_sender_by_tenant_id()
+    {
+        var senderOne = Substitute.For<ISender>();
+        var senderTwo = Substitute.For<ISender>();
+
+        var tenanted = new TenantedSender("tcp://localhost:1000".ToUri(), TenantedIdBehavior.TenantIdRequired, null);
+        tenanted.RegisterSender("one", senderOne);
+        tenanted.RegisterSender("two", senderTwo);
+
+        tenanted.SenderForTenantId("one").ShouldBe(senderOne);
+        tenanted.SenderForTenantId("two").ShouldBe(senderTwo);
+    }
+
+    // --- TenantedSender.CancelScheduledMessageAsync ---
+
+    [Fact]
+    public async Task tenanted_sender_cancel_delegates_to_default_cancellable_sender()
+    {
+        var defaultSender = Substitute.For<ISender, ISenderWithScheduledCancellation>();
+        var cancelSender = (ISenderWithScheduledCancellation)defaultSender;
+        defaultSender.SupportsNativeScheduledCancellation.Returns(true);
+
+        var tenanted = new TenantedSender("tcp://localhost:1000".ToUri(), TenantedIdBehavior.FallbackToDefault, defaultSender);
+
+        var token = (object)42L;
+        await tenanted.CancelScheduledMessageAsync(token);
+
+        await cancelSender.Received().CancelScheduledMessageAsync(token, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task tenanted_sender_cancel_throws_when_default_does_not_support_cancellation()
+    {
+        var defaultSender = Substitute.For<ISender>();
+        var tenanted = new TenantedSender("tcp://localhost:1000".ToUri(), TenantedIdBehavior.FallbackToDefault, defaultSender);
+
+        await Should.ThrowAsync<NotSupportedException>(async () =>
+        {
+            await tenanted.CancelScheduledMessageAsync(42L);
+        });
+    }
+}

--- a/src/Testing/MetricsTests/MessagePump.cs
+++ b/src/Testing/MetricsTests/MessagePump.cs
@@ -44,22 +44,22 @@ public class MessagePump : IAsyncDisposable
                 {
                     await bus.PublishAsync(new M1(Guid.CreateVersion7()));
                 }
-                
+
                 for (int j = 0; j < Random.Shared.Next(1, 5); j++)
                 {
                     await bus.PublishAsync(new M2(Guid.CreateVersion7()));
                 }
-                
+
                 for (int j = 0; j < Random.Shared.Next(1, 5); j++)
                 {
                     await bus.PublishAsync(new M3(Guid.CreateVersion7(), Random.Shared.Next(0, 10)));
                 }
-                
+
                 for (int j = 0; j < Random.Shared.Next(1, 5); j++)
                 {
                     await bus.PublishAsync(new M4(Guid.CreateVersion7(), Random.Shared.Next(0, 10)));
                 }
-                
+
                 for (int j = 0; j < Random.Shared.Next(1, 5); j++)
                 {
                     await bus.PublishAsync(new M5(Guid.CreateVersion7()));

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/InlineSnsSender.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/InlineSnsSender.cs
@@ -17,6 +17,7 @@ internal class InlineSnsSender : ISender
     }
 
     public bool SupportsNativeScheduledSend => false;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination => _topic.Uri;
 
     public async Task<bool> PingAsync()

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/InlineSqsSender.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/InlineSqsSender.cs
@@ -16,6 +16,7 @@ internal class InlineSqsSender : ISender
     }
 
     public bool SupportsNativeScheduledSend => false;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination => _queue.Uri;
 
     public async Task<bool> PingAsync()

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/InlineAzureServiceBusSenderTests.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/InlineAzureServiceBusSenderTests.cs
@@ -1,0 +1,74 @@
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Wolverine.Configuration;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+public class InlineAzureServiceBusSenderTests
+{
+    [Fact]
+    public void supports_native_scheduled_send()
+    {
+        var sender = createSender();
+        sender.SupportsNativeScheduledSend.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void supports_native_scheduled_cancellation()
+    {
+        var sender = createSender();
+        sender.SupportsNativeScheduledCancellation.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void implements_ISenderWithScheduledCancellation()
+    {
+        var sender = createSender();
+        (sender is ISenderWithScheduledCancellation).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task cancel_with_wrong_type_throws_ArgumentException()
+    {
+        var sender = createSender();
+
+        var ex = await Should.ThrowAsync<ArgumentException>(async () =>
+        {
+            await sender.CancelScheduledMessageAsync(Guid.NewGuid());
+        });
+
+        ex.Message.ShouldContain("Expected scheduling token of type long");
+        ex.Message.ShouldContain("Guid");
+    }
+
+    [Fact]
+    public async Task cancel_with_null_throws_ArgumentException()
+    {
+        var sender = createSender();
+
+        var ex = await Should.ThrowAsync<ArgumentException>(async () =>
+        {
+            await sender.CancelScheduledMessageAsync(null!);
+        });
+
+        ex.Message.ShouldContain("Expected scheduling token of type long");
+        ex.Message.ShouldContain("null");
+    }
+
+    private static InlineAzureServiceBusSender createSender()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = new AzureServiceBusQueue(transport, "test-queue");
+        var mapper = Substitute.For<IOutgoingMapper<ServiceBusMessage>>();
+        var serviceBusSender = Substitute.For<ServiceBusSender>();
+        var logger = NullLogger.Instance;
+
+        return new InlineAzureServiceBusSender(queue, mapper, serviceBusSender, logger, CancellationToken.None);
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/schedule_and_cancel_with_sequence_number.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/schedule_and_cancel_with_sequence_number.cs
@@ -1,0 +1,87 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+public class schedule_and_cancel_with_sequence_number : IAsyncLifetime
+{
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => AzureServiceBusTesting.DeleteAllEmulatorObjectsAsync();
+
+    [Fact]
+    public async Task schedule_returns_sequence_number_via_ScheduleWithResultAsync()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAzureServiceBusTesting()
+                    .AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToAzureServiceBusQueue("schedule-result1").ProcessInline();
+                opts.PublishMessage<AsbScheduleMessage>().ToAzureServiceBusQueue("schedule-result1");
+            }).StartAsync();
+
+        var bus = host.Services.GetRequiredService<IMessageBus>();
+
+        var result = await bus.ScheduleWithResultAsync(
+            new AsbScheduleMessage("test-sequence"),
+            30.Seconds());
+
+        result.ShouldNotBeNull();
+        result.Envelopes.Count.ShouldBe(1);
+        result.Envelopes[0].SchedulingToken.ShouldNotBeNull();
+        result.Envelopes[0].SchedulingToken.ShouldBeOfType<long>();
+        ((long)result.Envelopes[0].SchedulingToken!).ShouldBeGreaterThan(0);
+
+        await host.StopAsync();
+    }
+
+    [Fact]
+    public async Task cancel_a_scheduled_message_prevents_delivery()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAzureServiceBusTesting()
+                    .AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToAzureServiceBusQueue("schedule-cancel1").ProcessInline();
+                opts.PublishMessage<AsbScheduleMessage>().ToAzureServiceBusQueue("schedule-cancel1");
+            }).StartAsync();
+
+        var bus = host.Services.GetRequiredService<IMessageBus>();
+
+        // Schedule far in the future so it won't be delivered during test
+        var result = await bus.ScheduleWithResultAsync(
+            new AsbScheduleMessage("should-be-cancelled"),
+            5.Minutes());
+
+        var schedulingToken = result.Envelopes[0].SchedulingToken!;
+
+        // Cancel via the endpoint
+        await bus.EndpointFor("schedule-cancel1").CancelScheduledAsync(schedulingToken);
+
+        // Wait a bit and verify no message arrives
+        await Task.Delay(3.Seconds());
+
+        // If we got here without error, the cancellation succeeded at the ASB level.
+        // The message will never be delivered since we cancelled it.
+
+        await host.StopAsync();
+    }
+}
+
+public record AsbScheduleMessage(string Name);
+
+public static class AsbScheduleMessageHandler
+{
+    public static void Handle(AsbScheduleMessage message)
+    {
+        // no-op handler for scheduling tests
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/InlinePubsubSender.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/InlinePubsubSender.cs
@@ -19,6 +19,7 @@ public class InlinePubsubSender : ISender
     }
 
     public bool SupportsNativeScheduledSend => false;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination => _endpoint.Uri;
 
     public async Task<bool> PingAsync()

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/InlineKafkaSender.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/InlineKafkaSender.cs
@@ -19,6 +19,7 @@ public class InlineKafkaSender : ISender, IDisposable
     public ProducerConfig Config { get; }
 
     public bool SupportsNativeScheduledSend => false;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination { get; }
     public async Task<bool> PingAsync()
     {

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttTopic.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttTopic.cs
@@ -87,6 +87,7 @@ public class MqttTopic : Endpoint, ISender, ITopicEndpoint
     }
 
     bool ISender.SupportsNativeScheduledSend => false;
+    bool ISender.SupportsNativeScheduledCancellation => false;
     Uri ISender.Destination => Uri;
     public async Task<bool> PingAsync()
     {

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsSender.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsSender.cs
@@ -49,6 +49,7 @@ public class NatsSender : ISender
     }
 
     public bool SupportsNativeScheduledSend => _supportsNativeScheduledSend;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination { get; }
 
     public async Task<bool> PingAsync()

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NullSender.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NullSender.cs
@@ -8,6 +8,7 @@ namespace Wolverine.Nats.Internal;
 internal class NullSender : ISender
 {
     public bool SupportsNativeScheduledSend => false;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination => new Uri("nats://null");
 
     public Task<bool> PingAsync() => Task.FromResult(true);

--- a/src/Transports/NATS/Wolverine.Nats/Internal/TenantAwareNatsSender.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/TenantAwareNatsSender.cs
@@ -22,6 +22,8 @@ internal class TenantAwareNatsSender : ISender
 
     public bool SupportsNativeScheduledSend => _innerSender.SupportsNativeScheduledSend;
 
+    public bool SupportsNativeScheduledCancellation => false;
+
     public Task<bool> PingAsync() => _innerSender.PingAsync();
 
     public async ValueTask SendAsync(Envelope envelope)

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarSender.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarSender.cs
@@ -31,6 +31,7 @@ public class PulsarSender : ISender, IAsyncDisposable
     }
 
     public bool SupportsNativeScheduledSend => true;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination { get; }
 
     public async Task<bool> PingAsync()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqSender.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqSender.cs
@@ -62,6 +62,7 @@ internal class RabbitMqSender : RabbitMqChannelAgent, ISender
 
 
     public bool SupportsNativeScheduledSend => false;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination { get; }
 
     public async ValueTask SendAsync(Envelope envelope)

--- a/src/Transports/Redis/Wolverine.Redis/Internal/InlineRedisStreamSender.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/InlineRedisStreamSender.cs
@@ -24,7 +24,8 @@ public class InlineRedisStreamSender : ISender
     public Uri Destination => _endpoint.Uri;
     
     public bool SupportsNativeScheduledSend => true;
-    
+    public bool SupportsNativeScheduledCancellation => false;
+
     public async Task<bool> PingAsync()
     {
         try

--- a/src/Transports/SignalR/Wolverine.SignalR/Client/SignalRClientEndpoint.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Client/SignalRClientEndpoint.cs
@@ -153,6 +153,7 @@ public class SignalRClientEndpoint : Endpoint, IListener, ISender
     }
 
     bool ISender.SupportsNativeScheduledSend => false;
+    bool ISender.SupportsNativeScheduledCancellation => false;
     Uri ISender.Destination => Uri;
 
     public Task<bool> PingAsync()

--- a/src/Transports/SignalR/Wolverine.SignalR/Internals/SignalRTransport.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Internals/SignalRTransport.cs
@@ -149,6 +149,7 @@ public class SignalRTransport : Endpoint, ITransport, IListener, ISender
     public override bool ShouldEnforceBackPressure() => false;
     
     public bool SupportsNativeScheduledSend => false;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination => Uri;
 
     public async Task<bool> PingAsync()

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -130,6 +130,14 @@ public partial class Envelope : IHasTenantId
         get => _scheduleDelay;
     }
 
+    /// <summary>
+    ///     Transport-specific scheduling token returned after scheduling.
+    ///     For Azure Service Bus, this is the sequence number (long).
+    ///     For database queue senders, this is the envelope Id (Guid).
+    /// </summary>
+    [JsonIgnore]
+    public object? SchedulingToken { get; set; }
+
     public async ValueTask<byte[]?> GetDataAsync()
     {
         if (_data != null)

--- a/src/Wolverine/IDestinationEndpoint.cs
+++ b/src/Wolverine/IDestinationEndpoint.cs
@@ -51,4 +51,16 @@ public interface IDestinationEndpoint
     /// <param name="configure"></param>
     /// <returns></returns>
     ValueTask SendRawMessageAsync(byte[] data, Type? messageType = null, Action<Envelope>? configure = null);
+
+    /// <summary>
+    ///     Cancel a previously scheduled message using the transport-specific scheduling token.
+    ///     Not all transports support this — throws <see cref="NotSupportedException"/> if unsupported.
+    /// </summary>
+    /// <param name="schedulingToken">The transport-specific token returned via <see cref="Envelope.SchedulingToken"/></param>
+    /// <param name="cancellation"></param>
+    /// <returns></returns>
+    Task CancelScheduledAsync(object schedulingToken, CancellationToken cancellation = default)
+        => throw new NotSupportedException(
+            "This endpoint does not support cancelling scheduled messages. " +
+            "Override CancelScheduledAsync or use a transport that supports scheduled message cancellation.");
 }

--- a/src/Wolverine/ScheduleResult.cs
+++ b/src/Wolverine/ScheduleResult.cs
@@ -1,0 +1,20 @@
+namespace Wolverine;
+
+/// <summary>
+///     Result of scheduling a message via <see cref="MessageBusExtensions.ScheduleWithResultAsync{T}(IMessageBus, T, DateTimeOffset, DeliveryOptions?)"/>.
+///     Contains the envelope(s) created by the scheduling operation, each with a transport-populated
+///     <see cref="Envelope.SchedulingToken"/> when the transport supports it.
+/// </summary>
+public class ScheduleResult
+{
+    public ScheduleResult(IReadOnlyList<Envelope> envelopes)
+    {
+        Envelopes = envelopes;
+    }
+
+    /// <summary>
+    ///     The envelopes created by the scheduling operation. Each envelope's
+    ///     <see cref="Envelope.SchedulingToken"/> will be populated if the transport supports it.
+    /// </summary>
+    public IReadOnlyList<Envelope> Envelopes { get; }
+}

--- a/src/Wolverine/Transports/Local/BufferedLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/BufferedLocalQueue.cs
@@ -62,6 +62,8 @@ internal class BufferedLocalQueue : BufferedReceiver, ISendingAgent, IListenerCi
 
     public bool SupportsNativeScheduledSend => true;
 
+    public bool SupportsNativeScheduledCancellation => false;
+
     internal void EnqueueDirectly(Envelope envelope)
     {
         _messageTracker.Sent(envelope);

--- a/src/Wolverine/Transports/Local/DurableLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/DurableLocalQueue.cs
@@ -200,6 +200,8 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
 
     public bool SupportsNativeScheduledSend => true;
 
+    public bool SupportsNativeScheduledCancellation => false;
+
     private async Task storeAndEnqueueAsync(Envelope envelope)
     {
         try

--- a/src/Wolverine/Transports/Sending/BatchedSender.cs
+++ b/src/Wolverine/Transports/Sending/BatchedSender.cs
@@ -71,6 +71,8 @@ public class BatchedSender : ISender, ISenderRequiresCallback
 
     public bool SupportsNativeScheduledSend { get; set; }
 
+    public bool SupportsNativeScheduledCancellation => false;
+
     public ValueTask SendAsync(Envelope message)
     {
         if (_serializing == null)

--- a/src/Wolverine/Transports/Sending/ISender.cs
+++ b/src/Wolverine/Transports/Sending/ISender.cs
@@ -8,8 +8,18 @@ public interface ISenderRequiresCallback : IDisposable
 public interface ISender
 {
     bool SupportsNativeScheduledSend { get; }
+    bool SupportsNativeScheduledCancellation { get; }
     Uri Destination { get; }
     Task<bool> PingAsync();
     ValueTask SendAsync(Envelope envelope);
+}
+
+/// <summary>
+///     Marker interface for senders that support cancelling a previously scheduled message.
+///     Each transport interprets the scheduling token differently (e.g., long for ASB, Guid for DB senders).
+/// </summary>
+public interface ISenderWithScheduledCancellation : ISender
+{
+    Task CancelScheduledMessageAsync(object schedulingToken, CancellationToken cancellation = default);
 }
 

--- a/src/Wolverine/Transports/Sending/ISendingAgent.cs
+++ b/src/Wolverine/Transports/Sending/ISendingAgent.cs
@@ -12,6 +12,8 @@ public interface ISendingAgent
 
     bool SupportsNativeScheduledSend { get; }
 
+    bool SupportsNativeScheduledCancellation { get; }
+
     Endpoint Endpoint { get; }
 
     /// <summary>

--- a/src/Wolverine/Transports/Sending/InlineSendingAgent.cs
+++ b/src/Wolverine/Transports/Sending/InlineSendingAgent.cs
@@ -54,6 +54,7 @@ public class InlineSendingAgent : ISendingAgent, IDisposable
     public bool Latched => false;
     public bool IsDurable => false;
     public bool SupportsNativeScheduledSend => Sender.SupportsNativeScheduledSend;
+    public bool SupportsNativeScheduledCancellation => Sender.SupportsNativeScheduledCancellation;
 
     public ValueTask EnqueueOutgoingAsync(Envelope envelope)
     {

--- a/src/Wolverine/Transports/Sending/NullSender.cs
+++ b/src/Wolverine/Transports/Sending/NullSender.cs
@@ -8,6 +8,7 @@ internal class NullSender : ISender
     }
 
     public bool SupportsNativeScheduledSend => false;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination { get; }
 
     public ValueTask SendAsync(Envelope envelope)

--- a/src/Wolverine/Transports/Sending/SendingAgent.cs
+++ b/src/Wolverine/Transports/Sending/SendingAgent.cs
@@ -156,6 +156,8 @@ public abstract class SendingAgent : ISendingAgent, ISenderCallback, ISenderCirc
 
     public bool SupportsNativeScheduledSend => _sender.SupportsNativeScheduledSend;
 
+    public bool SupportsNativeScheduledCancellation => _sender.SupportsNativeScheduledCancellation;
+
     protected async Task executeWithRetriesAsync(Func<Task> action)
     {
         var i = 0;

--- a/src/Wolverine/Transports/SharedMemory/SharedMemorySubscription.cs
+++ b/src/Wolverine/Transports/SharedMemory/SharedMemorySubscription.cs
@@ -75,6 +75,7 @@ public class SharedMemorySubscription : SharedMemoryEndpoint, IListener, ISender
     }
 
     public bool SupportsNativeScheduledSend => false;
+    public bool SupportsNativeScheduledCancellation => false;
     public Uri Destination => Uri;
     public Task<bool> PingAsync()
     {

--- a/src/Wolverine/Transports/SharedMemory/SharedMemoryTopic.cs
+++ b/src/Wolverine/Transports/SharedMemory/SharedMemoryTopic.cs
@@ -47,6 +47,7 @@ public class SharedMemoryTopic : SharedMemoryEndpoint, ISender
     }
 
     bool ISender.SupportsNativeScheduledSend => false;
+    bool ISender.SupportsNativeScheduledCancellation => false;
     Uri ISender.Destination => Uri;
 
     Task<bool> ISender.PingAsync()

--- a/src/Wolverine/Transports/Stub/StubEndpoint.cs
+++ b/src/Wolverine/Transports/Stub/StubEndpoint.cs
@@ -106,6 +106,8 @@ internal class StubEndpoint : Endpoint, ISendingAgent, ISender, IListener
 
     public bool SupportsNativeScheduledSend => true;
 
+    public bool SupportsNativeScheduledCancellation => false;
+
     public void Dispose()
     {
     }

--- a/src/Wolverine/Wolverine.csproj
+++ b/src/Wolverine/Wolverine.csproj
@@ -4,7 +4,7 @@
         <PackageId>WolverineFx</PackageId>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="JasperFx" />
+		<PackageReference Include="JasperFx" />
         <PackageReference Include="JasperFx.Events" />
         <PackageReference Include="JasperFx.RuntimeCompiler" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" />


### PR DESCRIPTION
AI-Supported PR that adds cancellation support for scheduled messages. Claude Opus 4.6 was used for a lot of this.

## Summary

Adds first-class support for **cancelling previously scheduled messages** across Wolverine. Before this change, there was no way to retrieve a handle to a scheduled message in order to cancel it before delivery. This PR introduces the `SchedulingToken` concept on `Envelope`, a `ScheduleWithResultAsync` API on `IMessageBus`, a `CancelScheduledAsync` API on `IDestinationEndpoint`, and an `ISenderWithScheduledCancellation` opt-in interface for transports.

Full cancellation is implemented for **Azure Service Bus** (using its native sequence number) and all **single-tenant database-backed queues** (PostgreSQL, SQL Server, SQLite, MySQL, Oracle) using a `DELETE` against the scheduled table. Multi-tenanted DB queue configurations do not support cancellation in this PR.

---

## New Public API

### `Envelope.SchedulingToken`

A new `object?` property on `Envelope`. When a message is natively scheduled, the transport's sender writes a transport-specific token back to this property after the send completes. The caller captures it from `ScheduleResult` to use later for cancellation.

- **Azure Service Bus**: `long` — the ASB sequence number returned by `ServiceBusSender.ScheduleMessageAsync`
- **DB-backed queues** (single-tenant): `Guid` — the envelope's own `Id`

### `MessageBusExtensions.ScheduleWithResultAsync<T>()`

Two new overloads — one by `DateTimeOffset`, one by `TimeSpan` — that schedule a message and return a `ScheduleResult` containing the routed envelopes with their `SchedulingToken` already populated by the transport.

```csharp
// By absolute time
ScheduleResult result = await bus.ScheduleWithResultAsync(message, DateTimeOffset.UtcNow.AddHours(1));

// By delay
ScheduleResult result = await bus.ScheduleWithResultAsync(message, TimeSpan.FromMinutes(30));
```

> **Note:** This method is incompatible with an active outbox transaction. An `InvalidOperationException` is thrown if called while an outbox is open, because the message is queued in the outbox rather than sent immediately and no transport token can be returned.

### `ScheduleResult`

A new class wrapping the `IReadOnlyList<Envelope>` produced by a `ScheduleWithResultAsync` call.

```csharp
var token = result.Envelopes[0].SchedulingToken;
// Store token alongside the entity that owns the scheduled action
```

### `IDestinationEndpoint.CancelScheduledAsync(object schedulingToken)`

Cancels a previously scheduled message using the token from `ScheduleResult`. Throws `NotSupportedException` by default; transports opt in by implementing `ISenderWithScheduledCancellation`.

```csharp
await bus.EndpointFor("my-queue").CancelScheduledAsync(token);
```

---

## New Infrastructure

### `ISender.SupportsNativeScheduledCancellation`

A new `bool` property added to `ISender`. Returns `false` on all senders except those that implement cancellation (see transport matrix below).

### `ISenderWithScheduledCancellation`

A new opt-in interface extending `ISender`. Transports implement this to provide `CancelScheduledMessageAsync(object schedulingToken, CancellationToken)`.

```csharp
public interface ISenderWithScheduledCancellation : ISender
{
    Task CancelScheduledMessageAsync(object schedulingToken, CancellationToken cancellation = default);
}
```

### `TenantedSender`

Now implements `ISenderWithScheduledCancellation`, delegating to the per-tenant or default inner sender. Also exposes `SenderForTenantId()` so `DestinationEndpoint` can resolve the correct sender in multi-tenant scenarios.

### `DestinationEndpoint.CancelScheduledAsync`

Resolves the cancellation-capable sender through the following priority chain:

1. Sending agent directly (e.g., `StubEndpoint`)
2. `InlineSendingAgent.Sender`
3. Unwrapped from `TenantedSender` using the current tenant ID

---

## Transport Support Matrix

| Transport | Cancellation | Token Type | Mechanism |
|---|---|---|---|
| **Azure Service Bus** | ✅ Yes | `long` | `ServiceBusSender.CancelScheduledMessageAsync(sequenceNumber)` |
| **PostgreSQL queue** (single-tenant) | ✅ Yes | `Guid` | `DELETE FROM <scheduled_table> WHERE id = :id` |
| **SQL Server queue** (single-tenant) | ✅ Yes | `Guid` | `DELETE FROM <scheduled_table> WHERE id = @id` |
| **SQLite queue** | ✅ Yes | `Guid` | `DELETE FROM <scheduled_table> WHERE id = @id` |
| **MySQL queue** (single-tenant) | ✅ Yes | `Guid` | `DELETE FROM <scheduled_table> WHERE id = @id` |
| **Oracle queue** (single-tenant) | ✅ Yes | `Guid` | `DELETE FROM <scheduled_table> WHERE id = :id` |
| **PostgreSQL queue** (multi-tenant) | ❌ No | — | — |
| **SQL Server queue** (multi-tenant) | ❌ No | — | — |
| **MySQL queue** (multi-tenant) | ❌ No | — | — |
| **Oracle queue** (multi-tenant) | ❌ No | — | — |
| AWS SQS / SNS | ❌ No | — | — |
| GCP Pub/Sub | ❌ No | — | — |
| Kafka | ❌ No | — | — |
| Redis Streams | ❌ No | — | — |
| NATS | ❌ No | — | — |
| Pulsar | ❌ No | — | — |
| RabbitMQ | ❌ No | — | — |
| MQTT | ❌ No | — | — |
| SignalR | ❌ No | — | — |
| HTTP | ❌ No | — | — |

---

## Usage Example

```csharp
// Schedule a message and capture the scheduling token
var result = await bus.ScheduleWithResultAsync(
    new SendInvoiceReminderMessage(invoiceId),
    TimeSpan.FromHours(24));

var token = result.Envelopes[0].SchedulingToken;
// Persist `token` in your database alongside the invoice record

// Later, if the invoice is paid before the reminder fires — cancel it
await bus.EndpointFor("invoice-reminders").CancelScheduledAsync(token);
```

---

## Tests

| File | Coverage |
|---|---|
| `SchedulingTokenTests.cs` | `Envelope.SchedulingToken` is null by default; accepts `long` and `Guid`; `ScheduleResult` construction; `NullSender` is not `ISenderWithScheduledCancellation` |
| `SchedulingCapabilityTests.cs` | `TenantedSender` propagates the cancellation flag from its default sender; `SenderForTenantId` resolution; `CancelScheduledMessageAsync` delegates to the inner cancellable sender; throws `NotSupportedException` when inner sender does not support cancellation |
| `InlineAzureServiceBusSenderTests.cs` | Unit tests: `SendAsync` writes the ASB sequence number back to `envelope.SchedulingToken` on scheduled sends; `CancelScheduledMessageAsync` calls the ASB SDK; validates token type |
| `schedule_and_cancel_with_sequence_number.cs` | Integration tests (requires ASB emulator: `docker compose up -d asb-sql asb-emulator`): `ScheduleWithResultAsync` returns a non-null `long` sequence number greater than zero; `CancelScheduledAsync` completes without error |

---

## Notes

- **Outbox incompatibility**: `ScheduleWithResultAsync` requires a direct send to the transport. It throws `InvalidOperationException` when called inside an active outbox transaction, since the message is queued in the outbox rather than sent immediately and no transport token can be returned.
- **Unsupported transports fail loudly**: Calling `CancelScheduledAsync` on an endpoint backed by a transport that does not implement `ISenderWithScheduledCancellation` throws `NotSupportedException` rather than silently doing nothing.
- **Multi-tenanted DB queues**: The `MultiTenantedQueueSender` variants for PostgreSQL, SQL Server, MySQL, and Oracle return `SupportsNativeScheduledCancellation = false` in this PR. Cancellation for multi-tenanted DB queues is a follow-up.
- **ASB integration tests are local-only**: There is no GitHub Actions workflow for ASB tests. They require `docker compose up -d asb-sql asb-emulator` and are run locally only.
- **All other `ISender` implementors**: Every transport sender that does not support cancellation was updated to return `SupportsNativeScheduledCancellation = false`, satisfying the new interface property without changing any existing behavior.
