### PR TITLE
Latch receiver after stopping listener on shutdown

### DIFF
--- a/src/Wolverine/Configuration/EndpointCollection.cs
+++ b/src/Wolverine/Configuration/EndpointCollection.cs
@@ -384,8 +384,9 @@ public class EndpointCollection : IEndpointCollection
 
     /// <summary>
     /// Immediately latch all receivers to stop picking up new messages from their internal queues.
-    /// This is called as early as possible during shutdown (via IHostApplicationLifetime.ApplicationStopping)
-    /// so that messages already queued internally are not processed after the shutdown signal.
+    /// During normal shutdown this is no longer called globally; instead each ListeningAgent
+    /// latches its own receiver after stopping the listener (see StopAndDrainAsync).
+    /// Kept to not break public api compatability.
     /// </summary>
     public void LatchAllReceivers()
     {

--- a/src/Wolverine/Configuration/EndpointCollection.cs
+++ b/src/Wolverine/Configuration/EndpointCollection.cs
@@ -403,8 +403,7 @@ public class EndpointCollection : IEndpointCollection
 
     public async Task DrainAsync()
     {
-        // Drain the listeners
-        foreach (var listener in ActiveListeners().ToArray())
+        await Task.WhenAll(ActiveListeners().ToArray().Select(async listener =>
         {
             try
             {
@@ -414,9 +413,9 @@ public class EndpointCollection : IEndpointCollection
             {
                 _runtime.Logger.LogError(e, "Failed to 'drain' outstanding messages in listener {Uri}", listener.Uri);
             }
-        }
+        }));
 
-        foreach (var queue in _localSenders.Enumerate().Select(x => x.Value).OfType<ILocalQueue>())
+        await Task.WhenAll(_localSenders.Enumerate().Select(x => x.Value).OfType<ILocalQueue>().Select(async queue =>
         {
             try
             {
@@ -426,7 +425,7 @@ public class EndpointCollection : IEndpointCollection
             {
                 _runtime.Logger.LogError(e, "Failed to 'drain' outstanding messages in local sender {Queue}", queue);
             }
-        }
+        }));
     }
 
     internal void StoreSendingAgent(ISendingAgent agent)

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -126,8 +126,7 @@ public partial class WolverineRuntime
 
     internal void OnApplicationStopping()
     {
-        Logger.LogInformation("Application stopping signal received, latching all message receivers");
-        _endpoints.LatchAllReceivers();
+        Logger.LogInformation("Application stopping signal received");
     }
 
     private bool _hasMigratedStorage;
@@ -219,10 +218,9 @@ public partial class WolverineRuntime
 
         if (StopMode == StopMode.Normal)
         {
-            // Step 1: Drain endpoints first — stop listeners from accepting new messages
-            // and wait for in-flight handlers to complete before releasing ownership.
-            // Receivers were already latched via IHostApplicationLifetime.ApplicationStopping
-            // to prevent new messages from being picked up, so this just waits for completion.
+            // Step 1: Drain endpoints — each listener is stopped, its receiver latched,
+            // then in-flight handlers are drained. Receivers are not latched up front,
+            // since messages might be unnecessarily deferred before listeners are stopped.
             await _endpoints.DrainAsync();
 
             if (_accumulator.IsValueCreated)

--- a/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
@@ -125,7 +125,7 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
     public async ValueTask DrainAsync()
     {
         // If _latched was already true, this drain was triggered during shutdown
-        // (after OnApplicationStopping called Latch()). Safe to wait for in-flight items.
+        // (after StopAndDrainAsync called Latch()). Safe to wait for in-flight items.
         // If _latched was false, this drain may have been triggered from within the handler
         // pipeline (e.g., rate limiting pause via PauseListenerContinuation). Waiting for
         // the receiving block to complete would deadlock because the current message's

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -284,7 +284,7 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
     public async ValueTask DrainAsync()
     {
         // If _latched was already true, this drain was triggered during shutdown
-        // (after OnApplicationStopping called Latch()). Safe to wait for in-flight items.
+        // (after StopAndDrainAsync called Latch()). Safe to wait for in-flight items.
         // If _latched was false, this drain may have been triggered from within the handler
         // pipeline (e.g., rate limiting pause via PauseListenerContinuation). Waiting for
         // the receiver block to complete would deadlock because the current message's

--- a/src/Wolverine/Runtime/WorkerQueues/InlineReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/InlineReceiver.cs
@@ -43,7 +43,7 @@ internal class InlineReceiver : IReceiver
     public ValueTask DrainAsync()
     {
         // If _latched was already true, this drain was triggered during shutdown
-        // (after OnApplicationStopping called Latch()). Safe to wait for in-flight items.
+        // (after StopAndDrainAsync called LatchReceiver()). Safe to wait for in-flight items.
         // If _latched was false, this drain may have been triggered from within the handler
         // pipeline (e.g., rate limiting pause via PauseListenerContinuation). Waiting for
         // in-flight items to complete would deadlock because the current message's

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -182,15 +182,18 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
             return;
         }
 
-        Listener = null;
-        _receiver = null;
-
         try
         {
             using var activity = WolverineTracing.ActivitySource.StartActivity(WolverineTracing.StoppingListener);
             activity?.SetTag(WolverineTracing.EndpointAddress, Uri);
 
             await listener.StopAsync();
+
+            LatchReceiver();
+
+            Listener = null;
+            _receiver = null;
+
             if (receiver != null)
             {
                 await receiver.DrainAsync();

--- a/src/Wolverine/Transports/ParallelListener.cs
+++ b/src/Wolverine/Transports/ParallelListener.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using JasperFx.Core;
 using Wolverine.Runtime;
 
@@ -32,7 +33,13 @@ public class ParallelListener : IListener, IDisposable
 
     public async ValueTask StopAsync()
     {
-        foreach (var listener in _listeners) await listener.StopAsync();
+        var exceptions = new ConcurrentBag<Exception>();
+        await Task.WhenAll(_listeners.Select(async l =>
+        {
+            try { await l.StopAsync(); }
+            catch (Exception e) { exceptions.Add(e); }
+        }));
+        if (!exceptions.IsEmpty) throw new AggregateException(exceptions);
     }
 
     public ValueTask DisposeAsync() =>


### PR DESCRIPTION
Currently, wolverine latches all receivers immediately when shutdown is requested. This means that any messages consumed by listeners after that happens are deferred, which (for the same reasons as in https://github.com/JasperFx/wolverine/pull/2347) can have poor performance characteristics.

This change moves latching each receiver to after its respective listener is stopped, so all consumed messages get a fair shot at being processed.

This also moves to shutting down the listeners in parallel so that they don't wait to latch before the previous ones finish shutting down. This was also done to the ParallelListener, with similar exception aggregation to the CompoundListener. I think this is a general improvement to the shutdown flow, but also avoids extra bad behavior from moving latching.