### PR TITLE
Add CI target and workflow for RavenDb (GH-2558)

### DIFF
--- a/.github/workflows/ravendb.yml
+++ b/.github/workflows/ravendb.yml
@@ -1,0 +1,41 @@
+name: ravendb
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  config: Release
+  disable_test_parallelization: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run RavenDb Tests
+        run: ./build.sh CIRavenDb --framework net9.0

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -43,6 +43,7 @@
         "CIPolecat",
         "CIPulsar",
         "CIRabbitMQ",
+        "CIRavenDb",
         "CIRedis",
         "CISqlite",
         "CISqlServer",

--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -437,6 +437,19 @@ partial class Build
             RunSingleProjectOneClassAtATime(leaderElectionTests);
         });
 
+    Target CIRavenDb => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            var ravenDbTests = RootDirectory / "src" / "Persistence" / "RavenDbTests" / "RavenDbTests.csproj";
+            var leaderElectionTests = RootDirectory / "src" / "Persistence" / "LeaderElection" / "RavenDbTests.LeaderElection" / "RavenDbTests.LeaderElection.csproj";
+
+            BuildTestProjectsWithFramework("net9.0", ravenDbTests, leaderElectionTests);
+
+            RunSingleProjectOneClassAtATime(ravenDbTests, frameworkOverride: "net9.0");
+            RunSingleProjectOneClassAtATime(leaderElectionTests, frameworkOverride: "net9.0");
+        });
+
     Target CIAzureServiceBus => _ => _
         .ProceedAfterFailure()
         .Executes(() =>

--- a/build/TestAllPersistence.cs
+++ b/build/TestAllPersistence.cs
@@ -88,7 +88,9 @@ partial class Build
 
     /// <summary>
     /// Discovers individual test method names from source files for leader election projects.
-    /// Returns tuples of (className, methodName).
+    /// Returns tuples of (className, methodName). Also follows class inheritance into
+    /// compliance base classes in src/Testing/Wolverine.ComplianceTests/ so that inherited
+    /// [Fact]/[Theory] methods are attributed to the concrete class.
     /// </summary>
     static List<(string ClassName, string MethodName)> DiscoverTestMethods(string projectDir)
     {
@@ -96,12 +98,27 @@ partial class Build
             @"\[\s*(?:Fact|Theory).*?\]\s*(?:\[.*?\]\s*)*public\s+(?:async\s+)?(?:Task|void)\s+(\w+)\s*\(",
             RegexOptions.Compiled | RegexOptions.Singleline);
 
+        var classDeclarationPattern = new Regex(
+            @"(?:public\s+|internal\s+|abstract\s+|sealed\s+)*class\s+(\w+)\s*(?::\s*([\w<>,\s\.]+?))?\s*(?:\{|where\b)",
+            RegexOptions.Compiled);
+
+        var complianceBaseDir = FindComplianceTestsDir(projectDir);
+
         var testFiles = Directory.GetFiles(projectDir, "*.cs", SearchOption.AllDirectories)
             .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
                      && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
             .ToList();
 
         var results = new List<(string, string)>();
+        var seen = new HashSet<(string, string)>();
+
+        void AddMethod(string className, string methodName)
+        {
+            if (seen.Add((className, methodName)))
+            {
+                results.Add((className, methodName));
+            }
+        }
 
         foreach (var testFile in testFiles)
         {
@@ -111,10 +128,38 @@ partial class Build
             try
             {
                 var content = File.ReadAllText(testFile);
-                var matches = methodPattern.Matches(content);
-                foreach (Match match in matches)
+
+                foreach (Match match in methodPattern.Matches(content))
                 {
-                    results.Add((className, match.Groups[1].Value));
+                    AddMethod(className, match.Groups[1].Value);
+                }
+
+                if (complianceBaseDir == null) continue;
+
+                foreach (Match classMatch in classDeclarationPattern.Matches(content))
+                {
+                    var baseList = classMatch.Groups[2].Value;
+                    if (string.IsNullOrWhiteSpace(baseList)) continue;
+
+                    var concreteClassName = classMatch.Groups[1].Value;
+                    var baseTypeName = baseList.Split(',')[0].Trim().Split('<')[0].Trim();
+                    if (string.IsNullOrWhiteSpace(baseTypeName)) continue;
+
+                    var baseFile = Path.Combine(complianceBaseDir, baseTypeName + ".cs");
+                    if (!File.Exists(baseFile)) continue;
+
+                    try
+                    {
+                        var baseContent = File.ReadAllText(baseFile);
+                        foreach (Match baseMatch in methodPattern.Matches(baseContent))
+                        {
+                            AddMethod(concreteClassName, baseMatch.Groups[1].Value);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Warning("Could not read compliance base {File}: {Message}", baseFile, ex.Message);
+                    }
                 }
             }
             catch (Exception ex)
@@ -124,6 +169,23 @@ partial class Build
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Walks up from the project directory to locate src/Testing/Wolverine.ComplianceTests/
+    /// so inherited compliance tests can be discovered.
+    /// </summary>
+    static string? FindComplianceTestsDir(string projectDir)
+    {
+        var current = new DirectoryInfo(projectDir);
+        while (current != null)
+        {
+            var candidate = Path.Combine(current.FullName, "src", "Testing", "Wolverine.ComplianceTests");
+            if (Directory.Exists(candidate)) return candidate;
+            current = current.Parent;
+        }
+
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- New `CIRavenDb` Nuke target + `.github/workflows/ravendb.yml` workflow covering `RavenDbTests` and `RavenDbTests.LeaderElection` (no docker — uses embedded `RavenDB.TestDriver`)
- Fix `DiscoverTestMethods` in `build/TestAllPersistence.cs` so inherited `[Fact]` methods on compliance base classes (e.g. `LeadershipElectionCompliance`) are attributed to the concrete derived class — previously leader-election projects silently discovered zero methods
- Incorporates merged community bug fixes #2554 (scheduled-job lock) and #2555 (NRE on orphaned listener URIs) via a main merge

Closes #2558

## Test plan
- [x] `./build.sh CIRavenDb --framework net9.0` passes locally (3:12 runtime)
- [x] `RavenDbTests` — 139/139 pass (including the 4 new regression tests from #2554/#2555)
- [x] `RavenDbTests.LeaderElection` — 12 inherited compliance tests discovered and all pass
- [ ] CI `ravendb` workflow green on remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)