### PR TITLE
Expose WolverineOptions.MetadataRules publicly

### DIFF
--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -267,9 +267,7 @@ public sealed partial class WolverineOptions
     public MessagePartitioningRules MessagePartitioning { get; }
 
     /// <summary>
-    /// List of <see cref="IEnvelopeRule"/> instances applied to every outgoing envelope via
-    /// <see cref="IMessageContext.ApplyCorrelation"/>. Add custom rules here to propagate
-    /// metadata from incoming to outgoing messages within a handler context.
+    /// List of <see cref="IEnvelopeRule"/> instances applied to every outgoing envelope.
     /// </summary>
     public List<IEnvelopeRule> MetadataRules { get; } = new();
 

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -267,10 +267,11 @@ public sealed partial class WolverineOptions
     public MessagePartitioningRules MessagePartitioning { get; }
 
     /// <summary>
-    /// Internal list of IEnvelopeRule instances that are applied via ApplyCorrelation
-    /// to outgoing envelopes in PersistOrSendAsync
+    /// List of <see cref="IEnvelopeRule"/> instances applied to every outgoing envelope via
+    /// <see cref="IMessageContext.ApplyCorrelation"/>. Add custom rules here to propagate
+    /// metadata from incoming to outgoing messages within a handler context.
     /// </summary>
-    internal List<IEnvelopeRule> MetadataRules { get; } = new();
+    public List<IEnvelopeRule> MetadataRules { get; } = new();
 
     
     /// For advanced usages, this gives you the ability to register pre-canned message handling


### PR DESCRIPTION
The [Header Propagation](https://wolverinefx.net/guide/messaging/header-propagation.html) docs indicate that custom IEnvelopeRule's can be registered by adding them to `MetadataRules` but this list was not exposed publicly.