### PR TITLE
AOT chunk Q: long-tail small-file cleanups (#2746)

### DIFF
--- a/src/Wolverine/Configuration/Capabilities/CapabilitiesCommand.cs
+++ b/src/Wolverine/Configuration/Capabilities/CapabilitiesCommand.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using JasperFx.CommandLine;
 using JasperFx.Core;
@@ -19,6 +20,16 @@ public class CapabilitiesCommand : JasperFxAsyncCommand<CapabilitiesInput>
         Usage("Write the Wolverine capabilities to the designated file name");
     }
 
+    // CapabilitiesCommand is a CLI tool (dotnet run -- describe) — not on the
+    // dispatch hot path. The JsonSerializer.SerializeAsync<TValue> overload is
+    // reflection-based; the ServiceCapabilities type tree is bounded but
+    // sufficiently large that a JsonSerializerContext upgrade is a separate
+    // refactor (chunk N's NodeRecord precedent). Suppress at the leaf and
+    // document the migration target.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "CLI tool, not dispatch path; ServiceCapabilities serialization should migrate to JsonSerializerContext (see chunk N pattern). See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "CLI tool, not dispatch path; ServiceCapabilities serialization should migrate to JsonSerializerContext (see chunk N pattern). See AOT guide.")]
     public override async Task<bool> Execute(CapabilitiesInput input)
     {
         if (input.FileName.IsEmpty())

--- a/src/Wolverine/Configuration/HandlerDiscovery.Diagnostics.cs
+++ b/src/Wolverine/Configuration/HandlerDiscovery.Diagnostics.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 
@@ -5,6 +6,12 @@ namespace Wolverine.Configuration;
 
 public sealed partial class HandlerDiscovery
 {
+    // GetMethods on a runtime-resolved candidate type used for diagnostic
+    // output (`dotnet run -- describe`). Same handler-discovery-as-assembly-
+    // scan story as actionsFromType (chunk Q sibling). Diagnostic-only path —
+    // not on dispatch hot path.
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Diagnostic GetMethods walk over candidate handler type; AOT-clean apps use TypeLoadMode.Static. See AOT guide.")]
     internal string DescribeHandlerMatch(WolverineOptions options, Type candidateType)
     {
         if (candidateType.IsOpenGeneric())

--- a/src/Wolverine/Configuration/HandlerDiscovery.cs
+++ b/src/Wolverine/Configuration/HandlerDiscovery.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.Core.Reflection;
 using JasperFx.Core;
@@ -205,6 +206,14 @@ public sealed partial class HandlerDiscovery
         return this;
     }
 
+    // GetMethods on a runtime-resolved handler type from assembly scanning.
+    // Same chunk D / chunk G pattern: handler types come from
+    // Assembly.ExportedTypes walking, which is fundamentally not AOT-clean
+    // (the trimmer can't follow assembly scans). AOT-clean apps use
+    // TypeLoadMode.Static where the handler graph is pre-discovered into
+    // source-generated registration; this method is bypassed entirely.
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Handler-type method walk from assembly scanning; AOT-clean apps run TypeLoadMode.Static with pre-generated handler registration. See AOT guide.")]
     private IEnumerable<(Type, MethodInfo)> actionsFromType(Type type)
     {
         return type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.Static)

--- a/src/Wolverine/ErrorHandling/ErrorHandlingPolicyExtensions.cs
+++ b/src/Wolverine/ErrorHandling/ErrorHandlingPolicyExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 using Wolverine.ErrorHandling.Matches;
 
@@ -46,6 +47,15 @@ public static class ErrorHandlingPolicyExtensions
     /// <param name="policies"></param>
     /// <param name="exceptionType">An exception type to match against</param>
     /// <returns>The PolicyBuilder instance.</returns>
+    // TypeMatch<> closed over a runtime exceptionType. Same CloseAndBuildAs
+    // pattern as chunks D/I/J/K/O. AOT-clean apps that need typed exception
+    // filtering should prefer the strongly-typed OnException<TException>
+    // overload below — the closed generic instantiation is then statically
+    // known by the compiler.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "TypeMatch<> closed over runtime exception type; AOT consumers prefer the OnException<TException> typed overload. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "TypeMatch<> closed over runtime exception type; AOT consumers prefer the OnException<TException> typed overload. See AOT guide.")]
     public static PolicyExpression OnExceptionOfType(this IWithFailurePolicies policies, Type exceptionType)
     {
         var match = typeof(TypeMatch<>).CloseAndBuildAs<IExceptionMatch>(exceptionType);

--- a/src/Wolverine/ExtensionLoader.cs
+++ b/src/Wolverine/ExtensionLoader.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
@@ -66,6 +67,16 @@ internal static class ExtensionLoader
         return _extensions;
     }
 
+    // Activator.CreateInstance(x!) on a Type-typed lambda parameter loses the
+    // [DAM(PublicConstructors)] annotation that's present on the source field
+    // (WolverineModuleAttribute.WolverineExtensionType — annotated in chunk G
+    // #2760). The IL flow analyzer can't track DAM through a Select projection.
+    // Suppression here is honest: the constructor preservation requirement IS
+    // met at the source, IL just can't see it. AOT-clean apps register
+    // extensions explicitly via WolverineOptions.AddExtension<T> and avoid
+    // assembly scanning entirely (see AOT publishing guide).
+    [UnconditionalSuppressMessage("Trimming", "IL2067",
+        Justification = "Constructor preservation requirement is met at the source (WolverineExtensionType is [DAM(PublicConstructors)]); IL flow analyzer can't see through Select projection. AOT consumers register explicitly via WolverineOptions.AddExtension<T>. See AOT guide.")]
     internal static void ApplyExtensions(WolverineOptions options)
     {
         var assemblies = FindExtensionAssemblies();

--- a/src/Wolverine/Middleware/MiddlewarePolicy.cs
+++ b/src/Wolverine/Middleware/MiddlewarePolicy.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
@@ -165,6 +166,17 @@ public class MiddlewarePolicy : IChainPolicy
         private readonly MethodInfo[] _finals;
         private readonly MethodInfo[] _onExceptions;
 
+        // GetConstructors / GetMethods walk over a runtime-resolved middleware
+        // type. Middleware is opt-in (registered explicitly via
+        // opts.Policies.AddMiddleware<T> or AddMiddleware(typeof(T))) — the
+        // user-provided type is statically rooted by the call site. A future
+        // chunk could propagate [DAM(PublicConstructors|PublicMethods)] up
+        // through MiddlewarePolicy.AddType + IPolicies.AddMiddleware<T> /
+        // AddMiddleware(Type) to make the requirement explicit, but that's a
+        // 3-hop public-API cascade scoped for the CloseAndBuildAs follow-up
+        // (#2769) rather than this small-file batch.
+        [UnconditionalSuppressMessage("Trimming", "IL2070",
+            Justification = "Middleware types are opt-in via opts.Policies.AddMiddleware; user-supplied types are statically rooted by the registration call site. See AOT guide.")]
         public Application(IChain? chain, Type middlewareType, Func<IChain, bool> filter)
         {
             if (!middlewareType.IsPublic && !middlewareType.IsVisible)

--- a/src/Wolverine/Persistence/ClaimCheck/Internal/BlobTypeInfo.cs
+++ b/src/Wolverine/Persistence/ClaimCheck/Internal/BlobTypeInfo.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Wolverine.Persistence.ClaimCheck.Internal;
@@ -20,6 +21,14 @@ internal sealed class BlobTypeInfo
         Properties = properties;
     }
 
+    // GetProperties on a runtime-resolved message type, walking for [Blob]-
+    // decorated properties. Claim-check is opt-in (registered via
+    // opts.UseClaimCheckStorage); user message types that opt in are
+    // statically rooted via handler discovery / explicit registration. The
+    // cache is keyed on Type so each user message type is visited exactly
+    // once at first dispatch.
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Claim-check is opt-in; user message types are statically rooted via handler discovery. See AOT guide.")]
     public static BlobTypeInfo For(Type type)
     {
         return _cache.GetOrAdd(type, static t =>

--- a/src/Wolverine/Persistence/FromQuerySpecificationAttribute.cs
+++ b/src/Wolverine/Persistence/FromQuerySpecificationAttribute.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
@@ -70,6 +71,17 @@ public class FromQuerySpecificationAttribute : WolverineParameterAttribute
     /// </summary>
     public Type SpecificationType { get; }
 
+    // Modify is called at codegen time to construct the spec instance via
+    // GetProperties + ChoosePublicConstructor (GetConstructors below). Spec
+    // types are user-supplied via [FromQuerySpecification(typeof(MySpec))]
+    // and statically rooted by the attribute argument; the AOT-clean Static
+    // codegen path bakes the constructor/property resolution into pre-
+    // generated code, so this reflective walk only fires under Dynamic
+    // codegen (intentionally not AOT-clean per docs/guide/aot.md).
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "Spec type from runtime-resolved SpecificationType; statically rooted via [FromQuerySpecification(typeof(...))]. Dynamic codegen path. See AOT guide.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Spec type from runtime-resolved SpecificationType; statically rooted via [FromQuerySpecification(typeof(...))]. Dynamic codegen path. See AOT guide.")]
     public override Variable Modify(IChain chain, ParameterInfo parameter, IServiceContainer container,
         GenerationRules rules)
     {
@@ -127,6 +139,8 @@ public class FromQuerySpecificationAttribute : WolverineParameterAttribute
             "Did you forget to call IntegrateWithWolverine() (Marten) or UseEntityFrameworkCoreTransactions() (EF Core)?");
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Spec type from runtime-resolved SpecificationType; statically rooted via [FromQuerySpecification(typeof(...))]. Dynamic codegen path. See AOT guide.")]
     private static ConstructorInfo ChoosePublicConstructor(Type type)
     {
         var ctors = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);


### PR DESCRIPTION
Batched 8 isolated single-site files into one PR — each is a leaf suppression (no cascade) themed around assembly-scanning, Dynamic-mode codegen, or opt-in features whose user-supplied types are statically rooted by the registration call site.

Files and IL codes cleared:

- Configuration/Capabilities/CapabilitiesCommand.cs (Execute) — IL2026 + IL3050 on JsonSerializer.SerializeAsync; CLI tool, not dispatch path. Pointer note on a future JsonSerializerContext upgrade per chunk N (#2767) precedent.

- ErrorHandling/ErrorHandlingPolicyExtensions.cs (OnExceptionOfType) — IL2026 + IL3050 on TypeMatch<>.CloseAndBuildAs. Migration target: prefer the strongly-typed OnException<TException> overload below.

- ExtensionLoader.cs (ApplyExtensions) — IL2067 on Activator.CreateInstance of the WolverineExtensionType. Source IS annotated [DAM(PublicConstructors)] on WolverineModuleAttribute.WolverineExtensionType (chunk G #2760), but IL flow analyzer can't track DAM through Select projections.

- Configuration/HandlerDiscovery.cs (actionsFromType) — IL2070 on GetMethods walk. Handler-discovery-as-assembly-scan is fundamentally not AOT-clean. AOT-clean apps run TypeLoadMode.Static with pre-generated registration.

- Configuration/HandlerDiscovery.Diagnostics.cs (DescribeHandlerMatch) — IL2070 on GetMethods walk. Diagnostic-only path (`dotnet run -- describe`).

- Middleware/MiddlewarePolicy.cs (Application ctor) — IL2070 covering both GetConstructors and GetMethods on the user middleware type. Note on the future contained-cascade fix: propagate [DAM(PublicConstructors|PublicMethods)] up through MiddlewarePolicy.AddType + IPolicies.AddMiddleware<T> / AddMiddleware(Type) — scoped for the CloseAndBuildAs follow-up (#2769).

- Persistence/ClaimCheck/Internal/BlobTypeInfo.cs (For) — IL2070 on GetProperties walk for [Blob]-decorated properties. Claim-check is opt-in.

- Persistence/FromQuerySpecificationAttribute.cs (Modify, ChoosePublicConstructor) — IL2075 + IL2070 on GetProperties + GetConstructors. Spec types statically rooted via [FromQuerySpecification(typeof(...))]; Dynamic-mode codegen path.

Surface impact: Wolverine.csproj IL warning count drops by 24 (12 unique sites × 2 TFMs). Combined with chunk P (30 cleared), total drop from main baseline of 120 is 54 → 66 IL warnings remaining. AotSmoke build remains 0 IL warnings. 34/34 CoreTests Middleware tests pass.