### PR TITLE
#2584: surface upcoming 6.0 ServiceLocationPolicy.NotAllowed default

### DIFF
--- a/docs/guide/codegen.md
+++ b/docs/guide/codegen.md
@@ -206,6 +206,10 @@ for your IoC configuration.
 As of Wolverine 5.0, you now have the ability to better control the usage of the service locator in Wolverine's
 code generation to potentially avoid unwanted usage:
 
+::: warning
+Starting in Wolverine 6.0, the default `ServiceLocationPolicy` will change from `AllowedButWarn` to `NotAllowed`. Code that currently triggers warnings will throw `InvalidServiceLocationException` after upgrading. See the [migration guide](/guide/migration.html) for how to prepare on 5.x.
+:::
+
 <!-- snippet: sample_configuring_servicelocationpolicy -->
 <a id='snippet-sample_configuring_servicelocationpolicy'></a>
 ```cs

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,5 +1,17 @@
 # Migration Guide
 
+## Coming in 6.0: ServiceLocationPolicy.NotAllowed becomes the default
+
+In Wolverine 6.0, `WolverineOptions.ServiceLocationPolicy` will default to `NotAllowed` instead of `AllowedButWarn`. Apps that currently rely on Wolverine's code generation falling back to service location at runtime will throw `InvalidServiceLocationException` on startup after upgrading.
+
+To prepare while still on 5.x:
+
+1. Run your app with `Warning`-level (or lower) logging on the `Wolverine` category. Look for log messages starting with `Utilizing service location for ...`.
+2. For each one, either register the service in DI in a way that the codegen can resolve through constructor injection, or — if it genuinely must be service-located — opt in explicitly with `opts.CodeGeneration.AlwaysUseServiceLocationFor<T>()`.
+3. Once the warnings are gone, you can set `opts.ServiceLocationPolicy = ServiceLocationPolicy.NotAllowed` to assert the absence going forward.
+
+See [Code Generation](/guide/codegen.html) for details.
+
 ## Key Changes in 5.0
 
 5.0 had very few breaking changes in the public API, but some in "publinternals" types most users would never touch. The

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+dotnet = "9.0"

--- a/src/Http/Wolverine.Http.Tests/CodeGeneration/service_location_assertions.cs
+++ b/src/Http/Wolverine.Http.Tests/CodeGeneration/service_location_assertions.cs
@@ -129,11 +129,12 @@ public class service_location_assertions
             new ServiceLocationReport(descriptor1, "Because I said so!"),
             new ServiceLocationReport(descripter2, "I didn't like this one")
         };
-        
+
         theChain.AssertServiceLocationsAreAllowed(reports, services);
-        
-        // Don't even bother to log anything if we're AlwaysAllowed
+
         theLogger.Messages.Count.ShouldBe(2);
+        theLogger.Messages.ShouldAllBe(m => m.Contains("Wolverine 6.0"));
+        theLogger.Levels.ShouldAllBe(l => l == LogLevel.Warning);
     }
 
     [Fact]
@@ -147,10 +148,12 @@ public class service_location_assertions
             new ServiceLocationReport(descripter2, "I didn't like this one")
         };
 
-        Should.Throw<InvalidServiceLocationException>(() =>
+        var ex = Should.Throw<InvalidServiceLocationException>(() =>
         {
             theChain.AssertServiceLocationsAreAllowed(reports, services);
         });
+
+        ex.Message.ShouldContain("Wolverine 6.0");
     }
     
     [Theory]
@@ -307,10 +310,11 @@ public static class UseWidgetHandler
 public class RecordingLogger : ILoggerFactory, ILogger
 {
     public List<string> Messages { get; } = new();
-    
+    public List<LogLevel> Levels { get; } = new();
+
     public void Dispose()
     {
-        
+
     }
 
     public void AddProvider(ILoggerProvider provider)
@@ -336,6 +340,7 @@ public class RecordingLogger : ILoggerFactory, ILogger
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
         Messages.Add(formatter(state, exception));
+        Levels.Add(logLevel);
     }
 }
 

--- a/src/Wolverine/Configuration/Chain.cs
+++ b/src/Wolverine/Configuration/Chain.cs
@@ -476,11 +476,11 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
                 {
                     if (report.ServiceDescriptor.IsKeyedService)
                     {
-                        logger.LogInformation("Utilizing service location for {Chain} for Service {ServiceType} ({Key}): {Reason}. See https://wolverinefx.net/guide/codegen.html", Description, report.ServiceDescriptor.ServiceType, report.ServiceDescriptor.ServiceKey, report.Reason);
+                        logger.LogWarning("Utilizing service location for {Chain} for Service {ServiceType} ({Key}): {Reason}. This will throw in Wolverine 6.0 when ServiceLocationPolicy.NotAllowed becomes the default. See https://wolverinefx.net/guide/codegen.html", Description, report.ServiceDescriptor.ServiceType, report.ServiceDescriptor.ServiceKey, report.Reason);
                     }
                     else
                     {
-                        logger.LogInformation("Utilizing service location for {Chain} for Service {ServiceType}: {Reason}. See https://wolverinefx.net/guide/codegen.html", Description, report.ServiceDescriptor.ServiceType, report.Reason);
+                        logger.LogWarning("Utilizing service location for {Chain} for Service {ServiceType}: {Reason}. This will throw in Wolverine 6.0 when ServiceLocationPolicy.NotAllowed becomes the default. See https://wolverinefx.net/guide/codegen.html", Description, report.ServiceDescriptor.ServiceType, report.Reason);
                     }
                 }
                 break;
@@ -501,7 +501,7 @@ public class InvalidServiceLocationException : Exception
     public static string ToMessage(IChain chain, ServiceLocationReport[] reports)
     {
         var writer = new StringWriter();
-        writer.WriteLine($"Found service locations while generating code for {chain.Description}, but the policy is configured as {nameof(WolverineOptions)}.{nameof(WolverineOptions.ServiceLocationPolicy)} = {ServiceLocationPolicy.NotAllowed}");
+        writer.WriteLine($"Found service locations while generating code for {chain.Description}, but {nameof(ServiceLocationPolicy)}.{nameof(ServiceLocationPolicy.NotAllowed)} is in effect (this will become the default in Wolverine 6.0).");
         writer.WriteLine("See https://wolverinefx.net/guide/codegen.html for more information");
         writer.WriteLine("Service location(s):");
         foreach (var report in reports)


### PR DESCRIPTION
Refs #2584 — preparation only; **does not close the issue**. The actual flip of `WolverineOptions.ServiceLocationPolicy` from `AllowedButWarn` to `NotAllowed` is the 6.0
cut-over and will be a separate PR against the 6.0 line. This PR lands on 5.x to give upgrading users runway.

## Summary

- Flag the upcoming 6.0 default change in the existing per-report warning in `Chain.AssertServiceLocationsAreAllowed` and bump the level from `Information` to `Warning` so
production logs surface it.
- Reframe the `InvalidServiceLocationException` preamble so it reads naturally on both 5.x (where users opt in to `NotAllowed` explicitly) and 6.0 (where it will be the
default).
- Add a "Coming in 6.0" entry to `docs/guide/migration.md` and a Vitepress `:::warning` callout in `docs/guide/codegen.md`, both pointing at the existing
`AlwaysUseServiceLocationFor<T>()` opt-in for cases that genuinely need service location.

## What this PR does NOT change

- `WolverineOptions.ServiceLocationPolicy` still defaults to `AllowedButWarn` on 5.x.
- `src/Testing/CoreTests/WolverineOptionsTests.cs:46` (the default-value assertion) is unchanged and still passes.
- `src/Samples/DocumentationSamples/ServiceLocationUsage.cs` doc sample comment ("This is the default behavior") still sits on the `AllowedButWarn` line.

Those three pieces are the entirety of the future 6.0 cut-over PR.
