### PR TITLE
Add query-plan (Specification pattern) support for EF Core

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -328,7 +328,8 @@ const config: UserConfig<DefaultTheme.Config> = {
                                 {text: 'Saga Storage', link: '/guide/durability/efcore/sagas'},
                                 {text: 'Multi-Tenancy', link: '/guide/durability/efcore/multi-tenancy'},
                                 {text: 'Domain Events', link: '/guide/durability/efcore/domain-events'},
-                                {text: 'Database Migrations', link: '/guide/durability/efcore/migrations'}
+                                {text: 'Database Migrations', link: '/guide/durability/efcore/migrations'},
+                                {text: 'Query Plans', link: '/guide/durability/efcore/query-plans'}
 
                             ]},
                         {text: 'Managing Message Storage', link: '/guide/durability/managing'},

--- a/docs/guide/durability/efcore/query-plans.md
+++ b/docs/guide/durability/efcore/query-plans.md
@@ -1,0 +1,135 @@
+# Query Plans <Badge type="tip" text="5.32" />
+
+Wolverine.EntityFrameworkCore provides a first-class implementation of the
+[Specification pattern](https://specification.ardalis.com/) called a *query plan*,
+adapted from Marten's [IQueryPlan](https://martendb.io/documents/querying/compiled-queries.html#query-plans)
+and consistent with it across the Critter Stack.
+
+A query plan is a reusable, testable unit of query logic that encapsulates a
+LINQ query over a `DbContext`. Handlers can consume complex reads without
+reaching for a repository/adapter layer — a middle ground between
+`[Entity]` (primary-key lookup only) and a bespoke repository service.
+
+## Why query plans?
+
+In real-world codebases, handlers frequently need queries more complex than a
+primary-key lookup, but not complex enough to justify an adapter layer. Query
+plans give you:
+
+- **Reusability** — one query class, many callers
+- **Testability** — instantiate and call `FetchAsync` against an in-memory
+  `DbContext`; no host, no mocking
+- **Composability** — parameters flow through the constructor; plans can be
+  combined inside a handler
+- **No magic** — no source generators, no DI registration, no runtime
+  reflection. A plan is just a class with a `Query()` method.
+
+## Defining a plan
+
+Inherit from `QueryPlan<TDbContext, TEntity>` for a single result, or
+`QueryListPlan<TDbContext, TEntity>` for a list:
+
+```csharp
+using Wolverine.EntityFrameworkCore;
+
+public class ActiveOrderForCustomer(Guid customerId) : QueryPlan<OrderDbContext, Order>
+{
+    public override IQueryable<Order> Query(OrderDbContext db)
+        => db.Orders
+            .Where(x => x.CustomerId == customerId && !x.IsArchived)
+            .OrderByDescending(x => x.CreatedAt);
+}
+
+public class OrdersForCustomer(Guid customerId) : QueryListPlan<OrderDbContext, Order>
+{
+    public override IQueryable<Order> Query(OrderDbContext db)
+        => db.Orders
+            .Where(x => x.CustomerId == customerId)
+            .Include(x => x.LineItems)
+            .OrderBy(x => x.CreatedAt);
+}
+```
+
+Everything LINQ-to-EF supports — `Include`, `OrderBy`, `Select`, `Skip`,
+`Take`, projection into DTOs — works inside `Query()`.
+
+## Using a plan in a handler
+
+The simplest pattern: inject your `DbContext` into the handler and execute the
+plan against it.
+
+```csharp
+public static async Task Handle(
+    ApproveOrder msg,
+    OrderDbContext db,
+    CancellationToken ct)
+{
+    var order = await db.QueryByPlanAsync(
+        new ActiveOrderForCustomer(msg.CustomerId), ct);
+
+    if (order is null) throw new InvalidOperationException("No active order");
+
+    order.Approve();
+    // DbContext.SaveChangesAsync() is invoked automatically by Wolverine's
+    // EF Core transactional middleware.
+}
+```
+
+`QueryByPlanAsync` is a convenience extension on `DbContext`. Equivalent to
+calling `plan.FetchAsync(db, ct)` directly.
+
+## Testing a plan in isolation
+
+Because plans have no framework dependencies, you can unit-test them with EF
+Core's in-memory provider (or a real SQLite in-memory connection) without
+starting a Wolverine host:
+
+```csharp
+[Fact]
+public async Task active_order_plan_finds_most_recent_unarchived_order()
+{
+    var options = new DbContextOptionsBuilder<OrderDbContext>()
+        .UseInMemoryDatabase($"plan-test-{Guid.NewGuid():N}")
+        .Options;
+
+    await using var db = new OrderDbContext(options);
+    var customerId = Guid.NewGuid();
+    db.Orders.AddRange(
+        new Order { CustomerId = customerId, IsArchived = true,  CreatedAt = DateTime.UtcNow.AddDays(-2) },
+        new Order { CustomerId = customerId, IsArchived = false, CreatedAt = DateTime.UtcNow.AddHours(-1) });
+    await db.SaveChangesAsync();
+
+    var plan = new ActiveOrderForCustomer(customerId);
+    var result = await plan.FetchAsync(db, default);
+
+    result.ShouldNotBeNull();
+    result.IsArchived.ShouldBeFalse();
+}
+```
+
+## When to reach for a query plan
+
+| Situation                                             | Recommendation                |
+| ----------------------------------------------------- | ----------------------------- |
+| Load one entity by primary key                        | `[Entity]` attribute          |
+| Load by a simple predicate, used in one handler       | Inline LINQ is fine           |
+| Reusable query used across multiple handlers          | **Query plan**                |
+| Complex query with projection/paging/caching rules    | **Query plan**                |
+| Cross-aggregate read model with data shaping          | **Query plan** or a dedicated query service |
+
+## Relationship to Marten
+
+This is the same shape as Marten's `IQueryPlan<T>` (see the
+[Marten docs](https://martendb.io/documents/querying/compiled-queries.html#query-plans))
+with the signature tweaked for EF Core's `DbContext`. If you are using both
+Marten and EF Core in a Critter Stack application, plans on both sides read
+identically.
+
+## Relationship to Ardalis.Specification
+
+The programming model — a class that encapsulates query logic, parameters via
+constructor, composition of `Where`/`Include`/`OrderBy` — matches
+[Ardalis.Specification](https://specification.ardalis.com/). The key
+difference is that query plans expose the raw `IQueryable<T>` builder (so any
+LINQ operator EF Core supports is available) rather than a curated DSL, and
+integrate directly with Wolverine's handler pipeline.

--- a/src/Persistence/EfCoreTests/QueryPlans/QueryPlan_end_to_end.cs
+++ b/src/Persistence/EfCoreTests/QueryPlans/QueryPlan_end_to_end.cs
@@ -1,0 +1,101 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using SharedPersistenceModels.Items;
+using Shouldly;
+using Wolverine;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.SqlServer;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace EfCoreTests.QueryPlans;
+
+/// <summary>
+/// End-to-end smoke test proving a handler can consume an IQueryPlan against
+/// the real EF Core + Wolverine transactional pipeline — not just the
+/// in-memory provider. GH-2505.
+/// </summary>
+[Collection("sqlserver")]
+public class QueryPlan_end_to_end : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddDbContext<ItemsDbContext>(x => x.UseSqlServer(Servers.SqlServerConnectionString));
+            })
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "qpe2e");
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.Policies.AutoApplyTransactions();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+            })
+            .StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task handler_uses_query_plan_to_approve_matching_items()
+    {
+        var prefix = $"qp_{Guid.NewGuid():N}"[..16];
+
+        using (var scope = _host.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ItemsDbContext>();
+            db.Items.Add(new Item { Id = Guid.NewGuid(), Name = $"{prefix}_a", Approved = false });
+            db.Items.Add(new Item { Id = Guid.NewGuid(), Name = $"{prefix}_b", Approved = false });
+            db.Items.Add(new Item { Id = Guid.NewGuid(), Name = "untouched",   Approved = false });
+            await db.SaveChangesAsync();
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new ApproveItemsByPrefix(prefix));
+
+        using var verify = _host.Services.CreateScope();
+        var verifyDb = verify.ServiceProvider.GetRequiredService<ItemsDbContext>();
+
+        var approved = await verifyDb.Items
+            .Where(x => x.Name.StartsWith(prefix) && x.Approved)
+            .CountAsync();
+        approved.ShouldBe(2);
+
+        var untouched = await verifyDb.Items.SingleAsync(x => x.Name == "untouched");
+        untouched.Approved.ShouldBeFalse();
+    }
+}
+
+public record ApproveItemsByPrefix(string Prefix);
+
+public static class ApproveItemsByPrefixHandler
+{
+    public static async Task Handle(ApproveItemsByPrefix msg, ItemsDbContext db, CancellationToken ct)
+    {
+        // The reusable query lives in its own testable class. The handler
+        // just consumes it — no repository, no ad-hoc LINQ embedded in the
+        // handler body.
+        var items = await db.QueryByPlanAsync(new ItemsWithNamePrefix(msg.Prefix), ct);
+
+        foreach (var item in items)
+        {
+            item.Approved = true;
+        }
+    }
+}
+
+public class ItemsWithNamePrefix(string prefix) : QueryListPlan<ItemsDbContext, Item>
+{
+    public override IQueryable<Item> Query(ItemsDbContext db)
+        => db.Items.Where(x => x.Name.StartsWith(prefix));
+}

--- a/src/Persistence/EfCoreTests/QueryPlans/QueryPlan_specs.cs
+++ b/src/Persistence/EfCoreTests/QueryPlans/QueryPlan_specs.cs
@@ -1,0 +1,171 @@
+using Microsoft.EntityFrameworkCore;
+using SharedPersistenceModels.Items;
+using Shouldly;
+using Wolverine.EntityFrameworkCore;
+using Xunit;
+
+namespace EfCoreTests.QueryPlans;
+
+/// <summary>
+/// Unit tests for the Phase 1 query-plan abstractions (GH-2505). These
+/// exercise the base classes and extension method against EF Core's
+/// in-memory provider — no SQL Server required.
+/// </summary>
+public class QueryPlan_specs : IAsyncLifetime
+{
+    private QueryPlanDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        var options = new DbContextOptionsBuilder<QueryPlanDbContext>()
+            .UseInMemoryDatabase($"querypans-{Guid.NewGuid():N}")
+            .Options;
+
+        _db = new QueryPlanDbContext(options);
+
+        _db.Items.AddRange(
+            new Item { Id = Guid.NewGuid(), Name = "Red Chair",   Approved = true  },
+            new Item { Id = Guid.NewGuid(), Name = "Red Table",   Approved = false },
+            new Item { Id = Guid.NewGuid(), Name = "Blue Sofa",   Approved = true  },
+            new Item { Id = Guid.NewGuid(), Name = "Green Lamp",  Approved = true  });
+
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _db.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task query_list_plan_returns_matching_rows()
+    {
+        var plan = new ItemsByNamePrefix("Red");
+        var results = await plan.FetchAsync(_db, CancellationToken.None);
+
+        results.Count.ShouldBe(2);
+        results.ShouldAllBe(x => x.Name.StartsWith("Red"));
+    }
+
+    [Fact]
+    public async Task query_list_plan_returns_empty_when_no_match()
+    {
+        var plan = new ItemsByNamePrefix("Zzz");
+        var results = await plan.FetchAsync(_db, CancellationToken.None);
+
+        results.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task query_plan_returns_first_match()
+    {
+        var plan = new FirstApprovedItem();
+        var result = await plan.FetchAsync(_db, CancellationToken.None);
+
+        result.ShouldNotBeNull();
+        result.Approved.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task query_plan_returns_null_when_no_match()
+    {
+        // Delete everything, then run the plan
+        _db.Items.RemoveRange(_db.Items);
+        await _db.SaveChangesAsync();
+
+        var plan = new FirstApprovedItem();
+        var result = await plan.FetchAsync(_db, CancellationToken.None);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task QueryByPlanAsync_extension_routes_to_the_plan()
+    {
+        var result = await _db.QueryByPlanAsync(new FirstApprovedItem());
+
+        result.ShouldNotBeNull();
+        result.Approved.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task QueryByPlanAsync_extension_works_with_list_plan()
+    {
+        var results = await _db.QueryByPlanAsync(new ItemsByNamePrefix("Red"));
+
+        results.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task QueryByPlanAsync_throws_on_null_plan()
+    {
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await _db.QueryByPlanAsync<QueryPlanDbContext, Item?>(null!));
+    }
+
+    [Fact]
+    public async Task plan_can_compose_ordering_and_projection_inside_query()
+    {
+        var plan = new ItemsOrderedByName();
+        var results = await plan.FetchAsync(_db, CancellationToken.None);
+
+        // Alphabetical: Blue Sofa, Green Lamp, Red Chair, Red Table
+        results.Select(x => x.Name).ShouldBe(new[]
+        {
+            "Blue Sofa", "Green Lamp", "Red Chair", "Red Table"
+        });
+    }
+
+    [Fact]
+    public async Task plan_parameters_via_constructor_flow_through_to_query()
+    {
+        // Verify that distinct parameter values yield distinct results — the
+        // core claim of the specification pattern
+        var red = await _db.QueryByPlanAsync(new ItemsByNamePrefix("Red"));
+        var blue = await _db.QueryByPlanAsync(new ItemsByNamePrefix("Blue"));
+
+        red.Count.ShouldBe(2);
+        blue.Count.ShouldBe(1);
+        blue.Single().Name.ShouldBe("Blue Sofa");
+    }
+}
+
+// Test DbContext — distinct from SampleDbContext to avoid cross-test state
+public class QueryPlanDbContext(DbContextOptions<QueryPlanDbContext> options) : DbContext(options)
+{
+    public DbSet<Item> Items => Set<Item>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<Item>(map =>
+        {
+            map.HasKey(x => x.Id);
+            map.Property(x => x.Name);
+            map.Ignore(x => x.Events);
+        });
+    }
+}
+
+// Sample query plans — live in the test assembly to prove that user-defined
+// plans in arbitrary assemblies work without any registration
+
+public class ItemsByNamePrefix(string prefix) : QueryListPlan<QueryPlanDbContext, Item>
+{
+    public string Prefix { get; } = prefix;
+
+    public override IQueryable<Item> Query(QueryPlanDbContext db)
+        => db.Items.Where(x => x.Name.StartsWith(Prefix));
+}
+
+public class FirstApprovedItem : QueryPlan<QueryPlanDbContext, Item>
+{
+    public override IQueryable<Item> Query(QueryPlanDbContext db)
+        => db.Items.Where(x => x.Approved).OrderBy(x => x.Name);
+}
+
+public class ItemsOrderedByName : QueryListPlan<QueryPlanDbContext, Item>
+{
+    public override IQueryable<Item> Query(QueryPlanDbContext db)
+        => db.Items.OrderBy(x => x.Name);
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/QueryPlans/IQueryPlan.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/QueryPlans/IQueryPlan.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolverine.EntityFrameworkCore;
+
+/// <summary>
+/// A reusable, testable unit of query logic over an Entity Framework Core
+/// <see cref="DbContext"/> — Wolverine's adaptation of Marten's
+/// <c>IQueryPlan</c> and a first-class implementation of the
+/// <see href="https://specification.ardalis.com/">Specification pattern</see>
+/// for EF Core.
+/// <para>
+/// A query plan encapsulates query logic in its own class so handlers can
+/// consume complex reads without reaching for a repository/adapter layer.
+/// Pass parameters through the constructor and execute the plan against any
+/// <see cref="DbContext"/> instance Wolverine provides to the handler (including
+/// tenanted ones).
+/// </para>
+/// </summary>
+/// <typeparam name="TDbContext">The <see cref="DbContext"/> the plan queries.</typeparam>
+/// <typeparam name="TResult">The result type the plan returns.</typeparam>
+public interface IQueryPlan<in TDbContext, TResult> where TDbContext : DbContext
+{
+    /// <summary>
+    /// Execute the query plan and return its result.
+    /// </summary>
+    Task<TResult> FetchAsync(TDbContext dbContext, CancellationToken cancellation);
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/QueryPlans/QueryListPlan.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/QueryPlans/QueryListPlan.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolverine.EntityFrameworkCore;
+
+/// <summary>
+/// Convenience base class for query plans that return a list of entities.
+/// Subclasses override <see cref="Query"/> to build an <see cref="IQueryable{T}"/>;
+/// the base class materializes it with
+/// <see cref="EntityFrameworkQueryableExtensions.ToListAsync{TSource}(IQueryable{TSource}, CancellationToken)"/>.
+/// </summary>
+/// <typeparam name="TDbContext">The <see cref="DbContext"/> the plan queries.</typeparam>
+/// <typeparam name="TEntity">The entity type returned by the plan.</typeparam>
+public abstract class QueryListPlan<TDbContext, TEntity> : IQueryPlan<TDbContext, IReadOnlyList<TEntity>>
+    where TDbContext : DbContext
+    where TEntity : class
+{
+    /// <summary>
+    /// Build the <see cref="IQueryable{T}"/> the plan represents. Called once per
+    /// <see cref="FetchAsync"/> invocation. All LINQ operators (<c>Where</c>,
+    /// <c>Include</c>, <c>OrderBy</c>, <c>Select</c>, etc.) are available.
+    /// </summary>
+    public abstract IQueryable<TEntity> Query(TDbContext dbContext);
+
+    public async Task<IReadOnlyList<TEntity>> FetchAsync(TDbContext dbContext, CancellationToken cancellation)
+    {
+        return await Query(dbContext).ToListAsync(cancellation).ConfigureAwait(false);
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/QueryPlans/QueryPlan.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/QueryPlans/QueryPlan.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolverine.EntityFrameworkCore;
+
+/// <summary>
+/// Convenience base class for query plans that return a single matching entity
+/// (or <c>null</c>). Subclasses override <see cref="Query"/> to build an
+/// <see cref="IQueryable{T}"/>; the base class materializes it with
+/// <see cref="EntityFrameworkQueryableExtensions.FirstOrDefaultAsync{TSource}(IQueryable{TSource}, CancellationToken)"/>.
+/// </summary>
+/// <typeparam name="TDbContext">The <see cref="DbContext"/> the plan queries.</typeparam>
+/// <typeparam name="TEntity">The entity type returned by the plan.</typeparam>
+public abstract class QueryPlan<TDbContext, TEntity> : IQueryPlan<TDbContext, TEntity?>
+    where TDbContext : DbContext
+    where TEntity : class
+{
+    /// <summary>
+    /// Build the <see cref="IQueryable{T}"/> the plan represents. Called once per
+    /// <see cref="FetchAsync"/> invocation. All LINQ operators (<c>Where</c>,
+    /// <c>Include</c>, <c>OrderBy</c>, <c>Select</c>, etc.) are available.
+    /// </summary>
+    public abstract IQueryable<TEntity> Query(TDbContext dbContext);
+
+    public async Task<TEntity?> FetchAsync(TDbContext dbContext, CancellationToken cancellation)
+    {
+        return await Query(dbContext).FirstOrDefaultAsync(cancellation).ConfigureAwait(false);
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/QueryPlans/QueryPlanExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/QueryPlans/QueryPlanExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolverine.EntityFrameworkCore;
+
+/// <summary>
+/// Convenience extension methods for executing <see cref="IQueryPlan{TDbContext,TResult}"/>
+/// instances against a <see cref="DbContext"/>. Parallels Marten's
+/// <c>IQuerySession.QueryByPlanAsync</c>.
+/// </summary>
+public static class QueryPlanExtensions
+{
+    /// <summary>
+    /// Execute a query plan against this <see cref="DbContext"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var order = await db.QueryByPlanAsync(new ActiveOrderForCustomer(customerId), ct);
+    /// </code>
+    /// </example>
+    public static Task<TResult> QueryByPlanAsync<TDbContext, TResult>(
+        this TDbContext dbContext,
+        IQueryPlan<TDbContext, TResult> plan,
+        CancellationToken cancellation = default)
+        where TDbContext : DbContext
+    {
+        if (dbContext == null) throw new ArgumentNullException(nameof(dbContext));
+        if (plan == null) throw new ArgumentNullException(nameof(plan));
+
+        return plan.FetchAsync(dbContext, cancellation);
+    }
+}


### PR DESCRIPTION
## Summary
Phase 1 of #2505. Introduces `Wolverine.EntityFrameworkCore.IQueryPlan<TDbContext, TResult>` plus convenience base classes — the Specification pattern implemented as a first-class concept, patterned after [Marten's IQueryPlan](https://martendb.io/documents/querying/compiled-queries.html#query-plans) and [Ardalis.Specification](https://specification.ardalis.com/).

This fills the gap between `[Entity]` (primary-key lookup only) and a full repository/adapter layer. Handlers can now encapsulate reusable LINQ over a `DbContext` in a testable class, without any code generation or DI plumbing.

## API

```csharp
// Interface — minimal, matches Marten's shape
public interface IQueryPlan<in TDbContext, TResult> where TDbContext : DbContext
{
    Task<TResult> FetchAsync(TDbContext dbContext, CancellationToken cancellation);
}

// Convenience base: single result via FirstOrDefaultAsync
public abstract class QueryPlan<TDb, TEntity> : IQueryPlan<TDb, TEntity?>
    where TDb : DbContext where TEntity : class
{
    public abstract IQueryable<TEntity> Query(TDb db);
}

// Convenience base: list result via ToListAsync
public abstract class QueryListPlan<TDb, TEntity> : IQueryPlan<TDb, IReadOnlyList<TEntity>>
    where TDb : DbContext where TEntity : class
{
    public abstract IQueryable<TEntity> Query(TDb db);
}

// Sugar on DbContext (mirrors Marten's session.QueryByPlanAsync)
await db.QueryByPlanAsync(new ActiveOrderForCustomer(customerId), ct);
```

## User code
```csharp
public class ActiveOrderForCustomer(Guid customerId) : QueryPlan<OrderDbContext, Order>
{
    public override IQueryable<Order> Query(OrderDbContext db)
        => db.Orders.Where(x => x.CustomerId == customerId && !x.IsArchived)
                    .OrderByDescending(x => x.CreatedAt);
}

public static async Task Handle(ApproveOrder msg, OrderDbContext db, CancellationToken ct)
{
    var order = await db.QueryByPlanAsync(new ActiveOrderForCustomer(msg.CustomerId), ct);
    order?.Approve();
}
```

## Design notes
- **Naming matches Marten (`IQueryPlan` / `QueryPlan` / `QueryListPlan`)** rather than `ISpecification` — consistency inside the Critter Stack wins, and avoids conflict with users already using Ardalis.Specification
- **No code generation** — plans are plain classes. Zero DI registration, zero source generators, zero runtime reflection
- **Full `IQueryable<T>` surface** — no custom DSL to learn. `Include`, `OrderBy`, `Select`, `Skip`, `Take`, projection to DTOs all work
- **Testable in isolation** — unit tests use EF Core's in-memory provider, no host required
- **Multi-tenancy compatible** — the plan receives whatever `DbContext` the handler receives (already tenant-scoped by existing middleware)

## Out of scope (deferred to follow-up)
- **Phase 2**: `[FromQueryPlan(typeof(TPlan))]` parameter attribute that constructs the plan from message fields at codegen time (mirrors how `[Entity]` resolves its identity). Worth its own PR once the core shape is settled.
- **Phase 3**: batched query plan (if there's demand — existing `BatchedLoadEntityFrame` infrastructure is the template)

## Files
- **New** under `src/Persistence/Wolverine.EntityFrameworkCore/QueryPlans/`: `IQueryPlan.cs`, `QueryPlan.cs`, `QueryListPlan.cs`, `QueryPlanExtensions.cs`
- **New** tests under `src/Persistence/EfCoreTests/QueryPlans/`: `QueryPlan_specs.cs` (9 unit tests), `QueryPlan_end_to_end.cs` (1 SQL Server integration test)
- **New** docs: `docs/guide/durability/efcore/query-plans.md` + nav entry in `.vitepress/config.mts`

## Test plan
- [x] 9 unit tests against EF Core in-memory provider — constructor parameters, empty results, null results, extension method, ordering, null-arg validation
- [x] 1 end-to-end integration test: handler consumes a plan against real SQL Server + Wolverine's transactional middleware; verifies downstream `SaveChangesAsync` commits the mutations the plan's results triggered
- [x] 18 existing `batch_query_tests` + `end_to_end_efcore_persistence` tests still pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)