### PR TITLE
Fix GroupIdToPartitionKeyRule to prefer outgoing GroupId over originator's consumer group

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -231,9 +231,9 @@ public static ValueTask publish_by_partition_key(IMessageBus bus)
 
 ## Propagating GroupId to PartitionKey <Badge type="tip" text="5.17" />
 
-When consuming from a Kafka topic, the incoming envelope's `GroupId` is automatically set from the Kafka consumer's
-configured `GroupId`. If your handler produces cascaded messages that should land on the same partition, you can
-enable automatic propagation of the originating `GroupId` to the outgoing `PartitionKey`:
+By default, Wolverine stamps the Kafka consumer's configured `GroupId` onto the `GroupId` property of every incoming
+envelope. If your handler produces cascaded messages that should land on the same partition, you can enable automatic
+propagation of the originating `GroupId` to the outgoing `PartitionKey`:
 
 ```csharp
 opts.Policies.PropagateGroupIdToPartitionKey();
@@ -242,6 +242,35 @@ opts.Policies.PropagateGroupIdToPartitionKey();
 This eliminates the need to manually set `DeliveryOptions.PartitionKey` on every outgoing message from your handlers.
 The rule will never override an explicitly set `PartitionKey`. See the [Partitioned Sequential Messaging](/guide/messaging/partitioning#propagating-groupid-to-partitionkey)
 documentation for more details and a code sample.
+
+::: warning
+When using `PropagateGroupIdToPartitionKey()` together with business-level partition key derivation (e.g.
+`UseInferredMessageGrouping().ByPropertyNamed(...)`), you should disable consumer group ID stamping on your listeners.
+Otherwise the consumer group name (e.g. `"my-application-name"`) will be written to `envelope.GroupId` and may
+pollute the partition key derivation for cascaded messages:
+
+```csharp
+opts.ListenToKafkaTopic("my-topic")
+    .DisableConsumerGroupIdStamping()
+    .ConfigureConsumer(config =>
+    {
+        config.GroupId = "my-application-name";
+    });
+```
+:::
+
+### Disabling Consumer Group ID Stamping
+
+If you do not want the Kafka consumer group name written to `envelope.GroupId` at all, call
+`DisableConsumerGroupIdStamping()` on the listener:
+
+```csharp
+opts.ListenToKafkaTopic("orders")
+    .ProcessInline()
+    .DisableConsumerGroupIdStamping();
+```
+
+The same method is available on `ListenToKafkaTopics()` (multi-topic listeners).
 
 ## Interoperability
 

--- a/src/Testing/CoreTests/GroupIdToPartitionKeyRuleTests.cs
+++ b/src/Testing/CoreTests/GroupIdToPartitionKeyRuleTests.cs
@@ -72,4 +72,72 @@ public class GroupIdToPartitionKeyRuleTests
 
         outgoing.PartitionKey.ShouldBeNull();
     }
+
+    [Fact]
+    public void prefers_outgoing_group_id_over_originator_group_id()
+    {
+        // Simulates: ByPropertyNamed has set outgoing.GroupId from the message property,
+        // while the originator (a Kafka consumer) has GroupId = consumer group name.
+        var rule = new GroupIdToPartitionKeyRule();
+        var originator = Substitute.For<IMessageContext>();
+        var originatingEnvelope = ObjectMother.Envelope();
+        originatingEnvelope.GroupId = "my-application-name"; // Kafka consumer group
+        originator.Envelope.Returns(originatingEnvelope);
+
+        var outgoing = ObjectMother.Envelope();
+        outgoing.PartitionKey = null;
+        outgoing.GroupId = "fixture-abc"; // set by ByPropertyNamed
+
+        rule.ApplyCorrelation(originator, outgoing);
+
+        outgoing.PartitionKey.ShouldBe("fixture-abc");
+    }
+
+    [Fact]
+    public void falls_back_to_originator_partition_key_when_outgoing_has_no_group_id()
+    {
+        // Simulates: no ByPropertyNamed, but originator has a PartitionKey (e.g. from Kafka message key)
+        var rule = new GroupIdToPartitionKeyRule();
+        var originator = Substitute.For<IMessageContext>();
+        var originatingEnvelope = ObjectMother.Envelope();
+        originatingEnvelope.PartitionKey = "fixture-xyz";
+        originatingEnvelope.GroupId = null;
+        originator.Envelope.Returns(originatingEnvelope);
+
+        var outgoing = ObjectMother.Envelope();
+        outgoing.PartitionKey = null;
+        outgoing.GroupId = null;
+
+        rule.ApplyCorrelation(originator, outgoing);
+
+        outgoing.PartitionKey.ShouldBe("fixture-xyz");
+    }
+
+    [Fact]
+    public void modify_promotes_group_id_to_partition_key_when_no_originator()
+    {
+        // Simulates: published outside a handler context (background service etc.)
+        // ByPropertyNamed has set GroupId; Modify should promote it to PartitionKey.
+        var rule = new GroupIdToPartitionKeyRule();
+        var envelope = ObjectMother.Envelope();
+        envelope.GroupId = "fixture-abc";
+        envelope.PartitionKey = null;
+
+        rule.Modify(envelope);
+
+        envelope.PartitionKey.ShouldBe("fixture-abc");
+    }
+
+    [Fact]
+    public void modify_does_not_override_explicit_partition_key()
+    {
+        var rule = new GroupIdToPartitionKeyRule();
+        var envelope = ObjectMother.Envelope();
+        envelope.GroupId = "fixture-abc";
+        envelope.PartitionKey = "explicit-key";
+
+        rule.Modify(envelope);
+
+        envelope.PartitionKey.ShouldBe("explicit-key");
+    }
 }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/propagate_group_id_to_partition_key.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/propagate_group_id_to_partition_key.cs
@@ -55,16 +55,17 @@ public class propagate_group_id_to_partition_key : IAsyncLifetime
     }
 
     [Fact]
-    public async Task cascaded_message_receives_partition_key_from_originating_group_id()
+    public async Task cascaded_message_inherits_partition_key_from_originating_message()
     {
         var session = await _host.TrackActivity()
             .IncludeExternalTransports()
             .Timeout(30.Seconds())
             .WaitForMessageToBeReceivedAt<TargetFromGroupId>(_host)
-            .PublishMessageAndWaitAsync(new TriggerFromGroupId("hello"));
+            .PublishMessageAndWaitAsync(new TriggerFromGroupId("hello"),
+                new DeliveryOptions { PartitionKey = "fixture-abc" });
 
         var envelope = session.Received.SingleEnvelope<TargetFromGroupId>();
-        envelope.PartitionKey.ShouldBe("source-group-123");
+        envelope.PartitionKey.ShouldBe("fixture-abc");
     }
 
     public async Task DisposeAsync()
@@ -91,6 +92,100 @@ public static class TriggerFromGroupIdHandler
 public static class TargetFromGroupIdHandler
 {
     public static void Handle(TargetFromGroupId message)
+    {
+        // no-op, just receive
+    }
+}
+
+/// <summary>
+/// Verifies that when ByPropertyNamed is configured, the message property is used as the
+/// partition key on outgoing messages, even when the originating message came from Kafka
+/// (where the Kafka consumer GroupId is unrelated to the business partition key).
+/// </summary>
+public class propagate_group_id_via_property_name : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "PropagateGroupIdByPropertyTests";
+
+                opts.UseKafka(KafkaContainerFixture.ConnectionString).AutoProvision();
+
+                opts.Policies.PropagateGroupIdToPartitionKey();
+                opts.MessagePartitioning.UseInferredMessageGrouping().ByPropertyNamed("Id");
+
+                opts.Policies.DisableConventionalLocalRouting();
+
+                opts.ListenToKafkaTopic("groupid-property-source")
+                    .ProcessInline()
+                    .ConfigureConsumer(config =>
+                    {
+                        config.GroupId = "my-application-name";
+                        config.AutoOffsetReset = AutoOffsetReset.Earliest;
+                    });
+
+                opts.ListenToKafkaTopic("groupid-property-target")
+                    .ProcessInline();
+
+                opts.PublishMessage<TriggerWithId>()
+                    .ToKafkaTopic("groupid-property-source")
+                    .SendInline();
+
+                opts.PublishMessage<TargetWithId>()
+                    .ToKafkaTopic("groupid-property-target")
+                    .SendInline();
+
+                opts.Discovery.IncludeAssembly(GetType().Assembly);
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task cascaded_message_uses_message_property_as_partition_key_not_consumer_group()
+    {
+        var fixtureId = "fixture-789";
+
+        var session = await _host.TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<TargetWithId>(_host)
+            .PublishMessageAndWaitAsync(new TriggerWithId(fixtureId));
+
+        var envelope = session.Received.SingleEnvelope<TargetWithId>();
+
+        // Must be the fixture id from the message property, not the Kafka consumer GroupId
+        envelope.PartitionKey.ShouldBe(fixtureId);
+        envelope.PartitionKey.ShouldNotBe("my-application-name");
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+}
+
+[Topic("groupid-property-source")]
+public record TriggerWithId(string Id);
+
+[Topic("groupid-property-target")]
+public record TargetWithId(string Id);
+
+public static class TriggerWithIdHandler
+{
+    public static TargetWithId Handle(TriggerWithId message)
+    {
+        return new TargetWithId(message.Id);
+    }
+}
+
+public static class TargetWithIdHandler
+{
+    public static void Handle(TargetWithId message)
     {
         // no-op, just receive
     }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/propagate_group_id_to_partition_key.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/propagate_group_id_to_partition_key.cs
@@ -29,6 +29,7 @@ public class propagate_group_id_to_partition_key : IAsyncLifetime
                 // Listen to source topic with an explicit GroupId
                 opts.ListenToKafkaTopic("groupid-source")
                     .ProcessInline()
+                    .DisableConsumerGroupIdStamping()
                     .ConfigureConsumer(config =>
                     {
                         config.GroupId = "source-group-123";
@@ -122,6 +123,7 @@ public class propagate_group_id_via_property_name : IAsyncLifetime
 
                 opts.ListenToKafkaTopic("groupid-property-source")
                     .ProcessInline()
+                    .DisableConsumerGroupIdStamping()
                     .ConfigureConsumer(config =>
                     {
                         config.GroupId = "my-application-name";

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -47,6 +47,7 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
                         var envelope = mapper!.CreateEnvelope(result.Topic, message);
                         envelope.Offset = result.Offset.Value;
                         envelope.MessageType ??= _messageTypeName;
+                        if (topic.StampConsumerGroupIdOnEnvelope) envelope.GroupId = config.GroupId;
 
                         await receiver.ReceivedAsync(this, envelope);
                     }

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -47,7 +47,6 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
                         var envelope = mapper!.CreateEnvelope(result.Topic, message);
                         envelope.Offset = result.Offset.Value;
                         envelope.MessageType ??= _messageTypeName;
-                        envelope.GroupId = config.GroupId;
 
                         await receiver.ReceivedAsync(this, envelope);
                     }

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
@@ -45,7 +45,6 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
 
                         var envelope = mapper!.CreateEnvelope(result.Topic, message);
                         envelope.Offset = result.Offset.Value;
-                        envelope.GroupId = config.GroupId;
 
                         await receiver.ReceivedAsync(this, envelope);
                     }

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
@@ -45,6 +45,7 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
 
                         var envelope = mapper!.CreateEnvelope(result.Topic, message);
                         envelope.Offset = result.Offset.Value;
+                        if (endpoint.StampConsumerGroupIdOnEnvelope) envelope.GroupId = config.GroupId;
 
                         await receiver.ReceivedAsync(this, envelope);
                     }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -105,6 +105,18 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
     }
 
     /// <summary>
+    /// Disables stamping of the Kafka consumer group ID onto the GroupId property
+    /// of each incoming envelope. Use this when the consumer group name is not
+    /// meaningful as envelope metadata (e.g. when using PropagateGroupIdToPartitionKey).
+    /// </summary>
+    /// <returns></returns>
+    public KafkaListenerConfiguration DisableConsumerGroupIdStamping()
+    {
+        add(topic => topic.StampConsumerGroupIdOnEnvelope = false);
+        return this;
+    }
+
+    /// <summary>
     /// Configure the consumer config for only this topic. This overrides the default
     /// settings at the transport level. This is not combinatorial with the parent configuration
     /// and overwrites all ConsumerConfig from the parent

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -58,6 +58,14 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     /// </summary>
     public bool NativeDeadLetterQueueEnabled { get; set; }
 
+    /// <summary>
+    /// When true, the Kafka consumer group ID will be stamped onto the incoming
+    /// envelope's GroupId property. Useful when you want the consumer group name
+    /// to be available as envelope metadata for routing or correlation purposes.
+    /// Default is true.
+    /// </summary>
+    public bool StampConsumerGroupIdOnEnvelope { get; set; } = true;
+
     public static string TopicNameForUri(Uri uri)
     {
         return uri.Segments.Last().Trim('/');

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroupListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroupListenerConfiguration.cs
@@ -27,6 +27,18 @@ public class KafkaTopicGroupListenerConfiguration : ListenerConfiguration<KafkaT
     }
 
     /// <summary>
+    /// Disables stamping of the Kafka consumer group ID onto the GroupId property
+    /// of each incoming envelope. Use this when the consumer group name is not
+    /// meaningful as envelope metadata (e.g. when using PropagateGroupIdToPartitionKey).
+    /// </summary>
+    /// <returns></returns>
+    public KafkaTopicGroupListenerConfiguration DisableConsumerGroupIdStamping()
+    {
+        add(group => group.StampConsumerGroupIdOnEnvelope = false);
+        return this;
+    }
+
+    /// <summary>
     /// Enable native dead letter queue support for this listener group.
     /// </summary>
     /// <returns></returns>

--- a/src/Wolverine/IEnvelopeRule.cs
+++ b/src/Wolverine/IEnvelopeRule.cs
@@ -110,25 +110,43 @@ internal class DeliverWithinRule : IEnvelopeRule
 }
 
 /// <summary>
-/// Propagates the originating message's GroupId to the outgoing envelope's PartitionKey.
-/// This is useful for automatically carrying forward a stream/group id as a Kafka partition key
-/// on cascaded or published messages without manually setting DeliveryOptions on every message.
+/// Propagates a partition key to outgoing envelopes using the following priority:
+/// 1. The outgoing message's own GroupId (set by ByPropertyNamed / UseInferredMessageGrouping)
+/// 2. The originator's PartitionKey (the actual Kafka message key of the incoming message)
+/// 3. The originator's GroupId as a last resort
+/// This is useful when using Kafka and you want cascaded messages to inherit the partition key
+/// from the originating message's group/stream id without manually specifying DeliveryOptions.
 /// </summary>
 internal class GroupIdToPartitionKeyRule : IEnvelopeRule
 {
     public void Modify(Envelope envelope)
     {
-        // No-op when used without an originator context
+        // When published outside a handler context, promote the message's own GroupId
+        // (set by ByPropertyNamed / UseInferredMessageGrouping) to the PartitionKey.
+        if (envelope.PartitionKey.IsEmpty() && envelope.GroupId.IsNotEmpty())
+        {
+            envelope.PartitionKey = envelope.GroupId;
+        }
     }
 
     public void ApplyCorrelation(IMessageContext originator, Envelope outgoing)
     {
         if (outgoing.PartitionKey.IsNotEmpty()) return;
 
-        var groupId = originator.Envelope?.GroupId;
-        if (groupId.IsNotEmpty())
+        // Prefer the outgoing message's own GroupId — this is set by ByPropertyNamed or
+        // UseInferredMessageGrouping and reflects the actual business partition key.
+        if (outgoing.GroupId.IsNotEmpty())
         {
-            outgoing.PartitionKey = groupId;
+            outgoing.PartitionKey = outgoing.GroupId;
+            return;
+        }
+
+        // Fall back to the originator's PartitionKey (the Kafka message key on the incoming
+        // message), then to GroupId as a last resort.
+        var key = originator.Envelope?.PartitionKey ?? originator.Envelope?.GroupId;
+        if (key.IsNotEmpty())
+        {
+            outgoing.PartitionKey = key;
         }
     }
 }


### PR DESCRIPTION
This fix aims to solve two cases where the outgoing Kafka partition key was observed to be either:

- Kafka consumer group name (e.g. application name)
- Wolverine message id

The first case is caused by the Kafka listener setting the envelope.GroupId = config.GroupId on the incoming message. If the handler from the Kafka topic cascades an outgoing message, the GroupIdToPartitionKeyRule runs and copies this GroupId value to be the outgoing partition key.

The second case happens when the handler is processing a message from a local queue, or when publishing fresh from application code. At routing time, DetermineGroupId correctly resolves outgoing.GroupId = stream id (via ByPropertyNamed). But GroupIdToPartitionKeyRule only looks at originator.Envelope?.GroupId, which is null or unrelated, so it sets nothing, and outgoing.PartitionKey stays null. Then CreateMessage in the Kafka producer reaches its fallback: envelope.Id.ToString().

Fix the propagation priority in ApplyCorrelation:
1. Outgoing message's own GroupId (set by ByPropertyNamed) - the business partition key
2. Originator's PartitionKey (the actual Kafka message key of the incoming message)
3. Originator's GroupId as a last resort

Also implement Modify so that messages published outside a handler context (e.g. background services) have their GroupId promoted to PartitionKey when no explicit key is set.

Stop stamping envelope.GroupId = config.GroupId in KafkaListener and KafkaTopicGroupListener - the consumer group name is not meaningful metadata on the incoming envelope.