### PR TITLE
Remove obsolete attribute from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 networks:
   app-tier:
     driver: bridge


### PR DESCRIPTION
This PR avoids the warning from docker-compose: _the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"_