### PR TITLE
Allow NATS messages without message-type header when DefaultIncomingMessage is set

### DIFF
--- a/src/Transports/NATS/Wolverine.Nats.Tests/NatsTransportIntegrationTests.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/NatsTransportIntegrationTests.cs
@@ -8,6 +8,7 @@ using Wolverine.Tracking;
 using Xunit;
 using Xunit.Abstractions;
 using FluentAssertions;
+using NATS.Client.Core;
 
 namespace Wolverine.Nats.Tests;
 
@@ -184,6 +185,42 @@ public class NatsTransportIntegrationTests : IAsyncLifetime
         }
     }
 
+    [Fact]
+    public async Task receive_message_without_type_header_using_default_incoming_message()
+    {
+        var natsUrl = Environment.GetEnvironmentVariable("NATS_URL") ?? "nats://localhost:4222";
+        if (!await IsNatsAvailable(natsUrl)) return;
+
+        var subject = Guid.NewGuid().ToString();
+
+        using var receiver = await Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.AddXunitLogging(_output))
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "ReceiverWithDefault";
+                opts.UseNats(natsUrl).AutoProvision();
+                opts.ListenToNatsSubject(subject)
+                    .DefaultIncomingMessage<DefaultTestMessage>()
+                    .BufferedInMemory();
+            })
+            .StartAsync();
+
+        await using var nats = new NatsConnection(new NatsOpts { Url = natsUrl });
+        await nats.ConnectAsync();
+
+        var messageData = System.Text.Encoding.UTF8.GetBytes("{\"Text\":\"Hello without header\"}");
+
+        var tracked = await receiver.TrackActivity()
+            .Timeout(10.Seconds())
+            .WaitForMessageToBeReceivedAt<DefaultTestMessage>(receiver)
+            .ExecuteAndWaitAsync(c =>
+            {
+                return nats.PublishAsync(subject, messageData).AsTask();
+            });
+
+        tracked.Received.SingleMessage<DefaultTestMessage>().Text.Should().Be("Hello without header");
+    }
+
     private async Task<bool> IsNatsAvailable(string natsUrl)
     {
         try
@@ -210,6 +247,15 @@ public record TestMessage(Guid Id, string Text);
 public class TestMessageHandler
 {
     public void Handle(TestMessage message)
+    {
+    }
+}
+
+public record DefaultTestMessage(string Text);
+
+public class DefaultTestMessageHandler
+{
+    public void Handle(DefaultTestMessage message)
     {
     }
 }

--- a/src/Transports/NATS/Wolverine.Nats/Internal/CoreNatsSubscriber.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/CoreNatsSubscriber.cs
@@ -105,7 +105,7 @@ internal class CoreNatsSubscriber : INatsSubscriber
                                 // Skip messages without headers or without message-type header.
                                 // These are typically NATS protocol messages (JetStream acks, etc.)
                                 // that should not be processed by Wolverine.
-                                if (msg.Headers == null || !msg.Headers.ContainsKey("message-type"))
+                                if (_endpoint.MessageType == null && (msg.Headers == null || !msg.Headers.ContainsKey("message-type")))
                                 {
                                     _logger.LogDebug(
                                         "Skipping NATS message without message-type header from subject {Subject}. DataLength={DataLength}, HasHeaders={HasHeaders}",

--- a/src/Transports/NATS/Wolverine.Nats/Internal/JetStreamSubscriber.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/JetStreamSubscriber.cs
@@ -129,12 +129,17 @@ internal class JetStreamSubscriber : INatsSubscriber
 
                         // Skip messages without headers or without message-type header.
                         // These are typically NATS protocol messages that should not be processed by Wolverine.
-                        if (msg.Headers == null || !msg.Headers.ContainsKey("message-type"))
+                        if (_endpoint.MessageType == null && (msg.Headers == null || !msg.Headers.ContainsKey("message-type")))
                         {
+                            _logger.LogDebug(
+                                "Skipping NATS message without message-type header from subject {Subject}. DataLength={DataLength}, HasHeaders={HasHeaders}",
+                                msg.Subject,
+                                msg.Data.Length,
+                                msg.Headers != null
+                            );
                             await msg.AckAsync(cancellationToken: cancellation);
                             continue;
                         }
-
                         var envelope = new NatsEnvelope(null, msg);
                         _mapper.MapIncomingToEnvelope(envelope, msg);
 


### PR DESCRIPTION
* Fix bug where message_type header was required for NATS even with DefaultIncomingMessage

- Updated CoreNatsSubscriber and JetStreamSubscriber to allow messages without 'message-type' header if the endpoint has a defined MessageType (configured via DefaultIncomingMessage).
- Added debug logging to JetStreamSubscriber for skipped messages, consistent with CoreNatsSubscriber.
- Added a regression test in NatsTransportIntegrationTests.cs verifying that raw NATS messages without headers are correctly received when a default message type is set.
- Ensured consistency with other transports like RabbitMQ which do not have this restriction.