### PR TITLE
fix(http): honor [RoutePrefix] when no global prefix is configured

### DIFF
--- a/src/Http/Wolverine.Http.Tests/RoutePrefixTests.cs
+++ b/src/Http/Wolverine.Http.Tests/RoutePrefixTests.cs
@@ -162,6 +162,56 @@ public class RoutePrefixTests
         // Should match the most specific (longest) namespace
         prefix.ShouldBe("api/http/tests");
     }
+
+    [Fact]
+    public void apply_honors_attribute_prefix_when_no_global_or_namespace_prefix_configured()
+    {
+        // Regression for GH-2705: when no global/namespace prefix is configured, the
+        // policy used to short-circuit before iterating chains, silently dropping every
+        // [RoutePrefix] attribute. Surfaced when API Versioning was enabled because the
+        // version-segment policy still ran, producing routes like "v1/create" instead of
+        // "v1/items/create" for [RoutePrefix("items")].
+        var options = new WolverineHttpOptions();
+
+        var chain = HttpChain.ChainFor<PrefixedEndpoints>(x => x.GetOrders());
+        chain.RoutePattern!.RawText.ShouldBe("/orders");
+
+        var policy = new RoutePrefixPolicy(options);
+        policy.Apply(new[] { chain }, new JasperFx.CodeGeneration.GenerationRules(), null!);
+
+        chain.RoutePattern!.RawText.ShouldBe("/v2/orders/orders");
+    }
+
+    [Fact]
+    public void gh_2705_attribute_prefix_combines_with_api_versioning()
+    {
+        // Mirrors the exact reproduction from GH-2705:
+        //   [RoutePrefix("items")]
+        //   public static class TodoCreationEndpoint
+        //   {
+        //       [WolverinePost("/create")] public static void Post() { }
+        //   }
+        // with API Versioning configured DefaultVersion=v1 + AssignDefault.
+        // Expected route: /v1/items/create.
+        var httpOptions = new WolverineHttpOptions();
+        var versioningOptions = new Wolverine.Http.ApiVersioning.WolverineApiVersioningOptions
+        {
+            DefaultVersion = new Asp.Versioning.ApiVersion(1, 0),
+            UnversionedPolicy = Wolverine.Http.ApiVersioning.UnversionedPolicy.AssignDefault
+        };
+
+        var chain = HttpChain.ChainFor(typeof(TodoCreationEndpoint), nameof(TodoCreationEndpoint.Post));
+        chain.RoutePattern!.RawText.ShouldBe("/create");
+
+        // HttpGraph.DiscoverEndpoints applies RoutePrefixPolicy before the API versioning policy,
+        // so reproduce that order here.
+        new RoutePrefixPolicy(httpOptions)
+            .Apply(new[] { chain }, new JasperFx.CodeGeneration.GenerationRules(), null!);
+        new Wolverine.Http.ApiVersioning.ApiVersioningPolicy(versioningOptions)
+            .Apply(new[] { chain }, new JasperFx.CodeGeneration.GenerationRules(), null!);
+
+        chain.RoutePattern!.RawText.ShouldBe("/v1/items/create");
+    }
 }
 
 // Test handler types
@@ -179,4 +229,13 @@ public class PrefixedEndpoints
 {
     [WolverineGet("/orders")]
     public string GetOrders() => "orders";
+}
+
+[RoutePrefix("items")]
+public static class TodoCreationEndpoint
+{
+    [WolverinePost("/create")]
+    public static void Post()
+    {
+    }
 }

--- a/src/Http/Wolverine.Http/RoutePrefixPolicy.cs
+++ b/src/Http/Wolverine.Http/RoutePrefixPolicy.cs
@@ -16,12 +16,6 @@ internal class RoutePrefixPolicy : IHttpPolicy
 
     public void Apply(IReadOnlyList<HttpChain> chains, GenerationRules rules, IServiceContainer container)
     {
-        // Nothing to do if no prefixes are configured
-        if (_options.GlobalRoutePrefix == null && _options.NamespacePrefixes.Count == 0)
-        {
-            return;
-        }
-
         foreach (var chain in chains)
         {
             if (chain.RoutePattern == null) continue;


### PR DESCRIPTION
Fixes #2705.

`RoutePrefixPolicy.Apply` had an early-exit that skipped iterating chains whenever there was no `GlobalRoutePrefix` and no `NamespacePrefixes`. That short-circuit also bypassed the per-handler `[RoutePrefix]` attribute, so a class-level prefix declared on its own was silently dropped.

You normally wouldn't notice — the route just ended up missing one segment. API Versioning made it obvious because the version-segment policy still ran and produced things like `/v1/create` instead of `/v1/items/create` for:

```csharp
[RoutePrefix("items")]
public static class TodoCreationEndpoint
{
    [WolverinePost("/create")]
    public static void Post() { }
}
```

The fix is just to drop the early-exit. `DeterminePrefix` already returns `null` when nothing applies, so the loop is a no-op for chains without any prefix.

## Tests

- `apply_honors_attribute_prefix_when_no_global_or_namespace_prefix_configured` — unit test for the `Apply` path that wasn't covered before (existing tests only exercised `DeterminePrefix` in isolation, which never tripped the bug).
- `gh_2705_attribute_prefix_combines_with_api_versioning` — exact reproduction from the issue: `[RoutePrefix("items")]` + `[WolverinePost("/create")]` + versioning with `DefaultVersion = ApiVersion(1)` and `UnversionedPolicy.AssignDefault`. Asserts the final route is `/v1/items/create`.

Verified red → green by stashing the fix (test fails with `/v1/create`) and restoring it.