### PR TITLE
Add DeliveryOptions overloads to InvokeAsync methods

### DIFF
--- a/src/Wolverine/IDestinationEndpoint.cs
+++ b/src/Wolverine/IDestinationEndpoint.cs
@@ -30,6 +30,17 @@ public interface IDestinationEndpoint
         TimeSpan? timeout = null);
 
     /// <summary>
+    ///     Execute the message at this destination
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="options">Use to pass in extra metadata like headers or group id or correlation information to the command execution</param>
+    /// <param name="cancellation"></param>
+    /// <param name="timeout"></param>
+    /// <returns></returns>
+    Task<Acknowledgement> InvokeAsync(object message, DeliveryOptions options, CancellationToken cancellation = default,
+        TimeSpan? timeout = null);
+
+    /// <summary>
     ///     Execute the summary at this destination and retrieve the expected
     ///     response from the destination
     /// </summary>
@@ -41,6 +52,18 @@ public interface IDestinationEndpoint
     Task<T> InvokeAsync<T>(object message, CancellationToken cancellation = default, TimeSpan? timeout = null)
         where T : class;
 
+    /// <summary>
+    ///     Execute the summary at this destination and retrieve the expected
+    ///     response from the destination
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="options">Use to pass in extra metadata like headers or group id or correlation information to the command execution</param>
+    /// <param name="cancellation"></param>
+    /// <param name="timeout"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    Task<T> InvokeAsync<T>(object message, DeliveryOptions options, CancellationToken cancellation = default, TimeSpan? timeout = null)
+        where T : class;
 
     /// <summary>
     /// Send a message by its raw binary contents and optionally configure how Wolverine

--- a/src/Wolverine/Runtime/DestinationEndpoint.cs
+++ b/src/Wolverine/Runtime/DestinationEndpoint.cs
@@ -112,6 +112,18 @@ internal class DestinationEndpoint : IDestinationEndpoint
         return route.InvokeAsync<Acknowledgement>(message, _parent, cancellation, timeout);
     }
 
+    public Task<Acknowledgement> InvokeAsync(object message, DeliveryOptions options, CancellationToken cancellation = default,
+        TimeSpan? timeout = null)
+    {
+        if (message == null)
+        {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var route = _endpoint.RouteFor(message.GetType(), _parent.Runtime);
+        return route.InvokeAsync<Acknowledgement>(message, _parent, cancellation, timeout, options);
+    }
+
     public Task<T> InvokeAsync<T>(object message, CancellationToken cancellation = default, TimeSpan? timeout = null)
         where T : class
     {
@@ -124,5 +136,19 @@ internal class DestinationEndpoint : IDestinationEndpoint
 
         var route = _endpoint.RouteFor(message.GetType(), _parent.Runtime);
         return route.InvokeAsync<T>(message, _parent, cancellation, timeout);
+    }
+
+    public Task<T> InvokeAsync<T>(object message, DeliveryOptions options, CancellationToken cancellation = default,
+        TimeSpan? timeout = null) where T : class
+    {
+        _parent.Runtime.RegisterMessageType(typeof(T));
+
+        if (message == null)
+        {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var route = _endpoint.RouteFor(message.GetType(), _parent.Runtime);
+        return route.InvokeAsync<T>(message, _parent, cancellation, timeout, options);
     }
 }


### PR DESCRIPTION
#fixes 2219

Introduce new InvokeAsync overloads on IDestinationEndpoint and implementations to accept DeliveryOptions, enabling callers to specify headers, tenant IDs, and other metadata when invoking messages.