### PR TITLE
feat: upgrade to JasperFx 2.0-alpha and drop net8.0 (Wolverine 6.0 BREAKING)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <PackageIconUrl>https://github.com/JasperFx/wolverine/blob/main/docs/public/logo.png?raw=true</PackageIconUrl>
         <PackageProjectUrl>http://github.com/jasperfx/wolverine</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618;VSTHRD200</NoWarn>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,10 +31,10 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="1.31.0" />
-    <PackageVersion Include="JasperFx.Events" Version="1.36.0" />
-    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.5.0" />
-    <PackageVersion Include="JasperFx.SourceGeneration" Version="1.1.0" />
+    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.8" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.3" />
+    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="2.0.0-alpha.2" />
+    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.2" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
     <PackageVersion Include="Marten" Version="8.35.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
@@ -117,19 +117,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
   <!-- TFM-conditional Microsoft.Extensions.* for Wolverine core (version ranges for NuGet compatibility) -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="[8.0.0,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="[8.0.0,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[8.0.2,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="[8.0.1,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[8.0.8,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="[8.0.8,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.1,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.1,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="[8.0.23,10.0.0)" />
-  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="[9.0.0,11.0.0)" />
@@ -162,15 +149,6 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0-rc.2" />
   </ItemGroup>
   <!-- TFM-conditional EF Core ecosystem -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.4.0" />
-  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />

--- a/src/Http/SqlServerOutboxWebService/SqlServerOutboxWebService.csproj
+++ b/src/Http/SqlServerOutboxWebService/SqlServerOutboxWebService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/Http/WolverineWebApiFSharp/WolverineWebApiFSharp.fsproj
+++ b/src/Http/WolverineWebApiFSharp/WolverineWebApiFSharp.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <LangVersion>8.0</LangVersion>
         <OutputType>Exe</OutputType>

--- a/src/Persistence/CosmosDbTests/CosmosDbTests.csproj
+++ b/src/Persistence/CosmosDbTests/CosmosDbTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Persistence/DuplicateMessageSending/DuplicateMessageSending.csproj
+++ b/src/Persistence/DuplicateMessageSending/DuplicateMessageSending.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Persistence/LeaderElection/RavenDbTests.LeaderElection/RavenDbTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/RavenDbTests.LeaderElection/RavenDbTests.LeaderElection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Persistence/MartenTests/AggregateHandlerWorkflow/aggregate_handler_workflow_with_ievent.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerWorkflow/aggregate_handler_workflow_with_ievent.cs
@@ -38,7 +38,7 @@ public class aggregate_handler_workflow_with_ievent
                 opts.Services.AddMarten(m =>
                     {
                         m.Connection(Servers.PostgresConnectionString);
-                        m.Projections.Snapshot<LetterAggregate>(SnapshotLifecycle.Inline);
+                        m.Projections.Snapshot<LetterAggregate>(Marten.Events.Projections.SnapshotLifecycle.Inline);
 
                         m.DisableNpgsqlLogging = true;
                     })

--- a/src/Persistence/PausingAndRestartingListener/PausingAndRestartingListener.csproj
+++ b/src/Persistence/PausingAndRestartingListener/PausingAndRestartingListener.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Persistence/RavenDbTests/RavenDbTests.csproj
+++ b/src/Persistence/RavenDbTests/RavenDbTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Wolverine.EntityFrameworkCore.csproj
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Wolverine.EntityFrameworkCore.csproj
@@ -19,7 +19,7 @@
         <ProjectReference Include="..\Wolverine.RDBMS\Wolverine.RDBMS.csproj"/>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
         <PackageReference Include="Microsoft.Build.Tasks.Core" />
     </ItemGroup>

--- a/src/Samples/CQRSWithMarten/TeleHealth.Backend/Program.cs
+++ b/src/Samples/CQRSWithMarten/TeleHealth.Backend/Program.cs
@@ -13,7 +13,7 @@ var builder = Host.CreateDefaultBuilder()
                 opts.Connection(ConnectionSource.ConnectionString);
 
                 opts.Projections.Add<AppointmentProjection>(ProjectionLifecycle.Inline);
-                opts.Projections.Snapshot<ProviderShift>(SnapshotLifecycle.Inline);
+                opts.Projections.Snapshot<ProviderShift>(Marten.Events.Projections.SnapshotLifecycle.Inline);
 
                 opts.Projections.Add<BoardViewProjection>(ProjectionLifecycle.Async);
             })

--- a/src/Samples/CQRSWithMarten/TeleHealth.WebApi/Program.cs
+++ b/src/Samples/CQRSWithMarten/TeleHealth.WebApi/Program.cs
@@ -75,7 +75,7 @@ builder.Services.AddMarten(opts =>
 
         opts.Projections.Add<AppointmentProjection>(ProjectionLifecycle.Inline);
         opts.Projections
-            .Snapshot<ProviderShift>(SnapshotLifecycle.Async);
+            .Snapshot<ProviderShift>(Marten.Events.Projections.SnapshotLifecycle.Async);
     })
 
     // This adds a hosted service to run

--- a/src/Samples/GreeterCodeFirstGrpc/Client/Client.csproj
+++ b/src/Samples/GreeterCodeFirstGrpc/Client/Client.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>GreeterCodeFirstGrpc.Client</RootNamespace>
         <AssemblyName>GreeterCodeFirstGrpc.Client</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/GreeterCodeFirstGrpc/Messages/Messages.csproj
+++ b/src/Samples/GreeterCodeFirstGrpc/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>GreeterCodeFirstGrpc.Messages</RootNamespace>
         <AssemblyName>GreeterCodeFirstGrpc.Messages</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/GreeterCodeFirstGrpc/Server/Server.csproj
+++ b/src/Samples/GreeterCodeFirstGrpc/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>GreeterCodeFirstGrpc.Server</RootNamespace>
         <AssemblyName>GreeterCodeFirstGrpc.Server</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/GreeterProtoFirstGrpc/Client/Client.csproj
+++ b/src/Samples/GreeterProtoFirstGrpc/Client/Client.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>GreeterProtoFirstGrpc.Client</RootNamespace>
         <AssemblyName>GreeterProtoFirstGrpc.Client</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/GreeterProtoFirstGrpc/Messages/Messages.csproj
+++ b/src/Samples/GreeterProtoFirstGrpc/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>GreeterProtoFirstGrpc.Messages</RootNamespace>
         <AssemblyName>GreeterProtoFirstGrpc.Messages</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/GreeterProtoFirstGrpc/Server/Server.csproj
+++ b/src/Samples/GreeterProtoFirstGrpc/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>GreeterProtoFirstGrpc.Server</RootNamespace>
         <AssemblyName>GreeterProtoFirstGrpc.Server</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/GreeterWithGrpcErrors/Client/Client.csproj
+++ b/src/Samples/GreeterWithGrpcErrors/Client/Client.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>GreeterWithGrpcErrors.Client</RootNamespace>
         <AssemblyName>GreeterWithGrpcErrors.Client</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/GreeterWithGrpcErrors/Messages/Messages.csproj
+++ b/src/Samples/GreeterWithGrpcErrors/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>GreeterWithGrpcErrors.Messages</RootNamespace>
         <AssemblyName>GreeterWithGrpcErrors.Messages</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/GreeterWithGrpcErrors/Server/Server.csproj
+++ b/src/Samples/GreeterWithGrpcErrors/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>GreeterWithGrpcErrors.Server</RootNamespace>
         <AssemblyName>GreeterWithGrpcErrors.Server</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/OrderChainWithGrpc/Contracts/Contracts.csproj
+++ b/src/Samples/OrderChainWithGrpc/Contracts/Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>OrderChainWithGrpc.Contracts</RootNamespace>
         <AssemblyName>OrderChainWithGrpc.Contracts</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/OrderChainWithGrpc/InventoryServer/InventoryServer.csproj
+++ b/src/Samples/OrderChainWithGrpc/InventoryServer/InventoryServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>OrderChainWithGrpc.InventoryServer</RootNamespace>
         <AssemblyName>OrderChainWithGrpc.InventoryServer</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/OrderChainWithGrpc/OrderClient/OrderClient.csproj
+++ b/src/Samples/OrderChainWithGrpc/OrderClient/OrderClient.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>OrderChainWithGrpc.OrderClient</RootNamespace>
         <AssemblyName>OrderChainWithGrpc.OrderClient</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/OrderChainWithGrpc/OrderServer/OrderServer.csproj
+++ b/src/Samples/OrderChainWithGrpc/OrderServer/OrderServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>OrderChainWithGrpc.OrderServer</RootNamespace>
         <AssemblyName>OrderChainWithGrpc.OrderServer</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/OrderManagement/Messages/Messages.csproj
+++ b/src/Samples/OrderManagement/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Samples/OrderManagement/Orders/Orders.csproj
+++ b/src/Samples/OrderManagement/Orders/Orders.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Samples/OrderManagement/RetailClient/RetailClient.csproj
+++ b/src/Samples/OrderManagement/RetailClient/RetailClient.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Samples/PingPongWithGrpc/Messages/Messages.csproj
+++ b/src/Samples/PingPongWithGrpc/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>PingPongWithGrpc.Messages</RootNamespace>
         <AssemblyName>PingPongWithGrpc.Messages</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/PingPongWithGrpc/Pinger/Pinger.csproj
+++ b/src/Samples/PingPongWithGrpc/Pinger/Pinger.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>PingPongWithGrpc.Pinger</RootNamespace>
         <AssemblyName>PingPongWithGrpc.Pinger</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/PingPongWithGrpc/Ponger/Ponger.csproj
+++ b/src/Samples/PingPongWithGrpc/Ponger/Ponger.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>PingPongWithGrpc.Ponger</RootNamespace>
         <AssemblyName>PingPongWithGrpc.Ponger</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/PingPongWithGrpcStreaming/Messages/Messages.csproj
+++ b/src/Samples/PingPongWithGrpcStreaming/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>PingPongWithGrpcStreaming.Messages</RootNamespace>
         <AssemblyName>PingPongWithGrpcStreaming.Messages</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/PingPongWithGrpcStreaming/Pinger/Pinger.csproj
+++ b/src/Samples/PingPongWithGrpcStreaming/Pinger/Pinger.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>PingPongWithGrpcStreaming.Pinger</RootNamespace>
         <AssemblyName>PingPongWithGrpcStreaming.Pinger</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/PingPongWithGrpcStreaming/Ponger/Ponger.csproj
+++ b/src/Samples/PingPongWithGrpcStreaming/Ponger/Ponger.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>PingPongWithGrpcStreaming.Ponger</RootNamespace>
         <AssemblyName>PingPongWithGrpcStreaming.Ponger</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/PingPongWithRabbitMq/Pinger/Pinger.csproj
+++ b/src/Samples/PingPongWithRabbitMq/Pinger/Pinger.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\Transports\RabbitMQ\Wolverine.RabbitMQ\Wolverine.RabbitMQ.csproj"/>

--- a/src/Samples/PingPongWithRabbitMq/Ponger/Ponger.csproj
+++ b/src/Samples/PingPongWithRabbitMq/Ponger/Ponger.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Samples/ProgressTrackerWithGrpc/Client/Client.csproj
+++ b/src/Samples/ProgressTrackerWithGrpc/Client/Client.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>ProgressTrackerWithGrpc.Client</RootNamespace>
         <AssemblyName>ProgressTrackerWithGrpc.Client</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/ProgressTrackerWithGrpc/Messages/Messages.csproj
+++ b/src/Samples/ProgressTrackerWithGrpc/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>ProgressTrackerWithGrpc.Messages</RootNamespace>
         <AssemblyName>ProgressTrackerWithGrpc.Messages</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/ProgressTrackerWithGrpc/Server/Server.csproj
+++ b/src/Samples/ProgressTrackerWithGrpc/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>ProgressTrackerWithGrpc.Server</RootNamespace>
         <AssemblyName>ProgressTrackerWithGrpc.Server</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/RacerWithGrpc/RacerClient/RacerClient.csproj
+++ b/src/Samples/RacerWithGrpc/RacerClient/RacerClient.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>RacerClient</RootNamespace>
         <AssemblyName>RacerClient</AssemblyName>
     </PropertyGroup>

--- a/src/Samples/RacerWithGrpc/RacerContracts/RacerContracts.csproj
+++ b/src/Samples/RacerWithGrpc/RacerContracts/RacerContracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <AssemblyName>RacerContracts</AssemblyName>
         <RootNamespace>RacerContracts</RootNamespace>
     </PropertyGroup>

--- a/src/Samples/RacerWithGrpc/RacerServer/RacerServer.csproj
+++ b/src/Samples/RacerWithGrpc/RacerServer/RacerServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <RootNamespace>RacerServer</RootNamespace>
         <AssemblyName>RacerServer</AssemblyName>
     </PropertyGroup>


### PR DESCRIPTION
## Summary

- Brings Wolverine in sync with the critter-stack 2.0 era. Marten 9.0 already moved to this JasperFx 2.0-alpha line; matching here unblocks the 6.0 cold-start / runtime-perf pass (#1577, #2724, #2726, #2728) and keeps cross-stack runtime types aligned.
- **BREAKING**: drops net8.0. JasperFx 2.0-alpha targets only `net9.0` / `net10.0`. The new `5.0` maintenance branch carries forward bug-fix support for the 5.x line for .NET 8 LTS users.
- **One commit**: the package bumps and the net8.0 drop are causally linked — you can't pick up JasperFx 2.0 while keeping net8.0.

## Package bumps in `Directory.Packages.props`

| Package | Before | After |
|---|---|---|
| JasperFx | 1.31.0 | 2.0.0-alpha.8 |
| JasperFx.Events | 1.36.0 | 2.0.0-alpha.3 |
| JasperFx.RuntimeCompiler | 4.5.0 | 2.0.0-alpha.2 *(track switch; pre-2.0 line was 4.x)* |
| JasperFx.SourceGeneration | 1.1.0 | 2.0.0-alpha.2 |

Matches Marten's current pinned alphas (`JasperFx 2.0.0-alpha.6`, others identical) for cross-stack compat, with the JasperFx package itself bumped to the latest alpha.8.

## net8.0 drop scope

- `Directory.Build.props` central `TargetFrameworks` → `net9.0;net10.0`.
- `Directory.Packages.props` two net8.0 conditional `ItemGroup`s removed (Microsoft.Extensions.* + EF Core).
- 39 csprojs + 1 fsproj swept: `net8.0;net9.0;net10.0` → `net9.0;net10.0`, `net8.0;net9.0` → `net9.0`, single `<TargetFramework>net8.0</…>` → `net9.0`.
- `Wolverine.EntityFrameworkCore.csproj`: conditional ItemGroup that pinned `Microsoft.CodeAnalysis.Workspaces.MSBuild` / `Microsoft.Build.Tasks.Core` for net8.0+net9.0 is now net9.0-only.

## `SnapshotLifecycle` disambiguation

JasperFx.Events 2.0 introduces `JasperFx.Events.Projections.SnapshotLifecycle` alongside the existing `Marten.Events.Projections.SnapshotLifecycle`. Three sample/test files that import both namespaces hit `CS0104` ambiguity. Marten 8.35's `Snapshot<T>` API still consumes the **Marten-namespaced** type, so each call site is fully qualified to `Marten.Events.Projections.SnapshotLifecycle` for now. When Marten 9.0 unifies on the JasperFx.Events type, these can be relaxed.

Affected:
- `src/Samples/CQRSWithMarten/TeleHealth.WebApi/Program.cs`
- `src/Samples/CQRSWithMarten/TeleHealth.Backend/Program.cs`
- `src/Persistence/MartenTests/AggregateHandlerWorkflow/aggregate_handler_workflow_with_ievent.cs`

## `IAssemblyGenerator` — Wolverine was already ahead

Marten's 2.0 adapter had to wrap codegen call sites with a `RuntimeCompilerFallback` stub `IServiceProvider` because most of its `InitializeSynchronously` sites pass `services: null`. Wolverine doesn't need that — `HostBuilderExtensions.cs:115` and `Wolverine.RuntimeCompilation`'s extensions already register `IAssemblyGenerator` idempotently, and the four `InitializeSynchronously` sites all pass real container service providers. The `runtime_compilation_extension` tests confirm the DI registration still resolves correctly.

## Validation

| Step | Result |
|---|---|
| `dotnet build wolverine.slnx --framework net9.0` | ✅ 0 errors |
| `dotnet build` (5 core packages, --framework net10.0) | ✅ all succeeded |
| `dotnet test src/Testing/CoreTests/CoreTests.csproj --framework net9.0` | ✅ **1676 passed / 0 failed / 0 skipped** in 2m07s |

> Solution-level `dotnet build --framework net10.0` surfaces pre-existing `NETSDK1005` from sample projects that target only net9.0 — unrelated to this PR.

## Migration note for #2717

The 5→6 migration guide will need a section explaining:
- net8.0 dropped; users on .NET 8 LTS should pin to Wolverine 5.x off the `5.0` maintenance branch.
- New JasperFx package versions; existing custom `IAssemblyGenerator` registrations continue to work.
- `SnapshotLifecycle` ambiguity heads-up for any user code that imports both `JasperFx.Events.Projections` and `Marten.Events.Projections`.

## Test plan

- [x] Builds clean on net9.0 (full solution)
- [x] Builds clean on net10.0 (core packages)
- [x] Full CoreTests pass on net9.0
- [ ] CI green across all test matrix entries
- [ ] Integration tests with live infrastructure (Docker compose suites) — gated on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)