### PR TITLE
Fix RavenDb scheduled messages not being delivered when using a durable transport

### DIFF
--- a/src/Persistence/RavenDbTests/scheduled_job_locking.cs
+++ b/src/Persistence/RavenDbTests/scheduled_job_locking.cs
@@ -1,0 +1,91 @@
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Raven.Client.Documents;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.RavenDb;
+using Wolverine.RavenDb.Internals;
+
+namespace RavenDbTests;
+
+[Collection("raven")]
+public class scheduled_job_locking : IAsyncLifetime
+{
+    private readonly DatabaseFixture _fixture;
+    private IDocumentStore _store = null!;
+    private IHost _host = null!;
+
+    public scheduled_job_locking(DatabaseFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _store = _fixture.StartRavenStore();
+        _host = await buildHost();
+    }
+
+    private async Task<IHost> buildHost()
+    {
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(_store);
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ServiceName = "scheduled-locking";
+                opts.UseRavenDbPersistence();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task try_to_lock_scheduled_happy_path()
+    {
+        var store = _host.Services.GetService<IMessageStore>()!.As<RavenDbMessageStore>();
+
+        (await store.TryAttainScheduledJobLockAsync(CancellationToken.None)).ShouldBeTrue();
+
+        await store.ReleaseScheduledJobLockAsync();
+    }
+
+    [Fact]
+    public async Task scheduled_lock_is_exclusive()
+    {
+        using var host2 = await buildHost();
+        var store = _host.Services.GetService<IMessageStore>()!.As<RavenDbMessageStore>();
+        var store2 = host2.Services.GetService<IMessageStore>()!.As<RavenDbMessageStore>();
+
+        (await store.TryAttainScheduledJobLockAsync(CancellationToken.None)).ShouldBeTrue();
+
+        (await store2.TryAttainScheduledJobLockAsync(CancellationToken.None)).ShouldBeFalse();
+
+        await store.ReleaseScheduledJobLockAsync();
+
+        (await store2.TryAttainScheduledJobLockAsync(CancellationToken.None)).ShouldBeTrue();
+        await store2.ReleaseScheduledJobLockAsync();
+    }
+
+    [Fact]
+    public async Task scheduled_lock_can_be_reattained_while_leader_lock_is_held()
+    {
+        var store = _host.Services.GetService<IMessageStore>()!.As<RavenDbMessageStore>();
+
+        (await store.TryAttainScheduledJobLockAsync(CancellationToken.None)).ShouldBeTrue();
+        await store.ReleaseScheduledJobLockAsync();
+
+        (await store.Nodes.TryAttainLeadershipLockAsync(CancellationToken.None)).ShouldBeTrue();
+
+        (await store.TryAttainScheduledJobLockAsync(CancellationToken.None)).ShouldBeTrue();
+
+        await store.ReleaseScheduledJobLockAsync();
+        await store.Nodes.ReleaseLeadershipLockAsync();
+    }
+}

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.Locking.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.Locking.cs
@@ -73,7 +73,7 @@ public partial class RavenDbMessageStore
             ExpirationTime = DateTimeOffset.UtcNow.AddMinutes(5),
         };
         
-        if (_leaderLock == null)
+        if (_scheduledLock == null)
         {
             var result = await _store.Operations.SendAsync(new PutCompareExchangeValueOperation<DistributedLock>(_scheduledLockId, newLock, 0), token: token);
             if (result.Successful)
@@ -101,6 +101,7 @@ public partial class RavenDbMessageStore
     {
         if (_scheduledLock == null) return;
         await _store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<DistributedLock>(_scheduledLockId, _lastScheduledLockIndex));
+        _scheduledLock = null;
     }
 }
 


### PR DESCRIPTION
## Summary

I hit this chasing down why `bus.ScheduleAsync(...)` against a durable external sender was not working in our app - we were seeing saga timeouts persisted to the `IncomingMessage` collection in RavenDB, but they were never being delivered. We observed that `RavenDbDurabilityAgent.runScheduledJobs` was never releasing these messages. After some digging, I traced it to `RavenDbMessageStore.Locking.cs` and found the issue noted below.

## Root cause

`TryAttainScheduledJobLockAsync` decides between its two branches with:
```
if (_leaderLock == null)
```
but nothing in this method (or anywhere else that matters to the scheduled lock) reads or writes `_leaderLock`.

## Fix

- Changing to use the `_scheduledLock` variable
- Ensure we set `_scheduledLock = null` at the end of the method (to match what happens in `ReleaseLeadershipLockAsync`)