### PR TITLE
OptionsDescription audit: clean transport rendering + secret-safe connection info

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="1.24.1" />
+    <PackageVersion Include="JasperFx" Version="1.26.0" />
     <PackageVersion Include="JasperFx.Events" Version="1.28.1" />
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.4.0" />
     <PackageVersion Include="JasperFx.SourceGeneration" Version="1.1.0" />

--- a/src/Http/Wolverine.Http/Transport/HttpEndpoint.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpEndpoint.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
@@ -21,6 +22,7 @@ public class HttpEndpoint : Endpoint
         return ValueTask.FromResult<IListener>(new NulloListener(Uri));
     }
 
+    [IgnoreDescription]
     public JsonSerializerOptions SerializerOptions { get; set; } = new JsonSerializerOptions
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsSubscription.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsSubscription.cs
@@ -37,4 +37,10 @@ public class AmazonSnsSubscription
         };
 
     public AmazonSnsSubscriptionAttributes Attributes { get; }
+
+    /// <summary>
+    /// Used by OptionsDescription (via [DescribeAsStringArray]) to render this
+    /// subscription as a single readable line.
+    /// </summary>
+    public override string ToString() => $"{Protocol}:{Endpoint}";
 }

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTopic.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTopic.cs
@@ -3,6 +3,7 @@ using Amazon.SimpleNotificationService.Model;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
@@ -59,7 +60,9 @@ public class AmazonSnsTopic : Endpoint, IBrokerQueue
     public string TopicName { get; }
     public string TopicArn { get; set; }
     
+    [ChildDescription]
     public CreateTopicRequest Configuration { get; }
+    [DescribeAsStringArray]
     public IList<AmazonSnsSubscription> TopicSubscriptions { get; set; } = new List<AmazonSnsSubscription>();
     
     public async ValueTask<bool> CheckAsync()

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTransport.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTransport.cs
@@ -2,6 +2,7 @@
 using Amazon.SimpleNotificationService;
 using Amazon.SQS;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Wolverine.AmazonSqs.Internal;
 using Wolverine.Runtime;
 using Wolverine.Transports;
@@ -29,9 +30,12 @@ public class AmazonSnsTransport : BrokerTransport<AmazonSnsTopic>
 
     public override Uri ResourceUri => new(SnsConfig.ServiceURL);
 
+    [DescribeAsConfigurationState]
     public Func<IWolverineRuntime, AWSCredentials>? CredentialSource { get; set; }
+    [IgnoreDescription]
     public LightweightCache<string, AmazonSnsTopic> Topics { get; }
-    
+
+    [ChildDescription]
     public AmazonSimpleNotificationServiceConfig SnsConfig { get; } = new();
     internal IAmazonSimpleNotificationService? SnsClient { get; private set; }
     internal IAmazonSQS? SqsClient { get; private set; }
@@ -131,6 +135,7 @@ public class AmazonSnsTransport : BrokerTransport<AmazonSnsTopic>
     /// Override to customize the queue policy for permissions for an AWS SQS queue that subscribes to
     /// an SNS topic
     /// </summary>
+    [IgnoreDescription]
     public Func<SqsTopicDescription, string> QueuePolicyBuilder { get; set; } = description =>
     {
         var queuePolicy = $$"""

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/CloudEventsSnsMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/CloudEventsSnsMapper.cs
@@ -12,6 +12,8 @@ internal class CloudEventsSnsMapper : ISnsEnvelopeMapper
         _inner = inner;
     }
 
+    public override string ToString() => "Cloud Events";
+
     public string BuildMessageBody(Envelope envelope)
     {
         return _inner.WriteToString(envelope);

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/MassTransitMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/MassTransitMapper.cs
@@ -16,6 +16,8 @@ internal class MassTransitMapper : ISnsEnvelopeMapper
         _serializer = new MassTransitJsonSerializer(endpoint);
     }
 
+    public override string ToString() => "MassTransit Interop";
+
     public MassTransitJsonSerializer Serializer => _serializer;
 
     public string BuildMessageBody(Envelope envelope)

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/NServiceBusEnvelopeMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/NServiceBusEnvelopeMapper.cs
@@ -22,6 +22,8 @@ internal class NServiceBusEnvelopeMapper : ISnsEnvelopeMapper
         _endpoint = endpoint;
     }
 
+    public override string ToString() => "NServiceBus Interop";
+
     public IEnumerable<KeyValuePair<string, MessageAttributeValue>> ToAttributes(Envelope envelope)
     {
         yield return new ("NServiceBus.ConversationId",

--- a/src/Transports/AWS/Wolverine.AmazonSns/RawJsonSnsEnvelopeMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/RawJsonSnsEnvelopeMapper.cs
@@ -16,6 +16,8 @@ internal class RawJsonSnsEnvelopeMapper : ISnsEnvelopeMapper
         _serializerOptions = serializerOptions;
     }
 
+    public override string ToString() => "Raw JSON";
+
     public string BuildMessageBody(Envelope envelope)
     {
         return JsonSerializer.Serialize(

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -2,6 +2,7 @@ using Amazon.SQS;
 using Amazon.SQS.Model;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
@@ -84,6 +85,7 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
     /// <summary>
     ///     Additional configuration for how an SQS queue should be created
     /// </summary>
+    [ChildDescription]
     public CreateQueueRequest Configuration { get; }
 
     /// <summary>

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
@@ -2,6 +2,7 @@ using Amazon.Runtime;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Wolverine.Configuration;
@@ -41,10 +42,13 @@ public class AmazonSqsTransport : BrokerTransport<AmazonSqsQueue>
         Client = client;
     }
 
+    [DescribeAsConfigurationState]
     public Func<IWolverineRuntime, AWSCredentials>? CredentialSource { get; set; }
 
+    [IgnoreDescription]
     public LightweightCache<string, AmazonSqsQueue> Queues { get; }
 
+    [ChildDescription]
     public AmazonSQSConfig Config { get; } = new();
 
     internal IAmazonSQS? Client { get; private set; }

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/CloudEventsSqsMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/CloudEventsSqsMapper.cs
@@ -13,6 +13,8 @@ internal class CloudEventsSqsMapper : ISqsEnvelopeMapper
         _inner = inner;
     }
 
+    public override string ToString() => "Cloud Events";
+
     public string BuildMessageBody(Envelope envelope)
     {
         return _inner.WriteToString(envelope);

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/MassTransitMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/MassTransitMapper.cs
@@ -18,6 +18,8 @@ internal class MassTransitMapper : ISqsEnvelopeMapper
         _serializer = new MassTransitJsonSerializer(endpoint);
     }
 
+    public override string ToString() => "MassTransit Interop";
+
     public MassTransitJsonSerializer Serializer => _serializer;
 
     public string BuildMessageBody(Envelope envelope)

--- a/src/Transports/AWS/Wolverine.AmazonSqs/RawJsonSqsEnvelopeMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/RawJsonSqsEnvelopeMapper.cs
@@ -16,6 +16,8 @@ internal class RawJsonSqsEnvelopeMapper : ISqsEnvelopeMapper
         _serializerOptions = serializerOptions;
     }
 
+    public override string ToString() => "Raw JSON";
+
     public string BuildMessageBody(Envelope envelope)
     {
         return JsonSerializer.Serialize(

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
@@ -3,6 +3,7 @@ using Azure.Core;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using Wolverine.AzureServiceBus.Internal;
 using Wolverine.Configuration;
@@ -84,9 +85,14 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
     /// </summary>
     public bool SystemQueuesEnabled { get; set; } = true;
 
+    [IgnoreDescription]
     public LightweightCache<string, AzureServiceBusQueue> Queues { get; }
+    [IgnoreDescription]
     public LightweightCache<string, AzureServiceBusTopic> Topics { get; }
 
+    // Contains shared access key / password — hidden to avoid leaking secrets
+    // in diagnostic views. See wolverine follow-up for secret-safe rendering.
+    [IgnoreDescription]
     public string? ConnectionString { get; set; }
 
     /// <summary>
@@ -94,13 +100,18 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
     /// When set, the management client uses this instead of ConnectionString.
     /// Useful for the Azure Service Bus Emulator which exposes management on a different port.
     /// </summary>
+    [IgnoreDescription]
     public string? ManagementConnectionString { get; set; }
 
     public string? FullyQualifiedNamespace { get; set; }
+    [IgnoreDescription]
     public TokenCredential? TokenCredential { get; set; }
+    [IgnoreDescription]
     public AzureNamedKeyCredential? NamedKeyCredential { get; set; }
+    [IgnoreDescription]
     public AzureSasCredential? SasCredential { get; set; }
 
+    [ChildDescription]
     public ServiceBusClientOptions ClientOptions { get; } = new()
     {
         TransportType = ServiceBusTransportType.AmqpTcp

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
@@ -90,8 +90,8 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
     [IgnoreDescription]
     public LightweightCache<string, AzureServiceBusTopic> Topics { get; }
 
-    // Contains shared access key / password — hidden to avoid leaking secrets
-    // in diagnostic views. See wolverine follow-up for secret-safe rendering.
+    // Contains shared access key / password — raw value hidden to avoid
+    // leaking secrets in diagnostic views. Surfaced via ConnectionSummary below.
     [IgnoreDescription]
     public string? ConnectionString { get; set; }
 
@@ -102,6 +102,22 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
     /// </summary>
     [IgnoreDescription]
     public string? ManagementConnectionString { get; set; }
+
+    /// <summary>
+    /// The configured connection string with the <c>SharedAccessKey</c> value
+    /// masked. Safe to render in diagnostic output.
+    /// </summary>
+    public string? ConnectionSummary => ConnectionString == null
+        ? null
+        : ConnectionStringRedactor.Redact(ConnectionString, "SharedAccessKey");
+
+    /// <summary>
+    /// The configured management connection string with the <c>SharedAccessKey</c>
+    /// value masked. Safe to render in diagnostic output.
+    /// </summary>
+    public string? ManagementConnectionSummary => ManagementConnectionString == null
+        ? null
+        : ConnectionStringRedactor.Redact(ManagementConnectionString, "SharedAccessKey");
 
     public string? FullyQualifiedNamespace { get; set; }
     [IgnoreDescription]

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
@@ -1,5 +1,6 @@
 using Azure.Messaging.ServiceBus;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
@@ -31,6 +32,7 @@ public abstract class AzureServiceBusEndpoint : Endpoint<IAzureServiceBusEnvelop
         Parent = parent;
     }
 
+    [IgnoreDescription]
     public AzureServiceBusTransport Parent { get; }
 
     /// <summary>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
@@ -4,6 +4,7 @@ using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Wolverine.Configuration;
@@ -36,6 +37,7 @@ public class AzureServiceBusQueue : AzureServiceBusEndpoint, IBrokerQueue, IMass
         };
     }
 
+    [ChildDescription]
     public CreateQueueOptions Options { get; }
 
     public string QueueName { get; }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
@@ -4,6 +4,7 @@ using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Wolverine.Configuration;
@@ -41,12 +42,16 @@ public class AzureServiceBusSubscription : AzureServiceBusEndpoint, IBrokerQueue
         RuleOptions = new CreateRuleOptions();
     }
 
+    [ChildDescription]
     public CreateSubscriptionOptions Options { get; }
 
+    [ChildDescription]
     public CreateRuleOptions RuleOptions { get; }
 
     public string SubscriptionName { get; }
 
+    // No attribute needed — AzureServiceBusTopic.ToString() returns TopicName,
+    // so this property renders as the topic name string (per audit decision).
     public AzureServiceBusTopic Topic { get; }
 
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
@@ -3,6 +3,7 @@ using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Wolverine.Configuration;
@@ -33,6 +34,12 @@ public class AzureServiceBusTopic : AzureServiceBusEndpoint, IMassTransitInterop
 
     public string TopicName { get; }
 
+    /// <summary>
+    /// Used by OptionsDescription to render references to this topic (for example
+    /// from <see cref="AzureServiceBusSubscription.Topic"/>) as just the topic name.
+    /// </summary>
+    public override string ToString() => TopicName;
+
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
     {
         throw new NotSupportedException();
@@ -60,6 +67,7 @@ public class AzureServiceBusTopic : AzureServiceBusEndpoint, IMassTransitInterop
         return new ValueTask(Parent.WithManagementClientAsync(client => client.DeleteTopicAsync(TopicName)));
     }
 
+    [ChildDescription]
     public CreateTopicOptions Options { get; }
 
     public override ValueTask SetupAsync(ILogger logger)

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -1,5 +1,6 @@
 using Confluent.Kafka;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Routing;
@@ -16,17 +17,24 @@ public enum KafkaUsage
 
 public class KafkaTransport : BrokerTransport<KafkaTopic>
 {
+    [IgnoreDescription]
     public Cache<string, KafkaTopic> Topics { get; }
 
     internal List<KafkaTopicGroup> TopicGroups { get; } = new();
 
+    [ChildDescription]
     public ProducerConfig ProducerConfig { get; } = new();
+    [IgnoreDescription]
     public Action<ProducerBuilder<string, byte[]>> ConfigureProducerBuilders { get; internal set; } = _ => {};
 
+    [ChildDescription]
     public ConsumerConfig ConsumerConfig { get; } = new();
+    [IgnoreDescription]
     public Action<ConsumerBuilder<string, byte[]>> ConfigureConsumerBuilders { get; internal set; } = _ => {};
 
+    [ChildDescription]
     public AdminClientConfig AdminClientConfig { get; } = new();
+    [IgnoreDescription]
     public Action<AdminClientBuilder> ConfigureAdminClientBuilders { get; internal set; } = _ => {};
 
     public KafkaTransport() : this("kafka")

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -1,5 +1,6 @@
 using Confluent.Kafka;
 using Confluent.Kafka.Admin;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using System.Text;
 using Wolverine.Configuration;
@@ -15,6 +16,7 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     // Strictly an identifier for the endpoint
     public const string WolverineTopicsName = "wolverine.topics";
 
+    [IgnoreDescription]
     public KafkaTransport Parent { get; }
 
     public KafkaTopic(KafkaTransport parent, string topicName, EndpointRole role) : base(new Uri($"{parent.Protocol}://topic/" + topicName), role)
@@ -36,6 +38,7 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
         return true;
     }
 
+    [ChildDescription]
     public TopicSpecification Specification { get; } = new();
 
     public string TopicName { get; }
@@ -43,11 +46,13 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     /// <summary>
     /// Override for this specific Kafka Topic
     /// </summary>
+    [ChildDescription]
     public ConsumerConfig? ConsumerConfig { get; internal set; }
 
     /// <summary>
     /// Override for this specific Kafka Topic
     /// </summary>
+    [ChildDescription]
     public ProducerConfig? ProducerConfig { get; internal set; }
 
     /// <summary>
@@ -204,6 +209,7 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     /// <summary>
     /// Override how this Kafka topic is created
     /// </summary>
+    [IgnoreDescription]
     public Func<IAdminClient, KafkaTopic, Task> CreateTopicFunc { get; internal set; } = (c, t) => c.CreateTopicsAsync([t.Specification]);
 }
 

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTransport.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTransport.cs
@@ -1,5 +1,6 @@
 using ImTools;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using MQTTnet;
 using MQTTnet.Client;
@@ -15,6 +16,7 @@ namespace Wolverine.MQTT.Internals;
 
 public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
 {
+    [IgnoreDescription]
     public LightweightCache<string, MqttTopic> Topics { get; } = new();
     private List<MqttListener> _listeners = new();
     private ImHashMap<string, MqttListener> _topicListeners = ImHashMap<string, MqttListener>.Empty;
@@ -164,6 +166,7 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
     internal IManagedMqttClient Client { get; private set; } = null!;
     internal MqttJwtAuthenticationOptions? JwtAuthenticationOptions { get; set; }
 
+    [ChildDescription]
     public ManagedMqttClientOptions Options { get; set; } = new ManagedMqttClientOptions
         { ClientOptions = new MqttClientOptions() };
 

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttTopic.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttTopic.cs
@@ -1,3 +1,4 @@
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using MQTTnet;
 using MQTTnet.Extensions.ManagedClient;
@@ -42,6 +43,7 @@ public class MqttTopic : Endpoint, ISender, ITopicEndpoint
         Mode = EndpointMode.BufferedInMemory;
     }
 
+    [IgnoreDescription]
     public MqttTransport Parent { get; }
     
     /// <summary>
@@ -55,6 +57,7 @@ public class MqttTopic : Endpoint, ISender, ITopicEndpoint
     /// When set, overrides the built in envelope mapping with a custom
     /// implementation
     /// </summary>
+    [IgnoreDescription]
     public IMqttEnvelopeMapper EnvelopeMapper { get; set; }
 
     public override bool AutoStartSendingAgent()

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsEndpoint.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsEndpoint.cs
@@ -1,3 +1,4 @@
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
 using NATS.Client.JetStream.Models;
@@ -27,6 +28,7 @@ public class NatsEndpoint : Endpoint, IBrokerEndpoint
     }
 
     public string Subject { get; }
+    [IgnoreDescription]
     public object? NatsSerializer { get; set; }
     public Dictionary<string, string> CustomHeaders { get; set; } = new();
     public string? QueueGroup { get; set; }

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsTransport.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsTransport.cs
@@ -1,3 +1,4 @@
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
 using NATS.Client.JetStream;
@@ -49,6 +50,7 @@ public class NatsTransport : BrokerTransport<NatsEndpoint>, IAsyncDisposable
 
     public string ResponseSubject { get; private set; } = "wolverine.response";
 
+    [ChildDescription]
     public NatsTransportConfiguration Configuration { get; } = new();
 
     public NatsConnection Connection =>

--- a/src/Transports/Pulsar/Wolverine.Pulsar/DeadLetterTopic.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/DeadLetterTopic.cs
@@ -39,6 +39,11 @@ public class DeadLetterTopic
         set => _topicName = value ?? throw new ArgumentNullException(nameof(TopicName));
     }
 
+    /// <summary>
+    /// Used by OptionsDescription to render this as the bare topic name.
+    /// </summary>
+    public override string ToString() => _topicName ?? string.Empty;
+
     protected bool Equals(DeadLetterTopic other)
     {
         return _topicName == other._topicName;

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransport.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransport.cs
@@ -1,6 +1,7 @@
 using DotPulsar;
 using DotPulsar.Abstractions;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Transports;
@@ -23,6 +24,7 @@ public class PulsarTransport : TransportBase<PulsarEndpoint>, IAsyncDisposable
 
     public PulsarEndpoint this[Uri uri] => _endpoints[uri];
 
+    [IgnoreDescription]
     public IPulsarClientBuilder Builder { get; }
 
     internal IPulsarClient? Client { get; private set; }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/RetryLetterTopic.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/RetryLetterTopic.cs
@@ -39,6 +39,11 @@ public class RetryLetterTopic
         set => _topicName = value ?? throw new ArgumentNullException(nameof(TopicName));
     }
 
+    /// <summary>
+    /// Used by OptionsDescription to render this as the bare topic name.
+    /// </summary>
+    public override string ToString() => _topicName ?? string.Empty;
+
     public List<TimeSpan> Retry => _retries.ToList();
 
     protected bool Equals(RetryLetterTopic other)

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/DeadLetterQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/DeadLetterQueue.cs
@@ -74,6 +74,13 @@ public class DeadLetterQueue
         };
     }
 
+    public override string ToString()
+    {
+        // Used by OptionsDescription to render the value as the bare queue name
+        // rather than the default type-qualified name.
+        return _queueName;
+    }
+
     protected bool Equals(DeadLetterQueue other)
     {
         return _queueName == other._queueName && ExchangeName == other.ExchangeName;

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqConnectionDescription.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqConnectionDescription.cs
@@ -1,0 +1,53 @@
+using JasperFx.Descriptors;
+using RabbitMQ.Client;
+
+namespace Wolverine.RabbitMQ.Internal;
+
+/// <summary>
+/// Secret-safe description of a <see cref="ConnectionFactory"/> for use with
+/// <see cref="OptionsDescription"/>. Exposes non-secret connection fields
+/// (host, port, vhost, username, SSL, heartbeat) and deliberately omits the
+/// password and any credential-carrying properties.
+/// </summary>
+public sealed class RabbitMqConnectionDescription : IDescribeMyself
+{
+    private readonly ConnectionFactory _factory;
+
+    public RabbitMqConnectionDescription(ConnectionFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public OptionsDescription ToDescription()
+    {
+        var description = new OptionsDescription
+        {
+            Subject = "Wolverine.RabbitMQ.ConnectionFactory",
+            Title = "Connection"
+        };
+
+        description.AddValue(nameof(_factory.HostName), _factory.HostName);
+        description.AddValue(nameof(_factory.Port), _factory.Port);
+        description.AddValue(nameof(_factory.VirtualHost), _factory.VirtualHost);
+        description.AddValue(nameof(_factory.UserName), _factory.UserName);
+        // Password intentionally omitted.
+
+        description.AddValue(nameof(_factory.RequestedHeartbeat), _factory.RequestedHeartbeat);
+        description.AddValue(nameof(_factory.RequestedConnectionTimeout), _factory.RequestedConnectionTimeout);
+        description.AddValue(nameof(_factory.ClientProvidedName), _factory.ClientProvidedName ?? string.Empty);
+        description.AddValue(nameof(_factory.AutomaticRecoveryEnabled), _factory.AutomaticRecoveryEnabled);
+        description.AddValue(nameof(_factory.TopologyRecoveryEnabled), _factory.TopologyRecoveryEnabled);
+
+        if (_factory.Ssl != null)
+        {
+            description.AddValue("Ssl.Enabled", _factory.Ssl.Enabled);
+            if (_factory.Ssl.Enabled)
+            {
+                description.AddValue("Ssl.ServerName", _factory.Ssl.ServerName ?? string.Empty);
+                description.AddValue("Ssl.Version", _factory.Ssl.Version.ToString());
+            }
+        }
+
+        return description;
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqExchange.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqExchange.cs
@@ -1,4 +1,5 @@
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 using Wolverine.Configuration;
@@ -32,11 +33,13 @@ public class RabbitMqExchange : RabbitMqEndpoint, IRabbitMqExchange
     /// <summary>
     /// All active topic endpoints by name
     /// </summary>
+    [IgnoreDescription]
     public LightweightCache<string, RabbitMqTopicEndpoint> Topics { get; }
-    
+
     /// <summary>
     /// All active routing keys
     /// </summary>
+    [IgnoreDescription]
     public LightweightCache<string, RabbitMqRouting> Routings { get; }
 
     public override bool AutoStartSendingAgent()
@@ -57,6 +60,7 @@ public class RabbitMqExchange : RabbitMqEndpoint, IRabbitMqExchange
     public ExchangeType ExchangeType { get; set; } = ExchangeType.Fanout;
     public bool AutoDelete { get; set; } = false;
 
+    [IgnoreDescription]
     public IDictionary<string, object?> Arguments { get; } = new Dictionary<string, object?>();
     
     internal bool HasExchangeBindings => _exchangeBindings.Count > 0;

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -1,3 +1,4 @@
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Exceptions;
@@ -201,11 +202,13 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
     ///     Arguments for Rabbit MQ queue declarations. See the Rabbit MQ .NET client documentation at
     ///     https://www.rabbitmq.com/dotnet.html
     /// </summary>
+    [IgnoreDescription]
     public IDictionary<string, object?> Arguments { get; } = new Dictionary<string, object?>();
 
     /// <summary>
     ///     Arguments for Rabbit MQ channel consume operations
     /// </summary>
+    [IgnoreDescription]
     public IDictionary<string, object?> ConsumerArguments { get; } = new Dictionary<string, object?>();
 
     /// <summary>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -100,8 +101,10 @@ public partial class RabbitMqTransport : BrokerTransport<RabbitMqEndpoint>, IAsy
     /// Allows users to modify properties and behaviors of channels used in RabbitMQ communication
     /// by providing a delegate to apply specific settings.
     /// </summary>
+    [ChildDescription]
     public Action<WolverineRabbitMqChannelOptions>? ChannelCreationOptions { get; set; }
 
+    [IgnoreDescription]
     public ConnectionFactory? ConnectionFactory { get; private set; }
 
     internal void ConfigureFactory(Action<ConnectionFactory> configure)
@@ -118,11 +121,15 @@ public partial class RabbitMqTransport : BrokerTransport<RabbitMqEndpoint>, IAsy
         ConnectionFactory = factory;
     }
 
+    [IgnoreDescription]
     public IList<AmqpTcpEndpoint> AmqpTcpEndpoints { get; } = new List<AmqpTcpEndpoint>();
 
+    [IgnoreDescription]
     public LightweightCache<Uri, RabbitMqTopicEndpoint> Topics { get; }
+    [IgnoreDescription]
     public LightweightCache<string, RabbitMqExchange> Exchanges { get; }
 
+    [IgnoreDescription]
     public LightweightCache<string, RabbitMqQueue> Queues { get; }
 
     internal bool DeclareRequestReplySystemQueue { get; set; } = true;
@@ -336,6 +343,7 @@ public partial class RabbitMqTransport : BrokerTransport<RabbitMqEndpoint>, IAsy
         return new ConnectionMonitor(this, role);
     }
 
+    [IgnoreDescription]
     public ILogger<RabbitMqTransport> Logger { get; private set; } = NullLogger<RabbitMqTransport>.Instance;
     
     /// <summary>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
@@ -107,6 +107,15 @@ public partial class RabbitMqTransport : BrokerTransport<RabbitMqEndpoint>, IAsy
     [IgnoreDescription]
     public ConnectionFactory? ConnectionFactory { get; private set; }
 
+    /// <summary>
+    /// Secret-safe summary of <see cref="ConnectionFactory"/> for diagnostic
+    /// rendering. Exposes host / port / vhost / user / SSL / heartbeat and
+    /// omits the password.
+    /// </summary>
+    [ChildDescription]
+    public RabbitMqConnectionDescription? ConnectionDescription =>
+        ConnectionFactory == null ? null : new RabbitMqConnectionDescription(ConnectionFactory);
+
     internal void ConfigureFactory(Action<ConnectionFactory> configure)
     {
         var factory = new ConnectionFactory

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
@@ -73,15 +73,21 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
             // Parse connection string to build resource URI
             var options = ConfigurationOptions.Parse(_connectionString);
             var endpoint = options.EndPoints.FirstOrDefault();
-            
+
             if (endpoint == null)
             {
                 return new Uri($"{ProtocolName}://localhost:6379");
             }
-            
+
             return new Uri($"{ProtocolName}://{endpoint}");
         }
     }
+
+    /// <summary>
+    /// The configured Redis connection string with the <c>password</c> value
+    /// masked. Safe to render in diagnostic output.
+    /// </summary>
+    public string ConnectionSummary => SanitizeConnectionStringForLogging(_connectionString);
 
     internal IDatabase GetDatabase(string? connectionString = null, int database = 0)
     {

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Linq;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 using Spectre.Console;
@@ -34,6 +35,7 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     /// Customizable selector to build a stable consumer name for listeners when an endpoint-level ConsumerName is not set.
     /// Defaults to ServiceName-NodeNumber-MachineName (lowercased and sanitized).
     /// </summary>
+    [DescribeAsConfigurationState]
     public Func<IWolverineRuntime, RedisStreamEndpoint, string>? DefaultConsumerNameSelector { get; set; }
     
     /// <summary>

--- a/src/Transports/SignalR/Wolverine.SignalR/Client/SignalRClientEndpoint.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Client/SignalRClientEndpoint.cs
@@ -1,4 +1,5 @@
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
@@ -37,8 +38,10 @@ public class SignalRClientEndpoint : Endpoint, IListener, ISender
         JsonOptions = new SignalRTransport().JsonOptions;
     }
 
+    [IgnoreDescription]
     public JsonSerializerOptions JsonOptions { get; set; }
 
+    [DescribeAsConfigurationState]
     public Func<IServiceProvider, Func<Task<string?>>> AccessTokenProvider { get; set; } = null!;
 
     public Uri SignalRUri { get; }
@@ -105,6 +108,7 @@ public class SignalRClientEndpoint : Endpoint, IListener, ISender
         }
     }
 
+    [IgnoreDescription]
     public IReceiver? Receiver { get; private set; }
 
     protected override ISender CreateSender(IWolverineRuntime runtime)
@@ -119,6 +123,7 @@ public class SignalRClientEndpoint : Endpoint, IListener, ISender
         return this;
     }
 
+    [IgnoreDescription]
     public IHandlerPipeline? Pipeline { get; private set; }
 
     ValueTask IChannelCallback.CompleteAsync(Envelope envelope)

--- a/src/Transports/SignalR/Wolverine.SignalR/Internals/SignalRTransport.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Internals/SignalRTransport.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using JasperFx.Resources;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
@@ -69,6 +70,7 @@ public class SignalRTransport : Endpoint, ITransport, IListener, ISender
         return new ValueTask();
     }
 
+    [IgnoreDescription]
     public IHubContext<Hub>? HubContext { get; private set; }
     public Type HubType { get; internal set; } = typeof(WolverineHub);
 
@@ -80,8 +82,10 @@ public class SignalRTransport : Endpoint, ITransport, IListener, ISender
 
     internal ILogger<SignalRTransport>? Logger { get; set; }
 
+    [IgnoreDescription]
     public JsonSerializerOptions JsonOptions { get; set; }
 
+    [IgnoreDescription]
     public IReceiver? Receiver { get; private set; }
     
     internal async Task ReceiveAsync(HubCallerContext context, string json)
@@ -116,6 +120,7 @@ public class SignalRTransport : Endpoint, ITransport, IListener, ISender
         return new ValueTask<IListener>(this);
     }
 
+    [IgnoreDescription]
     public IHandlerPipeline? Pipeline => Receiver?.Pipeline;
 
     ValueTask IChannelCallback.CompleteAsync(Envelope envelope)

--- a/src/Wolverine/ErrorHandling/FailureRule.cs
+++ b/src/Wolverine/ErrorHandling/FailureRule.cs
@@ -55,4 +55,23 @@ public class FailureRule : IEnumerable<FailureSlot>
 
         return slot;
     }
+
+    public override string ToString()
+    {
+        var parts = new List<string>(_slots.Count + 1);
+
+        foreach (var slot in _slots)
+        {
+            parts.Add($"attempt {slot.Attempt}: {slot.Describe()}");
+        }
+
+        if (InfiniteSource != null)
+        {
+            var prefix = _slots.Count > 0 ? "then repeat" : "repeat";
+            parts.Add($"{prefix}: {InfiniteSource.Description}");
+        }
+
+        var actions = parts.Count > 0 ? string.Join("; ", parts) : "no action";
+        return $"On {Match.Description} \u2014 {actions}";
+    }
 }

--- a/src/Wolverine/ErrorHandling/SendingFailurePolicies.cs
+++ b/src/Wolverine/ErrorHandling/SendingFailurePolicies.cs
@@ -1,3 +1,4 @@
+using JasperFx.Descriptors;
 using Wolverine.Runtime;
 
 namespace Wolverine.ErrorHandling;
@@ -7,8 +8,15 @@ namespace Wolverine.ErrorHandling;
 /// Unlike handler failure policies, unmatched exceptions return null
 /// so the existing retry/circuit-breaker behavior is preserved.
 /// </summary>
-public class SendingFailurePolicies : IWithFailurePolicies
+public class SendingFailurePolicies : IWithFailurePolicies, IOptionsValueAsStringArray
 {
+    /// <summary>
+    /// Renders the failure rules as a string array so <see cref="OptionsDescription"/>
+    /// shows one entry per rule instead of the default class ToString().
+    /// </summary>
+    public IReadOnlyList<string> ToOptionsValueStrings()
+        => Failures.Select(rule => rule.ToString()!).ToArray();
+
     /// <summary>
     /// Collection of error handling policies for exception handling during the sending of a message
     /// </summary>

--- a/src/Wolverine/Runtime/Handlers/HandlerGraph.ISystemDescribedPart.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerGraph.ISystemDescribedPart.cs
@@ -62,7 +62,7 @@ public partial class HandlerGraph
                 }
             }
 
-            AnsiConsole.Render(table);
+            AnsiConsole.Write(table);
         }
 
         return Task.CompletedTask;

--- a/src/Wolverine/Runtime/Interop/CloudEventsMapper.cs
+++ b/src/Wolverine/Runtime/Interop/CloudEventsMapper.cs
@@ -92,6 +92,8 @@ public class CloudEventsMapper : IUnwrapsMetadataMessageSerializer
         _options = options;
     }
 
+    public override string ToString() => "Cloud Events";
+
     public string WriteToString(Envelope envelope)
     {
         return JsonSerializer.Serialize(new CloudEventsEnvelope(envelope), _options);

--- a/src/Wolverine/Transports/BrokerResource.cs
+++ b/src/Wolverine/Transports/BrokerResource.cs
@@ -95,10 +95,7 @@ public class BrokerResource : IStatefulResource
 
     public async Task<IRenderable> DetermineStatus(CancellationToken token)
     {
-        var table = new Table
-        {
-            Alignment = Justify.Left
-        };
+        var table = new Table();
 
         var columns = _transport.DiagnosticColumns().ToArray();
         if (columns.Length == 0) return table;

--- a/src/Wolverine/Transports/ConnectionStringRedactor.cs
+++ b/src/Wolverine/Transports/ConnectionStringRedactor.cs
@@ -1,0 +1,61 @@
+using System.Text;
+
+namespace Wolverine.Transports;
+
+/// <summary>
+/// Small helper for masking credential-bearing keys in a connection string
+/// while preserving the rest of the content. Used to render a transport's
+/// connection string in <see cref="JasperFx.Descriptors.OptionsDescription"/>
+/// output without leaking secrets into logs or diagnostic UIs.
+/// </summary>
+public static class ConnectionStringRedactor
+{
+    /// <summary>
+    /// Mask the values of any <c>key=value</c> segments whose key (case-insensitive)
+    /// appears in <paramref name="secretKeys"/>. Segments are delimited by
+    /// <c>;</c>. Unknown keys pass through unchanged.
+    /// </summary>
+    public static string Redact(string? connectionString, params string[] secretKeys)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString)) return string.Empty;
+        if (secretKeys == null || secretKeys.Length == 0) return connectionString!;
+
+        var builder = new StringBuilder(connectionString!.Length);
+        var segments = connectionString.Split(';');
+        for (var i = 0; i < segments.Length; i++)
+        {
+            var segment = segments[i];
+            if (segment.Length == 0) continue;
+
+            var equalsIndex = segment.IndexOf('=');
+            if (equalsIndex > 0)
+            {
+                var key = segment.Substring(0, equalsIndex);
+                if (IsSecretKey(key, secretKeys))
+                {
+                    if (builder.Length > 0) builder.Append(';');
+                    builder.Append(key).Append("=****");
+                    continue;
+                }
+            }
+
+            if (builder.Length > 0) builder.Append(';');
+            builder.Append(segment);
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool IsSecretKey(string key, string[] secretKeys)
+    {
+        foreach (var secret in secretKeys)
+        {
+            if (string.Equals(key.Trim(), secret, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

Sweeps every `Endpoint` and `ITransport` implementation so that `wolverine describe` output (and anything that consumes the `OptionsDescription` tree, e.g. CritterWatch) renders cleanly instead of leaking raw `ToString()` class names, dumping `null` as `"None"` for nested objects, or silently skipping structured config as "generic enumerable."

Two commits, each independently reviewable:

1. **`OptionsDescription audit across all transports`** — 40 files. Every transport's public properties now have one of `[IgnoreDescription]` / `[ChildDescription]` / `[DescribeAsStringArray]` / `[DescribeAsConfigurationState]`, plus `ToString()` overrides on mappers, `DeadLetterQueue`, `AzureServiceBusTopic`, the Pulsar dead/retry topic types, and `AmazonSnsSubscription`. `FailureRule` gets a readable `ToString()` and `SendingFailurePolicies` implements `IOptionsValueAsStringArray` so failure policies render as one entry per rule.

2. **`Render connection credentials safely in OptionsDescription (GH-2547, GH-2548)`** — 5 files.
   - GH-2547: `ConnectionStringRedactor` masks `SharedAccessKey=` / `password=` in semicolon-delimited connection strings. `AzureServiceBusTransport` exposes `ConnectionSummary` + `ManagementConnectionSummary`; `RedisTransport` exposes `ConnectionSummary`.
   - GH-2548: `RabbitMqConnectionDescription : IDescribeMyself` wraps `ConnectionFactory` with only the non-secret fields (host, port, vhost, user, heartbeat, SSL). `RabbitMqTransport.ConnectionDescription` surfaces it as `[ChildDescription]`.

Bumps `JasperFx` to **1.26.0**, which brings `IOptionsValueAsStringArray` + `[DescribeAsStringArray]` (1.25.0) and `[DescribeAsConfigurationState]` (1.26.0). The Spectre.Console 0.55 transitive required two small fixups: `Table.Alignment` removal in `BrokerResource`, and `AnsiConsole.Render` → `AnsiConsole.Write` in `HandlerGraph.ISystemDescribedPart`.

Closes GH-2547.
Closes GH-2548.

## Test plan

- [x] `dotnet build wolverine_slim.slnx` — 0 errors
- [x] `CoreTests` Descriptors suite in JasperFx — 22/22 pass × net8/net9/net10
- [ ] Manual: run `wolverine describe` against a sample app with each transport configured; verify:
  - No connection-string secrets in the output for ASB / Redis / RabbitMQ
  - Nested `ChildDescription` blocks appear for `BufferingLimits`, `CircuitBreakerOptions`, `ClientOptions`, `ConnectionDescription`, etc.
  - `SendingFailurePolicies` renders as one string per rule, not as a class name
  - Delegate-valued properties (`CredentialSource`, `DefaultConsumerNameSelector`, `AccessTokenProvider`) render as `"Configured"` or `"Default"`
  - `AmazonSnsTopic.TopicSubscriptions` renders as a string array
- [ ] CritterWatch UI smoke: endpoint detail pages render the new `Children` / `StringArray` values correctly (the `OptionsDescriptionView` recurses generically — no frontend changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)