### PR TITLE
Add Wolverine.SourceGeneration to slnx (supersedes #2575)

### DIFF
--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -283,6 +283,18 @@
   <Project Path="build/build.csproj">
     <Build Project="false" />
   </Project>
-  <Project Path="src/Wolverine.SourceGeneration/Wolverine.SourceGeneration.csproj" />
+  <Project Path="src/Wolverine.SourceGeneration/Wolverine.SourceGeneration.csproj">
+    <!--
+      Roslyn analyzer / source generator project. Targets only netstandard2.0
+      (required for analyzer loadability) and is pulled in transitively via
+      Wolverine.csproj's ProjectReference (OutputItemType="Analyzer") entry.
+      Marking it Build="false" here keeps the project visible in the IDE
+      solution view while preventing solution-level builds (especially when
+      a single TargetFramework is forced via the dotnet build framework flag,
+      e.g. net9.0) from failing with NETSDK1005 because no net9.0 target
+      exists in this project.
+    -->
+    <Build Project="false" />
+  </Project>
   <Project Path="src/Wolverine/Wolverine.csproj" />
 </Solution>

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -283,5 +283,6 @@
   <Project Path="build/build.csproj">
     <Build Project="false" />
   </Project>
+  <Project Path="src/Wolverine.SourceGeneration/Wolverine.SourceGeneration.csproj" />
   <Project Path="src/Wolverine/Wolverine.csproj" />
 </Solution>


### PR DESCRIPTION
Supersedes #2575 by @saithis. Their original commit is preserved verbatim with their authorship intact; this PR adds one follow-up commit on top to fix the resulting framework-pinned build failure.

## What @saithis fixed

`Wolverine.SourceGeneration.csproj` is referenced from `Wolverine.csproj` as an analyzer (`OutputItemType="Analyzer"`, `ReferenceOutputAssembly="false"`) but was missing from `wolverine.slnx`, so the IDE solution view couldn't see it and a `dotnet build wolverine.slnx` would fail to find it. Adding the project to the slnx is the right call.

## Why a follow-up commit was needed

After @saithis's add, `dotnet build wolverine.slnx --framework net9.0` started failing with:

```
error NETSDK1005: Assets file '.../Wolverine.SourceGeneration/obj/project.assets.json'
doesn't have a target for 'net9.0'.
```

The analyzer project only targets `netstandard2.0` (required for Roslyn analyzer loadability). Without `--framework`, MSBuild lets each project pick its own target framework and the analyzer builds happily. With `--framework net9.0` pinned, MSBuild tries to build the analyzer for net9.0 too and there's no such target.

The follow-up commit marks the project `Build="false"` in the slnx — the same pattern already used for `build/build.csproj`. The project stays visible in the IDE solution view, but solution-level builds skip it. It still gets built whenever `Wolverine.csproj` is built, via the existing `<ProjectReference OutputItemType="Analyzer" />`, so nothing downstream changes.

## Verification

- `dotnet build wolverine.slnx --framework net9.0` → **0 errors** (was 1 NETSDK1005)
- `dotnet build src/Wolverine/Wolverine.csproj --framework net9.0` → **0 errors, 0 warnings** (analyzer still attached and runs)
- `dotnet build wolverine.slnx` (no framework) → 27 pre-existing OpenAPI sample-app errors, none related to this change

## Test plan

- [x] Verify `dotnet build wolverine.slnx --framework net9.0` succeeds
- [x] Verify Wolverine.csproj still uses SourceGeneration as an analyzer
- [x] No new errors compared to current `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)