### PR TITLE
Add response content negotiation with [Writes] and ConnegMode

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -222,6 +222,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                         {text: 'Integration with ASP.Net Core', link: '/guide/http/integration'},
                         {text: 'Endpoints', link: '/guide/http/endpoints'},
                         {text: 'Json', link: '/guide/http/json'},
+                        {text: 'Content Negotiation', link: '/guide/http/conneg'},
                         {text: 'Routing', link: '/guide/http/routing'},
                         {text: 'Authentication and Authorization', link: '/guide/http/security'},
                         {text: 'Antiforgery / CSRF Protection', link: '/guide/http/antiforgery'},

--- a/docs/guide/http/conneg.md
+++ b/docs/guide/http/conneg.md
@@ -1,0 +1,184 @@
+# Content Negotiation
+
+Wolverine supports content negotiation for HTTP endpoints, allowing you to serve different response formats based on the client's `Accept` header. This is done through the `[Writes]` attribute and the `WriteResponse` naming convention.
+
+## Response Content Negotiation
+
+To add content negotiation support for responses, add methods with the `[Writes("content-type")]` attribute to your endpoint class. These methods will be called instead of the default JSON serialization when the client's `Accept` header matches:
+
+<!-- snippet: sample_conneg_write_response -->
+<a id='snippet-sample_conneg_write_response'></a>
+```cs
+/// <summary>
+/// Demonstrates content negotiation with [Writes] attribute.
+/// Multiple WriteResponse methods handle different content types.
+/// </summary>
+public static class ConnegWriteEndpoints
+{
+    [WolverineGet("/conneg/write")]
+    public static ConnegItem GetItem()
+    {
+        return new ConnegItem("Widget", 42);
+    }
+
+    /// <summary>
+    /// Writes the response as plain text when Accept: text/plain
+    /// </summary>
+    [Writes("text/plain")]
+    public static Task WriteResponse(HttpContext context, ConnegItem response)
+    {
+        context.Response.ContentType = "text/plain";
+        return context.Response.WriteAsync($"{response.Name}: {response.Value}");
+    }
+
+    /// <summary>
+    /// Writes the response as CSV when Accept: text/csv
+    /// </summary>
+    [Writes("text/csv")]
+    public static Task WriteResponseCsv(HttpContext context, ConnegItem response)
+    {
+        context.Response.ContentType = "text/csv";
+        return context.Response.WriteAsync($"Name,Value\n{response.Name},{response.Value}");
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/ConnegEndpoints.cs#L11-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conneg_write_response' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Key points:
+- Methods must have the `[Writes("content-type")]` attribute to specify which content type they handle
+- The method name can be anything — it's the `[Writes]` attribute that matters
+- Methods receive the `HttpContext` and the response resource as parameters
+- Methods can be sync (`void`) or async (`Task`)
+- Multiple `[Writes]` methods can coexist on the same class for different content types
+
+## Loose vs Strict Mode
+
+By default, content negotiation uses **Loose** mode: if no `[Writes]` method matches the client's `Accept` header, Wolverine falls back to JSON serialization. This ensures clients always get a response.
+
+### Strict Mode
+
+Use `[StrictConneg]` to enable **Strict** mode. In strict mode, if no `[Writes]` method matches, Wolverine returns HTTP 406 Not Acceptable:
+
+<!-- snippet: sample_conneg_strict -->
+<a id='snippet-sample_conneg_strict'></a>
+```cs
+/// <summary>
+/// Strict content negotiation — returns 406 when Accept header doesn't match
+/// </summary>
+[StrictConneg]
+public static class StrictConnegEndpoints
+{
+    [WolverineGet("/conneg/strict")]
+    public static ConnegItem GetStrictItem()
+    {
+        return new ConnegItem("StrictWidget", 99);
+    }
+
+    [Writes("text/plain")]
+    public static Task WriteResponse(HttpContext context, ConnegItem response)
+    {
+        context.Response.ContentType = "text/plain";
+        return context.Response.WriteAsync($"{response.Name}: {response.Value}");
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/ConnegEndpoints.cs#L54-L76' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conneg_strict' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+### Global Configuration
+
+You can set the default `ConnegMode` for all endpoints using a policy:
+
+```csharp
+app.MapWolverineEndpoints(opts =>
+{
+    // Set strict mode globally
+    opts.ConfigureEndpoints(chain =>
+    {
+        chain.ConnegMode = ConnegMode.Strict;
+    });
+});
+```
+
+Per-endpoint configuration (via `[StrictConneg]` attribute) overrides the global setting.
+
+## Loose Mode Fallback
+
+In the default **Loose** mode, when no `[Writes]` method matches the `Accept` header, the response falls back to JSON serialization — exactly the same as an endpoint without any content negotiation:
+
+<!-- snippet: sample_conneg_loose_fallback -->
+<a id='snippet-sample_conneg_loose_fallback'></a>
+```cs
+/// <summary>
+/// Loose content negotiation (default) — falls back to JSON when no match
+/// </summary>
+public static class LooseConnegEndpoints
+{
+    [WolverineGet("/conneg/loose")]
+    public static ConnegItem GetLooseItem()
+    {
+        return new ConnegItem("LooseWidget", 77);
+    }
+
+    [Writes("text/plain")]
+    public static Task WriteResponse(HttpContext context, ConnegItem response)
+    {
+        context.Response.ContentType = "text/plain";
+        return context.Response.WriteAsync($"{response.Name}: {response.Value}");
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/ConnegEndpoints.cs#L78-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conneg_loose_fallback' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## How It Works
+
+At code generation time, Wolverine generates branching code that checks the `Accept` header and dispatches to the correct writer:
+
+```csharp
+// Generated code (simplified)
+var acceptHeader = httpContext.Request.Headers.Accept.ToString();
+
+if (acceptHeader.Contains("text/plain"))
+{
+    httpContext.Response.ContentType = "text/plain";
+    await ConnegWriteEndpoints.WriteResponse(httpContext, item_response);
+}
+else if (acceptHeader.Contains("text/csv"))
+{
+    httpContext.Response.ContentType = "text/csv";
+    await ConnegWriteEndpoints.WriteResponseCsv(httpContext, item_response);
+}
+else
+{
+    // Loose: fallback to JSON
+    await WriteJsonAsync(httpContext, item_response);
+    // Strict: httpContext.Response.StatusCode = 406;
+}
+```
+
+This means there is **zero runtime reflection** — the content type dispatching is compiled at startup.
+
+## Request Content Type Negotiation
+
+For request-side content negotiation (dispatching based on `Content-Type` header), use the existing `[AcceptsContentType]` attribute to create separate endpoint methods for different request formats:
+
+```csharp
+public static class RequestConnegEndpoints
+{
+    [WolverinePost("/items"), AcceptsContentType("application/vnd.item.v1+json")]
+    public static ItemCreated CreateV1(CreateItemV1 command)
+    {
+        return new ItemCreated(command.Name, "v1");
+    }
+
+    [WolverinePost("/items"), AcceptsContentType("application/vnd.item.v2+json")]
+    public static ItemCreated CreateV2(CreateItemV2 command)
+    {
+        return new ItemCreated(command.Name, "v2");
+    }
+}
+```
+
+This allows the same route and HTTP method to handle different request body formats.

--- a/src/Http/Wolverine.Http.Tests/ContentNegotiationTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ContentNegotiationTests.cs
@@ -1,0 +1,115 @@
+using Alba;
+using Shouldly;
+using WolverineWebApi;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Wolverine.Http.Tests;
+
+public class ContentNegotiationTests : IntegrationContext
+{
+    private readonly ITestOutputHelper _output;
+
+    public ContentNegotiationTests(AppFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task writes_text_plain_when_accept_header_matches()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/conneg/write");
+            x.WithRequestHeader("Accept", "text/plain");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var text = result.ReadAsText();
+        text.ShouldBe("Widget: 42");
+    }
+
+    [Fact]
+    public async Task writes_csv_when_accept_header_matches()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/conneg/write");
+            x.WithRequestHeader("Accept", "text/csv");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var text = result.ReadAsText();
+        text.ShouldBe("Name,Value\nWidget,42");
+    }
+
+    [Fact]
+    public async Task falls_back_to_json_in_loose_mode()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/conneg/write");
+            x.WithRequestHeader("Accept", "application/json");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var item = result.ReadAsJson<ConnegItem>();
+        item.ShouldNotBeNull();
+        item!.Name.ShouldBe("Widget");
+        item.Value.ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task falls_back_to_json_with_no_accept_header()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/conneg/loose");
+            // No Accept header — falls back to JSON in loose mode
+            x.StatusCodeShouldBeOk();
+        });
+
+        var item = result.ReadAsJson<ConnegItem>();
+        item.ShouldNotBeNull();
+        item!.Name.ShouldBe("LooseWidget");
+    }
+
+    [Fact]
+    public async Task strict_mode_returns_406_when_no_match()
+    {
+        await Scenario(x =>
+        {
+            x.Get.Url("/conneg/strict");
+            x.WithRequestHeader("Accept", "application/xml");
+            x.StatusCodeShouldBe(406);
+        });
+    }
+
+    [Fact]
+    public async Task strict_mode_returns_ok_when_match()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/conneg/strict");
+            x.WithRequestHeader("Accept", "text/plain");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var text = result.ReadAsText();
+        text.ShouldBe("StrictWidget: 99");
+    }
+
+    [Fact]
+    public async Task loose_mode_text_plain_works()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/conneg/loose");
+            x.WithRequestHeader("Accept", "text/plain");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var text = result.ReadAsText();
+        text.ShouldBe("LooseWidget: 77");
+    }
+}

--- a/src/Http/Wolverine.Http/ContentNegotiation/ConnegMode.cs
+++ b/src/Http/Wolverine.Http/ContentNegotiation/ConnegMode.cs
@@ -1,0 +1,19 @@
+namespace Wolverine.Http.ContentNegotiation;
+
+/// <summary>
+/// Controls how content negotiation behaves when no matching content type writer is found
+/// </summary>
+public enum ConnegMode
+{
+    /// <summary>
+    /// Default. Falls back to JSON serialization when no specific writer matches the Accept header.
+    /// This is the most permissive mode and ensures clients always get a response.
+    /// </summary>
+    Loose,
+
+    /// <summary>
+    /// Returns HTTP 406 Not Acceptable when no specific writer matches the Accept header.
+    /// Use this mode to strictly enforce content negotiation.
+    /// </summary>
+    Strict
+}

--- a/src/Http/Wolverine.Http/ContentNegotiation/ContentNegotiationPolicy.cs
+++ b/src/Http/Wolverine.Http/ContentNegotiation/ContentNegotiationPolicy.cs
@@ -1,0 +1,180 @@
+using System.Reflection;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Wolverine.Http.CodeGen;
+using Wolverine.Http.Resources;
+
+namespace Wolverine.Http.ContentNegotiation;
+
+/// <summary>
+/// Resource writer policy that discovers WriteResponse/WriteResponseAsync methods
+/// on the handler type and generates content-negotiated response writing code.
+/// </summary>
+internal class ContentNegotiationWriterPolicy : IResourceWriterPolicy
+{
+    public static readonly string[] WriteResponseMethodNames = ["WriteResponse", "WriteResponseAsync"];
+
+    public bool TryApply(HttpChain chain)
+    {
+        if (!chain.HasResourceType()) return false;
+
+        var handlerType = chain.Method.HandlerType;
+        var writers = DiscoverWriteMethods(handlerType);
+
+        if (writers.Count == 0) return false;
+
+        var resourceVariable = chain.ResourceVariable ?? chain.Method.Creates.First();
+        resourceVariable.OverrideName(resourceVariable.Usage + "_response");
+
+        chain.Postprocessors.Add(new ContentNegotiationWriteFrame(resourceVariable, writers, chain.ConnegMode));
+
+        return true;
+    }
+
+    internal static List<ContentTypeWriter> DiscoverWriteMethods(Type handlerType)
+    {
+        var writers = new List<ContentTypeWriter>();
+
+        foreach (var method in handlerType.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance))
+        {
+            if (method.TryGetAttribute<WritesAttribute>(out var attr))
+            {
+                writers.Add(new ContentTypeWriter(attr!.ContentType, handlerType, method));
+            }
+            else if (WriteResponseMethodNames.Contains(method.Name))
+            {
+                // Convention-based, but needs [Writes] to specify content type
+                // Without [Writes], skip — we don't know what content type to match
+                continue;
+            }
+        }
+
+        return writers;
+    }
+}
+
+/// <summary>
+/// Represents a discovered WriteResponse method with its content type binding
+/// </summary>
+internal class ContentTypeWriter
+{
+    public ContentTypeWriter(string contentType, Type handlerType, MethodInfo method)
+    {
+        ContentType = contentType;
+        HandlerType = handlerType;
+        Method = method;
+        IsAsync = method.ReturnType == typeof(Task) || method.ReturnType == typeof(ValueTask);
+    }
+
+    public string ContentType { get; }
+    public Type HandlerType { get; }
+    public MethodInfo Method { get; }
+    public bool IsAsync { get; }
+}
+
+/// <summary>
+/// Frame that generates content-negotiated response writing code.
+/// Checks the Accept header and dispatches to the appropriate WriteResponse method.
+/// </summary>
+internal class ContentNegotiationWriteFrame : AsyncFrame
+{
+    private readonly Variable _resourceVariable;
+    private readonly List<ContentTypeWriter> _writers;
+    private readonly ConnegMode _mode;
+    private Variable? _httpContext;
+
+    public ContentNegotiationWriteFrame(Variable resourceVariable, List<ContentTypeWriter> writers, ConnegMode mode)
+    {
+        _resourceVariable = resourceVariable;
+        _writers = writers;
+        _mode = mode;
+        uses.Add(resourceVariable);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _httpContext = chain.FindVariable(typeof(Microsoft.AspNetCore.Http.HttpContext));
+        yield return _httpContext;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment("Content negotiation: selecting response writer based on Accept header");
+        writer.Write($"var acceptHeader = {_httpContext!.Usage}.Request.Headers.Accept.ToString();");
+        writer.BlankLine();
+
+        var first = true;
+        foreach (var contentWriter in _writers)
+        {
+            var keyword = first ? "if" : "else if";
+            first = false;
+
+            writer.Write($"BLOCK:{keyword} (acceptHeader.Contains(\"{contentWriter.ContentType}\"))");
+
+            // Set content type
+            writer.Write($"{_httpContext.Usage}.Response.ContentType = \"{contentWriter.ContentType}\";");
+
+            // Call the WriteResponse method
+            var call = BuildMethodCall(contentWriter);
+            if (contentWriter.IsAsync)
+            {
+                writer.Write($"await {call};");
+            }
+            else
+            {
+                writer.Write($"{call};");
+            }
+
+            writer.FinishBlock();
+        }
+
+        // Fallback
+        if (_mode == ConnegMode.Loose)
+        {
+            writer.Write("BLOCK:else");
+            writer.WriteComment("Fallback to JSON serialization");
+            writer.Write($"await {nameof(HttpHandler.WriteJsonAsync)}({_httpContext.Usage}, {_resourceVariable.Usage});");
+            writer.FinishBlock();
+        }
+        else
+        {
+            writer.Write("BLOCK:else");
+            writer.WriteComment("Strict content negotiation: return 406 Not Acceptable");
+            writer.Write($"{_httpContext.Usage}.Response.StatusCode = 406;");
+            writer.FinishBlock();
+        }
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    private string BuildMethodCall(ContentTypeWriter contentWriter)
+    {
+        var typeName = contentWriter.HandlerType.FullNameInCode();
+        var methodName = contentWriter.Method.Name;
+
+        // Build parameter list from method signature
+        var parameters = contentWriter.Method.GetParameters();
+        var args = new List<string>();
+
+        foreach (var param in parameters)
+        {
+            if (param.ParameterType == typeof(Microsoft.AspNetCore.Http.HttpContext))
+            {
+                args.Add(_httpContext!.Usage);
+            }
+            else if (param.ParameterType.IsAssignableFrom(_resourceVariable.VariableType))
+            {
+                args.Add(_resourceVariable.Usage);
+            }
+            else
+            {
+                // For other parameters, use the variable name directly
+                args.Add(param.Name!);
+            }
+        }
+
+        return $"{typeName}.{methodName}({string.Join(", ", args)})";
+    }
+}

--- a/src/Http/Wolverine.Http/ContentNegotiation/ReadsAttribute.cs
+++ b/src/Http/Wolverine.Http/ContentNegotiation/ReadsAttribute.cs
@@ -1,0 +1,18 @@
+namespace Wolverine.Http.ContentNegotiation;
+
+/// <summary>
+/// Marks a method as a request body reader for a specific content type.
+/// Used for content negotiation — the method will be called when the
+/// client's Content-Type header matches the specified content type.
+/// The method should read from HttpContext.Request and return the deserialized body.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public class ReadsAttribute : Attribute
+{
+    public ReadsAttribute(string contentType)
+    {
+        ContentType = contentType;
+    }
+
+    public string ContentType { get; }
+}

--- a/src/Http/Wolverine.Http/ContentNegotiation/StrictConnegAttribute.cs
+++ b/src/Http/Wolverine.Http/ContentNegotiation/StrictConnegAttribute.cs
@@ -1,0 +1,16 @@
+using JasperFx.CodeGeneration;
+
+namespace Wolverine.Http.ContentNegotiation;
+
+/// <summary>
+/// Apply strict content negotiation to this endpoint. When the client's Accept header
+/// does not match any registered content type writer, returns HTTP 406 Not Acceptable
+/// instead of falling back to JSON.
+/// </summary>
+public class StrictConnegAttribute : ModifyHttpChainAttribute
+{
+    public override void Modify(HttpChain chain, GenerationRules rules)
+    {
+        chain.ConnegMode = ConnegMode.Strict;
+    }
+}

--- a/src/Http/Wolverine.Http/ContentNegotiation/WritesAttribute.cs
+++ b/src/Http/Wolverine.Http/ContentNegotiation/WritesAttribute.cs
@@ -1,0 +1,18 @@
+namespace Wolverine.Http.ContentNegotiation;
+
+/// <summary>
+/// Marks a method as a response writer for a specific content type.
+/// Used for content negotiation — the method will be called when the
+/// client's Accept header matches the specified content type.
+/// The method should write the response body to HttpContext.Response.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public class WritesAttribute : Attribute
+{
+    public WritesAttribute(string contentType)
+    {
+        ContentType = contentType;
+    }
+
+    public string ContentType { get; }
+}

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -20,6 +20,7 @@ using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 using Wolverine.Configuration;
 using Wolverine.Http.CodeGen;
+using Wolverine.Http.ContentNegotiation;
 using Wolverine.Http.Metadata;
 using Wolverine.Http.Policies;
 using Wolverine.Persistence;
@@ -75,6 +76,12 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
     /// </summary>
     [IgnoreDescription]
     public Variable? ResourceVariable { get; set; }
+
+    /// <summary>
+    /// Controls how content negotiation behaves when no matching content type writer is found.
+    /// Default is Loose (falls back to JSON). Set to Strict to return 406 Not Acceptable.
+    /// </summary>
+    public ConnegMode ConnegMode { get; set; } = ConnegMode.Loose;
 
     // Make the assumption that the route argument has to match the parameter name
     private GeneratedType? _generatedType;

--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Wolverine.Configuration;
 using Wolverine.Http.CodeGen;
+using Wolverine.Http.ContentNegotiation;
 using Wolverine.Http.Resources;
 using Wolverine.Runtime;
 using Endpoint = Microsoft.AspNetCore.Http.Endpoint;
@@ -25,6 +26,7 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
         new StatusCodePolicy(),
         new ResultWriterPolicy(),
         new StringResourceWriterPolicy(),
+        new ContentNegotiationWriterPolicy(),
         new JsonResourceWriterPolicy()
     ];
 

--- a/src/Http/WolverineWebApi/ConnegEndpoints.cs
+++ b/src/Http/WolverineWebApi/ConnegEndpoints.cs
@@ -1,0 +1,92 @@
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Wolverine.Http;
+using Wolverine.Http.ContentNegotiation;
+
+namespace WolverineWebApi;
+
+public record ConnegItem(string Name, int Value);
+
+#region sample_conneg_write_response
+
+/// <summary>
+/// Demonstrates content negotiation with [Writes] attribute.
+/// Multiple WriteResponse methods handle different content types.
+/// </summary>
+public static class ConnegWriteEndpoints
+{
+    [WolverineGet("/conneg/write")]
+    public static ConnegItem GetItem()
+    {
+        return new ConnegItem("Widget", 42);
+    }
+
+    /// <summary>
+    /// Writes the response as plain text when Accept: text/plain
+    /// </summary>
+    [Writes("text/plain")]
+    public static Task WriteResponse(HttpContext context, ConnegItem response)
+    {
+        context.Response.ContentType = "text/plain";
+        return context.Response.WriteAsync($"{response.Name}: {response.Value}");
+    }
+
+    /// <summary>
+    /// Writes the response as CSV when Accept: text/csv
+    /// </summary>
+    [Writes("text/csv")]
+    public static Task WriteResponseCsv(HttpContext context, ConnegItem response)
+    {
+        context.Response.ContentType = "text/csv";
+        return context.Response.WriteAsync($"Name,Value\n{response.Name},{response.Value}");
+    }
+}
+
+#endregion
+
+#region sample_conneg_strict
+
+/// <summary>
+/// Strict content negotiation — returns 406 when Accept header doesn't match
+/// </summary>
+[StrictConneg]
+public static class StrictConnegEndpoints
+{
+    [WolverineGet("/conneg/strict")]
+    public static ConnegItem GetStrictItem()
+    {
+        return new ConnegItem("StrictWidget", 99);
+    }
+
+    [Writes("text/plain")]
+    public static Task WriteResponse(HttpContext context, ConnegItem response)
+    {
+        context.Response.ContentType = "text/plain";
+        return context.Response.WriteAsync($"{response.Name}: {response.Value}");
+    }
+}
+
+#endregion
+
+#region sample_conneg_loose_fallback
+
+/// <summary>
+/// Loose content negotiation (default) — falls back to JSON when no match
+/// </summary>
+public static class LooseConnegEndpoints
+{
+    [WolverineGet("/conneg/loose")]
+    public static ConnegItem GetLooseItem()
+    {
+        return new ConnegItem("LooseWidget", 77);
+    }
+
+    [Writes("text/plain")]
+    public static Task WriteResponse(HttpContext context, ConnegItem response)
+    {
+        context.Response.ContentType = "text/plain";
+        return context.Response.WriteAsync($"{response.Name}: {response.Value}");
+    }
+}
+
+#endregion


### PR DESCRIPTION
## Summary
- Adds `[Writes("content-type")]` attribute for marking methods as content type-specific response writers
- New `ContentNegotiationWriterPolicy` (IResourceWriterPolicy) discovers `[Writes]` methods and generates Accept header-based dispatch code
- `ConnegMode` enum: `Loose` (default, JSON fallback) vs `Strict` (406 Not Acceptable)
- `[StrictConneg]` ModifyHttpChainAttribute for per-endpoint strict mode
- `ConnegMode` property on `HttpChain` for programmatic configuration
- `[Reads("content-type")]` attribute placeholder for future request body negotiation
- Zero runtime reflection — content type dispatch is compiled at startup
- 7 integration tests via Alba (text/plain, text/csv, JSON fallback, strict 406, loose mode)
- Documentation page with usage guide

Closes #2406

## Test plan
- [x] Content negotiation tests: `dotnet test src/Http/Wolverine.Http.Tests/ --framework net9.0 --filter ContentNegotiationTests` (7/7 pass)
- [x] Full HTTP test suite: 560 passed, 10 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)