### PR TITLE
Update JasperFx and Marten packages to latest versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,14 +21,14 @@
     <PackageVersion Include="Grpc.Core" Version="2.46.6" />
     <PackageVersion Include="Grpc.Tools" Version="2.72.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="1.21.0" />
-    <PackageVersion Include="JasperFx.Events" Version="1.23.1" />
+    <PackageVersion Include="JasperFx" Version="1.21.1" />
+    <PackageVersion Include="JasperFx.Events" Version="1.24.0" />
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.4.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-    <PackageVersion Include="Marten" Version="8.23.0" />
+    <PackageVersion Include="Marten" Version="8.25.0" />
     <PackageVersion Include="Polecat" Version="0.9.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="8.23.0" />
+    <PackageVersion Include="Marten.AspNetCore" Version="8.25.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />


### PR DESCRIPTION
## Summary
- Updates JasperFx 1.21.0 → 1.21.1, JasperFx.Events 1.23.1 → 1.24.0
- Updates Marten 8.23.0 → 8.25.0, Marten.AspNetCore 8.23.0 → 8.25.0
- JasperFx.RuntimeCompiler and Weasel.* packages are already at latest versions

The JasperFx 1.21.1 update includes a fix for generated handler code that was using synchronous `Dispose()` on service scopes instead of `DisposeAsync()`, causing `InvalidOperationException` with `IAsyncDisposable` services.

Closes #2302

## Test plan
- [x] `nuke compile` succeeds across all target frameworks (net8.0, net9.0, net10.0)
- [ ] Run full test suite to verify no regressions from package updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)