### PR TITLE
Fix per-handler [Transactional] mode override ignored with Storage si…

### DIFF
--- a/src/Persistence/EfCoreTests/transaction_middleware_mode_tests.cs
+++ b/src/Persistence/EfCoreTests/transaction_middleware_mode_tests.cs
@@ -2,6 +2,7 @@ using IntegrationTests;
 using JasperFx.CodeGeneration.Frames;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
+using SharedPersistenceModels.Items;
 using Shouldly;
 using Wolverine;
 using Wolverine.Attributes;
@@ -157,6 +158,69 @@ public class transaction_middleware_mode_tests
     }
 
     [Fact]
+    public async Task lightweight_attribute_with_storage_side_effects_should_not_add_transaction_frame()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<CleanDbContext>(x =>
+                    x.UseSqlServer(Servers.SqlServerConnectionString));
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "txmode");
+                opts.UseEntityFrameworkCoreTransactions(TransactionMiddlewareMode.Eager);
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<LightweightStorageSideEffectHandler>();
+            }).StartAsync();
+
+        // Force compilation
+        host.GetRuntime().Handlers.HandlerFor<LightweightStorageSideEffectMessage>();
+        var chain = host.GetRuntime().Handlers.ChainFor<LightweightStorageSideEffectMessage>();
+
+        // The [Transactional(Mode = Lightweight)] should override even with Storage side effects
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ShouldBeEmpty();
+        chain.Middleware.OfType<StartDatabaseTransactionForDbContext>().ShouldBeEmpty();
+
+        chain.Postprocessors.OfType<MethodCall>()
+            .Any(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task eager_attribute_with_storage_side_effects_should_add_transaction_frame()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<CleanDbContext>(x =>
+                    x.UseSqlServer(Servers.SqlServerConnectionString));
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "txmode");
+                opts.UseEntityFrameworkCoreTransactions(TransactionMiddlewareMode.Lightweight);
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<EagerStorageSideEffectHandler>();
+            }).StartAsync();
+
+        // Force compilation
+        host.GetRuntime().Handlers.HandlerFor<EagerStorageSideEffectMessage>();
+        var chain = host.GetRuntime().Handlers.ChainFor<EagerStorageSideEffectMessage>();
+
+        // The [Transactional(Mode = Eager)] should override the Lightweight default
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ShouldNotBeEmpty();
+
+        chain.Postprocessors.OfType<MethodCall>()
+            .Any(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
     public async Task default_mode_is_eager()
     {
         using var host = await Host.CreateDefaultBuilder()
@@ -250,6 +314,28 @@ public class LightweightAutoApplyHandler
 {
     public static void Handle(LightweightAutoApplyMessage message, CleanDbContext db)
     {
+    }
+}
+
+public record LightweightStorageSideEffectMessage;
+
+public class LightweightStorageSideEffectHandler
+{
+    [Transactional(Mode = TransactionMiddlewareMode.Lightweight)]
+    public static Insert<Item> Handle(LightweightStorageSideEffectMessage message)
+    {
+        return Storage.Insert(new Item { Id = Guid.NewGuid(), Name = "test" });
+    }
+}
+
+public record EagerStorageSideEffectMessage;
+
+public class EagerStorageSideEffectHandler
+{
+    [Transactional(Mode = TransactionMiddlewareMode.Eager)]
+    public static Insert<Item> Handle(EagerStorageSideEffectMessage message)
+    {
+        return Storage.Insert(new Item { Id = Guid.NewGuid(), Name = "test" });
     }
 }
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using ImTools;
 using JasperFx;
 using JasperFx.CodeGeneration;
@@ -8,6 +9,7 @@ using JasperFx.Core.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Wolverine.Attributes;
 using Wolverine.Configuration;
 using Wolverine.EntityFrameworkCore.Internals;
 using Wolverine.Persistence;
@@ -125,10 +127,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 
         var dbContextType = DetermineDbContextType(chain, container);
 
-        // Resolve effective mode: per-chain override from [Transactional] attribute, or default
-        var mode = chain.Tags.TryGetValue(TransactionModeKey, out var modeObj)
-            ? (TransactionMiddlewareMode)modeObj
-            : DefaultMode;
+        var mode = ResolveEffectiveMode(chain);
 
         var runtime = container.Services.GetRequiredService<IWolverineRuntime>();
         if (runtime.Stores.HasAncillaryStoreFor(dbContextType))
@@ -170,6 +169,44 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
         }
     }
 
+    /// <summary>
+    /// Resolves the effective transaction mode for a chain by checking (in order):
+    /// 1. The chain tag (set when TransactionalAttribute.Modify has already run)
+    /// 2. The [Transactional] attribute directly on handler methods/types (for when
+    ///    side effects are processed by SideEffectPolicy before the attribute's Modify runs)
+    /// 3. The configured DefaultMode
+    /// </summary>
+    internal TransactionMiddlewareMode ResolveEffectiveMode(IChain chain)
+    {
+        // Check the tag first (set by TransactionalAttribute.Modify when it has already run)
+        if (chain.Tags.TryGetValue(TransactionModeKey, out var modeObj))
+        {
+            return (TransactionMiddlewareMode)modeObj;
+        }
+
+        // Check handler method and type attributes directly for when SideEffectPolicy
+        // processes Storage return types before TransactionalAttribute.Modify has run
+        foreach (var call in chain.HandlerCalls())
+        {
+            var methodAttr = call.Method.GetCustomAttribute<TransactionalAttribute>();
+            if (methodAttr is { IsModeExplicitlySet: true })
+            {
+                // Cache it in the tag for subsequent calls
+                chain.Tags[TransactionModeKey] = methodAttr.Mode;
+                return methodAttr.Mode;
+            }
+
+            var typeAttr = call.HandlerType.GetCustomAttribute<TransactionalAttribute>();
+            if (typeAttr is { IsModeExplicitlySet: true })
+            {
+                chain.Tags[TransactionModeKey] = typeAttr.Mode;
+                return typeAttr.Mode;
+            }
+        }
+
+        return DefaultMode;
+    }
+
     private bool isMultiTenanted(IServiceContainer container, Type dbContextType)
     {
         return container.HasRegistrationFor(typeof(IDbContextBuilder<>).MakeGenericType(dbContextType));
@@ -182,10 +219,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 
         var dbType = DetermineDbContextType(entityType, container);
 
-        // Resolve effective mode: per-chain override from [Transactional] attribute, or default
-        var mode = chain.Tags.TryGetValue(TransactionModeKey, out var modeObj)
-            ? (TransactionMiddlewareMode)modeObj
-            : DefaultMode;
+        var mode = ResolveEffectiveMode(chain);
 
         if (mode == TransactionMiddlewareMode.Eager)
         {

--- a/src/Wolverine/Attributes/TransactionalAttribute.cs
+++ b/src/Wolverine/Attributes/TransactionalAttribute.cs
@@ -53,6 +53,13 @@ public class TransactionalAttribute : ModifyChainAttribute
     }
     private TransactionMiddlewareMode _mode;
 
+    /// <summary>
+    /// Returns true if <see cref="Mode"/> was explicitly set on this attribute instance.
+    /// Used by persistence providers to resolve the effective mode even before
+    /// <see cref="Modify"/> has been called (e.g. when side effects are processed at startup).
+    /// </summary>
+    public bool IsModeExplicitlySet => _modeExplicitlySet;
+
     public TransactionalAttribute()
     {
     }


### PR DESCRIPTION
…de effects

When SideEffectPolicy processes Storage return types (Insert<T>, Update<T>, etc.) at startup, it calls ApplyTransactionSupport before TransactionalAttribute.Modify has run. This caused the per-handler Mode override to be ignored, always falling back to the global DefaultMode.

Added ResolveEffectiveMode() to EFCorePersistenceFrameProvider that checks handler method/type [Transactional] attributes directly via reflection when the chain tag isn't yet set. Added IsModeExplicitlySet property to TransactionalAttribute to support this check.

Closes #2319