### PR TITLE
Add kafka-partition-id header to envelop

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/multi_topic_listening.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/multi_topic_listening.cs
@@ -106,6 +106,26 @@ public class multi_topic_listening : IAsyncLifetime
         groupEndpoint.Uri.ToString().ShouldContain("topic/");
     }
 
+    [Fact]
+    public async Task received_message_from_topic_group_has_partition_id_header()
+    {
+        MultiTopicAlphaHandler.Received = new TaskCompletionSource<bool>();
+
+        var session = await _sender
+            .TrackActivity()
+            .AlsoTrack(_receiver)
+            .Timeout(60.Seconds())
+            .WaitForMessageToBeReceivedAt<AlphaMessage>(_receiver)
+            .PublishMessageAndWaitAsync(new AlphaMessage("partition-check"));
+
+        await MultiTopicAlphaHandler.Received.Task.TimeoutAfterAsync(30000);
+
+        var envelope = session.Received.SingleEnvelope<AlphaMessage>();
+        envelope.TryGetHeader("kafka-partition-id", out var partitionIdValue).ShouldBeTrue();
+        int.TryParse(partitionIdValue, out var partitionId).ShouldBeTrue();
+        partitionId.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
     public async Task DisposeAsync()
     {
         await _sender.StopAsync();

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/when_publishing_and_receiving_by_partition_key.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/when_publishing_and_receiving_by_partition_key.cs
@@ -95,6 +95,22 @@ public class when_publishing_and_receiving_by_partition_key : IAsyncLifetime
 
     }
 
+    [Fact]
+    public async Task received_message_has_partition_id_header()
+    {
+        var session = await _sender.TrackActivity()
+            .AlsoTrack(_receiver)
+            .WaitForMessageToBeReceivedAt<ColorMessage>(_receiver)
+            .PublishMessageAndWaitAsync(new ColorMessage("parrot"), new DeliveryOptions()
+            {
+                PartitionKey = "key1"
+            });
+        var singleEnvelope = session.Received.SingleEnvelope<ColorMessage>();
+        singleEnvelope.TryGetHeader("kafka-partition-id", out var partitionIdValue).ShouldBeTrue();
+        int.TryParse(partitionIdValue, out var partitionId).ShouldBeTrue();
+        partitionId.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
     public async Task DisposeAsync()
     {
         await _sender.StopAsync();

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -46,6 +46,7 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
 
                         var envelope = mapper!.CreateEnvelope(result.Topic, message);
                         envelope.Offset = result.Offset.Value;
+                        envelope.Headers["kafka-partition-id"] = result.Partition.Value.ToString();
                         envelope.MessageType ??= _messageTypeName;
 
                         if (topic.StampConsumerGroupIdOnEnvelope)

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
@@ -45,6 +45,7 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
 
                         var envelope = mapper!.CreateEnvelope(result.Topic, message);
                         envelope.Offset = result.Offset.Value;
+                        envelope.Headers["kafka-partition-id"] = result.Partition.Value.ToString();
 
                         if (endpoint.StampConsumerGroupIdOnEnvelope)
                             envelope.GroupId = config.GroupId;


### PR DESCRIPTION
Add "kafka-partition-id" header to message envelopes in both KafkaListener and KafkaTopicGroupListener. Introduce tests to verify the presence and validity of this header for received messages, ensuring partition information is available for consumers and test assertions.