### PR TITLE
Preserve correlation/trace context across Global Partitioning interceptor (supersedes #2709)

### DIFF
--- a/src/Testing/CoreTests/Runtime/MockWolverineRuntime.cs
+++ b/src/Testing/CoreTests/Runtime/MockWolverineRuntime.cs
@@ -95,9 +95,11 @@ public class MockWolverineRuntime : IWolverineRuntime, IObserver<IWolverineEvent
     public IHandlerPipeline Pipeline { get; } = Substitute.For<IHandlerPipeline>();
     public WolverineTracker Tracker { get; } = new(NullLogger.Instance);
 
+    public Dictionary<Type, IMessageRouter> Routers { get; } = new();
+
     public IMessageRouter RoutingFor(Type messageType)
     {
-        return Substitute.For<IMessageRouter>();
+        return Routers.TryGetValue(messageType, out var router) ? router : Substitute.For<IMessageRouter>();
     }
 
     public T? TryFindExtension<T>() where T : class

--- a/src/Testing/CoreTests/Runtime/Partitioning/global_partitioning_tests.cs
+++ b/src/Testing/CoreTests/Runtime/Partitioning/global_partitioning_tests.cs
@@ -1,12 +1,17 @@
+using System.Diagnostics;
+using CoreTests.Runtime;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using Wolverine;
 using Wolverine.Configuration;
 using Wolverine.ComplianceTests;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Partitioning;
+using Wolverine.Runtime.Routing;
 using Wolverine.Runtime.WorkerQueues;
 using Wolverine.Transports;
+using Wolverine.Transports.Sending;
 using Xunit;
 
 namespace CoreTests.Runtime.Partitioning;
@@ -361,31 +366,57 @@ public class GlobalPartitionedReceiverBridgeTests
 public class GlobalPartitionedInterceptorTests
 {
     private readonly IReceiver _inner;
-    private readonly IMessageBus _messageBus;
     private readonly IListener _listener;
-    private readonly ILogger _logger;
-    private readonly WolverineOptions _options;
+    private readonly MockWolverineRuntime _runtime;
+    private readonly List<Envelope> _routedEnvelopes = new();
 
     public GlobalPartitionedInterceptorTests()
     {
         _inner = Substitute.For<IReceiver>();
-        _messageBus = Substitute.For<IMessageBus>();
         _listener = Substitute.For<IListener>();
-        _logger = Substitute.For<ILogger>();
-        _options = new WolverineOptions();
+        _runtime = new MockWolverineRuntime();
     }
 
     private GlobalPartitionedInterceptor CreateInterceptor(params Type[] matchingTypes)
     {
-        var topologies = new List<GlobalPartitionedMessageTopology>();
         foreach (var type in matchingTypes)
         {
-            var topology = new GlobalPartitionedMessageTopology(_options);
+            var topology = new GlobalPartitionedMessageTopology(_runtime.Options);
             topology.Message(type);
-            topologies.Add(topology);
+            _runtime.Options.MessagePartitioning.GlobalPartitionedTopologies.Add(topology);
         }
 
-        return new GlobalPartitionedInterceptor(_inner, _messageBus, topologies, _logger);
+        return new GlobalPartitionedInterceptor(_inner, _runtime);
+    }
+
+    private void ArrangeRouter<T>(Func<DeliveryOptions?, Envelope[]>? routeFactory = null)
+    {
+        var router = Substitute.For<IMessageRouter>();
+        router.RouteForPublish(Arg.Any<object>(), Arg.Any<DeliveryOptions?>())
+            .Returns(callInfo =>
+            {
+                var message = callInfo.Arg<object>();
+                var options = callInfo.Arg<DeliveryOptions?>();
+                Envelope[] outgoing;
+                if (routeFactory is not null)
+                {
+                    outgoing = routeFactory(options);
+                }
+                else
+                {
+                    var envelope = new Envelope(message)
+                    {
+                        Sender = NoopSendingAgent.Instance,
+                        Destination = NoopSendingAgent.Instance.Destination,
+                        Status = EnvelopeStatus.Outgoing,
+                    };
+                    options?.Override(envelope);
+                    outgoing = [envelope];
+                }
+                _routedEnvelopes.AddRange(outgoing);
+                return outgoing;
+            });
+        _runtime.Routers[typeof(T)] = router;
     }
 
     [Fact]
@@ -398,7 +429,7 @@ public class GlobalPartitionedInterceptorTests
         await interceptor.ReceivedAsync(_listener, envelope);
 
         await _inner.Received(1).ReceivedAsync(_listener, envelope);
-        await _messageBus.DidNotReceive().PublishAsync(Arg.Any<object>(), Arg.Any<DeliveryOptions>());
+        _routedEnvelopes.ShouldBeEmpty();
     }
 
     [Fact]
@@ -417,15 +448,16 @@ public class GlobalPartitionedInterceptorTests
     public async Task re_publishes_matching_messages_via_message_bus()
     {
         var interceptor = CreateInterceptor(typeof(GlobalTestMessage));
-        var message = new GlobalTestMessage("123");
+        ArrangeRouter<GlobalTestMessage>();
+
         var envelope = ObjectMother.Envelope();
-        envelope.Message = message;
+        envelope.Message = new GlobalTestMessage("123");
         envelope.GroupId = "group1";
 
         await interceptor.ReceivedAsync(_listener, envelope);
 
-        await _messageBus.Received(1).PublishAsync(message, Arg.Is<DeliveryOptions>(o =>
-            o.GroupId == "group1"));
+        _routedEnvelopes.Count.ShouldBe(1);
+        _routedEnvelopes[0].GroupId.ShouldBe("group1");
         await _inner.DidNotReceive().ReceivedAsync(_listener, envelope);
     }
 
@@ -433,9 +465,10 @@ public class GlobalPartitionedInterceptorTests
     public async Task completes_intercepted_messages_on_the_listener()
     {
         var interceptor = CreateInterceptor(typeof(GlobalTestMessage));
-        var message = new GlobalTestMessage("123");
+        ArrangeRouter<GlobalTestMessage>();
+
         var envelope = ObjectMother.Envelope();
-        envelope.Message = message;
+        envelope.Message = new GlobalTestMessage("123");
 
         await interceptor.ReceivedAsync(_listener, envelope);
 
@@ -446,29 +479,13 @@ public class GlobalPartitionedInterceptorTests
     public async Task defers_messages_when_re_publish_fails()
     {
         var interceptor = CreateInterceptor(typeof(GlobalTestMessage));
-        var message = new GlobalTestMessage("123");
+        var router = Substitute.For<IMessageRouter>();
+        router.RouteForPublish(Arg.Any<object>(), Arg.Any<DeliveryOptions?>())
+            .Throws(new Exception("Transport failure"));
+        _runtime.Routers[typeof(GlobalTestMessage)] = router;
+
         var envelope = ObjectMother.Envelope();
-        envelope.Message = message;
-
-        _messageBus.PublishAsync(Arg.Any<GlobalTestMessage>(), Arg.Any<DeliveryOptions>())
-            .Returns(ValueTask.FromException(new Exception("Transport failure")));
-
-        await interceptor.ReceivedAsync(_listener, envelope);
-
-        await _listener.Received(1).DeferAsync(envelope);
-        await _listener.DidNotReceive().CompleteAsync(envelope);
-    }
-
-    [Fact]
-    public async Task defers_messages_when_re_publish_fails_single_envelope()
-    {
-        var interceptor = CreateInterceptor(typeof(GlobalTestMessage));
-        var message = new GlobalTestMessage("123");
-        var envelope = ObjectMother.Envelope();
-        envelope.Message = message;
-
-        _messageBus.PublishAsync(Arg.Any<GlobalTestMessage>(), Arg.Any<DeliveryOptions>())
-            .Returns(ValueTask.FromException(new Exception("Transport failure")));
+        envelope.Message = new GlobalTestMessage("123");
 
         await interceptor.ReceivedAsync(_listener, envelope);
 
@@ -480,6 +497,7 @@ public class GlobalPartitionedInterceptorTests
     public async Task batch_splits_matching_and_non_matching()
     {
         var interceptor = CreateInterceptor(typeof(GlobalTestMessage));
+        ArrangeRouter<GlobalTestMessage>();
 
         var matching = ObjectMother.Envelope();
         matching.Message = new GlobalTestMessage("1");
@@ -489,11 +507,8 @@ public class GlobalPartitionedInterceptorTests
 
         await interceptor.ReceivedAsync(_listener, new[] { matching, nonMatching });
 
-        // Matching message should be re-published
-        await _messageBus.Received(1).PublishAsync(Arg.Any<GlobalTestMessage>(), Arg.Any<DeliveryOptions>());
+        _routedEnvelopes.Count.ShouldBe(1);
         await _listener.Received(1).CompleteAsync(matching);
-
-        // Non-matching should pass through to inner
         await _inner.Received(1).ReceivedAsync(_listener, Arg.Is<Envelope[]>(arr => arr.Length == 1));
     }
 
@@ -501,6 +516,7 @@ public class GlobalPartitionedInterceptorTests
     public async Task does_not_call_inner_when_all_messages_are_intercepted()
     {
         var interceptor = CreateInterceptor(typeof(GlobalTestMessage));
+        ArrangeRouter<GlobalTestMessage>();
 
         var e1 = ObjectMother.Envelope();
         e1.Message = new GlobalTestMessage("1");
@@ -547,8 +563,128 @@ public class GlobalPartitionedInterceptorTests
         await interceptor.ReceivedAsync(_listener, envelope);
 
         await _inner.Received(1).ReceivedAsync(_listener, envelope);
-        await _messageBus.DidNotReceive().PublishAsync(Arg.Any<object>(), Arg.Any<DeliveryOptions>());
+        _routedEnvelopes.ShouldBeEmpty();
     }
+
+    [Fact]
+    public async Task does_not_copy_custom_inbound_headers_when_propagation_rule_not_configured()
+    {
+        var interceptor = CreateInterceptor(typeof(GlobalTestMessage));
+        ArrangeRouter<GlobalTestMessage>();
+
+        var envelope = ObjectMother.Envelope();
+        envelope.Message = new GlobalTestMessage("123");
+        envelope.Headers["Opta-X-Metrics-Id"] = "metrics-abc";
+        envelope.Headers["Opta-X-Causation-Id"] = "causation-xyz";
+
+        await interceptor.ReceivedAsync(_listener, envelope);
+
+        var outgoing = _routedEnvelopes.ShouldHaveSingleItem();
+        outgoing.Headers.ShouldNotContainKey("Opta-X-Metrics-Id");
+        outgoing.Headers.ShouldNotContainKey("Opta-X-Causation-Id");
+    }
+
+    [Fact]
+    public async Task copies_only_allowlisted_custom_headers_when_propagation_rule_configured()
+    {
+        _runtime.Options.Policies.PropagateIncomingHeadersToOutgoing("Opta-X-Metrics-Id");
+
+        var interceptor = CreateInterceptor(typeof(GlobalTestMessage));
+        ArrangeRouter<GlobalTestMessage>(_ => [new Envelope(new GlobalTestMessage("123"))
+        {
+            Sender = NoopSendingAgent.Instance,
+            Destination = NoopSendingAgent.Instance.Destination,
+            Status = EnvelopeStatus.Outgoing,
+        }]);
+
+        var envelope = ObjectMother.Envelope();
+        envelope.Message = new GlobalTestMessage("123");
+        envelope.Headers["Opta-X-Metrics-Id"] = "metrics-abc";
+        envelope.Headers["Opta-X-Causation-Id"] = "causation-xyz";
+
+        await interceptor.ReceivedAsync(_listener, envelope);
+
+        var outgoing = _routedEnvelopes.ShouldHaveSingleItem();
+        outgoing.Headers["Opta-X-Metrics-Id"].ShouldBe("metrics-abc");
+        outgoing.Headers.ShouldNotContainKey("Opta-X-Causation-Id");
+    }
+
+    [Fact]
+    public async Task carries_inbound_correlation_id_onto_re_routed_envelope()
+    {
+        var interceptor = CreateInterceptor(typeof(GlobalTestMessage));
+        ArrangeRouter<GlobalTestMessage>();
+
+        var envelope = ObjectMother.Envelope();
+        envelope.Message = new GlobalTestMessage("123");
+        envelope.CorrelationId = "inbound-correlation";
+
+        await interceptor.ReceivedAsync(_listener, envelope);
+
+        var outgoing = _routedEnvelopes.ShouldHaveSingleItem();
+        outgoing.CorrelationId.ShouldBe("inbound-correlation");
+    }
+
+    [Fact]
+    public async Task carries_inbound_tenant_id_onto_re_routed_envelope()
+    {
+        var interceptor = CreateInterceptor(typeof(GlobalTestMessage));
+        ArrangeRouter<GlobalTestMessage>();
+
+        var envelope = ObjectMother.Envelope();
+        envelope.Message = new GlobalTestMessage("123");
+        envelope.TenantId = "tenant-42";
+
+        await interceptor.ReceivedAsync(_listener, envelope);
+
+        var outgoing = _routedEnvelopes.ShouldHaveSingleItem();
+        outgoing.TenantId.ShouldBe("tenant-42");
+    }
+
+    [Fact]
+    public async Task continues_inbound_distributed_trace_on_re_routed_envelope()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Wolverine",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = _ => { },
+            ActivityStopped = _ => { },
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var inboundParentId = $"00-{traceId}-{spanId}-01";
+
+        var interceptor = CreateInterceptor(typeof(GlobalTestMessage));
+        ArrangeRouter<GlobalTestMessage>();
+
+        var envelope = ObjectMother.Envelope();
+        envelope.Message = new GlobalTestMessage("123");
+        envelope.ParentId = inboundParentId;
+
+        await interceptor.ReceivedAsync(_listener, envelope);
+
+        var outgoing = _routedEnvelopes.ShouldHaveSingleItem();
+        outgoing.ParentId.ShouldNotBeNull();
+        outgoing.ParentId.ShouldContain(traceId.ToString());
+    }
+}
+
+internal sealed class NoopSendingAgent : ISendingAgent
+{
+    public static readonly NoopSendingAgent Instance = new();
+
+    public Uri Destination { get; } = new("noop://test");
+    public Uri? ReplyUri { get; set; }
+    public bool Latched => false;
+    public bool IsDurable => false;
+    public bool SupportsNativeScheduledSend => false;
+    public Endpoint Endpoint { get; } = null!;
+    public DateTimeOffset LastMessageSentAt => DateTimeOffset.UtcNow;
+    public ValueTask EnqueueOutgoingAsync(Envelope envelope) => ValueTask.CompletedTask;
+    public ValueTask StoreAndForwardAsync(Envelope envelope) => ValueTask.CompletedTask;
 }
 
 #endregion

--- a/src/Testing/CoreTests/Runtime/Partitioning/global_partitioning_tests.cs
+++ b/src/Testing/CoreTests/Runtime/Partitioning/global_partitioning_tests.cs
@@ -580,8 +580,10 @@ public class GlobalPartitionedInterceptorTests
         await interceptor.ReceivedAsync(_listener, envelope);
 
         var outgoing = _routedEnvelopes.ShouldHaveSingleItem();
-        outgoing.Headers.ShouldNotContainKey("Opta-X-Metrics-Id");
-        outgoing.Headers.ShouldNotContainKey("Opta-X-Causation-Id");
+        // Cast disambiguates between Shouldly's IDictionary / IReadOnlyDictionary
+        // ShouldNotContainKey overloads (Envelope.Headers is a concrete Dictionary).
+        ((IDictionary<string, string?>)outgoing.Headers).ShouldNotContainKey("Opta-X-Metrics-Id");
+        ((IDictionary<string, string?>)outgoing.Headers).ShouldNotContainKey("Opta-X-Causation-Id");
     }
 
     [Fact]
@@ -606,7 +608,7 @@ public class GlobalPartitionedInterceptorTests
 
         var outgoing = _routedEnvelopes.ShouldHaveSingleItem();
         outgoing.Headers["Opta-X-Metrics-Id"].ShouldBe("metrics-abc");
-        outgoing.Headers.ShouldNotContainKey("Opta-X-Causation-Id");
+        ((IDictionary<string, string?>)outgoing.Headers).ShouldNotContainKey("Opta-X-Causation-Id");
     }
 
     [Fact]

--- a/src/Wolverine/Runtime/Partitioning/GlobalPartitionedInterceptor.cs
+++ b/src/Wolverine/Runtime/Partitioning/GlobalPartitionedInterceptor.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using JasperFx.Core;
 using Microsoft.Extensions.Logging;
 using Wolverine.Runtime.WorkerQueues;
 using Wolverine.Transports;
@@ -12,17 +14,16 @@ namespace Wolverine.Runtime.Partitioning;
 internal class GlobalPartitionedInterceptor : IReceiver
 {
     private readonly IReceiver _inner;
-    private readonly IMessageBus _messageBus;
+    private readonly IWolverineRuntime _runtime;
     private readonly List<GlobalPartitionedMessageTopology> _topologies;
     private readonly ILogger _logger;
 
-    public GlobalPartitionedInterceptor(IReceiver inner, IMessageBus messageBus,
-        List<GlobalPartitionedMessageTopology> topologies, ILogger logger)
+    public GlobalPartitionedInterceptor(IReceiver inner, IWolverineRuntime runtime)
     {
         _inner = inner;
-        _messageBus = messageBus;
-        _topologies = topologies;
-        _logger = logger;
+        _runtime = runtime;
+        _topologies = runtime.Options.MessagePartitioning.GlobalPartitionedTopologies;
+        _logger = runtime.LoggerFactory.CreateLogger<GlobalPartitionedInterceptor>();
     }
 
     public IHandlerPipeline Pipeline => _inner.Pipeline;
@@ -81,12 +82,18 @@ internal class GlobalPartitionedInterceptor : IReceiver
                 }
             }
 
-            // Re-route through Wolverine's routing which will hit GlobalPartitionedRoute
-            await _messageBus.PublishAsync(envelope.Message!, new DeliveryOptions
+            var options = new DeliveryOptions
             {
                 GroupId = envelope.GroupId,
-                TenantId = envelope.TenantId
-            });
+                TenantId = envelope.TenantId,
+                CorrelationId = envelope.CorrelationId,
+            };
+
+            var bus = new RouteBus(_runtime, envelope);
+
+            using var activity = StartReRouteActivity(envelope);
+
+            await bus.PublishAsync(envelope.Message!, options);
             await listener.CompleteAsync(envelope);
             return true;
         }
@@ -97,6 +104,19 @@ internal class GlobalPartitionedInterceptor : IReceiver
             await listener.DeferAsync(envelope);
             return true;
         }
+    }
+
+    private static Activity? StartReRouteActivity(Envelope envelope)
+    {
+        if (envelope.ParentId.IsEmpty())
+        {
+            return null;
+        }
+
+        return WolverineTracing.ActivitySource.StartActivity(
+            "wolverine global-partitioning re-route",
+            ActivityKind.Internal,
+            envelope.ParentId);
     }
 
     public ValueTask DrainAsync() => _inner.DrainAsync();
@@ -118,5 +138,16 @@ internal class GlobalPartitionedInterceptor : IReceiver
         }
 
         return false;
+    }
+
+    private sealed class RouteBus : MessageBus
+    {
+        public RouteBus(IWolverineRuntime runtime, Envelope inbound) : base(runtime)
+        {
+            Envelope = inbound;
+            CorrelationId = inbound.CorrelationId;
+            TenantId = inbound.TenantId;
+            UserName = inbound.UserName;
+        }
     }
 }

--- a/src/Wolverine/Runtime/Partitioning/GlobalPartitionedInterceptor.cs
+++ b/src/Wolverine/Runtime/Partitioning/GlobalPartitionedInterceptor.cs
@@ -82,11 +82,17 @@ internal class GlobalPartitionedInterceptor : IReceiver
                 }
             }
 
+            // The bus is seeded with the inbound envelope so PropagateHeadersRule and
+            // every other IMetadataRule.ApplyCorrelation impl can read the originator
+            // when they enrich each outbound envelope — same shape as the publish path
+            // inside a regular handler. Context-correlation field copying (CorrelationId,
+            // ConversationId, TenantId, UserName, ParentId, SagaId) happens in the bus's
+            // overridden TrackEnvelopeCorrelation via Envelope.CopyContextCorrelationFrom,
+            // so we don't need to re-state any of those fields on DeliveryOptions here —
+            // GroupId is the only piece the routing layer itself needs to read.
             var options = new DeliveryOptions
             {
                 GroupId = envelope.GroupId,
-                TenantId = envelope.TenantId,
-                CorrelationId = envelope.CorrelationId,
             };
 
             var bus = new RouteBus(_runtime, envelope);
@@ -140,14 +146,53 @@ internal class GlobalPartitionedInterceptor : IReceiver
         return false;
     }
 
+    /// <summary>
+    /// MessageBus subclass used only by the global-partitioning re-route path.
+    /// Two responsibilities:
+    /// <list type="number">
+    ///   <item>Seed <see cref="MessageContext.Envelope"/> with the inbound envelope so
+    ///   <see cref="IEnvelopeRule.ApplyCorrelation"/> implementations such as
+    ///   <c>PropagateHeadersRule</c> see <c>originator.Envelope</c> when they enrich
+    ///   the outbound envelopes — without this seed those rules short-circuit and the
+    ///   <c>PropagateIncomingHeadersToOutgoing</c> allowlist is silently ignored for
+    ///   globally-partitioned messages.</item>
+    ///   <item>Override <see cref="MessageBus.TrackEnvelopeCorrelation"/> so each
+    ///   re-routed outbound envelope inherits the inbound's full context-correlation
+    ///   set (<c>CorrelationId</c>, <c>ConversationId</c>, <c>TenantId</c>,
+    ///   <c>UserName</c>, <c>ParentId</c>, <c>SagaId</c>) via
+    ///   <see cref="Envelope.CopyContextCorrelationFrom"/> — the same forwarding
+    ///   semantics already used by <c>ScheduledSendEnvelopeHandler</c> for unwrapped
+    ///   scheduled sends and by <c>TrackedSession.ReplayAll</c> for replayed envelopes.
+    ///   The base <c>TrackEnvelopeCorrelation</c> only pulls <c>CorrelationId</c> /
+    ///   <c>TenantId</c> / <c>UserName</c> from the bus's own properties and writes a
+    ///   fresh <c>ParentId</c> from <c>Activity.Current</c>, which is the wrong shape
+    ///   for a forwarded envelope: <c>ConversationId</c> would restart, <c>SagaId</c>
+    ///   would drop, and the trace would re-root at the interceptor hop instead of
+    ///   continuing the inbound's parent.</item>
+    /// </list>
+    /// </summary>
     private sealed class RouteBus : MessageBus
     {
+        private readonly Envelope _inbound;
+
         public RouteBus(IWolverineRuntime runtime, Envelope inbound) : base(runtime)
         {
+            _inbound = inbound;
             Envelope = inbound;
-            CorrelationId = inbound.CorrelationId;
-            TenantId = inbound.TenantId;
-            UserName = inbound.UserName;
+        }
+
+        internal override void TrackEnvelopeCorrelation(Envelope outbound, Activity? activity)
+        {
+            // Preserve any per-message Source override (e.g. CloudEvents producer
+            // setting a spec-valid `source` URI) before the inherited copy stamps
+            // the application service name as a default.
+            if (outbound.Source.IsEmpty())
+            {
+                outbound.Source = Runtime.Options.ServiceName;
+            }
+
+            outbound.CopyContextCorrelationFrom(_inbound);
+            outbound.Store = Storage;
         }
     }
 }

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -316,11 +316,7 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
                  && !Endpoint.UsedInShardedTopology
                  && Endpoint.Uri.Scheme != "local")
         {
-            _receiver = new GlobalPartitionedInterceptor(
-                _receiver,
-                new Runtime.MessageBus(_runtime),
-                _runtime.Options.MessagePartitioning.GlobalPartitionedTopologies,
-                _logger);
+            _receiver = new GlobalPartitionedInterceptor(_receiver, _runtime);
         }
 
         if (Endpoint.ListenerCount > 1)


### PR DESCRIPTION
Supersedes #2709 — same problem, same test contract, alternative implementation.

## Why a new PR

The original PR's test surface is a strict improvement and Lyall's underlying analysis is correct: `GlobalPartitionedInterceptor` previously built a fresh `MessageBus(_runtime)` with no inbound envelope, so `PropagateHeadersRule.ApplyCorrelation` short-circuited (`originator.Envelope` was null) and the re-published envelope dropped correlation, tenant id, and distributed-trace continuity. Allowlists declared via `PropagateIncomingHeadersToOutgoing` were silently ignored.

The implementation here keeps every behavioural improvement from #2709 but routes the field copying through the existing `Envelope.CopyContextCorrelationFrom` helper rather than re-stating the field list inline.

## What changed vs #2709

#2709 copies context fields via two distinct mechanisms:
1. `RouteBus` constructor manually copies `CorrelationId` / `TenantId` / `UserName` from the inbound onto the bus.
2. `DeliveryOptions` carries `CorrelationId` / `TenantId` / `GroupId` into the routing call.

This PR collapses both into a single override of `MessageBus.TrackEnvelopeCorrelation`:

```csharp
internal override void TrackEnvelopeCorrelation(Envelope outbound, Activity? activity)
{
    if (outbound.Source.IsEmpty())
        outbound.Source = Runtime.Options.ServiceName;

    outbound.CopyContextCorrelationFrom(_inbound);
    outbound.Store = Storage;
}
```

`Envelope.CopyContextCorrelationFrom` (added in GH-2571 / PR #2572) is the canonical helper for "this envelope is forwarding another's context". The other two callers — `ScheduledSendEnvelopeHandler` (durable scheduled-send unwrap) and `TrackedSession.ReplayAll` (in-memory tracked-session replay) — are both forwarding shapes; the global-partitioning re-route is a third instance of exactly the same shape (same logical message, different shard) so it should reuse the same helper.

The benefit is that the helper covers the **full** context-correlation set in one call:

| Field | base bus tracking | `CopyContextCorrelationFrom` |
|---|---|---|
| `CorrelationId` | from bus property | from inbound |
| `ConversationId` | reset to outbound's own Id | from inbound |
| `TenantId` | from bus property | from inbound |
| `UserName` | from bus property | from inbound |
| `ParentId` | from `Activity.Current` | from inbound |
| `SagaId` | not copied | from inbound |

So `ConversationId` no longer restarts at the interceptor hop and `SagaId` continues to flow on saga-spawned messages — both implicit gaps in the base bus's per-field copy that #2709's `RouteBus` constructor didn't address either.

The interceptor's `DeliveryOptions` payload is reduced to just `GroupId`, which is the only piece routing itself needs to read — every context field flows through the bus's overridden tracker.

## Authorship

Lyall's original commit (`a7788771f`) is cherry-picked onto this branch unchanged so his test contribution (`global_partitioning_tests.cs` + `MockWolverineRuntime` router map) is preserved with his authorship. The implementation switch is a follow-up commit on top, co-authored with Lyall to credit the diagnosis.

The two `ShouldNotContainKey` calls in his tests were tweaked to disambiguate Shouldly's `IDictionary` / `IReadOnlyDictionary` overloads (`Envelope.Headers` is a concrete `Dictionary` that satisfies both) — behavioural assertions are otherwise verbatim.

## Test plan

- [x] `GlobalPartitionedInterceptorTests`: 16/16 on net9.0, including the four new behavioural tests from #2709:
  - `carries_inbound_correlation_id_onto_re_routed_envelope`
  - `carries_inbound_tenant_id_onto_re_routed_envelope`
  - `continues_inbound_distributed_trace_on_re_routed_envelope`
  - `does_not_copy_custom_inbound_headers_when_propagation_rule_not_configured`
  - `copies_only_allowlisted_custom_headers_when_propagation_rule_configured`
- [x] Full `CoreTests.Runtime.Partitioning` suite: 78/78 on net9.0 (no regressions in adjacent partitioning behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)