### PR TITLE
Set minimum MaxDegreeOfParallelism to 5 on all endpoints

### DIFF
--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -133,6 +133,28 @@ ListeningAgent-->CircuitBreaker: potentially stops the listening
 * `ListeningAgent` is a controller within Wolverine that governs the listener lifecycle including pauses and restarts depending
   on load or error conditions
 
+## Maximum Parallel Messages
+
+::: tip
+Wolverine defaults the maximum number of parallel messages per endpoint to the greater of `Environment.ProcessorCount`
+or 5. This ensures reasonable throughput even on low-core environments like containers or CI runners where `ProcessorCount`
+may be as low as 1 or 2.
+:::
+
+You can override the default parallelism per endpoint:
+
+```csharp
+opts.ListenToRabbitQueue("high-throughput")
+    .BufferedInMemory()
+    .MaximumParallelMessages(20);
+```
+
+Or set a global default for all listening endpoints using a policy:
+
+```csharp
+opts.Policies.AllListeners(x => x.MaximumParallelMessages = 5);
+```
+
 ## Strictly Ordered Listeners <Badge type="tip" text="2.3" />
 
 In the case where you need messages from a single endpoint to be processed in strict, global order across the entire application,

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -184,11 +184,11 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     }
 
     /// <summary>
-    /// Controls the maximum number of messages that could be processed at one time
-    /// Default is the Environment.ProcessorCount. Setting this to 1 makes this listening endpoint
-    /// be ordered in its processing
+    /// Controls the maximum number of messages that could be processed at one time.
+    /// Default is the greater of Environment.ProcessorCount or 5. Setting this to 1 makes this listening endpoint
+    /// be ordered in its processing.
     /// </summary>
-    public int MaxDegreeOfParallelism { get; set; } = Environment.ProcessorCount;
+    public int MaxDegreeOfParallelism { get; set; } = Math.Max(Environment.ProcessorCount, 5);
     
     /// <summary>
     /// If specified, directs this endpoint to use by GroupId sharding in processing.


### PR DESCRIPTION
## Summary

- Change `Endpoint.MaxDegreeOfParallelism` default from `Environment.ProcessorCount` to `Math.Max(Environment.ProcessorCount, 5)` so low-core environments (containers, CI runners) get reasonable throughput
- Add "Maximum Parallel Messages" section to the listeners documentation explaining the default behavior and how to override it

## Test plan

- [x] CoreTests: 1193 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)