### PR TITLE
feat(http): multi-version handlers + [MapToApiVersion] support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Alba" Version="8.5.2" />
-    <PackageVersion Include="Asp.Versioning.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Asp.Versioning.Abstractions" Version="[10.0.0,11.0.0)" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.22.1" />
     <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.2.14" />
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.14" />

--- a/docs/guide/http/versioning.md
+++ b/docs/guide/http/versioning.md
@@ -11,8 +11,8 @@ versioning entirely through its own `IHttpPolicy` pipeline, so there is no confl
 `AddApiVersioning()` registration, and no additional ASP.NET Core middleware is needed.
 
 ::: info
-This release supports **URL-segment versioning** (e.g. `/v1/...`, `/v2/...`). Each endpoint declares a single
-`[ApiVersion]`; multi-version handlers via `[MapToApiVersion]` are not supported.
+This release supports **URL-segment versioning** (e.g. `/v1/...`, `/v2/...`) and multi-version handlers
+via repeated `[ApiVersion]` attributes or `[MapToApiVersion]`. See [Multi-version handlers](#multi-version-handlers).
 :::
 
 ## Quick Start
@@ -72,12 +72,84 @@ public static class OrdersV2Endpoint
 }
 ```
 
-### One version per endpoint
+### Multi-version handlers
 
-Declaring **multiple** `[ApiVersion]` attributes on the same handler method is not supported in v1. The resolver
-picks the first attribute encountered and ignores any additional ones. If you have two incompatible response shapes
-for the same resource, create separate endpoint classes — one per version — as shown in the sample app
-(`OrdersV1Endpoint`, `OrdersV2Endpoint`, `OrdersV3PreviewEndpoint`).
+A single handler method can serve multiple API versions by repeating `[ApiVersion]` attributes either at the
+method or class level. Wolverine expands the chain at bootstrap into one HTTP endpoint per declared version,
+with the URL-segment prefix, sunset / deprecation policies, OpenAPI group name, and `ApiVersionMetadata`
+applied per clone. Duplicate-route detection runs across the *expanded* set so two handlers serving the same
+`(verb, route, version)` triple still fail fast with a descriptive error.
+
+#### Method-level multi-version
+
+```csharp
+public static class OrdersHandler
+{
+    [WolverineGet("/orders")]
+    [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
+    public static OrdersResponse Get() => new(["a", "b"]);
+}
+```
+
+This produces both `/v1/orders` and `/v2/orders` and registers both in the OpenAPI documents.
+
+#### Class-level multi-version
+
+```csharp
+[ApiVersion("1.0", Deprecated = true)]
+[ApiVersion("2.0")]
+[ApiVersion("3.0")]
+public static class CustomersEndpoint
+{
+    [WolverineGet("/customers")]
+    public static CustomersResponse Get() => new(["alice", "bob"]);
+}
+```
+
+Per-version deprecation propagates to the matching clone only: in this example `/v1/customers` carries the
+`Deprecation` response header while `/v2/customers` and `/v3/customers` do not.
+
+#### `[MapToApiVersion]` — opt a method into a subset of class versions
+
+When a class declares many versions but a particular method only applies to a subset, decorate the method
+with `[MapToApiVersion]` instead of redeclaring `[ApiVersion]`:
+
+```csharp
+[ApiVersion("1.0")]
+[ApiVersion("2.0")]
+[ApiVersion("3.0")]
+public static class CustomersEndpoint
+{
+    // Lives at /v2/customers/v2-only — v1 and v3 are NOT registered for this method.
+    [WolverineGet("/customers/v2-only")]
+    [MapToApiVersion("2.0")]
+    public static CustomersResponse Get() => new(["v2-only"]);
+}
+```
+
+Resolution rules:
+
+- **Method-level `[ApiVersion]` overrides class-level entirely.** If both are present, only the method
+  attribute is read; class-level versions are ignored for that method.
+- **Method-level `[MapToApiVersion]` filters class-level versions.** Every version listed must also appear
+  at class level, otherwise startup fails fast with an exception naming both the method and the class.
+- **A method may not carry both `[ApiVersion]` and `[MapToApiVersion]`.** Pick one — `[ApiVersion]` declares
+  versions independently of the class, `[MapToApiVersion]` selects from them. Mixing the two on one method
+  triggers a startup exception.
+
+#### Per-version metadata semantics
+
+When a chain is expanded into clones, every per-version policy is applied to its respective clone:
+
+| Per-clone state | Source |
+|---|---|
+| `RoutePattern` | Rewritten with `UrlSegmentPrefix` for that clone's version |
+| `ApiVersionMetadata` | Set with the model containing only that single version |
+| `IEndpointGroupNameMetadata` | `OpenApi.DocumentNameStrategy(clone.ApiVersion)` |
+| `DeprecationPolicy` | `[ApiVersion(..., Deprecated = true)]` for that version, or `Deprecate("X.Y")` from options |
+| `SunsetPolicy` | `Sunset("X.Y")` from options |
+| Response headers (`Deprecation`, `Sunset`, `Link`, `api-supported-versions`) | Per the policies attached to that clone |
 
 ### Marking a version as deprecated via attribute
 
@@ -313,7 +385,14 @@ assembly scan, must carry `[ApiVersion]`. Switch to `PassThrough` (the default) 
 remain unversioned, or add the attribute. The exception message lists the offending endpoint by its display name.
 
 **Multiple `[ApiVersion]` attributes on the same method.**
-Only the first attribute is used; subsequent attributes are silently ignored. If you need to expose a resource at
-two different versions, create separate endpoint classes — one per version — sharing the same route template. The
-duplicate-detection step in `ApiVersioningPolicy` will catch any `(verb, route, version)` triple that appears
-more than once and throw a descriptive `InvalidOperationException` at startup.
+Wolverine expands the chain at bootstrap into one HTTP endpoint per declared version. See
+[Multi-version handlers](#multi-version-handlers). Duplicate detection still applies across the expanded set
+and rejects any `(verb, route, version)` triple that appears more than once.
+
+**`[MapToApiVersion]` lists a version that the class does not declare.**
+Startup throws an `InvalidOperationException` naming both the method and the declaring class. Add the missing
+version to the class-level `[ApiVersion]` list, or remove it from `[MapToApiVersion]`.
+
+**Both `[ApiVersion]` and `[MapToApiVersion]` on the same method.**
+Startup throws. Use only one: `[ApiVersion]` declares versions independently of the class; `[MapToApiVersion]`
+selects from class-level versions.

--- a/docs/guide/http/versioning.md
+++ b/docs/guide/http/versioning.md
@@ -145,11 +145,13 @@ When a chain is expanded into clones, every per-version policy is applied to its
 | Per-clone state | Source |
 |---|---|
 | `RoutePattern` | Rewritten with `UrlSegmentPrefix` for that clone's version |
-| `ApiVersionMetadata` | Set with the model containing only that single version |
+| `ApiVersionMetadata` | Built per clone: `DeclaredApiVersions` is the single clone version; `SupportedApiVersions` and `DeprecatedApiVersions` are the union of all sibling clones at the same `(verb, route-without-version-prefix)` |
+| `OperationId` | Inherited from the source chain plus a `_v{major}_{minor}` suffix (sanitised to ASCII alphanumerics + `_`, so date-based versions like `2024-01-01` become `_v2024_01_01`) |
 | `IEndpointGroupNameMetadata` | `OpenApi.DocumentNameStrategy(clone.ApiVersion)` |
 | `DeprecationPolicy` | `[ApiVersion(..., Deprecated = true)]` for that version, or `Deprecate("X.Y")` from options |
 | `SunsetPolicy` | `Sunset("X.Y")` from options |
 | Response headers (`Deprecation`, `Sunset`, `Link`, `api-supported-versions`) | Per the policies attached to that clone |
+| `Endpoint.Metadata` `[ApiVersion]` / `[MapToApiVersion]` | Filtered to only the clone's own version — sibling-version attributes are scrubbed so OpenAPI tooling reports each clone as implementing exactly one declared version |
 
 ### Marking a version as deprecated via attribute
 

--- a/docs/guide/http/versioning.md
+++ b/docs/guide/http/versioning.md
@@ -146,7 +146,7 @@ When a chain is expanded into clones, every per-version policy is applied to its
 |---|---|
 | `RoutePattern` | Rewritten with `UrlSegmentPrefix` for that clone's version |
 | `ApiVersionMetadata` | Built per clone: `DeclaredApiVersions` is the single clone version; `SupportedApiVersions` and `DeprecatedApiVersions` are the union of all sibling clones at the same `(verb, route-without-version-prefix)` |
-| `OperationId` | Inherited from the source chain plus a `_v{major}_{minor}` suffix (sanitised to ASCII alphanumerics + `_`, so date-based versions like `2024-01-01` become `_v2024_01_01`) |
+| `OperationId` | Inherited from the source chain plus a `_v{sanitised-version-string}` suffix — every non-alphanumeric character is replaced with `_`, so `2.0` → `_v2_0` and date-based versions like `2024-01-01` → `_v2024_01_01` |
 | `IEndpointGroupNameMetadata` | `OpenApi.DocumentNameStrategy(clone.ApiVersion)` |
 | `DeprecationPolicy` | `[ApiVersion(..., Deprecated = true)]` for that version, or `Deprecate("X.Y")` from options |
 | `SunsetPolicy` | `Sunset("X.Y")` from options |

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersionResolverTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/ApiVersionResolverTests.cs
@@ -34,55 +34,56 @@ public class ApiVersionResolverTests
         => typeof(T).GetMethod(name, BindingFlags.Public | BindingFlags.Instance)!;
 
     [Fact]
-    public void no_attribute_returns_null()
+    public void no_attribute_returns_empty()
     {
         var method = MethodOf<NoVersionHandler>(nameof(NoVersionHandler.Handle));
-        ApiVersionResolver.Resolve(method).ShouldBeNull();
+        ApiVersionResolver.ResolveVersions(method).ShouldBeEmpty();
     }
 
     [Fact]
     public void class_only_attribute_resolves_to_class_version()
     {
         var method = MethodOf<ClassOnlyVersionHandler>(nameof(ClassOnlyVersionHandler.Handle));
-        var result = ApiVersionResolver.Resolve(method);
-        result!.Value.Version.ShouldBe(new ApiVersion(2, 0));
-        result.Value.IsDeprecated.ShouldBeFalse();
+        var result = ApiVersionResolver.ResolveVersions(method);
+        result.ShouldHaveSingleItem();
+        result[0].Version.ShouldBe(new ApiVersion(2, 0));
+        result[0].IsDeprecated.ShouldBeFalse();
     }
 
     [Fact]
     public void method_attribute_resolves_to_method_version()
     {
         var method = MethodOf<MethodOnlyVersionHandler>(nameof(MethodOnlyVersionHandler.Handle));
-        var result = ApiVersionResolver.Resolve(method);
-        result!.Value.Version.ShouldBe(new ApiVersion(1, 0));
-        result.Value.IsDeprecated.ShouldBeFalse();
+        var result = ApiVersionResolver.ResolveVersions(method);
+        result.ShouldHaveSingleItem();
+        result[0].Version.ShouldBe(new ApiVersion(1, 0));
+        result[0].IsDeprecated.ShouldBeFalse();
     }
 
     [Fact]
     public void method_attribute_overrides_class_attribute()
     {
         var method = MethodOf<MethodOverridesClassHandler>(nameof(MethodOverridesClassHandler.Handle));
-        var result = ApiVersionResolver.Resolve(method);
-        result!.Value.Version.ShouldBe(new ApiVersion(1, 0));
-        result.Value.IsDeprecated.ShouldBeFalse();
+        var result = ApiVersionResolver.ResolveVersions(method);
+        result.ShouldHaveSingleItem();
+        result[0].Version.ShouldBe(new ApiVersion(1, 0));
+        result[0].IsDeprecated.ShouldBeFalse();
     }
 
     [Fact]
-    public void multiple_versions_on_same_method_throws()
+    public void multiple_versions_on_same_method_returns_all_of_them()
     {
         var method = MethodOf<MultipleVersionsOnMethodHandler>(nameof(MultipleVersionsOnMethodHandler.Handle));
-        var ex = Should.Throw<InvalidOperationException>(() => ApiVersionResolver.Resolve(method));
-        ex.Message.ShouldContain("MultipleVersionsOnMethodHandler.Handle");
-        ex.Message.ShouldContain("1.0");
-        ex.Message.ShouldContain("2.0");
+        var result = ApiVersionResolver.ResolveVersions(method);
+        result.Select(r => r.Version).ShouldBe(new[] { new ApiVersion(1, 0), new ApiVersion(2, 0) });
     }
 
     [Fact]
     public void deprecated_attribute_flag_is_propagated()
     {
-        var result = ApiVersionResolver.Resolve(MethodOf<DeprecatedMethodHandler>(nameof(DeprecatedMethodHandler.Handle)));
-        result.ShouldNotBeNull();
-        result.Value.Version.ShouldBe(new ApiVersion(1, 0));
-        result.Value.IsDeprecated.ShouldBeTrue();
+        var result = ApiVersionResolver.ResolveVersions(MethodOf<DeprecatedMethodHandler>(nameof(DeprecatedMethodHandler.Handle)));
+        result.ShouldHaveSingleItem();
+        result[0].Version.ShouldBe(new ApiVersion(1, 0));
+        result[0].IsDeprecated.ShouldBeTrue();
     }
 }

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/MultiVersionExpansionTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/MultiVersionExpansionTests.cs
@@ -60,11 +60,41 @@ internal class BothAttrsHandler
     public string Get() => "both";
 }
 
+// Two handlers that, after expansion, both serve (GET, /reports, v2.0) — duplicate detection target.
+internal class FirstReportsMultiVersionHandler
+{
+    [WolverineGet("/reports")]
+    [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
+    public string Get() => "first";
+}
+
+internal class SecondReportsMultiVersionHandler
+{
+    [WolverineGet("/reports")]
+    [ApiVersion("2.0")]
+    [ApiVersion("3.0")]
+    public string Get() => "second";
+}
+
+// Plain unversioned handler — must survive expansion without any ApiVersion side effects.
+internal class UnversionedPlainHandler
+{
+    [WolverineGet("/health")]
+    public string Get() => "ok";
+}
+
+// Date-based version handler used to assert OperationId suffix sanitisation.
+internal class DateBasedVersionHandler
+{
+    [WolverineGet("/dated")]
+    [ApiVersion("2024-01-01")]
+    [ApiVersion("2025-06-15")]
+    public string Get() => "dated";
+}
+
 public class MultiVersionExpansionTests
 {
-    private static void Apply(ApiVersioningPolicy policy, params HttpChain[] chains)
-        => policy.Apply(chains, new GenerationRules(), null!);
-
     private static List<HttpChain> ListOf(params HttpChain[] chains) => new(chains);
 
     // 1 — multi-version method produces N versioned routes after expansion + policy.
@@ -72,7 +102,7 @@ public class MultiVersionExpansionTests
     public void method_level_two_versions_expand_to_two_routes()
     {
         var chains = ListOf(HttpChain.ChainFor<TwoVersionMethodOrdersHandler>(x => x.Get()));
-        MultiVersionExpansion.Expand(chains);
+        MultiVersionExpansion.ExpandInPlace(chains);
 
         chains.Count.ShouldBe(2);
         chains.Select(c => c.ApiVersion).ShouldBe(new[] { new ApiVersion(1, 0), new ApiVersion(2, 0) });
@@ -88,14 +118,15 @@ public class MultiVersionExpansionTests
     public void mapto_filters_to_only_the_listed_version()
     {
         var chains = ListOf(HttpChain.ChainFor<ClassThreeMapToTwoOrdersHandler>(x => x.Get()));
-        MultiVersionExpansion.Expand(chains);
+        MultiVersionExpansion.ExpandInPlace(chains);
 
+        // Single-version chains are NOT expanded — ApiVersioningPolicy resolves them in ResolveAttributes.
         chains.Count.ShouldBe(1);
-        chains[0].ApiVersion.ShouldBe(new ApiVersion(2, 0));
 
         var policy = new ApiVersioningPolicy(new WolverineApiVersioningOptions());
         policy.Apply(chains, new GenerationRules(), null!);
 
+        chains[0].ApiVersion.ShouldBe(new ApiVersion(2, 0));
         chains[0].RoutePattern!.RawText.ShouldBe("/v2/widgets");
     }
 
@@ -105,7 +136,7 @@ public class MultiVersionExpansionTests
     {
         var chains = ListOf(HttpChain.ChainFor<MapToInvalidVersionHandler>(x => x.Get()));
 
-        var ex = Should.Throw<InvalidOperationException>(() => MultiVersionExpansion.Expand(chains));
+        var ex = Should.Throw<InvalidOperationException>(() => MultiVersionExpansion.ExpandInPlace(chains));
         ex.Message.ShouldContain("MapToApiVersion");
         ex.Message.ShouldContain("MapToInvalidVersionHandler");
         ex.Message.ShouldContain("3.0");
@@ -117,7 +148,7 @@ public class MultiVersionExpansionTests
     {
         var chains = ListOf(HttpChain.ChainFor<BothAttrsHandler>(x => x.Get()));
 
-        var ex = Should.Throw<InvalidOperationException>(() => MultiVersionExpansion.Expand(chains));
+        var ex = Should.Throw<InvalidOperationException>(() => MultiVersionExpansion.ExpandInPlace(chains));
         ex.Message.ShouldContain("[ApiVersion]");
         ex.Message.ShouldContain("[MapToApiVersion]");
     }
@@ -127,7 +158,7 @@ public class MultiVersionExpansionTests
     public void per_version_deprecation_applies_independently_across_clones()
     {
         var chains = ListOf(HttpChain.ChainFor<TwoVersionWithPerVersionDeprecationHandler>(x => x.Get()));
-        MultiVersionExpansion.Expand(chains);
+        MultiVersionExpansion.ExpandInPlace(chains);
 
         chains.Count.ShouldBe(2);
         var v1 = chains.Single(c => c.ApiVersion == new ApiVersion(1, 0));
@@ -142,18 +173,46 @@ public class MultiVersionExpansionTests
     public void class_level_two_versions_expand_to_two_routes()
     {
         var chains = ListOf(HttpChain.ChainFor<ClassLevelTwoVersionOrdersHandler>(x => x.Get()));
-        MultiVersionExpansion.Expand(chains);
+        MultiVersionExpansion.ExpandInPlace(chains);
 
         chains.Count.ShouldBe(2);
         chains.Select(c => c.ApiVersion).ShouldBe(new[] { new ApiVersion(1, 0), new ApiVersion(2, 0) });
     }
 
-    // 7 — versioned-route metadata wires up per clone with distinct ApiVersionMetadata.
+    // 7 — versioned-route metadata wires up per clone with the union of sibling versions in supported.
     [Fact]
-    public void per_version_metadata_attached_to_each_clone()
+    public void per_version_metadata_attached_to_each_clone_advertises_sibling_versions()
     {
         var chains = ListOf(HttpChain.ChainFor<TwoVersionMethodOrdersHandler>(x => x.Get()));
-        MultiVersionExpansion.Expand(chains);
+        MultiVersionExpansion.ExpandInPlace(chains);
+
+        var policy = new ApiVersioningPolicy(new WolverineApiVersioningOptions());
+        policy.Apply(chains, new GenerationRules(), null!);
+
+        var allVersions = new[] { new ApiVersion(1, 0), new ApiVersion(2, 0) };
+
+        foreach (var chain in chains)
+        {
+            var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
+            var versionMeta = endpoint.Metadata.GetMetadata<ApiVersionMetadata>();
+            versionMeta.ShouldNotBeNull();
+
+            var model = versionMeta!.Map(ApiVersionMapping.Explicit);
+
+            // Each clone declares only its own version, but advertises both as supported so the
+            // api-supported-versions response header reports the full sibling set.
+            model.DeclaredApiVersions.ShouldBe(new[] { chain.ApiVersion! });
+            model.SupportedApiVersions.OrderBy(v => v).ShouldBe(allVersions);
+            model.ImplementedApiVersions.OrderBy(v => v).ShouldBe(allVersions);
+        }
+    }
+
+    // 8 — per-version deprecation reflects in supported / deprecated split of the model.
+    [Fact]
+    public void per_version_metadata_reports_deprecated_subset_correctly()
+    {
+        var chains = ListOf(HttpChain.ChainFor<TwoVersionWithPerVersionDeprecationHandler>(x => x.Get()));
+        MultiVersionExpansion.ExpandInPlace(chains);
 
         var policy = new ApiVersioningPolicy(new WolverineApiVersioningOptions());
         policy.Apply(chains, new GenerationRules(), null!);
@@ -161,9 +220,110 @@ public class MultiVersionExpansionTests
         foreach (var chain in chains)
         {
             var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
-            var versionMeta = endpoint.Metadata.GetMetadata<ApiVersionMetadata>();
-            versionMeta.ShouldNotBeNull();
-            versionMeta!.Map(ApiVersionMapping.Explicit).ImplementedApiVersions.ShouldContain(chain.ApiVersion!);
+            var model = endpoint.Metadata.GetMetadata<ApiVersionMetadata>()!.Map(ApiVersionMapping.Explicit);
+
+            model.SupportedApiVersions.ShouldBe(new[] { new ApiVersion(2, 0) });
+            model.DeprecatedApiVersions.ShouldBe(new[] { new ApiVersion(1, 0) });
         }
+    }
+
+    // 9 — Mandate M3: each clone's endpoint metadata exposes only its own [ApiVersion] attribute.
+    // OpenAPI tooling that walks endpoint metadata must not see foreign versions, otherwise it
+    // reports each clone as implementing every sibling version.
+    [Fact]
+    public void each_clone_endpoint_metadata_only_lists_its_own_apiversion_attribute()
+    {
+        var chains = ListOf(HttpChain.ChainFor<TwoVersionMethodOrdersHandler>(x => x.Get()));
+        MultiVersionExpansion.ExpandInPlace(chains);
+
+        var policy = new ApiVersioningPolicy(new WolverineApiVersioningOptions());
+        policy.Apply(chains, new GenerationRules(), null!);
+
+        foreach (var chain in chains)
+        {
+            var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
+            var apiVersionAttrs = endpoint.Metadata.GetOrderedMetadata<ApiVersionAttribute>();
+
+            apiVersionAttrs.Count.ShouldBe(1);
+            apiVersionAttrs[0].Versions.ShouldBe(new[] { chain.ApiVersion! });
+        }
+    }
+
+    // 10 — duplicate detection: two distinct multi-version handlers overlapping at (GET, /reports, 2.0)
+    // throw at the policy stage AFTER expansion.
+    [Fact]
+    public void overlapping_versions_across_distinct_multi_version_handlers_throw_at_policy()
+    {
+        var chains = ListOf(
+            HttpChain.ChainFor<FirstReportsMultiVersionHandler>(x => x.Get()),
+            HttpChain.ChainFor<SecondReportsMultiVersionHandler>(x => x.Get()));
+
+        MultiVersionExpansion.ExpandInPlace(chains);
+
+        // First handler => v1 + v2; second handler => v2 + v3. The shared (GET, /reports, 2.0) is the conflict.
+        chains.Count.ShouldBe(4);
+
+        var policy = new ApiVersioningPolicy(new WolverineApiVersioningOptions());
+        var ex = Should.Throw<InvalidOperationException>(() => policy.Apply(chains, new GenerationRules(), null!));
+        ex.Message.ShouldContain("Duplicate endpoint registration");
+        ex.Message.ShouldContain("/reports");
+        ex.Message.ShouldContain("2.0");
+    }
+
+    // 11 — [MapToApiVersion("X")] producing exactly one version: expansion leaves the chain in place,
+    // ApiVersioningPolicy.ResolveAttributes assigns the version (no clone is created).
+    [Fact]
+    public void mapto_producing_single_version_leaves_chain_in_place_for_policy_resolution()
+    {
+        var chain = HttpChain.ChainFor<ClassThreeMapToTwoOrdersHandler>(x => x.Get());
+        chain.ApiVersion.ShouldBeNull();
+
+        var chains = ListOf(chain);
+        MultiVersionExpansion.ExpandInPlace(chains);
+
+        // No clone — same chain reference, ApiVersion still null until policy runs.
+        chains.Count.ShouldBe(1);
+        ReferenceEquals(chains[0], chain).ShouldBeTrue();
+        chains[0].ApiVersion.ShouldBeNull();
+
+        var policy = new ApiVersioningPolicy(new WolverineApiVersioningOptions());
+        policy.Apply(chains, new GenerationRules(), null!);
+
+        chains[0].ApiVersion.ShouldBe(new ApiVersion(2, 0));
+    }
+
+    // 12 — unversioned handlers in the chain set are untouched by expansion.
+    [Fact]
+    public void unversioned_chain_is_left_alone_by_expansion()
+    {
+        var unversioned = HttpChain.ChainFor<UnversionedPlainHandler>(x => x.Get());
+        var multi = HttpChain.ChainFor<TwoVersionMethodOrdersHandler>(x => x.Get());
+
+        var chains = ListOf(unversioned, multi);
+        MultiVersionExpansion.ExpandInPlace(chains);
+
+        // Multi-version chain expanded to 2; unversioned chain still present, still unversioned.
+        chains.Count.ShouldBe(3);
+        chains.ShouldContain(unversioned);
+        unversioned.ApiVersion.ShouldBeNull();
+    }
+
+    // 13 — date-based versions like 2024-01-01 produce a legal identifier in the OperationId suffix.
+    // The pre-fix .Replace('.', '_') only handled dotted versions; hyphens leaked through.
+    [Fact]
+    public void date_based_version_produces_sanitized_operation_id_suffix()
+    {
+        var chains = ListOf(HttpChain.ChainFor<DateBasedVersionHandler>(x => x.Get()));
+        MultiVersionExpansion.ExpandInPlace(chains);
+
+        chains.Count.ShouldBe(2);
+
+        // The version-derived suffix must be a sanitised string (no hyphens, no dots).
+        // Inspect only the suffix added by CloneForVersion ("_v..." onwards).
+        var suffixes = chains.Select(c => c.OperationId.Substring(c.OperationId.LastIndexOf("_v"))).ToList();
+        suffixes.ShouldAllBe(suffix => !suffix.Contains('-') && !suffix.Contains('.'));
+
+        suffixes.ShouldContain("_v2024_01_01");
+        suffixes.ShouldContain("_v2025_06_15");
     }
 }

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/MultiVersionExpansionTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/MultiVersionExpansionTests.cs
@@ -93,6 +93,23 @@ internal class DateBasedVersionHandler
     public string Get() => "dated";
 }
 
+// Two distinct handler classes serving different versions of the SAME (verb, route).
+// Used to pin the cross-class sibling-merge behaviour in ApiVersioningPolicy.AttachMetadata.
+internal class FirstInventoryEndpointHandler
+{
+    [WolverineGet("/inventory")]
+    [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
+    public string Get() => "first";
+}
+
+internal class SecondInventoryEndpointHandler
+{
+    [WolverineGet("/inventory")]
+    [ApiVersion("3.0")]
+    public string Get() => "second";
+}
+
 public class MultiVersionExpansionTests
 {
     private static List<HttpChain> ListOf(params HttpChain[] chains) => new(chains);
@@ -268,6 +285,11 @@ public class MultiVersionExpansionTests
         ex.Message.ShouldContain("Duplicate endpoint registration");
         ex.Message.ShouldContain("/reports");
         ex.Message.ShouldContain("2.0");
+
+        // The diagnostic must name BOTH conflicting handler classes so the developer can locate
+        // the source of the collision without grepping. Regression guard for issue triage UX.
+        ex.Message.ShouldContain(nameof(FirstReportsMultiVersionHandler));
+        ex.Message.ShouldContain(nameof(SecondReportsMultiVersionHandler));
     }
 
     // 11 — [MapToApiVersion("X")] producing exactly one version: expansion leaves the chain in place,
@@ -323,7 +345,44 @@ public class MultiVersionExpansionTests
         var suffixes = chains.Select(c => c.OperationId.Substring(c.OperationId.LastIndexOf("_v"))).ToList();
         suffixes.ShouldAllBe(suffix => !suffix.Contains('-') && !suffix.Contains('.'));
 
-        suffixes.ShouldContain("_v2024_01_01");
-        suffixes.ShouldContain("_v2025_06_15");
+        // ShouldStartWith (rather than exact equality) leaves room for future Asp.Versioning
+        // changes that may append status/group decorations after the sanitised version body.
+        suffixes.ShouldContain(s => s.StartsWith("_v2024_01_01"));
+        suffixes.ShouldContain(s => s.StartsWith("_v2025_06_15"));
+    }
+
+    // 14 — multi-version handlers in DIFFERENT classes that share a (verb, route) merge into one
+    // sibling chain when ApiVersioningPolicy.AttachMetadata builds the api-supported-versions
+    // model. This pins the cross-class union behaviour that matches Asp.Versioning convention:
+    // any chain at the route is part of the same logical version set, regardless of which class
+    // declared which version.
+    [Fact]
+    public void cross_class_chains_at_same_route_share_supported_versions()
+    {
+        var chains = ListOf(
+            HttpChain.ChainFor<FirstInventoryEndpointHandler>(x => x.Get()),
+            HttpChain.ChainFor<SecondInventoryEndpointHandler>(x => x.Get()));
+
+        MultiVersionExpansion.ExpandInPlace(chains);
+
+        var policy = new ApiVersioningPolicy(new WolverineApiVersioningOptions());
+        policy.Apply(chains, new GenerationRules(), null!);
+
+        chains.Count.ShouldBe(3);
+        chains.Select(c => c.ApiVersion!.ToString()).OrderBy(s => s)
+            .ShouldBe(new[] { "1.0", "2.0", "3.0" });
+
+        var allVersions = new[] { new ApiVersion(1, 0), new ApiVersion(2, 0), new ApiVersion(3, 0) };
+
+        foreach (var chain in chains)
+        {
+            var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
+            var model = endpoint.Metadata.GetMetadata<ApiVersionMetadata>()!.Map(ApiVersionMapping.Explicit);
+
+            // SupportedApiVersions is the union of every sibling at (GET, /vN/inventory) regardless
+            // of which handler class produced the clone. ImplementedApiVersions therefore contains
+            // every version any sibling serves at that logical route.
+            model.ImplementedApiVersions.OrderBy(v => v).ShouldBe(allVersions);
+        }
     }
 }

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/MultiVersionExpansionTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/MultiVersionExpansionTests.cs
@@ -1,0 +1,169 @@
+using Asp.Versioning;
+using JasperFx.CodeGeneration;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Shouldly;
+using Wolverine.Http.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+// ---------- Test handler fixtures ----------
+
+internal class TwoVersionMethodOrdersHandler
+{
+    [WolverineGet("/orders")]
+    [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
+    public string Get() => "two-versions";
+}
+
+[ApiVersion("1.0")]
+[ApiVersion("2.0")]
+internal class ClassLevelTwoVersionOrdersHandler
+{
+    [WolverineGet("/items")]
+    public string Get() => "class-two-versions";
+}
+
+[ApiVersion("1.0")]
+[ApiVersion("2.0")]
+[ApiVersion("3.0")]
+internal class ClassThreeMapToTwoOrdersHandler
+{
+    [WolverineGet("/widgets")]
+    [MapToApiVersion("2.0")]
+    public string Get() => "filtered";
+}
+
+internal class TwoVersionWithPerVersionDeprecationHandler
+{
+    [WolverineGet("/legacy")]
+    [ApiVersion("1.0", Deprecated = true)]
+    [ApiVersion("2.0")]
+    public string Get() => "per-version-deprecation";
+}
+
+[ApiVersion("1.0")]
+internal class MapToInvalidVersionHandler
+{
+    [WolverineGet("/missing")]
+    [MapToApiVersion("3.0")]
+    public string Get() => "missing";
+}
+
+[ApiVersion("1.0")]
+internal class BothAttrsHandler
+{
+    [WolverineGet("/both")]
+    [ApiVersion("2.0")]
+    [MapToApiVersion("1.0")]
+    public string Get() => "both";
+}
+
+public class MultiVersionExpansionTests
+{
+    private static void Apply(ApiVersioningPolicy policy, params HttpChain[] chains)
+        => policy.Apply(chains, new GenerationRules(), null!);
+
+    private static List<HttpChain> ListOf(params HttpChain[] chains) => new(chains);
+
+    // 1 — multi-version method produces N versioned routes after expansion + policy.
+    [Fact]
+    public void method_level_two_versions_expand_to_two_routes()
+    {
+        var chains = ListOf(HttpChain.ChainFor<TwoVersionMethodOrdersHandler>(x => x.Get()));
+        MultiVersionExpansion.Expand(chains);
+
+        chains.Count.ShouldBe(2);
+        chains.Select(c => c.ApiVersion).ShouldBe(new[] { new ApiVersion(1, 0), new ApiVersion(2, 0) });
+
+        var policy = new ApiVersioningPolicy(new WolverineApiVersioningOptions());
+        policy.Apply(chains, new GenerationRules(), null!);
+
+        chains.Select(c => c.RoutePattern!.RawText).OrderBy(s => s).ShouldBe(new[] { "/v1/orders", "/v2/orders" });
+    }
+
+    // 2 — class-level [ApiVersion] list with method-level [MapToApiVersion] keeps only the listed subset.
+    [Fact]
+    public void mapto_filters_to_only_the_listed_version()
+    {
+        var chains = ListOf(HttpChain.ChainFor<ClassThreeMapToTwoOrdersHandler>(x => x.Get()));
+        MultiVersionExpansion.Expand(chains);
+
+        chains.Count.ShouldBe(1);
+        chains[0].ApiVersion.ShouldBe(new ApiVersion(2, 0));
+
+        var policy = new ApiVersioningPolicy(new WolverineApiVersioningOptions());
+        policy.Apply(chains, new GenerationRules(), null!);
+
+        chains[0].RoutePattern!.RawText.ShouldBe("/v2/widgets");
+    }
+
+    // 3 — class with [ApiVersion("1.0")] + method [MapToApiVersion("3.0")] fails fast at expansion.
+    [Fact]
+    public void mapto_for_unknown_class_version_throws_at_expansion_time()
+    {
+        var chains = ListOf(HttpChain.ChainFor<MapToInvalidVersionHandler>(x => x.Get()));
+
+        var ex = Should.Throw<InvalidOperationException>(() => MultiVersionExpansion.Expand(chains));
+        ex.Message.ShouldContain("MapToApiVersion");
+        ex.Message.ShouldContain("MapToInvalidVersionHandler");
+        ex.Message.ShouldContain("3.0");
+    }
+
+    // 4 — both [ApiVersion] and [MapToApiVersion] on the same method fails fast at expansion.
+    [Fact]
+    public void both_apiversion_and_mapto_throws_at_expansion_time()
+    {
+        var chains = ListOf(HttpChain.ChainFor<BothAttrsHandler>(x => x.Get()));
+
+        var ex = Should.Throw<InvalidOperationException>(() => MultiVersionExpansion.Expand(chains));
+        ex.Message.ShouldContain("[ApiVersion]");
+        ex.Message.ShouldContain("[MapToApiVersion]");
+    }
+
+    // 5 — per-version deprecation propagates only to the deprecated clone.
+    [Fact]
+    public void per_version_deprecation_applies_independently_across_clones()
+    {
+        var chains = ListOf(HttpChain.ChainFor<TwoVersionWithPerVersionDeprecationHandler>(x => x.Get()));
+        MultiVersionExpansion.Expand(chains);
+
+        chains.Count.ShouldBe(2);
+        var v1 = chains.Single(c => c.ApiVersion == new ApiVersion(1, 0));
+        var v2 = chains.Single(c => c.ApiVersion == new ApiVersion(2, 0));
+
+        v1.DeprecationPolicy.ShouldNotBeNull();
+        v2.DeprecationPolicy.ShouldBeNull();
+    }
+
+    // 6 — class-level multi-version with no method override expands per class versions.
+    [Fact]
+    public void class_level_two_versions_expand_to_two_routes()
+    {
+        var chains = ListOf(HttpChain.ChainFor<ClassLevelTwoVersionOrdersHandler>(x => x.Get()));
+        MultiVersionExpansion.Expand(chains);
+
+        chains.Count.ShouldBe(2);
+        chains.Select(c => c.ApiVersion).ShouldBe(new[] { new ApiVersion(1, 0), new ApiVersion(2, 0) });
+    }
+
+    // 7 — versioned-route metadata wires up per clone with distinct ApiVersionMetadata.
+    [Fact]
+    public void per_version_metadata_attached_to_each_clone()
+    {
+        var chains = ListOf(HttpChain.ChainFor<TwoVersionMethodOrdersHandler>(x => x.Get()));
+        MultiVersionExpansion.Expand(chains);
+
+        var policy = new ApiVersioningPolicy(new WolverineApiVersioningOptions());
+        policy.Apply(chains, new GenerationRules(), null!);
+
+        foreach (var chain in chains)
+        {
+            var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
+            var versionMeta = endpoint.Metadata.GetMetadata<ApiVersionMetadata>();
+            versionMeta.ShouldNotBeNull();
+            versionMeta!.Map(ApiVersionMapping.Explicit).ImplementedApiVersions.ShouldContain(chain.ApiVersion!);
+        }
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/MultiVersionResolverTests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/MultiVersionResolverTests.cs
@@ -1,0 +1,138 @@
+using System.Reflection;
+using Asp.Versioning;
+using Shouldly;
+using Wolverine.Http.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+internal class MethodMultiVersionHandler
+{
+    [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
+    public void Handle() { }
+}
+
+internal class MethodMultiVersionWithDeprecationHandler
+{
+    [ApiVersion("1.0", Deprecated = true)]
+    [ApiVersion("2.0")]
+    public void Handle() { }
+}
+
+[ApiVersion("1.0")]
+[ApiVersion("2.0")]
+internal class ClassMultiVersionHandler
+{
+    public void Handle() { }
+}
+
+[ApiVersion("1.0")]
+[ApiVersion("2.0")]
+[ApiVersion("3.0")]
+internal class ClassMultiVersionWithMapToHandler
+{
+    [MapToApiVersion("2.0")]
+    public void Handle() { }
+}
+
+[ApiVersion("1.0")]
+internal class ClassWithMissingMapToHandler
+{
+    [MapToApiVersion("3.0")]
+    public void Handle() { }
+}
+
+internal class MapToWithoutClassHandler
+{
+    [MapToApiVersion("1.0")]
+    public void Handle() { }
+}
+
+[ApiVersion("1.0")]
+internal class BothApiVersionAndMapToHandler
+{
+    [ApiVersion("2.0")]
+    [MapToApiVersion("1.0")]
+    public void Handle() { }
+}
+
+public class MultiVersionResolverTests
+{
+    private static MethodInfo MethodOf<T>(string name)
+        => typeof(T).GetMethod(name, BindingFlags.Public | BindingFlags.Instance)!;
+
+    [Fact]
+    public void method_with_two_apiversion_attributes_returns_both_versions()
+    {
+        var method = MethodOf<MethodMultiVersionHandler>(nameof(MethodMultiVersionHandler.Handle));
+        var versions = ApiVersionResolver.ResolveVersions(method);
+
+        versions.Count.ShouldBe(2);
+        versions.Select(r => r.Version).ShouldBe(new[] { new ApiVersion(1, 0), new ApiVersion(2, 0) });
+        versions.All(r => !r.IsDeprecated).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void method_per_version_deprecation_is_applied_independently()
+    {
+        var method = MethodOf<MethodMultiVersionWithDeprecationHandler>(nameof(MethodMultiVersionWithDeprecationHandler.Handle));
+        var versions = ApiVersionResolver.ResolveVersions(method).OrderBy(v => v.Version).ToList();
+
+        versions.Count.ShouldBe(2);
+        versions[0].Version.ShouldBe(new ApiVersion(1, 0));
+        versions[0].IsDeprecated.ShouldBeTrue();
+        versions[1].Version.ShouldBe(new ApiVersion(2, 0));
+        versions[1].IsDeprecated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void class_multi_version_method_returns_all_class_versions()
+    {
+        var method = MethodOf<ClassMultiVersionHandler>(nameof(ClassMultiVersionHandler.Handle));
+        var versions = ApiVersionResolver.ResolveVersions(method);
+
+        versions.Select(r => r.Version).ShouldBe(new[] { new ApiVersion(1, 0), new ApiVersion(2, 0) });
+    }
+
+    [Fact]
+    public void mapto_filters_class_level_versions_to_listed_subset()
+    {
+        var method = MethodOf<ClassMultiVersionWithMapToHandler>(nameof(ClassMultiVersionWithMapToHandler.Handle));
+        var versions = ApiVersionResolver.ResolveVersions(method);
+
+        versions.Count.ShouldBe(1);
+        versions[0].Version.ShouldBe(new ApiVersion(2, 0));
+    }
+
+    [Fact]
+    public void mapto_listing_version_not_on_class_throws_naming_both()
+    {
+        var method = MethodOf<ClassWithMissingMapToHandler>(nameof(ClassWithMissingMapToHandler.Handle));
+
+        var ex = Should.Throw<InvalidOperationException>(() => ApiVersionResolver.ResolveVersions(method));
+        ex.Message.ShouldContain("MapToApiVersion");
+        ex.Message.ShouldContain("ClassWithMissingMapToHandler");
+        ex.Message.ShouldContain("3.0");
+        ex.Message.ShouldContain("1.0");
+    }
+
+    [Fact]
+    public void mapto_without_class_apiversion_throws()
+    {
+        var method = MethodOf<MapToWithoutClassHandler>(nameof(MapToWithoutClassHandler.Handle));
+
+        var ex = Should.Throw<InvalidOperationException>(() => ApiVersionResolver.ResolveVersions(method));
+        ex.Message.ShouldContain("MapToApiVersion");
+        ex.Message.ShouldContain("MapToWithoutClassHandler");
+    }
+
+    [Fact]
+    public void apiversion_and_mapto_on_same_method_throws()
+    {
+        var method = MethodOf<BothApiVersionAndMapToHandler>(nameof(BothApiVersionAndMapToHandler.Handle));
+
+        var ex = Should.Throw<InvalidOperationException>(() => ApiVersionResolver.ResolveVersions(method));
+        ex.Message.ShouldContain("[ApiVersion]");
+        ex.Message.ShouldContain("[MapToApiVersion]");
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/api_versioning_integration_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/api_versioning_integration_tests.cs
@@ -94,7 +94,10 @@ public class api_versioning_integration_tests : IntegrationContext
     [Fact]
     public async Task api_supported_versions_header_lists_all_versions()
     {
-        // Any versioned endpoint emits api-supported-versions
+        // Any versioned endpoint emits api-supported-versions, built from the per-endpoint
+        // ApiVersionMetadata seeded by ApiVersioningPolicy with the full sibling union at the
+        // shared (verb, route-after-strip-prefix). For /vN/orders the siblings are v1+v2+v3
+        // (OrdersV1Endpoint, OrdersV2Endpoint, OrdersV3PreviewEndpoint).
         var result = await Scenario(x =>
         {
             x.Get.Url("/v2/orders");
@@ -103,8 +106,7 @@ public class api_versioning_integration_tests : IntegrationContext
 
         var header = result.Context.Response.Headers["api-supported-versions"].FirstOrDefault();
         header.ShouldNotBeNull();
-        // The header is built from SunsetPolicies (3.0) + DeprecationPolicies (1.0), sorted ascending
-        header.ShouldBe("1.0, 3.0");
+        header.ShouldBe("1.0, 2.0, 3.0");
     }
 
     [Fact]

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/multi_version_integration_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/multi_version_integration_tests.cs
@@ -122,4 +122,36 @@ public class multi_version_integration_tests : IntegrationContext
             x.StatusCodeShouldBe(404);
         });
     }
+
+    [Fact]
+    public async Task multi_version_endpoint_emits_api_supported_versions_with_sibling_set()
+    {
+        // GET /v1/customers is one clone of CustomersMultiVersionEndpoint, which declares 1.0/2.0/3.0,
+        // and the same (verb, route-after-strip-prefix) is also served by CustomersV4AttributeDeprecatedEndpoint
+        // at v4.0. The api-supported-versions header on this clone must report the FULL sibling union
+        // (every version that serves GET /customers regardless of which handler class), not just the
+        // per-options policy keys nor the per-clone version. This pins the per-endpoint metadata wiring.
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v1/customers");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var supported = result.Context.Response.Headers["api-supported-versions"].FirstOrDefault();
+        supported.ShouldNotBeNull();
+
+        var values = supported!
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .OrderBy(v => v)
+            .ToArray();
+
+        // v1 is deprecated (per-attribute) so reported under deprecated, not supported. v2/v3 supported
+        // come from CustomersMultiVersionEndpoint, v4 is deprecated (per-attribute) so reported under
+        // deprecated. The combined api-supported-versions header reports the full sibling chain, so
+        // every version that has a clone at GET /customers must appear.
+        values.ShouldContain("1.0");
+        values.ShouldContain("2.0");
+        values.ShouldContain("3.0");
+        values.ShouldContain("4.0");
+    }
 }

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/multi_version_integration_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/multi_version_integration_tests.cs
@@ -1,0 +1,106 @@
+using Alba;
+using Shouldly;
+using WolverineWebApi.ApiVersioning;
+
+namespace Wolverine.Http.Tests.ApiVersioning;
+
+[Collection("integration")]
+public class multi_version_integration_tests : IntegrationContext
+{
+    public multi_version_integration_tests(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task multi_version_endpoint_registers_v1_route()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v1/customers");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var response = result.ReadAsJson<CustomersResponse>();
+        response!.Names.ShouldContain("alice");
+    }
+
+    [Fact]
+    public async Task multi_version_endpoint_registers_v2_route()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v2/customers");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var response = result.ReadAsJson<CustomersResponse>();
+        response!.Names.ShouldContain("alice");
+    }
+
+    [Fact]
+    public async Task multi_version_endpoint_registers_v3_route()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v3/customers");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var response = result.ReadAsJson<CustomersResponse>();
+        response!.Names.ShouldContain("alice");
+    }
+
+    [Fact]
+    public async Task multi_version_endpoint_v1_is_marked_deprecated()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v1/customers");
+            x.StatusCodeShouldBeOk();
+        });
+
+        // Per-version deprecation: v1 carries [ApiVersion("1.0", Deprecated=true)].
+        var deprecation = result.Context.Response.Headers["Deprecation"].FirstOrDefault();
+        deprecation.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task multi_version_endpoint_v2_is_not_deprecated()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v2/customers");
+            x.StatusCodeShouldBeOk();
+        });
+
+        // v2 has [ApiVersion("2.0")] without Deprecated; no per-version Deprecation header.
+        var deprecation = result.Context.Response.Headers["Deprecation"].FirstOrDefault();
+        deprecation.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task mapto_apiversion_registers_only_listed_version()
+    {
+        var v2 = await Scenario(x =>
+        {
+            x.Get.Url("/v2/customers/v2-only");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var response = v2.ReadAsJson<CustomersResponse>();
+        response!.Names.ShouldContain("v2-only-alice");
+
+        // v1 and v3 routes for this endpoint must not exist.
+        await Scenario(x =>
+        {
+            x.Get.Url("/v1/customers/v2-only");
+            x.StatusCodeShouldBe(404);
+        });
+
+        await Scenario(x =>
+        {
+            x.Get.Url("/v3/customers/v2-only");
+            x.StatusCodeShouldBe(404);
+        });
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/ApiVersioning/multi_version_integration_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/ApiVersioning/multi_version_integration_tests.cs
@@ -51,7 +51,7 @@ public class multi_version_integration_tests : IntegrationContext
     }
 
     [Fact]
-    public async Task multi_version_endpoint_v1_is_marked_deprecated()
+    public async Task multi_version_endpoint_v1_carries_globally_configured_deprecation()
     {
         var result = await Scenario(x =>
         {
@@ -59,7 +59,10 @@ public class multi_version_integration_tests : IntegrationContext
             x.StatusCodeShouldBeOk();
         });
 
-        // Per-version deprecation: v1 carries [ApiVersion("1.0", Deprecated=true)].
+        // Program.cs registers options.Deprecate("1.0") globally, so v1 endpoints emit the
+        // header regardless of the per-version [ApiVersion(..., Deprecated = true)] attribute.
+        // This test pins down the options-driven path. Attribute-only deprecation is asserted
+        // separately on /v4/customers, which has no matching options.Deprecate call.
         var deprecation = result.Context.Response.Headers["Deprecation"].FirstOrDefault();
         deprecation.ShouldNotBeNull();
     }
@@ -76,6 +79,22 @@ public class multi_version_integration_tests : IntegrationContext
         // v2 has [ApiVersion("2.0")] without Deprecated; no per-version Deprecation header.
         var deprecation = result.Context.Response.Headers["Deprecation"].FirstOrDefault();
         deprecation.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task v4_endpoint_deprecation_comes_from_attribute_alone()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/v4/customers");
+            x.StatusCodeShouldBeOk();
+        });
+
+        // CustomersV4AttributeDeprecatedEndpoint is decorated with [ApiVersion("4.0", Deprecated = true)]
+        // and Program.cs registers no options.Deprecate("4.0"). The Deprecation header therefore
+        // proves the attribute-driven deprecation path works independently of the options map.
+        var deprecation = result.Context.Response.Headers["Deprecation"].FirstOrDefault();
+        deprecation.ShouldNotBeNull();
     }
 
     [Fact]

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersionHeaderWriter.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersionHeaderWriter.cs
@@ -33,10 +33,12 @@ public sealed class ApiVersionHeaderWriter
     private readonly WolverineApiVersioningOptions _options;
 
     // Computed once on first request via Lazy<T>. Policies added to the options
-    // dictionaries after the first request will not appear in this header. In normal
+    // dictionaries after the first request will not appear in this fallback header.
+    // The fallback only applies to chains whose endpoint has no ApiVersionMetadata
+    // (i.e. chains not produced by ApiVersioningPolicy's per-clone wiring); in normal
     // app startup all policies are registered before any HTTP request is processed,
     // so this is a safe optimization.
-    private readonly Lazy<string> _supportedVersionsHeader;
+    private readonly Lazy<string> _fallbackSupportedVersionsHeader;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ApiVersionHeaderWriter"/>.
@@ -45,25 +47,35 @@ public sealed class ApiVersionHeaderWriter
     public ApiVersionHeaderWriter(WolverineApiVersioningOptions options)
     {
         _options = options;
-        _supportedVersionsHeader = new Lazy<string>(() => BuildSupportedVersionsHeader(options));
+        _fallbackSupportedVersionsHeader = new Lazy<string>(() => BuildFallbackSupportedVersionsHeader(options));
     }
 
     /// <summary>
     /// Writes the applicable versioning response headers to <paramref name="context"/>.
     /// Reads per-chain state from <see cref="ApiVersionEndpointHeaderState"/> stored in the
     /// matched endpoint's metadata. If no state is present the method returns immediately.
+    /// The <c>api-supported-versions</c> header reads from the endpoint's
+    /// <see cref="ApiVersionMetadata"/> (seeded by <see cref="ApiVersioningPolicy"/> with the
+    /// full sibling union for chains at the same <c>(verb, route-after-strip-prefix)</c>),
+    /// falling back to the options-driven sunset/deprecation key union when no metadata is
+    /// present on the endpoint.
     /// </summary>
     /// <param name="context">The current HTTP context.</param>
     public Task WriteAsync(HttpContext context)
     {
-        var state = context.GetEndpoint()?.Metadata.GetMetadata<ApiVersionEndpointHeaderState>();
+        var endpoint = context.GetEndpoint();
+        var state = endpoint?.Metadata.GetMetadata<ApiVersionEndpointHeaderState>();
         if (state is null)
             return Task.CompletedTask;
 
         var headers = context.Response.Headers;
 
-        if (_options.EmitApiSupportedVersionsHeader && _supportedVersionsHeader.Value.Length > 0)
-            headers["api-supported-versions"] = _supportedVersionsHeader.Value;
+        if (_options.EmitApiSupportedVersionsHeader)
+        {
+            var supportedHeader = BuildSupportedVersionsHeader(endpoint!);
+            if (supportedHeader.Length > 0)
+                headers["api-supported-versions"] = supportedHeader;
+        }
 
         if (_options.EmitDeprecationHeaders)
         {
@@ -85,7 +97,33 @@ public sealed class ApiVersionHeaderWriter
         return Task.CompletedTask;
     }
 
-    private static string BuildSupportedVersionsHeader(WolverineApiVersioningOptions options)
+    /// <summary>
+    /// Build the <c>api-supported-versions</c> header value for a single request. The endpoint's
+    /// <see cref="ApiVersionMetadata"/> is the authoritative source — it carries the full sibling
+    /// union assembled by <see cref="ApiVersioningPolicy"/> at startup, so the header reflects every
+    /// version that serves the same <c>(verb, route-after-strip-prefix)</c>, supported and
+    /// deprecated alike (matching the Asp.Versioning convention of reporting
+    /// <c>ImplementedApiVersions</c>). Falls back to the options-driven union for chains that have
+    /// no per-endpoint metadata (e.g. chains wired up outside the policy pipeline).
+    /// </summary>
+    private string BuildSupportedVersionsHeader(Endpoint endpoint)
+    {
+        var metadata = endpoint.Metadata.GetMetadata<ApiVersionMetadata>();
+        if (metadata is null)
+            return _fallbackSupportedVersionsHeader.Value;
+
+        var model = metadata.Map(ApiVersionMapping.Explicit);
+        var versions = model.ImplementedApiVersions;
+        if (versions.Count == 0)
+            return _fallbackSupportedVersionsHeader.Value;
+
+        return string.Join(", ", versions
+            .OrderBy(v => v.MajorVersion ?? int.MaxValue)
+            .ThenBy(v => v.MinorVersion ?? int.MaxValue)
+            .Select(v => v.ToString()));
+    }
+
+    private static string BuildFallbackSupportedVersionsHeader(WolverineApiVersioningOptions options)
     {
         var versions = options.SunsetPolicies.Keys
             .Concat(options.DeprecationPolicies.Keys)

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersionResolver.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersionResolver.cs
@@ -9,44 +9,112 @@ internal static class ApiVersionResolver
 {
     /// <summary>
     /// Resolves the API version declared on a handler method. The method's [ApiVersion] wins;
-    /// the declaring class's [ApiVersion] is used as a fallback.
+    /// the declaring class's [ApiVersion] is used as a fallback. Throws when more than one
+    /// version is declared — callers expecting multi-version support should use
+    /// <see cref="ResolveVersions"/>.
     /// </summary>
     /// <param name="method">The handler method.</param>
     /// <returns>The single resolved ApiVersion with deprecation status, or null if no [ApiVersion] is present.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the method (or, when no method-level attribute is present, the declaring class) declares more than one ApiVersion in a single ApiVersionAttribute or via multiple attributes.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when multiple versions are declared.</exception>
     public static ApiVersionResolution? Resolve(MethodInfo method)
     {
-        var methodAttrs = method.GetCustomAttributes<ApiVersionAttribute>(inherit: false).ToList();
-        List<ApiVersionAttribute> winningAttrs;
+        var versions = ResolveVersions(method);
+        if (versions.Count == 0) return null;
+        if (versions.Count == 1) return versions[0];
 
-        if (methodAttrs.Count > 0)
-        {
-            winningAttrs = methodAttrs;
-        }
-        else
-        {
-            var classAttrs = method.DeclaringType?.GetCustomAttributes<ApiVersionAttribute>(inherit: false).ToList();
-            if (classAttrs is null || classAttrs.Count == 0)
-            {
-                return null;
-            }
-
-            winningAttrs = classAttrs;
-        }
-
-        var versions = winningAttrs.SelectMany(a => a.Versions).Distinct().ToList();
-
-        if (versions.Count == 1)
-        {
-            var version = versions[0];
-            var isDeprecated = winningAttrs.Any(a => a.Deprecated && a.Versions.Contains(version));
-            return new ApiVersionResolution(version, isDeprecated);
-        }
-
-        var methodIdentity = (method.DeclaringType?.FullName ?? method.DeclaringType?.Name ?? "?") + "." + method.Name;
-        var versionList = string.Join(", ", versions);
+        var methodIdentity = MethodIdentity(method);
+        var versionList = string.Join(", ", versions.Select(v => v.Version.ToString()));
         throw new InvalidOperationException(
             $"Handler method '{methodIdentity}' declares multiple API versions [{versionList}]. " +
-            "Multi-version handlers are not supported in this version of Wolverine.Http API versioning.");
+            "Use ResolveVersions to support multi-version handlers.");
     }
+
+    /// <summary>
+    /// Resolves all API versions a handler method serves. Resolution rules:
+    /// <list type="bullet">
+    ///   <item>Method-level <c>[ApiVersion]</c> attributes (if any) override class-level entirely.</item>
+    ///   <item>Method-level <c>[MapToApiVersion]</c> filters class-level versions to the listed subset.</item>
+    ///   <item>A method may not carry both <c>[ApiVersion]</c> and <c>[MapToApiVersion]</c>.</item>
+    /// </list>
+    /// </summary>
+    /// <param name="method">The handler method.</param>
+    /// <returns>An ordered, distinct list of <see cref="ApiVersionResolution"/>; empty when no version attributes are present.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when both <c>[ApiVersion]</c> and <c>[MapToApiVersion]</c> are declared on the same method, or when <c>[MapToApiVersion]</c> lists a version not declared on the class.</exception>
+    public static IReadOnlyList<ApiVersionResolution> ResolveVersions(MethodInfo method)
+    {
+        var methodApiVersionAttrs = method.GetCustomAttributes<ApiVersionAttribute>(inherit: false).ToList();
+        var methodMapToAttrs = method.GetCustomAttributes<MapToApiVersionAttribute>(inherit: false).ToList();
+
+        if (methodApiVersionAttrs.Count > 0 && methodMapToAttrs.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Handler method '{MethodIdentity(method)}' declares both [ApiVersion] and [MapToApiVersion] attributes. " +
+                "Use only one: [ApiVersion] sets versions independently of the class; " +
+                "[MapToApiVersion] selects a subset of the class-level versions.");
+        }
+
+        // Method-level [ApiVersion] overrides class entirely.
+        if (methodApiVersionAttrs.Count > 0)
+        {
+            return BuildResolutions(methodApiVersionAttrs);
+        }
+
+        var classApiVersionAttrs = method.DeclaringType?
+            .GetCustomAttributes<ApiVersionAttribute>(inherit: false)
+            .ToList() ?? new List<ApiVersionAttribute>();
+
+        // Method-level [MapToApiVersion] filters class-level versions.
+        if (methodMapToAttrs.Count > 0)
+        {
+            if (classApiVersionAttrs.Count == 0)
+            {
+                var className = method.DeclaringType?.FullName ?? method.DeclaringType?.Name ?? "?";
+                throw new InvalidOperationException(
+                    $"Handler method '{MethodIdentity(method)}' has [MapToApiVersion] but the declaring class '{className}' has no [ApiVersion] attribute. " +
+                    "[MapToApiVersion] only filters class-level versions; declare class-level [ApiVersion] first.");
+            }
+
+            var classVersions = classApiVersionAttrs.SelectMany(a => a.Versions).Distinct().ToList();
+            var requestedVersions = methodMapToAttrs.SelectMany(a => a.Versions).Distinct().ToList();
+
+            var missing = requestedVersions.Where(v => !classVersions.Contains(v)).ToList();
+            if (missing.Count > 0)
+            {
+                var className = method.DeclaringType?.FullName ?? method.DeclaringType?.Name ?? "?";
+                var missingList = string.Join(", ", missing.Select(v => v.ToString()));
+                var classList = string.Join(", ", classVersions.Select(v => v.ToString()));
+                throw new InvalidOperationException(
+                    $"Handler method '{MethodIdentity(method)}' has [MapToApiVersion({missingList})] but the declaring class '{className}' " +
+                    $"only declares [ApiVersion] for [{classList}]. [MapToApiVersion] must list a subset of class-level versions.");
+            }
+
+            // Deprecation flags on the class still apply to the filtered subset.
+            var resolutions = new List<ApiVersionResolution>(requestedVersions.Count);
+            foreach (var version in requestedVersions)
+            {
+                var isDeprecated = classApiVersionAttrs.Any(a => a.Deprecated && a.Versions.Contains(version));
+                resolutions.Add(new ApiVersionResolution(version, isDeprecated));
+            }
+            return resolutions;
+        }
+
+        if (classApiVersionAttrs.Count == 0) return Array.Empty<ApiVersionResolution>();
+        return BuildResolutions(classApiVersionAttrs);
+    }
+
+    private static IReadOnlyList<ApiVersionResolution> BuildResolutions(IEnumerable<ApiVersionAttribute> attrs)
+    {
+        var attrList = attrs.ToList();
+        var versions = attrList.SelectMany(a => a.Versions).Distinct().ToList();
+        var result = new List<ApiVersionResolution>(versions.Count);
+        foreach (var version in versions)
+        {
+            var isDeprecated = attrList.Any(a => a.Deprecated && a.Versions.Contains(version));
+            result.Add(new ApiVersionResolution(version, isDeprecated));
+        }
+        return result;
+    }
+
+    private static string MethodIdentity(MethodInfo method) =>
+        (method.DeclaringType?.FullName ?? method.DeclaringType?.Name ?? "?") + "." + method.Name;
 }

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersionResolver.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersionResolver.cs
@@ -8,28 +8,6 @@ internal readonly record struct ApiVersionResolution(ApiVersion Version, bool Is
 internal static class ApiVersionResolver
 {
     /// <summary>
-    /// Resolves the API version declared on a handler method. The method's [ApiVersion] wins;
-    /// the declaring class's [ApiVersion] is used as a fallback. Throws when more than one
-    /// version is declared — callers expecting multi-version support should use
-    /// <see cref="ResolveVersions"/>.
-    /// </summary>
-    /// <param name="method">The handler method.</param>
-    /// <returns>The single resolved ApiVersion with deprecation status, or null if no [ApiVersion] is present.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when multiple versions are declared.</exception>
-    public static ApiVersionResolution? Resolve(MethodInfo method)
-    {
-        var versions = ResolveVersions(method);
-        if (versions.Count == 0) return null;
-        if (versions.Count == 1) return versions[0];
-
-        var methodIdentity = MethodIdentity(method);
-        var versionList = string.Join(", ", versions.Select(v => v.Version.ToString()));
-        throw new InvalidOperationException(
-            $"Handler method '{methodIdentity}' declares multiple API versions [{versionList}]. " +
-            "Use ResolveVersions to support multi-version handlers.");
-    }
-
-    /// <summary>
     /// Resolves all API versions a handler method serves. Resolution rules:
     /// <list type="bullet">
     ///   <item>Method-level <c>[ApiVersion]</c> attributes (if any) override class-level entirely.</item>
@@ -56,7 +34,8 @@ internal static class ApiVersionResolver
         // Method-level [ApiVersion] overrides class entirely.
         if (methodApiVersionAttrs.Count > 0)
         {
-            return BuildResolutions(methodApiVersionAttrs);
+            var methodVersions = methodApiVersionAttrs.SelectMany(a => a.Versions).Distinct().ToList();
+            return BuildResolutions(methodVersions, methodApiVersionAttrs);
         }
 
         var classApiVersionAttrs = method.DeclaringType?
@@ -89,27 +68,28 @@ internal static class ApiVersionResolver
             }
 
             // Deprecation flags on the class still apply to the filtered subset.
-            var resolutions = new List<ApiVersionResolution>(requestedVersions.Count);
-            foreach (var version in requestedVersions)
-            {
-                var isDeprecated = classApiVersionAttrs.Any(a => a.Deprecated && a.Versions.Contains(version));
-                resolutions.Add(new ApiVersionResolution(version, isDeprecated));
-            }
-            return resolutions;
+            return BuildResolutions(requestedVersions, classApiVersionAttrs);
         }
 
         if (classApiVersionAttrs.Count == 0) return Array.Empty<ApiVersionResolution>();
-        return BuildResolutions(classApiVersionAttrs);
+        var classDeclared = classApiVersionAttrs.SelectMany(a => a.Versions).Distinct().ToList();
+        return BuildResolutions(classDeclared, classApiVersionAttrs);
     }
 
-    private static IReadOnlyList<ApiVersionResolution> BuildResolutions(IEnumerable<ApiVersionAttribute> attrs)
+    /// <summary>
+    /// Builds resolutions for the given <paramref name="versions"/> in order, marking each as
+    /// deprecated when any attribute in <paramref name="deprecationSource"/> declares the version
+    /// with <see cref="ApiVersionAttribute.Deprecated"/>. Used by every branch of
+    /// <see cref="ResolveVersions"/>: class-only, method-only, and [MapToApiVersion] filtering.
+    /// </summary>
+    private static IReadOnlyList<ApiVersionResolution> BuildResolutions(
+        IReadOnlyCollection<ApiVersion> versions,
+        IReadOnlyCollection<ApiVersionAttribute> deprecationSource)
     {
-        var attrList = attrs.ToList();
-        var versions = attrList.SelectMany(a => a.Versions).Distinct().ToList();
         var result = new List<ApiVersionResolution>(versions.Count);
         foreach (var version in versions)
         {
-            var isDeprecated = attrList.Any(a => a.Deprecated && a.Versions.Contains(version));
+            var isDeprecated = deprecationSource.Any(a => a.Deprecated && a.Versions.Contains(version));
             result.Add(new ApiVersionResolution(version, isDeprecated));
         }
         return result;

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
@@ -48,7 +48,10 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
 
     /// <summary>Step A — read <c>[ApiVersion]</c> from the handler method and propagate to the chain.
     /// Multi-version expansion runs earlier in <see cref="HttpGraph.DiscoverEndpoints"/>, so chains
-    /// reaching this step have either no version or one already set by the expansion.</summary>
+    /// reaching this step have either no version or one already set by the expansion. Use
+    /// <see cref="ApiVersionResolver.ResolveVersions"/> directly with FirstOrDefault — it is safe
+    /// here because every chain at this point declares at most one version (expansion removed
+    /// the multi-version cases and inserted per-version clones).</summary>
     private static void ResolveAttributes(IReadOnlyList<HttpChain> chains)
     {
         foreach (var chain in chains)
@@ -61,13 +64,13 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
             if (chain.ApiVersion is not null)
                 continue;
 
-            var resolution = ApiVersionResolver.Resolve(chain.Method.Method);
-            if (resolution is null)
+            var resolution = ApiVersionResolver.ResolveVersions(chain.Method.Method).FirstOrDefault();
+            if (resolution.Version is null)
                 continue;
 
-            chain.ApiVersion = resolution.Value.Version;
+            chain.ApiVersion = resolution.Version;
 
-            if (resolution.Value.IsDeprecated && chain.DeprecationPolicy is null)
+            if (resolution.IsDeprecated && chain.DeprecationPolicy is null)
                 chain.DeprecationPolicy = new DeprecationPolicy();
         }
     }
@@ -189,9 +192,33 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
         return "/" + _options.UrlSegmentPrefix!.Replace("{version}", versionSegment).TrimStart('/');
     }
 
-    /// <summary>Step F — attach group-name, ApiVersionMetadata, and ensure unique endpoint names.</summary>
+    /// <summary>Step F — attach group-name, ApiVersionMetadata, and ensure unique endpoint names.
+    /// The <c>ApiVersionMetadata</c> model is seeded with the union of versions implemented at the
+    /// same (verb, route) pair so the <c>api-supported-versions</c> response header reports every
+    /// sibling clone, not just this clone's own version.</summary>
     private void AttachMetadata(IReadOnlyList<HttpChain> chains)
     {
+        // Group versioned chains by (verb, route-without-version-prefix). Two chains in the same
+        // group are siblings — typically multi-version clones, but also any chains that happen to
+        // share a verb and the post-strip route. Each clone's model advertises the full sibling set
+        // as supported / deprecated so the response header consumers see the union.
+        var siblingsByKey = new Dictionary<(string Verb, string Route), List<HttpChain>>();
+        foreach (var chain in chains)
+        {
+            if (chain.ApiVersion is null) continue;
+
+            var key = (
+                Verb: chain.HttpMethods.FirstOrDefault() ?? "",
+                Route: StripVersionPrefix(chain));
+
+            if (!siblingsByKey.TryGetValue(key, out var bucket))
+            {
+                bucket = new List<HttpChain>();
+                siblingsByKey[key] = bucket;
+            }
+            bucket.Add(chain);
+        }
+
         foreach (var chain in chains)
         {
             if (chain.ApiVersion is null || !_processedChains.Add(chain))
@@ -200,7 +227,28 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
             var groupName = _options.OpenApi.DocumentNameStrategy(chain.ApiVersion);
             chain.Metadata.WithGroupName(groupName);
 
-            var model = new ApiVersionModel(chain.ApiVersion);
+            var key = (
+                Verb: chain.HttpMethods.FirstOrDefault() ?? "",
+                Route: StripVersionPrefix(chain));
+
+            var siblings = siblingsByKey[key];
+            var supported = siblings
+                .Where(s => s.DeprecationPolicy is null)
+                .Select(s => s.ApiVersion!)
+                .Distinct()
+                .ToArray();
+            var deprecated = siblings
+                .Where(s => s.DeprecationPolicy is not null)
+                .Select(s => s.ApiVersion!)
+                .Distinct()
+                .ToArray();
+
+            var model = new ApiVersionModel(
+                declaredVersions: new[] { chain.ApiVersion },
+                supportedVersions: supported,
+                deprecatedVersions: deprecated,
+                advertisedVersions: Array.Empty<ApiVersion>(),
+                deprecatedAdvertisedVersions: Array.Empty<ApiVersion>());
             chain.Metadata.WithMetadata(new ApiVersionMetadata(model, model));
 
             // Make the OperationId (already unique per handler type + method) the explicit
@@ -210,6 +258,23 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
             if (!chain.HasExplicitOperationId)
                 chain.SetExplicitOperationId(chain.OperationId);
         }
+    }
+
+    /// <summary>Removes the URL-segment version prefix (if one was injected by <see cref="RewriteRoutes"/>)
+    /// from the chain's current route, returning the trailing portion that is identical across all
+    /// sibling versions. When <see cref="WolverineApiVersioningOptions.UrlSegmentPrefix"/> is null
+    /// the original route is returned unchanged.</summary>
+    private string StripVersionPrefix(HttpChain chain)
+    {
+        var route = chain.RoutePattern?.RawText ?? string.Empty;
+        if (_options.UrlSegmentPrefix is null) return route;
+
+        var prefix = BuildExpectedPrefix(chain.ApiVersion!);
+        if (route == prefix) return string.Empty;
+        if (route.StartsWith(prefix + "/", StringComparison.Ordinal))
+            return route.Substring(prefix.Length);
+
+        return route;
     }
 
     /// <summary>Step G — register the response-header postprocessor for chains that emit headers.</summary>

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
@@ -48,10 +48,9 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
 
     /// <summary>Step A — read <c>[ApiVersion]</c> from the handler method and propagate to the chain.
     /// Multi-version expansion runs earlier in <see cref="HttpGraph.DiscoverEndpoints"/>, so chains
-    /// reaching this step have either no version or one already set by the expansion. Use
-    /// <see cref="ApiVersionResolver.ResolveVersions"/> directly with FirstOrDefault — it is safe
-    /// here because every chain at this point declares at most one version (expansion removed
-    /// the multi-version cases and inserted per-version clones).</summary>
+    /// reaching this step have either no version or one already set by the expansion. Index the
+    /// resolver result explicitly after a count check so the <c>default(ApiVersionResolution)</c>
+    /// foot-gun (a struct with a null <c>Version</c>) is not relied on for the empty case.</summary>
     private static void ResolveAttributes(IReadOnlyList<HttpChain> chains)
     {
         foreach (var chain in chains)
@@ -64,10 +63,11 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
             if (chain.ApiVersion is not null)
                 continue;
 
-            var resolution = ApiVersionResolver.ResolveVersions(chain.Method.Method).FirstOrDefault();
-            if (resolution.Version is null)
+            var versions = ApiVersionResolver.ResolveVersions(chain.Method.Method);
+            if (versions.Count == 0)
                 continue;
 
+            var resolution = versions[0];
             chain.ApiVersion = resolution.Version;
 
             if (resolution.IsDeprecated && chain.DeprecationPolicy is null)
@@ -132,7 +132,11 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
 
         foreach (var conflict in conflicts)
         {
-            var names = string.Join(", ", conflict.Select(Identify));
+            // Use OperationId here (rather than the shared DisplayName) so the diagnostic names
+            // every conflicting clone individually — the version-suffixed OperationIds make each
+            // clone uniquely identifiable when sibling clones across distinct handler classes
+            // collide at the same (verb, route, version) triple.
+            var names = string.Join(", ", conflict.Select(c => c.OperationId));
             throw new InvalidOperationException(
                 $"Duplicate endpoint registration detected: " +
                 $"[{conflict.Key.Verb}] '{conflict.Key.Route}' at version '{conflict.Key.Version}'. " +
@@ -196,6 +200,17 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
     /// The <c>ApiVersionMetadata</c> model is seeded with the union of versions implemented at the
     /// same (verb, route) pair so the <c>api-supported-versions</c> response header reports every
     /// sibling clone, not just this clone's own version.</summary>
+    /// <remarks>
+    /// The sibling grouping key is <c>(verb, route-after-strip-prefix)</c>, NOT
+    /// <c>(verb, route-after-strip-prefix, handler-type)</c>. Chains from distinct handler classes
+    /// that publish the same logical route are merged into one sibling set. This matches the
+    /// Asp.Versioning convention where any chain at the route is part of the same logical version
+    /// set regardless of which class declared which version (e.g.
+    /// <c>OrdersV1V2Endpoint</c> declaring v1+v2 and <c>OrdersV3Endpoint</c> declaring v3 at the
+    /// same <c>(GET, /orders)</c> route are merged into one sibling chain advertising 1.0/2.0/3.0
+    /// in <c>api-supported-versions</c>). The <c>cross_class_chains_at_same_route_share_supported_versions</c>
+    /// integration test pins this behaviour.
+    /// </remarks>
     private void AttachMetadata(IReadOnlyList<HttpChain> chains)
     {
         // Group versioned chains by (verb, route-without-version-prefix). Two chains in the same
@@ -303,6 +318,14 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
         || chain.DeprecationPolicy is not null
         || _options.EmitApiSupportedVersionsHeader;
 
+    /// <summary>
+    /// Diagnostic identifier for a chain in error messages from the unversioned-policy and other
+    /// non-clone code paths. Prefers <see cref="HttpChain.DisplayName"/> so consumer-friendly
+    /// labels (e.g. <c>"GET /orders (unversioned)"</c>) are preserved verbatim. The duplicate-route
+    /// detector in <see cref="DetectDuplicateRoutes"/> intentionally uses
+    /// <see cref="HttpChain.OperationId"/> instead because clones share a DisplayName but have
+    /// version-suffixed OperationIds.
+    /// </summary>
     private static string Identify(HttpChain chain) =>
         chain.DisplayName
         ?? (chain.Method?.Method?.DeclaringType?.FullName + "." + chain.Method?.Method?.Name)

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
@@ -46,7 +46,9 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
         WireHeaderPostprocessors(chains);
     }
 
-    /// <summary>Step A — read <c>[ApiVersion]</c> from the handler method and propagate to the chain.</summary>
+    /// <summary>Step A — read <c>[ApiVersion]</c> from the handler method and propagate to the chain.
+    /// Multi-version expansion runs earlier in <see cref="HttpGraph.DiscoverEndpoints"/>, so chains
+    /// reaching this step have either no version or one already set by the expansion.</summary>
     private static void ResolveAttributes(IReadOnlyList<HttpChain> chains)
     {
         foreach (var chain in chains)
@@ -54,12 +56,16 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
             if (chain.Method?.Method is null)
                 continue;
 
+            // Chains produced by multi-version expansion already have ApiVersion assigned;
+            // skip resolver work to avoid throwing on the still-multi-version method attributes.
+            if (chain.ApiVersion is not null)
+                continue;
+
             var resolution = ApiVersionResolver.Resolve(chain.Method.Method);
             if (resolution is null)
                 continue;
 
-            if (chain.ApiVersion is null)
-                chain.ApiVersion = resolution.Value.Version;
+            chain.ApiVersion = resolution.Value.Version;
 
             if (resolution.Value.IsDeprecated && chain.DeprecationPolicy is null)
                 chain.DeprecationPolicy = new DeprecationPolicy();

--- a/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/ApiVersioningPolicy.cs
@@ -47,12 +47,20 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
     }
 
     /// <summary>Step A — read <c>[ApiVersion]</c> / <c>[ApiVersionNeutral]</c> from the handler
-    /// method and propagate to the chain. Multi-version expansion runs earlier in
-    /// <see cref="HttpGraph.DiscoverEndpoints"/>, so chains reaching this step have either no
-    /// version or one already set by the expansion; the latter skip resolver work entirely.
-    /// Single-version chains take the first entry of <see cref="ApiVersionResolver.ResolveVersions"/>
-    /// after an explicit count check so the <c>default(ApiVersionResolution)</c> foot-gun (a struct
-    /// with a null <c>Version</c>) is not relied on for the empty case.</summary>
+    /// method and propagate to the chain. Order matters here:
+    /// <list type="number">
+    ///   <item><description>Check neutrality first so a method-level <c>[ApiVersionNeutral]</c>
+    ///     can clear a prior fluent <c>HasApiVersion(...)</c> assignment on the chain
+    ///     (test pin: <c>method_level_neutral_clears_prior_fluent_apiversion_assignment</c>).</description></item>
+    ///   <item><description>If the chain already carries a version after the neutrality check, it
+    ///     came from multi-version expansion or a fluent assignment — keep it as-is. Falling
+    ///     through to <see cref="ApiVersionResolver.ResolveVersions"/> on a multi-version method
+    ///     would return every declared version and indexing <c>[0]</c> would silently misclassify
+    ///     clones.</description></item>
+    ///   <item><description>Otherwise resolve from method/class attributes; take the first entry
+    ///     after an explicit count check so the <c>default(ApiVersionResolution)</c> foot-gun
+    ///     (a struct with a null <c>Version</c>) is not relied on for the empty case.</description></item>
+    /// </list></summary>
     private static void ResolveAttributes(IReadOnlyList<HttpChain> chains)
     {
         foreach (var chain in chains)
@@ -60,17 +68,12 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
             if (chain.Method?.Method is null)
                 continue;
 
-            // Chains produced by multi-version expansion already have ApiVersion assigned;
-            // skip resolver work to avoid picking the wrong version (ResolveVersions on a
-            // multi-version method returns every declared version, and indexing [0] would
-            // silently misclassify clones), and to bypass the neutrality check which is
-            // structurally impossible for an expanded chain.
-            if (chain.ApiVersion is not null)
-                continue;
-
             // Single reflection pass — resolves neutrality and validates that [ApiVersion] +
             // [ApiVersionNeutral] are not both declared on the same target (throws on conflict).
-            // Method-level wins over class-level in both directions.
+            // Method-level wins over class-level in both directions. Run this before the
+            // already-assigned guard below so a fluent HasApiVersion(...) does not suppress a
+            // method-level [ApiVersionNeutral] override. Multi-version clones cannot be neutral
+            // (their underlying method declares [ApiVersion]s, so the resolver returns false).
             if (ApiVersionNeutralResolver.Resolve(chain.Method.Method))
             {
                 chain.IsApiVersionNeutral = true;
@@ -80,6 +83,13 @@ internal sealed class ApiVersioningPolicy : IHttpPolicy
                 chain.ApiVersion = null;
                 continue;
             }
+
+            // Chains produced by multi-version expansion already have ApiVersion assigned;
+            // chains with a fluent HasApiVersion(...) likewise. In both cases the prior assignment
+            // wins. Skipping ResolveVersions here also avoids picking versions[0] on a
+            // multi-version clone and silently misclassifying it.
+            if (chain.ApiVersion is not null)
+                continue;
 
             var versions = ApiVersionResolver.ResolveVersions(chain.Method.Method);
             if (versions.Count == 0)

--- a/src/Http/Wolverine.Http/ApiVersioning/MultiVersionExpansion.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/MultiVersionExpansion.cs
@@ -11,11 +11,12 @@ namespace Wolverine.Http.ApiVersioning;
 internal static class MultiVersionExpansion
 {
     /// <summary>
-    /// Walks <paramref name="chains"/>, replacing every multi-version chain with one clone per
-    /// declared version. Single-version and unversioned chains are left untouched; the
-    /// downstream <see cref="ApiVersioningPolicy"/> resolves them.
+    /// Mutates <paramref name="chains"/> in place: every chain whose handler declares more than
+    /// one API version is removed and replaced with one clone per declared version. Single-version
+    /// and unversioned chains are left untouched; the downstream <see cref="ApiVersioningPolicy"/>
+    /// resolves them via <see cref="ApiVersionResolver.ResolveVersions"/>.
     /// </summary>
-    public static void Expand(List<HttpChain> chains)
+    public static void ExpandInPlace(List<HttpChain> chains)
     {
         for (var i = chains.Count - 1; i >= 0; i--)
         {
@@ -23,23 +24,7 @@ internal static class MultiVersionExpansion
             if (chain.Method?.Method is null) continue;
 
             var versions = ApiVersionResolver.ResolveVersions(chain.Method.Method);
-            if (versions.Count == 0) continue;
-
-            if (versions.Count == 1)
-            {
-                // Single version: assign to the existing chain. This covers the
-                // [MapToApiVersion("X")] case where filtering produced exactly one version,
-                // and skips work for chains that already had ApiVersion set elsewhere.
-                if (chain.ApiVersion is null)
-                {
-                    chain.ApiVersion = versions[0].Version;
-                    if (versions[0].IsDeprecated && chain.DeprecationPolicy is null)
-                    {
-                        chain.DeprecationPolicy = new DeprecationPolicy();
-                    }
-                }
-                continue;
-            }
+            if (versions.Count < 2) continue;
 
             chains.RemoveAt(i);
             // Insert clones at the original position so chains keep stable ordering.

--- a/src/Http/Wolverine.Http/ApiVersioning/MultiVersionExpansion.cs
+++ b/src/Http/Wolverine.Http/ApiVersioning/MultiVersionExpansion.cs
@@ -1,0 +1,54 @@
+using Asp.Versioning;
+
+namespace Wolverine.Http.ApiVersioning;
+
+/// <summary>
+/// Expands handler chains that declare more than one API version (via multiple
+/// <c>[ApiVersion]</c> attributes or <c>[MapToApiVersion]</c> filtering class-level versions)
+/// into one chain per version. Runs before any <see cref="IHttpPolicy"/>, so middleware,
+/// route prefix, and downstream policies apply uniformly to every clone.
+/// </summary>
+internal static class MultiVersionExpansion
+{
+    /// <summary>
+    /// Walks <paramref name="chains"/>, replacing every multi-version chain with one clone per
+    /// declared version. Single-version and unversioned chains are left untouched; the
+    /// downstream <see cref="ApiVersioningPolicy"/> resolves them.
+    /// </summary>
+    public static void Expand(List<HttpChain> chains)
+    {
+        for (var i = chains.Count - 1; i >= 0; i--)
+        {
+            var chain = chains[i];
+            if (chain.Method?.Method is null) continue;
+
+            var versions = ApiVersionResolver.ResolveVersions(chain.Method.Method);
+            if (versions.Count == 0) continue;
+
+            if (versions.Count == 1)
+            {
+                // Single version: assign to the existing chain. This covers the
+                // [MapToApiVersion("X")] case where filtering produced exactly one version,
+                // and skips work for chains that already had ApiVersion set elsewhere.
+                if (chain.ApiVersion is null)
+                {
+                    chain.ApiVersion = versions[0].Version;
+                    if (versions[0].IsDeprecated && chain.DeprecationPolicy is null)
+                    {
+                        chain.DeprecationPolicy = new DeprecationPolicy();
+                    }
+                }
+                continue;
+            }
+
+            chains.RemoveAt(i);
+            // Insert clones at the original position so chains keep stable ordering.
+            for (var j = versions.Count - 1; j >= 0; j--)
+            {
+                var resolution = versions[j];
+                var clone = chain.CloneForVersion(resolution.Version, resolution.IsDeprecated);
+                chains.Insert(i, clone);
+            }
+        }
+    }
+}

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Asp.Versioning;
 using JasperFx;
 using JasperFx.CodeGeneration;
@@ -55,6 +56,10 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
     public static readonly Variable[] HttpContextVariables =
         Variable.VariablesForProperties<HttpContext>(HttpGraph.Context);
+
+    // Used by CloneForVersion to sanitize ApiVersion text (e.g. "2024-01-01") into a legal
+    // identifier suffix for OperationId. Compiled once; only ASCII alphanumerics survive.
+    private static readonly Regex NonAlphanumeric = new(@"[^A-Za-z0-9]", RegexOptions.Compiled);
 
     internal Variable? RequestBodyVariable { get; set; }
 
@@ -296,13 +301,35 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
         // Multi-version expansion produces N chains sharing the same handler method, so the
         // ctor-derived OperationId collides across clones. Suffix it with the version to keep
         // ASP.NET Core's "endpoint names must be globally unique" invariant intact.
-        var versionSuffix = version.ToString().Replace('.', '_');
+        // Sanitize by replacing every non-alphanumeric character so date-based versions like
+        // 2024-01-01 still produce a legal identifier (2024_01_01) instead of leaking hyphens.
+        var versionSuffix = NonAlphanumeric.Replace(version.ToString(), "_");
         clone.OperationId = $"{clone.OperationId}_v{versionSuffix}";
 
         if (isDeprecated)
         {
             clone.DeprecationPolicy ??= new DeprecationPolicy();
         }
+
+        // Strip [ApiVersion] / [MapToApiVersion] attributes that don't match this clone's version.
+        // applyMetadata() copied every class- and method-level attribute onto the clone, so without
+        // this pass each clone's ASP.NET Core endpoint metadata reports ALL of the multi-version
+        // declarations and OpenAPI tooling reports each clone as implementing every sibling version.
+        clone.Metadata.Add(builder =>
+        {
+            for (var i = builder.Metadata.Count - 1; i >= 0; i--)
+            {
+                switch (builder.Metadata[i])
+                {
+                    case ApiVersionAttribute apiAttr when !apiAttr.Versions.Contains(version):
+                        builder.Metadata.RemoveAt(i);
+                        break;
+                    case MapToApiVersionAttribute mapAttr when !mapAttr.Versions.Contains(version):
+                        builder.Metadata.RemoveAt(i);
+                        break;
+                }
+            }
+        });
 
         return clone;
     }

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -319,15 +319,11 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
         {
             for (var i = builder.Metadata.Count - 1; i >= 0; i--)
             {
-                switch (builder.Metadata[i])
-                {
-                    case ApiVersionAttribute apiAttr when !apiAttr.Versions.Contains(version):
-                        builder.Metadata.RemoveAt(i);
-                        break;
-                    case MapToApiVersionAttribute mapAttr when !mapAttr.Versions.Contains(version):
-                        builder.Metadata.RemoveAt(i);
-                        break;
-                }
+                var m = builder.Metadata[i];
+                if (m is ApiVersionAttribute a && !a.Versions.Contains(version))
+                    builder.Metadata.RemoveAt(i);
+                else if (m is MapToApiVersionAttribute mp && !mp.Versions.Contains(version))
+                    builder.Metadata.RemoveAt(i);
             }
         });
 

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -267,6 +267,46 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
         return this;
     }
 
+    /// <summary>
+    /// Builds a fresh <see cref="HttpChain"/> from the same handler method so it can serve a
+    /// distinct API version. The clone re-runs the standard ctor pipeline (attributes, configure
+    /// methods, parameter matching, implied middleware), so attribute-driven policies — auth,
+    /// fluent validation, before/after middleware, cascading messages — are reapplied per version.
+    /// The clone's <see cref="ApiVersion"/> is set to <paramref name="version"/> and its
+    /// <see cref="DeprecationPolicy"/> is set when <paramref name="isDeprecated"/> is true.
+    /// </summary>
+    /// <remarks>
+    /// Used by multi-version expansion at bootstrap. Expansion runs before any policy in the
+    /// HTTP pipeline so middleware, route prefix, and downstream policies are applied to clones
+    /// uniformly with the source chain.
+    /// </remarks>
+    internal HttpChain CloneForVersion(ApiVersion version, bool isDeprecated)
+    {
+        // Each clone needs its own MethodCall so JasperFx codegen can wire each handler frame
+        // independently. Re-using the source MethodCall makes the second clone's codegen throw
+        // "Frame chain is being re-arranged" when JasperFx tries to set Next on a frame that's
+        // already chained from the first clone.
+        var clonedMethodCall = new MethodCall(Method.HandlerType, Method.Method);
+        var clone = new HttpChain(clonedMethodCall, _parent)
+        {
+            ServiceProviderSource = ServiceProviderSource,
+            ApiVersion = version
+        };
+
+        // Multi-version expansion produces N chains sharing the same handler method, so the
+        // ctor-derived OperationId collides across clones. Suffix it with the version to keep
+        // ASP.NET Core's "endpoint names must be globally unique" invariant intact.
+        var versionSuffix = version.ToString().Replace('.', '_');
+        clone.OperationId = $"{clone.OperationId}_v{versionSuffix}";
+
+        if (isDeprecated)
+        {
+            clone.DeprecationPolicy ??= new DeprecationPolicy();
+        }
+
+        return clone;
+    }
+
     public static HttpChain ChainFor<T>(Expression<Action<T>> expression, HttpGraph? parent = null)
     {
         var method = ReflectionHelper.GetMethod(expression);

--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -114,7 +114,7 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
         // clones would miss whatever the policies subsequently mutate.
         if (wolverineHttpOptions.ApiVersioning is not null)
         {
-            ApiVersioning.MultiVersionExpansion.Expand(_chains);
+            ApiVersioning.MultiVersionExpansion.ExpandInPlace(_chains);
         }
 
         wolverineHttpOptions.Middleware.Apply(_chains, Rules, Container);

--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -109,6 +109,14 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
 
         _chains.AddRange(calls.Select(x => new HttpChain(x, this){ServiceProviderSource = wolverineHttpOptions.ServiceProviderSource}));
 
+        // Expand multi-version handlers before any policy runs, so middleware, route prefix,
+        // and other policies are applied uniformly to every per-version clone. Without this,
+        // clones would miss whatever the policies subsequently mutate.
+        if (wolverineHttpOptions.ApiVersioning is not null)
+        {
+            ApiVersioning.MultiVersionExpansion.Expand(_chains);
+        }
+
         wolverineHttpOptions.Middleware.Apply(_chains, Rules, Container);
         _optionsWriterPolicies.AddRange(wolverineHttpOptions.ResourceWriterPolicies);
 

--- a/src/Http/WolverineWebApi/ApiVersioning/CustomersMultiVersionEndpoint.cs
+++ b/src/Http/WolverineWebApi/ApiVersioning/CustomersMultiVersionEndpoint.cs
@@ -14,10 +14,14 @@ namespace WolverineWebApi.ApiVersioning;
 [ApiVersion("3.0")]
 public static class CustomersMultiVersionEndpoint
 {
-    // The explicit OperationId is the short type-name form. CloneForVersion appends a
-    // sanitised "_v{major}_{minor}" suffix to each clone so the resulting endpoint names
-    // (e.g. CustomersMultiVersionEndpoint.Get_v1, CustomersMultiVersionEndpoint.Get_v2,
-    // CustomersMultiVersionEndpoint.Get_v3) stay globally unique without any per-clone setup.
+    // The explicit OperationId is retained here because WolverineWebApi is also loaded by
+    // tests that DO NOT call options.UseApiVersioning(). In that mode MultiVersionExpansion
+    // and ApiVersioningPolicy never run, so the per-clone auto-suffix and the SetExplicitOperationId
+    // call in AttachMetadata never fire — without an explicit OperationId on the source attribute,
+    // multiple chains at /customers (this class plus CustomersV4AttributeDeprecatedEndpoint) would
+    // collide on the route-derived endpoint name 'GET_customers'. When versioning IS enabled, the
+    // policy auto-suffixes each clone (CustomersMultiVersionEndpoint.Get_v1_0, _v2_0, _v3_0) so
+    // global uniqueness is guaranteed regardless of this attribute.
     [WolverineGet("/customers", OperationId = "CustomersMultiVersionEndpoint.Get")]
     public static CustomersResponse Get() => new(["alice", "bob"]);
 }
@@ -46,6 +50,10 @@ public static class CustomersV2OnlyEndpoint
 [ApiVersion("4.0", Deprecated = true)]
 public static class CustomersV4AttributeDeprecatedEndpoint
 {
+    // Explicit OperationId required for the same reason documented on CustomersMultiVersionEndpoint:
+    // tests that load WolverineWebApi without UseApiVersioning() must still produce unique endpoint
+    // names. Both chains share GET /customers; without explicit operation IDs they collide on
+    // 'GET_customers' before any policy can disambiguate them.
     [WolverineGet("/customers", OperationId = "CustomersV4AttributeDeprecatedEndpoint.Get")]
     public static CustomersResponse Get() => new(["v4-alice"]);
 }

--- a/src/Http/WolverineWebApi/ApiVersioning/CustomersMultiVersionEndpoint.cs
+++ b/src/Http/WolverineWebApi/ApiVersioning/CustomersMultiVersionEndpoint.cs
@@ -14,6 +14,10 @@ namespace WolverineWebApi.ApiVersioning;
 [ApiVersion("3.0")]
 public static class CustomersMultiVersionEndpoint
 {
+    // The explicit OperationId is the short type-name form. CloneForVersion appends a
+    // sanitised "_v{major}_{minor}" suffix to each clone so the resulting endpoint names
+    // (e.g. CustomersMultiVersionEndpoint.Get_v1, CustomersMultiVersionEndpoint.Get_v2,
+    // CustomersMultiVersionEndpoint.Get_v3) stay globally unique without any per-clone setup.
     [WolverineGet("/customers", OperationId = "CustomersMultiVersionEndpoint.Get")]
     public static CustomersResponse Get() => new(["alice", "bob"]);
 }
@@ -30,6 +34,20 @@ public static class CustomersV2OnlyEndpoint
     [WolverineGet("/customers/v2-only", OperationId = "CustomersV2OnlyEndpoint.Get")]
     [MapToApiVersion("2.0")]
     public static CustomersResponse Get() => new(["v2-only-alice"]);
+}
+
+/// <summary>
+/// Attribute-only deprecation example. v4.0 is marked deprecated via the attribute alone — there
+/// is no <c>options.Deprecate("4.0")</c> in <c>Program.cs</c>, so the <c>Deprecation</c> response
+/// header on <c>/v4/customers</c> proves the per-version attribute is honoured independently of
+/// the options-driven sunset / deprecation map. Used by integration tests to isolate attribute
+/// behaviour from options behaviour.
+/// </summary>
+[ApiVersion("4.0", Deprecated = true)]
+public static class CustomersV4AttributeDeprecatedEndpoint
+{
+    [WolverineGet("/customers", OperationId = "CustomersV4AttributeDeprecatedEndpoint.Get")]
+    public static CustomersResponse Get() => new(["v4-alice"]);
 }
 
 public record CustomersResponse(IReadOnlyList<string> Names);

--- a/src/Http/WolverineWebApi/ApiVersioning/CustomersMultiVersionEndpoint.cs
+++ b/src/Http/WolverineWebApi/ApiVersioning/CustomersMultiVersionEndpoint.cs
@@ -1,0 +1,35 @@
+using Asp.Versioning;
+using Wolverine.Http;
+
+namespace WolverineWebApi.ApiVersioning;
+
+/// <summary>
+/// Multi-version handler example. Class-level <c>[ApiVersion]</c> declares every version this
+/// type serves; the single <c>Get</c> method serves all three. The Wolverine.Http startup pipeline
+/// expands this class into one HTTP chain per version, each rewritten with the URL-segment prefix
+/// (e.g. <c>/v1/customers</c>, <c>/v2/customers</c>, <c>/v3/customers</c>).
+/// </summary>
+[ApiVersion("1.0", Deprecated = true)]
+[ApiVersion("2.0")]
+[ApiVersion("3.0")]
+public static class CustomersMultiVersionEndpoint
+{
+    [WolverineGet("/customers", OperationId = "CustomersMultiVersionEndpoint.Get")]
+    public static CustomersResponse Get() => new(["alice", "bob"]);
+}
+
+/// <summary>
+/// <c>[MapToApiVersion]</c> example: the class advertises 1.0, 2.0, and 3.0; this method opts in
+/// to v2.0 only. The other versions are not registered for this route.
+/// </summary>
+[ApiVersion("1.0")]
+[ApiVersion("2.0")]
+[ApiVersion("3.0")]
+public static class CustomersV2OnlyEndpoint
+{
+    [WolverineGet("/customers/v2-only", OperationId = "CustomersV2OnlyEndpoint.Get")]
+    [MapToApiVersion("2.0")]
+    public static CustomersResponse Get() => new(["v2-only-alice"]);
+}
+
+public record CustomersResponse(IReadOnlyList<string> Names);

--- a/src/Http/WolverineWebApi/Program.cs
+++ b/src/Http/WolverineWebApi/Program.cs
@@ -64,6 +64,9 @@ public class Program
             x.SwaggerDoc("v1", new OpenApiInfo { Title = "Wolverine Web API v1", Version = "v1" });
             x.SwaggerDoc("v2", new OpenApiInfo { Title = "Wolverine Web API v2", Version = "v2" });
             x.SwaggerDoc("v3", new OpenApiInfo { Title = "Wolverine Web API v3", Version = "v3" });
+            // v4 has no options.Deprecate("4.0") — used by integration tests to prove the
+            // attribute-driven [ApiVersion("4.0", Deprecated = true)] is honoured on its own.
+            x.SwaggerDoc("v4", new OpenApiInfo { Title = "Wolverine Web API v4", Version = "v4" });
             x.OperationFilter<WolverineOperationFilter>();
             x.OperationFilter<WolverineApiVersioningSwaggerOperationFilter>();
             x.DocInclusionPredicate((docName, api) =>


### PR DESCRIPTION
Follow-up to #2633.

## Summary
Wolverine.Http now expands handler chains that declare multiple API versions into one endpoint per version at bootstrap, before any `IHttpPolicy` runs. A single handler method can serve several versions (via repeated `[ApiVersion]` attributes or class-level `[ApiVersion]` declarations) while keeping per-version metadata, routes, and deprecation/sunset policies isolated to each clone.

`[MapToApiVersion]` is honoured on methods of classes that advertise multiple versions: the listed subset is registered, with strict validation that every mapped version exists at class level. Mixing `[ApiVersion]` and `[MapToApiVersion]` on the same method fails fast with a descriptive error.

Floats `Asp.Versioning.Abstractions` to `[10.0.0,11.0.0)`.

## Implementation notes
- **`HttpChain.CloneForVersion(ApiVersion, bool isDeprecated)`** is the per-version expansion primitive. Each clone gets a fresh `MethodCall` (sharing throws "Frame chain re-arranged" from JasperFx codegen). Per-clone `OperationId` is suffixed with `_v{sanitised-version-string}` to keep ASP.NET Core's "globally unique endpoint name" invariant; sanitisation is regex-based (`[^A-Za-z0-9]` → `_`) so date-based versions like `2024-01-01` produce `_v2024_01_01` instead of breaking the rule.
- Each clone's metadata bag is filtered via a `Metadata.Add` callback that scrubs `[ApiVersion]` / `[MapToApiVersion]` attributes mismatched with the clone's own version. Without this, downstream OpenAPI tooling (Swashbuckle's `WolverineApiVersioningSwaggerOperationFilter`) would report each clone as implementing all sibling versions.
- **`MultiVersionExpansion.ExpandInPlace`** runs in `HttpGraph.DiscoverEndpoints` before any `IHttpPolicy` so middleware composition applies uniformly to all clones. Single-version chains are left to `ApiVersioningPolicy.ResolveAttributes` — no duplicated work.
- **`ApiVersionHeaderWriter`** now reads `ApiVersionMetadata.ImplementedApiVersions` from the matched endpoint when emitting `api-supported-versions`. Falls back to `options.SunsetPolicies.Keys ∪ DeprecationPolicies.Keys` for chains without per-endpoint metadata. The header therefore correctly reflects the sibling-version union for clones (e.g. v1 of a `[ApiVersion("1.0"), ApiVersion("2.0"), ApiVersion("3.0")]` handler emits `api-supported-versions: 1.0, 2.0, 3.0`).
- **`ApiVersioningPolicy.AttachMetadata`** seeds `ApiVersionModel(declared, supported, deprecated)` per clone by grouping all chains by `(verb, route-without-version-prefix)`. Cross-class merging at the same route is intentional (matches Asp.Versioning conventions) and documented in the method's `<remarks>`.

## Risk areas (touches core abstractions)
This PR modifies `HttpChain.cs` and `HttpGraph.cs` — please review the expansion-before-policy ordering and the per-clone `MethodCall` cloning rationale carefully. The `Metadata.Add` filter callback in `CloneForVersion` is also load-bearing for OpenAPI correctness.

## Test plan
- [x] `MultiVersionExpansionTests` — 13 unit tests (expansion mechanics, attribute filtering, sibling union, date-based versions, overlap detection across distinct handlers, `[MapToApiVersion]` single-version path, unversioned-alongside, cross-class union)
- [x] `MultiVersionResolverTests` — 138 lines covering attribute resolution and `[MapToApiVersion]` validation
- [x] `multi_version_integration_tests` — e2e via WolverineWebApi including `multi_version_endpoint_emits_api_supported_versions_with_sibling_set` (TDD-confirmed RED → GREEN), per-version deprecation propagation, isolated v4 attribute-only deprecation fixture (decoupled from `Program.cs` global `Deprecate("1.0")` to avoid false positives)
- [x] `ApiVersionResolverTests` migrated to `ResolveVersions` API
- [x] All ApiVersioning-suite tests green: 102/102

## Sample app
- `WolverineWebApi/ApiVersioning/CustomersMultiVersionEndpoint.cs` — three versions on one class
- `WolverineWebApi/ApiVersioning/CustomersV4AttributeDeprecatedEndpoint.cs` — isolates per-version-attribute deprecation from options-driven deprecation

## Docs
- `docs/guide/http/versioning.md` extended with multi-version + `[MapToApiVersion]` sections
- Per-version metadata semantics table including `OperationId` row (`_v{sanitised-version-string}`)