### PR TITLE
Fix EF domain event scraper enumeration

### DIFF
--- a/src/Persistence/EfCoreTests/DomainEvents/DomainEventScraperStateFilterTests.cs
+++ b/src/Persistence/EfCoreTests/DomainEvents/DomainEventScraperStateFilterTests.cs
@@ -1,7 +1,11 @@
 using Microsoft.EntityFrameworkCore;
+
+using NSubstitute;
 using SharedPersistenceModels.Items;
 using Shouldly;
+using Wolverine;
 using Wolverine.EntityFrameworkCore;
+using Wolverine.Runtime;
 
 namespace EfCoreTests.DomainEvents;
 
@@ -97,6 +101,31 @@ public class DomainEventScraperStateFilterTests
         events.OfType<ItemApproved>().ShouldContain(e => e.Id == addedItem.Id);
         events.OfType<ItemApproved>().ShouldContain(e => e.Id == modifiedItem.Id);
         events.OfType<ItemApproved>().ShouldNotContain(e => e.Id == unchangedItem.Id);
+    }
+
+    [Fact]
+    public async Task domain_event_scraper_materializes_events_before_publishing()
+    {
+        using var ctx = new ScraperTestDbContext(BuildOptions());
+
+        var item = new Item { Id = Guid.CreateVersion7(), Name = "Added" };
+        item.Events.Add(new MutatingDomainEvent(ctx));
+        ctx.Items.Add(item);
+
+        var runtime = Substitute.For<IWolverineRuntime>();
+        var context = new MessageContext(runtime);
+        var scraper = new DomainEventScraper<Item, object>(x => x.Events);
+
+        await Should.NotThrowAsync(() => scraper.ScrapeEvents(ctx, context));
+    }
+}
+
+public class MutatingDomainEvent(ScraperTestDbContext dbContext) : ISendMyself
+{
+    public ValueTask ApplyAsync(IMessageContext context)
+    {
+        dbContext.Items.Add(new Item { Id = Guid.CreateVersion7(), Name = "Added by PublishAsync" });
+        return ValueTask.CompletedTask;
     }
 }
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/OutgoingDomainEvents.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/OutgoingDomainEvents.cs
@@ -40,7 +40,7 @@ public class DomainEventScraper<T, TEvent> : IDomainEventScraper
     public async Task ScrapeEvents(DbContext dbContext, MessageContext bus)
     {
         var eventMessages = dbContext.ChangeTracker.Entries().Select(x => x.Entity)
-            .OfType<T>().SelectMany(_source);
+            .OfType<T>().SelectMany(_source).ToArray();
 
         foreach (var eventMessage in eventMessages)
         {


### PR DESCRIPTION
## Summary

Fixes `DomainEventScraper<T, TEvent>` so it snapshots EF Core domain events before publishing them.

The previous implementation enumerated this LINQ pipeline lazily:

```csharp
dbContext.ChangeTracker.Entries()
    .Select(x => x.Entity)
    .OfType<T>()
    .SelectMany(_source)
```

When `PublishAsync()` persists outgoing/incoming envelopes through the same EF-backed transaction, it can mutate the same `DbContext.ChangeTracker` while the scraper is still enumerating it. That can throw:

```text
InvalidOperationException: Collection was modified; enumeration operation may not execute.
```

Materializing the event messages before the first publish avoids enumerating a changing `ChangeTracker`.

Fixes #2585.

## Impact analysis

This changes the scraper from lazy enumeration to snapshot enumeration for the domain events found in the current EF unit of work.

Expected cost:

- One extra array allocation proportional to the number of scraped domain events.
- No extra database work.
- No additional publishing work; the same events are still published once.

Expected behavior change:

- `PublishAsync()` may mutate the `DbContext.ChangeTracker` without invalidating the scraper enumeration.
- Events added to tracked entities as a side effect of publishing are not picked up by the same scraper pass. That was already unsafe with the lazy implementation and could fail nondeterministically; this PR makes the scraper operate on the stable set of events present before publishing starts.

Given that domain events scraped from a single EF unit of work are normally a small in-memory set, the allocation cost should be low compared to the correctness benefit.

## Tests

Added a regression test that uses an `ISendMyself` domain event to mutate the same `DbContext` during `PublishAsync()`.

Validation performed locally:

- With the fix: `DomainEventScraperStateFilterTests` passes on `net9.0`.
- Additional local validation: the same focused tests also passed when temporarily targeting `net10.0`.
- Without the `.ToArray()` materialization: the new regression test fails with `Collection was modified; enumeration operation may not execute.`
