### PR TITLE
Make Kafka AutoProvision actually create missing topics (GH-2537)

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/Bugs/Bug_2537_autoprovision_creates_missing_topics.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/Bugs/Bug_2537_autoprovision_creates_missing_topics.cs
@@ -1,0 +1,102 @@
+using Confluent.Kafka;
+using Confluent.Kafka.Admin;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Xunit.Abstractions;
+
+namespace Wolverine.Kafka.Tests.Bugs;
+
+/// <summary>
+/// GH-2537: <c>AutoProvision()</c> on the Kafka transport is documented as
+/// "Create newly used Kafka topics on endpoint activation if the topic is missing",
+/// but on its own it has no effect — the topic never gets created, and the
+/// <c>ListenToKafkaTopics(...)</c> group listener then fails with "Subscribed topic
+/// not available: &lt;topic&gt;: Broker: Unknown topic or partition". The only
+/// workaround today is to additionally call <c>AddResourceSetupOnStartup()</c>,
+/// which runs for every broker and bypasses per-transport <c>AutoProvision</c>
+/// granularity.
+///
+/// This test focuses on the group-listener path the issue reporter used
+/// (<c>ListenToKafkaTopics</c>). To avoid Confluent's broker-level
+/// <c>auto.create.topics.enable=true</c> masking the bug, the test never produces
+/// to the topic — it just asserts, after host startup, that the topic exists
+/// in a broker metadata snapshot.
+///
+/// The test deliberately does NOT register <c>AddResourceSetupOnStartup()</c>,
+/// so AutoProvision is the only mechanism responsible for creating the topic.
+/// </summary>
+public class Bug_2537_autoprovision_creates_missing_topics : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _topicName = $"bug2537-{Guid.NewGuid():N}";
+
+    public Bug_2537_autoprovision_creates_missing_topics(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        // Clean up so reruns start from a blank state, regardless of pass/fail.
+        try
+        {
+            using var admin = new AdminClientBuilder(
+                new AdminClientConfig { BootstrapServers = KafkaContainerFixture.ConnectionString }).Build();
+            await admin.DeleteTopicsAsync([_topicName]);
+        }
+        catch
+        {
+            // Ignore: the topic may never have been created.
+        }
+    }
+
+    [Fact]
+    public async Task autoprovision_alone_creates_missing_topic_for_group_listener()
+    {
+        // Sanity: topic should not yet exist (full metadata snapshot, no per-topic
+        // query — that would trigger broker auto-creation on confluent-local).
+        ListAllTopics().ShouldNotContain(_topicName,
+            $"Test setup error — topic {_topicName} already exists on the broker");
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // NO AddResourceSetupOnStartup() — AutoProvision() is the only
+                // mechanism that should create the topic here.
+                opts.UseKafka(KafkaContainerFixture.ConnectionString)
+                    .AutoProvision()
+                    .ConfigureConsumers(c =>
+                    {
+                        c.AutoOffsetReset = AutoOffsetReset.Earliest;
+                        c.GroupId = $"bug2537-{Guid.NewGuid():N}";
+                    });
+
+                opts.ListenToKafkaTopics(_topicName).ProcessInline();
+
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Services.AddSingleton<ILoggerProvider>(new OutputLoggerProvider(_output));
+            }).StartAsync();
+
+        // AutoProvision should have created the topic during host startup.
+        ListAllTopics().ShouldContain(_topicName,
+            $"AutoProvision() should have created topic {_topicName} during host startup");
+    }
+
+    /// <summary>
+    /// Full-cluster metadata snapshot, which does NOT trigger broker-side
+    /// topic auto-creation on confluent-local.
+    /// </summary>
+    private static string[] ListAllTopics()
+    {
+        using var admin = new AdminClientBuilder(
+            new AdminClientConfig { BootstrapServers = KafkaContainerFixture.ConnectionString }).Build();
+        var metadata = admin.GetMetadata(TimeSpan.FromSeconds(10));
+        return metadata.Topics.Select(t => t.Topic).ToArray();
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -189,6 +189,19 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     }
 
     /// <summary>
+    /// Called during transport startup. When AutoProvision is on for the parent
+    /// transport, ensure the Kafka topic exists on the broker before listeners or
+    /// senders try to use it. See https://github.com/JasperFx/wolverine/issues/2537.
+    /// </summary>
+    public override async ValueTask InitializeAsync(ILogger logger)
+    {
+        if (Parent.AutoProvision)
+        {
+            await SetupAsync(logger);
+        }
+    }
+
+    /// <summary>
     /// Override how this Kafka topic is created
     /// </summary>
     public Func<IAdminClient, KafkaTopic, Task> CreateTopicFunc { get; internal set; } = (c, t) => c.CreateTopicsAsync([t.Specification]);

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
@@ -144,4 +144,21 @@ public class KafkaTopicGroup : KafkaTopic, IBrokerEndpoint
             }
         }
     }
+
+    /// <summary>
+    /// Called during transport startup. When AutoProvision is on for the parent
+    /// transport, ensure every Kafka topic in this group exists on the broker
+    /// before the listener subscribes. Without this, the KafkaTopicGroupListener's
+    /// consumer raises "Subscribed topic not available" on the first Consume().
+    /// Overrides the base KafkaTopic.InitializeAsync so the group's multi-topic
+    /// SetupAsync is invoked (not the single-topic base version).
+    /// See https://github.com/JasperFx/wolverine/issues/2537.
+    /// </summary>
+    public override async ValueTask InitializeAsync(ILogger logger)
+    {
+        if (Parent.AutoProvision)
+        {
+            await SetupAsync(logger);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes #2537: `AutoProvision()` on the Kafka transport is documented as "Create newly used Kafka topics on endpoint activation if the topic is missing", but on its own it had no effect — nothing in the Kafka transport ever read the flag during startup. The only workaround today is to additionally call `AddResourceSetupOnStartup()`, which runs for every broker and defeats per-transport granularity.
- `KafkaTopic` and `KafkaTopicGroup` now each override `InitializeAsync` and call their existing `SetupAsync` when `Parent.AutoProvision` is true — the same wiring `RabbitMqQueue.InitializeAsync` already uses.

## Root cause
`BrokerTransport.InitializeAsync` iterates endpoints and calls `endpoint.InitializeAsync(logger)`, but neither Kafka endpoint class overrode that hook, so the default no-op ran and the flag was never consulted. Both classes already had correct `SetupAsync` methods (create topic, swallow "already exists") — they just weren't being invoked on the AutoProvision path.

`KafkaTopicGroup` shadows `SetupAsync` with a multi-topic version via `new`, so it needs its own override — otherwise the base `KafkaTopic.SetupAsync` would create a single topic named after the sanitized composite group name instead of each topic in the group.

## Reproducer
Test: `src/Transports/Kafka/Wolverine.Kafka.Tests/Bugs/Bug_2537_autoprovision_creates_missing_topics.cs`

Targets the user's reported path (`ListenToKafkaTopics(…)`, group listener). Two deliberate design choices to avoid Confluent-local's defaults masking the bug:
- `confluent-local:7.7.1` has `auto.create.topics.enable=true`, so any *producer* publish would silently create the topic. The test never produces — it only asserts on broker metadata.
- `admin.GetMetadata(topicName, timeout)` also triggers broker auto-create on a per-topic query. The test uses `admin.GetMetadata(timeout)` (full-cluster snapshot) instead.

Without the fix, the test fails with the exact error the user reported:
```
Confluent.Kafka.ConsumeException: Subscribed topic not available: bug2537-…: Broker: Unknown topic or partition
```

## Test plan
- [x] Reproducer fails pre-fix with the user-reported error, passes post-fix
- [x] `dotnet test src/Transports/Kafka/Wolverine.Kafka.Tests --framework net9.0` → **137 / 137 pass** (2 pre-existing skips), 8m 36s locally against `confluentinc/confluent-local:7.7.1`
- [ ] CI across net8 / net9 / net10

🤖 Generated with [Claude Code](https://claude.com/claude-code)