### PR TITLE
Expose FluentValidation configuration through UseFluentValidation overload

### DIFF
--- a/src/Extensions/Wolverine.FluentValidation.Tests/Samples.cs
+++ b/src/Extensions/Wolverine.FluentValidation.Tests/Samples.cs
@@ -31,6 +31,32 @@ public class Samples
     }
 
     [Fact]
+    public async Task register_the_middleware_with_validator_options()
+    {
+        #region sample_bootstrap_with_fluent_validation_and_options
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Apply the validation middleware with full configuration access
+                opts.UseFluentValidation(fv =>
+                {
+                    // Configure FluentValidation's global validator options
+                    fv.ValidatorOptions.DefaultRuleLevelCascadeMode = CascadeMode.Stop;
+                    fv.ValidatorOptions.Severity = Severity.Warning;
+
+                    // Optionally control registration behavior
+                    fv.RegistrationBehavior = RegistrationBehavior.DiscoverAndRegisterValidators;
+                });
+
+                // Just a prerequisite for some of the test validators
+                opts.Services.AddSingleton<IDataService, DataService>();
+            }).StartAsync();
+
+        #endregion
+    }
+
+    [Fact]
     public async Task register_the_middleware_with_override_failure_condition()
     {
         #region sample_bootstrap_with_fluent_validation_and_custom_failure_condition

--- a/src/Extensions/Wolverine.FluentValidation.Tests/configuration_specs.cs
+++ b/src/Extensions/Wolverine.FluentValidation.Tests/configuration_specs.cs
@@ -11,8 +11,20 @@ using Wolverine.Runtime.Handlers;
 
 namespace Wolverine.FluentValidation.Tests;
 
-public class configuration_specs
+public class configuration_specs : IDisposable
 {
+    // Store original values to restore after tests that modify global state
+    private readonly CascadeMode _originalClassCascadeMode = ValidatorOptions.Global.DefaultClassLevelCascadeMode;
+    private readonly CascadeMode _originalRuleCascadeMode = ValidatorOptions.Global.DefaultRuleLevelCascadeMode;
+    private readonly Severity _originalSeverity = ValidatorOptions.Global.Severity;
+
+    public void Dispose()
+    {
+        ValidatorOptions.Global.DefaultClassLevelCascadeMode = _originalClassCascadeMode;
+        ValidatorOptions.Global.DefaultRuleLevelCascadeMode = _originalRuleCascadeMode;
+        ValidatorOptions.Global.Severity = _originalSeverity;
+    }
+
     [Fact]
     public async Task register_validators_in_application_assembly()
     {
@@ -82,6 +94,84 @@ public class configuration_specs
         handlers.ChainFor<Command3>()!.Middleware.OfType<MethodCall>()
             .Any(x => x.HandlerType == typeof(FluentValidationExecutor))
             .ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task configure_validator_options_via_action_overload()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseFluentValidation(fv =>
+                {
+                    fv.ValidatorOptions.DefaultRuleLevelCascadeMode = CascadeMode.Stop;
+                    fv.ValidatorOptions.DefaultClassLevelCascadeMode = CascadeMode.Stop;
+                    fv.ValidatorOptions.Severity = Severity.Warning;
+                });
+
+                opts.Services.AddScoped<IDataService, DataService>();
+            }).StartAsync();
+
+        ValidatorOptions.Global.DefaultRuleLevelCascadeMode.ShouldBe(CascadeMode.Stop);
+        ValidatorOptions.Global.DefaultClassLevelCascadeMode.ShouldBe(CascadeMode.Stop);
+        ValidatorOptions.Global.Severity.ShouldBe(Severity.Warning);
+    }
+
+    [Fact]
+    public async Task configure_registration_behavior_via_action_overload()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton<IValidator<Command1>, Command1Validator>();
+
+                opts.UseFluentValidation(fv =>
+                {
+                    fv.RegistrationBehavior = RegistrationBehavior.ExplicitRegistration;
+                });
+            }).StartAsync();
+
+        var container = host.Services.GetRequiredService<IServiceContainer>();
+
+        // Only the explicitly registered validator should be present
+        container.DefaultFor<IValidator<Command1>>()!
+            .ImplementationType.ShouldBe(typeof(Command1Validator));
+    }
+
+    [Fact]
+    public async Task action_overload_still_applies_middleware()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseFluentValidation(fv =>
+                {
+                    fv.ValidatorOptions.DefaultRuleLevelCascadeMode = CascadeMode.Stop;
+                });
+
+                opts.Services.AddScoped<IDataService, DataService>();
+            }).StartAsync();
+
+        var wolverineOptions = host.Services.GetRequiredService<IWolverineRuntime>()
+            .As<WolverineRuntime>().Options;
+
+        var handlers = (HandlerGraph)typeof(WolverineOptions)
+            .GetProperty(nameof(HandlerGraph), BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(wolverineOptions)!;
+
+        // Middleware should still be wired up
+        handlers.ChainFor<Command1>()!.Middleware.OfType<MethodCall>()
+            .Any(x => x.HandlerType == typeof(FluentValidationExecutor))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void fluent_validation_configuration_defaults()
+    {
+        var config = new FluentValidationConfiguration();
+
+        config.RegistrationBehavior.ShouldBe(RegistrationBehavior.DiscoverAndRegisterValidators);
+        config.ValidatorOptions.ShouldBe(ValidatorOptions.Global);
     }
 }
 

--- a/src/Extensions/Wolverine.FluentValidation.Tests/configuration_specs.cs
+++ b/src/Extensions/Wolverine.FluentValidation.Tests/configuration_specs.cs
@@ -166,11 +166,73 @@ public class configuration_specs : IDisposable
     }
 
     [Fact]
+    public async Task discover_internal_validators_when_include_internal_types_is_true()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseFluentValidation(fv =>
+                {
+                    fv.IncludeInternalTypes = true;
+                });
+
+                opts.Services.AddScoped<IDataService, DataService>();
+            }).StartAsync();
+
+        var container = host.Services.GetRequiredService<IServiceContainer>();
+
+        // InternalCommand6Validator is internal and should be discovered
+        container.DefaultFor<IValidator<Command6>>().ShouldNotBeNull();
+        container.DefaultFor<IValidator<Command6>>()!
+            .Lifetime.ShouldBe(ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public async Task do_not_discover_internal_validators_by_default()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseFluentValidation();
+
+                opts.Services.AddScoped<IDataService, DataService>();
+            }).StartAsync();
+
+        var container = host.Services.GetRequiredService<IServiceContainer>();
+
+        // InternalCommand6Validator is internal and should NOT be discovered by default
+        container.DefaultFor<IValidator<Command6>>().ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task discover_internal_validator_with_dependencies_as_scoped()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseFluentValidation(fv =>
+                {
+                    fv.IncludeInternalTypes = true;
+                });
+
+                opts.Services.AddScoped<IDataService, DataService>();
+            }).StartAsync();
+
+        var container = host.Services.GetRequiredService<IServiceContainer>();
+
+        // InternalCommand7Validator has a constructor dependency, so it should be Scoped
+        container.DefaultFor<IValidator<Command7>>().ShouldNotBeNull();
+        container.DefaultFor<IValidator<Command7>>()!
+            .Lifetime.ShouldBe(ServiceLifetime.Scoped);
+    }
+
+    [Fact]
     public void fluent_validation_configuration_defaults()
     {
         var config = new FluentValidationConfiguration();
 
         config.RegistrationBehavior.ShouldBe(RegistrationBehavior.DiscoverAndRegisterValidators);
+        config.IncludeInternalTypes.ShouldBeFalse();
         config.ValidatorOptions.ShouldBe(ValidatorOptions.Global);
     }
 }
@@ -282,6 +344,34 @@ public class Command5Validator : AbstractValidator<Command5>
     }
 }
 
+public class Command6
+{
+    public string Value { get; set; } = null!;
+}
+
+// Internal validator — only discoverable when IncludeInternalTypes is true
+internal class InternalCommand6Validator : AbstractValidator<Command6>
+{
+    public InternalCommand6Validator()
+    {
+        RuleFor(x => x.Value).NotNull().NotEmpty();
+    }
+}
+
+public class Command7
+{
+    public string Email { get; set; } = null!;
+}
+
+// Internal validator with a constructor dependency — should be registered as Scoped
+internal class InternalCommand7Validator : AbstractValidator<Command7>
+{
+    public InternalCommand7Validator(IDataService dataService)
+    {
+        RuleFor(x => x.Email).NotNull();
+    }
+}
+
 public class CommandHandler
 {
     public void Handle(Command1 command)
@@ -301,6 +391,14 @@ public class CommandHandler
     }
 
     public void Handle(Command5 command)
+    {
+    }
+
+    public void Handle(Command6 command)
+    {
+    }
+
+    public void Handle(Command7 command)
     {
     }
 }

--- a/src/Extensions/Wolverine.FluentValidation/FluentValidationConfiguration.cs
+++ b/src/Extensions/Wolverine.FluentValidation/FluentValidationConfiguration.cs
@@ -17,6 +17,18 @@ public class FluentValidationConfiguration
         RegistrationBehavior.DiscoverAndRegisterValidators;
 
     /// <summary>
+    ///     When true, FluentValidation's <see cref="AssemblyScanner"/> will also discover
+    ///     validators with <c>internal</c> visibility, not just public ones. Default is false.
+    /// </summary>
+    /// <remarks>
+    ///     By default, Wolverine's assembly scanning only discovers public validator types.
+    ///     Set this to true if you have internal validators that should be auto-registered.
+    ///     This option only takes effect when <see cref="RegistrationBehavior"/> is
+    ///     <see cref="FluentValidation.RegistrationBehavior.DiscoverAndRegisterValidators"/>.
+    /// </remarks>
+    public bool IncludeInternalTypes { get; set; }
+
+    /// <summary>
     ///     Direct access to FluentValidation's global validator options for configuring
     ///     cascade modes, severity, language manager, property name resolvers, and other settings.
     /// </summary>

--- a/src/Extensions/Wolverine.FluentValidation/FluentValidationConfiguration.cs
+++ b/src/Extensions/Wolverine.FluentValidation/FluentValidationConfiguration.cs
@@ -1,0 +1,33 @@
+using FluentValidation;
+
+namespace Wolverine.FluentValidation;
+
+/// <summary>
+///     Configuration options for the Wolverine FluentValidation middleware.
+///     Provides access to both Wolverine-specific registration behavior and
+///     FluentValidation's global validator options.
+/// </summary>
+public class FluentValidationConfiguration
+{
+    /// <summary>
+    ///     Controls whether Wolverine should auto-discover and register FluentValidation validators
+    ///     or assume they are registered externally. Default is <see cref="FluentValidation.RegistrationBehavior.DiscoverAndRegisterValidators" />.
+    /// </summary>
+    public RegistrationBehavior RegistrationBehavior { get; set; } =
+        RegistrationBehavior.DiscoverAndRegisterValidators;
+
+    /// <summary>
+    ///     Direct access to FluentValidation's global validator options for configuring
+    ///     cascade modes, severity, language manager, property name resolvers, and other settings.
+    /// </summary>
+    /// <example>
+    ///     <code>
+    ///     opts.UseFluentValidation(fv =>
+    ///     {
+    ///         fv.ValidatorOptions.DefaultRuleLevelCascadeMode = CascadeMode.Stop;
+    ///         fv.ValidatorOptions.Severity = Severity.Info;
+    ///     });
+    ///     </code>
+    /// </example>
+    public ValidatorConfiguration ValidatorOptions => global::FluentValidation.ValidatorOptions.Global;
+}

--- a/src/Extensions/Wolverine.FluentValidation/WolverineFluentValidationExtensions.cs
+++ b/src/Extensions/Wolverine.FluentValidation/WolverineFluentValidationExtensions.cs
@@ -27,9 +27,25 @@ public static class WolverineFluentValidationExtensions
 {
     /// <summary>
     ///     Apply FluentValidation middleware to message handlers that have known validators
+    ///     in the underlying container, with full access to FluentValidation configuration.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="configure">Action to configure FluentValidation behavior and validator options</param>
+    /// <returns></returns>
+    public static WolverineOptions UseFluentValidation(this WolverineOptions options,
+        Action<FluentValidationConfiguration> configure)
+    {
+        var config = new FluentValidationConfiguration();
+        configure(config);
+        return options.UseFluentValidation(config.RegistrationBehavior);
+    }
+
+    /// <summary>
+    ///     Apply FluentValidation middleware to message handlers that have known validators
     ///     in the underlying container
     /// </summary>
     /// <param name="options"></param>
+    /// <param name="behavior"></param>
     /// <returns></returns>
     public static WolverineOptions UseFluentValidation(this WolverineOptions options,
         RegistrationBehavior behavior = RegistrationBehavior.DiscoverAndRegisterValidators)

--- a/src/Extensions/Wolverine.FluentValidation/WolverineFluentValidationExtensions.cs
+++ b/src/Extensions/Wolverine.FluentValidation/WolverineFluentValidationExtensions.cs
@@ -37,7 +37,7 @@ public static class WolverineFluentValidationExtensions
     {
         var config = new FluentValidationConfiguration();
         configure(config);
-        return options.UseFluentValidation(config.RegistrationBehavior);
+        return options.UseFluentValidation(config.RegistrationBehavior, config.IncludeInternalTypes);
     }
 
     /// <summary>
@@ -46,9 +46,11 @@ public static class WolverineFluentValidationExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="behavior"></param>
+    /// <param name="includeInternalTypes">When true, also discovers validators with internal visibility</param>
     /// <returns></returns>
     public static WolverineOptions UseFluentValidation(this WolverineOptions options,
-        RegistrationBehavior behavior = RegistrationBehavior.DiscoverAndRegisterValidators)
+        RegistrationBehavior behavior = RegistrationBehavior.DiscoverAndRegisterValidators,
+        bool includeInternalTypes = false)
     {
         if (options.Services.Any(x => x.ServiceType == typeof(WolverineFluentValidationMarker)))
         {
@@ -75,13 +77,37 @@ public static class WolverineFluentValidationExtensions
                             "Wolverine (and JasperFx) have not been able to determine the ApplicationAssembly. Please set that explicitly");
                     }
                 }
-                
-                options.Services.Scan(x =>
-                {
-                    foreach (var assembly in options.Assemblies) x.Assembly(assembly);
 
-                    x.ConnectImplementationsToTypesClosing(typeof(IValidator<>), type => type.HasConstructorsWithArguments() ? ServiceLifetime.Scoped : ServiceLifetime.Singleton);
-                });
+                // Use FluentValidation's own AssemblyScanner when internal types are needed,
+                // since Lamar's ConnectImplementationsToTypesClosing only finds public types.
+                if (includeInternalTypes)
+                {
+                    var scanResults =
+                        global::FluentValidation.AssemblyScanner.FindValidatorsInAssemblies(options.Assemblies,
+                            includeInternalTypes: true);
+
+                    foreach (var result in scanResults)
+                    {
+                        var lifetime = result.ValidatorType.HasConstructorsWithArguments()
+                            ? ServiceLifetime.Scoped
+                            : ServiceLifetime.Singleton;
+
+                        options.Services.TryAdd(new ServiceDescriptor(result.InterfaceType, result.ValidatorType,
+                            lifetime));
+                    }
+                }
+                else
+                {
+                    options.Services.Scan(x =>
+                    {
+                        foreach (var assembly in options.Assemblies) x.Assembly(assembly);
+
+                        x.ConnectImplementationsToTypesClosing(typeof(IValidator<>),
+                            type => type.HasConstructorsWithArguments()
+                                ? ServiceLifetime.Scoped
+                                : ServiceLifetime.Singleton);
+                    });
+                }
             }
         });
 


### PR DESCRIPTION
## Summary

- Adds a `FluentValidationConfiguration` class that exposes `RegistrationBehavior`, `IncludeInternalTypes`, and direct access to `ValidatorOptions.Global` (cascade modes, severity, language manager, property name resolvers, etc.)
- Adds a new `UseFluentValidation(Action<FluentValidationConfiguration>)` overload — fully backward-compatible with the existing API
- Adds `IncludeInternalTypes` option that uses FluentValidation's own `AssemblyScanner` to discover `internal` validators, since Lamar's `ConnectImplementationsToTypesClosing` only finds public types
- Adds 7 tests covering options application, registration behavior, middleware wiring, internal type discovery, and defaults

## Motivation

Two gaps in the current FluentValidation extension:

1. **No access to FluentValidation configuration** — users cannot configure `ValidatorOptions.Global` (cascade modes, severity, language manager, etc.) through the Wolverine API. They must set these separately.

2. **Internal validators are not discovered** — Lamar's assembly scanning uses `Assembly.GetExportedTypes()` which only returns public types. FluentValidation's own `AssemblyScanner` supports an `includeInternalTypes` parameter.

This change lets users configure everything in one place:

```csharp
opts.UseFluentValidation(fv =>
{
    // Configure FluentValidation's global options
    fv.ValidatorOptions.DefaultRuleLevelCascadeMode = CascadeMode.Stop;
    fv.ValidatorOptions.Severity = Severity.Warning;

    // Discover internal validators too
    fv.IncludeInternalTypes = true;

    // Optionally control registration behavior
    fv.RegistrationBehavior = RegistrationBehavior.ExplicitRegistration;
});
```

## Test plan

- [x] `configure_validator_options_via_action_overload` — verifies global options are applied
- [x] `configure_registration_behavior_via_action_overload` — verifies explicit registration through new overload
- [x] `action_overload_still_applies_middleware` — verifies middleware is still wired up
- [x] `discover_internal_validators_when_include_internal_types_is_true` — internal validator is registered as Singleton
- [x] `do_not_discover_internal_validators_by_default` — internal validators are NOT found without the flag
- [x] `discover_internal_validator_with_dependencies_as_scoped` — internal validator with ctor deps is Scoped
- [x] `fluent_validation_configuration_defaults` — verifies default values
- [x] All existing FluentValidation tests still pass (24/24 on net9.0 and net10.0)