### PR TITLE
Surface 'Custom' interop mode + DefaultSerializerDescription on EndpointDescriptor (#2641)

### DIFF
--- a/src/Testing/CoreTests/Configuration/endpoint_descriptor_interop_mode_tests.cs
+++ b/src/Testing/CoreTests/Configuration/endpoint_descriptor_interop_mode_tests.cs
@@ -1,0 +1,214 @@
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Serialization;
+using Wolverine.Transports;
+using Wolverine.Transports.Local;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+/// <summary>
+/// Coverage for the <c>"Custom"</c> interop-mode signal added in #2641. The
+/// descriptor's <see cref="EndpointDescriptor.InteropMode"/> reports
+/// <c>"Custom"</c> when an endpoint has a non-default
+/// <see cref="IEnvelopeMapper"/> wired in, regardless of which serializer
+/// happens to be attached (mapper signal wins). Also locks down the new
+/// <see cref="EndpointDescriptor.DefaultSerializerDescription"/> friendly-name
+/// rendering.
+/// </summary>
+public class endpoint_descriptor_interop_mode_tests
+{
+    // ---- Base contract on the abstract Endpoint ----
+
+    [Fact]
+    public void default_typed_endpoint_with_no_mapper_override_reports_no_custom_mapper()
+    {
+        var endpoint = new TestTypedEndpoint();
+
+        endpoint.HasCustomEnvelopeMapper.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void typed_endpoint_with_explicit_mapper_reports_custom_mapper()
+    {
+        var endpoint = new TestTypedEndpoint
+        {
+            EnvelopeMapper = new TestMapper()
+        };
+
+        endpoint.HasCustomEnvelopeMapper.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void typed_endpoint_with_registered_mapper_factory_reports_custom_mapper()
+    {
+        var endpoint = new TestTypedEndpoint();
+        endpoint.RegisterMapperFactoryForTest(_ => new TestMapper());
+
+        endpoint.HasCustomEnvelopeMapper.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void non_typed_endpoint_always_reports_no_custom_mapper()
+    {
+        // Endpoints that do not derive from Endpoint<TMapper, TConcreteMapper> have no
+        // mapper-customization concept. Local queues, dbcontrol, oraclecontrol, TCP, etc.
+        // should report HasCustomEnvelopeMapper = false (and therefore InteropMode = null
+        // unless a serializer name match drives it).
+        var endpoint = new LocalQueue("local-x");
+
+        endpoint.HasCustomEnvelopeMapper.ShouldBeFalse();
+    }
+
+    // ---- Descriptor.InteropMode ----
+
+    [Fact]
+    public void descriptor_reports_null_interop_mode_when_no_mapper_override_and_default_serializer()
+    {
+        var endpoint = new TestTypedEndpoint
+        {
+            DefaultSerializer = new SystemTextJsonSerializer(new System.Text.Json.JsonSerializerOptions())
+        };
+        var descriptor = new EndpointDescriptor(endpoint);
+
+        descriptor.InteropMode.ShouldBeNull();
+    }
+
+    [Fact]
+    public void descriptor_reports_custom_when_mapper_is_overridden_with_default_serializer()
+    {
+        var endpoint = new TestTypedEndpoint
+        {
+            EnvelopeMapper = new TestMapper(),
+            DefaultSerializer = new SystemTextJsonSerializer(new System.Text.Json.JsonSerializerOptions())
+        };
+        var descriptor = new EndpointDescriptor(endpoint);
+
+        descriptor.InteropMode.ShouldBe("Custom");
+    }
+
+    [Fact]
+    public void custom_mapper_wins_over_well_known_serializer_name()
+    {
+        // Last-usage-wins: a custom mapper trumps a CloudEvents-named serializer.
+        // The mapper is the louder operator-relevant signal.
+        var endpoint = new TestTypedEndpoint
+        {
+            EnvelopeMapper = new TestMapper(),
+            DefaultSerializer = new FakeCloudEventsSerializer()
+        };
+        var descriptor = new EndpointDescriptor(endpoint);
+
+        descriptor.InteropMode.ShouldBe("Custom");
+    }
+
+    [Fact]
+    public void well_known_cloud_events_serializer_drives_interop_mode_when_no_mapper_override()
+    {
+        var endpoint = new TestTypedEndpoint
+        {
+            DefaultSerializer = new FakeCloudEventsSerializer()
+        };
+        var descriptor = new EndpointDescriptor(endpoint);
+
+        descriptor.InteropMode.ShouldBe("CloudEvents");
+    }
+
+    [Theory]
+    [InlineData("CloudEventsSerializer", "CloudEvents")]
+    [InlineData("NServiceBusSerializer", "NServiceBus")]
+    [InlineData("MassTransitJsonSerializer", "MassTransit")]
+    [InlineData("RawJsonSerializer", "RawJson")]
+    [InlineData("SystemTextJsonSerializer", null)]
+    [InlineData("MessagePackSerializer", null)]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    public void resolve_interop_mode_from_serializer_name(string? typeName, string? expected)
+    {
+        EndpointDescriptor.ResolveInteropMode(typeName).ShouldBe(expected);
+    }
+
+    // ---- Descriptor.DefaultSerializerDescription ----
+
+    [Theory]
+    [InlineData("SystemTextJsonSerializer", "System.Text.Json")]
+    [InlineData("MessagePackSerializer", "MessagePack")]
+    [InlineData("MemoryPackSerializer", "MemoryPack")]
+    [InlineData("NewtonsoftJsonSerializer", "Newtonsoft.Json")]
+    [InlineData("RawJsonSerializer", "Raw JSON")]
+    [InlineData("CloudEventsSerializer", "CloudEvents")]
+    [InlineData("NServiceBusSerializer", "NServiceBus")]
+    [InlineData("MassTransitJsonSerializer", "MassTransit")]
+    [InlineData("ProtobufSerializer", "Protobuf")]
+    [InlineData("AvroSerializer", "Avro")]
+    [InlineData("MyCompanySpecialSerializer", "MyCompanySpecialSerializer")] // unknown → raw type name
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    public void resolve_default_serializer_description_friendly_names(string? typeName, string? expected)
+    {
+        EndpointDescriptor.ResolveSerializerDescription(typeName).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void descriptor_lifts_default_serializer_description_from_endpoint()
+    {
+        var endpoint = new TestTypedEndpoint
+        {
+            DefaultSerializer = new SystemTextJsonSerializer(new System.Text.Json.JsonSerializerOptions())
+        };
+        var descriptor = new EndpointDescriptor(endpoint);
+
+        descriptor.SerializerType.ShouldBe("SystemTextJsonSerializer");
+        descriptor.DefaultSerializerDescription.ShouldBe("System.Text.Json");
+    }
+
+    [Fact]
+    public void descriptor_returns_null_serializer_description_when_no_serializer_attached()
+    {
+        var endpoint = new TestTypedEndpoint();
+        var descriptor = new EndpointDescriptor(endpoint);
+
+        descriptor.SerializerType.ShouldBeNull();
+        descriptor.DefaultSerializerDescription.ShouldBeNull();
+    }
+
+    // ---- Test plumbing ----
+
+    private interface ITestMapper : IEnvelopeMapper;
+
+    private class TestMapper : ITestMapper
+    {
+        public void ReceivesMessage(Type messageType) { }
+        public void MapPropertyToHeader(System.Linq.Expressions.Expression<Func<Envelope, object>> property, string headerKey) { }
+    }
+
+    private class TestTypedEndpoint : Endpoint<ITestMapper, TestMapper>
+    {
+        public TestTypedEndpoint() : base(new Uri("test://endpoint"), EndpointRole.Application) { }
+
+        public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+            => throw new NotSupportedException();
+
+        protected override Wolverine.Transports.Sending.ISender CreateSender(IWolverineRuntime runtime)
+            => throw new NotSupportedException();
+
+        protected override TestMapper buildMapper(IWolverineRuntime runtime) => new();
+
+        // Surface the protected helper so the registered-factory test can exercise it
+        // without needing to construct a full ListenerConfiguration to do it indirectly.
+        public void RegisterMapperFactoryForTest(Func<IWolverineRuntime, ITestMapper> factory)
+            => registerMapperFactory(factory);
+    }
+
+    private class FakeCloudEventsSerializer : IMessageSerializer
+    {
+        public string ContentType => "application/cloudevents+json";
+        public byte[] Write(Envelope envelope) => Array.Empty<byte>();
+        public object ReadFromData(Type messageType, Envelope envelope) => null!;
+        public object ReadFromData(byte[]? data) => null!;
+        public byte[] WriteMessage(object message) => Array.Empty<byte>();
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/endpoint_descriptor_interop_mode_tests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/endpoint_descriptor_interop_mode_tests.cs
@@ -1,0 +1,52 @@
+using Amazon.SimpleNotificationService.Model;
+using Shouldly;
+using Wolverine.AmazonSns.Internal;
+using Wolverine.Configuration.Capabilities;
+using Xunit;
+
+namespace Wolverine.AmazonSns.Tests;
+
+// Per-transport coverage for #2641 on AmazonSnsTopic. SNS inherits raw Endpoint
+// rather than the typed Endpoint<TMapper, TConcreteMapper>, so it needs its own
+// override of HasCustomEnvelopeMapper.
+public class endpoint_descriptor_interop_mode_tests
+{
+    [Fact]
+    public void sns_topic_with_no_mapper_override_does_not_report_custom()
+    {
+        var topic = new AmazonSnsTopic("default-t", new AmazonSnsTransport());
+
+        new EndpointDescriptor(topic).InteropMode.ShouldNotBe("Custom");
+    }
+
+    [Fact]
+    public void sns_topic_with_custom_mapper_reports_custom_interop_mode()
+    {
+        var topic = new AmazonSnsTopic("custom-t", new AmazonSnsTransport())
+        {
+            Mapper = new StubSnsMapper()
+        };
+
+        new EndpointDescriptor(topic).InteropMode.ShouldBe("Custom");
+    }
+
+    [Fact]
+    public void sns_topic_with_registered_mapper_factory_reports_custom_interop_mode()
+    {
+        var topic = new AmazonSnsTopic("custom-t-factory", new AmazonSnsTransport())
+        {
+            MapperFactory = (_, _) => new StubSnsMapper()
+        };
+
+        new EndpointDescriptor(topic).InteropMode.ShouldBe("Custom");
+    }
+
+    private sealed class StubSnsMapper : ISnsEnvelopeMapper
+    {
+        public string BuildMessageBody(Envelope envelope) => string.Empty;
+        public IEnumerable<KeyValuePair<string, MessageAttributeValue>> ToAttributes(Envelope envelope)
+            => Array.Empty<KeyValuePair<string, MessageAttributeValue>>();
+        public void ReadEnvelopeData(Envelope envelope, string messageBody,
+            IDictionary<string, MessageAttributeValue> attributes) { }
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTopic.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTopic.cs
@@ -39,9 +39,16 @@ public class AmazonSnsTopic : Endpoint, IBrokerQueue
     ///     are read and how outgoing messages are written to SNS
     /// </summary>
     public ISnsEnvelopeMapper? Mapper { get; set; }
-    
-    
+
+
     internal Func<AmazonSnsTopic, IWolverineRuntime, ISnsEnvelopeMapper>? MapperFactory = null;
+
+    // AmazonSnsTopic inherits raw Endpoint (not the typed Endpoint<,>), so the
+    // generic base override doesn't apply. Surface "user wired their own SNS
+    // mapper or factory" through the same protected hook so the
+    // EndpointDescriptor reports InteropMode = "Custom" for SNS too. See #2641.
+    protected internal override bool HasCustomEnvelopeMapper =>
+        Mapper is not null || MapperFactory is not null;
     
     internal ISnsEnvelopeMapper BuildMapper(IWolverineRuntime runtime)
     {

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/endpoint_descriptor_interop_mode_tests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/endpoint_descriptor_interop_mode_tests.cs
@@ -1,0 +1,54 @@
+using Amazon.SQS.Model;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Configuration.Capabilities;
+using Xunit;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+// Per-transport coverage for #2641 on AmazonSqsQueue. SQS inherits raw Endpoint
+// rather than the typed Endpoint<TMapper, TConcreteMapper>, so it needs its own
+// override of HasCustomEnvelopeMapper. This test pins down both directions
+// (override absent / present) so the behavior doesn't drift from the generic
+// case.
+public class endpoint_descriptor_interop_mode_tests
+{
+    [Fact]
+    public void sqs_queue_with_no_mapper_override_does_not_report_custom()
+    {
+        var queue = new AmazonSqsQueue("default-q", new AmazonSqsTransport());
+
+        new EndpointDescriptor(queue).InteropMode.ShouldNotBe("Custom");
+    }
+
+    [Fact]
+    public void sqs_queue_with_custom_mapper_reports_custom_interop_mode()
+    {
+        var queue = new AmazonSqsQueue("custom-q", new AmazonSqsTransport())
+        {
+            Mapper = new StubSqsMapper()
+        };
+
+        new EndpointDescriptor(queue).InteropMode.ShouldBe("Custom");
+    }
+
+    [Fact]
+    public void sqs_queue_with_registered_mapper_factory_reports_custom_interop_mode()
+    {
+        var queue = new AmazonSqsQueue("custom-q-factory", new AmazonSqsTransport())
+        {
+            MapperFactory = (_, _) => new StubSqsMapper()
+        };
+
+        new EndpointDescriptor(queue).InteropMode.ShouldBe("Custom");
+    }
+
+    private sealed class StubSqsMapper : ISqsEnvelopeMapper
+    {
+        public string BuildMessageBody(Envelope envelope) => string.Empty;
+        public IEnumerable<KeyValuePair<string, MessageAttributeValue>> ToAttributes(Envelope envelope)
+            => Array.Empty<KeyValuePair<string, MessageAttributeValue>>();
+        public void ReadEnvelopeData(Envelope envelope, string messageBody,
+            IDictionary<string, MessageAttributeValue> attributes) { }
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -43,6 +43,13 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
     /// </summary>
     public ISqsEnvelopeMapper? Mapper { get; set; }
 
+    // AmazonSqsQueue inherits raw Endpoint (not the typed Endpoint<,>), so the
+    // generic base override doesn't apply. Surface "user wired their own SQS
+    // mapper or factory" through the same protected hook so the
+    // EndpointDescriptor reports InteropMode = "Custom" for SQS too. See #2641.
+    protected internal override bool HasCustomEnvelopeMapper =>
+        Mapper is not null || MapperFactory is not null;
+
     public string QueueName { get; }
 
     internal bool IsFifoQueue => QueueName.EndsWith(".fifo", StringComparison.OrdinalIgnoreCase);

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/endpoint_descriptor_interop_mode_tests.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/endpoint_descriptor_interop_mode_tests.cs
@@ -1,0 +1,61 @@
+using Azure.Messaging.ServiceBus;
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Wolverine.Configuration.Capabilities;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+// Per-transport coverage for #2641: when a user wires a custom envelope mapper
+// onto an Azure Service Bus endpoint, the EndpointDescriptor must report
+// InteropMode = "Custom".
+public class endpoint_descriptor_interop_mode_tests
+{
+    [Fact]
+    public void asb_queue_with_no_mapper_override_does_not_report_custom()
+    {
+        var queue = new AzureServiceBusQueue(new AzureServiceBusTransport(), "q");
+        new EndpointDescriptor(queue).InteropMode.ShouldNotBe("Custom");
+    }
+
+    [Fact]
+    public void asb_queue_with_custom_mapper_reports_custom_interop_mode()
+    {
+        var queue = new AzureServiceBusQueue(new AzureServiceBusTransport(), "q")
+        {
+            EnvelopeMapper = new StubAsbMapper()
+        };
+
+        new EndpointDescriptor(queue).InteropMode.ShouldBe("Custom");
+    }
+
+    [Fact]
+    public void asb_topic_with_custom_mapper_reports_custom_interop_mode()
+    {
+        var topic = new AzureServiceBusTopic(new AzureServiceBusTransport(), "t")
+        {
+            EnvelopeMapper = new StubAsbMapper()
+        };
+
+        new EndpointDescriptor(topic).InteropMode.ShouldBe("Custom");
+    }
+
+    [Fact]
+    public void asb_subscription_with_custom_mapper_reports_custom_interop_mode()
+    {
+        var transport = new AzureServiceBusTransport();
+        var topic = new AzureServiceBusTopic(transport, "t");
+        var subscription = new AzureServiceBusSubscription(transport, topic, "s")
+        {
+            EnvelopeMapper = new StubAsbMapper()
+        };
+
+        new EndpointDescriptor(subscription).InteropMode.ShouldBe("Custom");
+    }
+
+    private sealed class StubAsbMapper : IAzureServiceBusEnvelopeMapper
+    {
+        public void MapEnvelopeToOutgoing(Envelope envelope, ServiceBusMessage outgoing) { }
+        public void MapIncomingToEnvelope(Envelope envelope, ServiceBusReceivedMessage incoming) { }
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/endpoint_descriptor_interop_mode_tests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/endpoint_descriptor_interop_mode_tests.cs
@@ -1,0 +1,40 @@
+using Confluent.Kafka;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Kafka;
+using Wolverine.Kafka.Internals;
+using Xunit;
+
+namespace Wolverine.Kafka.Tests;
+
+// Per-transport coverage for #2641: when a user wires a custom envelope mapper
+// onto a Kafka topic endpoint, the EndpointDescriptor must report
+// InteropMode = "Custom".
+public class endpoint_descriptor_interop_mode_tests
+{
+    [Fact]
+    public void kafka_topic_with_no_mapper_override_does_not_report_custom()
+    {
+        var topic = new KafkaTopic(new KafkaTransport(), "t", EndpointRole.Application);
+
+        new EndpointDescriptor(topic).InteropMode.ShouldNotBe("Custom");
+    }
+
+    [Fact]
+    public void kafka_topic_with_custom_mapper_reports_custom_interop_mode()
+    {
+        var topic = new KafkaTopic(new KafkaTransport(), "t", EndpointRole.Application)
+        {
+            EnvelopeMapper = new StubKafkaMapper()
+        };
+
+        new EndpointDescriptor(topic).InteropMode.ShouldBe("Custom");
+    }
+
+    private sealed class StubKafkaMapper : IKafkaEnvelopeMapper
+    {
+        public void MapEnvelopeToOutgoing(Envelope envelope, Message<string, byte[]> outgoing) { }
+        public void MapIncomingToEnvelope(Envelope envelope, Message<string, byte[]> incoming) { }
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/endpoint_descriptor_interop_mode_tests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/endpoint_descriptor_interop_mode_tests.cs
@@ -1,0 +1,79 @@
+using RabbitMQ.Client;
+using Shouldly;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.RabbitMQ.Internal;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+// Per-transport coverage for #2641: when a user wires a custom envelope mapper
+// onto a RabbitMQ endpoint, the EndpointDescriptor must report
+// InteropMode = "Custom". When no override is wired, the descriptor must NOT
+// report "Custom" — it falls through to the serializer-name signal (or null).
+//
+// Mirrors the in-tree "broker_role_tests" pattern: pure, no docker, no NSubstitute.
+public class endpoint_descriptor_interop_mode_tests
+{
+    [Fact]
+    public void rabbit_queue_with_no_mapper_override_does_not_report_custom()
+    {
+        var queue = new RabbitMqQueue("default-queue", new RabbitMqTransport());
+
+        new EndpointDescriptor(queue).InteropMode.ShouldNotBe("Custom");
+    }
+
+    [Fact]
+    public void rabbit_queue_with_custom_mapper_reports_custom_interop_mode()
+    {
+        var queue = new RabbitMqQueue("custom-queue", new RabbitMqTransport())
+        {
+            EnvelopeMapper = new StubRabbitMqMapper()
+        };
+
+        new EndpointDescriptor(queue).InteropMode.ShouldBe("Custom");
+    }
+
+    [Fact]
+    public void rabbit_exchange_with_custom_mapper_reports_custom_interop_mode()
+    {
+        var transport = new RabbitMqTransport();
+        var exchange = new RabbitMqExchange("custom-exchange", transport)
+        {
+            EnvelopeMapper = new StubRabbitMqMapper()
+        };
+
+        new EndpointDescriptor(exchange).InteropMode.ShouldBe("Custom");
+    }
+
+    [Fact]
+    public void rabbit_topic_endpoint_with_custom_mapper_reports_custom_interop_mode()
+    {
+        var transport = new RabbitMqTransport();
+        var exchange = new RabbitMqExchange("ex", transport);
+        var topic = new RabbitMqTopicEndpoint("t", exchange, transport)
+        {
+            EnvelopeMapper = new StubRabbitMqMapper()
+        };
+
+        new EndpointDescriptor(topic).InteropMode.ShouldBe("Custom");
+    }
+
+    [Fact]
+    public void rabbit_routing_with_custom_mapper_reports_custom_interop_mode()
+    {
+        var transport = new RabbitMqTransport();
+        var exchange = new RabbitMqExchange("ex", transport);
+        var routing = new RabbitMqRouting(exchange, "rk", transport)
+        {
+            EnvelopeMapper = new StubRabbitMqMapper()
+        };
+
+        new EndpointDescriptor(routing).InteropMode.ShouldBe("Custom");
+    }
+
+    private sealed class StubRabbitMqMapper : IRabbitMqEnvelopeMapper
+    {
+        public void MapEnvelopeToOutgoing(Envelope envelope, IBasicProperties outgoing) { }
+        public void MapIncomingToEnvelope(Envelope envelope, IReadOnlyBasicProperties incoming) { }
+    }
+}

--- a/src/Wolverine/Configuration/Capabilities/EndpointDescriptor.cs
+++ b/src/Wolverine/Configuration/Capabilities/EndpointDescriptor.cs
@@ -31,6 +31,7 @@ public class EndpointDescriptor : OptionsDescription
         Uri = endpoint.Uri;
         TransportType = ResolveTransportType(endpoint);
         SerializerType = endpoint.DefaultSerializer?.GetType().Name;
+        DefaultSerializerDescription = ResolveSerializerDescription(SerializerType);
         InteropMode = ResolveInteropMode(endpoint);
         IsSystemEndpoint = endpoint.Uri?.ToString().Contains("wolverine.response", StringComparison.OrdinalIgnoreCase) == true
                         || endpoint.Uri?.Scheme.Equals("local", StringComparison.OrdinalIgnoreCase) == true;
@@ -51,8 +52,22 @@ public class EndpointDescriptor : OptionsDescription
     public string? SerializerType { get; init; }
 
     /// <summary>
-    /// Interop mode if using a pre-canned interop format.
-    /// Values: "CloudEvents", "NServiceBus", "MassTransit", "RawJson", or null for default Wolverine format.
+    /// Human-readable name of the default serializer wired up for this endpoint
+    /// (e.g. <c>"System.Text.Json"</c>, <c>"MessagePack"</c>, <c>"CloudEvents"</c>).
+    /// Maps the framework's well-known <see cref="SerializerType"/> values to a
+    /// friendlier rendering for monitoring tools so operators don't have to recognize
+    /// the raw type name. Falls through to the raw type name when no friendly mapping
+    /// exists. <c>null</c> when no serializer is configured. See #2641.
+    /// </summary>
+    public string? DefaultSerializerDescription { get; init; }
+
+    /// <summary>
+    /// Interop mode for this endpoint. Values:
+    /// <list type="bullet">
+    ///   <item><c>"CloudEvents"</c> / <c>"NServiceBus"</c> / <c>"MassTransit"</c> / <c>"RawJson"</c> — well-known interop formats detected by serializer name.</item>
+    ///   <item><c>"Custom"</c> — the endpoint has a non-default <see cref="IEnvelopeMapper"/> wired in (mapper signal takes precedence over serializer name; #2641).</item>
+    ///   <item><c>null</c> — default Wolverine format.</item>
+    /// </list>
     /// </summary>
     public string? InteropMode { get; init; }
 
@@ -80,6 +95,12 @@ public class EndpointDescriptor : OptionsDescription
 
     internal static string? ResolveInteropMode(Endpoint endpoint)
     {
+        // Mapper signal wins over serializer signal (last-usage-wins). If the user
+        // wired their own envelope mapper for this endpoint, that's the louder
+        // operator-relevant signal regardless of which serializer happens to be
+        // attached. See #2641.
+        if (endpoint.HasCustomEnvelopeMapper) return "Custom";
+
         return ResolveInteropMode(endpoint.DefaultSerializer?.GetType().Name);
     }
 
@@ -91,6 +112,33 @@ public class EndpointDescriptor : OptionsDescription
         if (serializerTypeName.Contains("MassTransit", StringComparison.OrdinalIgnoreCase)) return "MassTransit";
         if (serializerTypeName.Contains("RawJson", StringComparison.OrdinalIgnoreCase)) return "RawJson";
         return null;
+    }
+
+    /// <summary>
+    /// Map a raw serializer type name to a friendly display string for
+    /// <see cref="DefaultSerializerDescription"/>. Well-known names get
+    /// human-readable equivalents (<c>"SystemTextJsonSerializer"</c> →
+    /// <c>"System.Text.Json"</c>, etc.); anything else falls through to the
+    /// raw type name unchanged.
+    /// </summary>
+    public static string? ResolveSerializerDescription(string? serializerTypeName)
+    {
+        if (string.IsNullOrEmpty(serializerTypeName)) return null;
+
+        // Order matters: more specific matches first (e.g. CloudEventsJsonSerializer
+        // hits the CloudEvents branch before falling into the System.Text.Json branch).
+        if (serializerTypeName.Contains("CloudEvents", StringComparison.OrdinalIgnoreCase)) return "CloudEvents";
+        if (serializerTypeName.Contains("NServiceBus", StringComparison.OrdinalIgnoreCase)) return "NServiceBus";
+        if (serializerTypeName.Contains("MassTransit", StringComparison.OrdinalIgnoreCase)) return "MassTransit";
+        if (serializerTypeName.Contains("RawJson", StringComparison.OrdinalIgnoreCase)) return "Raw JSON";
+        if (serializerTypeName.Contains("SystemTextJson", StringComparison.OrdinalIgnoreCase)) return "System.Text.Json";
+        if (serializerTypeName.Contains("Newtonsoft", StringComparison.OrdinalIgnoreCase)) return "Newtonsoft.Json";
+        if (serializerTypeName.Contains("MessagePack", StringComparison.OrdinalIgnoreCase)) return "MessagePack";
+        if (serializerTypeName.Contains("MemoryPack", StringComparison.OrdinalIgnoreCase)) return "MemoryPack";
+        if (serializerTypeName.Contains("Protobuf", StringComparison.OrdinalIgnoreCase)) return "Protobuf";
+        if (serializerTypeName.Contains("Avro", StringComparison.OrdinalIgnoreCase)) return "Avro";
+
+        return serializerTypeName;
     }
 
     internal static string ResolveTransportType(Endpoint endpoint) => ResolveTransportType(endpoint.GetType().Name);

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -152,13 +152,23 @@ public abstract class Endpoint<TMapper, TConcreteMapper> : Endpoint
     }
 
     protected abstract TConcreteMapper buildMapper(IWolverineRuntime runtime);
-    
-    
+
+
     /// <summary>
     /// When set, overrides the built in envelope mapping with a custom
     /// implementation
     /// </summary>
     public TMapper? EnvelopeMapper { get; set; }
+
+    /// <summary>
+    /// True when the user has explicitly wired a custom mapper instance or factory in
+    /// place of the per-transport default <see cref="buildMapper"/>. Drives the
+    /// <c>"Custom"</c> value on <see cref="Capabilities.EndpointDescriptor.InteropMode"/>
+    /// so monitoring tools (e.g. CritterWatch) can flag endpoints that are using a
+    /// non-default envelope shape. See #2641.
+    /// </summary>
+    protected internal override bool HasCustomEnvelopeMapper =>
+        EnvelopeMapper is not null || _mapperFactory is not null;
 }
 
 /// <summary>
@@ -320,6 +330,17 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     /// </summary>
     [IgnoreDescription]
     internal IWireTap? WireTap { get; set; }
+
+    /// <summary>
+    /// Used by <see cref="Capabilities.EndpointDescriptor"/> to surface a <c>"Custom"</c>
+    /// interop mode when the user has wired a non-default envelope mapper for this
+    /// endpoint. The base implementation returns <c>false</c> so non-typed endpoints
+    /// (local queues, the database control transports, TCP, etc.) are reported as
+    /// using the framework default. The generic <see cref="Endpoint{TMapper, TConcreteMapper}"/>
+    /// overrides this. See #2641.
+    /// </summary>
+    [IgnoreDescription]
+    protected internal virtual bool HasCustomEnvelopeMapper => false;
 
     /// <summary>
     ///     Get or override the default message serializer for just this endpoint


### PR DESCRIPTION
Closes #2641.

## Summary

`EndpointDescriptor.InteropMode` used to be populated by name-sniffing the serializer type (`CloudEvents` / `NServiceBus` / `MassTransit` / `RawJson`). A user who wired their own `IEnvelopeMapper` for an endpoint showed up with `InteropMode = null` and a non-default `SerializerType` — there was no clean way for an external consumer (e.g. CritterWatch's Endpoints tab) to distinguish "using framework default" from "custom interop wired in."

Two changes:

### 1. `InteropMode = "Custom"` when the endpoint has a non-default envelope mapper

Mapper signal wins over serializer name (last-usage-wins): a custom mapper paired with a CloudEvents serializer reports `"Custom"`, not `"CloudEvents"`.

Detection goes through a new `protected internal virtual bool HasCustomEnvelopeMapper` on the base `Endpoint`:

- **Generic `Endpoint<TMapper, TConcreteMapper>`** returns `true` when `EnvelopeMapper` is set or `_mapperFactory` is registered. Covers Rabbit, Azure Service Bus, Kafka, Pulsar, Pub/Sub, Redis stream — every transport that follows the typed-endpoint pattern.
- **`AmazonSqsQueue` and `AmazonSnsTopic`** inherit raw `Endpoint` and expose their own `Mapper` + `MapperFactory` properties, so they each override `HasCustomEnvelopeMapper` to surface the same signal.
- **Non-typed endpoints with no mapper concept** (local queues, `dbcontrol://` / `oraclecontrol://` agent endpoints, TCP, NATS, MQTT) inherit the base `false` and report `InteropMode = null` unless their serializer name matches a well-known interop format.

### 2. `DefaultSerializerDescription`

A new human-readable rendering of the per-endpoint default serializer (`"System.Text.Json"`, `"MessagePack"`, `"CloudEvents"`, etc.). Maps the framework's well-known `SerializerType` values to friendlier strings so monitoring tools don't have to translate raw type names; falls through to the raw type name for unknown serializers; `null` when no serializer is configured.

## Test plan

- [x] `CoreTests/Configuration/endpoint_descriptor_interop_mode_tests` — **31 tests**: base contract on a synthetic typed endpoint, precedence rules (custom mapper wins over CloudEvents serializer), all well-known interop names + `DefaultSerializerDescription` friendly mappings, and the "non-typed endpoints always report no custom mapper" guard via `LocalQueue`.
- [x] Per-transport tests using handwritten mapper stubs (no NSubstitute):
  - `Wolverine.RabbitMQ.Tests` — queue, exchange, topic, routing — **5 tests**.
  - `Wolverine.AzureServiceBus.Tests` — queue, topic, subscription — **4 tests**.
  - `Wolverine.Kafka.Tests` — topic — **2 tests**.
  - `Wolverine.AmazonSqs.Tests` — queue + factory — **3 tests**.
  - `Wolverine.AmazonSns.Tests` — topic + factory — **3 tests**.
- [x] Full **CoreTests regression**: `Failed: 0, Passed: 1544, Total: 1544, Duration: 3m 48s`.

## Out of scope

MQTT and NATS aren't covered. `MqttTopic` always populates `EnvelopeMapper` to a default instance in its constructor (so the simple non-null check would mis-detect every MQTT endpoint as Custom); NATS has no public custom-mapper concept today. Both can be picked up in a follow-up if the need surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)