### PR TITLE
Copy Envelope.Headers to MassTransitEnvelope on write path

### DIFF
--- a/src/Testing/CoreTests/Runtime/Interop/MassTransitEnvelopeTests.cs
+++ b/src/Testing/CoreTests/Runtime/Interop/MassTransitEnvelopeTests.cs
@@ -39,6 +39,9 @@ public class MassTransitEnvelopeTests
             Message = new object()
         };
 
+        envelope.Headers["color"] = "purple";
+        envelope.Headers["number"] = "1";
+
         var mtEnvelope = new MassTransitEnvelope(envelope);
 
         mtEnvelope.MessageId.ShouldBe(envelope.Id.ToString());
@@ -47,6 +50,9 @@ public class MassTransitEnvelopeTests
         mtEnvelope.SentTime.ShouldNotBeNull();
 
         mtEnvelope.ExpirationTime!.Value.ShouldBe(envelope.DeliverBy!.Value.DateTime);
+
+        mtEnvelope.Headers["color"].ShouldBe("purple");
+        mtEnvelope.Headers["number"].ShouldBe("1");
     }
 
     [Fact]

--- a/src/Wolverine/Runtime/Interop/MassTransit/MassTransitEnvelope.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/MassTransitEnvelope.cs
@@ -41,6 +41,11 @@ internal class MassTransitEnvelope<T> : IMassTransitEnvelope where T : class
         {
             ExpirationTime = envelope.DeliverBy.Value.UtcDateTime;
         }
+
+        foreach (var header in envelope.Headers)
+        {
+            Headers[header.Key] = header.Value;
+        }
     }
 
     public string? MessageId { get; set; }


### PR DESCRIPTION
## Summary

- The `MassTransitEnvelope<T>` constructor transfers message ID, correlation ID, conversation ID, and expiration time from a Wolverine `Envelope`, but **not custom headers**.
- `TransferData()` already handles the reverse direction (MassTransit → Wolverine), so header mapping was one-way only.
- This adds header copying in the constructor so headers flow both ways.

## ⚠️ Review note

@jeremydmiller — This change copies **all** `Envelope.Headers` into the outbound MassTransit envelope. This could potentially include headers that are Wolverine-internal and not intended for external consumers. Only E2E / integration tests with actual MassTransit consumers can confirm whether any unwanted headers leak through. Would appreciate your review to validate this is safe.

## Test plan

- [x] Extended existing `create_masstransit_envelope_from_envelope` test to verify headers are copied
- [x] All 7 `MassTransitEnvelopeTests` pass
- [ ] E2E validation with a MassTransit consumer to confirm no unwanted headers are exposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)