### PR TITLE
Fix #2622: Oracle persistence fails to boot in DurabilityMode.Balanced

### DIFF
--- a/src/Persistence/LeaderElection/OracleTests.LeaderElection/OracleTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/OracleTests.LeaderElection/OracleTests.LeaderElection.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Wolverine.RDBMS\Wolverine.RDBMS.csproj"/>
+        <ProjectReference Include="..\..\Oracle\Wolverine.Oracle\Wolverine.Oracle.csproj"/>
+        <ProjectReference Include="..\..\..\Testing\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Include="..\..\..\Servers.cs">
+            <Link>Servers.cs</Link>
+        </Compile>
+    </ItemGroup>
+
+</Project>

--- a/src/Persistence/LeaderElection/OracleTests.LeaderElection/leader_election.cs
+++ b/src/Persistence/LeaderElection/OracleTests.LeaderElection/leader_election.cs
@@ -1,0 +1,106 @@
+using IntegrationTests;
+using Oracle.ManagedDataAccess.Client;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Oracle;
+using Wolverine.RDBMS;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OracleTests.LeaderElection;
+
+// Regression coverage for #2622 — OracleMessageStore.Initialize must register
+// the OracleControlTransport / NodeControlEndpoint when running in Balanced
+// durability mode, otherwise leadership election cannot start.
+//
+// Marked Flaky so CI does not run them by default. The compliance suite spins up
+// 3-4 hosts per test and depends on TM/DML lock release between runs against a
+// single Oracle instance — fine to run locally one-at-a-time, but unstable
+// against the shared CI Oracle container. See #2618 (CI stabilization).
+[Trait("Category", "Flaky")]
+public class leader_election : LeadershipElectionCompliance
+{
+    public const string SchemaName = "WOLVERINE";
+
+    // Tables Wolverine declares for the Oracle backed message store. We drop these
+    // before each test run so the host's resource-setup-on-startup rebuilds a clean
+    // schema. Listed children-first so CASCADE CONSTRAINTS isn't strictly required
+    // (but we use it anyway as a belt-and-suspenders).
+    private static readonly string[] WolverineTables =
+    [
+        DatabaseConstants.AgentRestrictionsTableName,
+        DatabaseConstants.NodeRecordTableName,
+        DatabaseConstants.TenantsTableName,
+        DatabaseConstants.ControlQueueTableName,
+        DatabaseConstants.NodeAssignmentsTableName,
+        DatabaseConstants.NodeTableName,
+        DatabaseConstants.DeadLetterTable,
+        DatabaseConstants.IncomingTable,
+        DatabaseConstants.OutgoingTable,
+        "wolverine_locks"
+    ];
+
+    public leader_election(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void configureNode(WolverineOptions opts)
+    {
+        opts.PersistMessagesWithOracle(Servers.OracleConnectionString, SchemaName);
+    }
+
+    protected override async Task beforeBuildingHost()
+    {
+        // Tear down the Wolverine schema in the WOLVERINE user so each test run
+        // starts from a clean slate. AddResourceSetupOnStartup in the host
+        // bootstrapping will rebuild whatever it needs.
+        await using var conn = new OracleConnection(Servers.OracleConnectionString);
+        await conn.OpenAsync();
+
+        // DDL_LOCK_TIMEOUT makes DROP TABLE block (rather than fail with ORA-00054)
+        // for up to N seconds when another session holds the TM lock. Combined with
+        // the explicit per-table retry below, this makes the teardown resilient to a
+        // prior test run whose listeners are still draining their last few queries.
+        await using (var sessionCmd = conn.CreateCommand())
+        {
+            sessionCmd.CommandText = "ALTER SESSION SET DDL_LOCK_TIMEOUT = 30";
+            await sessionCmd.ExecuteNonQueryAsync();
+        }
+
+        foreach (var table in WolverineTables)
+        {
+            await dropTableWithRetryAsync(conn, table);
+        }
+
+        await conn.CloseAsync();
+    }
+
+    private static async Task dropTableWithRetryAsync(OracleConnection conn, string table)
+    {
+        // ORA-00054 fires when a previous run's listener still holds a TM/DML lock on
+        // the table. The lock releases as the prior process tears down its connections;
+        // a short retry is the simplest way to ride out that window.
+        const int maxAttempts = 5;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                await using var cmd = conn.CreateCommand();
+                cmd.CommandText =
+                    $"DROP TABLE {SchemaName}.{table.ToUpperInvariant()} CASCADE CONSTRAINTS";
+                await cmd.ExecuteNonQueryAsync();
+                return;
+            }
+            catch (OracleException e) when (e.Number == 942)
+            {
+                // ORA-00942: table or view does not exist — fine, nothing to drop.
+                return;
+            }
+            catch (OracleException e) when (e.Number == 54 && attempt < maxAttempts)
+            {
+                // ORA-00054: resource busy. Wait briefly and try again.
+                await Task.Delay(TimeSpan.FromSeconds(2 * attempt));
+            }
+        }
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
@@ -14,6 +14,7 @@ using Weasel.Oracle.Tables;
 using Wolverine.Logging;
 using Wolverine.Oracle.Sagas;
 using Wolverine.Oracle.Schema;
+using Wolverine.Oracle.Transport;
 using Wolverine.Persistence;
 using Wolverine.Persistence.Durability;
 using Wolverine.Persistence.Durability.ScheduledMessageManagement;
@@ -129,7 +130,26 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
 
     public void Initialize(IWolverineRuntime runtime)
     {
-        // No-op; initialization happens in MigrateAsync
+        // Mirror MessageDatabase.Initialize — when this is the main store and the host is
+        // running in Balanced durability mode, stand up the control transport and publish
+        // its endpoint as the NodeControlEndpoint so inter-node agent commands can flow
+        // without an external message broker. Without this, WolverineNode.For throws
+        // ArgumentOutOfRangeException("ControlEndpoint cannot be null for this usage") at
+        // startup.
+        //
+        // Oracle uses its own OracleControlTransport rather than the shared
+        // DatabaseControlTransport because the shared implementation assumes @-prefixed
+        // placeholders and Guid values that map directly to a DbParameter — both of which
+        // Oracle rejects (placeholders are :-prefixed and the id columns are RAW(16) so
+        // Guids must be passed as byte[]). See #2622.
+        if (Role == MessageStoreRole.Main
+            && runtime.Options.Transports.NodeControlEndpoint == null
+            && runtime.Options.Durability.Mode == DurabilityMode.Balanced)
+        {
+            var transport = new OracleControlTransport(this, runtime.Options);
+            runtime.Options.Transports.Add(transport);
+            runtime.Options.Transports.NodeControlEndpoint = transport.ControlEndpoint;
+        }
     }
 
     public IAgent BuildAgent(IWolverineRuntime runtime)

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleNodePersistence.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleNodePersistence.cs
@@ -313,12 +313,32 @@ internal class OracleNodePersistence : DatabaseConstants, INodeAgentPersistence
         await conn.CloseAsync();
     }
 
-    public Task LogRecordsAsync(params NodeRecord[] records)
+    public async Task LogRecordsAsync(params NodeRecord[] records)
     {
-        if (records.Length == 0) return Task.CompletedTask;
+        if (records.Length == 0) return;
 
-        var op = new PersistNodeRecord(_settings, records);
-        return _database.EnqueueAsync(op);
+        // OracleMessageStore.EnqueueAsync is a no-op (the shared DatabaseBatcher uses
+        // @-prefixed parameter syntax that Oracle rejects), so insert each record
+        // directly using the Oracle command extensions.
+        await using var conn = await _dataSource.OpenConnectionAsync();
+        try
+        {
+            foreach (var record in records)
+            {
+                await using var cmd = conn.CreateCommand(
+                    $"INSERT INTO {_settings.SchemaName}.{NodeRecordTableName} " +
+                    "(node_number, event_name, description) " +
+                    "VALUES (:nodeNumber, :eventName, :description)");
+                cmd.With("nodeNumber", record.NodeNumber);
+                cmd.With("eventName", record.RecordType.ToString());
+                cmd.With("description", record.Description ?? string.Empty);
+                await cmd.ExecuteNonQueryAsync();
+            }
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
     }
 
     public async Task<IReadOnlyList<NodeRecord>> FetchRecentRecordsAsync(int count)
@@ -340,7 +360,7 @@ internal class OracleNodePersistence : DatabaseConstants, INodeAgentPersistence
                 NodeNumber = Convert.ToInt32(reader.GetValue(0)),
                 RecordType = Enum.Parse<NodeRecordType>(await reader.GetFieldValueAsync<string>(1)),
                 Timestamp = await reader.GetFieldValueAsync<DateTimeOffset>(2),
-                Description = await reader.GetFieldValueAsync<string>(3)
+                Description = await reader.IsDBNullAsync(3) ? string.Empty : await reader.GetFieldValueAsync<string>(3)
             });
         }
         await conn.CloseAsync();

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleControlEndpoint.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleControlEndpoint.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.Oracle.Transport;
+
+/// <summary>
+/// Per-node endpoint for the Oracle-backed control queue. Mirrors
+/// <see cref="Wolverine.RDBMS.Transport.DatabaseControlEndpoint"/> but produces Oracle-aware
+/// senders and listeners. See #2622.
+/// </summary>
+internal class OracleControlEndpoint : Endpoint
+{
+    private readonly OracleControlTransport _parent;
+
+    public OracleControlEndpoint(OracleControlTransport parent, Guid nodeId) : base(
+        new Uri($"{OracleControlTransport.ProtocolName}://{nodeId}"), EndpointRole.System)
+    {
+        NodeId = nodeId;
+        _parent = parent;
+        Mode = EndpointMode.BufferedInMemory;
+        MaxDegreeOfParallelism = 1;
+        BrokerRole = "queue";
+
+        // No otel for this one!
+        TelemetryEnabled = false;
+    }
+
+    public Guid NodeId { get; }
+
+    public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+    {
+        return new ValueTask<IListener>(new OracleControlListener(_parent, this, receiver,
+            runtime.LoggerFactory.CreateLogger<OracleControlListener>(),
+            runtime.Options.Durability.Cancellation));
+    }
+
+    protected override ISender CreateSender(IWolverineRuntime runtime)
+    {
+        return new OracleControlSender(this, _parent,
+            runtime.LoggerFactory.CreateLogger<OracleControlSender>(),
+            runtime.Options.Durability.Cancellation);
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleControlListener.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleControlListener.cs
@@ -1,0 +1,173 @@
+using JasperFx.Blocks;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Oracle.ManagedDataAccess.Client;
+using Weasel.Oracle;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Serialization;
+using Wolverine.Transports;
+
+namespace Wolverine.Oracle.Transport;
+
+/// <summary>
+/// Oracle clone of <see cref="Wolverine.RDBMS.Transport.DatabaseControlListener"/> — polls the
+/// Oracle control queue directly (rather than going through DatabaseOperationBatch which uses
+/// <c>@param</c> placeholders and Guid-as-DbParameter values that Oracle rejects). Cleans up
+/// expired messages on each tick. See #2622.
+/// </summary>
+internal class OracleControlListener : IListener
+{
+    private readonly CancellationTokenSource _cancellation;
+    private readonly IReceiver _receiver;
+    private readonly Task _receivingLoop;
+    private readonly RetryBlock<Envelope> _retryBlock;
+    private readonly OracleControlTransport _transport;
+    private readonly ILogger _logger;
+
+    public OracleControlListener(OracleControlTransport transport, OracleControlEndpoint endpoint, IReceiver receiver,
+        ILogger<OracleControlListener> logger, CancellationToken cancellationToken)
+    {
+        _transport = transport;
+        _receiver = receiver;
+        _logger = logger;
+
+        _cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        _receivingLoop = Task.Run(async () =>
+        {
+            // Stagger startup so concurrent nodes don't hammer the table at the same instant.
+            await Task.Delay(Random.Shared.Next(100, 1000).Milliseconds(), _cancellation.Token);
+
+            while (!_cancellation.IsCancellationRequested)
+            {
+                try
+                {
+                    await pollOnceAsync(_cancellation.Token);
+                }
+                catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Error polling the Oracle control queue");
+                }
+
+                try
+                {
+                    await Task.Delay(1.Seconds(), _cancellation.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+        }, _cancellation.Token);
+
+        Address = endpoint.Uri;
+
+        _retryBlock = new RetryBlock<Envelope>(deleteEnvelopeAsync, logger, cancellationToken);
+    }
+
+    public IHandlerPipeline? Pipeline => _receiver.Pipeline;
+
+    public Uri Address { get; }
+
+    public async ValueTask CompleteAsync(Envelope envelope)
+    {
+        await _retryBlock.PostAsync(envelope);
+    }
+
+    public ValueTask DeferAsync(Envelope envelope) => ValueTask.CompletedTask;
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cancellation.CancelAsync();
+        _receivingLoop.SafeDispose();
+    }
+
+    public async ValueTask StopAsync()
+    {
+        await _cancellation.CancelAsync();
+        if (_receivingLoop != null)
+        {
+            try
+            {
+                await _receivingLoop;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+
+            _receivingLoop.Dispose();
+        }
+    }
+
+    private async Task pollOnceAsync(CancellationToken token)
+    {
+        if (_transport.Database.HasDisposed) return;
+
+        await using var conn = await _transport.Database.OracleDataSource.OpenConnectionAsync(token);
+        try
+        {
+            // 1) Drop expired control messages so the queue table doesn't grow unbounded.
+            await using (var deleteExpiredCmd = conn.CreateCommand(
+                             $"DELETE FROM {_transport.TableName.QualifiedName} WHERE expires < :utcnow"))
+            {
+                deleteExpiredCmd.With("utcnow", DateTimeOffset.UtcNow);
+                await deleteExpiredCmd.ExecuteNonQueryAsync(token);
+            }
+
+            // 2) Pull anything addressed to this node.
+            var envelopes = new List<Envelope>();
+            await using (var selectCmd = conn.CreateCommand(
+                             $"SELECT body FROM {_transport.TableName.QualifiedName} WHERE node_id = :node"))
+            {
+                selectCmd.With("node", _transport.Options.UniqueNodeId);
+
+                await using var reader = await selectCmd.ExecuteReaderAsync(token);
+                while (await reader.ReadAsync(token))
+                {
+                    var body = await reader.GetFieldValueAsync<byte[]>(0, token);
+                    envelopes.Add(EnvelopeSerializer.Deserialize(body));
+                }
+            }
+
+            if (envelopes.Count == 0) return;
+
+            await _receiver.ReceivedAsync(this, envelopes.ToArray());
+
+            // 3) Remove what we delivered. Failures land on the retry block via CompleteAsync,
+            //    matching DatabaseControlTransport's batched-delete semantics, but doing it here
+            //    inline keeps the implementation simple — the volume is small.
+            await _transport.DeleteEnvelopesAsync(envelopes, token);
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    private async Task deleteEnvelopeAsync(Envelope envelope, CancellationToken cancellationToken)
+    {
+        if (_transport.Database.HasDisposed)
+        {
+            return;
+        }
+
+        await using var conn =
+            await _transport.Database.OracleDataSource.OpenConnectionAsync(cancellationToken);
+        try
+        {
+            await using var cmd = conn.CreateCommand(
+                $"DELETE FROM {_transport.TableName.QualifiedName} WHERE id = :id");
+            cmd.With("id", envelope.Id);
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleControlSender.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleControlSender.cs
@@ -1,0 +1,101 @@
+using JasperFx.Blocks;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Oracle.ManagedDataAccess.Client;
+using Weasel.Oracle;
+using Wolverine.Runtime.Serialization;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.Oracle.Transport;
+
+/// <summary>
+/// Oracle clone of <see cref="Wolverine.RDBMS.Transport.DatabaseControlSender"/> — uses
+/// <c>:</c> placeholders and routes Guid values through Weasel.Oracle.With(...) which
+/// converts them to byte[] for the RAW(16) id columns. See #2622.
+/// </summary>
+internal class OracleControlSender : ISender, IAsyncDisposable
+{
+    private readonly OracleControlEndpoint _endpoint;
+    private readonly RetryBlock<Envelope> _retryBlock;
+    private readonly OracleControlTransport _transport;
+
+    public OracleControlSender(OracleControlEndpoint endpoint, OracleControlTransport transport, ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        _endpoint = endpoint;
+        _transport = transport;
+        Destination = endpoint.Uri;
+
+        _retryBlock = new RetryBlock<Envelope>(sendMessageAsync, logger, cancellationToken);
+    }
+
+    public bool SupportsNativeScheduledSend => false;
+    public Uri Destination { get; }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _retryBlock.DrainAsync();
+        _retryBlock.Dispose();
+    }
+
+    public async Task<bool> PingAsync()
+    {
+        try
+        {
+            await using var conn = await _transport.Database.OracleDataSource.OpenConnectionAsync();
+            await conn.CloseAsync();
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    public async ValueTask SendAsync(Envelope envelope)
+    {
+        envelope.DeliverWithin = 10.Seconds();
+        await _retryBlock.PostAsync(envelope);
+    }
+
+    private async Task sendMessageAsync(Envelope envelope, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested || _transport.Database.HasDisposed)
+        {
+            return;
+        }
+
+        try
+        {
+            await using var conn = await _transport.Database.OracleDataSource.OpenConnectionAsync(cancellationToken);
+            try
+            {
+                await using var cmd = conn.CreateCommand(
+                    $"INSERT INTO {_transport.TableName.QualifiedName} (id, message_type, node_id, body, expires) " +
+                    "VALUES (:id, :messagetype, :node, :body, :expires)");
+
+                cmd.With("id", envelope.Id);
+                cmd.With("messagetype", envelope.MessageType!);
+                cmd.With("node", _endpoint.NodeId);
+                cmd.Parameters.Add(new OracleParameter("body", OracleDbType.Blob)
+                {
+                    Value = EnvelopeSerializer.Serialize(envelope)
+                });
+                cmd.With("expires", DateTimeOffset.UtcNow.AddSeconds(30));
+
+                await cmd.ExecuteNonQueryAsync(cancellationToken);
+            }
+            finally
+            {
+                await conn.CloseAsync();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+        }
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleControlTransport.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleControlTransport.cs
@@ -1,0 +1,146 @@
+using JasperFx.Blocks;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.Logging;
+using Oracle.ManagedDataAccess.Client;
+using Weasel.Core;
+using Weasel.Oracle;
+using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.RDBMS;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.Oracle.Transport;
+
+/// <summary>
+/// Oracle-specific clone of <see cref="Wolverine.RDBMS.Transport.DatabaseControlTransport"/>.
+/// The shared RDBMS implementation assumes <c>@param</c> placeholders and Guid values that map
+/// directly onto a DbParameter — neither is true on Oracle, where placeholders use the
+/// <c>:param</c> syntax and the control queue's id columns are stored as RAW(16) requiring
+/// byte[]. Rather than generalize the shared implementation, we run a parallel one here.
+/// See #2622.
+/// </summary>
+internal class OracleControlTransport : ITransport, IAsyncDisposable
+{
+    public const string ProtocolName = "oraclecontrol";
+
+    private readonly Cache<Guid, OracleControlEndpoint> _endpoints;
+    private readonly WolverineOptions _options;
+    private RetryBlock<List<Envelope>>? _deleteBlock;
+
+    public OracleControlTransport(OracleMessageStore database, WolverineOptions options)
+    {
+        Database = database;
+        _options = options;
+
+        _endpoints = new Cache<Guid, OracleControlEndpoint>(nodeId => new OracleControlEndpoint(this, nodeId));
+
+        ControlEndpoint = _endpoints[_options.UniqueNodeId];
+        ControlEndpoint.IsListener = true;
+
+        Options = options;
+        TableName = new DbObjectName(database.SchemaName,
+            DatabaseConstants.ControlQueueTableName.ToUpperInvariant());
+    }
+
+    public OracleControlEndpoint ControlEndpoint { get; }
+
+    public OracleMessageStore Database { get; }
+
+    public DbObjectName TableName { get; }
+
+    public WolverineOptions Options { get; }
+
+    public string Protocol => ProtocolName;
+    public string Name => "Oracle-backed Control Message Transport for Wolverine Control Messages";
+
+    public bool TryBuildBrokerUsage(out BrokerDescription description)
+    {
+        description = default!;
+        return false;
+    }
+
+    public Endpoint ReplyEndpoint() => _endpoints[_options.UniqueNodeId];
+
+    public Endpoint GetOrCreateEndpoint(Uri uri)
+    {
+        var nodeId = Guid.Parse(uri.Host);
+        return _endpoints[nodeId];
+    }
+
+    public Endpoint? TryGetEndpoint(Uri uri)
+    {
+        var nodeId = Guid.Parse(uri.Host);
+        return _endpoints.TryFind(nodeId, out var e) ? e : null;
+    }
+
+    public IEnumerable<Endpoint> Endpoints() => _endpoints;
+
+    public ValueTask InitializeAsync(IWolverineRuntime runtime)
+    {
+        foreach (var endpoint in Endpoints()) endpoint.Compile(runtime);
+
+        _deleteBlock = new RetryBlock<List<Envelope>>(deleteEnvelopesAsync,
+            runtime.LoggerFactory.CreateLogger<OracleControlTransport>(), runtime.Options.Durability.Cancellation);
+        return ValueTask.CompletedTask;
+    }
+
+    public bool TryBuildStatefulResource(IWolverineRuntime runtime, out IStatefulResource? resource)
+    {
+        resource = default;
+        return false;
+    }
+
+    public Task DeleteEnvelopesAsync(List<Envelope> envelopes, CancellationToken cancellationToken)
+    {
+        if (_deleteBlock == null)
+        {
+            throw new InvalidOperationException("The OracleControlTransport has not been initialized");
+        }
+
+        return _deleteBlock.PostAsync(envelopes);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_deleteBlock != null)
+        {
+            try
+            {
+                await _deleteBlock.DrainAsync();
+            }
+            catch (TaskCanceledException)
+            {
+            }
+
+            _deleteBlock.SafeDispose();
+        }
+    }
+
+    private async Task deleteEnvelopesAsync(List<Envelope> envelopes, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested || Database.HasDisposed)
+        {
+            return;
+        }
+
+        await using var conn = await Database.OracleDataSource.OpenConnectionAsync(cancellationToken);
+
+        try
+        {
+            // Oracle has no reliable batch DELETE-by-id syntax in a single command, so we
+            // serialize the deletes. Volume here is tiny (control messages already consumed).
+            foreach (var envelope in envelopes)
+            {
+                await using var cmd = conn.CreateCommand($"DELETE FROM {TableName.QualifiedName} WHERE id = :id");
+                cmd.With("id", envelope.Id);
+                await cmd.ExecuteNonQueryAsync(cancellationToken);
+            }
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+}

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -80,6 +80,7 @@
   </Folder>
   <Folder Name="/Persistence/LeaderElection/">
     <Project Path="src/Persistence/LeaderElection/MySqlTests.LeaderElection/MySqlTests.LeaderElection.csproj" />
+    <Project Path="src/Persistence/LeaderElection/OracleTests.LeaderElection/OracleTests.LeaderElection.csproj" />
     <Project Path="src/Persistence/LeaderElection/PostgresqlTests.LeaderElection/PostgresqlTests.LeaderElection.csproj" />
     <Project Path="src/Persistence/LeaderElection/RavenDbTests.LeaderElection/RavenDbTests.LeaderElection.csproj" />
     <Project Path="src/Persistence/LeaderElection/SqlServerTests.LeaderElection/SqlServerTests.LeaderElection.csproj" />


### PR DESCRIPTION
## Summary

- `OracleMessageStore.Initialize` was a no-op, so when `Durability.Mode = Balanced` the host failed at startup with `ArgumentOutOfRangeException("ControlEndpoint cannot be null for this usage")` — the same hookup that `MessageDatabase.Initialize` performs for the other RDBMS stores was missing. Mirrors that hookup.
- Rather than retrofit the shared `DatabaseControlSender`/`Listener`/`Transport` to handle Oracle's `:`-prefixed placeholders and `RAW(16)` Guid columns, this PR introduces a parallel set of Oracle-specific transport classes (`OracleControlTransport` / `Endpoint` / `Sender` / `Listener`) under a new `oraclecontrol://` protocol and wires them up in `OracleMessageStore.Initialize`.
- Fixes a latent bug surfaced by the new compliance coverage: `OracleNodePersistence.LogRecordsAsync` was routed through `OracleMessageStore.EnqueueAsync` (a no-op on Oracle, since the `@`-prefixed batched path can't run there). Replaced with a direct `INSERT` per record, and made `FetchRecentRecordsAsync` `DBNull`-safe on the description column.
- Adds a new `OracleTests.LeaderElection` project mirroring the per-DB `LeaderElection` projects so `LeadershipElectionCompliance` runs against Oracle. Marked `[Trait("Category","Flaky")]` so CI doesn't run them by default — the suite needs careful sequencing of TM/DML lock release between back-to-back runs and is intended for local validation.

Fixes #2622.

## Test plan

- [x] Build clean: `dotnet build src/Persistence/Oracle/Wolverine.Oracle/Wolverine.Oracle.csproj --framework net9.0`
- [x] Build clean: `dotnet build src/Persistence/LeaderElection/OracleTests.LeaderElection/OracleTests.LeaderElection.csproj --framework net9.0`
- [x] All 12 `LeadershipElectionCompliance` tests pass locally (one-at-a-time, with the `wolverine-oracle-1` docker container running):
  - `the_only_known_node_is_automatically_the_leader`
  - `the_original_node_knows_about_all_the_possible_agents`
  - `add_second_node_see_balanced_nodes`
  - `singular_agent_is_only_running_on_one`
  - `leader_switchover_between_nodes`
  - `spin_up_several_nodes_take_away_original_node`
  - `spin_up_several_nodes_take_away_non_leader_node`
  - `eject_a_stale_node`
  - `take_over_leader_ship_if_leader_becomes_stale`
  - `persist_and_load_node_records`
  - `fan_out_message_to_all_nodes`
  - `ability_to_send_messages_to_correct_node_or_forward`

🤖 Generated with [Claude Code](https://claude.com/claude-code)