### PR TITLE
AOT chunk V: flip IsAotCompatible=true on Wolverine.csproj (#2746)

### DIFF
--- a/src/Wolverine/Wolverine.csproj
+++ b/src/Wolverine/Wolverine.csproj
@@ -3,25 +3,35 @@
         <Description>Build Robust Event Driven Architectures with Simpler Code</Description>
         <PackageId>WolverineFx</PackageId>
         <!--
-          AOT pillar (wolverine#2715). IsAotCompatible=true is intentionally NOT
-          set here yet. Wolverine's runtime-codegen surface (HandlerGraph.Compile,
-          AssemblyGenerator usage, reflective handler discovery, the dynamic
-          envelope-mapper reflection) needs [RequiresDynamicCode] /
-          [RequiresUnreferencedCode] annotations propagated through ~150 entry
-          points before the IsAotCompatible declaration would be honest — see
-          the AOT-pillar tracking issue for the per-file breakdown.
+          AOT pillar (wolverine#2715, tracked in #2746). The per-file annotation
+          pass is complete (chunks A–U, PRs #2747 / #2753–#2778). Every
+          reflective entry point in Wolverine's runtime-codegen surface
+          (HandlerGraph.Compile / Forwarders.FindForwards / EnvelopeMapper /
+          all CloseAndBuildAs sites in routing, partitioning, batching, sagas,
+          etc.) now carries either [RequiresDynamicCode]/[RequiresUnreferencedCode]
+          propagation or a leaf-level [UnconditionalSuppressMessage] with a
+          justification pointing at docs/guide/aot.md.
 
-          The regression-guard for the AOT-clean *subset* of Wolverine's surface
-          (Envelope value-shape, WolverineOptions configuration, DeliveryOptions,
-          etc.) lives in src/Testing/Wolverine.AotSmoke. That project sets
-          IsAotCompatible=true itself with WarningsAsErrors covering the IL2*/IL3*
-          codes, so if a previously-AOT-clean Wolverine API gains a reflective
-          dependency, the smoke build fails in CI.
+          Wolverine.csproj builds with 0 IL warnings under EnableTrimAnalyzer
+          + EnableAotAnalyzer on net9.0 + net10.0, so IsAotCompatible=true is
+          now honest. Setting it tells consumers' AOT publish that this
+          assembly is AOT-prepared and surfaces any future regression at the
+          consumer's build, not just at runtime.
 
-          Once the per-file annotation pass is complete, flip IsAotCompatible=true
-          here and the smoke project becomes a redundant (but still useful)
-          subset-coverage signal.
+          The regression-guard for the AOT-clean *subset* of Wolverine's
+          public-API surface (Envelope value-shape, WolverineOptions
+          configuration, DeliveryOptions, etc.) still lives in
+          src/Testing/Wolverine.AotSmoke. That project sets WarningsAsErrors
+          on IL2*/IL3* codes — so the smoke build is now a redundant (but
+          still useful) coverage signal alongside this declaration.
+
+          The architectural follow-ups that would let us *remove* the leaf
+          suppressions rather than just acknowledge them are tracked in:
+          - #2769 — eliminate CloseAndBuildAs reflection via cache pre-population
+          - #2757 — make IForwardsTo registration explicit (drop assembly scan)
+          - #2755 — eliminate FastExpressionCompiler in EnvelopeMapper
         -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" />


### PR DESCRIPTION
## 🎯 Milestone: Wolverine.csproj is AOT-compatible

This is the milestone commit for the AOT pillar (#2715, tracked in #2746). The per-file annotation pass is **complete** (chunks A–U, PRs #2747 / #2753–#2778). Every reflective entry point in Wolverine's runtime-codegen surface — `HandlerGraph.Compile`, `Forwarders.FindForwards`, `EnvelopeMapper`, all `CloseAndBuildAs` sites in routing, partitioning, batching, sagas, side effects, responses, and the central handler graph — now carries either `[RequiresDynamicCode]`/`[RequiresUnreferencedCode]` propagation or a leaf-level `[UnconditionalSuppressMessage]` with a justification pointing at `docs/guide/aot.md`.

**Wolverine.csproj builds with 0 IL warnings under `EnableTrimAnalyzer` + `EnableAotAnalyzer` on net9.0 + net10.0** (down from 206 IL warnings before chunks A began), so `IsAotCompatible=true` is now honest.

## Why now

Setting `IsAotCompatible=true`:
- Tells consumers' AOT publish that this assembly is AOT-prepared
- Surfaces any future regression at the consumer's build, not just at runtime
- Lets downstream packages built against Wolverine flip their own `IsAotCompatible=true` once their own annotation passes complete

The `Wolverine.AotSmoke` project (which already declares `IsAotCompatible=true` with `WarningsAsErrors` on IL2*/IL3* codes) remains in CI as a redundant subset-coverage signal — fail-fast on the AOT-clean *public-API* surface specifically.

## What this is NOT

- **Other Wolverine packages still have IL warnings.** Marten (~142), EFCore (~80), Http (~128), transport-specific packages (Rabbit ~8 / SQS ~12 / Service Bus ~56 / RavenDb ~16). Those need the same chunked approach, scoped per package — that's the next phase of the AOT pillar.
- **Suppressions are not the long-term answer.** The architectural follow-ups that would let us *remove* the leaf suppressions rather than just acknowledge them are tracked in:
  - **#2769** — eliminate `CloseAndBuildAs` reflection via cache pre-population at handler-graph compile time
  - **#2757** — make `IForwardsTo` registration explicit (drop the assembly scan)
  - **#2755** — eliminate `FastExpressionCompiler` in `EnvelopeMapper`

## Verification

- `Wolverine.csproj`: **0 IL warnings, 0 errors** (clean rebuild on net9.0 + net10.0)
- `AotSmoke`: still **0 IL warnings**
- `Wolverine.Marten` / `Wolverine.RDBMS` / `Wolverine.Http` / `CoreTests`: build clean
- Representative test cross-section: **320/320 pass** (Saga / Routing / Cascade / handler_chain / Partitioning / Middleware / side_effect / Response)

## Diff

`src/Wolverine/Wolverine.csproj` — +26 / -16 (mostly the explanatory comment block update).

## Cross-links

- #2746 — AOT pillar tracking issue
- #2715 — original AOT-compat issue
- #2769 / #2757 / #2755 — follow-ups for removing leaf suppressions
- All chunk PRs A–U: #2747, #2753, #2754, #2756, #2758–#2768 (chunk merges), #2770–#2778

🤖 Generated with [Claude Code](https://claude.com/claude-code)