### PR TITLE
Add IBrokerHealthProbe + RabbitMQ implementation (CritterWatch#70)

### DIFF
--- a/docs/guide/messaging/transports/broker-health-probes.md
+++ b/docs/guide/messaging/transports/broker-health-probes.md
@@ -1,0 +1,89 @@
+# Broker Health Probes
+
+Wolverine exposes an optional, transport-implemented contract for monitoring the
+underlying broker connection. It is intentionally distinct from the existing
+`WolverineTransportHealthCheck` (which feeds the ASP.NET Core health-check
+pipeline) -- the broker probe is meant for interactive monitoring layers like
+[CritterWatch](https://github.com/JasperFx/critterwatch) that want to render
+broker connectivity at a glance.
+
+## The contract
+
+```csharp
+public interface IBrokerHealthProbe
+{
+    Task<BrokerHealthSnapshot> ProbeAsync(CancellationToken ct);
+}
+
+public record BrokerHealthSnapshot(
+    Uri TransportUri,
+    string TransportType,
+    BrokerHealthStatus Status,           // Unknown / Healthy / Degraded / Unhealthy
+    string? Description,
+    string? CertificateExpiry,           // ISO-8601 if TLS configured
+    int ReconnectAttempts,
+    DateTimeOffset LastSuccessfulAt);
+```
+
+Probes are **non-destructive**: they do not reconnect, bounce the connection,
+or mutate transport state. They inspect the connection the transport already
+holds and return a snapshot. If the connection is currently down, the probe
+returns `Unhealthy` rather than throwing.
+
+## Discovering probes at runtime
+
+Every `ITransport` registered with Wolverine is iterable via
+`runtime.Options.Transports`. Probes are discovered by filtering that
+collection:
+
+```csharp
+var snapshots = await Task.WhenAll(
+    runtime.Options.Transports
+        .OfType<IBrokerHealthProbe>()
+        .Select(p => p.ProbeAsync(cancellationToken)));
+```
+
+A transport that does not implement `IBrokerHealthProbe` simply doesn't
+contribute a snapshot.
+
+## Status semantics
+
+| Status      | When it's reported                                                  |
+|-------------|---------------------------------------------------------------------|
+| `Unknown`   | Transport hasn't connected yet (host hasn't started, or disabled).  |
+| `Healthy`   | Connection open, no recent flap.                                    |
+| `Degraded`  | Connection open, but there's been a recent reconnect.               |
+| `Unhealthy` | Connection currently down.                                          |
+
+`ReconnectAttempts` counts genuine recovery events -- it is **not** incremented
+by the initial connect at host startup. `LastSuccessfulAt` is the timestamp of
+the most recent successful connect (initial or recovered).
+
+## Transport support
+
+| Transport             | Probe support              |
+|-----------------------|----------------------------|
+| RabbitMQ              | Yes (since this release)   |
+| Azure Service Bus     | Pending                    |
+| Amazon SQS / SNS      | Pending                    |
+| Apache Kafka          | Pending                    |
+| Apache Pulsar         | Pending                    |
+
+The follow-up transports will pattern-match the RabbitMQ implementation as
+their underlying client SDKs are surveyed.
+
+## RabbitMQ specifics
+
+For RabbitMQ, the probe inspects:
+
+- `IConnection.IsOpen` for both the listening and sending connections;
+- the most recent `ShutdownEventArgs` on those connections (used as the
+  `Description` when the connection is down);
+- the auto-recovery `RecoverySucceededAsync` event (used to track
+  `ReconnectAttempts`);
+- `ConnectionFactory.Ssl.CertPath` (parsed for `NotAfter` when TLS is
+  enabled).
+
+A reconnect within the last two minutes flips `Status` from `Healthy` to
+`Degraded`. After that window the connection is reported as `Healthy` again
+even if the reconnect counter is non-zero.

--- a/docs/guide/messaging/transports/rabbitmq/index.md
+++ b/docs/guide/messaging/transports/rabbitmq/index.md
@@ -349,6 +349,14 @@ using var host = await Host.CreateDefaultBuilder()
 
 This creates RabbitMQ queues named `sequenced1` through `sequenced5` with companion local queues `global-sequenced1` through `global-sequenced5`. Messages are routed to the correct shard based on their group id, and Wolverine handles the coordination between nodes automatically.
 
+## Broker health monitoring
+
+The RabbitMQ transport implements [`IBrokerHealthProbe`](../broker-health-probes.md),
+so monitoring layers (such as CritterWatch) can render a non-destructive,
+point-in-time view of the broker connection -- including reconnect counts and
+TLS certificate expiry. See [Broker Health Probes](../broker-health-probes.md)
+for details on the contract and discovery pattern.
+
 ## Compatibility Note
 
 ::: info

--- a/src/Testing/CoreTests/Transports/IBrokerHealthProbe_contract_tests.cs
+++ b/src/Testing/CoreTests/Transports/IBrokerHealthProbe_contract_tests.cs
@@ -1,0 +1,85 @@
+using Shouldly;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Transports;
+
+/// <summary>
+/// Contract-level sanity checks for <see cref="IBrokerHealthProbe"/>,
+/// <see cref="BrokerHealthSnapshot"/>, and <see cref="BrokerHealthStatus"/>. These
+/// don't exercise any real transport -- they just guarantee the public surface
+/// stays stable for downstream consumers (e.g. CritterWatch).
+/// </summary>
+public class IBrokerHealthProbe_contract_tests
+{
+    [Fact]
+    public void enum_has_expected_members()
+    {
+        Enum.GetNames<BrokerHealthStatus>()
+            .ShouldBe(new[]
+            {
+                nameof(BrokerHealthStatus.Unknown),
+                nameof(BrokerHealthStatus.Healthy),
+                nameof(BrokerHealthStatus.Degraded),
+                nameof(BrokerHealthStatus.Unhealthy)
+            }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void snapshot_is_a_value_record()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var a = new BrokerHealthSnapshot(
+            new Uri("rabbitmq://example/vhost"),
+            "RabbitMQ",
+            BrokerHealthStatus.Healthy,
+            "Connected",
+            "2099-01-01T00:00:00.0000000+00:00",
+            3,
+            now);
+
+        var b = a with { ReconnectAttempts = 4 };
+
+        a.ShouldNotBe(b);
+        a.ReconnectAttempts.ShouldBe(3);
+        b.ReconnectAttempts.ShouldBe(4);
+
+        // Records compare by value
+        var aPrime = new BrokerHealthSnapshot(
+            new Uri("rabbitmq://example/vhost"),
+            "RabbitMQ",
+            BrokerHealthStatus.Healthy,
+            "Connected",
+            "2099-01-01T00:00:00.0000000+00:00",
+            3,
+            now);
+
+        a.ShouldBe(aPrime);
+    }
+
+    [Fact]
+    public async Task probes_can_be_implemented_and_invoked()
+    {
+        IBrokerHealthProbe probe = new FakeBrokerHealthProbe();
+        var snapshot = await probe.ProbeAsync(CancellationToken.None);
+
+        snapshot.TransportType.ShouldBe("Fake");
+        snapshot.Status.ShouldBe(BrokerHealthStatus.Healthy);
+        snapshot.ReconnectAttempts.ShouldBe(0);
+    }
+
+    private sealed class FakeBrokerHealthProbe : IBrokerHealthProbe
+    {
+        public Task<BrokerHealthSnapshot> ProbeAsync(CancellationToken ct)
+        {
+            return Task.FromResult(new BrokerHealthSnapshot(
+                new Uri("fake://broker"),
+                "Fake",
+                BrokerHealthStatus.Healthy,
+                Description: null,
+                CertificateExpiry: null,
+                ReconnectAttempts: 0,
+                LastSuccessfulAt: DateTimeOffset.UtcNow));
+        }
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitMqBrokerHealthProbe_tests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitMqBrokerHealthProbe_tests.cs
@@ -1,0 +1,89 @@
+using RabbitMQ.Client;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+[Trait("Category", "Flaky")]
+public class RabbitMqBrokerHealthProbe_tests
+{
+    [Fact]
+    public async Task probe_before_transport_starts_is_unknown()
+    {
+        // RabbitMqTransport implements IBrokerHealthProbe directly so unstarted
+        // transports can still be probed -- they should report Unknown rather
+        // than blow up.
+        var transport = new RabbitMqTransport();
+        IBrokerHealthProbe probe = transport;
+
+        var snapshot = await probe.ProbeAsync(CancellationToken.None);
+
+        snapshot.TransportType.ShouldBe("RabbitMQ");
+        snapshot.Status.ShouldBe(BrokerHealthStatus.Unknown);
+        snapshot.ReconnectAttempts.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task probe_returns_healthy_for_a_running_transport()
+    {
+        using var host = WolverineHost.For(opts =>
+        {
+            opts.UseRabbitMq().AutoProvision();
+        });
+
+        var transport = host.GetRuntime().Options.Transports.GetOrCreate<RabbitMqTransport>();
+
+        // Transport should be discoverable as a broker health probe via the
+        // documented OfType<IBrokerHealthProbe>() extension point.
+        var runtime = host.GetRuntime();
+        runtime.Options.Transports.OfType<IBrokerHealthProbe>().ShouldContain(transport);
+
+        var snapshot = await ((IBrokerHealthProbe)transport).ProbeAsync(CancellationToken.None);
+
+        snapshot.TransportType.ShouldBe("RabbitMQ");
+        snapshot.Status.ShouldBe(BrokerHealthStatus.Healthy);
+        snapshot.TransportUri.Scheme.ShouldBe("rabbitmq");
+        // Initial connect doesn't count as a reconnect.
+        snapshot.ReconnectAttempts.ShouldBe(0);
+        snapshot.LastSuccessfulAt.ShouldBeGreaterThan(DateTimeOffset.MinValue);
+    }
+
+    [Fact]
+    public async Task probe_returns_unhealthy_when_underlying_connection_is_closed()
+    {
+        using var host = WolverineHost.For(opts =>
+        {
+            opts.UseRabbitMq().AutoProvision();
+        });
+
+        var transport = host.GetRuntime().Options.Transports.GetOrCreate<RabbitMqTransport>();
+
+        // Slam the listening connection shut from underneath the transport. This
+        // simulates a broker-side eviction without going through the host's own
+        // shutdown path.
+        var listening = transport.TryGetListeningConnection();
+        var sending = transport.TryGetSendingConnection();
+        if (listening?.Connection is { } listeningConnection)
+        {
+            await listeningConnection.CloseAsync(
+                Constants.ReplySuccess, "Test-induced close", TimeSpan.FromSeconds(5), abort: false, CancellationToken.None);
+        }
+        if (sending?.Connection is { } sendingConnection)
+        {
+            await sendingConnection.CloseAsync(
+                Constants.ReplySuccess, "Test-induced close", TimeSpan.FromSeconds(5), abort: false, CancellationToken.None);
+        }
+
+        // Give the connection-shutdown event a moment to fire on the client.
+        await Task.Delay(500);
+
+        var snapshot = await ((IBrokerHealthProbe)transport).ProbeAsync(CancellationToken.None);
+
+        snapshot.Status.ShouldBe(BrokerHealthStatus.Unhealthy);
+        snapshot.Description.ShouldNotBeNull();
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs
@@ -36,6 +36,9 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
     {
         _connection = await _transport.CreateConnectionAsync();
         IsConnected = true;
+        // Initial connection -- record the timestamp but don't bump the
+        // reconnect counter (that's reserved for genuine recoveries).
+        _transport.RecordInitialConnection();
 
         _connection.ConnectionShutdownAsync += connectionOnConnectionShutdownAsync;
         _connection.ConnectionUnblockedAsync += connectionOnConnectionUnblockedAsync;
@@ -98,6 +101,7 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
     private async Task connectionOnRecoverySucceededAsync(object sender, AsyncEventArgs @event)
     {
         IsConnected = true;
+        _transport.RecordReconnection();
 
         foreach (var agent in _agents)
         {
@@ -134,6 +138,11 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
     private Task connectionOnConnectionShutdownAsync(object? sender, ShutdownEventArgs e)
     {
         IsConnected = false;
+
+        // Capture the close reason for health snapshots (host-initiated shutdowns
+        // included — they're informative if the probe is called mid-shutdown).
+        _transport.RecordShutdown(e);
+
         if (e.Initiator == ShutdownInitiator.Application) return Task.CompletedTask;
 
         if (e.Exception != null)
@@ -142,6 +151,12 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
         }
         return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// Exposes the underlying RabbitMQ connection for diagnostics and probes.
+    /// May be null before <see cref="ConnectAsync"/> has run or after disposal.
+    /// </summary>
+    internal IConnection? Connection => _connection;
 
     public void Remove(RabbitMqChannelAgent agent)
     {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqBrokerHealthProbe.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqBrokerHealthProbe.cs
@@ -1,0 +1,156 @@
+using System.Security.Cryptography.X509Certificates;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Wolverine.Transports;
+
+namespace Wolverine.RabbitMQ.Internal;
+
+/// <summary>
+/// Implements <see cref="IBrokerHealthProbe"/> for the RabbitMQ transport. The
+/// probe is non-destructive: it inspects state already held by the transport's
+/// listening / sending connections (open flag, last shutdown reason, recent
+/// reconnect activity) without opening new channels or bouncing the connection.
+/// </summary>
+public partial class RabbitMqTransport : IBrokerHealthProbe
+{
+    /// <summary>
+    /// How long after a successful (re)connection the broker is reported as
+    /// <see cref="BrokerHealthStatus.Degraded"/> rather than <c>Healthy</c>.
+    /// Anything more recent than this is treated as a "just flapped" signal.
+    /// </summary>
+    private static readonly TimeSpan RecentReconnectWindow = TimeSpan.FromMinutes(2);
+
+    private int _reconnectAttempts;
+    private DateTimeOffset _lastSuccessfulAt;
+    private string? _lastShutdownDescription;
+
+    /// <summary>
+    /// Number of times the broker connection has been re-established by the
+    /// RabbitMQ client's auto-recovery loop since the host started. The initial
+    /// connect at startup does <b>not</b> count.
+    /// </summary>
+    public int ReconnectAttempts => Volatile.Read(ref _reconnectAttempts);
+
+    /// <summary>
+    /// Timestamp of the most recent successful (re)connection.
+    /// <see cref="DateTimeOffset.MinValue"/> until the first connect succeeds.
+    /// </summary>
+    public DateTimeOffset LastSuccessfulConnectionAt => _lastSuccessfulAt;
+
+    internal void RecordInitialConnection()
+    {
+        _lastSuccessfulAt = DateTimeOffset.UtcNow;
+    }
+
+    internal void RecordReconnection()
+    {
+        Interlocked.Increment(ref _reconnectAttempts);
+        _lastSuccessfulAt = DateTimeOffset.UtcNow;
+    }
+
+    internal void RecordShutdown(ShutdownEventArgs e)
+    {
+        // Record the close reason for inclusion in the next probe snapshot.
+        _lastShutdownDescription = e.ToString();
+    }
+
+    public Task<BrokerHealthSnapshot> ProbeAsync(CancellationToken ct)
+    {
+        var listening = TryGetListeningConnection();
+        var sending = TryGetSendingConnection();
+
+        // Neither connection has been built yet -- transport not started or disabled.
+        if (listening == null && sending == null)
+        {
+            return Task.FromResult(new BrokerHealthSnapshot(
+                TransportUri: ResourceUri,
+                TransportType: "RabbitMQ",
+                Status: BrokerHealthStatus.Unknown,
+                Description: "RabbitMQ transport has not been started",
+                CertificateExpiry: TryReadCertificateExpiry(),
+                ReconnectAttempts: ReconnectAttempts,
+                LastSuccessfulAt: _lastSuccessfulAt));
+        }
+
+        var listenerOpen = listening?.Connection?.IsOpen ?? true;
+        var senderOpen = sending?.Connection?.IsOpen ?? true;
+
+        BrokerHealthStatus status;
+        string? description;
+
+        if (!listenerOpen || !senderOpen)
+        {
+            status = BrokerHealthStatus.Unhealthy;
+
+            var listenerReason = listening?.Connection?.CloseReason?.ToString();
+            var senderReason = sending?.Connection?.CloseReason?.ToString();
+            description = listenerReason ?? senderReason ?? _lastShutdownDescription
+                ?? "RabbitMQ connection is not open";
+        }
+        else if (_reconnectAttempts > 0
+                 && (DateTimeOffset.UtcNow - _lastSuccessfulAt) <= RecentReconnectWindow)
+        {
+            // We've reconnected at least once and it was recent -- mark as Degraded
+            // so that monitoring layers can flag flapping connections.
+            status = BrokerHealthStatus.Degraded;
+            description = $"RabbitMQ connection recovered at {_lastSuccessfulAt:O} ({_reconnectAttempts} reconnect{(_reconnectAttempts == 1 ? "" : "s")}).";
+        }
+        else
+        {
+            status = BrokerHealthStatus.Healthy;
+            description = describeOpenConnection();
+        }
+
+        return Task.FromResult(new BrokerHealthSnapshot(
+            TransportUri: ResourceUri,
+            TransportType: "RabbitMQ",
+            Status: status,
+            Description: description,
+            CertificateExpiry: TryReadCertificateExpiry(),
+            ReconnectAttempts: ReconnectAttempts,
+            LastSuccessfulAt: _lastSuccessfulAt));
+    }
+
+    private string? describeOpenConnection()
+    {
+        if (ConnectionFactory == null) return null;
+        var vhost = ConnectionFactory.VirtualHost;
+        return string.IsNullOrEmpty(vhost) || vhost == "/"
+            ? $"Connected to {ConnectionFactory.HostName}"
+            : $"Connected to {ConnectionFactory.HostName} (vhost {vhost})";
+    }
+
+    private string? TryReadCertificateExpiry()
+    {
+        var ssl = ConnectionFactory?.Ssl;
+        if (ssl == null || !ssl.Enabled) return null;
+        if (string.IsNullOrEmpty(ssl.CertPath)) return null;
+
+        try
+        {
+            using var cert = LoadCertificate(ssl.CertPath, ssl.CertPassphrase);
+            return cert.NotAfter.ToUniversalTime().ToString("O");
+        }
+        catch
+        {
+            // We deliberately swallow here -- a bad cert path shouldn't make the
+            // probe throw; it just means the expiry is unavailable.
+            return null;
+        }
+    }
+
+    private static X509Certificate2 LoadCertificate(string certPath, string? passphrase)
+    {
+#if NET9_0_OR_GREATER
+        return string.IsNullOrEmpty(passphrase)
+            ? X509CertificateLoader.LoadCertificateFromFile(certPath)
+            : X509CertificateLoader.LoadPkcs12FromFile(certPath, passphrase);
+#else
+#pragma warning disable SYSLIB0057
+        return string.IsNullOrEmpty(passphrase)
+            ? new X509Certificate2(certPath)
+            : new X509Certificate2(certPath, passphrase);
+#pragma warning restore SYSLIB0057
+#endif
+    }
+}

--- a/src/Wolverine/Transports/IBrokerHealthProbe.cs
+++ b/src/Wolverine/Transports/IBrokerHealthProbe.cs
@@ -1,0 +1,87 @@
+namespace Wolverine.Transports;
+
+/// <summary>
+/// Coarse-grained connection health for a message broker.
+/// </summary>
+public enum BrokerHealthStatus
+{
+    /// <summary>
+    /// The transport has not yet connected to the broker (e.g., the host has
+    /// not started, or the transport has been disabled).
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// The broker connection is open and steady. No recent reconnects.
+    /// </summary>
+    Healthy,
+
+    /// <summary>
+    /// The connection is currently open but has recently flapped (lost and
+    /// recovered) or is otherwise in a recovering state.
+    /// </summary>
+    Degraded,
+
+    /// <summary>
+    /// The broker connection is currently down.
+    /// </summary>
+    Unhealthy
+}
+
+/// <summary>
+/// Point-in-time, broker-level connection snapshot returned by
+/// <see cref="IBrokerHealthProbe"/>.
+/// </summary>
+/// <param name="TransportUri">The resource URI for this transport (host/vhost
+/// for RabbitMQ, namespace for Azure Service Bus, etc.). Never contains
+/// credentials.</param>
+/// <param name="TransportType">Stable, human-readable transport identifier
+/// (e.g. <c>"RabbitMQ"</c>, <c>"AzureServiceBus"</c>) suitable for grouping
+/// or display in monitoring UIs.</param>
+/// <param name="Status">Current broker connection status.</param>
+/// <param name="Description">Optional free-form description (host, vhost,
+/// shutdown reason, etc.) for diagnostic display.</param>
+/// <param name="CertificateExpiry">If TLS is configured and the certificate
+/// is parseable, the certificate's <c>NotAfter</c> timestamp formatted as
+/// ISO-8601. Otherwise <c>null</c>.</param>
+/// <param name="ReconnectAttempts">Number of times the transport has lost and
+/// re-established the broker connection since the host started.</param>
+/// <param name="LastSuccessfulAt">Timestamp of the most recent successful
+/// connection (initial connect or recovery).</param>
+public record BrokerHealthSnapshot(
+    Uri TransportUri,
+    string TransportType,
+    BrokerHealthStatus Status,
+    string? Description,
+    string? CertificateExpiry,
+    int ReconnectAttempts,
+    DateTimeOffset LastSuccessfulAt);
+
+/// <summary>
+/// Optional contract a Wolverine <c>ITransport</c> can implement to expose a
+/// non-destructive, broker-level connection probe to monitoring layers (e.g.
+/// CritterWatch).
+/// <para>
+/// Implementations <b>must not</b> reconnect, bounce the connection, or alter
+/// transport state. The probe inspects whatever the transport already holds
+/// and returns a snapshot. If the transport has no current connection (e.g.
+/// it has not been started), return <see cref="BrokerHealthStatus.Unknown"/>;
+/// if the connection is currently down, return
+/// <see cref="BrokerHealthStatus.Unhealthy"/> rather than throwing.
+/// </para>
+/// <para>
+/// Probes are discovered by callers via
+/// <c>runtime.Options.Transports.OfType&lt;IBrokerHealthProbe&gt;()</c>, so
+/// implementing this on the transport itself (as opposed to a separate
+/// helper class) is the simplest path.
+/// </para>
+/// </summary>
+public interface IBrokerHealthProbe
+{
+    /// <summary>
+    /// Capture a point-in-time snapshot of the broker connection. Must not
+    /// throw if the connection is down — return an <c>Unhealthy</c> snapshot
+    /// instead.
+    /// </summary>
+    Task<BrokerHealthSnapshot> ProbeAsync(CancellationToken ct);
+}


### PR DESCRIPTION
## Summary

Introduces an opt-in `IBrokerHealthProbe` contract on `ITransport` so monitoring layers (CritterWatch in particular) can render broker connectivity at a glance without bouncing connections. Ships the contract plus a RabbitMQ implementation; other transports follow in separate PRs.

This pairs with [CritterWatch#73](https://github.com/JasperFx/critterwatch/issues/73)'s bus/listener health checks for a coherent broker-monitoring story: CritterWatch drives the existing per-listener `WolverineTransportHealthCheck` for fine-grained endpoint health, and `IBrokerHealthProbe` for connection-level rollup.

### What ships

- `src/Wolverine/Transports/IBrokerHealthProbe.cs` — `IBrokerHealthProbe`, `BrokerHealthSnapshot` record, `BrokerHealthStatus` enum (`Unknown`/`Healthy`/`Degraded`/`Unhealthy`). Class-level XML doc spells out the non-destructive contract: probes don't reconnect or bounce; if the connection is down they return `Unhealthy` rather than throw.
- `src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqBrokerHealthProbe.cs` — partial on `RabbitMqTransport` so the transport itself implements `IBrokerHealthProbe`. Inspects `IConnection.IsOpen` / `CloseReason`, tracks reconnect counts via the existing `RecoverySucceededAsync` event in `ConnectionMonitor`, and reads TLS cert expiry from `ConnectionFactory.Ssl.CertPath` when configured. Initial connect is recorded as a timestamp but does **not** bump the reconnect counter — only genuine recoveries do. A reconnect within the last two minutes flips status from `Healthy` to `Degraded`.
- `src/Testing/CoreTests/Transports/IBrokerHealthProbe_contract_tests.cs` — sanity-checks the public surface (enum members, record value-equality, custom probe implementation).
- `src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitMqBrokerHealthProbe_tests.cs` — boots a Wolverine host with `UseRabbitMq().AutoProvision()`, asserts the transport is discoverable via `runtime.Options.Transports.OfType<IBrokerHealthProbe>()`, probes for `Healthy`, then closes both connections externally and probes again for `Unhealthy`.
- `docs/guide/messaging/transports/broker-health-probes.md` — new docs page describing the contract, discovery pattern, status semantics, and per-transport support; linked from the RabbitMQ index page.

### Deliberate scope cut

Azure Service Bus, Amazon SQS/SNS, Kafka, and Pulsar are not in this PR. They'll pattern-match the RabbitMQ implementation as their underlying client SDKs are surveyed; doing them all here would bloat the diff without changing the shape of the contract. The docs page lists them as `Pending`.

### Test coverage

- Contract tests: `dotnet test src/Testing/CoreTests/CoreTests.csproj --filter IBrokerHealthProbe_contract_tests` — 3 tests passing on net9.0.
- RabbitMQ integration tests: `dotnet test src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests --filter RabbitMqBrokerHealthProbe_tests` — 3 tests passing locally on net9.0 against `rabbitmq:4-management`. Marked `[Trait("Category", "Flaky")]` to follow the project convention for tests that hit the broker.

## Test plan

- [x] `dotnet build` against `Wolverine`, `Wolverine.RabbitMQ`, `Wolverine.RabbitMQ.Tests`, `CoreTests` — 0 errors.
- [x] Contract tests pass without Docker.
- [x] Integration tests pass with Docker + RabbitMQ container running.
- [ ] CI runs the integration test on the standard RabbitMQ matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)