### PR TITLE
docs(readme): document branch strategy for the 5.x → 6.0 transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ docker compose up -d
 There's a separate README in the Azure Service Bus tests as those require an actual cloud set up (sorry, but blame
 Microsoft for not having a local Docker based emulator ala Localstack).
 
+## Branches
+
+This repository follows a major-line branching strategy:
+
+- **`main`** — Active development for Wolverine 6.0. Expect breaking changes and dependency bumps to in-development JasperFx 2.0-alpha packages. Day-to-day work, new features, and the cold-start / runtime-perf pass all land here.
+- **`5.0`** — Maintenance branch for the Wolverine 5.x line. Receives bug fixes only — no new features and no breaking changes. Patch releases off the 5.x line ship from this branch until 6.0 is generally available.
+- **`archive/cloudevents-attempt-2025`** — Preserved, abandoned. An incomplete CloudEvents-for-SQS-and-SNS feature branch from August 2025 that never merged. Kept for historical reference only.
+
+Older release-specific branches (e.g., `4.0`, `release/5.30`, `5.36`) exist for in-flight or completed work on prior versions and are not active development surfaces. New contributions should target `main`. Backport candidates for the 5.x line can be opened against `5.0` after the corresponding PR has merged to `main`.
+
 ## Contributor's Guide
 
 For contributors, there's a light naming style Jeremy refuses to let go of that he's used for *gulp* 20+ years:


### PR DESCRIPTION
## Summary

- Adds a **Branches** section to the README so contributors landing on the repo see at a glance: `main` is the 6.0 development line, `5.0` is the 5.x maintenance branch (bug-fixes only), and `archive/cloudevents-attempt-2025` is the preserved-but-abandoned 2025 CloudEvents feature branch.
- Cross-references older release-specific branches (`4.0`, `release/5.30`, `5.36`) as historical / inactive, and points new contributions at `main` with a note on the 5.x backport workflow.

## Notes

The `5.0` branch is currently being reclaimed from the abandoned CloudEvents tip (`fb6e118d2`) to point at the current `main` HEAD as the new 5.x maintenance line. Branch-protection rules on `5.0` need to be temporarily relaxed for the rename / force-update; the README copy already reflects the intended state so this PR can merge in either order.

## Test plan

- [ ] CI green