### PR TITLE
Allow configuration of the MessageBatchTimeout

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -687,6 +687,34 @@ using var host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L138-L152' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_all_kafka_sending' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Publisher Batching
+
+When publishing to Kafka through the default (buffered) sender, Wolverine coalesces outgoing envelopes into batches before handing them to the Kafka producer. A batch is flushed when **either** of two thresholds is hit:
+
+- the batch reaches `MessageBatchSize` envelopes (default **100**), or
+- the `MessageBatchTimeout` elapses since the first envelope entered the batch (default **250 ms**).
+
+The relevant settings on a publisher route:
+
+```cs
+opts.PublishMessage<OrderPlaced>()
+    .ToKafkaTopic("orders")
+
+    // Maximum envelopes per batch. Default 100.
+    .MessageBatchSize(100)
+
+    // Maximum time to wait for a batch to fill before flushing. Default 250ms.
+    .MessageBatchTimeout(10.Milliseconds())
+
+    // Maximum number of in-flight batches to the broker. Default 1.
+    .MessageBatchMaxDegreeOfParallelism(4)
+
+    // Bypass batching and send on the calling thread.
+    .SendInline();
+```
+
+`MessageBatchSize`, `MessageBatchTimeout`, and `MessageBatchMaxDegreeOfParallelism` apply to every transport that uses Wolverine's `BatchedSender` (Kafka, Azure Service Bus, SQS/SNS, Pub/Sub, Redis, TCP, HTTP). `SendInline()` swaps the sender type entirely; when it is set on a route, the batching settings on that same route are ignored.
+
 ## Global Partitioning
 
 Kafka topics can be used as the external transport for [global partitioned messaging](/guide/messaging/partitioning#global-partitioning). This creates a set of sharded Kafka topics with companion local queues for sequential processing across a multi-node cluster.

--- a/src/Testing/CoreTests/Transports/Sending/BatchedSenderTests.cs
+++ b/src/Testing/CoreTests/Transports/Sending/BatchedSenderTests.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Shouldly;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
 using Wolverine.Transports.Tcp;
@@ -75,5 +77,45 @@ public class BatchedSenderTests
 
         theSenderCallback.Received().MarkSenderIsLatchedAsync(theBatch);
 #pragma warning restore 4014
+    }
+
+    [Fact]
+    public async Task flushes_partial_batch_after_configured_timeout()
+    {
+        // A sub-batch-size payload will only flush because of the timer, so the elapsed
+        // time is a direct read of MessageBatchTimeout.
+        var endpoint = new TcpEndpoint(2256)
+        {
+            MessageBatchSize = 100,
+            MessageBatchTimeout = 50.Milliseconds()
+        };
+
+        var flushed = new TaskCompletionSource();
+        var protocol = Substitute.For<ISenderProtocol>();
+        protocol.SendBatchAsync(Arg.Any<ISenderCallback>(), Arg.Any<OutgoingMessageBatch>())
+            .Returns(_ =>
+            {
+                flushed.TrySetResult();
+                return Task.CompletedTask;
+            });
+
+        var callback = Substitute.For<ISenderCallback>();
+        using var sender = new BatchedSender(endpoint, protocol, CancellationToken.None, NullLogger.Instance);
+        sender.RegisterCallback(callback);
+
+        var sw = Stopwatch.StartNew();
+        await sender.SendAsync(Envelope.ForPing(TransportConstants.LocalUri));
+
+        await flushed.Task.WaitAsync(2.Seconds());
+        sw.Stop();
+
+        sw.Elapsed.ShouldBeGreaterThanOrEqualTo(40.Milliseconds());
+        sw.Elapsed.ShouldBeLessThan(500.Milliseconds());
+    }
+
+    [Fact]
+    public void default_batch_timeout_is_250ms()
+    {
+        new TcpEndpoint(2257).MessageBatchTimeout.ShouldBe(250.Milliseconds());
     }
 }

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -250,7 +250,7 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
 
     /// <summary>
     /// For endpoints that send or receive messages in batches, this governs the maximum
-    /// number of messages that will be received or sent in one batch
+    /// number of messages that will be received or sent in one batch. Defaults to 100.
     /// </summary>
     public int MessageBatchSize { get; set; } = 100;
 
@@ -259,6 +259,14 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     /// of concurrent outgoing batches
     /// </summary>
     public int MessageBatchMaxDegreeOfParallelism { get; set; } = 1;
+
+    /// <summary>
+    /// For endpoints that send messages in batches, this is the maximum time the
+    /// sender will wait to accumulate a full batch before flushing what it has.
+    /// Lower this on latency-sensitive transports (e.g. Kafka) where the default
+    /// 250ms window dominates end-to-end time on low-volume routes.
+    /// </summary>
+    public TimeSpan MessageBatchTimeout { get; set; } = TimeSpan.FromMilliseconds(250);
 
     /// <summary>
     ///     Mark whether or not the receiver for this listener should use

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -263,8 +263,7 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     /// <summary>
     /// For endpoints that send messages in batches, this is the maximum time the
     /// sender will wait to accumulate a full batch before flushing what it has.
-    /// Lower this on latency-sensitive transports (e.g. Kafka) where the default
-    /// 250ms window dominates end-to-end time on low-volume routes.
+    /// Defaults to 250ms.
     /// </summary>
     public TimeSpan MessageBatchTimeout { get; set; } = TimeSpan.FromMilliseconds(250);
 

--- a/src/Wolverine/Configuration/IListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/IListenerConfiguration.cs
@@ -31,7 +31,7 @@ public interface IEndpointConfiguration<T>
 
     /// <summary>
     /// For endpoints that send or receive messages in batches, this governs the maximum
-    /// number of messages that will be received or sent in one batch
+    /// number of messages that will be received or sent in one batch. Defaults to 100.
     /// </summary>
     T MessageBatchSize(int batchSize);
 

--- a/src/Wolverine/Configuration/SubscriberConfiguration.cs
+++ b/src/Wolverine/Configuration/SubscriberConfiguration.cs
@@ -135,7 +135,7 @@ public class SubscriberConfiguration<T, TEndpoint> : DelayedEndpointConfiguratio
 
     /// <summary>
     /// For endpoints that send or receive messages in batches, this governs the maximum
-    /// number of messages that will be received or sent in one batch
+    /// number of messages that will be received or sent in one batch. Defaults to 100.
     /// </summary>
     public T MessageBatchSize(int batchSize)
     {
@@ -151,6 +151,18 @@ public class SubscriberConfiguration<T, TEndpoint> : DelayedEndpointConfiguratio
     public T MessageBatchMaxDegreeOfParallelism(int batchMaxDegreeOfParallelism)
     {
         add(e => e.MessageBatchMaxDegreeOfParallelism = batchMaxDegreeOfParallelism);
+        return this.As<T>();
+    }
+
+    /// <summary>
+    /// For endpoints that send messages in batches, this is the maximum time the
+    /// sender will wait to accumulate a full batch before flushing what it has.
+    /// Defaults to 250ms. Lower this on latency-sensitive transports (e.g. Kafka)
+    /// where the batching window dominates end-to-end time on low-volume routes.
+    /// </summary>
+    public T MessageBatchTimeout(TimeSpan batchTimeout)
+    {
+        add(e => e.MessageBatchTimeout = batchTimeout);
         return this.As<T>();
     }
 

--- a/src/Wolverine/Configuration/SubscriberConfiguration.cs
+++ b/src/Wolverine/Configuration/SubscriberConfiguration.cs
@@ -157,8 +157,7 @@ public class SubscriberConfiguration<T, TEndpoint> : DelayedEndpointConfiguratio
     /// <summary>
     /// For endpoints that send messages in batches, this is the maximum time the
     /// sender will wait to accumulate a full batch before flushing what it has.
-    /// Defaults to 250ms. Lower this on latency-sensitive transports (e.g. Kafka)
-    /// where the batching window dominates end-to-end time on low-volume routes.
+    /// Defaults to 250ms.
     /// </summary>
     public T MessageBatchTimeout(TimeSpan batchTimeout)
     {

--- a/src/Wolverine/Transports/Sending/BatchedSender.cs
+++ b/src/Wolverine/Transports/Sending/BatchedSender.cs
@@ -27,7 +27,7 @@ public class BatchedSender : ISender, ISenderRequiresCallback
         var transforming =
             sender.PushUpstream<Envelope[]>(envelopes => new OutgoingMessageBatch(Destination, envelopes));
 
-        var batching = transforming.BatchUpstream(250.Milliseconds(), batchSize:destination.MessageBatchSize);
+        var batching = transforming.BatchUpstream(destination.MessageBatchTimeout, batchSize:destination.MessageBatchSize);
         _serializing = batching.PushUpstream<Envelope>(Environment.ProcessorCount, e =>
         {
             try


### PR DESCRIPTION
The BatchedSender waits for either 100 messages or 250ms before sending the current batch. The message count is configurable via MessageBatchSize but the timeout is not. Being able to control both of these settings will allow for more precise tuning of performance and throughput requirements.