### PR TITLE
Fix ancillary Marten store routing for durable local messages

### DIFF
--- a/src/Persistence/MartenTests/Bugs/Bug_2669_ancillary_marten_store_local_message_from_main_store.cs
+++ b/src/Persistence/MartenTests/Bugs/Bug_2669_ancillary_marten_store_local_message_from_main_store.cs
@@ -1,0 +1,171 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace MartenTests.Bugs;
+
+#region Test Infrastructure
+
+public interface IAncillaryStore2669 : IDocumentStore;
+
+public record DispatchAncillaryWorkFromMain2669(Guid Id);
+
+public record AncillaryWorkFromMain2669(Guid Id);
+
+public static class DispatchAncillaryWorkFromMain2669Handler
+{
+    public static AncillaryWorkFromMain2669 Handle(DispatchAncillaryWorkFromMain2669 message)
+    {
+        return new AncillaryWorkFromMain2669(message.Id);
+    }
+}
+
+[MartenStore(typeof(IAncillaryStore2669))]
+public static class AncillaryWorkFromMain2669Handler
+{
+    public static IMartenOp Handle(AncillaryWorkFromMain2669 message)
+    {
+        return MartenOps.Store(new AncillaryWorkDocument2669 { Id = message.Id });
+    }
+}
+
+public class AncillaryWorkDocument2669
+{
+    public Guid Id { get; set; }
+}
+
+#endregion
+
+/// <summary>
+/// Reproduces https://github.com/JasperFx/wolverine/issues/2669.
+///
+/// A durable local message published from a main-store handler can be handled
+/// transactionally by an ancillary Marten store. The receiving handler's
+/// ancillary store should own the inbox row, even when the envelope was
+/// originally stamped by the publishing context.
+/// </summary>
+public class Bug_2669_ancillary_marten_store_local_message_from_main_store : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private string _mainConnectionString = null!;
+    private string _ancillaryConnectionString = null!;
+    private static readonly string TargetFrameworkSuffix = AppContext.TargetFrameworkName?
+        .Split("Version=v")
+        .LastOrDefault()?
+        .Replace(".", "_")
+        .ToLowerInvariant() ?? "default";
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        _mainConnectionString = await CreateDatabaseIfNotExists(conn, $"bug_ancillary_from_main_{TargetFrameworkSuffix}");
+        _ancillaryConnectionString = await CreateDatabaseIfNotExists(conn, $"bug_ancillary_from_main_refs_{TargetFrameworkSuffix}");
+
+        await ResetSchema(_mainConnectionString, "public");
+        await ResetSchema(_ancillaryConnectionString, "public");
+        await ResetSchema(_ancillaryConnectionString, "organizations");
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(_mainConnectionString);
+                    m.DatabaseSchemaName = "public";
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine();
+
+                opts.Services.AddMartenStore<IAncillaryStore2669>(m =>
+                {
+                    m.Connection(_ancillaryConnectionString);
+                    m.DatabaseSchemaName = "organizations";
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine(x => x.SchemaName = "organizations");
+
+                opts.Policies.AutoApplyTransactions();
+                opts.Policies.UseDurableLocalQueues();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(DispatchAncillaryWorkFromMain2669Handler))
+                    .IncludeType(typeof(AncillaryWorkFromMain2669Handler));
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task durable_local_message_from_main_store_can_be_handled_by_ancillary_marten_store()
+    {
+        var id = Guid.NewGuid();
+
+        await _host
+            .TrackActivity()
+            .Timeout(30.Seconds())
+            .InvokeMessageAndWaitAsync(new DispatchAncillaryWorkFromMain2669(id));
+
+        await using var session = _host.Services
+            .GetRequiredService<IAncillaryStore2669>()
+            .LightweightSession();
+
+        var document = await session.LoadAsync<AncillaryWorkDocument2669>(id);
+        document.ShouldNotBeNull();
+    }
+
+    private static async Task<string> CreateDatabaseIfNotExists(NpgsqlConnection conn, string databaseName)
+    {
+        var builder = new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString);
+
+        var exists = await conn.DatabaseExists(databaseName);
+        if (!exists)
+        {
+            try
+            {
+                await new DatabaseSpecification().BuildDatabase(conn, databaseName);
+            }
+            catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.UniqueViolation)
+            {
+                // Parallel target framework runs can race to create the same database.
+            }
+        }
+
+        builder.Database = databaseName;
+
+        return builder.ConnectionString;
+    }
+
+    private static async Task ResetSchema(string connectionString, string schemaName)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+
+        await conn.DropSchemaAsync(schemaName);
+
+        if (schemaName == "public")
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "create schema if not exists public;";
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Marten/FlushOutgoingMessagesOnCommit.cs
+++ b/src/Persistence/Wolverine.Marten/FlushOutgoingMessagesOnCommit.cs
@@ -41,8 +41,19 @@ internal class FlushOutgoingMessagesOnCommit : DocumentSessionListenerBase
                 {
                     if (_context.Envelope.Store is PostgresqlMessageStore envelopeStore)
                     {
-                        // Envelope was routed to a specific store (possibly this one)
-                        incomingTableName = envelopeStore.IncomingFullName;
+                        // Envelope was routed to a specific store (possibly this one).
+                        // Only fold the handled update into this Marten transaction if the
+                        // inbox table is reachable from the current session connection.
+                        if (envelopeStore.Id.Equals(_messageStore.Id))
+                        {
+                            incomingTableName = envelopeStore.IncomingFullName;
+                        }
+                        else
+                        {
+                            // Different database - can't update cross-database in one transaction.
+                            // Let DurableReceiver handle it via the envelope's owning store.
+                            return Task.CompletedTask;
+                        }
                     }
                     else if (_context.Envelope.Store == null)
                     {

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -147,12 +147,12 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
     /// <summary>
     /// If the handler for this message type targets an ancillary store on a
     /// different database, set envelope.Store so that the DelegatingMessageInbox
-    /// persists it in the correct store for transactional atomicity.
+    /// persists it in the correct store for transactional atomicity. The receiving
+    /// handler's store association wins over the publishing context's store.
     /// </summary>
     private void assignAncillaryStoreIfNeeded(Envelope envelope)
     {
         if (_runtime.Stores == null) return;
-        if (envelope.Store != null) return; // already stamped (e.g. from Option B at read time)
         var store = _runtime.Stores.TryFindAncillaryStoreForMessageType(envelope.MessageType);
         if (store != null)
         {

--- a/src/Wolverine/Transports/Local/DurableLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/DurableLocalQueue.cs
@@ -30,8 +30,8 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
         _settings = runtime.DurabilitySettings;
 
         // When ancillary stores exist, wrap the inbox so that envelopes whose
-        // Store property has already been stamped (by ApplyAncillaryStoreFrame
-        // during handler execution) are persisted in the correct database.
+        // Store property is stamped for the receiving handler are persisted in
+        // the correct database.
         // Without this, all local-queue messages land in the main store's inbox
         // regardless of the handler's ancillary store association.
         _inbox = runtime.Stores != null && runtime.Stores.HasAnyAncillaryStores()
@@ -224,14 +224,13 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
     /// If the handler for this message type targets an ancillary store on a
     /// different database, set envelope.Store so that the DelegatingMessageInbox
     /// persists it in the correct store for transactional atomicity.
-    /// This is a safety net for envelopes that arrive without Store already set
-    /// (e.g. from scheduled-job recovery). Envelopes published via PublishAsync
-    /// from a handler will already have Store stamped by MessageBus.
+    /// The receiving handler's store association wins over the publishing
+    /// context's store. A message can be published from the main store and handled
+    /// transactionally by an ancillary store.
     /// </summary>
     private void assignAncillaryStoreIfNeeded(Envelope envelope)
     {
         if (_runtime.Stores == null) return;
-        if (envelope.Store != null) return;
         var store = _runtime.Stores.TryFindAncillaryStoreForMessageType(envelope.MessageType);
         if (store != null)
         {


### PR DESCRIPTION
Closes #2669.

## Summary

- Added a Marten regression test for a durable local message published from the main store and handled by an ancillary Marten store.
- Let the receiving handler's ancillary store association override the publishing context store for durable local queues and durable receivers.
- Avoid folding the handled-inbox update into an ancillary Marten transaction when the envelope belongs to a different PostgreSQL message store.

## Root Cause

Local durable envelopes published from a main-store handler could keep the main message store on `Envelope.Store`. When the receiving handler used `[MartenStore(typeof(...))]` for an ancillary Marten store, the handler session still attempted to mark the envelope handled in the main/public inbox table, which can fail when that table only exists in the ancillary schema/database.

## Testing

- `dotnet test src\Persistence\MartenTests\MartenTests.csproj --filter FullyQualifiedName~Bug_ancillary_marten_store_local_message_from_main_store.durable_local_message_from_main_store_can_be_handled_by_ancillary_marten_store`
- `dotnet test src\Persistence\MartenTests\MartenTests.csproj -f net9.0 --filter FullyQualifiedName~Bug_2576_ancillary_scheduled_message_stuck_incoming --no-restore --no-build`