### PR TITLE
Add transport endpoint URI helpers for all supported transports (#2502)

### DIFF
--- a/docs/guide/messaging/transports/azureservicebus/index.md
+++ b/docs/guide/messaging/transports/azureservicebus/index.md
@@ -146,8 +146,20 @@ builder.UseWolverine(opts =>
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end_with_named_broker.cs#L26-L44' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_named_azure_service_bus_broker' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## URI reference
 
+The `AzureServiceBusEndpointUri` helper class builds canonical endpoint URIs:
 
+| URI form | Helper call |
+|---|---|
+| `asb://queue/{name}` | `AzureServiceBusEndpointUri.Queue("name")` |
+| `asb://topic/{name}` | `AzureServiceBusEndpointUri.Topic("name")` |
+| `asb://topic/{topic}/{subscription}` | `AzureServiceBusEndpointUri.Subscription("topic", "sub")` |
 
+```csharp
+using Wolverine.AzureServiceBus;
+
+var uri = AzureServiceBusEndpointUri.Subscription("events", "audit");
+```
 
 

--- a/docs/guide/messaging/transports/gcp-pubsub/index.md
+++ b/docs/guide/messaging/transports/gcp-pubsub/index.md
@@ -100,3 +100,17 @@ opts.UsePubsub("your-project-id")
 ```
 
 The default delimiter between the prefix and the original name is `.` for GCP Pub/Sub (e.g., `dev-john.orders`).
+
+## URI reference
+
+The `GcpPubsubEndpointUri` helper class builds canonical endpoint URIs:
+
+| URI form | Helper call |
+|---|---|
+| `pubsub://{projectId}/{topicName}` | `GcpPubsubEndpointUri.Topic("projectId", "topicName")` |
+
+```csharp
+using Wolverine.Pubsub;
+
+var uri = GcpPubsubEndpointUri.Topic("my-project", "orders");
+```

--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -678,3 +678,17 @@ await bus.BroadcastToTopicAsync("my-topic", new KafkaTombstone("record-key-to-de
 When Wolverine encounters a `KafkaTombstone` message, it produces a Kafka message with the specified key and a `null` value. This signals to Kafka's log compaction process that the record with that key should be removed during the next compaction cycle.
 
 This is useful when your Kafka topics use [log compaction](https://docs.confluent.io/platform/current/kafka/design.html#log-compaction) to maintain a key-value snapshot of the latest state. Publishing a tombstone ensures that deleted records are eventually cleaned up from the topic.
+
+## URI reference
+
+The `KafkaEndpointUri` helper class builds canonical endpoint URIs:
+
+| URI form | Helper call |
+|---|---|
+| `kafka://topic/{name}` | `KafkaEndpointUri.Topic("name")` |
+
+```csharp
+using Wolverine.Kafka;
+
+var uri = KafkaEndpointUri.Topic("orders");
+```

--- a/docs/guide/messaging/transports/mqtt.md
+++ b/docs/guide/messaging/transports/mqtt.md
@@ -466,3 +466,16 @@ await host.StartAsync();
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/MQTT/Wolverine.MQTT.Tests/Samples.cs#L128-L159' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_applying_custom_mqtt_envelope_mapper' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## URI reference
+
+The `MqttEndpointUri` helper class builds canonical endpoint URIs:
+
+| URI form | Helper call |
+|---|---|
+| `mqtt://topic/{name}` | `MqttEndpointUri.Topic("name")` |
+
+```csharp
+using Wolverine.MQTT;
+
+var uri = MqttEndpointUri.Topic("sensor/temperature");
+```

--- a/docs/guide/messaging/transports/nats.md
+++ b/docs/guide/messaging/transports/nats.md
@@ -423,3 +423,17 @@ docker run -d --name nats -p 4222:4222 -p 8222:8222 nats:latest --jetstream -m 8
 # For scheduled delivery tests, use NATS 2.12+
 docker run -d --name nats -p 4222:4222 -p 8222:8222 nats:2.12-alpine --jetstream -m 8222
 ```
+
+## URI reference
+
+The `NatsEndpointUri` helper class builds canonical endpoint URIs:
+
+| URI form | Helper call |
+|---|---|
+| `nats://subject/{subject}` | `NatsEndpointUri.Subject("subject")` |
+
+```csharp
+using Wolverine.Nats;
+
+var uri = NatsEndpointUri.Subject("orders.created");
+```

--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -159,3 +159,24 @@ Also see the more generic [Wolverine Guide on Interoperability](/tutorials/inter
 :::
 
 Pulsar interoperability is done through the `IPulsarEnvelopeMapper` interface.
+
+## URI reference
+
+The `PulsarEndpointUri` helper class produces Wolverine endpoint URIs of the form `pulsar://persistent/{tenant}/{ns}/{topic}` or `pulsar://non-persistent/{tenant}/{ns}/{topic}` — the form Wolverine's parser accepts. Pulsar-native topic-path strings (`persistent://...`) used by the native Pulsar client are a separate concept and are not built by this helper.
+
+| Helper call | Resulting URI |
+|---|---|
+| `PulsarEndpointUri.PersistentTopic("public", "default", "orders")` | `pulsar://persistent/public/default/orders` |
+| `PulsarEndpointUri.NonPersistentTopic("public", "default", "orders")` | `pulsar://non-persistent/public/default/orders` |
+| `PulsarEndpointUri.Topic("public", "default", "orders", persistent: true)` | `pulsar://persistent/public/default/orders` |
+| `PulsarEndpointUri.Topic("persistent://public/default/orders")` | `pulsar://persistent/public/default/orders` |
+
+```csharp
+using Wolverine.Pulsar;
+
+var uri = PulsarEndpointUri.PersistentTopic("public", "default", "orders");
+```
+
+::: tip
+`PulsarEndpoint.UriFor` is deprecated. Use `PulsarEndpointUri.Topic` (string overload) or `PersistentTopic`/`NonPersistentTopic` instead. The old `UriFor(bool, ...)` overload returned a Pulsar-native topic path, not a Wolverine endpoint URI — if you need that format, build the string directly.
+:::

--- a/docs/guide/messaging/transports/rabbitmq/index.md
+++ b/docs/guide/messaging/transports/rabbitmq/index.md
@@ -272,3 +272,21 @@ This creates RabbitMQ queues named `sequenced1` through `sequenced5` with compan
 ::: info
 Wolverine with the `WolverineFX.RabbitMQ` transport has also been verified to work against [LavinMQ](https://lavinmq.com/), a modern RabbitMQ-protocol compatible message broker, using the RabbitMQ transport with 100% protocol compatibility when configured through the standard RabbitMQ integration shown above.
 :::
+
+## URI reference
+
+The `RabbitMqEndpointUri` helper class builds canonical endpoint URIs:
+
+| URI form | Helper call |
+|---|---|
+| `rabbitmq://queue/{name}` | `RabbitMqEndpointUri.Queue("name")` |
+| `rabbitmq://exchange/{name}` | `RabbitMqEndpointUri.Exchange("name")` |
+| `rabbitmq://topic/{exchange}/{routingKey}` | `RabbitMqEndpointUri.Topic("ex", "key")` |
+| `rabbitmq://exchange/{exchange}/routing/{routingKey}` | `RabbitMqEndpointUri.Routing("ex", "key")` |
+
+```csharp
+using Wolverine.RabbitMQ;
+
+var uri = RabbitMqEndpointUri.Queue("orders");
+// new Uri("rabbitmq://queue/orders")
+```

--- a/docs/guide/messaging/transports/redis.md
+++ b/docs/guide/messaging/transports/redis.md
@@ -259,4 +259,21 @@ using var host = await builder.UseWolverine(opts =>
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/Samples/RedisTransportWithScheduling.cs#L7-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_dead_letter_queue_for_redis' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## URI reference
 
+The `RedisEndpointUri` helper class builds canonical endpoint URIs:
+
+| URI form | Helper call |
+|---|---|
+| `redis://stream/{databaseId}/{streamKey}` | `RedisEndpointUri.Stream("key", databaseId: 0)` |
+| `redis://stream/{databaseId}/{streamKey}?consumerGroup={group}` | `RedisEndpointUri.Stream("key", 0, "group")` |
+
+```csharp
+using Wolverine.Redis;
+
+var uri = RedisEndpointUri.Stream("orders", databaseId: 3);
+```
+
+::: tip
+`RedisTransport.BuildRedisStreamUri` is deprecated. Use `RedisEndpointUri.Stream` instead.
+:::

--- a/docs/guide/messaging/transports/sns.md
+++ b/docs/guide/messaging/transports/sns.md
@@ -199,3 +199,19 @@ Also see the more generic [Wolverine Guide on Interoperability](/tutorials/inter
 
 SNS interoperability is done through the `ISnsEnvelopeMapper`. At this point, SNS supports interoperability through
 MassTransit, NServiceBus, CloudEvents, or user defined mapping strategies.
+
+## URI reference
+
+The `SnsEndpointUri` helper class builds canonical endpoint URIs:
+
+| URI form | Helper call |
+|---|---|
+| `sns://{name}` | `SnsEndpointUri.Topic("name")` |
+
+```csharp
+using Wolverine.AmazonSns;
+
+var uri = SnsEndpointUri.Topic("events");
+// FIFO topic (suffix preserved verbatim):
+var fifoUri = SnsEndpointUri.Topic("events.fifo");
+```

--- a/docs/guide/messaging/transports/sqs/index.md
+++ b/docs/guide/messaging/transports/sqs/index.md
@@ -264,3 +264,19 @@ using var host = await Host.CreateDefaultBuilder()
         opts.PublishAllMessages().ToSqsQueue("send-and-receive");
     }).StartAsync();
 ```
+
+## URI reference
+
+The `SqsEndpointUri` helper class builds canonical endpoint URIs:
+
+| URI form | Helper call |
+|---|---|
+| `sqs://{name}` | `SqsEndpointUri.Queue("name")` |
+
+```csharp
+using Wolverine.AmazonSqs;
+
+var uri = SqsEndpointUri.Queue("orders");
+// FIFO queue (suffix preserved verbatim):
+var fifoUri = SqsEndpointUri.Queue("orders.fifo");
+```

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/SnsEndpointUriTests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/SnsEndpointUriTests.cs
@@ -1,0 +1,39 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.AmazonSns.Tests;
+
+public class SnsEndpointUriTests
+{
+    [Fact]
+    public void topic_uri_has_expected_shape()
+    {
+        SnsEndpointUri.Topic("events")
+            .ShouldBe(new Uri("sns://events"));
+    }
+
+    [Fact]
+    public void topic_uri_preserves_fifo_suffix()
+    {
+        SnsEndpointUri.Topic("events.fifo")
+            .ShouldBe(new Uri("sns://events.fifo"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void topic_rejects_invalid_name(string? name)
+    {
+        Should.Throw<ArgumentException>(() => SnsEndpointUri.Topic(name!));
+    }
+
+    [Fact]
+    public void topic_uri_roundtrips_through_parser()
+    {
+        var uri = SnsEndpointUri.Topic("events");
+        var transport = new Wolverine.AmazonSns.Internal.AmazonSnsTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSns/SnsEndpointUri.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/SnsEndpointUri.cs
@@ -1,0 +1,21 @@
+namespace Wolverine.AmazonSns;
+
+/// <summary>
+/// Builds canonical Wolverine endpoint <see cref="Uri"/> values for AWS SNS transport endpoints.
+/// </summary>
+public static class SnsEndpointUri
+{
+    /// <summary>
+    /// Builds a URI referencing an SNS topic endpoint in the canonical form
+    /// <c>sns://{topicName}</c>. FIFO topic names (with <c>.fifo</c> suffix) are preserved verbatim.
+    /// </summary>
+    /// <param name="topicName">The SNS topic name.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>sns://{topicName}</c>.</returns>
+    /// <example><c>SnsEndpointUri.Topic("events")</c> returns <c>sns://events</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="topicName"/> is null, empty, or whitespace.</exception>
+    public static Uri Topic(string topicName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
+        return new Uri($"sns://{topicName}");
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/SqsEndpointUriTests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/SqsEndpointUriTests.cs
@@ -1,0 +1,39 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+public class SqsEndpointUriTests
+{
+    [Fact]
+    public void queue_uri_has_expected_shape()
+    {
+        SqsEndpointUri.Queue("orders")
+            .ShouldBe(new Uri("sqs://orders"));
+    }
+
+    [Fact]
+    public void queue_uri_preserves_fifo_suffix()
+    {
+        SqsEndpointUri.Queue("orders.fifo")
+            .ShouldBe(new Uri("sqs://orders.fifo"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void queue_rejects_invalid_name(string? name)
+    {
+        Should.Throw<ArgumentException>(() => SqsEndpointUri.Queue(name!));
+    }
+
+    [Fact]
+    public void queue_uri_roundtrips_through_parser()
+    {
+        var uri = SqsEndpointUri.Queue("orders");
+        var transport = new Wolverine.AmazonSqs.Internal.AmazonSqsTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/SqsEndpointUri.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/SqsEndpointUri.cs
@@ -1,0 +1,21 @@
+namespace Wolverine.AmazonSqs;
+
+/// <summary>
+/// Builds canonical Wolverine endpoint <see cref="Uri"/> values for AWS SQS transport endpoints.
+/// </summary>
+public static class SqsEndpointUri
+{
+    /// <summary>
+    /// Builds a URI referencing an SQS queue endpoint in the canonical form
+    /// <c>sqs://{queueName}</c>. FIFO queue names (with <c>.fifo</c> suffix) are preserved verbatim.
+    /// </summary>
+    /// <param name="queueName">The SQS queue name.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>sqs://{queueName}</c>.</returns>
+    /// <example><c>SqsEndpointUri.Queue("orders")</c> returns <c>sqs://orders</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="queueName"/> is null, empty, or whitespace.</exception>
+    public static Uri Queue(string queueName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(queueName);
+        return new Uri($"sqs://{queueName}");
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/AzureServiceBusEndpointUriTests.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/AzureServiceBusEndpointUriTests.cs
@@ -1,0 +1,85 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+public class AzureServiceBusEndpointUriTests
+{
+    [Fact]
+    public void queue_uri_has_expected_shape()
+    {
+        AzureServiceBusEndpointUri.Queue("orders")
+            .ShouldBe(new Uri("asb://queue/orders"));
+    }
+
+    [Fact]
+    public void topic_uri_has_expected_shape()
+    {
+        AzureServiceBusEndpointUri.Topic("events")
+            .ShouldBe(new Uri("asb://topic/events"));
+    }
+
+    [Fact]
+    public void subscription_uri_has_expected_shape()
+    {
+        AzureServiceBusEndpointUri.Subscription("events", "audit")
+            .ShouldBe(new Uri("asb://topic/events/audit"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void queue_rejects_invalid_name(string? name)
+    {
+        Should.Throw<ArgumentException>(() => AzureServiceBusEndpointUri.Queue(name!));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void topic_rejects_invalid_name(string? name)
+    {
+        Should.Throw<ArgumentException>(() => AzureServiceBusEndpointUri.Topic(name!));
+    }
+
+    [Theory]
+    [InlineData(null, "sub")]
+    [InlineData("", "sub")]
+    [InlineData("   ", "sub")]
+    [InlineData("topic", null)]
+    [InlineData("topic", "")]
+    [InlineData("topic", "   ")]
+    public void subscription_rejects_invalid_args(string? topic, string? sub)
+    {
+        Should.Throw<ArgumentException>(() => AzureServiceBusEndpointUri.Subscription(topic!, sub!));
+    }
+
+    [Fact]
+    public void queue_uri_roundtrips_through_parser()
+    {
+        var uri = AzureServiceBusEndpointUri.Queue("orders");
+        var transport = new AzureServiceBusTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+
+    [Fact]
+    public void topic_uri_roundtrips_through_parser()
+    {
+        var uri = AzureServiceBusEndpointUri.Topic("events");
+        var transport = new AzureServiceBusTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+
+    [Fact]
+    public void subscription_uri_roundtrips_through_parser()
+    {
+        var uri = AzureServiceBusEndpointUri.Subscription("events", "audit");
+        var transport = new AzureServiceBusTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusEndpointUri.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusEndpointUri.cs
@@ -1,0 +1,51 @@
+namespace Wolverine.AzureServiceBus;
+
+/// <summary>
+/// Builds canonical Wolverine endpoint <see cref="Uri"/> values for Azure Service Bus transport endpoints.
+/// </summary>
+public static class AzureServiceBusEndpointUri
+{
+    /// <summary>
+    /// Builds a URI referencing an Azure Service Bus queue endpoint in the canonical form
+    /// <c>asb://queue/{queueName}</c>.
+    /// </summary>
+    /// <param name="queueName">The Azure Service Bus queue name.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>asb://queue/{queueName}</c>.</returns>
+    /// <example><c>AzureServiceBusEndpointUri.Queue("orders")</c> returns <c>asb://queue/orders</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="queueName"/> is null, empty, or whitespace.</exception>
+    public static Uri Queue(string queueName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(queueName);
+        return new Uri($"asb://queue/{queueName}");
+    }
+
+    /// <summary>
+    /// Builds a URI referencing an Azure Service Bus topic endpoint in the canonical form
+    /// <c>asb://topic/{topicName}</c>.
+    /// </summary>
+    /// <param name="topicName">The Azure Service Bus topic name.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>asb://topic/{topicName}</c>.</returns>
+    /// <example><c>AzureServiceBusEndpointUri.Topic("events")</c> returns <c>asb://topic/events</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="topicName"/> is null, empty, or whitespace.</exception>
+    public static Uri Topic(string topicName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
+        return new Uri($"asb://topic/{topicName}");
+    }
+
+    /// <summary>
+    /// Builds a URI referencing an Azure Service Bus topic subscription endpoint in the canonical form
+    /// <c>asb://topic/{topicName}/{subscriptionName}</c>.
+    /// </summary>
+    /// <param name="topicName">The Azure Service Bus topic name.</param>
+    /// <param name="subscriptionName">The subscription name bound to the topic.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>asb://topic/{topicName}/{subscriptionName}</c>.</returns>
+    /// <example><c>AzureServiceBusEndpointUri.Subscription("events", "audit")</c> returns <c>asb://topic/events/audit</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when either parameter is null, empty, or whitespace.</exception>
+    public static Uri Subscription(string topicName, string subscriptionName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subscriptionName);
+        return new Uri($"asb://topic/{topicName}/{subscriptionName}");
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/GcpPubsubEndpointUriTests.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/GcpPubsubEndpointUriTests.cs
@@ -1,0 +1,26 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Pubsub.Tests;
+
+public class GcpPubsubEndpointUriTests
+{
+    [Fact]
+    public void topic_uri_has_expected_shape()
+    {
+        GcpPubsubEndpointUri.Topic("my-project", "orders")
+            .ShouldBe(new Uri("pubsub://my-project/orders"));
+    }
+
+    [Theory]
+    [InlineData(null, "orders")]
+    [InlineData("", "orders")]
+    [InlineData("   ", "orders")]
+    [InlineData("proj", null)]
+    [InlineData("proj", "")]
+    [InlineData("proj", "   ")]
+    public void topic_rejects_invalid_args(string? projectId, string? topicName)
+    {
+        Should.Throw<ArgumentException>(() => GcpPubsubEndpointUri.Topic(projectId!, topicName!));
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub/GcpPubsubEndpointUri.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/GcpPubsubEndpointUri.cs
@@ -1,0 +1,23 @@
+namespace Wolverine.Pubsub;
+
+/// <summary>
+/// Builds canonical Wolverine endpoint <see cref="Uri"/> values for Google Cloud Pub/Sub transport endpoints.
+/// </summary>
+public static class GcpPubsubEndpointUri
+{
+    /// <summary>
+    /// Builds a URI referencing a Google Cloud Pub/Sub topic endpoint in the canonical form
+    /// <c>pubsub://{projectId}/{topicName}</c>.
+    /// </summary>
+    /// <param name="projectId">The GCP project ID that owns the topic.</param>
+    /// <param name="topicName">The Pub/Sub topic name.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>pubsub://{projectId}/{topicName}</c>.</returns>
+    /// <example><c>GcpPubsubEndpointUri.Topic("my-project", "orders")</c> returns <c>pubsub://my-project/orders</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when either parameter is null, empty, or whitespace.</exception>
+    public static Uri Topic(string projectId, string topicName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
+        return new Uri($"pubsub://{projectId}/{topicName}");
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaEndpointUriTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaEndpointUriTests.cs
@@ -1,0 +1,32 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Kafka.Tests;
+
+public class KafkaEndpointUriTests
+{
+    [Fact]
+    public void topic_uri_has_expected_shape()
+    {
+        KafkaEndpointUri.Topic("orders")
+            .ShouldBe(new Uri("kafka://topic/orders"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void topic_rejects_invalid_name(string? name)
+    {
+        Should.Throw<ArgumentException>(() => KafkaEndpointUri.Topic(name!));
+    }
+
+    [Fact]
+    public void topic_uri_roundtrips_through_parser()
+    {
+        var uri = KafkaEndpointUri.Topic("orders");
+        var transport = new Wolverine.Kafka.Internals.KafkaTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaEndpointUri.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaEndpointUri.cs
@@ -1,0 +1,21 @@
+namespace Wolverine.Kafka;
+
+/// <summary>
+/// Builds canonical Wolverine endpoint <see cref="Uri"/> values for Kafka transport endpoints.
+/// </summary>
+public static class KafkaEndpointUri
+{
+    /// <summary>
+    /// Builds a URI referencing a Kafka topic endpoint in the canonical form
+    /// <c>kafka://topic/{topicName}</c>.
+    /// </summary>
+    /// <param name="topicName">The Kafka topic name.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>kafka://topic/{topicName}</c>.</returns>
+    /// <example><c>KafkaEndpointUri.Topic("orders")</c> returns <c>kafka://topic/orders</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="topicName"/> is null, empty, or whitespace.</exception>
+    public static Uri Topic(string topicName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
+        return new Uri($"kafka://topic/{topicName}");
+    }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/MqttEndpointUriTests.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/MqttEndpointUriTests.cs
@@ -1,0 +1,32 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.MQTT.Tests;
+
+public class MqttEndpointUriTests
+{
+    [Fact]
+    public void topic_uri_has_expected_shape()
+    {
+        MqttEndpointUri.Topic("sensor/temperature")
+            .ShouldBe(new Uri("mqtt://topic/sensor/temperature"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void topic_rejects_invalid_name(string? name)
+    {
+        Should.Throw<ArgumentException>(() => MqttEndpointUri.Topic(name!));
+    }
+
+    [Fact]
+    public void topic_uri_roundtrips_through_parser()
+    {
+        var uri = MqttEndpointUri.Topic("sensor/temperature");
+        var transport = new Wolverine.MQTT.Internals.MqttTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttEndpointUri.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttEndpointUri.cs
@@ -1,0 +1,22 @@
+namespace Wolverine.MQTT;
+
+/// <summary>
+/// Builds canonical Wolverine endpoint <see cref="Uri"/> values for MQTT transport endpoints.
+/// </summary>
+public static class MqttEndpointUri
+{
+    /// <summary>
+    /// Builds a URI referencing an MQTT topic endpoint in the canonical form
+    /// <c>mqtt://topic/{topicName}</c>. Slashes inside the topic name are preserved
+    /// as path separators.
+    /// </summary>
+    /// <param name="topicName">The MQTT topic name (may contain slashes).</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>mqtt://topic/{topicName}</c>.</returns>
+    /// <example><c>MqttEndpointUri.Topic("sensor/temperature")</c> returns <c>mqtt://topic/sensor/temperature</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="topicName"/> is null, empty, or whitespace.</exception>
+    public static Uri Topic(string topicName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
+        return new Uri("mqtt://topic/" + topicName.Trim('/'));
+    }
+}

--- a/src/Transports/NATS/Wolverine.Nats.Tests/NatsEndpointUriTests.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/NatsEndpointUriTests.cs
@@ -1,0 +1,32 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Nats.Tests;
+
+public class NatsEndpointUriTests
+{
+    [Fact]
+    public void subject_uri_has_expected_shape()
+    {
+        NatsEndpointUri.Subject("orders.created")
+            .ShouldBe(new Uri("nats://subject/orders.created"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void subject_rejects_invalid_name(string? subject)
+    {
+        Should.Throw<ArgumentException>(() => NatsEndpointUri.Subject(subject!));
+    }
+
+    [Fact]
+    public void subject_uri_roundtrips_through_parser()
+    {
+        var uri = NatsEndpointUri.Subject("orders.created");
+        var transport = new Wolverine.Nats.Internal.NatsTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+}

--- a/src/Transports/NATS/Wolverine.Nats/NatsEndpointUri.cs
+++ b/src/Transports/NATS/Wolverine.Nats/NatsEndpointUri.cs
@@ -1,0 +1,21 @@
+namespace Wolverine.Nats;
+
+/// <summary>
+/// Builds canonical Wolverine endpoint <see cref="Uri"/> values for NATS transport endpoints.
+/// </summary>
+public static class NatsEndpointUri
+{
+    /// <summary>
+    /// Builds a URI referencing a NATS subject endpoint in the canonical form
+    /// <c>nats://subject/{subject}</c>.
+    /// </summary>
+    /// <param name="subject">The NATS subject (dot-separated identifier).</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>nats://subject/{subject}</c>.</returns>
+    /// <example><c>NatsEndpointUri.Subject("orders.created")</c> returns <c>nats://subject/orders.created</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="subject"/> is null, empty, or whitespace.</exception>
+    public static Uri Subject(string subject)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+        return new Uri($"nats://subject/{subject}");
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/InlinePulsarTransportComplianceTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/InlinePulsarTransportComplianceTests.cs
@@ -14,7 +14,7 @@ public class InlinePulsarTransportFixture : TransportComplianceFixture, IAsyncLi
     {
         var topic = Guid.NewGuid().ToString();
         var topicPath = $"persistent://public/default/{topic}";
-        OutboundAddress = PulsarEndpoint.UriFor(topicPath);
+        OutboundAddress = PulsarEndpointUri.Topic(topicPath);
 
         await ReceiverIs(opts =>
         {

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarEndpointTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarEndpointTests.cs
@@ -81,4 +81,46 @@ public class PulsarEndpointTests
         endpoint.Tenant.ShouldBe("t1");
         endpoint.TopicName.ShouldBe("aaa");
     }
+
+    [Fact]
+    public void uri_for_topic_string_handles_non_persistent_scheme()
+    {
+        var uri = PulsarEndpoint.UriFor("non-persistent://t1/ns1/aaa");
+        var endpoint = new PulsarEndpoint(uri, null!);
+
+        endpoint.Persistence.ShouldBe(PulsarEndpoint.NonPersistent);
+        endpoint.Tenant.ShouldBe("t1");
+        endpoint.Namespace.ShouldBe("ns1");
+        endpoint.TopicName.ShouldBe("aaa");
+    }
+
+    [Fact]
+    public void uri_for_topic_string_preserves_realistic_topic_names()
+    {
+        var uri = PulsarEndpoint.UriFor("persistent://my-tenant/my-namespace/order.created.v2");
+        var endpoint = new PulsarEndpoint(uri, null!);
+
+        endpoint.Persistence.ShouldBe(PulsarEndpoint.Persistent);
+        endpoint.Tenant.ShouldBe("my-tenant");
+        endpoint.Namespace.ShouldBe("my-namespace");
+        endpoint.TopicName.ShouldBe("order.created.v2");
+    }
+
+    [Fact]
+    public void uri_for_bool_produces_retry_suffix_path_used_by_pulsar_listener()
+    {
+        // Mirrors the call pattern in PulsarListener.getRetryLetterTopicUri:
+        // PulsarEndpoint.UriFor(isPersistent, tenant, namespace, "{topic}-RETRY").
+        var uri = PulsarEndpoint.UriFor(true, "public", "default", "orders-RETRY");
+        uri.ShouldBe(new Uri("persistent://public/default/orders-RETRY"));
+    }
+
+    [Fact]
+    public void uri_for_bool_produces_dlq_suffix_path_used_by_pulsar_listener()
+    {
+        // Mirrors the call pattern in PulsarListener.getDeadLetteredTopicUri:
+        // PulsarEndpoint.UriFor(isPersistent, tenant, namespace, "{topic}-DLQ").
+        var uri = PulsarEndpoint.UriFor(true, "public", "default", "orders-DLQ");
+        uri.ShouldBe(new Uri("persistent://public/default/orders-DLQ"));
+    }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarEndpointUriTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarEndpointUriTests.cs
@@ -1,0 +1,125 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+public class PulsarEndpointUriTests
+{
+    [Fact]
+    public void persistent_topic_returns_wolverine_endpoint_uri()
+    {
+        PulsarEndpointUri.PersistentTopic("public", "default", "orders")
+            .ShouldBe(new Uri("pulsar://persistent/public/default/orders"));
+    }
+
+    [Fact]
+    public void non_persistent_topic_returns_wolverine_endpoint_uri()
+    {
+        PulsarEndpointUri.NonPersistentTopic("public", "default", "orders")
+            .ShouldBe(new Uri("pulsar://non-persistent/public/default/orders"));
+    }
+
+    [Fact]
+    public void topic_with_persistent_flag_true_matches_persistent_topic()
+    {
+        PulsarEndpointUri.Topic("public", "default", "orders", persistent: true)
+            .ShouldBe(new Uri("pulsar://persistent/public/default/orders"));
+    }
+
+    [Fact]
+    public void topic_with_persistent_flag_false_matches_non_persistent_topic()
+    {
+        PulsarEndpointUri.Topic("public", "default", "orders", persistent: false)
+            .ShouldBe(new Uri("pulsar://non-persistent/public/default/orders"));
+    }
+
+    [Fact]
+    public void topic_from_pulsar_native_path_returns_wolverine_endpoint_uri()
+    {
+        PulsarEndpointUri.Topic("persistent://t1/ns1/aaa")
+            .ShouldBe(new Uri("pulsar://persistent/t1/ns1/aaa"));
+    }
+
+    [Fact]
+    public void topic_from_non_persistent_native_path_returns_wolverine_endpoint_uri()
+    {
+        PulsarEndpointUri.Topic("non-persistent://t1/ns1/aaa")
+            .ShouldBe(new Uri("pulsar://non-persistent/t1/ns1/aaa"));
+    }
+
+    [Theory]
+    [InlineData(null, "ns", "topic")]
+    [InlineData("", "ns", "topic")]
+    [InlineData("   ", "ns", "topic")]
+    [InlineData("tenant", null, "topic")]
+    [InlineData("tenant", "", "topic")]
+    [InlineData("tenant", "   ", "topic")]
+    [InlineData("tenant", "ns", null)]
+    [InlineData("tenant", "ns", "")]
+    [InlineData("tenant", "ns", "   ")]
+    public void persistent_topic_rejects_invalid_args(string? tenant, string? ns, string? topic)
+    {
+        Should.Throw<ArgumentException>(() => PulsarEndpointUri.PersistentTopic(tenant!, ns!, topic!));
+    }
+
+    [Theory]
+    [InlineData(null, "ns", "topic")]
+    [InlineData("", "ns", "topic")]
+    [InlineData("tenant", null, "topic")]
+    [InlineData("tenant", "ns", null)]
+    public void non_persistent_topic_rejects_invalid_args(string? tenant, string? ns, string? topic)
+    {
+        Should.Throw<ArgumentException>(() => PulsarEndpointUri.NonPersistentTopic(tenant!, ns!, topic!));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void topic_from_path_rejects_invalid_path(string? path)
+    {
+        Should.Throw<ArgumentException>(() => PulsarEndpointUri.Topic(path!));
+    }
+
+    [Theory]
+    [InlineData("pulsar://persistent/t1/ns1/aaa")] // already a Wolverine endpoint URI
+    [InlineData("http://example.com/ns/topic")]     // unsupported scheme
+    [InlineData("ftp://server/ns/topic")]           // unsupported scheme
+    [InlineData("tcp://host:5000/a/b")]             // unsupported scheme
+    public void topic_from_path_rejects_unsupported_scheme(string path)
+    {
+        Should.Throw<ArgumentException>(() => PulsarEndpointUri.Topic(path));
+    }
+
+    [Theory]
+    [InlineData("persistent://tenant")]                  // only tenant, missing ns and topic
+    [InlineData("persistent://tenant/ns")]                // missing topic
+    [InlineData("persistent://tenant/ns/topic/extra")]    // extra segment
+    [InlineData("non-persistent://tenant/ns/topic/extra")] // extra segment, non-persistent
+    public void topic_from_path_rejects_wrong_segment_count(string path)
+    {
+        Should.Throw<ArgumentException>(() => PulsarEndpointUri.Topic(path));
+    }
+
+    [Fact]
+    public void persistent_topic_uri_roundtrips_through_parser()
+    {
+        var uri = PulsarEndpointUri.PersistentTopic("public", "default", "orders");
+        var endpoint = new PulsarEndpoint(uri, null!);
+        endpoint.Persistence.ShouldBe(PulsarEndpoint.Persistent);
+        endpoint.Tenant.ShouldBe("public");
+        endpoint.Namespace.ShouldBe("default");
+        endpoint.TopicName.ShouldBe("orders");
+    }
+
+    [Fact]
+    public void non_persistent_topic_uri_roundtrips_through_parser()
+    {
+        var uri = PulsarEndpointUri.NonPersistentTopic("public", "default", "orders");
+        var endpoint = new PulsarEndpoint(uri, null!);
+        endpoint.Persistence.ShouldBe(PulsarEndpoint.NonPersistent);
+        endpoint.Tenant.ShouldBe("public");
+        endpoint.Namespace.ShouldBe("default");
+        endpoint.TopicName.ShouldBe("orders");
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarTransportComplianceTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarTransportComplianceTests.cs
@@ -14,7 +14,7 @@ public class PulsarTransportFixture : TransportComplianceFixture, IAsyncLifetime
     {
         var topic = Guid.NewGuid().ToString();
         var topicPath = $"persistent://public/default/compliance{topic}";
-        OutboundAddress = PulsarEndpoint.UriFor(topicPath);
+        OutboundAddress = PulsarEndpointUri.Topic(topicPath);
 
         await SenderIs(opts =>
         {

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/WithCloudEvents.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/WithCloudEvents.cs
@@ -14,7 +14,7 @@ public class PulsarWithCloudEventsFixture : TransportComplianceFixture, IAsyncLi
     {
         var topic = Guid.NewGuid().ToString();
         var topicPath = $"persistent://public/default/compliance{topic}";
-        OutboundAddress = PulsarEndpoint.UriFor(topicPath);
+        OutboundAddress = PulsarEndpointUri.Topic(topicPath);
 
         await SenderIs(opts =>
         {

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/endpoint_configuration.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/endpoint_configuration.cs
@@ -39,7 +39,7 @@ public class endpoint_configuration : IDisposable
     [Fact]
     public void requeue_disabled()
     {
-        var uri = PulsarEndpoint.UriFor("persistent://public/default/one");
+        var uri = PulsarEndpointUri.Topic("persistent://public/default/one");
         var endpoint = theRuntime.Endpoints.EndpointFor(uri)?.As<PulsarEndpoint>();
 
         endpoint!.EnableRequeue.ShouldBeFalse();
@@ -48,7 +48,7 @@ public class endpoint_configuration : IDisposable
     [Fact]
     public void unsubscribe_on_close_disabled()
     {
-        var uri = PulsarEndpoint.UriFor("persistent://public/default/one");
+        var uri = PulsarEndpointUri.Topic("persistent://public/default/one");
         var endpoint = theRuntime.Endpoints.EndpointFor(uri)?.As<PulsarEndpoint>();
 
         endpoint!.UnsubscribeOnClose.ShouldBeFalse();

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -48,17 +48,17 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
 
     public bool IsPersistent => Persistence.Equals(Persistent);
 
+    [Obsolete("This overload returns a Pulsar-native topic path (persistent://...), not a Wolverine endpoint URI (pulsar://...). The native Pulsar client requires the former; PulsarEndpointUri produces the latter — they are NOT interchangeable, which is why this overload is not delegated. Build Pulsar-native topic paths directly. This helper will be removed in a future version.")]
     public static Uri UriFor(bool persistent, string tenant, string @namespace, string topicName)
     {
         var scheme = persistent ? "persistent" : "non-persistent";
         return new Uri($"{scheme}://{tenant}/{@namespace}/{topicName}");
     }
 
+    [Obsolete("Use PulsarEndpointUri.Topic instead. This helper will be removed in a future version.")]
     public static Uri UriFor(string topicPath)
     {
-        var uri = new Uri(topicPath);
-        return new Uri(
-            $"pulsar://{uri.Scheme}/{uri.Host}/{uri.Segments.Skip(1).Select(x => x.TrimEnd('/')).Join("/")}");
+        return PulsarEndpointUri.Topic(topicPath);
     }
 
     public override IDictionary<string, object> DescribeProperties()

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpointUri.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpointUri.cs
@@ -1,0 +1,100 @@
+namespace Wolverine.Pulsar;
+
+/// <summary>
+/// Builds canonical Wolverine endpoint <see cref="Uri"/> values for Pulsar transport endpoints.
+/// All methods return Wolverine endpoint URIs of the form <c>pulsar://persistent/{tenant}/{ns}/{topic}</c>
+/// or <c>pulsar://non-persistent/{tenant}/{ns}/{topic}</c>, matching what <see cref="PulsarEndpoint"/>'s parser
+/// accepts. For Pulsar-native topic-path strings (e.g. <c>persistent://...</c>) used by the native Pulsar client,
+/// build them directly — they are not Wolverine endpoint URIs and are out of scope for this helper.
+/// </summary>
+public static class PulsarEndpointUri
+{
+    /// <summary>
+    /// Builds a URI referencing a Pulsar persistent-topic endpoint in the canonical form
+    /// <c>pulsar://persistent/{tenant}/{namespace}/{topicName}</c>.
+    /// </summary>
+    /// <param name="tenant">The Pulsar tenant.</param>
+    /// <param name="namespace">The Pulsar namespace.</param>
+    /// <param name="topicName">The Pulsar topic name.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>pulsar://persistent/{tenant}/{namespace}/{topicName}</c>.</returns>
+    /// <example><c>PulsarEndpointUri.PersistentTopic("public", "default", "orders")</c> returns <c>pulsar://persistent/public/default/orders</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when any parameter is null, empty, or whitespace.</exception>
+    public static Uri PersistentTopic(string tenant, string @namespace, string topicName)
+    {
+        return BuildEndpointUri(PulsarEndpoint.Persistent, tenant, @namespace, topicName);
+    }
+
+    /// <summary>
+    /// Builds a URI referencing a Pulsar non-persistent-topic endpoint in the canonical form
+    /// <c>pulsar://non-persistent/{tenant}/{namespace}/{topicName}</c>.
+    /// </summary>
+    /// <param name="tenant">The Pulsar tenant.</param>
+    /// <param name="namespace">The Pulsar namespace.</param>
+    /// <param name="topicName">The Pulsar topic name.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>pulsar://non-persistent/{tenant}/{namespace}/{topicName}</c>.</returns>
+    /// <example><c>PulsarEndpointUri.NonPersistentTopic("public", "default", "orders")</c> returns <c>pulsar://non-persistent/public/default/orders</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when any parameter is null, empty, or whitespace.</exception>
+    public static Uri NonPersistentTopic(string tenant, string @namespace, string topicName)
+    {
+        return BuildEndpointUri(PulsarEndpoint.NonPersistent, tenant, @namespace, topicName);
+    }
+
+    /// <summary>
+    /// Builds a URI referencing a Pulsar topic endpoint, selecting persistent or non-persistent by flag.
+    /// </summary>
+    /// <param name="tenant">The Pulsar tenant.</param>
+    /// <param name="namespace">The Pulsar namespace.</param>
+    /// <param name="topicName">The Pulsar topic name.</param>
+    /// <param name="persistent"><c>true</c> for a persistent topic, <c>false</c> for non-persistent.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>pulsar://persistent/...</c> or <c>pulsar://non-persistent/...</c>.</returns>
+    /// <example><c>PulsarEndpointUri.Topic("public", "default", "orders", persistent: true)</c> returns <c>pulsar://persistent/public/default/orders</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when any string parameter is null, empty, or whitespace.</exception>
+    public static Uri Topic(string tenant, string @namespace, string topicName, bool persistent)
+    {
+        var scheme = persistent ? PulsarEndpoint.Persistent : PulsarEndpoint.NonPersistent;
+        return BuildEndpointUri(scheme, tenant, @namespace, topicName);
+    }
+
+    /// <summary>
+    /// Converts a Pulsar-native topic path (e.g. <c>persistent://tenant/ns/topic</c>) into a
+    /// Wolverine endpoint URI of the form <c>pulsar://persistent/tenant/ns/topic</c>.
+    /// </summary>
+    /// <param name="topicPath">A Pulsar-native topic path string with scheme <c>persistent</c> or <c>non-persistent</c> and exactly three path components (tenant, namespace, topic).</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>pulsar://{persistence}/{tenant}/{namespace}/{topicName}</c>.</returns>
+    /// <example><c>PulsarEndpointUri.Topic("persistent://t1/ns1/aaa")</c> returns <c>pulsar://persistent/t1/ns1/aaa</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="topicPath"/> is null, empty, whitespace, uses a scheme other than <c>persistent</c>/<c>non-persistent</c>, or does not contain exactly tenant/namespace/topic path parts.</exception>
+    /// <exception cref="UriFormatException">Thrown when <paramref name="topicPath"/> is not a parseable URI.</exception>
+    public static Uri Topic(string topicPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topicPath);
+
+        var parsed = new Uri(topicPath);
+
+        if (parsed.Scheme != PulsarEndpoint.Persistent && parsed.Scheme != PulsarEndpoint.NonPersistent)
+        {
+            throw new ArgumentException(
+                $"topicPath must use scheme '{PulsarEndpoint.Persistent}' or '{PulsarEndpoint.NonPersistent}', got '{parsed.Scheme}'. Use PulsarEndpointUri.PersistentTopic or NonPersistentTopic to build Wolverine endpoint URIs from components.",
+                nameof(topicPath));
+        }
+
+        var pathParts = parsed.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (pathParts.Length != 2)
+        {
+            throw new ArgumentException(
+                $"topicPath must have the form '{{scheme}}://{{tenant}}/{{namespace}}/{{topic}}', got '{topicPath}'.",
+                nameof(topicPath));
+        }
+
+        return parsed.Scheme == PulsarEndpoint.Persistent
+            ? PersistentTopic(parsed.Host, pathParts[0], pathParts[1])
+            : NonPersistentTopic(parsed.Host, pathParts[0], pathParts[1]);
+    }
+
+    private static Uri BuildEndpointUri(string persistence, string tenant, string @namespace, string topicName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenant);
+        ArgumentException.ThrowIfNullOrWhiteSpace(@namespace);
+        ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
+        return new Uri($"pulsar://{persistence}/{tenant}/{@namespace}/{topicName}");
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -138,16 +138,20 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
 
     private Uri? getRetryLetterTopicUri(PulsarEndpoint endpoint)
     {
+#pragma warning disable CS0618 // Pulsar-native topic-path form is required by the Pulsar client
         return NativeRetryLetterQueueEnabled
             ? PulsarEndpoint.UriFor(endpoint.IsPersistent, endpoint.Tenant, endpoint.Namespace,
                 endpoint.RetryLetterTopic?.TopicName ?? $"{endpoint.TopicName}-RETRY")
             : null;
+#pragma warning restore CS0618
     }
 
     private Uri getDeadLetteredTopicUri(PulsarEndpoint endpoint)
     {
+#pragma warning disable CS0618 // Pulsar-native topic-path form is required by the Pulsar client
         var topicDql = PulsarEndpoint.UriFor(endpoint.IsPersistent, endpoint.Tenant, endpoint.Namespace,
             endpoint.DeadLetterTopic?.TopicName ?? $"{endpoint.TopicName}-DLQ");
+#pragma warning restore CS0618
 
         return topicDql;
     }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransport.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransport.cs
@@ -95,7 +95,7 @@ public class PulsarTransport : TransportBase<PulsarEndpoint>, IAsyncDisposable
 
     public PulsarEndpoint EndpointFor(string topicPath)
     {
-        var uri = PulsarEndpoint.UriFor(topicPath);
+        var uri = PulsarEndpointUri.Topic(topicPath);
         return this[uri];
     }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -79,7 +79,7 @@ public static class PulsarTransportExtensions
     /// <returns></returns>
     public static PulsarListenerConfiguration ListenToPulsarTopic(this WolverineOptions endpoints, string topicPath)
     {
-        var uri = PulsarEndpoint.UriFor(topicPath);
+        var uri = PulsarEndpointUri.Topic(topicPath);
         var endpoint = endpoints.PulsarTransport()[uri];
         endpoint.IsListener = true;
         return new PulsarListenerConfiguration(endpoint);

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitMqEndpointUriTests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitMqEndpointUriTests.cs
@@ -1,0 +1,113 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+public class RabbitMqEndpointUriTests
+{
+    [Fact]
+    public void queue_uri_has_expected_shape()
+    {
+        RabbitMqEndpointUri.Queue("orders")
+            .ShouldBe(new Uri("rabbitmq://queue/orders"));
+    }
+
+    [Fact]
+    public void exchange_uri_has_expected_shape()
+    {
+        RabbitMqEndpointUri.Exchange("events")
+            .ShouldBe(new Uri("rabbitmq://exchange/events"));
+    }
+
+    [Fact]
+    public void topic_uri_has_expected_shape()
+    {
+        RabbitMqEndpointUri.Topic("prices", "usd.eur")
+            .ShouldBe(new Uri("rabbitmq://topic/prices/usd.eur"));
+    }
+
+    [Fact]
+    public void routing_uri_has_expected_shape()
+    {
+        RabbitMqEndpointUri.Routing("events", "order.created")
+            .ShouldBe(new Uri("rabbitmq://exchange/events/routing/order.created"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void queue_rejects_invalid_name(string? name)
+    {
+        Should.Throw<ArgumentException>(() => RabbitMqEndpointUri.Queue(name!));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void exchange_rejects_invalid_name(string? name)
+    {
+        Should.Throw<ArgumentException>(() => RabbitMqEndpointUri.Exchange(name!));
+    }
+
+    [Theory]
+    [InlineData(null, "key")]
+    [InlineData("", "key")]
+    [InlineData("   ", "key")]
+    [InlineData("ex", null)]
+    [InlineData("ex", "")]
+    [InlineData("ex", "   ")]
+    public void topic_rejects_invalid_args(string? exchange, string? key)
+    {
+        Should.Throw<ArgumentException>(() => RabbitMqEndpointUri.Topic(exchange!, key!));
+    }
+
+    [Theory]
+    [InlineData(null, "key")]
+    [InlineData("", "key")]
+    [InlineData("   ", "key")]
+    [InlineData("ex", null)]
+    [InlineData("ex", "")]
+    [InlineData("ex", "   ")]
+    public void routing_rejects_invalid_args(string? exchange, string? key)
+    {
+        Should.Throw<ArgumentException>(() => RabbitMqEndpointUri.Routing(exchange!, key!));
+    }
+
+    [Fact]
+    public void queue_uri_roundtrips_through_parser()
+    {
+        var uri = RabbitMqEndpointUri.Queue("orders");
+        var transport = new Wolverine.RabbitMQ.Internal.RabbitMqTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+
+    [Fact]
+    public void exchange_uri_roundtrips_through_parser()
+    {
+        var uri = RabbitMqEndpointUri.Exchange("events");
+        var transport = new Wolverine.RabbitMQ.Internal.RabbitMqTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+
+    [Fact]
+    public void topic_uri_roundtrips_through_parser()
+    {
+        var uri = RabbitMqEndpointUri.Topic("prices", "usd.eur");
+        var transport = new Wolverine.RabbitMQ.Internal.RabbitMqTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+
+    [Fact]
+    public void routing_uri_roundtrips_through_parser()
+    {
+        var uri = RabbitMqEndpointUri.Routing("events", "order.created");
+        var transport = new Wolverine.RabbitMQ.Internal.RabbitMqTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqEndpointUri.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqEndpointUri.cs
@@ -1,0 +1,67 @@
+namespace Wolverine.RabbitMQ;
+
+/// <summary>
+/// Builds canonical Wolverine endpoint <see cref="Uri"/> values for RabbitMQ transport endpoints.
+/// </summary>
+public static class RabbitMqEndpointUri
+{
+    /// <summary>
+    /// Builds a URI referencing a RabbitMQ queue endpoint in the canonical form
+    /// <c>rabbitmq://queue/{queueName}</c>.
+    /// </summary>
+    /// <param name="queueName">The RabbitMQ queue name.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>rabbitmq://queue/{queueName}</c>.</returns>
+    /// <example><c>RabbitMqEndpointUri.Queue("orders")</c> returns <c>rabbitmq://queue/orders</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="queueName"/> is null, empty, or whitespace.</exception>
+    public static Uri Queue(string queueName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(queueName);
+        return new Uri($"rabbitmq://queue/{queueName}");
+    }
+
+    /// <summary>
+    /// Builds a URI referencing a RabbitMQ exchange endpoint in the canonical form
+    /// <c>rabbitmq://exchange/{exchangeName}</c>.
+    /// </summary>
+    /// <param name="exchangeName">The RabbitMQ exchange name.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>rabbitmq://exchange/{exchangeName}</c>.</returns>
+    /// <example><c>RabbitMqEndpointUri.Exchange("events")</c> returns <c>rabbitmq://exchange/events</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="exchangeName"/> is null, empty, or whitespace.</exception>
+    public static Uri Exchange(string exchangeName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(exchangeName);
+        return new Uri($"rabbitmq://exchange/{exchangeName}");
+    }
+
+    /// <summary>
+    /// Builds a URI referencing a RabbitMQ topic-routed exchange endpoint in the canonical form
+    /// <c>rabbitmq://topic/{exchangeName}/{routingKey}</c>.
+    /// </summary>
+    /// <param name="exchangeName">The RabbitMQ exchange name.</param>
+    /// <param name="routingKey">The topic routing key.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>rabbitmq://topic/{exchangeName}/{routingKey}</c>.</returns>
+    /// <example><c>RabbitMqEndpointUri.Topic("prices", "usd.eur")</c> returns <c>rabbitmq://topic/prices/usd.eur</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when either parameter is null, empty, or whitespace.</exception>
+    public static Uri Topic(string exchangeName, string routingKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(exchangeName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(routingKey);
+        return new Uri($"rabbitmq://topic/{exchangeName}/{routingKey}");
+    }
+
+    /// <summary>
+    /// Builds a URI referencing a RabbitMQ exchange with an explicit routing key in the canonical form
+    /// <c>rabbitmq://exchange/{exchangeName}/routing/{routingKey}</c>.
+    /// </summary>
+    /// <param name="exchangeName">The RabbitMQ exchange name.</param>
+    /// <param name="routingKey">The routing key bound to the exchange.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>rabbitmq://exchange/{exchangeName}/routing/{routingKey}</c>.</returns>
+    /// <example><c>RabbitMqEndpointUri.Routing("events", "order.created")</c> returns <c>rabbitmq://exchange/events/routing/order.created</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when either parameter is null, empty, or whitespace.</exception>
+    public static Uri Routing(string exchangeName, string routingKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(exchangeName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(routingKey);
+        return new Uri($"rabbitmq://exchange/{exchangeName}/routing/{routingKey}");
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs
@@ -116,8 +116,8 @@ public class DocumentationSamples
         #region sample_redis_uri_helpers
 
         // Using URI builder helpers
-        var ordersUri = RedisTransport.BuildRedisStreamUri("orders", databaseId: 1);
-        var paymentsUri = RedisTransport.BuildRedisStreamUri("payments", databaseId: 2, "payment-processors");
+        var ordersUri = RedisEndpointUri.Stream("orders", databaseId: 1);
+        var paymentsUri = RedisEndpointUri.Stream("payments", databaseId: 2, "payment-processors");
 
         using var host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>

--- a/src/Transports/Redis/Wolverine.Redis.Tests/RedisEndpointUriTests.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/RedisEndpointUriTests.cs
@@ -1,0 +1,70 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+public class RedisEndpointUriTests
+{
+    [Fact]
+    public void stream_uri_has_expected_shape_with_default_database()
+    {
+        RedisEndpointUri.Stream("orders")
+            .ShouldBe(new Uri("redis://stream/0/orders"));
+    }
+
+    [Fact]
+    public void stream_uri_has_expected_shape_with_explicit_database()
+    {
+        RedisEndpointUri.Stream("orders", databaseId: 3)
+            .ShouldBe(new Uri("redis://stream/3/orders"));
+    }
+
+    [Fact]
+    public void stream_uri_includes_consumer_group_query_parameter()
+    {
+        RedisEndpointUri.Stream("orders", 3, "order-processors")
+            .ShouldBe(new Uri("redis://stream/3/orders?consumerGroup=order-processors"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void stream_rejects_invalid_key(string? key)
+    {
+        Should.Throw<ArgumentException>(() => RedisEndpointUri.Stream(key!));
+    }
+
+    [Fact]
+    public void stream_rejects_negative_database_id()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => RedisEndpointUri.Stream("orders", databaseId: -1));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void stream_with_consumer_group_rejects_invalid_group(string? group)
+    {
+        Should.Throw<ArgumentException>(() => RedisEndpointUri.Stream("orders", 0, group!));
+    }
+
+    [Fact]
+    public void stream_uri_roundtrips_through_parser()
+    {
+        var uri = RedisEndpointUri.Stream("orders", databaseId: 3);
+        var transport = new Wolverine.Redis.Internal.RedisTransport();
+        var endpoint = transport.GetOrCreateEndpoint(uri);
+        endpoint.Uri.ShouldBe(uri);
+    }
+
+    [Fact]
+    public void consumer_group_uri_roundtrips_through_parser()
+    {
+        var uri = RedisEndpointUri.Stream("orders", databaseId: 3, consumerGroup: "order-processors");
+        var transport = new Wolverine.Redis.Internal.RedisTransport();
+        var endpoint = (Wolverine.Redis.Internal.RedisStreamEndpoint)transport.GetOrCreateEndpoint(uri);
+        endpoint.ConsumerGroup.ShouldBe("order-processors");
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
@@ -293,25 +293,27 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     }
     
     /// <summary>
-    /// Helper method to create a Redis stream URI with database ID
+    /// Helper method to create a Redis stream URI with database ID.
     /// </summary>
     /// <param name="streamKey">Redis stream key name</param>
     /// <param name="databaseId">Redis database ID</param>
     /// <returns>Formatted Redis stream URI</returns>
+    [Obsolete("Use RedisEndpointUri.Stream instead. This helper will be removed in a future version.")]
     public static Uri BuildRedisStreamUri(string streamKey, int databaseId = 0)
     {
-        return new Uri($"redis://stream/{databaseId}/{streamKey}");
+        return RedisEndpointUri.Stream(streamKey, databaseId);
     }
 
     /// <summary>
-    /// Helper method to create a Redis stream URI with database ID and consumer group
+    /// Helper method to create a Redis stream URI with database ID and consumer group.
     /// </summary>
     /// <param name="streamKey">Redis stream key name</param>
     /// <param name="databaseId">Redis database ID</param>
     /// <param name="consumerGroup">Consumer group name</param>
     /// <returns>Formatted Redis stream URI</returns>
+    [Obsolete("Use RedisEndpointUri.Stream instead. This helper will be removed in a future version.")]
     public static Uri BuildRedisStreamUri(string streamKey, int databaseId, string consumerGroup)
     {
-        return new Uri($"redis://stream/{databaseId}/{streamKey}?consumerGroup={consumerGroup}");
+        return RedisEndpointUri.Stream(streamKey, databaseId, consumerGroup);
     }
 }

--- a/src/Transports/Redis/Wolverine.Redis/RedisEndpointUri.cs
+++ b/src/Transports/Redis/Wolverine.Redis/RedisEndpointUri.cs
@@ -1,0 +1,43 @@
+namespace Wolverine.Redis;
+
+/// <summary>
+/// Builds canonical Wolverine endpoint <see cref="Uri"/> values for Redis stream transport endpoints.
+/// </summary>
+public static class RedisEndpointUri
+{
+    /// <summary>
+    /// Builds a URI referencing a Redis stream endpoint in the canonical form
+    /// <c>redis://stream/{databaseId}/{streamKey}</c>.
+    /// </summary>
+    /// <param name="streamKey">The Redis stream key name.</param>
+    /// <param name="databaseId">The Redis database ID (default 0).</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>redis://stream/{databaseId}/{streamKey}</c>.</returns>
+    /// <example><c>RedisEndpointUri.Stream("orders", 3)</c> returns <c>redis://stream/3/orders</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="streamKey"/> is null, empty, or whitespace.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="databaseId"/> is negative.</exception>
+    public static Uri Stream(string streamKey, int databaseId = 0)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamKey);
+        ArgumentOutOfRangeException.ThrowIfNegative(databaseId);
+        return new Uri($"redis://stream/{databaseId}/{streamKey}");
+    }
+
+    /// <summary>
+    /// Builds a URI referencing a Redis stream endpoint with a consumer group in the canonical form
+    /// <c>redis://stream/{databaseId}/{streamKey}?consumerGroup={consumerGroup}</c>.
+    /// </summary>
+    /// <param name="streamKey">The Redis stream key name.</param>
+    /// <param name="databaseId">The Redis database ID.</param>
+    /// <param name="consumerGroup">The Redis consumer group name.</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>redis://stream/{databaseId}/{streamKey}?consumerGroup={consumerGroup}</c>.</returns>
+    /// <example><c>RedisEndpointUri.Stream("orders", 3, "order-processors")</c> returns <c>redis://stream/3/orders?consumerGroup=order-processors</c>.</example>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="streamKey"/> or <paramref name="consumerGroup"/> is null, empty, or whitespace.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="databaseId"/> is negative.</exception>
+    public static Uri Stream(string streamKey, int databaseId, string consumerGroup)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamKey);
+        ArgumentOutOfRangeException.ThrowIfNegative(databaseId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(consumerGroup);
+        return new Uri($"redis://stream/{databaseId}/{streamKey}?consumerGroup={consumerGroup}");
+    }
+}


### PR DESCRIPTION
## Summary

  Closes #2502

  Adds a static `<Transport>EndpointUri` helper class to every supported transport package so users no longer have to hand-write raw URI strings when identifying endpoints.
  Each helper exposes `Uri`-returning factory methods for every URI shape the transport's parser accepts, with consistent validation, XML docs, and URI-parser roundtrip tests.

  Before:
  ```csharp
  options.PublishMessage<OrderCreated>()
         .ToUri(new Uri("rabbitmq://queue/orders"));
  ```

  After:
  ```csharp
  options.PublishMessage<OrderCreated>()
         .ToUri(RabbitMqEndpointUri.Queue("orders"));
  ```

  ## What's included

  ### New helper classes (10 transports)

  | Package | Class | Methods |
  |---|---|---|
  | Wolverine.RabbitMQ | `RabbitMqEndpointUri` | `Queue`, `Exchange`, `Topic(ex, key)`, `Routing(ex, key)` |
  | Wolverine.Kafka | `KafkaEndpointUri` | `Topic` |
  | Wolverine.AzureServiceBus | `AzureServiceBusEndpointUri` | `Queue`, `Topic`, `Subscription(topic, sub)` |
  | Wolverine.AmazonSqs | `SqsEndpointUri` | `Queue` |
  | Wolverine.AmazonSns | `SnsEndpointUri` | `Topic` |
  | Wolverine.Redis | `RedisEndpointUri` | `Stream`, `Stream(..., consumerGroup)` |
  | Wolverine.MQTT | `MqttEndpointUri` | `Topic` |
  | Wolverine.Nats | `NatsEndpointUri` | `Subject` |
  | Wolverine.Pulsar | `PulsarEndpointUri` | `PersistentTopic`, `NonPersistentTopic`, `Topic(..., bool)`, `Topic(string)` |
  | Wolverine.Pubsub | `GcpPubsubEndpointUri` | `Topic(projectId, topicName)` |

  Every method validates string inputs with `ArgumentException.ThrowIfNullOrWhiteSpace` and carries full XML documentation (`<summary>`, `<param>`, `<returns>`, `<example>`,
  `<exception>`).

  ### Migration of existing ad-hoc helpers

  Two transports already shipped public URI builders. These are preserved with `[Obsolete]` attributes for backward compatibility:

  | Old | New | Migration |
  |---|---|---|
  | `RedisTransport.BuildRedisStreamUri(...)` | `RedisEndpointUri.Stream(...)` | One-line delegator. Obsolete. |
  | `PulsarEndpoint.UriFor(string topicPath)` | `PulsarEndpointUri.Topic(string)` | One-line delegator. Obsolete. |
  | `PulsarEndpoint.UriFor(bool, tenant, ns, topic)` | (no delegator) | Stays bit-exact. Obsolete. Returns a Pulsar-native topic path (`persistent://...`), which is a
  different URI form from the Wolverine endpoint URI (`pulsar://...`) produced by `PulsarEndpointUri`. The obsolete message explains the non-delegation. |

  Internal library callers were rewritten where sensible:
  - `PulsarTransport.EndpointFor` and `PulsarTransportExtensions` now call `PulsarEndpointUri.Topic` directly.
  - `PulsarListener`'s retry/DLQ topic builders still need the topic-path form for the native Pulsar client; those two call sites wrap the obsolete call with `#pragma warning
  disable CS0618`.

  ### Behavioural note on `PulsarEndpointUri.Topic(string)`

  The new canonical helper validates strictly: the input scheme must be `persistent` or `non-persistent`, and the path must contain exactly `tenant/namespace/topic`.
  Previously-accepted malformed input (e.g. `"http://..."` or a Wolverine endpoint URI passed by mistake) now throws an `ArgumentException` at the helper instead of silently
  producing a corrupt URI that only fails later in `PulsarEndpoint.Parse`. Callers passing well-formed Pulsar-native paths are unaffected.

  ## Testing

  - One new test class per transport (`<Transport>EndpointUriTests.cs`), covering shape assertions, null/whitespace validation theories, and — where feasible without a live
  broker — a URI-parser roundtrip via `transport.GetOrCreateEndpoint(uri)`. ~130 test cases total.
  - Additional compatibility tests in `PulsarEndpointTests` pin the deprecated `UriFor` behaviour:
    - `uri_for_topic_string_handles_non_persistent_scheme`
    - `uri_for_topic_string_preserves_realistic_topic_names`
    - `uri_for_bool_produces_retry_suffix_path_used_by_pulsar_listener`
    - `uri_for_bool_produces_dlq_suffix_path_used_by_pulsar_listener`

  The last two lock down the exact URI format that `PulsarListener` passes to the native Pulsar client for retry and dead-letter topics, guarding against accidental
  regressions in the interop-critical path.

  ## Documentation

  - Added a `## URI reference` section to every transport's Vitepress page under `docs/guide/messaging/transports/`, with a table mapping URI forms to helper calls and a short
   C# sample.
  - Redis and Pulsar pages carry a deprecation tip pointing users from `BuildRedisStreamUri` / `UriFor` to the new helpers.
  - The Redis `DocumentationSamples` and four incidentally-using Pulsar test files (`InlinePulsarTransportComplianceTests`, `PulsarTransportComplianceTests`,
  `WithCloudEvents`, `endpoint_configuration`) were migrated to the new helper.

  ## Breaking changes

  None for source compatibility. The deprecated `[Obsolete]` attributes are warnings (not errors), and all call sites that passed well-formed input continue to work.

  ## Test plan

  - `dotnet build wolverine.sln` — 0 warnings, 0 errors from library code.
  - Fast-test pass for every transport's `*EndpointUriTests` (all 10 classes green).
  - Redis and Pulsar existing tests still pass (proves obsolete delegators preserve behaviour).
  - Vitepress docs build picks up the new "URI reference" sections without layout regression.