### PR TITLE
Fix PublishingRelay misrouting default-tenant events under conjoined tenancy

### DIFF
--- a/src/Persistence/MartenSubscriptionTests/subscriptions_end_to_end.cs
+++ b/src/Persistence/MartenSubscriptionTests/subscriptions_end_to_end.cs
@@ -333,6 +333,140 @@ public class subscriptions_end_to_end
     }
 
     [Fact]
+    public async Task non_conjoined_store_preserves_legacy_default_tenant_fallthrough()
+    {
+        // Companion to carry_default_tenant_id_through_under_conjoined_tenancy:
+        // for non-conjoined stores the relay must keep falling through to the bus
+        // context's TenantId, so any setup that relied on the database identifier as
+        // the message tenant (e.g. per-tenant ancillary stores with a custom
+        // Database.Identifier) keeps working.
+        await dropSchema();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Policies.UseDurableLocalQueues();
+
+                opts.Services.AddMarten(m =>
+                    {
+                        m.DisableNpgsqlLogging = true;
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "subscriptions";
+                        // Default (single) tenancy on the events store
+                    }).IntegrateWithWolverine()
+                    .UseLightweightSessions()
+                    .PublishEventsToWolverine("Publish", x =>
+                    {
+                        x.PublishEvent<AEvent>();
+                    });
+            }).StartAsync();
+
+        var store = host.DocumentStore();
+
+        var daemon = await store.BuildProjectionDaemonAsync();
+
+        await daemon.StartAllAsync();
+
+        Func<IMessageContext, Task> writeEvents = async _ =>
+        {
+            await using var session = store.LightweightSession();
+            session.Events.StartStream(Guid.NewGuid(), new AEvent(), new AEvent());
+            await session.SaveChangesAsync();
+
+            await daemon.WaitForNonStaleData(30.Seconds());
+        };
+
+        var tracked = await host
+            .TrackActivity()
+            .ExecuteAndWaitAsync(writeEvents);
+
+        var aEnvelopes = tracked.MessageSucceeded.Envelopes()
+            .Where(x => x.Message is IEvent<AEvent>)
+            .ToList();
+
+        aEnvelopes.ShouldNotBeEmpty();
+
+        // Pre-fix and post-fix behaviour for non-conjoined stores: the relay falls through
+        // and envelope.TenantId is the bus context value that
+        // WolverineSubscriptionRunner set from operations.Database.Identifier
+        // (e.g. "Main" for a single-database Marten store). Crucially it must NOT be the
+        // default-tenant marker — that would mean the fix had over-applied and dropped the
+        // database-identifier-as-tenant convention used by some ancillary-store setups.
+        foreach (var envelope in aEnvelopes)
+        {
+            envelope.TenantId.ShouldNotBeNull();
+            envelope.TenantId.ShouldNotBe(JasperFx.StorageConstants.DefaultTenantId);
+        }
+    }
+
+    [Fact]
+    public async Task carry_default_tenant_id_through_under_conjoined_tenancy()
+    {
+        // Regression: PublishingRelay used to drop DeliveryOptions for default-tenant
+        // events, letting WolverineSubscriptionRunner's bus.TenantId
+        // (= operations.Database.Identifier) leak onto the outbound envelope. Under
+        // conjoined tenancy where the database identifier is not the tenant, that
+        // misrouted default-tenant events into the wrong tenant context.
+        await dropSchema();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Policies.UseDurableLocalQueues();
+
+                opts.Services.AddMarten(m =>
+                    {
+                        m.DisableNpgsqlLogging = true;
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "subscriptions";
+                        m.Events.TenancyStyle = Marten.Storage.TenancyStyle.Conjoined;
+                    }).IntegrateWithWolverine()
+                    .UseLightweightSessions()
+                    .PublishEventsToWolverine("Publish", x =>
+                    {
+                        x.PublishEvent<AEvent>();
+                    });
+            }).StartAsync();
+
+        var store = host.DocumentStore();
+
+        var daemon = await store.BuildProjectionDaemonAsync();
+
+        await daemon.StartAllAsync();
+
+        Func<IMessageContext, Task> writeEvents = async _ =>
+        {
+            // No tenant arg -> events get IEvent.TenantId == StorageConstants.DefaultTenantId
+            await using var session = store.LightweightSession();
+            session.Events.StartStream(Guid.NewGuid(), new AEvent(), new AEvent());
+            await session.SaveChangesAsync();
+
+            await daemon.WaitForNonStaleData(30.Seconds());
+        };
+
+        var tracked = await host
+            .TrackActivity()
+            .ExecuteAndWaitAsync(writeEvents);
+
+        var aEnvelopes = tracked.MessageSucceeded.Envelopes()
+            .Where(x => x.Message is IEvent<AEvent>)
+            .ToList();
+
+        aEnvelopes.ShouldNotBeEmpty();
+
+        foreach (var envelope in aEnvelopes)
+        {
+            // Marten's IEvent for a default-tenant event carries TenantId == "*DEFAULT*";
+            // the relayed Wolverine envelope must propagate that, not the database identifier.
+            envelope.TenantId.ShouldBe(JasperFx.StorageConstants.DefaultTenantId);
+        }
+    }
+
+    [Fact]
     public async Task carry_the_tenant_id_through_on_the_subscription()
     {
         await dropSchema();

--- a/src/Persistence/Wolverine.Marten/Subscriptions/PublishingRelay.cs
+++ b/src/Persistence/Wolverine.Marten/Subscriptions/PublishingRelay.cs
@@ -94,15 +94,26 @@ internal class PublishingRelay : BatchSubscription, IPublishingRelay
             }
             else
             {
-                if (e.TenantId != StorageConstants.DefaultTenantId)
+                // Under conjoined tenancy the tenant lives in the row, not the database, so
+                // IEvent<T>.TenantId is the authoritative attribution and must reach the
+                // outbound envelope verbatim — including StorageConstants.DefaultTenantId for
+                // default-tenant events. Otherwise WolverineSubscriptionRunner's
+                // bus.TenantId (= operations.Database.Identifier, a database identity) would
+                // misroute them. For non-conjoined stores the existing fallthrough is
+                // preserved so that any setup relying on the database identifier as the
+                // message tenant keeps working.
+                var tenancyStyle = ((IDocumentSession)operations).DocumentStore
+                    .Options.Events.TenancyStyle;
+
+                if (e.TenantId != StorageConstants.DefaultTenantId
+                    || tenancyStyle == TenancyStyle.Conjoined)
                 {
-                    await bus.PublishAsync(e, new DeliveryOptions{TenantId = e.TenantId});
+                    await bus.PublishAsync(e, new DeliveryOptions { TenantId = e.TenantId });
                 }
                 else
                 {
                     await bus.PublishAsync(e);
                 }
-                
             }
         }
     }


### PR DESCRIPTION
Closes #2675

## Summary

Under conjoined tenancy, `PublishingRelay`'s default-tenant fallthrough let `WolverineSubscriptionRunner`'s `bus.TenantId` (set to `operations.Database.Identifier`) leak onto the outbound envelope. Default-tenant events were dispatched under the database identifier (e.g. `"Main"`) instead of `*DEFAULT*`, the handler chain ran under the wrong tenant scope (or silently no-op'd), but Marten still advanced the subscription sequence because publishing succeeded.

This change gates the override on `Events.TenancyStyle == Conjoined`, so only the broken case is touched. Non-conjoined stores keep the existing fallthrough exactly, preserving setups that legitimately use `Database.Identifier` as the message tenant (e.g. per-tenant ancillary stores with `TenancyStyle.Single`).

## Compatibility

| Setup | Pre-fix `Envelope.TenantId` | Post-fix `Envelope.TenantId` |
|-------|------------------------------|--------------------------------|
| No tenancy (default Marten store) | `Database.Identifier` | `Database.Identifier` (unchanged) |
| Conjoined, default-tenant event | `Database.Identifier` (the bug) | `*DEFAULT*` (correct) |
| Conjoined, named-tenant event | `"one"` | `"one"` (unchanged) |
| `MultiTenantedDatabases(...AddSingleTenantDatabase("tenant1"...))` | `"tenant1"` | `"tenant1"` (unchanged) |
| Per-tenant ancillary stores with custom `Database.Identifier` (`TenancyStyle.Single`) | the custom identifier | the custom identifier (unchanged) |

The only behavioural delta is the targeted bug case. Every other row keeps its pre-fix behaviour because the override only activates in conjoined mode.

## Tests

Two regression tests added in `MartenSubscriptionTests`:

1. **`carry_default_tenant_id_through_under_conjoined_tenancy`** — sets up a conjoined store, publishes a default-tenant event, asserts `Envelope.TenantId == StorageConstants.DefaultTenantId`. Reproduces the bug on `main` (asserts `"*DEFAULT*"`, gets `"Main"`); passes after the fix.
2. **`non_conjoined_store_preserves_legacy_default_tenant_fallthrough`** — companion test using a plain non-conjoined Marten store; asserts the relay still falls through to the bus context's tenant id, guarding the per-tenant-ancillary-store pattern against accidental over-application. Passes both before and after.

`MartenSubscriptionTests` runs green on net8/net9/net10 (12/12).

## Test plan

- [x] Reproduce the bug with a failing test on `main`
- [x] Apply fix; regression test passes
- [x] Companion test confirms non-conjoined fallthrough preserved
- [x] Full `MartenSubscriptionTests` suite green on net8.0, net9.0, net10.0
- [ ] Full `MartenTests` suite (rerun in progress; previously: 433/439 with 6 unrelated infrastructure flakes — postgres connection pool exhaustion + agent-distribution timeouts; none touch `PublishingRelay`)

See #2675 for the full root-cause trace through `WolverineSubscriptionRunner` → `PublishingRelay` → `MessageBus`, and a side-by-side with the Polecat sibling that already handles tenancy correctly.