### PR TITLE
Acquire advisory lock around message database migrations

### DIFF
--- a/docs/guide/durability/postgresql.md
+++ b/docs/guide/durability/postgresql.md
@@ -335,4 +335,31 @@ See the details on [Lightweight Saga Storage](/guide/durability/sagas.html#light
 The PostgreSQL message persistence and transport is automatically included with the `AddMarten().IntegrateWithWolverine()`
 configuration syntax.
 
+### Aligning the migration advisory lock with Marten
+
+Wolverine takes a session-scoped PostgreSQL advisory lock around `MigrateAsync` to serialize schema migrations
+across concurrent processes (preventing duplicate `CREATE SCHEMA IF NOT EXISTS` races that surface as
+`23505` errors against `pg_namespace_nspname_index`). The default lock id is `4006`. Marten uses `4004`
+by default for its own migrations.
+
+When `IntegrateWithWolverine()` is in use, both frameworks target the same schema. To make them serialize
+against the *same* advisory lock — useful when many test fixtures or service replicas boot in parallel —
+align the two ids:
+
+```csharp
+services.AddMarten(opts =>
+{
+    opts.Connection(connectionString);
+    opts.ApplyChangesLockId = 4004; // default
+})
+.IntegrateWithWolverine();
+
+builder.Host.UseWolverine(opts =>
+{
+    opts.PersistMessagesWithPostgresql(connectionString)
+        // Reuse Marten's lock so Marten and Wolverine migrations serialize together
+        .OverrideMigrationLockId(4004);
+});
+```
+
 

--- a/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
@@ -159,6 +159,15 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
         return false;
     }
 
+    protected override async Task ReleaseLockAsync(int lockId, MySqlConnection connection, CancellationToken token)
+    {
+        var lockName = $"wolverine_{lockId}";
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT RELEASE_LOCK(@lockName)";
+        cmd.Parameters.AddWithValue("@lockName", lockName);
+        await cmd.ExecuteScalarAsync(token).ConfigureAwait(false);
+    }
+
     protected override DbCommand buildFetchSql(MySqlConnection conn, DbObjectName tableName, string[] columnNames,
         int maxRecords)
     {

--- a/src/Persistence/PostgresqlTests/Bugs/Bug_2518_concurrent_migration_advisory_lock.cs
+++ b/src/Persistence/PostgresqlTests/Bugs/Bug_2518_concurrent_migration_advisory_lock.cs
@@ -1,0 +1,110 @@
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Shouldly;
+using Weasel.Core.Migrations;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.RDBMS;
+
+namespace PostgresqlTests.Bugs;
+
+/// <summary>
+/// GH-2518: Concurrent calls to MigrateAsync against a fresh schema must not
+/// race on CREATE SCHEMA IF NOT EXISTS. Wolverine acquires a session-scoped
+/// advisory lock around the migration to serialize across processes.
+/// </summary>
+public class Bug_2518_concurrent_migration_advisory_lock : PostgresqlContext
+{
+    private const string TestSchemaName = "concurrent_migration_2518";
+
+    [Fact]
+    public async Task concurrent_migrate_async_calls_do_not_race_on_create_schema()
+    {
+        // Drop the schema first so we exercise the CREATE SCHEMA path on every store
+        await dropSchemaAsync();
+
+        const int concurrency = 16;
+        var stores = Enumerable.Range(0, concurrency).Select(_ => buildStore()).ToArray();
+
+        try
+        {
+            var migrations = stores.Select(s => s.Admin.MigrateAsync()).ToArray();
+
+            // All concurrent migrations must complete without throwing — the advisory
+            // lock serializes them so only one runs the DDL at a time.
+            await Task.WhenAll(migrations);
+        }
+        finally
+        {
+            foreach (var store in stores)
+            {
+                await store.DisposeAsync();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task migration_lock_id_is_actually_held_during_migration()
+    {
+        // Verify the migration lock primitive itself works: while one connection holds
+        // the configured MigrationLockId, another cannot acquire it.
+        var lockId = new DatabaseSettings().MigrationLockId;
+
+        await using var holder = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await holder.OpenAsync();
+
+        await using var contender = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await contender.OpenAsync();
+
+        var holderResult = await holder.TryGetGlobalLock(lockId);
+        try
+        {
+            holderResult.ShouldBe(AttainLockResult.Success);
+
+            var contenderResult = await contender.TryGetGlobalLock(lockId);
+            contenderResult.Succeeded.ShouldBeFalse(
+                "A second session must not be able to acquire the same advisory lock");
+        }
+        finally
+        {
+            await holder.ReleaseGlobalLock(lockId);
+        }
+
+        // After release, contender can acquire it
+        var afterRelease = await contender.TryGetGlobalLock(lockId);
+        try
+        {
+            afterRelease.ShouldBe(AttainLockResult.Success);
+        }
+        finally
+        {
+            await contender.ReleaseGlobalLock(lockId);
+        }
+    }
+
+    private static PostgresqlMessageStore buildStore()
+    {
+        var settings = new DatabaseSettings
+        {
+            ConnectionString = Servers.PostgresConnectionString,
+            Role = MessageStoreRole.Main,
+            SchemaName = TestSchemaName
+        };
+
+        var dataSource = NpgsqlDataSource.Create(Servers.PostgresConnectionString);
+        return new PostgresqlMessageStore(settings, new DurabilitySettings(), dataSource,
+            NullLogger<PostgresqlMessageStore>.Instance);
+    }
+
+    private static async Task dropSchemaAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"DROP SCHEMA IF EXISTS {TestSchemaName} CASCADE";
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
@@ -73,6 +73,17 @@ public interface IPostgresqlBackedPersistence
     IPostgresqlBackedPersistence OverrideScheduledJobLockId(int lockId);
 
     /// <summary>
+    /// Override the PostgreSQL advisory lock identifier that Wolverine uses to serialize
+    /// schema migrations across concurrent processes. The default is 4006. Set this to
+    /// match Marten's <c>StoreOptions.ApplyChangesLockId</c> (default 4004) when using
+    /// <c>IntegrateWithWolverine</c> if you want both frameworks to serialize against
+    /// the same lock.
+    /// </summary>
+    /// <param name="lockId"></param>
+    /// <returns></returns>
+    IPostgresqlBackedPersistence OverrideMigrationLockId(int lockId);
+
+    /// <summary>
     /// Should Wolverine provision PostgreSQL command queues for this Wolverine application? The default is true,
     /// but these queues are unnecessary if using an external broker for Wolverine command queues -- and the Wolverine team does recommend
     /// using external brokers for command queues when that's possible
@@ -154,7 +165,7 @@ internal class PostgresqlBackedPersistence : IPostgresqlBackedPersistence, IWolv
     public bool CommandQueuesEnabled { get; set; } = true;
 
     private int _scheduledJobLockId = 0;
-    
+
     // This would be an override
     public int ScheduledJobLockId
     {
@@ -169,6 +180,13 @@ internal class PostgresqlBackedPersistence : IPostgresqlBackedPersistence, IWolv
             _scheduledJobLockId = value;
         }
     }
+
+    /// <summary>
+    /// Advisory lock id used to serialize Wolverine schema migrations across concurrent
+    /// processes. Defaults to 4006. Align with Marten's ApplyChangesLockId (default 4004)
+    /// when using IntegrateWithWolverine to share the lock between the two frameworks.
+    /// </summary>
+    public int MigrationLockId { get; set; } = 4006;
     
 
     public void Configure(WolverineOptions options)
@@ -253,6 +271,7 @@ internal class PostgresqlBackedPersistence : IPostgresqlBackedPersistence, IWolv
             ConnectionString = ConnectionString,
             DataSource = DataSource,
             ScheduledJobLockId = ScheduledJobLockId,
+            MigrationLockId = MigrationLockId,
             SchemaName = EnvelopeStorageSchemaName,
             AddTenantLookupTable = UseMasterTableTenancy,
             TenantConnections = TenantConnections
@@ -309,6 +328,12 @@ internal class PostgresqlBackedPersistence : IPostgresqlBackedPersistence, IWolv
     IPostgresqlBackedPersistence IPostgresqlBackedPersistence.OverrideScheduledJobLockId(int lockId)
     {
         _scheduledJobLockId = lockId;
+        return this;
+    }
+
+    IPostgresqlBackedPersistence IPostgresqlBackedPersistence.OverrideMigrationLockId(int lockId)
+    {
+        MigrationLockId = lockId;
         return this;
     }
 

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -170,6 +170,11 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>
         return await connection.TryGetGlobalLock(lockId, cancellation: token) == AttainLockResult.Success;
     }
 
+    protected override Task ReleaseLockAsync(int lockId, NpgsqlConnection connection, CancellationToken token)
+    {
+        return connection.ReleaseGlobalLock(lockId, cancellation: token);
+    }
+
     protected override DbCommand buildFetchSql(NpgsqlConnection conn, DbObjectName tableName, string[] columnNames, int maxRecords)
     {
         return conn.CreateCommand($"select {columnNames.Join(", ")} from {tableName.QualifiedName} LIMIT :limit")

--- a/src/Persistence/Wolverine.RDBMS/DatabaseSettings.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabaseSettings.cs
@@ -30,6 +30,16 @@ public class DatabaseSettings
     public bool CommandQueuesEnabled { get; set; } = true;
 
     public int ScheduledJobLockId { get; set; } = 20000;
+
+    /// <summary>
+    /// Advisory lock identifier used to serialize Wolverine schema migrations across
+    /// concurrent processes. Prevents race conditions like duplicate CREATE SCHEMA
+    /// failures when many test hosts or service instances boot at once.
+    /// Defaults to 4006. Set this to Marten's <c>StoreOptions.ApplyChangesLockId</c>
+    /// (default 4004) when using <c>IntegrateWithWolverine</c> if you want both
+    /// frameworks' migrations to serialize against the same lock.
+    /// </summary>
+    public int MigrationLockId { get; set; } = 4006;
     
     /// <summary>
     /// Default databases by tenant and connection string to use for seeding

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
@@ -54,13 +54,35 @@ public abstract partial class MessageDatabase<T>
         Func<Task> tryMigrate = async () =>
         {
             await using var conn = await DataSource.OpenConnectionAsync(_cancellation);
+            var typedConn = (T)conn;
+            var lockId = _settings.MigrationLockId;
+            var lockAcquired = false;
 
             try
             {
+                // Acquire a global advisory lock to serialize migrations across processes.
+                // Without this, concurrent CREATE SCHEMA IF NOT EXISTS statements can race
+                // and produce 23505 duplicate-key errors against pg_namespace_nspname_index
+                // (or equivalents on other engines). See GH-2518.
+                lockAcquired = await acquireMigrationLockAsync(lockId, typedConn, _cancellation);
+
                 await migrateAsync(conn);
             }
             finally
             {
+                if (lockAcquired)
+                {
+                    try
+                    {
+                        await ReleaseLockAsync(lockId, typedConn, _cancellation);
+                    }
+                    catch
+                    {
+                        // Best-effort release. The session-scoped lock will be cleaned up
+                        // when the connection closes regardless.
+                    }
+                }
+
                 await conn.CloseAsync();
             }
         };
@@ -82,6 +104,30 @@ public abstract partial class MessageDatabase<T>
             await Task.Delay(new Random().Next(250, 1000).Milliseconds(), _cancellation);
             await tryMigrate();
         }
+    }
+
+    /// <summary>
+    /// Attempt to acquire the migration advisory lock with bounded retries.
+    /// Returns true if acquired (caller is responsible for the migration and release),
+    /// false if not acquired after the retry budget — in which case another process
+    /// is presumably finishing the migration; we proceed and let our own SchemaMigration
+    /// detect "no changes" as a no-op.
+    /// </summary>
+    private async Task<bool> acquireMigrationLockAsync(int lockId, T conn, CancellationToken token)
+    {
+        const int maxAttempts = 10;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            if (await TryAttainLockAsync(lockId, conn, token))
+            {
+                return true;
+            }
+
+            // Linear backoff: 100ms, 200ms, ..., 1000ms (~5.5s total worst case)
+            await Task.Delay(TimeSpan.FromMilliseconds(100 * (attempt + 1)), token);
+        }
+
+        return false;
     }
 
     public async Task<IReadOnlyList<Envelope>> AllIncomingAsync()

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Polling.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Polling.cs
@@ -63,6 +63,16 @@ public abstract partial class MessageDatabase<T>
 
     protected abstract Task<bool> TryAttainLockAsync(int lockId, T connection, CancellationToken token);
 
+    /// <summary>
+    /// Releases a previously-acquired session-scoped advisory lock. Default
+    /// implementation is a no-op for providers (e.g., SQLite) where the lock
+    /// is automatically released when the connection closes.
+    /// </summary>
+    protected virtual Task ReleaseLockAsync(int lockId, T connection, CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
+
     protected abstract DbCommand buildFetchSql(T conn, DbObjectName tableName, string[] columnNames, int maxRecords);
 
     public abstract Task PublishMessageToExternalTableAsync(ExternalMessageTable table, string messageTypeName,

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -362,6 +362,11 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>
         return connection.TryGetGlobalLock(lockId.ToString(), token);
     }
 
+    protected override Task ReleaseLockAsync(int lockId, SqlConnection connection, CancellationToken token)
+    {
+        return connection.ReleaseGlobalLock(lockId.ToString(), token);
+    }
+
     protected override DbCommand buildFetchSql(SqlConnection conn, DbObjectName tableName, string[] columnNames, int maxRecords)
     {
         return conn.CreateCommand($"select top(@limit) {columnNames.Join(", ")} from {tableName.QualifiedName}")


### PR DESCRIPTION
## Summary
Fixes #2518 — concurrent calls to `MessageDatabase.MigrateAsync` against a fresh schema race on `CREATE SCHEMA IF NOT EXISTS` and produce 23505 duplicate-key errors. Wolverine's previous behavior was a generic catch-all retry with random backoff that masked the race rather than preventing it.

## Approach
Mirror Marten's pattern: acquire a session-scoped advisory lock around the migration, run the DDL, release the lock. The new `DatabaseSettings.MigrationLockId` (default `4006`) is configurable so it can be aligned with Marten's `StoreOptions.ApplyChangesLockId` (default `4004`) when both frameworks share a database via `IntegrateWithWolverine`.

## Changes
- **`DatabaseSettings.MigrationLockId`** — new configurable lock id (default `4006`)
- **`MessageDatabase<T>.ReleaseLockAsync`** — new virtual method (no-op default for SQLite)
- **PostgreSQL / SQL Server / MySQL providers** — implement `ReleaseLockAsync`
- **`MigrateAsync`** — bounded-retry lock acquisition (10 attempts, linear backoff up to 1s each), guaranteed release in `finally`, existing catch-all retry preserved as a backstop
- **`PostgresqlBackedPersistence.OverrideMigrationLockId`** — fluent override to align with Marten
- **Tests** — concurrent-migration test + direct lock-primitive verification in `PostgresqlTests/Bugs/Bug_2518_*`
- **Docs** — updated `docs/guide/durability/postgresql.md` with alignment example

## Out of scope
- Automatic alignment with Marten's `ApplyChangesLockId` when `IntegrateWithWolverine` is active — would require coordination from `Wolverine.Marten`. Worth a follow-up issue.
- Oracle (`OracleMessageStore` doesn't inherit from `MessageDatabase<T>` and has its own admin path)

## Test plan
- [x] `Bug_2518_concurrent_migration_advisory_lock.concurrent_migrate_async_calls_do_not_race_on_create_schema` — 16 concurrent migrations against a fresh schema, all complete without errors
- [x] `migration_lock_id_is_actually_held_during_migration` — verifies the advisory lock primitive blocks a second session and is released cleanly
- [x] `PostgresqlMessageStoreTests` (38 tests) all still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)