### PR TITLE
Use pg_class estimation for outgoing and dead letter table counts

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -189,17 +189,54 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>
             await fetchCountsWithGroupBy(counts);
         }
 
-        var longCount = await CreateCommand($"select count(*) from {SchemaName}.{DatabaseConstants.OutgoingTable}")
-            .ExecuteScalarAsync();
-
-        counts.Outgoing = Convert.ToInt32(longCount);
-
-        var deadLetterCount = await CreateCommand($"select count(*) from {SchemaName}.{DatabaseConstants.DeadLetterTable}")
-            .ExecuteScalarAsync();
-
-        counts.DeadLetter = Convert.ToInt32(deadLetterCount);
+        counts.Outgoing = await estimateTableCount(DatabaseConstants.OutgoingTable);
+        counts.DeadLetter = await estimateTableCount(DatabaseConstants.DeadLetterTable);
 
         return counts;
+    }
+
+    private async Task<int> estimateTableCount(string tableName)
+    {
+        // Use pg_class reltuples for a fast estimation instead of expensive count(*).
+        // Same approach as the partition estimation: handles never-vacuumed tables
+        // (reltuples < 0) and empty tables (relpages = 0), then scales by current
+        // relation size.
+        var sql = $@"
+select (case when c.reltuples < 0 then 0
+             when c.relpages = 0 then 0
+             else (c.reltuples / c.relpages)
+                  * (pg_catalog.pg_relation_size(c.oid)
+                     / pg_catalog.current_setting('block_size')::int)
+        end)::bigint as estimated_count,
+       c.reltuples,
+       pg_catalog.pg_relation_size(c.oid) as relation_size
+from pg_catalog.pg_class c
+join pg_catalog.pg_namespace n on n.oid = c.relnamespace and n.nspname = '{SchemaName}'
+where c.relname = '{tableName}';";
+
+        await using var reader = await CreateCommand(sql).ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            var estimate = await reader.GetFieldValueAsync<long>(0);
+            var reltuples = await reader.GetFieldValueAsync<float>(1);
+            var relationSize = await reader.GetFieldValueAsync<long>(2);
+
+            await reader.CloseAsync();
+
+            // If the table has physical data but reltuples hasn't been updated
+            // by VACUUM/ANALYZE, fall back to exact count
+            if (reltuples <= 0 && relationSize > 0)
+            {
+                var exactCount = await CreateCommand($"select count(*) from {SchemaName}.{tableName}")
+                    .ExecuteScalarAsync();
+                return Convert.ToInt32(exactCount);
+            }
+
+            return (int)estimate;
+        }
+
+        await reader.CloseAsync();
+        return 0;
     }
 
     private async Task fetchCountsWithGroupBy(PersistedCounts counts)


### PR DESCRIPTION
## Summary

Fixes #2377

Replaces expensive `select count(*)` queries on the `wolverine_outgoing_envelopes` and `wolverine_dead_letters` tables with `pg_class reltuples`-based estimation in `PostgresqlMessageStore.FetchCountsAsync()`.

This matches the approach already used for the partitioned incoming table. The estimation uses PostgreSQL catalog statistics (`pg_class.reltuples` and `pg_relation_size`) which are virtually free compared to sequential scans. Falls back to exact `count(*)` only when the table has physical data but `reltuples` hasn't been updated by `VACUUM`/`ANALYZE`.

### Before
```sql
select count(*) from schema.wolverine_outgoing_envelopes   -- full sequential scan
select count(*) from schema.wolverine_dead_letters          -- full sequential scan
```

### After
```sql
-- Fast catalog lookup, no table scan
select (case when c.reltuples < 0 then 0 ... end)::bigint as estimated_count, ...
from pg_catalog.pg_class c ...
where c.relname = 'wolverine_outgoing_envelopes';
```

## Test plan

- [x] Build succeeds
- [x] 15 durability tests pass
- [x] 3 PostgreSQL-specific tests pass (10 failures are pre-existing SQL Server connection issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)