### PR TITLE
AOT chunk K: suppress CloseAndBuildAs in partitioning cluster (#2746)

### DIFF
--- a/src/Wolverine/Runtime/Partitioning/MessagePartitioningRules.cs
+++ b/src/Wolverine/Runtime/Partitioning/MessagePartitioningRules.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using ImTools;
 using JasperFx.Core;
@@ -220,6 +221,14 @@ internal class ExplicitGrouping : IGroupingRule
         return false;
     }
 
+    // CloseAndBuildAs closes Grouper<,> over (messageType, property.PropertyType).
+    // Same reflective pattern as PropertyNameGroupingRule.TryBuildGrouper; both
+    // sit on the user-opt-in MessagePartitioningRules surface. AOT-clean apps
+    // using partitioning preserve Grouper<,> closures via TrimmerRootDescriptor.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Closed Grouper<,> resolved from runtime types; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Closed Grouper<,> resolved from runtime types; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide.")]
     public void AddMessageType(Type messageType, PropertyInfo property)
     {
         _groupers = _groupers.AddOrUpdate(messageType,

--- a/src/Wolverine/Runtime/Partitioning/PropertyNameGroupingRule.cs
+++ b/src/Wolverine/Runtime/Partitioning/PropertyNameGroupingRule.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx.Core.Reflection;
 
@@ -38,6 +39,21 @@ internal class PropertyNameGroupingRule : IGroupingRule
         return false;
     }
 
+    // GetProperty(propertyName) (IL2070) requires PublicProperties on messageType;
+    // CloseAndBuildAs over typeof(Grouper<,>) closes the partitioner generic over
+    // (messageType, property.PropertyType) and trips IL2026 + IL3050. Both are
+    // best-effort opt-in partitioning. AOT-clean apps using property-name
+    // grouping must keep the targeted property (via [DynamicallyAccessedMembers]
+    // on the message type or a DynamicDependency) and the Grouper<,> closure
+    // (via TrimmerRootDescriptor). The PropertyNameGroupingRule is registered
+    // explicitly by the user (opts.MessagePartitioning.GroupBy(...)), not
+    // discovered reflectively, so the cascade stops here.
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Property-name grouping is opt-in; consumers preserve the target property via DAM or trim descriptor. See AOT guide.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Closed Grouper<,> resolved from runtime types; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Closed Grouper<,> resolved from runtime types; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide.")]
     private IGrouper? TryBuildGrouper(Type messageType)
     {
         foreach (var propertyName in _propertyNames)


### PR DESCRIPTION
Annotates two partitioning sites with [UnconditionalSuppressMessage] for the Grouper<,> reflective close-over-(messageType, propertyType) pattern.

1) PropertyNameGroupingRule.TryBuildGrouper — three IL codes:
   - IL2070 on messageType.GetProperty(propertyName)
   - IL2026 on typeof(Grouper<,>).CloseAndBuildAs<IGrouper>(...)
   - IL3050 on the same call All three suppressed at the same private method since PropertyNameGrouping is opt-in (registered explicitly by users via opts.MessagePartitioning. GroupBy(...)) and the cascade naturally stops here.

2) MessagePartitioningRules.AddMessageType — IL2026 + IL3050 on the same
   typeof(Grouper<,>).CloseAndBuildAs pattern.

The justification points at the AOT publishing guide. AOT-clean apps using property-name partitioning preserve the target property via [DAM] on the message type (or DynamicDependency) and the Grouper<,> closure via TrimmerRootDescriptor.

Used leaf suppression rather than [RequiresDynamicCode] on the public-facing MessagePartitioningRules surface because that's part of WolverineOptions and would cascade through the options-configuration call chain. Partitioning is already a registered-explicitly feature, so the suppression matches the opt-in nature.

Surface impact: Wolverine.csproj IL warning count drops by 10 (5 unique sites × 2 TFMs). AotSmoke build remains 0 IL warnings. 79/79 CoreTests Partitioning tests pass.