### PR TITLE
Fix duplicate variable names when multiple middleware return OutgoingMessages

### DIFF
--- a/src/Testing/CoreTests/Bugs/Bug_2326_disambiguate_outgoing_messages_from_multiple_middleware.cs
+++ b/src/Testing/CoreTests/Bugs/Bug_2326_disambiguate_outgoing_messages_from_multiple_middleware.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Hosting;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+public class Bug_2326_disambiguate_outgoing_messages_from_multiple_middleware
+{
+    [Fact]
+    public async Task can_compile_handler_with_multiple_middleware_returning_outgoing_messages()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<Bug2326Handler>();
+            }).StartAsync();
+
+        // If code gen produces duplicate variable names, compilation will fail here
+        var chain = host.GetRuntime().Handlers.ChainFor<Bug2326Command>();
+        chain.ShouldNotBeNull();
+
+        // Force compilation of the handler
+        var handler = host.GetRuntime().Handlers.HandlerFor<Bug2326Command>();
+        handler.ShouldNotBeNull();
+    }
+}
+
+public record Bug2326Command;
+public record Bug2326Cascaded(string Source);
+
+public class Bug2326Handler
+{
+    public static OutgoingMessages Before(Bug2326Command command)
+    {
+        return [new Bug2326Cascaded("Before")];
+    }
+
+    public static OutgoingMessages Load(Bug2326Command command)
+    {
+        return [new Bug2326Cascaded("Load")];
+    }
+
+    public static void Handle(Bug2326Command command)
+    {
+    }
+}

--- a/src/Wolverine/Configuration/Chain.cs
+++ b/src/Wolverine/Configuration/Chain.cs
@@ -287,6 +287,7 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
     }
 
     private bool _appliedImpliedMiddleware;
+    private int _middlewareOutgoingCounter = 100;
     
     public void ApplyImpliedMiddlewareFromHandlers(GenerationRules generationRules)
     {
@@ -348,10 +349,9 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
         // TODO -- might generalize this a bit. Have a more generic mode of understanding return values
         // like the HTTP support has
         var outgoings = frame.Creates.Where(x => x.VariableType == typeof(OutgoingMessages)).ToArray();
-        int start = 100;
         foreach (var outgoing in outgoings)
         {
-            outgoing.OverrideName(outgoing.Usage + (++start));
+            outgoing.OverrideName(outgoing.Usage + (++_middlewareOutgoingCounter));
             Middleware.Add(new CaptureCascadingMessages(outgoing));
         }
 


### PR DESCRIPTION
## Summary
- Fixed `Chain.AddMiddleware()` resetting the `OutgoingMessages` variable counter to 100 on every call, causing duplicate `outgoingMessages101` variable names when multiple middleware methods (e.g., `Before` and `Load`) return `OutgoingMessages`
- Changed the counter from a local variable to a persistent instance field (`_middlewareOutgoingCounter`) so each middleware gets a unique variable name
- Added regression test reproducing the exact scenario from the issue

Closes #2326

## Test plan
- [x] Added `Bug_2326_disambiguate_outgoing_messages_from_multiple_middleware` test that verifies a handler with two middleware methods both returning `OutgoingMessages` compiles successfully
- [x] All 1183 CoreTests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)