### PR TITLE
AOT chunk G: DAM annotations on small-cascade generic surface (#2746)

### DIFF
--- a/src/Wolverine/Attributes/WolverineModuleAttributeT.cs
+++ b/src/Wolverine/Attributes/WolverineModuleAttributeT.cs
@@ -1,10 +1,12 @@
-﻿namespace Wolverine.Attributes;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Wolverine.Attributes;
 
 /// <summary>
 ///     Marks the assembly as an automatically loaded Wolverine extension module
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly)]
-public class WolverineModuleAttribute<T> : WolverineModuleAttribute
+public class WolverineModuleAttribute<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T> : WolverineModuleAttribute
     where T : IWolverineExtension
 {
     /// <summary>

--- a/src/Wolverine/TransportCollection.cs
+++ b/src/Wolverine/TransportCollection.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core;
 using Wolverine.Configuration;
 using Wolverine.Transports;
@@ -70,7 +71,7 @@ public class TransportCollection : IEnumerable<ITransport>, IAsyncDisposable
         _transports[transport.Protocol] = transport;
     }
 
-    public T GetOrCreate<T>(BrokerName? name = null) where T : ITransport, new()
+    public T GetOrCreate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(BrokerName? name = null) where T : ITransport, new()
     {
         if (name == null)
         {

--- a/src/Wolverine/Transports/MessageRoutingConvention.cs
+++ b/src/Wolverine/Transports/MessageRoutingConvention.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Wolverine.Configuration;
@@ -8,7 +9,7 @@ using Wolverine.Util;
 
 namespace Wolverine.Transports;
 
-public abstract class MessageRoutingConvention<TTransport, TListener, TSubscriber, TSelf> : IMessageRoutingConvention
+public abstract class MessageRoutingConvention<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTransport, TListener, TSubscriber, TSelf> : IMessageRoutingConvention
     where TTransport : IBrokerTransport, new()
     where TSelf : MessageRoutingConvention<TTransport, TListener, TSubscriber, TSelf>
     where TSubscriber : IDelayedEndpointConfiguration

--- a/src/Wolverine/Util/WolverineMessageNaming.cs
+++ b/src/Wolverine/Util/WolverineMessageNaming.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using ImTools;
 using JasperFx.Core;
@@ -107,6 +108,15 @@ internal class InteropAssemblyInterfaces : IMessageTypeNaming
 {
     internal List<Assembly> Assemblies { get; } = [];
 
+    // Suppression rather than annotating the IMessageTypeNaming interface +
+    // 6 implementations: the messageType comes from runtime-resolved message
+    // types that are already kept by virtue of being instantiated. Trimming
+    // could in theory remove an interface from messageType's interface list,
+    // but the impl is opt-in interop naming — Apps that need it register the
+    // assemblies explicitly via opts.AddInteropAssembly(...), which keeps
+    // those assemblies' types in the trim graph.
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "InteropAssemblyInterfaces is opt-in interop naming; consumers register assemblies explicitly which preserves the relevant interfaces in the trim graph.")]
     public bool TryDetermineName(Type messageType, out string messageTypeName)
     {
         var @interface = messageType.GetInterfaces()


### PR DESCRIPTION
## Summary

Continues the AOT-pillar (#2746) granular-PR strategy. This is a **DAM-annotation** chunk (different IL codes than the prior leaf-suppression chunks): IL2087, IL2091, IL2070. Four file edits, all surgical.

| File | Change | IL code cleared |
|------|--------|-----------------|
| `WolverineModuleAttribute<T>` | `[DynamicallyAccessedMembers(PublicConstructors)]` on `T` | IL2087 |
| `TransportCollection.GetOrCreate<T>` | `[DynamicallyAccessedMembers(PublicConstructors)]` on `T` | IL2087 |
| `MessageRoutingConvention<TTransport,...>` | Forward `[DAM(PublicConstructors)]` onto `TTransport` (cascade from #2 above) | IL2091 |
| `InteropAssemblyInterfaces.TryDetermineName` | `[UnconditionalSuppressMessage]` on the leaf `messageType.GetInterfaces()` call | IL2070 |

## Why each edit

### 1. `WolverineModuleAttribute<T>`
The non-generic base ctor already declares `[DAM(PublicConstructors)]` on its `Type wolverineExtensionType` parameter. The generic variant was forwarding `typeof(T)` without matching annotations.

### 2. `TransportCollection.GetOrCreate<T>`
`Activator.CreateInstance(typeof(T), name.Name)` (line 91) needs ctor preservation. The `where T : new()` constraint already implies a public parameterless ctor; the DAM annotation makes it explicit for the string-arg overload too.

### 3. `MessageRoutingConvention<TTransport,...>`
This is the only generic caller of `GetOrCreate<T>` — concrete callers (the LocalTransport/StubTransport/etc. usages in `WolverineOptions.*`, `PublishingExpression`, etc.) pass concrete types and don't trigger the cascade. Concrete subclasses in transport packages (RabbitMq, AzureServiceBus, AmazonSqs, Pubsub) inherit the constraint via concrete TTransport types — no further changes needed. Verified by clean builds of all four transport packages.

### 4. `InteropAssemblyInterfaces.TryDetermineName`
Used `[UnconditionalSuppressMessage]` rather than annotating the `IMessageTypeNaming` interface, which would cascade to 6 implementations including hot-path `WebSocketMessageNaming` / `FullTypeNaming` / `FullTypeNaming` etc. Justification: `InteropAssemblyInterfaces` is opt-in interop naming; consumers register assemblies via `opts.AddInteropAssembly(...)`, which keeps those assemblies' types in the trim graph.

## Surface impact

- `Wolverine.csproj` IL warning count drops by **12**:
  - 4 × IL2087 (`WolverineModuleAttributeT` × 2 TFMs)
  - 4 × IL2087 (`TransportCollection` × 2 TFMs)
  - 4 × IL2070 (`WolverineMessageNaming` × 2 TFMs)
- Plus 4 × IL2091 cascaded sites cleared (`MessageRoutingConvention.cs` lines 42 + 221, × 2 TFMs) — these were caused by the upstream `GetOrCreate<T>` annotation propagating, then resolved by forwarding the same annotation onto `TTransport`.
- `AotSmoke` build: still **0** IL warnings
- Verified clean builds of `Wolverine.RabbitMQ`, `Wolverine.AzureServiceBus`, `Wolverine.AmazonSqs`, `Wolverine.Pubsub` (where the generic subclasses live)
- No public API change in observable behavior; `[DAM]` on a generic parameter is a constraint metadata addition, callers passing concrete types are unaffected

## Diff

4 files, +19 / -5.

## Cross-links

- #2746 — AOT pillar tracking issue
- #2754 — chunk A (HostBuilderExtensions DAM + AOT publishing guide)
- #2758 — chunk E (CloudEventsMapper STJ leaves)
- #2759 — chunk F (BusHostInfo IL3000 cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)