### PR TITLE
Skip logging when the count is zero

### DIFF
--- a/src/Persistence/Wolverine.RavenDb/Internals/Durability/RavenDbDurabilityAgent.Incoming.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/Durability/RavenDbDurabilityAgent.Incoming.cs
@@ -49,8 +49,11 @@ public partial class RavenDbDurabilityAgent
             await circuit.EnqueueDirectlyAsync(envelopes);
             _logger.RecoveredIncoming(envelopes);
 
-            _logger.LogInformation("Successfully recovered {Count} messages from the inbox for listener {Listener}",
-                envelopes.Count, listener);
+            if (envelopes.Count > 0)
+            {
+                _logger.LogInformation("Successfully recovered {Count} messages from the inbox for listener {Listener}",
+                    envelopes.Count, listener);
+            }
         }
         catch (Exception e)
         {

--- a/src/Persistence/Wolverine.RavenDb/Internals/Durability/RavenDbDurabilityAgent.Outgoing.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/Durability/RavenDbDurabilityAgent.Outgoing.cs
@@ -44,9 +44,12 @@ public partial class RavenDbDurabilityAgent
 
             foreach (var envelope in good) await sendingAgent.EnqueueOutgoingAsync(envelope);
 
-            _logger.LogInformation(
-                "Recovered {Count} messages from outbox for destination {Destination} while discarding {ExpiredCount} expired messages",
-                good.Length, sendingAgent.Destination, expiredMessages.Length);
+            if (good.Length > 0 || expiredMessages.Length > 0)
+            {
+                _logger.LogInformation(
+                    "Recovered {Count} messages from outbox for destination {Destination} while discarding {ExpiredCount} expired messages",
+                    good.Length, sendingAgent.Destination, expiredMessages.Length);
+            }
         }
         catch (Exception e)
         {

--- a/src/Wolverine/Logging/TransportLoggerExtensions.cs
+++ b/src/Wolverine/Logging/TransportLoggerExtensions.cs
@@ -110,12 +110,16 @@ public static class TransportLoggerExtensions
 
     public static void RecoveredIncoming(this ILogger logger, IEnumerable<Envelope> envelopes)
     {
-        _recoveredIncoming(logger, envelopes.Count(), null);
+        var count = envelopes.Count();
+        if (count == 0) return;
+        _recoveredIncoming(logger, count, null);
     }
 
     public static void RecoveredOutgoing(this ILogger logger, IEnumerable<Envelope> envelopes)
     {
-        _recoveredOutgoing(logger, envelopes.Count(), null);
+        var count = envelopes.Count();
+        if (count == 0) return;
+        _recoveredOutgoing(logger, count, null);
     }
 
     public static void DiscardedExpired(this ILogger logger, IEnumerable<Envelope> envelopes)


### PR DESCRIPTION
## Summary

Per our quick discussion in Discord, gating the durability agent's recovery logs behind `count > 0` so an idle app doesn't emit `Recovered 0 incoming envelopes` or `Successfully recovered 0 messages` every poll cycle.

## Changes

- `TransportLoggerExtensions.RecoveredIncoming` and `RecoveredOutgoing` early return when count is zero
   - These helpers are called by every persistence provider, but I still suggest it makes sense to avoid logging zeroes here
- `RavenDbDurabilityAgent.Incoming.cs` and `RavenDbDurabilityAgent.Outgoing.cs`
   - Avoid logging when the count is zero
