### PR TITLE
Fix RavenDb durability agent 'Unrecognized agent scheme' error

### DIFF
--- a/src/Persistence/Wolverine.RavenDb/Internals/Durability/RavenDbDurabilityAgent.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/Durability/RavenDbDurabilityAgent.cs
@@ -37,7 +37,7 @@ public partial class RavenDbDurabilityAgent : IAgent
         _localQueue = (ILocalQueue)runtime.Endpoints.AgentForLocalQueue(TransportConstants.Scheduled);
         _settings = runtime.DurabilitySettings;
 
-        Uri = new Uri("ravendb://durability");
+        Uri = new Uri($"{PersistenceConstants.AgentScheme}://ravendb/durability");
 
         _logger = runtime.LoggerFactory.CreateLogger<RavenDbDurabilityAgent>();
         

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.cs
@@ -1,6 +1,7 @@
 using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
 using Raven.Client.Documents;
+using Wolverine.Persistence;
 using Wolverine.Persistence.Durability;
 using Wolverine.RavenDb.Internals.Durability;
 using Wolverine.Runtime;
@@ -44,7 +45,7 @@ public partial class RavenDbMessageStore : IMessageStoreWithAgentSupport
 
     public string Name => _store.Identifier;
 
-    public Uri Uri => new("ravendb://durability");
+    public Uri Uri => new($"{PersistenceConstants.AgentScheme}://ravendb/durability");
 
     public string IdentityFor(Envelope envelope) => _identity(envelope);
 


### PR DESCRIPTION
## Summary
- `RavenDbDurabilityAgent` and `RavenDbMessageStore` used a `ravendb://` URI scheme, but `NodeAgentController` only registers `MessageStoreCollection` under the `wolverinedb` scheme (`PersistenceConstants.AgentScheme`). This caused an `ArgumentOutOfRangeException: Unrecognized agent scheme 'ravendb'` on startup, preventing the durability agent from starting.
- Changed both URIs from `ravendb://durability` to `wolverinedb://ravendb/durability` to match the scheme expected by the agent controller.

Closes #2260

## Test plan
- [x] All 129 RavenDbTests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)