### PR TITLE
Fix CloudEvents unwrap for inline listeners

### DIFF
--- a/src/Testing/CoreTests/Runtime/Interop/when_reading_and_writing_CloudEvents_data.cs
+++ b/src/Testing/CoreTests/Runtime/Interop/when_reading_and_writing_CloudEvents_data.cs
@@ -1,6 +1,11 @@
+using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Runtime;
 using Wolverine.Runtime.Handlers;
 using Wolverine.Runtime.Interop;
+using Wolverine.Util;
 using Xunit;
 
 namespace CoreTests.Runtime.Interop;
@@ -84,6 +89,31 @@ public class when_reading_and_writing_CloudEvents_data
     {
         theEnvelope.SentAt.ShouldBe(DateTimeOffset.Parse("2020-09-23T06:23:21Z"));
         theCloudEventEnvelope.Time.ShouldBe(theEnvelope.SentAt.ToString("O"));
+    }
+
+    [Fact]
+    public async Task try_deserialize_envelope_unwraps_metadata_when_message_type_is_missing()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.RegisterMessageType(typeof(ApproveOrder), "com.dapr.event.sent");
+            }).StartAsync();
+
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        var serializer = new CloudEventsMapper(runtime.Options.HandlerGraph,
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+        var envelope = new Envelope
+        {
+            Data = Encoding.UTF8.GetBytes(Json),
+            Serializer = serializer
+        };
+
+        await runtime.Pipeline.TryDeserializeEnvelope(envelope);
+
+        envelope.Message.ShouldBeOfType<ApproveOrder>().OrderId.ShouldBe(1);
+        envelope.MessageType.ShouldBe(typeof(ApproveOrder).ToMessageTypeName());
     }
 }
 

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/end_to_end_with_CloudEvents.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/end_to_end_with_CloudEvents.cs
@@ -13,6 +13,11 @@ using Wolverine.Tracking;
 
 namespace Wolverine.Kafka.Tests;
 
+internal static class CloudEventsKafkaTestConstants
+{
+    public const string ColorMessageTypeAlias = "wolverine.kafka.tests.color";
+}
+
 public class end_to_end_with_CloudEvents : IAsyncLifetime
 {
     private IHost _receiver;
@@ -25,12 +30,8 @@ public class end_to_end_with_CloudEvents : IAsyncLifetime
             {
                 //opts.EnableAutomaticFailureAcks = false;
                 opts.UseKafka("localhost:9092").AutoProvision();
-                opts.ListenToKafkaTopic("cloudevents")
-
-                    // You do have to tell Wolverine what the message type
-                    // is that you'll receive here so that it can deserialize the
-                    // incoming data
-                    .InteropWithCloudEvents();
+                opts.RegisterMessageType(typeof(ColorMessage), CloudEventsKafkaTestConstants.ColorMessageTypeAlias);
+                opts.ListenToKafkaTopic("cloudevents").InteropWithCloudEvents();
 
                 // Include test assembly for handler discovery
                 opts.Discovery.IncludeAssembly(GetType().Assembly);
@@ -49,6 +50,7 @@ public class end_to_end_with_CloudEvents : IAsyncLifetime
             {
                 opts.UseKafka("localhost:9092").AutoProvision();
                 opts.Policies.DisableConventionalLocalRouting();
+                opts.RegisterMessageType(typeof(ColorMessage), CloudEventsKafkaTestConstants.ColorMessageTypeAlias);
 
                 opts.Services.AddResourceSetupOnStartup();
 
@@ -67,6 +69,61 @@ public class end_to_end_with_CloudEvents : IAsyncLifetime
 
     [Fact]
     public async Task end_to_end()
+    {
+        var session = await _sender.TrackActivity()
+            .AlsoTrack(_receiver)
+            .WaitForMessageToBeReceivedAt<ColorMessage>(_receiver)
+            .PublishMessageAndWaitAsync(new ColorMessage("yellow"));
+
+        session.Received.SingleMessage<ColorMessage>()
+            .Color.ShouldBe("yellow");
+    }
+}
+
+public class inline_end_to_end_with_CloudEvents : IAsyncLifetime
+{
+    private IHost _receiver;
+    private IHost _sender;
+
+    public async Task InitializeAsync()
+    {
+        _receiver = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka("localhost:9092").AutoProvision();
+                opts.RegisterMessageType(typeof(ColorMessage), CloudEventsKafkaTestConstants.ColorMessageTypeAlias);
+                opts.ListenToKafkaTopic("cloudevents-inline")
+                    .InteropWithCloudEvents()
+                    .ProcessInline();
+
+                opts.Discovery.IncludeAssembly(GetType().Assembly);
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        _sender = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka("localhost:9092").AutoProvision();
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.RegisterMessageType(typeof(ColorMessage), CloudEventsKafkaTestConstants.ColorMessageTypeAlias);
+
+                opts.Services.AddResourceSetupOnStartup();
+
+                opts.PublishAllMessages().ToKafkaTopic("cloudevents-inline")
+                    .UseInterop((runtime, topic) => new CloudEventsOnlyMapper(new CloudEventsMapper(runtime.Options.HandlerGraph, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })));
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _sender.StopAsync();
+        _sender.Dispose();
+        await _receiver.StopAsync();
+        _receiver.Dispose();
+    }
+
+    [Fact]
+    public async Task end_to_end_without_default_incoming_message_type()
     {
         var session = await _sender.TrackActivity()
             .AlsoTrack(_receiver)

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -115,6 +115,7 @@ public class HandlerPipeline : IHandlerPipeline
         try
         {
             var serializer = envelope.Serializer ?? _runtime.Options.DetermineSerializer(envelope);
+            serializer.UnwrapEnvelopeIfNecessary(envelope);
 
             if (envelope.Data == null)
             {
@@ -122,7 +123,12 @@ public class HandlerPipeline : IHandlerPipeline
                     "Envelope does not have a message or deserialized message data");
             }
 
-            if (envelope.MessageType == null)
+            if (envelope.Message != null)
+            {
+                return NullContinuation.Instance;
+            }
+
+            if (string.IsNullOrEmpty(envelope.MessageType))
             {
                 throw new ArgumentOutOfRangeException(nameof(envelope),
                     "The envelope has no Message or MessageType name");

--- a/src/Wolverine/Runtime/Serialization/IMessageSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/IMessageSerializer.cs
@@ -26,6 +26,17 @@ public interface IUnwrapsMetadataMessageSerializer : IMessageSerializer
     void Unwrap(Envelope envelope);
 }
 
+public static class MessageSerializerExtensions
+{
+    public static void UnwrapEnvelopeIfNecessary(this IMessageSerializer serializer, Envelope envelope)
+    {
+        if (string.IsNullOrEmpty(envelope.MessageType) && serializer is IUnwrapsMetadataMessageSerializer metadataSerializer)
+        {
+            metadataSerializer.Unwrap(envelope);
+        }
+    }
+}
+
 /// <summary>
 ///  Async version of <seealso cref="IMessageSerializer"/>
 /// </summary>

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -413,26 +413,23 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
         {
             try
             {
-                if (envelope.MessageType.IsEmpty() && envelope.Serializer is IUnwrapsMetadataMessageSerializer serializer)
+                try
                 {
-                    try
-                    {
-                        serializer.Unwrap(envelope);
-                    }
-                    catch (Exception e)
-                    {
-                        _logger.LogInformation(e, "Failed to unwrap metadata for Envelope {Id} received at durable {Destination}. Moving to dead letter queue", envelope.Id, envelope.Destination);
+                    envelope.Serializer?.UnwrapEnvelopeIfNecessary(envelope);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogInformation(e, "Failed to unwrap metadata for Envelope {Id} received at durable {Destination}. Moving to dead letter queue", envelope.Id, envelope.Destination);
 
-                        if (envelope.Id == Guid.Empty)
-                        {
-                            envelope.Id = NewId.NextSequentialGuid();
-                        }
-
-                        envelope.MessageType ??= $"unknown/{e.GetType().Name}";
-                        envelope.Failure = e;
-                        await _moveToErrors.PostAsync(envelope);
-                        return;
+                    if (envelope.Id == Guid.Empty)
+                    {
+                        envelope.Id = NewId.NextSequentialGuid();
                     }
+
+                    envelope.MessageType ??= $"unknown/{e.GetType().Name}";
+                    envelope.Failure = e;
+                    await _moveToErrors.PostAsync(envelope);
+                    return;
                 }
 
                 // Have to do this before moving to the DLQ


### PR DESCRIPTION
This was actually the fast path to get to https://github.com/JasperFx/wolverine/pull/2306 problems. So when there was no default message type to fallback to and Kafka envelope didn't have `eventType` the routing wasn't able to extract it from cloud event envelope.

Now allowing the handler pipeline to unwrap metadata-aware serializers before requiring Envelope.MessageType so inline CloudEvents receivers can deserialize messages without DefaultIncomingMessage<T>(). Reuse the same helper in durable receivers and add runtime and Kafka regression coverage for inline CloudEvents handling.