### PR TITLE
RavenDB - Don't pause the listener for routine duplicate envelopes

### DIFF
--- a/src/Persistence/RavenDbTests/message_store_compliance.cs
+++ b/src/Persistence/RavenDbTests/message_store_compliance.cs
@@ -9,6 +9,7 @@ using Raven.TestDriver;
 using Shouldly;
 using Wolverine;
 using Wolverine.ComplianceTests;
+using Wolverine.Persistence.Durability;
 using Wolverine.RavenDb;
 using Wolverine.RavenDb.Internals;
 using Wolverine.Transports.Tcp;
@@ -108,6 +109,23 @@ public class message_store_compliance : MessageStoreCompliance
         var value = metadata["@expires"];
         Debug.WriteLine(value);
 
+    }
+
+    [Fact]
+    public async Task bulk_store_with_intra_batch_duplicate_throws_DuplicateIncomingEnvelopeException()
+    {
+        // Reproduces the on-startup race where ASB redelivers the same envelope twice
+        // in a single prefetched batch. The bulk Inbox.StoreIncomingAsync used to leak
+        // RavenDB's NonUniqueObjectException; DurableReceiver then mistook that for an
+        // inbox-unavailable signal and paused the listener.
+        var envelope = ObjectMother.Envelope();
+        envelope.Destination = new Uri("stub://incoming");
+        envelope.Status = EnvelopeStatus.Incoming;
+
+        await Should.ThrowAsync<DuplicateIncomingEnvelopeException>(async () =>
+        {
+            await thePersistence.Inbox.StoreIncomingAsync(new[] { envelope, envelope });
+        });
     }
 
 

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.Inbox.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.Inbox.cs
@@ -3,6 +3,7 @@ using Raven.Client;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Documents.Session;
 using Wolverine.Persistence.Durability;
 using Wolverine.Transports;
 
@@ -87,16 +88,29 @@ public partial class RavenDbMessageStore : IMessageInbox
     {
         using var session = _store.OpenAsyncSession();
         session.Advanced.UseOptimisticConcurrency = true;
-        
-        foreach (var envelope in envelopes)
-        {
-            var incoming = new IncomingMessage(envelope, this);
-            await session.StoreAsync(incoming);
-        }
 
-        // It's okay if it does fail here with the duplicate detection, because that
-        // will force the DurableReceiver to try envelope at a time to get at the actual differences
-        await session.SaveChangesAsync();
+        try
+        {
+            foreach (var envelope in envelopes)
+            {
+                var incoming = new IncomingMessage(envelope, this);
+                await session.StoreAsync(incoming);
+            }
+
+            await session.SaveChangesAsync();
+        }
+        catch (NonUniqueObjectException)
+        {
+            // Same envelope identity appeared twice in this batch (e.g. broker
+            // redelivery race). Surface as a duplicate so DurableReceiver falls back
+            // to the per-envelope path, which dedupes correctly without double-executing.
+            throw new DuplicateIncomingEnvelopeException(envelopes[0]);
+        }
+        catch (ConcurrencyException)
+        {
+            // At least one envelope is already in the inbox; same fallback contract.
+            throw new DuplicateIncomingEnvelopeException(envelopes[0]);
+        }
     }
 
     public async Task<bool> ExistsAsync(Envelope envelope, CancellationToken cancellation)

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -577,6 +577,12 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
                 
                 batchSucceeded = true;
             }
+            catch (DuplicateIncomingEnvelopeException)
+            {
+                // The batch contained a duplicate (e.g. broker redelivery race). The inbox is fine;
+                // fall through to the per-envelope path which dedupes correctly. Do NOT pause the listener.
+                foreach (var envelope in envelopes) await _receivingOne.PostAsync(envelope);
+            }
             catch (Exception e)
             {
                 _logger.LogError(e, "Error trying to persist incoming envelopes at {Uri}", Uri);


### PR DESCRIPTION
## Overview

I observed that the bulk `RavenDbMessageStore.StoreIncomingAsync(IReadOnlyList<Envelope>)` doesn't catch `NonUniqueObjectException` (same envelope identity twice in one batch) or `ConcurrencyException` (envelope already in the inbox), so both leak as raw RavenDB exceptions. The single-envelope overload always translated `ConcurrencyException` to `DuplicateIncomingEnvelopeException`, but the bulk overload didn't have the same affordances.

`DurableReceiver.ProcessReceivedMessagesAsync` then catches `Exception` broadly and calls `SignalInboxUnavailable()` for every failure, including these benign duplicates.

## Fix

- Bulk `StoreIncomingAsync` translates both `NonUniqueObjectException` and `ConcurrencyException` to `DuplicateIncomingEnvelopeException`, matching the single-envelope contract.
- `DurableReceiver` adds a typed `catch (DuplicateIncomingEnvelopeException)` before the generic catch which falls through to the existing per-envelope retry path without signaling inbox unavailability.