### PR TITLE
Saga timeout flag + scheduled-dispatch Activity tag (for CritterWatch saga visualization)

### DIFF
--- a/src/Testing/CoreTests/Acceptance/exporting_saga_capabilities.cs
+++ b/src/Testing/CoreTests/Acceptance/exporting_saga_capabilities.cs
@@ -59,9 +59,19 @@ public class exporting_saga_capabilities : IAsyncLifetime
     {
         var saga = _capabilities.Sagas.Single(s => s.StateType.FullName == typeof(DemoSaga).FullName!);
         // Wolverine pulls the saga id from each message's `{SagaName}Id`
-        // property by convention. All three of our test messages use
-        // `DemoSagaId` so they should all surface that name.
-        saga.Messages.ShouldAllBe(m => m.SagaIdMember == nameof(BeginDemoSaga.DemoSagaId));
+        // property by convention. The plain command messages all expose
+        // `DemoSagaId` so the descriptor surfaces that name. TimeoutMessage
+        // subclasses (DemoSagaReminder) don't carry the id as a property —
+        // the runtime threads it through the envelope instead — so their
+        // SagaIdMember is null on the descriptor, which is the correct
+        // signal for downstream tools rendering timeout arrows.
+        var commandMessages = saga.Messages
+            .Where(m => m.MessageType.FullName != typeof(DemoSagaReminder).FullName!)
+            .ToList();
+        commandMessages.ShouldAllBe(m => m.SagaIdMember == nameof(BeginDemoSaga.DemoSagaId));
+
+        var reminderMessage = saga.Messages.Single(m => m.MessageType.FullName == typeof(DemoSagaReminder).FullName!);
+        reminderMessage.SagaIdMember.ShouldBeNull();
     }
 
     [Fact]
@@ -97,6 +107,20 @@ public class exporting_saga_capabilities : IAsyncLifetime
     }
 
     [Fact]
+    public void marks_timeout_messages_on_message_descriptor()
+    {
+        // DemoSagaReminder derives from TimeoutMessage — the descriptor
+        // should reflect that so external tools can render saga timeout
+        // arrows with a clock affordance instead of a regular handler call.
+        var reminder = _capabilities.Messages.Single(m => m.Type.FullName == typeof(DemoSagaReminder).FullName!);
+        reminder.IsTimeoutMessage.ShouldBeTrue();
+
+        // Plain commands stay false so the flag is meaningfully discriminating.
+        var advance = _capabilities.Messages.Single(m => m.Type.FullName == typeof(AdvanceDemoSaga).FullName!);
+        advance.IsTimeoutMessage.ShouldBeFalse();
+    }
+
+    [Fact]
     public void surfaces_cascading_published_types()
     {
         // Begin* cascades a DemoSagaStarted event from its return tuple.
@@ -116,6 +140,15 @@ public record AdvanceDemoSaga(Guid DemoSagaId);
 public record EnsureDemoSaga(Guid DemoSagaId);
 public record DemoSagaStarted(Guid SagaId);
 
+/// <summary>
+/// Saga timeout message — a TimeoutMessage subclass so the
+/// MessageDescriptor.IsTimeoutMessage flag has something to assert
+/// against. In a real saga this would re-enter the saga after the
+/// configured DelayTime to drive a state transition (e.g. "if no payment
+/// received within 24h, cancel the booking").
+/// </summary>
+public record DemoSagaReminder() : TimeoutMessage(TimeSpan.FromMinutes(15));
+
 public class DemoSaga : Saga
 {
     public Guid Id { get; set; }
@@ -133,6 +166,12 @@ public class DemoSaga : Saga
     public void StartOrHandle(EnsureDemoSaga cmd)
     {
         Id = cmd.DemoSagaId;
+    }
+
+    public void Handle(DemoSagaReminder reminder)
+    {
+        // No-op: the test only cares that the message type is discovered
+        // and surfaces with IsTimeoutMessage = true on the descriptor.
     }
 }
 

--- a/src/Testing/CoreTests/Runtime/WolverineTracingTests.cs
+++ b/src/Testing/CoreTests/Runtime/WolverineTracingTests.cs
@@ -133,3 +133,33 @@ public class when_saga_id_is_set_on_envelope
         theActivity.GetTagItem(WolverineTracing.SagaId).ShouldBe(theEnvelope.SagaId);
     }
 }
+
+public class when_envelope_is_scheduled
+{
+    [Fact]
+    public void tags_activity_when_scheduled_time_is_set()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.ScheduledTime = DateTimeOffset.UtcNow.AddMinutes(5);
+
+        var activity = new Activity("process");
+        envelope.WriteTags(activity);
+
+        // Distinguishes a scheduled re-entrance (saga timeout firing,
+        // deferred command, retry-with-delay) from an immediate dispatch
+        // — see WolverineTracing.MessageScheduled.
+        activity.GetTagItem(WolverineTracing.MessageScheduled).ShouldBe(true);
+    }
+
+    [Fact]
+    public void does_not_tag_activity_when_scheduled_time_is_null()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.ScheduledTime = null;
+
+        var activity = new Activity("process");
+        envelope.WriteTags(activity);
+
+        activity.GetTagItem(WolverineTracing.MessageScheduled).ShouldBeNull();
+    }
+}

--- a/src/Wolverine/Configuration/Capabilities/MessageDescriptor.cs
+++ b/src/Wolverine/Configuration/Capabilities/MessageDescriptor.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Handlers;
@@ -20,9 +21,11 @@ public class MessageDescriptor
             ReadHandlerChain(handlerChain, handlers);
         }
     }
-    
+
     public MessageDescriptor(Type messageType, IWolverineRuntime runtime) : this(TypeDescriptor.For(messageType))
     {
+        IsTimeoutMessage = messageType.CanBeCastTo<TimeoutMessage>();
+
         var routes = runtime.RoutingFor(messageType).Routes;
         Subscriptions.AddRange(routes.Select(x => x.Describe()));
 
@@ -40,6 +43,17 @@ public class MessageDescriptor
     }
 
     public TypeDescriptor Type { get; }
+
+    /// <summary>
+    /// True when the message type derives from <see cref="TimeoutMessage"/>.
+    /// Surfaced so external monitoring tools (e.g. CritterWatch's saga
+    /// visualization) can render timeout messages distinctly — they're a
+    /// fundamentally different narrative element in saga workflows
+    /// ("delay then re-enter the saga") versus regular handler-driven
+    /// messages, and visualizations look much clearer when they're
+    /// shaped differently.
+    /// </summary>
+    public bool IsTimeoutMessage { get; set; }
 
     public List<MessageHandlerDescriptor> Handlers { get; set; } = new();
 

--- a/src/Wolverine/Envelope.Internals.cs
+++ b/src/Wolverine/Envelope.Internals.cs
@@ -377,6 +377,15 @@ public partial class Envelope
         activity.MaybeSetTag(WolverineTracing.PayloadSizeBytes, MessagePayloadSize);
         activity.MaybeSetTag(MetricsConstants.TenantIdKey, TenantId);
         activity.MaybeSetTag(WolverineTracing.SagaId, SagaId);
+
+        // True when this envelope was scheduled for delayed delivery and is
+        // now being processed (or sent) past its ScheduledTime. Useful for
+        // trace consumers that want to distinguish a saga-timeout
+        // re-entrance from an immediate-delivery handle.
+        if (ScheduledTime.HasValue)
+        {
+            activity.SetTag(WolverineTracing.MessageScheduled, true);
+        }
     }
 
     internal ValueTask PersistAsync(IEnvelopeTransaction transaction)

--- a/src/Wolverine/Runtime/WolverineTracing.cs
+++ b/src/Wolverine/Runtime/WolverineTracing.cs
@@ -124,6 +124,17 @@ internal static class WolverineTracing
     public const string SagaId = "wolverine.saga.id";
 
     /// <summary>
+    /// Activity tag set when an envelope being processed carries a
+    /// <see cref="Envelope.ScheduledTime"/> — i.e. it was previously
+    /// scheduled for delayed delivery (saga timeout, deferred command,
+    /// retry-with-delay, …) rather than dispatched immediately. Useful
+    /// for trace queries that want to distinguish "first-time delivery"
+    /// from "scheduled re-entry" in saga workflows where timeout
+    /// messages re-enter the saga after a wait.
+    /// </summary>
+    public const string MessageScheduled = "wolverine.message.scheduled";
+
+    /// <summary>
     /// Activity tag for the saga type full name when processing a saga message
     /// </summary>
     public const string SagaType = "wolverine.saga.type";


### PR DESCRIPTION
## Summary

Two small additive changes that together let CritterWatch's saga visualization (related: [JasperFx/CritterWatch#90](https://github.com/JasperFx/CritterWatch/issues/90)) render workflows accurately without re-deriving info from runtime types.

### `MessageDescriptor.IsTimeoutMessage`

New `bool IsTimeoutMessage` on `Wolverine.Configuration.Capabilities.MessageDescriptor`, set to `true` when the message type derives from `TimeoutMessage`. External tools render timeout arrows distinctly — they're a fundamentally different narrative element in saga workflows ("delay then re-enter") versus handler-driven messages.

### `wolverine.message.scheduled` Activity tag

`Envelope.WriteTags(Activity)` now emits `wolverine.message.scheduled = true` when the envelope carries a `ScheduledTime`. New constant `WolverineTracing.MessageScheduled = "wolverine.message.scheduled"`.

Useful for trace consumers distinguishing first-time delivery (no tag) from scheduled re-entrance (tag present — saga timeout firing, deferred command, retry-with-delay). In a saga timeline this collapses what looks like a 24-hour gap into a single explicit "timeout fired" beat.

### Why this PR is small

`wolverine.saga.type` was already emitted (by `SetSagaIdFrame` / `SetSagaIdFromSagaFrame`). Leaves only the two items above.

## Tests

- `when_envelope_is_scheduled` (2 cases) — both true and null branches in `WriteTags`
- `marks_timeout_messages_on_message_descriptor` — extends the saga-capability acceptance test with a `DemoSagaReminder : TimeoutMessage` fixture
- `captures_saga_id_member_per_message` updated to handle the TimeoutMessage case correctly (SagaIdMember is null on TimeoutMessages — the runtime threads id through the envelope, not a property)
- **97/97** saga + capability + tracing tests green on net9.0

## Test plan

- [x] `dotnet build src/Wolverine/Wolverine.csproj` clean
- [x] Targeted suites green (sagas, capabilities, tracing)
- [ ] CI green
- [ ] Manual: pull into CritterWatch, confirm `IsTimeoutMessage` arrives populated and `wolverine.message.scheduled` shows up in OTel traces for scheduled dispatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)