### PR TITLE
Fix code gen missing non-saga handler with Separated mode

### DIFF
--- a/src/Wolverine/Runtime/Handlers/HandlerGraph.GeneratesCode.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerGraph.GeneratesCode.cs
@@ -22,12 +22,10 @@ public partial class HandlerGraph
             {
                 yield return chain;
             }
-            else
+
+            foreach (var handlerChain in chain.ByEndpoint)
             {
-                foreach (var handlerChain in chain.ByEndpoint)
-                {
-                    yield return handlerChain;
-                }
+                yield return handlerChain;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fixes `explodeAllFiles()` in `HandlerGraph.GeneratesCode.cs` to always yield `ByEndpoint` chains, not only when the parent chain has no handlers
- When a message type has both a Saga handler and a non-saga handler with `MultipleHandlerBehavior.Separated`, the non-saga handler was moved to `ByEndpoint` but its code file was never generated because the `if/else` logic only yielded `ByEndpoint` chains when the parent had zero handlers

## Test plan
- [x] Existing saga separated behavior test passes (`using_a_saga_with_separated_behavior_mode`)
- [x] All 1160 CoreTests pass with no regressions

Closes #2289

🤖 Generated with [Claude Code](https://claude.com/claude-code)