### PR TITLE
Auto-execute Marten query specifications from Load methods + [FromQuerySpecification]

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -294,6 +294,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                                 {text: 'Transactional Outbox Support', link: '/guide/durability/marten/outbox'},
                                 {text: 'Transactional Inbox Support', link: '/guide/durability/marten/inbox'},
                                 {text: 'Operation Side Effects', link: '/guide/durability/marten/operations'},
+                                {text: 'Fetching Query Specifications', link: '/guide/durability/marten/fetch-specifications'},
                                 {text: 'Aggregate Handlers and Event Sourcing', link: '/guide/durability/marten/event-sourcing'},
                                 {text: 'Event Forwarding to Wolverine', link: '/guide/durability/marten/event-forwarding'},
                                 {text: 'Event Subscriptions', link: '/guide/durability/marten/subscriptions'},

--- a/docs/guide/durability/marten/fetch-specifications.md
+++ b/docs/guide/durability/marten/fetch-specifications.md
@@ -1,0 +1,177 @@
+# Fetching Query Specifications <Badge type="tip" text="5.x" />
+
+Wolverine recognizes Marten query specifications — either
+[compiled queries](https://martendb.io/documents/querying/compiled-queries.html)
+(`ICompiledQuery<TDoc, TResult>`) or
+[query plans](https://martendb.io/documents/querying/compiled-queries.html#query-plans)
+(`IQueryPlan<T>` / `IBatchQueryPlan<T>`) — when they appear as handler
+dependencies, executes them automatically, and **batches them into a single
+Marten `IBatchedQuery` whenever possible**, including alongside `[Entity]`
+and `[Aggregate]` loads on the same handler.
+
+This gives you two ergonomics for the same underlying machinery:
+
+1. **Return the specification directly from a `Load()` method.** Wolverine
+   sees the return type and wires up execution + relay to `Handle` /
+   `Validate` parameters.
+2. **Annotate a handler parameter with `[FromQuerySpecification]`.**
+   Wolverine constructs the spec from the message (and other variables
+   in scope) and runs it.
+
+Under the hood both paths produce the same codegen — specifications are
+collected and run through a single `CreateBatchQuery()` whenever two or
+more can be batched together.
+
+## Returning a specification from `Load`
+
+The handler's `Load` (or `LoadAsync`) method returns the specification
+object. Wolverine recognizes the return type and executes it; the
+materialized result is what the subsequent `Handle` / `Validate` method
+receives.
+
+```csharp
+public class NoteByIdCompiled : ICompiledQuery<Note, Note?>
+{
+    public Guid NoteId { get; set; }
+
+    public Expression<Func<IMartenQueryable<Note>, Note?>> QueryIs()
+        => q => q.FirstOrDefault(x => x.Id == NoteId);
+}
+
+public class LoadOneNoteHandler
+{
+    // The return type IS the specification. Wolverine runs it and passes
+    // the materialized Note? to Handle.
+    public static NoteByIdCompiled Load(LoadOneNote cmd)
+        => new() { NoteId = cmd.NoteId };
+
+    public static void Handle(LoadOneNote cmd, Note? note)
+    {
+        // note is the materialized query result
+    }
+}
+```
+
+### Tuple returns — multiple specifications in one round-trip
+
+When a `Load` returns a `ValueTuple` of specifications, Wolverine treats
+each tuple element as its own specification and batches them:
+
+```csharp
+public class LoadNoteAndListStarredHandler
+{
+    public static (NoteByIdCompiled, StarredNotesPlan) Load(LoadNoteAndListStarred cmd)
+        => (new() { NoteId = cmd.NoteId }, new());
+
+    public static void Handle(LoadNoteAndListStarred cmd, Note? note, IReadOnlyList<Note> notes)
+    {
+        // Both the Note and the list arrive in one IBatchedQuery round-trip
+    }
+}
+```
+
+The generated code is roughly:
+
+```csharp
+var (spec1, spec2) = Handler.Load(cmd);
+var batch = documentSession.CreateBatchQuery();
+var noteTask  = batch.Query<Note, Note?>(spec1);
+var notesTask = batch.QueryByPlan<IReadOnlyList<Note>>((IBatchQueryPlan<IReadOnlyList<Note>>)spec2);
+await batch.Execute(cancellation);
+var note  = await noteTask;
+var notes = await notesTask;
+Handler.Handle(cmd, note, notes);
+```
+
+## `[FromQuerySpecification]` — spec construction driven by the attribute
+
+When you don't need a dedicated `Load` method — the specification's inputs
+are all available on the message itself — attach
+`[FromQuerySpecification(typeof(TSpec))]` to the handler parameter:
+
+```csharp
+public class LoadNoteViaAttributeHandler
+{
+    public static void Handle(
+        LoadNoteViaAttribute cmd,
+        [FromQuerySpecification(typeof(NoteByIdCompiled))] Note? note)
+    {
+        // Wolverine constructs new NoteByIdCompiled(), sets NoteId from
+        // cmd.NoteId by name match, runs it, and passes the result here.
+    }
+}
+```
+
+Wolverine:
+
+1. Picks the spec's public constructor with the most parameters
+2. Resolves each constructor parameter from variables in scope (message
+   members, route values, headers, claims) by case-insensitive name match
+3. Assigns any remaining public settable properties on the spec from
+   variables in scope — the canonical Marten compiled-query pattern where
+   parameters are properties
+
+On .NET 7+ you can use the generic variant for less ceremony:
+
+```csharp
+public static void Handle(
+    LoadNoteViaAttribute cmd,
+    [FromQuerySpecification<NoteByIdCompiled>] Note? note)
+{
+}
+```
+
+## Batching with `[Entity]`, `[Aggregate]`, and other specs
+
+Specifications, `[Entity]` loads, and `[Aggregate]` loads all share the
+same batching machinery. A handler that mixes them loads everything in
+one `IBatchedQuery` round-trip:
+
+```csharp
+public class ApproveOrderHandler
+{
+    public static (NoteByIdCompiled, StarredNotesPlan) Load(ApproveOrder cmd)
+        => (new() { NoteId = cmd.NoteId }, new());
+
+    public static void Handle(
+        ApproveOrder cmd,
+        Note? note,                         // from compiled query
+        IReadOnlyList<Note> starred,        // from query plan
+        [Entity] Customer customer,         // from [Entity] by id
+        [Aggregate] Order order)            // from [Aggregate] event stream
+    {
+        // All four loads executed in a single IBatchedQuery round-trip.
+    }
+}
+```
+
+## Which specifications can be batched?
+
+| Specification kind | Batched? |
+| ------------------ | -------- |
+| `ICompiledQuery<TDoc, TResult>` | **Always** — via `IBatchedQuery.Query(compiled)` |
+| A class that implements `IBatchQueryPlan<T>` (including anything deriving from `QueryListPlan<T>`) | **Always** — via `IBatchedQuery.QueryByPlan(plan)` |
+| A class that implements only `IQueryPlan<T>` (no batch variant) | **Standalone** — runs via `session.QueryByPlanAsync(plan)` after the batch finishes |
+
+When a plan cannot be batched, it executes as a separate round-trip; the
+rest of the specifications on the same handler still share one batch.
+
+**Tip:** if you're writing a plan that returns a list, prefer inheriting
+from `QueryListPlan<T>` — it implements both `IQueryPlan<IReadOnlyList<T>>`
+and `IBatchQueryPlan<IReadOnlyList<T>>`, so your plan is batch-capable for
+free.
+
+## When to reach for each approach
+
+| Situation | Recommendation |
+| --------- | -------------- |
+| Load a single entity by primary key | `[Entity]` |
+| Load an event-sourced aggregate | `[Aggregate]` / `[ReadAggregate]` / `[WriteAggregate]` |
+| Reusable predicate used in multiple handlers | Extract to an `IQueryPlan<T>` and return from `Load` (or use `[FromQuerySpecification]`) |
+| Hot, repeatedly-executed LINQ query | Extract to `ICompiledQuery<,>` and return from `Load` (or use `[FromQuerySpecification]`) |
+| One-off LINQ that isn't reused elsewhere | Inline in the handler body |
+
+**Refactor heuristic:** when you find the same `session.Query<T>().Where(...)`
+expression in two or more handlers, extract it to a plan or compiled query.
+Return it from `Load`. Wolverine will handle the rest — including batching
+it with other loads on the same handler for a free performance win.

--- a/src/Persistence/MartenTests/fetch_specifications_tests.cs
+++ b/src/Persistence/MartenTests/fetch_specifications_tests.cs
@@ -1,0 +1,260 @@
+using System.Linq.Expressions;
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Resources;
+using Marten;
+using Marten.Linq;
+using Marten.Services.BatchQuerying;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace MartenTests;
+
+/// <summary>
+/// GH-1561 + GH-2527: Load methods that return Marten compiled queries or
+/// IQueryPlans get auto-executed and batched where possible; handler
+/// parameters decorated with [FromQuerySpecification] do the same without
+/// a Load method.
+/// </summary>
+public class fetch_specifications_tests : PostgresqlContext, IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "fetch_specs";
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine();
+
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<LoadOneNoteHandler>()
+                    .IncludeType<ListStarredHandler>()
+                    .IncludeType<LoadNoteAndListStarredHandler>()
+                    .IncludeType<LoadNoteViaAttributeHandler>()
+                    .IncludeType<ListStarredNonBatchableHandler>();
+            })
+            .StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+    }
+
+    private IDocumentStore Store => _host.Services.GetRequiredService<IDocumentStore>();
+
+    private async Task SeedAsync(params Note[] notes)
+    {
+        await using var session = Store.LightweightSession();
+        foreach (var n in notes) session.Store(n);
+        await session.SaveChangesAsync();
+    }
+
+    // ─────────────────── compiled query via Load ───────────────────
+
+    [Fact]
+    public async Task load_method_returning_compiled_query_runs_and_relays_result_to_handler()
+    {
+        var id = Guid.NewGuid();
+        await SeedAsync(new Note { Id = id, Body = "compiled-load" });
+
+        FetchSpecTestState.LastNoteBody = null;
+        await _host.InvokeMessageAndWaitAsync(new LoadOneNote(id));
+
+        FetchSpecTestState.LastNoteBody.ShouldBe("compiled-load");
+    }
+
+    // ─────────────────── query plan via Load ───────────────────
+
+    [Fact]
+    public async Task load_method_returning_query_plan_runs_and_relays_result_to_handler()
+    {
+        FetchSpecTestState.LastCount = -1;
+        await SeedAsync(
+            new Note { Id = Guid.NewGuid(), Body = "plan-1", Starred = true },
+            new Note { Id = Guid.NewGuid(), Body = "plan-2", Starred = true },
+            new Note { Id = Guid.NewGuid(), Body = "plan-3", Starred = false });
+
+        await _host.InvokeMessageAndWaitAsync(new ListStarred());
+
+        // Shared host across tests may already hold starred notes from earlier
+        // test methods — assert at least what we just seeded showed up.
+        FetchSpecTestState.LastCount.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    // ───────────── tuple return: both run batched ─────────────
+
+    [Fact]
+    public async Task load_method_returning_tuple_of_specs_runs_both_and_batches()
+    {
+        var id = Guid.NewGuid();
+        await SeedAsync(
+            new Note { Id = id, Body = "tuple-target", Starred = true },
+            new Note { Id = Guid.NewGuid(), Body = "other-starred", Starred = true });
+
+        FetchSpecTestState.LastNoteBody = null;
+        FetchSpecTestState.LastCount = -1;
+
+        await _host.InvokeMessageAndWaitAsync(new LoadNoteAndListStarred(id));
+
+        FetchSpecTestState.LastNoteBody.ShouldBe("tuple-target");
+        FetchSpecTestState.LastCount.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    // ─────────────── [FromQuerySpecification] param ───────────────
+
+    [Fact]
+    public async Task from_query_specification_attribute_runs_spec_from_message_fields()
+    {
+        var id = Guid.NewGuid();
+        await SeedAsync(new Note { Id = id, Body = "attribute-target" });
+
+        FetchSpecTestState.LastNoteBody = null;
+        await _host.InvokeMessageAndWaitAsync(new LoadNoteViaAttribute(id));
+
+        FetchSpecTestState.LastNoteBody.ShouldBe("attribute-target");
+    }
+
+    // ─────────────── non-batchable plan falls back to single fetch ───────────────
+
+    [Fact]
+    public async Task non_batchable_query_plan_falls_back_to_single_fetch()
+    {
+        await SeedAsync(
+            new Note { Id = Guid.NewGuid(), Body = "non-batch-a", Starred = true },
+            new Note { Id = Guid.NewGuid(), Body = "non-batch-b", Starred = false });
+
+        FetchSpecTestState.LastCount = -1;
+        await _host.InvokeMessageAndWaitAsync(new ListStarredNonBatchable());
+
+        FetchSpecTestState.LastCount.ShouldBeGreaterThanOrEqualTo(1);
+    }
+}
+
+// ─────────────────── Document type ───────────────────
+
+public class Note
+{
+    public Guid Id { get; set; }
+    public string Body { get; set; } = string.Empty;
+    public bool Starred { get; set; }
+}
+
+// ─────────────────── Messages ───────────────────
+
+public record LoadOneNote(Guid NoteId);
+public record ListStarred();
+public record LoadNoteAndListStarred(Guid NoteId);
+public record LoadNoteViaAttribute(Guid NoteId);
+public record ListStarredNonBatchable();
+
+// ─────────────────── Specifications ───────────────────
+
+// Compiled query — always batchable
+public class NoteByIdCompiled : ICompiledQuery<Note, Note?>
+{
+    public Guid NoteId { get; set; }
+
+    public Expression<Func<IMartenQueryable<Note>, Note?>> QueryIs()
+    {
+        return q => q.FirstOrDefault(x => x.Id == NoteId);
+    }
+}
+
+// Query plan using QueryListPlan<T> — implements both IQueryPlan<...> AND IBatchQueryPlan<...>
+public class StarredNotesPlan : QueryListPlan<Note>
+{
+    public override IQueryable<Note> Query(IQuerySession session)
+        => session.Query<Note>().Where(x => x.Starred);
+}
+
+// Plan implementing ONLY IQueryPlan<T> — Wolverine should fall back to single fetch
+public class StarredNotesNonBatchPlan : IQueryPlan<IReadOnlyList<Note>>
+{
+    public async Task<IReadOnlyList<Note>> Fetch(IQuerySession session, CancellationToken token)
+    {
+        // Uses LINQ ToListAsync; does NOT implement IBatchQueryPlan<T>
+        return await session.Query<Note>().Where(x => x.Starred).ToListAsync(token);
+    }
+}
+
+// ─────────────────── Handlers ───────────────────
+
+// Shared state for test assertions
+public static class FetchSpecTestState
+{
+    public static string? LastNoteBody;
+    public static int LastCount = -1;
+}
+
+// Compiled query via Load — Wolverine detects ICompiledQuery<Note, Note?>
+// on the return, executes it, and passes Note? to Handle.
+public class LoadOneNoteHandler
+{
+    public static NoteByIdCompiled Load(LoadOneNote cmd) => new() { NoteId = cmd.NoteId };
+
+    public static void Handle(LoadOneNote cmd, Note? note)
+    {
+        FetchSpecTestState.LastNoteBody = note?.Body;
+    }
+}
+
+// Query plan via Load — batch-capable (QueryListPlan).
+public class ListStarredHandler
+{
+    public static StarredNotesPlan Load(ListStarred cmd) => new();
+
+    public static void Handle(ListStarred cmd, IReadOnlyList<Note> notes)
+    {
+        FetchSpecTestState.LastCount = notes.Count;
+    }
+}
+
+// Tuple return — both run, batched into one IBatchedQuery
+public class LoadNoteAndListStarredHandler
+{
+    public static (NoteByIdCompiled, StarredNotesPlan) Load(LoadNoteAndListStarred cmd)
+        => (new() { NoteId = cmd.NoteId }, new());
+
+    public static void Handle(LoadNoteAndListStarred cmd, Note? note, IReadOnlyList<Note> notes)
+    {
+        FetchSpecTestState.LastNoteBody = note?.Body;
+        FetchSpecTestState.LastCount = notes.Count;
+    }
+}
+
+// Attribute-driven — construct spec from message fields, no Load needed.
+// Ctor-param "noteId" matches message member "NoteId" (case-insensitively).
+public class LoadNoteViaAttributeHandler
+{
+    public static void Handle(
+        LoadNoteViaAttribute cmd,
+        [FromQuerySpecification(typeof(NoteByIdCompiled))] Note? note)
+    {
+        FetchSpecTestState.LastNoteBody = note?.Body;
+    }
+}
+
+// Non-batchable plan (IQueryPlan<T>-only) — Wolverine falls back to single fetch
+public class ListStarredNonBatchableHandler
+{
+    public static StarredNotesNonBatchPlan Load(ListStarredNonBatchable cmd) => new();
+
+    public static void Handle(ListStarredNonBatchable cmd, IReadOnlyList<Note> notes)
+    {
+        FetchSpecTestState.LastCount = notes.Count;
+    }
+}

--- a/src/Persistence/Wolverine.Marten/Codegen/ConstructSpecificationFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/ConstructSpecificationFrame.cs
@@ -1,0 +1,59 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.Marten.Codegen;
+
+/// <summary>
+/// Constructs a Marten query specification (compiled query or query plan) at
+/// codegen time. Supports both constructor injection (resolve ctor parameters
+/// from other variables in the method) and property injection (resolve public
+/// settable properties — the canonical pattern for Marten compiled queries).
+/// Used by <see cref="FromQuerySpecificationAttribute"/> to turn a handler
+/// parameter decorated with that attribute into a spec-construct-then-fetch
+/// pair of frames.
+/// </summary>
+internal class ConstructSpecificationFrame : SyncFrame
+{
+    private readonly Variable[] _ctorArgs;
+    private readonly (string PropertyName, Variable Source)[] _propertyAssignments;
+
+    public ConstructSpecificationFrame(
+        Type specificationType,
+        Variable[] ctorArgs,
+        (string PropertyName, Variable Source)[] propertyAssignments,
+        string variableName)
+    {
+        if (specificationType == null) throw new ArgumentNullException(nameof(specificationType));
+        _ctorArgs = ctorArgs ?? throw new ArgumentNullException(nameof(ctorArgs));
+        _propertyAssignments = propertyAssignments ?? throw new ArgumentNullException(nameof(propertyAssignments));
+
+        Spec = new Variable(specificationType, variableName, this);
+    }
+
+    /// <summary>
+    /// The constructed specification variable, ready to be consumed by a
+    /// <see cref="FetchSpecificationFrame"/>.
+    /// </summary>
+    public Variable Spec { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        var args = string.Join(", ", _ctorArgs.Select(a => a.Usage));
+        writer.WriteLine($"var {Spec.Usage} = new {Spec.VariableType.FullNameInCode()}({args});");
+
+        foreach (var (propertyName, source) in _propertyAssignments)
+        {
+            writer.WriteLine($"{Spec.Usage}.{propertyName} = {source.Usage};");
+        }
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        foreach (var a in _ctorArgs) yield return a;
+        foreach (var (_, source) in _propertyAssignments) yield return source;
+    }
+}

--- a/src/Persistence/Wolverine.Marten/Codegen/FetchSpecificationFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/FetchSpecificationFrame.cs
@@ -1,0 +1,191 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Marten;
+using Marten.Linq;
+using Marten.Services.BatchQuerying;
+
+namespace Wolverine.Marten.Codegen;
+
+/// <summary>
+/// Codegen frame that executes a Marten query "specification" — either an
+/// <see cref="ICompiledQuery{TDoc,TOut}"/> or an <see cref="IQueryPlan{T}"/> —
+/// and produces the query's result as a new variable for downstream frames
+/// (Handle, Validate, After) to consume.
+///
+/// <para>
+/// Detects at construction time whether the spec supports batching
+/// (<see cref="IBatchQueryPlan{T}"/> for plans, always yes for compiled
+/// queries) and routes execution through <see cref="MartenBatchingPolicy"/>
+/// when multiple batchable operations are present in the same method.
+/// </para>
+/// </summary>
+internal class FetchSpecificationFrame : AsyncFrame, IBatchableFrame
+{
+    private readonly Variable _spec;
+    private readonly SpecKind _kind;
+    private readonly Type? _docType;
+    private readonly Type _resultType;
+
+    private Variable? _session;
+    private Variable? _cancellation;
+    private Variable? _batchQuery;
+    private Variable? _batchItem;
+
+    public FetchSpecificationFrame(Variable specVar)
+    {
+        _spec = specVar ?? throw new ArgumentNullException(nameof(specVar));
+
+        var specType = specVar.VariableType;
+
+        var compiled = specType.FindInterfaceThatCloses(typeof(ICompiledQuery<,>));
+        var batchPlan = specType.FindInterfaceThatCloses(typeof(IBatchQueryPlan<>));
+        var queryPlan = specType.FindInterfaceThatCloses(typeof(IQueryPlan<>));
+
+        if (compiled != null)
+        {
+            _kind = SpecKind.Compiled;
+            var args = compiled.GetGenericArguments();
+            _docType = args[0];
+            _resultType = args[1];
+            CanBatch = true;
+        }
+        else if (batchPlan != null)
+        {
+            _kind = SpecKind.Plan;
+            _resultType = batchPlan.GetGenericArguments()[0];
+            CanBatch = true;
+            IsBatchOnlyPlan = queryPlan is null;
+        }
+        else if (queryPlan != null)
+        {
+            _kind = SpecKind.Plan;
+            _resultType = queryPlan.GetGenericArguments()[0];
+            // batchable only if spec ALSO implements IBatchQueryPlan<T>
+            CanBatch = false;
+        }
+        else
+        {
+            throw new ArgumentException(
+                $"Type {specType.FullName} does not implement ICompiledQuery<,>, IQueryPlan<>, or IBatchQueryPlan<>",
+                nameof(specVar));
+        }
+
+        // Result variable — becomes available to downstream frames by type
+        // Name derived from the spec var's usage name so two fetches for the same result
+        // type don't collide (which can happen if the handler uses multiple compiled
+        // queries that all produce the same T).
+        var resultName = $"{specVar.Usage}_result";
+        Result = new Variable(_resultType, resultName, this);
+    }
+
+    /// <summary>
+    /// True if this spec can participate in a Marten <see cref="IBatchedQuery"/>
+    /// (all compiled queries, and plans that implement <see cref="IBatchQueryPlan{T}"/>).
+    /// </summary>
+    public bool CanBatch { get; }
+
+    /// <summary>
+    /// True for plans that implement <see cref="IBatchQueryPlan{T}"/> but NOT
+    /// the single-execution <see cref="IQueryPlan{T}"/> — these must always run
+    /// inside a batch (they have no standalone execution path).
+    /// </summary>
+    public bool IsBatchOnlyPlan { get; }
+
+    /// <summary>
+    /// Variable produced by this frame, typed as the spec's result type.
+    /// Downstream frames (Handle / Validate / After) bind to it by type.
+    /// </summary>
+    public Variable Result { get; }
+
+    // ── IBatchableFrame ───────────────────────────────────────────────
+
+    public void EnlistInBatchQuery(Variable batchQuery)
+    {
+        _batchQuery = batchQuery;
+        _batchItem = new Variable(
+            typeof(Task<>).MakeGenericType(_resultType),
+            $"{_spec.Usage}_BatchItem",
+            this);
+    }
+
+    public void WriteCodeToEnlistInBatchQuery(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_batchItem == null || _batchQuery == null) return;
+
+        if (_kind == SpecKind.Compiled)
+        {
+            writer.WriteLine(
+                $"var {_batchItem.Usage} = {_batchQuery.Usage}.{nameof(IBatchedQuery.Query)}" +
+                $"<{_docType!.FullNameInCode()}, {_resultType.FullNameInCode()}>({_spec.Usage});");
+        }
+        else
+        {
+            // Plan path — always uses IBatchQueryPlan<T>. Frame is only
+            // enlisted if CanBatch is true, which means either the plan
+            // type implements IBatchQueryPlan<T> directly, or (for plans
+            // that implement only IBatchQueryPlan<T>) it's batch-only.
+            var batchPlanType = typeof(IBatchQueryPlan<>).MakeGenericType(_resultType).FullNameInCode();
+            writer.WriteLine(
+                $"var {_batchItem.Usage} = {_batchQuery.Usage}.{nameof(IBatchedQuery.QueryByPlan)}" +
+                $"<{_resultType.FullNameInCode()}>(({batchPlanType}){_spec.Usage});");
+        }
+    }
+
+    // ── Frame ─────────────────────────────────────────────────────────
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_batchItem != null)
+        {
+            // Batched path — the Query/QueryByPlan call was already emitted inside
+            // MartenBatchFrame. Here we resolve the pending Task<T> into the result
+            // variable that downstream frames consume.
+            writer.WriteLine($"var {Result.Usage} = await {_batchItem.Usage}.ConfigureAwait(false);");
+        }
+        else
+        {
+            // Standalone path — emit direct session call
+            if (_kind == SpecKind.Compiled)
+            {
+                writer.WriteLine(
+                    $"var {Result.Usage} = await {_session!.Usage}.{nameof(IQuerySession.QueryAsync)}" +
+                    $"<{_docType!.FullNameInCode()}, {_resultType.FullNameInCode()}>" +
+                    $"({_spec.Usage}, {_cancellation!.Usage}).ConfigureAwait(false);");
+            }
+            else
+            {
+                writer.WriteLine(
+                    $"var {Result.Usage} = await {_session!.Usage}.{nameof(IQuerySession.QueryByPlanAsync)}" +
+                    $"<{_resultType.FullNameInCode()}>({_spec.Usage}, {_cancellation!.Usage}).ConfigureAwait(false);");
+            }
+        }
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        yield return _spec;
+
+        if (_batchQuery != null)
+        {
+            yield return _batchQuery;
+        }
+        else
+        {
+            _session = chain.FindVariable(typeof(IQuerySession));
+            yield return _session;
+
+            _cancellation = chain.FindVariable(typeof(CancellationToken));
+            yield return _cancellation;
+        }
+    }
+
+    private enum SpecKind
+    {
+        Compiled,
+        Plan
+    }
+}

--- a/src/Persistence/Wolverine.Marten/Codegen/MartenQueryingFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/MartenQueryingFrame.cs
@@ -35,6 +35,11 @@ internal class MartenBatchingPolicy : IMethodPreCompilationPolicy
         // Natural key aggregate loads cannot be batched because IBatchedQuery
         // does not have a FetchForWriting<T, TNaturalKey> overload
         if (frame is LoadAggregateFrame laf && laf.IsNaturalKey) return false;
+
+        // A query specification that implements only IQueryPlan<T> (no
+        // IBatchQueryPlan<T>) must execute standalone.
+        if (frame is FetchSpecificationFrame fsf && !fsf.CanBatch) return false;
+
         return true;
     }
 

--- a/src/Persistence/Wolverine.Marten/Codegen/QuerySpecificationPolicy.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/QuerySpecificationPolicy.cs
@@ -1,0 +1,104 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Marten;
+using Marten.Linq;
+
+namespace Wolverine.Marten.Codegen;
+
+/// <summary>
+/// Method pre-compilation policy that detects when a frame produces a variable
+/// whose type is a Marten query "specification" — <see cref="ICompiledQuery{TDoc,TOut}"/>
+/// or <see cref="IQueryPlan{T}"/> (or <see cref="IBatchQueryPlan{T}"/>) — and
+/// injects a <see cref="FetchSpecificationFrame"/> to execute it and produce
+/// the materialized result as a downstream-consumable variable.
+///
+/// <para>
+/// This enables the user ergonomic of returning a spec instance directly from a
+/// <c>Load()</c> / <c>LoadAsync()</c> method, possibly as part of a tuple,
+/// without wrapping in a marker type:
+/// </para>
+///
+/// <code>
+/// public static OrderByIdCompiled LoadOrder(ApproveOrder cmd)
+///     =&gt; new OrderByIdCompiled(cmd.OrderId);
+///
+/// public static LineItemsForOrder LoadItems(ApproveOrder cmd)
+///     =&gt; new LineItemsForOrder(cmd.OrderId);
+///
+/// public static void Handle(ApproveOrder cmd, Order order, IReadOnlyList&lt;LineItem&gt; items)
+///     =&gt; ... // Wolverine codegen has fetched both specs, batched where possible
+/// </code>
+///
+/// <para>
+/// Runs BEFORE <see cref="MartenBatchingPolicy"/> so that injected
+/// <see cref="FetchSpecificationFrame"/>s (which are <see cref="IBatchableFrame"/>)
+/// are picked up and grouped into a single <see cref="Marten.Services.BatchQuerying.IBatchedQuery"/>.
+/// </para>
+/// </summary>
+internal class QuerySpecificationPolicy : IMethodPreCompilationPolicy
+{
+    public void Apply(IGeneratedMethod method)
+    {
+        // Snapshot existing frames first — we'll mutate method.Frames as we go.
+        var frames = method.Frames.ToList();
+
+        foreach (var frame in frames)
+        {
+            // Skip our own injected machinery — ConstructSpecificationFrame is
+            // already paired with a FetchSpecificationFrame by
+            // FromQuerySpecificationAttribute; both are invisible to this policy.
+            if (frame is FetchSpecificationFrame) continue;
+            if (frame is ConstructSpecificationFrame) continue;
+
+            // Find all Create-d variables whose type is a query specification.
+            // A single frame may produce multiple specs (ValueTuple unpacking from
+            // a Load method that returns e.g. (OrderByIdCompiled, LineItemsForOrder)).
+            var specVars = frame.Creates.Where(v => IsSpecification(v.VariableType)).ToList();
+            if (specVars.Count == 0) continue;
+
+            // Insert a FetchSpecificationFrame immediately after the frame that
+            // produced the spec var. Iterate in reverse so indexes stay stable.
+            var baseIndex = method.Frames.IndexOf(frame);
+            foreach (var specVar in specVars)
+            {
+                var fetchFrame = new FetchSpecificationFrame(specVar);
+                method.Frames.Insert(baseIndex + 1, fetchFrame);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="type"/> implements any of the Marten
+    /// specification contracts (compiled query, query plan, or batch query plan).
+    /// Guards against false positives by requiring the closure to be on Marten's
+    /// own namespaces — a user type that happens to implement a custom
+    /// <c>IQueryPlan&lt;T&gt;</c> from a different library will not match.
+    /// </summary>
+    private static bool IsSpecification(Type type)
+    {
+        if (type == null) return false;
+
+        // ICompiledQuery<TDoc, TResult>
+        var compiled = type.FindInterfaceThatCloses(typeof(ICompiledQuery<,>));
+        if (compiled is not null && compiled.Namespace == typeof(ICompiledQuery<,>).Namespace)
+        {
+            return true;
+        }
+
+        var batchPlan = type.FindInterfaceThatCloses(typeof(IBatchQueryPlan<>));
+        if (batchPlan is not null && batchPlan.Namespace == typeof(IBatchQueryPlan<>).Namespace)
+        {
+            return true;
+        }
+
+        var queryPlan = type.FindInterfaceThatCloses(typeof(IQueryPlan<>));
+        if (queryPlan is not null && queryPlan.Namespace == typeof(IQueryPlan<>).Namespace)
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Persistence/Wolverine.Marten/FromQuerySpecificationAttribute.cs
+++ b/src/Persistence/Wolverine.Marten/FromQuerySpecificationAttribute.cs
@@ -1,0 +1,182 @@
+using System.Reflection;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Marten;
+using Marten.Linq;
+using Wolverine.Attributes;
+using Wolverine.Configuration;
+using Wolverine.Marten.Codegen;
+
+namespace Wolverine.Marten;
+
+/// <summary>
+/// Marks a handler or HTTP endpoint parameter as the result of executing a Marten
+/// query specification — either an <see cref="ICompiledQuery{TDoc,TOut}"/> or an
+/// <see cref="IQueryPlan{T}"/>. Wolverine constructs the specification by matching
+/// its constructor parameters against other variables in scope (message members,
+/// route values, headers, claims) and executes it at codegen time, batching with
+/// other batch-capable loads on the same handler when possible.
+///
+/// <para>
+/// Use this attribute when you want a specification-driven load tied directly
+/// to the handler signature without writing a <c>Load()</c> method. When you
+/// need complex construction logic, prefer returning the specification instance
+/// directly from a <c>Load()</c> method — Wolverine will detect and execute it
+/// the same way.
+/// </para>
+/// </summary>
+/// <example>
+/// <code>
+/// public static void Handle(
+///     ApproveOrder cmd,
+///     [FromQuerySpecification(typeof(OrderByIdCompiled))] Order order,
+///     [FromQuerySpecification(typeof(LineItemsForOrder))] IReadOnlyList&lt;LineItem&gt; items)
+/// {
+///     // Wolverine has built both specs from cmd's fields, batched them, and
+///     // passed the materialized results to this handler.
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class FromQuerySpecificationAttribute : WolverineParameterAttribute
+{
+    /// <summary>
+    /// Create a new <see cref="FromQuerySpecificationAttribute"/>.
+    /// </summary>
+    /// <param name="specificationType">
+    /// Concrete type implementing either <see cref="ICompiledQuery{TDoc,TOut}"/>
+    /// or <see cref="IQueryPlan{T}"/>. Must have a public constructor whose
+    /// parameters can be resolved from the handler's message / route / context.
+    /// </param>
+    public FromQuerySpecificationAttribute(Type specificationType)
+    {
+        SpecificationType = specificationType ?? throw new ArgumentNullException(nameof(specificationType));
+
+        if (!IsValidSpecification(specificationType))
+        {
+            throw new ArgumentException(
+                $"Type {specificationType.FullName} does not implement Marten's ICompiledQuery<,>, IQueryPlan<>, or IBatchQueryPlan<>.",
+                nameof(specificationType));
+        }
+
+        ValueSource = ValueSource.Anything;
+    }
+
+    /// <summary>
+    /// The specification type Wolverine will construct and execute.
+    /// </summary>
+    public Type SpecificationType { get; }
+
+    public override Variable Modify(IChain chain, ParameterInfo parameter, IServiceContainer container,
+        GenerationRules rules)
+    {
+        var ctor = ChoosePublicConstructor(SpecificationType);
+        var ctorParameters = ctor.GetParameters();
+
+        var args = new Variable[ctorParameters.Length];
+        for (var i = 0; i < ctorParameters.Length; i++)
+        {
+            var p = ctorParameters[i];
+            if (!chain.TryFindVariable(p.Name!, ValueSource, p.ParameterType, out var found))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot resolve constructor parameter '{p.Name}' of type {p.ParameterType.FullNameInCode()} " +
+                    $"on specification type {SpecificationType.FullNameInCode()}. Make sure the parameter name " +
+                    "matches a message member, route value, header, or other variable in scope.");
+            }
+            args[i] = found;
+        }
+
+        // Marten compiled queries typically declare their parameters as public
+        // settable properties rather than constructor arguments. Resolve any
+        // such property whose name matches a variable in scope and emit an
+        // assignment after construction. Writable instance properties only —
+        // static and read-only properties are left alone.
+        var propertyAssignments = new List<(string, Variable)>();
+        foreach (var prop in SpecificationType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!prop.CanWrite) continue;
+            if (prop.GetSetMethod(nonPublic: false) is null) continue;
+            // Skip properties already satisfied by constructor args (matched by name)
+            if (ctorParameters.Any(cp => string.Equals(cp.Name, prop.Name, StringComparison.OrdinalIgnoreCase)))
+                continue;
+
+            if (chain.TryFindVariable(prop.Name, ValueSource, prop.PropertyType, out var source))
+            {
+                propertyAssignments.Add((prop.Name, source));
+            }
+        }
+
+        var specVarName = $"{parameter.Name}_spec";
+        var construct = new ConstructSpecificationFrame(SpecificationType, args, propertyAssignments.ToArray(), specVarName);
+        chain.Middleware.Add(construct);
+
+        var fetch = new FetchSpecificationFrame(construct.Spec);
+        chain.Middleware.Add(fetch);
+
+        fetch.Result.OverrideName(parameter.Name!);
+        return fetch.Result;
+    }
+
+    private static ConstructorInfo ChoosePublicConstructor(Type type)
+    {
+        var ctors = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+        if (ctors.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"Specification type {type.FullNameInCode()} has no public constructors.");
+        }
+
+        if (ctors.Length == 1) return ctors[0];
+
+        // Prefer the constructor with the most parameters — matches typical
+        // "primary constructor with data, optional helper ctor for serialization"
+        // patterns commonly seen in compiled-query / plan classes.
+        return ctors.OrderByDescending(c => c.GetParameters().Length).First();
+    }
+
+    private static bool IsValidSpecification(Type type)
+    {
+        if (type.IsInterface || type.IsAbstract) return false;
+
+        var compiled = type.FindInterfaceThatCloses(typeof(ICompiledQuery<,>));
+        if (compiled is not null && compiled.Namespace == typeof(ICompiledQuery<,>).Namespace)
+        {
+            return true;
+        }
+
+        var batchPlan = type.FindInterfaceThatCloses(typeof(IBatchQueryPlan<>));
+        if (batchPlan is not null && batchPlan.Namespace == typeof(IBatchQueryPlan<>).Namespace)
+        {
+            return true;
+        }
+
+        var queryPlan = type.FindInterfaceThatCloses(typeof(IQueryPlan<>));
+        if (queryPlan is not null && queryPlan.Namespace == typeof(IQueryPlan<>).Namespace)
+        {
+            return true;
+        }
+
+        return false;
+    }
+}
+
+/// <summary>
+/// Generic variant of <see cref="FromQuerySpecificationAttribute"/> for C# 11+
+/// callers (targeting .NET 7 and newer). Equivalent to
+/// <c>[FromQuerySpecification(typeof(TSpecification))]</c> but avoids the
+/// <c>typeof(...)</c> ceremony.
+/// </summary>
+/// <typeparam name="TSpecification">
+/// Concrete type implementing either <see cref="ICompiledQuery{TDoc,TOut}"/>
+/// or <see cref="IQueryPlan{T}"/>.
+/// </typeparam>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class FromQuerySpecificationAttribute<TSpecification> : FromQuerySpecificationAttribute
+{
+    public FromQuerySpecificationAttribute() : base(typeof(TSpecification))
+    {
+    }
+}

--- a/src/Persistence/Wolverine.Marten/MartenIntegration.cs
+++ b/src/Persistence/Wolverine.Marten/MartenIntegration.cs
@@ -68,6 +68,11 @@ public class MartenIntegration : IWolverineExtension, IEventForwarding
 
         options.Policies.Add<MartenAggregateHandlerStrategy>();
         
+        // QuerySpecificationPolicy detects ICompiledQuery/IQueryPlan-typed variables
+        // produced by Load/LoadAsync methods and injects FetchSpecificationFrames to
+        // execute them. Must run BEFORE MartenBatchingPolicy so those injected frames
+        // (which are IBatchableFrame) are grouped into a single batched query.
+        options.CodeGeneration.MethodPreCompilation.Add(new QuerySpecificationPolicy());
         options.CodeGeneration.MethodPreCompilation.Add(new MartenBatchingPolicy());
 
         options.Discovery.CustomizeHandlerDiscovery(x =>


### PR DESCRIPTION
## Summary

Closes #1561 and ships the batching infrastructure portion of #2527.

Wolverine now recognizes Marten query specifications — `ICompiledQuery<TDoc, TResult>` and `IQueryPlan<T>` / `IBatchQueryPlan<T>` — wherever they appear as handler dependencies, executes them automatically, and **batches them into a single `IBatchedQuery` round-trip whenever possible** (including alongside `[Entity]` and `[Aggregate]` loads on the same handler).

## Two ergonomics, one pipeline

### 1. Return the specification directly from `Load` / `LoadAsync`

```csharp
public class LoadOneNoteHandler
{
    public static NoteByIdCompiled Load(LoadOneNote cmd)
        => new() { NoteId = cmd.NoteId };

    public static void Handle(LoadOneNote cmd, Note? note)
    {
        // note is the materialized query result
    }
}
```

**Tuple returns** are supported — each element is inspected separately and batched together:

```csharp
public static (NoteByIdCompiled, StarredNotesPlan) Load(LoadNoteAndListStarred cmd)
    => (new() { NoteId = cmd.NoteId }, new());
```

### 2. `[FromQuerySpecification]` parameter attribute

For handlers without a `Load` method — when the spec's inputs all live on the message:

```csharp
public static void Handle(
    LoadNoteViaAttribute cmd,
    [FromQuerySpecification(typeof(NoteByIdCompiled))] Note? note)
{
}
```

On .NET 7+, the generic variant drops the `typeof(...)`:

```csharp
public static void Handle(
    LoadNoteViaAttribute cmd,
    [FromQuerySpecification<NoteByIdCompiled>] Note? note)
{
}
```

The attribute constructs the spec by picking the public constructor with the most parameters, resolving ctor-parameter names from variables in scope (message members, route values, headers, claims), then assigning any remaining writable public properties from scope variables — the canonical Marten compiled-query pattern.

## Batching policy

| Specification kind | Batched? |
| ------------------ | -------- |
| `ICompiledQuery<TDoc, TResult>` | **Always** — via `IBatchedQuery.Query(compiled)` |
| Plan implementing `IBatchQueryPlan<T>` (incl. `QueryListPlan<T>` derivatives) | **Always** — via `IBatchedQuery.QueryByPlan(plan)` |
| Plan implementing only `IQueryPlan<T>` (no batch variant) | **Standalone** — runs via `session.QueryByPlanAsync(plan)`; other specs still batch |

A handler that mixes specs with `[Entity]` and `[Aggregate]` loads runs everything in **one** round-trip.

## Design notes

- Implemented as a pre-compilation policy `QuerySpecificationPolicy` that runs *before* the existing `MartenBatchingPolicy`. The new policy scans each method's frames, finds `Creates` variables whose types implement a Marten specification contract, and injects `FetchSpecificationFrame` (an `IBatchableFrame`) immediately after each such frame.
- Works for **HTTP endpoints as well as message handlers** — `IMethodPreCompilationPolicy` runs on both.
- Defensive type-matching: only types whose spec-interface closure is in Marten's own namespace match. A user's unrelated `IQueryPlan<T>` implementation in another library won't be picked up.
- Tuple destructuring "just works" — JasperFx's `MethodCall` already unpacks `ValueTuple<T1, T2>` returns into per-element `Variable`s in `Creates`; my policy iterates those.

## Files

**New**:
- `Wolverine.Marten/FromQuerySpecificationAttribute.cs` — attribute + generic variant
- `Wolverine.Marten/Codegen/FetchSpecificationFrame.cs` — the IBatchableFrame
- `Wolverine.Marten/Codegen/ConstructSpecificationFrame.cs` — attribute-path spec construction
- `Wolverine.Marten/Codegen/QuerySpecificationPolicy.cs` — the pre-compilation policy
- `MartenTests/fetch_specifications_tests.cs` — 5 integration tests
- `docs/guide/durability/marten/fetch-specifications.md` — user-facing docs

**Modified**:
- `Wolverine.Marten/MartenIntegration.cs` — registers the new policy before `MartenBatchingPolicy`
- `Wolverine.Marten/Codegen/MartenQueryingFrame.cs` — `MartenBatchingPolicy` now skips non-batchable FetchSpecificationFrames
- `docs/.vitepress/config.mts` — new page in Marten nav

## Test plan

- [x] `load_method_returning_compiled_query_runs_and_relays_result_to_handler` — single compiled query via Load
- [x] `load_method_returning_query_plan_runs_and_relays_result_to_handler` — single `QueryListPlan<T>` via Load, batch-capable
- [x] `load_method_returning_tuple_of_specs_runs_both_and_batches` — `(NoteByIdCompiled, StarredNotesPlan)` tuple, batched together
- [x] `from_query_specification_attribute_runs_spec_from_message_fields` — attribute-driven, property-setter injection
- [x] `non_batchable_query_plan_falls_back_to_single_fetch` — `IQueryPlan<T>`-only falls back cleanly
- [x] 69 existing Marten tests (Bug_225 compound handlers, MartenOps_store, AggregateHandlerWorkflow, etc.) still pass

## Deferred to follow-up PRs

- EF Core parallel in `Wolverine.EntityFrameworkCore` (same shape, different execution via Weasel's `BatchedQuery`)
- Polecat parallel in `Wolverine.Polecat`

## Related

- #1561 — closed by this PR
- #2527 — attribute + batching parts shipped here; the broader Phase 2 scope narrows to the cross-provider follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)