### PR TITLE
Add fluent CircuitBreaker configuration to Kafka listeners

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -114,7 +114,13 @@ using var host = await Host.CreateDefaultBuilder()
 
                 // Other configuration
             })
-            
+            // Configure circuit breaker behavior for
+            // this specific Kafka listener
+            .CircuitBreaker(cb =>
+            {
+                cb.MinimumThreshold = 10;
+                cb.PauseTime = TimeSpan.FromMinutes(1);
+            });
             // Fine tune how the Kafka Topic is declared by Wolverine
             .Specification(spec =>
             {

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs
@@ -106,6 +106,14 @@ public class DocumentationSamples
                         // Other configuration
                     })
                     
+                    // Configure circuit breaker behavior for
+                    // this specific Kafka listener
+                    .CircuitBreaker(cb =>
+                    {
+                        cb.MinimumThreshold = 10;
+                        cb.PauseTime = TimeSpan.FromMinutes(1);
+                    })
+                    
                     // Fine tune how the Kafka Topic is declared by Wolverine
                     .Specification(spec =>
                     {

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Confluent.Kafka;
 using Confluent.Kafka.Admin;
 using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
 using Wolverine.Kafka.Internals;
 
 namespace Wolverine.Kafka;
@@ -30,6 +31,29 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
         }
 
         add(topic => configure(topic.Specification));
+        return this;
+    }
+    
+    /// <summary>
+    /// Configures circuit breaker behavior for this Kafka listener.
+    /// </summary>
+    /// <param name="configure">
+    /// Optional configuration action for <see cref="CircuitBreakerOptions"/>.
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public KafkaListenerConfiguration CircuitBreaker(Action<CircuitBreakerOptions> configure)
+    {
+        if (configure == null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+
+        add(topic =>
+        {
+            topic.CircuitBreakerOptions = new CircuitBreakerOptions();
+            configure(topic.CircuitBreakerOptions);
+        });
+
         return this;
     }
 


### PR DESCRIPTION
Adds a `CircuitBreaker()` method to `KafkaListenerConfiguration` so Kafka listeners can opt into Wolverine's standard circuit breaker policy through the fluent API.

- Example
```csharp
.CircuitBreaker(cb =>
                    {
                        cb.MinimumThreshold = 10;
                        cb.PauseTime = TimeSpan.FromMinutes(1);
                    })
                   