### PR TITLE
Fix [SagaIdentityFrom] ignored when NotFound declared before Handle

### DIFF
--- a/src/Testing/CoreTests/Bugs/Bug_2521_saga_identity_from_ordering.cs
+++ b/src/Testing/CoreTests/Bugs/Bug_2521_saga_identity_from_ordering.cs
@@ -1,0 +1,107 @@
+using System.Diagnostics;
+using JasperFx.CodeGeneration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Persistence.Sagas;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+/// <summary>
+/// GH-2521: [SagaIdentityFrom] attribute is ignored when NotFound handler is declared
+/// before Handle in the saga class. The code generation was only scanning the first
+/// handler method found (via DistinctBy), which would be NotFound if declared first.
+/// </summary>
+public class Bug_2521_saga_identity_from_ordering : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(SagaWithNotFoundDeclaredFirst));
+
+                opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Auto;
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task saga_identity_from_attribute_works_when_notfound_is_declared_first()
+    {
+        var sagaId = Guid.NewGuid().ToString();
+
+        // Start the saga
+        await _host.InvokeMessageAndWaitAsync(new StartNotFoundFirstSaga(sagaId));
+
+        var persistor = _host.Services.GetRequiredService<InMemorySagaPersistor>();
+        persistor.Load<SagaWithNotFoundDeclaredFirst>(sagaId).ShouldNotBeNull();
+
+        // Reset tracking
+        SagaWithNotFoundDeclaredFirst.HandleCalled = false;
+        SagaWithNotFoundDeclaredFirst.NotFoundCalled = false;
+
+        // Send message with non-conventional property name — should find saga via [SagaIdentityFrom]
+        await _host.InvokeMessageAndWaitAsync(new NotFoundFirstMsg(sagaId));
+
+        // Handle should have been called on the existing saga, not NotFound
+        SagaWithNotFoundDeclaredFirst.HandleCalled.ShouldBeTrue(
+            "Handle() should be called when saga exists and [SagaIdentityFrom] correctly resolves the saga ID");
+        SagaWithNotFoundDeclaredFirst.NotFoundCalled.ShouldBeFalse(
+            "NotFound() should NOT be called when saga exists");
+    }
+
+    [Fact]
+    public async Task notfound_is_called_when_saga_does_not_exist()
+    {
+        SagaWithNotFoundDeclaredFirst.HandleCalled = false;
+        SagaWithNotFoundDeclaredFirst.NotFoundCalled = false;
+
+        // Send message for non-existent saga
+        await _host.InvokeMessageAndWaitAsync(new NotFoundFirstMsg(Guid.NewGuid().ToString()));
+
+        SagaWithNotFoundDeclaredFirst.NotFoundCalled.ShouldBeTrue();
+        SagaWithNotFoundDeclaredFirst.HandleCalled.ShouldBeFalse();
+    }
+}
+
+public record StartNotFoundFirstSaga(string Id);
+
+// Message with non-conventional property name (not "SagaWithNotFoundDeclaredFirstId", "SagaId", or "Id")
+public record NotFoundFirstMsg(string TargetId);
+
+// Key: NotFound is declared BEFORE Handle — this is what triggers GH-2521
+public class SagaWithNotFoundDeclaredFirst : Saga
+{
+    public string Id { get; set; } = string.Empty;
+
+    public static bool HandleCalled { get; set; }
+    public static bool NotFoundCalled { get; set; }
+
+    public static SagaWithNotFoundDeclaredFirst Start(StartNotFoundFirstSaga cmd)
+        => new() { Id = cmd.Id };
+
+    // NotFound declared FIRST — before Handle
+    public static void NotFound(NotFoundFirstMsg msg)
+    {
+        NotFoundCalled = true;
+        Debug.WriteLine($"NotFound called for TargetId {msg.TargetId}");
+    }
+
+    // Handle declared SECOND — with [SagaIdentityFrom] on a non-conventional property
+    public void Handle(
+        [SagaIdentityFrom(nameof(NotFoundFirstMsg.TargetId))] NotFoundFirstMsg msg)
+    {
+        HandleCalled = true;
+        Debug.WriteLine($"Handle called for saga {Id}");
+    }
+}

--- a/src/Testing/CoreTests/Persistence/Sagas/saga_id_member_determination.cs
+++ b/src/Testing/CoreTests/Persistence/Sagas/saga_id_member_determination.cs
@@ -24,6 +24,34 @@ public class saga_id_member_determination
         SagaChain.DetermineSagaIdMember(typeof(SomeSagaMessage5), typeof(SomeSaga), method)
             !.Name.ShouldBe(nameof(SomeSagaMessage5.Hello));
     }
+
+    [Fact]
+    public void member_is_determined_by_attribute_scanning_all_methods()
+    {
+        // When multiple methods are passed, [SagaIdentityFrom] should be found
+        // regardless of which method has it — fixes GH-2521
+        var notFoundMethod = typeof(SagaWithNotFoundFirst).GetMethod(nameof(SagaWithNotFoundFirst.NotFound))!;
+        var handleMethod = typeof(SagaWithNotFoundFirst).GetMethod(nameof(SagaWithNotFoundFirst.Handle))!;
+
+        // Even when NotFound is listed first (no [SagaIdentityFrom]), the Handle method's attribute is found
+        SagaChain.DetermineSagaIdMember(typeof(NonConventionalMessage), typeof(SagaWithNotFoundFirst),
+            [notFoundMethod, handleMethod])
+            !.Name.ShouldBe(nameof(NonConventionalMessage.TargetId));
+    }
+
+    [Fact]
+    public void member_is_determined_by_attribute_even_with_single_wrong_method()
+    {
+        // When only the NotFound method is passed (old behavior), the attribute is NOT found
+        var notFoundMethod = typeof(SagaWithNotFoundFirst).GetMethod(nameof(SagaWithNotFoundFirst.NotFound))!;
+
+        // Without scanning all methods, falls back to convention — which won't find "TargetId"
+        var result = SagaChain.DetermineSagaIdMember(typeof(NonConventionalMessage), typeof(SagaWithNotFoundFirst),
+            [notFoundMethod]);
+
+        // Should NOT find TargetId since NotFound doesn't have [SagaIdentityFrom]
+        result.ShouldBeNull();
+    }
 }
 
 public record SomeSagaMessage1(Guid Id, [property: SagaIdentity] Guid RandomName);
@@ -42,3 +70,17 @@ public class SomeSaga
 }
 
 #endregion
+
+// GH-2521: Message with non-conventional property name (no convention match for "SagaWithNotFoundFirst")
+public record NonConventionalMessage(string TargetId);
+
+// GH-2521: Saga where NotFound is declared BEFORE Handle
+public class SagaWithNotFoundFirst : Saga
+{
+    public string Id { get; set; } = string.Empty;
+
+    // NotFound is declared first — this caused the bug when only the first method was scanned
+    public static void NotFound(NonConventionalMessage msg) { }
+
+    public void Handle([SagaIdentityFrom(nameof(NonConventionalMessage.TargetId))] NonConventionalMessage msg) { }
+}

--- a/src/Wolverine/Persistence/Sagas/SagaChain.cs
+++ b/src/Wolverine/Persistence/Sagas/SagaChain.cs
@@ -46,10 +46,10 @@ public class SagaChain : HandlerChain
     {
         // After base constructor, saga handlers may have been moved to ByEndpoint (Separated mode).
         // Check what's left in Handlers (not the original grouping).
-        var remainingSagaCalls = Handlers.Where(x => x.HandlerType.CanBeCastTo<Saga>())
-            .DistinctBy(x => x.HandlerType).ToArray();
+        var allSagaHandlers = Handlers.Where(x => x.HandlerType.CanBeCastTo<Saga>()).ToArray();
+        var distinctSagaTypes = allSagaHandlers.DistinctBy(x => x.HandlerType).ToArray();
 
-        if (remainingSagaCalls.Length == 0)
+        if (distinctSagaTypes.Length == 0)
         {
             // All sagas were separated into ByEndpoint chains — this parent is routing-only.
             var anySaga = grouping.First(x => x.HandlerType.CanBeCastTo<Saga>());
@@ -59,11 +59,13 @@ public class SagaChain : HandlerChain
 
         try
         {
-            var saga = remainingSagaCalls.Single();
+            var saga = distinctSagaTypes.Single();
             SagaType = saga.HandlerType;
             SagaMethodInfo = saga.Method;
 
-            SagaIdMember = DetermineSagaIdMember(MessageType, SagaType, saga.Method);
+            // Pass ALL saga handler methods so [SagaIdentityFrom] is found regardless of declaration order
+            SagaIdMember = DetermineSagaIdMember(MessageType, SagaType,
+                allSagaHandlers.Select(x => x.Method).ToArray());
 
             // Automatically audit the saga id
             if (SagaIdMember != null && AuditedMembers.All(x => x.Member != SagaIdMember))
@@ -73,7 +75,7 @@ public class SagaChain : HandlerChain
         }
         catch (Exception e)
         {
-            var handlerTypes = remainingSagaCalls
+            var handlerTypes = distinctSagaTypes
                 .Select(x => x.HandlerType).Select(x => x.FullNameInCode()).Join(", ");
 
             throw new InvalidSagaException(
@@ -132,7 +134,7 @@ public class SagaChain : HandlerChain
         SagaType = saga.HandlerType;
         SagaMethodInfo = saga.Method;
 
-        SagaIdMember = DetermineSagaIdMember(MessageType, SagaType, saga.Method);
+        SagaIdMember = DetermineSagaIdMember(MessageType, SagaType, [saga.Method]);
 
         // Automatically audit the saga id
         if (SagaIdMember != null && AuditedMembers.All(x => x.Member != SagaIdMember))
@@ -151,7 +153,9 @@ public class SagaChain : HandlerChain
         SagaType = saga.HandlerType;
         SagaMethodInfo = saga.Method;
 
-        SagaIdMember = DetermineSagaIdMember(MessageType, SagaType, saga.Method);
+        // Pass ALL saga handler methods so [SagaIdentityFrom] is found regardless of declaration order
+        SagaIdMember = DetermineSagaIdMember(MessageType, SagaType,
+            sagaCalls.Select(x => x.Method).ToArray());
 
         if (SagaIdMember != null && AuditedMembers.All(x => x.Member != SagaIdMember))
         {
@@ -186,9 +190,18 @@ public class SagaChain : HandlerChain
 
     public static MemberInfo? DetermineSagaIdMember(Type messageType, Type sagaType, MethodInfo? sagaHandlerMethod = null)
     {
+        return DetermineSagaIdMember(messageType, sagaType,
+            sagaHandlerMethod != null ? [sagaHandlerMethod] : null);
+    }
+
+    public static MemberInfo? DetermineSagaIdMember(Type messageType, Type sagaType, MethodInfo[]? sagaHandlerMethods)
+    {
         var expectedSagaIdName = $"{sagaType.Name}Id";
 
-        var specifiedSagaIdMemberName = sagaHandlerMethod?.GetParameters()
+        // Scan ALL handler methods for [SagaIdentityFrom], not just the first one.
+        // This fixes the bug where declaration order of NotFound vs Handle matters.
+        var specifiedSagaIdMemberName = sagaHandlerMethods?
+            .SelectMany(m => m.GetParameters())
             .Select(x => x.GetCustomAttribute<SagaIdentityFromAttribute>())
             .FirstOrDefault(a => a != null)?.PropertyName;
 


### PR DESCRIPTION
## Summary
- Fixes #2521 — `[SagaIdentityFrom]` attribute was silently ignored when a `NotFound` handler was declared before the `Handle` method in a saga class
- **Root cause**: `SagaChain` used `DistinctBy(x => x.HandlerType)` to pick a single representative handler, then only scanned that one method's parameters for `[SagaIdentityFrom]`. Since `Type.GetMethods()` returns methods in declaration order, `NotFound` won the race when declared first — and it doesn't carry the attribute
- **Fix**: `DetermineSagaIdMember` now accepts all saga handler methods (`MethodInfo[]`) and scans all of them for `[SagaIdentityFrom]`. All three `SagaChain` constructor paths updated to pass the full method set

## Test plan
- [x] New integration test `Bug_2521_saga_identity_from_ordering` — verifies saga ID is correctly resolved from `[SagaIdentityFrom]` when `NotFound` is declared before `Handle`
- [x] New unit tests in `saga_id_member_determination` — verifies `DetermineSagaIdMember` finds the attribute when scanning multiple methods
- [x] Existing `Bug_2056_saga_code_generation` tests pass (no regression)
- [x] All 7 `saga_id_member_determination` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)