### PR TITLE
AOT chunk P: saga persistence cluster (#2746)

### DIFF
--- a/src/Wolverine/Persistence/Sagas/InMemoryPersistenceFrameProvider.cs
+++ b/src/Wolverine/Persistence/Sagas/InMemoryPersistenceFrameProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
@@ -36,6 +37,17 @@ public class InMemoryPersistenceFrameProvider : IPersistenceFrameProvider
         return SagaChain.DetermineSagaIdMember(sagaType, sagaType)?.GetMemberType() ?? typeof(object);
     }
 
+    // The DetermineXxxFrame methods are codegen-time helpers that close
+    // InMemorySagaPersistor.{Load,Store,Delete}<T> over the runtime-resolved
+    // saga type to emit MethodCall frames. AOT-clean apps run pre-generated
+    // handler code in TypeLoadMode.Static where the closed instantiations are
+    // baked into the source-generated registration; the IPersistenceFrameProvider
+    // surface only fires under Dynamic codegen, which is intentionally not
+    // AOT-clean (see AOT publishing guide). Leaf suppression matches the
+    // chunk M (LoggerVariableSource) precedent for Dynamic-mode codegen
+    // helpers.
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "InMemorySagaPersistor.Load<T> closed over runtime sagaType during Dynamic codegen; AOT consumers run pre-generated frames in TypeLoadMode.Static. See AOT guide.")]
     public Frame DetermineLoadFrame(IServiceContainer container, Type sagaType, Variable sagaId)
     {
         var method = typeof(InMemorySagaPersistor).GetMethod(nameof(InMemorySagaPersistor.Load))!
@@ -52,6 +64,10 @@ public class InMemoryPersistenceFrameProvider : IPersistenceFrameProvider
         return call;
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "InMemorySagaPersistor.Store<T> closed over runtime saga type during Dynamic codegen; AOT consumers run pre-generated frames in TypeLoadMode.Static. See AOT guide.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2076",
+        Justification = "saga.VariableType is the user's saga type, statically rooted by handler discovery; PublicProperties requirement is satisfied via the generated frame's static type knowledge.")]
     public Frame DetermineInsertFrame(Variable saga, IServiceContainer container)
     {
         var method = typeof(InMemorySagaPersistor).GetMethod(nameof(InMemorySagaPersistor.Store))!
@@ -77,6 +93,8 @@ public class InMemoryPersistenceFrameProvider : IPersistenceFrameProvider
         return DetermineInsertFrame(saga, container);
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "InMemorySagaPersistor.Delete<T> closed over runtime saga type during Dynamic codegen; AOT consumers run pre-generated frames in TypeLoadMode.Static. See AOT guide.")]
     public Frame DetermineDeleteFrame(Variable sagaId, Variable saga, IServiceContainer container)
     {
         var method = typeof(InMemorySagaPersistor).GetMethod(nameof(InMemorySagaPersistor.Delete))!
@@ -106,6 +124,10 @@ public class InMemoryPersistenceFrameProvider : IPersistenceFrameProvider
         return DetermineDeleteFrame(null!, variable, container);
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "InMemorySagaPersistorStore<> closed over runtime entityType during Dynamic codegen; AOT consumers run pre-generated frames in TypeLoadMode.Static. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "InMemorySagaPersistorStore<> closed over runtime entityType during Dynamic codegen; AOT consumers run pre-generated frames in TypeLoadMode.Static. See AOT guide.")]
     public Frame DetermineStorageActionFrame(Type entityType, Variable action, IServiceContainer container)
     {
         var call = typeof(InMemorySagaPersistorStore<>).CloseAndBuildAs<MethodCall>(entityType);
@@ -116,7 +138,10 @@ public class InMemoryPersistenceFrameProvider : IPersistenceFrameProvider
     public Frame[] DetermineFrameToNullOutMaybeSoftDeleted(Variable entity) => [];
 }
 
-internal class InMemorySagaPersistorStore<T> : MethodCall
+// T forwards the [DAM(PublicProperties)] requirement from the underlying
+// InMemorySagaPersistor.StoreAction<T> call so callers don't need to suppress
+// IL2091 at every InMemorySagaPersistorStore<entityType> closure site.
+internal class InMemorySagaPersistorStore<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MethodCall
 {
     public InMemorySagaPersistorStore() : base(typeof(InMemorySagaPersistor), ReflectionHelper.GetMethod<InMemorySagaPersistor>(x => x.StoreAction(Storage.Nothing<T>()))!)
     {

--- a/src/Wolverine/Persistence/Sagas/InMemorySagaPersistor.cs
+++ b/src/Wolverine/Persistence/Sagas/InMemorySagaPersistor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 
 namespace Wolverine.Persistence.Sagas;
@@ -24,7 +25,7 @@ public class InMemorySagaPersistor
         return null;
     }
 
-    public void Store<T>(T document)
+    public void Store<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(T document)
     {
         if (document == null)
         {
@@ -48,7 +49,7 @@ public class InMemorySagaPersistor
         _data.TryRemove(key, out _);
     }
 
-    public void StoreAction<T>(IStorageAction<T> action)
+    public void StoreAction<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(IStorageAction<T> action)
     {
         switch (action.Action)
         {
@@ -57,7 +58,7 @@ public class InMemorySagaPersistor
                 var id = idProp!.GetValue(action.Entity);
                 Delete<T>(id!);
                 break;
-            
+
             case StorageAction.Insert:
             case StorageAction.Store:
             case StorageAction.Update:

--- a/src/Wolverine/Persistence/Sagas/LightweightSagaPersistenceFrameProvider.cs
+++ b/src/Wolverine/Persistence/Sagas/LightweightSagaPersistenceFrameProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
@@ -9,11 +10,22 @@ namespace Wolverine.Persistence.Sagas;
 
 public class LightweightSagaPersistenceFrameProvider : IPersistenceFrameProvider
 {
+    // ApplyTransactionSupport closes EnrollAndFetchSagaStorageFrame<,> over
+    // (idType, sagaType) at codegen time; CanPersist closes ISagaStorage<,>
+    // over the same. AOT-clean apps in TypeLoadMode.Static run pre-generated
+    // frames where these closures are baked in by source-generated registration;
+    // the IPersistenceFrameProvider surface only fires under Dynamic codegen,
+    // which is intentionally not AOT-clean (see AOT publishing guide). Same
+    // chunk M / chunk P pattern.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "EnrollAndFetchSagaStorageFrame<,> closed over runtime saga types during Dynamic codegen; AOT consumers run pre-generated frames. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "EnrollAndFetchSagaStorageFrame<,> closed over runtime saga types during Dynamic codegen; AOT consumers run pre-generated frames. See AOT guide.")]
     public void ApplyTransactionSupport(IChain chain, IServiceContainer container)
     {
         // Idempotent here just in case
         if (chain.Middleware.OfType<ISagaStorageFrame>().Any()) return;
-        
+
         if (chain is SagaChain sagaChain)
         {
             var member = SagaChain.DetermineSagaIdMember(sagaChain.SagaType, sagaChain.SagaType);
@@ -22,12 +34,12 @@ public class LightweightSagaPersistenceFrameProvider : IPersistenceFrameProvider
                 throw new InvalidOperationException(
                     $"Wolverine is unable to determine a public identity member for the Saga type {sagaChain.SagaType}");
             }
-            
+
             var idType = member.GetRawMemberType();
 
             var enrollFrame =
                 typeof(EnrollAndFetchSagaStorageFrame<,>).CloseAndBuildAs<Frame>(idType!, sagaChain.SagaType);
-            
+
             sagaChain.Middleware.Add(enrollFrame);
         }
     }
@@ -42,6 +54,8 @@ public class LightweightSagaPersistenceFrameProvider : IPersistenceFrameProvider
         return chain is SagaChain || chain.ServiceDependencies(container, []).Any(x => x.Closes(typeof(ISagaStorage<,>)));
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "ISagaStorage<,> closed over runtime saga types during Dynamic codegen; AOT consumers register saga types explicitly. See AOT guide.")]
     public bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService)
     {
         if (entityType.CanBeCastTo<Saga>())
@@ -52,7 +66,7 @@ public class LightweightSagaPersistenceFrameProvider : IPersistenceFrameProvider
                 persistenceService = default!;
                 return false;
             }
-            
+
             persistenceService = typeof(ISagaStorage<,>).MakeGenericType(idType, entityType);
             return true;
         }

--- a/src/Wolverine/Persistence/Sagas/LoadSagaOperation.cs
+++ b/src/Wolverine/Persistence/Sagas/LoadSagaOperation.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
@@ -23,11 +24,16 @@ public class LoadSagaOperation : AsyncFrame
 
     public Variable Saga { get; }
 
+    // ISagaStorage<,> closed over (sagaIdType, sagaType) at codegen time. Same
+    // Dynamic-mode rationale as the saga frame providers (chunk P) — AOT-clean
+    // apps run pre-generated frames in TypeLoadMode.Static.
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "ISagaStorage<,> closed over runtime saga types during Dynamic codegen; AOT consumers register saga types explicitly. See AOT guide.")]
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
         _storage = chain.FindVariable(typeof(ISagaStorage<,>).MakeGenericType(_sagaId.VariableType, _sagaType));
         yield return _storage;
-        
+
         _cancellation = chain.FindVariable(typeof(CancellationToken));
         yield return _cancellation;
     }

--- a/src/Wolverine/Persistence/Sagas/SagaChain.cs
+++ b/src/Wolverine/Persistence/Sagas/SagaChain.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
@@ -194,6 +195,16 @@ public class SagaChain : HandlerChain
             sagaHandlerMethod != null ? [sagaHandlerMethod] : null);
     }
 
+    // GetFields() + GetProperties() walk over a runtime-resolved messageType.
+    // Saga handlers are an opt-in feature; the messageType is the user's command/
+    // event, statically rooted by handler discovery. Same chunk G / chunk K
+    // rationale: leaf suppression here keeps the IPersistenceFrameProvider /
+    // SagaChain surface free of [Requires*] cascade. AOT-clean apps preserve
+    // saga-message types via [DynamicallyAccessedMembers(PublicFields|PublicProperties)]
+    // on the message type or by registering them through the source-generated
+    // handler discovery path.
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Saga handlers are opt-in; user-supplied saga-message types are statically rooted via handler discovery. See AOT guide.")]
     public static MemberInfo? DetermineSagaIdMember(Type messageType, Type sagaType, MethodInfo[]? sagaHandlerMethods)
     {
         var expectedSagaIdName = $"{sagaType.Name}Id";

--- a/src/Wolverine/Persistence/Sagas/SagaOperation.cs
+++ b/src/Wolverine/Persistence/Sagas/SagaOperation.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
@@ -20,11 +21,16 @@ public class SagaOperation : AsyncFrame, ISagaOperation
 
     public SagaOperationType Operation { get; }
 
+    // ISagaStorage<> closed over runtime saga type at codegen time. Same
+    // Dynamic-mode rationale as the saga frame providers (chunk P) — AOT-clean
+    // apps run pre-generated frames in TypeLoadMode.Static.
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "ISagaStorage<> closed over runtime saga type during Dynamic codegen; AOT consumers register saga types explicitly. See AOT guide.")]
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
         _storage = chain.FindVariable(typeof(ISagaStorage<>).MakeGenericType(Saga.VariableType));
         yield return _storage;
-        
+
         _cancellation = chain.FindVariable(typeof(CancellationToken));
         yield return _cancellation;
     }

--- a/src/Wolverine/Persistence/Sagas/SagaStorageVariableSource.cs
+++ b/src/Wolverine/Persistence/Sagas/SagaStorageVariableSource.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
 
@@ -10,6 +11,14 @@ public class SagaStorageVariableSource : IVariableSource
         return type.Closes(typeof(ISagaStorage<,>)) || type.Closes(typeof(ISagaStorage<>));
     }
 
+    // EnrollAndFetchSagaStorageFrame<,> closed over (idType, sagaType) at
+    // codegen time. Same Dynamic-mode rationale as the saga frame providers
+    // and chunk M (LoggerVariableSource) — AOT-clean apps run pre-generated
+    // frames in TypeLoadMode.Static where these closures are baked in.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "EnrollAndFetchSagaStorageFrame<,> closed over runtime saga types during Dynamic codegen; AOT consumers run pre-generated frames. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "EnrollAndFetchSagaStorageFrame<,> closed over runtime saga types during Dynamic codegen; AOT consumers run pre-generated frames. See AOT guide.")]
     public Variable Create(Type type)
     {
         var sagaType = type.GetGenericArguments().Last();


### PR DESCRIPTION
Annotates the entire saga persistence subsystem in one PR — 7 files, 30 IL warnings cleared. The cluster shares a coherent theme: codegen-time helpers that close generic shapes over runtime-resolved saga and message types.

Files and IL codes cleared:

- InMemoryPersistenceFrameProvider.cs (4 method-level suppressions + 1 DAM forward on InMemorySagaPersistorStore<T>) — IL2026, IL3050, IL2076, IL2091
- LightweightSagaPersistenceFrameProvider.cs (ApplyTransactionSupport + CanPersist) — IL2026, IL3050
- SagaStorageVariableSource.cs (Create) — IL2026, IL3050
- SagaOperation.cs (FindVariables) — IL3050
- LoadSagaOperation.cs (FindVariables) — IL3050
- InMemorySagaPersistor.cs (Store<T>, StoreAction<T>) — IL2090 cleared via [DynamicallyAccessedMembers(PublicProperties)] forward to T
- SagaChain.cs (DetermineSagaIdMember) — IL2070 leaf suppression on the GetFields/GetProperties walk over user message types

Pattern matches:
- chunk M (LoggerVariableSource) for the codegen-frame Dynamic-mode rationale — AOT-clean apps run pre-generated frames in TypeLoadMode.Static where the closures are baked into source-generated registration; the IPersistenceFrameProvider surface only fires under Dynamic codegen, which is intentionally not AOT-clean per docs/guide/aot.md.
- chunk G (DAM annotations on small-cascade generic surface) for the InMemorySagaPersistor T-parameter annotations — Store<T>/StoreAction<T> reflect over typeof(T).GetProperty("Id"); declaring [DAM(PublicProperties)] on T documents the requirement explicitly. Cascaded into InMemorySagaPersistorStore<T> which forwards the same annotation.
- chunk K (PropertyNameGroupingRule) for SagaChain.DetermineSagaIdMember — saga handlers are opt-in; user-supplied saga-message types are statically rooted via handler discovery.

Surface impact: Wolverine.csproj IL warning count drops by 30 (120 → 90 on net10.0). AotSmoke build remains 0 IL warnings. 102/102 CoreTests Saga tests pass.