### PR TITLE
Fix global partitioning with Separated handler mode

### DIFF
--- a/src/Testing/CoreTests/Runtime/Partitioning/global_partitioning_with_separated_handlers.cs
+++ b/src/Testing/CoreTests/Runtime/Partitioning/global_partitioning_with_separated_handlers.cs
@@ -1,0 +1,200 @@
+using JasperFx.CodeGeneration;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Runtime.Partitioning;
+
+public class global_partitioning_with_separated_handlers
+{
+    [Fact]
+    public async Task multiple_global_partitions_with_separated_handlers_for_same_message()
+    {
+        // Track which handlers have been invoked
+        PartitionHandlerOne.Reset();
+        PartitionHandlerTwo.Reset();
+        CascadeHandlerOne.Reset();
+        CascadeHandlerTwo.Reset();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(PartitionHandlerOne))
+                    .IncludeType(typeof(PartitionHandlerTwo))
+                    .IncludeType(typeof(CascadeHandlerOne))
+                    .IncludeType(typeof(CascadeHandlerTwo));
+
+                opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Auto;
+                opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+
+                // First global partition
+                opts.MessagePartitioning.GlobalPartitioned(gp =>
+                {
+                    var external = new LocalPartitionedMessageTopology(opts, "partition-a", 3);
+                    gp.SetExternalTopology(external, "partition-a");
+                    gp.Message<PartitionedCommand>();
+                    gp.Message<CascadedFromPartition>();
+                });
+
+                // Second global partition for the same messages
+                opts.MessagePartitioning.GlobalPartitioned(gp =>
+                {
+                    var external = new LocalPartitionedMessageTopology(opts, "partition-b", 3);
+                    gp.SetExternalTopology(external, "partition-b");
+                    gp.Message<PartitionedCommand>();
+                    gp.Message<CascadedFromPartition>();
+                });
+
+                opts.MessagePartitioning
+                    .ByMessage<PartitionedCommand>(m => m.GroupId)
+                    .ByMessage<CascadedFromPartition>(m => m.GroupId);
+            }).StartAsync();
+
+        var tracked = await host.SendMessageAndWaitAsync(
+            new PartitionedCommand("group-1", "test-payload"),
+            timeoutInMilliseconds: 15000);
+
+        // Both handlers for PartitionedCommand should have been invoked
+        PartitionHandlerOne.Handled.ShouldBeTrue(
+            "PartitionHandlerOne should have handled PartitionedCommand");
+        PartitionHandlerTwo.Handled.ShouldBeTrue(
+            "PartitionHandlerTwo should have handled PartitionedCommand");
+
+        // PartitionHandlerOne returns a CascadedFromPartition message.
+        // Both cascade handlers should have been invoked.
+        CascadeHandlerOne.Handled.ShouldBeTrue(
+            "CascadeHandlerOne should have handled CascadedFromPartition");
+        CascadeHandlerTwo.Handled.ShouldBeTrue(
+            "CascadeHandlerTwo should have handled CascadedFromPartition");
+
+        // Verify the cascaded message carried the correct payload
+        CascadeHandlerOne.LastPayload.ShouldBe("test-payload");
+        CascadeHandlerTwo.LastPayload.ShouldBe("test-payload");
+    }
+}
+
+// --- Message types ---
+
+public record PartitionedCommand(string GroupId, string Payload);
+public record CascadedFromPartition(string GroupId, string Payload);
+
+// --- Handlers: two separate handlers for PartitionedCommand ---
+
+public static class PartitionHandlerOne
+{
+    private static bool _handled;
+    private static readonly object _lock = new();
+
+    public static bool Handled
+    {
+        get { lock (_lock) return _handled; }
+    }
+
+    public static void Reset()
+    {
+        lock (_lock) _handled = false;
+    }
+
+    // Returns a cascaded message
+    public static CascadedFromPartition Handle(PartitionedCommand command)
+    {
+        lock (_lock) _handled = true;
+        return new CascadedFromPartition(command.GroupId, command.Payload);
+    }
+}
+
+public static class PartitionHandlerTwo
+{
+    private static bool _handled;
+    private static readonly object _lock = new();
+
+    public static bool Handled
+    {
+        get { lock (_lock) return _handled; }
+    }
+
+    public static void Reset()
+    {
+        lock (_lock) _handled = false;
+    }
+
+    public static void Handle(PartitionedCommand command)
+    {
+        lock (_lock) _handled = true;
+    }
+}
+
+// --- Handlers: two separate handlers for CascadedFromPartition ---
+
+public static class CascadeHandlerOne
+{
+    private static bool _handled;
+    private static string? _lastPayload;
+    private static readonly object _lock = new();
+
+    public static bool Handled
+    {
+        get { lock (_lock) return _handled; }
+    }
+
+    public static string? LastPayload
+    {
+        get { lock (_lock) return _lastPayload; }
+    }
+
+    public static void Reset()
+    {
+        lock (_lock)
+        {
+            _handled = false;
+            _lastPayload = null;
+        }
+    }
+
+    public static void Handle(CascadedFromPartition message)
+    {
+        lock (_lock)
+        {
+            _handled = true;
+            _lastPayload = message.Payload;
+        }
+    }
+}
+
+public static class CascadeHandlerTwo
+{
+    private static bool _handled;
+    private static string? _lastPayload;
+    private static readonly object _lock = new();
+
+    public static bool Handled
+    {
+        get { lock (_lock) return _handled; }
+    }
+
+    public static string? LastPayload
+    {
+        get { lock (_lock) return _lastPayload; }
+    }
+
+    public static void Reset()
+    {
+        lock (_lock)
+        {
+            _handled = false;
+            _lastPayload = null;
+        }
+    }
+
+    public static void Handle(CascadedFromPartition message)
+    {
+        lock (_lock)
+        {
+            _handled = true;
+            _lastPayload = message.Payload;
+        }
+    }
+}

--- a/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
@@ -188,9 +188,19 @@ public partial class HandlerGraph : ICodeFileCollectionWithServices, IWithFailur
                 var allLocal = chain.ByEndpoint.All(
                     c => c.Endpoints.All(e => e is LocalQueue));
 
-                if (allLocal && endpoint is not LocalQueue)
+                if (allLocal)
                 {
-                    return getOrBuildFanoutHandler(messageType, chain);
+                    if (endpoint is not LocalQueue)
+                    {
+                        return getOrBuildFanoutHandler(messageType, chain);
+                    }
+
+                    // Also fanout when the incoming local queue is part of a sharded/global
+                    // partition topology rather than a sticky handler's own queue
+                    if (endpoint.UsedInShardedTopology)
+                    {
+                        return getOrBuildFanoutHandler(messageType, chain);
+                    }
                 }
 
                 throw new NoHandlerForEndpointException(messageType, endpoint.Uri);


### PR DESCRIPTION
## Summary
- Fixes `NoHandlerForEndpointException` when combining global partitioning with `MultipleHandlerBehavior.Separated`
- Extends the fanout handler logic in `HandlerGraph.HandlerFor(Type, Endpoint)` to also activate when the incoming local queue is part of a sharded/global partition topology (`UsedInShardedTopology = true`)
- Adds integration test with two global partitions, multiple handlers per message type, and cascading messages

## Problem

When global partitioning routes messages to companion local queues and `Separated` mode moves all handlers to sticky handler-specific local queues:

1. Message arrives at `local://partition-a2/` (global partition companion queue)
2. No sticky handler matches this endpoint
3. Fanout handler logic checks `endpoint is not LocalQueue` — but it IS a `LocalQueue` 
4. Falls through to `throw new NoHandlerForEndpointException`

## Fix

The fanout handler should also be created when the incoming `LocalQueue` is part of a sharded topology (not a sticky handler's own queue). The `UsedInShardedTopology` property on the endpoint distinguishes partition queues from arbitrary local queues, preserving the existing `NoHandlerForEndpointException` behavior for misrouted messages.

## Test plan
- [x] New integration test passes: two global partitions, four handlers (two per message type), cascading message flow
- [x] All 1161 CoreTests pass (1160 existing + 1 new), including `get_an_explanatory_message` which validates that `NoHandlerForEndpointException` is still thrown for arbitrary unhandled local queues

Supersedes #2292

🤖 Generated with [Claude Code](https://claude.com/claude-code)