### PR TITLE
Fix FromQuery(Name) with dots generating invalid C# variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - "MSSQL_PID=Developer"
 
   pulsar:
-    image: "apachepulsar/pulsar:4.0"
+    image: "apachepulsar/pulsar:4.0.3"
     ports:
       - "6650:6650"
       - "8080:8080"

--- a/src/Http/Wolverine.Http.Tests/Bugs/Bug_2352_fromquery_name_with_dots.cs
+++ b/src/Http/Wolverine.Http.Tests/Bugs/Bug_2352_fromquery_name_with_dots.cs
@@ -1,0 +1,32 @@
+using Shouldly;
+
+namespace Wolverine.Http.Tests.Bugs;
+
+public class Bug_2352_fromquery_name_with_dots : IntegrationContext
+{
+    public Bug_2352_fromquery_name_with_dots(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task should_use_dotted_fromquery_name_for_string_parameters()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/dotted?hub.mode=subscribe&hub.challenge=abc123&hub.verify_token=mytoken");
+        });
+
+        body.ReadAsText().ShouldBe("subscribe|abc123|mytoken");
+    }
+
+    [Fact]
+    public async Task should_use_dotted_fromquery_name_for_int_parameter()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/dotted-int?page.number=42");
+        });
+
+        body.ReadAsText().ShouldBe("page 42");
+    }
+}

--- a/src/Http/Wolverine.Http/CodeGen/CodeGenExtensions.cs
+++ b/src/Http/Wolverine.Http/CodeGen/CodeGenExtensions.cs
@@ -4,6 +4,6 @@ internal static class CodeGenExtensions
 {
     public static string SanitizeFormNameForVariable(this string variableName)
     {
-        return variableName.Replace("/", "_").Replace("-", "_");
+        return variableName.Replace("/", "_").Replace("-", "_").Replace(".", "_");
     }
 }

--- a/src/Http/WolverineWebApi/QuerystringEndpoints.cs
+++ b/src/Http/WolverineWebApi/QuerystringEndpoints.cs
@@ -74,6 +74,25 @@ public static class QuerystringEndpoints
     }
 }
 
+public static class DottedFromQueryEndpoints
+{
+    [WolverineGet("/querystring/dotted")]
+    public static string HandleDottedQueryNames(
+        [FromQuery(Name = "hub.mode")] string hubMode,
+        [FromQuery(Name = "hub.challenge")] string hubChallenge,
+        [FromQuery(Name = "hub.verify_token")] string hubVerifyToken)
+    {
+        return $"{hubMode}|{hubChallenge}|{hubVerifyToken}";
+    }
+
+    [WolverineGet("/querystring/dotted-int")]
+    public static string HandleDottedIntQueryName(
+        [FromQuery(Name = "page.number")] int pageNumber)
+    {
+        return $"page {pageNumber}";
+    }
+}
+
 public static class FromQueryEndpoints
 {
     [WolverineGet("/api/fromquery1")]


### PR DESCRIPTION
## Summary
- Fixes #2352: When `[FromQuery(Name = "hub.mode")]` is used, the code generator was using the dotted name as the C# variable name (e.g., `var hub.mode = ...`), which fails to compile
- Added dot (`.`) sanitization to `SanitizeFormNameForVariable` so dotted query string names produce valid C# identifiers (e.g., `hub_mode`)
- Also fixed the Pulsar docker image tag (`4.0` → `4.0.3`) since the `4.0` tag doesn't exist

## Test plan
- [x] Added `Bug_2352_fromquery_name_with_dots` test with dotted string and int query parameters
- [x] Verified the new test fails before the fix and passes after
- [x] All 537 Wolverine.Http.Tests pass (0 failures, 10 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)