### PR TITLE
Fix OpenAPI OperationId and add Summary/Description support

### DIFF
--- a/src/Http/Wolverine.Http/HttpChain.EndpointBuilder.cs
+++ b/src/Http/Wolverine.Http/HttpChain.EndpointBuilder.cs
@@ -120,6 +120,18 @@ public partial class HttpChain : IEndpointConventionBuilder
             builder.Metadata.Add(new RouteNameMetadata(RouteName));
         }
 
+        builder.Metadata.Add(new EndpointNameMetadata(OperationId));
+
+        if (EndpointSummary.IsNotEmpty())
+        {
+            builder.Metadata.Add(new WolverineEndpointSummaryMetadata(EndpointSummary));
+        }
+
+        if (EndpointDescription.IsNotEmpty())
+        {
+            builder.Metadata.Add(new WolverineEndpointDescriptionMetadata(EndpointDescription));
+        }
+
         Endpoint = (RouteEndpoint?)builder.Build();
         return Endpoint!;
     }
@@ -169,4 +181,14 @@ internal class ProducesProblemDetailsResponseTypeMetadata : IProducesResponseTyp
     public Type? Type => typeof(ProblemDetails);
     public int StatusCode => 400;
     public IEnumerable<string> ContentTypes => new string[] {"application/problem+json" };
+}
+
+internal class WolverineEndpointSummaryMetadata(string summary) : IEndpointSummaryMetadata
+{
+    public string Summary => summary;
+}
+
+internal class WolverineEndpointDescriptionMetadata(string description) : IEndpointDescriptionMetadata
+{
+    public string Description => description;
 }

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -69,7 +69,9 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
     private readonly List<HttpElementVariable> _formValueVariables = [];
 
     public string OperationId { get; set; }
-    
+    public string? EndpointSummary { get; set; }
+    public string? EndpointDescription { get; set; }
+
     /// <summary>
     /// This may be overridden by some IResponseAware policies in place of the first
     /// create variable of the method call
@@ -127,6 +129,16 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
             if (att.OperationId.IsNotEmpty())
             {
                 OperationId = att.OperationId;
+            }
+
+            if (att.Summary.IsNotEmpty())
+            {
+                EndpointSummary = att.Summary;
+            }
+
+            if (att.Description.IsNotEmpty())
+            {
+                EndpointDescription = att.Description;
             }
         }
 
@@ -729,9 +741,9 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
         return frame.Variable;
     }
 
-    string IEndpointNameMetadata.EndpointName => ToString();
+    string IEndpointNameMetadata.EndpointName => OperationId;
 
-    string IEndpointSummaryMetadata.Summary => ToString();
+    string IEndpointSummaryMetadata.Summary => EndpointSummary ?? ToString();
 
     public List<ParameterInfo> FileParameters { get; } = [];
 

--- a/src/Http/Wolverine.Http/ModifyHttpChainAttribute.cs
+++ b/src/Http/Wolverine.Http/ModifyHttpChainAttribute.cs
@@ -75,6 +75,16 @@ public abstract class WolverineHttpMethodAttribute : Attribute
     /// Swashbuckle
     /// </summary>
     public string? OperationId { get; set; }
+
+    /// <summary>
+    /// Sets the summary for this endpoint in OpenAPI documentation
+    /// </summary>
+    public string? Summary { get; set; }
+
+    /// <summary>
+    /// Sets the description for this endpoint in OpenAPI documentation
+    /// </summary>
+    public string? Description { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Problem
When setting `OperationId` on a Wolverine HTTP route attribute (e.g. `[WolverineDelete("/{id}", OperationId = "DeleteStaffMember")]`), the value is ignored in the generated OpenAPI document. Instead, the `operationId`, `summary`, and `description` fields all default to a generated filename like `DELETE_id`.

This happens because `HttpChain` implements `IEndpointNameMetadata`, `IEndpointSummaryMetadata`, and `IEndpointDescriptionMetadata`, but is never added to the endpoint's metadata collection — so the .NET OpenAPI document generator never sees these values.

## Changes
- Add `EndpointNameMetadata(OperationId)` to endpoint metadata in `BuildEndpoint()` so the OpenAPI generator picks up the user-provided `OperationId`
- Add `Summary` and `Description` properties to `WolverineHttpMethodAttribute` to allow setting these in OpenAPI documentation
- Fix `IEndpointNameMetadata.EndpointName` and `IEndpointSummaryMetadata.Summary` implementations on `HttpChain` to use user-provided values instead of `ToString()`