### PR TITLE
Add activity events, tags and span for handler-execution timing

### DIFF
--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -594,6 +594,43 @@ public const string StreamType = "wolverine.stream.type";
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/Runtime/WolverineTracing.cs#L28-L141' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_open_telemetry_tracing_spans_and_activities' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### Handler Boundary Activity Events
+
+The generated message handler emits a sequence of `Activity` events on the executing handler activity that lets you
+decompose the handler's wall-clock time into framework prep, user-handler work, database commit, and post-commit
+envelope routing without attaching a profiler.
+
+| Event | Marks |
+|---|---|
+| `wolverine.handler.user_started` | After middleware (DI scope, document session, aggregate `FetchForWriting`, etc.) has completed and immediately before the user handler method body is invoked. |
+| `wolverine.outbox.flushing` | Just before `IDocumentSession.SaveChangesAsync` (or the EF Core equivalent) is awaited. |
+| `wolverine.outbox.flushed` | Immediately after the unit-of-work commit returns. |
+| `wolverine.outbox.published` | After post-commit outgoing envelopes have been flushed to their senders. |
+
+In a tracing UI:
+
+- activity start → `user_started` ≈ middleware / framework preparation (DI scope, document session, `FetchForWriting`, etc.)
+- `user_started` → `flushing` ≈ user handler body execution
+- `flushing` → `flushed` ≈ database commit + outbox-envelope insert latency
+- `flushed` → `published` ≈ post-commit envelope routing and in-process dispatch
+
+`wolverine.handler.user_started` is emitted on every handler chain. The `outbox.*` events are emitted only when a
+persistence integration applies the standard outbox postprocessors (i.e. when the handler's chain uses Marten/EF Core
+transactional support). All four events are no-ops when no `Activity` is currently recording, so there is no
+observability cost when tracing is disabled.
+
+### Envelope Transport Lag
+
+Every Wolverine activity (receive, execute, send, streaming) carries a
+`wolverine.envelope.transport_lag_ms` tag holding the wall-clock milliseconds between when the
+producing side stamped `Envelope.SentAt` and when the consuming side started its activity. On a
+receive / execute activity this captures broker queue + transport + in-process partition-queue
+dwell — i.e. everything that happens to the envelope before the handler runs. On a send activity
+the value is typically zero. The tag is omitted when the computed lag is negative (clock skew).
+
+This is the metric to chart when you want to see how long messages are queued up before being
+processed, independent of handler execution time.
+
 ## Handler Type Tagging
 
 Wolverine automatically tags Open Telemetry activity spans with the handler type name during message processing. This provides per-handler tracing visibility in observability backends like Jaeger, Zipkin, or Honeycomb without any additional configuration.

--- a/src/Persistence/MartenTests/OutboxActivityEvents_emitted.cs
+++ b/src/Persistence/MartenTests/OutboxActivityEvents_emitted.cs
@@ -1,0 +1,107 @@
+using System.Diagnostics;
+using IntegrationTests;
+using JasperFx.Core;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+
+namespace MartenTests;
+
+public class OutboxActivityEvents_emitted : PostgresqlContext, IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(Servers.PostgresConnectionString)
+                    .IntegrateWithWolverine();
+
+                opts.Policies.UseDurableLocalQueues();
+                opts.Policies.ConfigureConventionalLocalRouting()
+                    .CustomizeQueues((_, q) => q.UseDurableInbox());
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task emits_flushing_flushed_and_published_events_around_outbox_commit()
+    {
+        var captured = new List<(string ActivityName, string EventName)>();
+        var capturedTags = new List<(string ActivityName, string TagKey, object? TagValue)>();
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Wolverine",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity =>
+            {
+                lock (captured)
+                {
+                    foreach (var evt in activity.Events)
+                    {
+                        captured.Add((activity.DisplayName, evt.Name));
+                    }
+                    foreach (var tag in activity.TagObjects)
+                    {
+                        capturedTags.Add((activity.DisplayName, tag.Key, tag.Value));
+                    }
+                }
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await _host.InvokeMessageAndWaitAsync(new ActivityProbeMessage(Guid.NewGuid()));
+
+        var probeEvents = captured
+            .Where(c => c.ActivityName.Contains(nameof(ActivityProbeMessage)))
+            .Select(c => c.EventName)
+            .ToList();
+
+        probeEvents.ShouldContain(WolverineTracing.HandlerUserStarted);
+        probeEvents.ShouldContain(WolverineTracing.OutboxFlushing);
+        probeEvents.ShouldContain(WolverineTracing.OutboxFlushed);
+        probeEvents.ShouldContain(WolverineTracing.OutboxPublished);
+
+        var userStartedIdx = probeEvents.IndexOf(WolverineTracing.HandlerUserStarted);
+        var flushingIdx = probeEvents.IndexOf(WolverineTracing.OutboxFlushing);
+        var flushedIdx = probeEvents.IndexOf(WolverineTracing.OutboxFlushed);
+        var publishedIdx = probeEvents.IndexOf(WolverineTracing.OutboxPublished);
+        userStartedIdx.ShouldBeLessThan(flushingIdx);
+        flushingIdx.ShouldBeLessThan(flushedIdx);
+        flushedIdx.ShouldBeLessThan(publishedIdx);
+
+        capturedTags.ShouldContain(t => t.TagKey == WolverineTracing.EnvelopeTransportLagMs);
+
+        capturedTags.ShouldContain(t =>
+            t.ActivityName.Contains(nameof(ActivityProbeMessage)) &&
+            t.TagKey == WolverineTracing.EnvelopeAppQueueDwellMs);
+    }
+}
+
+public record ActivityProbeMessage(Guid Id);
+
+public class ActivityProbeMessageHandler
+{
+    public void Handle(ActivityProbeMessage message, IDocumentSession session)
+    {
+        session.Store(new ActivityProbeRecord { Id = message.Id });
+    }
+}
+
+public class ActivityProbeRecord
+{
+    public Guid Id { get; set; }
+}

--- a/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenPersistenceFrameProvider.cs
@@ -43,12 +43,15 @@ internal class MartenPersistenceFrameProvider : IPersistenceFrameProvider
         {
             if (!chain.Postprocessors.OfType<DocumentSessionSaveChanges>().Any())
             {
+                chain.Postprocessors.Add(new ActivityEventFrame(WolverineTracing.OutboxFlushing));
                 chain.Postprocessors.Add(new DocumentSessionSaveChanges());
+                chain.Postprocessors.Add(new ActivityEventFrame(WolverineTracing.OutboxFlushed));
             }
 
             if (!chain.Postprocessors.OfType<FlushOutgoingMessages>().Any())
             {
                 chain.Postprocessors.Add(new FlushOutgoingMessages());
+                chain.Postprocessors.Add(new ActivityEventFrame(WolverineTracing.OutboxPublished));
             }
         }
     }

--- a/src/Testing/CoreTests/Runtime/Interop/when_reading_and_writing_CloudEvents_data.cs
+++ b/src/Testing/CoreTests/Runtime/Interop/when_reading_and_writing_CloudEvents_data.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
@@ -114,6 +115,41 @@ public class when_reading_and_writing_CloudEvents_data
 
         envelope.Message.ShouldBeOfType<ApproveOrder>().OrderId.ShouldBe(1);
         envelope.MessageType.ShouldBe(typeof(ApproveOrder).ToMessageTypeName());
+    }
+
+    [Fact]
+    public async Task try_deserialize_envelope_emits_deserialize_span()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.RegisterMessageType(typeof(ApproveOrder), "com.dapr.event.sent");
+            }).StartAsync();
+
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        var serializer = new CloudEventsMapper(runtime.Options.HandlerGraph,
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+        var captured = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Wolverine",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity => captured.Add(activity)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var envelope = new Envelope
+        {
+            Data = Encoding.UTF8.GetBytes(Json),
+            Serializer = serializer
+        };
+
+        await runtime.Pipeline.TryDeserializeEnvelope(envelope);
+
+        var deserialize = captured.ShouldHaveSingleItem();
+        deserialize.DisplayName.ShouldBe(WolverineTracing.Deserialize);
+        deserialize.GetTagItem(WolverineTracing.PayloadSizeBytes).ShouldBe(envelope.Data!.Length);
     }
 }
 

--- a/src/Testing/CoreTests/Runtime/WolverineTracingTests.cs
+++ b/src/Testing/CoreTests/Runtime/WolverineTracingTests.cs
@@ -163,3 +163,70 @@ public class when_envelope_is_scheduled
         activity.GetTagItem(WolverineTracing.MessageScheduled).ShouldBeNull();
     }
 }
+
+public class when_starting_envelope_activity : IDisposable
+{
+    private readonly ActivityListener _listener;
+
+    public when_starting_envelope_activity()
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Wolverine",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    public void Dispose() => _listener.Dispose();
+
+    [Fact]
+    public void sets_transport_lag_tag_from_sent_at()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.SentAt = DateTimeOffset.UtcNow.AddMilliseconds(-500);
+
+        using var activity = WolverineTracing.StartEnvelopeActivity("process", envelope);
+
+        activity.ShouldNotBeNull();
+        var lag = activity.GetTagItem(WolverineTracing.EnvelopeTransportLagMs).ShouldBeOfType<double>();
+        lag.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public void does_not_set_transport_lag_tag_when_sent_at_is_in_the_future()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.SentAt = DateTimeOffset.UtcNow.AddMinutes(1);
+
+        using var activity = WolverineTracing.StartEnvelopeActivity("process", envelope);
+
+        activity.ShouldNotBeNull();
+        activity.GetTagItem(WolverineTracing.EnvelopeTransportLagMs).ShouldBeNull();
+    }
+
+    [Fact]
+    public void start_executing_sets_app_queue_dwell_tag_when_enqueued_at_is_set()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.AppQueueEnqueuedAt = DateTimeOffset.UtcNow.AddMilliseconds(-50);
+
+        using var activity = WolverineTracing.StartExecuting(envelope);
+
+        activity.ShouldNotBeNull();
+        var dwell = activity.GetTagItem(WolverineTracing.EnvelopeAppQueueDwellMs).ShouldBeOfType<double>();
+        dwell.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public void start_executing_omits_app_queue_dwell_tag_when_enqueued_at_is_null()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.AppQueueEnqueuedAt = null;
+
+        using var activity = WolverineTracing.StartExecuting(envelope);
+
+        activity.ShouldNotBeNull();
+        activity.GetTagItem(WolverineTracing.EnvelopeAppQueueDwellMs).ShouldBeNull();
+    }
+}

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -246,6 +246,12 @@ public partial class Envelope : IHasTenantId
     public DateTimeOffset SentAt { get; set; } = DateTimeOffset.UtcNow;
 
     /// <summary>
+    /// Wall-clock timestamp set when the envelope is posted onto the in-process worker queue.
+    /// </summary>
+    [JsonIgnore]
+    public DateTimeOffset? AppQueueEnqueuedAt { get; set; }
+
+    /// <summary>
     ///     The name of the service that sent this envelope
     /// </summary>
     public string? Source { get; set; }

--- a/src/Wolverine/Runtime/ActivityEventFrame.cs
+++ b/src/Wolverine/Runtime/ActivityEventFrame.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.Runtime;
+
+/// <summary>
+/// Codegen frame that emits an <see cref="Activity.AddEvent"/> call against <see cref="Activity.Current"/>.
+/// </summary>
+internal class ActivityEventFrame : Frame
+{
+    private readonly string _eventName;
+
+    public ActivityEventFrame(string eventName) : base(false)
+    {
+        _eventName = eventName;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write(
+            $"{typeof(Activity).FullNameInCode()}.{nameof(Activity.Current)}?.AddEvent(new {typeof(ActivityEvent).FullNameInCode()}(\"{_eventName}\"));");
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain) => [];
+}

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -112,6 +112,8 @@ public class HandlerPipeline : IHandlerPipeline
     {
         if (envelope.Message != null) return NullContinuation.Instance;
 
+        using var activity = WolverineTracing.ActivitySource.StartActivity(WolverineTracing.Deserialize, ActivityKind.Internal);
+
         // Try to deserialize
         try
         {
@@ -129,6 +131,8 @@ public class HandlerPipeline : IHandlerPipeline
                 throw new ArgumentOutOfRangeException(nameof(envelope),
                     "Envelope does not have a message or deserialized message data");
             }
+
+            activity?.SetTag(WolverineTracing.PayloadSizeBytes, envelope.Data.Length);
 
             if (envelope.Message != null)
             {
@@ -167,6 +171,7 @@ public class HandlerPipeline : IHandlerPipeline
         }
         catch (Exception? e)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, e.GetType().Name);
             return new MoveToErrorQueue(e);
         }
         finally

--- a/src/Wolverine/Runtime/Handlers/HandlerChain.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerChain.cs
@@ -575,10 +575,17 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
         foreach (var methodCall in Middleware.OfType<MethodCall>())
             methodCall.TryReplaceVariableCreationWithAssignment(messageVariable);
 
+        var userStartedMarker = new[] { new ActivityEventFrame(WolverineTracing.HandlerUserStarted) };
+
         // The Enqueue cascading needs to happen before the post processors because of the
         // transactional & outbox support
-        return Middleware.Concat(container.TryCreateConstructorFrames(Handlers)).Concat(Handlers)
-            .Concat(handlerReturnValueFrames).Concat(Postprocessors).ToList();
+        return Middleware
+            .Concat(userStartedMarker)
+            .Concat(container.TryCreateConstructorFrames(Handlers))
+            .Concat(Handlers)
+            .Concat(handlerReturnValueFrames)
+            .Concat(Postprocessors)
+            .ToList();
     }
 
     protected void applyCustomizations(GenerationRules rules, IServiceContainer container)

--- a/src/Wolverine/Runtime/WolverineTracing.cs
+++ b/src/Wolverine/Runtime/WolverineTracing.cs
@@ -165,6 +165,41 @@ internal static class WolverineTracing
     /// </summary>
     public const string StreamingCompleted = "wolverine.stream.handler.completed";
 
+    /// <summary>
+    /// ActivityEvent emitted immediately before the user handler body runs, after middleware completes.
+    /// </summary>
+    public const string HandlerUserStarted = "wolverine.handler.user_started";
+
+    /// <summary>
+    /// ActivityEvent emitted immediately before the transactional unit-of-work is committed.
+    /// </summary>
+    public const string OutboxFlushing = "wolverine.outbox.flushing";
+
+    /// <summary>
+    /// ActivityEvent emitted immediately after the transactional unit-of-work commit returns.
+    /// </summary>
+    public const string OutboxFlushed = "wolverine.outbox.flushed";
+
+    /// <summary>
+    /// ActivityEvent emitted after post-commit outgoing messages have been flushed to their senders.
+    /// </summary>
+    public const string OutboxPublished = "wolverine.outbox.published";
+
+    /// <summary>
+    /// Activity tag (milliseconds): elapsed time from producer <see cref="Envelope.SentAt"/> to consumer activity start.
+    /// </summary>
+    public const string EnvelopeTransportLagMs = "wolverine.envelope.transport_lag_ms";
+
+    /// <summary>
+    /// Activity tag (milliseconds): elapsed time from worker-queue enqueue to handler activity start.
+    /// </summary>
+    public const string EnvelopeAppQueueDwellMs = "wolverine.envelope.app_queue_dwell_ms";
+
+    /// <summary>
+    /// Span emitted around inbound envelope deserialization.
+    /// </summary>
+    public const string Deserialize = "wolverine.deserialize";
+
     #endregion
 
     public static ActivitySource ActivitySource { get; } = new(
@@ -188,7 +223,18 @@ internal static class WolverineTracing
 
     public static Activity? StartExecuting(Envelope envelope)
     {
-        return StartEnvelopeActivity(envelope.MessageType ?? "process", envelope);
+        var activity = StartEnvelopeActivity(envelope.MessageType ?? "process", envelope);
+
+        if (activity != null && envelope.AppQueueEnqueuedAt.HasValue)
+        {
+            var dwellMs = (activity.StartTimeUtc - envelope.AppQueueEnqueuedAt.Value.UtcDateTime).TotalMilliseconds;
+            if (dwellMs >= 0)
+            {
+                activity.SetTag(EnvelopeAppQueueDwellMs, dwellMs);
+            }
+        }
+
+        return activity;
     }
 
     public static Activity? StartEnvelopeActivity(string spanName, Envelope envelope,
@@ -204,6 +250,12 @@ internal static class WolverineTracing
         }
 
         envelope.WriteTags(activity);
+
+        var lagMs = (activity.StartTimeUtc - envelope.SentAt.UtcDateTime).TotalMilliseconds;
+        if (lagMs >= 0)
+        {
+            activity.SetTag(EnvelopeTransportLagMs, lagMs);
+        }
 
         return activity;
     }

--- a/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
@@ -175,6 +175,7 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
         }
 
         var activity = _endpoint.TelemetryEnabled ? WolverineTracing.StartReceiving(envelope) : null;
+        envelope.AppQueueEnqueuedAt = DateTimeOffset.UtcNow;
         _receivingBlock.Post(envelope);
         activity?.Stop();
     }
@@ -187,6 +188,7 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
         }
 
         var activity = _endpoint.TelemetryEnabled ? WolverineTracing.StartReceiving(envelope) : null;
+        envelope.AppQueueEnqueuedAt = DateTimeOffset.UtcNow;
         await _receivingBlock.PostAsync(envelope).ConfigureAwait(false);
         activity?.Stop();
     }

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -252,6 +252,7 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
         // sure the ancillary-store routing is applied here too so the
         // mark-as-handled SQL goes to the correct store. See GH-2576.
         assignAncillaryStoreIfNeeded(envelope);
+        envelope.AppQueueEnqueuedAt = DateTimeOffset.UtcNow;
         _receiver.Post(envelope);
     }
 
@@ -265,6 +266,7 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
         // through the assignAncillaryStoreIfNeeded calls in receiveOneAsync /
         // ProcessReceivedMessagesAsync. See GH-2576.
         assignAncillaryStoreIfNeeded(envelope);
+        envelope.AppQueueEnqueuedAt = DateTimeOffset.UtcNow;
         return _receiver.PostAsync(envelope);
     }
 


### PR DESCRIPTION
- ActivityEvent wolverine.handler.user_started: end of middleware, start of user handler.
- ActivityEvents wolverine.outbox.flushing/flushed/published: emitted by Marten persistence frames around the unit-of-work commit and post-commit dispatch.
- Activity tag wolverine.envelope.transport_lag_ms: producer SentAt to consumer activity start.
- Activity tag wolverine.envelope.app_queue_dwell_ms: worker-queue enqueue to handler activity start (requires new Envelope.AppQueueEnqueuedAt, stamped in DurableReceiver / BufferedReceiver).
- Span wolverine.deserialize: wraps HandlerPipeline.TryDeserializeEnvelope, with payload-size tag.
- ActivityEventFrame: codegen frame that emits Activity.Current.AddEvent(...).
- Tests: MartenTests/OutboxActivityEvents_emitted verifies event ordering and the new tags; WolverineTracingTests covers transport_lag_ms and app_queue_dwell_ms; when_reading_and_writing_CloudEvents_data covers the deserialize span and payload-size tag.
- docs/guide/logging.md: documents the new events and tags.