### PR TITLE
AOT chunk F: clean up BusHostInfo IL3000 single-file warnings (#2746)

### DIFF
--- a/src/Wolverine/Runtime/Interop/MassTransit/BusHostInfo.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/BusHostInfo.cs
@@ -1,5 +1,5 @@
 using System.Diagnostics;
-using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Wolverine.Runtime.Interop.MassTransit;
 
@@ -47,28 +47,13 @@ internal class BusHostInfo
     public string? MassTransitVersion { get; set; }
     public string? OperatingSystemVersion { get; set; }
 
-    private static string GetAssemblyFileVersion(Assembly assembly)
-    {
-        var attribute = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
-        if (attribute != null)
-        {
-            return attribute.Version;
-        }
-
-        return FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion ?? "Unknown";
-    }
-
-    private static string GetAssemblyInformationalVersion(Assembly assembly)
-    {
-        var attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-        if (attribute != null)
-        {
-            return attribute.InformationalVersion;
-        }
-
-        return GetAssemblyFileVersion(assembly);
-    }
-
+    // GetEntryAssembly()?.Location returns an empty string for single-file deployments
+    // (IL3000). The IsNullOrWhiteSpace check below already handles that gracefully —
+    // we fall back to the caller-supplied defaultProcessName (e.g. "dotnet" or "UWP").
+    // The MassTransit interop layer is a best-effort host descriptor, so the empty-
+    // string return is treated as "unknown app name" rather than an error condition.
+    [UnconditionalSuppressMessage("SingleFile", "IL3000",
+        Justification = "Empty-string return from Assembly.Location in single-file scenarios is handled by the IsNullOrWhiteSpace fallback below.")]
     private static string GetUsefulProcessName(string defaultProcessName)
     {
         var entryAssemblyLocation = System.Reflection.Assembly.GetEntryAssembly()?.Location;


### PR DESCRIPTION
## Summary

Continues the AOT-pillar (#2746) granular-PR strategy with a small cleanup of `src/Wolverine/Runtime/Interop/MassTransit/BusHostInfo.cs`. Different IL code than the prior STJ-suppression chunks — this one tackles **IL3000** (single-file `Assembly.Location` returns empty string).

Two changes, both confined to one file:

### 1. Remove two dead-code helpers

`GetAssemblyFileVersion` and `GetAssemblyInformationalVersion` are never called from the `BusHostInfo` constructor — vestigial from the MassTransit shape this class was copied from. Removing them eliminates the IL3000 warning on `FileVersionInfo.GetVersionInfo(assembly.Location)` and lets us drop the unused `System.Reflection` import.

### 2. Suppress IL3000 on `GetUsefulProcessName`

`Assembly.GetEntryAssembly()?.Location` already handles the single-file empty-string return correctly via the existing `IsNullOrWhiteSpace` fallback — we degrade to the caller-supplied default `ProcessName` (`"dotnet"` or `"UWP"`) rather than emitting wrong data. The MassTransit interop layer is a best-effort host descriptor; empty `Location` is \"unknown app name,\" not an error. Annotated with `[UnconditionalSuppressMessage(\"SingleFile\", \"IL3000\")]` pointing at the fallback.

## Surface impact

- `Wolverine.csproj` IL warning count drops by **4** (2 unique IL3000 sites × 2 TFMs)
- `AotSmoke` build: still **0** IL warnings
- Net **-15** LoC (dead-code removal)
- No public API change; runtime behavior unchanged

## Diff

`src/Wolverine/Runtime/Interop/MassTransit/BusHostInfo.cs` — +8 / -23.

## Cross-links

- #2746 — AOT pillar tracking issue
- #2758 — chunk E (CloudEventsMapper) — sibling interop file
- #2756 — chunk D (Runtime/Serialization/*) — established the leaf-suppression pattern
- #2754 — chunk A (AOT publishing guide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)