### PR TITLE
Failing test: global partitioning + Separated mode

### DIFF
--- a/src/Testing/CoreTests/Runtime/Partitioning/global_partitioning_with_separated_handlers.cs
+++ b/src/Testing/CoreTests/Runtime/Partitioning/global_partitioning_with_separated_handlers.cs
@@ -1,0 +1,200 @@
+using JasperFx.CodeGeneration;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Runtime.Partitioning;
+
+public class global_partitioning_with_separated_handlers
+{
+    [Fact]
+    public async Task multiple_global_partitions_with_separated_handlers_for_same_message()
+    {
+        // Track which handlers have been invoked
+        PartitionHandlerOne.Reset();
+        PartitionHandlerTwo.Reset();
+        CascadeHandlerOne.Reset();
+        CascadeHandlerTwo.Reset();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(PartitionHandlerOne))
+                    .IncludeType(typeof(PartitionHandlerTwo))
+                    .IncludeType(typeof(CascadeHandlerOne))
+                    .IncludeType(typeof(CascadeHandlerTwo));
+
+                opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Auto;
+                opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+
+                // First global partition
+                opts.MessagePartitioning.GlobalPartitioned(gp =>
+                {
+                    var external = new LocalPartitionedMessageTopology(opts, "partition-a", 3);
+                    gp.SetExternalTopology(external, "partition-a");
+                    gp.Message<PartitionedCommand>();
+                    gp.Message<CascadedFromPartition>();
+                });
+
+                // Second global partition for the same messages
+                opts.MessagePartitioning.GlobalPartitioned(gp =>
+                {
+                    var external = new LocalPartitionedMessageTopology(opts, "partition-b", 3);
+                    gp.SetExternalTopology(external, "partition-b");
+                    gp.Message<PartitionedCommand>();
+                    gp.Message<CascadedFromPartition>();
+                });
+
+                opts.MessagePartitioning
+                    .ByMessage<PartitionedCommand>(m => m.GroupId)
+                    .ByMessage<CascadedFromPartition>(m => m.GroupId);
+            }).StartAsync();
+
+        var tracked = await host.SendMessageAndWaitAsync(
+            new PartitionedCommand("group-1", "test-payload"),
+            timeoutInMilliseconds: 15000);
+
+        // Both handlers for PartitionedCommand should have been invoked
+        PartitionHandlerOne.Handled.ShouldBeTrue(
+            "PartitionHandlerOne should have handled PartitionedCommand");
+        PartitionHandlerTwo.Handled.ShouldBeTrue(
+            "PartitionHandlerTwo should have handled PartitionedCommand");
+
+        // PartitionHandlerOne returns a CascadedFromPartition message.
+        // Both cascade handlers should have been invoked.
+        CascadeHandlerOne.Handled.ShouldBeTrue(
+            "CascadeHandlerOne should have handled CascadedFromPartition");
+        CascadeHandlerTwo.Handled.ShouldBeTrue(
+            "CascadeHandlerTwo should have handled CascadedFromPartition");
+
+        // Verify the cascaded message carried the correct payload
+        CascadeHandlerOne.LastPayload.ShouldBe("test-payload");
+        CascadeHandlerTwo.LastPayload.ShouldBe("test-payload");
+    }
+}
+
+// --- Message types ---
+
+public record PartitionedCommand(string GroupId, string Payload);
+public record CascadedFromPartition(string GroupId, string Payload);
+
+// --- Handlers: two separate handlers for PartitionedCommand ---
+
+public static class PartitionHandlerOne
+{
+    private static bool _handled;
+    private static readonly object _lock = new();
+
+    public static bool Handled
+    {
+        get { lock (_lock) return _handled; }
+    }
+
+    public static void Reset()
+    {
+        lock (_lock) _handled = false;
+    }
+
+    // Returns a cascaded message
+    public static CascadedFromPartition Handle(PartitionedCommand command)
+    {
+        lock (_lock) _handled = true;
+        return new CascadedFromPartition(command.GroupId, command.Payload);
+    }
+}
+
+public static class PartitionHandlerTwo
+{
+    private static bool _handled;
+    private static readonly object _lock = new();
+
+    public static bool Handled
+    {
+        get { lock (_lock) return _handled; }
+    }
+
+    public static void Reset()
+    {
+        lock (_lock) _handled = false;
+    }
+
+    public static void Handle(PartitionedCommand command)
+    {
+        lock (_lock) _handled = true;
+    }
+}
+
+// --- Handlers: two separate handlers for CascadedFromPartition ---
+
+public static class CascadeHandlerOne
+{
+    private static bool _handled;
+    private static string? _lastPayload;
+    private static readonly object _lock = new();
+
+    public static bool Handled
+    {
+        get { lock (_lock) return _handled; }
+    }
+
+    public static string? LastPayload
+    {
+        get { lock (_lock) return _lastPayload; }
+    }
+
+    public static void Reset()
+    {
+        lock (_lock)
+        {
+            _handled = false;
+            _lastPayload = null;
+        }
+    }
+
+    public static void Handle(CascadedFromPartition message)
+    {
+        lock (_lock)
+        {
+            _handled = true;
+            _lastPayload = message.Payload;
+        }
+    }
+}
+
+public static class CascadeHandlerTwo
+{
+    private static bool _handled;
+    private static string? _lastPayload;
+    private static readonly object _lock = new();
+
+    public static bool Handled
+    {
+        get { lock (_lock) return _handled; }
+    }
+
+    public static string? LastPayload
+    {
+        get { lock (_lock) return _lastPayload; }
+    }
+
+    public static void Reset()
+    {
+        lock (_lock)
+        {
+            _handled = false;
+            _lastPayload = null;
+        }
+    }
+
+    public static void Handle(CascadedFromPartition message)
+    {
+        lock (_lock)
+        {
+            _handled = true;
+            _lastPayload = message.Payload;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a failing integration test demonstrating that **global partitioning** combined with **`MultipleHandlerBehavior.Separated`** throws `NoHandlerForEndpointException`
- The test sets up two global partitions for the same message types, with two separate handlers per message type and a cascading message flow
- Related to #2273 (global partitioning feature)

## Root Cause Analysis

When `Separated` mode is active, all handlers are moved to sticky `ByEndpoint` chains bound to handler-type-specific local queues (e.g., `local://partitionhandlerone/`). Global partitioning routes messages to companion local queues (e.g., `local://partition-a2/`).

In `HandlerGraph.HandlerFor(Type, Endpoint)` (line 196), the fanout handler logic has this guard:

```csharp
if (allLocal && endpoint is not LocalQueue)
{
    return getOrBuildFanoutHandler(messageType, chain);
}

throw new NoHandlerForEndpointException(messageType, endpoint.Uri);
```

The fanout handler only activates when the incoming endpoint is **not** a `LocalQueue` (i.e., an external transport endpoint). But global partition companion queues ARE `LocalQueue` instances, so the fanout path is skipped and the exception is thrown.

## Error Output
```
NoHandlerForEndpointException: No handlers for message type PartitionedCommand 
at endpoint local://partition-a2/
```

## Test plan
- [x] New test correctly **fails** demonstrating the bug
- [x] All 1160 existing CoreTests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)