### PR TITLE
AOT chunk M: suppress MakeGenericType warning in LoggerVariableSource…

### DIFF
--- a/src/Wolverine/Runtime/Handlers/LoggerVariableSource.cs
+++ b/src/Wolverine/Runtime/Handlers/LoggerVariableSource.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.CodeGeneration.Model;
 using Microsoft.Extensions.Logging;
 
@@ -8,6 +9,15 @@ public class LoggerVariableSource : IVariableSource
     private readonly InjectedField _field;
     private readonly Type _loggerType;
 
+    // Closes ILogger<> over the runtime-resolved message type so the generated
+    // handler class has a typed logger field. AOT-clean apps in
+    // TypeLoadMode.Static run with pre-generated handler code where the closed
+    // ILogger<TMessage> is statically known; the source-generated registration
+    // path doesn't construct LoggerVariableSource at runtime. This ctor is
+    // only invoked by the Dynamic codegen mode, which already triggers
+    // AssemblyGenerator and is documented as not-AOT-clean in the AOT guide.
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "ILogger<> closed over runtime messageType during Dynamic codegen; AOT consumers run pre-generated handler code in TypeLoadMode.Static. See AOT guide.")]
     public LoggerVariableSource(Type messageType)
     {
         _loggerType = typeof(ILogger<>).MakeGenericType(messageType);


### PR DESCRIPTION
… (#2746)

Annotates LoggerVariableSource constructor with [UnconditionalSuppressMessage] for IL3050 on typeof(ILogger<>).MakeGenericType(messageType) at line 13.

This codegen helper builds an ILogger<TMessage> InjectedField for the generated handler class. It runs only during Dynamic-mode runtime codegen (JasperFx.RuntimeCompiler / Roslyn-at-startup) — TypeLoadMode.Static apps run with pre-generated handler code where the closed ILogger<TMessage> is statically known and LoggerVariableSource is not invoked at runtime. The AOT publishing guide (docs/guide/aot.md, landed in chunk A #2754) documents that Dynamic mode is not AOT-clean by design and that Static mode is the required AOT-clean path.

Leaf suppression rather than [RequiresDynamicCode] on the ctor because LoggerVariableSource is registered as an IVariableSource via the public CodeGeneration.Sources collection; propagating [Requires*] would cascade to every IVariableSource registration site and ultimately to the WolverineOptions ctor.

Surface impact: Wolverine.csproj IL warning count drops by 2 (1 unique IL3050 site × 2 TFMs). AotSmoke build remains 0 IL warnings.