### PR TITLE
Fix stale messages during rollout and improve graceful shutdown

### DIFF
--- a/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesForAncillaryOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesForAncillaryOperation.cs
@@ -1,0 +1,52 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Weasel.Core;
+using Wolverine.RDBMS.Polling;
+using Wolverine.Runtime.Agents;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Wolverine.RDBMS.Durability;
+
+/// <summary>
+/// Releases inbox/outbox messages owned by nodes that no longer exist.
+/// Used for ancillary/tenant databases that lack the wolverine_nodes table,
+/// so the active node list must be provided externally.
+/// </summary>
+internal class ReleaseOrphanedMessagesForAncillaryOperation : IDatabaseOperation, IDoNotReturnData
+{
+    private readonly IMessageDatabase _database;
+    private readonly IReadOnlyList<int> _activeNodeNumbers;
+
+    public ReleaseOrphanedMessagesForAncillaryOperation(IMessageDatabase database, IReadOnlyList<int> activeNodeNumbers)
+    {
+        _database = database;
+        _activeNodeNumbers = activeNodeNumbers;
+    }
+
+    public string Description => "Release inbox/outbox messages owned by nodes that no longer exist (ancillary database)";
+
+    public void ConfigureCommand(DbCommandBuilder builder)
+    {
+        if (_activeNodeNumbers.Count == 0) return;
+
+        var schemaName = _database.SchemaName;
+        var incomingTable = new DbObjectName(schemaName, DatabaseConstants.IncomingTable);
+        var outgoingTable = new DbObjectName(schemaName, DatabaseConstants.OutgoingTable);
+        var nodeList = string.Join(", ", _activeNodeNumbers);
+
+        builder.Append(
+            $"update {incomingTable} set {DatabaseConstants.OwnerId} = 0 where {DatabaseConstants.OwnerId} != 0 and {DatabaseConstants.OwnerId} not in ({nodeList});");
+        builder.Append(
+            $"update {outgoingTable} set {DatabaseConstants.OwnerId} = 0 where {DatabaseConstants.OwnerId} != 0 and {DatabaseConstants.OwnerId} not in ({nodeList});");
+    }
+
+    public Task ReadResultsAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
+
+    public IEnumerable<IAgentCommand> PostProcessingCommands()
+    {
+        yield break;
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesOperation.cs
@@ -1,0 +1,46 @@
+using System.Data.Common;
+using Weasel.Core;
+using Wolverine.RDBMS.Polling;
+using Wolverine.Runtime.Agents;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Wolverine.RDBMS.Durability;
+
+/// <summary>
+/// Releases inbox/outbox messages owned by nodes that no longer exist in the wolverine_nodes table.
+/// Used for main databases where the nodes table is co-located.
+/// </summary>
+internal class ReleaseOrphanedMessagesOperation : IDatabaseOperation, IDoNotReturnData
+{
+    private readonly IMessageDatabase _database;
+
+    public ReleaseOrphanedMessagesOperation(IMessageDatabase database)
+    {
+        _database = database;
+    }
+
+    public string Description => "Release inbox/outbox messages owned by nodes that no longer exist";
+
+    public void ConfigureCommand(DbCommandBuilder builder)
+    {
+        var schemaName = _database.SchemaName;
+        var incomingTable = new DbObjectName(schemaName, DatabaseConstants.IncomingTable);
+        var outgoingTable = new DbObjectName(schemaName, DatabaseConstants.OutgoingTable);
+        var nodesTable = new DbObjectName(schemaName, DatabaseConstants.NodeTableName);
+
+        builder.Append(
+            $"update {incomingTable} set {DatabaseConstants.OwnerId} = 0 where {DatabaseConstants.OwnerId} != 0 and {DatabaseConstants.OwnerId} not in (select {DatabaseConstants.NodeNumber} from {nodesTable});");
+        builder.Append(
+            $"update {outgoingTable} set {DatabaseConstants.OwnerId} = 0 where {DatabaseConstants.OwnerId} != 0 and {DatabaseConstants.OwnerId} not in (select {DatabaseConstants.NodeNumber} from {nodesTable});");
+    }
+
+    public Task ReadResultsAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
+
+    public IEnumerable<IAgentCommand> PostProcessingCommands()
+    {
+        yield break;
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
+++ b/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
@@ -76,9 +76,23 @@ internal class DurabilityAgent : IAgent
 
         var recoveryStart = _settings.ScheduledJobFirstExecution.Add(new Random().Next(0, 1000).Milliseconds());
 
-        _recoveryTimer = new Timer(_ =>
+        _recoveryTimer = new Timer(async _ =>
         {
-            var operations = buildOperationBatch();
+            IReadOnlyList<int>? activeNodeNumbers = null;
+            if (_database.Settings.Role != MessageStoreRole.Main)
+            {
+                try
+                {
+                    var nodes = await _runtime.Storage.Nodes.LoadAllNodesAsync(_runtime.Cancellation);
+                    activeNodeNumbers = nodes.Select(n => n.AssignedNodeNumber).ToList();
+                }
+                catch (Exception e)
+                {
+                    _logger.LogDebug(e, "Failed to load active nodes for orphaned message detection");
+                }
+            }
+
+            var operations = buildOperationBatch(activeNodeNumbers);
 
             var batch = new DatabaseOperationBatch(_database, operations);
             _runningBlock.Post(batch);
@@ -156,7 +170,7 @@ internal class DurabilityAgent : IAgent
         return false;
     }
 
-    private IDatabaseOperation[] buildOperationBatch()
+    private IDatabaseOperation[] buildOperationBatch(IReadOnlyList<int>? activeNodeNumbers = null)
     {
         var incomingTable = new DbObjectName(_database.SchemaName, DatabaseConstants.IncomingTable);
         var now = DateTimeOffset.UtcNow;
@@ -169,9 +183,18 @@ internal class DurabilityAgent : IAgent
             new MoveReplayableErrorMessagesToIncomingOperation(_database)
         ];
 
-        if (_database.Settings.Role == MessageStoreRole.Main && isTimeToPruneNodeEventRecords())
+        if (_database.Settings.Role == MessageStoreRole.Main)
         {
-            ops.Add(new DeleteOldNodeEventRecords(_database, _settings));
+            ops.Add(new ReleaseOrphanedMessagesOperation(_database));
+
+            if (isTimeToPruneNodeEventRecords())
+            {
+                ops.Add(new DeleteOldNodeEventRecords(_database, _settings));
+            }
+        }
+        else if (activeNodeNumbers is { Count: > 0 })
+        {
+            ops.Add(new ReleaseOrphanedMessagesForAncillaryOperation(_database, activeNodeNumbers));
         }
 
         if (_runtime.Options.Durability.OutboxStaleTime.HasValue)


### PR DESCRIPTION
## Summary

### Orphaned message recovery (#2279)
- Adds periodic recovery of messages stranded by dead nodes during rolling deployments
- `ReleaseOrphanedMessagesOperation` (main databases): uses `NOT IN (SELECT node_number FROM wolverine_nodes)` subquery
- `ReleaseOrphanedMessagesForAncillaryOperation` (ancillary/tenant databases): fetches active node numbers from the main store, builds explicit `NOT IN (1, 2, 3)` list
- Both operations run every recovery cycle in `DurabilityAgent.buildOperationBatch()`

### Graceful shutdown improvements (#2282)
- Reorder shutdown sequence: drain endpoints first (complete in-flight handlers), then release ownership and teardown agents
- Add bounded `WaitForCompletionAsync` in `DurableReceiver.DrainAsync()` and `BufferedReceiver.DrainAsync()` so in-flight message handlers finish before ownership is released
- Add configurable `DrainTimeout` setting (default 30 seconds) to `DurabilitySettings`
- New `GracefulShutdown` and `RollingRestart` chaos test scripts exercising shutdown scenarios

## Test plan
- [x] CoreTests: 1160 passed, 0 failed
- [x] PostgreSQL tests: 331 passed, 4 failed (pre-existing compliance test flakiness)
- [x] SQL Server tests: 294 passed, 1 failed (pre-existing tracking/timing issue)
- [x] Added GracefulShutdown and RollingRestart chaos test scripts with 6 new test methods

Closes #2279
Closes #2282

🤖 Generated with [Claude Code](https://claude.com/claude-code)