### PR TITLE
Honor [Consumes] / IAcceptsMetadata on form endpoints

### DIFF
--- a/src/Http/Wolverine.Http.Tests/using_form_parameters.cs
+++ b/src/Http/Wolverine.Http.Tests/using_form_parameters.cs
@@ -541,12 +541,13 @@ public class using_form_parameters : IntegrationContext
     public void form_endpoints_honor_consumes_metadata_for_supported_request_formats()
     {
         // fillRequestType only seeds SupportedRequestFormats from
-        // IAcceptsMetadata when the endpoint has a body request type and is
-        // not a form endpoint. Form endpoints used to fall through and rely
-        // on ASP.NET Core OpenAPI's "application/x-www-form-urlencoded"
-        // default, which silently dropped [Consumes("multipart/form-data")]
-        // and caused generated clients (Orval, NSwag) to emit URLSearchParams
-        // bodies instead of multipart for file-upload endpoints.
+        // IAcceptsMetadata when the endpoint has a body request type, is
+        // not a form endpoint, and is not a GET. Form endpoints used to
+        // fall through and rely on ASP.NET Core OpenAPI's
+        // "application/x-www-form-urlencoded" default, which silently
+        // dropped [Consumes("multipart/form-data")] and caused generated
+        // clients (Orval, NSwag) to emit URLSearchParams bodies instead of
+        // multipart for file-upload endpoints.
         var chain = HttpChains.ChainFor("POST", "/form/multipart-consumes");
         var apiDescription = chain!.CreateApiDescription("POST");
 

--- a/src/Http/Wolverine.Http.Tests/using_form_parameters.cs
+++ b/src/Http/Wolverine.Http.Tests/using_form_parameters.cs
@@ -536,4 +536,22 @@ public class using_form_parameters : IntegrationContext
         var variable = chain.TryFindOrCreateFormValue(parameter);
         variable!.Creator.ShouldBeOfType<ParsedArrayFormValue>();
     }
+
+    [Fact]
+    public void form_endpoints_honor_consumes_metadata_for_supported_request_formats()
+    {
+        // fillRequestType only seeds SupportedRequestFormats from
+        // IAcceptsMetadata when the endpoint has a body request type and is
+        // not a form endpoint. Form endpoints used to fall through and rely
+        // on ASP.NET Core OpenAPI's "application/x-www-form-urlencoded"
+        // default, which silently dropped [Consumes("multipart/form-data")]
+        // and caused generated clients (Orval, NSwag) to emit URLSearchParams
+        // bodies instead of multipart for file-upload endpoints.
+        var chain = HttpChains.ChainFor("POST", "/form/multipart-consumes");
+        var apiDescription = chain!.CreateApiDescription("POST");
+
+        apiDescription.SupportedRequestFormats
+            .Select(f => f.MediaType)
+            .ShouldContain("multipart/form-data");
+    }
 }

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -158,6 +158,29 @@ public partial class HttpChain
             apiDescription.ParameterDescriptions.Add(parameterDescription);
         }
 
+        // fillRequestType only honors [Consumes] / IAcceptsMetadata for body
+        // endpoints (HasRequestType && !IsFormData). Without this, form
+        // endpoints fall through and ASP.NET Core OpenAPI's GetFormRequestBody
+        // defaults SupportedRequestFormats to "application/x-www-form-urlencoded"
+        // — silently dropping [Consumes("multipart/form-data")] on file-upload
+        // endpoints and causing client generators (Orval, NSwag, Kiota) to emit
+        // URLSearchParams bodies instead of multipart.
+        if (apiDescription.SupportedRequestFormats.Count == 0 &&
+            apiDescription.ParameterDescriptions.Any(p =>
+                p.Source == BindingSource.Form || p.Source == BindingSource.FormFile))
+        {
+            foreach (var metadata in Endpoint!.Metadata.OfType<IAcceptsMetadata>())
+            {
+                foreach (var contentType in metadata.ContentTypes)
+                {
+                    apiDescription.SupportedRequestFormats.Add(new ApiRequestFormat
+                    {
+                        MediaType = contentType
+                    });
+                }
+            }
+        }
+
         return apiDescription;
     }
 

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -158,30 +158,37 @@ public partial class HttpChain
             apiDescription.ParameterDescriptions.Add(parameterDescription);
         }
 
-        // fillRequestType only honors [Consumes] / IAcceptsMetadata for body
-        // endpoints (HasRequestType && !IsFormData). Without this, form
-        // endpoints fall through and ASP.NET Core OpenAPI's GetFormRequestBody
-        // defaults SupportedRequestFormats to "application/x-www-form-urlencoded"
-        // — silently dropping [Consumes("multipart/form-data")] on file-upload
-        // endpoints and causing client generators (Orval, NSwag, Kiota) to emit
+        // fillRequestType only honors [Consumes] / IAcceptsMetadata when the
+        // endpoint has a body request type, is not a form endpoint, and is
+        // not a GET (HasRequestType && !IsFormData && HttpMethod != "GET").
+        // Without this, form endpoints fall through and ASP.NET Core OpenAPI's
+        // GetFormRequestBody defaults SupportedRequestFormats to
+        // "application/x-www-form-urlencoded" — silently dropping
+        // [Consumes("multipart/form-data")] on file-upload endpoints and
+        // causing client generators (Orval, NSwag, Kiota) to emit
         // URLSearchParams bodies instead of multipart.
         if (apiDescription.SupportedRequestFormats.Count == 0 &&
             apiDescription.ParameterDescriptions.Any(p =>
                 p.Source == BindingSource.Form || p.Source == BindingSource.FormFile))
         {
-            foreach (var metadata in Endpoint!.Metadata.OfType<IAcceptsMetadata>())
-            {
-                foreach (var contentType in metadata.ContentTypes)
-                {
-                    apiDescription.SupportedRequestFormats.Add(new ApiRequestFormat
-                    {
-                        MediaType = contentType
-                    });
-                }
-            }
+            copyAcceptsMetadataToRequestFormats(apiDescription);
         }
 
         return apiDescription;
+    }
+
+    private void copyAcceptsMetadataToRequestFormats(ApiDescription apiDescription)
+    {
+        foreach (var metadata in Endpoint!.Metadata.OfType<IAcceptsMetadata>())
+        {
+            foreach (var contentType in metadata.ContentTypes)
+            {
+                apiDescription.SupportedRequestFormats.Add(new ApiRequestFormat
+                {
+                    MediaType = contentType
+                });
+            }
+        }
     }
 
     public override MiddlewareScoping Scoping => MiddlewareScoping.HttpEndpoints;
@@ -356,16 +363,7 @@ public partial class HttpChain
 
             apiDescription.ParameterDescriptions.Add(parameterDescription);
 
-            foreach (var metadata in Endpoint!.Metadata.OfType<IAcceptsMetadata>())
-            {
-                foreach (var contentType in metadata.ContentTypes)
-                {
-                    apiDescription.SupportedRequestFormats.Add(new ApiRequestFormat
-                    {
-                        MediaType = contentType
-                    });
-                }
-            }
+            copyAcceptsMetadataToRequestFormats(apiDescription);
         }
     }
 

--- a/src/Http/WolverineWebApi/Forms/FormEndpoints.cs
+++ b/src/Http/WolverineWebApi/Forms/FormEndpoints.cs
@@ -111,6 +111,10 @@ public static class FromFormEndpoints{
     {
         return $"{form.Name}|{form.Files?.Count}";
     }
+
+    [WolverinePost("/form/multipart-consumes")]
+    [Consumes("multipart/form-data")]
+    public static string MultipartConsumes([FromForm] string value) => value ?? "";
 }
 
 public class FormWithFile


### PR DESCRIPTION
## Summary

`HttpChain.fillRequestType` only honors `[Consumes]` / `IAcceptsMetadata` when the endpoint has a body request type and is **not** a form endpoint (`HasRequestType && !IsFormData`). Form endpoints fall through and `apiDescription.SupportedRequestFormats` stays empty.

ASP.NET Core 10's `OpenApiDocumentService.GetFormRequestBody` then defaults to `application/x-www-form-urlencoded`:

```csharp
if (supportedRequestFormats.Count == 0)
{
    supportedRequestFormats = [new ApiRequestFormat { MediaType = "application/x-www-form-urlencoded" }];
}
```

This silently drops `[Consumes("multipart/form-data")]` on file-upload endpoints, so generated clients (Orval, NSwag, Kiota) emit `URLSearchParams` bodies instead of `FormData` — file uploads break at runtime.

## Fix

Extend `CreateApiDescription` so that for endpoints with form-source parameters and no formats already populated, `IAcceptsMetadata` flows into `SupportedRequestFormats`:

```csharp
if (apiDescription.SupportedRequestFormats.Count == 0 &&
    apiDescription.ParameterDescriptions.Any(p =>
        p.Source == BindingSource.Form || p.Source == BindingSource.FormFile))
{
    foreach (var metadata in Endpoint!.Metadata.OfType<IAcceptsMetadata>())
    {
        foreach (var contentType in metadata.ContentTypes)
        {
            apiDescription.SupportedRequestFormats.Add(new ApiRequestFormat
            {
                MediaType = contentType
            });
        }
    }
}
```

## Semantics

- **No `[Consumes]`** → no change. Wolverine still emits zero formats; MS OpenAPI still defaults to `application/x-www-form-urlencoded`.
- **`[Consumes("multipart/form-data")]`** → multipart is added to `SupportedRequestFormats`; MS OpenAPI no longer adds the urlencoded default (its `count == 0` guard); spec correctly emits multipart.
- **Non-form body endpoints** → unaffected (the form-parameter guard short-circuits).

## Regression test

New test endpoint:
```csharp
[WolverinePost("/form/multipart-consumes")]
[Consumes("multipart/form-data")]
public static string MultipartConsumes([FromForm] string value) => value ?? "";
```

New test:
```csharp
[Fact]
public void form_endpoints_honor_consumes_metadata_for_supported_request_formats()
{
    var chain = HttpChains.ChainFor("POST", "/form/multipart-consumes");
    var apiDescription = chain!.CreateApiDescription("POST");

    apiDescription.SupportedRequestFormats
        .Select(f => f.MediaType)
        .ShouldContain("multipart/form-data");
}
```

Fails on `main`:
```
but was actually
Failed!  - Failed: 1, Passed: 0
```

Passes after the fix:
```
Passed!  - Failed: 0, Passed: 1
```

## Test plan

- [x] New test fails on `main`
- [x] New test passes after fix
- [x] Form + OpenAPI / Swashbuckle filtered run: 64 passed, 0 failed, 8 pre-existing skips

## Related

Independent of #2587 (which fixes a separate `ParameterDescriptor` null-deref in the same file). Either can land first.
