### PR TITLE
Bump JasperFx 1.28.0 → 1.28.2 and JasperFx.Events 1.29.0 → 1.31.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,8 +30,8 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="1.28.0" />
-    <PackageVersion Include="JasperFx.Events" Version="1.29.0" />
+    <PackageVersion Include="JasperFx" Version="1.28.2" />
+    <PackageVersion Include="JasperFx.Events" Version="1.31.1" />
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.5.0" />
     <PackageVersion Include="JasperFx.SourceGeneration" Version="1.1.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />


### PR DESCRIPTION
Routine dependency refresh against the latest JasperFx packages on NuGet. Both move on patch / minor revisions only — no API changes anticipated downstream of Wolverine.

| Package | Was | Now |
|---|---|---|
| JasperFx | 1.28.0 | 1.28.2 |
| JasperFx.Events | 1.29.0 | 1.31.1 |

## Test plan

- [x] Full **CoreTests** suite green locally (`net9.0`): `Failed: 0, Passed: 1409, Total: 1409, Duration: 3m 57s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)