### PR TITLE
gRPC #2525 follow-up: Correctness Gaps

### DIFF
--- a/docs/guide/grpc/handlers.md
+++ b/docs/guide/grpc/handlers.md
@@ -80,12 +80,17 @@ Both paths feed into the same generated-code pipeline used by Wolverine's messag
 adapters, so your gRPC services show up in the standard diagnostics:
 
 ```bash
+# List every handler / HTTP endpoint / gRPC service Wolverine knows about
 dotnet run -- describe
-dotnet run -- describe-routing
+
+# Preview the generated wrapper for one proto-first gRPC stub
+dotnet run -- wolverine-diagnostics codegen-preview --grpc Greeter
 ```
 
-If you're debugging discovery, those commands will show the generated handler type name and the
-handler method it forwards to.
+If you're debugging discovery, `describe` proves Wolverine found the stub; `codegen-preview --grpc`
+shows the exact generated override and the handler method each RPC forwards to. See
+[`codegen-preview`](/guide/command-line#codegen-preview) for the full set of accepted identifiers
+(bare proto service name, stub class name, or short `-g` alias).
 
 ## Observability
 

--- a/docs/guide/grpc/index.md
+++ b/docs/guide/grpc/index.md
@@ -1,9 +1,8 @@
 # gRPC Services with Wolverine
 
 ::: info
-The `WolverineFx.Grpc` package (experimental, shipping alongside gRPC support on the
-`feature/grpc-and-streaming-support` branch) lets you expose Wolverine handlers as
-ASP.NET Core gRPC services with minimal wiring. It supports both the **code-first**
+The `WolverineFx.Grpc` package lets you expose Wolverine handlers as ASP.NET Core gRPC services
+with minimal wiring. It supports both the **code-first**
 ([protobuf-net.Grpc](https://protobuf-net.github.io/protobuf-net.Grpc/)) and **proto-first**
 ([Grpc.Tools](https://learn.microsoft.com/en-us/aspnet/core/grpc/)) styles.
 :::
@@ -116,41 +115,31 @@ and comparisons to the official `grpc-dotnet` examples.
   through `Bus.StreamAsync<TResp>(item, ct)` — see [Streaming](./streaming) for the pattern and the
   [RacerWithGrpc](https://github.com/JasperFx/wolverine/tree/main/src/Samples/RacerWithGrpc) sample.
 - **Exception mapping** of the canonical `Exception → StatusCode` table is not yet user-configurable
-  (follow-up item). Rich, structured responses are already available — see
-  [Error Handling](./errors).
+  on the server side (follow-up item). Rich, structured responses are already available — see
+  [Error Handling](./errors). On the client side, `WolverineGrpcClientOptions.MapRpcException`
+  already allows per-client overrides — see [Typed gRPC Clients](./client#per-client-override).
+- **`MiddlewareScoping.Grpc` middleware** — the enum value ships and is honored by Wolverine's
+  discovery primitives, but no code path yet *weaves* `[WolverineBefore(MiddlewareScoping.Grpc)]`
+  / `[WolverineAfter(MiddlewareScoping.Grpc)]` methods into the generated gRPC service wrappers.
+  The attribute is safe to apply — it compiles, it is correctly filtered away from message-handler
+  and HTTP chains, and it will start firing once the codegen path (tracked as M15) lands — but
+  today nothing runs at RPC time. Until then, middleware that needs to execute on gRPC calls
+  should live in a custom gRPC interceptor rather than rely on the attribute or on
+  `services.AddWolverineGrpc(g => g.AddMiddleware<T>())` (both take effect together in M15).
 
 ## Roadmap
 
-The gRPC integration is intentionally shipping as a focused, reviewable slice. The items below are
-on the roadmap but *not* in the initial drop — they're listed here so contributors can plan around
-them and consumers know what's coming.
+The gRPC integration has a handful of deferred items that are known-good fits but haven't shipped
+yet. They're listed here so contributors can plan around them and consumers know what's coming.
 
-### Shipping in this PR
-
-- **`MiddlewareScoping.Grpc`** — the existing [scoped middleware](/guide/handlers/middleware#applying-middleware-explicitly-by-attribute)
-  enum grows a `Grpc` value so gRPC-specific middleware can be registered the same way HTTP and
-  messaging middleware already are. Previously, gRPC service chains reported themselves as
-  `MessageHandlers`-scoped, which silently over-attached message middleware to gRPC calls. This is
-  a behavior correction, not an additive feature.
-- **`codegen-preview --grpc`** — the [`codegen-preview` CLI](/guide/command-line#codegen-preview)
-  grows a `--grpc` / `-g` flag (mirroring `--handler` / `-h` and `--route` / `-r`) so you can inspect
-  the code Wolverine generates for gRPC service chains without dropping into the full `codegen write`
-  output.
-- **Typed gRPC client extension (`AddWolverineGrpcClient<T>()`)** — a thin Wolverine wrapper over
-  `Grpc.Net.ClientFactory.AddGrpcClient<T>()` that layers envelope-header propagation and
-  `RpcException` → typed .NET exception translation onto both code-first (`protobuf-net.Grpc`
-  `[ServiceContract]`) and proto-first (`Grpc.Tools`-generated) typed clients. See
-  [Typed gRPC Clients](./client) for the full surface. Raw `GrpcChannel` + generated stubs (as used
-  in the samples today) remain a fully supported path.
-
-### Deferred to follow-up PRs
-
+- **`MiddlewareScoping.Grpc` codegen weaving (M15)** — attribute-based middleware on gRPC stubs
+  (see Current Limitations above). Phase 0 landed the discovery + options surface; Phase 1 will
+  wire execution into the generated `GrpcServiceChain` wrappers.
 - **`Validate` convention → `Status?`** — HTTP handlers already support an opt-in `Validate` method
   whose non-null return short-circuits the call. The gRPC equivalent would return
   `Grpc.Core.Status?` (or a richer `google.rpc.Status`) so a handler could express "this call is
-  invalid, return `InvalidArgument` with these field violations" without throwing. This is
-  deferred because it lands cleanest on top of the code-first codegen work below — shipping it
-  against the current runtime path would bake in assumptions we'll want to revisit.
+  invalid, return `InvalidArgument` with these field violations" without throwing. Deferred because
+  it lands cleanest on top of the code-first codegen work below.
 - **Code-first codegen parity** — proto-first services flow through a generated `GrpcServiceChain`
   with the usual JasperFx codegen pipeline; code-first services (the `WolverineGrpcServiceBase` path)
   currently resolve dependencies via service location inside each method. Generating per-method code

--- a/docs/guide/grpc/streaming.md
+++ b/docs/guide/grpc/streaming.md
@@ -122,7 +122,10 @@ but your detached tasks keep running. Always thread the token through.
 - **Exception timing:** an exception thrown **before** the first `yield return` surfaces on the
   client via the trailers as expected. An exception thrown **mid-stream** surfaces as a trailer
   after messages the client has already received — well-behaved clients must still check the final
-  status even after consuming messages successfully.
+  status even after consuming messages successfully. Server-side, the OpenTelemetry activity for
+  the handler is marked `Error` in both cases (including cancellation) — the activity stays open
+  until the stream fully drains or faults, so dashboards reflect the real terminal state rather
+  than the moment the handler returned the `IAsyncEnumerable<T>`.
 
 ## Related
 

--- a/src/Testing/CoreTests/Acceptance/streaming_handler_support.cs
+++ b/src/Testing/CoreTests/Acceptance/streaming_handler_support.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
@@ -199,6 +200,37 @@ public class streaming_handler_support
 
         ex.Message.ShouldBe("handler faulted mid-stream");
         items.Select(i => i.Value).ShouldBe([0, 1]);
+    }
+
+    [Fact]
+    public async Task mid_stream_throw_marks_activity_status_error()
+    {
+        var capturedActivities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Wolverine",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity => capturedActivities.Add(activity)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine()
+            .StartAsync();
+
+        var bus = host.Services.GetRequiredService<IMessageBus>();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in bus.StreamAsync<StreamItem>(new FaultingStreamRequest(2)))
+            {
+            }
+        });
+
+        var streamingActivity = capturedActivities
+            .FirstOrDefault(a => a.OperationName.Contains("stream", StringComparison.OrdinalIgnoreCase));
+        streamingActivity.ShouldNotBeNull();
+        streamingActivity.Status.ShouldBe(ActivityStatusCode.Error);
     }
 
     [Fact]

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/GreetMessageHandler.cs
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/GreetMessageHandler.cs
@@ -1,0 +1,29 @@
+using Wolverine.Grpc.Tests.GrpcMiddlewareScoping.Generated;
+
+namespace Wolverine.Grpc.Tests.GrpcMiddlewareScoping;
+
+/// <summary>
+///     Wolverine handler for the unary RPC. Records its invocation against the shared
+///     <see cref="MiddlewareInvocationSink"/> so middleware-ordering tests can assert
+///     before/after relative to the handler call.
+/// </summary>
+public static class GreetMessageHandler
+{
+    public const string Marker = "Handler";
+
+    public static GreetReply Handle(GreetRequest request, MiddlewareInvocationSink sink)
+    {
+        sink.Record(Marker);
+        return new GreetReply { Message = $"Hello, {request.Name}" };
+    }
+
+    public static async IAsyncEnumerable<GreetReply> Handle(GreetManyRequest request, MiddlewareInvocationSink sink)
+    {
+        sink.Record(Marker);
+        for (var i = 0; i < 3; i++)
+        {
+            yield return new GreetReply { Message = $"Hello #{i}, {request.Name}" };
+            await Task.Yield();
+        }
+    }
+}

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/GreeterMiddlewareTestStub.ScopeProbes.cs
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/GreeterMiddlewareTestStub.ScopeProbes.cs
@@ -1,0 +1,36 @@
+using Wolverine.Attributes;
+
+namespace Wolverine.Grpc.Tests.GrpcMiddlewareScoping;
+
+/// <summary>
+///     Probe methods used by <c>scope_discovery_tests</c> to verify that
+///     <see cref="GrpcServiceChain.DiscoveredBefores"/> / <see cref="GrpcServiceChain.DiscoveredAfters"/>
+///     respect <see cref="MiddlewareScoping"/>. Lives on the smoke stub via <c>partial</c> so tests
+///     don't need a second proto to exercise the discovery path. These are inert under Phase 0
+///     (no weaving yet); when Phase 1 lands, they'll be the first concrete demonstration that the
+///     M15 promise (middleware fires alongside the gRPC handler) actually holds.
+/// </summary>
+public abstract partial class GreeterMiddlewareTestStub
+{
+    public const string AnywhereMarker = "ScopeProbe.Anywhere";
+    public const string GrpcMarker = "ScopeProbe.Grpc";
+    public const string MessageHandlersMarker = "ScopeProbe.MessageHandlers";
+
+    [WolverineBefore]
+    public static void BeforeAnywhere(MiddlewareInvocationSink sink) => sink.Record(AnywhereMarker);
+
+    [WolverineBefore(MiddlewareScoping.Grpc)]
+    public static void BeforeGrpc(MiddlewareInvocationSink sink) => sink.Record(GrpcMarker);
+
+    [WolverineBefore(MiddlewareScoping.MessageHandlers)]
+    public static void BeforeMessageHandlers(MiddlewareInvocationSink sink) => sink.Record(MessageHandlersMarker);
+
+    [WolverineAfter]
+    public static void AfterAnywhere(MiddlewareInvocationSink sink) => sink.Record(AnywhereMarker + ".After");
+
+    [WolverineAfter(MiddlewareScoping.Grpc)]
+    public static void AfterGrpc(MiddlewareInvocationSink sink) => sink.Record(GrpcMarker + ".After");
+
+    [WolverineAfter(MiddlewareScoping.MessageHandlers)]
+    public static void AfterMessageHandlers(MiddlewareInvocationSink sink) => sink.Record(MessageHandlersMarker + ".After");
+}

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/GreeterMiddlewareTestStub.cs
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/GreeterMiddlewareTestStub.cs
@@ -1,0 +1,13 @@
+using Wolverine.Grpc.Tests.GrpcMiddlewareScoping.Generated;
+
+namespace Wolverine.Grpc.Tests.GrpcMiddlewareScoping;
+
+/// <summary>
+///     Proto-first Wolverine stub for the M15 (<see cref="Wolverine.Attributes.MiddlewareScoping.Grpc"/>)
+///     test suite. Intentionally bare — middleware methods carrying
+///     <c>[WolverineBefore]</c>/<c>[WolverineAfter]</c> are added per-test via partial-class
+///     extensions or test-specific subclasses so each scenario can scope its assertions
+///     without polluting the shared stub.
+/// </summary>
+[WolverineGrpcService]
+public abstract partial class GreeterMiddlewareTestStub : GreeterMiddlewareTest.GreeterMiddlewareTestBase;

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/MiddlewareInvocationSink.cs
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/MiddlewareInvocationSink.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+
+namespace Wolverine.Grpc.Tests.GrpcMiddlewareScoping;
+
+/// <summary>
+///     Thread-safe append-only ledger of named events that the M15 integration tests use to
+///     assert middleware ordering and scope filtering. Each captured entry records the marker
+///     name supplied by a test fixture (typically a stub-class method name like
+///     <c>"BeforeGrpc"</c> or a handler name like <c>"Handler"</c>) so the test can later
+///     assert what fired and in what order without coupling to clock timing.
+/// </summary>
+public sealed class MiddlewareInvocationSink
+{
+    private readonly ConcurrentQueue<string> _events = new();
+
+    public void Record(string marker) => _events.Enqueue(marker);
+
+    public IReadOnlyList<string> Events => _events.ToArray();
+
+    public void Clear()
+    {
+        while (_events.TryDequeue(out _))
+        {
+        }
+    }
+
+    public bool Contains(string marker) => _events.Contains(marker);
+
+    public int CountOf(string marker) => _events.Count(e => e == marker);
+}

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/MiddlewareScopingFixture.cs
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/MiddlewareScopingFixture.cs
@@ -1,0 +1,73 @@
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Grpc.Tests.GrpcMiddlewareScoping.Generated;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.GrpcMiddlewareScoping;
+
+/// <summary>
+///     Dedicated host fixture for the M15 <c>MiddlewareScoping.Grpc</c> integration tests.
+///     Booted as a per-class fixture (not collection-shared) so each test class can verify
+///     middleware-invocation ordering against a fresh <see cref="MiddlewareInvocationSink"/>
+///     without inter-test interference.
+/// </summary>
+/// <remarks>
+///     Modeled on <see cref="GrpcTestFixture"/> but isolated from the PingPong/Streaming/Faulting
+///     samples so M15 assertions don't drift when those samples evolve. Uses ASP.NET Core's
+///     <c>TestHost</c> for an in-process channel — no real network port.
+/// </remarks>
+public class MiddlewareScopingFixture : IAsyncLifetime
+{
+    private WebApplication? _app;
+    public GrpcChannel? Channel { get; private set; }
+    public MiddlewareInvocationSink Sink { get; } = new();
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+
+        builder.WebHost.UseTestServer();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.ApplicationAssembly = typeof(MiddlewareScopingFixture).Assembly;
+        });
+
+        builder.Services.AddSingleton(Sink);
+        builder.Services.AddGrpc();
+        builder.Services.AddWolverineGrpc();
+
+        _app = builder.Build();
+
+        _app.UseRouting();
+
+        // Trigger Wolverine's proto-first discovery + code-gen and register the generated
+        // wrapper. Pre-M15 weaving, this just emits forward-frames; once §7.3 lands the same
+        // generated code will additionally carry middleware/postprocessor frames per RPC.
+        _app.MapWolverineGrpcServices();
+
+        await _app.StartAsync();
+
+        var handler = _app.GetTestServer().CreateHandler();
+        Channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+        {
+            HttpHandler = handler
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        Channel?.Dispose();
+        if (_app != null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+
+    public GreeterMiddlewareTest.GreeterMiddlewareTestClient CreateClient()
+        => new(Channel!);
+}

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/Protos/middleware_scoping_test.proto
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/Protos/middleware_scoping_test.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+option csharp_namespace = "Wolverine.Grpc.Tests.GrpcMiddlewareScoping.Generated";
+
+package wolverine.grpc.tests.middleware_scoping;
+
+// Test-only service used by middleware-scoping tests. Two RPC shapes (unary + server-streaming)
+// so the same fixture exercises the per-RPC weaving paths from §7.3 of the M15 plan.
+service GreeterMiddlewareTest {
+  // Unary: maps to Wolverine via IMessageBus.InvokeAsync<GreetReply>.
+  rpc Greet (GreetRequest) returns (GreetReply);
+
+  // Server-streaming: maps to Wolverine via IMessageBus.StreamAsync<GreetReply>. Uses a
+  // distinct request type because Wolverine dispatches handlers by message type, so the
+  // unary and streaming RPCs cannot share GreetRequest.
+  rpc GreetMany (GreetManyRequest) returns (stream GreetReply);
+}
+
+message GreetRequest {
+  string name = 1;
+}
+
+message GreetManyRequest {
+  string name = 1;
+}
+
+message GreetReply {
+  string message = 1;
+}

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/frame_cloning_spike_tests.cs
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/frame_cloning_spike_tests.cs
@@ -1,0 +1,67 @@
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.GrpcMiddlewareScoping;
+
+/// <summary>
+///     Pins the invariant Phase-1 codegen relies on: two <see cref="MethodCall"/> instances
+///     built from one <see cref="System.Reflection.MethodInfo"/> do not share mutable state.
+///     If the <c>_discoveredBefores</c> caching on <see cref="GrpcServiceChain"/> ever became
+///     <em>instance</em> caching (e.g. storing a single <see cref="MethodCall"/> per method and
+///     reusing it across every RPC override), one RPC's argument resolution would contaminate
+///     its siblings during <c>GenerateCode</c>. The fix is "fresh MethodCall per emission site"
+///     (see §13 of the M15 plan). This test fails loudly if that invariant is broken.
+/// </summary>
+public class frame_cloning_spike_tests
+{
+    [Fact]
+    public void method_call_instances_from_one_method_info_do_not_share_mutable_state()
+    {
+        var methodInfo = typeof(GreeterMiddlewareTestStub)
+            .GetMethod(nameof(GreeterMiddlewareTestStub.BeforeGrpc))!;
+
+        var first = new MethodCall(typeof(GreeterMiddlewareTestStub), methodInfo);
+        var second = new MethodCall(typeof(GreeterMiddlewareTestStub), methodInfo);
+
+        // The reflection handle is immutable — sharing it is expected and safe.
+        ReferenceEquals(first.Method, second.Method)
+            .ShouldBeTrue("MethodInfo is an immutable reflection handle; sharing is fine");
+
+        // The MethodCall wrappers themselves must be distinct objects.
+        ReferenceEquals(first, second)
+            .ShouldBeFalse("Phase-1 must instantiate a fresh MethodCall per emission site");
+
+        // The mutable Arguments array — the one GenerateCode resolves Variables into — must be
+        // a per-instance array. If this ever becomes a shared reference, resolving one emission
+        // site would leak into every other emission site built from the same MethodInfo.
+        ReferenceEquals(first.Arguments, second.Arguments)
+            .ShouldBeFalse("Arguments[] must be per-instance — GenerateCode mutates it during codegen");
+
+        // Mutation proof: overwrite one site's arguments and confirm the sibling is unchanged.
+        // This is the concrete failure mode a caching bug would produce at runtime.
+        var sentinel = Variable.For<string>("sentinel");
+        first.Arguments[0] = sentinel;
+
+        second.Arguments[0]
+            .ShouldNotBe(sentinel,
+                "mutating one MethodCall's Arguments must not be visible on a sibling built from the same MethodInfo");
+    }
+
+    [Fact]
+    public void method_call_creates_collection_is_per_instance()
+    {
+        var methodInfo = typeof(GreeterMiddlewareTestStub)
+            .GetMethod(nameof(GreeterMiddlewareTestStub.BeforeGrpc))!;
+
+        var first = new MethodCall(typeof(GreeterMiddlewareTestStub), methodInfo);
+        var second = new MethodCall(typeof(GreeterMiddlewareTestStub), methodInfo);
+
+        // Creates holds output variables resolved during codegen. Like Arguments, it must be
+        // a distinct collection per instance so cascading-message detection on one emission
+        // doesn't leak to another.
+        ReferenceEquals(first.Creates, second.Creates)
+            .ShouldBeFalse("Creates collection must be per-instance");
+    }
+}

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/middleware_scoping_fixture_smoke_tests.cs
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/middleware_scoping_fixture_smoke_tests.cs
@@ -1,0 +1,53 @@
+using Grpc.Core;
+using Shouldly;
+using Wolverine.Grpc.Tests.GrpcMiddlewareScoping.Generated;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.GrpcMiddlewareScoping;
+
+/// <summary>
+///     Sanity-checks for the M15 test harness. These run BEFORE the production weaving lands
+///     (Phase 1) so the fixture itself is known-good — when P1 tests start asserting middleware
+///     invocations, any failure narrows to "P1 weaving" rather than "harness was never working."
+/// </summary>
+public class middleware_scoping_fixture_smoke_tests : IClassFixture<MiddlewareScopingFixture>
+{
+    private readonly MiddlewareScopingFixture _fixture;
+
+    public middleware_scoping_fixture_smoke_tests(MiddlewareScopingFixture fixture)
+    {
+        _fixture = fixture;
+        _fixture.Sink.Clear();
+    }
+
+    [Fact]
+    public async Task unary_rpc_round_trips_through_wolverine_handler()
+    {
+        var client = _fixture.CreateClient();
+
+        var reply = await client.GreetAsync(new GreetRequest { Name = "Erik" });
+
+        reply.Message.ShouldBe("Hello, Erik");
+        _fixture.Sink.Contains(GreetMessageHandler.Marker).ShouldBeTrue(
+            "the Wolverine handler must run for the unary RPC");
+    }
+
+    [Fact]
+    public async Task server_streaming_rpc_round_trips_through_wolverine_streaming_handler()
+    {
+        var client = _fixture.CreateClient();
+
+        using var call = client.GreetMany(new GreetManyRequest { Name = "Erik" });
+
+        var replies = new List<string>();
+        await foreach (var reply in call.ResponseStream.ReadAllAsync())
+        {
+            replies.Add(reply.Message);
+        }
+
+        replies.Count.ShouldBe(3);
+        replies[0].ShouldBe("Hello #0, Erik");
+        _fixture.Sink.Contains(GreetMessageHandler.Marker).ShouldBeTrue(
+            "the Wolverine streaming handler must run for the server-streaming RPC");
+    }
+}

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/policy_leak_tests.cs
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/policy_leak_tests.cs
@@ -1,0 +1,80 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Middleware;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.GrpcMiddlewareScoping;
+
+/// <summary>
+///     M15 §9.6 — pins the boundary between the message-handler middleware policy
+///     (<see cref="IPolicies.AddMiddleware{T}"/>) and gRPC chains. The handler-only filter
+///     baked into <c>WolverineOptions.Policies.cs:208-216</c> is the *only* thing keeping
+///     handler middleware from leaking into <see cref="GrpcServiceChain"/>; if Phase-1 wiring
+///     ever bypasses that filter (e.g. by registering <see cref="MiddlewarePolicy"/> as a
+///     global <c>IChainPolicy</c> against gRPC chains too), users would suddenly see their
+///     bus middleware run on every RPC call. Hence the explicit guard test here.
+/// </summary>
+public class policy_leak_tests
+{
+    [Fact]
+    public async Task ipolicies_add_middleware_does_not_attach_to_grpc_chain()
+    {
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+        try
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.ApplicationAssembly = typeof(GreeterMiddlewareTestStub).Assembly;
+                    opts.Policies.AddMiddleware<HandlerOnlyMiddleware>();
+                })
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton(new MiddlewareInvocationSink());
+                    services.AddWolverineGrpc();
+                })
+                .StartAsync();
+
+            var graph = host.Services.GetRequiredService<GrpcGraph>();
+            graph.DiscoverServices();
+            var chain = graph.Chains.Single(c => c.StubType == typeof(GreeterMiddlewareTestStub));
+
+            var options = host.Services.GetRequiredService<WolverineOptions>();
+            var policy = options.FindOrCreateMiddlewarePolicy();
+            var rules = options.CodeGeneration;
+            var container = host.Services.GetRequiredService<IServiceContainer>();
+
+            // Simulate the worst-case Phase-1 wiring: forcibly run the handler-only middleware
+            // policy against a GrpcServiceChain. The HandlerChain-only filter at
+            // WolverineOptions.Policies.cs:208-216 must reject the chain so no middleware lands.
+            policy.Apply([chain], rules, container);
+
+            chain.Middleware.ShouldBeEmpty(
+                "IPolicies.AddMiddleware uses a HandlerChain-only filter — middleware registered "
+                + "via the message-handler policy must never attach to a GrpcServiceChain. "
+                + "gRPC users should use AddWolverineGrpc(g => g.AddMiddleware<T>()) instead.");
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+
+}
+
+/// <summary>
+///     A trivial middleware whose only purpose is to be visible in the chain's middleware
+///     list IF the filter ever broke. Method named per <see cref="MiddlewarePolicy.BeforeMethodNames"/>
+///     so it is unambiguously a Before frame. Must be public + top-level — Wolverine rejects
+///     nested or non-public middleware types in <see cref="MiddlewarePolicy.Application"/>'s
+///     constructor.
+/// </summary>
+public sealed class HandlerOnlyMiddleware
+{
+    public static void Before(MiddlewareInvocationSink sink) => sink.Record("HandlerOnlyMiddleware.Before");
+}

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/scope_discovery_tests.cs
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/scope_discovery_tests.cs
@@ -1,0 +1,104 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.GrpcMiddlewareScoping;
+
+/// <summary>
+///     Verifies the M15 Phase-0 discovery: <see cref="GrpcServiceChain.DiscoveredBefores"/> and
+///     <see cref="GrpcServiceChain.DiscoveredAfters"/> walk the user's stub type and honor
+///     <see cref="Wolverine.Attributes.MiddlewareScoping"/>. These tests pin the contract that
+///     Phase-1 codegen will rely on — get this wrong and the eventual weaving will silently
+///     attach (or skip) the wrong methods.
+/// </summary>
+public class scope_discovery_tests
+{
+    [Fact]
+    public async Task discovers_anywhere_and_grpc_scoped_befores_on_stub_type()
+    {
+        var chain = await DiscoverStubChainAsync();
+
+        var names = chain.DiscoveredBefores.Select(m => m.Name).ToArray();
+
+        names.ShouldContain(nameof(GreeterMiddlewareTestStub.BeforeAnywhere));
+        names.ShouldContain(nameof(GreeterMiddlewareTestStub.BeforeGrpc));
+    }
+
+    [Fact]
+    public async Task does_not_discover_message_handlers_scoped_befores_on_stub_type()
+    {
+        var chain = await DiscoverStubChainAsync();
+
+        var names = chain.DiscoveredBefores.Select(m => m.Name).ToArray();
+
+        names.ShouldNotContain(nameof(GreeterMiddlewareTestStub.BeforeMessageHandlers),
+            "[WolverineBefore(MessageHandlers)] must not leak into a gRPC chain's discovered middleware");
+    }
+
+    [Fact]
+    public async Task discovers_anywhere_and_grpc_scoped_afters_on_stub_type()
+    {
+        var chain = await DiscoverStubChainAsync();
+
+        var names = chain.DiscoveredAfters.Select(m => m.Name).ToArray();
+
+        names.ShouldContain(nameof(GreeterMiddlewareTestStub.AfterAnywhere));
+        names.ShouldContain(nameof(GreeterMiddlewareTestStub.AfterGrpc));
+    }
+
+    [Fact]
+    public async Task does_not_discover_message_handlers_scoped_afters_on_stub_type()
+    {
+        var chain = await DiscoverStubChainAsync();
+
+        var names = chain.DiscoveredAfters.Select(m => m.Name).ToArray();
+
+        names.ShouldNotContain(nameof(GreeterMiddlewareTestStub.AfterMessageHandlers),
+            "[WolverineAfter(MessageHandlers)] must not leak into a gRPC chain's discovered postprocessors");
+    }
+
+    [Fact]
+    public async Task discovery_results_are_stable_across_repeated_reads()
+    {
+        // Phase 1 codegen will read DiscoveredBefores from inside AssembleTypes which can be
+        // invoked more than once during dynamic regeneration; cached results must not change
+        // shape between calls or the generated source becomes nondeterministic.
+        var chain = await DiscoverStubChainAsync();
+
+        var first = chain.DiscoveredBefores;
+        var second = chain.DiscoveredBefores;
+
+        ReferenceEquals(first, second).ShouldBeTrue("DiscoveredBefores should be cached after first access");
+    }
+
+    private static async Task<GrpcServiceChain> DiscoverStubChainAsync()
+    {
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+        try
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.ApplicationAssembly = typeof(GreeterMiddlewareTestStub).Assembly;
+                })
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton(new MiddlewareInvocationSink());
+                    services.AddWolverineGrpc();
+                })
+                .StartAsync();
+
+            var graph = host.Services.GetRequiredService<GrpcGraph>();
+            graph.DiscoverServices();
+
+            return graph.Chains.Single(c => c.StubType == typeof(GreeterMiddlewareTestStub));
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+}

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/scope_discovery_tests.cs
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/scope_discovery_tests.cs
@@ -61,6 +61,33 @@ public class scope_discovery_tests
     }
 
     [Fact]
+    public async Task discovered_befores_are_ordinally_sorted_for_deterministic_codegen()
+    {
+        // Reflection's GetMethods() order is unspecified — if Phase-1 emits middleware frames
+        // in whatever order reflection returns, the generated source is nondeterministic across
+        // runs, which breaks byte-stable codegen caches and makes diagnostic diffs unreadable.
+        // PR #2525 established this invariant for RPC-method discovery (GrpcServiceChain.cs:268);
+        // we match that pattern here.
+        var chain = await DiscoverStubChainAsync();
+
+        var names = chain.DiscoveredBefores.Select(m => m.Name).ToArray();
+        var sorted = names.OrderBy(n => n, StringComparer.Ordinal).ToArray();
+
+        names.ShouldBe(sorted);
+    }
+
+    [Fact]
+    public async Task discovered_afters_are_ordinally_sorted_for_deterministic_codegen()
+    {
+        var chain = await DiscoverStubChainAsync();
+
+        var names = chain.DiscoveredAfters.Select(m => m.Name).ToArray();
+        var sorted = names.OrderBy(n => n, StringComparer.Ordinal).ToArray();
+
+        names.ShouldBe(sorted);
+    }
+
+    [Fact]
     public async Task discovery_results_are_stable_across_repeated_reads()
     {
         // Phase 1 codegen will read DiscoveredBefores from inside AssembleTypes which can be

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/type_name_disambiguation_tests.cs
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/type_name_disambiguation_tests.cs
@@ -1,0 +1,126 @@
+using JasperFx.CodeGeneration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Grpc.Tests.GrpcMiddlewareScoping.Generated;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.GrpcMiddlewareScoping;
+
+/// <summary>
+///     Verifies the post-discovery disambiguation pass in <see cref="GrpcGraph.DisambiguateCollidingTypeNames"/>.
+///     Two proto services sharing a simple name (e.g. a <c>Greeter</c> in each of two bounded contexts)
+///     would otherwise both emit <c>GreeterGrpcHandler</c> into the same <c>WolverineHandlers</c> child
+///     namespace, and <c>AttachTypesSynchronously</c> would non-deterministically pick one.
+/// </summary>
+public class type_name_disambiguation_tests
+{
+    [Fact]
+    public async Task colliding_chains_get_disambiguated_with_stable_hashed_suffix()
+    {
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+        try
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts => opts.ApplicationAssembly = typeof(GreeterMiddlewareTestStub).Assembly)
+                .ConfigureServices(services => services.AddWolverineGrpc())
+                .StartAsync();
+
+            var graph = host.Services.GetRequiredService<GrpcGraph>();
+
+            // Two stubs, different FullNames, same proto base → same default TypeName.
+            var chainA = new GrpcServiceChain(typeof(AlphaCollisionStub), graph);
+            var chainB = new GrpcServiceChain(typeof(BetaCollisionStub), graph);
+
+            var originalName = chainA.TypeName;
+            chainB.TypeName.ShouldBe(originalName,
+                "pre-condition: both chains should emit the same default name so the disambiguator has something to fix");
+
+            var chains = new List<GrpcServiceChain> { chainA, chainB };
+            GrpcGraph.DisambiguateCollidingTypeNames(chains);
+
+            chainA.TypeName.ShouldNotBe(chainB.TypeName);
+            chainA.TypeName.ShouldStartWith(originalName + "_");
+            chainB.TypeName.ShouldStartWith(originalName + "_");
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+
+    [Fact]
+    public async Task disambiguation_is_stable_and_idempotent()
+    {
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+        try
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts => opts.ApplicationAssembly = typeof(GreeterMiddlewareTestStub).Assembly)
+                .ConfigureServices(services => services.AddWolverineGrpc())
+                .StartAsync();
+
+            var graph = host.Services.GetRequiredService<GrpcGraph>();
+
+            var chainA = new GrpcServiceChain(typeof(AlphaCollisionStub), graph);
+            var chainB = new GrpcServiceChain(typeof(BetaCollisionStub), graph);
+
+            var chains = new List<GrpcServiceChain> { chainA, chainB };
+            GrpcGraph.DisambiguateCollidingTypeNames(chains);
+
+            var snapshotA = chainA.TypeName;
+            var snapshotB = chainB.TypeName;
+
+            // Re-running must be a no-op: names are already unique so no collision exists.
+            GrpcGraph.DisambiguateCollidingTypeNames(chains);
+            chainA.TypeName.ShouldBe(snapshotA);
+            chainB.TypeName.ShouldBe(snapshotB);
+
+            // A second pair of freshly-constructed chains from the same stub types must produce
+            // the same disambiguated names — proves GetDeterministicHashCode is stable within
+            // a process (which is the invariant Wolverine relies on for generated-code caching).
+            var chainA2 = new GrpcServiceChain(typeof(AlphaCollisionStub), graph);
+            var chainB2 = new GrpcServiceChain(typeof(BetaCollisionStub), graph);
+            GrpcGraph.DisambiguateCollidingTypeNames([chainA2, chainB2]);
+            chainA2.TypeName.ShouldBe(snapshotA);
+            chainB2.TypeName.ShouldBe(snapshotB);
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+
+    [Fact]
+    public async Task non_colliding_chains_keep_their_default_type_names()
+    {
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+        try
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts => opts.ApplicationAssembly = typeof(GreeterMiddlewareTestStub).Assembly)
+                .ConfigureServices(services => services.AddWolverineGrpc())
+                .StartAsync();
+
+            var graph = host.Services.GetRequiredService<GrpcGraph>();
+            var chain = new GrpcServiceChain(typeof(AlphaCollisionStub), graph);
+            var originalName = chain.TypeName;
+
+            GrpcGraph.DisambiguateCollidingTypeNames([chain]);
+
+            chain.TypeName.ShouldBe(originalName,
+                "a single chain cannot collide with itself — its default name must be preserved");
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+
+    // Internal stubs so reflection-based discovery (which walks GetExportedTypes) ignores them,
+    // and the absence of [WolverineGrpcService] keeps them out of IsProtoFirstStub. Both safeguards
+    // matter — otherwise these would land in scope_discovery_tests' chain lists and skew counts.
+    internal abstract class AlphaCollisionStub : GreeterMiddlewareTest.GreeterMiddlewareTestBase;
+
+    internal abstract class BetaCollisionStub : GreeterMiddlewareTest.GreeterMiddlewareTestBase;
+}

--- a/src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj
+++ b/src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj
@@ -29,8 +29,14 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Google.Protobuf"/>
+        <PackageReference Include="Grpc.AspNetCore"/>
         <PackageReference Include="Grpc.Net.Client"/>
         <PackageReference Include="Grpc.StatusProto"/>
+        <PackageReference Include="Grpc.Tools">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="protobuf-net.Grpc"/>
@@ -46,6 +52,16 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <!--
+            Test-only proto used by GrpcMiddlewareScoping/ tests. Lives inside the test project
+            (not in src/Samples/) because it only exists to exercise [WolverineBefore]/[WolverineAfter]
+            scope behavior on a proto-first stub — it would just be noise as a sample. Folder name
+            avoids shadowing the Wolverine.Attributes.MiddlewareScoping enum from sibling tests.
+        -->
+        <Protobuf Include="GrpcMiddlewareScoping\Protos\middleware_scoping_test.proto" GrpcServices="Both"/>
     </ItemGroup>
 
 </Project>

--- a/src/Wolverine.Grpc.Tests/add_wolverine_grpc_idempotency_tests.cs
+++ b/src/Wolverine.Grpc.Tests/add_wolverine_grpc_idempotency_tests.cs
@@ -1,0 +1,123 @@
+using Grpc.AspNetCore.Server;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests;
+
+/// <summary>
+/// Regression tests for PR #2525 self-review §2.2 — without the marker guard,
+/// repeat <see cref="WolverineGrpcExtensions.AddWolverineGrpc(IServiceCollection)"/>
+/// invocations stack the <see cref="WolverineGrpcExceptionInterceptor"/> twice,
+/// doubling exception translation and log output on every unhandled exception.
+/// </summary>
+public class add_wolverine_grpc_idempotency_tests
+{
+    [Fact]
+    public void single_call_registers_exception_interceptor_exactly_once()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddWolverineGrpc();
+
+        var grpcOptions = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<GrpcServiceOptions>>().Value;
+
+        grpcOptions.Interceptors.Count(r => r.Type == typeof(WolverineGrpcExceptionInterceptor))
+            .ShouldBe(1);
+    }
+
+    [Fact]
+    public void repeat_calls_do_not_stack_the_exception_interceptor()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddWolverineGrpc();
+        services.AddWolverineGrpc();
+        services.AddWolverineGrpc();
+
+        var grpcOptions = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<GrpcServiceOptions>>().Value;
+
+        grpcOptions.Interceptors.Count(r => r.Type == typeof(WolverineGrpcExceptionInterceptor))
+            .ShouldBe(1);
+    }
+
+    [Fact]
+    public void repeat_calls_do_not_stack_the_grpc_graph_registration()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddWolverineGrpc();
+        services.AddWolverineGrpc();
+
+        services.Count(d => d.ServiceType == typeof(GrpcGraph)).ShouldBe(1);
+    }
+
+    [Fact]
+    public void marker_singleton_is_registered_after_first_call()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddWolverineGrpc();
+
+        services.Any(d => d.ServiceType == typeof(WolverineGrpcExtensions.WolverineGrpcMarker))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void configure_overload_runs_callback_on_first_call()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        var captured = false;
+        services.AddWolverineGrpc(_ => captured = true);
+
+        captured.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void configure_overload_runs_callback_on_repeat_calls_against_same_options_instance()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        WolverineGrpcOptions? first = null;
+        WolverineGrpcOptions? second = null;
+        services.AddWolverineGrpc(o => first = o);
+        services.AddWolverineGrpc(o => second = o);
+
+        first.ShouldNotBeNull();
+        second.ShouldNotBeNull();
+        first.ShouldBeSameAs(second);
+    }
+
+    [Fact]
+    public void options_singleton_is_resolvable_from_container()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddWolverineGrpc();
+
+        var resolved = services.BuildServiceProvider().GetService<WolverineGrpcOptions>();
+        resolved.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void repeat_calls_register_options_singleton_only_once()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddWolverineGrpc();
+        services.AddWolverineGrpc();
+        services.AddWolverineGrpc();
+
+        services.Count(d => d.ServiceType == typeof(WolverineGrpcOptions)).ShouldBe(1);
+    }
+}

--- a/src/Wolverine.Grpc/GrpcGraph.cs
+++ b/src/Wolverine.Grpc/GrpcGraph.cs
@@ -58,6 +58,37 @@ public class GrpcGraph : ICodeFileCollectionWithServices, IDescribeMyself
         {
             _chains.Add(new GrpcServiceChain(stub, this));
         }
+
+        DisambiguateCollidingTypeNames(_chains);
+    }
+
+    /// <summary>
+    ///     Post-discovery pass that guarantees unique <see cref="GrpcServiceChain.TypeName"/>s
+    ///     across the graph. Two proto services sharing a simple name (e.g., a <c>Greeter</c>
+    ///     in each of two bounded contexts) would otherwise both generate
+    ///     <c>GreeterGrpcHandler</c> into the same <c>WolverineHandlers</c> child namespace,
+    ///     and <c>AttachTypesSynchronously</c> would pick whichever exported type the CLR
+    ///     handed back first — an order that is not guaranteed across assemblies. Mirrors
+    ///     the pattern in <c>HandlerGraph</c> (issue #2004) but uses a stable hash of the
+    ///     stub's <see cref="Type.FullName"/> as the qualifier, since gRPC stub simple names
+    ///     are not reliably unique (users often pick ergonomic type names).
+    /// </summary>
+    internal static void DisambiguateCollidingTypeNames(IList<GrpcServiceChain> chains)
+    {
+        var collisions = chains
+            .GroupBy(c => c.TypeName, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .ToArray();
+
+        foreach (var group in collisions)
+        {
+            foreach (var chain in group)
+            {
+                var stubFullName = chain.StubType.FullName ?? chain.StubType.Name;
+                var hash = (uint)stubFullName.GetDeterministicHashCode();
+                chain.ApplyDisambiguatedTypeName($"{chain.ProtoServiceName}GrpcHandler_{hash:x8}");
+            }
+        }
     }
 
     /// <summary>

--- a/src/Wolverine.Grpc/GrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/GrpcServiceChain.cs
@@ -8,6 +8,7 @@ using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
 using Wolverine.Attributes;
 using Wolverine.Configuration;
+using Wolverine.Middleware;
 using Wolverine.Persistence;
 
 namespace Wolverine.Grpc;
@@ -96,6 +97,33 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
     public override string Description { get; }
 
     public override MiddlewareScoping Scoping => MiddlewareScoping.Grpc;
+
+    private MethodInfo[]? _discoveredBefores;
+    private MethodInfo[]? _discoveredAfters;
+
+    /// <summary>
+    ///     Methods declared on <see cref="StubType"/> (or its proto base) that qualify as
+    ///     <c>[WolverineBefore]</c> middleware for this chain — i.e., named per
+    ///     <see cref="MiddlewarePolicy.BeforeMethodNames"/> or carrying the attribute, and whose
+    ///     scope (<see cref="MiddlewareScoping"/>) admits <see cref="MiddlewareScoping.Grpc"/>.
+    ///     Computed lazily; the returned set is stable across reads. Phase-1 codegen consumes this
+    ///     to emit pre-call frames around each RPC override.
+    /// </summary>
+    public IReadOnlyList<MethodInfo> DiscoveredBefores
+        => _discoveredBefores ??= MiddlewarePolicy
+            .FilterMethods<WolverineBeforeAttribute>(this, StubType.GetMethods(), MiddlewarePolicy.BeforeMethodNames)
+            .ToArray();
+
+    /// <summary>
+    ///     Methods declared on <see cref="StubType"/> (or its proto base) that qualify as
+    ///     <c>[WolverineAfter]</c> postprocessors for this chain. Same scope and name-convention
+    ///     rules as <see cref="DiscoveredBefores"/>. Phase-1 codegen consumes this to emit
+    ///     post-call frames around each RPC override.
+    /// </summary>
+    public IReadOnlyList<MethodInfo> DiscoveredAfters
+        => _discoveredAfters ??= MiddlewarePolicy
+            .FilterMethods<WolverineAfterAttribute>(this, StubType.GetMethods(), MiddlewarePolicy.AfterMethodNames)
+            .ToArray();
 
     public override IdempotencyStyle Idempotency { get; set; } = IdempotencyStyle.None;
 

--- a/src/Wolverine.Grpc/GrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/GrpcServiceChain.cs
@@ -45,9 +45,12 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
     public IReadOnlyList<MethodInfo> UnaryMethods { get; }
 
     /// <summary>
-    ///     The C# identifier used for the generated wrapper type.
+    ///     The C# identifier used for the generated wrapper type. Initialised from
+    ///     <see cref="ProtoServiceName"/> as <c>{ProtoServiceName}GrpcHandler</c>; rewritten by
+    ///     <see cref="GrpcGraph.DisambiguateCollidingTypeNames"/> if two discovered chains end up
+    ///     with the same default name (e.g., two assemblies shipping a <c>Greeter</c> proto service).
     /// </summary>
-    public string TypeName { get; }
+    public string TypeName { get; private set; }
 
     public GrpcServiceChain(Type stubType, GrpcGraph parent)
     {
@@ -128,6 +131,16 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
             .ToArray();
 
     public override IdempotencyStyle Idempotency { get; set; } = IdempotencyStyle.None;
+
+    /// <summary>
+    ///     Applies a disambiguated <see cref="TypeName"/> on a chain whose default name collides
+    ///     with another discovered chain. Called exclusively from
+    ///     <see cref="GrpcGraph.DisambiguateCollidingTypeNames"/>.
+    /// </summary>
+    internal void ApplyDisambiguatedTypeName(string disambiguatedName)
+    {
+        TypeName = disambiguatedName;
+    }
 
     /// <summary>
     ///     The runtime <see cref="Type"/> of the generated wrapper once compiled. Null before compilation.

--- a/src/Wolverine.Grpc/GrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/GrpcServiceChain.cs
@@ -106,23 +106,25 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
     ///     <c>[WolverineBefore]</c> middleware for this chain — i.e., named per
     ///     <see cref="MiddlewarePolicy.BeforeMethodNames"/> or carrying the attribute, and whose
     ///     scope (<see cref="MiddlewareScoping"/>) admits <see cref="MiddlewareScoping.Grpc"/>.
-    ///     Computed lazily; the returned set is stable across reads. Phase-1 codegen consumes this
-    ///     to emit pre-call frames around each RPC override.
+    ///     Sorted ordinally by method name so Phase-1 generated source is byte-stable across
+    ///     runs (reflection order is not guaranteed). Computed lazily; the returned reference
+    ///     is stable across reads.
     /// </summary>
     public IReadOnlyList<MethodInfo> DiscoveredBefores
         => _discoveredBefores ??= MiddlewarePolicy
             .FilterMethods<WolverineBeforeAttribute>(this, StubType.GetMethods(), MiddlewarePolicy.BeforeMethodNames)
+            .OrderBy(m => m.Name, StringComparer.Ordinal)
             .ToArray();
 
     /// <summary>
     ///     Methods declared on <see cref="StubType"/> (or its proto base) that qualify as
-    ///     <c>[WolverineAfter]</c> postprocessors for this chain. Same scope and name-convention
-    ///     rules as <see cref="DiscoveredBefores"/>. Phase-1 codegen consumes this to emit
-    ///     post-call frames around each RPC override.
+    ///     <c>[WolverineAfter]</c> postprocessors for this chain. Same scope, name-convention,
+    ///     and ordinal-sort rules as <see cref="DiscoveredBefores"/>.
     /// </summary>
     public IReadOnlyList<MethodInfo> DiscoveredAfters
         => _discoveredAfters ??= MiddlewarePolicy
             .FilterMethods<WolverineAfterAttribute>(this, StubType.GetMethods(), MiddlewarePolicy.AfterMethodNames)
+            .OrderBy(m => m.Name, StringComparer.Ordinal)
             .ToArray();
 
     public override IdempotencyStyle Idempotency { get; set; } = IdempotencyStyle.None;

--- a/src/Wolverine.Grpc/WolverineGrpcExceptionInterceptor.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcExceptionInterceptor.cs
@@ -11,7 +11,7 @@ namespace Wolverine.Grpc;
 /// <summary>
 ///     Server-side gRPC interceptor that translates .NET exceptions thrown inside Wolverine-backed
 ///     gRPC service methods into <see cref="RpcException"/>s. Registered automatically by
-///     <see cref="WolverineGrpcExtensions.AddWolverineGrpc"/>.
+///     <see cref="WolverineGrpcExtensions.AddWolverineGrpc(Microsoft.Extensions.DependencyInjection.IServiceCollection)"/>.
 /// </summary>
 /// <remarks>
 ///     <para>

--- a/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
@@ -32,8 +32,39 @@ public static class WolverineGrpcExtensions
     /// gRPC host separately — use <c>services.AddCodeFirstGrpc()</c> for code-first
     /// services or <c>services.AddGrpc()</c> for proto-first services.
     /// </summary>
+    /// <remarks>
+    /// The call is idempotent — only the first invocation wires registrations,
+    /// subsequent calls are no-ops (matching <c>opts.UseGrpcRichErrorDetails()</c>'s
+    /// marker pattern). Without this guard, repeat calls would stack the
+    /// <see cref="WolverineGrpcExceptionInterceptor"/> twice, doubling exception
+    /// translation work and log output.
+    /// </remarks>
     public static IServiceCollection AddWolverineGrpc(this IServiceCollection services)
+        => AddWolverineGrpc(services, configure: null);
+
+    /// <summary>
+    /// Adds Wolverine's gRPC integration to the service collection and applies caller-supplied
+    /// configuration to the singleton <see cref="WolverineGrpcOptions"/>. Idempotent — repeat
+    /// invocations re-run <paramref name="configure"/> against the same options instance, so
+    /// additive registrations (e.g., <c>opts.AddMiddleware&lt;T&gt;()</c>) accumulate but service
+    /// registrations are not duplicated.
+    /// </summary>
+    /// <param name="services">The DI service collection.</param>
+    /// <param name="configure">Optional configuration callback for <see cref="WolverineGrpcOptions"/>.</param>
+    public static IServiceCollection AddWolverineGrpc(
+        this IServiceCollection services,
+        Action<WolverineGrpcOptions>? configure)
     {
+        var options = EnsureOptionsRegistered(services);
+
+        if (services.Any(x => x.ServiceType == typeof(WolverineGrpcMarker)))
+        {
+            configure?.Invoke(options);
+            return services;
+        }
+
+        services.AddSingleton<WolverineGrpcMarker>();
+
         services.AddSingleton<GrpcGraph>(sp =>
         {
             var runtime = (WolverineRuntime)sp.GetRequiredService<IWolverineRuntime>();
@@ -42,12 +73,32 @@ public static class WolverineGrpcExtensions
         });
 
         services.AddSingleton<WolverineGrpcExceptionInterceptor>();
-        services.Configure<GrpcServiceOptions>(options =>
+        services.Configure<GrpcServiceOptions>(opts =>
         {
-            options.Interceptors.Add<WolverineGrpcExceptionInterceptor>();
+            opts.Interceptors.Add<WolverineGrpcExceptionInterceptor>();
         });
 
+        configure?.Invoke(options);
+
         return services;
+    }
+
+    private static WolverineGrpcOptions EnsureOptionsRegistered(IServiceCollection services)
+    {
+        // The options instance must be reachable for the configure callback BEFORE the
+        // marker check returns, so additive customizations on a second AddWolverineGrpc()
+        // call land on the same singleton rather than silently dropping.
+        var existing = services.FirstOrDefault(d => d.ServiceType == typeof(WolverineGrpcOptions))
+            ?.ImplementationInstance as WolverineGrpcOptions;
+        if (existing != null) return existing;
+
+        var options = new WolverineGrpcOptions();
+        services.AddSingleton(options);
+        return options;
+    }
+
+    internal sealed class WolverineGrpcMarker
+    {
     }
 
     /// <summary>

--- a/src/Wolverine.Grpc/WolverineGrpcOptions.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcOptions.cs
@@ -1,0 +1,42 @@
+using Wolverine.Configuration;
+using Wolverine.Middleware;
+
+namespace Wolverine.Grpc;
+
+/// <summary>
+///     Wolverine-side configuration for proto-first gRPC services. The gRPC counterpart to
+///     <c>WolverineHttpOptions</c> — exposes a <see cref="MiddlewarePolicy"/> dedicated to
+///     <see cref="GrpcServiceChain"/>s so that policy-registered middleware can target gRPC
+///     services without leaking through the global <c>opts.Policies.AddMiddleware</c> path
+///     (which is intentionally <c>HandlerChain</c>-only).
+/// </summary>
+public sealed class WolverineGrpcOptions
+{
+    internal MiddlewarePolicy Middleware { get; } = new();
+
+    /// <summary>
+    ///     Register a middleware type that will be applied to every <see cref="GrpcServiceChain"/>
+    ///     unless <paramref name="filter"/> excludes it.
+    /// </summary>
+    /// <param name="filter">Optional predicate restricting which gRPC service chains receive the middleware.</param>
+    /// <typeparam name="T">The middleware class (looked up by convention for <c>Before</c>/<c>After</c>/<c>Finally</c> methods).</typeparam>
+    public void AddMiddleware<T>(Func<GrpcServiceChain, bool>? filter = null)
+        => AddMiddleware(typeof(T), filter);
+
+    /// <summary>
+    ///     Register a middleware type that will be applied to every <see cref="GrpcServiceChain"/>
+    ///     unless <paramref name="filter"/> excludes it.
+    /// </summary>
+    /// <param name="middlewareType">The middleware class.</param>
+    /// <param name="filter">Optional predicate restricting which gRPC service chains receive the middleware.</param>
+    public void AddMiddleware(Type middlewareType, Func<GrpcServiceChain, bool>? filter = null)
+    {
+        Func<IChain, bool> chainFilter = c => c is GrpcServiceChain;
+        if (filter != null)
+        {
+            chainFilter = c => c is GrpcServiceChain g && filter(g);
+        }
+
+        Middleware.AddType(middlewareType, chainFilter);
+    }
+}

--- a/src/Wolverine/Runtime/Handlers/Executor.cs
+++ b/src/Wolverine/Runtime/Handlers/Executor.cs
@@ -302,7 +302,6 @@ internal class Executor : IExecutor
             await context.FlushOutgoingMessagesAsync();
             stream = envelope.Response as IAsyncEnumerable<T>;
             activity?.AddEvent(new ActivityEvent(WolverineTracing.StreamingStarted));
-            _tracker.ExecutionFinished(envelope);
         }
         catch (Exception e)
         {
@@ -314,20 +313,39 @@ internal class Executor : IExecutor
 
         if (stream == null)
         {
-            _contextPool.Return(context);
             activity?.SetStatus(ActivityStatusCode.Ok);
+            _tracker.ExecutionFinished(envelope);
+            _contextPool.Return(context);
             yield break;
         }
 
+        await using var enumerator = stream.GetAsyncEnumerator(cancellation);
         try
         {
-            await foreach (var item in stream.WithCancellation(cancellation))
+            while (true)
             {
-                yield return item;
-            }
+                T current;
+                try
+                {
+                    if (!await enumerator.MoveNextAsync())
+                    {
+                        activity?.AddEvent(new ActivityEvent(WolverineTracing.StreamingCompleted));
+                        activity?.SetStatus(ActivityStatusCode.Ok);
+                        _tracker.ExecutionFinished(envelope);
+                        yield break;
+                    }
 
-            activity?.AddEvent(new ActivityEvent(WolverineTracing.StreamingCompleted));
-            activity?.SetStatus(ActivityStatusCode.Ok);
+                    current = enumerator.Current;
+                }
+                catch (Exception e)
+                {
+                    activity?.SetStatus(ActivityStatusCode.Error, e.GetType().Name);
+                    _tracker.ExecutionFinished(envelope, e);
+                    throw;
+                }
+
+                yield return current;
+            }
         }
         finally
         {

--- a/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
+++ b/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
@@ -268,9 +268,6 @@ internal class TracingExecutor : IExecutor
             await context.FlushOutgoingMessagesAsync();
             stream = envelope.Response as IAsyncEnumerable<T>;
             activity?.AddEvent(new ActivityEvent(WolverineTracing.StreamingStarted));
-            _tracker.ExecutionFinished(envelope);
-            _messageSucceeded(_logger, _messageTypeName, envelope.Id,
-                envelope.Destination?.ToString() ?? "local", null);
         }
         catch (Exception e)
         {
@@ -279,26 +276,52 @@ internal class TracingExecutor : IExecutor
             _messageFailed(_logger, _messageTypeName, envelope.Id,
                 envelope.Destination?.ToString() ?? "local", e);
             _contextPool.Return(context);
+            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
             throw;
         }
 
         if (stream == null)
         {
-            _contextPool.Return(context);
             activity?.SetStatus(ActivityStatusCode.Ok);
+            _tracker.ExecutionFinished(envelope);
+            _messageSucceeded(_logger, _messageTypeName, envelope.Id,
+                envelope.Destination?.ToString() ?? "local", null);
+            _contextPool.Return(context);
             _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
             yield break;
         }
 
+        await using var enumerator = stream.GetAsyncEnumerator(cancellation);
         try
         {
-            await foreach (var item in stream.WithCancellation(cancellation))
+            while (true)
             {
-                yield return item;
-            }
+                T current;
+                try
+                {
+                    if (!await enumerator.MoveNextAsync())
+                    {
+                        activity?.AddEvent(new ActivityEvent(WolverineTracing.StreamingCompleted));
+                        activity?.SetStatus(ActivityStatusCode.Ok);
+                        _tracker.ExecutionFinished(envelope);
+                        _messageSucceeded(_logger, _messageTypeName, envelope.Id,
+                            envelope.Destination?.ToString() ?? "local", null);
+                        yield break;
+                    }
 
-            activity?.AddEvent(new ActivityEvent(WolverineTracing.StreamingCompleted));
-            activity?.SetStatus(ActivityStatusCode.Ok);
+                    current = enumerator.Current;
+                }
+                catch (Exception e)
+                {
+                    activity?.SetStatus(ActivityStatusCode.Error, e.GetType().Name);
+                    _tracker.ExecutionFinished(envelope, e);
+                    _messageFailed(_logger, _messageTypeName, envelope.Id,
+                        envelope.Destination?.ToString() ?? "local", e);
+                    throw;
+                }
+
+                yield return current;
+            }
         }
         finally
         {

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
+using ImTools;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Microsoft.Extensions.Logging;
@@ -658,11 +659,10 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
         // the case above. When ResponseType is set (StreamAsync path), the check above this
         // switch already captured the sequence; we only reach here during regular InvokeAsync
         // with a handler that returns a typed async sequence.
-        var asyncEnumInterface = message.GetType().GetInterfaces()
-            .FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>));
-        if (asyncEnumInterface != null)
+        var cascader = ResolveTypedAsyncEnumerableCascader(message.GetType());
+        if (cascader != null)
         {
-            await CascadeTypedAsyncEnumerableAsync(message, asyncEnumInterface);
+            await (Task)cascader.Invoke(null, [message, this])!;
             return;
         }
 
@@ -685,19 +685,38 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
     private static readonly MethodInfo _cascadeTypedItemsMethod =
         typeof(MessageContext).GetMethod(nameof(CascadeTypedItemsAsync), BindingFlags.Static | BindingFlags.NonPublic)!;
 
+    // Per-message-type cache of the constructed CascadeTypedItemsAsync<T> MethodInfo (or null for
+    // message types that don't implement IAsyncEnumerable<T>). Eliminates GetInterfaces() and
+    // MakeGenericMethod() from every cascade after the first for each unique type. ImHashMap is
+    // lock-free and copy-on-write — appropriate because the set of cascading message types
+    // stabilizes quickly after startup, making this write-rare/read-heavy.
+    private static ImHashMap<Type, MethodInfo?> _typedEnumerableCascadeMethods =
+        ImHashMap<Type, MethodInfo?>.Empty;
+
+    private static MethodInfo? ResolveTypedAsyncEnumerableCascader(Type messageType)
+    {
+        if (_typedEnumerableCascadeMethods.TryFind(messageType, out var cached))
+        {
+            return cached;
+        }
+
+        var asyncEnumInterface = messageType.GetInterfaces()
+            .FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>));
+
+        var method = asyncEnumInterface != null
+            ? _cascadeTypedItemsMethod.MakeGenericMethod(asyncEnumInterface.GetGenericArguments()[0])
+            : null;
+
+        _typedEnumerableCascadeMethods = _typedEnumerableCascadeMethods.AddOrUpdate(messageType, method);
+        return method;
+    }
+
     private static async Task CascadeTypedItemsAsync<T>(IAsyncEnumerable<T> source, MessageContext context)
     {
         await foreach (var item in source)
         {
             await context.EnqueueCascadingAsync(item);
         }
-    }
-
-    private Task CascadeTypedAsyncEnumerableAsync(object asyncEnumerable, Type interfaceType)
-    {
-        var elementType = interfaceType.GetGenericArguments()[0];
-        var method = _cascadeTypedItemsMethod.MakeGenericMethod(elementType);
-        return (Task)method.Invoke(null, [asyncEnumerable, this])!;
     }
 
     internal void ClearState()


### PR DESCRIPTION
# fix(grpc): #2525 correctness gaps — PR-A

Closes four correctness gaps from #2525 plus Phase 0 of the `MiddlewareScoping.Grpc` fix.
Target release: **Wolverine 5.31.x**. or  **Wolverine 5.32.x**

**Test state:** 115/115 `Wolverine.Grpc.Tests` green · 7/7 `streaming_handler_support` green (incl. new mid-stream throw → OTel Error assertion) · 19/19 cascade-related CoreTests green · clean build, 0 errors (pre-existing VSTHRD warnings only).

**Scope:** 1125 insertions / 66 deletions across 24 files. Framework-side delta is ~165 lines across 6 source files; the rest is tests, fixtures, and two updated docs pages.

## Contents

- [Changes at a glance](#changes-at-a-glance)
- [§1.2 Streaming OTel + success-log fire post-iteration (P0)](#12-streaming-otel--success-log-fire-post-iteration-p0)
- [§1.3 `AddWolverineGrpc()` idempotent (P0)](#13-addwolverinegrpc-idempotent-p0)
- [§1.4 Generated gRPC type-name uniqueness (P1)](#14-generated-grpc-type-name-uniqueness-p1)
- [§1.5 Typed `IAsyncEnumerable<T>` cascading reflection cache (P1)](#15-typed-iasyncenumerablet-cascading-reflection-cache-p1)
- [M15 Phase 0 — `MiddlewareScoping.Grpc` groundwork](#m15-phase-0--middlewarescopinggrpc-groundwork)
- [Docs updated in-PR](#docs-updated-in-pr)
- [Review asks](#review-asks)
- [Not in this PR (by design)](#not-in-this-pr-by-design)

## Changes at a glance

| # | Fix | Priority | New tests |
|---|---|---|---|
| §1.2 | Streaming OTel + success-log post-iteration | P0 | 1 (+ 6 existing, all green) |
| §1.3 | `AddWolverineGrpc()` idempotent | P0 | 8 |
| §1.4 | Generated gRPC type-name uniqueness | P1 | 3 |
| §1.5 | Typed `IAsyncEnumerable<T>` reflection cache | P1 | 0 new (existing 19 cover it) |
| M15 Phase 0 | Scope-filtered middleware discovery + `WolverineGrpcOptions.AddMiddleware<T>` | — | 20 |

---

## §1.2 Streaming OTel + success-log fire post-iteration (P0)

**Bug.** `TracingExecutor.StreamCoreAsync` logged `_messageSucceeded` and closed the activity the moment the handler *returned* the `IAsyncEnumerable<T>`, before the consumer iterated. A cancellation or mid-stream throw closed the span with Ok status — real failures were invisible on dashboards.

**Fix.** Moved success/error signals to fire after iteration. C# CS1626 forbids `yield return` inside a `try/catch`, so switched to a manual `MoveNextAsync` loop where the try/catch wraps only the enumerator advance and `yield return current;` sits outside. Applied the same structural fix to `Executor.StreamCoreAsync`.

**Test.** New `mid_stream_throw_marks_activity_status_error` asserts activity status goes Error when iteration throws. Existing cancellation and faulting-stream tests continue to pass.

**Files.** `Runtime/Handlers/TracingExecutor.cs`, `Runtime/Handlers/Executor.cs`, `Testing/CoreTests/Acceptance/streaming_handler_support.cs`.

## §1.3 `AddWolverineGrpc()` idempotent (P0)

**Bug.** Double-calling `AddWolverineGrpc()` stacked `WolverineGrpcExceptionInterceptor` twice and double-registered `GrpcGraph`. Library extensions calling it defensively paid double log + translation overhead per unhandled exception.

**Fix.** Marker-singleton guard (`WolverineGrpcMarker`) matching the pattern `UseGrpcRichErrorDetails` / `UseFluentValidation` already use. Plus a new overload:

```csharp
services.AddWolverineGrpc(g => g.AddMiddleware<MyGrpcMiddleware>());
```

**Test.** `add_wolverine_grpc_idempotency_tests.cs` — 8 tests pinning single-registration invariants across interceptor, graph, options, and the new overload.

**Files.** `Wolverine.Grpc/WolverineGrpcExtensions.cs`, `Wolverine.Grpc/WolverineGrpcExceptionInterceptor.cs` (2-line XML-doc `cref` disambiguation — the bare cref became ambiguous with the new overload).

## §1.4 Generated gRPC type-name uniqueness (P1)

**Bug.** `GrpcServiceChain.TypeName = "{ProtoServiceName}GrpcHandler"`. Two assemblies shipping a `Greeter` proto — tests + production, or two bounded contexts — emit `GreeterGrpcHandler` into the same `WolverineHandlers` child namespace. `AttachTypesSynchronously` picks whichever `GetExportedTypes()` returns first; that order is unspecified across assemblies.

**Fix.** Mirrors `HandlerGraph.cs:370-383`'s post-hoc qualifier-based disambiguation (the issue #2004 pattern) but uses a stable hash of `StubType.FullName` as the qualifier — gRPC stub simple names aren't reliably unique. Runs once at the tail of `DiscoverServices`, never on a hot path; zero additional reflection.

**Tests.** `type_name_disambiguation_tests.cs` — 3 tests: collisions get hashed suffixes, disambiguation is idempotent + process-stable, single-chain input preserves default name. Collision stubs are `internal abstract` without `[WolverineGrpcService]`, so `GetExportedTypes()` and `IsProtoFirstStub` both skip them — they don't leak into adjacent test suites.

**Files.** `Wolverine.Grpc/GrpcGraph.cs`, `Wolverine.Grpc/GrpcServiceChain.cs` (`TypeName` now `get; private set;` plus internal `ApplyDisambiguatedTypeName` seam used only by the pass).

## §1.5 Typed `IAsyncEnumerable<T>` cascading reflection cache (P1)

**Bug.** In `MessageContext.EnqueueCascadingAsync`, every cascading non-enumerable message did `message.GetType().GetInterfaces()` (allocates) plus `MakeGenericMethod` on hit. Both per-call, on a hot path.

**Fix.** Single `ImHashMap<Type, MethodInfo?>` keyed on *message type*:

```csharp
private static ImHashMap<Type, MethodInfo?> _typedEnumerableCascadeMethods =
    ImHashMap<Type, MethodInfo?>.Empty;
```

Chose `ImHashMap` for codebase idiom (matches `WolverineMessageNaming.cs:128` + five other per-type cache sites — lock-free, copy-on-write, write-rare). Keyed on message type rather than element type because message-type keying eliminates *both* reflection ops on hit and negative-caches plain cascading messages (the common fall-through path). The only remaining reflection is `MethodInfo.Invoke` — Expression-compiled delegates could eliminate it, but not worth the diff today.

**Tests.** Existing `typed_async_enumerable_cascades_items_via_regular_invoke` plus 19 cascade-related CoreTests exercise the path; all green.

**Files.** `Runtime/MessageContext.cs`.

## M15 Phase 0 — `MiddlewareScoping.Grpc` groundwork

**Bug.** `MiddlewareScoping.Grpc` shipped in #2525 as a public enum member with attribute-level tests but **no execution path**. A handler annotated `[WolverineBefore(MiddlewareScoping.Grpc)]` compiled, tests passed, and the method never ran on any RPC call.

Phase 0 lands **the architecture-independent groundwork** so the service-wide-vs-per-RPC design question (see Review ask #1) can be resolved without blocking the release window. This PR lands what both options need; Phase 1 is a focused follow-up.

**What Phase 0 ships:**

1. **Scope-filtered discovery** on `GrpcServiceChain` — new lazy `DiscoveredBefores` / `DiscoveredAfters` reusing `MiddlewarePolicy.FilterMethods<T>` so scope filtering matches the canonical `Chain.ApplyImpliedMiddlewareFromHandlers` path. Ordinal-sorted for byte-stable codegen; reference-equal caching.
2. **`WolverineGrpcOptions.AddMiddleware<T>`** mirroring `WolverineHttpOptions.AddMiddleware`. Internal `MiddlewarePolicy`, typed `AddMiddleware<T>` with optional per-chain filter. Singleton options registered via the §1.3 idempotency guard.
3. **Invariant pins** that Phase 1 depends on:
   - `policy_leak_tests.cs` — `IPolicies.AddMiddleware<T>` must not attach to `GrpcServiceChain` (the `chain is HandlerChain` filter at `WolverineOptions.Policies.cs:208-216` is load-bearing).
   - `frame_cloning_spike_tests.cs` — two `MethodCall`s from the same `MethodInfo` are distinct instances with per-instance `Arguments[]` + `Creates`. Phase 1's per-RPC argument resolution depends on this non-sharing invariant.
4. **Test scaffolding for Phase 1** — proto with distinct request messages for unary/streaming, fixture, capture sink, probe methods covering Before/After × Anywhere/Grpc/MessageHandlers.

**No production behavior changes today.** `MapWolverineGrpcServices` is unchanged; nothing consumes `DiscoveredBefores` at emission time yet. End-user gRPC middleware behavior is byte-identical to `main`.

**Tests.** 20/20 green: 8 idempotency + 7 scope_discovery + 2 frame_cloning + 2 smoke + 1 policy_leak.

**Files.**

- `Wolverine.Grpc/WolverineGrpcOptions.cs` (new)
- `Wolverine.Grpc/WolverineGrpcExtensions.cs` (+overload)
- `Wolverine.Grpc/GrpcServiceChain.cs` (+discovery properties)
- `Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj` (proto + folder globs)
- `Wolverine.Grpc.Tests/GrpcMiddlewareScoping/*` (12 new fixture/test files; folder name `GrpcMiddlewareScoping/` — not `MiddlewareScoping/` — to avoid shadowing the enum)

## Docs updated in-PR

- **`docs/guide/grpc/index.md`** — drops the "experimental / feature branch" framing from the info block now that #2525 is merged. **Adds a Current Limitations bullet honestly disclosing the Phase 0/Phase 1 state of `MiddlewareScoping.Grpc`**: the attribute compiles and is scope-filtered correctly but doesn't weave yet; recommend custom gRPC interceptor until M15 Phase 1 lands. Expands the exception-mapping limitation to note that client-side `WolverineGrpcClientOptions.MapRpcException` already supports per-client override.
- **`docs/guide/grpc/handlers.md`** — replaces stale `dotnet run -- describe-routing` example with `wolverine-diagnostics codegen-preview --grpc Greeter` and forward-links the CLI page.
- **`docs/guide/grpc/streaming.md`** — extends the "Exception timing" limitation bullet to note that the server-side OpenTelemetry activity now stays open until the stream fully drains or faults, and is marked `Error` for both mid-stream throws and cancellation.

---

## Review asks

1. **M15 Phase 1 — Option A vs Option B.** Wire middleware via service-wide override (Option A: one override per RPC on the generated `GrpcHandler`) or per-RPC `GrpcRpcChain` with its own `HandlerChain`-like lifecycle (Option B)? Working default if no response: **Option A** (smaller blast radius; gRPC isn't on NuGet yet so a wrong-A → B refactor is cheap, but a wrong-B permanently reshapes chain topology). Full analysis: `.plans/grpc-streaming/M15-middleware-scoping-implementation.md` §6.
2. **§1.5 cache choice** — picked `ImHashMap<Type, MethodInfo?>` for codebase idiom (matches 5 existing sites). Flag if you'd rather `ConcurrentDictionary` for this one.
3. **§1.5 key choice** — picked message type (eliminates both reflection ops on hit + negative-caches plain messages) over element type. Flag if you'd prefer element-type.
4. **§1.4 qualifier** — `GetDeterministicHashCode()` on `StubType.FullName` (mirrors `HandlerChain`). Flag if you'd prefer a different qualifier (e.g., assembly name).

## Not in this PR (by design)

- **M15 Phase 1** — codegen weaving, awaiting Option A vs B direction.
- **`[WolverineOnException]` / `[WolverineFinally]` discovery on `GrpcServiceChain`** — similar Phase 0 treatment; separate PR.
- **Feature docs for `MiddlewareScoping.Grpc`** — walkthrough/examples deferred to Phase 1 so they describe real execution. Current Limitations disclosure ships now.
- **Tier 2 ambiguity calls** (streaming zero-item tolerance, client `MapToException` default posture, `IGrpcStatusDetailsProvider` ordering, `Google.Api.CommonProtos` footprint) — each wants its own decision thread and ships as small follow-ups.
- **Code-first codegen parity (M9)** and **bidi/client-streaming first-class surface** — each is a multi-day focused sprint and ships as its own PR per [`.plans/next-pr-roadmap.md`](.plans/next-pr-roadmap.md).
