### PR TITLE
AOT chunk L: suppress dynamic-code warnings on ResolveTypedAsyncEnume…

### DIFF
--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using ImTools;
 using JasperFx.Core;
@@ -724,6 +725,28 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
     private static ImHashMap<Type, MethodInfo?> _typedEnumerableCascadeMethods =
         ImHashMap<Type, MethodInfo?>.Empty;
 
+    // Resolves the constructed CascadeTypedItemsAsync<T> MethodInfo for a message
+    // type that implements IAsyncEnumerable<T>. Steady state hits the ImHashMap
+    // cache; the miss path walks GetInterfaces (IL2070) and MakeGenericMethod
+    // (IL2060 + IL3050). AOT-clean apps pre-populate the cache during handler-
+    // graph compilation: the source-generated handler registration knows which
+    // message types implement IAsyncEnumerable<T> and seeds _typedEnumerableCascade
+    // Methods, so the miss path never fires at steady state. The cached
+    // MethodInfo is invoked dynamically by the cascading dispatch site
+    // (line 693), which is also runtime codegen — same suppression rationale.
+    //
+    // Leaf suppression rather than [RequiresDynamicCode] propagation because
+    // this method is on the per-message cascading dispatch hot path through
+    // EnqueueCascadingAsync; cascading [Requires*] up there would force every
+    // user-facing handler-result API to declare it.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Cached typed-enumerable cascader for runtime messageType; AOT consumers pre-populate the cache at handler-graph compile time. See AOT guide.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2060",
+        Justification = "Cached typed-enumerable cascader for runtime messageType; AOT consumers pre-populate the cache at handler-graph compile time. See AOT guide.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "messageType reaches GetInterfaces from runtime-resolved message types that are statically rooted via handler registration.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "MakeGenericMethod over CascadeTypedItemsAsync<T>; AOT consumers pre-populate the cache at handler-graph compile time. See AOT guide.")]
     private static MethodInfo? ResolveTypedAsyncEnumerableCascader(Type messageType)
     {
         if (_typedEnumerableCascadeMethods.TryFind(messageType, out var cached))


### PR DESCRIPTION
…rableCascader (#2746)

Annotates the private static MessageContext.ResolveTypedAsyncEnumerableCascader helper with four [UnconditionalSuppressMessage] attributes covering the cold- miss reflective path:

- IL2070 on messageType.GetInterfaces()
- IL2026 on the resulting reflection
- IL2060 on MakeGenericMethod(asyncEnumInterface.GetGenericArguments()[0])
- IL3050 on the same MakeGenericMethod (AOT runtime-codegen)

ResolveTypedAsyncEnumerableCascader has an ImHashMap<Type, MethodInfo?> cache keyed on the runtime message type — steady-state cascading hits the cache and pays zero reflection. The miss path is what carries the warnings, and AOT-clean apps in TypeLoadMode.Static pre-populate the cache at handler-graph compile time: the source-generated handler registration knows which message types implement IAsyncEnumerable<T> and seeds _typedEnumerableCascadeMethods, so the cold-miss reflection never fires at steady state.

Leaf suppression rather than [RequiresDynamicCode] on the helper because the caller chain (EnqueueCascadingAsync) is on the per-message cascading dispatch hot path through MessageContext — propagating [Requires*] up there would force every user-facing handler-result API to declare it.

Surface impact: Wolverine.csproj IL warning count drops by 8 (4 unique IL codes × 2 TFMs). AotSmoke build remains 0 IL warnings. 5/5 CoreTests Cascade tests pass.