### PR TITLE
AOT chunk Y: flip IsAotCompatible=true on Wolverine.AmazonSqs (#2746)

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs/RawJsonSqsEnvelopeMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/RawJsonSqsEnvelopeMapper.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using Amazon.SQS.Model;
 using Wolverine.Transports;
 using Wolverine.Util;
@@ -18,6 +19,15 @@ internal class RawJsonSqsEnvelopeMapper : ISqsEnvelopeMapper
 
     public override string ToString() => "Raw JSON";
 
+    // Reflection-based JsonSerializer.Serialize/Deserialize over a runtime-
+    // resolved user message type. Same chunk D / E pattern (default JSON
+    // serializer for IMessageSerializer): AOT-clean apps supply their own
+    // ISqsEnvelopeMapper backed by a JsonSerializerContext (or pre-register
+    // a JsonTypeInfo for the message type). See AOT guide.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Raw JSON SQS mapper uses reflection-based STJ over a runtime-resolved message type; AOT consumers supply a JsonSerializerContext-backed mapper. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Raw JSON SQS mapper uses reflection-based STJ over a runtime-resolved message type; AOT consumers supply a JsonSerializerContext-backed mapper. See AOT guide.")]
     public string BuildMessageBody(Envelope envelope)
     {
         return JsonSerializer.Serialize(
@@ -32,6 +42,10 @@ internal class RawJsonSqsEnvelopeMapper : ISqsEnvelopeMapper
             new MessageAttributeValue { StringValue = "1.0", DataType = "String" });
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Raw JSON SQS mapper uses reflection-based STJ over a runtime-resolved message type; AOT consumers supply a JsonSerializerContext-backed mapper. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Raw JSON SQS mapper uses reflection-based STJ over a runtime-resolved message type; AOT consumers supply a JsonSerializerContext-backed mapper. See AOT guide.")]
     public void ReadEnvelopeData(Envelope envelope, string messageBody, IDictionary<string, MessageAttributeValue> attributes)
     {
         // assuming json serialized message

--- a/src/Transports/AWS/Wolverine.AmazonSqs/SnsTopicEnvelopeMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/SnsTopicEnvelopeMapper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using Amazon.SQS.Model;
 using Wolverine.Transports;
 
@@ -35,7 +36,7 @@ internal class SnsTopicEnvelopeMapper : ISqsEnvelopeMapper
     {
         try
         {
-            var json = JsonSerializer.Deserialize<SnsMessageMetadata>(messageBody) 
+            var json = JsonSerializer.Deserialize(messageBody, SnsMessageMetadataJsonContext.Default.SnsMessageMetadata)
                        ?? throw new NullReferenceException();
             return json.Message;
         }
@@ -44,7 +45,7 @@ internal class SnsTopicEnvelopeMapper : ISqsEnvelopeMapper
             return messageBody;
         }
     }
-    
+
     internal class SnsMessageMetadata
     {
         public string Type { get; set; } = null!;
@@ -54,3 +55,11 @@ internal class SnsTopicEnvelopeMapper : ISqsEnvelopeMapper
         public string UnsubscribeURL { get; set; } = null!;
     }
 }
+
+/// <summary>
+/// Source-generated JSON context for <see cref="SnsTopicEnvelopeMapper.SnsMessageMetadata"/>
+/// — replaces the reflection-based JsonSerializer.Deserialize&lt;T&gt; overload so this
+/// internal SNS-envelope detection stays AOT-clean. Same chunk N (NodeRecord) precedent.
+/// </summary>
+[JsonSerializable(typeof(SnsTopicEnvelopeMapper.SnsMessageMetadata))]
+internal partial class SnsMessageMetadataJsonContext : JsonSerializerContext;

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Wolverine.AmazonSqs.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Wolverine.AmazonSqs.csproj
@@ -3,6 +3,15 @@
     <PropertyGroup>
         <PackageId>WolverineFx.AmazonSqs</PackageId>
         <Description>Amazon SQS transport for Wolverine applications</Description>
+        <!--
+          AOT-compatible (#2746). Three IL warning sites resolved:
+          - RawJsonSqsEnvelopeMapper.BuildMessageBody / ReadEnvelopeData:
+            leaf-suppressed (runtime-resolved user message types; AOT
+            consumers supply a JsonSerializerContext-backed mapper)
+          - SnsTopicEnvelopeMapper.ReadMessageBody: refactored to use
+            source-generated SnsMessageMetadataJsonContext (chunk N pattern)
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Three IL warning sites:

- `RawJsonSqsEnvelopeMapper.{BuildMessageBody,ReadEnvelopeData}`: leaf-suppressed (runtime-resolved user message types; AOT consumers supply a JsonSerializerContext-backed mapper)
- `SnsTopicEnvelopeMapper.ReadMessageBody`: refactored to use source-generated `SnsMessageMetadataJsonContext` (chunk N pattern)

`IsAotCompatible=true` flipped. Wolverine.AmazonSqs.csproj: 12→0 IL warnings.

Cross-link: #2746 / #2767