### PR TITLE
Fix EnvelopeMapper swapped filter predicates breaking single-direction property overrides (#2551)

### DIFF
--- a/src/Testing/CoreTests/Transports/MapIncomingPropertyTests.cs
+++ b/src/Testing/CoreTests/Transports/MapIncomingPropertyTests.cs
@@ -1,3 +1,4 @@
+using Shouldly;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Transports;
@@ -25,6 +26,111 @@ public class MapIncomingPropertyTests
         });
 
         envelope.ReplyUri.ShouldBe(expectedReplyUri);
+    }
+
+    // Regression coverage for https://github.com/JasperFx/wolverine/issues/2551.
+    //
+    // MapIncomingProperty / MapOutgoingProperty customize a single direction.
+    // They must NOT disturb the opposite direction's default header mapping
+    // (registered via MapPropertyToHeader during the mapper's constructor).
+    //
+    // The bug was that compileIncoming/compileOutgoing had their filter
+    // predicates swapped — so MapIncomingProperty silently deleted the
+    // outgoing header mapping and vice versa.
+
+    [Fact]
+    public void custom_incoming_property_preserves_default_outgoing_header()
+    {
+        var mapper = new StubEnvelopeMapper(new StubEndpoint());
+
+        // Customize only the incoming direction for Id — read it from a
+        // transport-specific location. This must not stop Id from being
+        // written as the "id" header on outgoing messages.
+        mapper.MapIncomingProperty(x => x.Id, (envelope, incoming) =>
+        {
+            if (incoming.Headers.TryGetValue("custom-id", out var raw) && Guid.TryParse(raw, out var parsed))
+            {
+                envelope.Id = parsed;
+            }
+        });
+
+        var envelope = new Envelope { Id = Guid.NewGuid() };
+        var outgoing = new StubTransportMessage();
+
+        mapper.MapEnvelopeToOutgoing(envelope, outgoing);
+
+        outgoing.Headers.ContainsKey(EnvelopeConstants.IdKey).ShouldBeTrue(
+            "MapIncomingProperty(x => x.Id, ...) must not delete the default outgoing 'id' header mapping");
+        outgoing.Headers[EnvelopeConstants.IdKey].ShouldBe(envelope.Id.ToString());
+    }
+
+    [Fact]
+    public void custom_outgoing_property_preserves_default_incoming_header_read()
+    {
+        var mapper = new StubEnvelopeMapper(new StubEndpoint());
+
+        // Customize only the outgoing direction for Id — write it to a
+        // transport-specific location. This must not stop Id from being
+        // read from the default "id" header on incoming messages.
+        mapper.MapOutgoingProperty(x => x.Id, (envelope, outgoing) =>
+        {
+            outgoing.Headers["custom-id"] = envelope.Id.ToString();
+        });
+
+        var expected = Guid.NewGuid();
+        var envelope = new Envelope();
+        mapper.MapIncomingToEnvelope(envelope, new StubTransportMessage
+        {
+            Headers = { [EnvelopeConstants.IdKey] = expected.ToString() }
+        });
+
+        envelope.Id.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void custom_incoming_property_still_overrides_its_own_direction()
+    {
+        // Sanity check: the customization itself still works on the direction
+        // it actually targets. This complements
+        // custom_incoming_property_preserves_default_outgoing_header so a future
+        // regression that over-corrects can't slip past.
+        var mapper = new StubEnvelopeMapper(new StubEndpoint());
+
+        mapper.MapIncomingProperty(x => x.Id, (envelope, incoming) =>
+        {
+            if (incoming.Headers.TryGetValue("custom-id", out var raw) && Guid.TryParse(raw, out var parsed))
+            {
+                envelope.Id = parsed;
+            }
+        });
+
+        var expected = Guid.NewGuid();
+        var envelope = new Envelope();
+        mapper.MapIncomingToEnvelope(envelope, new StubTransportMessage
+        {
+            Headers = { ["custom-id"] = expected.ToString() }
+        });
+
+        envelope.Id.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void custom_outgoing_property_still_overrides_its_own_direction()
+    {
+        var mapper = new StubEnvelopeMapper(new StubEndpoint());
+
+        mapper.MapOutgoingProperty(x => x.Id, (envelope, outgoing) =>
+        {
+            outgoing.Headers["custom-id"] = envelope.Id.ToString();
+        });
+
+        var envelope = new Envelope { Id = Guid.NewGuid() };
+        var outgoing = new StubTransportMessage();
+
+        mapper.MapEnvelopeToOutgoing(envelope, outgoing);
+
+        outgoing.Headers.ContainsKey("custom-id").ShouldBeTrue();
+        outgoing.Headers["custom-id"].ShouldBe(envelope.Id.ToString());
     }
 }
 

--- a/src/Wolverine/Transports/EnvelopeMapper.cs
+++ b/src/Wolverine/Transports/EnvelopeMapper.cs
@@ -195,7 +195,12 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
             writeHeaders
         };
 
-        foreach (var pair in _envelopeToHeader.Where(x => !_envelopeToOutgoing.ContainsKey(x.Key)))
+        // Use the default header read for a property unless the caller has
+        // supplied a custom incoming mapping for it. Previously this predicate
+        // was accidentally checking _envelopeToOutgoing, which caused
+        // MapOutgoingProperty to silently delete the incoming header read for
+        // the same property. See https://github.com/JasperFx/wolverine/issues/2551.
+        foreach (var pair in _envelopeToHeader.Where(x => !_incomingToEnvelope.ContainsKey(x.Key)))
         {
             var getMethod = getString!;
             if (pair.Key.PropertyType == typeof(Uri))
@@ -278,7 +283,12 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
             writeHeaders
         };
 
-        var headers = _envelopeToHeader.Where(x => !_incomingToEnvelope.ContainsKey(x.Key));
+        // Use the default header write for a property unless the caller has
+        // supplied a custom outgoing mapping for it. Previously this predicate
+        // was accidentally checking _incomingToEnvelope, which caused
+        // MapIncomingProperty to silently delete the outgoing header write for
+        // the same property. See https://github.com/JasperFx/wolverine/issues/2551.
+        var headers = _envelopeToHeader.Where(x => !_envelopeToOutgoing.ContainsKey(x.Key));
         foreach (var pair in headers)
         {
             var setMethod = setString!;


### PR DESCRIPTION
Fixes #2551.

## The bug

`EnvelopeMapper<TIncoming, TOutgoing>` had its compile-time filter predicates swapped:

- `compileIncoming` skipped the default header *read* whenever a custom **outgoing** mapping existed, so `MapOutgoingProperty(x => x.Foo, ...)` silently deleted the incoming `"foo"` header read.
- `compileOutgoing` did the symmetric wrong thing — `MapIncomingProperty(x => x.Foo, ...)` silently deleted the outgoing `"foo"` header write.

The reporter observed it on Kafka:
```csharp
mapper.MapIncomingProperty(x => x.Id, ...);
// outgoing messages no longer carry the "id" header at all
```

Each filter now correctly checks its own direction's dictionary, so `MapIncomingProperty` / `MapOutgoingProperty` truly affect only the direction their name implies.

## Verification

- 4 new regression tests in `MapIncomingPropertyTests` cover both directions + sanity checks that the customization itself still wins on the direction it targets. They fail on `main` and pass with this change.
- Full `CoreTests` net9.0 run: **1350/1350 pass**.
- Full `Wolverine.Kafka.Tests` net9.0 run: **142/142 pass** (2 pre-existing flaky skips). Kafka exercises this codegen end-to-end on a live broker.

## Test plan

- [x] Reproducer tests fail on unfixed code
- [x] Reproducer tests pass after the fix
- [x] Full CoreTests pass (no regression in shared mapper codegen)
- [x] Full Kafka tests pass (live transport exercising the mapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)