### PR TITLE
RavenDb - Ensure only one durability agent is instantiated

### DIFF
--- a/src/Persistence/RavenDbTests/durability_agent_lifecycle.cs
+++ b/src/Persistence/RavenDbTests/durability_agent_lifecycle.cs
@@ -1,0 +1,100 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Raven.Client.Documents;
+using Shouldly;
+using Wolverine;
+using Wolverine.RavenDb;
+using Wolverine.RavenDb.Internals.Durability;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+
+namespace RavenDbTests;
+
+[Collection("raven")]
+public class durability_agent_lifecycle : IAsyncLifetime
+{
+    private readonly DatabaseFixture _fixture;
+    private IDocumentStore _store = null!;
+    private IHost _host = null!;
+
+    public durability_agent_lifecycle(DatabaseFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _store = _fixture.StartRavenStore();
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(_store);
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ServiceName = "durability-agent-lifecycle";
+                opts.UseRavenDbPersistence();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public void only_one_durability_agent_polls_after_host_start()
+    {
+        var live = LiveDurabilityAgents(_host).Where(HasStartedTimers).ToList();
+        live.Count.ShouldBe(1);
+    }
+
+    private static readonly FieldInfo RecoveryTaskField = typeof(RavenDbDurabilityAgent).GetField(
+        "_recoveryTask", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static readonly FieldInfo ScheduledJobField = typeof(RavenDbDurabilityAgent).GetField(
+        "_scheduledJob", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static bool HasStartedTimers(RavenDbDurabilityAgent agent)
+        => RecoveryTaskField.GetValue(agent) is not null || ScheduledJobField.GetValue(agent) is not null;
+
+    private static IEnumerable<RavenDbDurabilityAgent> LiveDurabilityAgents(IHost host)
+    {
+        var runtime = (WolverineRuntime)host.Services.GetRequiredService<IWolverineRuntime>();
+
+        if (runtime.NodeController != null)
+        {
+            foreach (var agent in runtime.NodeController.Agents.Values.OfType<RavenDbDurabilityAgent>())
+                yield return agent;
+        }
+
+        // DurableScheduledJobs is internal; reach for it via reflection rather than
+        // adding RavenDbTests to Wolverine's InternalsVisibleTo list.
+        var prop = typeof(WolverineRuntime).GetProperty(
+            "DurableScheduledJobs",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (prop?.GetValue(runtime) is IAgent root)
+        {
+            foreach (var agent in EnumerateInner(root).OfType<RavenDbDurabilityAgent>())
+                yield return agent;
+        }
+    }
+
+    private static IEnumerable<IAgent> EnumerateInner(IAgent agent)
+    {
+        if (agent is CompositeAgent composite)
+        {
+            var field = typeof(CompositeAgent).GetField(
+                "_agents",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            if (field?.GetValue(composite) is IEnumerable<IAgent> inner)
+            {
+                foreach (var a in inner) yield return a;
+            }
+        }
+        else
+        {
+            yield return agent;
+        }
+    }
+}

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.cs
@@ -86,9 +86,10 @@ public partial class RavenDbMessageStore : IMessageStoreWithAgentSupport
         _leaderLockId = "wolverine/leader/" + runtime.Options.ServiceName.ToLowerInvariant();
         _scheduledLockId = _scheduledLockId + "/" + runtime.Options.ServiceName.ToLowerInvariant();
         _runtime = runtime;
-        var agent = BuildAgent(runtime);
-        agent.As<RavenDbDurabilityAgent>().StartTimers();
-        return agent;
+
+        // NodeAgentController owns the durability agent lifecycle via the
+        // wolverinedb://ravendb/durability URI; do not start a second instance here.
+        return BuildAgent(runtime);
     }
 
     public IAgent BuildAgent(IWolverineRuntime runtime)


### PR DESCRIPTION
## Overview

`RavenDbMessageStore.StartScheduledJobs` eagerly built and started a `RavenDbDurabilityAgent` at boot. However, the `NodeAgentController` also built *another* agent for `wolverinedb://ravendb/durability` via the `IAgentFamily` / `MessageStoreCollection` path. The result is that we had two durability agents registered under different URIs (`internal://scheduledjobs` vs `wolverinedb://ravendb/durability`), so the controller didn't dedupe them, and they polled concurrently in the same process.

Both agents share the singleton `RavenDbMessageStore`, which led to this behavior:

- Agent 1 follows the code path to do an initial acquire and sets `_scheduledLock` and `_lastScheduledLockIndex`.
- Agent 2 sees `_scheduledLock != null` on the shared instance and takes the code path to do a renewal, which results in a PUT with the current index (this succeeds against the server because that index is still valid)
- Both agents now believe they hold the lock, and both fetch the same envelopes at the same change vector, and race to mark them `Incoming`. Loser surfaces `ConcurrencyException`, Wolverine requeues the failed message, and the timeout fires twice.

I observed this when testing a real workload, and added instrumentation which showed two `RavenDbDurabilityAgent` instance ids both LOCK-ACQUIRED in the same window, fetching the same `IncomingMessage` doc at the same change vector, which resulted in downstream concurrency exceptions.

## Fix

Drop the eager `StartTimers()` call. The cluster-managed agent built via `MessageStoreCollection.BuildAgentAsync` is the single owner of the scheduled-jobs poller and recovery loop; `NodeAgentController` calls `StartAsync` on it. The agent returned from
`StartScheduledJobs` is held by `WolverineRuntime.DurableScheduledJobs` purely for its disposal-time `StopAsync`, which is null-safe on the unstarted task fields.

## Note

`Wolverine.CosmosDb.Internals.CosmosDbMessageStore.StartScheduledJobs` mirrors this pattern (`agent.As<CosmosDbDurabilityAgent>().StartTimers()`) and very likely has the same bug. Flagging in case you want to look at that separately.