### PR TITLE
Upgrade Polecat dependency to 1.4.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
     <PackageVersion Include="Marten" Version="8.26.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="1.3.0" />
+    <PackageVersion Include="Polecat" Version="1.4.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageVersion Include="Marten.AspNetCore" Version="8.26.1" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />

--- a/src/Persistence/PolecatTests/Distribution/TripDomain/TripProjection.cs
+++ b/src/Persistence/PolecatTests/Distribution/TripDomain/TripProjection.cs
@@ -2,7 +2,7 @@ using Polecat.Projections;
 
 namespace PolecatTests.Distribution.TripDomain;
 
-public class TripProjection : SingleStreamProjection<Trip>
+public class TripProjection : SingleStreamProjection<Trip, Guid>
 {
     public TripProjection()
     {


### PR DESCRIPTION
## Summary

- Bump Polecat NuGet package from 1.3.0 to 1.4.0
- Fix `TripProjection` to use new `SingleStreamProjection<TDoc, TId>` two-argument generic signature (Polecat 1.4.0 API change)

## Test plan

- [x] Solution compiles for net9.0
- [ ] PolecatTests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)