### PR TITLE
RavenDb  - Disable optimistic concurrency on cluster-wide node sessions

### DIFF
--- a/src/Persistence/RavenDbTests/message_store_compliance.cs
+++ b/src/Persistence/RavenDbTests/message_store_compliance.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Hosting;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
 using Raven.Embedded;
 using Raven.TestDriver;
 using Shouldly;
@@ -126,6 +128,44 @@ public class message_store_compliance : MessageStoreCompliance
         {
             await thePersistence.Inbox.StoreIncomingAsync(new[] { envelope, envelope });
         });
+    }
+
+    [Fact]
+    public async Task node_persistence_works_when_store_has_optimistic_concurrency_enabled()
+    {
+        // Node-agent persistence has two failure modes when the consumer enables optimistic
+        // concurrency on the document store:
+        //   1. PersistAsync and PersistAgentRestrictionsAsync use cluster-wide transactions,
+        //      which RavenDB rejects in combination with optimistic concurrency.
+        //   2. AddAssignmentAsync and AssignAgentsAsync used to write a brand-new
+        //      agent-assignment document by id, which fails when re-electing an agent
+        //      whose document still exists from a prior run.
+        using var optimisticStore = new DocumentStore
+        {
+            Urls = _store.Urls,
+            Database = "wolverine-optimistic-concurrency-test-" + Guid.NewGuid()
+        };
+        optimisticStore.Conventions.UseOptimisticConcurrency = true;
+        optimisticStore.Initialize();
+        await optimisticStore.Maintenance.Server.SendAsync(
+            new CreateDatabaseOperation(new DatabaseRecord(optimisticStore.Database)));
+
+        var ravenStore = new RavenDbMessageStore(optimisticStore, new WolverineOptions());
+
+        var node = new Wolverine.Runtime.Agents.WolverineNode { NodeId = Guid.NewGuid() };
+        var assigned = await ravenStore.PersistAsync(node, CancellationToken.None);
+        assigned.ShouldBe(1);
+
+        await ravenStore.PersistAgentRestrictionsAsync(
+            new[] { new Wolverine.Runtime.Agents.AgentRestriction(Guid.NewGuid(), new Uri("wolverine://test"), Wolverine.Runtime.Agents.AgentRestrictionType.Pinned, 1) },
+            CancellationToken.None);
+
+        // Re-adding the same assignment must succeed — assignments are idempotent.
+        var agentUri = new Uri("wolverine://agents/leader");
+        await ravenStore.AddAssignmentAsync(node.NodeId, agentUri, CancellationToken.None);
+        await ravenStore.AddAssignmentAsync(node.NodeId, agentUri, CancellationToken.None);
+
+        await ravenStore.AssignAgentsAsync(node.NodeId, new[] { agentUri }, CancellationToken.None);
     }
 
 

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.NodeAgents.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.NodeAgents.cs
@@ -33,6 +33,9 @@ public partial class RavenDbMessageStore : INodeAgentPersistence
         {
             TransactionMode = TransactionMode.ClusterWide
         });
+        // RavenDB rejects cluster-wide transactions combined with optimistic concurrency.
+        // Disable it explicitly so a consumer-enabled convention doesn't break this session.
+        session.Advanced.UseOptimisticConcurrency = false;
 
         var sequence = await session.LoadAsync<NodeSequence>(NodeSequence.SequenceId, cancellationToken);
         sequence ??= new NodeSequence();
@@ -104,6 +107,8 @@ public partial class RavenDbMessageStore : INodeAgentPersistence
         {
             TransactionMode = TransactionMode.ClusterWide
         });
+        // Cluster-wide transactions can't run with optimistic concurrency. See PersistAsync.
+        session.Advanced.UseOptimisticConcurrency = false;
 
         foreach (var restriction in restrictions)
         {
@@ -159,10 +164,21 @@ public partial class RavenDbMessageStore : INodeAgentPersistence
     public async Task AssignAgentsAsync(Guid nodeId, IReadOnlyList<Uri> agents, CancellationToken cancellationToken)
     {
         using var session = _store.OpenAsyncSession();
+        // Agent assignments are idempotent: a re-assignment should overwrite the existing
+        // record. Load first so RavenDB uses the loaded change vector at save time and the
+        // write works whether or not the consumer has optimistic concurrency enabled.
         foreach (var agent in agents)
         {
-            var agentAssignment = new AgentAssignment(agent, nodeId);
-            await session.StoreAsync(agentAssignment, cancellationToken);
+            var id = AgentAssignment.ToId(agent);
+            var existing = await session.LoadAsync<AgentAssignment>(id, cancellationToken);
+            if (existing == null)
+            {
+                await session.StoreAsync(new AgentAssignment(agent, nodeId), id, cancellationToken);
+            }
+            else
+            {
+                existing.NodeId = nodeId;
+            }
         }
 
         await session.SaveChangesAsync(token: cancellationToken);
@@ -180,8 +196,19 @@ public partial class RavenDbMessageStore : INodeAgentPersistence
     {
         using var session = _store.OpenAsyncSession();
 
-        var agentAssignment = new AgentAssignment(agentUri, nodeId);
-        await session.StoreAsync(agentAssignment, agentAssignment.Id, cancellationToken);
+        // Agent assignments are idempotent: re-electing the same agent should overwrite the
+        // existing record. Load first so RavenDB uses the loaded change vector at save time
+        // instead of trying to write a brand-new document over an existing one.
+        var id = AgentAssignment.ToId(agentUri);
+        var existing = await session.LoadAsync<AgentAssignment>(id, cancellationToken);
+        if (existing == null)
+        {
+            await session.StoreAsync(new AgentAssignment(agentUri, nodeId), id, cancellationToken);
+        }
+        else
+        {
+            existing.NodeId = nodeId;
+        }
 
         await session.SaveChangesAsync(token: cancellationToken);
     }


### PR DESCRIPTION
## Overview

When a consumer enables `Conventions.UseOptimisticConcurrency = true` on their RavenDB document store, Wolverine's node-agent persistence breaks in two places during normal startup / leadership flow.

## Root cause

1. `PersistAsync` and `PersistAgentRestrictionsAsync` use cluster-wide transactions, which RavenDB rejects in combination with optimistic concurrency (`NotSupportedException` at `SaveChanges`)
2. `AddAssignmentAsync` and `AssignAgentsAsync` were using  `StoreAsync(entity, id)` with no change vector. This caused them to fail with concurrency errors when re-electing an agent whose assignment document already exists from a prior run.

## Fix

Cluster-wide sessions explicitly set `session.Advanced.UseOptimisticConcurrency = false` after opening, regardless of whatever default was set on the document store since this is a hard constraint in RavenDb.

Agent-assignment writes load the document first and mutate it in place if it already exists, so RavenDB uses the loaded change vector at save time.