### PR TITLE
AOT chunk N: NodeRecord JsonSerializerContext (#2746)

### DIFF
--- a/src/Wolverine/Runtime/Agents/NodeRecordType.cs
+++ b/src/Wolverine/Runtime/Agents/NodeRecordType.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Wolverine.Runtime.Agents;
 
@@ -60,11 +61,24 @@ public class NodeRecord : ISerializable
 
     public byte[] Write()
     {
-        return JsonSerializer.SerializeToUtf8Bytes(this);
+        return JsonSerializer.SerializeToUtf8Bytes(this, NodeRecordJsonContext.Default.NodeRecord);
     }
 
     public static object Read(byte[] bytes)
     {
-        return JsonSerializer.Deserialize<NodeRecord>(bytes)!;
+        return JsonSerializer.Deserialize(bytes, NodeRecordJsonContext.Default.NodeRecord)!;
     }
+}
+
+/// <summary>
+/// Source-generated JSON context for <see cref="NodeRecord"/>. Lets <c>Write</c> /
+/// <c>Read</c> use the AOT-friendly <c>JsonTypeInfo</c> overloads instead of the
+/// reflection-based <c>JsonSerializer</c> defaults — clearing IL2026/IL3050 in
+/// trim/AOT builds without leaf-site suppression. NodeRecord ships only the
+/// statically-known properties on the type above; if new properties are added
+/// in the future, the source generator picks them up automatically.
+/// </summary>
+[JsonSerializable(typeof(NodeRecord))]
+internal partial class NodeRecordJsonContext : JsonSerializerContext
+{
 }


### PR DESCRIPTION
Replaces the reflection-based JsonSerializer overloads on NodeRecord.Write and NodeRecord.Read with the JsonTypeInfo overloads backed by a source- generated NodeRecordJsonContext. This is the *correct* AOT fix (per MS recommendation) for serialization sites with statically-bounded type surface — no suppression required.

Why context generation over leaf suppression here: NodeRecord is an internal-to-Wolverine cluster-agent record. Its property surface is fully known at compile time and stable. The source generator emits all the necessary JsonTypeInfo metadata, so AOT/trim builds get proper coverage without runtime reflection — the JsonSerializer overloads that take a JsonTypeInfo / JsonSerializerContext are explicitly AOT-friendly per the System.Text.Json source-generation docs.

If new properties are added to NodeRecord, the source generator picks them up automatically.

Surface impact: Wolverine.csproj IL warning count drops by 8 (2 unique SerializeToUtf8Bytes/Deserialize sites × IL2026 + IL3050 × 2 TFMs). AotSmoke build remains 0 IL warnings. Intrinsic-serialization tests pass (1/1).

This chunk demonstrates the *upgrade* path for IMessageSerializer-style sites that have bounded type surface — contrasts with leaf suppression in chunks D/E/I/J/K which had unbounded message-type closures.