### PR TITLE
Fix broken link to RabbitMQ .NET API guide

### DIFF
--- a/docs/guide/messaging/transports/rabbitmq/index.md
+++ b/docs/guide/messaging/transports/rabbitmq/index.md
@@ -44,7 +44,7 @@ return await Host.CreateDefaultBuilder(args)
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/PingPongWithRabbitMq/Pinger/Program.cs#L7-L37' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_rabbitmq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-See the [Rabbit MQ .NET Client documentation](https://www.com/dotnet-api-guide.html#connecting) for more information about configuring the `ConnectionFactory` to connect to Rabbit MQ.
+See the [Rabbit MQ .NET Client documentation](https://www.rabbitmq.com/dotnet-api-guide.html#connecting) for more information about configuring the `ConnectionFactory` to connect to Rabbit MQ.
 
 
 ## Managing Rabbit MQ Connections


### PR DESCRIPTION
# Summary
Quick fix for something I stumbled across today while reading the docs. The previous link was missing the rabbitmq domain, leading to a dead link.

# Changes

* Updated the connection guide link from https://www.com/... to the correct https://www.rabbitmq.com/... address.