### PR TITLE
#2342 KafkaTombstone: Support for tombstone messages

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/send_kafka_tombstone.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/send_kafka_tombstone.cs
@@ -1,0 +1,60 @@
+using Confluent.Kafka;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Tracking;
+
+namespace Wolverine.Kafka.Tests;
+
+[Trait("Category", "Flaky")]
+public class send_kafka_tombstone : IAsyncLifetime
+{
+    private IHost _sender = null!;
+
+    public async Task InitializeAsync()
+    {
+        _sender = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka(KafkaContainerFixture.ConnectionString).AutoProvision();
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task send_tombstone_produces_message_with_null_value()
+    {
+        var topicName = "tombstone-test-" + Guid.NewGuid().ToString("N")[..8];
+        var tombstoneKey = "record-to-delete";
+
+        await _sender.TrackActivity()
+            .Timeout(30.Seconds())
+            .ExecuteAndWaitAsync(m => m.BroadcastToTopicAsync(topicName, new KafkaTombstone(tombstoneKey)));
+
+        var consumerConfig = new ConsumerConfig
+        {
+            BootstrapServers = KafkaContainerFixture.ConnectionString,
+            GroupId = "tombstone-verifier-" + Guid.NewGuid().ToString("N"),
+            AutoOffsetReset = AutoOffsetReset.Earliest
+        };
+
+        using var consumer = new ConsumerBuilder<string, byte[]>(consumerConfig).Build();
+        consumer.Subscribe(topicName);
+
+        var result = consumer.Consume(TimeSpan.FromSeconds(15));
+
+        consumer.Close();
+
+        result.ShouldNotBeNull();
+        result.Message.Key.ShouldBe(tombstoneKey);
+        result.Message.Value.ShouldBeNull();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _sender.StopAsync();
+        _sender.Dispose();
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTombstone.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTombstone.cs
@@ -1,0 +1,9 @@
+namespace Wolverine.Kafka;
+
+/// <summary>
+/// Sends a Kafka tombstone message to the specified topic key.
+/// A tombstone is a message with a non-null key and a null value, used to
+/// delete a key from a log-compacted Kafka topic.
+/// </summary>
+/// <param name="Key">The Kafka record key to tombstone.</param>
+public record KafkaTombstone(string Key);

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExtensions.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExtensions.cs
@@ -228,6 +228,16 @@ public static class KafkaTransportExtensions
 
     internal static async ValueTask<Message<string, byte[]>> CreateMessage(this IKafkaEnvelopeMapper mapper, Envelope envelope)
     {
+        if (envelope.Message is KafkaTombstone tombstone)
+        {
+            return new Message<string, byte[]>
+            {
+                Key = tombstone.Key,
+                Value = null,
+                Headers = new Headers()
+            };
+        }
+
         var data = await envelope.GetDataAsync();
         var message = new Message<string, byte[]>
         {


### PR DESCRIPTION
#2342 A new record, KafkaTombstone, has been introduced to enable the sending of tombstone messages (key with a null value) for deleting keys in log-compacted Kafka topics. The CreateMessage method now handles KafkaTombstone objects specifically. An integration test verifies the correct behaviour when sending tombstone messages.