### PR TITLE
fix(marten): publish IEvent.TenantId verbatim under conjoined tenancy

### DIFF
--- a/src/Persistence/MartenSubscriptionTests/subscriptions_end_to_end.cs
+++ b/src/Persistence/MartenSubscriptionTests/subscriptions_end_to_end.cs
@@ -333,6 +333,140 @@ public class subscriptions_end_to_end
     }
 
     [Fact]
+    public async Task non_conjoined_store_preserves_legacy_default_tenant_fallthrough()
+    {
+        // Companion to carry_default_tenant_id_through_under_conjoined_tenancy:
+        // for non-conjoined stores the relay must keep falling through to the bus
+        // context's TenantId, so any setup that relied on the database identifier as
+        // the message tenant (e.g. per-tenant ancillary stores with a custom
+        // Database.Identifier) keeps working.
+        await dropSchema();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Policies.UseDurableLocalQueues();
+
+                opts.Services.AddMarten(m =>
+                    {
+                        m.DisableNpgsqlLogging = true;
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "subscriptions";
+                        // Default (single) tenancy on the events store
+                    }).IntegrateWithWolverine()
+                    .UseLightweightSessions()
+                    .PublishEventsToWolverine("Publish", x =>
+                    {
+                        x.PublishEvent<AEvent>();
+                    });
+            }).StartAsync();
+
+        var store = host.DocumentStore();
+
+        var daemon = await store.BuildProjectionDaemonAsync();
+
+        await daemon.StartAllAsync();
+
+        Func<IMessageContext, Task> writeEvents = async _ =>
+        {
+            await using var session = store.LightweightSession();
+            session.Events.StartStream(Guid.NewGuid(), new AEvent(), new AEvent());
+            await session.SaveChangesAsync();
+
+            await daemon.WaitForNonStaleData(30.Seconds());
+        };
+
+        var tracked = await host
+            .TrackActivity()
+            .ExecuteAndWaitAsync(writeEvents);
+
+        var aEnvelopes = tracked.MessageSucceeded.Envelopes()
+            .Where(x => x.Message is IEvent<AEvent>)
+            .ToList();
+
+        aEnvelopes.ShouldNotBeEmpty();
+
+        // Pre-fix and post-fix behaviour for non-conjoined stores: the relay falls through
+        // and envelope.TenantId is the bus context value that
+        // WolverineSubscriptionRunner set from operations.Database.Identifier
+        // (e.g. "Main" for a single-database Marten store). Crucially it must NOT be the
+        // default-tenant marker — that would mean the fix had over-applied and dropped the
+        // database-identifier-as-tenant convention used by some ancillary-store setups.
+        foreach (var envelope in aEnvelopes)
+        {
+            envelope.TenantId.ShouldNotBeNull();
+            envelope.TenantId.ShouldNotBe(JasperFx.StorageConstants.DefaultTenantId);
+        }
+    }
+
+    [Fact]
+    public async Task carry_default_tenant_id_through_under_conjoined_tenancy()
+    {
+        // Regression: PublishingRelay used to drop DeliveryOptions for default-tenant
+        // events, letting WolverineSubscriptionRunner's bus.TenantId
+        // (= operations.Database.Identifier) leak onto the outbound envelope. Under
+        // conjoined tenancy where the database identifier is not the tenant, that
+        // misrouted default-tenant events into the wrong tenant context.
+        await dropSchema();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Policies.UseDurableLocalQueues();
+
+                opts.Services.AddMarten(m =>
+                    {
+                        m.DisableNpgsqlLogging = true;
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "subscriptions";
+                        m.Events.TenancyStyle = Marten.Storage.TenancyStyle.Conjoined;
+                    }).IntegrateWithWolverine()
+                    .UseLightweightSessions()
+                    .PublishEventsToWolverine("Publish", x =>
+                    {
+                        x.PublishEvent<AEvent>();
+                    });
+            }).StartAsync();
+
+        var store = host.DocumentStore();
+
+        var daemon = await store.BuildProjectionDaemonAsync();
+
+        await daemon.StartAllAsync();
+
+        Func<IMessageContext, Task> writeEvents = async _ =>
+        {
+            // No tenant arg -> events get IEvent.TenantId == StorageConstants.DefaultTenantId
+            await using var session = store.LightweightSession();
+            session.Events.StartStream(Guid.NewGuid(), new AEvent(), new AEvent());
+            await session.SaveChangesAsync();
+
+            await daemon.WaitForNonStaleData(30.Seconds());
+        };
+
+        var tracked = await host
+            .TrackActivity()
+            .ExecuteAndWaitAsync(writeEvents);
+
+        var aEnvelopes = tracked.MessageSucceeded.Envelopes()
+            .Where(x => x.Message is IEvent<AEvent>)
+            .ToList();
+
+        aEnvelopes.ShouldNotBeEmpty();
+
+        foreach (var envelope in aEnvelopes)
+        {
+            // Marten's IEvent for a default-tenant event carries TenantId == "*DEFAULT*";
+            // the relayed Wolverine envelope must propagate that, not the database identifier.
+            envelope.TenantId.ShouldBe(JasperFx.StorageConstants.DefaultTenantId);
+        }
+    }
+
+    [Fact]
     public async Task carry_the_tenant_id_through_on_the_subscription()
     {
         await dropSchema();

--- a/src/Persistence/Wolverine.Marten/AncillaryWolverineOptionsMartenExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/AncillaryWolverineOptionsMartenExtensions.cs
@@ -357,7 +357,7 @@ public static class AncillaryWolverineOptionsMartenExtensions
         {
             var runtime = sp.GetRequiredService<IWolverineRuntime>();
 
-            var relay = new PublishingRelay(subscriptionName);
+            var relay = new PublishingRelay(subscriptionName, opts.Events.TenancyStyle);
             configure?.Invoke(relay);
 
             var subscription = new WolverineSubscriptionRunner(relay, runtime);

--- a/src/Persistence/Wolverine.Marten/Subscriptions/PublishingRelay.cs
+++ b/src/Persistence/Wolverine.Marten/Subscriptions/PublishingRelay.cs
@@ -60,9 +60,24 @@ public interface IPublishingRelay
 internal class PublishingRelay : BatchSubscription, IPublishingRelay
 {
     private ImHashMap<Type, IPublisher> _publishers = ImHashMap<Type, IPublisher>.Empty;
+    private readonly Func<IEvent, IMessageBus, ValueTask> _relay;
 
-    public PublishingRelay(string subscriptionName) : base(subscriptionName)
+    public PublishingRelay(string subscriptionName, TenancyStyle tenancyStyle) : base(subscriptionName)
     {
+        // Bind the per-event publish path once at construction so the hot loop in
+        // ProcessEventsAsync needs neither a TenancyStyle comparison nor a downcast
+        // through IDocumentSession.DocumentStore. Under conjoined tenancy
+        // IEvent<T>.TenantId is the authoritative attribution (the tenant lives in
+        // the row, not the database) and must reach the outbound envelope verbatim
+        // — including StorageConstants.DefaultTenantId for default-tenant events,
+        // otherwise WolverineSubscriptionRunner's bus.TenantId
+        // (= operations.Database.Identifier) silently misroutes them. For
+        // non-conjoined stores the legacy fallthrough is preserved so any setup
+        // relying on the database identifier as the message tenant keeps working.
+        // See GH-2675.
+        _relay = tenancyStyle == TenancyStyle.Conjoined
+            ? RelayWithEventTenant
+            : RelayWithLegacyFallthrough;
     }
 
     public void PublishEvent<T>(Func<IEvent<T>, IMessageBus, ValueTask> publish) where T : notnull
@@ -94,18 +109,18 @@ internal class PublishingRelay : BatchSubscription, IPublishingRelay
             }
             else
             {
-                if (e.TenantId != StorageConstants.DefaultTenantId)
-                {
-                    await bus.PublishAsync(e, new DeliveryOptions{TenantId = e.TenantId});
-                }
-                else
-                {
-                    await bus.PublishAsync(e);
-                }
-                
+                await _relay(e, bus);
             }
         }
     }
+
+    private static ValueTask RelayWithEventTenant(IEvent e, IMessageBus bus)
+        => bus.PublishAsync(e, new DeliveryOptions { TenantId = e.TenantId });
+
+    private static ValueTask RelayWithLegacyFallthrough(IEvent e, IMessageBus bus)
+        => e.TenantId != StorageConstants.DefaultTenantId
+            ? bus.PublishAsync(e, new DeliveryOptions { TenantId = e.TenantId })
+            : bus.PublishAsync(e);
 
     internal interface IPublisher
     {

--- a/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
@@ -462,7 +462,7 @@ public static class WolverineOptionsMartenExtensions
         {
             var runtime = sp.GetRequiredService<IWolverineRuntime>();
 
-            var relay = new PublishingRelay(subscriptionName);
+            var relay = new PublishingRelay(subscriptionName, opts.Events.TenancyStyle);
             configure?.Invoke(relay);
 
             var subscription = new WolverineSubscriptionRunner(relay, runtime);


### PR DESCRIPTION
Closes #2675. Supersedes #2676.

## Summary
- Under conjoined tenancy `PublishingRelay`'s default-tenant fallthrough lets `WolverineSubscriptionRunner`'s `bus.TenantId` (= `operations.Database.Identifier`) leak onto the outbound envelope. Default-tenant events were dispatched under the database identifier (e.g. `"Main"`) instead of `*DEFAULT*`, the handler chain ran under the wrong tenant scope (or silently no-op'd), but Marten still advanced the subscription sequence because publishing succeeded.
- This PR keeps #2676's two regression tests but **simplifies the production code** so the hot loop in `ProcessEventsAsync` has **no `TenancyStyle` comparison and no downcast** through `IDocumentSession.DocumentStore`.

## Why this is simpler than #2676

#2676 added a per-event runtime check inside the loop:

```csharp
var tenancyStyle = ((IDocumentSession)operations).DocumentStore.Options.Events.TenancyStyle; // downcast
if (e.TenantId != StorageConstants.DefaultTenantId || tenancyStyle == TenancyStyle.Conjoined) // runtime check
    await bus.PublishAsync(e, new DeliveryOptions { TenantId = e.TenantId });
else
    await bus.PublishAsync(e);
```

This PR binds the publish path **once at construction** by capturing `TenancyStyle` from the surrounding `ConfigureMarten` lambda and picking between two static method-group delegates:

```csharp
public PublishingRelay(string subscriptionName, TenancyStyle tenancyStyle) : base(subscriptionName)
{
    _relay = tenancyStyle == TenancyStyle.Conjoined
        ? RelayWithEventTenant
        : RelayWithLegacyFallthrough;
}

// hot path in ProcessEventsAsync:
await _relay(e, bus);

private static ValueTask RelayWithEventTenant(IEvent e, IMessageBus bus)
    => bus.PublishAsync(e, new DeliveryOptions { TenantId = e.TenantId });

private static ValueTask RelayWithLegacyFallthrough(IEvent e, IMessageBus bus)
    => e.TenantId != StorageConstants.DefaultTenantId
        ? bus.PublishAsync(e, new DeliveryOptions { TenantId = e.TenantId })
        : bus.PublishAsync(e);
```

The downcast is gone entirely. The conjoined hot path has zero runtime checks. The legacy path keeps its single comparison — that one's intrinsic to its semantics, not avoidable without changing behaviour.

## Compatibility

| Setup | Pre-fix `Envelope.TenantId` | Post-fix `Envelope.TenantId` |
|-------|------------------------------|--------------------------------|
| No tenancy (default Marten store) | `Database.Identifier` | `Database.Identifier` (unchanged) |
| Conjoined, default-tenant event | `Database.Identifier` (the bug) | `*DEFAULT*` (correct) |
| Conjoined, named-tenant event | `"one"` | `"one"` (unchanged) |
| `MultiTenantedDatabases(...AddSingleTenantDatabase(...))` | `"tenant1"` | `"tenant1"` (unchanged) |
| Per-tenant ancillary stores with custom `Database.Identifier` (`TenancyStyle.Single`) | the custom identifier | the custom identifier (unchanged) |

Only the conjoined-default-tenant cell changes. Every other row keeps its pre-fix behaviour because the relay only switches into `RelayWithEventTenant` mode under conjoined.

## Tests (carried over from #2676)

1. **`carry_default_tenant_id_through_under_conjoined_tenancy`** — publishes a default-tenant event through a conjoined store; asserts `Envelope.TenantId == StorageConstants.DefaultTenantId`. Reproduces the bug on main.
2. **`non_conjoined_store_preserves_legacy_default_tenant_fallthrough`** — companion on a non-conjoined store; asserts the relay still falls through, guarding the per-tenant-ancillary-store pattern against accidental over-application.

## Test plan
- [x] `dotnet test src/Persistence/MartenSubscriptionTests --framework net9.0` — **12/12 passed** (both regression tests included)
- [x] `dotnet build src/Persistence/MartenTests` clean (the `PublishingRelay` consumers in the broader Marten test project still compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)