### PR TITLE
Fix conventionally-routed endpoints ignoring durable outbox policy

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_2304_conventional_routing_ignores_durable_outbox_policy.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_2304_conventional_routing_ignores_durable_outbox_policy.cs
@@ -1,0 +1,75 @@
+using IntegrationTests;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Configuration;
+using Wolverine.Marten;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Routing;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests.Bugs;
+
+public class Bug_2304_conventional_routing_ignores_durable_outbox_policy : IDisposable
+{
+    private readonly IHost _host;
+
+    public Bug_2304_conventional_routing_ignores_durable_outbox_policy()
+    {
+        _host = WolverineHost.For(opts =>
+        {
+            opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DisableNpgsqlLogging = true;
+                })
+                .IntegrateWithWolverine();
+
+            opts.UseRabbitMq()
+                .UseConventionalRouting()
+                .AutoProvision()
+                .AutoPurgeOnStartup();
+
+            opts.Policies.UseDurableOutboxOnAllSendingEndpoints();
+
+            opts.DisableConventionalDiscovery();
+        });
+    }
+
+    [Fact]
+    public void conventionally_routed_endpoint_should_be_durable()
+    {
+        var runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var routes = runtime.RoutingFor(typeof(Bug2304Message))
+            .ShouldBeOfType<MessageRouter<Bug2304Message>>()
+            .Routes;
+
+        routes.Length.ShouldBeGreaterThan(0);
+
+        var route = routes.Single().ShouldBeOfType<MessageRoute>();
+        var endpoint = route.Sender.Endpoint;
+
+        // The endpoint should be Durable because of UseDurableOutboxOnAllSendingEndpoints()
+        endpoint.Mode.ShouldBe(EndpointMode.Durable);
+    }
+
+    public void Dispose()
+    {
+        _host?.Dispose();
+    }
+}
+
+public class Bug2304Message;
+
+public class Bug2304Response;
+
+public static class Bug2304Handler
+{
+    public static void Handle(Bug2304Message message)
+    {
+        // no-op
+    }
+}

--- a/src/Wolverine/Transports/MessageRoutingConvention.cs
+++ b/src/Wolverine/Transports/MessageRoutingConvention.cs
@@ -148,6 +148,14 @@ public abstract class MessageRoutingConvention<TTransport, TListener, TSubscribe
         var (configuration, endpoint) = FindOrCreateSubscriber(corrected, transport);
         endpoint.EndpointName = destinationName;
 
+        // Register the subscription so that endpoint policies like
+        // UseDurableOutboxOnAllSendingEndpoints() recognize this as a sender
+        // endpoint when Compile() applies policies. See GH-2304.
+        if (!endpoint.Subscriptions.Any(s => s.Matches(messageType)))
+        {
+            endpoint.Subscriptions.Add(Subscription.ForType(messageType));
+        }
+
         _configureSending(configuration, new MessageRoutingContext(messageType, runtime));
 
         configuration.As<IDelayedEndpointConfiguration>().Apply();


### PR DESCRIPTION
## Summary
- Fixes #2304 — `UseDurableOutboxOnAllSendingEndpoints()` was not applied to endpoints discovered through conventional routing (e.g., `UseConventionalRouting()`)
- Root cause: `MessageRoutingConvention.DiscoverSenders()` never added a `Subscription` to the endpoint, so the `AllSenders` policy (which gates on `Subscriptions.Any()`) skipped it during `Endpoint.Compile()`
- Fix: register a `Subscription.ForType(messageType)` on the endpoint before it gets compiled, so endpoint policies correctly recognize it as a sender

## Test plan
- [x] Added `Bug_2304_conventional_routing_ignores_durable_outbox_policy` test in `Wolverine.RabbitMQ.Tests` that verifies conventionally-routed endpoints get `EndpointMode.Durable` when `UseDurableOutboxOnAllSendingEndpoints()` is configured
- [x] Verified the test fails without the fix (endpoint mode was `Inline`)
- [x] All 23 existing conventional routing tests pass
- [x] All 19 RabbitMQ bug regression tests pass
- [x] Core routing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)