### PR TITLE
Fix unbounded retry loop on durable receiver shutdown (GH-2671)

### DIFF
--- a/src/Testing/CoreTests/Runtime/WorkerQueues/durable_receiver_release_incoming_during_shutdown.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/durable_receiver_release_incoming_during_shutdown.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics;
+using System.Net.Sockets;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports.Stub;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// Regression coverage for GH-2671: <see cref="DurableReceiver.DrainAsync"/> must
+/// terminate within a reasonable time even when the underlying message store is
+/// throwing on every attempt to release inbox ownership. The pre-fix
+/// <c>executeWithRetriesAsync</c> was an unbounded <c>while (true)</c> that
+/// (a) ignored the cancellation token, (b) logged every failure at Error level,
+/// and (c) never gave up — so during a shutdown sequence, where the Npgsql
+/// <c>DbDataSource</c> has already been disposed, the loop would spin forever
+/// against a dead socket and emit a flood of <c>SocketException</c> log noise.
+/// </summary>
+public class durable_receiver_release_incoming_during_shutdown : IAsyncLifetime
+{
+    private readonly IHandlerPipeline _pipeline = Substitute.For<IHandlerPipeline>();
+    private readonly MockWolverineRuntime _runtime;
+    private readonly DurableReceiver _receiver;
+
+    public durable_receiver_release_incoming_during_shutdown()
+    {
+        _runtime = new MockWolverineRuntime();
+
+        // Simulate the user's reported failure mode: every call to ReleaseIncomingAsync
+        // throws SocketException because the Npgsql connector can't reach the server
+        // anymore. The exact exception type matches the Npgsql shutdown path the user
+        // reported in the issue; the implementation only needs *some* exception to
+        // demonstrate the retry-loop bug.
+        _runtime.Storage.Inbox
+            .When(x => x.ReleaseIncomingAsync(Arg.Any<int>(), Arg.Any<Uri>()))
+            .Do(_ => throw new SocketException(10054 /* WSAECONNRESET */));
+
+        var endpoint = new StubEndpoint("test://2671", new StubTransport());
+        _receiver = new DurableReceiver(endpoint, _runtime, _pipeline);
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task drain_terminates_within_seconds_when_inbox_release_throws_repeatedly()
+    {
+        // Shutdown not signalled — the bounded retry path applies. With
+        // MaxReleaseRetries = 5 and linear backoff (100ms, 200ms, 300ms, 400ms),
+        // the upper bound is around 1s of sleep + per-attempt work. Anything
+        // under five seconds proves we are no longer in an unbounded loop.
+        var sw = Stopwatch.StartNew();
+        await _receiver.DrainAsync();
+        sw.Stop();
+
+        sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(5),
+            "DrainAsync looped beyond the bounded retry budget — the GH-2671 unbounded " +
+            "while-true regression has returned.");
+    }
+
+    [Fact]
+    public async Task drain_exits_immediately_when_cancellation_is_signalled()
+    {
+        // Cancel the durability cancellation token before draining — this is the
+        // shape of the user-reported scenario where the host is shutting down and
+        // the connection pool has already gone away. We expect DrainAsync to bail
+        // out on the very first failure rather than burn the full retry budget.
+        _runtime.DurabilitySettings.Cancel();
+
+        var sw = Stopwatch.StartNew();
+        await _receiver.DrainAsync();
+        sw.Stop();
+
+        sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(1),
+            "Shutdown-aware exit didn't fire — cancellation signal must short-circuit " +
+            "the retry loop on the first failure.");
+    }
+}

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -537,10 +537,26 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
         }
     }
 
+    /// <summary>
+    /// Bounded retry helper used for best-effort persistence operations like
+    /// <see cref="IMessageInbox.ReleaseIncomingAsync"/> on drain. Three properties
+    /// matter for shutdown correctness (see GH-2671):
+    /// <list type="bullet">
+    /// <item>The loop is finite — capped at <see cref="MaxReleaseRetries"/> attempts —
+    /// so a permanently unreachable database can't hang shutdown.</item>
+    /// <item>The loop honours <see cref="DurabilitySettings.Cancellation"/>: when the
+    /// host is stopping we exit immediately on the first failure rather than
+    /// hammering an already-disposed connection pool.</item>
+    /// <item>Log severity is demoted to Debug when cancellation has been signalled.
+    /// During teardown, transient socket / connection failures from the data
+    /// source are expected and don't warrant Error-level noise.</item>
+    /// </list>
+    /// </summary>
+    internal const int MaxReleaseRetries = 5;
+
     private async Task executeWithRetriesAsync(Func<Task> action)
     {
-        var i = 0;
-        while (true)
+        for (var attempt = 1; ; attempt++)
         {
             try
             {
@@ -549,9 +565,41 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Unexpected failure");
-                i++;
-                await Task.Delay(i * 100).ConfigureAwait(false);
+                // Shutdown-aware exit: when the cancellation token has been signalled
+                // we treat any failure as terminal and demote the log level. Retrying
+                // here is futile (the DataSource is being torn down) and the inbox
+                // ownership we failed to release will be reclaimed by the durability
+                // agent on the next live node.
+                if (_settings.Cancellation.IsCancellationRequested)
+                {
+                    _logger.LogDebug(e,
+                        "Database operation failed during shutdown at {Uri}; exiting retry loop",
+                        Uri);
+                    return;
+                }
+
+                if (attempt >= MaxReleaseRetries)
+                {
+                    _logger.LogError(e,
+                        "Database operation at {Uri} failed after {Attempts} attempts; giving up",
+                        Uri, attempt);
+                    return;
+                }
+
+                _logger.LogError(e,
+                    "Unexpected failure at {Uri} (attempt {Attempt}/{Max})",
+                    Uri, attempt, MaxReleaseRetries);
+
+                try
+                {
+                    await Task.Delay(attempt * 100, _settings.Cancellation).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Cancellation fired while we were backing off — exit cleanly
+                    // instead of throwing out of a best-effort cleanup path.
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #2671.

## Diagnosis

`DurableReceiver.executeWithRetriesAsync` was an unbounded `while (true)` loop that:
1. **Never gave up** — no retry cap
2. **Ignored cancellation** — neither the loop guard nor the `Task.Delay` honoured the durability cancellation token
3. **Always logged at Error level** — including expected failures during host teardown

On shutdown, `DrainAsync` calls `_inbox.ReleaseIncomingAsync(...)` through this helper. When the Npgsql `DbDataSource` has already been disposed by DI ordering, every retry hammers a dead socket and emits a `SocketException` at Error level. The user reported the flood started after upgrading 5.22 → 5.27 — PR #2391's shutdown reordering made `DrainAsync` reliably reach this code path on a torn-down data source, exposing the latent bug.

## Fix

Three changes to `executeWithRetriesAsync`:

1. **Bounded retries** — cap at `MaxReleaseRetries = 5`. After the budget is exhausted, log a single Error and return rather than spinning forever. Any owned envelopes left as `owner_id = node_id` are reclaimed by `DurabilityAgent`'s recovery polling on the next live node, so silently giving up is functionally safe for this best-effort cleanup path.

2. **Cancellation-aware exit** — when `_settings.Cancellation` is signalled (which happens via `DurabilitySettings.Cancel()` during shutdown), bail out on the first failure. The cancellation token is also passed to `Task.Delay` so the backoff doesn't sleep through the entire shutdown sequence.

3. **Demoted log level on cancelled exit** — these failures are expected during teardown and don't deserve Error-level noise. Outside cancellation, the existing Error log is preserved with attempt counters added for diagnostics.

## Test plan

New `durable_receiver_release_incoming_during_shutdown` test class:

- [x] `drain_terminates_within_seconds_when_inbox_release_throws_repeatedly` asserts `DrainAsync` finishes inside a 5-second budget when the inbox throws `SocketException` on every call — the pre-fix code loops forever here.
- [x] `drain_exits_immediately_when_cancellation_is_signalled` cancels `DurabilitySettings.Cancel()` first and asserts the drain exits inside one second.
- [x] Full `Runtime.WorkerQueues` suite green (25/25) on net9.0 — existing receiver tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)