### PR TITLE
Fix NoHandlerForEndpointException during concurrent saga chain compile

### DIFF
--- a/src/Testing/CoreTests/Runtime/Handlers/concurrent_saga_chain_compilation.cs
+++ b/src/Testing/CoreTests/Runtime/Handlers/concurrent_saga_chain_compilation.cs
@@ -1,0 +1,68 @@
+using System.Collections.Concurrent;
+using JasperFx.CodeGeneration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace CoreTests.Runtime.Handlers;
+
+public class concurrent_saga_chain_compilation
+{
+    [Fact]
+    public async Task concurrent_first_time_resolution_of_a_saga_handler_does_not_throw()
+    {
+        const int iterations = 20;
+        const int concurrency = 64;
+
+        for (var i = 0; i < iterations; i++)
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Discovery.DisableConventionalDiscovery().IncludeType<RaceSaga>();
+                    opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+                    opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Dynamic;
+                }).StartAsync();
+
+            var graph = host.Services.GetRequiredService<HandlerGraph>();
+
+            var start = new ManualResetEventSlim(false);
+            var failures = new ConcurrentBag<Exception>();
+            var threads = new Thread[concurrency];
+
+            for (var t = 0; t < concurrency; t++)
+            {
+                threads[t] = new Thread(() =>
+                {
+                    start.Wait();
+                    try
+                    {
+                        graph.HandlerFor(typeof(StartRace));
+                    }
+                    catch (Exception ex)
+                    {
+                        failures.Add(ex);
+                    }
+                });
+                threads[t].Start();
+            }
+
+            start.Set();
+
+            foreach (var thread in threads) thread.Join();
+
+            failures.ShouldBeEmpty();
+        }
+    }
+}
+
+public record StartRace(Guid Id);
+
+public class RaceSaga : Wolverine.Saga
+{
+    public Guid Id { get; set; }
+
+    public static RaceSaga Start(StartRace cmd) => new() { Id = cmd.Id };
+}

--- a/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
@@ -272,30 +272,32 @@ public partial class HandlerGraph : ICodeFileCollectionWithServices, IWithFailur
         {
             handler = chain.Handler;
         }
-        else if (!chain.HasDefaultNonStickyHandlers())
-        {
-            throw new NoHandlerForEndpointException(messageType);
-        }
         else
         {
+            // SagaChain.DetermineFrames clears Handlers during codegen, so the
+            // HasDefaultNonStickyHandlers check has to happen inside the lock
             lock (_compilingLock)
             {
-                // TODO -- put this logic in JasperFx
-                var logger = Container?.Services.GetService<ILoggerFactory>()?.CreateLogger<HandlerGraph>() ?? new Logger<HandlerGraph>(new LoggerFactory([new DebugLoggerProvider()]));
-                
-                logger.LogDebug("Starting to compile chain {MessageType}", chain.MessageType.NameInCode());
-
-                if (chain.Handler == null)
-                {
-                    chain.InitializeSynchronously(Rules, this, Container!.Services);
-                    handler = chain.CreateHandler(Container!);
-                }
-                else
+                if (chain.Handler != null)
                 {
                     handler = chain.Handler;
                 }
+                else if (!chain.HasDefaultNonStickyHandlers())
+                {
+                    throw new NoHandlerForEndpointException(messageType);
+                }
+                else
+                {
+                    // TODO -- put this logic in JasperFx
+                    var logger = Container?.Services.GetService<ILoggerFactory>()?.CreateLogger<HandlerGraph>() ?? new Logger<HandlerGraph>(new LoggerFactory([new DebugLoggerProvider()]));
 
-                logger.LogDebug("Finished building the chain {MessageType}", chain.MessageType.NameInCode());
+                    logger.LogDebug("Starting to compile chain {MessageType}", chain.MessageType.NameInCode());
+
+                    chain.InitializeSynchronously(Rules, this, Container!.Services);
+                    handler = chain.CreateHandler(Container!);
+
+                    logger.LogDebug("Finished building the chain {MessageType}", chain.MessageType.NameInCode());
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

I ran into this running saga workloads under dynamic codegen. At cold-start, when two messages for the same saga type arrived concurrently, one would sometimes throw `NoHandlerForEndpointException` even though a valid handler was about to be assigned on the other thread. I traced it to `HandlerGraph.resolveHandlerFromChain`.

## Root cause

`SagaChain.DetermineFrames` calls `Handlers.Clear()` as a side effect of codegen before the generated handler gets registered.
`resolveHandlerFromChain` checks `HasDefaultNonStickyHandlers()` *outside* the compile lock:
```
  else if (!chain.HasDefaultNonStickyHandlers())   // read outside the lock
  {
      throw new NoHandlerForEndpointException(messageType);
  }
  else
  {
      lock (_compilingLock) { /* compile */ }
  }
```

A concurrent second caller arriving while the first is mid-compile sees the temporarily-empty Handlers, `HasDefaultNonStickyHandlers()` returns false, and the throw happens (even though the first thread is about to assign `chain.Handler`)

Note that this is only reproducible under dynamic codegen because pre-generated code doesn't hit this path.

## Fix

Move the full "handler present / compile / throw" decision inside `_compilingLock`, with a fast-path re-check on `chain.Handler` for threads that arrived after compilation finished.
