### PR TITLE
Fix unique SubjectUri for ancillary Marten stores (#2337)

### DIFF
--- a/src/Persistence/MartenTests/AncillaryStores/ancillary_store_subject_uri_uniqueness.cs
+++ b/src/Persistence/MartenTests/AncillaryStores/ancillary_store_subject_uri_uniqueness.cs
@@ -1,0 +1,88 @@
+using IntegrationTests;
+using JasperFx.Core.Reflection;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.Tracking;
+
+namespace MartenTests.AncillaryStores;
+
+/// <summary>
+/// Regression tests for https://github.com/JasperFx/wolverine/issues/2337
+/// When multiple Marten stores live in the same assembly, each store's SubjectUri
+/// must be unique so JasperFx can generate separate database schemas per store.
+/// </summary>
+public class ancillary_store_subject_uri_uniqueness : IAsyncLifetime
+{
+    private IHost theHost;
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Primary Marten store
+                opts.Services.AddMarten(Servers.PostgresConnectionString)
+                    .IntegrateWithWolverine();
+
+                // Ancillary store 1 – same database, different schema
+                opts.Services.AddMartenStore<IPlayerStore>(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "players";
+                }).IntegrateWithWolverine();
+
+                // Ancillary store 2 – same database, different schema
+                opts.Services.AddMartenStore<IThingStore>(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "things";
+                }).IntegrateWithWolverine();
+
+                opts.Durability.Mode = DurabilityMode.Solo;
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public void every_store_should_have_a_unique_subject_uri()
+    {
+        var runtime = theHost.GetRuntime();
+
+        // Primary store SubjectUri
+        var primarySubjectUri = runtime.Stores.Main
+            .As<MessageDatabase<NpgsqlConnection>>()
+            .SubjectUri;
+
+        var ancillaries = theHost.Services.GetServices<AncillaryMessageStore>().ToList();
+
+        // Ancillary store 1 (IPlayerStore)
+        var playerStore = ancillaries.Single(x => x.MarkerType == typeof(IPlayerStore));
+        var playerSubjectUri = playerStore.Inner
+            .As<MessageDatabase<NpgsqlConnection>>()
+            .SubjectUri;
+
+        // Ancillary store 2 (IThingStore)
+        var thingStore = ancillaries.Single(x => x.MarkerType == typeof(IThingStore));
+        var thingSubjectUri = thingStore.Inner
+            .As<MessageDatabase<NpgsqlConnection>>()
+            .SubjectUri;
+
+        // All three SubjectUris must be distinct so JasperFx can generate
+        // separate schema migration scripts per store (issue #2337)
+        playerSubjectUri.ShouldNotBe(primarySubjectUri);
+        thingSubjectUri.ShouldNotBe(primarySubjectUri);
+        thingSubjectUri.ShouldNotBe(playerSubjectUri);
+    }
+}

--- a/src/Persistence/Wolverine.Marten/AncillaryWolverineOptionsMartenExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/AncillaryWolverineOptionsMartenExtensions.cs
@@ -165,6 +165,7 @@ public static class AncillaryWolverineOptionsMartenExtensions
             runtime.LoggerFactory.CreateLogger<PostgresqlMessageStore>())
         {
             Name = "Master",
+            SubjectUri = new Uri($"wolverine://messages/{typeof(T).Name.ToLowerInvariant()}")
         };
 
         var source = new MartenMessageDatabaseSource<T>(schemaName, autoCreate ?? store.Options.AutoCreateSchemaObjects, store.As<T>(), runtime);
@@ -191,7 +192,10 @@ public static class AncillaryWolverineOptionsMartenExtensions
 
         var dataSource = store.Storage.Database.As<PostgresqlDatabase>().DataSource;
 
-        return new(typeof(T), new PostgresqlMessageStore(settings, runtime.Options.Durability, dataSource, logger)) ;
+        var messageStore = new PostgresqlMessageStore(settings, runtime.Options.Durability, dataSource, logger);
+        messageStore.SubjectUri = new Uri($"wolverine://messages/{typeof(T).Name.ToLowerInvariant()}");
+
+        return new(typeof(T), messageStore);
     }
 
     /// <summary>


### PR DESCRIPTION
Each ancillary store registered via AddMartenStore<T>().IntegrateWithWolverine() was assigned the same default SubjectUri ("wolverine://messages"), making it impossible for JasperFx to generate separate database schemas per store when multiple ancillary stores live in the same assembly.

Fix: assign "wolverine://messages/{typeof(T).Name.ToLowerInvariant()}" as the SubjectUri in BuildSinglePostgresqlMessageStore<T> and BuildMultiTenantedMessageDatabase<T>, so every store gets a unique identifier.

Adds regression test ancillary_store_subject_uri_uniqueness that registers a primary store plus two ancillary stores and asserts all three SubjectUris are distinct.