### PR TITLE
AOT chunk I: suppress CloseAndBuildAs warnings in LocalTransport (#2746)

### DIFF
--- a/src/Wolverine/Transports/Local/LocalTransport.cs
+++ b/src/Wolverine/Transports/Local/LocalTransport.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Wolverine.Attributes;
@@ -243,6 +244,26 @@ internal class LocalTransport : TransportBase<LocalQueue>, ILocalMessageRoutingC
         return configuration;
     }
 
+    // CloseAndBuildAs<IApplier>(handlerType) closes the internal Applier<>
+    // pseudo-generic over a runtime-resolved IConfigureLocalQueue handler type.
+    // Apps in TypeLoadMode.Static have their handler graph pre-discovered into
+    // source-generated registration code (see the AOT publishing guide); the
+    // handler types they reference are statically rooted and CloseAndBuildAs's
+    // reflection finds them safely. Trim-only apps without source generation
+    // need handler types preserved via TrimmerRootDescriptor or
+    // [DynamicallyAccessedMembers] on the surface that produces the handler
+    // type list.
+    //
+    // Leaf suppression rather than annotating ApplyConfiguration with
+    // [RequiresDynamicCode] because LocalTransport.ApplyConfiguration is on
+    // the bootstrap-time HandlerGraph.Compile cascade — propagating [Requires*]
+    // up that cascade would force every Wolverine startup path to acknowledge
+    // the warning. The AOT-clean Static-mode path doesn't add new runtime
+    // codegen at startup; it just runs the source-generated registrations.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Runtime-resolved handler types; AOT-clean apps in TypeLoadMode.Static have these baked into source-generated registration. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Runtime-resolved handler types; AOT-clean apps in TypeLoadMode.Static have these baked into source-generated registration. See AOT guide.")]
     internal void ApplyConfiguration(HandlerChain chain)
     {
         // Gotta go recursive
@@ -250,7 +271,7 @@ internal class LocalTransport : TransportBase<LocalQueue>, ILocalMessageRoutingC
         {
             ApplyConfiguration(handlerChain);
         }
-        
+
         var configured = chain.Handlers.Select(x => x.HandlerType)
             .Where(x => x.CanBeCastTo(typeof(IConfigureLocalQueue))).ToArray();
 


### PR DESCRIPTION
## Summary

Continues the AOT-pillar (#2746) granular-PR strategy. First chunk to tackle the **`CloseAndBuildAs<T>(messageType)` cluster** — `JasperFx.Core.Reflection.TypeExtensions.CloseAndBuildAs` reflectively closes a generic over a runtime-resolved type via `MakeGenericType` + `Activator.CreateInstance`, which trips both IL2026 (trimming) and IL3050 (AOT).

`LocalTransport.ApplyConfiguration` uses this pattern at lines 264 and 276 to call the static-virtual `Apply` method on `IConfigureLocalQueue` handler types via an internal `Applier<>` shape:

\`\`\`csharp
var applier = typeof(Applier<>).CloseAndBuildAs<IApplier>(handlerType);
\`\`\`

Annotated the method with `[UnconditionalSuppressMessage]` for both codes.

## Why leaf suppression on `ApplyConfiguration`, not `[RequiresDynamicCode]` propagation

`ApplyConfiguration` sits on the bootstrap-time `HandlerGraph.Compile` cascade — propagating `[Requires*]` up that cascade would force every Wolverine startup path to acknowledge the warning. The right architectural answer is the `TypeLoadMode.Static` AOT-clean path (documented in `docs/guide/aot.md`, landed in chunk A #2754): handler graphs are pre-discovered into source-generated registration code, the referenced handler types are statically rooted, and `CloseAndBuildAs`'s reflection finds them safely without runtime codegen surprises.

Trim-only apps without source generation need handler types preserved via `TrimmerRootDescriptor` or upstream DAM annotation on the surface producing the handler list — that's a separate concern from this method's correctness.

## Surface impact

- `Wolverine.csproj` IL warning count drops by **8** (2 unique sites × IL2026 + IL3050 × 2 TFMs)
- `AotSmoke` build: still **0** IL warnings
- `CoreTests` LocalTransport tests: **9/9 pass**
- No public API change; runtime behavior unchanged

## Diff

`src/Wolverine/Transports/Local/LocalTransport.cs` — +22 / -1.

## Cross-links

- #2746 — AOT pillar tracking issue
- #2756 — chunk D (Runtime/Serialization/*) — established the leaf-suppression pattern for the same `CloseAndBuildAs` reflective shape
- #2754 — chunk A (AOT publishing guide with TypeLoadMode.Static narrative)

Next chunks in the `CloseAndBuildAs` cluster: `WolverineRuntime.Routing.cs`, `MessageRoute.cs`, the partitioning files. Each is staying on its own granular PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)