### PR TITLE
Fix FluentValidation not applying to AsParameters type with FromBody

### DIFF
--- a/docs/guide/http/validation.md
+++ b/docs/guide/http/validation.md
@@ -419,6 +419,55 @@ public class ValidatedQuery
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Forms/FormEndpoints.cs#L230-L257' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_fluent_validation_with_asparameters' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### AsParameters with [FromBody] <Badge type="tip" text="5.25" />
+
+When using `[AsParameters]` with a `[FromBody]` property, the Fluent Validation middleware will validate
+**both** the `[FromBody]` type (if it has a validator) and the `[AsParameters]` type itself. This ensures
+that validation rules on the `[AsParameters]` type are always applied, even when a `[FromBody]` property
+is present:
+
+<!-- snippet: sample_using_fluent_validation_with_AsParameters_and_FromBody -->
+<a id='snippet-sample_using_fluent_validation_with_asparameters_and_frombody'></a>
+```cs
+public static class ValidatedAsParametersWithFromBodyEndpoint
+{
+    [WolverinePost("/asparameters/validated_with_from_body")]
+    public static string Post([AsParameters] ValidatedWithFromBody query)
+    {
+        return $"{query.Name} has dog: {query.Body?.HasDog}, has cat: {query.Body?.HasCat}";
+    }
+}
+
+public class ValidatedWithFromBody
+{
+    [FromQuery]
+    public string? Name { get; set; }
+
+    [FromQuery]
+    public int Age { get; set; }
+
+    [FromBody]
+    public ValidatedQueryBody? Body { get; set; }
+
+    public class ValidatedWithFromBodyValidator : AbstractValidator<ValidatedWithFromBody>
+    {
+        public ValidatedWithFromBodyValidator()
+        {
+            RuleFor(x => x.Name).NotNull();
+            RuleFor(x => x.Body).NotNull();
+        }
+    }
+
+    public class ValidatedQueryBody
+    {
+        public bool HasDog { get; set; }
+        public bool HasCat { get; set; }
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Forms/FormEndpoints.cs' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_fluent_validation_with_asparameters_and_frombody' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
 ## QueryString Binding <Badge type="tip" text="5.0" />
 
 Wolverine.HTTP can apply the Fluent Validation middleware to complex types that are bound by the `[FromQuery]` behavior:

--- a/src/Http/Wolverine.Http.FluentValidation/Internals/HttpChainFluentValidationPolicy.cs
+++ b/src/Http/Wolverine.Http.FluentValidation/Internals/HttpChainFluentValidationPolicy.cs
@@ -22,7 +22,20 @@ internal class HttpChainFluentValidationPolicy : IHttpPolicy
     {
         var validatedType = chain.HasRequestType ? chain.RequestType : chain.ComplexQueryStringType;
         if (validatedType == null) return;
-        
+
+        addValidationMiddleware(chain, container, validatedType);
+
+        // When using [AsParameters] with a [FromBody] property, the RequestType gets
+        // overwritten to the body property type. We still want to validate the
+        // AsParameters type itself if it has a validator registered.
+        if (chain.AsParametersType != null && chain.AsParametersType != validatedType)
+        {
+            addValidationMiddleware(chain, container, chain.AsParametersType);
+        }
+    }
+
+    private static void addValidationMiddleware(HttpChain chain, IServiceContainer container, Type validatedType)
+    {
         var validatorInterface = typeof(IValidator<>).MakeGenericType(validatedType);
 
         var registered = container.RegistrationsFor(validatorInterface);

--- a/src/Http/Wolverine.Http.Tests/asparameters_binding.cs
+++ b/src/Http/Wolverine.Http.Tests/asparameters_binding.cs
@@ -184,4 +184,45 @@ public class asparameters_binding : IntegrationContext
             x.ContentTypeShouldBe("application/problem+json");
         });
     }
+
+    [Fact]
+    public async Task using_FluentValidation_with_AsParameters_and_FromBody_happy_path()
+    {
+        await Scenario(x =>
+        {
+            x.Post.Json(new WolverineWebApi.Forms.ValidatedWithFromBody.ValidatedQueryBody { HasDog = true, HasCat = false })
+                .ToUrl("/asparameters/validated_with_from_body")
+                .QueryString("Name", "Jeremy")
+                .QueryString("Age", "51");
+        });
+    }
+
+    [Fact]
+    public async Task using_FluentValidation_with_AsParameters_and_FromBody_should_validate_asparameters_type()
+    {
+        // Missing Name (required by the ValidatedWithFromBody validator)
+        await Scenario(x =>
+        {
+            x.Post.Json(new WolverineWebApi.Forms.ValidatedWithFromBody.ValidatedQueryBody { HasDog = true, HasCat = false })
+                .ToUrl("/asparameters/validated_with_from_body")
+                .QueryString("Age", "51");
+
+            x.StatusCodeShouldBe(400);
+            x.ContentTypeShouldBe("application/problem+json");
+        });
+    }
+
+    [Fact]
+    public async Task using_FluentValidation_with_AsParameters_and_FromBody_missing_body_should_fail()
+    {
+        // No body at all (required by the ValidatedWithFromBody validator)
+        await Scenario(x =>
+        {
+            x.Post.Url("/asparameters/validated_with_from_body")
+                .QueryString("Name", "Jeremy")
+                .QueryString("Age", "51");
+
+            x.StatusCodeShouldBe(400);
+        });
+    }
 }

--- a/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
@@ -24,6 +24,7 @@ internal class AsParamatersAttributeUsage : IParameterStrategy
         if (IsClassOrNullableClassNotCollection(parameter.ParameterType))
         {
             chain.RequestType = parameter.ParameterType;
+            chain.AsParametersType = parameter.ParameterType;
             chain.IsFormData = true;
             variable = new AsParametersBindingFrame(parameter.ParameterType, chain, container).Variable;
             return true;

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -706,6 +706,13 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
     public bool IsFormData { get; internal set; }
     public Type? ComplexQueryStringType { get; set; }
+
+    /// <summary>
+    /// When using [AsParameters], this tracks the original AsParameters type even when
+    /// RequestType is overwritten by a [FromBody] property. This allows middleware like
+    /// FluentValidation to also validate the AsParameters type itself.
+    /// </summary>
+    public Type? AsParametersType { get; internal set; }
     public ServiceProviderSource ServiceProviderSource { get; set; } = ServiceProviderSource.IsolatedAndScoped;
 
     internal Variable BuildJsonDeserializationVariable()

--- a/src/Http/WolverineWebApi/Forms/FormEndpoints.cs
+++ b/src/Http/WolverineWebApi/Forms/FormEndpoints.cs
@@ -256,3 +256,43 @@ public class ValidatedQuery
 
 #endregion
 
+#region sample_using_fluent_validation_with_AsParameters_and_FromBody
+
+public static class ValidatedAsParametersWithFromBodyEndpoint
+{
+    [WolverinePost("/asparameters/validated_with_from_body")]
+    public static string Post([AsParameters] ValidatedWithFromBody query)
+    {
+        return $"{query.Name} has dog: {query.Body?.HasDog}, has cat: {query.Body?.HasCat}";
+    }
+}
+
+public class ValidatedWithFromBody
+{
+    [FromQuery]
+    public string? Name { get; set; }
+
+    [FromQuery]
+    public int Age { get; set; }
+
+    [FromBody]
+    public ValidatedQueryBody? Body { get; set; }
+
+    public class ValidatedWithFromBodyValidator : AbstractValidator<ValidatedWithFromBody>
+    {
+        public ValidatedWithFromBodyValidator()
+        {
+            RuleFor(x => x.Name).NotNull();
+            RuleFor(x => x.Body).NotNull();
+        }
+    }
+
+    public class ValidatedQueryBody
+    {
+        public bool HasDog { get; set; }
+        public bool HasCat { get; set; }
+    }
+}
+
+#endregion
+


### PR DESCRIPTION
## Summary

Fixes #2358

- **Root cause**: When `[AsParameters]` is used with a `[FromBody]` property, `AsParametersBindingFrame` overwrites `chain.RequestType` to the body property type. The FluentValidation policy only checked `RequestType`, so validators on the `[AsParameters]` type itself were silently ignored.
- **Fix**: Added `AsParametersType` property to `HttpChain` that tracks the original `[AsParameters]` type. The `HttpChainFluentValidationPolicy` now checks for validators on both the `RequestType` (body type) and the `AsParametersType`, adding middleware for both when validators exist.
- **Documentation**: Updated the validation docs with a new "AsParameters with [FromBody]" section (badged 5.25) showing the combined usage pattern.

### Files changed

| File | Change |
|------|--------|
| `HttpChain.cs` | Added `AsParametersType` property |
| `AsParametersBindingFrame.cs` | Sets `chain.AsParametersType` during parameter binding |
| `HttpChainFluentValidationPolicy.cs` | Extracted `addValidationMiddleware` helper; also validates `AsParametersType` when different from `RequestType` |
| `FormEndpoints.cs` | Added test endpoint with `[AsParameters]` + `[FromBody]` + validator |
| `asparameters_binding.cs` | Added 3 new tests (happy path, missing Name, missing body) |
| `validation.md` | Added documentation section with code sample |

## Test plan

- [x] 3 new tests pass (happy path, validation failure on AsParameters type, missing body)
- [x] All 9 AsParameters binding tests pass
- [x] All 14 FluentValidation tests pass
- [x] Full HTTP test suite: 540 passed, 0 failed, 10 skipped (pre-existing)
- [x] Existing `post_body_services_and_route_arguments` test still passes (mentioned in issue as potential regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)