### PR TITLE
Fix codegen for WriteAggregate with OnMissing.ThrowException and batch queries

### DIFF
--- a/src/Persistence/MartenTests/Bugs/Bug_2387_write_aggregate_throw_exception_codegen.cs
+++ b/src/Persistence/MartenTests/Bugs/Bug_2387_write_aggregate_throw_exception_codegen.cs
@@ -1,0 +1,119 @@
+using IntegrationTests;
+using JasperFx.CodeGeneration;
+using JasperFx.Events;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Persistence;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace MartenTests.Bugs;
+
+public class Bug_2387_write_aggregate_throw_exception_codegen : PostgresqlContext, IAsyncLifetime
+{
+    private IHost _host = null!;
+    private IDocumentStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Auto;
+
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Services.AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DisableNpgsqlLogging = true;
+                        m.Events.UseIdentityMapForAggregates = true;
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        _store = _host.Services.GetRequiredService<IDocumentStore>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task codegen_compiles_with_write_aggregate_throw_exception_and_validate()
+    {
+        // This test reproduces Bug #2387:
+        // When a message handler has [WriteAggregate(OnMissing = ThrowException)]
+        // AND a Validate() method that takes the aggregate as a parameter,
+        // AND AutoApplyTransactions + UseIdentityMapForAggregates,
+        // the codegen generates code where stream_entity is referenced before
+        // it is declared (the null check and Validate both use stream_entity.Aggregate
+        // before the batch query assigns stream_entity).
+
+        await using var session = _store.LightweightSession();
+        var action = session.Events.StartStream<Bug2387Aggregate>(new Bug2387Created("test"));
+        await session.SaveChangesAsync();
+
+        // If codegen is broken, this will throw a compilation error:
+        // CS0841: Cannot use local variable 'stream_entity' before it is declared
+        await _host.InvokeMessageAndWaitAsync(new Bug2387DeleteCommand(action.Id));
+    }
+
+    [Fact]
+    public async Task throws_on_missing_aggregate_with_validate()
+    {
+        var nonExistentId = Guid.NewGuid();
+
+        await Should.ThrowAsync<RequiredDataMissingException>(async () =>
+        {
+            await _host.InvokeMessageAndWaitAsync(new Bug2387DeleteCommand(nonExistentId));
+        });
+    }
+}
+
+public record Bug2387Created(string Name);
+public record Bug2387Deleted(Guid Id);
+
+public record Bug2387DeleteCommand(Guid Id);
+
+public class Bug2387Aggregate
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = "";
+    public bool IsDeleted { get; set; }
+
+    public void Apply(Bug2387Created created) => Name = created.Name;
+    public void Apply(Bug2387Deleted deleted) => IsDeleted = true;
+}
+
+// Matches the exact handler structure from the user's reproduction repo
+public class Bug2387DeleteHandler
+{
+    public static async Task BeforeAsync()
+    {
+        Console.WriteLine("Some Before tasks");
+    }
+
+    public static void Validate(Bug2387Aggregate entity)
+    {
+        Console.WriteLine("Some validation checks");
+    }
+
+    public static IEvent Handle(
+        Bug2387DeleteCommand command,
+        [WriteAggregate(Required = true, OnMissing = OnMissing.ThrowException)]
+        Bug2387Aggregate entity)
+    {
+        return Event.For(new Bug2387Deleted(entity.Id));
+    }
+}

--- a/src/Persistence/Wolverine.Marten/Codegen/LoadAggregateFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/LoadAggregateFrame.cs
@@ -102,8 +102,43 @@ internal class LoadAggregateFrame : AsyncFrame,  IBatchableFrame
         }
     }
 
+    /// <summary>
+    /// Set to true after GenerateCodeForBatchResolution has been called,
+    /// to prevent duplicate variable declarations.
+    /// </summary>
+    internal bool BatchResolutionGenerated { get; private set; }
+
+    /// <summary>
+    /// When this frame is part of a batch query, generate only the code that
+    /// resolves the batch item result (var stream_entity = await ...BatchItem).
+    /// This is called by MartenBatchFrame after the batch execute, ensuring
+    /// the variable is declared before any guard frames reference it.
+    /// </summary>
+    public void GenerateCodeForBatchResolution(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_batchQueryItem == null) return;
+
+        writer.WriteComment("Loading Marten aggregate as part of the aggregate handler workflow");
+        writer.Write(
+            $"var {Stream.Usage} = await {_batchQueryItem.Usage}.ConfigureAwait(false);");
+
+        if (_att.AlwaysEnforceConsistency)
+        {
+            writer.WriteLine($"{Stream.Usage}.{nameof(IEventStream<string>.AlwaysEnforceConsistency)} = true;");
+        }
+
+        BatchResolutionGenerated = true;
+    }
+
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
+        // If batch resolution already generated the variable declaration, skip
+        if (BatchResolutionGenerated)
+        {
+            Next?.GenerateCode(method, writer);
+            return;
+        }
+
         writer.WriteComment("Loading Marten aggregate as part of the aggregate handler workflow");
         if (_batchQueryItem == null)
         {

--- a/src/Persistence/Wolverine.Marten/Codegen/MartenQueryingFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/MartenQueryingFrame.cs
@@ -88,13 +88,26 @@ internal class MartenBatchFrame : AsyncFrame
             writer.BlankLine();
             op.WriteCodeToEnlistInBatchQuery(method, writer);
         }
-        
+
         writer.BlankLine();
-        
+
         writer.WriteLine($"await {BatchQuery.Usage}.{nameof(IBatchedQuery.Execute)}({_cancellation.Usage});");
-        
+
         writer.BlankLine();
-        
+
+        // After the batch query executes, generate the code to resolve each
+        // batched frame's result variable (e.g. var stream_entity = await stream_entity_BatchItem).
+        // This must happen BEFORE any guard frames that reference these variables.
+        foreach (var op in _operations)
+        {
+            if (op is LoadAggregateFrame loadFrame)
+            {
+                loadFrame.GenerateCodeForBatchResolution(method, writer);
+            }
+        }
+
+        writer.BlankLine();
+
         Next?.GenerateCode(method, writer);
     }
     

--- a/src/Wolverine/Persistence/EntityAttribute.cs
+++ b/src/Wolverine/Persistence/EntityAttribute.cs
@@ -41,15 +41,19 @@ public class LoadEntityFrameBlock : Frame
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
-        // The [WriteAggregate] somehow causes this
         if (Creator.Next == this || Creator.Next != null)
         {
-            for (int i = 1; i < _guardFrames.Length; i++)
+            // Creator has been handled elsewhere (e.g. by batching) —
+            // only render the guard frames
+            if (_guardFrames.Length > 0)
             {
-                _guardFrames[i - 1].Next = _guardFrames[i];
+                for (int i = 1; i < _guardFrames.Length; i++)
+                {
+                    _guardFrames[i - 1].Next = _guardFrames[i];
+                }
+
+                _guardFrames[0].GenerateCode(method, writer);
             }
-            
-            _guardFrames[0].GenerateCode(method, writer);
         }
         else
         {
@@ -59,7 +63,7 @@ public class LoadEntityFrameBlock : Frame
                 previous.Next = next;
                 previous = next;
             }
-        
+
             Creator.GenerateCode(method, writer);
         }
 


### PR DESCRIPTION
## Summary

Fixes #2387

- **Root cause**: When using `[WriteAggregate(OnMissing = ThrowException)]` with `UseIdentityMapForAggregates = true` and a `Validate()` middleware method, the Marten batch query policy enrolled the `LoadAggregateFrame` in a batch but didn't emit the variable declaration (`var stream_entity = await stream_entity_BatchItem`) until after guard frames had already tried to reference `stream_entity.Aggregate`, causing `CS0841: Cannot use local variable before it is declared`.
- **Fix**: Added `GenerateCodeForBatchResolution()` to `LoadAggregateFrame`, called by `MartenBatchFrame` immediately after `batchQuery.Execute()`. This ensures the stream variable is declared before any guard frames (null checks, Validate calls) reference it. The original `GenerateCode()` skips re-declaration when batch resolution has already run.

### Key conditions to reproduce
All three must be present:
1. `[WriteAggregate(OnMissing = OnMissing.ThrowException)]` on a **message handler** (not HTTP endpoint)
2. `UseIdentityMapForAggregates = true` (no snapshot projection)
3. A `Validate()` middleware method that takes the aggregate as a parameter

## Test plan

- [x] 2 new reproducing tests pass (codegen compiles, throws on missing aggregate)
- [x] Aggregate handler workflow tests: 17/17 passed
- [x] Marten HTTP tests: 65/65 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)