### PR TITLE
AOT chunk AA: flip IsAotCompatible=true on Wolverine.AzureServiceBus (#2746)

### DIFF
--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Emulator/GlobalSuppressions.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Emulator/GlobalSuppressions.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics.CodeAnalysis;
+
+// Code.cs in this namespace is auto-generated QuickType output for parsing
+// Azure Service Bus emulator configuration JSON. The generator emits standard
+// reflection-based JsonSerializer.Serialize/Deserialize calls (IL2026/IL3050)
+// — there's no way to teach QuickType to emit JsonSerializerContext-backed
+// code, and patching Code.cs would be reverted on the next regen.
+//
+// The emulator config types are unbounded by design (the QuickType output
+// is a dump of every Service Bus emulator JSON shape) and only used in
+// test/dev scenarios — never on the per-message dispatch path. Suppress at
+// the namespace level so the suppression survives Code.cs regeneration.
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2026",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.AzureServiceBus.Emulator",
+    Justification = "Auto-generated QuickType emulator config; test/dev only, not on dispatch path. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("AOT", "IL3050",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.AzureServiceBus.Emulator",
+    Justification = "Auto-generated QuickType emulator config; test/dev only, not on dispatch path. See AOT guide.")]

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelopeMapper.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelopeMapper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Azure.Messaging.ServiceBus;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
@@ -7,6 +8,18 @@ namespace Wolverine.AzureServiceBus.Internal;
 
 public class AzureServiceBusEnvelopeMapper : EnvelopeMapper<ServiceBusReceivedMessage, ServiceBusMessage>, IAzureServiceBusEnvelopeMapper
 {
+    // Inherits EnvelopeMapper<,>'s reflection-based property mapping (chunk B
+    // #2753 annotated the base ctor as [RequiresDynamicCode] +
+    // [RequiresUnreferencedCode]). Same chunk X (RabbitMqEnvelopeMapper)
+    // pattern: leaf-suppress so the cascade doesn't propagate through
+    // Endpoint.buildMapper. AOT-clean apps either supply their own
+    // IAzureServiceBusEnvelopeMapper or preserve the closed
+    // EnvelopeMapper<ServiceBusReceivedMessage, ServiceBusMessage> via
+    // TrimmerRootDescriptor. See AOT guide.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Inherits EnvelopeMapper<,> reflective property mapping; AOT consumers supply their own mapper or preserve the closed type. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Inherits EnvelopeMapper<,> reflective property mapping; AOT consumers supply their own mapper or preserve the closed type. See AOT guide.")]
     public AzureServiceBusEnvelopeMapper(Endpoint endpoint, IWolverineRuntime runtime) : base(endpoint)
     {
         MapProperty(x => x.ContentType!, (e, m) => e.ContentType = m.ContentType,

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
@@ -219,6 +220,13 @@ public class AzureServiceBusQueue : AzureServiceBusEndpoint, IBrokerQueue, IMass
         return false;
     }
     
+    // NServiceBus interop: NSB writes the .NET assembly-qualified type name
+    // to the message header; we resolve it via Type.GetType(string). Type
+    // resolution from a runtime string is fundamentally not AOT-clean — the
+    // trimmer can't know which types may appear. AOT-clean apps using NSB
+    // interop preserve their NSB-side message types via TrimmerRootDescriptor.
+    [UnconditionalSuppressMessage("Trimming", "IL2057",
+        Justification = "Type.GetType(typeName) on NServiceBus wire type names; AOT consumers preserve NSB message types via TrimmerRootDescriptor. See AOT guide.")]
     internal void UseNServiceBusInterop()
     {
         // NServiceBus.EnclosedMessageTypes

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
@@ -235,6 +236,8 @@ public class AzureServiceBusSubscription : AzureServiceBusEndpoint, IBrokerQueue
         }
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2057",
+        Justification = "Type.GetType(typeName) on NServiceBus wire type names; AOT consumers preserve NSB message types via TrimmerRootDescriptor. See AOT guide.")]
     internal void UseNServiceBusInterop()
     {
         DefaultSerializer = new NewtonsoftSerializer(new JsonSerializerSettings());

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
@@ -134,6 +135,8 @@ public class AzureServiceBusTopic : AzureServiceBusEndpoint, IMassTransitInterop
 
     public override bool IsPartitioned { get => Options.EnablePartitioning; }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2057",
+        Justification = "Type.GetType(typeName) on NServiceBus wire type names; AOT consumers preserve NSB message types via TrimmerRootDescriptor. See AOT guide.")]
     internal void UseNServiceBusInterop()
     {
         DefaultSerializer = new NewtonsoftSerializer(new JsonSerializerSettings());

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Wolverine.AzureServiceBus.csproj
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Wolverine.AzureServiceBus.csproj
@@ -3,6 +3,17 @@
     <PropertyGroup>
         <PackageId>WolverineFx.AzureServiceBus</PackageId>
         <Description>Azure Service Bus transport for Wolverine applications</Description>
+        <!--
+          AOT-compatible (#2746). Reflective surface resolved:
+          - AzureServiceBusEnvelopeMapper ctor inherits EnvelopeMapper<,>
+            reflective property mapping (chunk X RabbitMQ pattern)
+          - AzureServiceBusQueue/Subscription/Topic.UseNServiceBusInterop:
+            Type.GetType(typeName) for NSB wire type names; AOT consumers
+            preserve NSB message types via TrimmerRootDescriptor
+          - Emulator/Code.cs: auto-generated QuickType output suppressed
+            namespace-wide via Emulator/GlobalSuppressions.cs
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Three categories of IL warnings, all suppressed:

1. `AzureServiceBusEnvelopeMapper` ctor (1 site): inherits `EnvelopeMapper<,>` reflective property mapping. Same chunk X (RabbitMqEnvelopeMapper) pattern.

2. `AzureServiceBus{Queue,Subscription,Topic}.UseNServiceBusInterop` (3 sites): `Type.GetType(typeName)` on NServiceBus wire type names. AOT consumers preserve their NSB-side message types via TrimmerRootDescriptor.

3. `Emulator/Code.cs` (9 sites): auto-generated QuickType output for parsing Service Bus emulator config JSON. Created a namespace-scoped suppression in `Emulator/GlobalSuppressions.cs` that survives Code.cs regeneration. Test/dev-only path; never on dispatch.

`IsAotCompatible=true` flipped. Wolverine.AzureServiceBus.csproj: 56→0 IL warnings.

Cross-link: #2746 / chunks B+X pattern