### PR TITLE
Fix missing bracket in LogStartingActivity log message

### DIFF
--- a/src/Testing/CoreTests/Configuration/auditing_determination.cs
+++ b/src/Testing/CoreTests/Configuration/auditing_determination.cs
@@ -91,7 +91,7 @@ public class auditing_determination : IntegrationContext
         
         
         
-        chain.SourceCode!.ShouldContain("\"Starting to process CoreTests.Configuration.AuditedMessage2 ({EnvelopeId} with Id: {Id}, AccountIdentifier: {AccountId}\"");
+        chain.SourceCode!.ShouldContain("\"Starting to process CoreTests.Configuration.AuditedMessage2 ({EnvelopeId}) with Id: {Id}, AccountIdentifier: {AccountId}\"");
         
 /*
 ((Microsoft.Extensions.Logging.ILogger)_loggerForMessage).Log(Microsoft.Extensions.Logging.LogLevel.Information, "Starting to process CoreTests.Configuration.AuditedMessage2 ({EnvelopeId} with Id: {Id}, AccountIdentifier: {AccountId}", context.Envelope.Id, auditedMessage2.Id, auditedMessage2.AccountId);

--- a/src/Wolverine/Logging/LogStartingActivity.cs
+++ b/src/Wolverine/Logging/LogStartingActivity.cs
@@ -42,7 +42,7 @@ internal class LogStartingActivity : SyncFrame
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
         writer.WriteComment("Application specific auditing");
-        var template = _members.Any(x => x.Member.Name.EqualsIgnoreCase("id")) ? $"Starting to process {_inputType.FullNameInCode()} ({{EnvelopeId}}" : $"Starting to process {_inputType.FullNameInCode()} ({{Id}})" ;
+        var template = _members.Any(x => x.Member.Name.EqualsIgnoreCase("id")) ? $"Starting to process {_inputType.FullNameInCode()} ({{EnvelopeId}})" : $"Starting to process {_inputType.FullNameInCode()} ({{Id}})" ;
         if (_members.Count != 0)
         {
             template += " with " + _members.Select(m => $"{m.MemberName}: {{{m.Member.Name}}}").Join(", ");


### PR DESCRIPTION
## Summary
- Fixes missing closing `)` in the log template for messages with an `Id` member — was producing `({EnvelopeId} with ...` instead of `({EnvelopeId}) with ...`
- Updates the test assertion in `auditing_determination.use_audit_member_named_id_and_disambiguate` to match the corrected output

Based on @lyall-sc's fix in #2496, with the addition of the test update needed to pass CoreTests.

## Test plan
- [x] `dotnet test src/Testing/CoreTests/ --framework net9.0` — all 1289 tests pass

Closes #2496

🤖 Generated with [Claude Code](https://claude.com/claude-code)