### PR TITLE
6.0 hygiene: AOT publishing guide + HostBuilderExtensions DAM annotat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Microsoft for not having a local Docker based emulator ala Localstack).
 
 This repository follows a major-line branching strategy:
 
-- **`main`** — Active development for Wolverine 6.0. Expect breaking changes and dependency bumps to in-development JasperFx 2.0-alpha packages. Day-to-day work, new features, and the cold-start / runtime-perf pass all land here.
-- **`5.0`** — Maintenance branch for the Wolverine 5.x line. Receives bug fixes only — no new features and no breaking changes. Patch releases off the 5.x line ship from this branch until 6.0 is generally available.
+- **`main`** — Active development for Wolverine 6.0, currently published as `WolverineFx 6.0.0-alpha.*` pre-release packages. Expect breaking changes and dependency bumps to in-development JasperFx 2.0-alpha packages. Day-to-day work, new features, the cold-start / runtime-perf pass and the [AOT pillar](https://github.com/JasperFx/wolverine/issues/2746) all land here. See [`CHANGELOG.md`](./CHANGELOG.md#600-alpha1) for the cumulative 6.0 inventory and the [migration guide](https://wolverinefx.net/guide/migration.html#key-changes-in-6-0) for the at-a-glance table of changed defaults / removed APIs / moved namespaces.
+- **`5.0`** — Maintenance branch for the Wolverine 5.x line, branched from the `V5.39.0` tag. Receives bug fixes only — no new features and no breaking changes. Patch releases (5.39.1, 5.39.2 …) off the 5.x line ship from this branch until 6.0 is generally available.
 - **`archive/cloudevents-attempt-2025`** — Preserved, abandoned. An incomplete CloudEvents-for-SQS-and-SNS feature branch from August 2025 that never merged. Kept for historical reference only.
 
 Older release-specific branches (e.g., `4.0`, `release/5.30`, `5.36`) exist for in-flight or completed work on prior versions and are not active development surfaces. New contributions should target `main`. Backport candidates for the 5.x line can be opened against `5.0` after the corresponding PR has merged to `main`.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -139,6 +139,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                         {text: 'Test Automation Support', link: '/guide/testing'},
                         {text: 'Command Line Integration', link: '/guide/command-line'},
                         {text: 'Code Generation', link: '/guide/codegen'},
+                        {text: 'AOT Publishing', link: '/guide/aot'},
                         {text: 'Extensions', link: '/guide/extensions'},
                         {text: 'Sample Projects', link: '/guide/samples'}
                     ]

--- a/docs/guide/aot.md
+++ b/docs/guide/aot.md
@@ -1,0 +1,115 @@
+# AOT Publishing
+
+::: warning
+**Status: in progress.** Wolverine 6.0 sets up the AOT story but the full per-file annotation pass is still landing — see [the AOT-pillar tracking issue](https://github.com/JasperFx/wolverine/issues/2746). The guidance below describes the **target** end state plus the safe escape hatches that work today.
+:::
+
+Wolverine 6.0 introduces first-class support for publishing applications with [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/) (`dotnet publish /p:PublishAot=true`) and aggressive trimming. The story is two-part:
+
+1. **At build time** — pre-generate handler dispatch code via `dotnet run -- codegen write`, then ship that pre-generated code as ordinary, statically-analyzable C# inside your app's `Internal/Generated/` folder.
+2. **At runtime** — configure Wolverine in `TypeLoadMode.Static` so the host loads the pre-generated types instead of compiling them at boot. With Static mode in effect, Wolverine's Roslyn-based `AssemblyGenerator` is never invoked, and the AOT compiler / trimmer have everything they need statically.
+
+## Why this matters
+
+Wolverine's default `TypeLoadMode.Dynamic` (and `Auto`) configurations compile handler dispatch via [JasperFx.RuntimeCompiler](https://github.com/JasperFx/jasperfx/tree/main/src/JasperFx.RuntimeCompiler) on host startup. That path:
+
+- Loads `Microsoft.CodeAnalysis.CSharp` (~6 MB Roslyn binaries) into your process
+- Emits and JIT-compiles new types at runtime — fundamentally incompatible with Native AOT
+- Reflects over handler / saga / middleware types in ways the trimmer can't follow statically
+
+`TypeLoadMode.Static` shifts all of that to build time. Production binaries published with `Static` mode + pre-generated code do **not** carry Roslyn at all, start faster, and pass `dotnet publish /p:PublishAot=true` without `IL2026` / `IL3050` warnings outside the explicitly-annotated runtime-codegen surface.
+
+## Walkthrough
+
+### 1. Pre-generate handler code
+
+In your project root, run:
+
+```bash
+dotnet run -- codegen write
+```
+
+This invokes the JasperFx command-line surface that Wolverine extends. The command discovers handlers / sagas / middleware in the configured assemblies, runs the same code-generation passes the host would run at startup, and writes the resulting C# into `Internal/Generated/` (or wherever `opts.CodeGeneration.GeneratedCodeOutputPath` points). The files are normal C# — check them in, run them through the trimmer, set breakpoints in them.
+
+::: tip
+`codegen write` is the same command that's been available in earlier Wolverine versions for dev-time inspection. The 6.0 difference is that the **output is byte-stable and round-trips into `TypeLoadMode.Static`** — i.e. you can rely on the pre-generated files being the authoritative dispatch code, not just a debugging aid.
+:::
+
+### 2. Configure `TypeLoadMode.Static`
+
+In your application's `Program.cs`:
+
+```csharp
+builder.Host.UseWolverine(opts =>
+{
+    opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Static;
+    // … the rest of your configuration
+});
+```
+
+`TypeLoadMode.Static` tells Wolverine "the pre-generated handler types are in this assembly; load them by name and skip the runtime compile step entirely." If a handler is missing pre-generated code, host startup fails with a clear error pointing at the missing file — so the failure mode is "loud and at startup" rather than "silent fallback to Roslyn."
+
+### 3. Publish AOT
+
+Reference `PublishAot` in your csproj or pass it on the command line:
+
+```bash
+dotnet publish -c Release /p:PublishAot=true
+```
+
+A clean AOT-published Wolverine app in `Static` mode emits **no** `IL2026` / `IL3050` warnings from Wolverine itself today against the AOT-clean *subset* of the surface (`Envelope`, `WolverineOptions`, `DeliveryOptions`, the scheduling helpers — what the [`Wolverine.AotSmoke`](https://github.com/JasperFx/wolverine/tree/main/src/Testing/Wolverine.AotSmoke) regression-guard project exercises).
+
+::: warning
+Until the [AOT-pillar tracking issue (#2746)](https://github.com/JasperFx/wolverine/issues/2746) is fully closed out, Wolverine APIs outside the AOT-clean subset above may emit IL warnings under `PublishAot=true`. The warnings are informative — they tell you which Wolverine APIs require dynamic code / aren't trim-safe. The Static-mode runtime path avoids most of them; the rest get annotated as the pillar work progresses.
+:::
+
+## What `Wolverine.AotSmoke` already guarantees
+
+The [`Wolverine.AotSmoke`](https://github.com/JasperFx/wolverine/tree/main/src/Testing/Wolverine.AotSmoke) project in the Wolverine repo sets `IsAotCompatible=true`, `TrimMode=full`, and promotes the `IL2026/IL2046/IL2055/IL2065/IL2067/IL2070/IL2072/IL2075/IL2090/IL2091/IL2111/IL3050/IL3051` warning codes to errors. Every PR runs it via the [`aot` workflow](https://github.com/JasperFx/wolverine/blob/main/.github/workflows/aot.yml).
+
+Currently exercised AOT-clean surface (will fail the smoke build if any of these APIs gains a `[RequiresDynamicCode]` / `[RequiresUnreferencedCode]` annotation):
+
+- `Envelope` construction + value-shape (`Id`, `Headers`, `CorrelationId`, `MessageType`, …)
+- `Envelope.TryGetHeader` fast path
+- `Envelope.SetMessageType<T>` closed-generic
+- `Envelope.SetMetricsTag`
+- Envelope scheduling helpers (`ScheduleAt`, `ScheduleDelayed`, `IsScheduledForLater`, `IsExpired`)
+- `DeliveryOptions` construction
+- `WolverineOptions` construction
+- `WolverineOptions.DetermineSerializer` (dictionary lookup)
+
+As the per-file annotation pass in #2746 progresses, the smoke project expands to exercise the newly-annotated entry points — tightening the regression guard incrementally.
+
+## Surfaces that intentionally aren't AOT-clean
+
+A handful of Wolverine APIs **require** runtime codegen by design. They carry `[RequiresDynamicCode]` / `[RequiresUnreferencedCode]` annotations so the trimmer surfaces a clear warning if your AOT-published app reaches them:
+
+- `HandlerGraph.Compile` and its callees — runtime Roslyn codegen of handler dispatch. Static-mode apps don't reach this.
+- Reflective handler / saga / transport discovery (`HandlerDiscovery.IncludeAssembly` type-scan, the saga-type-descriptor `StartingMessages` reflection, transport `IMessageRoutingConvention` reflection). Static-mode + a pre-generated handler manifest avoid these.
+- `MakeGenericType` / `Activator.CreateInstance` driven factories — the few that still exist in core.
+- The `WolverineFx.Newtonsoft` companion package (Newtonsoft.Json itself isn't AOT-friendly; if you need Newtonsoft, you're not on the AOT path).
+
+If you publish AOT in `Dynamic` mode (the default), expect warnings from these surfaces — they tell you what to migrate before you can ship a working AOT binary.
+
+## Cold-start side benefit
+
+Even without publishing AOT, `TypeLoadMode.Static` produces meaningful cold-start improvements: the host doesn't pay the per-handler Roslyn compile cost on first message. The [`CritterStackScalability`](https://github.com/JasperFx/CritterStackScalability) `coldstart wolverine` harness measures this against the V5.39.0 baseline.
+
+## Migration checklist
+
+If you're moving an existing 5.x Wolverine app to 6.0 AOT:
+
+1. Upgrade to Wolverine 6.0 (see the [migration guide](/guide/migration.html))
+2. Run `dotnet run -- codegen write` locally; verify the `Internal/Generated/` folder gets populated and the files compile
+3. Add `opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Static;` to your `UseWolverine` configuration
+4. Run your existing test suite — same behavior, just no runtime codegen
+5. Add `/p:PublishAot=true` to your `dotnet publish` command, fix any remaining IL warnings (or accept them with `<NoWarn>`) and ship
+
+If a handler type changes between releases, re-run `codegen write` and commit the regenerated files. Add the regeneration step to your CI pipeline (or pre-commit hook) so the pre-generated code never drifts from the source handlers.
+
+## Related
+
+- [Code Generation](/guide/codegen.html) — full reference for `TypeLoadMode`, `codegen write`, and the underlying JasperFx runtime-compilation surface
+- [`Wolverine.AotSmoke`](https://github.com/JasperFx/wolverine/tree/main/src/Testing/Wolverine.AotSmoke) — the regression-guard project this guide references
+- [AOT-pillar tracking](https://github.com/JasperFx/wolverine/issues/2746) — what's annotated, what's left
+- [JasperFx 2.0 AOT pillar](https://github.com/JasperFx/jasperfx/issues/213) — the foundation Wolverine builds on

--- a/src/Wolverine/HostBuilderExtensions.cs
+++ b/src/Wolverine/HostBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -112,7 +113,17 @@ public static class HostBuilderExtensions
         // that pre-generate code with TypeLoadMode.Static will then be able to ship
         // without Roslyn at all (smaller binaries, faster cold start, AOT-readiness).
         // See issue #1577 for the full cold-start optimization roadmap.
-        services.AddSingleton<IAssemblyGenerator, AssemblyGenerator>();
+        //
+        // The IL2026 warning on the AssemblyGenerator() constructor is intentional and
+        // suppressed here: AssemblyGenerator emits and loads runtime-generated types,
+        // which is fundamentally incompatible with trimming. The whole point of the
+        // v6 Static-mode story is to let AOT-compatible apps avoid this registration
+        // entirely via UseRuntimeCompilation() opt-in. See AOT pillar #2715 / #2746.
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+            Justification = "Wolverine's runtime-codegen default; Static-mode AOT apps avoid this registration. See #2715/#2746.")]
+        static IServiceCollection RegisterAssemblyGenerator(IServiceCollection s)
+            => s.AddSingleton<IAssemblyGenerator, AssemblyGenerator>();
+        RegisterAssemblyGenerator(services);
 
         services.AddSingleton(typeof(AncillaryMessageStoreApplication<>));
         
@@ -387,7 +398,7 @@ public static class HostBuilderExtensions
     /// <param name="services"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static IServiceCollection AddWolverineExtension<T>(this IServiceCollection services) where T : class, IWolverineExtension
+    public static IServiceCollection AddWolverineExtension<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IWolverineExtension
     {
         return services.AddSingleton<IWolverineExtension, T>();
     }
@@ -398,7 +409,7 @@ public static class HostBuilderExtensions
     /// <param name="services"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static IServiceCollection AddAsyncWolverineExtension<T>(this IServiceCollection services) where T : class, IAsyncWolverineExtension
+    public static IServiceCollection AddAsyncWolverineExtension<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IAsyncWolverineExtension
     {
         return services.AddSingleton<IAsyncWolverineExtension, T>();
     }
@@ -419,7 +430,7 @@ public static class HostBuilderExtensions
     /// <param name="services"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static IServiceCollection AddSingularAgent<T>(this IServiceCollection services) where T : SingularAgent
+    public static IServiceCollection AddSingularAgent<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : SingularAgent
     {
         services.AddSingleton<IAgentFamily, T>();
         return services;


### PR DESCRIPTION
…ions + README

Three small but related pieces of the 6.0 release / AOT pillar story.

# AOT publishing guide (docs/guide/aot.md)

New top-of-`/guide/` doc page that walks users through publishing a Wolverine 6.0 application with `dotnet publish /p:PublishAot=true`. Covers:

  - The two-part story (build-time `codegen write` + runtime `TypeLoadMode.Static`)
  - Why `Static` mode matters (no Roslyn at runtime, faster cold start, AOT-clean publishing)
  - The current AOT-clean *subset* the `Wolverine.AotSmoke` regression-guard exercises today
  - The `[RequiresDynamicCode]` / `[RequiresUnreferencedCode]` surfaces that intentionally aren't AOT-clean by design (HandlerGraph.Compile, reflective discovery, MakeGenericType-driven factories, the WolverineFx.Newtonsoft companion)
  - Migration checklist for moving an existing 5.x app to 6.0 AOT

Wired into the docs sidebar at `/guide/aot`, immediately after `Code Generation` (which the AOT guide leans on for the underlying codegen mechanics).

# HostBuilderExtensions: incremental AOT chunk-A wins

  - `[DynamicallyAccessedMembers(PublicConstructors)]` on the generic T parameter of `AddWolverineExtension<T>`, `AddAsyncWolverineExtension<T>`, and `AddSingularAgent<T>` — clears 6 IL2091 warnings without cascading. Each of these methods registers T as a singleton via `AddSingleton<TService, T>`, which the trim analyzer needs to know preserves T's public constructors.
  - `[UnconditionalSuppressMessage("Trimming", "IL2026")]` wrapping the `IAssemblyGenerator` registration with an explicit comment pointing at the AOT pillar. The AssemblyGenerator constructor is annotated `[RequiresUnreferencedCode]` upstream because it emits runtime-generated types — fundamentally incompatible with trimming. Static-mode AOT apps avoid this registration entirely via the planned `UseRuntimeCompilation()` opt-in (see #1577).

This is intentionally a *small* slice of the AOT pillar chunk A scope. The deeper `HandlerGraph.Compile` / `HandlerChain.AttachTypes` / `Configuration/Chain` annotation pass needs careful design (the `[RequiresDynamicCode]` propagation cascades through the runtime dispatch path in non-trivial ways) and lands in subsequent sub-chunk PRs against #2746.

# README hygiene

The `Branches` section now:

  - References the actual `WolverineFx 6.0.0-alpha.*` pre-release package line on `main` (was just "Active development for 6.0")
  - Links to the CHANGELOG `6.0.0-alpha.1` entry + the migration guide's at-a-glance table
  - Mentions the AOT pillar as one of the in-flight `main` workstreams
  - Notes that the `5.0` branch was branched from the `V5.39.0` tag (the surgery you and I did when 5.39.1 came together)
  - Mentions 5.39.1 as the next 5.x patch shipping from `5.0`