### PR TITLE
Add Wolverine.HealthChecks for ASP.NET Core IHealthCheck integration (CritterWatch#73)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -124,6 +124,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="[8.0.0,10.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[8.0.2,10.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="[8.0.1,10.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[8.0.8,10.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="[8.0.8,10.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.1,10.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.1,10.0.0)" />
@@ -136,6 +137,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="[9.0.0,11.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[9.0.0,11.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="[9.0.0,11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[9.0.0,11.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="[9.0.0,11.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[9.0.0,11.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[9.0.0,11.0.0)" />
@@ -152,6 +154,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -133,6 +133,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                         {text: 'Message Encryption', link: '/guide/runtime/encryption'},
                         {text: 'Instrumentation and Metrics', link: '/guide/logging'},
                         {text: 'Diagnostics', link: '/guide/diagnostics'},
+                        {text: 'Health Checks', link: '/guide/health-checks'},
                         {text: 'Serverless Hosting', link: '/guide/serverless'},          
                         {text: 'Test Automation Support', link: '/guide/testing'},
                         {text: 'Command Line Integration', link: '/guide/command-line'},

--- a/docs/guide/health-checks.md
+++ b/docs/guide/health-checks.md
@@ -1,0 +1,102 @@
+# ASP.NET Core Health Checks
+
+The `WolverineFx.HealthChecks` package adds Wolverine-aware
+[`IHealthCheck`](https://learn.microsoft.com/aspnet/core/host-and-deploy/health-checks)
+implementations so you can plug Wolverine straight into the standard
+ASP.NET Core health-check pipeline. Two checks ship in the box:
+
+| Check | What it covers |
+| --- | --- |
+| `WolverineBusHealthCheck` | The Wolverine runtime itself — has it started? Is it cancelling? |
+| `WolverineListenerHealthCheck` | Listening agents — are they accepting, too busy, latched, or stopped? |
+
+Per-broker connectivity checks (RabbitMQ, Azure Service Bus, etc.) are
+intentionally out of scope here and will be addressed by transport-specific
+health-check helpers.
+
+## Install
+
+```bash
+dotnet add package WolverineFx.HealthChecks
+```
+
+## Register
+
+Both checks are registered through the conventional `IHealthChecksBuilder`
+extension shape, just like any other ASP.NET Core health check:
+
+```csharp
+using Wolverine.HealthChecks;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Host.UseWolverine();
+
+builder.Services.AddHealthChecks()
+    .AddWolverine()           // bus check, name: "wolverine"
+    .AddWolverineListeners(); // listener check, name: "wolverine-listeners"
+
+var app = builder.Build();
+
+app.MapHealthChecks("/health");
+
+app.Run();
+```
+
+## Kubernetes liveness vs. readiness
+
+Health checks accept the standard `tags` parameter, which means you can split
+Kubernetes liveness and readiness probes the same way you would with any other
+ASP.NET Core check. A typical pattern: the bus check feeds both probes, the
+listener check feeds only readiness.
+
+```csharp
+builder.Services.AddHealthChecks()
+    .AddWolverine(tags: new[] { "live", "ready" })
+    .AddWolverineListeners(tags: new[] { "ready" });
+
+app.MapHealthChecks("/health/live", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("live")
+});
+
+app.MapHealthChecks("/health/ready", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("ready")
+});
+```
+
+## Listener status mapping
+
+The listener check walks `IWolverineRuntime.Endpoints.ActiveListeners()` and
+maps the per-listener status to the overall health-check status:
+
+| Listener mix | Reported status |
+| --- | --- |
+| All `Accepting` | `Healthy` |
+| Any `TooBusy` or `GloballyLatched` | `Degraded` |
+| All `Stopped` | `Unhealthy` (uses the registered failure status) |
+| No listeners match the configured filter | `Healthy` (with a note) |
+
+Per-listener status counts and a URI-keyed map are surfaced through
+`HealthCheckResult.Data` so dashboards (CritterWatch, Grafana, etc.) can render
+detail without needing a second probe.
+
+## Filtering listeners
+
+`AddWolverineListeners` accepts an optional `filter` predicate so you can scope
+the check by listener name, URI scheme, or any property exposed by
+`IListeningAgent`. This is useful when you only care about a subset of
+transports for a given probe — for example, requiring the inbound RabbitMQ
+listeners to be up for readiness while ignoring local in-memory queues:
+
+```csharp
+builder.Services.AddHealthChecks()
+    .AddWolverineListeners(
+        name: "wolverine-rabbitmq-listeners",
+        filter: agent => agent.Uri.Scheme == "rabbitmq",
+        tags: new[] { "ready" });
+```
+
+If you want a missing scope to fail (rather than report healthy with a note),
+register a separate check per scope and let the absence of any matching
+listener bubble up as an explicit failure on that probe.

--- a/src/Wolverine.HealthChecks.Tests/EndToEndIntegrationTests.cs
+++ b/src/Wolverine.HealthChecks.Tests/EndToEndIntegrationTests.cs
@@ -1,0 +1,111 @@
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Wolverine.HealthChecks;
+using Wolverine.Runtime;
+
+namespace Wolverine.HealthChecks.Tests;
+
+public class EndToEndIntegrationTests
+{
+    private static IHostBuilder BuildHostBuilder()
+    {
+        return Host.CreateDefaultBuilder()
+            .ConfigureWebHost(web =>
+            {
+                web.UseTestServer();
+                web.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddHealthChecks()
+                        .AddWolverine()
+                        .AddWolverineListeners();
+                });
+                web.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(e =>
+                    {
+                        // Default endpoint = all checks.
+                        e.MapHealthChecks("/health");
+
+                        // Tag-filtered endpoints — the canonical K8s liveness/readiness split.
+                        e.MapHealthChecks("/health/ready", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+                        {
+                            Predicate = check => check.Tags.Contains("ready")
+                        });
+                        e.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+                        {
+                            Predicate = check => check.Tags.Contains("live")
+                        });
+                    });
+                });
+            })
+            .UseWolverine();
+    }
+
+    [Fact]
+    public async Task health_endpoint_reports_healthy_after_startup()
+    {
+        using var host = await BuildHostBuilder().StartAsync();
+        var client = host.GetTestClient();
+
+        var response = await client.GetAsync("/health");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task tag_scoping_separates_liveness_and_readiness()
+    {
+        var host = await Host.CreateDefaultBuilder()
+            .ConfigureWebHost(web =>
+            {
+                web.UseTestServer();
+                web.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddHealthChecks()
+                        .AddWolverine(tags: new[] { "live", "ready" })
+                        .AddWolverineListeners(tags: new[] { "ready" });
+                });
+                web.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(e =>
+                    {
+                        e.MapHealthChecks("/health/ready", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+                        {
+                            Predicate = check => check.Tags.Contains("ready")
+                        });
+                        e.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+                        {
+                            Predicate = check => check.Tags.Contains("live")
+                        });
+                    });
+                });
+            })
+            .UseWolverine()
+            .StartAsync();
+
+        try
+        {
+            var client = host.GetTestClient();
+
+            (await client.GetAsync("/health/ready")).StatusCode.ShouldBe(HttpStatusCode.OK);
+            (await client.GetAsync("/health/live")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+        finally
+        {
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+}

--- a/src/Wolverine.HealthChecks.Tests/Usings.cs
+++ b/src/Wolverine.HealthChecks.Tests/Usings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using Shouldly;

--- a/src/Wolverine.HealthChecks.Tests/Wolverine.HealthChecks.Tests.csproj
+++ b/src/Wolverine.HealthChecks.Tests/Wolverine.HealthChecks.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
+    <PackageReference Include="coverlet.collector" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Wolverine.HealthChecks\Wolverine.HealthChecks.csproj"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Wolverine.HealthChecks.Tests/WolverineBusHealthCheckTests.cs
+++ b/src/Wolverine.HealthChecks.Tests/WolverineBusHealthCheckTests.cs
@@ -1,0 +1,88 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NSubstitute;
+using Wolverine.Configuration;
+using Wolverine.HealthChecks;
+using Wolverine.Runtime;
+
+namespace Wolverine.HealthChecks.Tests;
+
+public class WolverineBusHealthCheckTests
+{
+    private static HealthCheckContext ContextFor(string name = "wolverine", HealthStatus failureStatus = HealthStatus.Unhealthy)
+    {
+        return new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(name, Substitute.For<IHealthCheck>(), failureStatus, tags: null)
+        };
+    }
+
+    private static IWolverineRuntime BuildRuntime(bool started, bool cancellationRequested)
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Options.Returns(new WolverineOptions { ServiceName = "test-service" });
+        var cts = new CancellationTokenSource();
+        if (cancellationRequested) cts.Cancel();
+        runtime.Cancellation.Returns(cts.Token);
+
+        if (!started)
+        {
+            runtime.When(r => r.AssertHasStarted()).Do(_ => throw new WolverineHasNotStartedException());
+        }
+
+        runtime.Endpoints.Returns(Substitute.For<IEndpointCollection>());
+        return runtime;
+    }
+
+    [Fact]
+    public async Task healthy_when_started_and_not_cancelling()
+    {
+        var runtime = BuildRuntime(started: true, cancellationRequested: false);
+        var check = new WolverineBusHealthCheck(runtime);
+
+        var result = await check.CheckHealthAsync(ContextFor());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+        result.Data.ShouldContainKey("started");
+        result.Data["started"].ShouldBe(true);
+        result.Data["cancellationRequested"].ShouldBe(false);
+        result.Data["serviceName"].ShouldBe("test-service");
+    }
+
+    [Fact]
+    public async Task unhealthy_when_not_yet_started()
+    {
+        var runtime = BuildRuntime(started: false, cancellationRequested: false);
+        var check = new WolverineBusHealthCheck(runtime);
+
+        var result = await check.CheckHealthAsync(ContextFor());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Data["started"].ShouldBe(false);
+        result.Exception.ShouldBeOfType<WolverineHasNotStartedException>();
+    }
+
+    [Fact]
+    public async Task uses_failure_status_from_registration()
+    {
+        var runtime = BuildRuntime(started: false, cancellationRequested: false);
+        var check = new WolverineBusHealthCheck(runtime);
+
+        var result = await check.CheckHealthAsync(ContextFor(failureStatus: HealthStatus.Degraded));
+
+        result.Status.ShouldBe(HealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task unhealthy_when_runtime_cancellation_requested()
+    {
+        var runtime = BuildRuntime(started: true, cancellationRequested: true);
+        var check = new WolverineBusHealthCheck(runtime);
+
+        var result = await check.CheckHealthAsync(ContextFor());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Data["cancellationRequested"].ShouldBe(true);
+    }
+}

--- a/src/Wolverine.HealthChecks.Tests/WolverineListenerHealthCheckTests.cs
+++ b/src/Wolverine.HealthChecks.Tests/WolverineListenerHealthCheckTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NSubstitute;
+using Wolverine.Configuration;
+using Wolverine.HealthChecks;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.HealthChecks.Tests;
+
+public class WolverineListenerHealthCheckTests
+{
+    private static HealthCheckContext ContextFor(string name = "wolverine-listeners", HealthStatus failureStatus = HealthStatus.Unhealthy)
+    {
+        return new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(name, Substitute.For<IHealthCheck>(), failureStatus, tags: null)
+        };
+    }
+
+    private static IListeningAgent FakeListener(ListeningStatus status, string uri)
+    {
+        var listener = Substitute.For<IListeningAgent>();
+        listener.Status.Returns(status);
+        listener.Uri.Returns(new Uri(uri));
+        return listener;
+    }
+
+    private static IWolverineRuntime RuntimeWithListeners(params IListeningAgent[] listeners)
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        var endpoints = Substitute.For<IEndpointCollection>();
+        endpoints.ActiveListeners().Returns(listeners);
+        runtime.Endpoints.Returns(endpoints);
+        return runtime;
+    }
+
+    [Fact]
+    public async Task healthy_when_all_listeners_accepting()
+    {
+        var runtime = RuntimeWithListeners(
+            FakeListener(ListeningStatus.Accepting, "rabbitmq://orders"),
+            FakeListener(ListeningStatus.Accepting, "local://default")
+        );
+
+        var result = await new WolverineListenerHealthCheck(runtime).CheckHealthAsync(ContextFor());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+        result.Data["accepting"].ShouldBe(2);
+        result.Data["listenerCount"].ShouldBe(2);
+        var perListener = (Dictionary<string, object>)result.Data["listeners"]!;
+        perListener["rabbitmq://orders/"].ShouldBe("Accepting");
+    }
+
+    [Fact]
+    public async Task degraded_when_any_listener_too_busy()
+    {
+        var runtime = RuntimeWithListeners(
+            FakeListener(ListeningStatus.Accepting, "local://default"),
+            FakeListener(ListeningStatus.TooBusy, "rabbitmq://orders")
+        );
+
+        var result = await new WolverineListenerHealthCheck(runtime).CheckHealthAsync(ContextFor());
+
+        result.Status.ShouldBe(HealthStatus.Degraded);
+        result.Data["tooBusy"].ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task degraded_when_any_listener_globally_latched()
+    {
+        var runtime = RuntimeWithListeners(
+            FakeListener(ListeningStatus.Accepting, "local://default"),
+            FakeListener(ListeningStatus.GloballyLatched, "rabbitmq://orders")
+        );
+
+        var result = await new WolverineListenerHealthCheck(runtime).CheckHealthAsync(ContextFor());
+
+        result.Status.ShouldBe(HealthStatus.Degraded);
+        result.Data["globallyLatched"].ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task unhealthy_when_all_listeners_stopped()
+    {
+        var runtime = RuntimeWithListeners(
+            FakeListener(ListeningStatus.Stopped, "rabbitmq://orders"),
+            FakeListener(ListeningStatus.Stopped, "local://default")
+        );
+
+        var result = await new WolverineListenerHealthCheck(runtime).CheckHealthAsync(ContextFor());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Data["stopped"].ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task healthy_with_note_when_no_listeners_match()
+    {
+        // No listeners at all → reported healthy with explanatory note. Operators
+        // who want a missing listener to fail can register a separate check.
+        var runtime = RuntimeWithListeners();
+
+        var result = await new WolverineListenerHealthCheck(runtime).CheckHealthAsync(ContextFor());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+        result.Data["listenerCount"].ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task filter_scopes_listeners()
+    {
+        var runtime = RuntimeWithListeners(
+            FakeListener(ListeningStatus.Stopped, "rabbitmq://orders"),
+            FakeListener(ListeningStatus.Accepting, "local://default")
+        );
+
+        // Only inspect the rabbit listener — should be Unhealthy because the
+        // filter narrows the population to one stopped listener.
+        var check = new WolverineListenerHealthCheck(runtime,
+            agent => agent.Uri.Scheme == "rabbitmq");
+
+        var result = await check.CheckHealthAsync(ContextFor());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Data["listenerCount"].ShouldBe(1);
+        result.Data["stopped"].ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task uses_failure_status_from_registration()
+    {
+        var runtime = RuntimeWithListeners(
+            FakeListener(ListeningStatus.Stopped, "rabbitmq://orders")
+        );
+
+        var result = await new WolverineListenerHealthCheck(runtime)
+            .CheckHealthAsync(ContextFor(failureStatus: HealthStatus.Degraded));
+
+        result.Status.ShouldBe(HealthStatus.Degraded);
+    }
+}

--- a/src/Wolverine.HealthChecks/HealthCheckBuilderExtensions.cs
+++ b/src/Wolverine.HealthChecks/HealthCheckBuilderExtensions.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.HealthChecks;
+
+/// <summary>
+/// Registration helpers for Wolverine's ASP.NET Core <see cref="IHealthCheck"/>
+/// integrations. Mirrors the conventional <c>AddX</c> shape used by other
+/// <see cref="IHealthChecksBuilder"/> extension packages.
+/// </summary>
+public static class HealthCheckBuilderExtensions
+{
+    /// <summary>
+    /// Register a <see cref="WolverineBusHealthCheck"/> with the supplied
+    /// <see cref="IHealthChecksBuilder"/>. The check is healthy once the
+    /// Wolverine runtime has finished starting up and the runtime cancellation
+    /// token has not been signalled.
+    /// </summary>
+    /// <param name="builder">The health-checks builder.</param>
+    /// <param name="name">Health-check name. Defaults to <c>"wolverine"</c>.</param>
+    /// <param name="failureStatus">Status reported when the check fails. Defaults to <see cref="HealthStatus.Unhealthy"/>.</param>
+    /// <param name="tags">Optional tags. Useful for splitting Kubernetes liveness vs. readiness probes (e.g. <c>"ready"</c>, <c>"live"</c>).</param>
+    /// <param name="timeout">Optional per-check timeout.</param>
+    public static IHealthChecksBuilder AddWolverine(
+        this IHealthChecksBuilder builder,
+        string name = "wolverine",
+        HealthStatus? failureStatus = null,
+        IEnumerable<string>? tags = null,
+        TimeSpan? timeout = null)
+    {
+        if (builder is null) throw new ArgumentNullException(nameof(builder));
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => new WolverineBusHealthCheck(sp.GetRequiredService<IWolverineRuntime>()),
+            failureStatus,
+            tags,
+            timeout));
+    }
+
+    /// <summary>
+    /// Register a <see cref="WolverineListenerHealthCheck"/> with the supplied
+    /// <see cref="IHealthChecksBuilder"/>. The check inspects each listener
+    /// returned by <c>IWolverineRuntime.Endpoints.ActiveListeners()</c>.
+    /// </summary>
+    /// <param name="builder">The health-checks builder.</param>
+    /// <param name="name">Health-check name. Defaults to <c>"wolverine-listeners"</c>.</param>
+    /// <param name="filter">Optional predicate used to scope the check (e.g. by listener name, URI scheme, or endpoint role). When omitted every active listener is included.</param>
+    /// <param name="failureStatus">Status reported when the check fails. Defaults to <see cref="HealthStatus.Unhealthy"/>.</param>
+    /// <param name="tags">Optional tags. Useful for splitting Kubernetes liveness vs. readiness probes.</param>
+    /// <param name="timeout">Optional per-check timeout.</param>
+    public static IHealthChecksBuilder AddWolverineListeners(
+        this IHealthChecksBuilder builder,
+        string name = "wolverine-listeners",
+        Func<IListeningAgent, bool>? filter = null,
+        HealthStatus? failureStatus = null,
+        IEnumerable<string>? tags = null,
+        TimeSpan? timeout = null)
+    {
+        if (builder is null) throw new ArgumentNullException(nameof(builder));
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => new WolverineListenerHealthCheck(sp.GetRequiredService<IWolverineRuntime>(), filter),
+            failureStatus,
+            tags,
+            timeout));
+    }
+}

--- a/src/Wolverine.HealthChecks/Wolverine.HealthChecks.csproj
+++ b/src/Wolverine.HealthChecks/Wolverine.HealthChecks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>ASP.NET Core IHealthCheck integration for Wolverine. Adds bus + listener health checks for Kubernetes liveness/readiness probes and other monitoring tooling.</Description>
+    <PackageId>WolverineFx.HealthChecks</PackageId>
+    <PackageTags>wolverine;health-checks;aspnetcore;kubernetes</PackageTags>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Wolverine\Wolverine.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Wolverine.HealthChecks/WolverineBusHealthCheck.cs
+++ b/src/Wolverine.HealthChecks/WolverineBusHealthCheck.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Wolverine.Runtime;
+
+namespace Wolverine.HealthChecks;
+
+/// <summary>
+/// Reports the high-level state of the Wolverine runtime as an ASP.NET Core
+/// <see cref="IHealthCheck"/>. The check is healthy when the runtime has finished
+/// starting up and the runtime cancellation token has not been signalled (which
+/// happens when the host begins shutting down).
+/// </summary>
+public sealed class WolverineBusHealthCheck : IHealthCheck
+{
+    private readonly IWolverineRuntime _runtime;
+
+    public WolverineBusHealthCheck(IWolverineRuntime runtime)
+    {
+        _runtime = runtime;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var data = new Dictionary<string, object>
+        {
+            ["serviceName"] = _runtime.Options.ServiceName ?? string.Empty,
+            ["uniqueNodeId"] = _runtime.Options.UniqueNodeId,
+            ["cancellationRequested"] = _runtime.Cancellation.IsCancellationRequested
+        };
+
+        if (_runtime.Cancellation.IsCancellationRequested)
+        {
+            return Task.FromResult(new HealthCheckResult(
+                context.Registration.FailureStatus,
+                description: "Wolverine runtime is shutting down (cancellation requested).",
+                data: data));
+        }
+
+        try
+        {
+            _runtime.AssertHasStarted();
+        }
+        catch (WolverineHasNotStartedException ex)
+        {
+            data["started"] = false;
+            return Task.FromResult(new HealthCheckResult(
+                context.Registration.FailureStatus,
+                description: "Wolverine runtime has not finished starting yet.",
+                exception: ex,
+                data: data));
+        }
+
+        data["started"] = true;
+        return Task.FromResult(HealthCheckResult.Healthy(
+            description: "Wolverine runtime is started and accepting messages.",
+            data: data));
+    }
+}

--- a/src/Wolverine.HealthChecks/WolverineListenerHealthCheck.cs
+++ b/src/Wolverine.HealthChecks/WolverineListenerHealthCheck.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.HealthChecks;
+
+/// <summary>
+/// Reports the state of Wolverine's active listening agents as an ASP.NET Core
+/// <see cref="IHealthCheck"/>.
+///
+/// Status mapping:
+/// <list type="bullet">
+///   <item><description><c>Healthy</c> — every listener is <see cref="ListeningStatus.Accepting"/>.</description></item>
+///   <item><description><c>Degraded</c> — at least one listener is <see cref="ListeningStatus.TooBusy"/> or <see cref="ListeningStatus.GloballyLatched"/>.</description></item>
+///   <item><description><c>Unhealthy</c> — every listener is <see cref="ListeningStatus.Stopped"/>, or no listeners exist when one is expected.</description></item>
+/// </list>
+///
+/// Pass an optional <c>filter</c> when constructing the check to scope it down to
+/// a subset of listeners (e.g. by name, tag, or URI scheme). When the filter
+/// excludes every listener the check reports <c>Healthy</c> with a note rather
+/// than failing — register a separate check per scope if you want a missing
+/// listener for that scope to fail.
+/// </summary>
+public sealed class WolverineListenerHealthCheck : IHealthCheck
+{
+    private readonly IWolverineRuntime _runtime;
+    private readonly Func<IListeningAgent, bool>? _filter;
+
+    public WolverineListenerHealthCheck(IWolverineRuntime runtime, Func<IListeningAgent, bool>? filter = null)
+    {
+        _runtime = runtime;
+        _filter = filter;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<IListeningAgent> listeners;
+        try
+        {
+            var all = _runtime.Endpoints.ActiveListeners();
+            listeners = (_filter is null ? all : all.Where(_filter)).ToList();
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new HealthCheckResult(
+                context.Registration.FailureStatus,
+                description: "Could not enumerate Wolverine active listeners.",
+                exception: ex));
+        }
+
+        var counts = new Dictionary<ListeningStatus, int>
+        {
+            [ListeningStatus.Accepting] = 0,
+            [ListeningStatus.TooBusy] = 0,
+            [ListeningStatus.Stopped] = 0,
+            [ListeningStatus.Unknown] = 0,
+            [ListeningStatus.GloballyLatched] = 0
+        };
+
+        var perListener = new Dictionary<string, object>();
+        foreach (var listener in listeners)
+        {
+            counts[listener.Status]++;
+            perListener[listener.Uri.ToString()] = listener.Status.ToString();
+        }
+
+        var data = new Dictionary<string, object>
+        {
+            ["listenerCount"] = listeners.Count,
+            ["accepting"] = counts[ListeningStatus.Accepting],
+            ["tooBusy"] = counts[ListeningStatus.TooBusy],
+            ["stopped"] = counts[ListeningStatus.Stopped],
+            ["unknown"] = counts[ListeningStatus.Unknown],
+            ["globallyLatched"] = counts[ListeningStatus.GloballyLatched],
+            ["listeners"] = perListener
+        };
+
+        if (listeners.Count == 0)
+        {
+            return Task.FromResult(HealthCheckResult.Healthy(
+                description: "No active Wolverine listeners matched the configured scope.",
+                data: data));
+        }
+
+        if (counts[ListeningStatus.Stopped] == listeners.Count)
+        {
+            return Task.FromResult(new HealthCheckResult(
+                context.Registration.FailureStatus,
+                description: "All Wolverine listeners are stopped.",
+                data: data));
+        }
+
+        if (counts[ListeningStatus.TooBusy] > 0 || counts[ListeningStatus.GloballyLatched] > 0)
+        {
+            return Task.FromResult(HealthCheckResult.Degraded(
+                description: "One or more Wolverine listeners are too busy or latched.",
+                data: data));
+        }
+
+        return Task.FromResult(HealthCheckResult.Healthy(
+            description: "All Wolverine listeners are accepting messages.",
+            data: data));
+    }
+}

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -296,5 +296,7 @@
     <Build Project="false" />
   </Project>
   <Project Path="src/Wolverine/Wolverine.csproj" />
+  <Project Path="src/Wolverine.HealthChecks/Wolverine.HealthChecks.csproj" />
+  <Project Path="src/Wolverine.HealthChecks.Tests/Wolverine.HealthChecks.Tests.csproj" />
   <Project Path="src/Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

Adds a new thin extension package, **`WolverineFx.HealthChecks`**, that plugs Wolverine into the standard ASP.NET Core
[health-check pipeline](https://learn.microsoft.com/aspnet/core/host-and-deploy/health-checks). Two checks ship in the box:

- **`WolverineBusHealthCheck`** — Healthy when the runtime has finished starting and the runtime cancellation token has not been signalled. `HealthCheckResult.Data` exposes `serviceName`, `uniqueNodeId`, `started`, `cancellationRequested`.
- **`WolverineListenerHealthCheck`** — Walks `IWolverineRuntime.Endpoints.ActiveListeners()` and reports:
  - `Healthy` — all listeners `Accepting`
  - `Degraded` — any listener `TooBusy` or `GloballyLatched`
  - `Unhealthy` — all listeners `Stopped`
  - Per-listener counts and a URI-keyed status map go into `HealthCheckResult.Data` so dashboards can render detail without a second probe.

## API shape

Conventional `IHealthChecksBuilder` extensions (mirrors `Microsoft.Extensions.Diagnostics.HealthChecks` + community packages):

```csharp
builder.Services.AddHealthChecks()
    .AddWolverine(tags: new[] { "live", "ready" })
    .AddWolverineListeners(
        filter: agent => agent.Uri.Scheme == "rabbitmq",
        tags: new[] { "ready" });
```

Both extensions accept `name` / `failureStatus` / `tags` / `timeout`. `AddWolverineListeners` also takes an optional `Func<IListeningAgent, bool>` filter for scoping a check to a subset of listeners — useful when you want a separate readiness probe per transport.

## Out of scope

Per-broker connectivity health checks (RabbitMQ, Azure Service Bus, Kafka, etc.) are deliberately not part of this PR — they live with each transport package and will be addressed by transport-specific helpers (tracked separately under CritterWatch#70).

## Implementation notes

- New project lives at `src/Wolverine.HealthChecks/`. It depends only on `Wolverine` core + `Microsoft.Extensions.Diagnostics.HealthChecks(.Abstractions)`. Microsoft.Extensions.* health-check packages are real dependencies, so we did not fold these checks into Wolverine.Http where they would weigh down every Wolverine.Http consumer.
- Versions are centrally managed in `Directory.Packages.props` against the existing TFM-conditional Microsoft.Extensions.* version ranges.
- The new project + tests project are added to `wolverine.slnx`. `wolverine_slim.slnx` is unchanged.
- Docs page added at `docs/guide/health-checks.md` and wired into the VitePress sidebar next to the existing Diagnostics page.

## Test plan

- [x] Unit tests against an `IWolverineRuntime` substitute cover started / not-started / cancellation-requested for the bus check, and Healthy / Degraded / Unhealthy / scope-filter cases for the listener check (NSubstitute, already a dev dependency).
- [x] Integration test boots an in-process `Microsoft.AspNetCore.TestHost` host with `.AddWolverine().AddWolverineListeners()` and asserts `/health`, `/health/live`, `/health/ready` all return 200.
- [x] `dotnet build wolverine.slnx` — clean (0 errors).
- [x] `dotnet test src/Wolverine.HealthChecks.Tests/Wolverine.HealthChecks.Tests.csproj` — 13/13 passing.

Refs CritterWatch#73.