### PR TITLE
Outbox behavior alignment with EF Core transaction model

### DIFF
--- a/src/Persistence/EfCoreTests/eager_idempotency_with_non_wolverine_mapped_db_context.cs
+++ b/src/Persistence/EfCoreTests/eager_idempotency_with_non_wolverine_mapped_db_context.cs
@@ -106,6 +106,7 @@ public class eager_idempotency_with_non_wolverine_mapped_db_context : IClassFixt
         };
 
         var transaction = new EfCoreEnvelopeTransaction(dbContext, context);
+        await dbContext.Database.BeginTransactionAsync();
         await transaction.PersistOutgoingAsync([envelope1, envelope2]);
         await dbContext.Database.CurrentTransaction!.CommitAsync();
 

--- a/src/Persistence/EfCoreTests/eager_idempotency_with_non_wolverine_mapped_db_context.cs
+++ b/src/Persistence/EfCoreTests/eager_idempotency_with_non_wolverine_mapped_db_context.cs
@@ -106,7 +106,6 @@ public class eager_idempotency_with_non_wolverine_mapped_db_context : IClassFixt
         };
 
         var transaction = new EfCoreEnvelopeTransaction(dbContext, context);
-        await dbContext.Database.BeginTransactionAsync();
         await transaction.PersistOutgoingAsync([envelope1, envelope2]);
         await dbContext.Database.CurrentTransaction!.CommitAsync();
 

--- a/src/Persistence/EfCoreTests/end_to_end_efcore_persistence.cs
+++ b/src/Persistence/EfCoreTests/end_to_end_efcore_persistence.cs
@@ -213,7 +213,6 @@ public class end_to_end_efcore_persistence : IClassFixture<EFCorePersistenceCont
             var messaging = nested.ServiceProvider.GetRequiredService<IDbContextOutbox<ItemsDbContext>>()
                 .ShouldBeOfType<DbContextOutbox<ItemsDbContext>>();
 
-            await messaging.DbContext.Database.BeginTransactionAsync();
             await messaging.Transaction!.PersistOutgoingAsync(envelope);
             messaging.DbContext.Items.Add(new Item { Id = Guid.NewGuid(), Name = Guid.NewGuid().ToString() });
 

--- a/src/Persistence/EfCoreTests/end_to_end_efcore_persistence.cs
+++ b/src/Persistence/EfCoreTests/end_to_end_efcore_persistence.cs
@@ -213,6 +213,7 @@ public class end_to_end_efcore_persistence : IClassFixture<EFCorePersistenceCont
             var messaging = nested.ServiceProvider.GetRequiredService<IDbContextOutbox<ItemsDbContext>>()
                 .ShouldBeOfType<DbContextOutbox<ItemsDbContext>>();
 
+            await messaging.DbContext.Database.BeginTransactionAsync();
             await messaging.Transaction!.PersistOutgoingAsync(envelope);
             messaging.DbContext.Items.Add(new Item { Id = Guid.NewGuid(), Name = Guid.NewGuid().ToString() });
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs
@@ -48,8 +48,12 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
         }
         else
         {
+            if (DbContext.Database.CurrentTransaction == null)
+            {
+                await DbContext.Database.BeginTransactionAsync();
+            }
             var conn = DbContext.Database.GetDbConnection();
-            var tx = DbContext.Database.CurrentTransaction?.GetDbTransaction();
+            var tx = DbContext.Database.CurrentTransaction!.GetDbTransaction();
             var cmd = DatabasePersistence.BuildOutgoingStorageCommand(envelope, envelope.OwnerId, _database);
             cmd.Transaction = tx;
             cmd.Connection = conn;
@@ -71,8 +75,12 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
         }
         else
         {
+            if (DbContext.Database.CurrentTransaction == null)
+            {
+                await DbContext.Database.BeginTransactionAsync();
+            }
             var conn = DbContext.Database.GetDbConnection();
-            var tx = DbContext.Database.CurrentTransaction?.GetDbTransaction();
+            var tx = DbContext.Database.CurrentTransaction!.GetDbTransaction();
             var cmd = DatabasePersistence.BuildOutgoingStorageCommand(envelopes, envelopes[0].OwnerId, _database);
             cmd.Transaction = tx;
             cmd.Connection = conn;

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs
@@ -42,11 +42,6 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
 
     public async Task PersistOutgoingAsync(Envelope envelope)
     {
-        if (DbContext.Database.CurrentTransaction == null)
-        {
-            await DbContext.Database.BeginTransactionAsync();
-        }
-
         if (DbContext.IsWolverineEnabled())
         {
             DbContext.Add(new OutgoingMessage(envelope));
@@ -54,15 +49,13 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
         else
         {
             var conn = DbContext.Database.GetDbConnection();
-            var tx = DbContext.Database.CurrentTransaction!.GetDbTransaction();
+            var tx = DbContext.Database.CurrentTransaction?.GetDbTransaction();
             var cmd = DatabasePersistence.BuildOutgoingStorageCommand(envelope, envelope.OwnerId, _database);
             cmd.Transaction = tx;
             cmd.Connection = conn;
 
             await cmd.ExecuteNonQueryAsync();
         }
-
-
     }
 
     public async Task PersistOutgoingAsync(Envelope[] envelopes)
@@ -72,11 +65,6 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
             return;
         }
 
-        if (DbContext.Database.CurrentTransaction == null)
-        {
-            await DbContext.Database.BeginTransactionAsync();
-        }
-
         if (DbContext.IsWolverineEnabled())
         {
             DbContext.AddRange(envelopes.Select(e => new OutgoingMessage(e)));
@@ -84,7 +72,7 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
         else
         {
             var conn = DbContext.Database.GetDbConnection();
-            var tx = DbContext.Database.CurrentTransaction!.GetDbTransaction();
+            var tx = DbContext.Database.CurrentTransaction?.GetDbTransaction();
             var cmd = DatabasePersistence.BuildOutgoingStorageCommand(envelopes, envelopes[0].OwnerId, _database);
             cmd.Transaction = tx;
             cmd.Connection = conn;
@@ -176,7 +164,7 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
         if (_messaging.Envelope != null && _messaging.Envelope.Destination != null)
         {
             var conn = DbContext.Database.GetDbConnection();
-            var tx = DbContext.Database.CurrentTransaction!.GetDbTransaction();
+            var tx = DbContext.Database.CurrentTransaction?.GetDbTransaction();
             
             // Are we marking an existing envelope as persisted?
             if (_messaging.Envelope.WasPersistedInInbox)


### PR DESCRIPTION
## This change fixes an inconsistency between Wolverine’s outbox behavior and EF Core’s transaction model.

#### EF Core allows two valid approaches:

- implicit transactions via `SaveChanges()`
- explicit transactions via `BeginTransaction()` (with isolation levels, etc.)

### The previous implementation enforced starting an explicit transaction during outbox message publishing when no active transaction existed. This behavior conflicted with EF Core’s design philosophy.

#### The new implementation removes this enforcement:

- If the calling code starts an explicit transaction, it will be used.
- If not, EF Core’s implicit transaction behavior is respected.

#### In other words, transaction ownership is now fully delegated to the application layer, making Wolverine more predictable and easier to integrate into existing unit-of-work or repository-based architectures.

```csharp

app.MapGet("/msg", async (IDbContextOutbox outbox, AppDbContext db) =>
{
    await db.Orders.AddAsync(new Order());
    outbox.Enroll(db);
    await outbox.PublishAsync(new Msg("New order!"));
    await db.SaveChangesAsync();
    await outbox.FlushOutgoingMessagesAsync();
});

```

now it acts like a publish and doesn't enforce starting the transaction
