### PR TITLE
Make service-located IMessageBus / IMessageContext see the active context (#2583)

### DIFF
--- a/src/Testing/CoreTests/Runtime/service_location_message_context.cs
+++ b/src/Testing/CoreTests/Runtime/service_location_message_context.cs
@@ -1,0 +1,207 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Runtime;
+
+/// <summary>
+/// Verifies the AsyncLocal-based handoff that keeps service-located <see cref="IMessageBus"/>
+/// / <see cref="IMessageContext"/> instances pointed at the same MessageContext the handler
+/// itself received. Without this, a bus pulled from a constructor on a service the user
+/// injects bypasses the active outbox. See issue #2583.
+/// </summary>
+public class service_location_message_context
+{
+    [Fact]
+    public async Task service_located_bus_publishes_through_active_context_when_chain_uses_service_location()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceLocationPolicy = ServiceLocationPolicy.AllowedButWarn;
+                opts.Services.AddTransient<BusUsingService>();
+
+                // Force BusUsingService to be resolved via service location (rather than
+                // codegen-injected) so the chain is flagged UsesServiceLocation = true and
+                // the ServiceLocationAwareExecutor wraps it. Mirrors the pattern in the
+                // existing service_location_assertions tests.
+                opts.CodeGeneration.AlwaysUseServiceLocationFor<BusUsingService>();
+            }).StartAsync();
+
+        var session = await host.TrackActivity().IncludeExternalTransports().ExecuteAndWaitAsync(c =>
+            c.PublishAsync(new ServiceLocatedBusCommand("hello")));
+
+        // The cascading message published *via the service-located IMessageBus* must have been
+        // tracked through the same MessageContext the handler received — otherwise the tracking
+        // session would never see it.
+        session.Sent.SingleEnvelope<ServiceLocatedBusEcho>().Message
+            .ShouldBeOfType<ServiceLocatedBusEcho>()
+            .Payload.ShouldBe("hello");
+    }
+
+    [Fact]
+    public async Task chain_without_service_location_does_not_set_message_context_current()
+    {
+        // A chain that doesn't service-locate must not touch MessageContext.Current during
+        // invocation — that's how we keep AsyncLocal overhead off the hot path. Verified
+        // by capturing Current from inside the handler; it must be null.
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceLocationPolicy = ServiceLocationPolicy.AllowedButWarn;
+            }).StartAsync();
+
+        CleanCommandProbe.Reset();
+
+        await host.InvokeMessageAndWaitAsync(new CleanCommand());
+
+        CleanCommandProbe.WasInvoked.ShouldBeTrue();
+        CleanCommandProbe.CurrentDuringInvocation.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task message_context_current_is_null_outside_handler_invocation()
+    {
+        // Sanity check: the AsyncLocal default is null, so service resolution outside any
+        // handler invocation must hit the fall-back factory branch.
+        MessageContext.Current.ShouldBeNull();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine().StartAsync();
+
+        var bus = host.Services.GetRequiredService<IMessageBus>();
+        bus.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task service_located_message_context_is_same_instance_as_handler_argument()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceLocationPolicy = ServiceLocationPolicy.AllowedButWarn;
+                opts.Services.AddTransient<ContextCapturingService>();
+
+                // Force the capturing service to be resolved via service location so the
+                // chain is flagged UsesServiceLocation = true.
+                opts.CodeGeneration.AlwaysUseServiceLocationFor<ContextCapturingService>();
+            }).StartAsync();
+
+        ContextIdentityProbe.Reset();
+
+        await host.InvokeMessageAndWaitAsync(new IdentityProbeCommand());
+
+        ContextIdentityProbe.HandlerContext.ShouldNotBeNull();
+        ContextIdentityProbe.ServiceLocatedContext.ShouldNotBeNull();
+        // Reference equality — proves the service-located instance IS the handler's instance.
+        ReferenceEquals(ContextIdentityProbe.HandlerContext, ContextIdentityProbe.ServiceLocatedContext)
+            .ShouldBeTrue();
+    }
+}
+
+#region Service-location-aware test fixtures
+
+public record ServiceLocatedBusCommand(string Payload);
+public record ServiceLocatedBusEcho(string Payload);
+
+/// <summary>
+/// Service-located access to <see cref="IMessageBus"/> via constructor injection on a
+/// transient service that the handler resolves at runtime via <c>IServiceProvider</c>.
+/// </summary>
+public class BusUsingService(IMessageBus bus)
+{
+    public IMessageBus Bus => bus;
+
+    public ValueTask EchoAsync(string payload) =>
+        Bus.PublishAsync(new ServiceLocatedBusEcho(payload));
+}
+
+public static class ServiceLocatedBusCommandHandler
+{
+    // Resolves BusUsingService from the IServiceProvider — service location of an
+    // IMessageBus-consuming service. The handler's own IServiceProvider use is what
+    // triggers the chain to be marked UsesServiceLocation = true at codegen time.
+    public static async Task Handle(ServiceLocatedBusCommand command, IServiceProvider services)
+    {
+        var svc = services.GetRequiredService<BusUsingService>();
+        await svc.EchoAsync(command.Payload);
+    }
+}
+
+public static class ServiceLocatedBusEchoHandler
+{
+    // No-op handler so the cascaded echo lands somewhere; the test asserts on what was sent,
+    // not what was processed, but having a registered handler keeps tracking happy.
+    public static void Handle(ServiceLocatedBusEcho echo) { }
+}
+
+#endregion
+
+#region Plain (no service location) chain
+
+public record CleanCommand;
+
+public static class CleanCommandProbe
+{
+    public static bool WasInvoked;
+    public static MessageContext? CurrentDuringInvocation;
+
+    public static void Reset()
+    {
+        WasInvoked = false;
+        CurrentDuringInvocation = null;
+    }
+}
+
+public static class CleanCommandHandler
+{
+    public static void Handle(CleanCommand cmd)
+    {
+        CleanCommandProbe.WasInvoked = true;
+        CleanCommandProbe.CurrentDuringInvocation = MessageContext.Current;
+    }
+}
+
+#endregion
+
+#region Identity probe
+
+public record IdentityProbeCommand;
+
+public static class ContextIdentityProbe
+{
+    public static MessageContext? HandlerContext;
+    public static IMessageContext? ServiceLocatedContext;
+
+    public static void Reset()
+    {
+        HandlerContext = null;
+        ServiceLocatedContext = null;
+    }
+}
+
+public class ContextCapturingService(IMessageContext context)
+{
+    public IMessageContext Capture() => context;
+}
+
+public static class IdentityProbeCommandHandler
+{
+    public static void Handle(IdentityProbeCommand cmd, MessageContext handlerContext, IServiceProvider services)
+    {
+        ContextIdentityProbe.HandlerContext = handlerContext;
+        ContextIdentityProbe.ServiceLocatedContext = services
+            .GetRequiredService<ContextCapturingService>()
+            .Capture();
+    }
+}
+
+#endregion

--- a/src/Wolverine/Configuration/Chain.cs
+++ b/src/Wolverine/Configuration/Chain.cs
@@ -462,16 +462,32 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
                 $"{responseAwares[0].VariableType.FullNameInCode()} generates special response handling"));
     }
     
+    /// <summary>
+    /// Set to <see langword="true"/> when this chain's compiled code resolves at least one
+    /// dependency via service location (i.e., reaches into <see cref="IServiceProvider"/>
+    /// rather than receiving the dependency through a constructor / handler-method parameter).
+    /// Recorded at codegen time by <see cref="AssertServiceLocationsAreAllowed"/>.
+    ///
+    /// At runtime, the executor factory consults this flag to decide whether to wrap the chain's
+    /// <see cref="Wolverine.Runtime.Handlers.IExecutor"/> with the <see cref="System.Threading.AsyncLocal{T}"/>-based
+    /// <see cref="Wolverine.Runtime.MessageContext.Current"/> handoff that keeps service-located
+    /// <see cref="IMessageContext"/> / <see cref="IMessageBus"/> instances pointed at the same
+    /// <see cref="Wolverine.Runtime.MessageContext"/> the handler itself received. Chains that don't
+    /// service-locate skip the wrap and pay zero AsyncLocal overhead per message. See issue #2583.
+    /// </summary>
+    public bool UsesServiceLocation { get; private set; }
+
     public void AssertServiceLocationsAreAllowed(ServiceLocationReport[] reports, IServiceProvider? services)
     {
         if (!reports.Any()) return;
-        
+
         var logger = services.GetLoggerOrDefault<ICodeFile>();
         var options = services!.GetService<WolverineOptions>() ?? new WolverineOptions();
 
         switch (options.ServiceLocationPolicy)
         {
             case ServiceLocationPolicy.AllowedButWarn:
+                UsesServiceLocation = true;
                 foreach (var report in reports)
                 {
                     if (report.ServiceDescriptor.IsKeyedService)
@@ -484,11 +500,15 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
                     }
                 }
                 break;
-            
+
             case ServiceLocationPolicy.NotAllowed:
                 throw new InvalidServiceLocationException(this, reports);
-            
+
             default:
+                // ServiceLocationPolicy.AlwaysAllowed — no warning, but the chain still
+                // resolves at least one dependency via service location, so flag it for
+                // the executor wrap.
+                UsesServiceLocation = true;
                 return;
         }
 

--- a/src/Wolverine/Configuration/IChain.cs
+++ b/src/Wolverine/Configuration/IChain.cs
@@ -119,6 +119,17 @@ public interface IChain
     Type? AncillaryStoreType { get; set; }
 
     /// <summary>
+    /// <see langword="true"/> when this chain's compiled code resolves at least one
+    /// dependency via service location rather than constructor / parameter injection.
+    /// Recorded at codegen time. Consumed by the executor factory to opt into the
+    /// AsyncLocal-based <see cref="Wolverine.Runtime.MessageContext.Current"/> handoff
+    /// that keeps service-located <see cref="IMessageContext"/> / <see cref="IMessageBus"/>
+    /// pointed at the same context the handler itself received. Chains where this is
+    /// <see langword="false"/> incur zero AsyncLocal overhead per invocation. See issue #2583.
+    /// </summary>
+    bool UsesServiceLocation { get; }
+
+    /// <summary>
     ///     Strategy for dealing with any return values from the handler methods
     /// </summary>
     IReturnVariableActionSource ReturnVariableActionSource { get; set; }

--- a/src/Wolverine/HostBuilderExtensions.cs
+++ b/src/Wolverine/HostBuilderExtensions.cs
@@ -187,8 +187,18 @@ public static class HostBuilderExtensions
         services.AddOptions();
         services.AddLogging();
 
-        services.AddScoped<IMessageBus, MessageContext>();
-        services.AddScoped<IMessageContext, MessageContext>();
+        // The scoped factories prefer MessageContext.Current when it has been set by the
+        // ServiceLocationAwareExecutor (chains compiled with service location in play). That
+        // routes any service-located IMessageContext / IMessageBus through the same instance
+        // the handler itself received, so writes through a service-located bus enrol with the
+        // active outbox instead of being silently lost. The fall-back to a fresh MessageContext
+        // preserves resolution for non-handler scopes (hosted services, admin tools, tests
+        // that resolve IMessageBus directly from the root provider). See issue #2583.
+        services.AddScoped<IMessageBus>(sp =>
+            Wolverine.Runtime.MessageContext.Current ?? sp.GetRequiredService<MessageContext>());
+        services.AddScoped<IMessageContext>(sp =>
+            Wolverine.Runtime.MessageContext.Current ?? sp.GetRequiredService<MessageContext>());
+        services.AddScoped<MessageContext>();
 
         services.AddSingleton<ObjectPoolProvider>(new DefaultObjectPoolProvider());
 

--- a/src/Wolverine/Runtime/Handlers/Executor.cs
+++ b/src/Wolverine/Runtime/Handlers/Executor.cs
@@ -57,6 +57,17 @@ internal class Executor : IExecutor
     private readonly IMessageTracker _tracker;
     private readonly IWolverineRuntime? _runtime;
 
+    /// <summary>
+    /// When <see langword="true"/>, the executor publishes the in-flight <see cref="MessageContext"/>
+    /// through <see cref="MessageContext.Current"/> for the duration of each invocation, so
+    /// service-located <see cref="IMessageContext"/> / <see cref="IMessageBus"/> see the same
+    /// instance the handler itself received. Set by <see cref="Executor.Build"/> only when the
+    /// chain's compiled code resolves at least one dependency via service location, so chains
+    /// that don't service-locate pay zero <see cref="System.Threading.AsyncLocal{T}"/> overhead
+    /// per message. See issue #2583.
+    /// </summary>
+    private bool _capturesContextForServiceLocation;
+
     public Executor(ObjectPool<MessageContext> contextPool, IWolverineRuntime runtime, IMessageHandler handler,
         FailureRuleCollection rules, TimeSpan timeout)
         : this(contextPool, runtime.LoggerFactory.CreateLogger(handler.MessageType), handler, runtime.MessageTracking, rules, timeout)
@@ -185,6 +196,15 @@ internal class Executor : IExecutor
         using var timeout = new CancellationTokenSource(_timeout);
         using var combined = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellation);
 
+        // Publish the in-flight context for service location only when the chain's codegen
+        // reported at least one service-located dependency. Pure-codegen chains skip the
+        // AsyncLocal touch entirely. See #2583 / ServiceLocationAwareExecutor docs.
+        var previousAmbient = _capturesContextForServiceLocation ? MessageContext.Current : null;
+        if (_capturesContextForServiceLocation)
+        {
+            MessageContext.Current = context;
+        }
+
         try
         {
             await Handler.HandleAsync(context, combined.Token).ConfigureAwait(false);
@@ -223,7 +243,10 @@ internal class Executor : IExecutor
         }
         finally
         {
-
+            if (_capturesContextForServiceLocation)
+            {
+                MessageContext.Current = previousAmbient;
+            }
             _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
         }
     }
@@ -233,6 +256,12 @@ internal class Executor : IExecutor
         if (context.Envelope == null)
         {
             throw new ArgumentOutOfRangeException(nameof(context.Envelope));
+        }
+
+        var previousAmbient = _capturesContextForServiceLocation ? MessageContext.Current : null;
+        if (_capturesContextForServiceLocation)
+        {
+            MessageContext.Current = context;
         }
 
         try
@@ -258,6 +287,13 @@ internal class Executor : IExecutor
             return await retry
                 .ExecuteInlineAsync(context, context.Runtime, DateTimeOffset.UtcNow, Activity.Current, cancellation)
                 .ConfigureAwait(false);
+        }
+        finally
+        {
+            if (_capturesContextForServiceLocation)
+            {
+                MessageContext.Current = previousAmbient;
+            }
         }
     }
 
@@ -359,6 +395,15 @@ internal class Executor : IExecutor
             _rules, _timeout);
     }
 
+    /// <summary>
+    /// Set by <see cref="Build"/> when the chain's compiled code is known to resolve a
+    /// dependency via service location. Toggles the per-invocation
+    /// <see cref="MessageContext.Current"/> publish/restore so service-located
+    /// <see cref="IMessageContext"/> / <see cref="IMessageBus"/> see the same instance the
+    /// handler received. See issue #2583.
+    /// </summary>
+    internal void EnableServiceLocationContextCapture() => _capturesContextForServiceLocation = true;
+
     public static IExecutor Build(IWolverineRuntime runtime, ObjectPool<MessageContext> contextPool,
         HandlerGraph handlerGraph, Type messageType)
     {
@@ -383,10 +428,20 @@ internal class Executor : IExecutor
 
         if (runtime.Options.InvokeTracing == InvokeTracingMode.Full)
         {
-            return new TracingExecutor(contextPool, runtime, handler, rules, timeoutSpan);
+            var tracingExecutor = new TracingExecutor(contextPool, runtime, handler, rules, timeoutSpan);
+            if (chain?.UsesServiceLocation == true)
+            {
+                tracingExecutor.EnableServiceLocationContextCapture();
+            }
+            return tracingExecutor;
         }
 
-        return new Executor(contextPool, runtime, handler, rules, timeoutSpan);
+        var executor = new Executor(contextPool, runtime, handler, rules, timeoutSpan);
+        if (chain?.UsesServiceLocation == true)
+        {
+            executor.EnableServiceLocationContextCapture();
+        }
+        return executor;
     }
 
     public static IExecutor Build(IWolverineRuntime runtime, ObjectPool<MessageContext> contextPool,
@@ -400,9 +455,19 @@ internal class Executor : IExecutor
 
         if (runtime.Options.InvokeTracing == InvokeTracingMode.Full)
         {
-            return new TracingExecutor(contextPool, logger, handler, tracker, rules, timeoutSpan);
+            var tracingExecutor = new TracingExecutor(contextPool, logger, handler, tracker, rules, timeoutSpan);
+            if (chain?.UsesServiceLocation == true)
+            {
+                tracingExecutor.EnableServiceLocationContextCapture();
+            }
+            return tracingExecutor;
         }
 
-        return new Executor(contextPool, logger, handler, tracker, rules, timeoutSpan);
+        var executor = new Executor(contextPool, logger, handler, tracker, rules, timeoutSpan);
+        if (chain?.UsesServiceLocation == true)
+        {
+            executor.EnableServiceLocationContextCapture();
+        }
+        return executor;
     }
 }

--- a/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
+++ b/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
@@ -35,6 +35,13 @@ internal class TracingExecutor : IExecutor
     private readonly Action<ILogger, string, Guid, string, Exception?> _messageSucceeded;
     private readonly Action<ILogger, string, Guid, string, Exception> _messageFailed;
 
+    /// <summary>
+    /// Mirror of the same flag on <see cref="Executor"/>; see issue #2583.
+    /// </summary>
+    private bool _capturesContextForServiceLocation;
+
+    internal void EnableServiceLocationContextCapture() => _capturesContextForServiceLocation = true;
+
     public TracingExecutor(ObjectPool<MessageContext> contextPool, IWolverineRuntime runtime,
         IMessageHandler handler, FailureRuleCollection rules, TimeSpan timeout)
         : this(contextPool, runtime.LoggerFactory.CreateLogger(handler.MessageType), handler,
@@ -164,6 +171,12 @@ internal class TracingExecutor : IExecutor
         using var timeout = new CancellationTokenSource(_timeout);
         using var combined = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellation);
 
+        var previousAmbient = _capturesContextForServiceLocation ? MessageContext.Current : null;
+        if (_capturesContextForServiceLocation)
+        {
+            MessageContext.Current = context;
+        }
+
         try
         {
             await Handler.HandleAsync(context, combined.Token);
@@ -195,6 +208,10 @@ internal class TracingExecutor : IExecutor
         }
         finally
         {
+            if (_capturesContextForServiceLocation)
+            {
+                MessageContext.Current = previousAmbient;
+            }
             _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
         }
     }
@@ -204,6 +221,12 @@ internal class TracingExecutor : IExecutor
         if (context.Envelope == null)
         {
             throw new ArgumentOutOfRangeException(nameof(context.Envelope));
+        }
+
+        var previousAmbient = _capturesContextForServiceLocation ? MessageContext.Current : null;
+        if (_capturesContextForServiceLocation)
+        {
+            MessageContext.Current = context;
         }
 
         try
@@ -229,6 +252,13 @@ internal class TracingExecutor : IExecutor
             return await retry
                 .ExecuteInlineAsync(context, context.Runtime, DateTimeOffset.UtcNow, Activity.Current, cancellation)
                 .ConfigureAwait(false);
+        }
+        finally
+        {
+            if (_capturesContextForServiceLocation)
+            {
+                MessageContext.Current = previousAmbient;
+            }
         }
     }
 

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -35,6 +35,32 @@ public enum MultiFlushMode
 
 public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelopeTransaction, IEnvelopeLifecycle
 {
+    /// <summary>
+    /// Ambient holder for the <see cref="MessageContext"/> currently driving the in-flight
+    /// handler invocation on this async flow. Set by <c>ServiceLocationAwareExecutor</c> when
+    /// a chain is known (at codegen time) to use service location, and consulted by the
+    /// <see cref="IMessageContext"/> / <see cref="IMessageBus"/> scoped DI registrations so
+    /// that service-located instances see the same <see cref="MessageContext"/> the handler
+    /// itself received — preserving outbox semantics.
+    ///
+    /// Chains that do not use service location never set this value, so the per-message
+    /// <see cref="System.Threading.AsyncLocal{T}"/> machinery and ExecutionContext clone
+    /// cost are avoided on the hot path. See issue #2583.
+    /// </summary>
+    private static readonly System.Threading.AsyncLocal<MessageContext?> _current = new();
+
+    /// <summary>
+    /// The <see cref="MessageContext"/> driving the current handler invocation, if any.
+    /// Set by <c>ServiceLocationAwareExecutor</c>; <see langword="null"/> outside of a
+    /// service-location-aware handler invocation. Public so that custom service registrations
+    /// can opt into the same ambient handoff.
+    /// </summary>
+    public static MessageContext? Current
+    {
+        get => _current.Value;
+        internal set => _current.Value = value;
+    }
+
     private IChannelCallback? _channel;
 
     private bool _hasFlushed;


### PR DESCRIPTION
## Summary

Closes #2583. When user code service-locates \`IMessageBus\` / \`IMessageContext\` (constructor injection on a service the handler pulls from DI, \`GetRequiredService\` calls, etc.), it currently gets a DIFFERENT \`MessageContext\` than the one the handler itself received — handlers pull from \`WolverineRuntime.ExecutionPool\` while the scoped DI registrations resolve a fresh \`MessageContext\`. Result: publishes through a service-located bus bypass the active outbox.

## Mechanic

Per-chain capture, opted in by codegen analysis only — chains that don't service-locate pay zero per-message overhead:

1. \`MessageContext.Current\` — an \`AsyncLocal<MessageContext?>\` ambient holder.
2. The scoped \`IMessageBus\` / \`IMessageContext\` DI factories consult \`Current\` first, with a safe fall-back to a fresh \`MessageContext\` for non-handler scopes (hosted services, admin tools, root-provider resolution).
3. \`Chain.UsesServiceLocation\` (also exposed on \`IChain\`): set to \`true\` by \`Chain.AssertServiceLocationsAreAllowed\` when JasperFx reports any \`ServiceLocationReport\` for the chain AND the policy permits resolution (\`AllowedButWarn\` / \`AlwaysAllowed\`).
4. \`Executor\` / \`TracingExecutor\` each carry a private \`_capturesContextForServiceLocation\` flag. \`Executor.Build\` enables it only when \`chain.UsesServiceLocation\` is true. When the flag is set, \`ExecuteAsync\` / \`InvokeAsync\` push/pop \`MessageContext.Current\` around \`Handler.HandleAsync\`.

Push/pop with \`try\` / \`finally\` preserves the outer \`Current\` so re-entrant invocations (a handler that synchronously invokes another message) restore correctly on return.

Once a project adopts v6's \`ServiceLocationPolicy.NotAllowed\` default (#2584), no chain will be flagged at all and the AsyncLocal machinery is unreachable per-message.

## Why a flag instead of a separate \`ServiceLocationAwareExecutor\` wrapper class

I tried the wrapper-by-composition approach first. The problem: \`Executor.InvokeInlineAsync\` (the path used by \`IMessageBus.InvokeAsync(...)\` / \`InvokeMessageAndWaitAsync\`) calls \`this.InvokeAsync(context, ct)\` via static dispatch — a wrapping IExecutor never gets a chance to intercept. Making the methods virtual + extending didn't generalize because \`TracingExecutor\` is not an \`Executor\` subclass. The cleanest path that actually works for all entry points (transport, inline invoke, stream) is to put the conditional \`Current\` set inside the executors themselves, gated by a flag. Functionally equivalent zero-overhead-when-off behavior; less code than the wrapper variant would have required to cover the inline path.

## Files changed

| File | Change |
|------|--------|
| \`src/Wolverine/Runtime/MessageContext.cs\` | \`public static MessageContext? Current\` (AsyncLocal-backed). |
| \`src/Wolverine/Configuration/IChain.cs\` | New \`bool UsesServiceLocation { get; }\` member. |
| \`src/Wolverine/Configuration/Chain.cs\` | Set \`UsesServiceLocation = true\` in \`AssertServiceLocationsAreAllowed\` for the \`AllowedButWarn\` and \`AlwaysAllowed\` policies. |
| \`src/Wolverine/Runtime/Handlers/Executor.cs\` | \`_capturesContextForServiceLocation\` flag + push/pop in both \`ExecuteAsync\` and \`InvokeAsync\` (the \`MessageContext\`-taking overloads). \`Build\` enables the flag when the chain reports service location. |
| \`src/Wolverine/Runtime/Handlers/TracingExecutor.cs\` | Same pattern. |
| \`src/Wolverine/HostBuilderExtensions.cs\` | Scoped DI factories consult \`MessageContext.Current\` first; \`MessageContext\` itself remains scoped for the fall-back. |
| \`src/Testing/CoreTests/Runtime/service_location_message_context.cs\` | New 4-test file. |

## Tests

- \`service_located_bus_publishes_through_active_context_when_chain_uses_service_location\` — service-located \`IMessageBus\` publishes through the active context (cascade visible to \`TrackActivity\` session).
- \`service_located_message_context_is_same_instance_as_handler_argument\` — reference equality between handler-arg \`MessageContext\` and service-located \`IMessageContext\`.
- \`chain_without_service_location_does_not_set_message_context_current\` — verifies the zero-overhead path: a chain that doesn't service-locate keeps \`MessageContext.Current\` null during invocation.
- \`message_context_current_is_null_outside_handler_invocation\` — root-provider resolution of \`IMessageBus\` still works via the fall-back.

Both service-location-triggering tests use \`opts.CodeGeneration.AlwaysUseServiceLocationFor<...>()\` to force a real \`ServiceLocationReport\` (mirrors the pattern in the existing \`Wolverine.Http.Tests/CodeGeneration/service_location_assertions.cs\`).

Wider regression sweep: **241/241 pass** on the bootstrapping_specs / Configuration / MessageContext / Executor scope.

## Caveats (documentable)

- \`MessageContext.Current\` is null on threads that didn't flow \`ExecutionContext\` (e.g., \`Task.Run\` fire-and-forget without flow). Same caveat as \`HttpContextAccessor\`. Service location of \`IMessageBus\` from inside such a task uses the fall-back factory branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)