### PR TITLE
fix(MessageBus): preserve per-message Envelope.Source instead of clob…

### DIFF
--- a/src/Testing/CoreTests/Runtime/MessageContextTests.cs
+++ b/src/Testing/CoreTests/Runtime/MessageContextTests.cs
@@ -128,6 +128,11 @@ public class MessageContextTests
     [Fact]
     public void track_envelope_correlation()
     {
+        // Source is preserved when already set on the envelope (see
+        // track_envelope_correlation_does_not_override_existing_source);
+        // clear it here so the ServiceName fallback path is exercised.
+        theEnvelope.Source = null;
+
         using var activity = new Activity("DoWork");
         activity.Start();
 
@@ -186,6 +191,36 @@ public class MessageContextTests
         theContext.TrackEnvelopeCorrelation(theEnvelope, activity);
 
         theEnvelope.UserName.ShouldBe("envelopeuser");
+    }
+
+    [Fact]
+    public void track_envelope_correlation_does_not_override_existing_source()
+    {
+        // A CustomizeOutgoingMessagesOfType<T> rule (or any per-message
+        // DeliveryOptions override) may have already set Source — for example
+        // when publishing CloudEvents and the producer needs a spec-valid
+        // per-message `source` URI. The framework must not clobber it.
+        theEnvelope.Source = "https://api.example.com/users/123";
+
+        using var activity = new Activity("DoWork");
+        activity.Start();
+
+        theContext.TrackEnvelopeCorrelation(theEnvelope, activity);
+
+        theEnvelope.Source.ShouldBe("https://api.example.com/users/123");
+    }
+
+    [Fact]
+    public void track_envelope_correlation_falls_back_to_service_name_when_source_is_empty()
+    {
+        theEnvelope.Source = null;
+
+        using var activity = new Activity("DoWork");
+        activity.Start();
+
+        theContext.TrackEnvelopeCorrelation(theEnvelope, activity);
+
+        theEnvelope.Source.ShouldBe("MyService");
     }
 
     [Fact]

--- a/src/Wolverine/Runtime/MessageBus.cs
+++ b/src/Wolverine/Runtime/MessageBus.cs
@@ -350,7 +350,15 @@ public partial class MessageBus : IMessageBus, IMessageContext
 
     internal virtual void TrackEnvelopeCorrelation(Envelope outbound, Activity? activity)
     {
-        outbound.Source = Runtime.Options.ServiceName;
+        // A CustomizeOutgoingMessagesOfType<T> rule (or any other DeliveryOptions
+        // override) may have already stamped a per-message Source — for example,
+        // when InteropWithCloudEvents() is in play and the producer needs to set
+        // a spec-valid CloudEvents `source` URI per message. Don't clobber it.
+        if (outbound.Source.IsEmpty())
+        {
+            outbound.Source = Runtime.Options.ServiceName;
+        }
+
         // DeliveryOptions.Override may have already stamped a per-message
         // CorrelationId (e.g. from a Marten projection's RaiseSideEffects
         // call passing MessageMetadata) — don't clobber it. See GH-2545.


### PR DESCRIPTION
TrackEnvelopeCorrelation unconditionally overwrote Envelope.Source with WolverineOptions.ServiceName, which silently discarded any per-message Source set by a CustomizeOutgoingMessagesOfType<T> rule or other DeliveryOptions override. This made it impossible to publish CloudEvents with a spec-valid per-message `source` URI via .InteropWithCloudEvents().

The same method already takes care to preserve pre-populated CorrelationId (#2545), TenantId, and UserName values — Source is now treated the same way: ServiceName is applied only as a fallback when Source is empty.

Updated the existing track_envelope_correlation test to clear Source first (it was implicitly asserting the buggy clobbering behavior since ObjectMother.Envelope() pre-sets Source) and added two new tests covering the override-preservation and fallback paths.

#2619 