### PR TITLE
Return No Content if reading request body is canceled

### DIFF
--- a/src/Http/Wolverine.Http.Tests/posting_json.cs
+++ b/src/Http/Wolverine.Http.Tests/posting_json.cs
@@ -112,4 +112,22 @@ public class posting_json : IntegrationContext
             x.StatusCodeShouldBe(406);
         });
     }
+
+    [Fact]
+    public async Task reading_json_from_canceled_request_gets_204()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var response = await Scenario(x =>
+        {
+            x.ConfigureHttpContext(ctx =>
+            {
+                ctx.Request.HttpContext.RequestAborted = cts.Token;
+            });
+            x.Post.Json(new Question { One = 3, Two = 4 }).ToUrl("/question");
+            x.WithRequestHeader("accept", "application/json");
+            x.StatusCodeShouldBe(204);
+        });
+    }
 }

--- a/src/Http/Wolverine.Http/HttpHandler.cs
+++ b/src/Http/Wolverine.Http/HttpHandler.cs
@@ -156,6 +156,11 @@ public abstract class HttpHandler
 
             return (body, HandlerContinuation.Continue);
         }
+        catch (OperationCanceledException)
+        {
+            context.Response.StatusCode = 204;
+            return (default, HandlerContinuation.Stop);
+        }
         catch (Exception e)
         {
             var logger = context.RequestServices.GetService<ILogger<T>>();


### PR DESCRIPTION
We have a large form, a bit Excel-like, where every change (with a tiny debounce) triggers a new request to get the latest calculated values. We only want one request in-flight and the latest response, so we use cancellations heavily on this page.
Wolverine causes a bit of noisy "errors" in the logs since experienced and fast users can send quite a few requests that all get cancelled before they really get anywhere.