### PR TITLE
AOT chunk H: suppress IL2026 on determineCallingAssembly fallback (#2746)

### DIFF
--- a/src/Wolverine/WolverineOptions.Assemblies.cs
+++ b/src/Wolverine/WolverineOptions.Assemblies.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
@@ -50,6 +51,18 @@ public sealed partial class WolverineOptions
     public IEnumerable<Assembly> Assemblies => HandlerGraph.Discovery.Assemblies;
 
 
+    // determineCallingAssembly is a best-effort fallback that runs only when the
+    // caller didn't pass an assemblyName to UseWolverine, the cached
+    // RememberedApplicationAssembly is empty, AND jasperfx.ApplicationAssembly is
+    // also empty. AOT-clean apps avoid this path entirely: they explicitly set
+    // ApplicationAssembly (or pass assemblyName to UseWolverine) — see the AOT
+    // publishing guide. The StackFrame.GetMethod() reflection is only used to
+    // identify which calling assembly *registered* Wolverine; the call doesn't
+    // need full method metadata, just DeclaringType.Assembly. Trim removal of
+    // method bodies still leaves the declaring-type metadata intact for normally-
+    // reachable methods, so the practical risk is low even outside the AOT path.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Best-effort caller-assembly resolution; AOT-clean apps set ApplicationAssembly explicitly. See AOT guide.")]
     private Assembly? determineCallingAssembly()
     {
         var stack = new StackTrace();


### PR DESCRIPTION
## Summary

Continues the AOT-pillar (#2746) granular-PR strategy. Single-file edit on `src/Wolverine/WolverineOptions.Assemblies.cs`. Different reflective surface than the prior chunks: `StackFrame.GetMethod()` (IL2026).

`determineCallingAssembly` walks the call stack looking for the first non-System/Microsoft assembly above the Wolverine frame, treating it as the application assembly. **It only runs when all three upstream paths are empty:**

1. The `assemblyName` parameter to `UseWolverine` was null
2. `WolverineOptions.RememberedApplicationAssembly` is null (cold cache)
3. `jasperfx.ApplicationAssembly` is null

AOT-clean apps avoid this path entirely — the AOT publishing guide (`docs/guide/aot.md`, landed in chunk A #2754) requires explicit `ApplicationAssembly` or `assemblyName` registration. The suppression justification points there.

## Why leaf suppression, not `[RequiresUnreferencedCode]` propagation

I considered propagating `[RequiresUnreferencedCode]` up through `establishApplicationAssembly` to the `WolverineOptions` ctor, but that's the public Wolverine entry point — the cascade would force every consumer to acknowledge the warning **even when they pass `assemblyName`** (the AOT-clean path). Leaf suppression at `determineCallingAssembly` keeps the requirement honest only for callers that actually trigger the reflective path.

## Surface impact

- `Wolverine.csproj` IL warning count drops by **4** (2 unique IL2026 sites × 2 TFMs)
- `AotSmoke` build: still **0** IL warnings
- No public API change; runtime behavior unchanged

## Diff

`src/Wolverine/WolverineOptions.Assemblies.cs` — +13 / -0.

## Cross-links

- #2746 — AOT pillar tracking issue
- #2754 — chunk A (AOT publishing guide)
- #2758 — chunk E (CloudEventsMapper STJ leaves)
- #2759 — chunk F (BusHostInfo IL3000 cleanup)
- #2760 — chunk G (DAM annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)