### PR TITLE
Add Endpoint.BrokerRole for CritterWatch endpoint display (#2601)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/broker_role_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/broker_role_tests.cs
@@ -1,0 +1,16 @@
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Http.Transport;
+using Xunit;
+
+namespace Wolverine.Http.Tests;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void http_endpoint_broker_role_is_route()
+    {
+        new HttpEndpoint(new Uri("http://localhost:5000/orders"), EndpointRole.Application)
+            .BrokerRole.ShouldBe("route");
+    }
+}

--- a/src/Http/Wolverine.Http/Transport/HttpEndpoint.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpEndpoint.cs
@@ -12,6 +12,7 @@ public class HttpEndpoint : Endpoint
 {
     public HttpEndpoint(Uri uri, EndpointRole role) : base(uri, role)
     {
+        BrokerRole = "route";
     }
 
     internal bool SupportsNativeScheduledSend { get; set; }

--- a/src/Persistence/MySql/MySqlTests/Transport/broker_role_tests.cs
+++ b/src/Persistence/MySql/MySqlTests/Transport/broker_role_tests.cs
@@ -1,0 +1,14 @@
+using Shouldly;
+using Wolverine.MySql.Transport;
+using Xunit;
+
+namespace MySqlTests.Transport;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void mysql_queue_broker_role_is_queue()
+    {
+        new MySqlQueue("q", new MySqlTransport()).BrokerRole.ShouldBe("queue");
+    }
+}

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueue.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueue.cs
@@ -37,6 +37,7 @@ public class MySqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         Mode = EndpointMode.Durable;
         Name = name;
         EndpointName = name;
+        BrokerRole = "queue";
 
         _queueTable = new Lazy<QueueTable>(() => new QueueTable(Parent, queueTableName));
         _scheduledMessageTable =

--- a/src/Persistence/Oracle/OracleTests/Transport/broker_role_tests.cs
+++ b/src/Persistence/Oracle/OracleTests/Transport/broker_role_tests.cs
@@ -1,0 +1,14 @@
+using Shouldly;
+using Wolverine.Oracle.Transport;
+using Xunit;
+
+namespace OracleTests.Transport;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void oracle_queue_broker_role_is_queue()
+    {
+        new OracleQueue("q", new OracleTransport()).BrokerRole.ShouldBe("queue");
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleQueue.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleQueue.cs
@@ -37,6 +37,7 @@ public class OracleQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         Mode = EndpointMode.Durable;
         Name = name;
         EndpointName = name;
+        BrokerRole = "queue";
 
         _queueTable = new Lazy<QueueTable>(() => new QueueTable(Parent, queueTableName));
         _scheduledMessageTable =

--- a/src/Persistence/PostgresqlTests/Transport/broker_role_tests.cs
+++ b/src/Persistence/PostgresqlTests/Transport/broker_role_tests.cs
@@ -1,0 +1,14 @@
+using Shouldly;
+using Wolverine.Postgresql.Transport;
+using Xunit;
+
+namespace PostgresqlTests.Transport;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void postgresql_queue_broker_role_is_queue()
+    {
+        new PostgresqlQueue("q", new PostgresqlTransport()).BrokerRole.ShouldBe("queue");
+    }
+}

--- a/src/Persistence/SqlServerTests/Transport/broker_role_tests.cs
+++ b/src/Persistence/SqlServerTests/Transport/broker_role_tests.cs
@@ -1,0 +1,21 @@
+using IntegrationTests;
+using Shouldly;
+using Wolverine.RDBMS;
+using Wolverine.SqlServer.Transport;
+using Xunit;
+
+namespace SqlServerTests.Transport;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void sql_server_queue_broker_role_is_queue()
+    {
+        var transport = new SqlServerTransport(new DatabaseSettings
+        {
+            ConnectionString = Servers.SqlServerConnectionString,
+            SchemaName = "transport"
+        });
+        new SqlServerQueue("q", transport).BrokerRole.ShouldBe("queue");
+    }
+}

--- a/src/Persistence/SqliteTests/Transport/broker_role_tests.cs
+++ b/src/Persistence/SqliteTests/Transport/broker_role_tests.cs
@@ -1,0 +1,14 @@
+using Shouldly;
+using Wolverine.Sqlite.Transport;
+using Xunit;
+
+namespace SqliteTests.Transport;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void sqlite_queue_broker_role_is_queue()
+    {
+        new SqliteQueue("q", new SqliteTransport()).BrokerRole.ShouldBe("queue");
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueue.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueue.cs
@@ -37,8 +37,9 @@ public class PostgresqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         Mode = EndpointMode.Durable;
         Name = name;
         EndpointName = name;
+        BrokerRole = "queue";
 
-        // Gotta be lazy so the schema names get set 
+        // Gotta be lazy so the schema names get set
         _queueTable = new Lazy<QueueTable>(() => new QueueTable(Parent, queueTableName));
         _scheduledMessageTable =
             new Lazy<ScheduledMessageTable>(() => new ScheduledMessageTable(Parent, scheduledTableName));

--- a/src/Persistence/Wolverine.Postgresql/Transport/TenantedPostgresqlQueue.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/TenantedPostgresqlQueue.cs
@@ -18,6 +18,7 @@ internal class TenantedPostgresqlQueue : Endpoint, IDatabaseBackedEndpoint
         _parent = parent;
         _dataSource = dataSource;
         _databaseName = databaseName;
+        BrokerRole = "queue";
     }
 
     public override async ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)

--- a/src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlEndpoint.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlEndpoint.cs
@@ -17,6 +17,7 @@ internal class DatabaseControlEndpoint : Endpoint
         _parent = parent;
         Mode = EndpointMode.BufferedInMemory;
         MaxDegreeOfParallelism = 1;
+        BrokerRole = "queue";
 
         // No otel for this one!
         TelemetryEnabled = false;

--- a/src/Persistence/Wolverine.RDBMS/Transport/ExternalMessageTable.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/ExternalMessageTable.cs
@@ -17,6 +17,7 @@ public class ExternalMessageTable : Endpoint, IExternalMessageTable
         IsListener = true;
         TableName = tableName;
         Mode = EndpointMode.Durable;
+        BrokerRole = "table";
     }
 
     protected override bool supportsMode(EndpointMode mode)

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueue.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueue.cs
@@ -42,6 +42,7 @@ public class SqlServerQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         Mode = EndpointMode.Durable;
         Name = name;
         EndpointName = name;
+        BrokerRole = "queue";
 
         // Gotta be lazy so the schema names get set
         _queueTable = new Lazy<QueueTable>(() => new QueueTable(Parent, _queueTableName));

--- a/src/Persistence/Wolverine.Sqlite/Transport/SqliteQueue.cs
+++ b/src/Persistence/Wolverine.Sqlite/Transport/SqliteQueue.cs
@@ -41,6 +41,7 @@ public class SqliteQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         Mode = EndpointMode.Durable;
         Name = name;
         EndpointName = name;
+        BrokerRole = "queue";
 
         _queueTable = new Lazy<QueueTable>(() => new QueueTable(Parent, queueTableName));
         _scheduledMessageTable =

--- a/src/Testing/CoreTests/Configuration/broker_role_tests.cs
+++ b/src/Testing/CoreTests/Configuration/broker_role_tests.cs
@@ -1,5 +1,6 @@
 using Shouldly;
 using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
 using Wolverine.Transports.Local;
 using Wolverine.Transports.SharedMemory;
 using Wolverine.Transports.Stub;
@@ -30,6 +31,31 @@ public class broker_role_tests
     public void core_endpoint_has_expected_broker_role(Endpoint endpoint, string expectedRole)
     {
         endpoint.BrokerRole.ShouldBe(expectedRole);
+    }
+
+    [Fact]
+    public void endpoint_descriptor_lifts_broker_role_and_endpoint_role()
+    {
+        // EndpointDescriptor is what CritterWatch reads. Both the existing
+        // EndpointRole (System / Application) and the new BrokerRole string
+        // should be first-class properties on the descriptor, populated from
+        // the underlying Endpoint. See GH-2601.
+        var queue = new LocalQueue("queue-x");
+        var descriptor = new EndpointDescriptor(queue);
+
+        descriptor.BrokerRole.ShouldBe("queue");
+        descriptor.EndpointRole.ShouldBe(EndpointRole.Application);
+    }
+
+    [Fact]
+    public void endpoint_descriptor_endpoint_role_reflects_system_endpoints()
+    {
+        var systemSubscription = new SharedMemorySubscription(
+            new SharedMemoryTopic("topic-y"), "sub-y", EndpointRole.System);
+        var descriptor = new EndpointDescriptor(systemSubscription);
+
+        descriptor.EndpointRole.ShouldBe(EndpointRole.System);
+        descriptor.BrokerRole.ShouldBe("subscription");
     }
 
     public static TheoryData<Endpoint, string> CoreEndpoints()

--- a/src/Testing/CoreTests/Configuration/broker_role_tests.cs
+++ b/src/Testing/CoreTests/Configuration/broker_role_tests.cs
@@ -1,0 +1,49 @@
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Transports.Local;
+using Wolverine.Transports.SharedMemory;
+using Wolverine.Transports.Stub;
+using Wolverine.Transports.Tcp;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+/// <summary>
+/// Locks down GH-2601: every endpoint kind exposes a short, non-empty
+/// <see cref="Endpoint.BrokerRole"/> string identifying the underlying
+/// broker object kind ("queue", "exchange", "topic", "subscription",
+/// "stream", etc.). CritterWatch and other diagnostic UIs read this.
+/// </summary>
+public class broker_role_tests
+{
+    [Fact]
+    public void base_default_when_subclass_does_not_set_broker_role()
+    {
+        // The base Endpoint default — should be a sentinel value, not empty,
+        // so a custom subclass that forgets to set BrokerRole still produces
+        // something a UI can render.
+        new TestEndpoint(EndpointRole.Application).BrokerRole.ShouldBe("endpoint");
+    }
+
+    [Theory]
+    [MemberData(nameof(CoreEndpoints))]
+    public void core_endpoint_has_expected_broker_role(Endpoint endpoint, string expectedRole)
+    {
+        endpoint.BrokerRole.ShouldBe(expectedRole);
+    }
+
+    public static TheoryData<Endpoint, string> CoreEndpoints()
+    {
+        var stubTransport = new StubTransport();
+        var sharedTopic = new SharedMemoryTopic("topic-x");
+
+        return new TheoryData<Endpoint, string>
+        {
+            { new LocalQueue("queue-x"), "queue" },
+            { new StubEndpoint("stub-x", stubTransport), "stub" },
+            { new TcpEndpoint("localhost", 2222), "socket" },
+            { sharedTopic, "topic" },
+            { new SharedMemorySubscription(sharedTopic, "sub-x", EndpointRole.Application), "subscription" },
+        };
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/broker_role_tests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/broker_role_tests.cs
@@ -1,0 +1,14 @@
+using Shouldly;
+using Wolverine.AmazonSns.Internal;
+using Xunit;
+
+namespace Wolverine.AmazonSns.Tests;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void sns_topic_broker_role_is_topic()
+    {
+        new AmazonSnsTopic("t", new AmazonSnsTransport()).BrokerRole.ShouldBe("topic");
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTopic.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTopic.cs
@@ -21,13 +21,14 @@ public class AmazonSnsTopic : Endpoint, IBrokerQueue
         : base(new Uri($"{AmazonSnsTransport.SnsProtocol}://{topicName}"), EndpointRole.Application)
     {
         Parent = parent;
-        
+
         TopicName = topicName;
         EndpointName = topicName;
         TopicArn = string.Empty;
+        BrokerRole = "topic";
 
         Configuration = new CreateTopicRequest(TopicName);
-        
+
         MessageBatchSize = 10;
     }
 

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/broker_role_tests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/broker_role_tests.cs
@@ -1,0 +1,14 @@
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Xunit;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void sqs_queue_broker_role_is_queue()
+    {
+        new AmazonSqsQueue("q", new AmazonSqsTransport()).BrokerRole.ShouldBe("queue");
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -30,6 +30,7 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
         _parent = parent;
         QueueName = queueName;
         EndpointName = queueName;
+        BrokerRole = "queue";
 
         Configuration = new CreateQueueRequest(QueueName);
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/broker_role_tests.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/broker_role_tests.cs
@@ -1,0 +1,31 @@
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+// Locks down GH-2601 for the Azure Service Bus endpoints.
+public class broker_role_tests
+{
+    [Fact]
+    public void queue_broker_role_is_queue()
+    {
+        var transport = new AzureServiceBusTransport();
+        new AzureServiceBusQueue(transport, "q").BrokerRole.ShouldBe("queue");
+    }
+
+    [Fact]
+    public void topic_broker_role_is_topic()
+    {
+        var transport = new AzureServiceBusTransport();
+        new AzureServiceBusTopic(transport, "t").BrokerRole.ShouldBe("topic");
+    }
+
+    [Fact]
+    public void subscription_broker_role_is_subscription()
+    {
+        var transport = new AzureServiceBusTransport();
+        var topic = new AzureServiceBusTopic(transport, "t");
+        new AzureServiceBusSubscription(transport, topic, "s").BrokerRole.ShouldBe("subscription");
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
@@ -35,6 +35,7 @@ public class AzureServiceBusQueue : AzureServiceBusEndpoint, IBrokerQueue, IMass
         {
             DeadLetteringOnMessageExpiration = false
         };
+        BrokerRole = "queue";
     }
 
     [ChildDescription]

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
@@ -40,6 +40,7 @@ public class AzureServiceBusSubscription : AzureServiceBusEndpoint, IBrokerQueue
         // This is the same rule as the one used if you
         // use CreateSubscriptionAsync() without specifying a rule
         RuleOptions = new CreateRuleOptions();
+        BrokerRole = "subscription";
     }
 
     [ChildDescription]

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
@@ -30,6 +30,7 @@ public class AzureServiceBusTopic : AzureServiceBusEndpoint, IMassTransitInterop
 
         TopicName = EndpointName = topicName ?? throw new ArgumentNullException(nameof(topicName));
         Options = new CreateTopicOptions(TopicName);
+        BrokerRole = "topic";
     }
 
     public string TopicName { get; }

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/broker_role_tests.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/broker_role_tests.cs
@@ -1,0 +1,23 @@
+using Google.Api.Gax;
+using Google.Cloud.PubSub.V1;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Pubsub.Tests;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void pubsub_endpoint_broker_role_is_pubsub()
+    {
+        var transport = new PubsubTransport("wolverine")
+        {
+            PublisherApiClient = Substitute.For<PublisherServiceApiClient>(),
+            SubscriberApiClient = Substitute.For<SubscriberServiceApiClient>(),
+            EmulatorDetection = EmulatorDetection.EmulatorOnly
+        };
+
+        new PubsubEndpoint("foo", transport).BrokerRole.ShouldBe("pubsub");
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub/PubsubEndpoint.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/PubsubEndpoint.cs
@@ -55,6 +55,7 @@ public class PubsubEndpoint : Endpoint<IPubsubEnvelopeMapper, PubsubEnvelopeMapp
                 : topicName
         );
         EndpointName = topicName;
+        BrokerRole = "pubsub";
 
         if (transport.DeadLetter.Enabled)
         {

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/broker_role_tests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/broker_role_tests.cs
@@ -1,0 +1,15 @@
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Kafka.Internals;
+using Xunit;
+
+namespace Wolverine.Kafka.Tests;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void kafka_topic_broker_role_is_topic()
+    {
+        new KafkaTopic(new KafkaTransport(), "t", EndpointRole.Application).BrokerRole.ShouldBe("topic");
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -24,6 +24,7 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
         Parent = parent;
         EndpointName = topicName;
         TopicName = topicName;
+        BrokerRole = "topic";
 
         Specification.Name = topicName;
     }

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/broker_role_tests.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/broker_role_tests.cs
@@ -1,0 +1,16 @@
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.MQTT.Internals;
+using Xunit;
+
+namespace Wolverine.MQTT.Tests;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void mqtt_topic_broker_role_is_topic()
+    {
+        new MqttTopic("orders/created", new MqttTransport(), EndpointRole.Application)
+            .BrokerRole.ShouldBe("topic");
+    }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttTopic.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttTopic.cs
@@ -38,6 +38,7 @@ public class MqttTopic : Endpoint, ISender, ITopicEndpoint
         }
 
         EndpointName = topicName;
+        BrokerRole = "topic";
 
         EnvelopeMapper = new MqttEnvelopeMapper(this);
         Mode = EndpointMode.BufferedInMemory;

--- a/src/Transports/NATS/Wolverine.Nats.Tests/broker_role_tests.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/broker_role_tests.cs
@@ -1,0 +1,31 @@
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Nats.Internal;
+using Xunit;
+
+namespace Wolverine.Nats.Tests;
+
+// Locks down GH-2601 for NATS. Unlike other transports, NatsEndpoint
+// computes BrokerRole at runtime: Core NATS surfaces a "subject" while
+// JetStream surfaces a "stream". Toggling the UseJetStream flag must
+// flip the reported role without reconstruction.
+public class broker_role_tests
+{
+    [Fact]
+    public void core_nats_endpoint_broker_role_is_subject()
+    {
+        new NatsEndpoint("orders.created", new NatsTransport(), EndpointRole.Application)
+            .BrokerRole.ShouldBe("subject");
+    }
+
+    [Fact]
+    public void jetstream_endpoint_broker_role_is_stream()
+    {
+        var endpoint = new NatsEndpoint("orders.created", new NatsTransport(), EndpointRole.Application)
+        {
+            UseJetStream = true
+        };
+
+        endpoint.BrokerRole.ShouldBe("stream");
+    }
+}

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsEndpoint.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsEndpoint.cs
@@ -27,6 +27,14 @@ public class NatsEndpoint : Endpoint, IBrokerEndpoint
         Mode = EndpointMode.BufferedInMemory;
     }
 
+    /// <summary>
+    /// NATS plays both roles: Core NATS surfaces a "subject", while JetStream surfaces
+    /// a "stream". The choice is configuration-driven (<see cref="UseJetStream"/>) so
+    /// it can change after construction — compute it on access rather than fixing it
+    /// in the constructor. See GH-2601.
+    /// </summary>
+    public override string BrokerRole => UseJetStream ? "stream" : "subject";
+
     public string Subject { get; }
     [IgnoreDescription]
     public object? NatsSerializer { get; set; }

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/broker_role_tests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/broker_role_tests.cs
@@ -1,0 +1,15 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void pulsar_endpoint_broker_role_is_topic()
+    {
+        var transport = new PulsarTransport();
+        new PulsarEndpoint(new Uri("pulsar://persistent/public/default/sample"), transport)
+            .BrokerRole.ShouldBe("topic");
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -20,6 +20,7 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
     {
         _parent = parent;
         Parse(uri);
+        BrokerRole = "topic";
     }
 
     protected override PulsarEnvelopeMapper buildMapper(IWolverineRuntime runtime)

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/broker_role_tests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/broker_role_tests.cs
@@ -1,0 +1,39 @@
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.RabbitMQ.Internal;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+// Locks down GH-2601: every concrete RabbitMQ endpoint type reports the
+// expected BrokerRole the CritterWatch UI expects.
+public class broker_role_tests
+{
+    [Fact]
+    public void rabbitmq_queue_broker_role_is_queue()
+    {
+        new RabbitMqQueue("q", new RabbitMqTransport()).BrokerRole.ShouldBe("queue");
+    }
+
+    [Fact]
+    public void rabbitmq_exchange_broker_role_is_exchange()
+    {
+        new RabbitMqExchange("ex", new RabbitMqTransport()).BrokerRole.ShouldBe("exchange");
+    }
+
+    [Fact]
+    public void rabbitmq_topic_endpoint_broker_role_is_topic()
+    {
+        var transport = new RabbitMqTransport();
+        var exchange = new RabbitMqExchange("ex", transport);
+        new RabbitMqTopicEndpoint("t", exchange, transport).BrokerRole.ShouldBe("topic");
+    }
+
+    [Fact]
+    public void rabbitmq_routing_broker_role_is_exchange()
+    {
+        var transport = new RabbitMqTransport();
+        var exchange = new RabbitMqExchange("ex", transport);
+        new RabbitMqRouting(exchange, "rk", transport).BrokerRole.ShouldBe("exchange");
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqExchange.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqExchange.cs
@@ -25,6 +25,7 @@ public class RabbitMqExchange : RabbitMqEndpoint, IRabbitMqExchange
         ExchangeName = name;
 
         EndpointName = name;
+        BrokerRole = "exchange";
 
         Topics = new(topic => new RabbitMqTopicEndpoint(topic, this, _parent));
         Routings = new LightweightCache<string, RabbitMqRouting>(key => new RabbitMqRouting(this, key, _parent));

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -41,7 +41,8 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
         _parent = parent;
         QueueName = EndpointName = queueName;
         Mode = EndpointMode.Inline;
-        
+        BrokerRole = "queue";
+
         if (Role == EndpointRole.Application && QueueName != _parent.DeadLetterQueue.QueueName)
         {
             DeadLetterQueue = _parent.DeadLetterQueue.Clone();

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqRouting.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqRouting.cs
@@ -21,6 +21,7 @@ public class RabbitMqRouting : RabbitMqEndpoint
         _routingKey = routingKey;
 
         ExchangeName = _exchange.ExchangeName;
+        BrokerRole = "exchange";
     }
 
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqTopicEndpoint.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqTopicEndpoint.cs
@@ -15,6 +15,7 @@ public class RabbitMqTopicEndpoint : RabbitMqEndpoint
         Exchange = exchange;
 
         ExchangeName = Exchange.Name;
+        BrokerRole = "topic";
     }
 
     public RabbitMqExchange Exchange { get; }

--- a/src/Transports/Redis/Wolverine.Redis.Tests/broker_role_tests.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/broker_role_tests.cs
@@ -1,0 +1,17 @@
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Redis.Internal;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void redis_stream_endpoint_broker_role_is_stream()
+    {
+        var transport = new RedisTransport();
+        new RedisStreamEndpoint(new Uri("redis://stream/0/sample"), transport, EndpointRole.Application)
+            .BrokerRole.ShouldBe("stream");
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamEndpoint.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamEndpoint.cs
@@ -24,7 +24,8 @@ public class RedisStreamEndpoint : Endpoint<IRedisEnvelopeMapper, RedisEnvelopeM
         DatabaseId = databaseId;
         ConsumerGroup = ParseConsumerGroup(uri);
         EndpointName = StreamKey;
-        
+        BrokerRole = "stream";
+
         // Redis Streams work well in buffered mode by default
         Mode = EndpointMode.BufferedInMemory;
     }

--- a/src/Transports/SignalR/Wolverine.SignalR.Tests/broker_role_tests.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR.Tests/broker_role_tests.cs
@@ -1,0 +1,23 @@
+using Shouldly;
+using Wolverine.SignalR.Client;
+using Wolverine.SignalR.Internals;
+using Xunit;
+
+namespace Wolverine.SignalR.Tests;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void signalr_transport_broker_role_is_hub()
+    {
+        new SignalRTransport().BrokerRole.ShouldBe("hub");
+    }
+
+    [Fact]
+    public void signalr_client_endpoint_broker_role_is_hub()
+    {
+        var clientTransport = new SignalRClientTransport();
+        new SignalRClientEndpoint(new Uri("https://localhost:5000/hub"), clientTransport)
+            .BrokerRole.ShouldBe("hub");
+    }
+}

--- a/src/Transports/SignalR/Wolverine.SignalR/Client/SignalRClientEndpoint.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Client/SignalRClientEndpoint.cs
@@ -31,6 +31,7 @@ public class SignalRClientEndpoint : Endpoint, IListener, ISender
         SignalRUri = uri;
 
         IsListener = true;
+        BrokerRole = "hub";
 
         Mode = EndpointMode.Inline;
 

--- a/src/Transports/SignalR/Wolverine.SignalR/Internals/SignalRTransport.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Internals/SignalRTransport.cs
@@ -24,6 +24,7 @@ public class SignalRTransport : Endpoint, ITransport, IListener, ISender
     public SignalRTransport() : base($"{ProtocolName}://wolverine".ToUri(), EndpointRole.Application)
     {
         IsListener = true;
+        BrokerRole = "hub";
 
         #region sample_signalr_default_json_configuration
         JsonOptions = new(JsonSerializerOptions.Web) { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };

--- a/src/Wolverine.Grpc.Tests/broker_role_tests.cs
+++ b/src/Wolverine.Grpc.Tests/broker_role_tests.cs
@@ -1,0 +1,13 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests;
+
+public class broker_role_tests
+{
+    [Fact]
+    public void grpc_endpoint_broker_role_is_grpc()
+    {
+        new GrpcEndpoint(new Uri("grpc://localhost:5001")).BrokerRole.ShouldBe("grpc");
+    }
+}

--- a/src/Wolverine.Grpc/GrpcEndpoint.cs
+++ b/src/Wolverine.Grpc/GrpcEndpoint.cs
@@ -13,6 +13,7 @@ public class GrpcEndpoint : Endpoint
     {
         Host = uri.Host;
         Port = uri.IsDefaultPort ? 5000 : uri.Port;
+        BrokerRole = "grpc";
     }
 
     public string Host { get; }

--- a/src/Wolverine/Configuration/Capabilities/EndpointDescriptor.cs
+++ b/src/Wolverine/Configuration/Capabilities/EndpointDescriptor.cs
@@ -34,6 +34,8 @@ public class EndpointDescriptor : OptionsDescription
         InteropMode = ResolveInteropMode(endpoint);
         IsSystemEndpoint = endpoint.Uri?.ToString().Contains("wolverine.response", StringComparison.OrdinalIgnoreCase) == true
                         || endpoint.Uri?.Scheme.Equals("local", StringComparison.OrdinalIgnoreCase) == true;
+        EndpointRole = endpoint.Role;
+        BrokerRole = endpoint.BrokerRole;
     }
 
     public Uri Uri { get; set; } = null!;
@@ -58,6 +60,23 @@ public class EndpointDescriptor : OptionsDescription
     /// Whether this is a Wolverine system endpoint (reply queue, control queue, etc.)
     /// </summary>
     public bool IsSystemEndpoint { get; init; }
+
+    /// <summary>
+    /// Whether the endpoint is owned by Wolverine itself (<c>System</c>) or by the
+    /// application (<c>Application</c>). Lifted from <see cref="Endpoint.Role"/> so
+    /// CritterWatch and other UIs can filter system-owned endpoints (e.g., reply
+    /// queues, control queues) without having to crack the underlying URI. See GH-2601.
+    /// </summary>
+    public EndpointRole EndpointRole { get; init; }
+
+    /// <summary>
+    /// Short, human-readable name of the underlying broker object kind this endpoint
+    /// represents — <c>"queue"</c>, <c>"exchange"</c>, <c>"topic"</c>,
+    /// <c>"subscription"</c>, <c>"stream"</c>, etc. Lifted from
+    /// <see cref="Endpoint.BrokerRole"/>; see that property for the full per-transport
+    /// mapping. See GH-2601.
+    /// </summary>
+    public string? BrokerRole { get; init; }
 
     internal static string? ResolveInteropMode(Endpoint endpoint)
     {

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -185,6 +185,17 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     }
 
     /// <summary>
+    /// Short, human-readable name of the underlying broker object kind this endpoint
+    /// represents — e.g. <c>"queue"</c>, <c>"exchange"</c>, <c>"topic"</c>,
+    /// <c>"subscription"</c>, <c>"stream"</c>. Each transport-specific subclass sets
+    /// this value in its constructor; transports whose role is only knowable at
+    /// runtime (e.g. <c>NatsEndpoint</c> choosing between Core <c>subject</c> and
+    /// JetStream <c>stream</c>) override the property. Surfaced to CritterWatch and
+    /// other diagnostic UIs to drive endpoint display. See GH-2601.
+    /// </summary>
+    public virtual string BrokerRole { get; protected set; } = "endpoint";
+
+    /// <summary>
     /// Controls the maximum number of messages that could be processed at one time.
     /// Default is the greater of Environment.ProcessorCount or 5. Setting this to 1 makes this listening endpoint
     /// be ordered in its processing.

--- a/src/Wolverine/Transports/Local/LocalQueue.cs
+++ b/src/Wolverine/Transports/Local/LocalQueue.cs
@@ -12,6 +12,7 @@ public class LocalQueue : Endpoint
     public LocalQueue(string name) : base($"local://{name}".ToUri(), EndpointRole.Application)
     {
         EndpointName = name.ToLowerInvariant();
+        BrokerRole = "queue";
     }
 
     internal List<Type> HandledMessageTypes { get; } = new();

--- a/src/Wolverine/Transports/SharedMemory/SharedMemorySubscription.cs
+++ b/src/Wolverine/Transports/SharedMemory/SharedMemorySubscription.cs
@@ -17,6 +17,7 @@ public class SharedMemorySubscription : SharedMemoryEndpoint, IListener, ISender
         Parent = parent;
         Name = name;
         IsListener = true;
+        BrokerRole = "subscription";
     }
 
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)

--- a/src/Wolverine/Transports/SharedMemory/SharedMemoryTopic.cs
+++ b/src/Wolverine/Transports/SharedMemory/SharedMemoryTopic.cs
@@ -26,6 +26,8 @@ public class SharedMemoryTopic : SharedMemoryEndpoint, ISender
             TopicSubscriptions[topicName] = new SharedMemorySubscription(this, topicName, EndpointRole.System);
         }
 
+        BrokerRole = "topic";
+
         // Placeholder
         ReplyUri = Uri;
     }

--- a/src/Wolverine/Transports/Stub/StubEndpoint.cs
+++ b/src/Wolverine/Transports/Stub/StubEndpoint.cs
@@ -25,6 +25,7 @@ internal class StubEndpoint : Endpoint, ISendingAgent, ISender, IListener
         _stubTransport = stubTransport;
         Agent = this;
         EndpointName = queueName;
+        BrokerRole = "stub";
     }
 
     public ValueTask StopAsync()

--- a/src/Wolverine/Transports/Tcp/TcpEndpoint.cs
+++ b/src/Wolverine/Transports/Tcp/TcpEndpoint.cs
@@ -24,6 +24,7 @@ public class TcpEndpoint : Endpoint
 
         // ReSharper disable once VirtualMemberCallInConstructor
         EndpointName = Uri.ToString();
+        BrokerRole = "socket";
     }
 
     public string HostName { get; }


### PR DESCRIPTION
## Summary

Closes #2601.

Adds a new virtual `string BrokerRole { get; protected set; }` on the base `Endpoint` class with default `"endpoint"`. Each transport-specific subclass sets it in its own ctor; `NatsEndpoint` overrides because Core NATS vs JetStream is a runtime choice.

The companion `DisplayName` property described in the issue was deferred — see the audit below; `EndpointName` already covers most of that need.

## BrokerRole values per endpoint

| Endpoint | `BrokerRole` |
|---|---|
| `RabbitMqQueue` | `queue` |
| `RabbitMqExchange`, `RabbitMqRouting` | `exchange` |
| `RabbitMqTopicEndpoint` | `topic` |
| `AzureServiceBusQueue` | `queue` |
| `AzureServiceBusTopic` | `topic` |
| `AzureServiceBusSubscription` | `subscription` |
| `AmazonSqsQueue` | `queue` |
| `AmazonSnsTopic` | `topic` |
| `KafkaTopic` | `topic` |
| `PulsarEndpoint` | `topic` |
| `PubsubEndpoint` | `pubsub` (per @jeremydmiller) |
| `MqttTopic` | `topic` |
| `RedisStreamEndpoint` | `stream` |
| `NatsEndpoint` | `subject` (Core NATS) / `stream` (JetStream) — runtime override |
| `SqlServerQueue`, `PostgresqlQueue`, `TenantedPostgresqlQueue`, `SqliteQueue`, `OracleQueue`, `MySqlQueue` | `queue` |
| `DatabaseControlEndpoint` | `queue` |
| `ExternalMessageTable` | `table` |
| `LocalQueue` | `queue` |
| `SharedMemoryTopic` | `topic` |
| `SharedMemorySubscription` | `subscription` |
| `StubEndpoint` | `stub` |
| `TcpEndpoint` | `socket` (per @jeremydmiller) |
| `HttpEndpoint` | `route` (per @jeremydmiller) |
| `GrpcEndpoint` | `grpc` (per @jeremydmiller) |
| `SignalRTransport`, `SignalRClientEndpoint` | `hub` (per @jeremydmiller) |

Endpoint base default is `"endpoint"` for any custom subclass that forgets to override.

## Tests

- `CoreTests/Configuration/broker_role_tests.cs` — base default + LocalQueue, StubEndpoint, TcpEndpoint, SharedMemoryTopic, SharedMemorySubscription.
- A `broker_role_tests.cs` added to every transport / persistence test assembly with a one-line check per concrete endpoint type, so any future endpoint addition that forgets to set `BrokerRole` fails at test time.
- NATS test specifically covers both `subject` and `stream` to exercise the runtime override.

All `broker_role_tests` pass across 19 test assemblies. Full `CoreTests` suite (1369/1369) passes — no regression.

## EndpointName audit (per Q2 in the design discussion)

`Endpoint`'s base ctor sets `EndpointName = uri.ToString()` and most subclasses override it to a friendly value. The following concrete subclasses currently fall back to the URI string and may want a friendlier `EndpointName` for CritterWatch (none are touched in this PR — flagged for follow-up decision):

| Endpoint | Falls back to | Suggested |
|---|---|---|
| `SharedMemoryTopic` | `memory://topicName` | `topicName` |
| `SharedMemorySubscription` | `memory://topic/sub` | `Name` (subscription) |
| `HttpEndpoint` | full HTTP URI | route template (no obvious constructor source) |
| `GrpcEndpoint` | `grpc://host:port` | `\"$host:$port\"` |
| `SignalRClientEndpoint` | `signalr://host:port/hub` | hub path |
| `PulsarEndpoint` | `persistent://tenant/ns/topic` | `TopicName` |
| `TenantedPostgresqlQueue` | `postgresql://q/dbname` | `\"$queue@$dbname\"` |
| `DatabaseControlEndpoint` | `db-control://nodeId` | `\"Control-{NodeId}\"` |
| `CosmosDbControlEndpoint` | `cosmosdb-control://nodeId` | same |
| `ExternalMessageTable` | `external-db://schema.table` | `TableName.QualifiedName` (already friendly) |
| `TcpEndpoint` | `tcp://host:port` (set explicitly to URI) | `\"$host:$port\"` |

## Test plan

- [x] `dotnet build wolverine.slnx` — full solution clean, 0 errors.
- [x] `dotnet test src/Testing/CoreTests --framework net9.0` — 1369/1369 pass.
- [x] `broker_role_tests` pass across 19 transport / persistence test assemblies (RabbitMQ, ASB, SQS, SNS, Kafka, Pulsar, NATS, Pub/Sub, MQTT, Redis, SignalR, SqlServer, Postgresql, Sqlite, Oracle, MySql, Wolverine.Http, Wolverine.Grpc, CoreTests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)