### PR TITLE
Fix RabbitMQ double acknowledgement on InvokeAsync deserialization exceptions

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelCallback.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelCallback.cs
@@ -99,7 +99,9 @@ internal class RabbitMqChannelCallback : IChannelCallback, IDisposable, ISupport
         {
             if (envelope.RabbitMqListener.Channel is not null)
             {
-                // For idempotency
+                // Mark as acknowledged before the NACK so that any subsequent
+                // CompleteAsync() call is a no-op (prevents double ack/nack)
+                envelope.Acknowledged = true;
                 envelope.HasBeenAcked = true;
                 await envelope.RabbitMqListener.Channel.BasicNackAsync(envelope.DeliveryTag, false, false, token);
             }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelope.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelope.cs
@@ -21,10 +21,12 @@ internal class RabbitMqEnvelope : Envelope
     internal RabbitMqListener RabbitMqListener { get;  }
     internal ulong DeliveryTag { get; private set;}
 
-    public bool Acknowledged { get; private set; }
+    public bool Acknowledged { get; internal set; }
 
     internal async Task CompleteAsync()
     {
+        if (Acknowledged) return;
+
         await RabbitMqListener.CompleteAsync(DeliveryTag);
         Acknowledged = true;
     }


### PR DESCRIPTION
## Summary
- Make `RabbitMqEnvelope.CompleteAsync()` idempotent so a second call is a no-op
- Set `Acknowledged = true` before the NACK in `moveToErrorQueueAsync` so the subsequent `CompleteAsync()` from `MoveToErrorQueue.ExecuteAsync()` is skipped

## Root Cause
`MoveToErrorQueue.ExecuteAsync()` calls both `MoveToDeadLetterQueueAsync()` (which NACKs the message) and `CompleteAsync()` (which ACKs it). The second ack/nack on an already-consumed delivery tag causes RabbitMQ to close the channel with `PRECONDITION_FAILED - unknown delivery tag`, which deletes the response queue and breaks all subsequent `InvokeAsync()` calls.

## Test plan
- [x] `Wolverine.RabbitMQ` builds clean
- Fixes #2232

🤖 Generated with [Claude Code](https://claude.com/claude-code)