### PR TITLE
chore(ci): post-#2584 CI sanity sweep — tracer bump to surface remaining failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ and highly performant server side development in .NET.
 
 
 
-<!-- ci-stabilization tracer (no-op) -->
+<!-- ci-stabilization tracer (no-op) — post-#2584 sweep 2026-05-12 -->


### PR DESCRIPTION
## Purpose

Pure tracer bump (one line in README's existing \`ci-stabilization tracer\` comment) to trigger a fresh CI run against the new \`main\` HEAD after today's major landings:

- #2730 (JasperFx 2.0-alpha + net8.0 drop)
- #2732 (#2724 Site 3 — Endpoint serializer Compile-time pre-population)
- #2733 (Marten 9 + Polecat 4 + dep cascades)
- #2734 (5→6 migration guide)
- #2736 (#2584 — \`ServiceLocationPolicy.NotAllowed\` default + JasperFx alpha.10 + Bug_568 Refit fix)

## Plan

- Watch CI here.
- Address any cascading failures that surface (besides the pre-existing #2735 efcore multi-tenant fixture, which has been red since May 8 and is tracked separately).
- Once green, the 6.0 development line has a clean baseline for the next batch of work.

## Test plan

- [ ] CI green (excluding #2735 known failure)