### PR TITLE
docs(logging): correct OpenTelemetry AddMeter sample

### DIFF
--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -438,11 +438,17 @@ builder.Services.AddOpenTelemetryTracing(x =>
 ```cs
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => { tracing.AddSource("Wolverine"); })
-    .WithMetrics(metrics => { metrics.AddMeter("Wolverine"); })
+    .WithMetrics(metrics => { metrics.AddMeter("Wolverine*"); })
     .UseOtlpExporter();
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/OpenTelemetry/OtelWebApiWolverineMarten/Program.cs#L36-L42' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_open_telemetry-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+::: tip
+The exported `Meter` is named `Wolverine:{ApplicationName}` (e.g. `Wolverine:MyService`), so the wildcard
+`AddMeter("Wolverine*")` is required — a bare `AddMeter("Wolverine")` matches nothing. The `ActivitySource`
+for traces is still just `Wolverine`.
+:::
 
 ::: tip
 Wolverine 1.7 added the ability to disable Open Telemetry tracing on an endpoint by endpoint basis, and **finally** turned

--- a/src/Testing/OpenTelemetry/OtelWebApiWolverineMarten/Program.cs
+++ b/src/Testing/OpenTelemetry/OtelWebApiWolverineMarten/Program.cs
@@ -36,7 +36,7 @@ builder.Services.AddWolverineHttp();
 #region sample_enabling_open_telemetry
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => { tracing.AddSource("Wolverine"); })
-    .WithMetrics(metrics => { metrics.AddMeter("Wolverine"); })
+    .WithMetrics(metrics => { metrics.AddMeter("Wolverine*"); })
     .UseOtlpExporter();
 
 #endregion


### PR DESCRIPTION
The OTel sample on the logging page suggests registering `AddMeter("Wolverine")`, but the actual exported meter is named `Wolverine:{ApplicationName}`.

Since `AddMeter` requires an exact match, the bare name silently captures zero metrics. Switching the sample to `AddMeter("Wolverine*")`.