### PR TITLE
Add Confluent Schema Registry Avro/JSON serializers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,8 @@
     <PackageVersion Include="Azure.Identity" Version="1.17.0" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageVersion Include="Confluent.Kafka" Version="2.12.0" />
+    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.14.0" />
+    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.14.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="DotPulsar" Version="5.1.2" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />

--- a/src/Transports/Kafka/Wolverine.Kafka/Serialization/SchemaRegistryAvroSerializer.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Serialization/SchemaRegistryAvroSerializer.cs
@@ -1,0 +1,56 @@
+using Confluent.Kafka;
+using Confluent.SchemaRegistry;
+using Confluent.SchemaRegistry.Serdes;
+
+namespace Wolverine.Kafka.Serialization;
+
+/// <summary>
+/// Schema Registry–aware Wolverine serializer for Avro (Confluent wire format).
+/// <para>
+/// Message types must implement <see cref="Avro.Specific.ISpecificRecord"/>.
+/// </para>
+/// </summary>
+public sealed class SchemaRegistryAvroSerializer : SchemaRegistrySerializer
+{
+    private readonly ISchemaRegistryClient _schemaRegistry;
+    private readonly AvroSerializerConfig? _serializerConfig;
+
+    public SchemaRegistryAvroSerializer(
+        ISchemaRegistryClient schemaRegistry,
+        AvroSerializerConfig? serializerConfig = null)
+    {
+        _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
+        _serializerConfig = serializerConfig;
+    }
+
+    public override string ContentType => "application/avro";
+
+    protected override Func<object, string?, byte[]> CreateTypedSerializer<T>()
+    {
+        var serializer = new AvroSerializer<T>(_schemaRegistry, _serializerConfig);
+
+        return (message, topicName) =>
+        {
+            var context = new SerializationContext(
+                MessageComponentType.Value, topicName ?? string.Empty);
+
+            return serializer.SerializeAsync((T)message, context)
+                .GetAwaiter().GetResult();
+        };
+    }
+
+    protected override Func<byte[], string?, object> CreateTypedDeserializer<T>()
+    {
+        var deserializer = new AvroDeserializer<T>(_schemaRegistry);
+
+        return (data, topicName) =>
+        {
+            var context = new SerializationContext(
+                MessageComponentType.Value, topicName ?? string.Empty);
+
+            return deserializer.DeserializeAsync(
+                new ReadOnlyMemory<byte>(data), isNull: false, context)
+                .GetAwaiter().GetResult()!;
+        };
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Serialization/SchemaRegistryJsonSerializer.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Serialization/SchemaRegistryJsonSerializer.cs
@@ -1,0 +1,53 @@
+using Confluent.Kafka;
+using Confluent.SchemaRegistry;
+using Confluent.SchemaRegistry.Serdes;
+
+namespace Wolverine.Kafka.Serialization;
+
+/// <summary>
+/// Schema Registry–aware Wolverine serializer for JSON (Confluent wire format).
+/// </summary>
+public sealed class SchemaRegistryJsonSerializer : SchemaRegistrySerializer
+{
+    private readonly ISchemaRegistryClient _schemaRegistry;
+    private readonly JsonSerializerConfig? _serializerConfig;
+
+    public SchemaRegistryJsonSerializer(
+        ISchemaRegistryClient schemaRegistry,
+        JsonSerializerConfig? serializerConfig = null)
+    {
+        _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
+        _serializerConfig = serializerConfig;
+    }
+
+    public override string ContentType => "application/json";
+
+    protected override Func<object, string?, byte[]> CreateTypedSerializer<T>()
+    {
+        var serializer = new JsonSerializer<T>(_schemaRegistry, _serializerConfig);
+
+        return (message, topicName) =>
+        {
+            var context = new SerializationContext(
+                MessageComponentType.Value, topicName ?? string.Empty);
+
+            return serializer.SerializeAsync((T)message, context)
+                .GetAwaiter().GetResult();
+        };
+    }
+
+    protected override Func<byte[], string?, object> CreateTypedDeserializer<T>()
+    {
+        var deserializer = new JsonDeserializer<T>(_schemaRegistry);
+
+        return (data, topicName) =>
+        {
+            var context = new SerializationContext(
+                MessageComponentType.Value, topicName ?? string.Empty);
+
+            return deserializer.DeserializeAsync(
+                new ReadOnlyMemory<byte>(data), isNull: false, context)
+                .GetAwaiter().GetResult()!;
+        };
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Serialization/SchemaRegistrySerializer.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Serialization/SchemaRegistrySerializer.cs
@@ -1,0 +1,90 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Wolverine.Runtime.Serialization;
+
+namespace Wolverine.Kafka.Serialization;
+
+/// <summary>
+/// Abstract base for Wolverine <see cref="IMessageSerializer"/> implementations that
+/// delegate to Confluent Schema Registry–aware serde pairs (e.g. JSON, Avro, Protobuf).
+/// <para>
+/// Subclasses only provide <see cref="ContentType"/> and the two typed factory methods
+/// <see cref="CreateTypedSerializer{T}"/> / <see cref="CreateTypedDeserializer{T}"/>.
+/// All caching, reflection bridging, and <see cref="IMessageSerializer"/> plumbing live here.
+/// </para>
+/// </summary>
+public abstract class SchemaRegistrySerializer : IMessageSerializer
+{
+    private readonly ConcurrentDictionary<Type, Func<object, string?, byte[]>> _serializerCache = new();
+    private readonly ConcurrentDictionary<Type, Func<byte[], string?, object>> _deserializerCache = new();
+
+    private readonly MethodInfo _createTypedSerializerMethod;
+    private readonly MethodInfo _createTypedDeserializerMethod;
+
+    protected SchemaRegistrySerializer()
+    {
+        var type = GetType();
+
+        _createTypedSerializerMethod = type
+            .GetMethod(nameof(CreateTypedSerializer), BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new MissingMethodException(type.Name, nameof(CreateTypedSerializer));
+
+        _createTypedDeserializerMethod = type
+            .GetMethod(nameof(CreateTypedDeserializer), BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new MissingMethodException(type.Name, nameof(CreateTypedDeserializer));
+    }
+
+    public abstract string ContentType { get; }
+
+    public byte[] Write(Envelope envelope)
+    {
+        ArgumentNullException.ThrowIfNull(envelope.Message);
+
+        var serialize = GetOrCreateSerializer(envelope.Message.GetType());
+        return serialize(envelope.Message, envelope.TopicName);
+    }
+
+    public byte[] WriteMessage(object message)
+    {
+        var serialize = GetOrCreateSerializer(message.GetType());
+        return serialize(message, null);
+    }
+
+    public object ReadFromData(Type messageType, Envelope envelope)
+    {
+        var data = envelope.Data ?? throw new InvalidOperationException("Envelope has no data.");
+
+        var deserialize = _deserializerCache.GetOrAdd(messageType, type =>
+            (Func<byte[], string?, object>)_createTypedDeserializerMethod
+                .MakeGenericMethod(type)
+                .Invoke(this, null)!);
+
+        return deserialize(data, envelope.TopicName);
+    }
+
+    public object ReadFromData(byte[] data)
+    {
+        throw new NotSupportedException(
+            $"{GetType().Name} requires a known message type. Use ReadFromData(Type, Envelope) instead.");
+    }
+
+    /// <summary>
+    /// Creates a delegate that serializes <typeparamref name="T"/> into Confluent wire-format
+    /// bytes using the concrete serde. Called once per message type, then cached.
+    /// </summary>
+    protected abstract Func<object, string?, byte[]> CreateTypedSerializer<T>() where T : class;
+
+    /// <summary>
+    /// Creates a delegate that deserializes Confluent wire-format bytes into
+    /// <typeparamref name="T"/> using the concrete serde. Called once per message type, then cached.
+    /// </summary>
+    protected abstract Func<byte[], string?, object> CreateTypedDeserializer<T>() where T : class;
+
+    private Func<object, string?, byte[]> GetOrCreateSerializer(Type messageType)
+    {
+        return _serializerCache.GetOrAdd(messageType, type =>
+            (Func<object, string?, byte[]>)_createTypedSerializerMethod
+                .MakeGenericMethod(type)
+                .Invoke(this, null)!);
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Wolverine.Kafka.csproj
+++ b/src/Transports/Kafka/Wolverine.Kafka/Wolverine.Kafka.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Description>Kafka Transport for Wolverine Messaging Systems</Description>
@@ -15,7 +15,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Confluent.Kafka" />
+        <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" />
+        <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Replaced Confluent.Kafka with Confluent.SchemaRegistry.Serdes.Avro and .Json dependencies. Introduced SchemaRegistrySerializer base class and concrete Avro/JSON serializer implementations for Wolverine. These serializers enable plug-and-play support for Confluent Schema Registry wire formats, supporting schema evolution and interoperability with other Kafka clients. All serializer/deserializer caching and reflection is handled internally for performance and type safety.