### PR TITLE
Add IAgent.Description for monitoring-tool tooltips

### DIFF
--- a/src/Persistence/Wolverine.CosmosDb/Internals/Durability/CosmosDbDurabilityAgent.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/Durability/CosmosDbDurabilityAgent.cs
@@ -158,6 +158,12 @@ public partial class CosmosDbDurabilityAgent : IAgent
     public AgentStatus Status { get; set; }
 
     /// <summary>
+    /// Human-readable description for monitoring tools — see
+    /// <see cref="IAgent.Description"/>.
+    /// </summary>
+    public string Description => $"Wolverine Cosmos DB durability agent for {Uri} — recovers persisted inbox/outbox messages and runs scheduled jobs against the Cosmos DB message store.";
+
+    /// <summary>
     /// True once <see cref="StartTimers"/> has wired up the recovery and scheduled-job
     /// background loops. Exposed for diagnostic and test inspection so callers can detect
     /// the multi-instance "two pollers" condition without reflection. See #2623.

--- a/src/Persistence/Wolverine.Postgresql/Transport/StickyPostgresqlQueueListenerAgent.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/StickyPostgresqlQueueListenerAgent.cs
@@ -52,4 +52,10 @@ internal class StickyPostgresqlQueueListenerAgent : IAgent
     }
 
     public Uri Uri { get; }
+
+    /// <summary>
+    /// Human-readable description for monitoring tools — see
+    /// <see cref="IAgent.Description"/>.
+    /// </summary>
+    public string Description => $"Sticky Postgres queue listener — pinned to the per-tenant database '{_databaseName}' for queue '{_queue}'. Only one node listens to each tenant database to avoid duplicate consumption.";
 }

--- a/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
+++ b/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
@@ -149,6 +149,16 @@ internal class DurabilityAgent : IAgent
 
     public Uri Uri { get; internal set; }
 
+    /// <summary>
+    /// Human-readable description for monitoring tools — see
+    /// <see cref="IAgent.Description"/>. This agent recovers
+    /// persisted inbox / outbox messages from the relational
+    /// message store, runs scheduled jobs, and emits persistence
+    /// metrics. The URI carries the store identity so operators
+    /// can disambiguate when a service has multiple stores.
+    /// </summary>
+    public string Description => $"Wolverine durability agent for {Uri} — recovers persisted inbox/outbox messages, runs scheduled jobs, and emits persistence metrics.";
+
     public static Uri SimplifyUri(Uri uri)
     {
         return new Uri($"{PersistenceConstants.AgentScheme}://{uri.Host}");

--- a/src/Persistence/Wolverine.RavenDb/Internals/Durability/RavenDbDurabilityAgent.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/Durability/RavenDbDurabilityAgent.cs
@@ -140,6 +140,12 @@ public partial class RavenDbDurabilityAgent : IAgent
     public AgentStatus Status { get; set; }
 
     /// <summary>
+    /// Human-readable description for monitoring tools — see
+    /// <see cref="IAgent.Description"/>.
+    /// </summary>
+    public string Description => $"Wolverine RavenDB durability agent for {Uri} — recovers persisted inbox/outbox messages and runs scheduled jobs against the RavenDB message store.";
+
+    /// <summary>
     /// True once <see cref="StartTimers"/> has wired up the recovery and scheduled-job
     /// background loops. Exposed for diagnostic and test inspection so callers can detect
     /// the multi-instance "two pollers" condition without reflection. See #2623.

--- a/src/Testing/CoreTests/Runtime/Agents/IAgentDescriptionTests.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/IAgentDescriptionTests.cs
@@ -1,0 +1,87 @@
+using JasperFx;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Shouldly;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Coverage for <see cref="IAgent.Description"/> — the human-readable
+/// "what does this agent do" string surfaced to monitoring tools
+/// (e.g. CritterWatch). Verifies the default-interface fallback for
+/// implementations that don't override it, and verifies an explicit
+/// override wins through.
+/// </summary>
+public class IAgentDescriptionTests
+{
+    [Fact]
+    public void default_description_includes_uri_scheme_and_full_uri()
+    {
+        // Default-interface members are only accessible through the
+        // interface, not the concrete type — so cast deliberately.
+        // The default implementation derives a generic description
+        // from the URI; implementations are expected to override for
+        // anything more specific, but the fallback should always
+        // produce a non-empty string identifying scheme and URI so a
+        // monitoring tool isn't left with a blank tooltip.
+        IAgent agent = new BareBonesAgent(new Uri("test-agent://default"));
+
+        agent.Description.ShouldNotBeNullOrWhiteSpace();
+        agent.Description.ShouldContain("test-agent");
+        agent.Description.ShouldContain(agent.Uri.ToString());
+    }
+
+    [Fact]
+    public void overridden_description_wins_over_default()
+    {
+        IAgent agent = new DescribedAgent(
+            new Uri("test-agent://configured"),
+            "Custom description for this agent");
+
+        agent.Description.ShouldBe("Custom description for this agent");
+        agent.Description.ShouldNotContain("test-agent://configured");
+    }
+
+    /// <summary>
+    /// Minimal IAgent that doesn't override Description. The default
+    /// interface member should provide the fallback — covers the
+    /// "existing IAgent implementations stay source-compatible"
+    /// guarantee.
+    /// </summary>
+    private sealed class BareBonesAgent : IAgent
+    {
+        public BareBonesAgent(Uri uri)
+        {
+            Uri = uri;
+        }
+
+        public Uri Uri { get; }
+        public AgentStatus Status => AgentStatus.Stopped;
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Agent that explicitly overrides the description — exercises
+    /// the implementation-side override path that built-in agents
+    /// (DurabilityAgent, ExclusiveListenerAgent, etc.) use to give
+    /// CritterWatch operators agent-specific tooltip text.
+    /// </summary>
+    private sealed class DescribedAgent : IAgent
+    {
+        private readonly string _description;
+
+        public DescribedAgent(Uri uri, string description)
+        {
+            Uri = uri;
+            _description = description;
+        }
+
+        public Uri Uri { get; }
+        public AgentStatus Status => AgentStatus.Stopped;
+        public string Description => _description;
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/Wolverine/Runtime/Agents/ExclusiveListenerFamily.cs
+++ b/src/Wolverine/Runtime/Agents/ExclusiveListenerFamily.cs
@@ -34,6 +34,12 @@ internal class ExclusiveListenerAgent : IAgent
 
     public AgentStatus Status { get; set; } = AgentStatus.Running;
 
+    /// <summary>
+    /// Human-readable description for monitoring tools — see
+    /// <see cref="IAgent.Description"/>.
+    /// </summary>
+    public string Description => $"Exclusive listener for {_endpoint.Uri} — only one node at a time holds the listening role for this endpoint, so the cluster avoids competing consumers.";
+
     public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {

--- a/src/Wolverine/Runtime/Agents/IAgent.cs
+++ b/src/Wolverine/Runtime/Agents/IAgent.cs
@@ -24,6 +24,18 @@ public interface IAgent : IHostedService, IHealthCheck
     AgentStatus Status { get; }
 
     /// <summary>
+    ///     Human-readable description of what this agent does on a given
+    ///     node. Surfaced in monitoring tools (e.g. CritterWatch) so
+    ///     operators don't have to recognise an agent purely by its URI
+    ///     scheme. The default implementation returns a generic
+    ///     "{scheme} agent: {Uri}" string; override in concrete agent
+    ///     types to provide more specific text. Kept as a default
+    ///     interface member so existing <see cref="IAgent"/>
+    ///     implementations stay source-compatible.
+    /// </summary>
+    string Description => $"{Uri.Scheme} agent: {Uri}";
+
+    /// <summary>
     ///     Default health check implementation based on agent status.
     ///     Override in implementations for more specific health reporting.
     /// </summary>

--- a/src/Wolverine/Runtime/Agents/LeaderPinnedAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/LeaderPinnedAgentFamily.cs
@@ -34,6 +34,12 @@ internal class LeaderPinnedListenerAgent : IAgent
 
     public AgentStatus Status { get; set; } = AgentStatus.Running;
 
+    /// <summary>
+    /// Human-readable description for monitoring tools — see
+    /// <see cref="IAgent.Description"/>.
+    /// </summary>
+    public string Description => $"Leader-pinned listener for {_endpoint.Uri} — runs only on the cluster's elected leader node, so the listening role moves with leader elections.";
+
     public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
External monitoring tools (e.g. [CritterWatch](https://github.com/JasperFx/CritterWatch)) want to render a human-readable explanation of what each running agent does on a given node. Today the only metadata available is the agent's URI, which means tooltips collapse to *"you have to know what \`wolverinedb://default\` means."*

This PR adds a default-implemented \`Description\` property on \`IAgent\`. The default returns \`"{scheme} agent: {uri}"\` so existing third-party \`IAgent\` implementations stay source-compatible with no code change. Built-in agent types override the property with text describing what they actually do:

| Agent | Description |
|-------|-------------|
| \`DurabilityAgent\` (RDBMS) | "Wolverine durability agent for {uri} — recovers persisted inbox/outbox messages, runs scheduled jobs, and emits persistence metrics." |
| \`RavenDbDurabilityAgent\` | Same shape, RavenDB-flavoured. |
| \`CosmosDbDurabilityAgent\` | Same shape, Cosmos-DB-flavoured. |
| \`ExclusiveListenerAgent\` | "Exclusive listener for {endpoint} — only one node at a time holds the listening role for this endpoint, so the cluster avoids competing consumers." |
| \`LeaderPinnedListenerAgent\` | "Leader-pinned listener for {endpoint} — runs only on the cluster's elected leader node, so the listening role moves with leader elections." |
| \`StickyPostgresqlQueueListenerAgent\` | "Sticky Postgres queue listener — pinned to the per-tenant database '{name}' for queue '{name}'." |

## Consuming the description

Monitoring tools that want the per-agent description can read it after looking up the \`IAgent\`:

\`\`\`csharp
if (runtime.Agents.TryFindActiveAgent<IAgent>(agentUri, out var agent))
{
    var description = agent.Description;
    // ...emit to telemetry / monitoring envelope...
}
\`\`\`

No new public API surface beyond the property — \`TryFindActiveAgent\` already returns the strongly-typed agent.

## Tests

Two new xUnit cases in \`CoreTests/Runtime/Agents/IAgentDescriptionTests.cs\`:
1. \`default_description_includes_uri_scheme_and_full_uri\` — verifies a bare-bones IAgent that doesn't override Description still produces a non-empty description containing the scheme and URI.
2. \`overridden_description_wins_over_default\` — verifies an explicit override takes precedence over the default-interface member.

All four persistence projects (RDBMS, RavenDb, CosmosDb, Postgresql) build clean. Existing test suite unaffected.

## Motivation / consumer

CritterWatch issue [#93](https://github.com/JasperFx/CritterWatch/issues/93) is the immediate consumer — its Service / Nodes tab wants per-agent tooltips so operators can see at a glance what each running agent is doing without having to recognise URI conventions.