### PR TITLE
test(efcore): regression guard for managed-multi-tenancy host-build (…

### DIFF
--- a/src/Persistence/EfCoreTests.MultiTenancy/Bug_2739_host_build_with_managed_multi_tenancy.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/Bug_2739_host_build_with_managed_multi_tenancy.cs
@@ -1,0 +1,107 @@
+using IntegrationTests;
+using JasperFx;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using SharedPersistenceModels.Items;
+using Shouldly;
+using Wolverine;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.SqlServer;
+using Xunit;
+
+namespace EfCoreTests.MultiTenancy;
+
+/// <summary>
+/// Regression guard for wolverine#2739.
+///
+/// On Wolverine <b>5.39.0</b>, an app that called
+/// <c>AddDbContextWithWolverineManagedMultiTenancy&lt;T&gt;(...)</c> threw on
+/// <c>app.Run()</c>:
+///
+/// <code>
+///   System.InvalidOperationException:
+///     As of Wolverine 3.0, it's no longer supported to alter IoC service
+///     registrations through Wolverine extensions that are themselves
+///     registered in the IoC container
+///   at Wolverine.WolverineOptions.ApplyExtensions(IWolverineExtension[] extensions)
+///   at Wolverine.HostBuilderExtensions...
+/// </code>
+///
+/// The bug was introduced when <c>EntityFrameworkCoreBackedPersistence&lt;T&gt;.Configure</c>
+/// added an <c>options.Services.AddSingleton&lt;ISagaStoreDiagnostics&gt;(...)</c>
+/// call at host-build time — past the point where <c>IServiceCollection</c>
+/// is still mutable. The fix (committed alongside this test on the 5.0
+/// branch) moves that registration to the four <c>IServiceCollection</c>
+/// extension entry-points in <c>WolverineEntityCoreExtensions</c>, where
+/// Services is still mutable, gated by a private marker type so multiple
+/// entry-point calls produce a single registration without ever using
+/// <c>TryAddSingleton</c> on the additive <c>ISagaStoreDiagnostics</c>
+/// fan-out slot.
+///
+/// The test runs the host-build path with <c>AutoCreate.None</c> so no
+/// per-tenant schema is provisioned — the bug fires during the first
+/// singleton resolution at <c>StartAsync</c>, well before any database
+/// I/O. The single master <c>PersistMessagesWithSqlServer</c> call needs
+/// a reachable SQL Server because the master message-store schema gets
+/// provisioned at startup, but no actual tenant database is required.
+/// </summary>
+[Collection("multi-tenancy")]
+public class Bug_2739_host_build_with_managed_multi_tenancy
+{
+    [Fact]
+    public async Task host_build_does_not_throw_with_AddDbContextWithWolverineManagedMultiTenancy()
+    {
+        // Use HostApplicationBuilder (.NET 8+) rather than the older
+        // Host.CreateDefaultBuilder() pattern. WebApplicationBuilder and
+        // HostApplicationBuilder both make the underlying IServiceCollection
+        // read-only after Build, which is the condition the bug fires
+        // under — Host.CreateDefaultBuilder() does NOT freeze the
+        // collection, and won't reproduce the issue.
+        //
+        // The user's report (#2739) was on an ASP.NET Core app built
+        // with WebApplication.CreateBuilder; HostApplicationBuilder
+        // gives the same freeze semantics without pulling in
+        // Microsoft.AspNetCore.App as a FrameworkReference here.
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            opts.Durability.Mode = DurabilityMode.Solo;
+
+            opts.PersistMessagesWithSqlServer(
+                    Servers.SqlServerConnectionString,
+                    "bug2739_master")
+                .RegisterStaticTenants(tenants =>
+                {
+                    // A single static tenant is enough — the bug fires
+                    // during the EFCore extension's Configure call,
+                    // before any tenant routing happens.
+                    tenants.Register("alpha", Servers.SqlServerConnectionString);
+                });
+
+            opts.Services.AddDbContextWithWolverineManagedMultiTenancy<ItemsDbContext>(
+                (builder, connectionString, _) =>
+                {
+                    builder.UseSqlServer(connectionString.Value);
+                },
+                AutoCreate.None);
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        // Force WolverineOptions singleton resolution. The bug from #2739
+        // fires inside the WolverineOptions factory lambda in
+        // HostBuilderExtensions.AddWolverine — specifically the
+        // `options.ApplyExtensions(extensions.ToArray())` line, which
+        // calls EntityFrameworkCoreBackedPersistence<T>.Configure, which
+        // (on V5.39.0) tries options.Services.AddSingleton<ISagaStoreDiagnostics>
+        // against the already-frozen IServiceCollection.
+        var options = host.Services.GetRequiredService<WolverineOptions>();
+        options.ShouldNotBeNull();
+
+        // Reaching here without an InvalidOperationException is the
+        // assertion — the bug from #2739 fired during this resolution.
+        host.ShouldNotBeNull();
+    }
+}


### PR DESCRIPTION
…#2739)

Locks in the assertion that calling
`AddDbContextWithWolverineManagedMultiTenancy<T>(...)` followed by `Host.StartAsync()` doesn't throw the "no longer supported to alter IoC service registrations through Wolverine extensions" exception that surfaced for users on the 5.39.0 NuGet release.

The bug was introduced by commit 28b06d600 (the ISagaStoreDiagnostics work for #2713) on the now-6.0-development trajectory and never made it to this 5.0 maintenance branch — `git merge-base origin/5.0 origin/main` shows the branches forked at e4922d8bf, well before 28b06d600 landed.

So the test PASSES on 5.0 as written. Its purpose:

  1. Lock in the regression-guard so the bug can never re-enter this branch.
  2. Provide a cherry-pickable commit for `main`, where PR #2738 already fixed the bug — adding the test to main keeps that fix locked in too.

The test uses SqlServer because the existing multi-tenancy test infrastructure on this branch already provides the SQL Server connection string. AutoCreate.None means no per-tenant schema gets provisioned; the test runs the host-build / StartAsync path only, which is exactly where the bug fires.