### PR TITLE
AOT chunk J: suppress CloseAndBuildAs in routing cluster (#2746)

### DIFF
--- a/src/Wolverine/Runtime/Routing/MessageRoute.cs
+++ b/src/Wolverine/Runtime/Routing/MessageRoute.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
@@ -25,6 +26,17 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
     private readonly MessagePartitioningRules _partitioning;
     private readonly Endpoint _endpoint;
 
+    // CloseAndBuildAs<IMessageSerializer> on typeof(IntrinsicSerializer<>) closes
+    // over the runtime-resolved message type when the type implements
+    // ISerializable. Same reflective shape as the IntrinsicSerializer.Write path
+    // suppressed in chunk D (#2756) — apps in TypeLoadMode.Static pre-discover
+    // their ISerializable message types into a registered IMessageSerializer
+    // cache at bootstrap, so this constructor's miss path never fires at steady
+    // state. The AOT publishing guide documents the migration story.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Closed generic resolved from runtime messageType; AOT consumers pre-register ISerializable serializers. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Closed generic resolved from runtime messageType; AOT consumers pre-register ISerializable serializers. See AOT guide.")]
     public MessageRoute(Type messageType, Endpoint endpoint, IWolverineRuntime runtime)
     {
         IsLocal = endpoint is LocalQueue;

--- a/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
@@ -136,6 +137,24 @@ public partial class WolverineRuntime
     private ImHashMap<Type, IMessageRouter> _messageTypeRouting = ImHashMap<Type, IMessageRouter>.Empty;
 
 
+    // RoutingFor is the per-message-type router-resolution entry point. The cache-
+    // miss path closes MessageRouter<T> / EmptyMessageRouter<T> over the runtime-
+    // resolved messageType — same CloseAndBuildAs reflective pattern as chunk D
+    // and chunk I. AOT-clean apps in TypeLoadMode.Static pre-populate this cache
+    // at bootstrap (envelope-mapper / message-type discovery sources, see #2715
+    // and the AOT publishing guide) so the steady-state hot path is pure lookups
+    // and the miss path's reflective close never fires. Trim-only apps without
+    // source generation need MessageRouter<>/EmptyMessageRouter<> closed types
+    // preserved via TrimmerRootDescriptor on their message types.
+    //
+    // Leaf suppression rather than [RequiresDynamicCode] on RoutingFor because
+    // RoutingFor is on the per-message dispatch hot path through MessageContext.
+    // Cascading [Requires*] up there would force every user-facing send/publish
+    // API to declare it.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Closed generic resolved from runtime messageType; AOT consumers pre-populate _messageTypeRouting via source-generated discovery. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Closed generic resolved from runtime messageType; AOT consumers pre-populate _messageTypeRouting via source-generated discovery. See AOT guide.")]
     public IMessageRouter RoutingFor(Type messageType)
     {
         if (messageType == typeof(object))


### PR DESCRIPTION
## Summary

Continues the AOT-pillar (#2746) granular-PR strategy. Same `CloseAndBuildAs<T>(messageType)` reflective shape as chunks D and I, this time on the **routing cluster** — two files, both annotated with `[UnconditionalSuppressMessage(IL2026/IL3050)]` at the leaf method.

| File | Site | Closed generic |
|------|------|----------------|
| `WolverineRuntime.Routing.cs` (`RoutingFor`) | lines 155-156 | `MessageRouter<T>` / `EmptyMessageRouter<T>` |
| `Runtime/Routing/MessageRoute.cs` (ctor) | line 48 | `IntrinsicSerializer<T>` (for `ISerializable` messages) |

`RoutingFor` is the per-message-type router-resolution entry point with an `ImHashMap`-backed cache. Steady-state hot path is pure lookups; the miss path is what carries the warning. `MessageRoute`'s ctor mirrors the `IntrinsicSerializer.Write` shape already suppressed in chunk D #2756.

## Why leaf suppression, not `[RequiresDynamicCode]` propagation

`RoutingFor` is on the per-message dispatch hot path through `MessageContext.Send/Publish/...` — propagating `[Requires*]` up there would force every user-facing send/publish API surface to declare it. The architectural answer remains `TypeLoadMode.Static` (documented in `docs/guide/aot.md`, landed in chunk A #2754): AOT-clean apps pre-discover message types and routers into bootstrap-time caches via source-generated registration code (#2715 envelope-mapper pre-discovery), so the reflective close never fires at steady state.

Trim-only apps without source generation preserve closed generics via `TrimmerRootDescriptor` on their message types.

## Surface impact

- `Wolverine.csproj` IL warning count drops by **12** (3 unique sites × IL2026 + IL3050 × 2 TFMs)
- `AotSmoke` build: still **0** IL warnings
- `CoreTests` Routing suite: **31/31 pass**
- No public API change; runtime behavior unchanged

## Diff

2 files, +31 / -0.

## Cross-links

- #2746 — AOT pillar tracking issue
- #2756 — chunk D (Runtime/Serialization/*) — established the leaf-suppression pattern for `CloseAndBuildAs`
- #2762 — chunk I (LocalTransport `Applier<>` — same reflective shape on the bootstrap-time cascade)
- #2754 — chunk A (AOT publishing guide with TypeLoadMode.Static narrative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)