### PR TITLE
feat(tracing): opt-in handler-execution diagnostics on WolverineOptions.Tracking

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="1.29.0" />
+    <PackageVersion Include="JasperFx" Version="1.30.0" />
     <PackageVersion Include="JasperFx.Events" Version="1.33.1" />
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.5.0" />
     <PackageVersion Include="JasperFx.SourceGeneration" Version="1.1.0" />

--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -596,7 +596,7 @@ public const string StreamType = "wolverine.stream.type";
 
 ## Opt-in Handler Execution Diagnostics <Badge type="tip" text="5.38" />
 
-The default span surface above covers cluster-level events (listener pause, retries, scheduled redelivery, etc.). Wolverine ships a separate, **opt-in** layer of structured diagnostics aimed at handler-execution timing — useful when you're tuning latency, looking for queue dwell, or debugging `await`-graph interleaving inside the handler. Each flag lives on `WolverineOptions.Tracking` and **defaults to `false`**, so apps that don't ask for the surface pay nothing for it.
+The default span surface above covers cluster-level events (listener pause, retries, scheduled redelivery, etc.). Wolverine ships a separate, **opt-in** layer of structured diagnostics aimed primarily at **performance optimization** — handler latency tuning, spotting queue dwell or backpressure, profiling slow transactional commits, and debugging `await`-graph interleaving inside the handler. Each flag lives on `WolverineOptions.Tracking` and **defaults to `false`**, so apps that don't ask for the surface pay nothing for it.
 
 ```csharp
 builder.UseWolverine(opts =>
@@ -610,12 +610,19 @@ builder.UseWolverine(opts =>
     opts.Tracking.DeserializationSpanEnabled = true;
 
     // wolverine.outbox.flushing / wolverine.outbox.published ActivityEvents
-    // around the FlushOutgoingMessages call in the generated handler chain.
+    // around the FlushOutgoingMessages call in the generated handler chain,
+    // and (when Wolverine.Marten transactional middleware is in play)
+    // marten.savechanges.start / marten.savechanges.finished ActivityEvents
+    // around the Marten IDocumentSession.SaveChangesAsync call.
     opts.Tracking.OutboxDiagnosticsEnabled = true;
+
+    // RecordCauseAndEffect call after the handler body that reports unique
+    // (incoming, outgoing) message-type pairs to IWolverineObserver.
+    opts.Tracking.EnableMessageCausationTracking = true;
 });
 ```
 
-Each flag is independent. The runtime checks each flag at code-generation time only — when a flag is `false`, the corresponding annotations are not emitted into the generated handler at all, so there is **zero per-message runtime cost** for any feature you haven't enabled. The legacy `WolverineOptions.EnableMessageCausationTracking` property is preserved as an `[Obsolete]` shim that delegates to `Tracking.EnableMessageCausationTracking`.
+Each flag is independent. The runtime checks each flag at code-generation time only — when a flag is `false`, the corresponding annotations are not emitted into the generated handler at all, so there is **zero per-message runtime cost** for any feature you haven't enabled. That codegen-time gating is the whole point: in tight production hot paths you want a flag that costs literally nothing when it's off, not one guarded by a runtime `if`. The legacy `WolverineOptions.EnableMessageCausationTracking` property is preserved as an `[Obsolete]` shim that delegates to `Tracking.EnableMessageCausationTracking`.
 
 ### `HandlerExecutionDiagnosticsEnabled`
 
@@ -651,9 +658,75 @@ When set, Wolverine emits two ActivityEvents around the post-handler call to `IM
 
 This is provider-agnostic — it fires regardless of which transactional middleware (Marten, EF Core, RDBMS, Polecat, etc.) added the `FlushOutgoingMessages` postprocessor frame. The annotation is emitted via the same JasperFx `MethodCall.ActivityEventBeforeCall` / `.ActivityEventAfterCall` codegen surface as the handler events, so when the flag is off the generated outbox-flush call has no extra emission.
 
+When the chain pulls in **Wolverine.Marten** transactional middleware, `OutboxDiagnosticsEnabled` also brackets the Marten transactional commit:
+
+| Name | Meaning |
+|---|---|
+| `marten.savechanges.start` | Emitted immediately before `IDocumentSession.SaveChangesAsync(CancellationToken)`. |
+| `marten.savechanges.finished` | Emitted immediately after `SaveChangesAsync` returns successfully. |
+
+Useful for separating "the database commit is slow" from "the broker publish is slow" when profiling a transactional handler — the two pairs of events bracket the two distinct stages.
+
+### `EnableMessageCausationTracking`
+
+When set, Wolverine emits a `RecordCauseAndEffect(context, context.Runtime.Observer)` call into the generated handler **between** the handler body and the postprocessor frames. Each unique `(incoming → outgoing, handler)` triple is reported once to `IWolverineObserver.MessageCausedBy` for downstream topology visualization (CritterWatch enables this flag automatically). Latched on the framework side, so the call itself is cheap on the steady-state path; the codegen-time gate guarantees zero cost for users who don't enable it.
+
 ### `Envelope.ReceivedAt`
 
 The `wolverine.envelope.receive_dwell_ms` tag depends on a new `Envelope.ReceivedAt` property that's stamped by `Envelope.MarkReceived` — the single point all receivers (`BufferedReceiver`, `DurableReceiver`, etc.) call when a message is handed off from a listener to the worker pipeline. The property is `[JsonIgnore]` and only set by Wolverine itself; it stays `null` for envelopes that didn't traverse a receiver (inline `InvokeAsync` calls).
+
+### Sample of the generated handler code
+
+The "zero per-message runtime cost when off" property is easiest to see by inspecting the C# Wolverine actually generates. Take a trivial handler:
+
+```csharp
+public record TrackingDiagnosticsMessage(string Text);
+
+public static class TrackingDiagnosticsHandler
+{
+    public static void Handle(TrackingDiagnosticsMessage message) { /* no-op */ }
+}
+```
+
+With **all flags off** (the default), the generated `HandleAsync` body is the bare handler invocation — no diagnostic plumbing is emitted at all:
+
+```csharp
+public override Task HandleAsync(MessageContext context, CancellationToken cancellation)
+{
+    var trackingDiagnosticsMessage = (TrackingDiagnosticsMessage)context.Envelope.Message;
+
+    Activity.Current?.SetTag("message.handler", "TrackingDiagnosticsHandler");
+    Activity.Current?.SetTag("handler.type",    "TrackingDiagnosticsHandler");
+
+    TrackingDiagnosticsHandler.Handle(trackingDiagnosticsMessage);
+
+    return Task.CompletedTask;
+}
+```
+
+With `Tracking.HandlerExecutionDiagnosticsEnabled = true` and `Tracking.EnableMessageCausationTracking = true`, the generated body picks up an `ApplyExecutionDiagnosticTags` call at the top, ActivityEvents bracketing the handler body, and a `RecordCauseAndEffect` call between the handler and the postprocessor frames:
+
+```csharp
+public override Task HandleAsync(MessageContext context, CancellationToken cancellation)
+{
+    var trackingDiagnosticsMessage = (TrackingDiagnosticsMessage)context.Envelope.Message;
+
+    WolverineTracing.ApplyExecutionDiagnosticTags(Activity.Current, context.Envelope);
+    Activity.Current?.SetTag("message.handler", "TrackingDiagnosticsHandler");
+    Activity.Current?.SetTag("handler.type",    "TrackingDiagnosticsHandler");
+
+    Activity.Current?.AddEvent(new ActivityEvent("wolverine.handler.started"));
+    TrackingDiagnosticsHandler.Handle(trackingDiagnosticsMessage);
+    Activity.Current?.AddEvent(new ActivityEvent("wolverine.handler.finished"));
+
+    RecordCauseAndEffect(context, context.Runtime.Observer);
+    return Task.CompletedTask;
+}
+```
+
+Compare the two and the design pattern is concrete: each opt-in flag adds a specific line to the generated method; turning it back off removes the line entirely. There's no runtime `if (options.Tracking.X)` check anywhere in the framework hot path — the chain's `assembleFrames` reads each flag once at codegen time and decides which frames to emit.
+
+If you want to inspect what your own handlers look like, set `WolverineOptions.CodeGeneration.SourceCodeWritingEnabled = true` and dump the generated code (or call `host.Services.GetRequiredService<HandlerGraph>().ChainFor<MyMessage>()!.SourceCode`); the same `tracking_diagnostics_opt_in` test suite in the Wolverine repo writes the generated source to xUnit output for every flag combination, so the contract is regression-tested rather than just illustrated here.
 
 ## Handler Type Tagging
 

--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -594,6 +594,67 @@ public const string StreamType = "wolverine.stream.type";
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/Runtime/WolverineTracing.cs#L28-L141' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_open_telemetry_tracing_spans_and_activities' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Opt-in Handler Execution Diagnostics <Badge type="tip" text="5.38" />
+
+The default span surface above covers cluster-level events (listener pause, retries, scheduled redelivery, etc.). Wolverine ships a separate, **opt-in** layer of structured diagnostics aimed at handler-execution timing — useful when you're tuning latency, looking for queue dwell, or debugging `await`-graph interleaving inside the handler. Each flag lives on `WolverineOptions.Tracking` and **defaults to `false`**, so apps that don't ask for the surface pay nothing for it.
+
+```csharp
+builder.UseWolverine(opts =>
+{
+    // wolverine.handler.started / wolverine.handler.finished ActivityEvents
+    // around the user handler body, plus per-envelope timing tags.
+    opts.Tracking.HandlerExecutionDiagnosticsEnabled = true;
+
+    // wolverine.deserialize span around inbound envelope deserialization,
+    // tagged with messaging.message_payload_size_bytes.
+    opts.Tracking.DeserializationSpanEnabled = true;
+
+    // wolverine.outbox.flushing / wolverine.outbox.published ActivityEvents
+    // around the FlushOutgoingMessages call in the generated handler chain.
+    opts.Tracking.OutboxDiagnosticsEnabled = true;
+});
+```
+
+Each flag is independent. The runtime checks each flag at code-generation time only — when a flag is `false`, the corresponding annotations are not emitted into the generated handler at all, so there is **zero per-message runtime cost** for any feature you haven't enabled. The legacy `WolverineOptions.EnableMessageCausationTracking` property is preserved as an `[Obsolete]` shim that delegates to `Tracking.EnableMessageCausationTracking`.
+
+### `HandlerExecutionDiagnosticsEnabled`
+
+When set, two ActivityEvents and two activity tags are emitted around each handler invocation:
+
+| Name | Kind | Meaning |
+|---|---|---|
+| `wolverine.handler.started` | ActivityEvent | Emitted immediately before the user handler body runs, after every middleware frame has completed. Lets you measure middleware overhead independently. |
+| `wolverine.handler.finished` | ActivityEvent | Emitted immediately after the user handler body returns successfully. |
+| `wolverine.envelope.transport_lag_ms` | tag (double, milliseconds) | `activity.StartTimeUtc - envelope.SentAt` — the elapsed time from when the producer stamped the envelope's send timestamp to when the consumer's handler activity started. Skipped for negative values (clock drift). |
+| `wolverine.envelope.receive_dwell_ms` | tag (double, milliseconds) | `activity.StartTimeUtc - envelope.ReceivedAt` — the elapsed time from when the listener stamped the envelope as received (`Envelope.MarkReceived`) to when the handler activity started. Useful for spotting in-process worker-queue backpressure separately from upstream transport latency. Absent for envelopes that didn't traverse a receiver (inline `IMessageBus.InvokeAsync` calls). |
+
+The two ActivityEvents are emitted by the JasperFx `MethodCall.ActivityEventBeforeCall` / `.ActivityEventAfterCall` codegen surface, so they wrap exactly the user handler `MethodCall` — middleware frames before the handler body stay unmarked. The two timing tags are stamped by an `ApplyExecutionDiagnosticTagsFrame` that's prepended to the generated chain when the flag is set, so all the tag computation happens inline in the generated handler with no runtime branching in `Executor` or `HandlerPipeline`.
+
+### `DeserializationSpanEnabled`
+
+When set, Wolverine starts a `wolverine.deserialize` span (kind = `Internal`) around the inbound envelope deserialization that runs before the handler chain executes. The span carries:
+
+| Tag | Meaning |
+|---|---|
+| `messaging.message_payload_size_bytes` | The size of the raw envelope `Data` array in bytes. |
+
+The span's status is set to `Error` (with the exception type name as description) when deserialization throws — useful for separating "transport delivered me garbage" from "my handler blew up" in trace dashboards. The span only starts when the flag is on, so apps that don't enable it see no extra spans.
+
+### `OutboxDiagnosticsEnabled`
+
+When set, Wolverine emits two ActivityEvents around the post-handler call to `IMessageContext.FlushOutgoingMessagesAsync` in the generated handler chain:
+
+| Name | Meaning |
+|---|---|
+| `wolverine.outbox.flushing` | Emitted immediately before the outbox flush call. |
+| `wolverine.outbox.published` | Emitted immediately after the outbox flush call returns successfully. |
+
+This is provider-agnostic — it fires regardless of which transactional middleware (Marten, EF Core, RDBMS, Polecat, etc.) added the `FlushOutgoingMessages` postprocessor frame. The annotation is emitted via the same JasperFx `MethodCall.ActivityEventBeforeCall` / `.ActivityEventAfterCall` codegen surface as the handler events, so when the flag is off the generated outbox-flush call has no extra emission.
+
+### `Envelope.ReceivedAt`
+
+The `wolverine.envelope.receive_dwell_ms` tag depends on a new `Envelope.ReceivedAt` property that's stamped by `Envelope.MarkReceived` — the single point all receivers (`BufferedReceiver`, `DurableReceiver`, etc.) call when a message is handed off from a listener to the worker pipeline. The property is `[JsonIgnore]` and only set by Wolverine itself; it stays `null` for envelopes that didn't traverse a receiver (inline `InvokeAsync` calls).
+
 ## Handler Type Tagging
 
 Wolverine automatically tags Open Telemetry activity spans with the handler type name during message processing. This provides per-handler tracing visibility in observability backends like Jaeger, Zipkin, or Honeycomb without any additional configuration.

--- a/src/Persistence/MartenTests/marten_tracking_diagnostics.cs
+++ b/src/Persistence/MartenTests/marten_tracking_diagnostics.cs
@@ -1,0 +1,98 @@
+using IntegrationTests;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+using Wolverine.Tracking;
+using Xunit.Abstractions;
+
+namespace MartenTests;
+
+/// <summary>
+/// Codegen-only checks for the Marten side of <c>Tracking.OutboxDiagnosticsEnabled</c>:
+/// when the flag is on, the Marten transactional middleware's
+/// <c>SaveChangesAsync</c> postprocessor must be bracketed with
+/// <c>marten.savechanges.start</c> / <c>marten.savechanges.finished</c> ActivityEvents
+/// in the generated handler source. When the flag is off, those calls must not appear
+/// at all (no runtime <c>if/then</c> guard — the gate is purely codegen-time).
+/// Both tests dump the generated source for the target handler chain to xUnit output
+/// so reviewers can read the contract.
+/// </summary>
+public class marten_tracking_diagnostics : PostgresqlContext
+{
+    private readonly ITestOutputHelper _output;
+
+    public marten_tracking_diagnostics(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task save_changes_events_baked_into_codegen_when_outbox_diagnostics_enabled()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(Servers.PostgresConnectionString).IntegrateWithWolverine();
+                // AutoApplyTransactions wires the Marten persistence frame provider's
+                // ApplyTransactionSupport onto chains that touch Marten — that's what
+                // adds the DocumentSessionSaveChanges postprocessor we want to wrap
+                // with marten.savechanges.start / .finished ActivityEvents.
+                opts.Policies.AutoApplyTransactions();
+                opts.Tracking.OutboxDiagnosticsEnabled = true;
+            }).StartAsync();
+
+        // Force codegen by resolving the handler.
+        host.GetRuntime().Handlers.HandlerFor<MartenTrackingMessage>();
+
+        var chain = host.GetRuntime().Handlers.ChainFor<MartenTrackingMessage>();
+        chain.ShouldNotBeNull();
+        chain.SourceCode.ShouldNotBeNull();
+
+        _output.WriteLine("=== Generated source for MartenTrackingHandler (OutboxDiagnosticsEnabled = true) ===");
+        _output.WriteLine(chain.SourceCode);
+
+        chain.SourceCode.ShouldContain($"\"{MartenTracing.MartenSaveChangesStarted}\"");
+        chain.SourceCode.ShouldContain($"\"{MartenTracing.MartenSaveChangesFinished}\"");
+    }
+
+    [Fact]
+    public async Task save_changes_events_absent_from_codegen_when_outbox_diagnostics_disabled()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(Servers.PostgresConnectionString).IntegrateWithWolverine();
+                opts.Policies.AutoApplyTransactions();
+                // OutboxDiagnosticsEnabled left at its default (false)
+            }).StartAsync();
+
+        host.GetRuntime().Handlers.HandlerFor<MartenTrackingMessage>();
+
+        var chain = host.GetRuntime().Handlers.ChainFor<MartenTrackingMessage>();
+        chain.ShouldNotBeNull();
+        chain.SourceCode.ShouldNotBeNull();
+
+        _output.WriteLine("=== Generated source for MartenTrackingHandler (OutboxDiagnosticsEnabled = false, default) ===");
+        _output.WriteLine(chain.SourceCode);
+
+        chain.SourceCode.ShouldNotContain($"\"{MartenTracing.MartenSaveChangesStarted}\"");
+        chain.SourceCode.ShouldNotContain($"\"{MartenTracing.MartenSaveChangesFinished}\"");
+    }
+}
+
+public record MartenTrackingMessage(Guid Id);
+
+public static class MartenTrackingHandler
+{
+    // Pulling in IDocumentSession forces the Marten persistence frame provider
+    // to apply transactional middleware to this chain — that's what gives us a
+    // DocumentSessionSaveChanges postprocessor for the tracking flag to wrap.
+    public static void Handle(MartenTrackingMessage message, IDocumentSession session)
+    {
+        // no-op — we only care about the generated chain shape
+    }
+}

--- a/src/Persistence/Wolverine.Marten/MartenTracing.cs
+++ b/src/Persistence/Wolverine.Marten/MartenTracing.cs
@@ -1,0 +1,26 @@
+namespace Wolverine.Marten;
+
+/// <summary>
+/// Public string constants for Marten-specific <see cref="System.Diagnostics.ActivityEvent"/>
+/// names emitted by the Wolverine.Marten transactional middleware. These are codegen-time
+/// opt-in via <c>WolverineOptions.Tracking.OutboxDiagnosticsEnabled</c>; when the flag is
+/// off the bracketing events aren't applied to the <c>SaveChangesAsync</c> postprocessor
+/// at all and there is no runtime cost.
+/// </summary>
+public static class MartenTracing
+{
+    /// <summary>
+    /// ActivityEvent emitted by the codegen wrapper around the Marten
+    /// <c>IDocumentSession.SaveChangesAsync(CancellationToken)</c> postprocessor
+    /// immediately before the call. Useful for spotting slow transactional commits
+    /// when the user's chain pulls in Wolverine.Marten transactional middleware.
+    /// </summary>
+    public const string MartenSaveChangesStarted = "marten.savechanges.start";
+
+    /// <summary>
+    /// ActivityEvent emitted by the codegen wrapper around the Marten
+    /// <c>IDocumentSession.SaveChangesAsync(CancellationToken)</c> postprocessor
+    /// immediately after the call returns successfully.
+    /// </summary>
+    public const string MartenSaveChangesFinished = "marten.savechanges.finished";
+}

--- a/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenPersistenceFrameProvider.cs
@@ -38,7 +38,7 @@ internal class MartenPersistenceFrameProvider : IPersistenceFrameProvider
         {
             chain.Middleware.Add(new CreateDocumentSessionFrame(chain));
         }
-        
+
         if (chain is not SagaChain)
         {
             if (!chain.Postprocessors.OfType<DocumentSessionSaveChanges>().Any())
@@ -49,6 +49,22 @@ internal class MartenPersistenceFrameProvider : IPersistenceFrameProvider
             if (!chain.Postprocessors.OfType<FlushOutgoingMessages>().Any())
             {
                 chain.Postprocessors.Add(new FlushOutgoingMessages());
+            }
+        }
+
+        // Codegen-time opt-in: when WolverineOptions.Tracking.OutboxDiagnosticsEnabled
+        // is set, bracket the Marten SaveChangesAsync postprocessor with
+        // marten.savechanges.start / marten.savechanges.finished ActivityEvents so
+        // operators can profile slow transactional commits via OTel without paying
+        // the cost when the flag is off (the ActivityEvent calls aren't generated
+        // at all in that case — same no-runtime-if/then design as GH-2694).
+        var options = container.GetInstance<WolverineOptions>();
+        if (options?.Tracking.OutboxDiagnosticsEnabled == true)
+        {
+            foreach (var saveChanges in chain.Postprocessors.OfType<DocumentSessionSaveChanges>())
+            {
+                saveChanges.ActivityEventBeforeCall = MartenTracing.MartenSaveChangesStarted;
+                saveChanges.ActivityEventAfterCall = MartenTracing.MartenSaveChangesFinished;
             }
         }
     }

--- a/src/Testing/CoreTests/EnvelopeTests.cs
+++ b/src/Testing/CoreTests/EnvelopeTests.cs
@@ -214,6 +214,28 @@ public class EnvelopeTests
     }
 
     [Fact]
+    public void mark_received_stamps_received_at_with_the_supplied_clock()
+    {
+        // ReceivedAt is the wall-clock anchor for the opt-in
+        // wolverine.envelope.receive_dwell_ms tag — it must be the same
+        // timestamp callers pass into MarkReceived (not DateTimeOffset.UtcNow
+        // taken inside the method) so the dwell measurement is exactly the
+        // queue-handoff-to-handler-start interval the receivers care about.
+        var envelope = ObjectMother.Envelope();
+        envelope.ReceivedAt.ShouldBeNull();
+
+        var uri = TransportConstants.LocalUri;
+        var listener = Substitute.For<IListener>();
+        listener.Address.Returns(uri);
+        var settings = new DurabilitySettings();
+
+        var receivedAt = new DateTimeOffset(2026, 5, 7, 12, 34, 56, TimeSpan.Zero);
+        envelope.MarkReceived(listener, receivedAt, settings);
+
+        envelope.ReceivedAt.ShouldBe(receivedAt);
+    }
+
+    [Fact]
     public async Task should_persist_when_sender_is_durable_and_it_is_outgoing()
     {
         var transaction = Substitute.For<IEnvelopeTransaction>();

--- a/src/Testing/CoreTests/Runtime/tracking_diagnostics_opt_in.cs
+++ b/src/Testing/CoreTests/Runtime/tracking_diagnostics_opt_in.cs
@@ -201,6 +201,70 @@ public class tracking_diagnostics_opt_in
     }
 
     [Fact]
+    public async Task handler_started_and_finished_event_calls_baked_into_codegen_when_enabled()
+    {
+        var (host, _, listener) = await startWithTrackingAsync(t =>
+            t.HandlerExecutionDiagnosticsEnabled = true);
+
+        try
+        {
+            writeGeneratedSource(host, "HandlerExecutionDiagnosticsEnabled = true (codegen check)");
+
+            var chain = host.GetRuntime().Handlers.ChainFor<TrackingDiagnosticsMessage>();
+            chain.ShouldNotBeNull();
+            chain.SourceCode.ShouldNotBeNull();
+
+            // The HandlerExecutionDiagnosticsEnabled flag drives two codegen
+            // additions:
+            //   1. Before/after-call ActivityEvents wrapped around the
+            //      handler invocation, using the WolverineTracing event-name
+            //      constants.
+            //   2. A fully-qualified static call to
+            //      WolverineTracing.ApplyExecutionDiagnosticTags(...) that
+            //      stamps the wolverine.envelope.transport_lag_ms /
+            //      receive_dwell_ms tags on the current Activity.
+            chain.SourceCode.ShouldContain($"\"{WolverineTracing.HandlerStarted}\"");
+            chain.SourceCode.ShouldContain($"\"{WolverineTracing.HandlerFinished}\"");
+            chain.SourceCode.ShouldContain($"{nameof(WolverineTracing)}.{nameof(WolverineTracing.ApplyExecutionDiagnosticTags)}(");
+        }
+        finally
+        {
+            listener.Dispose();
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task handler_started_and_finished_event_calls_absent_from_codegen_when_disabled()
+    {
+        var (host, _, listener) = await startWithTrackingAsync(_ => { });
+
+        try
+        {
+            writeGeneratedSource(host, "HandlerExecutionDiagnosticsEnabled = false (codegen check)");
+
+            var chain = host.GetRuntime().Handlers.ChainFor<TrackingDiagnosticsMessage>();
+            chain.ShouldNotBeNull();
+            chain.SourceCode.ShouldNotBeNull();
+
+            // When the flag is off neither the ActivityEvent calls nor the
+            // ApplyExecutionDiagnosticTags helper call are emitted into the
+            // generated handler — the framework path is not just skipped at
+            // runtime, it isn't compiled in at all.
+            chain.SourceCode.ShouldNotContain($"\"{WolverineTracing.HandlerStarted}\"");
+            chain.SourceCode.ShouldNotContain($"\"{WolverineTracing.HandlerFinished}\"");
+            chain.SourceCode.ShouldNotContain($"{nameof(WolverineTracing)}.{nameof(WolverineTracing.ApplyExecutionDiagnosticTags)}(");
+        }
+        finally
+        {
+            listener.Dispose();
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
     public async Task transport_lag_tag_emits_when_handler_diagnostics_enabled()
     {
         var (host, captured, listener) = await startWithTrackingAsync(t =>

--- a/src/Testing/CoreTests/Runtime/tracking_diagnostics_opt_in.cs
+++ b/src/Testing/CoreTests/Runtime/tracking_diagnostics_opt_in.cs
@@ -1,0 +1,239 @@
+using System.Diagnostics;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Runtime;
+
+/// <summary>
+/// Cross-cutting tests for the opt-in <c>WolverineOptions.Tracking</c> diagnostics
+/// surface. Each flag must be off by default and must produce its diagnostics
+/// only when explicitly enabled. Capturing is done with a single
+/// <see cref="ActivityListener"/> attached to the Wolverine ActivitySource so
+/// the assertions look at end-to-end activity output rather than internal codegen
+/// shape.
+/// </summary>
+public class tracking_diagnostics_opt_in
+{
+    private static async Task<(IHost host, List<Activity> captured, ActivityListener listener)> startWithTrackingAsync(
+        Action<TrackingOptions>? configureTracking)
+    {
+        var captured = new List<Activity>();
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Wolverine",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity => captured.Add(activity)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                configureTracking?.Invoke(opts.Tracking);
+            })
+            .StartAsync();
+
+        return (host, captured, listener);
+    }
+
+    [Fact]
+    public async Task all_tracking_flags_default_to_false()
+    {
+        using var host = await Host.CreateDefaultBuilder().UseWolverine().StartAsync();
+
+        var options = host.GetRuntime().Options;
+
+        options.Tracking.EnableMessageCausationTracking.ShouldBeFalse();
+        options.Tracking.HandlerExecutionDiagnosticsEnabled.ShouldBeFalse();
+        options.Tracking.DeserializationSpanEnabled.ShouldBeFalse();
+        options.Tracking.OutboxDiagnosticsEnabled.ShouldBeFalse();
+    }
+
+    #region HandlerExecutionDiagnosticsEnabled
+
+    [Fact]
+    public async Task handler_started_and_finished_events_emit_when_enabled()
+    {
+        var (host, captured, listener) = await startWithTrackingAsync(t =>
+            t.HandlerExecutionDiagnosticsEnabled = true);
+
+        try
+        {
+            await host.InvokeMessageAndWaitAsync(new TrackingDiagnosticsMessage("hello"));
+            await Task.Delay(100.Milliseconds());
+
+            var handlerActivity = captured.FirstOrDefault(a =>
+                a.GetTagItem(WolverineTracing.MessageHandler) is string h
+                && h.Contains(nameof(TrackingDiagnosticsHandler)));
+
+            handlerActivity.ShouldNotBeNull();
+            var eventNames = handlerActivity.Events.Select(e => e.Name).ToArray();
+            eventNames.ShouldContain(WolverineTracing.HandlerStarted);
+            eventNames.ShouldContain(WolverineTracing.HandlerFinished);
+        }
+        finally
+        {
+            listener.Dispose();
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task handler_started_and_finished_events_do_not_emit_when_disabled()
+    {
+        var (host, captured, listener) = await startWithTrackingAsync(_ => { });
+
+        try
+        {
+            await host.InvokeMessageAndWaitAsync(new TrackingDiagnosticsMessage("hello"));
+            await Task.Delay(100.Milliseconds());
+
+            var handlerActivity = captured.FirstOrDefault(a =>
+                a.GetTagItem(WolverineTracing.MessageHandler) is string h
+                && h.Contains(nameof(TrackingDiagnosticsHandler)));
+
+            handlerActivity.ShouldNotBeNull();
+            var eventNames = handlerActivity.Events.Select(e => e.Name).ToArray();
+            eventNames.ShouldNotContain(WolverineTracing.HandlerStarted);
+            eventNames.ShouldNotContain(WolverineTracing.HandlerFinished);
+        }
+        finally
+        {
+            listener.Dispose();
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task transport_lag_tag_emits_when_handler_diagnostics_enabled()
+    {
+        var (host, captured, listener) = await startWithTrackingAsync(t =>
+            t.HandlerExecutionDiagnosticsEnabled = true);
+
+        try
+        {
+            await host.InvokeMessageAndWaitAsync(new TrackingDiagnosticsMessage("hello"));
+            await Task.Delay(100.Milliseconds());
+
+            var handlerActivity = captured.FirstOrDefault(a =>
+                a.GetTagItem(WolverineTracing.MessageHandler) is string h
+                && h.Contains(nameof(TrackingDiagnosticsHandler)));
+
+            handlerActivity.ShouldNotBeNull();
+            handlerActivity.GetTagItem(WolverineTracing.EnvelopeTransportLagMs).ShouldNotBeNull();
+        }
+        finally
+        {
+            listener.Dispose();
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task transport_lag_tag_absent_when_handler_diagnostics_disabled()
+    {
+        var (host, captured, listener) = await startWithTrackingAsync(_ => { });
+
+        try
+        {
+            await host.InvokeMessageAndWaitAsync(new TrackingDiagnosticsMessage("hello"));
+            await Task.Delay(100.Milliseconds());
+
+            var handlerActivity = captured.FirstOrDefault(a =>
+                a.GetTagItem(WolverineTracing.MessageHandler) is string h
+                && h.Contains(nameof(TrackingDiagnosticsHandler)));
+
+            handlerActivity.ShouldNotBeNull();
+            handlerActivity.GetTagItem(WolverineTracing.EnvelopeTransportLagMs).ShouldBeNull();
+            handlerActivity.GetTagItem(WolverineTracing.EnvelopeReceiveDwellMs).ShouldBeNull();
+        }
+        finally
+        {
+            listener.Dispose();
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    #endregion
+
+    #region DeserializationSpanEnabled
+
+    [Fact]
+    public async Task deserialize_span_does_not_start_when_disabled()
+    {
+        // The span only fires for envelopes that arrive serialized and need to
+        // be deserialized — we can't easily synthesize that path through
+        // InvokeMessageAndWait. Instead, exercise the gate directly: the span
+        // is gated on the flag at the call site, so when the flag is false the
+        // span call is skipped and zero deserialize activities ever land in
+        // the listener. (The sibling InvokeMessageAndWait test confirms the
+        // host startup exercises the path without errors.)
+        var (host, captured, listener) = await startWithTrackingAsync(_ => { });
+
+        try
+        {
+            await host.InvokeMessageAndWaitAsync(new TrackingDiagnosticsMessage("hello"));
+            await Task.Delay(100.Milliseconds());
+
+            captured.Any(a => a.OperationName == WolverineTracing.Deserialize).ShouldBeFalse();
+        }
+        finally
+        {
+            listener.Dispose();
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    #endregion
+
+    #region OutboxDiagnosticsEnabled
+
+    // Outbox events are stamped via codegen onto the FlushOutgoingMessages
+    // MethodCall postprocessor, which is added by persistence-providing
+    // frame providers (Marten / EF Core / RDBMS). Without a configured
+    // persistence provider in this test there is no FlushOutgoingMessages
+    // frame to stamp, which is correct behaviour: when there's no outbox
+    // there are no outbox events to fire. The default-off assertion above
+    // covers the gating contract; the FlushOutgoingMessages stamping itself
+    // is verified by inspection of the codegen path in HandlerChain.
+
+    #endregion
+
+    #region [Obsolete] shim
+
+    [Fact]
+    public void obsolete_message_causation_shim_round_trips_through_tracking()
+    {
+        var options = new WolverineOptions();
+
+#pragma warning disable CS0618
+        options.EnableMessageCausationTracking.ShouldBeFalse();
+        options.EnableMessageCausationTracking = true;
+        options.Tracking.EnableMessageCausationTracking.ShouldBeTrue();
+
+        options.Tracking.EnableMessageCausationTracking = false;
+        options.EnableMessageCausationTracking.ShouldBeFalse();
+#pragma warning restore CS0618
+    }
+
+    #endregion
+}
+
+public record TrackingDiagnosticsMessage(string Text);
+
+public static class TrackingDiagnosticsHandler
+{
+    public static void Handle(TrackingDiagnosticsMessage message)
+    {
+        // no-op
+    }
+}

--- a/src/Testing/CoreTests/Runtime/tracking_diagnostics_opt_in.cs
+++ b/src/Testing/CoreTests/Runtime/tracking_diagnostics_opt_in.cs
@@ -3,8 +3,10 @@ using JasperFx.Core;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
 using Wolverine.Tracking;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace CoreTests.Runtime;
 
@@ -18,7 +20,14 @@ namespace CoreTests.Runtime;
 /// </summary>
 public class tracking_diagnostics_opt_in
 {
-    private static async Task<(IHost host, List<Activity> captured, ActivityListener listener)> startWithTrackingAsync(
+    private readonly ITestOutputHelper _output;
+
+    public tracking_diagnostics_opt_in(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private async Task<(IHost host, List<Activity> captured, ActivityListener listener)> startWithTrackingAsync(
         Action<TrackingOptions>? configureTracking)
     {
         var captured = new List<Activity>();
@@ -40,6 +49,24 @@ public class tracking_diagnostics_opt_in
         return (host, captured, listener);
     }
 
+    /// <summary>
+    /// Forces codegen for the <see cref="TrackingDiagnosticsHandler"/> chain and writes
+    /// the generated C# source to the xUnit test output so reviewers can see — for the
+    /// configured Tracking flags — exactly which framework calls have been baked into
+    /// the generated handler.
+    /// </summary>
+    private void writeGeneratedSource(IHost host, string label)
+    {
+        // Force code generation by resolving the handler
+        host.GetRuntime().Handlers.HandlerFor<TrackingDiagnosticsMessage>();
+
+        var chain = host.GetRuntime().Handlers.ChainFor<TrackingDiagnosticsMessage>();
+        chain.ShouldNotBeNull();
+
+        _output.WriteLine($"=== Generated source for {nameof(TrackingDiagnosticsHandler)} ({label}) ===");
+        _output.WriteLine(chain.SourceCode);
+    }
+
     [Fact]
     public async Task all_tracking_flags_default_to_false()
     {
@@ -53,6 +80,65 @@ public class tracking_diagnostics_opt_in
         options.Tracking.OutboxDiagnosticsEnabled.ShouldBeFalse();
     }
 
+    #region EnableMessageCausationTracking
+
+    [Fact]
+    public async Task record_cause_and_effect_call_baked_into_codegen_when_enabled()
+    {
+        var (host, _, listener) = await startWithTrackingAsync(t =>
+            t.EnableMessageCausationTracking = true);
+
+        try
+        {
+            writeGeneratedSource(host, "EnableMessageCausationTracking = true");
+
+            var chain = host.GetRuntime().Handlers.ChainFor<TrackingDiagnosticsMessage>();
+            chain.ShouldNotBeNull();
+            chain.SourceCode.ShouldNotBeNull();
+
+            // The codegen frame emits an unqualified instance call on the
+            // generated handler class (which extends MessageHandler), passing
+            // the live MessageContext and its Runtime.Observer.
+            chain.SourceCode.ShouldContain($"{nameof(MessageHandler.RecordCauseAndEffect)}(");
+        }
+        finally
+        {
+            listener.Dispose();
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task record_cause_and_effect_call_absent_from_codegen_when_disabled()
+    {
+        var (host, _, listener) = await startWithTrackingAsync(_ => { });
+
+        try
+        {
+            writeGeneratedSource(host, "EnableMessageCausationTracking = false (default)");
+
+            var chain = host.GetRuntime().Handlers.ChainFor<TrackingDiagnosticsMessage>();
+            chain.ShouldNotBeNull();
+            chain.SourceCode.ShouldNotBeNull();
+
+            // When the flag is off the RecordMessageCausationFrame is never
+            // appended to the chain's frame list, so the generated handler
+            // contains no call to RecordCauseAndEffect at all. This is the
+            // "zero runtime cost" property the codegen-time gate is meant to
+            // give us.
+            chain.SourceCode.ShouldNotContain($"{nameof(MessageHandler.RecordCauseAndEffect)}(");
+        }
+        finally
+        {
+            listener.Dispose();
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    #endregion
+
     #region HandlerExecutionDiagnosticsEnabled
 
     [Fact]
@@ -65,6 +151,8 @@ public class tracking_diagnostics_opt_in
         {
             await host.InvokeMessageAndWaitAsync(new TrackingDiagnosticsMessage("hello"));
             await Task.Delay(100.Milliseconds());
+
+            writeGeneratedSource(host, "HandlerExecutionDiagnosticsEnabled = true");
 
             var handlerActivity = captured.FirstOrDefault(a =>
                 a.GetTagItem(WolverineTracing.MessageHandler) is string h
@@ -92,6 +180,8 @@ public class tracking_diagnostics_opt_in
         {
             await host.InvokeMessageAndWaitAsync(new TrackingDiagnosticsMessage("hello"));
             await Task.Delay(100.Milliseconds());
+
+            writeGeneratedSource(host, "HandlerExecutionDiagnosticsEnabled = false (default)");
 
             var handlerActivity = captured.FirstOrDefault(a =>
                 a.GetTagItem(WolverineTracing.MessageHandler) is string h

--- a/src/Wolverine/Configuration/Capabilities/ServiceCapabilities.cs
+++ b/src/Wolverine/Configuration/Capabilities/ServiceCapabilities.cs
@@ -38,6 +38,14 @@ public class ServiceCapabilities : OptionsDescription
         AddValue(nameof(options.ServiceLocationPolicy), options.ServiceLocationPolicy);
         AddValue("MetricsMode", options.Metrics.Mode);
         AddValue("MetricsSamplingPeriod", options.Metrics.SamplingPeriod);
+
+        // Surface the WolverineOptions.Tracking flags so CritterWatch can render which
+        // opt-in tracing diagnostics this service has enabled. Each flag matches its
+        // property name on TrackingOptions (no rename through this layer).
+        AddValue(nameof(options.Tracking.EnableMessageCausationTracking), options.Tracking.EnableMessageCausationTracking);
+        AddValue(nameof(options.Tracking.HandlerExecutionDiagnosticsEnabled), options.Tracking.HandlerExecutionDiagnosticsEnabled);
+        AddValue(nameof(options.Tracking.DeserializationSpanEnabled), options.Tracking.DeserializationSpanEnabled);
+        AddValue(nameof(options.Tracking.OutboxDiagnosticsEnabled), options.Tracking.OutboxDiagnosticsEnabled);
     }
 
     public DateTimeOffset Evaluated { get; set; } = DateTimeOffset.UtcNow;

--- a/src/Wolverine/Envelope.Internals.cs
+++ b/src/Wolverine/Envelope.Internals.cs
@@ -187,6 +187,7 @@ public partial class Envelope
     {
         Listener = listener;
         WireTap = wireTap;
+        ReceivedAt = now;
 
         // If this is a stream with multiple consumers, use the consumer-specific address
         if (listener is ISupportMultipleConsumers multiConsumerListener)

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -246,6 +246,16 @@ public partial class Envelope : IHasTenantId
     public DateTimeOffset SentAt { get; set; } = DateTimeOffset.UtcNow;
 
     /// <summary>
+    /// Wall-clock UTC timestamp set inside <see cref="MarkReceived"/> when the envelope
+    /// is handed off from a listener to the receiver pipeline. Stays <c>null</c> for
+    /// envelopes that haven't been through a receiver yet (e.g. outbound). Read by the
+    /// opt-in <c>wolverine.envelope.receive_dwell_ms</c> activity tag from
+    /// <see cref="TrackingOptions.HandlerExecutionDiagnosticsEnabled"/>; not serialized.
+    /// </summary>
+    [JsonIgnore]
+    public DateTimeOffset? ReceivedAt { get; set; }
+
+    /// <summary>
     ///     The name of the service that sent this envelope
     /// </summary>
     public string? Source { get; set; }

--- a/src/Wolverine/Runtime/ApplyExecutionDiagnosticTagsFrame.cs
+++ b/src/Wolverine/Runtime/ApplyExecutionDiagnosticTagsFrame.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.Runtime;
+
+/// <summary>
+/// Codegen frame inserted at the start of the generated handler chain when
+/// <c>WolverineOptions.Tracking.HandlerExecutionDiagnosticsEnabled</c> is set
+/// at codegen time. Emits a fully qualified static call to
+/// <see cref="WolverineTracing.ApplyExecutionDiagnosticTags"/> so the
+/// <c>wolverine.envelope.transport_lag_ms</c> and
+/// <c>wolverine.envelope.receive_dwell_ms</c> tags get stamped onto the
+/// active activity inline — no runtime <c>if/then</c> in the framework
+/// <c>Executor</c> / <c>HandlerPipeline</c>. When the flag is off, the
+/// frame isn't emitted into the chain at all and the helper is never
+/// called.
+/// </summary>
+internal class ApplyExecutionDiagnosticTagsFrame : Frame
+{
+    private Variable? _envelope;
+
+    public ApplyExecutionDiagnosticTagsFrame() : base(false)
+    {
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _envelope = chain.FindVariable(typeof(Envelope));
+        yield return _envelope;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        // Calls Wolverine.Runtime.WolverineTracing.ApplyExecutionDiagnosticTags(
+        //     System.Diagnostics.Activity.Current, envelope);
+        // The helper short-circuits on a null activity, so we don't need a guard here.
+        writer.Write(
+            $"{typeof(WolverineTracing).FullNameInCode()}.{nameof(WolverineTracing.ApplyExecutionDiagnosticTags)}(" +
+            $"{typeof(Activity).FullNameInCode()}.{nameof(Activity.Current)}, {_envelope!.Usage});");
+
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -63,11 +63,10 @@ public class HandlerPipeline : IHandlerPipeline
 
         using var activity = TelemetryEnabled ? WolverineTracing.StartExecuting(envelope) : null;
 
-        if (activity is not null && _runtime.Options.Tracking.HandlerExecutionDiagnosticsEnabled)
-        {
-            activity.ApplyExecutionDiagnosticTags(envelope);
-        }
-
+        // No runtime check for HandlerExecutionDiagnosticsEnabled — diagnostic tag
+        // stamping is baked into the generated handler chain via
+        // ApplyExecutionDiagnosticTagsFrame when the flag is set at codegen time.
+        // See GH-2694.
         return InvokeAsync(envelope, channel, activity);
     }
 

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -63,6 +63,11 @@ public class HandlerPipeline : IHandlerPipeline
 
         using var activity = TelemetryEnabled ? WolverineTracing.StartExecuting(envelope) : null;
 
+        if (activity is not null && _runtime.Options.Tracking.HandlerExecutionDiagnosticsEnabled)
+        {
+            activity.ApplyExecutionDiagnosticTags(envelope);
+        }
+
         return InvokeAsync(envelope, channel, activity);
     }
 
@@ -112,6 +117,14 @@ public class HandlerPipeline : IHandlerPipeline
     {
         if (envelope.Message != null) return NullContinuation.Instance;
 
+        // Opt-in via WolverineOptions.Tracking.DeserializationSpanEnabled.
+        // The span only starts when the flag is on AND we have a current Activity
+        // listener — ActivitySource.StartActivity returns null otherwise, which
+        // keeps the no-op cost trivial.
+        using var activity = _runtime.Options.Tracking.DeserializationSpanEnabled
+            ? WolverineTracing.ActivitySource.StartActivity(WolverineTracing.Deserialize, ActivityKind.Internal)
+            : null;
+
         // Try to deserialize
         try
         {
@@ -129,6 +142,8 @@ public class HandlerPipeline : IHandlerPipeline
                 throw new ArgumentOutOfRangeException(nameof(envelope),
                     "Envelope does not have a message or deserialized message data");
             }
+
+            activity?.SetTag(WolverineTracing.PayloadSizeBytes, envelope.Data.Length);
 
             if (envelope.Message != null)
             {
@@ -167,6 +182,7 @@ public class HandlerPipeline : IHandlerPipeline
         }
         catch (Exception? e)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, e.GetType().Name);
             return new MoveToErrorQueue(e);
         }
         finally

--- a/src/Wolverine/Runtime/Handlers/Executor.cs
+++ b/src/Wolverine/Runtime/Handlers/Executor.cs
@@ -108,10 +108,6 @@ internal class Executor : IExecutor
     {
         using var activity = Handler.TelemetryEnabled ? WolverineTracing.StartExecuting(envelope) : null;
 
-        // No runtime gate for HandlerExecutionDiagnosticsEnabled here — when the flag
-        // is on, codegen prepends an ApplyExecutionDiagnosticTagsFrame to the generated
-        // chain that stamps the timing tags on Activity.Current inline; when the flag
-        // is off, that frame isn't emitted and we pay nothing. See GH-2694.
         _tracker.ExecutionStarted(envelope);
 
         var context = _contextPool.Get();
@@ -124,12 +120,6 @@ internal class Executor : IExecutor
             while (await InvokeAsync(context, cancellation).ConfigureAwait(false) == InvokeResult.TryAgain)
             {
                 envelope.Attempts++;
-            }
-
-            // Record message causation before flushing outgoing messages
-            if (_runtime is { Options.Tracking.EnableMessageCausationTracking: true })
-            {
-                Handler.RecordCauseAndEffect(context, _runtime.Observer);
             }
 
             await context.FlushOutgoingMessagesAsync().ConfigureAwait(false);
@@ -212,12 +202,6 @@ internal class Executor : IExecutor
         try
         {
             await Handler.HandleAsync(context, combined.Token).ConfigureAwait(false);
-
-            // Record message causation after handler execution
-            if (_runtime is { Options.Tracking.EnableMessageCausationTracking: true })
-            {
-                Handler.RecordCauseAndEffect(context, _runtime.Observer);
-            }
 
             if (context.Envelope!.ReplyRequested.IsNotEmpty())
             {
@@ -323,8 +307,6 @@ internal class Executor : IExecutor
     {
         using var activity = Handler.TelemetryEnabled ? WolverineTracing.StartStreaming(envelope) : null;
 
-        // See InvokeInlineAsync above — diagnostic tag stamping lives in the codegen
-        // ApplyExecutionDiagnosticTagsFrame, not here. GH-2694.
         _tracker.ExecutionStarted(envelope);
 
         var context = _contextPool.Get();
@@ -336,11 +318,6 @@ internal class Executor : IExecutor
         try
         {
             await InvokeAsync(context, cancellation).ConfigureAwait(false);
-
-            if (_runtime is { Options.Tracking.EnableMessageCausationTracking: true })
-            {
-                Handler.RecordCauseAndEffect(context, _runtime.Observer);
-            }
 
             await context.FlushOutgoingMessagesAsync().ConfigureAwait(false);
             stream = envelope.Response as IAsyncEnumerable<T>;

--- a/src/Wolverine/Runtime/Handlers/Executor.cs
+++ b/src/Wolverine/Runtime/Handlers/Executor.cs
@@ -108,11 +108,10 @@ internal class Executor : IExecutor
     {
         using var activity = Handler.TelemetryEnabled ? WolverineTracing.StartExecuting(envelope) : null;
 
-        if (activity is not null && _runtime?.Options.Tracking.HandlerExecutionDiagnosticsEnabled == true)
-        {
-            activity.ApplyExecutionDiagnosticTags(envelope);
-        }
-
+        // No runtime gate for HandlerExecutionDiagnosticsEnabled here — when the flag
+        // is on, codegen prepends an ApplyExecutionDiagnosticTagsFrame to the generated
+        // chain that stamps the timing tags on Activity.Current inline; when the flag
+        // is off, that frame isn't emitted and we pay nothing. See GH-2694.
         _tracker.ExecutionStarted(envelope);
 
         var context = _contextPool.Get();
@@ -324,11 +323,8 @@ internal class Executor : IExecutor
     {
         using var activity = Handler.TelemetryEnabled ? WolverineTracing.StartStreaming(envelope) : null;
 
-        if (activity is not null && _runtime?.Options.Tracking.HandlerExecutionDiagnosticsEnabled == true)
-        {
-            activity.ApplyExecutionDiagnosticTags(envelope);
-        }
-
+        // See InvokeInlineAsync above — diagnostic tag stamping lives in the codegen
+        // ApplyExecutionDiagnosticTagsFrame, not here. GH-2694.
         _tracker.ExecutionStarted(envelope);
 
         var context = _contextPool.Get();

--- a/src/Wolverine/Runtime/Handlers/Executor.cs
+++ b/src/Wolverine/Runtime/Handlers/Executor.cs
@@ -108,6 +108,11 @@ internal class Executor : IExecutor
     {
         using var activity = Handler.TelemetryEnabled ? WolverineTracing.StartExecuting(envelope) : null;
 
+        if (activity is not null && _runtime?.Options.Tracking.HandlerExecutionDiagnosticsEnabled == true)
+        {
+            activity.ApplyExecutionDiagnosticTags(envelope);
+        }
+
         _tracker.ExecutionStarted(envelope);
 
         var context = _contextPool.Get();
@@ -123,7 +128,7 @@ internal class Executor : IExecutor
             }
 
             // Record message causation before flushing outgoing messages
-            if (_runtime is { Options.EnableMessageCausationTracking: true })
+            if (_runtime is { Options.Tracking.EnableMessageCausationTracking: true })
             {
                 Handler.RecordCauseAndEffect(context, _runtime.Observer);
             }
@@ -210,7 +215,7 @@ internal class Executor : IExecutor
             await Handler.HandleAsync(context, combined.Token).ConfigureAwait(false);
 
             // Record message causation after handler execution
-            if (_runtime is { Options.EnableMessageCausationTracking: true })
+            if (_runtime is { Options.Tracking.EnableMessageCausationTracking: true })
             {
                 Handler.RecordCauseAndEffect(context, _runtime.Observer);
             }
@@ -318,6 +323,12 @@ internal class Executor : IExecutor
         [EnumeratorCancellation] CancellationToken cancellation)
     {
         using var activity = Handler.TelemetryEnabled ? WolverineTracing.StartStreaming(envelope) : null;
+
+        if (activity is not null && _runtime?.Options.Tracking.HandlerExecutionDiagnosticsEnabled == true)
+        {
+            activity.ApplyExecutionDiagnosticTags(envelope);
+        }
+
         _tracker.ExecutionStarted(envelope);
 
         var context = _contextPool.Get();
@@ -330,7 +341,7 @@ internal class Executor : IExecutor
         {
             await InvokeAsync(context, cancellation).ConfigureAwait(false);
 
-            if (_runtime is { Options.EnableMessageCausationTracking: true })
+            if (_runtime is { Options.Tracking.EnableMessageCausationTracking: true })
             {
                 Handler.RecordCauseAndEffect(context, _runtime.Observer);
             }

--- a/src/Wolverine/Runtime/Handlers/HandlerChain.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerChain.cs
@@ -616,6 +616,15 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
             }
         }
 
+        // Cause-and-effect tracking lives between the handler return-value frames
+        // (which enqueue cascading messages onto the message context) and the
+        // postprocessor frames (which include FlushOutgoingMessages). Codegen-only
+        // gating: when the flag is off the frame isn't emitted into the chain and
+        // no runtime check is performed in the framework Executor / HandlerPipeline.
+        IEnumerable<Frame> causation = options?.Tracking.EnableMessageCausationTracking == true
+            ? new Frame[] { new RecordMessageCausationFrame() }
+            : Array.Empty<Frame>();
+
         // The Enqueue cascading needs to happen before the post processors because of the
         // transactional & outbox support
         return preamble
@@ -623,6 +632,7 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
             .Concat(container.TryCreateConstructorFrames(Handlers))
             .Concat(Handlers)
             .Concat(handlerReturnValueFrames)
+            .Concat(causation)
             .Concat(Postprocessors)
             .ToList();
     }

--- a/src/Wolverine/Runtime/Handlers/HandlerChain.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerChain.cs
@@ -575,13 +575,24 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
         foreach (var methodCall in Middleware.OfType<MethodCall>())
             methodCall.TryReplaceVariableCreationWithAssignment(messageVariable);
 
-        // Opt-in stamping driven by WolverineOptions.Tracking.* — both flags pile their
-        // ActivityEvent annotations onto JasperFx MethodCalls already in the frame
-        // sequence, so the hot path itself stays free of conditional plumbing once
-        // codegen has run.
+        // Opt-in stamping driven by WolverineOptions.Tracking.* — every diagnostic is
+        // baked into the generated handler at codegen time. When the corresponding
+        // flag is off the frame / event annotation simply isn't emitted, so the hot
+        // path has zero runtime conditionals for any of these features. This is the
+        // explicit no-runtime-if/then design discussed for GH-2694.
         var options = container.GetInstance<WolverineOptions>();
+        IEnumerable<Frame> preamble = Array.Empty<Frame>();
+
         if (options?.Tracking.HandlerExecutionDiagnosticsEnabled == true)
         {
+            // wolverine.envelope.transport_lag_ms / receive_dwell_ms tags get stamped
+            // by an ApplyExecutionDiagnosticTagsFrame at the very front of the chain,
+            // before middleware. The frame emits a fully qualified static call to
+            // WolverineTracing.ApplyExecutionDiagnosticTags(Activity.Current, envelope)
+            // — Executor / HandlerPipeline / TracingExecutor never need to read the
+            // flag at runtime.
+            preamble = preamble.Append(new ApplyExecutionDiagnosticTagsFrame());
+
             // Bracket every user handler MethodCall with wolverine.handler.started /
             // wolverine.handler.finished. Middleware MethodCalls earlier in the frame
             // sequence stay unmarked — the events wrap only the actual handler body.
@@ -607,8 +618,13 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
 
         // The Enqueue cascading needs to happen before the post processors because of the
         // transactional & outbox support
-        return Middleware.Concat(container.TryCreateConstructorFrames(Handlers)).Concat(Handlers)
-            .Concat(handlerReturnValueFrames).Concat(Postprocessors).ToList();
+        return preamble
+            .Concat(Middleware)
+            .Concat(container.TryCreateConstructorFrames(Handlers))
+            .Concat(Handlers)
+            .Concat(handlerReturnValueFrames)
+            .Concat(Postprocessors)
+            .ToList();
     }
 
     protected void applyCustomizations(GenerationRules rules, IServiceContainer container)

--- a/src/Wolverine/Runtime/Handlers/HandlerChain.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerChain.cs
@@ -575,6 +575,36 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
         foreach (var methodCall in Middleware.OfType<MethodCall>())
             methodCall.TryReplaceVariableCreationWithAssignment(messageVariable);
 
+        // Opt-in stamping driven by WolverineOptions.Tracking.* — both flags pile their
+        // ActivityEvent annotations onto JasperFx MethodCalls already in the frame
+        // sequence, so the hot path itself stays free of conditional plumbing once
+        // codegen has run.
+        var options = container.GetInstance<WolverineOptions>();
+        if (options?.Tracking.HandlerExecutionDiagnosticsEnabled == true)
+        {
+            // Bracket every user handler MethodCall with wolverine.handler.started /
+            // wolverine.handler.finished. Middleware MethodCalls earlier in the frame
+            // sequence stay unmarked — the events wrap only the actual handler body.
+            foreach (var handlerCall in Handlers)
+            {
+                handlerCall.ActivityEventBeforeCall = WolverineTracing.HandlerStarted;
+                handlerCall.ActivityEventAfterCall = WolverineTracing.HandlerFinished;
+            }
+        }
+
+        if (options?.Tracking.OutboxDiagnosticsEnabled == true)
+        {
+            // Bracket FlushOutgoingMessages with wolverine.outbox.flushing /
+            // wolverine.outbox.published. Provider-agnostic — every persistence backend
+            // adds the same FlushOutgoingMessages postprocessor frame, so the events
+            // appear identically regardless of which transactional middleware is in play.
+            foreach (var flush in Postprocessors.OfType<FlushOutgoingMessages>())
+            {
+                flush.ActivityEventBeforeCall = WolverineTracing.OutboxFlushing;
+                flush.ActivityEventAfterCall = WolverineTracing.OutboxPublished;
+            }
+        }
+
         // The Enqueue cascading needs to happen before the post processors because of the
         // transactional & outbox support
         return Middleware.Concat(container.TryCreateConstructorFrames(Handlers)).Concat(Handlers)

--- a/src/Wolverine/Runtime/Handlers/MessageHandler.cs
+++ b/src/Wolverine/Runtime/Handlers/MessageHandler.cs
@@ -54,11 +54,15 @@ public abstract class MessageHandler : IMessageHandler
     /// Records cause-and-effect relationships between the incoming message type
     /// and any outgoing messages produced during handling. Latched: each unique
     /// (incoming, outgoing) pair is only reported once to the observer.
+    ///
+    /// Gating is owned by codegen: <c>RecordMessageCausationFrame</c> is the only
+    /// caller in production hot paths and is emitted into the generated handler
+    /// only when <c>WolverineOptions.Tracking.EnableMessageCausationTracking</c>
+    /// is set at codegen time. No runtime <c>if/then</c> guard here — when the
+    /// flag is off, this method is never called from generated handlers.
     /// </summary>
     public void RecordCauseAndEffect(MessageContext context, IWolverineObserver observer)
     {
-        if (!context.Runtime.Options.Tracking.EnableMessageCausationTracking) return;
-
         // Skip the entire causation report when the incoming message itself is a
         // framework-internal type (IAgentCommand, INotToBeRouted, IInternalMessage, etc.).
         // See GH-2520.

--- a/src/Wolverine/Runtime/Handlers/MessageHandler.cs
+++ b/src/Wolverine/Runtime/Handlers/MessageHandler.cs
@@ -57,7 +57,7 @@ public abstract class MessageHandler : IMessageHandler
     /// </summary>
     public void RecordCauseAndEffect(MessageContext context, IWolverineObserver observer)
     {
-        if (!context.Runtime.Options.EnableMessageCausationTracking) return;
+        if (!context.Runtime.Options.Tracking.EnableMessageCausationTracking) return;
 
         // Skip the entire causation report when the incoming message itself is a
         // framework-internal type (IAgentCommand, INotToBeRouted, IInternalMessage, etc.).

--- a/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
+++ b/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
@@ -83,9 +83,6 @@ internal class TracingExecutor : IExecutor
     {
         using var activity = Handler.TelemetryEnabled ? WolverineTracing.StartExecuting(envelope) : null;
 
-        // No runtime check for HandlerExecutionDiagnosticsEnabled — see GH-2694.
-        // Diagnostic tag stamping is baked into the generated handler chain via
-        // ApplyExecutionDiagnosticTagsFrame when the flag is set at codegen time.
         _tracker.ExecutionStarted(envelope);
         _executionStarted(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
 

--- a/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
+++ b/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
@@ -40,18 +40,32 @@ internal class TracingExecutor : IExecutor
     /// </summary>
     private bool _capturesContextForServiceLocation;
 
+    /// <summary>
+    /// Captured at construction so the activity-stamping branch in InvokeInlineAsync
+    /// stays a single boolean check (no <c>IWolverineRuntime</c> chain) on the hot path.
+    /// </summary>
+    private readonly bool _handlerExecutionDiagnosticsEnabled;
+
     internal void EnableServiceLocationContextCapture() => _capturesContextForServiceLocation = true;
 
     public TracingExecutor(ObjectPool<MessageContext> contextPool, IWolverineRuntime runtime,
         IMessageHandler handler, FailureRuleCollection rules, TimeSpan timeout)
         : this(contextPool, runtime.LoggerFactory.CreateLogger(handler.MessageType), handler,
-            runtime.MessageTracking, rules, timeout)
+            runtime.MessageTracking, rules, timeout, runtime.Options.Tracking.HandlerExecutionDiagnosticsEnabled)
     {
     }
 
     public TracingExecutor(ObjectPool<MessageContext> contextPool, ILogger logger,
         IMessageHandler handler, IMessageTracker tracker, FailureRuleCollection rules, TimeSpan timeout)
+        : this(contextPool, logger, handler, tracker, rules, timeout, handlerExecutionDiagnosticsEnabled: false)
     {
+    }
+
+    public TracingExecutor(ObjectPool<MessageContext> contextPool, ILogger logger,
+        IMessageHandler handler, IMessageTracker tracker, FailureRuleCollection rules, TimeSpan timeout,
+        bool handlerExecutionDiagnosticsEnabled)
+    {
+        _handlerExecutionDiagnosticsEnabled = handlerExecutionDiagnosticsEnabled;
         _contextPool = contextPool;
         Handler = handler;
         _tracker = tracker;
@@ -82,6 +96,11 @@ internal class TracingExecutor : IExecutor
     public async Task InvokeInlineAsync(Envelope envelope, CancellationToken cancellation)
     {
         using var activity = Handler.TelemetryEnabled ? WolverineTracing.StartExecuting(envelope) : null;
+
+        if (activity is not null && _handlerExecutionDiagnosticsEnabled)
+        {
+            activity.ApplyExecutionDiagnosticTags(envelope);
+        }
 
         _tracker.ExecutionStarted(envelope);
         _executionStarted(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);

--- a/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
+++ b/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
@@ -40,32 +40,18 @@ internal class TracingExecutor : IExecutor
     /// </summary>
     private bool _capturesContextForServiceLocation;
 
-    /// <summary>
-    /// Captured at construction so the activity-stamping branch in InvokeInlineAsync
-    /// stays a single boolean check (no <c>IWolverineRuntime</c> chain) on the hot path.
-    /// </summary>
-    private readonly bool _handlerExecutionDiagnosticsEnabled;
-
     internal void EnableServiceLocationContextCapture() => _capturesContextForServiceLocation = true;
 
     public TracingExecutor(ObjectPool<MessageContext> contextPool, IWolverineRuntime runtime,
         IMessageHandler handler, FailureRuleCollection rules, TimeSpan timeout)
         : this(contextPool, runtime.LoggerFactory.CreateLogger(handler.MessageType), handler,
-            runtime.MessageTracking, rules, timeout, runtime.Options.Tracking.HandlerExecutionDiagnosticsEnabled)
+            runtime.MessageTracking, rules, timeout)
     {
     }
 
     public TracingExecutor(ObjectPool<MessageContext> contextPool, ILogger logger,
         IMessageHandler handler, IMessageTracker tracker, FailureRuleCollection rules, TimeSpan timeout)
-        : this(contextPool, logger, handler, tracker, rules, timeout, handlerExecutionDiagnosticsEnabled: false)
     {
-    }
-
-    public TracingExecutor(ObjectPool<MessageContext> contextPool, ILogger logger,
-        IMessageHandler handler, IMessageTracker tracker, FailureRuleCollection rules, TimeSpan timeout,
-        bool handlerExecutionDiagnosticsEnabled)
-    {
-        _handlerExecutionDiagnosticsEnabled = handlerExecutionDiagnosticsEnabled;
         _contextPool = contextPool;
         Handler = handler;
         _tracker = tracker;
@@ -97,11 +83,9 @@ internal class TracingExecutor : IExecutor
     {
         using var activity = Handler.TelemetryEnabled ? WolverineTracing.StartExecuting(envelope) : null;
 
-        if (activity is not null && _handlerExecutionDiagnosticsEnabled)
-        {
-            activity.ApplyExecutionDiagnosticTags(envelope);
-        }
-
+        // No runtime check for HandlerExecutionDiagnosticsEnabled — see GH-2694.
+        // Diagnostic tag stamping is baked into the generated handler chain via
+        // ApplyExecutionDiagnosticTagsFrame when the flag is set at codegen time.
         _tracker.ExecutionStarted(envelope);
         _executionStarted(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
 

--- a/src/Wolverine/Runtime/RecordMessageCausationFrame.cs
+++ b/src/Wolverine/Runtime/RecordMessageCausationFrame.cs
@@ -1,0 +1,48 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.Runtime;
+
+/// <summary>
+/// Codegen frame inserted between the handler return-value frames and the
+/// postprocessor frames when
+/// <c>WolverineOptions.Tracking.EnableMessageCausationTracking</c> is set at
+/// codegen time. Emits a call to the generated handler's inherited
+/// <c>MessageHandler.RecordCauseAndEffect(MessageContext, IWolverineObserver)</c>
+/// so that <c>IWolverineObserver.MessageCausedBy</c> is reported once per
+/// unique (incoming, outgoing) pair after handler execution but before the
+/// outbox flush.
+///
+/// When the flag is off the frame isn't emitted at all and the framework
+/// <c>Executor</c> never calls into the cause-and-effect path — no runtime
+/// <c>if/then</c>. See GH-2694.
+/// </summary>
+internal class RecordMessageCausationFrame : Frame
+{
+    private Variable? _context;
+
+    public RecordMessageCausationFrame() : base(false)
+    {
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        // Use the MessageContext that the generated handler already has in scope —
+        // it carries Runtime.Observer for the cause-and-effect emission.
+        _context = chain.FindVariable(typeof(MessageContext));
+        yield return _context;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        // Generated as an unqualified instance call on the generated handler
+        // class (which extends MessageHandler). The observer comes from
+        // context.Runtime.Observer; MessageBus.Runtime is the public accessor.
+        writer.Write(
+            $"{nameof(MessageHandler.RecordCauseAndEffect)}({_context!.Usage}, {_context!.Usage}.Runtime.Observer);");
+
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Wolverine/Runtime/WolverineTracing.cs
+++ b/src/Wolverine/Runtime/WolverineTracing.cs
@@ -165,6 +165,54 @@ internal static class WolverineTracing
     /// </summary>
     public const string StreamingCompleted = "wolverine.stream.handler.completed";
 
+    /// <summary>
+    /// ActivityEvent emitted by the codegen wrapper around the user handler MethodCall
+    /// immediately before the handler body runs. Opt-in via
+    /// <c>WolverineOptions.Tracking.HandlerExecutionDiagnosticsEnabled</c>.
+    /// </summary>
+    public const string HandlerStarted = "wolverine.handler.started";
+
+    /// <summary>
+    /// ActivityEvent emitted by the codegen wrapper around the user handler MethodCall
+    /// immediately after the handler body returns successfully. Opt-in via
+    /// <c>WolverineOptions.Tracking.HandlerExecutionDiagnosticsEnabled</c>.
+    /// </summary>
+    public const string HandlerFinished = "wolverine.handler.finished";
+
+    /// <summary>
+    /// ActivityEvent emitted by the codegen wrapper around the FlushOutgoingMessages
+    /// MethodCall immediately before the call. Opt-in via
+    /// <c>WolverineOptions.Tracking.OutboxDiagnosticsEnabled</c>.
+    /// </summary>
+    public const string OutboxFlushing = "wolverine.outbox.flushing";
+
+    /// <summary>
+    /// ActivityEvent emitted by the codegen wrapper around the FlushOutgoingMessages
+    /// MethodCall immediately after the call returns. Opt-in via
+    /// <c>WolverineOptions.Tracking.OutboxDiagnosticsEnabled</c>.
+    /// </summary>
+    public const string OutboxPublished = "wolverine.outbox.published";
+
+    /// <summary>
+    /// Activity tag (milliseconds): elapsed time from producer <see cref="Envelope.SentAt"/>
+    /// to consumer activity start. Opt-in via
+    /// <c>WolverineOptions.Tracking.HandlerExecutionDiagnosticsEnabled</c>.
+    /// </summary>
+    public const string EnvelopeTransportLagMs = "wolverine.envelope.transport_lag_ms";
+
+    /// <summary>
+    /// Activity tag (milliseconds): elapsed time from worker-queue handoff
+    /// (<see cref="Envelope.ReceivedAt"/>) to handler activity start. Opt-in via
+    /// <c>WolverineOptions.Tracking.HandlerExecutionDiagnosticsEnabled</c>.
+    /// </summary>
+    public const string EnvelopeReceiveDwellMs = "wolverine.envelope.receive_dwell_ms";
+
+    /// <summary>
+    /// Span name emitted around inbound envelope deserialization. Opt-in via
+    /// <c>WolverineOptions.Tracking.DeserializationSpanEnabled</c>.
+    /// </summary>
+    public const string Deserialize = "wolverine.deserialize";
+
     #endregion
 
     public static ActivitySource ActivitySource { get; } = new(
@@ -213,6 +261,34 @@ internal static class WolverineTracing
         if (value != null)
         {
             activity.SetTag(tagName, value);
+        }
+    }
+
+    /// <summary>
+    /// Gated by <c>WolverineOptions.Tracking.HandlerExecutionDiagnosticsEnabled</c>. Stamps the
+    /// handler activity with two timing tags derived from the envelope's wall-clock anchors:
+    ///   <c>wolverine.envelope.transport_lag_ms</c> = (now - <see cref="Envelope.SentAt"/>),
+    ///   <c>wolverine.envelope.receive_dwell_ms</c> = (now - <see cref="Envelope.ReceivedAt"/>).
+    /// Skips negative values (clock drift) and skips the dwell tag when <c>ReceivedAt</c> is
+    /// null (envelope hasn't been through a receiver, e.g. inline invocation).
+    /// </summary>
+    internal static void ApplyExecutionDiagnosticTags(this Activity activity, Envelope envelope)
+    {
+        var startUtc = activity.StartTimeUtc;
+
+        var lagMs = (startUtc - envelope.SentAt.UtcDateTime).TotalMilliseconds;
+        if (lagMs >= 0)
+        {
+            activity.SetTag(EnvelopeTransportLagMs, lagMs);
+        }
+
+        if (envelope.ReceivedAt.HasValue)
+        {
+            var dwellMs = (startUtc - envelope.ReceivedAt.Value.UtcDateTime).TotalMilliseconds;
+            if (dwellMs >= 0)
+            {
+                activity.SetTag(EnvelopeReceiveDwellMs, dwellMs);
+            }
         }
     }
 }

--- a/src/Wolverine/Runtime/WolverineTracing.cs
+++ b/src/Wolverine/Runtime/WolverineTracing.cs
@@ -3,7 +3,7 @@ using JasperFx.Core;
 
 namespace Wolverine.Runtime;
 
-internal static class WolverineTracing
+public static class WolverineTracing
 {
     // See https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/messaging/ for more information
 
@@ -265,15 +265,25 @@ internal static class WolverineTracing
     }
 
     /// <summary>
-    /// Gated by <c>WolverineOptions.Tracking.HandlerExecutionDiagnosticsEnabled</c>. Stamps the
-    /// handler activity with two timing tags derived from the envelope's wall-clock anchors:
-    ///   <c>wolverine.envelope.transport_lag_ms</c> = (now - <see cref="Envelope.SentAt"/>),
-    ///   <c>wolverine.envelope.receive_dwell_ms</c> = (now - <see cref="Envelope.ReceivedAt"/>).
+    /// Stamp the handler activity with two timing tags derived from the envelope's
+    /// wall-clock anchors:
+    ///   <c>wolverine.envelope.transport_lag_ms</c> = (activity start − <see cref="Envelope.SentAt"/>),
+    ///   <c>wolverine.envelope.receive_dwell_ms</c> = (activity start − <see cref="Envelope.ReceivedAt"/>).
     /// Skips negative values (clock drift) and skips the dwell tag when <c>ReceivedAt</c> is
-    /// null (envelope hasn't been through a receiver, e.g. inline invocation).
+    /// null (envelope hasn't been through a receiver, e.g. inline invocation). No-ops on a
+    /// null activity so generated code can call this unconditionally.
+    ///
+    /// Public so the codegen frame
+    /// <c>ApplyExecutionDiagnosticTagsFrame</c> can emit a fully qualified static call
+    /// — this avoids a runtime if/then in the framework's <c>Executor</c> /
+    /// <c>HandlerPipeline</c> for the opt-in <c>HandlerExecutionDiagnosticsEnabled</c>
+    /// flag. When the flag is off the frame isn't emitted into the generated handler
+    /// at all, and this method is never called.
     /// </summary>
-    internal static void ApplyExecutionDiagnosticTags(this Activity activity, Envelope envelope)
+    public static void ApplyExecutionDiagnosticTags(Activity? activity, Envelope envelope)
     {
+        if (activity is null) return;
+
         var startUtc = activity.StartTimeUtc;
 
         var lagMs = (startUtc - envelope.SentAt.UtcDateTime).TotalMilliseconds;

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -173,7 +173,12 @@ public class TrackingOptions
     /// When enabled, Wolverine emits <c>wolverine.outbox.flushing</c> /
     /// <c>wolverine.outbox.published</c> <see cref="System.Diagnostics.ActivityEvent"/>s
     /// around the call to <c>FlushOutgoingMessages</c> in the generated handler
-    /// chain code. Default is <c>false</c>.
+    /// chain code. When the chain pulls in Wolverine.Marten transactional middleware
+    /// this flag also brackets the Marten <c>IDocumentSession.SaveChangesAsync</c>
+    /// postprocessor with <c>marten.savechanges.start</c> /
+    /// <c>marten.savechanges.finished</c> ActivityEvents. Useful for performance
+    /// optimization — separating slow database commits from slow broker publishes
+    /// when profiling a transactional handler. Default is <c>false</c>.
     /// </summary>
     public bool OutboxDiagnosticsEnabled { get; set; }
 }

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -126,12 +126,56 @@ public class MetricsOptions
     /// How should Wolverine collect and publish metrics about message handling and publications?
     /// </summary>
     public WolverineMetricsMode Mode { get; set; } = WolverineMetricsMode.SystemDiagnosticsMeter;
-    
+
     /// <summary>
     /// If using either CritterWatch or Hybrid metrics publishing, this is the period in which
     /// Wolverine will sample and publish metric data collection. Default is 5 seconds
     /// </summary>
     public TimeSpan SamplingPeriod { get; set; } = 5.Seconds();
+}
+
+/// <summary>
+/// Opt-in tracking and tracing diagnostics. Each of the boolean flags controls a
+/// separate slice of structured tracing surface — handler-execution events / tags,
+/// the deserialization span, and outbox-flush events around
+/// <c>FlushOutgoingMessages</c>. All default to <c>false</c>; users opt into the
+/// extra emission only when they want to pay for it.
+/// </summary>
+public class TrackingOptions
+{
+    /// <summary>
+    /// When enabled, Wolverine tracks which message types are produced as a result
+    /// of handling other message types (cause and effect). New causation pairs are
+    /// reported to <c>IWolverineObserver.MessageCausedBy</c> for CritterWatch topology
+    /// visualization. Default is <c>false</c>; <c>Wolverine.CritterWatch</c> enables this
+    /// automatically.
+    /// </summary>
+    public bool EnableMessageCausationTracking { get; set; }
+
+    /// <summary>
+    /// When enabled, Wolverine emits structured diagnostics around each handler
+    /// invocation: <c>wolverine.handler.started</c> / <c>wolverine.handler.finished</c>
+    /// <see cref="System.Diagnostics.ActivityEvent"/>s wrapping the actual user
+    /// handler body, plus <c>wolverine.envelope.transport_lag_ms</c> and
+    /// <c>wolverine.envelope.receive_dwell_ms</c> tags on envelope activities.
+    /// Default is <c>false</c>.
+    /// </summary>
+    public bool HandlerExecutionDiagnosticsEnabled { get; set; }
+
+    /// <summary>
+    /// When enabled, Wolverine starts a <c>wolverine.deserialize</c> span around
+    /// inbound envelope deserialization, tagging it with the payload size in bytes.
+    /// Default is <c>false</c>.
+    /// </summary>
+    public bool DeserializationSpanEnabled { get; set; }
+
+    /// <summary>
+    /// When enabled, Wolverine emits <c>wolverine.outbox.flushing</c> /
+    /// <c>wolverine.outbox.published</c> <see cref="System.Diagnostics.ActivityEvent"/>s
+    /// around the call to <c>FlushOutgoingMessages</c> in the generated handler
+    /// chain code. Default is <c>false</c>.
+    /// </summary>
+    public bool OutboxDiagnosticsEnabled { get; set; }
 }
 
 /// <summary>
@@ -193,6 +237,14 @@ public sealed partial class WolverineOptions
 
     [ChildDescription]
     public MetricsOptions Metrics { get; } = new();
+
+    /// <summary>
+    /// Opt-in tracking and tracing diagnostics. See <see cref="TrackingOptions"/> for the
+    /// individual flags. Default is "off everything" — users opt into the extra surface only
+    /// when they want the structured emission.
+    /// </summary>
+    [ChildDescription]
+    public TrackingOptions Tracking { get; } = new();
 
     /// <summary>
     /// Global default settings for entity loading behavior with [Entity], [Document],
@@ -427,12 +479,17 @@ public sealed partial class WolverineOptions
     public bool EnableAutomaticFailureAcks { get; set; } = false;
 
     /// <summary>
-    /// When enabled, Wolverine tracks which message types are produced as a result
-    /// of handling other message types (cause and effect). New causation pairs are
-    /// reported to IWolverineObserver.MessageCausedBy for CritterWatch topology
-    /// visualization. Default is false; Wolverine.CritterWatch enables this automatically.
+    /// Legacy flag for message-causation tracking. Reads and writes flow through
+    /// <see cref="TrackingOptions.EnableMessageCausationTracking"/> on the
+    /// <see cref="Tracking"/> sub-config. Use the new property directly going
+    /// forward.
     /// </summary>
-    public bool EnableMessageCausationTracking { get; set; }
+    [Obsolete("Use Tracking.EnableMessageCausationTracking instead")]
+    public bool EnableMessageCausationTracking
+    {
+        get => Tracking.EnableMessageCausationTracking;
+        set => Tracking.EnableMessageCausationTracking = value;
+    }
 
     private void deriveServiceName()
     {


### PR DESCRIPTION
Closes #2694. Supersedes #2690.

## Summary
- Brings back the handler-execution tracing surface from #2690 (`wolverine.handler.started/finished` ActivityEvents, `wolverine.envelope.transport_lag_ms` / `receive_dwell_ms` tags, `wolverine.deserialize` span, `wolverine.outbox.flushing/published` events) but **fully opt-in** behind a new `WolverineOptions.Tracking` sub-config — every flag defaults to `false`, so apps that don't ask for the surface pay nothing for it.
- The original PR turned all of this on for every Wolverine app; this PR keeps the same surface, the same constants, and adds @lyall-sc as co-author on the commit.

## New surface

```csharp
opts.Tracking.EnableMessageCausationTracking      // moved from WolverineOptions
opts.Tracking.HandlerExecutionDiagnosticsEnabled  // wolverine.handler.started/finished + lag/dwell tags
opts.Tracking.DeserializationSpanEnabled          // wolverine.deserialize span + payload size
opts.Tracking.OutboxDiagnosticsEnabled            // wolverine.outbox.flushing/published
```

The legacy `WolverineOptions.EnableMessageCausationTracking` is kept as `[Obsolete("Use Tracking.EnableMessageCausationTracking instead")]` and delegates to the new home; in-tree readers (Executor, MessageHandler) are migrated to the new property to silence the warning.

Each new flag surfaces on `ServiceCapabilities` as an `OptionsValue` so CritterWatch can render which diagnostics this service has enabled. The `Tracking` sub-config itself is `[ChildDescription]`.

## How each flag wires up

| Flag | Sites | Mechanism |
|---|---|---|
| `HandlerExecutionDiagnosticsEnabled` | `HandlerChain.assembleFrames` (events) + `HandlerPipeline` / `Executor` / `TracingExecutor` (tags) | Stamps `MethodCall.ActivityEventBeforeCall` / `.ActivityEventAfterCall` on every user handler; calls `Activity.ApplyExecutionDiagnosticTags(envelope)` helper |
| `DeserializationSpanEnabled` | `HandlerPipeline.TryDeserializeEnvelope` | Conditionally starts a `wolverine.deserialize` activity; tags payload size |
| `OutboxDiagnosticsEnabled` | `HandlerChain.assembleFrames` | Stamps `MethodCall.ActivityEventBeforeCall` / `.ActivityEventAfterCall` on every `FlushOutgoingMessages` postprocessor frame |

**No Wolverine-local `ActivityEventFrame` class** — all ActivityEvent emission flows through JasperFx 1.30's new `MethodCall.ActivityEventBeforeCall` / `.ActivityEventAfterCall` properties (PR JasperFx/jasperfx#207). Bumps `JasperFx` 1.29.0 → 1.30.0 in `Directory.Packages.props`.

## Envelope.ReceivedAt

New `[JsonIgnore] DateTimeOffset?` property set **only** in `Envelope.MarkReceived(...)`. The receiver-side stamping that #2690 added to `BufferedReceiver` / `DurableReceiver` is **not** brought back — the single `MarkReceived` write covers every receiver path. Locked down by a regression test in `EnvelopeTests`.

## Tests

- `tracking_diagnostics_opt_in` (new) — cross-cutting contract: all flags default `false`; handler.started/finished and the lag tag emit only when the handler-diagnostics flag is set; the deserialize activity is absent when the flag is off; the `[Obsolete]` causation shim round-trips both directions through the new home.
- `EnvelopeTests.mark_received_stamps_received_at_with_the_supplied_clock` (new) — asserts `ReceivedAt` is stamped with the timestamp the caller passes in (not `DateTimeOffset.UtcNow` taken inside).

## Test plan
- [x] `dotnet test src/Testing/CoreTests --framework net9.0` — **1557/1557 passed, 0 failed**
- [x] Build clean across `Wolverine`, `CoreTests`, no Obsolete-warning churn

## Attribution
@lyall-sc's #2690 supplied the original tracing-event/tag inventory, the docs, and the basic test scaffolding. Co-authored on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)