### PR TITLE
perf(endpoint): pre-populate serializer cache at Compile() to eliminate hot-path mutation (closes #2724 Site 3)

### DIFF
--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -508,6 +508,21 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
             WireTap = ResolveWireTap(runtime);
         }
 
+        // Pre-populate the endpoint-local serializer cache with every globally-
+        // registered serializer (keyed by content-type). This eliminates the
+        // first-miss hot-path mutation in TryFindSerializer (formerly an
+        // ImHashMap.AddOrUpdate on every previously-unseen content-type), making
+        // steady-state lookups pure reads. Endpoint-level overrides registered
+        // via RegisterSerializer prior to Compile() are preserved — they take
+        // precedence because TryAdd skips entries already in the map.
+        foreach (var pair in runtime.Options.ToSerializerDictionary())
+        {
+            if (!_serializers.Contains(pair.Key))
+            {
+                _serializers = _serializers.AddOrUpdate(pair.Key, pair.Value);
+            }
+        }
+
         _hasCompiled = true;
     }
 
@@ -574,10 +589,14 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
             return serializer;
         }
 
-        serializer = Runtime?.Options.TryFindSerializer(contentType);
-        _serializers = _serializers!.AddOrUpdate(contentType, serializer)!;
-
-        return serializer;
+        // Compile() pre-seeds _serializers with every globally-registered content-
+        // type, so reaching this fallback means the message arrived with a content-
+        // type that wasn't registered at bootstrap. Read from the global registry
+        // without mutating the endpoint cache — under sustained traffic with an
+        // unregistered content-type that would otherwise be a hot-path write on
+        // every call, but in practice this branch fires rarely (and the global
+        // lookup is itself O(1) against a small dictionary).
+        return Runtime?.Options.TryFindSerializer(contentType);
     }
 
     /// <summary>

--- a/src/Wolverine/WolverineOptions.Serialization.cs
+++ b/src/Wolverine/WolverineOptions.Serialization.cs
@@ -13,7 +13,10 @@ public sealed partial class WolverineOptions
     private IMessageSerializer? _defaultSerializer;
 
     /// <summary>
-    ///     Override or get the default message serializer for the application. The default is based around Newtonsoft.Json
+    ///     Override or get the default message serializer for the application. The default is
+    ///     <see cref="SystemTextJsonSerializer"/> (wired in the <see cref="WolverineOptions"/>
+    ///     constructor via <see cref="UseSystemTextJsonForSerialization"/>). To restore the
+    ///     5.x-and-earlier default, call <see cref="UseNewtonsoftForSerialization"/>.
     /// </summary>
     /// <exception cref="InvalidOperationException"></exception>
     public IMessageSerializer DefaultSerializer


### PR DESCRIPTION
## Summary

`Endpoint.TryFindSerializer(string contentType)` was performing an `ImHashMap.AddOrUpdate` on every first-miss for a content-type — a real hot-path write under sustained traffic with multiple content-types. This PR pre-populates `Endpoint._serializers` during `Endpoint.Compile()` from `runtime.Options.ToSerializerDictionary()`, making steady-state hot-path lookups pure reads.

Per the [Performance conventions in CLAUDE.md](https://github.com/JasperFx/wolverine/blob/main/CLAUDE.md#performance-conventions) (just added in #2731), `ImHashMap` stays as the field type. The fix is bootstrap-time pre-population, not a data-structure swap.

## Changes

- `Endpoint.Compile(IWolverineRuntime)`: seeds `_serializers` with every globally-registered serializer. Endpoint-level overrides registered via `RegisterSerializer(...)` before `Compile()` are preserved (the seed step skips entries already present).
- `Endpoint.TryFindSerializer(string?)`: fallback for content-types not known at bootstrap now reads from `Runtime?.Options.TryFindSerializer` **without** mutating the endpoint cache. That trades a small per-call cost in the rare path for eliminating the hot-path write in the common one.
- Drive-by: fix the stale XmlDoc on `WolverineOptions.DefaultSerializer` that still claimed Newtonsoft.Json as the default (STJ has been the default since 5.0 per closed #2725).

## Trade-off note

The new fallback branch — which used to be a hot-path write — no longer caches a runtime-discovered serializer in the endpoint. If a content-type that wasn't known at bootstrap shows up under sustained traffic, every call pays the global-registry lookup. The right path for that case is to register the serializer via `WolverineOptions.AddSerializer(...)` before host startup, so it's seen at `Compile()` time. This is the documented pattern; I don't think the previous \"cache on first miss\" behavior was ever a documented expectation.

If we discover production usage that depends on the old behavior, the right re-add is **per-listener** registration via the existing `RegisterSerializer` API rather than re-introducing the hot-path write.

## Not in scope

The #2724 issue body covers two other sites:

- **Site 1** `WolverineMessageNaming._typeNames` — already pre-populated via `PrepopulateCache` at startup; no work needed.
- **Site 2** `HandlerGraph._handlers` lazy fill for `IAgentCommand` derivatives — multiple call sites with a complex read/write pattern (writes by concrete type, reads by marker type at one site, by concrete type at another). Whether the write is reachable as a read needs more investigation; deferring to a follow-up.

I'll leave #2724 open for Site 2 follow-up after this lands. Site 3 (this PR) was the highest-value of the three — it kills a real hot-path mutation, not a one-time bootstrap cost.

## Validation

- `dotnet build src/Wolverine/Wolverine.csproj --framework net9.0` — clean.
- Full `dotnet test src/Testing/CoreTests/CoreTests.csproj --framework net9.0`: **1676 passed / 0 failed / 0 skipped** in 1m58s.
- *(One flaky failure on the first run cleared on rerun — known pre-existing intermittent, not caused by this change.)*

## Test plan

- [x] CoreTests pass on net9.0
- [ ] CI green across all matrix entries
- [ ] CritterStackScalability serializer-lookup benchmark shows measurable per-message latency improvement once the harness lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)