### PR TITLE
RavenDb - Ensure scheduled job and leadership locks that are stale can be taken over

### DIFF
--- a/src/Persistence/RavenDbTests/leadership_locking.cs
+++ b/src/Persistence/RavenDbTests/leadership_locking.cs
@@ -1,11 +1,13 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Embedded;
 using Shouldly;
 using Wolverine;
 using Wolverine.Persistence.Durability;
 using Wolverine.RavenDb;
+using Wolverine.RavenDb.Internals;
 
 namespace RavenDbTests;
 
@@ -87,5 +89,27 @@ public class leadership_locking : IAsyncLifetime
         (await store2.Nodes.TryAttainLeadershipLockAsync(CancellationToken.None))
             .ShouldBeTrue();
         store2.Nodes.HasLeadershipLock().ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task expired_scheduled_job_lock_from_dead_predecessor_can_be_taken_over()
+    {
+        // Simulate a prior process that crashed without releasing — leaves a CE value
+        // with an ExpirationTime in the past. A fresh process should take it over
+        // rather than be blocked indefinitely.
+        var staleLock = new DistributedLock
+        {
+            NodeId = Guid.NewGuid(),
+            ExpirationTime = DateTimeOffset.UtcNow.AddMinutes(-10)
+        };
+        var put = await _store.Operations.SendAsync(
+            new PutCompareExchangeValueOperation<DistributedLock>("wolverine/scheduled", staleLock, 0));
+        put.Successful.ShouldBeTrue();
+
+        // Build a brand-new message store with no in-memory lock state — mirrors a
+        // fresh process starting up against the predecessor's leftover CE value.
+        var ravenStore = new RavenDbMessageStore(_store, new WolverineOptions());
+        (await ravenStore.TryAttainScheduledJobLockAsync(CancellationToken.None))
+            .ShouldBeTrue();
     }
 }

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.Locking.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.Locking.cs
@@ -31,7 +31,7 @@ public partial class RavenDbMessageStore
             NodeId = _options.UniqueNodeId,
             ExpirationTime = DateTimeOffset.UtcNow.AddMinutes(5),
         };
-        
+
         if (_leaderLock == null)
         {
             var result = await _store.Operations.SendAsync(new PutCompareExchangeValueOperation<DistributedLock>(_leaderLockId, newLock, 0), token: token);
@@ -42,9 +42,9 @@ public partial class RavenDbMessageStore
                 return true;
             }
 
-            return false;
+            return await tryTakeOverIfExpiredAsync(_leaderLockId, newLock, lockSet: l => _leaderLock = l, indexSet: i => _lastLockIndex = i, token);
         }
-        
+
         var result2 = await _store.Operations.SendAsync(new PutCompareExchangeValueOperation<DistributedLock>(_leaderLockId, newLock, _lastLockIndex), token: token);
         if (result2.Successful)
         {
@@ -83,7 +83,7 @@ public partial class RavenDbMessageStore
                 return true;
             }
 
-            return false;
+            return await tryTakeOverIfExpiredAsync(_scheduledLockId, newLock, lockSet: l => _scheduledLock = l, indexSet: i => _lastScheduledLockIndex = i, token);
         }
         
         var result2 = await _store.Operations.SendAsync(new PutCompareExchangeValueOperation<DistributedLock>(_scheduledLockId, newLock, _lastScheduledLockIndex), token: token);
@@ -102,6 +102,24 @@ public partial class RavenDbMessageStore
         if (_scheduledLock == null) return;
         await _store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<DistributedLock>(_scheduledLockId, _lastScheduledLockIndex));
         _scheduledLock = null;
+    }
+
+    // A predecessor process can crash without releasing its lock, leaving the CE value
+    // behind indefinitely. The DistributedLock.ExpirationTime field is the recovery
+    // hook: if the existing lock is past its expiration, CAS-replace it using the
+    // current CE index. Mirrors the equivalent path in CosmosDbMessageStore.Locking.
+    private async Task<bool> tryTakeOverIfExpiredAsync(string lockId, DistributedLock newLock, Action<DistributedLock> lockSet, Action<long> indexSet, CancellationToken token)
+    {
+        var existing = await _store.Operations.SendAsync(new GetCompareExchangeValueOperation<DistributedLock>(lockId), token: token);
+        if (existing?.Value == null) return false;
+        if (existing.Value.ExpirationTime > DateTimeOffset.UtcNow) return false;
+
+        var takeover = await _store.Operations.SendAsync(new PutCompareExchangeValueOperation<DistributedLock>(lockId, newLock, existing.Index), token: token);
+        if (!takeover.Successful) return false;
+
+        lockSet(newLock);
+        indexSet(takeover.Index);
+        return true;
     }
 }
 


### PR DESCRIPTION
## Overview
`bus.ScheduleAsync(...)` timeouts were not firing after a hard process kill. The next startup found the previous compare-exchange lock still in the database, wasn't able to claim it, resulting in `runScheduledJobs` quietly skips every cycle. Manual workaround was to delete the compare exchange value via Raven Studio.

## Root cause

`DistributedLock.ExpirationTime` is written on every acquisition but never read by competitors. `TryAttainScheduledJobLockAsync` (and the leadership counterpart) put with `index=0`, and if any value exists they would return `false` - no expiry check, no takeover. The Cosmos implementation appears to handle this correctly already (`CosmosDbMessageStore.Locking.cs:131-156`), so this appears to be an issue that only affects the RavenDB implementation.

## Fix

When the initial put fails, the lock methods now fetch the existing compare-exchange value and check its `ExpirationTime`. If the existing lock is past its expiration, the new process replaces it (using the current index, so two processes racing to take over the same stale lock won't both succeed). If the existing lock is still within its expiration, the method returns `false` as before.