### PR TITLE
Fix deadlock in DrainAsync causing Redis scheduling test failure

### DIFF
--- a/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
@@ -124,19 +124,27 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
 
     public async ValueTask DrainAsync()
     {
+        // If _latched was already true, this drain was triggered during shutdown
+        // (after OnApplicationStopping called Latch()). Safe to wait for in-flight items.
+        // If _latched was false, this drain may have been triggered from within the handler
+        // pipeline (e.g., rate limiting pause via PauseListenerContinuation). Waiting for
+        // the receiving block to complete would deadlock because the current message's
+        // execute function is still on the call stack.
+        var waitForCompletion = _latched;
         _latched = true;
         _receivingBlock.Complete();
 
-        // Wait for in-flight handler executions to complete, bounded by a timeout
-        // to prevent hanging during shutdown
-        try
+        if (waitForCompletion)
         {
-            var completion = _receivingBlock.WaitForCompletionAsync();
-            await Task.WhenAny(completion, Task.Delay(_settings.DrainTimeout));
-        }
-        catch (Exception e)
-        {
-            _logger.LogDebug(e, "Error waiting for in-flight message processing to complete at {Uri}", Uri);
+            try
+            {
+                var completion = _receivingBlock.WaitForCompletionAsync();
+                await Task.WhenAny(completion, Task.Delay(_settings.DrainTimeout));
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e, "Error waiting for in-flight message processing to complete at {Uri}", Uri);
+            }
         }
 
         await _completeBlock.DrainAsync();

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -283,19 +283,27 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
 
     public async ValueTask DrainAsync()
     {
+        // If _latched was already true, this drain was triggered during shutdown
+        // (after OnApplicationStopping called Latch()). Safe to wait for in-flight items.
+        // If _latched was false, this drain may have been triggered from within the handler
+        // pipeline (e.g., rate limiting pause via PauseListenerContinuation). Waiting for
+        // the receiver block to complete would deadlock because the current message's
+        // execute function is still on the call stack.
+        var waitForCompletion = _latched;
         _latched = true;
         _receiver.Complete();
 
-        // Wait for in-flight handler executions to complete, bounded by a timeout
-        // to prevent hanging during shutdown
-        try
+        if (waitForCompletion)
         {
-            var completion = _receiver.WaitForCompletionAsync();
-            await Task.WhenAny(completion, Task.Delay(_settings.DrainTimeout));
-        }
-        catch (Exception e)
-        {
-            _logger.LogDebug(e, "Error waiting for in-flight message processing to complete at {Uri}", Uri);
+            try
+            {
+                var completion = _receiver.WaitForCompletionAsync();
+                await Task.WhenAny(completion, Task.Delay(_settings.DrainTimeout));
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e, "Error waiting for in-flight message processing to complete at {Uri}", Uri);
+            }
         }
 
         await _incrementAttempts.DrainAsync();


### PR DESCRIPTION
## Summary
- Fixes a deadlock in `DurableReceiver.DrainAsync()` and `BufferedReceiver.DrainAsync()` introduced by #2288
- The `WaitForCompletionAsync` call now only executes during actual shutdown (when `Latch()` was called separately via `OnApplicationStopping`), not during pipeline-triggered pauses

## Root Cause

PR #2288 added `WaitForCompletionAsync` to `DrainAsync()` to wait for in-flight messages during graceful shutdown. However, `DrainAsync()` is also called from within the handler pipeline when a rate-limited message triggers `PauseListenerContinuation`:

```
_receiver block execute(message B)
  → pipeline.InvokeAsync()
    → RateLimitContinuation → ReScheduleAsync (stores in Redis sorted set)
    → PauseListenerContinuation → agent.PauseAsync()
      → StopAndDrainAsync()
        → receiver.DrainAsync()
          → _receiver.WaitForCompletionAsync()  ← waits for message B to finish
                                                  but message B is waiting for THIS to return
```

This circular dependency causes a 30-second deadlock (bounded by `DrainTimeout`), after which the rate-limited message's retry window has long passed, and the test's 20-second polling timeout expires first.

## Fix

Use the `_latched` flag to distinguish the two call paths:
- **Shutdown**: `OnApplicationStopping` calls `Latch()` first → `_latched` is already `true` when `DrainAsync()` runs → safe to wait
- **Pipeline pause**: no prior `Latch()` call → `_latched` is `false` when `DrainAsync()` runs → skip the wait to avoid deadlock

## Test plan
- [x] `rate_limited_messages_are_delayed_with_native_scheduling` passes consistently (was failing every run)
- [x] All 87 Wolverine.Redis.Tests pass
- [x] All 1160 CoreTests pass

Closes #2291

🤖 Generated with [Claude Code](https://claude.com/claude-code)