### PR TITLE
Fix [AlwaysPublishResponse] on remote request/reply

### DIFF
--- a/src/Testing/CoreTests/Acceptance/remote_invocation.cs
+++ b/src/Testing/CoreTests/Acceptance/remote_invocation.cs
@@ -63,7 +63,8 @@ public class remote_invocation : IAsyncLifetime
 
                 opts.PublishMessage<Request4>().ToPort(_receiver1Port);
                 opts.PublishMessage<Request4>().ToPort(_receiver2Port);
-                
+                opts.PublishMessage<AlwaysPublishRequest>().ToPort(_receiver1Port);
+
                 opts.EnableAutomaticFailureAcks = true;
             }).StartAsync();
     }
@@ -400,6 +401,27 @@ public class remote_invocation : IAsyncLifetime
 
         await Should.ThrowAsync<IndeterminateRoutesException>(() => publisher.InvokeAsync(new RequestWithNoHandler()));
     }
+
+    [Fact]
+    public async Task always_publish_response_should_also_publish_on_remote_request_reply()
+    {
+        AlwaysPublishResponseReceivedHandler.Received = new TaskCompletionSource<bool>();
+
+        var (session, response) = await _sender.TrackActivity()
+            .AlsoTrack(_receiver1)
+            .Timeout(10.Seconds())
+            .WaitForMessageToBeReceivedAt<AlwaysPublishResponse>(_receiver1)
+            .InvokeAndWaitAsync<AlwaysPublishResponse>(new AlwaysPublishRequest { Name = "test" });
+
+        // The response should have been returned to the sender via request/reply
+        response.ShouldNotBeNull();
+        response.Name.ShouldBe("test");
+
+        // The response should ALSO have been published as a cascading message
+        // and handled by AlwaysPublishResponseReceivedHandler on the receiver
+        var handled = await AlwaysPublishResponseReceivedHandler.Received.Task.WaitAsync(10.Seconds());
+        handled.ShouldBeTrue();
+    }
 }
 
 public class Request1
@@ -432,6 +454,35 @@ public class Response1
 public class Response3
 {
     public string Name { get; set; }
+}
+
+public class AlwaysPublishRequest
+{
+    public string Name { get; set; }
+}
+
+public class AlwaysPublishResponse
+{
+    public string Name { get; set; }
+}
+
+public static class AlwaysPublishResponseReceivedHandler
+{
+    public static TaskCompletionSource<bool> Received { get; set; } = new();
+
+    public static void Handle(AlwaysPublishResponse response)
+    {
+        Received.TrySetResult(true);
+    }
+}
+
+public static class AlwaysPublishRequestHandler
+{
+    [AlwaysPublishResponse]
+    public static AlwaysPublishResponse Handle(AlwaysPublishRequest request)
+    {
+        return new AlwaysPublishResponse { Name = request.Name };
+    }
 }
 
 public class RequestHandler

--- a/src/Wolverine/Attributes/AlwaysPublishResponseAttribute.cs
+++ b/src/Wolverine/Attributes/AlwaysPublishResponseAttribute.cs
@@ -26,6 +26,7 @@ internal class AlwaysPublishResponseFrame : SyncFrame
     {
         writer.WriteComment("Always publish the response as a message due to the [AlwaysPublishResponse] usage");
         writer.WriteLine($"{_envelope.Usage}.{nameof(Envelope.DoNotCascadeResponse)} = false;");
+        writer.WriteLine($"{_envelope.Usage}.{nameof(Envelope.AlwaysPublishResponse)} = true;");
         Next?.GenerateCode(method, writer);
     }
 

--- a/src/Wolverine/Envelope.Internals.cs
+++ b/src/Wolverine/Envelope.Internals.cs
@@ -80,6 +80,15 @@ public partial class Envelope
     public bool DoNotCascadeResponse { get; set; }
 
     /// <summary>
+    /// Used by the [AlwaysPublishResponse] attribute to explicitly signal
+    /// that the response should be published as a cascading message in addition
+    /// to being sent back via request/reply. This flag works for both in-process
+    /// and remote request/reply scenarios.
+    /// </summary>
+    [JsonIgnore]
+    public bool AlwaysPublishResponse { get; set; }
+
+    /// <summary>
     ///     Status according to the message persistence
     /// </summary>
     [JsonIgnore]

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -626,6 +626,13 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
         if (Envelope?.ReplyUri != null && message.GetType().ToMessageTypeName() == Envelope.ReplyRequested)
         {
             await EndpointFor(Envelope.ReplyUri!).SendAsync(message, new DeliveryOptions { IsResponse = true });
+
+            // If [AlwaysPublishResponse] was used, also publish as a cascading message
+            if (Envelope.AlwaysPublishResponse)
+            {
+                await PublishAsync(message);
+            }
+
             return;
         }
 


### PR DESCRIPTION
## Summary

Closes #2299

- `[AlwaysPublishResponse]` was silently ignored when a handler processed a message via remote request/reply (e.g., TCP, RabbitMQ). The response was sent back to the caller's `ReplyUri` but never published as a cascading message.
- Root cause: remote request/reply hits the `ReplyUri` code path in `EnqueueCascadingAsync` which always returned after sending the reply, never checking if the response should also be published. The in-process path worked because it sets `Envelope.ResponseType` (a CLR `Type` not serializable over the wire).
- Fix: added an explicit `AlwaysPublishResponse` flag on `Envelope` that the attribute's generated code sets. The `ReplyUri` code path now checks this flag and also publishes the response when true.

## Test plan

- [x] New test `always_publish_response_should_also_publish_on_remote_request_reply` — verifies remote `InvokeAsync<T>` with `[AlwaysPublishResponse]` both returns the response AND publishes it
- [x] All 21 existing `remote_invocation` tests pass (no regressions)
- [x] All 18 TCP transport compliance tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)