### PR TITLE
Fix UseDurableOutboxOnAllSendingEndpoints() not applying to topic exchange endpoints

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_topic_exchange_ignores_durable_outbox_policy.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_topic_exchange_ignores_durable_outbox_policy.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RabbitMQ.Client;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests.Bugs;
+
+public class Bug_topic_exchange_ignores_durable_outbox_policy : IDisposable
+{
+    private readonly IHost _host;
+
+    public Bug_topic_exchange_ignores_durable_outbox_policy()
+    {
+        _host = Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRabbitMq()
+                    .AutoProvision();
+
+                opts.StubAllExternalTransports();
+
+                opts.UseRabbitMq().DeclareExchange("members", e =>
+                {
+                    e.ExchangeType = ExchangeType.Topic;
+                    e.IsDurable = true;
+                });
+
+                opts.PublishMessagesToRabbitMqExchange<TopicExchangeBugMessage>("members",
+                    _ => "member.created");
+
+                opts.Policies.UseDurableOutboxOnAllSendingEndpoints();
+            })
+            .Start();
+    }
+
+    [Fact]
+    public void topic_exchange_endpoint_should_be_durable()
+    {
+        var runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var endpoint = runtime.Options.Transports
+            .AllEndpoints()
+            .OfType<RabbitMqExchange>()
+            .FirstOrDefault(e => e.ExchangeName == "members");
+
+        endpoint.ShouldNotBeNull();
+        endpoint.Mode.ShouldBe(EndpointMode.Durable);
+    }
+
+    public void Dispose()
+    {
+        _host?.Dispose();
+    }
+}
+
+public class TopicExchangeBugMessage;
+
+public static class TopicExchangeBugHandler
+{
+    public static void Handle(TopicExchangeBugMessage message)
+    {
+        // no-op
+    }
+}

--- a/src/Wolverine/Runtime/Routing/TopicRouting.cs
+++ b/src/Wolverine/Runtime/Routing/TopicRouting.cs
@@ -9,7 +9,7 @@ using Wolverine.Util;
 
 namespace Wolverine.Runtime.Routing;
 
-public class TopicRouting<T> : IMessageRouteSource, IMessageRoute, IMessageInvoker
+public class TopicRouting<T> : IMessageRouteSource, IMessageRoute, IMessageInvoker, IEndpointSource
 {
     private readonly Func<T, string> _topicSource;
     private readonly Endpoint _topicEndpoint;
@@ -30,6 +30,11 @@ public class TopicRouting<T> : IMessageRouteSource, IMessageRoute, IMessageInvok
     }
 
     public bool IsAdditive => true;
+
+    public IEnumerable<Endpoint> ActiveEndpoints()
+    {
+        yield return _topicEndpoint;
+    }
 
     public Envelope CreateForSending(object message, DeliveryOptions? options, ISendingAgent localDurableQueue,
         WolverineRuntime runtime, string? topicName)

--- a/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
@@ -1,6 +1,7 @@
 using ImTools;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using Wolverine.Configuration;
 using Wolverine.Runtime.Agents;
 using Wolverine.Runtime.Routing;
 using Wolverine.Transports;
@@ -29,6 +30,16 @@ public interface IMessageRouteSource
 }
 
 #endregion
+
+/// <summary>
+/// Optional interface for IMessageRouteSource implementations to expose their
+/// target endpoints, enabling endpoint policies (like UseDurableOutboxOnAllSendingEndpoints)
+/// to discover and configure them.
+/// </summary>
+public interface IEndpointSource
+{
+    IEnumerable<Endpoint> ActiveEndpoints();
+}
 
 internal class AgentMessages : IMessageRouteSource
 {

--- a/src/Wolverine/WolverineOptions.Policies.cs
+++ b/src/Wolverine/WolverineOptions.Policies.cs
@@ -153,7 +153,10 @@ public sealed partial class WolverineOptions : IPolicies
 
             if (!e.Subscriptions.Any())
             {
-                return;
+                var isRoutingTarget = CustomRouteSources
+                    .OfType<IEndpointSource>()
+                    .Any(rs => rs.ActiveEndpoints().Contains(e));
+                if (!isRoutingTarget) return;
             }
 
             var configuration = new SubscriberConfiguration(e);


### PR DESCRIPTION
- `UseDurableOutboxOnAllSendingEndpoints()` did not apply to RabbitMQ topic exchange endpoints created via `PublishMessagesToRabbitMqExchange<T>()`, causing messages to be discarded when the broker is unreachable instead of being persisted in the outbox
- The root cause is that `AllSenders()` only iterates over subscriber endpoints, but `PublishMessagesToRabbitMqExchange` registers a `TopicRouting<T>` via `PublishWithMessageRoutingSource()` — the underlying exchange endpoint was never visited by the policy

Fixes #2385