### PR TITLE
Add PartitionId to Envelope for Kafka partition tracking

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/multi_topic_listening.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/multi_topic_listening.cs
@@ -106,6 +106,25 @@ public class multi_topic_listening : IAsyncLifetime
         groupEndpoint.Uri.ToString().ShouldContain("topic/");
     }
 
+    [Fact]
+    public async Task received_message_from_topic_group_has_partition_id()
+    {
+        MultiTopicAlphaHandler.Received = new TaskCompletionSource<bool>();
+
+        var session = await _sender
+            .TrackActivity()
+            .AlsoTrack(_receiver)
+            .Timeout(60.Seconds())
+            .WaitForMessageToBeReceivedAt<AlphaMessage>(_receiver)
+            .PublishMessageAndWaitAsync(new AlphaMessage("partition-check"));
+
+        await MultiTopicAlphaHandler.Received.Task.TimeoutAfterAsync(30000);
+
+        var envelope = session.Received.SingleEnvelope<AlphaMessage>();
+        envelope.PartitionId.ShouldNotBeNull();
+        envelope.PartitionId.Value.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
     public async Task DisposeAsync()
     {
         await _sender.StopAsync();

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/when_publishing_and_receiving_by_partition_key.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/when_publishing_and_receiving_by_partition_key.cs
@@ -95,6 +95,21 @@ public class when_publishing_and_receiving_by_partition_key : IAsyncLifetime
 
     }
 
+    [Fact]
+    public async Task received_message_has_partition_id()
+    {
+        var session = await _sender.TrackActivity()
+            .AlsoTrack(_receiver)
+            .WaitForMessageToBeReceivedAt<ColorMessage>(_receiver)
+            .PublishMessageAndWaitAsync(new ColorMessage("parrot"), new DeliveryOptions()
+            {
+                PartitionKey = "key1"
+            });
+        var singleEnvelope = session.Received.SingleEnvelope<ColorMessage>();
+        singleEnvelope.PartitionId.ShouldNotBeNull();
+        singleEnvelope.PartitionId.Value.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
     public async Task DisposeAsync()
     {
         await _sender.StopAsync();

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -46,6 +46,7 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
 
                         var envelope = mapper!.CreateEnvelope(result.Topic, message);
                         envelope.Offset = result.Offset.Value;
+                        envelope.PartitionId = result.Partition.Value;
                         envelope.MessageType ??= _messageTypeName;
 
                         if (topic.StampConsumerGroupIdOnEnvelope)

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
@@ -45,6 +45,7 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
 
                         var envelope = mapper!.CreateEnvelope(result.Topic, message);
                         envelope.Offset = result.Offset.Value;
+                        envelope.PartitionId = result.Partition.Value;
 
                         if (endpoint.StampConsumerGroupIdOnEnvelope)
                             envelope.GroupId = config.GroupId;

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -1,9 +1,8 @@
-﻿using System.Text.Json.Serialization;
-using JasperFx;
-using JasperFx.Core;
+﻿using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.MultiTenancy;
 using MassTransit;
+using System.Text.Json.Serialization;
 using Wolverine.Attributes;
 using Wolverine.Persistence.Durability;
 using Wolverine.Runtime.Serialization;
@@ -512,8 +511,13 @@ public partial class Envelope : IHasTenantId
     /// For stream based transports (Kafka/RedPanda, this will reflect the message offset. This is strictly informational
     /// </summary>
     public long Offset { get; set; }
-    
-    
+
+    /// <summary>
+    /// For stream based transports (Kafka), this will reflect the partition the message was consumed from. This is strictly informational
+    /// </summary>
+    public int? PartitionId { get; set; }
+
+
     /// <summary>
     /// For some forms of modular monoliths, Wolverine needs to track what message store
     /// persisted this envelope for later tracking


### PR DESCRIPTION
Envelope now includes a nullable PartitionId property to record the partition number from which a Kafka message was consumed. Both KafkaListener and KafkaTopicGroupListener set this property when processing messages. Added tests to verify that received messages have a valid PartitionId when consumed from topic groups or with a partition key. This enhances observability and debugging for stream-based transports.