### PR TITLE
Skip orphaned message reassignment in Solo durability mode

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.19.0</Version>
+        <Version>5.19.1</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Persistence/SqlServerTests/solo_mode_does_not_release_orphaned_messages.cs
+++ b/src/Persistence/SqlServerTests/solo_mode_does_not_release_orphaned_messages.cs
@@ -1,0 +1,92 @@
+using IntegrationTests;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Durability;
+using Wolverine.RDBMS.Polling;
+using Wolverine.Runtime;
+using Wolverine.SqlServer;
+using Wolverine.Tracking;
+
+namespace SqlServerTests;
+
+public class solo_mode_does_not_release_orphaned_messages : IAsyncLifetime
+{
+    private IHost theSoloHost;
+    private IHost theBalancedHost;
+    private const string SoloSchema = "solo_orphan";
+    private const string BalancedSchema = "balanced_orphan";
+
+    public async Task InitializeAsync()
+    {
+        theSoloHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, SoloSchema);
+                opts.Durability.Mode = DurabilityMode.Solo;
+            }).StartAsync();
+
+        await theSoloHost.RebuildAllEnvelopeStorageAsync();
+
+        theBalancedHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, BalancedSchema);
+                opts.Durability.Mode = DurabilityMode.Balanced;
+            }).StartAsync();
+
+        await theBalancedHost.RebuildAllEnvelopeStorageAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theSoloHost.StopAsync();
+        await theBalancedHost.StopAsync();
+    }
+
+    [Fact]
+    public void solo_mode_build_operation_batch_excludes_orphaned_release()
+    {
+        var runtime = theSoloHost.GetRuntime();
+        var database = (IMessageDatabase)runtime.Storage;
+
+        var agent = new DurabilityAgent(runtime, database);
+
+        var operations = agent.buildOperationBatch();
+
+        // Should NOT contain any orphaned message release operations in Solo mode
+        operations.ShouldNotContain(op => op is ReleaseOrphanedMessagesOperation);
+        operations.ShouldNotContain(op => op is ReleaseOrphanedMessagesForAncillaryOperation);
+    }
+
+    [Fact]
+    public void solo_mode_build_operation_batch_excludes_orphaned_release_even_with_active_nodes()
+    {
+        var runtime = theSoloHost.GetRuntime();
+        var database = (IMessageDatabase)runtime.Storage;
+
+        var agent = new DurabilityAgent(runtime, database);
+
+        var operations = agent.buildOperationBatch(activeNodeNumbers: new List<int> { 1, 2, 3 });
+
+        // Should NOT contain any orphaned message release operations in Solo mode
+        operations.ShouldNotContain(op => op is ReleaseOrphanedMessagesOperation);
+        operations.ShouldNotContain(op => op is ReleaseOrphanedMessagesForAncillaryOperation);
+    }
+
+    [Fact]
+    public void balanced_mode_build_operation_batch_includes_orphaned_release()
+    {
+        var runtime = theBalancedHost.GetRuntime();
+        var database = (IMessageDatabase)runtime.Storage;
+
+        var agent = new DurabilityAgent(runtime, database);
+
+        var operations = agent.buildOperationBatch();
+
+        // SHOULD contain the orphaned message release operation for main databases in Balanced mode
+        operations.ShouldContain(op => op is ReleaseOrphanedMessagesOperation);
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
+++ b/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
@@ -79,7 +79,7 @@ internal class DurabilityAgent : IAgent
         _recoveryTimer = new Timer(async _ =>
         {
             IReadOnlyList<int>? activeNodeNumbers = null;
-            if (_database.Settings.Role != MessageStoreRole.Main)
+            if (_settings.Mode != DurabilityMode.Solo && _database.Settings.Role != MessageStoreRole.Main)
             {
                 try
                 {
@@ -170,7 +170,7 @@ internal class DurabilityAgent : IAgent
         return false;
     }
 
-    private IDatabaseOperation[] buildOperationBatch(IReadOnlyList<int>? activeNodeNumbers = null)
+    internal IDatabaseOperation[] buildOperationBatch(IReadOnlyList<int>? activeNodeNumbers = null)
     {
         var incomingTable = new DbObjectName(_database.SchemaName, DatabaseConstants.IncomingTable);
         var now = DateTimeOffset.UtcNow;
@@ -183,18 +183,24 @@ internal class DurabilityAgent : IAgent
             new MoveReplayableErrorMessagesToIncomingOperation(_database)
         ];
 
+        if (_settings.Mode != DurabilityMode.Solo)
+        {
+            if (_database.Settings.Role == MessageStoreRole.Main)
+            {
+                ops.Add(new ReleaseOrphanedMessagesOperation(_database));
+            }
+            else if (activeNodeNumbers is { Count: > 0 })
+            {
+                ops.Add(new ReleaseOrphanedMessagesForAncillaryOperation(_database, activeNodeNumbers));
+            }
+        }
+
         if (_database.Settings.Role == MessageStoreRole.Main)
         {
-            ops.Add(new ReleaseOrphanedMessagesOperation(_database));
-
             if (isTimeToPruneNodeEventRecords())
             {
                 ops.Add(new DeleteOldNodeEventRecords(_database, _settings));
             }
-        }
-        else if (activeNodeNumbers is { Count: > 0 })
-        {
-            ops.Add(new ReleaseOrphanedMessagesForAncillaryOperation(_database, activeNodeNumbers));
         }
 
         if (_runtime.Options.Durability.OutboxStaleTime.HasValue)


### PR DESCRIPTION
## Summary
- Prevents orphaned message release operations (`ReleaseOrphanedMessagesOperation` and `ReleaseOrphanedMessagesForAncillaryOperation`) from running when `DurabilityMode = Solo`
- Solo mode is single-node optimized, so reclaiming messages from "dead nodes" is unnecessary and could cause unintended side effects during local dev restarts
- Bumps version to 5.19.1

## Changes
- `DurabilityAgent.buildOperationBatch()` — conditionally excludes orphaned message release operations when Solo mode is active
- `DurabilityAgent` recovery timer — skips loading active nodes from persistence when Solo mode is active
- Added 3 tests verifying Solo mode excludes orphaned release operations and Balanced mode includes them

## Test plan
- [x] New tests pass: `solo_mode_build_operation_batch_excludes_orphaned_release`, `solo_mode_build_operation_batch_excludes_orphaned_release_even_with_active_nodes`, `balanced_mode_build_operation_batch_includes_orphaned_release`
- [x] Full SqlServerTests suite passes (298/298)

🤖 Generated with [Claude Code](https://claude.com/claude-code)