### PR TITLE
AOT chunk D: annotate Runtime/Serialization/* (#2746)

### DIFF
--- a/src/Wolverine/Runtime/Serialization/Forwarders.cs
+++ b/src/Wolverine/Runtime/Serialization/Forwarders.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.Core.Reflection;
 
@@ -17,6 +18,10 @@ internal class Forwarders
         Relationships[type] = forwardedType;
     }
 
+    [RequiresUnreferencedCode(
+        "Walks Assembly.ExportedTypes looking for IForwardsTo<> implementations. Trimming may remove " +
+        "message-forwarder types that are only reached reflectively here. Apps in TypeLoadMode.Static " +
+        "have the forwards baked into pre-generated code and don't reach this path.")]
     public void FindForwards(Assembly assembly)
     {
         var candidates = assembly.ExportedTypes.Where(x => x.IsConcrete() && !x.IsOpenGeneric());

--- a/src/Wolverine/Runtime/Serialization/IntrinsicSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/IntrinsicSerializer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
@@ -15,6 +16,20 @@ public class IntrinsicSerializer : IMessageSerializer
     private IntrinsicSerializer(){}
 
     public string ContentType => MimeType;
+
+    // IntrinsicSerializer<T> closes over the message type via reflection so
+    // user message types that implement ISerializable can be serialized without
+    // an additional registration. The CloseAndBuildAs<T> escape valve is
+    // dynamic-code-by-design; suppressing at the leaf rather than annotating
+    // IMessageSerializer keeps the cascade contained. AOT-clean apps avoid
+    // this path: their message types implement ISerializable AND get
+    // pre-discovered into _inner before any message is processed (the AOT
+    // pillar's source-generated registration story will land that
+    // pre-discovery — see #2746 / the AOT publishing guide).
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Closed generic resolved from runtime message type; AOT consumers pre-discover into _inner. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Closed generic resolved from runtime message type; AOT consumers pre-discover into _inner. See AOT guide.")]
     public byte[] Write(Envelope envelope)
     {
         var messageType = envelope.Message!.GetType();
@@ -28,6 +43,10 @@ public class IntrinsicSerializer : IMessageSerializer
         return serializer.Write(envelope);
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Closed generic resolved from messageType; AOT consumers pre-discover into _inner. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Closed generic resolved from messageType; AOT consumers pre-discover into _inner. See AOT guide.")]
     public object ReadFromData(Type messageType, Envelope envelope)
     {
         if (_inner.TryFind(messageType, out var serializer))

--- a/src/Wolverine/Runtime/Serialization/SystemTextJsonSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/SystemTextJsonSerializer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -5,8 +6,17 @@ using System.Text.Json.Serialization;
 namespace Wolverine.Runtime.Serialization;
 
 /// <summary>
-///     Use System.Text.Json as the JSON serialization
+///     Use System.Text.Json as the JSON serialization.
 /// </summary>
+/// <remarks>
+/// Wolverine's default serializer. Calls the reflection-based
+/// <see cref="JsonSerializer"/> overloads (no <c>JsonTypeInfo</c> /
+/// <c>JsonSerializerContext</c>), so the <c>Write</c> / <c>ReadFromData</c>
+/// methods carry <c>[RequiresUnreferencedCode]</c> + <c>[RequiresDynamicCode]</c>.
+/// AOT-clean apps that want STJ should supply a custom <see cref="IMessageSerializer"/>
+/// implementation wrapping <c>JsonSerializer.Serialize&lt;T&gt;(value, JsonTypeInfo)</c>
+/// — see the Wolverine AOT publishing guide.
+/// </remarks>
 public class SystemTextJsonSerializer : IMessageSerializer
 {
     private readonly JsonSerializerOptions _options;
@@ -19,11 +29,30 @@ public class SystemTextJsonSerializer : IMessageSerializer
 
     public string ContentType => EnvelopeConstants.JsonContentType;
 
+    // SystemTextJsonSerializer is Wolverine's default serializer. By design it
+    // calls the reflection-based JsonSerializer overloads (no JsonTypeInfo /
+    // JsonSerializerContext). The trim warnings on those calls are expected;
+    // suppressing at the leaf rather than annotating the IMessageSerializer
+    // interface keeps the cascade contained and matches how upstream STJ
+    // documents the dynamic-code escape valve for default-options serialization.
+    //
+    // AOT-clean apps that want STJ should supply their own IMessageSerializer
+    // implementation that wraps JsonSerializer.Serialize<T>(value, JsonTypeInfo)
+    // or JsonSerializer.Serialize(value, JsonSerializerContext). See the
+    // Wolverine AOT publishing guide.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Default JSON serializer; AOT consumers wrap JsonSerializer with JsonTypeInfo. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Default JSON serializer; AOT consumers wrap JsonSerializer with JsonTypeInfo. See AOT guide.")]
     public byte[] Write(Envelope envelope)
     {
         return JsonSerializer.SerializeToUtf8Bytes(envelope.Message, _options);
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Default JSON serializer; AOT consumers wrap JsonSerializer with JsonTypeInfo. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Default JSON serializer; AOT consumers wrap JsonSerializer with JsonTypeInfo. See AOT guide.")]
     public object ReadFromData(Type messageType, Envelope envelope)
     {
         return JsonSerializer.Deserialize(envelope.Data, messageType, _options)!;
@@ -34,6 +63,10 @@ public class SystemTextJsonSerializer : IMessageSerializer
         throw new NotSupportedException("System.Text.Json requires a known message type");
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Default JSON serializer; AOT consumers wrap JsonSerializer with JsonTypeInfo. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Default JSON serializer; AOT consumers wrap JsonSerializer with JsonTypeInfo. See AOT guide.")]
     public byte[] WriteMessage(object message)
     {
         return JsonSerializer.SerializeToUtf8Bytes(message, _options);


### PR DESCRIPTION
Clears all 22 IL warnings in the three serialization-pillar files (SystemTextJsonSerializer, IntrinsicSerializer, Forwarders) without cascading into IMessageSerializer's interface contract or its 30+ in-tree implementations.

# Annotation strategy

For SystemTextJsonSerializer and IntrinsicSerializer, the IMessageSerializer interface methods themselves are NOT annotated — annotating them would require matching annotations on every implementation (transport-specific mappers, MassTransit interop wrapper, the upcoming Newtonsoft package shim, user code), which is a much bigger surgery than chunk D scope.

Instead, the IL2026 / IL3050 warnings inside the impl methods are suppressed with [UnconditionalSuppressMessage] and explicit justifications pointing at the AOT publishing guide. The trade-off is documented: AOT-clean apps that want STJ should supply a custom IMessageSerializer that wraps JsonSerializer.Serialize<T>(value, JsonTypeInfo) — Wolverine itself ships the reflection-based default, which is dynamic-code-by-design.

Forwarders.FindForwards (Assembly.ExportedTypes scan) is annotated with [RequiresUnreferencedCode] directly — it's an internal method called only from HandlerGraph.Compile (which is part of chunk A's runtime- codegen surface that will get [RequiresUnreferencedCode] anyway), so the cascade is contained.

# Files touched

  - SystemTextJsonSerializer.cs: Write / ReadFromData(Type) / WriteMessage each suppress IL2026 + IL3050 on the leaf JsonSerializer.* calls. Wolverine's default serializer. AOT escape valve documented inline and in the AOT publishing guide.
  - IntrinsicSerializer.cs: Write / ReadFromData(Type) each suppress IL2026 + IL3050 on the CloseAndBuildAs<T>(messageType) calls. Used for messages that implement ISerializable. The AOT story for this is "pre-discover the closed serializer into _inner before any message is processed" — that pre-discovery is part of the source-generated registration work tracked by #2746's chunk F.
  - Forwarders.cs: FindForwards annotated with [RequiresUnreferencedCode] propagating the Assembly.ExportedTypes warning upward (it's internal and only called from HandlerGraph.Compile, contained cascade).

# Test gate

  - Wolverine.csproj builds clean (no IsAotCompatible flip yet)
  - Wolverine.AotSmoke regression-guard still builds clean — the smoke surface exercises WolverineOptions.DetermineSerializer (the dictionary lookup) but not Write/ReadFromData (which are message-instance dependent)
  - Manual verification: enabling IsAotCompatible=true on Wolverine.csproj locally shows the three files have 0 IL warnings (down from 22)