### PR TITLE
AOT chunk E: annotate Runtime/Interop/CloudEventsMapper.cs (#2746)

### DIFF
--- a/src/Wolverine/Runtime/Interop/CloudEventsMapper.cs
+++ b/src/Wolverine/Runtime/Interop/CloudEventsMapper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -94,11 +95,33 @@ public class CloudEventsMapper : IUnwrapsMetadataMessageSerializer
 
     public override string ToString() => "Cloud Events";
 
+    // CloudEvents interop layer wraps the user message inside CloudEventsEnvelope
+    // and serializes the wrapper with the default reflection-based STJ overloads
+    // (no JsonTypeInfo / JsonSerializerContext). The wrapper itself is statically
+    // known here, but `Data` is `object` carrying an arbitrary user message — so
+    // even if we taught this call site to use a JsonTypeInfo for the wrapper, the
+    // inner-payload reflection survives. Treat this as IMessageSerializer-style
+    // default JSON: suppress at the leaf with an AOT-guide-pointing justification
+    // rather than cascading `[Requires*]` through the IMessageSerializer /
+    // IUnwrapsMetadataMessageSerializer surface and every implementation.
+    //
+    // AOT-clean apps that need CloudEvents interop should supply their own
+    // IUnwrapsMetadataMessageSerializer that wraps JsonSerializer with a
+    // JsonSerializerContext covering both CloudEventsEnvelope and the message
+    // payload types. See the Wolverine AOT publishing guide.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "CloudEvents interop default serializer; AOT consumers supply a JsonSerializerContext-backed mapper. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "CloudEvents interop default serializer; AOT consumers supply a JsonSerializerContext-backed mapper. See AOT guide.")]
     public string WriteToString(Envelope envelope)
     {
         return JsonSerializer.Serialize(new CloudEventsEnvelope(envelope), _options);
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "CloudEvents interop default serializer; AOT consumers supply a JsonSerializerContext-backed mapper. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "CloudEvents interop default serializer; AOT consumers supply a JsonSerializerContext-backed mapper. See AOT guide.")]
     public byte[] WriteToBytes(Envelope envelope)
     {
         return JsonSerializer.SerializeToUtf8Bytes(new CloudEventsEnvelope(envelope), _options);
@@ -115,6 +138,16 @@ public class CloudEventsMapper : IUnwrapsMetadataMessageSerializer
         mapIncoming(envelope, node, fallbackType: null);
     }
 
+    // Inbound CloudEvents JSON is parsed into a JsonNode tree, then the "data"
+    // child is materialized into the resolved message type via JsonNode.Deserialize.
+    // That overload is reflection-based and carries IL2026/IL3050 — same AOT story
+    // as the outbound Serialize calls above. Leaf suppression with a guide pointer
+    // keeps the IMessageSerializer / IUnwrapsMetadataMessageSerializer interfaces
+    // free of cascading [Requires*] annotations.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "CloudEvents interop default deserializer; AOT consumers supply a JsonSerializerContext-backed mapper. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "CloudEvents interop default deserializer; AOT consumers supply a JsonSerializerContext-backed mapper. See AOT guide.")]
     private void mapIncoming(Envelope envelope, JsonNode? node, Type? fallbackType)
     {
         if (node == null) return;
@@ -209,7 +242,11 @@ public class CloudEventsMapper : IUnwrapsMetadataMessageSerializer
     }
 
     public string ContentType { get; } = "application/json";
-    
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "CloudEvents interop default serializer; AOT consumers supply a JsonSerializerContext-backed mapper. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "CloudEvents interop default serializer; AOT consumers supply a JsonSerializerContext-backed mapper. See AOT guide.")]
     public byte[] Write(Envelope envelope)
     {
         return JsonSerializer.SerializeToUtf8Bytes(new CloudEventsEnvelope(envelope), _options);


### PR DESCRIPTION
## Summary

Continues the AOT-pillar (#2746) granular-PR strategy by annotating `Runtime/Interop/CloudEventsMapper.cs`. This is the natural follow-on from chunk D (#2756) which landed the same pattern in Wolverine's default serializer trio (`SystemTextJsonSerializer`, `IntrinsicSerializer`, `Forwarders`).

Adds `[UnconditionalSuppressMessage(IL2026/IL3050)]` at the four reflection-based STJ leaf call sites:

| Method | Call |
| --- | --- |
| `WriteToString` | `JsonSerializer.Serialize<TValue>(value, options)` |
| `WriteToBytes` | `JsonSerializer.SerializeToUtf8Bytes<TValue>(value, options)` |
| `mapIncoming` | `JsonNode.Deserialize(Type, JsonSerializerOptions)` |
| `Write` | `JsonSerializer.SerializeToUtf8Bytes<TValue>(value, options)` |

## Why leaf suppression, not `[Requires*]`

CloudEvents interop wraps the user message in `CloudEventsEnvelope` and serializes the wrapper. The wrapper itself is statically known at the call site, but `CloudEventsEnvelope.Data` is `object` carrying an arbitrary user-supplied message type — so even if we taught the call to use a `JsonTypeInfo` for the wrapper, the inner-payload reflection survives. Treat this as default-JSON IMessageSerializer behavior: suppress at the leaf with an AOT-guide-pointing justification rather than cascading `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]` through the `IMessageSerializer` / `IUnwrapsMetadataMessageSerializer` surface and every implementation.

AOT-clean apps that need CloudEvents interop should supply their own `IUnwrapsMetadataMessageSerializer` that wraps `JsonSerializer` with a `JsonSerializerContext` covering both `CloudEventsEnvelope` and the message payload types. The Wolverine AOT publishing guide (`docs/guide/aot.md`, landed in chunk A #2754) documents this migration target — same pattern users follow for chunk D's STJ default.

## Surface impact

- `Wolverine.csproj` IL warning count drops by **16** (4 unique sites × 2 TFMs × 2 codes — IL2026 + IL3050)
- `AotSmoke` build: still **0** IL warnings
- `CoreTests` Interop CloudEvents suite: **12/12 pass**
- No public API change; runtime behavior unchanged

## Diff

`src/Wolverine/Runtime/Interop/CloudEventsMapper.cs` — +38 / -1.

## Cross-links

- #2746 — AOT pillar tracking issue
- #2756 — chunk D (Runtime/Serialization/*) — established the leaf-suppression pattern for IMessageSerializer surface
- #2754 — chunk A (AOT publishing guide)
- #2755 — FastExpressionCompiler research follow-up
- #2757 — IForwardsTo explicit-registration follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)