### PR TITLE
Fix PrefixIdentifiers not applied to GlobalPartitioned slot endpoints

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/sharded_topology_with_prefix.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/sharded_topology_with_prefix.cs
@@ -1,0 +1,47 @@
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+public interface IShardedPrefixTestMessage
+{
+    string GroupId { get; }
+}
+
+public record ShardedPrefixTestPayload(string GroupId) : IShardedPrefixTestMessage;
+
+public class sharded_topology_with_prefix
+{
+    // Regression: GlobalPartitioned with UseShardedAmazonSqsQueues used to register
+    // slot endpoints with the un-prefixed base name, bypassing PrefixIdentifiers.
+    // At broker startup the slot endpoint's GetQueueUrl call would then look up
+    // "<baseName><N>" in AWS instead of "<prefix>-<baseName><N>" and crash with
+    // QueueDoesNotExistException, taking the whole transport down.
+    [Fact]
+    public void prefix_is_applied_to_sharded_slot_endpoints()
+    {
+        var options = new WolverineOptions();
+        options.UseAmazonSqsTransport().PrefixIdentifiers("foo");
+
+        options.MessagePartitioning.ByMessage<IShardedPrefixTestMessage>(x => x.GroupId);
+
+        options.MessagePartitioning.GlobalPartitioned(topology =>
+        {
+            topology.UseShardedAmazonSqsQueues("orders", 4);
+            topology.MessagesImplementing<IShardedPrefixTestMessage>();
+        });
+
+        var transport = options.AmazonSqsTransport();
+        var queueNames = transport.Queues.Select(q => q.QueueName).ToList();
+
+        queueNames.ShouldContain("foo-orders1");
+        queueNames.ShouldContain("foo-orders2");
+        queueNames.ShouldContain("foo-orders3");
+        queueNames.ShouldContain("foo-orders4");
+
+        queueNames.ShouldNotContain("orders1");
+        queueNames.ShouldNotContain("orders2");
+        queueNames.ShouldNotContain("orders3");
+        queueNames.ShouldNotContain("orders4");
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/PartitionedMessageTopologyWithQueues.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/PartitionedMessageTopologyWithQueues.cs
@@ -12,7 +12,8 @@ public class PartitionedMessageTopologyWithQueues : PartitionedMessageTopology<A
 
     protected override Endpoint buildEndpoint(WolverineOptions options, string name)
     {
-        return options.AmazonSqsTransport().Queues[name];
+        var transport = options.AmazonSqsTransport();
+        return transport.Queues[transport.MaybeCorrectName(name)];
     }
 
     protected override AmazonSqsListenerConfiguration buildListener(WolverineOptions options, string name)

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/PartitionedMessageTopologyWithQueues.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/PartitionedMessageTopologyWithQueues.cs
@@ -12,7 +12,8 @@ public class PartitionedMessageTopologyWithQueues : PartitionedMessageTopology<A
 
     protected override Endpoint buildEndpoint(WolverineOptions options, string name)
     {
-        return options.AzureServiceBusTransport().Queues[name];
+        var transport = options.AzureServiceBusTransport();
+        return transport.Queues[transport.MaybeCorrectName(name)];
     }
 
     protected override AzureServiceBusQueueListenerConfiguration buildListener(WolverineOptions options, string name)

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/PartitionedMessageTopologyWithTopics.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/PartitionedMessageTopologyWithTopics.cs
@@ -12,7 +12,8 @@ public class PartitionedMessageTopologyWithTopics : PartitionedMessageTopology<P
 
     protected override Endpoint buildEndpoint(WolverineOptions options, string name)
     {
-        return options.PubsubTransport().Topics[name];
+        var transport = options.PubsubTransport();
+        return transport.Topics[transport.MaybeCorrectName(name)];
     }
 
     protected override PubsubTopicListenerConfiguration buildListener(WolverineOptions options, string name)

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/PartitionedMessageTopologyWithQueues.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/PartitionedMessageTopologyWithQueues.cs
@@ -12,7 +12,8 @@ public class PartitionedMessageTopologyWithQueues : PartitionedMessageTopology<R
 
     protected override Endpoint buildEndpoint(WolverineOptions options, string name)
     {
-        return options.RabbitMqTransport().Queues[name];
+        var transport = options.RabbitMqTransport();
+        return transport.Queues[transport.MaybeCorrectName(name)];
     }
 
     protected override RabbitMqListenerConfiguration buildListener(WolverineOptions options, string name)


### PR DESCRIPTION
## Summary

I ran into this combining `PrefixIdentifiers` with the global partitioning
feature added in #2273. With both enabled, the partitioned slot endpoints get
registered with the **un-prefixed** base name while listeners for the same
shards correctly get the prefix applied. At broker startup the slot endpoint's
`GetQueueUrl` looks up `{baseName}{N}` instead of `{prefix}-{baseName}{N}` and
the entire transport fails to initialize:

```
Wolverine.AmazonSqs.WolverineSqsTransportException: Error while trying to
  initialize Amazon SQS queue 'snap-action4'
  ---> Amazon.SQS.Model.QueueDoesNotExistException: The specified queue does not exist.
...
Wolverine.Transports.BrokerInitializationException: Unable to initialize the Broker sqs in time
```

## Root cause

`PartitionedMessageTopology<>` (base) calls the transport-specific
`buildEndpoint(options, name)` for each shard slot in its constructor. For
every transport that implements `PrefixIdentifiers`, `buildEndpoint` routes
through the endpoint cache directly, bypassing `MaybeCorrectName`:

```csharp
// e.g. Wolverine.AmazonSqs
protected override Endpoint buildEndpoint(WolverineOptions options, string name)
{
    return options.AmazonSqsTransport().Queues[name];  // un-prefixed
}
```

Meanwhile `buildListener` / `buildSubscriber` go through the public
`ListenTo*` / `To*` helpers, which DO call `MaybeCorrectName`. The result is
two different cache entries per shard:

- `{baseName}{N}` — slot endpoint (un-prefixed), does not exist in the broker
- `{prefix}-{baseName}{N}` — listener endpoint (prefixed), matches the real queue/topic

Both endpoints are initialized at broker startup, and the un-prefixed slot
endpoint's `GetQueueUrl` call fails because no such queue exists.

## Fix

Apply `MaybeCorrectName` in `buildEndpoint` so slot and listener resolve to
the same prefixed cache entry. Identical 1-line shape across the four affected
transports (SQS, Azure Service Bus, RabbitMQ, GCP Pub/Sub):

```diff
 protected override Endpoint buildEndpoint(WolverineOptions options, string name)
 {
-    return options.XxxTransport().Queues[name];
+    var transport = options.XxxTransport();
+    return transport.Queues[transport.MaybeCorrectName(name)];
 }
```

NATS / Kafka / Pulsar / Redis don't trigger this mismatch — they don't
reference `MaybeCorrectName` anywhere, so `buildEndpoint` and `buildListener`
are already consistent (both un-prefixed) for those transports.

## Test plan

- [x] Added `sharded_topology_with_prefix.prefix_is_applied_to_sharded_slot_endpoints` in `Wolverine.AmazonSqs.Tests` — fails on `main` (un-prefixed slots leak), passes after the fix. Inspects options synchronously without starting the host, so no LocalStack required.
- [x] All four affected transport projects build clean.
- [ ] Existing E2E suites for SQS / ASB / Rabbit / GCP — most need real broker infrastructure I don't have running locally; CI should cover.
