### PR TITLE
AOT chunk X: flip IsAotCompatible=true on Wolverine.RabbitMQ (#2746)

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelopeMapper.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelopeMapper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using JasperFx.Core;
 using RabbitMQ.Client;
@@ -16,6 +17,18 @@ public interface IRabbitMqEnvelopeMapper : IEnvelopeMapper<IReadOnlyBasicPropert
 
 public class RabbitMqEnvelopeMapper : EnvelopeMapper<IReadOnlyBasicProperties, IBasicProperties>, IRabbitMqEnvelopeMapper
 {
+    // Inherits EnvelopeMapper<,>'s reflection-based property mapping (chunk B
+    // #2753 annotated the base ctor as [RequiresDynamicCode] +
+    // [RequiresUnreferencedCode]). Suppress at the leaf so the cascade
+    // doesn't propagate through Endpoint.buildMapper (an abstract method
+    // overridden by every transport-specific endpoint). AOT-clean apps
+    // either supply their own IRabbitMqEnvelopeMapper or preserve the
+    // closed EnvelopeMapper<IReadOnlyBasicProperties, IBasicProperties> via
+    // TrimmerRootDescriptor. See AOT guide.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Inherits EnvelopeMapper<,> reflective property mapping; AOT consumers supply their own mapper or preserve the closed type. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Inherits EnvelopeMapper<,> reflective property mapping; AOT consumers supply their own mapper or preserve the closed type. See AOT guide.")]
     public RabbitMqEnvelopeMapper(Endpoint endpoint, IWolverineRuntime runtime) : base(endpoint)
     {
         MapProperty(x => x.CorrelationId!, (e, p) => e.CorrelationId = p.CorrelationId,

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Wolverine.RabbitMQ.csproj
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Wolverine.RabbitMQ.csproj
@@ -7,6 +7,15 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          AOT-compatible (#2746). Single inherited-from-EnvelopeMapper<,>
+          reflective-property-mapping site in RabbitMqEnvelopeMapper ctor;
+          suppressed at the leaf to avoid cascading [Requires*] through
+          Endpoint.buildMapper (an abstract method overridden by every
+          transport-specific endpoint). All other reflective surface inherits
+          annotations from Wolverine.csproj (chunks A–U).
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\Wolverine\Wolverine.csproj"/>


### PR DESCRIPTION
Single `RabbitMqEnvelopeMapper` ctor inheriting `EnvelopeMapper<,>`'s reflective property mapping (chunk B annotated the base ctor). Leaf-suppressed at the ctor — propagating `[Requires*]` would cascade through `Endpoint.buildMapper`, an abstract method overridden by every transport. Same pattern needed for SQS / Service Bus / RavenDb. `IsAotCompatible=true` flipped. Wolverine.RabbitMQ.csproj: 8→0 IL warnings.

Cross-link: #2746 / #2753 (chunk B EnvelopeMapper annotation)