### PR TITLE
Replace Encoding.Default with Encoding.UTF8 for clarity

### DIFF
--- a/docs/guide/messages.md
+++ b/docs/guide/messages.md
@@ -427,14 +427,14 @@ public class SerializedMessage : ISerializable
 
     public byte[] Write()
     {
-        return Encoding.Default.GetBytes(Name);
+        return Encoding.UTF8.GetBytes(Name);
     }
 
     // You'll need at least C# 11 for static methods
     // on interfaces!
     public static object Read(byte[] bytes)
     {
-        var name = Encoding.Default.GetString(bytes);
+        var name = Encoding.UTF8.GetString(bytes);
         return new SerializedMessage { Name = name };
     }
 }

--- a/docs/guide/messaging/message-bus.md
+++ b/docs/guide/messaging/message-bus.md
@@ -515,7 +515,7 @@ IMessageBus bus = host.MessageBus();
 // The raw message data, but pretend this was sourced from a database
 // table or some other non-Wolverine storage in your system
 byte[] messageData 
-    = Encoding.Default.GetBytes("{\"Name\": \"George Karlaftis\"}");
+    = Encoding.UTF8.GetBytes("{\"Name\": \"George Karlaftis\"}");
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/sending_raw_messages.cs#L164-L176' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_context_for_raw_message_sending' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/messaging/transports/sqs/interoperability.md
+++ b/docs/guide/messaging/transports/sqs/interoperability.md
@@ -65,7 +65,7 @@ public class CustomSqsMapper : ISqsEnvelopeMapper
     public string BuildMessageBody(Envelope envelope)
     {
         // Serialized data from the Wolverine message
-        return Encoding.Default.GetString(envelope.Data);
+        return Encoding.UTF8.GetString(envelope.Data);
     }
 
     // Specify header values for the SQS message from the Wolverine envelope
@@ -81,7 +81,7 @@ public class CustomSqsMapper : ISqsEnvelopeMapper
     public void ReadEnvelopeData(Envelope envelope, string messageBody,
         IDictionary<string, MessageAttributeValue> attributes)
     {
-        envelope.Data = Encoding.Default.GetBytes(messageBody);
+        envelope.Data = Encoding.UTF8.GetBytes(messageBody);
 
         if (attributes.TryGetValue("tenant-id", out var att))
         {

--- a/docs/tutorials/interop.md
+++ b/docs/tutorials/interop.md
@@ -229,7 +229,7 @@ public void UseNServiceBusInterop()
         {
             if (props.Headers.TryGetValue("NServiceBus.ReplyToAddress", out var raw))
             {
-                var queueName = (raw is byte[] b ? Encoding.Default.GetString(b) : raw.ToString())!;
+                var queueName = (raw is byte[] b ? Encoding.UTF8.GetString(b) : raw.ToString())!;
                 e.ReplyUri = new Uri($"{_parent.Protocol}://queue/{queueName}");
             }
         }

--- a/src/Http/Wolverine.Http/NewtonsoftHttpSerialization.cs
+++ b/src/Http/Wolverine.Http/NewtonsoftHttpSerialization.cs
@@ -40,7 +40,7 @@ public class NewtonsoftHttpSerialization
 
         var responseStream = response.Body;
 
-        await using var textWriter = new HttpResponseStreamWriter(responseStream, Encoding.Default, _bufferSize, _bytePool,
+        await using var textWriter = new HttpResponseStreamWriter(responseStream, Encoding.UTF8, _bufferSize, _bytePool,
             ArrayPool<char>.Shared);
         using var jsonWriter = new JsonTextWriter(textWriter)
         {

--- a/src/Testing/CoreTests/Serialization/intrinsic_serialization.cs
+++ b/src/Testing/CoreTests/Serialization/intrinsic_serialization.cs
@@ -26,14 +26,14 @@ public class SerializedMessage : ISerializable
 
     public byte[] Write()
     {
-        return Encoding.Default.GetBytes(Name);
+        return Encoding.UTF8.GetBytes(Name);
     }
 
     // You'll need at least C# 11 for static methods
     // on interfaces!
     public static object Read(byte[] bytes)
     {
-        var name = Encoding.Default.GetString(bytes);
+        var name = Encoding.UTF8.GetString(bytes);
         return new SerializedMessage { Name = name };
     }
 }

--- a/src/Testing/SlowTests/intrinsic_serialization_end_to_end.cs
+++ b/src/Testing/SlowTests/intrinsic_serialization_end_to_end.cs
@@ -52,12 +52,12 @@ public class SerializedMessage : ISerializable
 
     public byte[] Write()
     {
-        return Encoding.Default.GetBytes(Name);
+        return Encoding.UTF8.GetBytes(Name);
     }
 
     public static object Read(byte[] bytes)
     {
-        var name = Encoding.Default.GetString(bytes);
+        var name = Encoding.UTF8.GetString(bytes);
         return new SerializedMessage { Name = name };
     }
 }

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs
@@ -389,7 +389,7 @@ public class CustomSqsMapper : ISqsEnvelopeMapper
     public string BuildMessageBody(Envelope envelope)
     {
         // Serialized data from the Wolverine message
-        return Encoding.Default.GetString(envelope.Data!);
+        return Encoding.UTF8.GetString(envelope.Data!);
     }
 
     // Specify header values for the SQS message from the Wolverine envelope
@@ -405,7 +405,7 @@ public class CustomSqsMapper : ISqsEnvelopeMapper
     public void ReadEnvelopeData(Envelope envelope, string messageBody,
         IDictionary<string, MessageAttributeValue> attributes)
     {
-        envelope.Data = Encoding.Default.GetBytes(messageBody);
+        envelope.Data = Encoding.UTF8.GetBytes(messageBody);
 
         if (attributes.TryGetValue("tenant-id", out var att))
         {

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
@@ -243,7 +243,7 @@ public class AzureServiceBusQueue : AzureServiceBusEndpoint, IBrokerQueue, IMass
                 if (serviceBusReceivedMessage.ApplicationProperties.TryGetValue("NServiceBus.ReplyToAddress",
                         out var raw))
                 {
-                    var queueName = (raw is byte[] b ? Encoding.Default.GetString(b) : raw.ToString())!;
+                    var queueName = (raw is byte[] b ? Encoding.UTF8.GetString(b) : raw.ToString())!;
                     e.ReplyUri = new Uri($"{Parent.Protocol}://queue/{queueName}");
                 }
             }
@@ -255,7 +255,7 @@ public class AzureServiceBusQueue : AzureServiceBusEndpoint, IBrokerQueue, IMass
                 // Incoming
                 if (m.ApplicationProperties.TryGetValue("NServiceBus.EnclosedMessageTypes", out var raw))
                 {
-                    var typeName = (raw is byte[] b ? Encoding.Default.GetString(b) : raw.ToString())!;
+                    var typeName = (raw is byte[] b ? Encoding.UTF8.GetString(b) : raw.ToString())!;
                     if (typeName.IsNotEmpty())
                     {
                         var messageType = Type.GetType(typeName);

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
@@ -254,7 +254,7 @@ public class AzureServiceBusSubscription : AzureServiceBusEndpoint, IBrokerQueue
                 if (serviceBusReceivedMessage.ApplicationProperties.TryGetValue("NServiceBus.ReplyToAddress",
                         out var raw))
                 {
-                    var queueName = (raw is byte[] b ? Encoding.Default.GetString(b) : raw.ToString())!;
+                    var queueName = (raw is byte[] b ? Encoding.UTF8.GetString(b) : raw.ToString())!;
                     e.ReplyUri = new Uri($"{Parent.Protocol}://queue/{queueName}");
                 }
             }
@@ -265,7 +265,7 @@ public class AzureServiceBusSubscription : AzureServiceBusEndpoint, IBrokerQueue
             {
                 if (msg.ApplicationProperties.TryGetValue("NServiceBus.EnclosedMessageTypes", out var raw))
                 {
-                    var typeName = (raw is byte[] b ? Encoding.Default.GetString(b) : raw.ToString())!;
+                    var typeName = (raw is byte[] b ? Encoding.UTF8.GetString(b) : raw.ToString())!;
                     if (typeName.IsNotEmpty())
                     {
                         var messageType = Type.GetType(typeName);

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
@@ -150,7 +150,7 @@ public class AzureServiceBusTopic : AzureServiceBusEndpoint, IMassTransitInterop
                 if (serviceBusReceivedMessage.ApplicationProperties.TryGetValue("NServiceBus.ReplyToAddress",
                         out var raw))
                 {
-                    var queueName = (raw is byte[] b ? Encoding.Default.GetString(b) : raw.ToString())!;
+                    var queueName = (raw is byte[] b ? Encoding.UTF8.GetString(b) : raw.ToString())!;
                     e.ReplyUri = new Uri($"{Parent.Protocol}://queue/{queueName}");
                 }
             }
@@ -161,7 +161,7 @@ public class AzureServiceBusTopic : AzureServiceBusEndpoint, IMassTransitInterop
             {
                 if (msg.ApplicationProperties.TryGetValue("NServiceBus.EnclosedMessageTypes", out var raw))
                 {
-                    var typeName = (raw is byte[] b ? Encoding.Default.GetString(b) : raw.ToString())!;
+                    var typeName = (raw is byte[] b ? Encoding.UTF8.GetString(b) : raw.ToString())!;
                     if (typeName.IsNotEmpty())
                     {
                         var messageType = Type.GetType(typeName);

--- a/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
@@ -33,7 +33,7 @@ internal class JsonOnlyMapper : IKafkaEnvelopeMapper
         }
         else if (envelope.Message != null)
         {
-            outgoing.Value = Encoding.Default.GetBytes(JsonSerializer.Serialize(envelope.Message, _options));
+            outgoing.Value = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(envelope.Message, _options));
         }
         else
         {

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaEnvelopeMapper.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaEnvelopeMapper.cs
@@ -14,14 +14,14 @@ public class KafkaEnvelopeMapper : EnvelopeMapper<Message<string, byte[]>, Messa
 
     protected override void writeOutgoingHeader(Message<string, byte[]> outgoing, string key, string value)
     {
-        outgoing.Headers.Add(key, Encoding.Default.GetBytes(value));
+        outgoing.Headers.Add(key, Encoding.UTF8.GetBytes(value));
     }
 
     protected override bool tryReadIncomingHeader(Message<string, byte[]> incoming, string key, out string value)
     {
         if (incoming.Headers.TryGetLastBytes(key, out var bytes))
         {
-            value = Encoding.Default.GetString(bytes);
+            value = Encoding.UTF8.GetString(bytes);
             return true;
         }
 
@@ -35,7 +35,7 @@ public class KafkaEnvelopeMapper : EnvelopeMapper<Message<string, byte[]>, Messa
         foreach (var header in incoming.Headers)
         {
             var bytes = header.GetValueBytes();
-            envelope.Headers[header.Key] = bytes != null ? Encoding.Default.GetString(bytes) : null;
+            envelope.Headers[header.Key] = bytes != null ? Encoding.UTF8.GetString(bytes) : null;
         }
     }
 

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -149,7 +149,7 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
             await client.ProduceAsync(TopicName, new Message<string, byte[]>
             {
                 Key = "ping",
-                Value = Encoding.Default.GetBytes("ping")
+                Value = Encoding.UTF8.GetBytes("ping")
             });
 
 

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
@@ -86,7 +86,7 @@ public class KafkaTopicGroup : KafkaTopic, IBrokerEndpoint
                 await client.ProduceAsync(topicName, new Message<string, byte[]>
                 {
                     Key = "ping",
-                    Value = System.Text.Encoding.Default.GetBytes("ping")
+                    Value = System.Text.Encoding.UTF8.GetBytes("ping")
                 });
             }
 

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/connectivity.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/connectivity.cs
@@ -34,7 +34,7 @@ public class Connectivity
 
         managedClient.ApplicationMessageReceivedAsync += e =>
         {
-            _output.WriteLine(">> RECEIVED: " + e.ApplicationMessage.Topic + ", " + Encoding.Default.GetString(e.ApplicationMessage.PayloadSegment));
+            _output.WriteLine(">> RECEIVED: " + e.ApplicationMessage.Topic + ", " + Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment));
             return CompletedTask.Instance;
         };
 

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttListener.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttListener.cs
@@ -100,7 +100,7 @@ internal class MqttListener : IListener
         {
             _logger.LogError(e, "Error trying to map an incoming MQTT message {MessageId} to an Envelope",
                 args.ApplicationMessage.CorrelationData != null
-                    ? Encoding.Default.GetString(args.ApplicationMessage.CorrelationData)
+                    ? Encoding.UTF8.GetString(args.ApplicationMessage.CorrelationData)
                     : "(none)");
 
             // MoveToErrorsAsync keys the envelope by Id; the mapper threw before

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/sending_raw_messages.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/sending_raw_messages.cs
@@ -172,7 +172,7 @@ public class sending_raw_messages
         // The raw message data, but pretend this was sourced from a database
         // table or some other non-Wolverine storage in your system
         byte[] messageData 
-            = Encoding.Default.GetBytes("{\"Name\": \"George Karlaftis\"}");
+            = Encoding.UTF8.GetBytes("{\"Name\": \"George Karlaftis\"}");
 
             #endregion
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEndpoint.NServiceBus.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEndpoint.NServiceBus.cs
@@ -36,7 +36,7 @@ public abstract partial class RabbitMqEndpoint
             {
                 if (props.Headers!.TryGetValue("NServiceBus.ReplyToAddress", out var raw))
                 {
-                    var queueName = (raw is byte[] b ? Encoding.Default.GetString(b) : raw!.ToString())!;
+                    var queueName = (raw is byte[] b ? Encoding.UTF8.GetString(b) : raw!.ToString())!;
                     e.ReplyUri = new Uri($"{_parent.Protocol}://queue/{queueName}");
                 }
             }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelopeMapper.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelopeMapper.cs
@@ -68,7 +68,7 @@ public class RabbitMqEnvelopeMapper : EnvelopeMapper<IReadOnlyBasicProperties, I
 
         if (incoming.Headers.TryGetValue(key, out var raw))
         {
-            value = (raw is byte[] b ? Encoding.Default.GetString(b) : raw!.ToString())!;
+            value = (raw is byte[] b ? Encoding.UTF8.GetString(b) : raw!.ToString())!;
             return true;
         }
 
@@ -82,7 +82,7 @@ public class RabbitMqEnvelopeMapper : EnvelopeMapper<IReadOnlyBasicProperties, I
         foreach (var pair in incoming.Headers)
         {
             envelope.Headers[pair.Key] =
-                pair.Value is byte[] b ? Encoding.Default.GetString(b) : pair.Value?.ToString();
+                pair.Value is byte[] b ? Encoding.UTF8.GetString(b) : pair.Value?.ToString();
         }
     }
 }


### PR DESCRIPTION
Closes #2513

`Encoding.Default` returns `UTF8Encoding` on .NET Core / .NET 5+, so this is
a no-op at runtime. The rename removes the misleading "locale-dependent ANSI"
connotation carried over from .NET Framework and aligns the source with the
UTF-8 contract that AMQP 0-9-1, JSON (RFC 8259) and Kafka all mandate.
## Scope
- Production: HTTP, Kafka, MQTT, RabbitMQ, Azure Service Bus (11 files)
- Tests: CoreTests, SlowTests, MQTT, RabbitMQ, AWS SQS (5 files)
- Docs: messages, message-bus, sqs/interoperability, interop (4 files)
## Verification
- All touched projects build with 0 warnings / 0 errors.
- `CoreTests` on net10.0: 1319 passed, 0 failed.
- No behavioural change — both properties resolve to the same `UTF8Encoding`
  singleton on every TFM Wolverine targets.