### PR TITLE
fix(test): lock AllItemsReceived state in batch_processing tests

### DIFF
--- a/src/Persistence/MartenTests/batch_processing.cs
+++ b/src/Persistence/MartenTests/batch_processing.cs
@@ -182,19 +182,34 @@ public class batch_processing
 
 public class AllItemsReceived(params BatchItem[] Items) : ITrackedCondition
 {
+    // Record fires from the tracking infrastructure on whichever thread the
+    // handler completes on. In end_to_end_with_tenancy two tenant batches
+    // ("blue" and "green") complete in parallel and both reach Record at the
+    // same time. List<T>.AddRange is not thread-safe — concurrent callers
+    // race on the internal array resize and writes, leaving null slots that
+    // surface as an NRE when IsCompleted reads `r.Id` in the polling
+    // predicate. Lock both the writer and the reader so the polling thread
+    // sees a consistent snapshot.
+    private readonly object _lock = new();
     private readonly List<BatchItem> _received = new();
-    
+
     public void Record(EnvelopeRecord record)
     {
         if (record.MessageEventType == MessageEventType.MessageSucceeded && record.Message is BatchItem[] items)
         {
-            _received.AddRange(items);
+            lock (_lock)
+            {
+                _received.AddRange(items);
+            }
         }
     }
 
     public bool IsCompleted()
     {
-        return Items.All(x => _received.Any(r => r.Id == x.Id));
+        lock (_lock)
+        {
+            return Items.All(x => _received.Any(r => r.Id == x.Id));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- `MartenTests.batch_processing.end_to_end_with_tenancy` has been failing on every recent Marten CI run with an `AggregateException` of NREs out of `AllItemsReceived.IsCompleted`. Root cause: in the multi-tenant variant the "blue" and "green" tenant batches complete in parallel and both call `Record(EnvelopeRecord)` from the tracking infrastructure on whichever thread the handler finishes on. The helper fed the records into a plain `List<BatchItem>` via `AddRange`, which is not thread-safe — concurrent callers race on the internal array's resize and writes, leaving null slots that surface as NRE when the polling thread reads `r.Id` in the `IsCompleted` predicate.
- Locks both `Record` (writer) and `IsCompleted` (reader) so the polling thread sees a consistent snapshot.
- **No production code is touched** — the lock lives entirely in the test helper class.

## Repro / verification
- Without fix: 1/10 fail locally on a fast box; deterministically failing in CI on slower runners (same NRE on every recent Marten run that's been retried twice and still red — see e.g. runs `25434414670`, `25391326016`, `25380002472`, `25373294046`, `25492035820`).
- With fix: 15/15 pass locally for `end_to_end_with_tenancy`; sibling `end_to_end_with_durable` (which uses the same helper) also passes.

## Test plan
- [x] `dotnet test --filter FullyQualifiedName=MartenTests.batch_processing.end_to_end_with_tenancy` — 15/15 passed
- [x] `dotnet test --filter FullyQualifiedName~MartenTests.batch_processing` — 2/2 passed
- [ ] CI Marten run on this PR clears

## Note
This PR is also serving to put the Marten CI under load while you watch for any timeout regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)