### PR TITLE
Adding a new overload for MessagesImplementing

### DIFF
--- a/src/Wolverine/Configuration/PublishingExpression.cs
+++ b/src/Wolverine/Configuration/PublishingExpression.cs
@@ -117,7 +117,7 @@ public class PublishingExpression : IPublishToExpression
     public PublishingExpression MessagesFromNamespace(string @namespace)
     {
         AutoAddSubscriptions = true;
-        
+
         _subscriptions.Add(new Subscription
         {
             Match = @namespace,
@@ -182,6 +182,11 @@ public class PublishingExpression : IPublishToExpression
     /// <typeparam name="T"></typeparam>
     public void MessagesImplementing<T>()
     {
-        _subscriptions.Add(new Subscription { BaseType = typeof(T), Scope = RoutingScope.Implements });
+        MessagesImplementing(typeof(T));
+    }
+
+    public void MessagesImplementing(Type baseType)
+    {
+        _subscriptions.Add(new Subscription { BaseType = baseType, Scope = RoutingScope.Implements });
     }
 }


### PR DESCRIPTION
I needed to register messages that have been implemented a base type, but I didn't have the generic type.
So, we can have a new overload to get the type and do the same as generic implementation.