### PR TITLE
Fix #2571: preserve context fields on scheduled-send wrap unwrap

### DIFF
--- a/src/Testing/CoreTests/Runtime/Scheduled/inner_envelope_is_stamped_before_serialization.cs
+++ b/src/Testing/CoreTests/Runtime/Scheduled/inner_envelope_is_stamped_before_serialization.cs
@@ -1,0 +1,84 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.ComplianceTests.Compliance;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Transports.SharedMemory;
+using Xunit;
+
+namespace CoreTests.Runtime.Scheduled;
+
+public class inner_envelope_is_stamped_before_serialization : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        ScheduledEnvelopeCapture.Reset();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.EnableRelayOfUserName = true;
+                opts.PublishAllMessages().ToSharedMemoryTopic("scheduled_tenant_topic");
+                opts.ListenToSharedMemorySubscription("scheduled_tenant_topic", "sub").ProcessInline();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task scheduled_send_to_non_native_transport_preserves_context_fields()
+    {
+        var bus = (MessageBus)_host.MessageBus();
+        bus.TenantId = "red";
+        bus.CorrelationId = "corr-123";
+        bus.UserName = "alice";
+
+        var tracked = await _host.TrackActivity()
+            .Timeout(10.Seconds())
+            .ExecuteAndWaitAsync(_ =>
+                bus.PublishAsync(new Message1(), new DeliveryOptions { ScheduleDelay = 1.Minutes() }).AsTask());
+        
+        await tracked.PlayScheduledMessagesAsync(2.Hours());
+        await Task.Delay(2.Minutes());
+        
+        var captured = await ScheduledEnvelopeCapture.WaitAsync(5.Seconds());
+        captured.TenantId.ShouldBe("red");
+        captured.CorrelationId.ShouldBe("corr-123");
+        captured.UserName.ShouldBe("alice");
+    }
+}
+
+public class Message1CapturingHandler
+{
+    public void Handle(Message1 _, Envelope envelope)
+    {
+        ScheduledEnvelopeCapture.Capture(envelope);
+    }
+}
+
+public static class ScheduledEnvelopeCapture
+{
+    public record Snapshot(string? TenantId, string? CorrelationId, string? UserName);
+
+    private static TaskCompletionSource<Snapshot> _tcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static void Reset()
+    {
+        _tcs = new TaskCompletionSource<Snapshot>(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public static void Capture(Envelope envelope)
+    {
+        _tcs.TrySetResult(new Snapshot(envelope.TenantId, envelope.CorrelationId, envelope.UserName));
+    }
+
+    public static Task<Snapshot> WaitAsync(TimeSpan timeout) => _tcs.Task.WaitAsync(timeout);
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/scheduled_saga_timeout_preserves_tenant.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/scheduled_saga_timeout_preserves_tenant.cs
@@ -1,0 +1,158 @@
+using IntegrationTests;
+using JasperFx.Core;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using JasperFx;
+using JasperFx.Resources;
+using Shouldly;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+public class scheduled_saga_timeout_preserves_tenant : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private string _queueName = null!;
+
+    public async Task InitializeAsync()
+    {
+        SagaTimeoutCapture.Reset();
+
+        _queueName = RabbitTesting.NextQueueName();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "scheduled_saga_tenant";
+                    m.Policies.AllDocumentsAreMultiTenanted();
+                    m.AutoCreateSchemaObjects = AutoCreate.All;
+                    m.DisableNpgsqlLogging = true;
+                })
+                .IntegrateWithWolverine()
+                .UseLightweightSessions();
+
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToRabbitQueue(_queueName);
+                opts.PublishMessage<SagaTimeoutMsg>().ToRabbitQueue(_queueName);
+
+                opts.Policies.UseDurableInboxOnAllListeners();
+                opts.Policies.UseDurableOutboxOnAllSendingEndpoints();
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Durability.ScheduledJobFirstExecution = 500.Milliseconds();
+                opts.Durability.ScheduledJobPollingTime = 1.Seconds();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task saga_timeout_delivered_through_rabbit_is_handled_under_original_tenant()
+    {
+        var sagaId = Guid.NewGuid();
+
+        await _host.MessageBus().InvokeForTenantAsync("red", new StartSaga(sagaId));
+
+        SagaTimeoutCapture.Snapshot captured;
+        try
+        {
+            captured = await SagaTimeoutCapture.WaitAsync(30.Seconds());
+        }
+        catch (TimeoutException)
+        {
+            var store = _host.Services.GetRequiredService<IDocumentStore>();
+            var snapshots = new List<string>();
+            foreach (var tenant in new[] { "red", "*DEFAULT*" })
+            {
+                await using var diag = store.QuerySession(tenant);
+                var row = await diag.LoadAsync<TenantedRabbitSaga>(sagaId);
+                if (row != null)
+                {
+                    snapshots.Add($"tenant={tenant}, storedTenant={row.StoredTenantId ?? "null"}, timedOut={row.TimedOut}");
+                }
+            }
+            throw new ShouldAssertException(
+                $"The scheduled saga timeout never reached the saga handler within 30s — " +
+                $"the TimeoutMessage was silently dropped because the saga lookup missed. " +
+                $"Saga rows for id {sagaId}: " +
+                (snapshots.Count > 0 ? string.Join(" | ", snapshots) : "none"));
+        }
+
+        captured.WasFound.ShouldBeTrue();
+        captured.EnvelopeTenantId.ShouldBe("red");
+        captured.EnvelopeSagaId.ShouldBe(sagaId.ToString());
+        captured.ContextTenantId.ShouldBe("red");
+
+        // After Handle ran and called MarkCompleted, Marten removes the saga row.
+        var store2 = _host.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store2.QuerySession();
+        var remaining = await session.Query<TenantedRabbitSaga>()
+            .Where(x => x.Id == sagaId)
+            .ToListAsync();
+
+        remaining.ShouldBeEmpty();
+    }
+}
+
+public record StartSaga(Guid SagaId);
+
+public record SagaTimeoutMsg(Guid SagaId) : TimeoutMessage(2.Seconds());
+
+public class TenantedRabbitSaga : Saga
+{
+    public Guid Id { get; set; }
+    public string? StoredTenantId { get; set; }
+    public bool TimedOut { get; set; }
+
+    public static (TenantedRabbitSaga, SagaTimeoutMsg) Start(StartSaga cmd, Envelope envelope)
+    {
+        return (
+            new TenantedRabbitSaga { Id = cmd.SagaId, StoredTenantId = envelope.TenantId },
+            new SagaTimeoutMsg(cmd.SagaId)
+        );
+    }
+
+    public void Handle(SagaTimeoutMsg timeout, Envelope envelope, IMessageContext context)
+    {
+        TimedOut = true;
+        SagaTimeoutCapture.Capture(envelope, context, wasFound: true);
+        MarkCompleted();
+    }
+}
+
+public static class SagaTimeoutCapture
+{
+    public record Snapshot(
+        string? EnvelopeTenantId,
+        string? EnvelopeSagaId,
+        string? ContextTenantId,
+        bool WasFound);
+
+    private static TaskCompletionSource<Snapshot> _tcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static void Reset()
+    {
+        _tcs = new TaskCompletionSource<Snapshot>(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public static void Capture(Envelope envelope, IMessageContext context, bool wasFound)
+    {
+        _tcs.TrySetResult(new Snapshot(envelope.TenantId, envelope.SagaId, context.TenantId, wasFound));
+    }
+
+    public static Task<Snapshot> WaitAsync(TimeSpan timeout) => _tcs.Task.WaitAsync(timeout);
+}

--- a/src/Wolverine/Envelope.Internals.cs
+++ b/src/Wolverine/Envelope.Internals.cs
@@ -211,6 +211,26 @@ public partial class Envelope
     }
 
     /// <summary>
+    ///     Copy the context-correlation fields (<see cref="CorrelationId"/>,
+    ///     <see cref="ConversationId"/>, <see cref="TenantId"/>, <see cref="UserName"/>,
+    ///     <see cref="ParentId"/>, <see cref="SagaId"/>) from <paramref name="source"/>
+    ///     onto this envelope. Used wherever a wrapped scheduled envelope is unwrapped
+    ///     and forwarded so the inner picks up the wrapper's context — the durable
+    ///     scheduled-send unwrap path (<c>ScheduledSendEnvelopeHandler</c>) and the
+    ///     in-memory tracked-session replay path (<c>TrackedSession.ReplayAll</c>).
+    ///     See GH-2571 / PR #2572.
+    /// </summary>
+    internal void CopyContextCorrelationFrom(Envelope source)
+    {
+        CorrelationId = source.CorrelationId;
+        ConversationId = source.ConversationId;
+        TenantId = source.TenantId;
+        UserName = source.UserName;
+        ParentId = source.ParentId;
+        SagaId = source.SagaId;
+    }
+
+    /// <summary>
     ///     Create a new Envelope that is a response to the current
     ///     Envelope
     /// </summary>

--- a/src/Wolverine/Runtime/Scheduled/ScheduledSendEnvelopeHandler.cs
+++ b/src/Wolverine/Runtime/Scheduled/ScheduledSendEnvelopeHandler.cs
@@ -24,6 +24,11 @@ internal class ScheduledSendEnvelopeHandler : MessageHandler
         scheduled.Source = context.Runtime.Options.ServiceName;
         scheduled.ScheduledTime = null;
         scheduled.Status = EnvelopeStatus.Outgoing;
+        scheduled.CorrelationId = context.Envelope.CorrelationId;
+        scheduled.ConversationId = context.Envelope.ConversationId;
+        scheduled.TenantId = context.Envelope.TenantId;
+        scheduled.UserName = context.Envelope.UserName;
+        scheduled.ParentId = context.Envelope.ParentId;
 
         return context.ForwardScheduledEnvelopeAsync(scheduled).AsTask();
     }

--- a/src/Wolverine/Runtime/Scheduled/ScheduledSendEnvelopeHandler.cs
+++ b/src/Wolverine/Runtime/Scheduled/ScheduledSendEnvelopeHandler.cs
@@ -24,11 +24,13 @@ internal class ScheduledSendEnvelopeHandler : MessageHandler
         scheduled.Source = context.Runtime.Options.ServiceName;
         scheduled.ScheduledTime = null;
         scheduled.Status = EnvelopeStatus.Outgoing;
-        scheduled.CorrelationId = context.Envelope.CorrelationId;
-        scheduled.ConversationId = context.Envelope.ConversationId;
-        scheduled.TenantId = context.Envelope.TenantId;
-        scheduled.UserName = context.Envelope.UserName;
-        scheduled.ParentId = context.Envelope.ParentId;
+
+        // The wrapper that just fired carries the context-correlation fields
+        // that were stamped on the way out (TenantId, CorrelationId, UserName,
+        // ParentId, ConversationId). Copy them onto the inner before forwarding
+        // so the eventual handler runs under the original tenant / correlation.
+        // See GH-2571 / PR #2572.
+        scheduled.CopyContextCorrelationFrom(context.Envelope);
 
         return context.ForwardScheduledEnvelopeAsync(scheduled).AsTask();
     }

--- a/src/Wolverine/Tracking/TrackedSession.cs
+++ b/src/Wolverine/Tracking/TrackedSession.cs
@@ -195,16 +195,48 @@ internal partial class TrackedSession : ITrackedSession
     internal async Task ReplayAll(IMessageContext context, EnvelopeRecord[] records)
     {
         var envelopes = records.Select(x => x.Envelope!).Distinct().ToArray();
+        var bus = context as MessageBus;
 
-        foreach (var envelope in envelopes)
+        foreach (var capturedEnvelope in envelopes)
         {
-            if (envelope!.Destination!.Scheme == TransportConstants.Local)
+            // Captured records for scheduled sends to non-native-scheduling
+            // transports are wrappers around the original envelope (see
+            // EnvelopeScheduleExtensions.ForScheduledSend). In production the
+            // durable scheduler eventually fires the wrapper through
+            // ScheduledSendEnvelopeHandler, which unwraps the inner and
+            // copies the wrapper's context-correlation fields onto it before
+            // forwarding. Replay doesn't go through that round-trip — there's
+            // no broker, no serialization — so we have to do the same unwrap
+            // and stamp here so the inner envelope's destination + tenant /
+            // correlation / user fields drive the replay. See GH-2571 / PR #2572.
+            var dispatched = capturedEnvelope;
+            if (capturedEnvelope.MessageType == TransportConstants.ScheduledEnvelope &&
+                capturedEnvelope.Message is Envelope inner)
             {
-                await context.InvokeAsync(envelope.Message!);
+                inner.CopyContextCorrelationFrom(capturedEnvelope);
+                dispatched = inner;
+            }
+
+            // The replay context is fresh — its bus.TenantId / CorrelationId /
+            // UserName start out null. Propagate the dispatched envelope's
+            // values onto the bus so the outgoing envelope that InvokeAsync /
+            // SendAsync builds picks them up via TrackEnvelopeCorrelation.
+            // Without this, a scheduled message published under
+            // TenantId="red" would replay under no tenant.
+            if (bus != null)
+            {
+                bus.TenantId = dispatched.TenantId;
+                bus.CorrelationId = dispatched.CorrelationId;
+                bus.UserName = dispatched.UserName;
+            }
+
+            if (dispatched.Destination!.Scheme == TransportConstants.Local)
+            {
+                await context.InvokeAsync(dispatched.Message!);
             }
             else
             {
-                await context.EndpointFor(envelope.Destination).SendAsync(envelope.Message);
+                await context.EndpointFor(dispatched.Destination).SendAsync(dispatched.Message);
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #2571. Alternative fix to PR #2572 — keeps that PR's two test files as the failing reproducers (which they were on plain `main`), but takes a different (smaller, hot-path-untouched) implementation path.

When an envelope is scheduled to a transport without native scheduled-send (RabbitMQ, Kafka, SharedMemory, …), `MessageRoute.ForScheduledSend` wraps it. The wrapper carried the right context fields but the inner — which is what eventually gets forwarded to the real destination — did not. End result: the cascaded timeout fires with `TenantId=null` and `SagaId=null`, multi-tenanted sagas miss their lookup, and observability fields drop.

## Approach

Single-source-of-truth helper on `Envelope`, **internal**, six fields:

```csharp
internal void CopyContextCorrelationFrom(Envelope source)
{
    CorrelationId  = source.CorrelationId;
    ConversationId = source.ConversationId;
    TenantId       = source.TenantId;
    UserName       = source.UserName;
    ParentId       = source.ParentId;
    SagaId         = source.SagaId;     // needed for the saga-timeout test
}
```

Two callers, **both off the production hot path** per the no-overhead constraint:

1. **`ScheduledSendEnvelopeHandler.HandleAsync`** — when the durable scheduler fires the wrapper back in, unwrap the inner and stamp it from the wrapper before forwarding via `ForwardScheduledEnvelopeAsync` (which deliberately does not re-stamp). The 5-line ad-hoc copy that was there in the WIP collapses into one helper call.

2. **`TrackedSession.ReplayAll`** — test-only replay path. No broker, no serialization, so unwrap + stamp + dispatch the inner here too. `PlayScheduledMessagesAsync` was the original culprit Jeremy pointed at: it dispatched `wrapper.Message` (the inner `Envelope` object) through a fresh `InvokeAsync`/`SendAsync` that built a new outgoing envelope with empty context. Now it unwraps to the inner, calls `CopyContextCorrelationFrom`, primes the replay bus's `TenantId`/`CorrelationId`/`UserName` so `TrackEnvelopeCorrelation` propagates them when building the freshly outgoing envelope (UserName isn't on `DeliveryOptions`, so the bus is the only path), then dispatches the inner's destination instead of the local-durable URI.

`ForScheduledSend`, `MessageRoute`, `MessageBus.PublishAsync`, `TrackEnvelopeCorrelation`, and the per-record tracker plumbing are all untouched.

## Test plan

- [x] `CoreTests.Runtime.Scheduled.inner_envelope_is_stamped_before_serialization` (in-process via SharedMemory + `PlayScheduledMessagesAsync`, asserts `TenantId`/`CorrelationId`/`UserName`) — passes
- [x] `Wolverine.RabbitMQ.Tests.scheduled_saga_timeout_preserves_tenant` (Marten + RabbitMQ + durable outbox, end-to-end multi-tenant saga) — passes
- [x] Full `dotnet test src/Testing/CoreTests --framework net9.0` — 1364/1364 pass, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)