### PR TITLE
feat(sqs): add DefaultDeadLetterQueueName to AmazonSqsTransportConfiguration

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -35,6 +35,8 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
         Configuration = new CreateQueueRequest(QueueName);
 
         MessageBatchSize = 10;
+
+        DeadLetterQueueName = parent.DefaultDeadLetterQueueName;
     }
 
     /// <summary>

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
@@ -58,6 +58,14 @@ public class AmazonSqsTransport : BrokerTransport<AmazonSqsQueue>
     public bool UseLocalStackInDevelopment { get; set; }
     public bool DisableDeadLetterQueues { get; set; }
 
+
+    /// <summary>
+    /// Override the default dead letter queue name applied to all SQS listener queues.
+    /// Defaults to <see cref="DeadLetterQueueConstants.DefaultQueueName"/>.
+    /// Per-queue overrides via <c>ConfigureDeadLetterQueue</c> still take precedence.
+    /// </summary>
+    public string DefaultDeadLetterQueueName { get; set; } = DeadLetterQueueConstants.DefaultQueueName;
+
     /// <summary>
     /// Is this transport connection allowed to build and use response and control queues
     /// for just this node? Default is false, requiring explicit opt-in.

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransportConfiguration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransportConfiguration.cs
@@ -106,6 +106,17 @@ public class AmazonSqsTransportConfiguration : BrokerExpression<AmazonSqsTranspo
     }
 
     /// <summary>
+    /// Override the global default dead letter queue name applied to all SQS listener queues.
+    /// Per-queue overrides via <c>ConfigureDeadLetterQueue</c> still take precedence.
+    /// </summary>
+    /// <param name="queueName">The base queue name (without environment prefix).</param>
+    public AmazonSqsTransportConfiguration DefaultDeadLetterQueueName(string queueName)
+    {
+        Transport.DefaultDeadLetterQueueName = AmazonSqsTransport.SanitizeSqsName(queueName);
+        return this;
+    }
+
+    /// <summary>
     /// Enable Wolverine system queues for request/reply support.
     /// Creates a per-node response queue that is automatically cleaned up.
     /// </summary>


### PR DESCRIPTION
## Summary

Closes #2653

- Adds `DefaultDeadLetterQueueName(string)` fluent method on `AmazonSqsTransportConfiguration` to set a custom global DLQ name for all SQS listener queues
- Adds `DefaultDeadLetterQueueName` instance property to `AmazonSqsTransport` (defaults to `wolverine-dead-letter-queue`)
- `AmazonSqsQueue` constructor now reads the DLQ name from the parent transport, so the global default is picked up automatically at queue creation time
- Per-queue overrides via `.ConfigureDeadLetterQueue(...)` and `.DisableDeadLetterQueueing()` continue to take precedence

## Usage

```cs
opts.UseAmazonSqsTransport()
    .DefaultDeadLetterQueueName("my-service-dlq")
    .AutoProvision();
```

## Test plan

- [ ] Verify `AmazonSqsQueue.DeadLetterQueueName` defaults to the transport-level value when no per-queue override is set
- [ ] Verify per-queue `.ConfigureDeadLetterQueue("other-dlq")` still overrides the global default
- [ ] Verify `.DisableAllNativeDeadLetterQueues()` still disables DLQ for all queues regardless of global name
- [ ] Verify existing behaviour unchanged when `DefaultDeadLetterQueueName` is not called (defaults to `wolverine-dead-letter-queue`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)