### PR TITLE
Add SagaDescriptor to ServiceCapabilities for CritterWatch saga visualization

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618;VSTHRD200</NoWarn>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.34.0</Version>
+        <Version>5.35.0</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Testing/CoreTests/Acceptance/exporting_saga_capabilities.cs
+++ b/src/Testing/CoreTests/Acceptance/exporting_saga_capabilities.cs
@@ -1,0 +1,151 @@
+using JasperFx.Resources;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+/// <summary>
+/// Validates the saga-shape surface added to <see cref="ServiceCapabilities"/>
+/// for downstream tools (CritterWatch). Each role classification path
+/// (Start / StartOrHandle / Orchestrate / NotFound) plus the cascading
+/// PublishedTypes wiring needs end-to-end coverage so a regression on the
+/// SagaChain method-name lookup or HandlerChain.PublishedTypes() shows up
+/// here, not in a downstream UI bug report.
+/// </summary>
+public class exporting_saga_capabilities : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private ServiceCapabilities _capabilities = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddResourceSetupOnStartup();
+                opts.Discovery.IncludeType<DemoSaga>();
+                opts.Discovery.IncludeType<NotFoundOnlySaga>();
+            }).StartAsync();
+
+        _capabilities = await ServiceCapabilities.ReadFrom(_host.GetRuntime(), null, CancellationToken.None);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public void emits_one_descriptor_per_saga_state_type()
+    {
+        _capabilities.Sagas.ShouldNotBeEmpty();
+        _capabilities.Sagas
+            .Select(s => s.StateType.FullName)
+            .ShouldContain(typeof(DemoSaga).FullName!);
+    }
+
+    [Fact]
+    public void captures_saga_id_type_at_saga_level()
+    {
+        var saga = _capabilities.Sagas.Single(s => s.StateType.FullName == typeof(DemoSaga).FullName!);
+        saga.SagaIdType.ShouldBe(typeof(Guid).FullName!);
+    }
+
+    [Fact]
+    public void captures_saga_id_member_per_message()
+    {
+        var saga = _capabilities.Sagas.Single(s => s.StateType.FullName == typeof(DemoSaga).FullName!);
+        // Wolverine pulls the saga id from each message's `{SagaName}Id`
+        // property by convention. All three of our test messages use
+        // `DemoSagaId` so they should all surface that name.
+        saga.Messages.ShouldAllBe(m => m.SagaIdMember == nameof(BeginDemoSaga.DemoSagaId));
+    }
+
+    [Fact]
+    public void classifies_start_handler()
+    {
+        var saga = _capabilities.Sagas.Single(s => s.StateType.FullName == typeof(DemoSaga).FullName!);
+        var role = saga.Messages.Single(m => m.MessageType.FullName == typeof(BeginDemoSaga).FullName!);
+        role.Role.ShouldBe(SagaRole.Start);
+    }
+
+    [Fact]
+    public void classifies_orchestrate_handler()
+    {
+        var saga = _capabilities.Sagas.Single(s => s.StateType.FullName == typeof(DemoSaga).FullName!);
+        var role = saga.Messages.Single(m => m.MessageType.FullName == typeof(AdvanceDemoSaga).FullName!);
+        role.Role.ShouldBe(SagaRole.Orchestrate);
+    }
+
+    [Fact]
+    public void classifies_start_or_handle()
+    {
+        var saga = _capabilities.Sagas.Single(s => s.StateType.FullName == typeof(DemoSaga).FullName!);
+        var role = saga.Messages.Single(m => m.MessageType.FullName == typeof(EnsureDemoSaga).FullName!);
+        role.Role.ShouldBe(SagaRole.StartOrHandle);
+    }
+
+    [Fact]
+    public void classifies_not_found_only_handler()
+    {
+        var saga = _capabilities.Sagas.Single(s => s.StateType.FullName == typeof(NotFoundOnlySaga).FullName!);
+        var role = saga.Messages.Single(m => m.MessageType.FullName == typeof(MissingSagaQuery).FullName!);
+        role.Role.ShouldBe(SagaRole.NotFound);
+    }
+
+    [Fact]
+    public void surfaces_cascading_published_types()
+    {
+        // Begin* cascades a DemoSagaStarted event from its return tuple.
+        var saga = _capabilities.Sagas.Single(s => s.StateType.FullName == typeof(DemoSaga).FullName!);
+        var startRole = saga.Messages.Single(m => m.MessageType.FullName == typeof(BeginDemoSaga).FullName!);
+
+        startRole.PublishedTypes
+            .Select(t => t.FullName)
+            .ShouldContain(typeof(DemoSagaStarted).FullName!);
+    }
+}
+
+// ---- Test fixtures ----
+
+public record BeginDemoSaga(Guid DemoSagaId);
+public record AdvanceDemoSaga(Guid DemoSagaId);
+public record EnsureDemoSaga(Guid DemoSagaId);
+public record DemoSagaStarted(Guid SagaId);
+
+public class DemoSaga : Saga
+{
+    public Guid Id { get; set; }
+
+    public DemoSagaStarted Start(BeginDemoSaga cmd)
+    {
+        Id = cmd.DemoSagaId;
+        return new DemoSagaStarted(cmd.DemoSagaId);
+    }
+
+    public void Orchestrate(AdvanceDemoSaga cmd)
+    {
+    }
+
+    public void StartOrHandle(EnsureDemoSaga cmd)
+    {
+        Id = cmd.DemoSagaId;
+    }
+}
+
+public record MissingSagaQuery(Guid NotFoundOnlySagaId);
+
+public class NotFoundOnlySaga : Saga
+{
+    public Guid Id { get; set; }
+
+    // Deliberately no Start/Orchestrate — this saga only defines a NotFound
+    // compensating path so the test can assert the NotFound classification
+    // works in isolation. NotFound is static per the Wolverine pattern.
+    public static void NotFound(MissingSagaQuery query)
+    {
+    }
+}

--- a/src/Wolverine/Configuration/Capabilities/SagaDescriptor.cs
+++ b/src/Wolverine/Configuration/Capabilities/SagaDescriptor.cs
@@ -1,0 +1,92 @@
+using JasperFx.Descriptors;
+
+namespace Wolverine.Configuration.Capabilities;
+
+/// <summary>
+/// Capability shape for a Wolverine <see cref="Saga"/>. Surfaced through
+/// <see cref="ServiceCapabilities.Sagas"/> so external monitoring tools
+/// (CritterWatch in particular) can render the saga as a workflow without
+/// having to introspect runtime types. One descriptor per concrete saga
+/// state class, regardless of how many handler chains feed it.
+/// </summary>
+/// <remarks>
+/// Populated from <see cref="Persistence.Sagas.SagaChain"/> instances on
+/// <see cref="WolverineOptions.HandlerGraph"/>. The role classification
+/// mirrors the same method-name lookup that <c>SagaChain.DetermineFrames</c>
+/// uses internally for code generation, so the static descriptor and the
+/// generated runtime behaviour stay in lock-step.
+/// </remarks>
+public class SagaDescriptor
+{
+    public SagaDescriptor()
+    {
+    }
+
+    public SagaDescriptor(TypeDescriptor stateType)
+    {
+        StateType = stateType;
+    }
+
+    /// <summary>The concrete <c>: Saga</c> class.</summary>
+    public TypeDescriptor StateType { get; set; } = null!;
+
+    /// <summary>
+    /// CLR type of the saga identity (Guid / int / long / string / a
+    /// strong-typed identifier), reported as a fully-qualified type name
+    /// so the descriptor stays JSON-serialisable. Inferred from the
+    /// first message in <see cref="Messages"/> that exposes a saga-id
+    /// member; null when Wolverine couldn't determine it (a runtime
+    /// error would also be raised in that case, but the descriptor is
+    /// still useful for diagnostics).
+    /// </summary>
+    public string? SagaIdType { get; set; }
+
+    /// <summary>
+    /// Every message that touches this saga, with the role each message
+    /// plays. Use to render the saga sequence diagram in CritterWatch.
+    /// </summary>
+    public List<SagaMessageRole> Messages { get; set; } = new();
+}
+
+/// <summary>
+/// One incoming message's role inside a saga, plus the messages that
+/// handler cascades when it runs.
+/// </summary>
+/// <param name="MessageType">The message that triggers this handler.</param>
+/// <param name="Role">What the handler does with the saga (Start / Orchestrate / etc).</param>
+/// <param name="SagaIdMember">
+/// Name of the property/field on <paramref name="MessageType"/> that
+/// carries the saga identity. Null when Wolverine couldn't infer one —
+/// in that case the runtime falls back to pulling the id from the
+/// envelope. Per-message because Wolverine's id-resolution rules
+/// (<c>[SagaIdentity]</c>, <c>{SagaName}Id</c>, <c>Id</c>, …) frequently
+/// produce different property names across the messages that touch the
+/// same saga.
+/// </param>
+/// <param name="PublishedTypes">
+/// Cascading message types this handler emits, derived from
+/// <c>HandlerChain.PublishedTypes()</c>. Empty when the handler
+/// returns no messages.
+/// </param>
+public record SagaMessageRole(
+    TypeDescriptor MessageType,
+    SagaRole Role,
+    string? SagaIdMember,
+    TypeDescriptor[] PublishedTypes);
+
+/// <summary>
+/// What a particular handler does to / for the saga.
+///   <list type="bullet">
+///     <item><description><b>Start</b> — <c>Start(...)</c> / <c>Starts(...)</c>. Creates a brand-new saga instance.</description></item>
+///     <item><description><b>StartOrHandle</b> — <c>StartOrHandle(...)</c> / <c>StartsOrHandles(...)</c>. Creates a saga if none exists for the id, otherwise advances the existing one.</description></item>
+///     <item><description><b>Orchestrate</b> — <c>Orchestrate(...)</c> / <c>Handle(...)</c> / <c>Consume(...)</c>. Advances an existing saga; errors if no saga matches the id.</description></item>
+///     <item><description><b>NotFound</b> — <c>NotFound(...)</c>. Compensating handler invoked when no saga matches the inbound message's id.</description></item>
+///   </list>
+/// </summary>
+public enum SagaRole
+{
+    Start,
+    StartOrHandle,
+    Orchestrate,
+    NotFound
+}

--- a/src/Wolverine/Configuration/Capabilities/ServiceCapabilities.cs
+++ b/src/Wolverine/Configuration/Capabilities/ServiceCapabilities.cs
@@ -5,7 +5,9 @@ using JasperFx.Descriptors;
 using JasperFx.Events;
 using JasperFx.Events.Descriptors;
 using Microsoft.Extensions.DependencyInjection;
+using Wolverine.Persistence.Sagas;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
 
 namespace Wolverine.Configuration.Capabilities;
 
@@ -48,6 +50,17 @@ public class ServiceCapabilities : OptionsDescription
 
     public List<MessageDescriptor> Messages { get; set; } = [];
 
+    /// <summary>
+    /// One descriptor per concrete <see cref="Saga"/> state class
+    /// discovered in the handler graph. Each descriptor lists the
+    /// messages that touch the saga, the role each message plays
+    /// (Start / StartOrHandle / Orchestrate / NotFound), and the
+    /// cascading messages each handler emits. Consumed by external
+    /// monitoring tools (CritterWatch) to render saga workflow
+    /// diagrams without having to introspect runtime types.
+    /// </summary>
+    public List<SagaDescriptor> Sagas { get; set; } = [];
+
     public List<MessageStore> MessageStores { get; set; } = [];
 
     public List<EndpointDescriptor> MessagingEndpoints { get; set; } = [];
@@ -87,6 +100,8 @@ public class ServiceCapabilities : OptionsDescription
 
         readEndpoints(runtime, capabilities);
 
+        readSagas(runtime, capabilities);
+
         readAdditionalCapabilities(runtime, capabilities);
 
         return capabilities;
@@ -110,6 +125,125 @@ public class ServiceCapabilities : OptionsDescription
             capabilities.Messages.Add(new MessageDescriptor(messageType, runtime));
         }
     }
+
+    /// <summary>
+    /// Walk every <see cref="SagaChain"/> on the handler graph (including
+    /// per-endpoint variants in MultipleHandlerBehavior.Separated mode) and
+    /// emit one <see cref="SagaDescriptor"/> per concrete saga state type.
+    /// Each handler call inside the chain contributes a
+    /// <see cref="SagaMessageRole"/> classified by the same method-name
+    /// matching that <see cref="SagaChain.DetermineFrames"/> uses for
+    /// code-gen, so what the descriptor reports is exactly what Wolverine
+    /// will execute at runtime.
+    /// </summary>
+    private static void readSagas(IWolverineRuntime runtime, ServiceCapabilities capabilities)
+    {
+        var sagaChains = collectSagaChains(runtime.Options.HandlerGraph).ToArray();
+        if (sagaChains.Length == 0) return;
+
+        // (sagaStateType, messageType) is unique within a saga — a single
+        // chain handles one message type, classified by its handler method
+        // name. We group by saga state type to produce one descriptor per
+        // saga, and within each group preserve the (chain → role) mapping.
+        var groups = sagaChains
+            .Where(c => c.Handlers.Any(h => h.HandlerType.CanBeCastTo<Saga>()))
+            .GroupBy(c => c.SagaType);
+
+        foreach (var group in groups.OrderBy(g => g.Key.FullNameInCode()))
+        {
+            var stateType = group.Key;
+            var descriptor = new SagaDescriptor(TypeDescriptor.For(stateType));
+
+            // SagaIdType is consistent across every chain for a single saga
+            // (Wolverine would error at runtime if it weren't), so pull it
+            // from whichever chain first resolved a SagaIdMember. The id
+            // member NAME varies per message, hence is captured per-role.
+            var typeSource = group.FirstOrDefault(c => c.SagaIdMember != null);
+            if (typeSource is not null)
+            {
+                descriptor.SagaIdType = sagaIdMemberType(typeSource.SagaIdMember!)?.FullName;
+            }
+
+            foreach (var chain in group.OrderBy(c => c.MessageType.FullNameInCode()))
+            {
+                var role = classifySagaChainRole(chain);
+                if (role is null) continue;
+
+                var published = chain.PublishedTypes()
+                    .Distinct()
+                    .Select(TypeDescriptor.For)
+                    .ToArray();
+
+                descriptor.Messages.Add(new SagaMessageRole(
+                    TypeDescriptor.For(chain.MessageType),
+                    role.Value,
+                    chain.SagaIdMember?.Name,
+                    published));
+            }
+
+            capabilities.Sagas.Add(descriptor);
+        }
+    }
+
+    /// <summary>
+    /// Classify a single SagaChain into the role that best summarises the
+    /// chain's handler method names. A chain may contain multiple methods
+    /// for the same message (e.g. both <c>StartOrHandle</c> and a separate
+    /// <c>NotFound</c>) — in that case <c>StartOrHandle</c> wins because
+    /// it's the strictly-more-capable role. Returns null when the chain
+    /// has no recognisable saga-handler methods (shouldn't happen in
+    /// practice, but defensive).
+    /// </summary>
+    private static SagaRole? classifySagaChainRole(SagaChain chain)
+    {
+        var methodNames = chain.Handlers
+            .Where(h => h.HandlerType.CanBeCastTo<Saga>())
+            .Select(h => h.Method.Name)
+            .Select(n => n.EndsWith("Async") ? n[..^"Async".Length] : n)
+            .ToHashSet();
+
+        if (methodNames.Contains(SagaChain.StartOrHandle) || methodNames.Contains(SagaChain.StartsOrHandles))
+            return SagaRole.StartOrHandle;
+
+        if (methodNames.Contains(SagaChain.Start) || methodNames.Contains(SagaChain.Starts))
+            return SagaRole.Start;
+
+        if (methodNames.Contains(SagaChain.Orchestrate) || methodNames.Contains(SagaChain.Orchestrates)
+            || methodNames.Contains("Handle") || methodNames.Contains("Handles")
+            || methodNames.Contains("Consume") || methodNames.Contains("Consumes"))
+            return SagaRole.Orchestrate;
+
+        if (methodNames.Contains(SagaChain.NotFound))
+            return SagaRole.NotFound;
+
+        return null;
+    }
+
+    /// <summary>
+    /// Recursively yield every SagaChain reachable through the handler
+    /// graph, including per-endpoint variants created by
+    /// MultipleHandlerBehavior.Separated. Top-level chains may have moved
+    /// their handlers into ByEndpoint sub-chains, leaving the outer chain
+    /// "routing only" — we still want the inner chains' roles.
+    /// </summary>
+    private static IEnumerable<SagaChain> collectSagaChains(HandlerGraph graph)
+    {
+        foreach (var chain in graph.Chains.OfType<SagaChain>())
+        {
+            yield return chain;
+            foreach (var inner in chain.ByEndpoint.OfType<SagaChain>())
+            {
+                yield return inner;
+            }
+        }
+    }
+
+    private static Type? sagaIdMemberType(MemberInfo member) => member switch
+    {
+        PropertyInfo p => p.PropertyType,
+        FieldInfo f => f.FieldType,
+        _ => null
+    };
 
     public const string EventSubscriptionAgentScheme = "event-subscriptions";
 


### PR DESCRIPTION
## Summary

CritterWatch wants to render Wolverine sagas as workflow / sequence diagrams (related: [JasperFx/CritterWatch#90](https://github.com/JasperFx/CritterWatch/issues/90) and follow-ups). Today the `ServiceCapabilities` manifest tells external tools nothing about sagas beyond "this message has a handler that lives on a `Saga` subclass" — every tool has to re-derive the shape by reflecting on runtime types.

This change surfaces the saga shape in the manifest, so any consumer of `ServiceCapabilities` (CritterWatch and others) can render a saga without poking at runtime types.

## What's new

- **`SagaDescriptor`** — state type + saga-id CLR type + per-message roles.
- **`SagaMessageRole(MessageType, Role, SagaIdMember, PublishedTypes)`** — `PublishedTypes` is fed from the existing `HandlerChain.PublishedTypes()` so cascading messages out of saga handlers are visible without re-walking the handler graph.
- **`SagaRole` enum** — `Start | StartOrHandle | Orchestrate | NotFound`, classified by the same method-name lookup that `SagaChain.DetermineFrames` uses for code-gen, so the descriptor reports exactly what Wolverine will execute.
- **`Sagas: List<SagaDescriptor>`** on `ServiceCapabilities`, populated via a new `readSagas` walk over `HandlerGraph.Chains` (including `ByEndpoint` sub-chains so `MultipleHandlerBehavior.Separated` is captured).

Purely additive — no breaking changes to existing `ServiceCapabilities` consumers.

## Versioning

- `5.34.0 → 5.35.0` (minor bump for the additive surface).

## Tests

- New `exporting_saga_capabilities` acceptance test (8 cases) exercising each role classification path, the cascading `PublishedTypes` wiring, and saga-id-type inference.
- Existing saga + capability suites stay green: **78/78**.

## Test plan

- [x] `dotnet build src/Wolverine/Wolverine.csproj` clean
- [x] `dotnet test src/Testing/CoreTests/CoreTests.csproj --filter "FullyQualifiedName~Sagas|FullyQualifiedName~Capabilities"` → 78/78 passed (net9.0)
- [ ] CI green
- [ ] Manual: pull into CritterWatch, confirm `ServiceUpdates.Capabilities.Sagas` arrives populated for sample apps that ship a saga

🤖 Generated with [Claude Code](https://claude.com/claude-code)