### PR TITLE
Fix [FromQuery] array binding ignoring Name alias

### DIFF
--- a/src/Http/Wolverine.Http.Tests/from_query_binding.cs
+++ b/src/Http/Wolverine.Http.Tests/from_query_binding.cs
@@ -184,4 +184,109 @@ public class from_query_binding : IntegrationContext
         (await forQuerystring("name=Jones&number=95&Aliased=foo")).ValueWithAlias.ShouldBe("foo");
         (await forQuerystring("name=Jones&number=95&valueWithAlias=foo")).ValueWithAlias.ShouldBeNull();
     }
+
+    [Fact]
+    public async Task aliased_string_array_as_property()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get
+                .Url("/api/bigquery")
+                .QueryString("v", "one")
+                .QueryString("v", "two");
+        });
+
+        var query = result.ReadAsJson<BigQuery>();
+        query.AliasedValues.ShouldBe(["one", "two"]);
+    }
+
+    [Fact]
+    public async Task aliased_int_array_as_property()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get
+                .Url("/api/bigquery")
+                .QueryString("n", "10")
+                .QueryString("n", "20");
+        });
+
+        var query = result.ReadAsJson<BigQuery>();
+        query.AliasedNumbers.ShouldBe([10, 20]);
+    }
+
+    [Fact]
+    public async Task aliased_enum_list_as_property()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get
+                .Url("/api/bigquery")
+                .QueryString("d", "North")
+                .QueryString("d", "South");
+        });
+
+        var query = result.ReadAsJson<BigQuery>();
+        query.AliasedEnumList.ShouldBe([Direction.North, Direction.South]);
+    }
+
+    [Fact]
+    public async Task aliased_string_array_in_record_with_fromquery()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get
+                .Url("/api/fromquery/aliased-array")
+                .QueryString("v", "one")
+                .QueryString("v", "two");
+        });
+
+        var query = result.ReadAsJson<AliasedArrayQuery>();
+        query.Values.ShouldBe(["one", "two"]);
+    }
+
+    [Fact]
+    public async Task aliased_int_array_in_record_with_fromquery()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get
+                .Url("/api/fromquery/aliased-int-array")
+                .QueryString("n", "5")
+                .QueryString("n", "10");
+        });
+
+        var query = result.ReadAsJson<AliasedIntArrayQuery>();
+        query.Numbers.ShouldBe([5, 10]);
+    }
+
+    [Fact]
+    public async Task aliased_string_array_in_record_with_asparameters()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get
+                .Url("/api/asparameters/aliased-array")
+                .QueryString("v", "one")
+                .QueryString("v", "two");
+        });
+
+        var query = result.ReadAsJson<AliasedArrayQuery>();
+        query.Values.ShouldBe(["one", "two"]);
+    }
+
+    [Fact]
+    public async Task aliased_int_array_in_record_with_asparameters()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get
+                .Url("/api/asparameters/aliased-int-array")
+                .QueryString("n", "5")
+                .QueryString("n", "10");
+        });
+
+        var query = result.ReadAsJson<AliasedIntArrayQuery>();
+        query.Numbers.ShouldBe([5, 10]);
+    }
 }

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -522,7 +522,7 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
             if (parameterType == typeof(string[]))
             {
-                variable = new ParsedArrayQueryStringValue(parameterType, parameterName).Variable;
+                variable = new ParsedArrayQueryStringValue(parameterType, key).Variable;
                 variable.Name = key;
                 _querystringVariables.Add(variable);
             }
@@ -533,22 +533,22 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
                 if (RouteParameterStrategy.CanParse(inner))
                 {
                     //variable = new ParsedNullableQueryStringValue(parameterType, parameterName).Variable;
-                    variable = new ReadHttpFrame(BindingSource.QueryString, parameterType, parameterName).Variable;
+                    variable = new ReadHttpFrame(BindingSource.QueryString, parameterType, key).Variable;
                     variable.Name = key;
                     _querystringVariables.Add(variable);
                 }
             }
-            
+
             if (parameterType.IsArray && RouteParameterStrategy.CanParse(parameterType.GetElementType()))
             {
-                variable = new ParsedArrayQueryStringValue(parameterType, parameterName).Variable;
+                variable = new ParsedArrayQueryStringValue(parameterType, key).Variable;
                 variable.Name = key;
                 _querystringVariables.Add(variable);
             }
 
             if (ParsedCollectionQueryStringValue.CanParse(parameterType))
             {
-                variable = new ParsedCollectionQueryStringValue(parameterType, parameterName).Variable;
+                variable = new ParsedCollectionQueryStringValue(parameterType, key).Variable;
                 variable.Name = key;
                 _querystringVariables.Add(variable);
             }

--- a/src/Http/WolverineWebApi/QuerystringEndpoints.cs
+++ b/src/Http/WolverineWebApi/QuerystringEndpoints.cs
@@ -90,6 +90,18 @@ public static class FromQueryEndpoints
 
     [WolverineGet("/api/bigquery")]
     public static BigQuery Get([FromQuery] BigQuery query) => query;
+
+    [WolverineGet("/api/fromquery/aliased-array")]
+    public static AliasedArrayQuery GetAliasedArray([FromQuery] AliasedArrayQuery query) => query;
+
+    [WolverineGet("/api/fromquery/aliased-int-array")]
+    public static AliasedIntArrayQuery GetAliasedIntArray([FromQuery] AliasedIntArrayQuery query) => query;
+
+    [WolverineGet("/api/asparameters/aliased-array")]
+    public static AliasedArrayQuery GetAliasedArrayAsParams([AsParameters] AliasedArrayQuery query) => query;
+
+    [WolverineGet("/api/asparameters/aliased-int-array")]
+    public static AliasedIntArrayQuery GetAliasedIntArrayAsParams([AsParameters] AliasedIntArrayQuery query) => query;
 }
 
 
@@ -98,6 +110,10 @@ public record Query2(int Number);
 public record Query3(Guid Id);
 
 public record Query4(string Name, int Number, Direction Direction);
+
+public record AliasedArrayQuery([FromQuery(Name = "v")] string[] Values);
+
+public record AliasedIntArrayQuery([FromQuery(Name = "n")] int[] Numbers);
 
 
 public class BigQuery
@@ -122,4 +138,16 @@ public class BigQuery
     public List<Direction> EnumListValues { get; set; } = new();
 
     public List<int> IntList { get; set; }
+
+    [FromQuery(Name = "v")]
+    [FromForm(Name = "v")]
+    public string[] AliasedValues { get; set; }
+
+    [FromQuery(Name = "n")]
+    [FromForm(Name = "n")]
+    public int[] AliasedNumbers { get; set; }
+
+    [FromQuery(Name = "d")]
+    [FromForm(Name = "d")]
+    public List<Direction> AliasedEnumList { get; set; } = new();
 }


### PR DESCRIPTION
## Summary
- When a record used `[FromQuery(Name = "v")] string[] Values` and was bound via `[FromQuery]`, the generated code read from `httpContext.Request.Query["Values"]` instead of `httpContext.Request.Query["v"]`. The `[AsParameters]` path handled this correctly.
- Root cause: `HttpChain.TryFindOrCreateQuerystringValue(Type, string, string?)` passed `parameterName` (C# name) instead of `key` (the alias) when constructing `ParsedArrayQueryStringValue`, `ParsedCollectionQueryStringValue`, and nullable type frames.
- Added tests covering aliased arrays/collections for both `[FromQuery]` and `[AsParameters]` on records and settable properties.

Closes #2257

## Test plan
- [x] All 512 Wolverine.Http.Tests pass (10 skipped, unchanged)
- [x] New tests verify aliased string arrays, int arrays, and enum lists via `[FromQuery]` on records
- [x] New tests verify parity between `[FromQuery]` and `[AsParameters]` for aliased arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)