### PR TITLE
AOT chunk Z: flip IsAotCompatible=true on Wolverine.RavenDb (#2746)

### DIFF
--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbPersistenceFrameProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Expressions;
@@ -105,6 +106,12 @@ public class RavenDbPersistenceFrameProvider : IPersistenceFrameProvider
         return new DeleteDocumentFrame(variable);
     }
 
+    // MakeGenericMethod over a runtime-resolved entity type at codegen time.
+    // Same chunk P (saga frame providers) pattern: AOT-clean apps run pre-
+    // generated frames in TypeLoadMode.Static; this Dynamic-mode codegen
+    // helper is bypassed.
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "RavenDbStorageActionApplier.ApplyAction<T> closed over runtime entityType during Dynamic codegen; AOT consumers run pre-generated frames in TypeLoadMode.Static. See AOT guide.")]
     public Frame DetermineStorageActionFrame(Type entityType, Variable action, IServiceContainer container)
     {
         var method = typeof(RavenDbStorageActionApplier).GetMethod("ApplyAction")!

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbSagaStoreDiagnostics.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbSagaStoreDiagnostics.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
 using JasperFx.Core.Reflection;
@@ -45,6 +46,18 @@ internal sealed class RavenDbSagaStoreDiagnostics : ISagaStoreDiagnostics
         return Task.FromResult<IReadOnlyList<SagaTypeDescriptor>>(descriptors);
     }
 
+    // session.LoadAsync<TSaga>(string id, ct) is invoked reflectively because
+    // sagaType is only known at runtime. The Task<TSaga> return value is
+    // unwrapped via Result-property reflection. AOT-clean apps that need
+    // saga diagnostics on RavenDb preserve their saga state types via
+    // TrimmerRootDescriptor (or use the Wolverine codegen-static path which
+    // bakes the typed LoadAsync invocation into source-generated code).
+    [UnconditionalSuppressMessage("Trimming", "IL2060",
+        Justification = "Generic IAsyncDocumentSession.LoadAsync<TSaga> invoked reflectively; saga types statically rooted via handler discovery. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Generic IAsyncDocumentSession.LoadAsync<TSaga> invoked reflectively; saga types statically rooted via handler discovery. See AOT guide.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "task.GetType().GetProperty(\"Result\") on a Task<TSaga>; the closed Task<TSaga> type has Result by construction. See AOT guide.")]
     public async Task<SagaInstanceState?> ReadSagaAsync(string sagaTypeName, object identity, CancellationToken ct)
     {
         if (!sagaIndex().TryGetValue(sagaTypeName, out var sagaType)) return null;
@@ -112,6 +125,14 @@ internal sealed class RavenDbSagaStoreDiagnostics : ISagaStoreDiagnostics
             "RavenDb");
     }
 
+    // JsonSerializer.SerializeToElement(saga, sagaType) over a runtime-resolved
+    // saga type. AOT-clean apps that need saga diagnostics on RavenDb supply
+    // a JsonSerializerContext covering their saga types (or preserve via
+    // TrimmerRootDescriptor). Same chunk D (default JSON serializer) pattern.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Reflection-based STJ over runtime saga type; AOT consumers supply a JsonSerializerContext for their saga types. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Reflection-based STJ over runtime saga type; AOT consumers supply a JsonSerializerContext for their saga types. See AOT guide.")]
     private static SagaInstanceState buildInstance(Type sagaType, object identity, object saga)
     {
         var stateJson = JsonSerializer.SerializeToElement(saga, sagaType);
@@ -124,6 +145,12 @@ internal sealed class RavenDbSagaStoreDiagnostics : ISagaStoreDiagnostics
             null);
     }
 
+    // GetProperty("Id") / GetField("Id") on a runtime-resolved saga type when
+    // RavenDB's session.Advanced.GetDocumentId fails. Same chunk Q
+    // (InMemorySagaPersistor) / chunk P (SagaChain.DetermineSagaIdMember)
+    // pattern: saga types are statically rooted via handler discovery.
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "GetProperty/GetField(\"Id\") on runtime saga type; saga types statically rooted via handler discovery. See AOT guide.")]
     private static object? extractIdentity(object saga, Type sagaType)
     {
         var idMember = (MemberInfo?)sagaType.GetProperty("Id") ?? sagaType.GetField("Id");

--- a/src/Persistence/Wolverine.RavenDb/Wolverine.RavenDb.csproj
+++ b/src/Persistence/Wolverine.RavenDb/Wolverine.RavenDb.csproj
@@ -8,6 +8,16 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          AOT-compatible (#2746). Reflective surface limited to:
+          - RavenDbPersistenceFrameProvider.DetermineStorageActionFrame
+            (codegen-time MakeGenericMethod over saga entity type)
+          - RavenDbSagaStoreDiagnostics (LoadAsync<TSaga> reflective invoke +
+            SerializeToElement(saga, sagaType) + Id member walk)
+          All leaf-suppressed; consumers preserve saga state types via
+          TrimmerRootDescriptor or supply a JsonSerializerContext.
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Five IL warning sites across two files in saga-related reflective surface:

- `RavenDbPersistenceFrameProvider.DetermineStorageActionFrame` — IL3050 on `MakeGenericMethod` over runtime entity type at codegen time
- `RavenDbSagaStoreDiagnostics.ReadSagaAsync` — IL2060 + IL3050 on reflective `IAsyncDocumentSession.LoadAsync<TSaga>` invoke + IL2075 on `Task<TSaga>.GetType().GetProperty("Result")`
- `RavenDbSagaStoreDiagnostics.buildInstance` — IL2026 + IL3050 on `JsonSerializer.SerializeToElement(saga, sagaType)`
- `RavenDbSagaStoreDiagnostics.extractIdentity` — IL2070 on `GetProperty/GetField("Id")` fallback

All leaf-suppressed; saga types statically rooted via handler discovery. `IsAotCompatible=true` flipped. Wolverine.RavenDb.csproj: 16→0 IL warnings.

Cross-link: #2746 / chunks P+Z saga pattern