### PR TITLE
Propagate authenticated user name from HTTP to Marten LastModifiedBy

### DIFF
--- a/docs/guide/http/security.md
+++ b/docs/guide/http/security.md
@@ -28,3 +28,31 @@ public void RequireAuthorizeOnAll()
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http/WolverineHttpOptions.cs#L240-L250' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_RequireAuthorizeOnAll' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Tracking User Name
+
+Wolverine can automatically propagate the authenticated user's identity from the HTTP `ClaimsPrincipal` through the messaging infrastructure. When enabled, the `ClaimsPrincipal.Identity.Name` is:
+
+1. Set on `IMessageContext.UserName` for the current request
+2. Propagated to all outgoing message envelopes via `Envelope.UserName`
+3. Automatically set as `IDocumentSession.LastModifiedBy` when using the Wolverine + Marten integration
+4. Added as an OpenTelemetry tag (`enduser.id`) on the current activity
+
+To enable this feature, set `EnableRelayOfUserName` in your Wolverine configuration:
+
+```csharp
+builder.Host.UseWolverine(opts =>
+{
+    // Automatically relay the authenticated user name from HTTP
+    // through the messaging infrastructure
+    opts.EnableRelayOfUserName = true;
+});
+```
+
+When this option is enabled, Wolverine will automatically apply middleware to any HTTP endpoint that uses `IMessageContext` or `IMessageBus`. The middleware reads `HttpContext.User?.Identity?.Name` and sets it on the message context before your endpoint code executes.
+
+The user name is carried on outgoing envelopes, so downstream message handlers will also have access to the original user name via `IMessageContext.UserName` or `Envelope.UserName`. This is particularly useful for auditing and tracking who initiated a chain of messages.
+
+### Marten Integration
+
+When using the Wolverine + Marten integration, the user name is automatically applied to `IDocumentSession.LastModifiedBy`. This means Marten's built-in `mt_last_modified_by` metadata column will be populated with the authenticated user's name for any documents stored during message handling -- even for cascading messages downstream from the original HTTP request.

--- a/src/Http/Wolverine.Http.Tests/user_name_relay_from_http.cs
+++ b/src/Http/Wolverine.Http.Tests/user_name_relay_from_http.cs
@@ -1,0 +1,40 @@
+using System.Security.Claims;
+using Shouldly;
+using WolverineWebApi;
+
+namespace Wolverine.Http.Tests;
+
+public class user_name_relay_from_http : IntegrationContext
+{
+    public user_name_relay_from_http(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task user_name_is_set_from_claims_principal()
+    {
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimTypes.Name, "testuser@example.com")],
+            "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        var result = await Scenario(x =>
+        {
+            x.ConfigureHttpContext(c => c.User = principal);
+            x.Get.Url("/user/name");
+        });
+
+        result.ReadAsText().ShouldBe("testuser@example.com");
+    }
+
+    [Fact]
+    public async Task user_name_is_none_when_not_authenticated()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/user/name");
+        });
+
+        result.ReadAsText().ShouldBe("NONE");
+    }
+}

--- a/src/Http/Wolverine.Http/Runtime/UserNameMiddleware.cs
+++ b/src/Http/Wolverine.Http/Runtime/UserNameMiddleware.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.Core.Reflection;
+using Microsoft.AspNetCore.Http;
+
+namespace Wolverine.Http.Runtime;
+
+public static class UserNameMiddleware
+{
+    public static void Apply(HttpContext httpContext, IMessageContext messaging)
+    {
+        var userName = httpContext.User?.Identity?.Name;
+        if (userName is not null)
+        {
+            messaging.UserName = userName;
+            Activity.Current?.SetTag("enduser.id", userName);
+        }
+    }
+}
+
+internal class UserNamePolicy : IHttpPolicy
+{
+    public void Apply(IReadOnlyList<HttpChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        var options = container.GetInstance<WolverineOptions>();
+        if (!options.EnableRelayOfUserName) return;
+
+        foreach (var chain in chains)
+        {
+            var serviceDependencies = chain.ServiceDependencies(container, Type.EmptyTypes).ToArray();
+            if (serviceDependencies.Contains(typeof(IMessageContext)) ||
+                serviceDependencies.Contains(typeof(IMessageBus)))
+            {
+                chain.Middleware.Insert(0,
+                    new MethodCall(typeof(UserNameMiddleware), nameof(UserNameMiddleware.Apply)));
+            }
+        }
+    }
+}

--- a/src/Http/Wolverine.Http/WolverineHttpOptions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpOptions.cs
@@ -126,6 +126,7 @@ public class WolverineHttpOptions
     {
         Policies.Add(new HttpAwarePolicy());
         Policies.Add(new RequestIdPolicy());
+        Policies.Add(new UserNamePolicy());
         Policies.Add(new RequiredEntityPolicy());
         Policies.Add(new HttpChainResponseCacheHeaderPolicy());
 

--- a/src/Http/WolverineWebApi/Program.cs
+++ b/src/Http/WolverineWebApi/Program.cs
@@ -116,6 +116,8 @@ public class Program
 
             opts.Durability.Mode = DurabilityMode.Solo;
 
+            opts.EnableRelayOfUserName = true;
+
             // Other Wolverine configuration...
             opts.Policies.AutoApplyTransactions();
             opts.Policies.UseDurableLocalQueues();

--- a/src/Http/WolverineWebApi/UserNameEndpoint.cs
+++ b/src/Http/WolverineWebApi/UserNameEndpoint.cs
@@ -1,0 +1,13 @@
+using Wolverine;
+using Wolverine.Http;
+
+namespace WolverineWebApi;
+
+public static class UserNameEndpoint
+{
+    [WolverineGet("/user/name")]
+    public static string GetUserName(IMessageContext context)
+    {
+        return context.UserName ?? "NONE";
+    }
+}

--- a/src/Persistence/Wolverine.Marten/Publishing/OutboxedSessionFactory.cs
+++ b/src/Persistence/Wolverine.Marten/Publishing/OutboxedSessionFactory.cs
@@ -145,6 +145,15 @@ public class OutboxedSessionFactory
 
         session.CorrelationId = context.CorrelationId;
 
+        if (context.Envelope?.UserName is not null)
+        {
+            session.LastModifiedBy = context.Envelope.UserName;
+        }
+        else if (context.UserName is not null)
+        {
+            session.LastModifiedBy = context.UserName;
+        }
+
         var transaction = new MartenEnvelopeTransaction(session, context);
         context.EnlistInOutbox(transaction);
 

--- a/src/Testing/CoreTests/Runtime/MessageContextTests.cs
+++ b/src/Testing/CoreTests/Runtime/MessageContextTests.cs
@@ -146,6 +146,61 @@ public class MessageContextTests
     }
 
     [Fact]
+    public void track_envelope_correlation_relays_user_name_when_enabled()
+    {
+        theRuntime.Options.EnableRelayOfUserName = true;
+        theContext.UserName = "testuser";
+
+        using var activity = new Activity("DoWork");
+        activity.Start();
+
+        theContext.TrackEnvelopeCorrelation(theEnvelope, activity);
+
+        theEnvelope.UserName.ShouldBe("testuser");
+    }
+
+    [Fact]
+    public void track_envelope_correlation_does_not_relay_user_name_when_disabled()
+    {
+        theRuntime.Options.EnableRelayOfUserName = false;
+        theContext.UserName = "testuser";
+
+        using var activity = new Activity("DoWork");
+        activity.Start();
+
+        theContext.TrackEnvelopeCorrelation(theEnvelope, activity);
+
+        theEnvelope.UserName.ShouldBeNull();
+    }
+
+    [Fact]
+    public void track_envelope_correlation_does_not_override_existing_user_name()
+    {
+        theRuntime.Options.EnableRelayOfUserName = true;
+        theContext.UserName = "contextuser";
+        theEnvelope.UserName = "envelopeuser";
+
+        using var activity = new Activity("DoWork");
+        activity.Start();
+
+        theContext.TrackEnvelopeCorrelation(theEnvelope, activity);
+
+        theEnvelope.UserName.ShouldBe("envelopeuser");
+    }
+
+    [Fact]
+    public void reads_user_name_from_envelope()
+    {
+        var original = ObjectMother.Envelope();
+        original.UserName = "fromenvelope";
+
+        var context = new MessageContext(theRuntime);
+        context.ReadEnvelope(original, InvocationCallback.Instance);
+
+        context.UserName.ShouldBe("fromenvelope");
+    }
+
+    [Fact]
     public void reads_tenant_id_from_envelope()
     {
         theContext.TenantId.ShouldBe("some tenant");

--- a/src/Testing/CoreTests/Serialization/serialization_and_deserialization.cs
+++ b/src/Testing/CoreTests/Serialization/serialization_and_deserialization.cs
@@ -50,6 +50,20 @@ public class serialization_and_deserialization_of_single_message
     }
 
     [Fact]
+    public void user_name_is_round_tripped()
+    {
+        outgoing.UserName = "testuser@example.com";
+        incoming.UserName.ShouldBe(outgoing.UserName);
+    }
+
+    [Fact]
+    public void user_name_null_is_round_tripped()
+    {
+        outgoing.UserName = null;
+        incoming.UserName.ShouldBeNull();
+    }
+
+    [Fact]
     public void accepted_content_types_positive()
     {
         outgoing.AcceptedContentTypes = ["a", "b"];

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -306,6 +306,11 @@ public partial class Envelope : IHasTenantId
     public string? TenantId { get; set; }
 
     /// <summary>
+    ///     The authenticated user name for tracking and auditing purposes
+    /// </summary>
+    public string? UserName { get; set; }
+
+    /// <summary>
     ///     Specifies the accepted content types for the requested reply
     /// </summary>
     internal static readonly string?[] DefaultAcceptedContentTypes = ["application/json"];

--- a/src/Wolverine/EnvelopeConstants.cs
+++ b/src/Wolverine/EnvelopeConstants.cs
@@ -26,4 +26,5 @@ public static class EnvelopeConstants
     public const string PartitionKey = "partition-key";
     public const string TopicNameKey = "topic-name";
     public const string KeepUntilKey = "keep-until";
+    public const string UserNameKey = "user-name";
 }

--- a/src/Wolverine/IMessageContext.cs
+++ b/src/Wolverine/IMessageContext.cs
@@ -10,6 +10,13 @@ public interface IMessageContext : IMessageBus
     string? CorrelationId { get; set; }
 
     /// <summary>
+    ///     The authenticated user name for tracking and auditing purposes.
+    ///     When EnableRelayOfUserName is true, this is automatically propagated
+    ///     to outgoing messages and Marten's LastModifiedBy.
+    /// </summary>
+    string? UserName { get; set; }
+
+    /// <summary>
     ///     The envelope being currently handled. This will only be non-null during
     ///     the handling of a message
     /// </summary>

--- a/src/Wolverine/Runtime/MessageBus.cs
+++ b/src/Wolverine/Runtime/MessageBus.cs
@@ -42,6 +42,7 @@ public partial class MessageBus : IMessageBus, IMessageContext
     }
 
     public string? CorrelationId { get; set; }
+    public string? UserName { get; set; }
     public Envelope? Envelope { get; protected set; }
     public virtual ValueTask RespondToSenderAsync(object response)
     {
@@ -305,6 +306,12 @@ public partial class MessageBus : IMessageBus, IMessageContext
         outbound.CorrelationId = CorrelationId;
         outbound.ConversationId = outbound.Id; // the message chain originates here
         outbound.TenantId ??= TenantId; // don't override a tenant id that's specifically set on the envelope itself
+
+        if (Runtime.Options.EnableRelayOfUserName)
+        {
+            outbound.UserName ??= UserName;
+        }
+
         outbound.ParentId = activity?.Id;
         outbound.Store = Storage;
     }

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -662,6 +662,7 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
         _channel = channel;
         _sagaId = originalEnvelope.SagaId;
         TenantId = originalEnvelope.TenantId;
+        UserName = originalEnvelope.UserName;
 
         Transaction = this;
 

--- a/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
@@ -128,7 +128,11 @@ public static class EnvelopeSerializer
                 case EnvelopeConstants.TopicNameKey:
                     env.TopicName = value;
                     break;
-                
+
+                case EnvelopeConstants.UserNameKey:
+                    env.UserName = value;
+                    break;
+
                 case EnvelopeConstants.PartitionKey:
                     env.PartitionKey = value;
                     break;
@@ -255,7 +259,7 @@ public static class EnvelopeSerializer
         writer.WriteProp(ref count, EnvelopeConstants.ParentIdKey, env.ParentId);
         writer.WriteProp(ref count, EnvelopeConstants.TenantIdKey, env.TenantId);
         writer.WriteProp(ref count, EnvelopeConstants.TopicNameKey, env.TopicName);
-        
+        writer.WriteProp(ref count, EnvelopeConstants.UserNameKey, env.UserName);
 
         if (env.AcceptedContentTypes.Length != 0)
         {

--- a/src/Wolverine/TestMessageContext.cs
+++ b/src/Wolverine/TestMessageContext.cs
@@ -179,6 +179,7 @@ public class TestMessageContext : IMessageContext
     }
 
     public string? CorrelationId { get; set; }
+    public string? UserName { get; set; }
     public Envelope? Envelope { get; }
 
     Task ICommandBus.InvokeAsync(object message, CancellationToken cancellation, TimeSpan? timeout)

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -168,6 +168,13 @@ public sealed partial class WolverineOptions
     public SendingFailurePolicies SendingFailure { get; } = new();
 
     /// <summary>
+    /// When enabled, Wolverine will automatically relay the authenticated user name
+    /// from HTTP ClaimsPrincipal through the messaging infrastructure, propagating it
+    /// on outgoing envelopes and into Marten's IDocumentSession.LastModifiedBy
+    /// </summary>
+    public bool EnableRelayOfUserName { get; set; }
+
+    /// <summary>
     /// What is the policy within this application for whether or not it is valid to allow Service Location within
     /// the generated code for message handlers or HTTP endpoints. Default is AllowedByWarn. Just keep in mind that
     /// Wolverine really does not want you to use service location if you don't have to!


### PR DESCRIPTION
## Summary
- Adds `EnableRelayOfUserName` option to `WolverineOptions` that, when enabled, automatically extracts `HttpContext.User.Identity.Name` and propagates it through the messaging infrastructure
- Sets `IMessageContext.UserName` from the authenticated `ClaimsPrincipal`, carries it on outgoing `Envelope.UserName`, and applies it to Marten's `IDocumentSession.LastModifiedBy`
- Adds OpenTelemetry `enduser.id` tag on the current activity

## Changes
- **Core**: Added `UserName` property to `Envelope`, `IMessageContext`, `MessageBus`, `MessageContext`, `TestMessageContext`, and `EnvelopeConstants`
- **Serialization**: `EnvelopeSerializer` reads/writes `UserName` for binary round-trip
- **Relay**: `MessageBus.TrackEnvelopeCorrelation()` propagates `UserName` to outgoing envelopes when enabled
- **HTTP Middleware**: New `UserNameMiddleware` + `UserNamePolicy` (follows `RequestIdMiddleware` pattern) registered in `WolverineHttpOptions`
- **Marten**: `OutboxedSessionFactory.configureSession()` sets `session.LastModifiedBy` from `UserName`
- **Docs**: Added "Tracking User Name" section to HTTP security documentation

## Test plan
- [x] Unit: `EnvelopeSerializer` round-trip for `UserName` (set and null)
- [x] Unit: `TrackEnvelopeCorrelation` relays `UserName` when enabled, skips when disabled, doesn't override existing
- [x] Unit: `ReadEnvelope` reads `UserName` from incoming envelope
- [x] Integration: HTTP endpoint returns `UserName` from authenticated `ClaimsPrincipal`
- [x] Integration: Returns "NONE" when not authenticated

Closes #2203

🤖 Generated with [Claude Code](https://claude.com/claude-code)