### PR TITLE
Add API versioning docs to routing guide

### DIFF
--- a/docs/guide/http/routing.md
+++ b/docs/guide/http/routing.md
@@ -110,6 +110,72 @@ public static StrongLetterAggregate Handle(
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/StrongTypedIdentifiers.cs#L11-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_strong_typed_id_as_route_argument' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Route Prefixes
+
+You can apply a common URL prefix to all endpoints in a handler class using the `[RoutePrefix]` attribute:
+
+```csharp
+[RoutePrefix("/api/v1")]
+public static class V1Endpoints
+{
+    // Resolves to /api/v1/orders
+    [WolverineGet("/orders")]
+    public static string GetOrders() => "V1 Orders";
+
+    // Resolves to /api/v1/orders/{id}
+    [WolverineGet("/orders/{id}")]
+    public static string GetOrder(int id) => $"V1 Order {id}";
+}
+```
+
+You can also configure route prefixes globally or by namespace in your application setup:
+
+```csharp
+app.MapWolverineEndpoints(opts =>
+{
+    // Apply a global prefix to all Wolverine endpoints
+    opts.RoutePrefix("api");
+
+    // Apply a prefix to all endpoints in a specific namespace
+    opts.RoutePrefix("api/v2", forEndpointsInNamespace: "MyApp.Endpoints.V2");
+});
+```
+
+When multiple prefix sources apply, the precedence is: `[RoutePrefix]` attribute > namespace prefix > global prefix. Only one prefix is applied per endpoint — they do not stack.
+
+## API Versioning
+
+For API versioning scenarios, Wolverine recommends using route prefixes to version your endpoints. This approach is simple, explicit, and requires no additional packages:
+
+```csharp
+[RoutePrefix("/api/v1")]
+public static class OrdersV1
+{
+    [WolverineGet("/orders")]
+    public static OrderListResponse GetOrders() => /* ... */;
+}
+
+[RoutePrefix("/api/v2")]
+public static class OrdersV2
+{
+    // V2 returns a different shape
+    [WolverineGet("/orders")]
+    public static OrderListResponseV2 GetOrders() => /* ... */;
+}
+```
+
+You can also version by namespace:
+
+```csharp
+app.MapWolverineEndpoints(opts =>
+{
+    opts.RoutePrefix("api/v1", forEndpointsInNamespace: "MyApp.Endpoints.V1");
+    opts.RoutePrefix("api/v2", forEndpointsInNamespace: "MyApp.Endpoints.V2");
+});
+```
+
+This lets you organize versioned endpoints into separate namespaces and apply the version prefix automatically without any attributes on individual classes.
+
 ## Route Name
 
 You can add a name to the ASP.Net route with this property that is on all of the route definition attributes:


### PR DESCRIPTION
## Summary
- Adds documentation for `[RoutePrefix]` attribute and namespace-based route prefixes
- Adds "API Versioning" section showing how to use route prefixes for versioned APIs
- Documents precedence rules: attribute > namespace > global prefix

Closes #2401

## Test plan
- [ ] Verify docs build with `npm run docs`
- [ ] Review rendered documentation for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)