### PR TITLE
feat(http): support [ApiVersionNeutral] for opt-out endpoints

### DIFF
--- a/docs/guide/http/versioning.md
+++ b/docs/guide/http/versioning.md
@@ -219,31 +219,52 @@ the metadata), but they deliberately get no `IEndpointGroupNameMetadata`. Withou
 match the default Swashbuckle partitioning (`api.GroupName == doc`), so by default they will not appear in
 any versioned document.
 
-To make a neutral endpoint visible across every versioned OpenAPI document, opt it in from your
-`DocInclusionPredicate`. The most common pattern is "include if the endpoint has no group name OR the
-group matches the document":
+#### Recommended: surface neutral endpoints only in a dedicated `default` document
+
+The conservative default — and the pattern the WolverineWebApi sample uses — is to keep a separate
+`default` Swagger document for unversioned/neutral endpoints and route them there only:
 
 ```csharp
 builder.Services.AddSwaggerGen(x =>
 {
+    x.SwaggerDoc("default", new OpenApiInfo { Title = "Internal & Neutral", Version = "default" });
     x.SwaggerDoc("v1", new OpenApiInfo { Title = "API v1", Version = "v1" });
     x.SwaggerDoc("v2", new OpenApiInfo { Title = "API v2", Version = "v2" });
 
-    // Version-neutral chains have no GroupName — surface them in every document.
+    // Neutral chains have no GroupName — show them only in the "default" document.
     x.DocInclusionPredicate((docName, api) =>
-        api.GroupName is null || api.GroupName == docName);
+        (docName == "default" && api.GroupName is null) || api.GroupName == docName);
 
     x.OperationFilter<WolverineApiVersioningSwaggerOperationFilter>();
 });
 ```
 
-If you maintain a separate `default` document for unversioned/neutral endpoints (as the WolverineWebApi
-sample does), keep that branch in your predicate:
+This keeps `/swagger/v1` and `/swagger/v2` clean: only endpoints that explicitly belong to a public
+version appear there. Health checks, webhook receivers, internal admin endpoints, and other neutral
+chains stay out of the consumer-facing contract.
+
+#### Alternative: include neutral endpoints in every versioned document
+
+If a neutral endpoint really is part of every public version's contract (a global ping or `/whoami`
+endpoint, for example), broaden the predicate to include neutral chains in every doc as well:
 
 ```csharp
 x.DocInclusionPredicate((docName, api) =>
-    docName == "default" || api.GroupName == docName);
+    api.GroupName is null || api.GroupName == docName);
 ```
+
+Trade-off: every neutral endpoint will now appear in **every** versioned document. That is rarely what
+you want for things like webhook receivers or internal-only endpoints, since publishing them in `v1` and
+`v2` invites consumers to call them under those versions and creates an implicit compatibility promise
+you did not intend to make. Prefer the `default`-only pattern unless you are certain the endpoint is a
+true cross-version concern.
+
+#### Combining the two
+
+You can mix both: surface most neutral endpoints in `default` only, and use a per-endpoint convention
+(for instance, an attribute or a marker tag) to selectively include the genuinely cross-version ones in
+every document. The `DocInclusionPredicate` receives the full `ApiDescription`, so you can branch on
+metadata you attach yourself.
 
 ## Sunset and Deprecation Policies
 

--- a/docs/guide/http/versioning.md
+++ b/docs/guide/http/versioning.md
@@ -222,7 +222,11 @@ any versioned document.
 #### Recommended: surface neutral endpoints only in a dedicated `default` document
 
 The conservative default — and the pattern the WolverineWebApi sample uses — is to keep a separate
-`default` Swagger document for unversioned/neutral endpoints and route them there only:
+`default` Swagger document for unversioned/neutral endpoints and route them there only.
+
+Note: chains that pass through `UnversionedPolicy.PassThrough` (no `[ApiVersion]`, not `[ApiVersionNeutral]`)
+also land in `default` since they share the null `GroupName` with neutral chains, so the predicate below
+treats both alike:
 
 ```csharp
 builder.Services.AddSwaggerGen(x =>

--- a/docs/guide/http/versioning.md
+++ b/docs/guide/http/versioning.md
@@ -166,6 +166,85 @@ opts.UseApiVersioning(v =>
 });
 ```
 
+## Version-Neutral Endpoints <Badge type="tip" text="5.36" />
+
+Some endpoints — health checks, webhooks, metrics, infrastructure utilities — are intentionally outside the
+versioning lifecycle. Mark them with `[ApiVersionNeutral]` to opt out explicitly:
+
+- The chain keeps its declared route — no `/v1`, `/v2`, etc. prefix is injected.
+- No `Deprecation`, `Sunset`, `Link`, or `api-supported-versions` headers are emitted.
+- The chain is excluded from duplicate-detection on the version axis (a neutral chain at the same
+  `(verb, route)` as a versioned chain does **not** collide).
+- The chain satisfies `UnversionedPolicy.RequireExplicit` — neutrality is treated as an explicit choice,
+  not a missing annotation.
+
+### Class-level neutrality
+
+```csharp
+[ApiVersionNeutral]
+public static class HealthCheckEndpoint
+{
+    [WolverineGet("/health")]
+    public static HealthCheckResponse Get() => new("ok");
+}
+```
+
+### Method-level neutrality
+
+A single utility method on an otherwise versioned controller can opt out without affecting its siblings.
+Method-level `[ApiVersionNeutral]` overrides the class-level `[ApiVersion]` for that method only:
+
+```csharp
+[ApiVersion("1.0")]
+public static class CustomersEndpoint
+{
+    // Versioned at v1.0, lives at /v1/customers
+    [WolverineGet("/customers")]
+    public static CustomerList GetCustomers() => /* ... */;
+
+    // Version-neutral; lives at /customers/ping with no version-related headers
+    [ApiVersionNeutral]
+    [WolverineGet("/customers/ping")]
+    public static string Ping() => "pong";
+}
+```
+
+Combining `[ApiVersion]` and `[ApiVersionNeutral]` on **the same target** (same method or same class) is
+contradictory and fails fast at startup with an `InvalidOperationException`.
+
+### OpenAPI integration
+
+Neutral chains receive `Asp.Versioning.ApiVersionMetadata.Neutral` (so `IsApiVersionNeutral` is `true` on
+the metadata), but they deliberately get no `IEndpointGroupNameMetadata`. Without a group name they do not
+match the default Swashbuckle partitioning (`api.GroupName == doc`), so by default they will not appear in
+any versioned document.
+
+To make a neutral endpoint visible across every versioned OpenAPI document, opt it in from your
+`DocInclusionPredicate`. The most common pattern is "include if the endpoint has no group name OR the
+group matches the document":
+
+```csharp
+builder.Services.AddSwaggerGen(x =>
+{
+    x.SwaggerDoc("v1", new OpenApiInfo { Title = "API v1", Version = "v1" });
+    x.SwaggerDoc("v2", new OpenApiInfo { Title = "API v2", Version = "v2" });
+
+    // Version-neutral chains have no GroupName — surface them in every document.
+    x.DocInclusionPredicate((docName, api) =>
+        api.GroupName is null || api.GroupName == docName);
+
+    x.OperationFilter<WolverineApiVersioningSwaggerOperationFilter>();
+});
+```
+
+If you maintain a separate `default` document for unversioned/neutral endpoints (as the WolverineWebApi
+sample does), keep that branch in your predicate:
+
+```csharp
+x.DocInclusionPredicate((docName, api) =>
+    docName == "default" || api.GroupName == docName);
+```
+
 ## Sunset and Deprecation Policies
 
 Beyond the attribute-driven `Deprecated = true` flag, you can configure per-version sunset and deprecation

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersionNeutralTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersionNeutralTests.cs
@@ -1,0 +1,192 @@
+using Asp.Versioning;
+using JasperFx.CodeGeneration;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Shouldly;
+using Wolverine.Http.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+// ---------- Test handler fixtures ----------
+
+[ApiVersionNeutral]
+internal class HealthHandler
+{
+    [WolverineGet("/health")]
+    public string Get() => "ok";
+}
+
+[ApiVersion("1.0")]
+internal class MixedVersionedHandler
+{
+    [WolverineGet("/customers")]
+    public string GetCustomers() => "v1-customers";
+
+    [ApiVersionNeutral]
+    [WolverineGet("/customers/ping")]
+    public string Ping() => "pong";
+}
+
+[ApiVersion("1.0")]
+[ApiVersionNeutral]
+internal class ConflictingClassHandler
+{
+    [WolverineGet("/conflict-class")]
+    public string Get() => "conflict";
+}
+
+internal class ConflictingMethodHandler
+{
+    [ApiVersion("1.0")]
+    [ApiVersionNeutral]
+    [WolverineGet("/conflict-method")]
+    public string Get() => "conflict";
+}
+
+[ApiVersion("1.0")]
+internal class HealthVersionedHandler
+{
+    [WolverineGet("/health")]
+    public string Get() => "v1-health";
+}
+
+// ---------- Tests ----------
+
+public class ApiVersionNeutralTests
+{
+    private static void Apply(ApiVersioningPolicy policy, params HttpChain[] chains)
+        => policy.Apply(chains, new GenerationRules(), null!);
+
+    // 1 — class-level neutrality: no rewrite, no version, ApiVersion stays null
+    [Fact]
+    public void class_level_neutral_does_not_rewrite_route()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<HealthHandler>(x => x.Get());
+        var originalRoute = chain.RoutePattern!.RawText;
+
+        Apply(policy, chain);
+
+        chain.IsApiVersionNeutral.ShouldBeTrue();
+        chain.ApiVersion.ShouldBeNull();
+        chain.RoutePattern!.RawText.ShouldBe(originalRoute);
+    }
+
+    // 1b — class-level neutrality: ApiVersionMetadata.IsApiVersionNeutral is true
+    [Fact]
+    public void class_level_neutral_attaches_neutral_apiversion_metadata()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<HealthHandler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
+        var versionMeta = endpoint.Metadata.GetMetadata<ApiVersionMetadata>();
+        versionMeta.ShouldNotBeNull();
+        versionMeta!.IsApiVersionNeutral.ShouldBeTrue();
+    }
+
+    // 1c — neutral chains do not get a group name (so they fall into the default OpenAPI doc).
+    [Fact]
+    public void class_level_neutral_attaches_no_group_name()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<HealthHandler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
+        endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>().ShouldBeNull();
+    }
+
+    // 1d — neutral chains do not get sunset/deprecation/api-supported-versions header writers.
+    [Fact]
+    public void class_level_neutral_does_not_get_header_state_metadata()
+    {
+        var opts = new WolverineApiVersioningOptions { EmitApiSupportedVersionsHeader = true };
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<HealthHandler>(x => x.Get());
+
+        Apply(policy, chain);
+
+        var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
+        endpoint.Metadata.GetMetadata<ApiVersionEndpointHeaderState>().ShouldBeNull();
+    }
+
+    // 2 — method-level neutrality inside an [ApiVersion] class only affects that one method
+    [Fact]
+    public void method_level_neutral_inside_versioned_class_only_affects_that_method()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+
+        var pingChain = HttpChain.ChainFor<MixedVersionedHandler>(x => x.Ping());
+        var customersChain = HttpChain.ChainFor<MixedVersionedHandler>(x => x.GetCustomers());
+
+        Apply(policy, pingChain, customersChain);
+
+        pingChain.IsApiVersionNeutral.ShouldBeTrue();
+        pingChain.ApiVersion.ShouldBeNull();
+        pingChain.RoutePattern!.RawText.ShouldBe("/customers/ping");
+
+        customersChain.IsApiVersionNeutral.ShouldBeFalse();
+        customersChain.ApiVersion.ShouldBe(new ApiVersion(1, 0));
+        customersChain.RoutePattern!.RawText.ShouldBe("/v1/customers");
+    }
+
+    // 3 — neutral chain satisfies RequireExplicit
+    [Fact]
+    public void neutral_chain_satisfies_require_explicit_policy()
+    {
+        var opts = new WolverineApiVersioningOptions { UnversionedPolicy = UnversionedPolicy.RequireExplicit };
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<HealthHandler>(x => x.Get());
+
+        Should.NotThrow(() => Apply(policy, chain));
+    }
+
+    // 4 — class-level conflict: [ApiVersion] + [ApiVersionNeutral] on same class throws
+    [Fact]
+    public void conflicting_attributes_on_class_throws()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<ConflictingClassHandler>(x => x.Get());
+
+        var ex = Should.Throw<InvalidOperationException>(() => Apply(policy, chain));
+        ex.Message.ShouldContain(nameof(ConflictingClassHandler));
+        ex.Message.ShouldContain("[ApiVersion]");
+        ex.Message.ShouldContain("[ApiVersionNeutral]");
+    }
+
+    // 4b — method-level conflict: [ApiVersion] + [ApiVersionNeutral] on same method throws
+    [Fact]
+    public void conflicting_attributes_on_method_throws()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<ConflictingMethodHandler>(x => x.Get());
+
+        var ex = Should.Throw<InvalidOperationException>(() => Apply(policy, chain));
+        ex.Message.ShouldContain("[ApiVersion]");
+        ex.Message.ShouldContain("[ApiVersionNeutral]");
+    }
+
+    // 5 — neutral chain skipped from duplicate-detection on the version axis: a versioned chain
+    // and a neutral chain at the same (verb, route) do not collide.
+    [Fact]
+    public void neutral_chain_does_not_participate_in_duplicate_detection()
+    {
+        var opts = new WolverineApiVersioningOptions { UrlSegmentPrefix = null };
+        var policy = new ApiVersioningPolicy(opts);
+
+        var neutralChain = HttpChain.ChainFor<HealthHandler>(x => x.Get());
+        var versionedAtSameRoute = HttpChain.ChainFor<HealthVersionedHandler>(x => x.Get());
+
+        Should.NotThrow(() => Apply(policy, neutralChain, versionedAtSameRoute));
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersionNeutralTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersionNeutralTests.cs
@@ -95,6 +95,16 @@ internal class FluentlyVersionedNeutralHandler
     public string Ping() => "pong";
 }
 
+// Sibling chain at a *different* route with [ApiVersion("3.0")]. Used in test 10 to
+// prove that a neutral chain whose pre-policy ApiVersion was 3.0 (cleared by ResolveAttributes)
+// does not poison the version axis seen by DetectDuplicateRoutes.
+[ApiVersion("3.0")]
+internal class V3SiblingHandler
+{
+    [WolverineGet("/legacy/sibling")]
+    public string Get() => "v3-sibling";
+}
+
 // ---------- Tests ----------
 
 public class ApiVersionNeutralTests
@@ -103,7 +113,13 @@ public class ApiVersionNeutralTests
     // Passing null! works while ApiVersioningPolicy never touches the container, but as soon
     // as any future step (or a misordered call) does, null! produces an opaque NRE far from
     // the call site. A real container is a few lines of code and zero risk.
-    private static IServiceContainer NewContainer()
+    //
+    // Cached at class level: 13 tests * multiple Apply() calls would otherwise leak ~20+ fresh
+    // ServiceProviders per run. None of the tests mutate DI state, so a single container is
+    // safe and meaningfully faster.
+    private static readonly IServiceContainer _container = BuildContainer();
+
+    private static IServiceContainer BuildContainer()
     {
         var registry = new ServiceCollection();
         registry.AddSingleton<IServiceContainer, ServiceContainer>();
@@ -112,7 +128,7 @@ public class ApiVersionNeutralTests
     }
 
     private static void Apply(ApiVersioningPolicy policy, params HttpChain[] chains)
-        => policy.Apply(chains, new GenerationRules(), NewContainer());
+        => policy.Apply(chains, new GenerationRules(), _container);
 
     // 1 — class-level neutrality: no rewrite, no version, ApiVersion stays null
     [Fact]
@@ -217,8 +233,8 @@ public class ApiVersionNeutralTests
 
         var ex = Should.Throw<InvalidOperationException>(() => Apply(policy, chain));
         ex.Message.ShouldContain(nameof(ConflictingClassHandler));
-        ex.Message.ShouldContain("[ApiVersion]");
-        ex.Message.ShouldContain("[ApiVersionNeutral]");
+        ex.Message.ShouldContain(ApiVersionNeutralResolver.ApiVersionAttributeName);
+        ex.Message.ShouldContain(ApiVersionNeutralResolver.ApiVersionNeutralAttributeName);
     }
 
     // 4b — method-level conflict: message names handler type, method name, and both attributes.
@@ -232,8 +248,8 @@ public class ApiVersionNeutralTests
         var ex = Should.Throw<InvalidOperationException>(() => Apply(policy, chain));
         ex.Message.ShouldContain(nameof(ConflictingMethodHandler));
         ex.Message.ShouldContain(nameof(ConflictingMethodHandler.Get));
-        ex.Message.ShouldContain("[ApiVersion]");
-        ex.Message.ShouldContain("[ApiVersionNeutral]");
+        ex.Message.ShouldContain(ApiVersionNeutralResolver.ApiVersionAttributeName);
+        ex.Message.ShouldContain(ApiVersionNeutralResolver.ApiVersionNeutralAttributeName);
     }
 
     // 5 — neutral chain skipped from duplicate-detection on the version axis: a versioned chain
@@ -302,14 +318,30 @@ public class ApiVersionNeutralTests
     }
 
     // 8 — direction A of "method wins": class-level [ApiVersion] + method-level [ApiVersionNeutral]
-    // → method is neutral. (Already covered by test 2 above; reasserted here to keep both
-    // directions visible side by side for the spec.)
+    // → method is neutral. Mirrors test 9 (the inverse direction) so both branches of the
+    // "method wins" rule are exercised through the full ApiVersioningPolicy pipeline (chain build →
+    // Apply → assert IsApiVersionNeutral / ApiVersion / RoutePattern), not via direct resolver
+    // reflection. This is the symmetric counterpart to test 9.
     [Fact]
     public void method_level_neutral_overrides_class_level_apiversion()
     {
-        ApiVersionNeutralResolver.Resolve(
-            typeof(MixedVersionedHandler).GetMethod(nameof(MixedVersionedHandler.Ping))!)
-            .ShouldBeTrue();
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+
+        var customersChain = HttpChain.ChainFor<MixedVersionedHandler>(x => x.GetCustomers());
+        var pingChain = HttpChain.ChainFor<MixedVersionedHandler>(x => x.Ping());
+
+        Apply(policy, customersChain, pingChain);
+
+        // GetCustomers keeps class-level [ApiVersion("1.0")].
+        customersChain.IsApiVersionNeutral.ShouldBeFalse();
+        customersChain.ApiVersion.ShouldBe(new ApiVersion(1, 0));
+        customersChain.RoutePattern!.RawText.ShouldBe("/v1/customers");
+
+        // Ping carries method-level [ApiVersionNeutral] which must beat class-level [ApiVersion].
+        pingChain.IsApiVersionNeutral.ShouldBeTrue();
+        pingChain.ApiVersion.ShouldBeNull();
+        pingChain.RoutePattern!.RawText.ShouldBe("/customers/ping");
     }
 
     // 9 — direction B of "method wins": class-level [ApiVersionNeutral] + method-level [ApiVersion]
@@ -340,21 +372,35 @@ public class ApiVersionNeutralTests
     // 10 — method-level [ApiVersionNeutral] must clear any earlier fluent HasApiVersion(...)
     // assignment before later steps (DetectDuplicateRoutes, RewriteRoutes) observe the chain.
     // Otherwise a rogue version would survive on a chain the user explicitly opted out.
+    //
+    // The companion versioned sibling at /legacy/sibling@3.0 proves the cleared neutral chain
+    // does NOT poison the version axis: if ResolveAttributes failed to null out the stale 3.0
+    // on the neutral chain, DetectDuplicateRoutes would group both chains at version 3.0 and
+    // — because they're at different routes — wouldn't throw on the version axis directly, but
+    // the cleared chain would appear in the versioned (verb,route,version) bucket at all,
+    // which is the bug. Asserting NotThrow here pins the contract: a chain marked neutral is
+    // entirely absent from the versioned conflict pass.
     [Fact]
     public void method_level_neutral_clears_prior_fluent_apiversion_assignment()
     {
         var opts = new WolverineApiVersioningOptions();
         var policy = new ApiVersioningPolicy(opts);
-        var chain = HttpChain.ChainFor<FluentlyVersionedNeutralHandler>(x => x.Ping());
-        var originalRoute = chain.RoutePattern!.RawText;
+        var neutralChain = HttpChain.ChainFor<FluentlyVersionedNeutralHandler>(x => x.Ping());
+        var originalRoute = neutralChain.RoutePattern!.RawText;
+        var versionedSibling = HttpChain.ChainFor<V3SiblingHandler>(x => x.Get());
 
         // Simulate a fluent .HasApiVersion("3.0") assignment that ran before the policy.
-        chain.ApiVersion = new ApiVersion(3, 0);
+        neutralChain.ApiVersion = new ApiVersion(3, 0);
 
-        Apply(policy, chain);
+        Should.NotThrow(() => Apply(policy, neutralChain, versionedSibling));
 
-        chain.IsApiVersionNeutral.ShouldBeTrue();
-        chain.ApiVersion.ShouldBeNull();
-        chain.RoutePattern!.RawText.ShouldBe(originalRoute);   // not rewritten
+        neutralChain.IsApiVersionNeutral.ShouldBeTrue();
+        neutralChain.ApiVersion.ShouldBeNull();
+        neutralChain.RoutePattern!.RawText.ShouldBe(originalRoute);   // not rewritten
+
+        // The genuinely versioned sibling is unaffected by the neutral chain's prior 3.0.
+        versionedSibling.IsApiVersionNeutral.ShouldBeFalse();
+        versionedSibling.ApiVersion.ShouldBe(new ApiVersion(3, 0));
+        versionedSibling.RoutePattern!.RawText.ShouldBe("/v3/legacy/sibling");
     }
 }

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersionNeutralTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersionNeutralTests.cs
@@ -1,7 +1,9 @@
 using Asp.Versioning;
+using JasperFx;
 using JasperFx.CodeGeneration;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Wolverine.Http.ApiVersioning;
 
@@ -16,6 +18,26 @@ internal class HealthHandler
     public string Get() => "ok";
 }
 
+// Second neutral handler at a *different* route — exercises the
+// "two neutral chains at distinct routes do not collide" path. The handler-method
+// name `Get` deliberately mirrors HealthHandler.Get so we also exercise the
+// EndpointName / OperationId disambiguation.
+[ApiVersionNeutral]
+internal class StatusHandler
+{
+    [WolverineGet("/status")]
+    public string Get() => "ok";
+}
+
+// Second neutral handler at the *same* route as HealthHandler — exercises the
+// "two neutral chains at the same (verb, route) throw" path.
+[ApiVersionNeutral]
+internal class DuplicateHealthHandler
+{
+    [WolverineGet("/health")]
+    public string Get() => "dup";
+}
+
 [ApiVersion("1.0")]
 internal class MixedVersionedHandler
 {
@@ -25,6 +47,20 @@ internal class MixedVersionedHandler
     [ApiVersionNeutral]
     [WolverineGet("/customers/ping")]
     public string Ping() => "pong";
+}
+
+// Class-level [ApiVersionNeutral] but with a method that explicitly opts back
+// in via [ApiVersion]. Per the documented rule "method wins", this method must
+// be treated as versioned, NOT as neutral.
+[ApiVersionNeutral]
+internal class MixedNeutralHandler
+{
+    [WolverineGet("/inventory/stock")]
+    public string Stock() => "neutral-stock";
+
+    [ApiVersion("2.0")]
+    [WolverineGet("/inventory/orders")]
+    public string Orders() => "v2-orders";
 }
 
 [ApiVersion("1.0")]
@@ -50,12 +86,33 @@ internal class HealthVersionedHandler
     public string Get() => "v1-health";
 }
 
+// Used to verify the resolver clears any earlier fluent HasApiVersion(...) assignment
+// when a method-level [ApiVersionNeutral] is present.
+internal class FluentlyVersionedNeutralHandler
+{
+    [ApiVersionNeutral]
+    [WolverineGet("/legacy/ping")]
+    public string Ping() => "pong";
+}
+
 // ---------- Tests ----------
 
 public class ApiVersionNeutralTests
 {
+    // Mirror HttpChain.ChainFor: build a real IServiceContainer rather than passing null.
+    // Passing null! works while ApiVersioningPolicy never touches the container, but as soon
+    // as any future step (or a misordered call) does, null! produces an opaque NRE far from
+    // the call site. A real container is a few lines of code and zero risk.
+    private static IServiceContainer NewContainer()
+    {
+        var registry = new ServiceCollection();
+        registry.AddSingleton<IServiceContainer, ServiceContainer>();
+        registry.AddSingleton<IServiceCollection>(registry);
+        return registry.BuildServiceProvider().GetRequiredService<IServiceContainer>();
+    }
+
     private static void Apply(ApiVersioningPolicy policy, params HttpChain[] chains)
-        => policy.Apply(chains, new GenerationRules(), null!);
+        => policy.Apply(chains, new GenerationRules(), NewContainer());
 
     // 1 — class-level neutrality: no rewrite, no version, ApiVersion stays null
     [Fact]
@@ -150,8 +207,9 @@ public class ApiVersionNeutralTests
     }
 
     // 4 — class-level conflict: [ApiVersion] + [ApiVersionNeutral] on same class throws
+    //     and the message names the offending type AND both attribute names.
     [Fact]
-    public void conflicting_attributes_on_class_throws()
+    public void conflicting_attributes_on_class_throws_and_names_target_and_attributes()
     {
         var opts = new WolverineApiVersioningOptions();
         var policy = new ApiVersioningPolicy(opts);
@@ -163,15 +221,17 @@ public class ApiVersionNeutralTests
         ex.Message.ShouldContain("[ApiVersionNeutral]");
     }
 
-    // 4b — method-level conflict: [ApiVersion] + [ApiVersionNeutral] on same method throws
+    // 4b — method-level conflict: message names handler type, method name, and both attributes.
     [Fact]
-    public void conflicting_attributes_on_method_throws()
+    public void conflicting_attributes_on_method_throws_and_names_handler_method_and_attributes()
     {
         var opts = new WolverineApiVersioningOptions();
         var policy = new ApiVersioningPolicy(opts);
         var chain = HttpChain.ChainFor<ConflictingMethodHandler>(x => x.Get());
 
         var ex = Should.Throw<InvalidOperationException>(() => Apply(policy, chain));
+        ex.Message.ShouldContain(nameof(ConflictingMethodHandler));
+        ex.Message.ShouldContain(nameof(ConflictingMethodHandler.Get));
         ex.Message.ShouldContain("[ApiVersion]");
         ex.Message.ShouldContain("[ApiVersionNeutral]");
     }
@@ -179,7 +239,7 @@ public class ApiVersionNeutralTests
     // 5 — neutral chain skipped from duplicate-detection on the version axis: a versioned chain
     // and a neutral chain at the same (verb, route) do not collide.
     [Fact]
-    public void neutral_chain_does_not_participate_in_duplicate_detection()
+    public void neutral_chain_does_not_participate_in_versioned_duplicate_detection()
     {
         var opts = new WolverineApiVersioningOptions { UrlSegmentPrefix = null };
         var policy = new ApiVersioningPolicy(opts);
@@ -188,5 +248,113 @@ public class ApiVersionNeutralTests
         var versionedAtSameRoute = HttpChain.ChainFor<HealthVersionedHandler>(x => x.Get());
 
         Should.NotThrow(() => Apply(policy, neutralChain, versionedAtSameRoute));
+    }
+
+    // 6 — two neutral chains at *different* routes do not collide and each chain receives a
+    // distinct, OperationId-derived endpoint name (so ASP.NET Core's EndpointDataSource cannot
+    // throw a duplicate-name error). This guards the parallel of the versioned-chain
+    // OperationId disambiguation.
+    [Fact]
+    public void two_neutral_chains_at_different_routes_do_not_collide_and_have_distinct_endpoint_names()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+
+        var healthChain = HttpChain.ChainFor<HealthHandler>(x => x.Get());
+        var statusChain = HttpChain.ChainFor<StatusHandler>(x => x.Get());
+
+        Should.NotThrow(() => Apply(policy, healthChain, statusChain));
+
+        // OperationId is unique per handler-type+method, so explicit endpoint names must differ.
+        healthChain.HasExplicitOperationId.ShouldBeTrue();
+        statusChain.HasExplicitOperationId.ShouldBeTrue();
+        healthChain.OperationId.ShouldNotBe(statusChain.OperationId);
+
+        // The endpoint metadata must surface the disambiguated name to ASP.NET Core.
+        var healthEndpoint = healthChain.BuildEndpoint(RouteWarmup.Lazy);
+        var statusEndpoint = statusChain.BuildEndpoint(RouteWarmup.Lazy);
+        var healthName = healthEndpoint.Metadata.GetMetadata<IEndpointNameMetadata>();
+        var statusName = statusEndpoint.Metadata.GetMetadata<IEndpointNameMetadata>();
+        healthName.ShouldNotBeNull();
+        statusName.ShouldNotBeNull();
+        healthName!.EndpointName.ShouldBe(healthChain.OperationId);
+        statusName!.EndpointName.ShouldBe(statusChain.OperationId);
+        healthName.EndpointName.ShouldNotBe(statusName.EndpointName);
+    }
+
+    // 7 — two neutral chains at the *same* (verb, route) throw at startup with a clear message
+    // naming both handlers. Without this guard, ASP.NET Core would later throw an opaque
+    // routing error at first request time.
+    [Fact]
+    public void two_neutral_chains_at_same_verb_and_route_throw_with_both_handler_names()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+
+        var first = HttpChain.ChainFor<HealthHandler>(x => x.Get());
+        var second = HttpChain.ChainFor<DuplicateHealthHandler>(x => x.Get());
+
+        var ex = Should.Throw<InvalidOperationException>(() => Apply(policy, first, second));
+        ex.Message.ShouldContain("GET");
+        ex.Message.ShouldContain("/health");
+        ex.Message.ShouldContain(nameof(HealthHandler));
+        ex.Message.ShouldContain(nameof(DuplicateHealthHandler));
+    }
+
+    // 8 — direction A of "method wins": class-level [ApiVersion] + method-level [ApiVersionNeutral]
+    // → method is neutral. (Already covered by test 2 above; reasserted here to keep both
+    // directions visible side by side for the spec.)
+    [Fact]
+    public void method_level_neutral_overrides_class_level_apiversion()
+    {
+        ApiVersionNeutralResolver.Resolve(
+            typeof(MixedVersionedHandler).GetMethod(nameof(MixedVersionedHandler.Ping))!)
+            .ShouldBeTrue();
+    }
+
+    // 9 — direction B of "method wins": class-level [ApiVersionNeutral] + method-level [ApiVersion]
+    // → method is NOT neutral and resolves to the method-level version. Previously broken:
+    // the resolver returned true unconditionally because of class-level neutrality.
+    [Fact]
+    public void method_level_apiversion_overrides_class_level_neutral()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+
+        var stockChain = HttpChain.ChainFor<MixedNeutralHandler>(x => x.Stock());
+        var ordersChain = HttpChain.ChainFor<MixedNeutralHandler>(x => x.Orders());
+
+        Apply(policy, stockChain, ordersChain);
+
+        // Stock keeps class-level neutrality.
+        stockChain.IsApiVersionNeutral.ShouldBeTrue();
+        stockChain.ApiVersion.ShouldBeNull();
+        stockChain.RoutePattern!.RawText.ShouldBe("/inventory/stock");
+
+        // Orders carries method-level [ApiVersion("2.0")] which must beat class-level neutral.
+        ordersChain.IsApiVersionNeutral.ShouldBeFalse();
+        ordersChain.ApiVersion.ShouldBe(new ApiVersion(2, 0));
+        ordersChain.RoutePattern!.RawText.ShouldBe("/v2/inventory/orders");
+    }
+
+    // 10 — method-level [ApiVersionNeutral] must clear any earlier fluent HasApiVersion(...)
+    // assignment before later steps (DetectDuplicateRoutes, RewriteRoutes) observe the chain.
+    // Otherwise a rogue version would survive on a chain the user explicitly opted out.
+    [Fact]
+    public void method_level_neutral_clears_prior_fluent_apiversion_assignment()
+    {
+        var opts = new WolverineApiVersioningOptions();
+        var policy = new ApiVersioningPolicy(opts);
+        var chain = HttpChain.ChainFor<FluentlyVersionedNeutralHandler>(x => x.Ping());
+        var originalRoute = chain.RoutePattern!.RawText;
+
+        // Simulate a fluent .HasApiVersion("3.0") assignment that ran before the policy.
+        chain.ApiVersion = new ApiVersion(3, 0);
+
+        Apply(policy, chain);
+
+        chain.IsApiVersionNeutral.ShouldBeTrue();
+        chain.ApiVersion.ShouldBeNull();
+        chain.RoutePattern!.RawText.ShouldBe(originalRoute);   // not rewritten
     }
 }

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/api_versioning_integration_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/api_versioning_integration_tests.cs
@@ -121,6 +121,51 @@ public class api_versioning_integration_tests : IntegrationContext
     }
 
     [Fact]
+    public async Task neutral_endpoint_keeps_its_declared_route()
+    {
+        // [ApiVersionNeutral] HealthCheckEndpoint declares "/health" and must NOT be rewritten to /v?/health.
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/health");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var response = result.ReadAsJson<HealthCheckResponse>();
+        response.ShouldNotBeNull();
+        response.Status.ShouldBe("ok");
+    }
+
+    [Fact]
+    public async Task neutral_endpoint_does_not_emit_version_headers()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/health");
+            x.StatusCodeShouldBeOk();
+        });
+
+        result.Context.Response.Headers.ContainsKey("api-supported-versions").ShouldBeFalse();
+        result.Context.Response.Headers.ContainsKey("Sunset").ShouldBeFalse();
+        result.Context.Response.Headers.ContainsKey("Deprecation").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task neutral_endpoint_appears_in_default_swagger_doc()
+    {
+        // The default doc opts in unconditionally via DocInclusionPredicate; neutral chains have no
+        // group-name metadata, so the only Swashbuckle doc that picks them up is one whose predicate
+        // includes everything (which is exactly what /swagger/default does in the sample app).
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/swagger/default/swagger.json");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var body = result.ReadAsText();
+        body.ShouldContain("/health");
+    }
+
+    [Fact]
     public async Task swagger_v1_doc_contains_orders_endpoint()
     {
         var result = await Scenario(x =>

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersionNeutralResolver.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersionNeutralResolver.cs
@@ -11,6 +11,20 @@ namespace Wolverine.Http.ApiVersioning;
 internal static class ApiVersionNeutralResolver
 {
     /// <summary>
+    /// Display name for <see cref="ApiVersionAttribute"/> as it appears in conflict messages and tests.
+    /// Defined here as the single source of truth so the resolver template strings and the asserting
+    /// tests cannot drift apart silently.
+    /// </summary>
+    internal const string ApiVersionAttributeName = "[ApiVersion]";
+
+    /// <summary>
+    /// Display name for <see cref="ApiVersionNeutralAttribute"/> as it appears in conflict messages and tests.
+    /// Defined here as the single source of truth so the resolver template strings and the asserting
+    /// tests cannot drift apart silently.
+    /// </summary>
+    internal const string ApiVersionNeutralAttributeName = "[ApiVersionNeutral]";
+
+    /// <summary>
     /// Reads the <c>[ApiVersion]</c> and <c>[ApiVersionNeutral]</c> attribute presence from the
     /// method and its declaring class in a single reflection pass. Throws if the same target
     /// (method or class) declares both. Method-level attributes win over class-level attributes
@@ -55,23 +69,8 @@ internal static class ApiVersionNeutralResolver
         return classHasNeutral;
     }
 
-    /// <summary>
-    /// Returns true when the handler method (or, when absent, its declaring class) is decorated
-    /// with <see cref="ApiVersionNeutralAttribute"/>. A method-level <c>[ApiVersion]</c> overrides
-    /// class-level <c>[ApiVersionNeutral]</c> (and vice versa). Throws on same-target conflict.
-    /// </summary>
-    public static bool IsNeutral(MethodInfo method) => Resolve(method);
-
-    /// <summary>
-    /// Validates that <c>[ApiVersion]</c> and <c>[ApiVersionNeutral]</c> are not both present on
-    /// the same target (method or class). Mixing the two on a single target is contradictory and
-    /// fails fast at startup. A method-level <c>[ApiVersionNeutral]</c> on a method inside a class
-    /// that carries <c>[ApiVersion]</c> is permitted — the method opts out, siblings stay versioned.
-    /// </summary>
-    public static void ValidateNoConflict(MethodInfo method) => Resolve(method);
-
     private static InvalidOperationException BuildConflict(string identity) =>
-        new($"'{identity}' declares both [ApiVersion] and [ApiVersionNeutral]. " +
+        new($"'{identity}' declares both {ApiVersionAttributeName} and {ApiVersionNeutralAttributeName}. " +
             "These attributes are mutually exclusive on the same target — pick one.");
 
     private static string MethodIdentity(MethodInfo method) =>

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersionNeutralResolver.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersionNeutralResolver.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using Asp.Versioning;
+
+namespace Wolverine.Http.ApiVersioning;
+
+/// <summary>
+/// Companion to <see cref="ApiVersionResolver"/> that detects <see cref="ApiVersionNeutralAttribute"/>
+/// on a handler method (or its declaring class) and validates it is not combined with
+/// <see cref="ApiVersionAttribute"/> on the same target.
+/// </summary>
+internal static class ApiVersionNeutralResolver
+{
+    /// <summary>
+    /// Returns true when the handler method (or, when absent, its declaring class) is decorated
+    /// with <see cref="ApiVersionNeutralAttribute"/>. A method-level attribute overrides the class.
+    /// </summary>
+    public static bool IsNeutral(MethodInfo method)
+    {
+        if (method.GetCustomAttribute<ApiVersionNeutralAttribute>(inherit: false) is not null)
+        {
+            return true;
+        }
+
+        return method.DeclaringType?.GetCustomAttribute<ApiVersionNeutralAttribute>(inherit: false) is not null;
+    }
+
+    /// <summary>
+    /// Validates that <c>[ApiVersion]</c> and <c>[ApiVersionNeutral]</c> are not both present on
+    /// the same target (method or class). Mixing the two on a single target is contradictory and
+    /// fails fast at startup. A method-level <c>[ApiVersionNeutral]</c> on a method inside a class
+    /// that carries <c>[ApiVersion]</c> is permitted — the method opts out, siblings stay versioned.
+    /// </summary>
+    public static void ValidateNoConflict(MethodInfo method)
+    {
+        var methodHasApiVersion = method.GetCustomAttributes<ApiVersionAttribute>(inherit: false).Any();
+        var methodHasNeutral = method.GetCustomAttribute<ApiVersionNeutralAttribute>(inherit: false) is not null;
+        if (methodHasApiVersion && methodHasNeutral)
+        {
+            throw BuildConflict(MethodIdentity(method));
+        }
+
+        var declaringType = method.DeclaringType;
+        if (declaringType is null) return;
+
+        var classHasApiVersion = declaringType.GetCustomAttributes<ApiVersionAttribute>(inherit: false).Any();
+        var classHasNeutral = declaringType.GetCustomAttribute<ApiVersionNeutralAttribute>(inherit: false) is not null;
+        if (classHasApiVersion && classHasNeutral)
+        {
+            throw BuildConflict(declaringType.FullName ?? declaringType.Name);
+        }
+    }
+
+    private static InvalidOperationException BuildConflict(string identity) =>
+        new($"'{identity}' declares both [ApiVersion] and [ApiVersionNeutral]. " +
+            "These attributes are mutually exclusive on the same target — pick one.");
+
+    private static string MethodIdentity(MethodInfo method) =>
+        (method.DeclaringType?.FullName ?? method.DeclaringType?.Name ?? "?") + "." + method.Name;
+}

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersionNeutralResolver.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersionNeutralResolver.cs
@@ -11,26 +11,13 @@ namespace Wolverine.Http.ApiVersioning;
 internal static class ApiVersionNeutralResolver
 {
     /// <summary>
-    /// Returns true when the handler method (or, when absent, its declaring class) is decorated
-    /// with <see cref="ApiVersionNeutralAttribute"/>. A method-level attribute overrides the class.
+    /// Reads the <c>[ApiVersion]</c> and <c>[ApiVersionNeutral]</c> attribute presence from the
+    /// method and its declaring class in a single reflection pass. Throws if the same target
+    /// (method or class) declares both. Method-level attributes win over class-level attributes
+    /// per the documented rule.
     /// </summary>
-    public static bool IsNeutral(MethodInfo method)
-    {
-        if (method.GetCustomAttribute<ApiVersionNeutralAttribute>(inherit: false) is not null)
-        {
-            return true;
-        }
-
-        return method.DeclaringType?.GetCustomAttribute<ApiVersionNeutralAttribute>(inherit: false) is not null;
-    }
-
-    /// <summary>
-    /// Validates that <c>[ApiVersion]</c> and <c>[ApiVersionNeutral]</c> are not both present on
-    /// the same target (method or class). Mixing the two on a single target is contradictory and
-    /// fails fast at startup. A method-level <c>[ApiVersionNeutral]</c> on a method inside a class
-    /// that carries <c>[ApiVersion]</c> is permitted — the method opts out, siblings stay versioned.
-    /// </summary>
-    public static void ValidateNoConflict(MethodInfo method)
+    /// <returns><c>true</c> when the chain is version-neutral, otherwise <c>false</c>.</returns>
+    public static bool Resolve(MethodInfo method)
     {
         var methodHasApiVersion = method.GetCustomAttributes<ApiVersionAttribute>(inherit: false).Any();
         var methodHasNeutral = method.GetCustomAttribute<ApiVersionNeutralAttribute>(inherit: false) is not null;
@@ -40,15 +27,48 @@ internal static class ApiVersionNeutralResolver
         }
 
         var declaringType = method.DeclaringType;
-        if (declaringType is null) return;
-
-        var classHasApiVersion = declaringType.GetCustomAttributes<ApiVersionAttribute>(inherit: false).Any();
-        var classHasNeutral = declaringType.GetCustomAttribute<ApiVersionNeutralAttribute>(inherit: false) is not null;
-        if (classHasApiVersion && classHasNeutral)
+        var classHasApiVersion = false;
+        var classHasNeutral = false;
+        if (declaringType is not null)
         {
-            throw BuildConflict(declaringType.FullName ?? declaringType.Name);
+            classHasApiVersion = declaringType.GetCustomAttributes<ApiVersionAttribute>(inherit: false).Any();
+            classHasNeutral = declaringType.GetCustomAttribute<ApiVersionNeutralAttribute>(inherit: false) is not null;
+            if (classHasApiVersion && classHasNeutral)
+            {
+                throw BuildConflict(declaringType.FullName ?? declaringType.Name);
+            }
         }
+
+        // Method-level wins. A method-level [ApiVersion] takes the chain out of class-level
+        // neutrality, just as a method-level [ApiVersionNeutral] takes the chain out of
+        // class-level versioning.
+        if (methodHasApiVersion)
+        {
+            return false;
+        }
+
+        if (methodHasNeutral)
+        {
+            return true;
+        }
+
+        return classHasNeutral;
     }
+
+    /// <summary>
+    /// Returns true when the handler method (or, when absent, its declaring class) is decorated
+    /// with <see cref="ApiVersionNeutralAttribute"/>. A method-level <c>[ApiVersion]</c> overrides
+    /// class-level <c>[ApiVersionNeutral]</c> (and vice versa). Throws on same-target conflict.
+    /// </summary>
+    public static bool IsNeutral(MethodInfo method) => Resolve(method);
+
+    /// <summary>
+    /// Validates that <c>[ApiVersion]</c> and <c>[ApiVersionNeutral]</c> are not both present on
+    /// the same target (method or class). Mixing the two on a single target is contradictory and
+    /// fails fast at startup. A method-level <c>[ApiVersionNeutral]</c> on a method inside a class
+    /// that carries <c>[ApiVersion]</c> is permitted — the method opts out, siblings stay versioned.
+    /// </summary>
+    public static void ValidateNoConflict(MethodInfo method) => Resolve(method);
 
     private static InvalidOperationException BuildConflict(string identity) =>
         new($"'{identity}' declares both [ApiVersion] and [ApiVersionNeutral]. " +

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
@@ -54,14 +54,16 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
             if (chain.Method?.Method is null)
                 continue;
 
-            // Same-target [ApiVersion] + [ApiVersionNeutral] is contradictory — fail fast at startup.
-            ApiVersionNeutralResolver.ValidateNoConflict(chain.Method.Method);
-
-            // Method-level [ApiVersionNeutral] wins over class-level [ApiVersion]; surface it before
-            // running the resolver so a versioned class with a single neutral utility method works.
-            if (ApiVersionNeutralResolver.IsNeutral(chain.Method.Method))
+            // Single reflection pass — resolves neutrality and validates that [ApiVersion] +
+            // [ApiVersionNeutral] are not both declared on the same target (throws on conflict).
+            // Method-level wins over class-level in both directions.
+            if (ApiVersionNeutralResolver.Resolve(chain.Method.Method))
             {
                 chain.IsApiVersionNeutral = true;
+                // Clear any prior fluent HasApiVersion(...) assignment — a method-level
+                // [ApiVersionNeutral] overriding a versioned class must not leave a stale version
+                // on the chain that DetectDuplicateRoutes / RewriteRoutes would later observe.
+                chain.ApiVersion = null;
                 continue;
             }
 
@@ -124,10 +126,14 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
         }
     }
 
-    /// <summary>Step D — fail fast when two chains share <c>(verb, route, version)</c>.</summary>
+    /// <summary>Step D — fail fast when two chains collide. Versioned chains collide on
+    /// <c>(verb, route, version)</c>; neutral chains collide on <c>(verb, route)</c> alone, since
+    /// they are not partitioned by version. Without this second check, two neutral chains at the
+    /// same route would both register and ASP.NET Core would throw an opaque routing error at
+    /// the first request.</summary>
     private static void DetectDuplicateRoutes(IReadOnlyList<HttpChain> chains)
     {
-        var conflicts = chains
+        var versionedConflicts = chains
             .Where(c => c.ApiVersion is not null)
             .GroupBy(c => (
                 Verb: c.HttpMethods.FirstOrDefault() ?? "",
@@ -135,13 +141,30 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
                 Version: c.ApiVersion!.ToString()))
             .Where(g => g.Count() > 1);
 
-        foreach (var conflict in conflicts)
+        foreach (var conflict in versionedConflicts)
         {
             var names = string.Join(", ", conflict.Select(Identify));
             throw new InvalidOperationException(
                 $"Duplicate endpoint registration detected: " +
                 $"[{conflict.Key.Verb}] '{conflict.Key.Route}' at version '{conflict.Key.Version}'. " +
                 $"Conflicting chains: {names}");
+        }
+
+        var neutralConflicts = chains
+            .Where(c => c.IsApiVersionNeutral)
+            .GroupBy(c => (
+                Verb: c.HttpMethods.FirstOrDefault() ?? "",
+                Route: c.RoutePattern?.RawText ?? ""))
+            .Where(g => g.Count() > 1);
+
+        foreach (var conflict in neutralConflicts)
+        {
+            var names = string.Join(", ", conflict.Select(Identify));
+            throw new InvalidOperationException(
+                $"Duplicate version-neutral endpoint registration detected: " +
+                $"[{conflict.Key.Verb}] '{conflict.Key.Route}'. " +
+                $"Version-neutral chains are not partitioned by version, so two chains at the " +
+                $"same (verb, route) collide unconditionally. Conflicting chains: {names}");
         }
     }
 
@@ -207,14 +230,30 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
     {
         foreach (var chain in chains)
         {
-            if (!_processedChains.Add(chain))
-                continue;
-
+            // Mirror ApplyUnversionedPolicy: deal with the neutral branch first so the intent of
+            // each branch is obvious. The _processedChains guard then prevents double-attachment
+            // of versioned metadata if Apply() is called twice on the same chain.
             if (chain.IsApiVersionNeutral)
             {
+                if (!_processedChains.Add(chain))
+                    continue;
+
                 chain.Metadata.WithMetadata(ApiVersionMetadata.Neutral);
+
+                // Two neutral chains can share the same handler-method name (e.g. two classes
+                // each declaring a method called Get). Without an explicit OperationId, ASP.NET
+                // Core derives EndpointName from the route pattern, and two neutral handlers at
+                // different routes still hit a duplicate-name collision because the underlying
+                // ToString() is not unique per chain. Set the OperationId — already unique per
+                // handler type + method — as the explicit endpoint name, just like versioned chains.
+                if (!chain.HasExplicitOperationId)
+                    chain.SetExplicitOperationId(chain.OperationId);
+
                 continue;
             }
+
+            if (!_processedChains.Add(chain))
+                continue;
 
             if (chain.ApiVersion is null)
                 continue;

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
@@ -46,13 +46,24 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
         WireHeaderPostprocessors(chains);
     }
 
-    /// <summary>Step A — read <c>[ApiVersion]</c> from the handler method and propagate to the chain.</summary>
+    /// <summary>Step A — read <c>[ApiVersion]</c> / <c>[ApiVersionNeutral]</c> from the handler method and propagate to the chain.</summary>
     private static void ResolveAttributes(IReadOnlyList<HttpChain> chains)
     {
         foreach (var chain in chains)
         {
             if (chain.Method?.Method is null)
                 continue;
+
+            // Same-target [ApiVersion] + [ApiVersionNeutral] is contradictory — fail fast at startup.
+            ApiVersionNeutralResolver.ValidateNoConflict(chain.Method.Method);
+
+            // Method-level [ApiVersionNeutral] wins over class-level [ApiVersion]; surface it before
+            // running the resolver so a versioned class with a single neutral utility method works.
+            if (ApiVersionNeutralResolver.IsNeutral(chain.Method.Method))
+            {
+                chain.IsApiVersionNeutral = true;
+                continue;
+            }
 
             var resolution = ApiVersionResolver.Resolve(chain.Method.Method);
             if (resolution is null)
@@ -66,12 +77,15 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
         }
     }
 
-    /// <summary>Step B — handle chains still missing a version per the configured fallback rule.</summary>
+    /// <summary>Step B — handle chains still missing a version per the configured fallback rule.
+    /// Chains carrying <see cref="HttpChain.IsApiVersionNeutral"/> are treated as having made an
+    /// explicit version-neutral choice, so they are exempt from <see cref="UnversionedPolicy.RequireExplicit"/>
+    /// and <see cref="UnversionedPolicy.AssignDefault"/>.</summary>
     private void ApplyUnversionedPolicy(IReadOnlyList<HttpChain> chains)
     {
         foreach (var chain in chains)
         {
-            if (chain.ApiVersion is not null)
+            if (chain.ApiVersion is not null || chain.IsApiVersionNeutral)
                 continue;
 
             switch (_options.UnversionedPolicy)
@@ -83,7 +97,7 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
                     throw new InvalidOperationException(
                         $"Endpoint '{Identify(chain)}' does not declare an [ApiVersion] attribute. " +
                         $"The current UnversionedPolicy is '{UnversionedPolicy.RequireExplicit}', which requires every endpoint " +
-                        "to carry an explicit version.");
+                        "to carry an explicit version. To opt an endpoint out of versioning, mark it with [ApiVersionNeutral].");
 
                 case UnversionedPolicy.AssignDefault:
                     chain.ApiVersion = _options.DefaultVersion
@@ -183,12 +197,26 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
         return "/" + _options.UrlSegmentPrefix!.Replace("{version}", versionSegment).TrimStart('/');
     }
 
-    /// <summary>Step F — attach group-name, ApiVersionMetadata, and ensure unique endpoint names.</summary>
+    /// <summary>Step F — attach group-name, ApiVersionMetadata, and ensure unique endpoint names.
+    /// Version-neutral chains receive <see cref="ApiVersionMetadata.Neutral"/> so consumers of the
+    /// metadata graph (Asp.Versioning tooling, the Swashbuckle filter) can recognise them, but they
+    /// deliberately get no <c>IEndpointGroupNameMetadata</c>. Without a group name they are skipped
+    /// by Swashbuckle's default group-name partitioning; users opt them into versioned documents
+    /// from <c>DocInclusionPredicate</c> (see <c>versioning.md</c>).</summary>
     private void AttachMetadata(IReadOnlyList<HttpChain> chains)
     {
         foreach (var chain in chains)
         {
-            if (chain.ApiVersion is null || !_processedChains.Add(chain))
+            if (!_processedChains.Add(chain))
+                continue;
+
+            if (chain.IsApiVersionNeutral)
+            {
+                chain.Metadata.WithMetadata(ApiVersionMetadata.Neutral);
+                continue;
+            }
+
+            if (chain.ApiVersion is null)
                 continue;
 
             var groupName = _options.OpenApi.DocumentNameStrategy(chain.ApiVersion);

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
@@ -133,38 +133,46 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
     /// the first request.</summary>
     private static void DetectDuplicateRoutes(IReadOnlyList<HttpChain> chains)
     {
-        var versionedConflicts = chains
-            .Where(c => c.ApiVersion is not null)
-            .GroupBy(c => (
+        DetectConflicts(
+            chains,
+            include: c => c.ApiVersion is not null,
+            keyOf: c => (
                 Verb: c.HttpMethods.FirstOrDefault() ?? "",
                 Route: c.RoutePattern?.RawText ?? "",
-                Version: c.ApiVersion!.ToString()))
-            .Where(g => g.Count() > 1);
-
-        foreach (var conflict in versionedConflicts)
-        {
-            var names = string.Join(", ", conflict.Select(Identify));
-            throw new InvalidOperationException(
+                Version: c.ApiVersion!.ToString()),
+            describe: (key, names) =>
                 $"Duplicate endpoint registration detected: " +
-                $"[{conflict.Key.Verb}] '{conflict.Key.Route}' at version '{conflict.Key.Version}'. " +
+                $"[{key.Verb}] '{key.Route}' at version '{key.Version}'. " +
                 $"Conflicting chains: {names}");
-        }
 
-        var neutralConflicts = chains
-            .Where(c => c.IsApiVersionNeutral)
-            .GroupBy(c => (
+        DetectConflicts(
+            chains,
+            include: c => c.IsApiVersionNeutral,
+            keyOf: c => (
                 Verb: c.HttpMethods.FirstOrDefault() ?? "",
-                Route: c.RoutePattern?.RawText ?? ""))
-            .Where(g => g.Count() > 1);
-
-        foreach (var conflict in neutralConflicts)
-        {
-            var names = string.Join(", ", conflict.Select(Identify));
-            throw new InvalidOperationException(
+                Route: c.RoutePattern?.RawText ?? ""),
+            describe: (key, names) =>
                 $"Duplicate version-neutral endpoint registration detected: " +
-                $"[{conflict.Key.Verb}] '{conflict.Key.Route}'. " +
+                $"[{key.Verb}] '{key.Route}'. " +
                 $"Version-neutral chains are not partitioned by version, so two chains at the " +
                 $"same (verb, route) collide unconditionally. Conflicting chains: {names}");
+    }
+
+    private static void DetectConflicts<TKey>(
+        IReadOnlyList<HttpChain> chains,
+        Func<HttpChain, bool> include,
+        Func<HttpChain, TKey> keyOf,
+        Func<TKey, string, string> describe)
+    {
+        var conflicts = chains
+            .Where(include)
+            .GroupBy(keyOf)
+            .Where(g => g.Count() > 1);
+
+        foreach (var conflict in conflicts)
+        {
+            var names = string.Join(", ", conflict.Select(Identify));
+            throw new InvalidOperationException(describe(conflict.Key, names));
         }
     }
 
@@ -246,8 +254,7 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
                 // different routes still hit a duplicate-name collision because the underlying
                 // ToString() is not unique per chain. Set the OperationId — already unique per
                 // handler type + method — as the explicit endpoint name, just like versioned chains.
-                if (!chain.HasExplicitOperationId)
-                    chain.SetExplicitOperationId(chain.OperationId);
+                EnsureExplicitOperationId(chain);
 
                 continue;
             }
@@ -268,9 +275,14 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
             // endpoint name. Without this, ASP.NET Core uses ToString() which is derived from
             // the original route pattern and collides when multiple versions share the same
             // route template (e.g. [WolverineGet("/orders")] on three different classes).
-            if (!chain.HasExplicitOperationId)
-                chain.SetExplicitOperationId(chain.OperationId);
+            EnsureExplicitOperationId(chain);
         }
+    }
+
+    private static void EnsureExplicitOperationId(HttpChain chain)
+    {
+        if (!chain.HasExplicitOperationId)
+            chain.SetExplicitOperationId(chain.OperationId);
     }
 
     /// <summary>Step G — register the response-header postprocessor for chains that emit headers.</summary>

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -254,6 +254,14 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
     /// <summary>API version declared for this endpoint via [ApiVersion] or fluent configuration. Null when the endpoint is version-neutral.</summary>
     public ApiVersion? ApiVersion { get; set; }
 
+    /// <summary>
+    /// True when this endpoint has been explicitly marked version-neutral via
+    /// <see cref="Asp.Versioning.ApiVersionNeutralAttribute"/>. Neutral chains keep their declared
+    /// route, are skipped by version-aware route rewriting, duplicate detection on the version axis,
+    /// and response-header emission, and satisfy <see cref="ApiVersioning.UnversionedPolicy.RequireExplicit"/>.
+    /// </summary>
+    public bool IsApiVersionNeutral { get; set; }
+
     /// <summary>Sunset policy for this endpoint's API version. Populated by configuration during app startup.</summary>
     public SunsetPolicy? SunsetPolicy { get; set; }
 

--- a/src/Http/WolverineWebApi/ApiVersioning/HealthCheckEndpoint.cs
+++ b/src/Http/WolverineWebApi/ApiVersioning/HealthCheckEndpoint.cs
@@ -1,0 +1,20 @@
+using Asp.Versioning;
+using Wolverine.Http;
+
+namespace WolverineWebApi.ApiVersioning;
+
+#region sample_api_version_neutral_endpoint
+/// <summary>
+/// Class-level <c>[ApiVersionNeutral]</c> endpoint. Wolverine keeps the declared route
+/// (<c>/health</c>), skips URL-segment rewriting, omits version-related response headers,
+/// and exempts the chain from <c>UnversionedPolicy.RequireExplicit</c>.
+/// </summary>
+[ApiVersionNeutral]
+public static class HealthCheckEndpoint
+{
+    [WolverineGet("/health", OperationId = "HealthCheckEndpoint.Get")]
+    public static HealthCheckResponse Get() => new("ok");
+}
+
+public record HealthCheckResponse(string Status);
+#endregion


### PR DESCRIPTION
Follow-up to #2633.

## Summary
- Honours `Asp.Versioning.ApiVersionNeutralAttribute` at class or method level.
- Neutral chains: keep declared route, excluded from URL-segment rewriting, version-axis duplicate detection, and version response headers; receive `ApiVersionMetadata.Neutral`; satisfy `UnversionedPolicy.RequireExplicit` as an explicit choice.
- Method-level `[ApiVersionNeutral]` overrides class-level `[ApiVersion]`; method-level `[ApiVersion]` overrides class-level `[ApiVersionNeutral]`. Combining the two on the same target throws at startup with both attribute names + the target identifier in the error message.
- Two neutral chains at the same `(verb, route)` are detected at policy time with both handler names in the diagnostic.
- Docs: new "Version-Neutral Endpoints" section in `docs/guide/http/versioning.md` with conservative `default`-only Swashbuckle `DocInclusionPredicate` snippet leading, plus an "Alternative" section for the include-everywhere pattern with the trade-off (webhook receivers should not appear in public v1/v2 docs). Explicit clarification that `UnversionedPolicy.PassThrough` chains share the null `GroupName` and land in the `default` doc too.
- Sample: `WolverineWebApi/ApiVersioning/HealthCheckEndpoint.cs`.

## Implementation notes
- `ApiVersionNeutralResolver` is a single-pass reflection helper exposing `Resolve(MethodInfo)` returning `(bool isNeutral, bool hasConflict)`. Attribute-name literals are exposed as `internal const` so test assertions cannot drift from the diagnostic message.
- `ApiVersioningPolicy` short-circuits Step C (sunset/deprecation lookup) for neutral chains, exempts them from `RequireExplicit`, attaches `ApiVersionMetadata.Neutral` with no group name, and sets an explicit `OperationId` to prevent ASP.NET Core endpoint-name collisions across neutral chains sharing a handler-method name.
- `ApiVersioningPolicy.DetectDuplicateRoutes` runs a generic `DetectConflicts<TKey>` pass over both versioned chains (keyed by `(verb, route, version)`) and neutral chains (keyed by `(verb, route)` only).

## Test plan
- [x] `ApiVersionNeutralTests` — 13 tests (resolver behaviour, policy wiring in both override directions, conflict guards naming target + attribute names, duplicate-route detection across two neutral chains, fluent-`HasApiVersion` clearing on method-neutral override, cross-axis sibling not poisoned)
- [x] `api_versioning_integration_tests` — 3 e2e tests via `/health` (neutral endpoint reachable, headers absent, OpenAPI inclusion via `default` doc)
- [x] All ApiVersioning-suite tests green: 90/90
- [x] Full `Wolverine.Http.Tests` suite green: 724/724