### PR TITLE
Introduce WolverineFx.RuntimeCompilation opt-in package (#1577)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,9 +28,9 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="1.26.0" />
+    <PackageVersion Include="JasperFx" Version="1.28.0" />
     <PackageVersion Include="JasperFx.Events" Version="1.29.0" />
-    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.4.0" />
+    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.5.0" />
     <PackageVersion Include="JasperFx.SourceGeneration" Version="1.1.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
     <PackageVersion Include="Marten" Version="8.32.0" />

--- a/src/Http/Wolverine.Http/HttpChain.EndpointBuilder.cs
+++ b/src/Http/Wolverine.Http/HttpChain.EndpointBuilder.cs
@@ -2,7 +2,6 @@ using System.Reflection;
 using JasperFx.CodeGeneration;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
-using JasperFx.RuntimeCompiler;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;

--- a/src/Testing/CoreTests/Configuration/runtime_compilation_extension.cs
+++ b/src/Testing/CoreTests/Configuration/runtime_compilation_extension.cs
@@ -1,0 +1,69 @@
+using JasperFx.CodeGeneration;
+using JasperFx.RuntimeCompiler;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+public class runtime_compilation_extension
+{
+    [Fact]
+    public async Task use_runtime_compilation_registers_assembly_generator()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRuntimeCompilation();
+            }).StartAsync();
+
+        var generator = host.Services.GetService<IAssemblyGenerator>();
+        generator.ShouldNotBeNull();
+        generator.ShouldBeOfType<AssemblyGenerator>();
+    }
+
+    [Fact]
+    public async Task use_runtime_compilation_is_idempotent()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRuntimeCompilation();
+                opts.UseRuntimeCompilation();
+                opts.UseRuntimeCompilation();
+            }).StartAsync();
+
+        // Should resolve a single registered instance and not throw at startup
+        var generator = host.Services.GetService<IAssemblyGenerator>();
+        generator.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void add_wolverine_runtime_compilation_registers_assembly_generator_directly_on_services()
+    {
+        var services = new ServiceCollection();
+
+        services.AddWolverineRuntimeCompilation();
+
+        var provider = services.BuildServiceProvider();
+        var generator = provider.GetService<IAssemblyGenerator>();
+
+        generator.ShouldNotBeNull();
+        generator.ShouldBeOfType<AssemblyGenerator>();
+    }
+
+    [Fact]
+    public void add_wolverine_runtime_compilation_does_not_replace_an_existing_registration()
+    {
+        var services = new ServiceCollection();
+        var existing = new AssemblyGenerator { AssemblyName = "Custom" };
+        services.AddSingleton<IAssemblyGenerator>(existing);
+
+        services.AddWolverineRuntimeCompilation();
+
+        var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IAssemblyGenerator>().ShouldBeSameAs(existing);
+    }
+}

--- a/src/Testing/CoreTests/CoreTests.csproj
+++ b/src/Testing/CoreTests/CoreTests.csproj
@@ -22,6 +22,7 @@
         <ProjectReference Include="..\OrderExtension\OrderExtension.csproj"/>
         <ProjectReference Include="..\Module1\Module1.csproj"/>
         <ProjectReference Include="..\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj" />
+        <ProjectReference Include="..\..\Wolverine.RuntimeCompilation\Wolverine.RuntimeCompilation.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
@@ -3,7 +3,6 @@ using Grpc.AspNetCore.Server;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
-using JasperFx.RuntimeCompiler;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Wolverine.RuntimeCompilation/RuntimeCompilationExtensions.cs
+++ b/src/Wolverine.RuntimeCompilation/RuntimeCompilationExtensions.cs
@@ -1,0 +1,62 @@
+using JasperFx.CodeGeneration;
+using JasperFx.RuntimeCompiler;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Wolverine;
+
+/// <summary>
+/// Opt-in extension methods that enable runtime Roslyn compilation of Wolverine
+/// generated code. Add the <c>WolverineFx.RuntimeCompilation</c> package and call
+/// <see cref="UseRuntimeCompilation"/> from <c>UseWolverine(...)</c> if your
+/// application uses <see cref="JasperFx.CodeGeneration.TypeLoadMode.Dynamic"/>
+/// or <see cref="JasperFx.CodeGeneration.TypeLoadMode.Auto"/> mode (the
+/// development defaults), OR if you pre-generate code with
+/// <see cref="JasperFx.CodeGeneration.TypeLoadMode.Static"/> but want a fallback
+/// to runtime compilation for missing files.
+/// <para>
+/// Production deployments that pre-generate ALL code with
+/// <see cref="JasperFx.CodeGeneration.TypeLoadMode.Static"/> do not need this
+/// package and can ship without Roslyn — smaller binaries, faster cold start,
+/// and AOT compatibility.
+/// </para>
+/// </summary>
+public static class RuntimeCompilationExtensions
+{
+    /// <summary>
+    /// Register the Roslyn-backed <see cref="IAssemblyGenerator"/>
+    /// (<see cref="AssemblyGenerator"/>) so Wolverine can compile generated
+    /// handler/middleware code at runtime. Required when running with
+    /// <see cref="JasperFx.CodeGeneration.TypeLoadMode.Dynamic"/> mode or when
+    /// <see cref="JasperFx.CodeGeneration.TypeLoadMode.Auto"/>/<see cref="JasperFx.CodeGeneration.TypeLoadMode.Static"/>
+    /// fall back to compilation because pre-generated code is missing.
+    /// <para>
+    /// Idempotent — safe to call multiple times. If <see cref="IAssemblyGenerator"/>
+    /// is already registered, this is a no-op.
+    /// </para>
+    /// </summary>
+    /// <param name="options">The Wolverine options being configured.</param>
+    /// <returns>The same <paramref name="options"/> for chaining.</returns>
+    public static WolverineOptions UseRuntimeCompilation(this WolverineOptions options)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+
+        options.Services.TryAddSingleton<IAssemblyGenerator, AssemblyGenerator>();
+
+        return options;
+    }
+
+    /// <summary>
+    /// Convenience overload that registers <see cref="IAssemblyGenerator"/>
+    /// directly on an <see cref="IServiceCollection"/> for advanced scenarios
+    /// where the registration must happen outside of <c>UseWolverine(...)</c>.
+    /// </summary>
+    public static IServiceCollection AddWolverineRuntimeCompilation(this IServiceCollection services)
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
+
+        services.TryAddSingleton<IAssemblyGenerator, AssemblyGenerator>();
+
+        return services;
+    }
+}

--- a/src/Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj
+++ b/src/Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <Description>Opt-in runtime Roslyn compilation support for Wolverine. Add this package and call opts.UseRuntimeCompilation() to enable on-the-fly handler/middleware code generation in development mode. Production deployments that pre-generate code (TypeLoadMode.Static) do not need this package and ship without Roslyn — smaller binaries, faster cold starts, and AOT-readiness. See issue #1577.</Description>
+        <PackageId>WolverineFx.RuntimeCompilation</PackageId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="JasperFx.RuntimeCompiler" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Wolverine\Wolverine.csproj" />
+    </ItemGroup>
+
+    <Import Project="../../Analysis.Build.props" />
+</Project>

--- a/src/Wolverine/HostBuilderExtensions.cs
+++ b/src/Wolverine/HostBuilderExtensions.cs
@@ -101,6 +101,15 @@ public static class HostBuilderExtensions
 
         services.AddJasperFx();
         services.AddSingleton<MessageStoreCollection>();
+        // NOTE: this default registration is preserved in v5.x for backward compatibility
+        // so existing apps that rely on Wolverine compiling handler/middleware code at
+        // runtime continue to work without additional configuration. In v6, this line is
+        // expected to be removed: applications using TypeLoadMode.Dynamic / Auto fallback
+        // will need to install the WolverineFx.RuntimeCompilation package and call
+        // opts.UseRuntimeCompilation() inside UseWolverine(...). Production deployments
+        // that pre-generate code with TypeLoadMode.Static will then be able to ship
+        // without Roslyn at all (smaller binaries, faster cold start, AOT-readiness).
+        // See issue #1577 for the full cold-start optimization roadmap.
         services.AddSingleton<IAssemblyGenerator, AssemblyGenerator>();
 
         services.AddSingleton(typeof(AncillaryMessageStoreApplication<>));

--- a/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
@@ -6,7 +6,6 @@ using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
-using JasperFx.RuntimeCompiler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -301,4 +301,5 @@
     <Build Project="false" />
   </Project>
   <Project Path="src/Wolverine/Wolverine.csproj" />
+  <Project Path="src/Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

Step toward making `JasperFx.RuntimeCompiler` (and through it, Roslyn) a development-time-only dependency for Wolverine apps that pre-generate code with `TypeLoadMode.Static`. **Non-breaking on v5.x** — existing apps keep working without changes; the new package is opt-in and the cleanup of the default registration is a v6 concern.

This builds on the JasperFx-side split (jasperfx#194 / JasperFx 1.28 / JasperFx.RuntimeCompiler 4.5) which moved the code-generation orchestration extensions (`Initialize` / `InitializeSynchronously` / `WriteCodeFile`) from the `JasperFx.RuntimeCompiler` namespace into `JasperFx.CodeGeneration` and removed the silent \"`?? new AssemblyGenerator()`\" fallback.

## Changes

### Package version bump
- `JasperFx`: 1.26.0 → 1.28.0
- `JasperFx.RuntimeCompiler`: 4.4.0 → 4.5.0

### `using` migration (3 files)
Drop `using JasperFx.RuntimeCompiler;` from files that don't directly reference the `AssemblyGenerator` type. Calls to `InitializeSynchronously` / `Initialize` now resolve to the non-deprecated `JasperFx.CodeGeneration.CodeFileExtensions` methods:

- `src/Wolverine/Runtime/Handlers/HandlerGraph.cs`
- `src/Http/Wolverine.Http/HttpChain.EndpointBuilder.cs`
- `src/Wolverine.Grpc/WolverineGrpcExtensions.cs`

Build is clean with zero `CS0618` (obsolete-usage) warnings.

### New `WolverineFx.RuntimeCompilation` NuGet package
One project, two extension methods:

- `opts.UseRuntimeCompilation()` — registers `IAssemblyGenerator` inside `UseWolverine(...)`. Uses `TryAddSingleton`, so it is idempotent and safe to layer with other registrations.
- `services.AddWolverineRuntimeCompilation()` — the same registration on a raw `IServiceCollection` for advanced bootstrap scenarios.

```csharp
// New, future-facing API:
builder.Host.UseWolverine(opts =>
{
    opts.UseRuntimeCompilation();
    // ... rest of configuration
});
```

### v6 migration note in `HostBuilderExtensions.cs`
Added a comment above the existing default `services.AddSingleton<IAssemblyGenerator, AssemblyGenerator>()` registration explaining that the line is preserved for v5.x backward compatibility and is expected to be removed in v6, at which point apps using Dynamic / Auto code generation will need to install `WolverineFx.RuntimeCompilation` explicitly.

## Behavior contract

For v5.x, **nothing changes** for existing users:

| Scenario | v5.x behavior |
|----------|---------------|
| Default (no `UseRuntimeCompilation()`) | Works exactly as before — `IAssemblyGenerator` is still registered by `UseWolverine(...)`. |
| Add `WolverineFx.RuntimeCompilation` + call `UseRuntimeCompilation()` | Works — `TryAddSingleton` is a no-op since the default registration is already there. |
| User registered a custom `IAssemblyGenerator` | Their registration wins — neither the default nor `UseRuntimeCompilation` overwrites it. |

For v6, the default registration is expected to be removed and `WolverineFx.RuntimeCompilation` becomes mandatory for Dynamic / Auto modes (Static-mode pre-generated apps will run without Roslyn).

## Verification

- `Wolverine`, `Wolverine.Http`, `Wolverine.Grpc`, `Wolverine.RuntimeCompilation` all build clean on net9.0
- New `runtime_compilation_extension` test file: 4/4 pass
  - `use_runtime_compilation_registers_assembly_generator`
  - `use_runtime_compilation_is_idempotent`
  - `add_wolverine_runtime_compilation_registers_assembly_generator_directly_on_services`
  - `add_wolverine_runtime_compilation_does_not_replace_an_existing_registration`
- Full CoreTests suite: **1379/1379 pass** on net9.0

## Still pending (separate PRs)

- **v6 cleanup**: drop the default `IAssemblyGenerator` registration and the `JasperFx.RuntimeCompiler` `<PackageReference>` from `Wolverine.csproj`.
- **Marten coordination**: similar 4-file `using` migration plus a refactor of the direct `new AssemblyGenerator()` in `EventDocumentStorageGenerator.cs:47`.
- **Template + docs updates**: when users hit the v6 \"no IAssemblyGenerator\" error, they should land on a docs page pointing them at `opts.UseRuntimeCompilation()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)