### PR TITLE
Fix Oracle leadership NRE on non-UTC DB sessions (timestamp default expressions)

### DIFF
--- a/src/Persistence/Oracle/OracleTests/Agents/health_check_timestamp_round_trip.cs
+++ b/src/Persistence/Oracle/OracleTests/Agents/health_check_timestamp_round_trip.cs
@@ -1,0 +1,80 @@
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Weasel.Oracle;
+using Wolverine;
+using Wolverine.Oracle;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+
+namespace OracleTests.Agents;
+
+// Regression coverage for the user-reported NullReferenceException at
+// NodeAgentController.tryStartLeadershipAsync line 163 (`self!.AssignAgents(...)`).
+//
+// Root cause sits in the Oracle schema: timestamp columns are declared as
+// AddColumn<DateTimeOffset>("health_check") (TIMESTAMP WITH TIME ZONE) with a
+// DEFAULT of `SYS_EXTRACT_UTC(SYSTIMESTAMP)`. SYS_EXTRACT_UTC returns a TIMESTAMP
+// WITHOUT time zone carrying the UTC instant. When that bare TIMESTAMP is implicitly
+// cast into the TIMESTAMP WITH TIME ZONE column, Oracle stamps it with the
+// SESSION time zone. For any session whose TZ is not UTC, the stored value's UTC
+// equivalent is N hours off from the actual UTC instant.
+//
+// In production this bites NodeAgentController.DoHealthChecksAsync: the
+// just-persisted current node is read back with LastHealthCheck older than
+// `UtcNow - StaleNodeTimeout` (1 minute by default), gets filtered out by the
+// staleness check, and `nodes.FirstOrDefault(x => x.NodeId == self.NodeId)` returns
+// null. tryStartLeadershipAsync then NREs on `self!.AssignAgents([LeaderUri])`.
+[Collection("oracle")]
+public class health_check_timestamp_round_trip
+{
+    [Fact]
+    public async Task just_persisted_node_must_not_be_filtered_as_stale_under_non_utc_session_tz()
+    {
+        var dataSource = new OracleDataSource(Servers.OracleConnectionString);
+        var settings = new DatabaseSettings
+        {
+            SchemaName = "WOLVERINE",
+            Role = MessageStoreRole.Main
+        };
+
+        var store = new OracleMessageStore(settings, new DurabilitySettings(), dataSource,
+            NullLogger<OracleMessageStore>.Instance);
+        await store.Admin.RebuildAsync();
+
+        // Force this connection's session time zone to non-UTC so the column DEFAULT
+        // expression bakes in the wrong offset — mirrors a real Oracle DB hosted in
+        // a non-UTC region.
+        var nodeId = Guid.NewGuid();
+        await using (var conn = await dataSource.OpenConnectionAsync())
+        {
+            await conn.CreateCommand("ALTER SESSION SET TIME_ZONE = '+05:00'")
+                .ExecuteNonQueryAsync();
+
+            // Insert a node row using the column DEFAULT for health_check (the path
+            // that NodeAgentController hits via PersistAsync on first heartbeat).
+            var insertCmd = conn.CreateCommand(
+                "INSERT INTO WOLVERINE.WOLVERINE_NODES (id, uri, capabilities, description, version) " +
+                "VALUES (:id, :uri, :capabilities, :description, :version)");
+            insertCmd.With("id", nodeId);
+            insertCmd.With("uri", "tcp://localhost:1234/");
+            insertCmd.With("capabilities", string.Empty);
+            insertCmd.With("description", "tz-repro");
+            insertCmd.With("version", "1.0");
+            await insertCmd.ExecuteNonQueryAsync();
+        }
+
+        // Read back via the production API and apply the exact staleness predicate
+        // NodeAgentController.DoHealthChecksAsync uses.
+        var nodes = await store.Nodes.LoadAllNodesAsync(CancellationToken.None);
+        var self = nodes.SingleOrDefault(x => x.NodeId == nodeId);
+        self.ShouldNotBeNull("LoadAllNodesAsync did not return the just-inserted node");
+
+        var staleTime = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(1));
+        self!.LastHealthCheck.ShouldBeGreaterThan(staleTime,
+            $"Just-persisted node read back as stale (would be filtered out by NodeAgentController). " +
+            $"LastHealthCheck={self.LastHealthCheck:O}, UtcNow={DateTimeOffset.UtcNow:O}, " +
+            $"StaleCutoff={staleTime:O}.");
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
@@ -232,9 +232,9 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
             nodeTable.AddColumn("description", "VARCHAR2(4000)").NotNull();
             nodeTable.AddColumn("uri", "VARCHAR2(500)").NotNull();
             nodeTable.AddColumn<DateTimeOffset>("started")
-                .DefaultValueByExpression("SYS_EXTRACT_UTC(SYSTIMESTAMP)").NotNull();
+                .DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''").NotNull();
             nodeTable.AddColumn<DateTimeOffset>("health_check").NotNull()
-                .DefaultValueByExpression("SYS_EXTRACT_UTC(SYSTIMESTAMP)");
+                .DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''");
             nodeTable.AddColumn("version", "VARCHAR2(4000)");
             nodeTable.AddColumn("capabilities", "VARCHAR2(4000)").AllowNulls();
 
@@ -245,7 +245,7 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
             assignmentTable.AddColumn<Guid>("node_id")
                 .ForeignKeyTo(nodeTable.Identifier, "id", onDelete: CascadeAction.Cascade);
             assignmentTable.AddColumn<DateTimeOffset>("started")
-                .DefaultValueByExpression("SYS_EXTRACT_UTC(SYSTIMESTAMP)").NotNull();
+                .DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''").NotNull();
 
             yield return assignmentTable;
 
@@ -257,7 +257,7 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
                 queueTable.AddColumn<Guid>("node_id").NotNull();
                 queueTable.AddColumn(DatabaseConstants.Body, "BLOB").NotNull();
                 queueTable.AddColumn<DateTimeOffset>("posted").NotNull()
-                    .DefaultValueByExpression("SYS_EXTRACT_UTC(SYSTIMESTAMP)");
+                    .DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''");
                 queueTable.AddColumn<DateTimeOffset>("expires");
 
                 yield return queueTable;
@@ -277,7 +277,7 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
             eventTable.AddColumn<int>("node_number").NotNull();
             eventTable.AddColumn("event_name", "VARCHAR2(500)").NotNull();
             eventTable.AddColumn<DateTimeOffset>("timestamp")
-                .DefaultValueByExpression("SYS_EXTRACT_UTC(SYSTIMESTAMP)").NotNull();
+                .DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''").NotNull();
             eventTable.AddColumn("description", "VARCHAR2(500)").AllowNulls();
             yield return eventTable;
 
@@ -407,7 +407,7 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
         if (definition.TimestampColumnName.IsNotEmpty())
         {
             table.AddColumn<DateTimeOffset>(definition.TimestampColumnName)
-                .DefaultValueByExpression("SYS_EXTRACT_UTC(SYSTIMESTAMP)");
+                .DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''");
         }
 
         if (definition.MessageTypeColumnName.IsNotEmpty())

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleNodePersistence.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleNodePersistence.cs
@@ -299,7 +299,7 @@ internal class OracleNodePersistence : DatabaseConstants, INodeAgentPersistence
     {
         await using var conn = await _dataSource.OpenConnectionAsync(token);
         var cmd = conn.CreateCommand(
-            $"UPDATE {_nodeTable} SET health_check = SYS_EXTRACT_UTC(SYSTIMESTAMP) WHERE id = :id");
+            $"UPDATE {_nodeTable} SET health_check = SYSTIMESTAMP AT TIME ZONE 'UTC' WHERE id = :id");
         cmd.With("id", node.NodeId);
         var count = await cmd.ExecuteNonQueryAsync(token);
 

--- a/src/Persistence/Oracle/Wolverine.Oracle/Sagas/OracleSagaSchema.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Sagas/OracleSagaSchema.cs
@@ -31,7 +31,7 @@ public class OracleSagaSchema<T, TId> : IDatabaseSagaSchema<TId, T> where T : Sa
         _insertSql =
             $"INSERT INTO {schemaName}.{tableName} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.Version}) VALUES (:id, :body, 1)";
         _updateSql =
-            $"UPDATE {schemaName}.{tableName} SET {DatabaseConstants.Body} = :body, {DatabaseConstants.Version} = :version + 1, last_modified = SYS_EXTRACT_UTC(SYSTIMESTAMP) WHERE {DatabaseConstants.Id} = :id AND {DatabaseConstants.Version} = :version";
+            $"UPDATE {schemaName}.{tableName} SET {DatabaseConstants.Body} = :body, {DatabaseConstants.Version} = :version + 1, last_modified = SYSTIMESTAMP AT TIME ZONE 'UTC' WHERE {DatabaseConstants.Id} = :id AND {DatabaseConstants.Version} = :version";
         _loadSql =
             $"SELECT body, version FROM {schemaName}.{tableName} WHERE {DatabaseConstants.Id} = :id";
 
@@ -64,8 +64,8 @@ public class OracleSagaSchema<T, TId> : IDatabaseSagaSchema<TId, T> where T : Sa
 
         table.AddColumn(DatabaseConstants.Body, "CLOB").NotNull();
         table.AddColumn(DatabaseConstants.Version, "NUMBER(10)").DefaultValue(1).NotNull();
-        table.AddColumn<DateTimeOffset>("created").DefaultValueByExpression("SYS_EXTRACT_UTC(SYSTIMESTAMP)").NotNull();
-        table.AddColumn<DateTimeOffset>("last_modified").DefaultValueByExpression("SYS_EXTRACT_UTC(SYSTIMESTAMP)").NotNull();
+        table.AddColumn<DateTimeOffset>("created").DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''").NotNull();
+        table.AddColumn<DateTimeOffset>("last_modified").DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''").NotNull();
 
         Table = table;
     }

--- a/src/Persistence/Oracle/Wolverine.Oracle/Schema/IncomingEnvelopeTable.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Schema/IncomingEnvelopeTable.cs
@@ -32,7 +32,7 @@ internal class IncomingEnvelopeTable : Table
         if (durability.InboxStaleTime.HasValue)
         {
             AddColumn<DateTimeOffset>(DatabaseConstants.Timestamp)
-                .DefaultValueByExpression("SYS_EXTRACT_UTC(SYSTIMESTAMP)");
+                .DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''");
         }
     }
 }

--- a/src/Persistence/Oracle/Wolverine.Oracle/Schema/OutgoingEnvelopeTable.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Schema/OutgoingEnvelopeTable.cs
@@ -21,7 +21,7 @@ internal class OutgoingEnvelopeTable : Table
         if (durability.OutboxStaleTime.HasValue)
         {
             AddColumn<DateTimeOffset>(DatabaseConstants.Timestamp)
-                .DefaultValueByExpression("SYS_EXTRACT_UTC(SYSTIMESTAMP)");
+                .DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''");
         }
     }
 }

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleQueueListener.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleQueueListener.cs
@@ -147,7 +147,7 @@ internal class OracleQueueListener : IListener
             // Select scheduled messages that are ready and lock them
             var selectCmd = CreateCmd(
                 $"SELECT id, body, message_type, keep_until FROM {_scheduledTableName} " +
-                $"WHERE {DatabaseConstants.ExecutionTime} <= SYS_EXTRACT_UTC(SYSTIMESTAMP) " +
+                $"WHERE {DatabaseConstants.ExecutionTime} <= SYSTIMESTAMP AT TIME ZONE 'UTC' " +
                 "FOR UPDATE SKIP LOCKED");
 
             var idsToMove = new List<Guid>();
@@ -415,11 +415,11 @@ internal class OracleQueueListener : IListener
         try
         {
             var cmd1 = conn.CreateCommand(
-                $"DELETE FROM {_queueTableName} WHERE {DatabaseConstants.KeepUntil} IS NOT NULL AND {DatabaseConstants.KeepUntil} <= SYS_EXTRACT_UTC(SYSTIMESTAMP)");
+                $"DELETE FROM {_queueTableName} WHERE {DatabaseConstants.KeepUntil} IS NOT NULL AND {DatabaseConstants.KeepUntil} <= SYSTIMESTAMP AT TIME ZONE 'UTC'");
             await cmd1.ExecuteNonQueryAsync(cancellationToken);
 
             var cmd2 = conn.CreateCommand(
-                $"DELETE FROM {_scheduledTableName} WHERE {DatabaseConstants.KeepUntil} IS NOT NULL AND {DatabaseConstants.KeepUntil} <= SYS_EXTRACT_UTC(SYSTIMESTAMP)");
+                $"DELETE FROM {_scheduledTableName} WHERE {DatabaseConstants.KeepUntil} IS NOT NULL AND {DatabaseConstants.KeepUntil} <= SYSTIMESTAMP AT TIME ZONE 'UTC'");
             await cmd2.ExecuteNonQueryAsync(cancellationToken);
         }
         finally

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleTransport.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleTransport.cs
@@ -103,7 +103,7 @@ public class OracleTransport : BrokerTransport<OracleQueue>
         await using var conn = await dataSource!.OpenConnectionAsync();
         try
         {
-            var cmd = conn.CreateCommand("SELECT SYS_EXTRACT_UTC(SYSTIMESTAMP) FROM DUAL");
+            var cmd = conn.CreateCommand("SELECT SYSTIMESTAMP AT TIME ZONE 'UTC' FROM DUAL");
             var raw = await cmd.ExecuteScalarAsync();
             return (DateTimeOffset)raw!;
         }

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/QueueTable.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/QueueTable.cs
@@ -13,6 +13,6 @@ internal class QueueTable : Table
         AddColumn(DatabaseConstants.Body, "BLOB").NotNull();
         AddColumn(DatabaseConstants.MessageType, "VARCHAR2(500)").NotNull();
         AddColumn<DateTimeOffset>(DatabaseConstants.KeepUntil);
-        AddColumn<DateTimeOffset>("timestamp").DefaultValueByExpression("SYS_EXTRACT_UTC(SYSTIMESTAMP)");
+        AddColumn<DateTimeOffset>("timestamp").DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''");
     }
 }

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/ScheduledMessageTable.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/ScheduledMessageTable.cs
@@ -14,7 +14,7 @@ internal class ScheduledMessageTable : Table
         AddColumn(DatabaseConstants.MessageType, "VARCHAR2(500)").NotNull();
         AddColumn<DateTimeOffset>(DatabaseConstants.ExecutionTime).NotNull();
         AddColumn<DateTimeOffset>(DatabaseConstants.KeepUntil);
-        AddColumn<DateTimeOffset>("timestamp").DefaultValueByExpression("SYS_EXTRACT_UTC(SYSTIMESTAMP)");
+        AddColumn<DateTimeOffset>("timestamp").DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''");
 
         Indexes.Add(new IndexDefinition($"idx_{tableName}_execution_time")
         {


### PR DESCRIPTION
## Summary

Fixes a user-reported `NullReferenceException` at `NodeAgentController.HeartBeat.cs:163` (`self!.AssignAgents([LeaderUri])`) on Oracle persistence whenever the DB session's time zone is anything other than UTC. After this PR a node hosted in any region survives the leadership-election heartbeat.

```
fail: Wolverine.Runtime.Agents.NodeAgentController[0]
  Error trying to attain a leadership lock
  System.NullReferenceException: Object reference not set to an instance of an object.
     at NodeAgentController.tryStartLeadershipAsync(...) line 163
     at NodeAgentController.DoHealthChecksAsync() line 75
```

## Root cause

Oracle timestamp columns (`health_check`, `started`, `posted`, `timestamp`, `expires`, saga `created`/`last_modified`, etc.) are declared `AddColumn<DateTimeOffset>(...)` — `TIMESTAMP WITH TIME ZONE` in Oracle — with a DEFAULT of `SYS_EXTRACT_UTC(SYSTIMESTAMP)`. A handful of UPDATE / SELECT sites mirror the same expression.

`SYS_EXTRACT_UTC` returns a `TIMESTAMP` *without* a time zone carrying the UTC instant. When that bare value is assigned into a `TIMESTAMP WITH TIME ZONE` column (or compared against one), Oracle stamps it with the **session** time zone — for any non-UTC session, the stored value's UTC equivalent is N hours offset from the actual UTC instant.

That bites `NodeAgentController.DoHealthChecksAsync` (HeartBeat.cs:39-47):

```csharp
await _persistence.MarkHealthCheckAsync(WolverineNode.For(_runtime.Options), ct); // upserts row
var (nodes, restrictions) = await _persistence.LoadNodeAgentStateAsync(ct);

var staleTime = DateTimeOffset.UtcNow.Subtract(_runtime.Options.Durability.StaleNodeTimeout); // 1 min default
var staleNodes = nodes.Where(x => x.LastHealthCheck < staleTime).ToArray();
nodes = nodes.Where(x => !staleNodes.Contains(x)).ToList();   // ← drops self
```

The just-persisted current node reads back with `LastHealthCheck` older than `UtcNow - 1min`, gets filtered out, and `nodes.FirstOrDefault(x => x.NodeId == self.NodeId)` returns `null` — NRE on the next line.

## Fix

Replace every `SYS_EXTRACT_UTC(SYSTIMESTAMP)` with `SYSTIMESTAMP AT TIME ZONE 'UTC'`, which returns a `TIMESTAMP WITH TIME ZONE` in UTC. Stored value round-trips correctly regardless of session TZ.

Two contexts:

* **DDL** (column DEFAULT expressions emitted into Weasel's `EXECUTE IMMEDIATE '...'` wrapper): inner quotes doubled to `SYSTIMESTAMP AT TIME ZONE ''UTC''` so they survive the surrounding PL/SQL string literal.
* **Runtime DML** (UPDATE / SELECT / WHERE clauses, executed directly): single-quoted `SYSTIMESTAMP AT TIME ZONE 'UTC'`.

## Test plan

- [x] **New regression test**: `OracleTests.Agents.health_check_timestamp_round_trip.just_persisted_node_must_not_be_filtered_as_stale_under_non_utc_session_tz` — forces `ALTER SESSION SET TIME_ZONE = '+05:00'` on the inserting connection, then asserts `LoadAllNodesAsync` returns the just-inserted node with a `LastHealthCheck` newer than `UtcNow - 1min`. Verified failing pre-fix (LastHealthCheck offset by 5 hours) and passing post-fix.
- [x] **Full OracleTests suite green**: `Failed: 0, Passed: 67, Skipped: 0, Total: 67, Duration: 20s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)