### PR TITLE
Add MassTransit and NServiceBus interop for ASB topics and subscriptions

### DIFF
--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusSubscriptionListenerConfiguration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusSubscriptionListenerConfiguration.cs
@@ -2,6 +2,7 @@ using Azure.Messaging.ServiceBus.Administration;
 using Wolverine.AzureServiceBus.Internal;
 using Wolverine.Configuration;
 using Wolverine.ErrorHandling;
+using Wolverine.Runtime.Interop.MassTransit;
 
 namespace Wolverine.AzureServiceBus;
 
@@ -135,6 +136,27 @@ public class AzureServiceBusSubscriptionListenerConfiguration : InteroperableLis
     public AzureServiceBusSubscriptionListenerConfiguration InteropWith(IAzureServiceBusEnvelopeMapper mapper)
     {
         add(e => e.EnvelopeMapper = mapper);
+        return this;
+    }
+
+    /// <summary>
+    /// Utilize an envelope mapper that is interoperable with MassTransit
+    /// </summary>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public AzureServiceBusSubscriptionListenerConfiguration UseMassTransitInterop(Action<IMassTransitInterop>? configure = null)
+    {
+        add(e => e.UseMassTransitInterop(configure));
+        return this;
+    }
+
+    /// <summary>
+    /// Use an envelope mapper that is interoperable with NServiceBus
+    /// </summary>
+    /// <returns></returns>
+    public AzureServiceBusSubscriptionListenerConfiguration UseNServiceBusInterop()
+    {
+        add(e => e.UseNServiceBusInterop());
         return this;
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTopicSubscriberConfiguration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTopicSubscriberConfiguration.cs
@@ -1,6 +1,7 @@
 using Azure.Messaging.ServiceBus.Administration;
 using Wolverine.AzureServiceBus.Internal;
 using Wolverine.Configuration;
+using Wolverine.Runtime.Interop.MassTransit;
 
 namespace Wolverine.AzureServiceBus;
 
@@ -32,6 +33,26 @@ public class AzureServiceBusTopicSubscriberConfiguration : InteroperableSubscrib
     public AzureServiceBusTopicSubscriberConfiguration InteropWith(IAzureServiceBusEnvelopeMapper mapper)
     {
         add(e => e.EnvelopeMapper = mapper);
+        return this;
+    }
+
+    /// <summary>
+    /// Use envelope mapping that is interoperable with MassTransit
+    /// </summary>
+    /// <returns></returns>
+    public AzureServiceBusTopicSubscriberConfiguration UseMassTransitInterop()
+    {
+        add(e => e.UseMassTransitInterop());
+        return this;
+    }
+
+    /// <summary>
+    /// Use envelope mapping that is interoperable with NServiceBus
+    /// </summary>
+    /// <returns></returns>
+    public AzureServiceBusTopicSubscriberConfiguration UseNServiceBusInterop()
+    {
+        add(e => e.UseNServiceBusInterop());
         return this;
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
@@ -1,16 +1,22 @@
 using System.Diagnostics;
+using System.Text;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using JasperFx.Core;
+using JasperFx.Core.Reflection;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Interop.MassTransit;
+using Wolverine.Runtime.Serialization;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
+using Wolverine.Util;
 
 namespace Wolverine.AzureServiceBus.Internal;
 
-public class AzureServiceBusSubscription : AzureServiceBusEndpoint, IBrokerQueue
+public class AzureServiceBusSubscription : AzureServiceBusEndpoint, IBrokerQueue, IMassTransitInteropEndpoint
 {
     private bool _hasInitialized;
 
@@ -221,5 +227,77 @@ public class AzureServiceBusSubscription : AzureServiceBusEndpoint, IBrokerQueue
         {
             await PurgeAsync(logger);
         }
+    }
+
+    internal void UseNServiceBusInterop()
+    {
+        DefaultSerializer = new NewtonsoftSerializer(new JsonSerializerSettings());
+        customizeMapping((m, _) =>
+        {
+            m.MapPropertyToHeader(x => x.ConversationId, "NServiceBus.ConversationId");
+            m.MapPropertyToHeader(x => x.SentAt, "NServiceBus.TimeSent");
+            m.MapPropertyToHeader(x => x.CorrelationId!, "NServiceBus.CorrelationId");
+
+            var replyAddress = new Lazy<string>(() =>
+            {
+                var replyEndpoint = Parent.ReplyEndpoint() as AzureServiceBusQueue;
+                return replyEndpoint?.QueueName ?? string.Empty;
+            });
+
+            void WriteReplyToAddress(Envelope e, ServiceBusMessage props)
+            {
+                props.ApplicationProperties["NServiceBus.ReplyToAddress"] = replyAddress.Value;
+            }
+
+            void ReadReplyUri(Envelope e, ServiceBusReceivedMessage serviceBusReceivedMessage)
+            {
+                if (serviceBusReceivedMessage.ApplicationProperties.TryGetValue("NServiceBus.ReplyToAddress",
+                        out var raw))
+                {
+                    var queueName = (raw is byte[] b ? Encoding.Default.GetString(b) : raw.ToString())!;
+                    e.ReplyUri = new Uri($"{Parent.Protocol}://queue/{queueName}");
+                }
+            }
+
+            m.MapProperty(x => x.ReplyUri!, ReadReplyUri, WriteReplyToAddress);
+
+            m.MapProperty(x => x.MessageType!, (e, msg) =>
+            {
+                if (msg.ApplicationProperties.TryGetValue("NServiceBus.EnclosedMessageTypes", out var raw))
+                {
+                    var typeName = (raw is byte[] b ? Encoding.Default.GetString(b) : raw.ToString())!;
+                    if (typeName.IsNotEmpty())
+                    {
+                        var messageType = Type.GetType(typeName);
+                        e.MessageType = messageType!.ToMessageTypeName();
+                    }
+                }
+            },
+                (e, msg) =>
+            {
+                msg.ApplicationProperties["NServiceBus.EnclosedMessageTypes"] = e.Message!.GetType().ToMessageTypeName();
+            });
+        });
+    }
+
+    Uri? IMassTransitInteropEndpoint.MassTransitUri()
+    {
+        return new Uri($"sb://{Parent.HostName}/topic/{Topic.TopicName}/{SubscriptionName}");
+    }
+
+    Uri? IMassTransitInteropEndpoint.MassTransitReplyUri()
+    {
+        return Parent.ReplyEndpoint()!.As<IMassTransitInteropEndpoint>().MassTransitUri();
+    }
+
+    Uri? IMassTransitInteropEndpoint.TranslateMassTransitToWolverineUri(Uri uri)
+    {
+        var lastSegment = uri.Segments.Last();
+        return Parent.Queues[lastSegment].Uri;
+    }
+
+    internal void UseMassTransitInterop(Action<IMassTransitInterop>? configure = null)
+    {
+        customizeMapping((m, _) => m.InteropWithMassTransit(configure));
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
@@ -1,15 +1,21 @@
+using System.Text;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
-using JasperFx.CodeGeneration;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Interop.MassTransit;
+using Wolverine.Runtime.Serialization;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
+using Wolverine.Util;
 
 namespace Wolverine.AzureServiceBus.Internal;
 
-public class AzureServiceBusTopic : AzureServiceBusEndpoint
+public class AzureServiceBusTopic : AzureServiceBusEndpoint, IMassTransitInteropEndpoint
 {
     private bool _hasInitialized;
 
@@ -118,4 +124,76 @@ public class AzureServiceBusTopic : AzureServiceBusEndpoint
     }
 
     public override bool IsPartitioned { get => Options.EnablePartitioning; }
+
+    internal void UseNServiceBusInterop()
+    {
+        DefaultSerializer = new NewtonsoftSerializer(new JsonSerializerSettings());
+        customizeMapping((m, _) =>
+        {
+            m.MapPropertyToHeader(x => x.ConversationId, "NServiceBus.ConversationId");
+            m.MapPropertyToHeader(x => x.SentAt, "NServiceBus.TimeSent");
+            m.MapPropertyToHeader(x => x.CorrelationId!, "NServiceBus.CorrelationId");
+
+            var replyAddress = new Lazy<string>(() =>
+            {
+                var replyEndpoint = Parent.ReplyEndpoint() as AzureServiceBusQueue;
+                return replyEndpoint?.QueueName ?? string.Empty;
+            });
+
+            void WriteReplyToAddress(Envelope e, ServiceBusMessage props)
+            {
+                props.ApplicationProperties["NServiceBus.ReplyToAddress"] = replyAddress.Value;
+            }
+
+            void ReadReplyUri(Envelope e, ServiceBusReceivedMessage serviceBusReceivedMessage)
+            {
+                if (serviceBusReceivedMessage.ApplicationProperties.TryGetValue("NServiceBus.ReplyToAddress",
+                        out var raw))
+                {
+                    var queueName = (raw is byte[] b ? Encoding.Default.GetString(b) : raw.ToString())!;
+                    e.ReplyUri = new Uri($"{Parent.Protocol}://queue/{queueName}");
+                }
+            }
+
+            m.MapProperty(x => x.ReplyUri!, ReadReplyUri, WriteReplyToAddress);
+
+            m.MapProperty(x => x.MessageType!, (e, msg) =>
+            {
+                if (msg.ApplicationProperties.TryGetValue("NServiceBus.EnclosedMessageTypes", out var raw))
+                {
+                    var typeName = (raw is byte[] b ? Encoding.Default.GetString(b) : raw.ToString())!;
+                    if (typeName.IsNotEmpty())
+                    {
+                        var messageType = Type.GetType(typeName);
+                        e.MessageType = messageType!.ToMessageTypeName();
+                    }
+                }
+            },
+                (e, msg) =>
+            {
+                msg.ApplicationProperties["NServiceBus.EnclosedMessageTypes"] = e.Message!.GetType().ToMessageTypeName();
+            });
+        });
+    }
+
+    Uri? IMassTransitInteropEndpoint.MassTransitUri()
+    {
+        return new Uri($"sb://{Parent.HostName}/topic/{TopicName}");
+    }
+
+    Uri? IMassTransitInteropEndpoint.MassTransitReplyUri()
+    {
+        return Parent.ReplyEndpoint()!.As<IMassTransitInteropEndpoint>().MassTransitUri();
+    }
+
+    Uri? IMassTransitInteropEndpoint.TranslateMassTransitToWolverineUri(Uri uri)
+    {
+        var lastSegment = uri.Segments.Last();
+        return Parent.Queues[lastSegment].Uri;
+    }
+
+    internal void UseMassTransitInterop(Action<IMassTransitInterop>? configure = null)
+    {
+        customizeMapping((m, _) => m.InteropWithMassTransit(configure));
+    }
 }


### PR DESCRIPTION
## Summary
- Add `UseMassTransitInterop()` and `UseNServiceBusInterop()` to `AzureServiceBusTopic` (publishing) and `AzureServiceBusSubscription` (listening)
- Implement `IMassTransitInteropEndpoint` on both `AzureServiceBusTopic` and `AzureServiceBusSubscription`
- Add fluent configuration methods to `AzureServiceBusTopicSubscriberConfiguration` and `AzureServiceBusSubscriptionListenerConfiguration`

Previously, MassTransit/NServiceBus interop was only available on Azure Service Bus **queues**. This enables sending Wolverine messages to ASB topics that can be received by MassTransit or NServiceBus, and receiving messages from MassTransit or NServiceBus on ASB subscriptions.

### Usage

```csharp
// Publish to a topic with NServiceBus interop
opts.PublishAllMessages().ToAzureServiceBusTopic("nsb-topic")
    .UseNServiceBusInterop();

// Listen on a subscription with MassTransit interop
opts.ListenToAzureServiceBusSubscription("wolverine-sub")
    .FromTopic("wolverine-topic")
    .UseMassTransitInterop(mt => { })
    .DefaultIncomingMessage<ResponseMessage>().UseForReplies();
```

## Test plan
- [x] All 6 NServiceBus Azure interop tests pass (including 2 new topic/subscription tests)
- [x] All 4 MassTransit Azure interop tests pass (including 2 new topic/subscription tests)
- [x] Tests run against the Azure Service Bus emulator via docker-compose
- [ ] Verify no regressions in existing ASB test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)