### PR TITLE
Fix Kafka durable mode offset management by removing EnableAutoOffset…

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -146,17 +146,19 @@ processes messages. Understanding these settings is important for getting the de
 ### How Endpoint Mode Affects Consumer Configuration
 
 When an endpoint uses `EndpointMode.Durable` (i.e., you've called `.UseDurableInbox()` or applied durable inbox
-globally), Wolverine overrides two key consumer settings before building the listener:
+globally), Wolverine overrides the following consumer setting before building the listener:
 
 | Consumer Setting | Durable (`UseDurableInbox`) | Non-Durable (`BufferedInMemory` / `Inline`) |
 |---|---|---|
 | `EnableAutoCommit` | `false` | `true` (Kafka default) |
-| `EnableAutoOffsetStore` | `false` | `true` (Kafka default) |
+| `EnableAutoOffsetStore` | `true` (Kafka default) | `true` (Kafka default) |
 
-In **durable mode**, Wolverine disables Kafka's automatic offset management so that offsets are only committed
-after a message has been successfully processed and persisted to the transactional inbox. This prevents message loss
-if the application shuts down unexpectedly -- unprocessed messages will be re-delivered when the consumer rejoins
-the group.
+In **durable mode**, Wolverine disables Kafka's automatic offset *commit* so that offsets are only committed
+when Wolverine explicitly calls `Commit()` after a message has been successfully persisted to the transactional
+inbox. The Kafka client still auto-stores the offset on each `Consume()` call (the default behavior), which
+tracks the consumer's position. However, the stored offset is not pushed to the broker until `Commit()` is
+called. This gives correct at-least-once semantics -- if the application shuts down unexpectedly before
+committing, unprocessed messages will be re-delivered when the consumer rejoins the group.
 
 In **non-durable mode** (`BufferedInMemory` or `ProcessInline`), Kafka's default auto-commit behavior is left
 in place. The Kafka client library periodically commits offsets automatically, which provides higher throughput

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/configure_consumers_and_publishers.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/configure_consumers_and_publishers.cs
@@ -1,7 +1,9 @@
+using IntegrationTests;
 using JasperFx.Resources;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Wolverine.Kafka.Internals;
+using Wolverine.Postgresql;
 using Wolverine.Tracking;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
@@ -81,6 +83,11 @@ public class configure_consumers_and_publishers : IAsyncLifetime
                 opts.ListenToKafkaTopic("green")
                     .BufferedInMemory();
 
+                opts.ListenToKafkaTopic("blue")
+                    .UseDurableInbox();
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "kafka_config");
+
                 // Include test assembly for handler discovery
                 opts.Discovery.IncludeAssembly(GetType().Assembly);
 
@@ -139,6 +146,17 @@ public class configure_consumers_and_publishers : IAsyncLifetime
         var colors = _host.GetRuntime().Endpoints.GetOrBuildSendingAgent(new Uri("kafka://topic/colors"))
             .ShouldBeOfType<InlineSendingAgent>().Sender.ShouldBeOfType<InlineKafkaSender>();
         colors.Config.BatchSize.ShouldBe(222);
+    }
+
+    [Fact]
+    public void durable_mode_disables_auto_commit_but_not_auto_offset_store()
+    {
+        var blue = _host.GetRuntime().Endpoints.ActiveListeners()
+            .Single(x => x.Uri.ToString().Contains("blue")).ShouldBeOfType<ListeningAgent>()
+            .Listener.ShouldBeOfType<KafkaListener>();
+
+        blue.Config.EnableAutoCommit.ShouldBe(false);
+        blue.Config.EnableAutoOffsetStore.ShouldBeNull();
     }
 
 }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/propagate_group_id_to_partition_key.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/propagate_group_id_to_partition_key.cs
@@ -1,7 +1,9 @@
+using Confluent.Kafka;
 using JasperFx.Core;
 using JasperFx.Resources;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
+using Wolverine.Attributes;
 using Wolverine.Tracking;
 
 namespace Wolverine.Kafka.Tests;
@@ -30,11 +32,17 @@ public class propagate_group_id_to_partition_key : IAsyncLifetime
                     .ConfigureConsumer(config =>
                     {
                         config.GroupId = "source-group-123";
+                        config.AutoOffsetReset = AutoOffsetReset.Earliest;
                     });
 
                 // Listen to target topic where cascaded messages arrive
                 opts.ListenToKafkaTopic("groupid-target")
                     .ProcessInline();
+
+                // Route TriggerFromGroupId to the source topic
+                opts.PublishMessage<TriggerFromGroupId>()
+                    .ToKafkaTopic("groupid-source")
+                    .SendInline();
 
                 // Route cascaded TargetFromGroupId messages to the target topic
                 opts.PublishMessage<TargetFromGroupId>()
@@ -65,8 +73,10 @@ public class propagate_group_id_to_partition_key : IAsyncLifetime
     }
 }
 
+[Topic("groupid-source")]
 public record TriggerFromGroupId(string Name);
 
+[Topic("groupid-target")]
 public record TargetFromGroupId(string Name);
 
 public static class TriggerFromGroupIdHandler

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -98,7 +98,6 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
         if (Mode == EndpointMode.Durable)
         {
             config.EnableAutoCommit = false;
-            config.EnableAutoOffsetStore = false;
         }
 
         var listener = new KafkaListener(this, config,


### PR DESCRIPTION
…Store override

Remove EnableAutoOffsetStore = false so offsets are auto-stored on each Consume() call, while keeping EnableAutoCommit = false so offsets are only committed when Wolverine explicitly calls Commit() in CompleteAsync(). This gives correct at-least-once semantics without needing to thread ConsumeResult through to CompleteAsync. Previously, offsets never advanced because StoreOffset() was never called, causing message loss on consumer restart.

Also fix propagate_group_id_to_partition_key test by adding the missing publish route for TriggerFromGroupId and setting AutoOffsetReset.Earliest to avoid consumer group join timing races.