### PR TITLE
Lock dbcontrol:// and oraclecontrol:// endpoints to BufferedInMemory

### DIFF
--- a/src/Persistence/Oracle/OracleTests/Transport/oracle_control_endpoint_mode_tests.cs
+++ b/src/Persistence/Oracle/OracleTests/Transport/oracle_control_endpoint_mode_tests.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Oracle;
+using Wolverine.Oracle.Transport;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+
+namespace OracleTests.Transport;
+
+// Mirror of the shared DatabaseControlEndpoint mode lock — Oracle has its own
+// control transport (oraclecontrol://) introduced in #2622 and must enforce the
+// same invariant: the control endpoint can ONLY ever be BufferedInMemory.
+// Marking it Durable would push every leader-election / agent-reassignment
+// envelope through the durable inbox/outbox (which sits on top of the same
+// Oracle store, leading to deadlocks); marking it Inline contradicts the
+// transport's batched-poll semantics. Built-in policies already guard their
+// setters with SupportsMode checks; this test pins down that direct setter
+// abuse fails fast.
+public class oracle_control_endpoint_mode_tests
+{
+    private static OracleControlEndpoint endpoint()
+    {
+        // No live connection is needed for endpoint construction — OracleMessageStore's
+        // ctor only inspects connection-string parts via OracleConnectionStringBuilder.
+        var dataSource = new OracleDataSource(
+            "User Id=mode_test;Password=x;Data Source=localhost:1521/FREEPDB1");
+        var settings = new DatabaseSettings
+        {
+            SchemaName = "MODE_TEST",
+            Role = MessageStoreRole.Main
+        };
+        var store = new OracleMessageStore(settings, new DurabilitySettings(), dataSource,
+            NullLogger<OracleMessageStore>.Instance);
+        var transport = new OracleControlTransport(store, new WolverineOptions());
+        return transport.ControlEndpoint;
+    }
+
+    [Fact]
+    public void supports_only_buffered_in_memory_mode()
+    {
+        var e = endpoint();
+
+        e.SupportsMode(EndpointMode.BufferedInMemory).ShouldBeTrue();
+        e.SupportsMode(EndpointMode.Durable).ShouldBeFalse();
+        e.SupportsMode(EndpointMode.Inline).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void setting_mode_to_durable_throws()
+    {
+        var e = endpoint();
+        Should.Throw<InvalidOperationException>(() => e.Mode = EndpointMode.Durable);
+    }
+
+    [Fact]
+    public void setting_mode_to_inline_throws()
+    {
+        var e = endpoint();
+        Should.Throw<InvalidOperationException>(() => e.Mode = EndpointMode.Inline);
+    }
+
+    [Fact]
+    public void setting_mode_to_buffered_in_memory_succeeds()
+    {
+        var e = endpoint();
+        e.Mode = EndpointMode.BufferedInMemory;
+        e.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleControlEndpoint.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleControlEndpoint.cs
@@ -30,6 +30,13 @@ internal class OracleControlEndpoint : Endpoint
 
     public Guid NodeId { get; }
 
+    // The Oracle control transport polls the WOLVERINE_CONTROL_QUEUE table on a
+    // 1s tick. Forcing this endpoint to Durable would route every inter-node
+    // agent command through the same Oracle store the durability agent owns
+    // (deadlock); forcing Inline would defeat the batched-poll semantics. Lock
+    // to BufferedInMemory regardless of any global endpoint policy.
+    protected override bool supportsMode(EndpointMode mode) => mode == EndpointMode.BufferedInMemory;
+
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
     {
         return new ValueTask<IListener>(new OracleControlListener(_parent, this, receiver,

--- a/src/Persistence/PersistenceTests/Bugs/database_control_endpoint_mode_tests.cs
+++ b/src/Persistence/PersistenceTests/Bugs/database_control_endpoint_mode_tests.cs
@@ -1,0 +1,71 @@
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Transport;
+using Xunit;
+
+namespace PersistenceTests.Bugs;
+
+// The database-backed control transport is the inter-node command channel for
+// Wolverine's leader election + agent reassignment workflow. Marking its endpoint
+// as Durable would push every control envelope through the durable inbox/outbox,
+// which both deadlocks the durability layer (it depends on the same store) and
+// produces nonsensical outbox rows for transient cluster-coordination messages.
+// Marking it Inline is similarly wrong — control messages are batched + polled.
+//
+// These tests pin down the contract: SupportsMode returns true ONLY for
+// BufferedInMemory, and any direct attempt to set Mode to anything else throws.
+// Built-in policies (UseDurableInboxOnAllListeners, etc.) already guard their
+// setters with SupportsMode checks and will silently skip; explicit programmer
+// errors via custom IEndpointPolicy.Apply will surface as a clear exception.
+public class database_control_endpoint_mode_tests
+{
+    private static DatabaseControlEndpoint endpoint()
+    {
+        // The transport instance is held only for its TableName / Database refs at
+        // listen/send time; SupportsMode is a pure property of the endpoint itself.
+        var database = Substitute.For<IMessageDatabase>();
+        database.SchemaName.Returns("registry");
+        var transport = new DatabaseControlTransport(database, new WolverineOptions());
+        return (DatabaseControlEndpoint)transport.ControlEndpoint;
+    }
+
+    [Fact]
+    public void supports_only_buffered_in_memory_mode()
+    {
+        var e = endpoint();
+
+        e.SupportsMode(EndpointMode.BufferedInMemory).ShouldBeTrue();
+        e.SupportsMode(EndpointMode.Durable).ShouldBeFalse();
+        e.SupportsMode(EndpointMode.Inline).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void setting_mode_to_durable_throws()
+    {
+        var e = endpoint();
+        Should.Throw<InvalidOperationException>(() => e.Mode = EndpointMode.Durable);
+    }
+
+    [Fact]
+    public void setting_mode_to_inline_throws()
+    {
+        var e = endpoint();
+        Should.Throw<InvalidOperationException>(() => e.Mode = EndpointMode.Inline);
+    }
+
+    [Fact]
+    public void setting_mode_to_buffered_in_memory_succeeds()
+    {
+        var e = endpoint();
+
+        // Idempotent — already BufferedInMemory by default; this just exercises the
+        // happy path of the setter so a future regression that flips the predicate
+        // backwards (allow nothing) is caught loudly.
+        e.Mode = EndpointMode.BufferedInMemory;
+
+        e.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+    }
+}

--- a/src/Persistence/PersistenceTests/PersistenceTests.csproj
+++ b/src/Persistence/PersistenceTests/PersistenceTests.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="NSubstitute"/>
         <PackageReference Include="xunit"/>
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Persistence/SqliteTests/control_endpoint_policy_resistance.cs
+++ b/src/Persistence/SqliteTests/control_endpoint_policy_resistance.cs
@@ -1,0 +1,87 @@
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.RDBMS.Transport;
+using Wolverine.Runtime;
+using Wolverine.Sqlite;
+
+namespace SqliteTests;
+
+// End-to-end coverage for the dbcontrol:// endpoint mode lock.
+//
+// Even when the user installs the broadest policies the framework offers —
+// UseDurableInboxOnAllListeners() and UseDurableOutboxOnAllSendingEndpoints() —
+// the control endpoint must stay BufferedInMemory. Marking it Durable would
+// force every leader-election / agent-reassignment envelope through the same
+// store-backed inbox/outbox the durability agent itself owns, which deadlocks.
+//
+// The unit-level tests in PersistenceTests pin down the Mode setter contract.
+// This test sits one layer up and proves the framework's built-in policies
+// silently skip the control endpoint via SupportsMode, rather than throwing.
+public class control_endpoint_policy_resistance : SqliteContext, IAsyncLifetime
+{
+    private IHost _host = null!;
+    private SqliteTestDatabase _database = null!;
+
+    public async Task InitializeAsync()
+    {
+        _database = Servers.CreateDatabase(nameof(control_endpoint_policy_resistance));
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithSqlite(_database.ConnectionString);
+
+                opts.Policies.UseDurableInboxOnAllListeners();
+                opts.Policies.UseDurableOutboxOnAllSendingEndpoints();
+                opts.Policies.UseDurableLocalQueues();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_host != null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        _database?.Dispose();
+    }
+
+    [Fact]
+    public void global_durable_policies_do_not_promote_the_dbcontrol_endpoint()
+    {
+        var runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var control = runtime.Options.Transports.NodeControlEndpoint!;
+        control.ShouldBeOfType<DatabaseControlEndpoint>();
+        control.Mode.ShouldBe(EndpointMode.BufferedInMemory,
+            "UseDurableInboxOnAllListeners + UseDurableOutboxOnAllSendingEndpoints must " +
+            "skip the dbcontrol:// endpoint — promoting it to Durable would deadlock the " +
+            "durability layer (the control queue lives on the same store).");
+    }
+
+    [Fact]
+    public void all_dbcontrol_endpoints_remain_buffered_after_policies()
+    {
+        var runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var dbControlEndpoints = runtime.Options.Transports
+            .OfType<DatabaseControlTransport>()
+            .SelectMany(t => t.Endpoints())
+            .OfType<DatabaseControlEndpoint>()
+            .ToArray();
+
+        dbControlEndpoints.ShouldNotBeEmpty();
+        foreach (var endpoint in dbControlEndpoints)
+        {
+            endpoint.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+        }
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlEndpoint.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlEndpoint.cs
@@ -25,6 +25,15 @@ internal class DatabaseControlEndpoint : Endpoint
 
     public Guid NodeId { get; }
 
+    // The control transport polls the DB control queue table on a 1s tick and
+    // dispatches inter-node agent commands. Forcing it to Durable would route
+    // every control envelope through the same store-backed inbox/outbox the
+    // durability agent itself owns (deadlock); forcing Inline would skip the
+    // batched-poll semantics. Lock to BufferedInMemory regardless of any
+    // global endpoint policy. Built-in policies already guard via SupportsMode;
+    // direct Mode-setter abuse will throw via the base setter.
+    protected override bool supportsMode(EndpointMode mode) => mode == EndpointMode.BufferedInMemory;
+
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
     {
         return new ValueTask<IListener>(new DatabaseControlListener(_parent, this, receiver,


### PR DESCRIPTION
## Summary

The database-backed control transport (`dbcontrol://`) and its Oracle sibling (`oraclecontrol://`) carry inter-node leader-election and agent-reassignment commands. Promoting either of those endpoints to `Durable` would route every control envelope through the same store-backed inbox/outbox the durability agent itself owns — that's a deadlock waiting to happen. Marking them `Inline` contradicts the batched-poll semantics. The constructors set `Mode = BufferedInMemory`, but nothing kept a sufficiently aggressive endpoint policy from flipping it later.

This PR overrides `supportsMode` on both `DatabaseControlEndpoint` and `OracleControlEndpoint` so only `EndpointMode.BufferedInMemory` is accepted. The `Mode` setter on the `Endpoint` base class already throws `InvalidOperationException` when `supportsMode` returns `false`, so:

- Built-in policies that already guard their setters with `SupportsMode` (`UseDurableInboxOnAllListeners`, `UseDurableOutboxOnAllSendingEndpoints`, `UseDurableLocalQueues`, etc.) **silently skip** the control endpoint.
- Custom `IEndpointPolicy.Apply` callers that flip `Mode` directly will surface a clear `InvalidOperationException` — that's a programmer error, fail fast.

## Test plan

- [x] **PersistenceTests/Bugs/database_control_endpoint_mode_tests** — unit-level contract on the shared RDBMS endpoint: `SupportsMode` is `true` only for `BufferedInMemory`; setter throws for `Durable` / `Inline`; setter accepts `BufferedInMemory`.
- [x] **OracleTests/Transport/oracle_control_endpoint_mode_tests** — mirrors the same contract on the Oracle side.
- [x] **SqliteTests/control_endpoint_policy_resistance** — end-to-end guard: builds a host with `UseDurableInboxOnAllListeners` + `UseDurableOutboxOnAllSendingEndpoints` + `UseDurableLocalQueues`, then asserts the `dbcontrol://` endpoint stays `BufferedInMemory` and that no endpoint produced by `DatabaseControlTransport` got promoted.
- [x] Verified failing pre-fix (3 of 4 unit tests fail — setter accepts `Durable`); passing post-fix.
- [x] Full **OracleTests** suite green: `Failed: 0, Passed: 71, Total: 71, Duration: 18s`.
- [x] Full **SqliteTests** suite green modulo a pre-existing `[Trait("Category","Flaky")]` test (`multi_tenancy_with_multiple_files`) that is already filtered out in CI: `Failed: 1, Passed: 120, Total: 121` — the failing test is unrelated and tagged Flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)