### PR TITLE
Fix exchange naming with FromHandlerType routing

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_using_handler_type_naming.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_using_handler_type_naming.cs
@@ -21,9 +21,8 @@ public class when_using_handler_type_naming : IDisposable
         _host = WolverineHost.For(opts =>
         {
             opts.UseRabbitMq()
-                .UseConventionalRouting(NamingSource.FromHandlerType)
                 .AutoProvision()
-                .AutoPurgeOnStartup();
+                .UseConventionalRouting(NamingSource.FromHandlerType);
 
             opts.Discovery.DisableConventionalDiscovery()
                 .IncludeType(typeof(HandlerTypeNamingHandler));
@@ -67,6 +66,40 @@ public class when_using_handler_type_naming : IDisposable
 
         _runtime.Endpoints.ActiveListeners().Any(x => x.Uri == expectedUri)
             .ShouldBeTrue($"Expected active listener at {expectedUri}");
+    }
+
+    [Fact]
+    public void exchange_should_be_named_after_message_type_not_handler_type()
+    {
+        var messageName = typeof(HandlerTypeNamingMessage).ToMessageTypeName();
+        var handlerName = typeof(HandlerTypeNamingHandler).ToMessageTypeName();
+
+        var transport = _runtime.Options.RabbitMqTransport();
+
+        // The exchange should be named after the message type
+        transport.Exchanges.Any(e => e.Name == messageName).ShouldBeTrue(
+            $"Expected exchange named '{messageName}' for message type, but found exchanges: {string.Join(", ", transport.Exchanges.Select(e => e.Name))}");
+
+        // The exchange should NOT be named after the handler type
+        transport.Exchanges.Any(e => e.Name == handlerName).ShouldBeFalse(
+            $"Exchange should not be named '{handlerName}' (handler type). Exchanges should use the message type name.");
+    }
+
+    [Fact]
+    public void queue_should_be_bound_to_message_type_exchange()
+    {
+        var queueName = typeof(HandlerTypeNamingHandler).ToMessageTypeName();
+        var messageName = typeof(HandlerTypeNamingMessage).ToMessageTypeName();
+
+        var transport = _runtime.Options.RabbitMqTransport();
+        var queue = transport.Queues[queueName];
+
+        queue.HasBindings.ShouldBeTrue(
+            $"Queue '{queueName}' should have bindings");
+
+        // The queue should be bound to the exchange named after the message type
+        queue.Bindings().Any(b => b.ExchangeName == messageName).ShouldBeTrue(
+            $"Queue '{queueName}' should be bound to exchange '{messageName}', but found bindings to: {string.Join(", ", queue.Bindings().Select(b => b.ExchangeName))}");
     }
 
     public void Dispose()

--- a/src/Wolverine/Transports/MessageRoutingConvention.cs
+++ b/src/Wolverine/Transports/MessageRoutingConvention.cs
@@ -57,7 +57,7 @@ public abstract class MessageRoutingConvention<TTransport, TListener, TSubscribe
                 foreach (var handler in chain.Handlers)
                 {
                     var handlerType = handler.HandlerType;
-                    var endpoint = maybeCreateListenerForMessageOrHandlerType(transport, handlerType, runtime);
+                    var endpoint = maybeCreateListenerForMessageOrHandlerType(transport, handlerType, runtime, messageType);
                     if (endpoint != null)
                     {
                         endpoint.StickyHandlers.Add(handlerType);
@@ -118,7 +118,7 @@ public abstract class MessageRoutingConvention<TTransport, TListener, TSubscribe
         return endpoint;
     }
 
-    private Endpoint? maybeCreateListenerForMessageOrHandlerType(TTransport transport, Type messageOrHandlerType, IWolverineRuntime runtime)
+    private Endpoint? maybeCreateListenerForMessageOrHandlerType(TTransport transport, Type messageOrHandlerType, IWolverineRuntime runtime, Type? originalMessageType = null)
     {
         // Can be null, so bail out if there's no queue
         var queueName = _queueNameForListener(messageOrHandlerType);
@@ -139,8 +139,11 @@ public abstract class MessageRoutingConvention<TTransport, TListener, TSubscribe
         _configureListener(configuration, context);
 
         configuration!.As<IDelayedEndpointConfiguration>().Apply();
-            
-        ApplyListenerRoutingDefaults(corrected, transport, messageOrHandlerType);
+
+        // When using FromHandlerType naming, the exchange should still be named
+        // after the message type so that senders (which always use message type)
+        // and listeners share the same exchange. See GH-2397.
+        ApplyListenerRoutingDefaults(corrected, transport, originalMessageType ?? messageOrHandlerType);
 
         return endpoint;
     }


### PR DESCRIPTION
## Summary
- When using `UseConventionalRouting(NamingSource.FromHandlerType)`, exchanges were incorrectly named after the handler type instead of the message type, causing sender/listener exchange mismatch
- Fixed `MessageRoutingConvention` to pass the original message type through to `ApplyListenerRoutingDefaults` so queues use handler type names while exchanges use message type names
- Added tests verifying exchange naming and queue-to-exchange binding

## Test plan
- [x] All 5 `when_using_handler_type_naming` tests pass against live RabbitMQ
- [x] `exchange_should_be_named_after_message_type_not_handler_type` verifies exchange uses message type
- [x] `queue_should_be_bound_to_message_type_exchange` verifies queue binds to message-type exchange

Closes #2397

🤖 Generated with [Claude Code](https://claude.com/claude-code)