### PR TITLE
Add transport configuration to database discovery

### DIFF
--- a/src/Persistence/PostgresqlTests/Transport/stateful_resource_smoke_tests.cs
+++ b/src/Persistence/PostgresqlTests/Transport/stateful_resource_smoke_tests.cs
@@ -118,6 +118,20 @@ public class stateful_resource_smoke_tests : IAsyncLifetime
         (await ConfigureBuilder(false, 30)
             .RunJasperFxCommands(["resources", "teardown"])).ShouldBe(0);
     }
+
+    [Fact]
+    public async Task db_assert_includes_transport_tables()
+    {
+        (await ConfigureBuilder(false, 40)
+            .RunJasperFxCommands(["db-apply"])).ShouldBe(0);
+        
+        var result = await ConfigureBuilder(false, 40)
+            .RunJasperFxCommands(["resources", "check"]);
+        
+        // resources check should succeed because db-apply have included
+        // endpoints in the database schema configuration
+        result.ShouldBe(0);
+    }
 }
 
 public class SRMessage1;

--- a/src/Persistence/Wolverine.RDBMS/MultiTenancy/MessageDatabaseDiscovery.cs
+++ b/src/Persistence/Wolverine.RDBMS/MultiTenancy/MessageDatabaseDiscovery.cs
@@ -2,6 +2,7 @@ using JasperFx.Descriptors;
 using Weasel.Core.Migrations;
 using Wolverine.Persistence.Durability;
 using Wolverine.Runtime;
+using Wolverine.Transports;
 
 namespace Wolverine.RDBMS.MultiTenancy;
 
@@ -44,9 +45,17 @@ public class MessageDatabaseDiscovery : IDatabaseSource
         return usage;
     }
 
-    public ValueTask<IReadOnlyList<IDatabase>> BuildDatabases()
+    public async ValueTask<IReadOnlyList<IDatabase>> BuildDatabases()
     {
-        return _runtime.Stores.FindAllAsync<IDatabase>();
+        if (!_runtime.Options.ExternalTransportsAreStubbed)
+        {
+            foreach (var transport in _runtime.Options.Transports.OfType<ITransportConfiguresRuntime>().ToArray())
+            {
+                await transport.ConfigureAsync(_runtime);
+            }
+        }
+        
+        return await _runtime.Stores.FindAllAsync<IDatabase>();
     }
 
     public DatabaseCardinality Cardinality => _runtime.Stores.Cardinality();


### PR DESCRIPTION
This means that `db-*` commands will pickup any registered transport changes similar to `resources *` commands.

I think applying the change in `Wolverine.RDBMS` should mean it applies to all database transport queues but let me know if there's anywhere else that would make more sense.