### PR TITLE
AOT chunk R: SideEffectPolicy + ResponsePolicy leaf suppressions (#2746)

### DIFF
--- a/src/Wolverine/IResponse.cs
+++ b/src/Wolverine/IResponse.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
@@ -59,6 +60,12 @@ internal class ResponsePolicy : IHandlerPolicy
         }
     }
 
+    // GetMethod / GetInterfaces walk over a runtime-resolved IResponse
+    // implementation type. IResponse is opt-in: user types implement IResponse
+    // and are statically rooted via handler-return-type discovery. Same pattern
+    // as the saga / claim-check / partitioning suppressions in chunks K / P / Q.
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "IResponse is opt-in; user-supplied response types are statically rooted via handler return-type discovery. See AOT guide.")]
     private MethodInfo findMethod(Type responseType)
     {
         return

--- a/src/Wolverine/ISideEffect.cs
+++ b/src/Wolverine/ISideEffect.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
@@ -44,6 +45,16 @@ internal class SideEffectPolicy : IChainPolicy
         }
     }
 
+    // typeof(Applier<>).CloseAndBuildAs<IApplier>(effect.VariableType) closes the
+    // internal Applier<T : ISideEffectAware> shape over a runtime-resolved side-
+    // effect type so the generic static-virtual `BuildFrame` can be invoked.
+    // Same chunk D / I / J / K pattern: side effect types are user-supplied via
+    // handler return values and statically rooted by handler discovery; the
+    // closure fires only at codegen time, not on the per-message dispatch path.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Applier<TSideEffect> closed over runtime side-effect type at codegen time; user-supplied types are statically rooted via handler return-type discovery. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Applier<TSideEffect> closed over runtime side-effect type at codegen time; user-supplied types are statically rooted via handler return-type discovery. See AOT guide.")]
     private static void lookForSingularSideEffects(GenerationRules rules, IServiceContainer container, IChain chain)
     {
         var sideEffects = chain.ReturnVariablesOfType<ISideEffect>();
@@ -109,6 +120,12 @@ internal class SideEffectPolicy : IChainPolicy
         }, "Side Effect Policy");
     }
 
+    // GetMethod / GetInterfaces walk over a runtime-resolved ISideEffect
+    // implementation type. ISideEffect is opt-in: user types implement
+    // ISideEffect and are statically rooted via handler return-type discovery.
+    // Mirrors the IResponse.findMethod suppression in the same chunk R.
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "ISideEffect is opt-in; user-supplied side-effect types are statically rooted via handler return-type discovery. See AOT guide.")]
     private static MethodInfo? findMethod(Type effectType)
     {
         return


### PR DESCRIPTION
## Summary

Continues the AOT-pillar (#2746) granular-PR strategy. Annotates the two policy classes that handle handler return-type discovery for `ISideEffect` and `IResponse` implementations.

**Critical:** The interface declarations themselves (`ISideEffect`, `ISideEffectAware`, `IResponse`, `IResponseAware`) are NOT annotated — only the policy classes' reflective helpers are. So no cascade reaches user-implemented response/side-effect types.

| Site | IL codes cleared |
|------|------------------|
| `IResponse.cs` (`ResponsePolicy.findMethod`) | IL2070 (`responseType.GetMethod` / `GetInterfaces`) |
| `ISideEffect.cs` (`SideEffectPolicy.lookForSingularSideEffects`) | IL2026 + IL3050 (`typeof(Applier<>).CloseAndBuildAs<IApplier>`) |
| `ISideEffect.cs` (`SideEffectPolicy.findMethod`) | IL2070 (`effectType.GetMethod` / `GetInterfaces`) |

## Justification

`ISideEffect` and `IResponse` are opt-in user interfaces; concrete implementations are statically rooted via handler return-type discovery (which itself carries `[RequiresUnreferencedCode]` upstream after chunk Q's annotation of `HandlerDiscovery.actionsFromType`). The reflective walks here only fire at codegen time, not on the per-message dispatch path. Same chunk K / Q pattern.

## Surface impact

- `Wolverine.csproj` IL warning count drops by **16** (8 unique sites × 2 TFMs)
- `AotSmoke` build: still **0** IL warnings
- `CoreTests`: 6/6 side_effect + 48/48 Response tests pass

## Diff

2 files, +25 / -1.

## Cross-links

- #2746 — AOT pillar tracking
- #2769 — `CloseAndBuildAs` elimination (covers the Applier<> site long-term)