### PR TITLE
fix(build): include Wolverine.HealthChecks in the Pack target

### DIFF
--- a/build/build.cs
+++ b/build/build.cs
@@ -321,6 +321,7 @@ partial class Build : NukeBuild
             var nugetProjects = new[]
             {
                 Solution.Wolverine,
+                Solution.Wolverine_HealthChecks,
                 Solution.Transports.RabbitMQ.Wolverine_RabbitMQ,
                 Solution.Transports.Azure.Wolverine_AzureServiceBus,
                 Solution.Transports.AWS.Wolverine_AmazonSqs,


### PR DESCRIPTION
Closes #2704.

## Diagnosis

The release workflow (`.github/workflows/publish_nugets.yml`) runs `./build.sh pack` and then a `find . -name '*.nupkg' -exec dotnet nuget push` over the artifacts. The `Pack` target in `build/build.cs` only packs the projects named in a hardcoded `nugetProjects` array.

`Wolverine.HealthChecks` was never added to that array. The project is in `wolverine.slnx`, references core via `<ProjectReference>`, has the right `<PackageId>WolverineFx.HealthChecks</PackageId>` metadata, and has tests — but `dotnet pack` is never invoked on it during a release, so no `.nupkg` is produced and nothing reaches nuget.org. The reporter ran `dotnet add package WolverineFx.HealthChecks` and got "no versions available" because no version has ever been pushed, even though every other piece of the pipeline (project, docs page, tests) has been in place since the package was introduced.

## Fix

One line: slot `Solution.Wolverine_HealthChecks` into the `Pack` target's `nugetProjects` array next to `Solution.Wolverine` (parallel naming since both `.csproj`s sit at the top level of `src/`).

## Verification

```bash
$ dotnet pack src/Wolverine.HealthChecks/Wolverine.HealthChecks.csproj \
    --configuration Release --output /tmp/check
$ ls /tmp/check
WolverineFx.HealthChecks.5.38.0.nupkg
```

The build script itself (`build/build.csproj`) compiles cleanly with the new `Solution.Wolverine_HealthChecks` accessor — Nuke's solution-property generator picks it up from the existing `<Project Path="src/Wolverine.HealthChecks/Wolverine.HealthChecks.csproj" />` entry in `wolverine.slnx`.

The next manual run of the **Publish Wolverine Nugets** workflow will produce and push `WolverineFx.HealthChecks.<version>.nupkg`.