### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.2.9" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.32.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
@@ -61,6 +61,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.14.3" />
     <PackageVersion Include="Nuke.Common" Version="10.1.0" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.0.0" />
     <PackageVersion Include="OpenTelemetry" Version="1.14.0" />
@@ -90,6 +91,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.1" />
     <PackageVersion Include="System.ComponentModel" Version="4.3.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.LocalStack" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
@@ -161,7 +163,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.13.26" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.4.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
@@ -171,6 +173,6 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.13.26" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.4.0" />
   </ItemGroup>
 </Project>

--- a/build/build.csproj
+++ b/build/build.csproj
@@ -16,7 +16,9 @@
     <PackageReference Include="MySqlConnector" />
     <PackageReference Include="Npgsql" />
     <PackageReference Include="Nuke.Common" />
+    <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates NuGet packages to avoid vulnerable dependencies.

* `Microsoft.AspNetCore.WebSockets` 2.2.0 has a vulnerability with high severity (https://github.com/advisories/GHSA-6px8-22w5-w334). It's comes with `Microsoft.AspNetCore.SignalR`. 
<img width="1167" height="718" alt="image" src="https://github.com/user-attachments/assets/ebd02198-ed55-458d-b5e9-7929aec10fde" />

* Other vulnerabilities (`System.Security.Cryptography.Xml` and `NuGet.Packaging`) come from Nuke (atm no fixed version) and `Microsoft.Build.Tasks.Core` (used in EFCore). See `dotnet restore` for `wolverine.slnx` and `build.csproj` below.

```
E:\dmp\JasperFx\wolverine>dotnet restore wolverine.slnx
Restore succeeded with 6 warning(s) in 15.0s
    E:\dmp\JasperFx\wolverine\src\Persistence\SharedPersistenceModels\SharedPersistenceModels.csproj : warning NU1903: Package 'System.Security.Cryptography.Xml' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-37gx-xxp4-5rgx
    E:\dmp\JasperFx\wolverine\src\Persistence\Wolverine.EntityFrameworkCore\Wolverine.EntityFrameworkCore.csproj : warning NU1903: Package 'System.Security.Cryptography.Xml' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-37gx-xxp4-5rgx
    E:\dmp\JasperFx\wolverine\src\Persistence\Wolverine.EntityFrameworkCore\Wolverine.EntityFrameworkCore.csproj : warning NU1903: Package 'System.Security.Cryptography.Xml' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
    E:\dmp\JasperFx\wolverine\src\Persistence\SharedPersistenceModels\SharedPersistenceModels.csproj : warning NU1903: Package 'System.Security.Cryptography.Xml' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
    E:\dmp\JasperFx\wolverine\src\Persistence\EFCore\DomainEventsWithEfCore\BackLogService\BackLogService.csproj : warning NU1903: Package 'System.Security.Cryptography.Xml' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-37gx-xxp4-5rgx
    E:\dmp\JasperFx\wolverine\src\Persistence\EFCore\DomainEventsWithEfCore\BackLogService\BackLogService.csproj : warning NU1903: Package 'System.Security.Cryptography.Xml' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3x6-4m5h-cxqf

Build succeeded with 6 warning(s) in 15.3s

E:\dmp\JasperFx\wolverine\build>dotnet restore
Restore succeeded with 3 warning(s) in 0.8s
    E:\dmp\JasperFx\wolverine\build\build.csproj : warning NU1901: Package 'NuGet.Packaging' 6.12.1 has a known low severity vulnerability, https://github.com/advisories/GHSA-g4vj-cjjj-v7hg
    E:\dmp\JasperFx\wolverine\build\build.csproj : warning NU1903: Package 'System.Security.Cryptography.Xml' 9.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-37gx-xxp4-5rgx
    E:\dmp\JasperFx\wolverine\build\build.csproj : warning NU1903: Package 'System.Security.Cryptography.Xml' 9.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
```