### PR TITLE
Native API versioning for Wolverine.Http (closes #2627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+### WolverineFx.Http
+
+- Added native API versioning support via `Asp.Versioning.Abstractions` 10.x. Supports URL-segment versioning
+  (`/v1/...`, `/v2/...`), sunset/deprecation policies with RFC 9745/8594/8288 response headers, and automatic
+  OpenAPI document partitioning with Swashbuckle/Scalar/Microsoft.AspNetCore.OpenApi. No dependency on
+  `Asp.Versioning.Http` — versioning is driven entirely via `IHttpPolicy`.
+  See [versioning guide](docs/guide/http/versioning.md).

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Alba" Version="8.5.2" />
+    <PackageVersion Include="Asp.Versioning.Abstractions" Version="10.0.0" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.22.1" />
     <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.2.14" />
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.14" />
@@ -83,6 +84,7 @@
     <PackageVersion Include="RavenDB.TestDriver" Version="7.0.2" />
     <PackageVersion Include="Refit" Version="8.0.0" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.8" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Spectre.Console" Version="0.55.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.9.17" />

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -264,6 +264,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                         {text: 'Exception Handling', link: '/guide/http/exception-handling'},
                         {text: 'Policies', link: '/guide/http/policies.md'},
                         {text: 'OpenAPI Metadata', link: '/guide/http/metadata'},
+                        {text: 'API Versioning', link: '/guide/http/versioning'},
                         {text: 'Using as Mediator', link: '/guide/http/mediator'},
                         {text: 'Multi-Tenancy and ASP.Net Core', link: '/guide/http/multi-tenancy'},
                         {text: 'Publishing Messages', link: '/guide/http/messaging'},

--- a/docs/guide/http/index.md
+++ b/docs/guide/http/index.md
@@ -273,4 +273,10 @@ leads to code that is hard to reason about and hence, potentially buggy in real 
 need this functionality in the real world, so here you go. 
 :::
 
+## API Versioning <Badge type="tip" text="5.36" />
+
+Wolverine.Http has native support for versioning your HTTP APIs over time using URL-segment strategies (e.g.
+`/v1/orders`, `/v2/orders`), per-version sunset and deprecation policies with RFC 9745/8594 response headers,
+and automatic OpenAPI document partitioning. See the [HTTP API Versioning guide](./versioning.md) for full details.
+
 

--- a/docs/guide/http/metadata.md
+++ b/docs/guide/http/metadata.md
@@ -58,6 +58,12 @@ public static void Configure(HttpChain chain)
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http/Runtime/PublishingEndpoint.cs#L15-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_programmatic_one_off_openapi_metadata' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+::: tip
+For HTTP API versioning that partitions the OpenAPI output into one document per version, see the
+[Versioning guide](./versioning.md). It covers the multi-document `SwaggerDoc` setup, `DocInclusionPredicate`,
+`DescribeWolverineApiVersions()`, and Scalar integration.
+:::
+
 ## Swashbuckle and Wolverine
 
 [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) is de facto the OpenAPI tooling for ASP.Net Core

--- a/docs/guide/http/versioning.md
+++ b/docs/guide/http/versioning.md
@@ -1,0 +1,319 @@
+# HTTP API Versioning <Badge type="tip" text="5.36" />
+
+Wolverine.Http provides native API versioning support that lets you evolve your HTTP services over time without
+breaking existing clients. Versioned endpoints coexist at separate URL prefixes (e.g. `/v1/orders` and `/v2/orders`),
+carry the correct OpenAPI metadata, and can emit RFC 9745 `Deprecation` and RFC 8594 `Sunset` response headers to
+signal planned end-of-life to callers.
+
+The feature depends on the `Asp.Versioning.Abstractions` 10.x NuGet package — the thin, framework-neutral abstraction
+layer. It does **not** require `Asp.Versioning.Http` (the ASP.NET Core-specific middleware pack). Wolverine drives
+versioning entirely through its own `IHttpPolicy` pipeline, so there is no conflict with an existing
+`AddApiVersioning()` registration, and no additional ASP.NET Core middleware is needed.
+
+::: info
+This release supports **URL-segment versioning** (e.g. `/v1/...`, `/v2/...`). Each endpoint declares a single
+`[ApiVersion]`; multi-version handlers via `[MapToApiVersion]` are not supported.
+:::
+
+## Quick Start
+
+**1. Add the package** (if not already present via `WolverineFx.Http`):
+
+```bash
+dotnet add package Asp.Versioning.Abstractions
+```
+
+**2. Decorate your endpoint class or method:**
+
+```csharp
+using Asp.Versioning;
+using Wolverine.Http;
+
+[ApiVersion("1.0")]
+public static class OrdersV1Endpoint
+{
+    [WolverineGet("/orders", OperationId = "OrdersV1Endpoint.Get")]
+    public static OrdersV1Response Get() => new(["order-a", "order-b"]);
+}
+
+public record OrdersV1Response(IReadOnlyList<string> Orders);
+```
+
+**3. Enable versioning inside `MapWolverineEndpoints`:**
+
+```csharp
+app.MapWolverineEndpoints(opts =>
+{
+    opts.UseApiVersioning(v =>
+    {
+        // All options are optional — the defaults work out of the box.
+        v.UnversionedPolicy = UnversionedPolicy.PassThrough;
+    });
+});
+```
+
+With these two pieces in place Wolverine will rewrite the route to `/v1/orders` and attach the appropriate
+`ApiVersionMetadata` and OpenAPI group name automatically.
+
+## Declaring Versions
+
+### Attribute placement
+
+Apply `[ApiVersion]` to the endpoint class or to the handler method. **Method-level wins over class-level:**
+if both declare a version, the method attribute is used.
+
+```csharp
+// Class-level — all methods in this class are v2.
+[ApiVersion("2.0")]
+public static class OrdersV2Endpoint
+{
+    [WolverineGet("/orders")]
+    public static OrdersV2Response Get() => new("ok", ["v2-a", "v2-b"]);
+}
+```
+
+### One version per endpoint
+
+Declaring **multiple** `[ApiVersion]` attributes on the same handler method is not supported in v1. The resolver
+picks the first attribute encountered and ignores any additional ones. If you have two incompatible response shapes
+for the same resource, create separate endpoint classes — one per version — as shown in the sample app
+(`OrdersV1Endpoint`, `OrdersV2Endpoint`, `OrdersV3PreviewEndpoint`).
+
+### Marking a version as deprecated via attribute
+
+The `Deprecated` property on `[ApiVersion]` is honoured and will automatically attach a deprecation policy to
+the chain:
+
+```csharp
+[ApiVersion("1.0", Deprecated = true)]
+public static class LegacyOrdersEndpoint
+{
+    [WolverineGet("/orders")]
+    public static OrdersV1Response Get() => new([]);
+}
+```
+
+When this attribute is present, Wolverine emits a `Deprecation: true` response header (RFC 9745) and marks the
+OpenAPI operation as deprecated without any additional configuration.
+
+## URL-Segment Versioning
+
+### Default behaviour
+
+By default, Wolverine prepends `v{major}` to every versioned route. Given `[ApiVersion("2.0")]` and the route
+`/orders`, the live URL becomes `/v2/orders`.
+
+### Customising the URL segment prefix
+
+The prefix template is controlled by `UrlSegmentPrefix` (default `"v{version}"`). The `{version}` token is
+**required** — omitting it causes a startup exception (see [Troubleshooting](#troubleshooting)):
+
+```csharp
+opts.UseApiVersioning(v =>
+{
+    // Changes /v2/orders → /api/v2/orders
+    v.UrlSegmentPrefix = "api/v{version}";
+});
+```
+
+Set `UrlSegmentPrefix = null` to disable URL-segment versioning entirely. In that case the original route is
+kept unchanged and no prefix is injected.
+
+### Version format in the URL
+
+The `UrlSegmentVersionFormatter` callback controls how an `ApiVersion` is turned into the string substituted
+into the prefix. The default formats `ApiVersion(2, 0)` as `"2"` (major-only), giving clean URLs like `/v2/`.
+
+Override it to emit `major.minor` format:
+
+```csharp
+opts.UseApiVersioning(v =>
+{
+    // Produces /v2.0/orders instead of /v2/orders
+    v.UrlSegmentVersionFormatter = apiVersion =>
+        apiVersion.MajorVersion.HasValue
+            ? $"{apiVersion.MajorVersion}.{apiVersion.MinorVersion ?? 0}"
+            : apiVersion.ToString();
+});
+```
+
+For date-based versions where `MajorVersion` is `null`, the default formatter falls back to `ApiVersion.ToString()`,
+which may include hyphens (e.g. `2024-01-01`). Override the formatter if your URL scheme needs a different shape.
+
+## Unversioned-Endpoint Policy
+
+When `UseApiVersioning` is active, every endpoint that lacks an `[ApiVersion]` attribute is subject to the
+`UnversionedPolicy`. Three behaviours are available:
+
+| Policy | Behaviour |
+|---|---|
+| `PassThrough` *(default)* | Unversioned endpoints stay at their declared route with no version metadata. They coexist alongside versioned endpoints. |
+| `RequireExplicit` | Bootstrap throws an `InvalidOperationException` if any endpoint is missing `[ApiVersion]`. Recommended for greenfield APIs that should be fully versioned from day one. |
+| `AssignDefault` | All unversioned endpoints are silently promoted to `DefaultVersion`. Set `DefaultVersion` when using this mode. |
+
+```csharp
+// RequireExplicit — every endpoint must carry [ApiVersion]
+opts.UseApiVersioning(v =>
+{
+    v.UnversionedPolicy = UnversionedPolicy.RequireExplicit;
+});
+
+// AssignDefault — migrate an existing unversioned API to a v1 baseline
+opts.UseApiVersioning(v =>
+{
+    v.UnversionedPolicy = UnversionedPolicy.AssignDefault;
+    v.DefaultVersion = new ApiVersion(1, 0);
+});
+```
+
+## Sunset and Deprecation Policies
+
+Beyond the attribute-driven `Deprecated = true` flag, you can configure per-version sunset and deprecation
+policies with dates and RFC 8288 link references directly in the options:
+
+```csharp
+opts.UseApiVersioning(v =>
+{
+    // Announce that v1.0 is deprecated as of a specific date with a migration link.
+    v.Deprecate("1.0")
+        .On(DateTimeOffset.Parse("2026-12-31T00:00:00Z"))
+        .WithLink(new Uri("https://example.com/migration-guide"));
+
+    // Announce that v3.0 will sunset (be removed) on a future date.
+    v.Sunset("3.0")
+        .On(DateTimeOffset.Parse("2027-01-01T00:00:00Z"))
+        .WithLink(new Uri("https://example.com/migrate-from-v3"), "Migration guide", "text/html");
+});
+```
+
+### Response headers
+
+When a versioned endpoint is matched, Wolverine emits response headers according to the applicable RFCs:
+
+| Header | RFC | When emitted |
+|---|---|---|
+| `api-supported-versions` | — | All versioned endpoints (toggleable via `EmitApiSupportedVersionsHeader`) |
+| `Deprecation` | RFC 9745 | Endpoints with a deprecation policy |
+| `Sunset` | RFC 8594 | Endpoints with a sunset date configured |
+| `Link` | RFC 8288 | Endpoints with link references on either policy |
+
+Toggle the headers globally:
+
+```csharp
+opts.UseApiVersioning(v =>
+{
+    v.EmitApiSupportedVersionsHeader = false; // suppress the supported-versions header
+    v.EmitDeprecationHeaders = false;          // suppress Deprecation/Sunset/Link headers
+});
+```
+
+## OpenAPI Integration
+
+Wolverine attaches two pieces of metadata to every versioned chain during bootstrapping:
+
+- `IEndpointGroupNameMetadata` — the document name string (e.g. `"v1"`, `"v2"`) used by Swashbuckle, Scalar,
+  and Microsoft.AspNetCore.OpenApi to partition the OpenAPI output.
+- `Asp.Versioning.ApiVersionMetadata` — the typed version model consumed by `Asp.Versioning.Http` tooling if
+  it is also present in the application.
+
+### Customising the document name strategy
+
+The default strategy maps `ApiVersion(2, 0)` → `"v2"`. Override it via:
+
+```csharp
+opts.UseApiVersioning(v =>
+{
+    // Use "api-v2" as the Swashbuckle document name for version 2.x
+    v.OpenApi.DocumentNameStrategy = apiVersion =>
+        apiVersion.MajorVersion.HasValue
+            ? $"api-v{apiVersion.MajorVersion}"
+            : apiVersion.ToString();
+});
+```
+
+### Swashbuckle multi-document setup
+
+Register one `SwaggerDoc` per version. Use `DocInclusionPredicate` to route each endpoint to the correct document
+via the group name Wolverine has set. Register `WolverineApiVersioningSwaggerOperationFilter` to surface sunset
+and deprecation state in the OpenAPI output:
+
+```csharp
+builder.Services.AddSwaggerGen(x =>
+{
+    x.SwaggerDoc("v1", new OpenApiInfo { Title = "API v1", Version = "v1" });
+    x.SwaggerDoc("v2", new OpenApiInfo { Title = "API v2", Version = "v2" });
+
+    // Route each endpoint to the document whose name matches the endpoint group name.
+    x.DocInclusionPredicate((doc, api) => api.GroupName == doc);
+
+    // Surfaces deprecation / sunset state in the OpenAPI output.
+    x.OperationFilter<WolverineApiVersioningSwaggerOperationFilter>();
+});
+```
+
+`WolverineApiVersioningSwaggerOperationFilter` is **not distributed as a NuGet library**. Copy it from the sample
+app (`src/Http/WolverineWebApi/ApiVersioning/WolverineApiVersioningSwaggerOperationFilter.cs`) into your own
+project and register it as shown above.
+
+### SwaggerUI version dropdown
+
+Use `DescribeWolverineApiVersions()` to enumerate the discovered versions and wire each into the SwaggerUI
+endpoint list:
+
+```csharp
+app.UseSwagger();
+app.UseSwaggerUI(c =>
+{
+    // Wire in non-versioned endpoints under a "default" document if you have them.
+    c.SwaggerEndpoint("/swagger/default/swagger.json", "default");
+
+    foreach (var description in app.DescribeWolverineApiVersions())
+    {
+        c.SwaggerEndpoint(
+            $"/swagger/{description.DocumentName}/swagger.json",
+            description.DisplayName);
+    }
+});
+```
+
+`DescribeWolverineApiVersions()` returns an empty list when versioning is not configured or no versioned
+endpoints have been discovered, so the loop is always safe to call.
+
+### Scalar integration
+
+Scalar follows the same pattern. Register one document per version, then iterate `DescribeWolverineApiVersions()`:
+
+```csharp
+app.MapScalarApiReference(opts =>
+{
+    opts.Title = "My API";
+    foreach (var description in app.DescribeWolverineApiVersions())
+        opts.AddDocument(description.DocumentName, description.DisplayName);
+});
+```
+
+### Microsoft.AspNetCore.OpenApi
+
+When using the built-in `Microsoft.AspNetCore.OpenApi` package, Wolverine's group name is surfaced as
+`ApiDescription.GroupName` in `ApiDescriptionGroupCollection`. The standard ASP.NET Core document filter
+mechanism can be used to partition endpoints by group name in exactly the same way as Swashbuckle's
+`DocInclusionPredicate`.
+
+## Troubleshooting
+
+**`UrlSegmentPrefix` is set but the route is unchanged.**
+Check that the prefix string contains the literal `{version}` token. If no `{version}` is present and there are
+versioned endpoints, Wolverine throws at startup:
+
+> `WolverineApiVersioningOptions.UrlSegmentPrefix is set to 'myprefix' which does not contain the required '{version}' token. ... Set UrlSegmentPrefix to null to disable URL-segment versioning, or include '{version}' in the prefix template.`
+
+**All my existing endpoints stopped resolving after I turned on `RequireExplicit`.**
+`RequireExplicit` means every endpoint, including infrastructure or health-check endpoints discovered by Wolverine's
+assembly scan, must carry `[ApiVersion]`. Switch to `PassThrough` (the default) for any endpoints that should
+remain unversioned, or add the attribute. The exception message lists the offending endpoint by its display name.
+
+**Multiple `[ApiVersion]` attributes on the same method.**
+Only the first attribute is used; subsequent attributes are silently ignored. If you need to expose a resource at
+two different versions, create separate endpoint classes — one per version — sharing the same route template. The
+duplicate-detection step in `ApiVersioningPolicy` will catch any `(verb, route, version)` triple that appears
+more than once and throw a descriptive `InvalidOperationException` at startup.

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersionHeaderWriterTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersionHeaderWriterTests.cs
@@ -1,0 +1,214 @@
+using System.Globalization;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Wolverine.Http.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+public class ApiVersionHeaderWriterTests
+{
+    // Helper: build a DefaultHttpContext that has the given state attached as endpoint metadata.
+    private static DefaultHttpContext ContextWithState(ApiVersionEndpointHeaderState state)
+    {
+        var ctx = new DefaultHttpContext();
+        var endpoint = new Endpoint(
+            _ => Task.CompletedTask,
+            new EndpointMetadataCollection(state),
+            "test");
+        ctx.SetEndpoint(endpoint);
+        return ctx;
+    }
+
+    // Helper: build a DefaultHttpContext with NO endpoint state.
+    private static DefaultHttpContext ContextWithNoState()
+    {
+        return new DefaultHttpContext();
+    }
+
+    // 1 — no state → no headers emitted
+    [Fact]
+    public async Task no_state_metadata_emits_no_headers()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var writer = new ApiVersionHeaderWriter(opts);
+        var ctx = ContextWithNoState();
+
+        await writer.WriteAsync(ctx);
+
+        ctx.Response.Headers.ContainsKey("api-supported-versions").ShouldBeFalse();
+        ctx.Response.Headers.ContainsKey("Deprecation").ShouldBeFalse();
+        ctx.Response.Headers.ContainsKey("Sunset").ShouldBeFalse();
+        ctx.Response.Headers.ContainsKey("Link").ShouldBeFalse();
+    }
+
+    // 2 — api-supported-versions is union of sunset + deprecation policy keys, sorted ascending
+    [Fact]
+    public async Task api_supported_versions_includes_sunset_and_deprecation_keys()
+    {
+        var date1 = new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var date2 = new DateTimeOffset(2028, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var opts = new WolverineApiVersioningOptions();
+        opts.Sunset("1.0").On(date1);
+        opts.Deprecate("2.0").On(date2);
+
+        var writer = new ApiVersionHeaderWriter(opts);
+        var state = new ApiVersionEndpointHeaderState(
+            new ApiVersion(1, 0),
+            opts.SunsetPolicies[new ApiVersion(1, 0)],
+            null);
+        var ctx = ContextWithState(state);
+
+        await writer.WriteAsync(ctx);
+
+        ctx.Response.Headers["api-supported-versions"].ToString().ShouldBe("1.0, 2.0");
+    }
+
+    // 3 — Deprecation header uses IMF-fixdate when policy has a date
+    [Fact]
+    public async Task deprecation_with_date_uses_imf_fixdate()
+    {
+        var depDate = new DateTimeOffset(2030, 6, 15, 0, 0, 0, TimeSpan.Zero);
+        var opts = new WolverineApiVersioningOptions();
+        var depPolicy = new DeprecationPolicy(depDate);
+        var state = new ApiVersionEndpointHeaderState(new ApiVersion(1, 0), null, depPolicy);
+        var writer = new ApiVersionHeaderWriter(opts);
+        var ctx = ContextWithState(state);
+
+        await writer.WriteAsync(ctx);
+
+        var expected = depDate.UtcDateTime.ToString("R", CultureInfo.InvariantCulture);
+        ctx.Response.Headers["Deprecation"].ToString().ShouldBe(expected);
+    }
+
+    // 4 — Deprecation header is "true" when policy has no date
+    [Fact]
+    public async Task deprecation_without_date_emits_true_token()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var depPolicy = new DeprecationPolicy();
+        var state = new ApiVersionEndpointHeaderState(new ApiVersion(1, 0), null, depPolicy);
+        var writer = new ApiVersionHeaderWriter(opts);
+        var ctx = ContextWithState(state);
+
+        await writer.WriteAsync(ctx);
+
+        ctx.Response.Headers["Deprecation"].ToString().ShouldBe("true");
+    }
+
+    // 5 — Sunset header uses IMF-fixdate
+    [Fact]
+    public async Task sunset_emits_imf_fixdate()
+    {
+        var sunsetDate = new DateTimeOffset(2029, 12, 31, 0, 0, 0, TimeSpan.Zero);
+        var opts = new WolverineApiVersioningOptions();
+        var sunsetPolicy = new SunsetPolicy(sunsetDate);
+        var state = new ApiVersionEndpointHeaderState(new ApiVersion(1, 0), sunsetPolicy, null);
+        var writer = new ApiVersionHeaderWriter(opts);
+        var ctx = ContextWithState(state);
+
+        await writer.WriteAsync(ctx);
+
+        var expected = sunsetDate.UtcDateTime.ToString("R", CultureInfo.InvariantCulture);
+        ctx.Response.Headers["Sunset"].ToString().ShouldBe(expected);
+    }
+
+    // 6 — Link header: single sunset link with rel="sunset", title, type
+    [Fact]
+    public async Task single_link_with_sunset_rel()
+    {
+        var sunsetDate = new DateTimeOffset(2029, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var linkUri = new Uri("https://example.com/info");
+        var link = new LinkHeaderValue(linkUri, "sunset") { Title = "Info", Type = "text/html" };
+        var sunsetPolicy = new SunsetPolicy(sunsetDate, link);
+        var opts = new WolverineApiVersioningOptions();
+        var state = new ApiVersionEndpointHeaderState(new ApiVersion(1, 0), sunsetPolicy, null);
+        var writer = new ApiVersionHeaderWriter(opts);
+        var ctx = ContextWithState(state);
+
+        await writer.WriteAsync(ctx);
+
+        ctx.Response.Headers["Link"].ToString()
+            .ShouldBe("<https://example.com/info>; rel=\"sunset\"; title=\"Info\"; type=\"text/html\"");
+    }
+
+    // 7 — multiple links from one SunsetPolicy are comma-space joined
+    [Fact]
+    public async Task multiple_links_are_comma_separated()
+    {
+        var sunsetDate = new DateTimeOffset(2029, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var link1 = new LinkHeaderValue(new Uri("https://example.com/first"), "sunset");
+        var link2 = new LinkHeaderValue(new Uri("https://example.com/second"), "sunset");
+        var sunsetPolicy = new SunsetPolicy(sunsetDate, link1);
+        sunsetPolicy.Links.Add(link2);
+
+        var opts = new WolverineApiVersioningOptions();
+        var state = new ApiVersionEndpointHeaderState(new ApiVersion(1, 0), sunsetPolicy, null);
+        var writer = new ApiVersionHeaderWriter(opts);
+        var ctx = ContextWithState(state);
+
+        await writer.WriteAsync(ctx);
+
+        var linkHeader = ctx.Response.Headers["Link"].ToString();
+        linkHeader.ShouldContain("<https://example.com/first>; rel=\"sunset\"");
+        linkHeader.ShouldContain("<https://example.com/second>; rel=\"sunset\"");
+        linkHeader.ShouldContain(", ");
+    }
+
+    // 8 — EmitDeprecationHeaders=false suppresses Deprecation/Sunset/Link; api-supported-versions still emits
+    [Fact]
+    public async Task disabled_emit_deprecation_headers_skips_deprecation_sunset_and_link()
+    {
+        var date = new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var opts = new WolverineApiVersioningOptions
+        {
+            EmitDeprecationHeaders = false,
+            EmitApiSupportedVersionsHeader = true
+        };
+        opts.Sunset("1.0").On(date);
+
+        var sunsetPolicy = opts.SunsetPolicies[new ApiVersion(1, 0)];
+        var depPolicy = new DeprecationPolicy(date);
+        var linkUri = new Uri("https://example.com");
+        var link = new LinkHeaderValue(linkUri, "sunset");
+        sunsetPolicy.Links.Add(link);
+
+        var state = new ApiVersionEndpointHeaderState(new ApiVersion(1, 0), sunsetPolicy, depPolicy);
+        var writer = new ApiVersionHeaderWriter(opts);
+        var ctx = ContextWithState(state);
+
+        await writer.WriteAsync(ctx);
+
+        // api-supported-versions should still be present
+        ctx.Response.Headers.ContainsKey("api-supported-versions").ShouldBeTrue();
+        // Deprecation/Sunset/Link should be absent
+        ctx.Response.Headers.ContainsKey("Deprecation").ShouldBeFalse();
+        ctx.Response.Headers.ContainsKey("Sunset").ShouldBeFalse();
+        ctx.Response.Headers.ContainsKey("Link").ShouldBeFalse();
+    }
+
+    // 9 — EmitApiSupportedVersionsHeader=false suppresses api-supported-versions
+    [Fact]
+    public async Task disabled_emit_supported_versions_skips_supported_versions()
+    {
+        var date = new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var opts = new WolverineApiVersioningOptions
+        {
+            EmitApiSupportedVersionsHeader = false,
+            EmitDeprecationHeaders = true
+        };
+        opts.Deprecate("1.0").On(date);
+
+        var depPolicy = opts.DeprecationPolicies[new ApiVersion(1, 0)];
+        var state = new ApiVersionEndpointHeaderState(new ApiVersion(1, 0), null, depPolicy);
+        var writer = new ApiVersionHeaderWriter(opts);
+        var ctx = ContextWithState(state);
+
+        await writer.WriteAsync(ctx);
+
+        ctx.Response.Headers.ContainsKey("api-supported-versions").ShouldBeFalse();
+        // Deprecation still fires
+        ctx.Response.Headers.ContainsKey("Deprecation").ShouldBeTrue();
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersionResolverTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersionResolverTests.cs
@@ -1,0 +1,88 @@
+using System.Reflection;
+using Asp.Versioning;
+using Shouldly;
+using Wolverine.Http.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+internal class NoVersionHandler { public void Handle() { } }
+
+[ApiVersion("2.0")]
+internal class ClassOnlyVersionHandler { public void Handle() { } }
+
+internal class MethodOnlyVersionHandler { [ApiVersion("1.0")] public void Handle() { } }
+
+[ApiVersion("2.0")]
+internal class MethodOverridesClassHandler { [ApiVersion("1.0")] public void Handle() { } }
+
+internal class MultipleVersionsOnMethodHandler
+{
+    [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
+    public void Handle() { }
+}
+
+internal class DeprecatedMethodHandler
+{
+    [ApiVersion("1.0", Deprecated = true)]
+    public void Handle() { }
+}
+
+public class ApiVersionResolverTests
+{
+    private static MethodInfo MethodOf<T>(string name)
+        => typeof(T).GetMethod(name, BindingFlags.Public | BindingFlags.Instance)!;
+
+    [Fact]
+    public void no_attribute_returns_null()
+    {
+        var method = MethodOf<NoVersionHandler>(nameof(NoVersionHandler.Handle));
+        ApiVersionResolver.Resolve(method).ShouldBeNull();
+    }
+
+    [Fact]
+    public void class_only_attribute_resolves_to_class_version()
+    {
+        var method = MethodOf<ClassOnlyVersionHandler>(nameof(ClassOnlyVersionHandler.Handle));
+        var result = ApiVersionResolver.Resolve(method);
+        result!.Value.Version.ShouldBe(new ApiVersion(2, 0));
+        result.Value.IsDeprecated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void method_attribute_resolves_to_method_version()
+    {
+        var method = MethodOf<MethodOnlyVersionHandler>(nameof(MethodOnlyVersionHandler.Handle));
+        var result = ApiVersionResolver.Resolve(method);
+        result!.Value.Version.ShouldBe(new ApiVersion(1, 0));
+        result.Value.IsDeprecated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void method_attribute_overrides_class_attribute()
+    {
+        var method = MethodOf<MethodOverridesClassHandler>(nameof(MethodOverridesClassHandler.Handle));
+        var result = ApiVersionResolver.Resolve(method);
+        result!.Value.Version.ShouldBe(new ApiVersion(1, 0));
+        result.Value.IsDeprecated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void multiple_versions_on_same_method_throws()
+    {
+        var method = MethodOf<MultipleVersionsOnMethodHandler>(nameof(MultipleVersionsOnMethodHandler.Handle));
+        var ex = Should.Throw<InvalidOperationException>(() => ApiVersionResolver.Resolve(method));
+        ex.Message.ShouldContain("MultipleVersionsOnMethodHandler.Handle");
+        ex.Message.ShouldContain("1.0");
+        ex.Message.ShouldContain("2.0");
+    }
+
+    [Fact]
+    public void deprecated_attribute_flag_is_propagated()
+    {
+        var result = ApiVersionResolver.Resolve(MethodOf<DeprecatedMethodHandler>(nameof(DeprecatedMethodHandler.Handle)));
+        result.ShouldNotBeNull();
+        result.Value.Version.ShouldBe(new ApiVersion(1, 0));
+        result.Value.IsDeprecated.ShouldBeTrue();
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersioningPolicyHeaderWiringTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersioningPolicyHeaderWiringTests.cs
@@ -1,0 +1,119 @@
+using Asp.Versioning;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using Microsoft.AspNetCore.Routing;
+using Shouldly;
+using Wolverine.Http.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+// ---------- Handler fixtures ----------
+
+internal class SunsetV1EndpointHandler
+{
+    [WolverineGet("/sunset-items")]
+    [ApiVersion("1.0")]
+    public string Get() => "v1 sunset";
+}
+
+internal class NoDeprecationV1EndpointHandler
+{
+    [WolverineGet("/plain-items")]
+    [ApiVersion("1.0")]
+    public string Get() => "v1 plain";
+}
+
+internal class OrdersHeaderTestHandler
+{
+    [WolverineGet("/orders-header-test")]
+    [ApiVersion("1.0")]
+    public string Get() => "v1 orders";
+}
+
+// ---------- Tests ----------
+
+public class ApiVersioningPolicyHeaderWiringTests
+{
+    private static void Apply(ApiVersioningPolicy policy, params HttpChain[] chains)
+        => policy.Apply(chains, new GenerationRules(), null!);
+
+    // 1 — chain with sunset policy gets ApiVersionHeaderWriter postprocessor
+    [Fact]
+    public void chain_with_sunset_policy_gets_header_writer_postprocessor()
+    {
+        var date = new DateTimeOffset(2027, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var opts = new WolverineApiVersioningOptions();
+        opts.Sunset("1.0").On(date);
+
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<SunsetV1EndpointHandler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        chain.Postprocessors
+            .OfType<MethodCall>()
+            .Any(c => c.HandlerType == typeof(ApiVersionHeaderWriter))
+            .ShouldBeTrue();
+    }
+
+    // 2 — chain with all header emit flags disabled and no deprecation/sunset gets no postprocessor
+    [Fact]
+    public void chain_with_no_policies_and_emit_supported_disabled_gets_no_postprocessor()
+    {
+        var opts = new WolverineApiVersioningOptions
+        {
+            EmitApiSupportedVersionsHeader = false,
+            EmitDeprecationHeaders = false
+        };
+
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<NoDeprecationV1EndpointHandler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        chain.Postprocessors
+            .OfType<MethodCall>()
+            .Any(c => c.HandlerType == typeof(ApiVersionHeaderWriter))
+            .ShouldBeFalse();
+    }
+
+    // 3 — ApiVersionEndpointHeaderState metadata is attached to the endpoint after policy runs
+    [Fact]
+    public void chain_with_state_metadata_attached()
+    {
+        var date = new DateTimeOffset(2027, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var opts = new WolverineApiVersioningOptions();
+        opts.Sunset("1.0").On(date);
+
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<SunsetV1EndpointHandler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
+        var state = endpoint.Metadata.GetMetadata<ApiVersionEndpointHeaderState>();
+
+        state.ShouldNotBeNull();
+        state!.Version.ShouldBe(new ApiVersion(1, 0));
+        state.Sunset.ShouldNotBeNull();
+        state.Sunset!.Date.ShouldBe(date);
+    }
+
+    // 4 — apply twice does not add duplicate header postprocessor (idempotency guard)
+    [Fact]
+    public void apply_twice_does_not_add_duplicate_header_postprocessor()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        opts.Sunset("1.0").On(DateTimeOffset.UtcNow.AddDays(30));
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<OrdersHeaderTestHandler>(x => x.Get());
+
+        Apply(policy, chain);
+        var firstCount = chain.Postprocessors.OfType<MethodCall>().Count(c => c.HandlerType == typeof(ApiVersionHeaderWriter));
+
+        Apply(policy, chain);
+        var secondCount = chain.Postprocessors.OfType<MethodCall>().Count(c => c.HandlerType == typeof(ApiVersionHeaderWriter));
+
+        secondCount.ShouldBe(firstCount);
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersioningPolicyTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersioningPolicyTests.cs
@@ -1,0 +1,300 @@
+using Asp.Versioning;
+using JasperFx.CodeGeneration;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Shouldly;
+using Wolverine.Http.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+// ---------- Test handler fixtures ----------
+
+internal class OrdersV1Handler
+{
+    [WolverineGet("/orders")]
+    [ApiVersion("1.0")]
+    public string Get() => "v1";
+}
+
+internal class OrdersV2Handler
+{
+    [WolverineGet("/orders")]
+    [ApiVersion("2.0")]
+    public string Get() => "v2";
+}
+
+internal class OrdersV1DuplicateHandler
+{
+    [WolverineGet("/orders")]
+    [ApiVersion("1.0")]
+    public string Get() => "v1-dup";
+}
+
+internal class UnversionedOrdersHandler
+{
+    [WolverineGet("/orders")]
+    public string Get() => "unversioned";
+}
+
+internal class DeprecatedV1Handler
+{
+    [WolverineGet("/items")]
+    [ApiVersion("1.0", Deprecated = true)]
+    public string Get() => "deprecated";
+}
+
+// ---------- Tests ----------
+
+public class ApiVersioningPolicyTests
+{
+
+    private static void Apply(ApiVersioningPolicy policy, params HttpChain[] chains)
+        => policy.Apply(chains, new GenerationRules(), null!);
+
+    // 1
+    [Fact]
+    public void attribute_resolves_version_onto_chain()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<OrdersV1Handler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        chain.ApiVersion.ShouldBe(new ApiVersion(1, 0));
+    }
+
+    // 2
+    [Fact]
+    public void versioned_chain_has_url_segment_prefixed()
+    {
+        var opts = new WolverineApiVersioningOptions(); // default UrlSegmentPrefix = "v{version}"
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<OrdersV1Handler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        chain.RoutePattern!.RawText.ShouldBe("/v1/orders");
+    }
+
+    // 3
+    [Fact]
+    public void unversioned_passthrough_leaves_chain_alone()
+    {
+        var opts = new WolverineApiVersioningOptions { UnversionedPolicy = UnversionedPolicy.PassThrough };
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<UnversionedOrdersHandler>(x => x.Get());
+        var originalRoute = chain.RoutePattern!.RawText;
+
+        Apply(policy, chain);
+
+        chain.ApiVersion.ShouldBeNull();
+        chain.RoutePattern!.RawText.ShouldBe(originalRoute);
+    }
+
+    // 4
+    [Fact]
+    public void unversioned_require_explicit_throws()
+    {
+        var opts = new WolverineApiVersioningOptions { UnversionedPolicy = UnversionedPolicy.RequireExplicit };
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<UnversionedOrdersHandler>(x => x.Get());
+        chain.DisplayName = "GET /orders (unversioned)";
+
+        var ex = Should.Throw<InvalidOperationException>(() => Apply(policy, chain));
+        ex.Message.ShouldContain("GET /orders (unversioned)");
+    }
+
+    // 5
+    [Fact]
+    public void unversioned_assign_default_uses_default_version()
+    {
+        var opts = new WolverineApiVersioningOptions
+        {
+            UnversionedPolicy = UnversionedPolicy.AssignDefault,
+            DefaultVersion = new ApiVersion(1, 0)
+        };
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<UnversionedOrdersHandler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        chain.ApiVersion.ShouldBe(new ApiVersion(1, 0));
+        chain.RoutePattern!.RawText.ShouldBe("/v1/orders");
+    }
+
+    // 6
+    [Fact]
+    public void assign_default_without_default_version_throws()
+    {
+        var opts = new WolverineApiVersioningOptions
+        {
+            UnversionedPolicy = UnversionedPolicy.AssignDefault,
+            DefaultVersion = null
+        };
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<UnversionedOrdersHandler>(x => x.Get());
+
+        var ex = Should.Throw<InvalidOperationException>(() => Apply(policy, chain));
+        ex.Message.ShouldContain("DefaultVersion must be set");
+    }
+
+    // 7
+    [Fact]
+    public void sunset_policy_attached_from_options()
+    {
+        var date = new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var opts = new WolverineApiVersioningOptions();
+        opts.Sunset("1.0").On(date);
+
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<OrdersV1Handler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        chain.SunsetPolicy.ShouldNotBeNull();
+        chain.SunsetPolicy!.Date.ShouldBe(date);
+    }
+
+    // 8
+    [Fact]
+    public void deprecation_attribute_marks_chain_deprecated()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<DeprecatedV1Handler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        chain.DeprecationPolicy.ShouldNotBeNull();
+    }
+
+    // 9
+    [Fact]
+    public void attribute_deprecation_takes_precedence_over_options()
+    {
+        var otherDate = new DateTimeOffset(2028, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var opts = new WolverineApiVersioningOptions();
+        opts.Deprecate("1.0").On(otherDate);
+
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<DeprecatedV1Handler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        chain.DeprecationPolicy.ShouldNotBeNull();
+        chain.DeprecationPolicy!.Date.ShouldBeNull();  // attribute-driven, no date
+    }
+
+    // 10
+    [Fact]
+    public void duplicate_route_and_version_throws()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain1 = HttpChain.ChainFor<OrdersV1Handler>(x => x.Get());
+        var chain2 = HttpChain.ChainFor<OrdersV1DuplicateHandler>(x => x.Get());
+        chain1.DisplayName = "OrdersV1Handler";
+        chain2.DisplayName = "OrdersV1DuplicateHandler";
+
+        var ex = Should.Throw<InvalidOperationException>(() => Apply(policy, chain1, chain2));
+        ex.Message.ShouldContain("GET");
+        ex.Message.ShouldContain("/orders");
+        ex.Message.ShouldContain("1.0");
+        ex.Message.ShouldContain("OrdersV1Handler");
+        ex.Message.ShouldContain("OrdersV1DuplicateHandler");
+    }
+
+    // 11
+    [Fact]
+    public void duplicate_route_with_different_versions_does_not_throw()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain1 = HttpChain.ChainFor<OrdersV1Handler>(x => x.Get());
+        var chain2 = HttpChain.ChainFor<OrdersV2Handler>(x => x.Get());
+
+        Should.NotThrow(() => Apply(policy, chain1, chain2));
+    }
+
+    // 12 — group-name metadata attached
+    [Fact]
+    public void group_name_metadata_attached()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<OrdersV1Handler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        // BuildEndpoint commits all metadata callbacks to the RouteEndpointBuilder.
+        var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
+
+        var groupMeta = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+        groupMeta.ShouldNotBeNull();
+        groupMeta!.EndpointGroupName.ShouldBe("v1");
+    }
+
+    // 13 — ApiVersionMetadata attached
+    [Fact]
+    public void apiversion_metadata_attached()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<OrdersV1Handler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
+
+        var versionMeta = endpoint.Metadata.GetMetadata<ApiVersionMetadata>();
+        versionMeta.ShouldNotBeNull();
+        versionMeta!.IsApiVersionNeutral.ShouldBeFalse();
+        versionMeta.Map(ApiVersionMapping.Explicit).ImplementedApiVersions.ShouldContain(new ApiVersion(1, 0));
+    }
+
+    // 14 — UrlSegmentPrefix validation
+    [Fact]
+    public void url_segment_prefix_without_version_token_throws()
+    {
+        var opts = new WolverineApiVersioningOptions { UrlSegmentPrefix = "api" };
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<OrdersV1Handler>(x => x.Get());
+
+        Should.Throw<InvalidOperationException>(() =>
+            policy.Apply(new[] { chain }, new GenerationRules(), null!))
+            .Message.ShouldContain("{version}");
+    }
+
+    // 15 — Idempotency: apply() called twice should not double-prefix
+    [Fact]
+    public void apply_twice_is_idempotent()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<OrdersV1Handler>(x => x.Get());
+
+        policy.Apply(new[] { chain }, new GenerationRules(), null!);
+        var routeAfterFirstApply = chain.RoutePattern!.RawText;
+
+        policy.Apply(new[] { chain }, new GenerationRules(), null!);
+
+        chain.RoutePattern!.RawText.ShouldBe(routeAfterFirstApply);
+    }
+
+    // 16 — Custom document name strategy drives group name
+    [Fact]
+    public void custom_document_name_strategy_drives_group_name()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        opts.OpenApi.DocumentNameStrategy = v => $"api-v{v.MajorVersion}";
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<OrdersV1Handler>(x => x.Get());
+
+        policy.Apply(new[] { chain }, new GenerationRules(), null!);
+        var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
+
+        endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>()!.EndpointGroupName.ShouldBe("api-v1");
+    }
+
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/DescribeWolverineApiVersionsTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/DescribeWolverineApiVersionsTests.cs
@@ -1,0 +1,275 @@
+using Asp.Versioning;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.Core.IoC;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Http.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+// ---------------------------------------------------------------------------
+// Handler fixtures — dedicated to these tests to avoid fixture name collisions
+// ---------------------------------------------------------------------------
+
+internal class DescribeV1Handler
+{
+    [WolverineGet("/describe-v1")]
+    [ApiVersion("1.0")]
+    public string Get() => "v1";
+}
+
+internal class DescribeV2HandlerA
+{
+    [WolverineGet("/describe-v2-a")]
+    [ApiVersion("2.0")]
+    public string Get() => "v2a";
+}
+
+internal class DescribeV2HandlerB
+{
+    [WolverineGet("/describe-v2-b")]
+    [ApiVersion("2.0")]
+    public string Get() => "v2b";
+}
+
+internal class DescribeV3Handler
+{
+    [WolverineGet("/describe-v3")]
+    [ApiVersion("3.0")]
+    public string Get() => "v3";
+}
+
+internal class DescribeDeprecatedV1Handler
+{
+    [WolverineGet("/describe-deprecated-v1")]
+    [ApiVersion("1.0", Deprecated = true)]
+    public string Get() => "deprecated-v1";
+}
+
+internal class DescribeUnversionedHandler
+{
+    [WolverineGet("/describe-unversioned")]
+    public string Get() => "unversioned";
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// <summary>
+/// Constructs an <see cref="IEndpointRouteBuilder"/> stub backed by a real
+/// <see cref="WolverineHttpOptions"/> with the supplied chains pre-installed.
+/// </summary>
+internal static class DescribeTestHelper
+{
+    /// <summary>
+    /// Builds a minimal service provider, populates a <see cref="HttpGraph"/> with
+    /// the given <paramref name="chains"/> (which must already have ApiVersion etc.
+    /// set via a policy), wires it into <see cref="WolverineHttpOptions.Endpoints"/>,
+    /// and returns a stub <see cref="IEndpointRouteBuilder"/> whose
+    /// <c>ServiceProvider</c> resolves that options instance.
+    /// </summary>
+    public static IEndpointRouteBuilder BuildEndpoints(
+        WolverineHttpOptions httpOptions,
+        IReadOnlyList<HttpChain> chains)
+    {
+        // Build a minimal IServiceContainer so HttpGraph can be constructed.
+        var registry = new ServiceCollection();
+        registry.AddSingleton<IServiceContainer, ServiceContainer>();
+        registry.AddSingleton<IServiceCollection>(registry);
+        var sp = registry.BuildServiceProvider();
+        var container = sp.GetRequiredService<IServiceContainer>();
+
+        var graph = new HttpGraph(new WolverineOptions(), container);
+
+        // Inject the pre-built chains into the graph.
+        // HttpGraph.Chains is public read-only, but _chains (the backing field) is private.
+        // Direct field access is necessary to preserve pre-built chains with their applied policies.
+        InjectChainsIntoGraph(graph, chains);
+
+        httpOptions.Endpoints = graph;
+
+        // Build a fake IServiceProvider that returns our WolverineHttpOptions.
+        var fakeServiceProvider = Substitute.For<IServiceProvider>();
+        fakeServiceProvider.GetService(typeof(WolverineHttpOptions)).Returns(httpOptions);
+
+        var fakeEndpoints = Substitute.For<IEndpointRouteBuilder>();
+        fakeEndpoints.ServiceProvider.Returns(fakeServiceProvider);
+
+        return fakeEndpoints;
+    }
+
+    /// <summary>
+    /// Injects pre-built HttpChain instances into an HttpGraph's internal _chains collection.
+    /// This preserves chains with their applied policies (e.g., ApiVersioning metadata).
+    /// HttpGraph.Chains is public read-only, so direct field access via reflection is required.
+    /// </summary>
+    private static void InjectChainsIntoGraph(HttpGraph graph, IReadOnlyList<HttpChain> chains)
+    {
+        var chainsField = typeof(HttpGraph)
+            .GetField("_chains", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var list = (List<HttpChain>)chainsField.GetValue(graph)!;
+        foreach (var chain in chains)
+            list.Add(chain);
+    }
+
+    /// <summary>
+    /// Convenience overload: applies the versioning policy and builds the stubs in one step.
+    /// </summary>
+    public static IEndpointRouteBuilder BuildEndpointsWithPolicy(
+        WolverineHttpOptions httpOptions,
+        params HttpChain[] chains)
+    {
+        if (httpOptions.ApiVersioning is not null)
+        {
+            var policy = new ApiVersioningPolicy(httpOptions.ApiVersioning);
+            policy.Apply(chains, new GenerationRules(), null!);
+        }
+
+        return BuildEndpoints(httpOptions, chains);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+public class DescribeWolverineApiVersionsTests
+{
+    // 1 — returns empty list when versioning is not configured
+    [Fact]
+    public void returns_empty_list_when_versioning_not_configured()
+    {
+        var httpOptions = new WolverineHttpOptions();
+        // No UseApiVersioning call — ApiVersioning is null.
+
+        var chain = HttpChain.ChainFor<DescribeV1Handler>(x => x.Get());
+        var endpoints = DescribeTestHelper.BuildEndpoints(httpOptions, new[] { chain });
+
+        var result = endpoints.DescribeWolverineApiVersions();
+
+        result.ShouldBeEmpty();
+    }
+
+    // 2 — returns one description per distinct version
+    [Fact]
+    public void returns_one_description_per_distinct_version()
+    {
+        var httpOptions = new WolverineHttpOptions();
+        httpOptions.UseApiVersioning(_ => { });
+
+        var v1Chain = HttpChain.ChainFor<DescribeV1Handler>(x => x.Get());
+        var v2aChain = HttpChain.ChainFor<DescribeV2HandlerA>(x => x.Get());
+        var v2bChain = HttpChain.ChainFor<DescribeV2HandlerB>(x => x.Get());
+
+        var endpoints = DescribeTestHelper.BuildEndpointsWithPolicy(
+            httpOptions, v1Chain, v2aChain, v2bChain);
+
+        var result = endpoints.DescribeWolverineApiVersions();
+
+        result.Count.ShouldBe(2);
+        result.Select(d => d.ApiVersion).ShouldBe(
+            new[] { new ApiVersion(1, 0), new ApiVersion(2, 0) },
+            ignoreOrder: false);
+    }
+
+    // 3 — results are sorted ascending by version
+    [Fact]
+    public void descriptions_sorted_ascending_by_version()
+    {
+        var httpOptions = new WolverineHttpOptions();
+        httpOptions.UseApiVersioning(_ => { });
+
+        var v3Chain = HttpChain.ChainFor<DescribeV3Handler>(x => x.Get());
+        var v1Chain = HttpChain.ChainFor<DescribeV1Handler>(x => x.Get());
+
+        // Pass v3 first intentionally.
+        var endpoints = DescribeTestHelper.BuildEndpointsWithPolicy(
+            httpOptions, v3Chain, v1Chain);
+
+        var result = endpoints.DescribeWolverineApiVersions();
+
+        result.Count.ShouldBe(2);
+        result[0].ApiVersion.ShouldBe(new ApiVersion(1, 0));
+        result[1].ApiVersion.ShouldBe(new ApiVersion(3, 0));
+    }
+
+    // 4 — document name comes from the configured strategy
+    [Fact]
+    public void description_has_correct_document_name_from_strategy()
+    {
+        var httpOptions = new WolverineHttpOptions();
+        httpOptions.UseApiVersioning(opts =>
+            opts.OpenApi.DocumentNameStrategy = v => "v" + v.MajorVersion);
+
+        var v1Chain = HttpChain.ChainFor<DescribeV1Handler>(x => x.Get());
+
+        var endpoints = DescribeTestHelper.BuildEndpointsWithPolicy(httpOptions, v1Chain);
+
+        var result = endpoints.DescribeWolverineApiVersions();
+
+        result.Count.ShouldBe(1);
+        result[0].DocumentName.ShouldBe("v1");
+        result[0].DisplayName.ShouldBe("API v1");
+    }
+
+    // 5 — IsDeprecated is true when [ApiVersion(Deprecated = true)] is on the handler
+    [Fact]
+    public void is_deprecated_true_when_attribute_marks_handler()
+    {
+        var httpOptions = new WolverineHttpOptions();
+        httpOptions.UseApiVersioning(_ => { });
+
+        var chain = HttpChain.ChainFor<DescribeDeprecatedV1Handler>(x => x.Get());
+
+        var endpoints = DescribeTestHelper.BuildEndpointsWithPolicy(httpOptions, chain);
+
+        var result = endpoints.DescribeWolverineApiVersions();
+
+        result.Count.ShouldBe(1);
+        result[0].IsDeprecated.ShouldBeTrue();
+    }
+
+    // 6 — IsDeprecated is true when options.Deprecate() was called (no attribute)
+    [Fact]
+    public void is_deprecated_true_when_options_deprecate_called()
+    {
+        var date = new DateTimeOffset(2027, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var httpOptions = new WolverineHttpOptions();
+        httpOptions.UseApiVersioning(opts => opts.Deprecate("2.0").On(date));
+
+        var v2aChain = HttpChain.ChainFor<DescribeV2HandlerA>(x => x.Get());
+        var v2bChain = HttpChain.ChainFor<DescribeV2HandlerB>(x => x.Get());
+
+        var endpoints = DescribeTestHelper.BuildEndpointsWithPolicy(
+            httpOptions, v2aChain, v2bChain);
+
+        var result = endpoints.DescribeWolverineApiVersions();
+
+        result.Count.ShouldBe(1);
+        result[0].ApiVersion.ShouldBe(new ApiVersion(2, 0));
+        result[0].IsDeprecated.ShouldBeTrue();
+    }
+
+    // 7 — SunsetPolicy is present when opts.Sunset() is configured
+    [Fact]
+    public void sunset_policy_present_when_configured()
+    {
+        var date = new DateTimeOffset(2028, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var httpOptions = new WolverineHttpOptions();
+        httpOptions.UseApiVersioning(opts => opts.Sunset("1.0").On(date));
+
+        var v1Chain = HttpChain.ChainFor<DescribeV1Handler>(x => x.Get());
+
+        var endpoints = DescribeTestHelper.BuildEndpointsWithPolicy(httpOptions, v1Chain);
+
+        var result = endpoints.DescribeWolverineApiVersions();
+
+        result.Count.ShouldBe(1);
+        result[0].SunsetPolicy.ShouldNotBeNull();
+        result[0].SunsetPolicy!.Date.ShouldBe(date);
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/HttpChainApiVersioningTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/HttpChainApiVersioningTests.cs
@@ -1,0 +1,47 @@
+using Asp.Versioning;
+using Shouldly;
+using Wolverine.Http;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+internal class SampleApiVersioningEndpoint
+{
+    [WolverineGet("/api-versioning/sample")]
+    public string Get() => "ok";
+}
+
+public class HttpChainApiVersioningTests
+{
+    private static HttpChain BuildChain()
+        => HttpChain.ChainFor<SampleApiVersioningEndpoint>(x => x.Get());
+
+    [Fact]
+    public void chain_with_no_version_has_null_api_version()
+    {
+        var chain = BuildChain();
+        chain.ApiVersion.ShouldBeNull();
+    }
+
+    [Fact]
+    public void has_api_version_sets_property_and_returns_chain()
+    {
+        var chain = BuildChain();
+        var version = new ApiVersion(1, 0);
+
+        var returned = chain.HasApiVersion(version);
+
+        returned.ShouldBeSameAs(chain);
+        chain.ApiVersion.ShouldBe(version);
+    }
+
+    [Fact]
+    public void sunset_policy_round_trips()
+    {
+        var chain = BuildChain();
+        var policy = new SunsetPolicy(DateTimeOffset.UtcNow.AddDays(30));
+
+        chain.SunsetPolicy = policy;
+
+        chain.SunsetPolicy.ShouldBeSameAs(policy);
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/UseApiVersioningTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/UseApiVersioningTests.cs
@@ -1,0 +1,43 @@
+using Shouldly;
+using Wolverine.Http.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+public class UseApiVersioningTests
+{
+    [Fact]
+    public void use_api_versioning_stores_options()
+    {
+        var opts = new WolverineHttpOptions();
+
+        opts.UseApiVersioning(v => v.UrlSegmentPrefix = "api/v{version}");
+
+        opts.ApiVersioning.ShouldNotBeNull();
+        opts.ApiVersioning.UrlSegmentPrefix.ShouldBe("api/v{version}");
+    }
+
+    [Fact]
+    public void use_api_versioning_called_twice_accumulates()
+    {
+        var opts = new WolverineHttpOptions();
+        var date1 = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var date2 = new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        opts.UseApiVersioning(v => v.Sunset("1.0").On(date1));
+        opts.UseApiVersioning(v => v.Deprecate("2.0").On(date2));
+
+        opts.ApiVersioning.ShouldNotBeNull();
+
+        var av = opts.ApiVersioning;
+        av.SunsetPolicies.ContainsKey(new Asp.Versioning.ApiVersion(1, 0)).ShouldBeTrue();
+        av.DeprecationPolicies.ContainsKey(new Asp.Versioning.ApiVersion(2, 0)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void null_configure_throws_argument_null()
+    {
+        var opts = new WolverineHttpOptions();
+
+        Should.Throw<ArgumentNullException>(() => opts.UseApiVersioning(null!));
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/WolverineApiVersioningOpenApiOptionsTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/WolverineApiVersioningOpenApiOptionsTests.cs
@@ -1,0 +1,38 @@
+using Asp.Versioning;
+using Shouldly;
+using Wolverine.Http.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+public class WolverineApiVersioningOpenApiOptionsTests
+{
+    [Fact]
+    public void default_strategy_emits_v_major_for_major_minor()
+    {
+        var opts = new WolverineApiVersioningOpenApiOptions();
+
+        opts.DocumentNameStrategy(new ApiVersion(1, 0)).ShouldBe("v1");
+        opts.DocumentNameStrategy(new ApiVersion(2, 5)).ShouldBe("v2");
+    }
+
+    [Fact]
+    public void default_strategy_falls_back_for_date_versions()
+    {
+        var opts = new WolverineApiVersioningOpenApiOptions();
+        var dateVersion = new ApiVersion(new DateTime(2024, 11, 1));
+
+        var result = opts.DocumentNameStrategy(dateVersion);
+
+        result.ShouldBe(dateVersion.ToString());
+    }
+
+    [Fact]
+    public void custom_strategy_overrides_default()
+    {
+        var opts = new WolverineApiVersioningOpenApiOptions();
+        opts.DocumentNameStrategy = v => $"v{v.MajorVersion}.{v.MinorVersion}";
+
+        opts.DocumentNameStrategy(new ApiVersion(1, 0)).ShouldBe("v1.0");
+        opts.DocumentNameStrategy(new ApiVersion(2, 3)).ShouldBe("v2.3");
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/WolverineApiVersioningOptionsTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/WolverineApiVersioningOptionsTests.cs
@@ -1,0 +1,104 @@
+using Asp.Versioning;
+using Shouldly;
+using Wolverine.Http.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+public class WolverineApiVersioningOptionsTests
+{
+    [Fact]
+    public void default_url_segment_prefix_is_v_token()
+    {
+        new WolverineApiVersioningOptions().UrlSegmentPrefix.ShouldBe("v{version}");
+    }
+
+    [Fact]
+    public void default_url_formatter_emits_major_only()
+    {
+        var formatter = new WolverineApiVersioningOptions().UrlSegmentVersionFormatter;
+
+        formatter(new ApiVersion(1, 0)).ShouldBe("1");
+        formatter(new ApiVersion(2, 5)).ShouldBe("2");
+    }
+
+    [Fact]
+    public void default_unversioned_policy_is_passthrough()
+    {
+        new WolverineApiVersioningOptions().UnversionedPolicy.ShouldBe(UnversionedPolicy.PassThrough);
+    }
+
+    [Fact]
+    public void sunset_builder_stores_date_and_links()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var date = new DateTimeOffset(2026, 12, 31, 0, 0, 0, TimeSpan.Zero);
+        var linkUri = new Uri("https://example.com/sunset");
+
+        opts.Sunset("1.0")
+            .On(date)
+            .WithLink(linkUri, "info", "text/html");
+
+        var key = new ApiVersion(1, 0);
+        opts.SunsetPolicies.ContainsKey(key).ShouldBeTrue();
+
+        var policy = opts.SunsetPolicies[key];
+        policy.Date.ShouldBe(date);
+        policy.Links.Count.ShouldBe(1);
+        policy.Links[0].LinkTarget.ShouldBe(linkUri);
+        policy.Links[0].Title.ShouldBe("info");
+        policy.Links[0].Type.ShouldBe("text/html");
+    }
+
+    [Fact]
+    public void sunset_builder_supports_chaining_with_multiple_links()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var date = new DateTimeOffset(2026, 12, 31, 0, 0, 0, TimeSpan.Zero);
+        var uri1 = new Uri("https://example.com/sunset/1");
+        var uri2 = new Uri("https://example.com/sunset/2");
+
+        opts.Sunset("1.0")
+            .On(date)
+            .WithLink(uri1)
+            .WithLink(uri2);
+
+        var policy = opts.SunsetPolicies[new ApiVersion(1, 0)];
+        policy.Links.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void deprecate_builder_stores_date()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var date = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero);
+
+        opts.Deprecate(new ApiVersion(2, 0)).On(date);
+
+        var key = new ApiVersion(2, 0);
+        opts.DeprecationPolicies.ContainsKey(key).ShouldBeTrue();
+        opts.DeprecationPolicies[key].Date.ShouldBe(date);
+    }
+
+    [Fact]
+    public void parse_string_overload_yields_same_dictionary_key()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var date = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        opts.Sunset("1.0").On(date);
+
+        opts.SunsetPolicies.ContainsKey(new ApiVersion(1, 0)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void sunset_builder_stores_date_only_with_no_links()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var date = DateTimeOffset.UtcNow.AddDays(30);
+        opts.Sunset("1.0").On(date);
+
+        var policy = opts.SunsetPolicies[new ApiVersion(1, 0)];
+        policy.Date.ShouldBe(date);
+        policy.Links.Count.ShouldBe(0);
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/WolverineApiVersioningSwaggerOperationFilterTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/WolverineApiVersioningSwaggerOperationFilterTests.cs
@@ -1,0 +1,88 @@
+using Asp.Versioning;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+using Shouldly;
+using Wolverine.Http.ApiVersioning;
+using WolverineWebApi.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+public class WolverineApiVersioningSwaggerOperationFilterTests
+{
+    private static OpenApiOperation MakeOperation() => new() { Summary = "Test" };
+
+    [Fact]
+    public void filter_marks_operation_deprecated_when_state_has_deprecation_policy()
+    {
+        var state = new ApiVersionEndpointHeaderState(
+            new ApiVersion(1, 0),
+            Sunset: null,
+            Deprecation: new DeprecationPolicy());
+        var metadata = new List<object> { state };
+        var operation = MakeOperation();
+
+        WolverineApiVersioningSwaggerOperationFilter.ApplyFromMetadata(operation, metadata);
+
+        operation.Deprecated.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void filter_does_nothing_when_no_state_metadata()
+    {
+        var metadata = new List<object>();
+        var operation = MakeOperation();
+
+        WolverineApiVersioningSwaggerOperationFilter.ApplyFromMetadata(operation, metadata);
+
+        operation.Deprecated.ShouldBeFalse();
+        ((IDictionary<string, IOpenApiExtension>)operation.Extensions).ShouldNotContainKey("x-api-versioning");
+    }
+
+    [Fact]
+    public void filter_emits_x_api_versioning_with_sunset_date()
+    {
+        var sunsetDate = new DateTimeOffset(2027, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var sunsetPolicy = new SunsetPolicy(sunsetDate);
+        var state = new ApiVersionEndpointHeaderState(
+            new ApiVersion(1, 0),
+            Sunset: sunsetPolicy,
+            Deprecation: new DeprecationPolicy());
+        var metadata = new List<object> { state };
+        var operation = MakeOperation();
+
+        WolverineApiVersioningSwaggerOperationFilter.ApplyFromMetadata(operation, metadata);
+
+        var extensions = (IDictionary<string, IOpenApiExtension>)operation.Extensions;
+        extensions.ShouldContainKey("x-api-versioning");
+        var ext = (OpenApiObject)extensions["x-api-versioning"];
+        ((IDictionary<string, IOpenApiAny>)ext).ShouldContainKey("sunset");
+        var sunsetStr = ((OpenApiString)ext["sunset"]).Value;
+        sunsetStr.ShouldBe(sunsetDate.UtcDateTime.ToString("R"));
+    }
+
+    [Fact]
+    public void filter_emits_links_array_in_x_api_versioning()
+    {
+        var linkUri = new Uri("https://example.com/sunset");
+        var sunsetPolicy = new SunsetPolicy(new LinkHeaderValue(linkUri, "sunset"));
+        var state = new ApiVersionEndpointHeaderState(
+            new ApiVersion(1, 0),
+            Sunset: sunsetPolicy,
+            Deprecation: null);
+        var metadata = new List<object> { state };
+        var operation = MakeOperation();
+
+        WolverineApiVersioningSwaggerOperationFilter.ApplyFromMetadata(operation, metadata);
+
+        var extensions = (IDictionary<string, IOpenApiExtension>)operation.Extensions;
+        extensions.ShouldContainKey("x-api-versioning");
+        var ext = (OpenApiObject)extensions["x-api-versioning"];
+        ((IDictionary<string, IOpenApiAny>)ext).ShouldContainKey("links");
+        var links = (OpenApiArray)ext["links"];
+        links.Count.ShouldBe(1);
+        var firstLink = (OpenApiObject)links[0];
+        ((IDictionary<string, IOpenApiAny>)firstLink).ShouldContainKey("href");
+        ((OpenApiString)firstLink["href"]).Value.ShouldBe(linkUri.ToString());
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/api_versioning_integration_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/api_versioning_integration_tests.cs
@@ -1,0 +1,175 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Alba;
+using Shouldly;
+using WolverineWebApi.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+[Collection("integration")]
+public class api_versioning_integration_tests : IntegrationContext
+{
+    public api_versioning_integration_tests(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task v1_orders_returns_v1_response()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v1/orders");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var response = result.ReadAsJson<OrdersV1Response>();
+        response.ShouldNotBeNull();
+        response.Orders.ShouldContain("v1-order-1");
+        response.Orders.ShouldContain("v1-order-2");
+    }
+
+    [Fact]
+    public async Task v2_orders_returns_v2_response()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v2/orders");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var response = result.ReadAsJson<OrdersV2Response>();
+        response.ShouldNotBeNull();
+        response.Status.ShouldBe("ok");
+        response.Items.ShouldContain("v2-a");
+    }
+
+    [Fact]
+    public async Task v3_orders_emits_sunset_header()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v3/orders");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var sunsetHeader = result.Context.Response.Headers["Sunset"].FirstOrDefault();
+        sunsetHeader.ShouldNotBeNull();
+
+        // RFC 1123 of 2027-01-01T00:00:00Z
+        var expectedSunset = new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero)
+            .UtcDateTime.ToString("R", CultureInfo.InvariantCulture);
+        sunsetHeader.ShouldBe(expectedSunset);
+    }
+
+    [Fact]
+    public async Task v1_orders_emits_deprecation_header()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v1/orders");
+            x.StatusCodeShouldBeOk();
+        });
+
+        // Deprecation header must be present (either a date or "true")
+        var deprecationHeader = result.Context.Response.Headers["Deprecation"].FirstOrDefault();
+        deprecationHeader.ShouldNotBeNull();
+        deprecationHeader.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task v1_orders_emits_link_header_for_deprecation()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v1/orders");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var linkHeader = result.Context.Response.Headers["Link"].FirstOrDefault();
+        linkHeader.ShouldNotBeNull();
+        linkHeader.ShouldContain("rel=\"deprecation\"");
+    }
+
+    [Fact]
+    public async Task api_supported_versions_header_lists_all_versions()
+    {
+        // Any versioned endpoint emits api-supported-versions
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v2/orders");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var header = result.Context.Response.Headers["api-supported-versions"].FirstOrDefault();
+        header.ShouldNotBeNull();
+        // The header is built from SunsetPolicies (3.0) + DeprecationPolicies (1.0), sorted ascending
+        header.ShouldBe("1.0, 3.0");
+    }
+
+    [Fact]
+    public async Task unversioned_endpoint_does_not_emit_api_supported_versions()
+    {
+        // /hello is an unversioned endpoint (PassThrough) — no header writer attached
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/hello");
+            x.StatusCodeShouldBeOk();
+        });
+
+        result.Context.Response.Headers.ContainsKey("api-supported-versions").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task swagger_v1_doc_contains_orders_endpoint()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/swagger/v1/swagger.json");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var body = result.ReadAsText();
+        body.ShouldContain("/v1/orders");
+    }
+
+    [Fact]
+    public async Task swagger_default_doc_contains_all_orders_versions()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/swagger/default/swagger.json");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var body = result.ReadAsText();
+        body.ShouldContain("/v1/orders");
+        body.ShouldContain("/v2/orders");
+        body.ShouldContain("/v3/orders");
+    }
+
+    [Fact]
+    public async Task swagger_v1_doc_marks_orders_deprecated()
+    {
+        // v1 has a DeprecationPolicy from options, so the operation should be marked deprecated
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/swagger/v1/swagger.json");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var body = result.ReadAsText();
+
+        // Parse JSON and navigate to the deprecated property
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        // Navigate to paths./v1/orders.get.deprecated
+        var paths = root.GetProperty("paths");
+        var v1OrdersPath = paths.GetProperty("/v1/orders");
+        var getOperation = v1OrdersPath.GetProperty("get");
+        var deprecated = getOperation.GetProperty("deprecated");
+
+        deprecated.GetBoolean().ShouldBeTrue();
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/IntegrationContext.cs
+++ b/src/Http/Wolverine.Http.Tests/IntegrationContext.cs
@@ -131,7 +131,7 @@ public abstract class IntegrationContext : IAsyncLifetime, IOpenApiSource
     protected (OpenApiPathItem, OpenApiOperation) FindOpenApiDocument(string path)
     {
         var swagger = Host.Services.GetRequiredService<ISwaggerProvider>();
-        var document = swagger.GetSwagger("v1");
+        var document = swagger.GetSwagger("default");
 
         if (document.Paths.TryGetValue(path, out var item))
         {
@@ -144,7 +144,7 @@ public abstract class IntegrationContext : IAsyncLifetime, IOpenApiSource
     public (OpenApiPathItem, OpenApiOperation) FindOpenApiDocument(OperationType httpMethod, string path)
     {
         var swagger = Host.Services.GetRequiredService<ISwaggerProvider>();
-        var document = swagger.GetSwagger("v1");
+        var document = swagger.GetSwagger("default");
 
         if (document.Paths.TryGetValue(path, out var item))
         {

--- a/src/Http/Wolverine.Http.Tests/swashbuckle_integration.cs
+++ b/src/Http/Wolverine.Http.Tests/swashbuckle_integration.cs
@@ -15,7 +15,7 @@ public class swashbuckle_integration : IntegrationContext
     [Fact]
     public async Task wolverine_stuff_is_in_the_document()
     {
-        var results = await Scenario(x => { x.Get.Url("/swagger/v1/swagger.json"); });
+        var results = await Scenario(x => { x.Get.Url("/swagger/default/swagger.json"); });
 
         var doc = results.ReadAsText();
 
@@ -30,7 +30,7 @@ public class swashbuckle_integration : IntegrationContext
         HttpChains.Chains.Any(x => x.RoutePattern!.RawText == "/ignore").ShouldBeTrue();
 
         var generator = Host.Services.GetRequiredService<ISwaggerProvider>();
-        var doc = generator.GetSwagger("v1");
+        var doc = generator.GetSwagger("default");
 
         doc.Paths.Any(x => x.Key == "/ignore").ShouldBeFalse();
     }

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersionHeaderWriter.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersionHeaderWriter.cs
@@ -1,0 +1,129 @@
+using System.Globalization;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+
+namespace Wolverine.Http.ApiVersioning;
+
+/// <summary>
+/// Metadata record attached to the endpoint for each versioned chain, carrying the per-chain
+/// version and optional sunset / deprecation policies so they can be read at request time
+/// without per-chain code-gen arguments. This is part of the framework's observable contract
+/// and is consumed by <see cref="ApiVersionHeaderWriter"/> at request time and by user-defined
+/// OpenAPI filters (e.g., Swashbuckle <c>IOperationFilter</c>) for documentation generation.
+/// </summary>
+public sealed record ApiVersionEndpointHeaderState(
+    ApiVersion Version,
+    SunsetPolicy? Sunset,
+    DeprecationPolicy? Deprecation);
+
+/// <summary>
+/// Singleton service that emits RFC 9745 <c>Deprecation</c>, RFC 8594 <c>Sunset</c>/<c>Link</c>,
+/// and Asp.Versioning-style <c>api-supported-versions</c> response headers on versioned endpoints.
+/// The per-chain state is read from <see cref="ApiVersionEndpointHeaderState"/> stored in the
+/// endpoint metadata (set by <see cref="ApiVersioningPolicy"/>), so this writer can be a plain
+/// singleton with no per-chain constructor arguments.
+/// </summary>
+/// <remarks>
+/// Must remain public: Wolverine's dynamic code generation emits handler code at runtime that references
+/// this type by name for postprocessor wiring. The generated code is in a separate assembly without
+/// InternalsVisibleTo access to Wolverine.Http, so internal types are not accessible.
+/// </remarks>
+public sealed class ApiVersionHeaderWriter
+{
+    private readonly WolverineApiVersioningOptions _options;
+
+    // Computed once on first request via Lazy<T>. Policies added to the options
+    // dictionaries after the first request will not appear in this header. In normal
+    // app startup all policies are registered before any HTTP request is processed,
+    // so this is a safe optimization.
+    private readonly Lazy<string> _supportedVersionsHeader;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ApiVersionHeaderWriter"/>.
+    /// </summary>
+    /// <param name="options">The API versioning options used to compute the supported-versions header.</param>
+    public ApiVersionHeaderWriter(WolverineApiVersioningOptions options)
+    {
+        _options = options;
+        _supportedVersionsHeader = new Lazy<string>(() => BuildSupportedVersionsHeader(options));
+    }
+
+    /// <summary>
+    /// Writes the applicable versioning response headers to <paramref name="context"/>.
+    /// Reads per-chain state from <see cref="ApiVersionEndpointHeaderState"/> stored in the
+    /// matched endpoint's metadata. If no state is present the method returns immediately.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    public Task WriteAsync(HttpContext context)
+    {
+        var state = context.GetEndpoint()?.Metadata.GetMetadata<ApiVersionEndpointHeaderState>();
+        if (state is null)
+            return Task.CompletedTask;
+
+        var headers = context.Response.Headers;
+
+        if (_options.EmitApiSupportedVersionsHeader && _supportedVersionsHeader.Value.Length > 0)
+            headers["api-supported-versions"] = _supportedVersionsHeader.Value;
+
+        if (_options.EmitDeprecationHeaders)
+        {
+            if (state.Deprecation is not null)
+            {
+                headers["Deprecation"] = state.Deprecation.Date is { } depDate
+                    ? depDate.UtcDateTime.ToString("R", CultureInfo.InvariantCulture)
+                    : "true";
+            }
+
+            if (state.Sunset?.Date is { } sunsetDate)
+                headers["Sunset"] = sunsetDate.UtcDateTime.ToString("R", CultureInfo.InvariantCulture);
+
+            var links = BuildLinks(state.Sunset, state.Deprecation);
+            if (links.Length > 0)
+                headers["Link"] = links;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static string BuildSupportedVersionsHeader(WolverineApiVersioningOptions options)
+    {
+        var versions = options.SunsetPolicies.Keys
+            .Concat(options.DeprecationPolicies.Keys)
+            .Distinct()
+            .OrderBy(v => v.MajorVersion ?? int.MaxValue)
+            .ThenBy(v => v.MinorVersion ?? int.MaxValue)
+            .Select(v => v.ToString())
+            .ToArray();
+
+        return versions.Length == 0 ? string.Empty : string.Join(", ", versions);
+    }
+
+    private static string BuildLinks(SunsetPolicy? sunset, DeprecationPolicy? deprecation)
+    {
+        var entries = new List<string>();
+
+        if (sunset is not null)
+            foreach (var link in sunset.Links)
+                entries.Add(FormatLink(link, "sunset"));
+
+        if (deprecation is not null)
+            foreach (var link in deprecation.Links)
+                entries.Add(FormatLink(link, "deprecation"));
+
+        return entries.Count == 0 ? string.Empty : string.Join(", ", entries);
+    }
+
+    private static string FormatLink(LinkHeaderValue link, string rel)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append('<').Append(link.LinkTarget).Append(">; rel=\"").Append(rel).Append('"');
+
+        var title = link.Title.Value;
+        if (!string.IsNullOrEmpty(title)) sb.Append("; title=\"").Append(title).Append('"');
+
+        var type = link.Type.Value;
+        if (!string.IsNullOrEmpty(type)) sb.Append("; type=\"").Append(type).Append('"');
+
+        return sb.ToString();
+    }
+}

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersionResolver.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersionResolver.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using Asp.Versioning;
+
+namespace Wolverine.Http.ApiVersioning;
+
+internal readonly record struct ApiVersionResolution(ApiVersion Version, bool IsDeprecated);
+
+internal static class ApiVersionResolver
+{
+    /// <summary>
+    /// Resolves the API version declared on a handler method. The method's [ApiVersion] wins;
+    /// the declaring class's [ApiVersion] is used as a fallback.
+    /// </summary>
+    /// <param name="method">The handler method.</param>
+    /// <returns>The single resolved ApiVersion with deprecation status, or null if no [ApiVersion] is present.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the method (or, when no method-level attribute is present, the declaring class) declares more than one ApiVersion in a single ApiVersionAttribute or via multiple attributes.</exception>
+    public static ApiVersionResolution? Resolve(MethodInfo method)
+    {
+        var methodAttrs = method.GetCustomAttributes<ApiVersionAttribute>(inherit: false).ToList();
+        List<ApiVersionAttribute> winningAttrs;
+
+        if (methodAttrs.Count > 0)
+        {
+            winningAttrs = methodAttrs;
+        }
+        else
+        {
+            var classAttrs = method.DeclaringType?.GetCustomAttributes<ApiVersionAttribute>(inherit: false).ToList();
+            if (classAttrs is null || classAttrs.Count == 0)
+            {
+                return null;
+            }
+
+            winningAttrs = classAttrs;
+        }
+
+        var versions = winningAttrs.SelectMany(a => a.Versions).Distinct().ToList();
+
+        if (versions.Count == 1)
+        {
+            var version = versions[0];
+            var isDeprecated = winningAttrs.Any(a => a.Deprecated && a.Versions.Contains(version));
+            return new ApiVersionResolution(version, isDeprecated);
+        }
+
+        var methodIdentity = (method.DeclaringType?.FullName ?? method.DeclaringType?.Name ?? "?") + "." + method.Name;
+        var versionList = string.Join(", ", versions);
+        throw new InvalidOperationException(
+            $"Handler method '{methodIdentity}' declares multiple API versions [{versionList}]. " +
+            "Multi-version handlers are not supported in this version of Wolverine.Http API versioning.");
+    }
+}

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
@@ -1,0 +1,239 @@
+using Asp.Versioning;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+namespace Wolverine.Http.ApiVersioning;
+
+/// <summary>
+/// An <see cref="IHttpPolicy"/> that applies API versioning semantics to every
+/// <see cref="HttpChain"/> during bootstrapping. Steps run in order:
+/// <list type="bullet">
+///   <item><description>A — Resolve <c>[ApiVersion]</c> attributes on handler methods.</description></item>
+///   <item><description>B — Apply <see cref="UnversionedPolicy"/> to chains that remain unversioned.</description></item>
+///   <item><description>C — Attach sunset / deprecation policies from <see cref="WolverineApiVersioningOptions"/>.</description></item>
+///   <item><description>D — Reject duplicate (verb, route, version) triples.</description></item>
+///   <item><description>E — Rewrite route patterns with the URL-segment version prefix.</description></item>
+///   <item><description>F — Attach group-name and <c>Asp.Versioning.ApiVersionMetadata</c> to the endpoint.</description></item>
+///   <item><description>G — Wire the response-header postprocessor on chains that need it.</description></item>
+/// </list>
+/// </summary>
+internal sealed class ApiVersioningPolicy : IHttpPolicy
+{
+    private readonly WolverineApiVersioningOptions _options;
+    private readonly HashSet<HttpChain> _processedChains = new();
+    private readonly HashSet<HttpChain> _headerProcessedChains = new();
+
+    /// <summary>Initializes a new instance of <see cref="ApiVersioningPolicy"/>.</summary>
+    /// <param name="options">The API versioning options that drive this policy's behaviour.</param>
+    public ApiVersioningPolicy(WolverineApiVersioningOptions options)
+    {
+        _options = options;
+    }
+
+    /// <inheritdoc/>
+    public void Apply(IReadOnlyList<HttpChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        ResolveAttributes(chains);
+        ApplyUnversionedPolicy(chains);
+        ApplyOptionsPolicies(chains);
+        DetectDuplicateRoutes(chains);
+        RewriteRoutes(chains);
+        AttachMetadata(chains);
+        WireHeaderPostprocessors(chains);
+    }
+
+    /// <summary>Step A — read <c>[ApiVersion]</c> from the handler method and propagate to the chain.</summary>
+    private static void ResolveAttributes(IReadOnlyList<HttpChain> chains)
+    {
+        foreach (var chain in chains)
+        {
+            if (chain.Method?.Method is null)
+                continue;
+
+            var resolution = ApiVersionResolver.Resolve(chain.Method.Method);
+            if (resolution is null)
+                continue;
+
+            if (chain.ApiVersion is null)
+                chain.ApiVersion = resolution.Value.Version;
+
+            if (resolution.Value.IsDeprecated && chain.DeprecationPolicy is null)
+                chain.DeprecationPolicy = new DeprecationPolicy();
+        }
+    }
+
+    /// <summary>Step B — handle chains still missing a version per the configured fallback rule.</summary>
+    private void ApplyUnversionedPolicy(IReadOnlyList<HttpChain> chains)
+    {
+        foreach (var chain in chains)
+        {
+            if (chain.ApiVersion is not null)
+                continue;
+
+            switch (_options.UnversionedPolicy)
+            {
+                case UnversionedPolicy.PassThrough:
+                    break;
+
+                case UnversionedPolicy.RequireExplicit:
+                    throw new InvalidOperationException(
+                        $"Endpoint '{Identify(chain)}' does not declare an [ApiVersion] attribute. " +
+                        $"The current UnversionedPolicy is '{UnversionedPolicy.RequireExplicit}', which requires every endpoint " +
+                        "to carry an explicit version.");
+
+                case UnversionedPolicy.AssignDefault:
+                    chain.ApiVersion = _options.DefaultVersion
+                        ?? throw new InvalidOperationException(
+                            "DefaultVersion must be set when UnversionedPolicy is AssignDefault.");
+                    break;
+            }
+        }
+    }
+
+    /// <summary>Step C — apply sunset / deprecation policies from options without overwriting attribute-driven values.</summary>
+    private void ApplyOptionsPolicies(IReadOnlyList<HttpChain> chains)
+    {
+        foreach (var chain in chains)
+        {
+            if (chain.ApiVersion is null)
+                continue;
+
+            if (chain.SunsetPolicy is null && _options.SunsetPolicies.TryGetValue(chain.ApiVersion, out var sunset))
+                chain.SunsetPolicy = sunset;
+
+            if (chain.DeprecationPolicy is null && _options.DeprecationPolicies.TryGetValue(chain.ApiVersion, out var dep))
+                chain.DeprecationPolicy = dep;
+        }
+    }
+
+    /// <summary>Step D — fail fast when two chains share <c>(verb, route, version)</c>.</summary>
+    private static void DetectDuplicateRoutes(IReadOnlyList<HttpChain> chains)
+    {
+        var conflicts = chains
+            .Where(c => c.ApiVersion is not null)
+            .GroupBy(c => (
+                Verb: c.HttpMethods.FirstOrDefault() ?? "",
+                Route: c.RoutePattern?.RawText ?? "",
+                Version: c.ApiVersion!.ToString()))
+            .Where(g => g.Count() > 1);
+
+        foreach (var conflict in conflicts)
+        {
+            var names = string.Join(", ", conflict.Select(Identify));
+            throw new InvalidOperationException(
+                $"Duplicate endpoint registration detected: " +
+                $"[{conflict.Key.Verb}] '{conflict.Key.Route}' at version '{conflict.Key.Version}'. " +
+                $"Conflicting chains: {names}");
+        }
+    }
+
+    /// <summary>Step E — prepend the URL-segment version prefix to every versioned chain.</summary>
+    private void RewriteRoutes(IReadOnlyList<HttpChain> chains)
+    {
+        if (_options.UrlSegmentPrefix is null)
+            return;
+
+        ValidateUrlSegmentPrefix(chains);
+
+        foreach (var chain in chains)
+        {
+            if (chain.ApiVersion is null || chain.RoutePattern is null)
+                continue;
+
+            RewriteRouteForChain(chain);
+        }
+    }
+
+    private void ValidateUrlSegmentPrefix(IReadOnlyList<HttpChain> chains)
+    {
+        if (_options.UrlSegmentPrefix!.Contains("{version}", StringComparison.Ordinal))
+            return;
+
+        if (!chains.Any(c => c.ApiVersion is not null))
+            return;
+
+        throw new InvalidOperationException(
+            $"WolverineApiVersioningOptions.UrlSegmentPrefix is set to '{_options.UrlSegmentPrefix}' which does not contain the required '{{version}}' token. All versioned endpoints would map to the same URL prefix. Set UrlSegmentPrefix to null to disable URL-segment versioning, or include '{{version}}' in the prefix template (e.g. 'v{{version}}' or 'api/v{{version}}').");
+    }
+
+    private void RewriteRouteForChain(HttpChain chain)
+    {
+        var expectedPrefix = BuildExpectedPrefix(chain.ApiVersion!);
+        var currentRoute = chain.RoutePattern!.RawText ?? string.Empty;
+
+        // Idempotency guard: skip if the chain is already prefixed.
+        if (currentRoute == expectedPrefix ||
+            currentRoute.StartsWith(expectedPrefix + "/", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var trimmed = currentRoute.TrimStart('/');
+        var newRoute = string.IsNullOrEmpty(trimmed) ? expectedPrefix : $"{expectedPrefix}/{trimmed}";
+        chain.RoutePattern = RoutePatternFactory.Parse(newRoute);
+    }
+
+    private string BuildExpectedPrefix(ApiVersion version)
+    {
+        var versionSegment = _options.UrlSegmentVersionFormatter(version);
+        return "/" + _options.UrlSegmentPrefix!.Replace("{version}", versionSegment).TrimStart('/');
+    }
+
+    /// <summary>Step F — attach group-name, ApiVersionMetadata, and ensure unique endpoint names.</summary>
+    private void AttachMetadata(IReadOnlyList<HttpChain> chains)
+    {
+        foreach (var chain in chains)
+        {
+            if (chain.ApiVersion is null || !_processedChains.Add(chain))
+                continue;
+
+            var groupName = _options.OpenApi.DocumentNameStrategy(chain.ApiVersion);
+            chain.Metadata.WithGroupName(groupName);
+
+            var model = new ApiVersionModel(chain.ApiVersion);
+            chain.Metadata.WithMetadata(new ApiVersionMetadata(model, model));
+
+            // Make the OperationId (already unique per handler type + method) the explicit
+            // endpoint name. Without this, ASP.NET Core uses ToString() which is derived from
+            // the original route pattern and collides when multiple versions share the same
+            // route template (e.g. [WolverineGet("/orders")] on three different classes).
+            if (!chain.HasExplicitOperationId)
+                chain.SetExplicitOperationId(chain.OperationId);
+        }
+    }
+
+    /// <summary>Step G — register the response-header postprocessor for chains that emit headers.</summary>
+    private void WireHeaderPostprocessors(IReadOnlyList<HttpChain> chains)
+    {
+        foreach (var chain in chains)
+        {
+            if (chain.ApiVersion is null || !RequiresHeaderWriter(chain))
+                continue;
+
+            if (!_headerProcessedChains.Add(chain))
+                continue;
+
+            // Per-chain state lives on endpoint metadata so the singleton writer can read it at request time.
+            var state = new ApiVersionEndpointHeaderState(chain.ApiVersion, chain.SunsetPolicy, chain.DeprecationPolicy);
+            chain.Metadata.WithMetadata(state);
+
+            // MethodCall has no .Target — Wolverine codegen resolves ApiVersionHeaderWriter from DI
+            // at request time, then satisfies HttpContext from the request scope.
+            chain.Postprocessors.Add(MethodCall.For<ApiVersionHeaderWriter>(x => x.WriteAsync(null!)));
+        }
+    }
+
+    private bool RequiresHeaderWriter(HttpChain chain) =>
+        chain.SunsetPolicy is not null
+        || chain.DeprecationPolicy is not null
+        || _options.EmitApiSupportedVersionsHeader;
+
+    private static string Identify(HttpChain chain) =>
+        chain.DisplayName
+        ?? (chain.Method?.Method?.DeclaringType?.FullName + "." + chain.Method?.Method?.Name)
+        ?? "(unknown)";
+}

--- a/src/Http/Wolverine.Http/ApiVersioning/DeprecationPolicyBuilder.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/DeprecationPolicyBuilder.cs
@@ -1,0 +1,89 @@
+using Asp.Versioning;
+
+namespace Wolverine.Http.ApiVersioning;
+
+/// <summary>
+/// Fluent builder for configuring a deprecation policy on a specific API version.
+/// Obtain an instance from <see cref="WolverineApiVersioningOptions.Deprecate(ApiVersion)"/>.
+/// </summary>
+public interface IWolverineDeprecationPolicyBuilder
+{
+    /// <summary>Set the deprecation date for this version.</summary>
+    /// <param name="date">The date on which the version is deprecated.</param>
+    /// <returns>The builder for chaining.</returns>
+    IWolverineDeprecationPolicyBuilder On(DateTimeOffset date);
+
+    /// <summary>
+    /// Add an RFC 8288 Link header reference pointing to information about this deprecation.
+    /// </summary>
+    /// <param name="uri">The link target URI.</param>
+    /// <param name="title">Optional human-readable title for the link.</param>
+    /// <param name="type">Optional media type hint for the linked resource.</param>
+    /// <returns>The builder for chaining.</returns>
+    IWolverineDeprecationPolicyBuilder WithLink(Uri uri, string? title = null, string? type = null);
+}
+
+internal sealed class DeprecationPolicyBuilder : IWolverineDeprecationPolicyBuilder
+{
+    private readonly WolverineApiVersioningOptions _options;
+    private readonly ApiVersion _version;
+    private DateTimeOffset? _date;
+    private readonly List<LinkHeaderValue> _links = new();
+
+    internal DeprecationPolicyBuilder(WolverineApiVersioningOptions options, ApiVersion version)
+    {
+        _options = options;
+        _version = version;
+    }
+
+    /// <inheritdoc/>
+    public IWolverineDeprecationPolicyBuilder On(DateTimeOffset date)
+    {
+        _date = date;
+        CommitPolicy();
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public IWolverineDeprecationPolicyBuilder WithLink(Uri uri, string? title = null, string? type = null)
+    {
+        var link = new LinkHeaderValue(uri, "deprecation");
+        if (title != null) link.Title = title;
+        if (type != null) link.Type = type;
+        _links.Add(link);
+        CommitPolicy();
+        return this;
+    }
+
+    private void CommitPolicy()
+    {
+        DeprecationPolicy policy;
+
+        if (_date.HasValue && _links.Count > 0)
+        {
+            policy = new DeprecationPolicy(_date.Value, _links[0]);
+            for (var i = 1; i < _links.Count; i++)
+            {
+                policy.Links.Add(_links[i]);
+            }
+        }
+        else if (_date.HasValue)
+        {
+            policy = new DeprecationPolicy(_date.Value);
+        }
+        else if (_links.Count > 0)
+        {
+            policy = new DeprecationPolicy(_links[0]);
+            for (var i = 1; i < _links.Count; i++)
+            {
+                policy.Links.Add(_links[i]);
+            }
+        }
+        else
+        {
+            policy = new DeprecationPolicy();
+        }
+
+        _options.DeprecationPolicies[_version] = policy;
+    }
+}

--- a/src/Http/Wolverine.Http/ApiVersioning/HttpChainApiVersioningExtensions.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/HttpChainApiVersioningExtensions.cs
@@ -1,0 +1,14 @@
+using Asp.Versioning;
+
+namespace Wolverine.Http.ApiVersioning;
+
+/// <summary>Fluent helpers for declaring API versioning behavior on individual <see cref="HttpChain"/> instances inside <c>ConfigureEndpoints</c>.</summary>
+public static class HttpChainApiVersioningExtensions
+{
+    /// <summary>Mark this chain as deprecated by attaching a default <see cref="DeprecationPolicy"/> with no scheduled date or links.</summary>
+    public static HttpChain MarkDeprecated(this HttpChain chain)
+    {
+        chain.DeprecationPolicy ??= new DeprecationPolicy();
+        return chain;
+    }
+}

--- a/src/Http/Wolverine.Http/ApiVersioning/SunsetPolicyBuilder.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/SunsetPolicyBuilder.cs
@@ -1,0 +1,89 @@
+using Asp.Versioning;
+
+namespace Wolverine.Http.ApiVersioning;
+
+/// <summary>
+/// Fluent builder for configuring a sunset policy on a specific API version.
+/// Obtain an instance from <see cref="WolverineApiVersioningOptions.Sunset(ApiVersion)"/>.
+/// </summary>
+public interface IWolverineSunsetPolicyBuilder
+{
+    /// <summary>Set the sunset date for this version.</summary>
+    /// <param name="date">The date on which the version will sunset.</param>
+    /// <returns>The builder for chaining.</returns>
+    IWolverineSunsetPolicyBuilder On(DateTimeOffset date);
+
+    /// <summary>
+    /// Add an RFC 8288 Link header reference pointing to information about this sunset.
+    /// </summary>
+    /// <param name="uri">The link target URI.</param>
+    /// <param name="title">Optional human-readable title for the link.</param>
+    /// <param name="type">Optional media type hint for the linked resource.</param>
+    /// <returns>The builder for chaining.</returns>
+    IWolverineSunsetPolicyBuilder WithLink(Uri uri, string? title = null, string? type = null);
+}
+
+internal sealed class SunsetPolicyBuilder : IWolverineSunsetPolicyBuilder
+{
+    private readonly WolverineApiVersioningOptions _options;
+    private readonly ApiVersion _version;
+    private DateTimeOffset? _date;
+    private readonly List<LinkHeaderValue> _links = new();
+
+    internal SunsetPolicyBuilder(WolverineApiVersioningOptions options, ApiVersion version)
+    {
+        _options = options;
+        _version = version;
+    }
+
+    /// <inheritdoc/>
+    public IWolverineSunsetPolicyBuilder On(DateTimeOffset date)
+    {
+        _date = date;
+        CommitPolicy();
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public IWolverineSunsetPolicyBuilder WithLink(Uri uri, string? title = null, string? type = null)
+    {
+        var link = new LinkHeaderValue(uri, "sunset");
+        if (title != null) link.Title = title;
+        if (type != null) link.Type = type;
+        _links.Add(link);
+        CommitPolicy();
+        return this;
+    }
+
+    private void CommitPolicy()
+    {
+        SunsetPolicy policy;
+
+        if (_date.HasValue && _links.Count > 0)
+        {
+            policy = new SunsetPolicy(_date.Value, _links[0]);
+            for (var i = 1; i < _links.Count; i++)
+            {
+                policy.Links.Add(_links[i]);
+            }
+        }
+        else if (_date.HasValue)
+        {
+            policy = new SunsetPolicy(_date.Value);
+        }
+        else if (_links.Count > 0)
+        {
+            policy = new SunsetPolicy(_links[0]);
+            for (var i = 1; i < _links.Count; i++)
+            {
+                policy.Links.Add(_links[i]);
+            }
+        }
+        else
+        {
+            policy = new SunsetPolicy();
+        }
+
+        _options.SunsetPolicies[_version] = policy;
+    }
+}

--- a/src/Http/Wolverine.Http/ApiVersioning/UnversionedPolicy.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/UnversionedPolicy.cs
@@ -1,0 +1,17 @@
+namespace Wolverine.Http.ApiVersioning;
+
+/// <summary>
+/// Behaviour applied by <see cref="WolverineApiVersioningOptions"/> when an HTTP endpoint is discovered
+/// without an <see cref="Asp.Versioning.ApiVersionAttribute"/>.
+/// </summary>
+public enum UnversionedPolicy
+{
+    /// <summary>Endpoint stays at its declared route, no version metadata is attached.</summary>
+    PassThrough,
+
+    /// <summary>Bootstrap throws if any chain is missing an <see cref="Asp.Versioning.ApiVersionAttribute"/>.</summary>
+    RequireExplicit,
+
+    /// <summary>Endpoint is automatically assigned <see cref="WolverineApiVersioningOptions.DefaultVersion"/>.</summary>
+    AssignDefault
+}

--- a/src/Http/Wolverine.Http/ApiVersioning/WolverineApiVersionDescription.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/WolverineApiVersionDescription.cs
@@ -1,0 +1,28 @@
+using Asp.Versioning;
+
+namespace Wolverine.Http.ApiVersioning;
+
+/// <summary>
+/// Describes a discovered API version with the metadata needed to wire SwaggerUI / Scalar
+/// version dropdowns. Returned by
+/// <see cref="WolverineOpenApiEndpointRouteBuilderExtensions.DescribeWolverineApiVersions"/>.
+/// </summary>
+/// <param name="ApiVersion">The discovered API version.</param>
+/// <param name="DocumentName">
+/// Document name produced by
+/// <see cref="WolverineApiVersioningOpenApiOptions.DocumentNameStrategy"/>; matches the
+/// chain's <c>EndpointGroupName</c>.
+/// </param>
+/// <param name="DisplayName">Human-friendly label suitable for UI display (e.g. "API v1").</param>
+/// <param name="IsDeprecated">
+/// <see langword="true"/> when at least one chain at this version has an attribute-driven
+/// <c>[ApiVersion(..., Deprecated = true)]</c> declaration or a configured
+/// <see cref="DeprecationPolicy"/>.
+/// </param>
+/// <param name="SunsetPolicy">The configured sunset policy for this version, if any.</param>
+public sealed record WolverineApiVersionDescription(
+    ApiVersion ApiVersion,
+    string DocumentName,
+    string DisplayName,
+    bool IsDeprecated,
+    SunsetPolicy? SunsetPolicy);

--- a/src/Http/Wolverine.Http/ApiVersioning/WolverineApiVersioningOpenApiOptions.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/WolverineApiVersioningOpenApiOptions.cs
@@ -1,0 +1,28 @@
+using Asp.Versioning;
+using System.Globalization;
+
+namespace Wolverine.Http.ApiVersioning;
+
+/// <summary>
+/// OpenAPI integration options exposed via <see cref="WolverineApiVersioningOptions.OpenApi"/>.
+/// </summary>
+public sealed class WolverineApiVersioningOpenApiOptions
+{
+    /// <summary>
+    /// Strategy that maps an <see cref="ApiVersion"/> to a Swashbuckle / Microsoft.AspNetCore.OpenApi
+    /// document name. The same string is also used as the
+    /// <c>IEndpointGroupNameMetadata.EndpointGroupName</c> attached to each chain by
+    /// <see cref="ApiVersioningPolicy"/>. Defaults to <c>v{major}</c> for major.minor versions
+    /// (e.g. <c>v1</c>, <c>v2</c>); falls back to <see cref="ApiVersion.ToString"/> for
+    /// date-based versions.
+    /// </summary>
+    /// <remarks>
+    /// Configure this strategy before calling <c>MapWolverineEndpoints</c>. The strategy is
+    /// invoked once per versioned chain during policy application at startup; reassigning the
+    /// property after startup has no effect on already-bound endpoints.
+    /// </remarks>
+    public Func<ApiVersion, string> DocumentNameStrategy { get; set; }
+        = static v => v.MajorVersion is { } major
+            ? "v" + major.ToString(CultureInfo.InvariantCulture)
+            : v.ToString();
+}

--- a/src/Http/Wolverine.Http/ApiVersioning/WolverineApiVersioningOptions.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/WolverineApiVersioningOptions.cs
@@ -1,0 +1,102 @@
+using System.Globalization;
+using Asp.Versioning;
+
+namespace Wolverine.Http.ApiVersioning;
+
+/// <summary>
+/// Configuration options for Wolverine's native API versioning support. Pass an instance to
+/// <see cref="WolverineHttpOptions.UseApiVersioning"/> to configure URL-segment behaviour,
+/// unversioned-endpoint policy, and per-version sunset / deprecation policies.
+/// </summary>
+public sealed class WolverineApiVersioningOptions
+{
+    /// <summary>
+    /// URL-segment template injected ahead of versioned routes. The literal <c>{version}</c> is
+    /// replaced with the formatted version string produced by <see cref="UrlSegmentVersionFormatter"/>.
+    /// Set to <see langword="null"/> to disable URL-segment versioning.
+    /// </summary>
+    /// <remarks>
+    /// Must contain the literal '{version}' token when non-null. Setting a prefix without
+    /// the token causes <see cref="ApiVersioningPolicy"/> to throw at startup. Set to null
+    /// to disable URL-segment versioning entirely.
+    /// </remarks>
+    public string? UrlSegmentPrefix { get; set; } = "v{version}";
+
+    /// <summary>
+    /// Formatter producing the version string substituted into <see cref="UrlSegmentPrefix"/>.
+    /// Defaults to major-only (e.g. <c>"1"</c> for <c>ApiVersion(1, 0)</c> rather than <c>"1.0"</c>).
+    /// </summary>
+    /// <remarks>
+    /// Date-based versions (where <see cref="ApiVersion.MajorVersion"/> is null) fall back to
+    /// <see cref="ApiVersion.ToString()"/> which may include hyphens. Override this formatter
+    /// if your URL scheme requires a different shape for date-based versions.
+    /// </remarks>
+    public Func<ApiVersion, string> UrlSegmentVersionFormatter { get; set; }
+        = static v => v.MajorVersion?.ToString(CultureInfo.InvariantCulture) ?? v.ToString();
+
+    /// <summary>
+    /// Behaviour for endpoints that do not declare an <c>[ApiVersion]</c> attribute.
+    /// Defaults to <see cref="UnversionedPolicy.PassThrough"/>.
+    /// </summary>
+    public UnversionedPolicy UnversionedPolicy { get; set; } = UnversionedPolicy.PassThrough;
+
+    /// <summary>
+    /// Used when <see cref="UnversionedPolicy"/> is <see cref="UnversionedPolicy.AssignDefault"/>.
+    /// Required in that mode; otherwise ignored.
+    /// </summary>
+    public ApiVersion? DefaultVersion { get; set; }
+
+    /// <summary>
+    /// Emit the <c>api-supported-versions</c> response header on every versioned endpoint.
+    /// </summary>
+    public bool EmitApiSupportedVersionsHeader { get; set; } = true;
+
+    /// <summary>
+    /// Emit RFC 9745 <c>Deprecation</c> and RFC 8594 <c>Sunset</c>/<c>Link</c> headers on endpoints
+    /// that have a configured policy.
+    /// </summary>
+    public bool EmitDeprecationHeaders { get; set; } = true;
+
+    /// <summary>OpenAPI integration options.</summary>
+    public WolverineApiVersioningOpenApiOptions OpenApi { get; } = new();
+
+    /// <summary>
+    /// Per-version sunset policies. Populated via <see cref="Sunset(ApiVersion)"/> or
+    /// <see cref="Sunset(string)"/>.
+    /// </summary>
+    internal Dictionary<ApiVersion, SunsetPolicy> SunsetPolicies { get; } = new();
+
+    /// <summary>
+    /// Per-version deprecation policies. Populated via <see cref="Deprecate(ApiVersion)"/> or
+    /// <see cref="Deprecate(string)"/>.
+    /// </summary>
+    internal Dictionary<ApiVersion, DeprecationPolicy> DeprecationPolicies { get; } = new();
+
+    /// <summary>Configure a sunset policy for the given version.</summary>
+    /// <param name="version">The API version to configure a sunset policy for.</param>
+    /// <returns>A builder that can be used to set dates and link references.</returns>
+    public IWolverineSunsetPolicyBuilder Sunset(ApiVersion version) => new SunsetPolicyBuilder(this, version);
+
+    /// <summary>Convenience overload that parses the version string (e.g. <c>"1.0"</c>).</summary>
+    /// <param name="version">A version string such as <c>"1.0"</c> or <c>"2"</c>.</param>
+    /// <returns>A builder that can be used to set dates and link references.</returns>
+    public IWolverineSunsetPolicyBuilder Sunset(string version)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        return Sunset(ApiVersionParser.Default.Parse(version));
+    }
+
+    /// <summary>Configure a deprecation policy for the given version.</summary>
+    /// <param name="version">The API version to configure a deprecation policy for.</param>
+    /// <returns>A builder that can be used to set dates and link references.</returns>
+    public IWolverineDeprecationPolicyBuilder Deprecate(ApiVersion version) => new DeprecationPolicyBuilder(this, version);
+
+    /// <summary>Convenience overload that parses the version string (e.g. <c>"1.0"</c>).</summary>
+    /// <param name="version">A version string such as <c>"1.0"</c> or <c>"2"</c>.</param>
+    /// <returns>A builder that can be used to set dates and link references.</returns>
+    public IWolverineDeprecationPolicyBuilder Deprecate(string version)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        return Deprecate(ApiVersionParser.Default.Parse(version));
+    }
+}

--- a/src/Http/Wolverine.Http/ApiVersioning/WolverineOpenApiEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/WolverineOpenApiEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,97 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Wolverine.Http.ApiVersioning;
+
+/// <summary>
+/// Extensions for surfacing Wolverine API-versioning information into ASP.NET Core endpoint
+/// routing — primarily for wiring SwaggerUI / Scalar version dropdowns.
+/// </summary>
+public static class WolverineOpenApiEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Returns one description per discovered API version, sorted ascending by major then minor.
+    /// Returns an empty list when API versioning is not configured or no versioned endpoint
+    /// has been discovered.
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder (typically the <c>WebApplication</c> instance).</param>
+    /// <returns>
+    /// A read-only list of <see cref="WolverineApiVersionDescription"/> instances, one per
+    /// distinct <see cref="ApiVersion"/> found across all registered Wolverine HTTP chains,
+    /// sorted ascending by major version then minor version.
+    /// </returns>
+    public static IReadOnlyList<WolverineApiVersionDescription> DescribeWolverineApiVersions(
+        this IEndpointRouteBuilder endpoints)
+    {
+        var httpOptions = endpoints.ServiceProvider.GetService<WolverineHttpOptions>();
+
+        // Not configured or AddWolverineHttp() was never called — return empty.
+        if (httpOptions?.ApiVersioning is null)
+            return Array.Empty<WolverineApiVersionDescription>();
+
+        var graph = httpOptions.Endpoints;
+
+        // MapWolverineEndpoints has not been called yet — return empty rather than throwing.
+        if (graph is null)
+            return Array.Empty<WolverineApiVersionDescription>();
+
+        var apiVersioning = httpOptions.ApiVersioning;
+        var openApiOptions = apiVersioning.OpenApi;
+
+        // Gather every chain that has a resolved ApiVersion, then group by version.
+        var byVersion = graph.Chains
+            .Where(c => c.ApiVersion is not null)
+            .GroupBy(c => c.ApiVersion!)
+            .ToList();
+
+        if (byVersion.Count == 0)
+            return Array.Empty<WolverineApiVersionDescription>();
+
+        var descriptions = new List<WolverineApiVersionDescription>(byVersion.Count);
+
+        foreach (var group in byVersion)
+        {
+            var version = group.Key;
+
+            var documentName = openApiOptions.DocumentNameStrategy(version);
+            var displayName = $"API {documentName}";
+
+            // A version is deprecated when any chain in the group has a deprecation policy,
+            // OR when the options-level DeprecationPolicies map contains an entry for it.
+            var isDeprecated = group.Any(c => c.DeprecationPolicy is not null)
+                || apiVersioning.DeprecationPolicies.ContainsKey(version);
+
+            // Prefer the policy already attached to a chain (set during policy application);
+            // fall back to the options-level map (handles the case where the chain was
+            // PassThrough / not reachable by the policy).
+            var sunsetPolicy = group.Select(c => c.SunsetPolicy).FirstOrDefault(p => p is not null)
+                ?? apiVersioning.SunsetPolicies.GetValueOrDefault(version);
+
+            descriptions.Add(new WolverineApiVersionDescription(
+                version,
+                documentName,
+                displayName,
+                isDeprecated,
+                sunsetPolicy));
+        }
+
+        // Sort ascending by major version then minor version.
+        // Treat null MajorVersion (date-based versions) as int.MaxValue so they sort last.
+        descriptions.Sort((a, b) =>
+        {
+            var majorA = a.ApiVersion.MajorVersion ?? int.MaxValue;
+            var majorB = b.ApiVersion.MajorVersion ?? int.MaxValue;
+
+            var majorCmp = majorA.CompareTo(majorB);
+            if (majorCmp != 0)
+                return majorCmp;
+
+            var minorA = a.ApiVersion.MinorVersion ?? 0;
+            var minorB = b.ApiVersion.MinorVersion ?? 0;
+            return minorA.CompareTo(minorB);
+        });
+
+        return descriptions.AsReadOnly();
+    }
+}

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
+using Asp.Versioning;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
@@ -249,6 +250,22 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
     /// Required TenancyMode for this http chain
     /// </summary>
     public TenancyMode? TenancyMode { get; set; }
+
+    /// <summary>API version declared for this endpoint via [ApiVersion] or fluent configuration. Null when the endpoint is version-neutral.</summary>
+    public ApiVersion? ApiVersion { get; set; }
+
+    /// <summary>Sunset policy for this endpoint's API version. Populated by configuration during app startup.</summary>
+    public SunsetPolicy? SunsetPolicy { get; set; }
+
+    /// <summary>Deprecation policy for this endpoint's API version. Populated by configuration during app startup.</summary>
+    public DeprecationPolicy? DeprecationPolicy { get; set; }
+
+    /// <summary>Fluent helper to declare an API version on this chain. Returns this chain.</summary>
+    public HttpChain HasApiVersion(ApiVersion version)
+    {
+        ApiVersion = version;
+        return this;
+    }
 
     public static HttpChain ChainFor<T>(Expression<Action<T>> expression, HttpGraph? parent = null)
     {
@@ -746,6 +763,18 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
     string IEndpointNameMetadata.EndpointName => HasExplicitOperationId ? OperationId : ToString();
 
     string IEndpointSummaryMetadata.Summary => EndpointSummary ?? ToString();
+
+    /// <summary>
+    /// Sets an explicit operation ID (endpoint name) and marks it as explicit so it is used
+    /// as the endpoint name in the ASP.NET Core routing infrastructure. This is used by
+    /// <see cref="ApiVersioning.ApiVersioningPolicy"/> to disambiguate endpoints that share the
+    /// same handler method name after URL-segment version prefixes are applied.
+    /// </summary>
+    internal void SetExplicitOperationId(string operationId)
+    {
+        OperationId = operationId;
+        HasExplicitOperationId = true;
+    }
 
     public List<ParameterInfo> FileParameters { get; } = [];
 

--- a/src/Http/Wolverine.Http/Wolverine.Http.csproj
+++ b/src/Http/Wolverine.Http/Wolverine.Http.csproj
@@ -8,5 +8,6 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
         <ProjectReference Include="..\..\Wolverine\Wolverine.csproj"/>
+        <PackageReference Include="Asp.Versioning.Abstractions"/>
     </ItemGroup>
 </Project>

--- a/src/Http/Wolverine.Http/WolverineHttpEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpEndpointRouteBuilderExtensions.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Wolverine.Configuration;
 using Wolverine.Configuration.Capabilities;
+using Wolverine.Http.ApiVersioning;
 using Wolverine.Http.CodeGen;
 using Wolverine.Http.Transport;
 using Wolverine.Http.Validation;
@@ -168,6 +169,14 @@ public static class WolverineHttpEndpointRouteBuilderExtensions
         services.AddSingleton<MatcherPolicy, ContentTypeEndpointSelectorPolicy>();
 
         services.AddSingleton<ICapabilityDescriptor, HttpCapabilityDescriptor>();
+
+        // Registered unconditionally — harmless when no versioned endpoint uses it.
+        services.AddSingleton<ApiVersionHeaderWriter>(sp =>
+        {
+            var httpOptions = sp.GetRequiredService<WolverineHttpOptions>();
+            var versioningOptions = httpOptions.ApiVersioning ?? new WolverineApiVersioningOptions();
+            return new ApiVersionHeaderWriter(versioningOptions);
+        });
 
         services.ConfigureWolverine(opts =>
         {

--- a/src/Http/Wolverine.Http/WolverineHttpOptions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpOptions.cs
@@ -7,6 +7,7 @@ using Wolverine.Http.Antiforgery;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 using Wolverine.Configuration;
+using Wolverine.Http.ApiVersioning;
 using Wolverine.Http.CodeGen;
 using Wolverine.Http.Policies;
 using Wolverine.Http.Resources;
@@ -150,6 +151,27 @@ public class WolverineHttpOptions
     public void UseDataAnnotationsValidationProblemDetailMiddleware()
     {
         AddPolicy<HttpChainDataAnnotationsValidationPolicy>();
+    }
+
+    internal WolverineApiVersioningOptions? ApiVersioning { get; private set; }
+
+    /// <summary>
+    /// Enable native API versioning support. On the first call, creates the
+    /// <see cref="WolverineApiVersioningOptions"/> instance and registers an
+    /// <c>ApiVersioningPolicy</c> that applies versioning semantics at bootstrap time.
+    /// Subsequent calls accumulate configuration onto the same options instance without
+    /// registering a second policy.
+    /// </summary>
+    /// <param name="configure">An action to configure the <see cref="WolverineApiVersioningOptions"/>.</param>
+    public void UseApiVersioning(Action<WolverineApiVersioningOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        if (ApiVersioning is null)
+        {
+            ApiVersioning = new WolverineApiVersioningOptions();
+            Policies.Add(new ApiVersioningPolicy(ApiVersioning));
+        }
+        configure(ApiVersioning);
     }
     
     public async ValueTask<string?> TryDetectTenantId(HttpContext httpContext)

--- a/src/Http/WolverineWebApi/ApiVersioning/OrdersV1Endpoint.cs
+++ b/src/Http/WolverineWebApi/ApiVersioning/OrdersV1Endpoint.cs
@@ -1,0 +1,13 @@
+using Asp.Versioning;
+using Wolverine.Http;
+
+namespace WolverineWebApi.ApiVersioning;
+
+[ApiVersion("1.0")]
+public static class OrdersV1Endpoint
+{
+    [WolverineGet("/orders", OperationId = "OrdersV1Endpoint.Get")]
+    public static OrdersV1Response Get() => new(["v1-order-1", "v1-order-2"]);
+}
+
+public record OrdersV1Response(IReadOnlyList<string> Orders);

--- a/src/Http/WolverineWebApi/ApiVersioning/OrdersV2Endpoint.cs
+++ b/src/Http/WolverineWebApi/ApiVersioning/OrdersV2Endpoint.cs
@@ -1,0 +1,13 @@
+using Asp.Versioning;
+using Wolverine.Http;
+
+namespace WolverineWebApi.ApiVersioning;
+
+[ApiVersion("2.0")]
+public static class OrdersV2Endpoint
+{
+    [WolverineGet("/orders", OperationId = "OrdersV2Endpoint.Get")]
+    public static OrdersV2Response Get() => new("ok", ["v2-a", "v2-b", "v2-c"]);
+}
+
+public record OrdersV2Response(string Status, IReadOnlyList<string> Items);

--- a/src/Http/WolverineWebApi/ApiVersioning/OrdersV3PreviewEndpoint.cs
+++ b/src/Http/WolverineWebApi/ApiVersioning/OrdersV3PreviewEndpoint.cs
@@ -1,0 +1,11 @@
+using Asp.Versioning;
+using Wolverine.Http;
+
+namespace WolverineWebApi.ApiVersioning;
+
+[ApiVersion("3.0")]
+public static class OrdersV3PreviewEndpoint
+{
+    [WolverineGet("/orders", OperationId = "OrdersV3PreviewEndpoint.Get")]
+    public static OrdersV2Response Get() => new("preview", ["v3-preview"]);
+}

--- a/src/Http/WolverineWebApi/ApiVersioning/WolverineApiVersioningSwaggerOperationFilter.cs
+++ b/src/Http/WolverineWebApi/ApiVersioning/WolverineApiVersioningSwaggerOperationFilter.cs
@@ -1,0 +1,65 @@
+using Asp.Versioning;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Globalization;
+using Wolverine.Http.ApiVersioning;
+
+namespace WolverineWebApi.ApiVersioning;
+
+/// <summary>
+/// Swashbuckle operation filter that surfaces Wolverine API-versioning metadata in OpenAPI:
+/// <list type="bullet">
+///   <item><description>Sets <see cref="OpenApiOperation.Deprecated"/> when the chain has a deprecation policy.</description></item>
+///   <item><description>Adds an <c>x-api-versioning</c> extension carrying sunset date and links.</description></item>
+/// </list>
+/// Copy this filter into your own project and register it via <c>opts.OperationFilter&lt;...&gt;()</c>.
+/// </summary>
+public sealed class WolverineApiVersioningSwaggerOperationFilter : IOperationFilter
+{
+    /// <inheritdoc/>
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        var metadata = context.ApiDescription.ActionDescriptor.EndpointMetadata;
+        ApplyFromMetadata(operation, metadata);
+    }
+
+    /// <summary>
+    /// Core logic extracted for testability. Reads <see cref="ApiVersionEndpointHeaderState"/>
+    /// from <paramref name="metadata"/> and mutates <paramref name="operation"/> accordingly.
+    /// </summary>
+    internal static void ApplyFromMetadata(OpenApiOperation operation, IList<object> metadata)
+    {
+        var state = metadata.OfType<ApiVersionEndpointHeaderState>().FirstOrDefault();
+        if (state is null) return;
+
+        if (state.Deprecation is not null)
+            operation.Deprecated = true;
+
+        if (state.Sunset is null && state.Deprecation is null) return;
+
+        var ext = new OpenApiObject();
+
+        if (state.Sunset?.Date is { } sunsetDate)
+            ext["sunset"] = new OpenApiString(sunsetDate.UtcDateTime.ToString("R", CultureInfo.InvariantCulture));
+
+        var links = new OpenApiArray();
+        foreach (var link in (state.Sunset?.Links ?? []).Concat(state.Deprecation?.Links ?? []))
+        {
+            var linkObj = new OpenApiObject
+            {
+                ["href"] = new OpenApiString(link.LinkTarget?.ToString() ?? string.Empty)
+            };
+            if (link.Title.HasValue && link.Title.Length > 0)
+                linkObj["title"] = new OpenApiString(link.Title.Value);
+            if (link.Type.HasValue && link.Type.Length > 0)
+                linkObj["type"] = new OpenApiString(link.Type.Value);
+            links.Add(linkObj);
+        }
+        if (links.Count > 0)
+            ext["links"] = links;
+
+        if (ext.Count > 0)
+            operation.Extensions["x-api-versioning"] = ext;
+    }
+}

--- a/src/Http/WolverineWebApi/Program.cs
+++ b/src/Http/WolverineWebApi/Program.cs
@@ -12,18 +12,22 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
+using Scalar.AspNetCore;
 using Wolverine;
 using Wolverine.AdminApi;
 using Wolverine.EntityFrameworkCore;
 using Wolverine.ErrorHandling;
 using Wolverine.FluentValidation;
 using Wolverine.Http;
+using Wolverine.Http.ApiVersioning;
 using Wolverine.Http.FluentValidation;
 using Wolverine.Http.Marten;
 using Wolverine.Http.Tests.DifferentAssembly.Validation;
 using Wolverine.Http.Transport;
 using Wolverine.Marten;
 using WolverineWebApi;
+using WolverineWebApi.ApiVersioning;
 using WolverineWebApi.Bugs;
 using WolverineWebApi.Marten;
 using WolverineWebApi.Samples;
@@ -56,7 +60,14 @@ public class Program
         #region sample_register_custom_swashbuckle_filter
         builder.Services.AddSwaggerGen(x =>
         {
+            x.SwaggerDoc("default", new OpenApiInfo { Title = "Wolverine Web API", Version = "default" });
+            x.SwaggerDoc("v1", new OpenApiInfo { Title = "Wolverine Web API v1", Version = "v1" });
+            x.SwaggerDoc("v2", new OpenApiInfo { Title = "Wolverine Web API v2", Version = "v2" });
+            x.SwaggerDoc("v3", new OpenApiInfo { Title = "Wolverine Web API v3", Version = "v3" });
             x.OperationFilter<WolverineOperationFilter>();
+            x.OperationFilter<WolverineApiVersioningSwaggerOperationFilter>();
+            x.DocInclusionPredicate((docName, api) =>
+                docName == "default" || api.GroupName == docName);
             x.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
         });
 
@@ -207,7 +218,29 @@ public class Program
 
 // Configure the HTTP request pipeline.
         app.UseSwagger();
-        app.UseSwaggerUI();
+        app.UseSwaggerUI(c =>
+        {
+            c.SwaggerEndpoint("/swagger/default/swagger.json", "default");
+            foreach (var description in app.DescribeWolverineApiVersions())
+            {
+                c.SwaggerEndpoint(
+                    $"/swagger/{description.DocumentName}/swagger.json",
+                    description.DisplayName + (description.IsDeprecated ? " (deprecated)" : ""));
+            }
+        });
+
+        app.MapScalarApiReference(options =>
+        {
+            options.AddDocument("default", "Wolverine Web API (all)",
+                $"/swagger/default/swagger.json");
+            foreach (var description in app.DescribeWolverineApiVersions())
+            {
+                options.AddDocument(
+                    description.DocumentName,
+                    description.DisplayName + (description.IsDeprecated ? " (deprecated)" : ""),
+                    $"/swagger/{description.DocumentName}/swagger.json");
+            }
+        });
 
         app.UseAuthorization();
 
@@ -249,6 +282,16 @@ public class Program
         #region sample_using_configure_endpoints
         app.MapWolverineEndpoints(opts =>
         {
+            opts.UseApiVersioning(v =>
+            {
+                // Existing unversioned endpoints are left unchanged
+                v.UnversionedPolicy = UnversionedPolicy.PassThrough;
+                v.Sunset("3.0").On(DateTimeOffset.Parse("2027-01-01T00:00:00Z"))
+                    .WithLink(new Uri("https://example.com/migrate-to-v2"), "Migration guide", "text/html");
+                v.Deprecate("1.0").On(DateTimeOffset.Parse("2026-12-31T00:00:00Z"))
+                    .WithLink(new Uri("https://example.com/sunset-v1"));
+            });
+
             // This is strictly to test the endpoint policy
 
             opts.ConfigureEndpoints(httpChain =>

--- a/src/Http/WolverineWebApi/WolverineWebApi.csproj
+++ b/src/Http/WolverineWebApi/WolverineWebApi.csproj
@@ -6,6 +6,7 @@
         <PackageReference Include="FSharp.Core" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR" />
+        <PackageReference Include="Scalar.AspNetCore" />
         <PackageReference Include="Shouldly" />
         <PackageReference Include="StronglyTypedId" />
         <PackageReference Include="Swashbuckle.AspNetCore" />


### PR DESCRIPTION
Closes #2627. Sibling reference: #2401.

## Summary

Adds native API versioning to `WolverineFx.Http` with first-class SwaggerUI / Scalar compatibility. Single dependency on `Asp.Versioning.Abstractions` (no `Asp.Versioning.Http`, no `Microsoft.AspNetCore.OpenApi`).

```csharp
[ApiVersion("1.0")]
public static class OrdersV1Endpoint
{
    [WolverineGet("/orders")] public static OrdersV1Response Get() => new(...);
}

app.MapWolverineEndpoints(opts =>
{
    opts.UseApiVersioning(v =>
    {
        v.Sunset("3.0").On(DateTimeOffset.Parse("2027-01-01")).WithLink(new Uri("https://example.com/migrate"));
        v.Deprecate("1.0").On(DateTimeOffset.Parse("2026-12-31"));
    });
});
```

Produces `/v1/orders`, `/v2/orders`, `/v3/orders` automatically, plus per-version OpenAPI documents and the right RFC headers on every response.

## What's included

- **URL-segment versioning**. `[ApiVersion("1.0")]` → `/v1/orders` by default. `UrlSegmentPrefix` and `UrlSegmentVersionFormatter` are both overridable.
- **Method-wins attribute resolution**. Method-level `[ApiVersion]` takes precedence over class-level. Multiple `[ApiVersion]` attributes on a single method are explicitly rejected at startup.
- **`UnversionedPolicy`** with three modes: `PassThrough` (default), `RequireExplicit` (throws at startup if any chain lacks `[ApiVersion]`), `AssignDefault` (assigns a configured `DefaultVersion`).
- **Sunset / deprecation policies** with fluent `Sunset("1.0").On(date).WithLink(uri, title?, type?)` builders. Attribute-driven `[ApiVersion(..., Deprecated = true)]` takes precedence over options-driven deprecation per chain.
- **Response headers**: RFC 9745 `Deprecation` (with `true` token when no date), RFC 8594 `Sunset`, RFC 8288 `Link`, plus `api-supported-versions`. Two independent toggles (`EmitDeprecationHeaders`, `EmitApiSupportedVersionsHeader`).
- **Duplicate detection**. Two chains with the same `(verb, original-route, version)` triple throw at bootstrap with both display names in the message.
- **OpenAPI document partitioning** via `IEndpointGroupNameMetadata` (already plumbed through to `ApiDescription.GroupName`). `WolverineApiVersioningOpenApiOptions.DocumentNameStrategy` lets users customise the document name (default `v{major}`).
- **`app.DescribeWolverineApiVersions()`** returns one description per discovered version for wiring SwaggerUI / Scalar dropdowns.
- **Sample Swashbuckle `IOperationFilter`** (`WolverineApiVersioningSwaggerOperationFilter`) lives in `WolverineWebApi` as copy-paste reference code — sets `OpenApiOperation.Deprecated` and emits an `x-api-versioning` extension carrying sunset date and links.

## Dependency choice

`Asp.Versioning.Abstractions` 10.0.0 only — **not** `Asp.Versioning.Http`. Routing is driven from `IHttpPolicy`, so we need the types (`ApiVersion`, `ApiVersionAttribute`, `SunsetPolicy`, `DeprecationPolicy`, `ApiVersionMetadata`, `LinkHeaderValue`) but not the readers, version sets, or DI policy manager. Smaller surface, no MVC-centric assumptions.

`Asp.Versioning.Http` is verified absent from the transitive closure (`dotnet list package --include-transitive`).

## Default URL-segment format

`[ApiVersion("1.0")]` produces `/v1/orders` (major-only) by default. Users wanting `/v1.0/orders` set `UrlSegmentVersionFormatter = v => v.ToString()`. Documentation explicitly notes both options.

## Implementation notes

- Wolverine.Http does not have an internal OpenAPI document builder; it surfaces metadata via `IApiDescription` and external tools (Swashbuckle, MS.AspNetCore.OpenApi) read it. The policy attaches `IEndpointGroupNameMetadata` so document partitioning works automatically with Swashbuckle's `DocInclusionPredicate` or the equivalent ASP.NET Core mechanism.
- `ApiVersionEndpointHeaderState` and `ApiVersionHeaderWriter` are public. The state record is part of the observable contract for user OpenAPI filters; the writer is referenced by Wolverine's dynamic codegen (empirically verified — `internal` produces CS0122 in generated source).

## Tests

| Suite | Count | Status |
|---|---|---|
| Full `Wolverine.Http.Tests` (net9.0) | 707 | ✅ |
| ApiVersioning suite | 73 | ✅ |
| Swashbuckle integration | 7 | ✅ |
| Alba integration scenarios (`api_versioning_integration_tests.cs`) | 10 | ✅ |

Smoke test on the WolverineWebApi sample confirms `/v1/orders`, `/v2/orders`, `/v3/orders` all 200 with the expected `Deprecation` / `Sunset` / `Link` / `api-supported-versions` headers, and `/swagger/{default,v1,v2,v3}/swagger.json` all serve correctly.

## Test plan

- [ ] `dotnet build` succeeds on net8.0 / net9.0 / net10.0
- [ ] `dotnet test src/Http/Wolverine.Http.Tests` is green
- [ ] Run `WolverineWebApi` and visit `/swagger` — confirm dropdown shows `default`, `v1`, `v2`, `v3` and the v1 endpoint shows the deprecated marker
- [ ] Visit `/scalar/v1` — confirm the Scalar UI renders versioned operations
- [ ] `curl -i /v1/orders` shows `Deprecation`, `Link`, `api-supported-versions` headers
- [ ] `curl -i /v3/orders` shows `Sunset`, `Link`, `api-supported-versions` headers
- [ ] `dotnet list src/Http/Wolverine.Http package --include-transitive` confirms `Asp.Versioning.Http` is **not** present

## Documentation

`docs/guide/http/versioning.md` covers attribute rules, URL-segment strategy, the three `UnversionedPolicy` modes, sunset/deprecation policies, OpenAPI integration (Swashbuckle + Scalar + MS.AspNetCore.OpenApi). Cross-linked from `metadata.md`. Sidebar entry registered in `docs/.vitepress/config.mts`.