### PR TITLE
Prevent leadership re-election every 5 minutes

### DIFF
--- a/src/Persistence/RavenDbTests/leadership_locking.cs
+++ b/src/Persistence/RavenDbTests/leadership_locking.cs
@@ -1,3 +1,4 @@
+using JasperFx.Core.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Raven.Client.Documents;
@@ -111,5 +112,30 @@ public class leadership_locking : IAsyncLifetime
         var ravenStore = new RavenDbMessageStore(_store, new WolverineOptions());
         (await ravenStore.TryAttainScheduledJobLockAsync(CancellationToken.None))
             .ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task try_attain_renews_the_server_side_lease_when_already_held()
+    {
+        // Calling TryAttain when the lease is already held must refresh the
+        // server-side entry — that's the contract the heartbeat relies on to
+        // keep the lease alive.
+        var store = _host.Services.GetService<IMessageStore>()!.As<RavenDbMessageStore>();
+        var lockId = "wolverine/leader/locking";
+
+        (await store.Nodes.TryAttainLeadershipLockAsync(CancellationToken.None)).ShouldBeTrue();
+        var initial = await _store.Operations.SendAsync(
+            new GetCompareExchangeValueOperation<DistributedLock>(lockId));
+
+        await Task.Delay(10);
+
+        (await store.Nodes.TryAttainLeadershipLockAsync(CancellationToken.None)).ShouldBeTrue();
+        var renewed = await _store.Operations.SendAsync(
+            new GetCompareExchangeValueOperation<DistributedLock>(lockId));
+
+        renewed.Index.ShouldBeGreaterThan(initial.Index);
+        renewed.Value.ExpirationTime.ShouldBeGreaterThan(initial.Value.ExpirationTime);
+
+        await store.Nodes.ReleaseLeadershipLockAsync();
     }
 }

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
@@ -62,17 +62,25 @@ public partial class NodeAgentController
             await stepDownAsync("the leadership advisory lock was released server-side");
         }
 
-        if (_persistence.HasLeadershipLock())
-        {
-            IsLeader = true;
-            return await EvaluateAssignmentsAsync(nodes, restrictions);
-        }
-
+        // Always call TryAttainLeadershipLockAsync. If we're already leader it
+        // refreshes the lease so lease-based backends (RavenDb, Cosmos) don't
+        // age out and trigger a false stepdown; otherwise it's the normal
+        // election attempt.
         try
         {
             if (await _persistence.TryAttainLeadershipLockAsync(_cancellation.Token))
             {
+                if (IsLeader)
+                {
+                    return await EvaluateAssignmentsAsync(nodes, restrictions);
+                }
+
                 return await tryStartLeadershipAsync(nodes, restrictions);
+            }
+
+            if (IsLeader)
+            {
+                await stepDownAsync("the leadership advisory lock could not be renewed");
             }
         }
         catch (Exception e)


### PR DESCRIPTION
 ## Overview

On lease-based persistence backends (RavenDb, Cosmos) a single-node deployment fires a spurious `LostLeadership` / `AssumedLeadership` pair every 5 minutes.

`NodeAgentController.HeartBeat.cs` returned early when `HasLeadershipLock()` was true and never called `TryAttainLeadershipLockAsync`, so the existing renewal branch in `TryAttain` (the path taken when `_leaderLock != null`) was unreachable. The in-memory lease aged out at the 5-minute mark, `HasLeadershipLock` flipped to false on its next read, and the leader would step down, only to immediately re-elect itself in the same heartbeat tick.

From what I could see, SQL persistence backend didn't expose this because the lock is bound to the open connection, and thus there is no lease to renew.

## Fix

Always go through `TryAttainLeadershipLockAsync`, and then branch on `IsLeader` afterwards:
- If `IsLeader == true`, we go through the existing renewal branch and refresh the lease
- If `IsLeader == false`, we go through a normal election attempt
- If we fail to renew, we explicitly step down