### PR TITLE
Remove OTEL Activity from circuit breaker to fix trace ID leak

### DIFF
--- a/src/Wolverine/ErrorHandling/CircuitBreaker.cs
+++ b/src/Wolverine/ErrorHandling/CircuitBreaker.cs
@@ -177,8 +177,6 @@ internal class CircuitBreaker : IAsyncDisposable, IMessageSuccessTracker
 
         if (failures > 0 && ShouldStopProcessing())
         {
-            using var activity = WolverineTracing.ActivitySource.StartActivity(WolverineTracing.CircuitBreakerTripped);
-            activity?.SetTag(WolverineTracing.EndpointAddress, _circuit.Endpoint.Uri);
             await _circuit.PauseAsync(Options.PauseTime);
 
             if (_observer != null)

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -350,8 +350,6 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
     {
         try
         {
-            using var activity = WolverineTracing.ActivitySource.StartActivity(WolverineTracing.PausingListener);
-            activity?.SetTag(WolverineTracing.EndpointAddress, Uri);
             // Do NOT pre-latch the receiver here. PauseAsync may be called from within the
             // handler pipeline (e.g. via RateLimitContinuation → PauseListenerContinuation).
             // Pre-latching causes DrainAsync to wait for the ActionBlock to drain, which


### PR DESCRIPTION
## Summary
- Fixes #2494 — after a circuit breaker trip/resume cycle, all subsequent messages inherited a stale trace ID from the circuit breaker's Activity
- Removes the `Activity` creation from the circuit breaker trip handler (`CircuitBreaker.UpdateTotalsAsync`) and the listener `PauseAsync` method
- The root cause was `Activity.Current` (stored in `AsyncLocal`) leaking from the background batching thread into message processing threads after the listener restarted

## Test plan
- [ ] Verify with a Kafka consumer + circuit breaker that each message gets a unique trace ID after CB resume
- [ ] Confirm other OTEL spans (stop listener, back-pressure pause) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)