### PR TITLE
Fix silent message loss when envelope mapper throws (RabbitMQ + MQTT)

### DIFF
--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/Bugs/Bug_mapper_exception_routes_to_dlq.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/Bugs/Bug_mapper_exception_routes_to_dlq.cs
@@ -1,0 +1,98 @@
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using MQTTnet;
+using MQTTnet.Client;
+using Shouldly;
+using Wolverine.Persistence.Durability.DeadLetterManagement;
+using Wolverine.Runtime;
+using Wolverine.SqlServer;
+using Wolverine.Tracking;
+
+namespace Wolverine.MQTT.Tests.Bugs;
+
+[Collection("mosquitto")]
+public class Bug_mapper_exception_routes_to_dlq : IAsyncLifetime
+{
+    private readonly string _topic = "mapper-explosion/" + Guid.NewGuid().ToString("N");
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseMqtt(builder =>
+                {
+                    builder.WithClientOptions(client =>
+                        client.WithTcpServer(MosquittoContainerFixture.Host, MosquittoContainerFixture.Port));
+                });
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "wolverine");
+
+                opts.ListenToMqttTopic(_topic)
+                    .UseInterop(new AlwaysThrowingMqttMapper())
+                    .UseDurableInbox();
+            }).StartAsync();
+
+        // Clear prior dead-letter rows so the test is deterministic.
+        await _host.RebuildAllEnvelopeStorageAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_host is not null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task unmappable_message_is_persisted_to_wolverine_dead_letters()
+    {
+        var factory = new MqttFactory();
+        using var client = factory.CreateMqttClient();
+
+        var options = new MqttClientOptionsBuilder()
+            .WithTcpServer(MosquittoContainerFixture.Host, MosquittoContainerFixture.Port)
+            .Build();
+
+        await client.ConnectAsync(options);
+        await client.PublishStringAsync(_topic, "hello");
+
+        var storage = _host.GetRuntime().Storage;
+
+        var attempts = 0;
+        while (attempts < 40)
+        {
+            var results = await storage.DeadLetters.QueryAsync(
+                new DeadLetterEnvelopeQuery(TimeRange.AllTime()),
+                CancellationToken.None);
+
+            if (results.Envelopes.Count > 0)
+            {
+                results.Envelopes[0].ExceptionType.ShouldContain(nameof(InvalidOperationException));
+                return;
+            }
+
+            attempts++;
+            await Task.Delay(250.Milliseconds());
+        }
+
+        throw new Exception(
+            "Expected an entry in wolverine_dead_letters after a mapper exception, but none was persisted (silent loss).");
+    }
+}
+
+internal class AlwaysThrowingMqttMapper : IMqttEnvelopeMapper
+{
+    public void MapEnvelopeToOutgoing(Envelope envelope, MqttApplicationMessage outgoing)
+    {
+    }
+
+    public void MapIncomingToEnvelope(Envelope envelope, MqttApplicationMessage incoming)
+    {
+        throw new InvalidOperationException("simulated mapper failure");
+    }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj
@@ -25,6 +25,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\..\Testing\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj" />
         <ProjectReference Include="..\Wolverine.MQTT\Wolverine.MQTT.csproj"/>
+        <ProjectReference Include="..\..\..\Persistence\Wolverine.SqlServer\Wolverine.SqlServer.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttListener.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttListener.cs
@@ -99,9 +99,47 @@ internal class MqttListener : IListener
         catch (Exception e)
         {
             _logger.LogError(e, "Error trying to map an incoming MQTT message {MessageId} to an Envelope",
-                Encoding.Default.GetString(args.ApplicationMessage.CorrelationData));
-            await _complete.PostAsync(envelope);
+                args.ApplicationMessage.CorrelationData != null
+                    ? Encoding.Default.GetString(args.ApplicationMessage.CorrelationData)
+                    : "(none)");
 
+            // MoveToErrorsAsync keys the envelope by Id; the mapper threw before
+            // setting one, so synthesize a Guid to satisfy the dead-letter store contract.
+            // MqttEnvelope already populates Data and Destination in its constructor.
+            if (envelope.Id == Guid.Empty)
+            {
+                envelope.Id = Guid.NewGuid();
+            }
+
+            var dlq = _receiver as ISupportDeadLetterQueue;
+            if (dlq is not null)
+            {
+                try
+                {
+                    await dlq.MoveToErrorsAsync(envelope, e);
+                }
+                catch (Exception moveEx)
+                {
+                    _logger.LogError(moveEx,
+                        "Failed to move un-mappable MQTT message {MessageId} to the dead-letter store; falling back to ack to avoid poison redelivery",
+                        envelope.Id);
+                }
+            }
+
+            // Always PUBACK. If MoveToErrorsAsync succeeded, the dead-letter store has
+            // the record. If not (no durable inbox, or it threw), acking is still the
+            // best available option because MQTT has no broker DLQ and leaving the
+            // message unacked would cause a poison-redelivery loop.
+            try
+            {
+                await _complete.PostAsync(envelope);
+            }
+            catch (Exception ackEx)
+            {
+                _logger.LogError(ackEx,
+                    "Failed to ack un-mappable MQTT message {MessageId}",
+                    envelope.Id);
+            }
             return;
         }
 

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttEnvelope.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttEnvelope.cs
@@ -14,5 +14,6 @@ public class MqttEnvelope : Envelope
         Args = args;
         Data = args.ApplicationMessage.PayloadSegment.Array;
         MessageType = topic.MessageTypeName;
+        Destination = topic.Uri;
     }
 }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_mapper_exception_routes_to_dlq.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_mapper_exception_routes_to_dlq.cs
@@ -1,0 +1,82 @@
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RabbitMQ.Client;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests.Bugs;
+
+public class Bug_mapper_exception_routes_to_dlq : IDisposable
+{
+    private readonly string _queueName = "mapper_explosion_" + Guid.NewGuid().ToString("N");
+    private IHost _host = null!;
+
+    public void Dispose()
+    {
+        _host?.TeardownResources();
+        _host?.Dispose();
+    }
+
+    [Fact]
+    public async Task unmappable_message_is_routed_to_broker_dlq_not_silently_acked()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToRabbitQueue(_queueName)
+                    .UseInterop(new AlwaysThrowingMapper());
+            }).StartAsync();
+
+        var transport = _host.Services
+            .GetRequiredService<IWolverineRuntime>()
+            .Options
+            .Transports
+            .GetOrCreate<RabbitMqTransport>();
+
+        // Publish via the admin channel so we bypass Wolverine's outgoing mapper —
+        // the bug under test is on the receiving side when the incoming mapper throws.
+        await transport.WithAdminChannelAsync(async channel =>
+        {
+            var props = new BasicProperties { MessageId = Guid.NewGuid().ToString() };
+
+            await channel.BasicPublishAsync(
+                exchange: "",
+                routingKey: _queueName,
+                mandatory: false,
+                basicProperties: props,
+                body: "hello"u8.ToArray());
+        });
+
+        // The default dead-letter queue that Wolverine provisions automatically
+        var deadLetterQueue = transport.Queues[RabbitMqTransport.DeadLetterQueueName];
+
+        var attempts = 0;
+        while (attempts < 40)
+        {
+            var count = await deadLetterQueue.QueuedCountAsync();
+            if (count > 0) return;
+            attempts++;
+            await Task.Delay(250.Milliseconds());
+        }
+
+        throw new Exception(
+            $"Expected unmappable message to arrive in {RabbitMqTransport.DeadLetterQueueName}, but it never did (silent loss).");
+    }
+}
+
+internal class AlwaysThrowingMapper : IRabbitMqEnvelopeMapper
+{
+    public void MapEnvelopeToOutgoing(Envelope envelope, IBasicProperties outgoing)
+    {
+    }
+
+    public void MapIncomingToEnvelope(Envelope envelope, IReadOnlyBasicProperties incoming)
+    {
+        throw new InvalidOperationException("simulated mapper failure");
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
@@ -52,7 +52,39 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
         catch (Exception e)
         {
             _logger.LogError(e, "Error trying to map an incoming RabbitMQ message {MessageId} to an Envelope", properties.MessageId);
-            await Channel.BasicAckAsync(envelope.DeliveryTag, false, _cancellation);
+
+            // MoveToErrorsAsync keys the envelope by Id; the mapper threw before
+            // setting one, so synthesize a Guid to satisfy the dead-letter store contract.
+            if (envelope.Id == Guid.Empty)
+            {
+                envelope.Id = Guid.NewGuid();
+            }
+
+            try
+            {
+                if (_workerQueue is ISupportDeadLetterQueue dlq)
+                {
+                    await dlq.MoveToErrorsAsync(envelope, e);
+                    return;
+                }
+            }
+            catch (Exception moveEx)
+            {
+                _logger.LogError(moveEx,
+                    "Failed to move un-mappable RabbitMQ message {MessageId} to the dead-letter store; falling back to broker DLX",
+                    properties.MessageId);
+            }
+
+            try
+            {
+                await Channel.BasicNackAsync(envelope.DeliveryTag, multiple: false, requeue: false, _cancellation);
+            }
+            catch (Exception nackEx)
+            {
+                _logger.LogError(nackEx,
+                    "Failed to Nack un-mappable RabbitMQ message {MessageId}",
+                    properties.MessageId);
+            }
 
             return;
         }


### PR DESCRIPTION
Closes #2510

  ## Summary

  When the incoming envelope mapper threw, both RabbitMQ's `WorkerQueueMessageConsumer` and MQTT's `MqttListener` acked the broker delivery and dropped the message. No broker
  DLQ, no entry in `wolverine_dead_letters`, no redelivery — the message was simply lost. Triggered in the wild by foreign producers (e.g. MassTransit) whose headers the
  mapper can't decode, custom mappers that throw, or header decoding on hosts with a non-UTF8 system codepage.

  Both listeners now:

  1. Synthesize `envelope.Id` (white lie — the mapper failed before populating it, but `MoveToErrorsAsync` keys by Id).
  2. Attempt `ISupportDeadLetterQueue.MoveToErrorsAsync` on the receiver so the message lands in `wolverine_dead_letters` when the durable inbox is configured.
  3. Transport-specific fallback:
     - **RabbitMQ:** `BasicNack(requeue: false)` so the broker's DLX captures the message even without durable inbox.
     - **MQTT:** always PUBACK after the dead-letter attempt — MQTT has no broker DLQ, so leaving the message unacked would cause a poison-redelivery loop.
  4. Wrap every outbound call in try/catch so a failure inside the fix path cannot propagate out of the consumer callback.

  `MqttEnvelope` now sets `Destination = topic.Uri` in its constructor, matching how `Data` and `MessageType` are already populated. Previously `Destination` was set by
  `DurableReceiver.MarkReceived`, which is bypassed when the mapper throws — causing `MessageDatabase.MoveToDeadLetterStorageAsync` to NRE on
  `envelope.Destination!.ToString()`.

  ## Transport behavior comparison (before → after)

  | Transport | Before | After |
  |---|---|---|
  | RabbitMQ | `BasicAck` → silent loss | `MoveToErrorsAsync` → broker DLX + DB when configured |
  | MQTT | `_complete.PostAsync` → silent loss | `MoveToErrorsAsync` → DB (when durable inbox) + PUBACK |
  | Azure SB / GCP Pub/Sub / Kafka / SQS / Redis / NATS / Pulsar | already correct | unchanged |

  ## Test plan

  - [x] New integration test `Bug_mapper_exception_routes_to_dlq` under `Wolverine.RabbitMQ.Tests.Bugs` — publishes a raw AMQP message to a queue with a throwing
  `IRabbitMqEnvelopeMapper` and asserts the broker DLQ receives it.
  - [x] New integration test `Bug_mapper_exception_routes_to_dlq` under `Wolverine.MQTT.Tests.Bugs` — durable inbox on SQL Server + throwing `IMqttEnvelopeMapper`; asserts an
  entry appears in `wolverine_dead_letters` with `ExceptionType` containing `InvalidOperationException`.
  - [x] Both tests fail on `main` with a "(silent loss)" exception and pass on this branch.
  - [x] Close regression sweep over RabbitMQ DLQ / interop / unknown-message suites: no new failures.
  - [x] Full MQTT test suite: 89/89 pass (1 pre-existing skip).

  ## Files changed

  - `src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs`
  - `src/Transports/MQTT/Wolverine.MQTT/Internals/MqttListener.cs`
  - `src/Transports/MQTT/Wolverine.MQTT/MqttEnvelope.cs` (1 line — set `Destination` in constructor)
  - `src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj` (added `Wolverine.SqlServer` project reference)
  - New: `src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_mapper_exception_routes_to_dlq.cs`
  - New: `src/Transports/MQTT/Wolverine.MQTT.Tests/Bugs/Bug_mapper_exception_routes_to_dlq.cs`