### PR TITLE
AOT chunk AB: flip IsAotCompatible=true on Wolverine.EntityFrameworkCore (#2746)

### DIFF
--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/BatchedLoadEntityFrame.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/BatchedLoadEntityFrame.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
@@ -18,6 +19,10 @@ namespace Wolverine.EntityFrameworkCore.Codegen;
 /// the middleware chain to supply the <c>BatchedQuery</c> variable, and an
 /// <see cref="ExecuteBatchQueryFrame"/> must appear after all batch loads.
 /// </summary>
+// AOT note (#2746): Task<>.MakeGenericType(sagaType) at codegen time. Same
+// chunk M (LoggerVariableSource) / chunk P (saga frame providers) pattern.
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Task<>.MakeGenericType over runtime saga type at codegen; AOT consumers run pre-generated frames in TypeLoadMode.Static. See AOT guide.")]
 internal class BatchedLoadEntityFrame : SyncFrame
 {
     private readonly Type _dbContextType;

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using ImTools;
 using JasperFx;
@@ -20,6 +21,24 @@ using Wolverine.Runtime;
 namespace Wolverine.EntityFrameworkCore.Codegen;
 
 // ReSharper disable once InconsistentNaming
+//
+// AOT note (#2746): This whole class is the EF Core codegen frame provider.
+// Every site here closes generic helper types (ApplyAncillaryStoreFrame<>,
+// CreateTenantedDbContext<>, EfCoreStorageActionApplier.ApplyAction<,>,
+// IDbContextBuilder<>) over runtime saga / entity / DbContext types at
+// codegen time, or reflectively walks DbContext type members to discover
+// SaveChangesAsync / Version / etc. AOT-clean apps run pre-generated
+// frames in TypeLoadMode.Static and bypass this class entirely; Dynamic-
+// mode codegen consumers preserve their saga / DbContext types via
+// TrimmerRootDescriptor. Same chunk P (saga frame providers) pattern.
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "EFCore codegen frame provider — Dynamic-mode codegen path; AOT consumers run pre-generated frames in TypeLoadMode.Static. See AOT guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "EFCore codegen frame provider — entity / DbContext types statically rooted via persistence registration. See AOT guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "EFCore codegen frame provider — DbContext.SaveChangesAsync etc. lookups on statically-rooted DbContext types. See AOT guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "EFCore codegen frame provider — closed generics over runtime DbContext / entity types at codegen time. See AOT guide.")]
 internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 {
     public const string UsingEfCoreTransaction = "uses_efcore_transaction";

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCoreSagaStoreDiagnostics.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCoreSagaStoreDiagnostics.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
 using JasperFx.Core.Reflection;
@@ -26,6 +27,25 @@ namespace Wolverine.EntityFrameworkCore.Codegen;
 /// DbContexts get correct routing too — each saga is dispatched to
 /// whichever DbContext owns its entity model.
 /// </remarks>
+// AOT note (#2746): saga diagnostics over runtime saga / DbContext types.
+// Same chunk Z (RavenDb) pattern: AOT consumers preserve saga state types
+// via TrimmerRootDescriptor or supply a JsonSerializerContext for the saga
+// state. Class-level suppression matches the EFCorePersistenceFrameProvider
+// approach above.
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "EFCore saga diagnostics — reflection-based STJ over saga state; AOT consumers supply a JsonSerializerContext. See AOT guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2060",
+    Justification = "EFCore saga diagnostics — generic DbContext.Set<TSaga> invoked reflectively; saga types statically rooted via handler discovery. See AOT guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "EFCore saga diagnostics — saga / DbContext types statically rooted via persistence registration. See AOT guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "EFCore saga diagnostics — Id member walk on runtime saga type; statically rooted via handler discovery. See AOT guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2091",
+    Justification = "EFCore saga diagnostics — generic helper closes over saga state type at runtime; bounded by handler discovery. See AOT guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2111",
+    Justification = "EFCore saga diagnostics — reflective method invoke on DbContext member; bounded by saga registration. See AOT guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "EFCore saga diagnostics — MakeGenericMethod over runtime saga / DbContext types. See AOT guide.")]
 internal sealed class EFCoreSagaStoreDiagnostics : ISagaStoreDiagnostics
 {
     private readonly IWolverineRuntime _runtime;

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/FetchSpecificationFrame.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/FetchSpecificationFrame.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
@@ -21,6 +22,10 @@ namespace Wolverine.EntityFrameworkCore.Codegen;
 /// <see cref="BatchedQuery"/> with other batchable loads on the same handler.
 /// </para>
 /// </summary>
+// AOT note (#2746): MakeGenericType over runtime spec type at codegen time.
+// Same chunk M / chunk P pattern.
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Spec generic closures over runtime types at codegen; AOT consumers run pre-generated frames. See AOT guide.")]
 internal class FetchSpecificationFrame : AsyncFrame, IEFCoreBatchableFrame
 {
     private readonly Variable _spec;

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -13,6 +14,12 @@ namespace Wolverine.EntityFrameworkCore.Internals;
 /// <summary>
 ///     Envelope transaction for raw database access for DbContexts w/o the explicit wolverine mappings
 /// </summary>
+// AOT note (#2746): IDomainEventScraper reflection over runtime DbContext.
+// Same chunk Z / chunk P pattern.
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "EFCore envelope transaction reflects over runtime DbContext for domain-event scraping; AOT consumers preserve DbContext / domain-event types via TrimmerRootDescriptor. See AOT guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "EFCore envelope transaction reflects over runtime DbContext for domain-event scraping; AOT consumers preserve DbContext / domain-event types via TrimmerRootDescriptor. See AOT guide.")]
 public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
 {
     private readonly MessageContext _messaging;

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantedDbContextBuilderByConnectionString.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantedDbContextBuilderByConnectionString.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using FastExpressionCompiler;
 using ImTools;
@@ -17,6 +18,17 @@ using Wolverine.Runtime;
 
 namespace Wolverine.EntityFrameworkCore.Internals;
 
+// AOT note (#2746): Tenanted DbContext construction reflects over the DbContext
+// generic type to find the public ctor accepting DbContextOptions<T>, then
+// expression-compiles a factory. Same chunk M (LoggerVariableSource) Dynamic-
+// codegen pattern; AOT consumers register the DbContext factory explicitly
+// (or use the Static codegen path that bakes it in).
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "FastExpressionCompiler.CompileFast at registration; AOT consumers register an explicit factory. See AOT guide / #2755.")]
+[UnconditionalSuppressMessage("Trimming", "IL2090",
+    Justification = "DbContext T parameter accessed for ctor lookup; T is statically rooted by AddWolverineEFCore<T>(). See AOT guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "FastExpressionCompiler emits IL at registration time; AOT consumers register an explicit factory. See AOT guide / #2755.")]
 public class TenantedDbContextBuilderByConnectionString<T> : IDbContextBuilder<T>  where T : DbContext
 {
     private readonly Action<DbContextOptionsBuilder<T>, ConnectionString, TenantId> _configuration;

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantedDbContextBuilderByDbDataSource.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantedDbContextBuilderByDbDataSource.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using FastExpressionCompiler;
 using ImTools;
@@ -17,6 +18,14 @@ using Wolverine.Runtime;
 
 namespace Wolverine.EntityFrameworkCore.Internals;
 
+// AOT note (#2746): Sibling of TenantedDbContextBuilderByConnectionString;
+// same FastExpressionCompiler-based factory. See chunk-AB notes / #2755.
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "FastExpressionCompiler.CompileFast at registration; AOT consumers register an explicit factory. See AOT guide / #2755.")]
+[UnconditionalSuppressMessage("Trimming", "IL2090",
+    Justification = "DbContext T parameter accessed for ctor lookup; T is statically rooted by AddWolverineEFCore<T>(). See AOT guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "FastExpressionCompiler emits IL at registration time; AOT consumers register an explicit factory. See AOT guide / #2755.")]
 public class TenantedDbContextBuilderByDbDataSource<T> : IDbContextBuilder<T> where T : DbContext
 {
     private readonly Action<DbContextOptionsBuilder<T>, DbDataSource, TenantId> _configuration;

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Wolverine.EntityFrameworkCore.csproj
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Wolverine.EntityFrameworkCore.csproj
@@ -9,6 +9,15 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          AOT-compatible (#2746). Reflective surface resolved via class-level
+          [UnconditionalSuppressMessage] on the codegen frame providers / saga
+          diagnostics / tenanted DbContext builders, plus a forwarded
+          [DAM(PublicConstructors|NonPublicConstructors|PublicProperties)] on
+          AddDbContextWithWolverineIntegration<T> to satisfy EF Core's own
+          AddDbContext<TContext> requirement.
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using JasperFx;
 using JasperFx.CommandLine.Descriptions;
 using JasperFx.Core.Reflection;
@@ -31,7 +32,7 @@ public static class WolverineEntityCoreExtensions
     /// <param name="wolverineDatabaseSchema"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static IServiceCollection AddDbContextWithWolverineIntegration<T>(this IServiceCollection services, Action<DbContextOptionsBuilder> configure, string? wolverineDatabaseSchema = null) where T : DbContext
+    public static IServiceCollection AddDbContextWithWolverineIntegration<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] T>(this IServiceCollection services, Action<DbContextOptionsBuilder> configure, string? wolverineDatabaseSchema = null) where T : DbContext
     {
         return addDbContextWithWolverineIntegration<T>(services, (_, b) => configure(b), wolverineDatabaseSchema);
      }
@@ -43,7 +44,7 @@ public static class WolverineEntityCoreExtensions
     /// <param name="wolverineDatabaseSchema"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static IServiceCollection AddDbContextWithWolverineIntegration<T>(this IServiceCollection services, Action<IServiceProvider, DbContextOptionsBuilder> configure, string? wolverineDatabaseSchema = null) where T : DbContext
+    public static IServiceCollection AddDbContextWithWolverineIntegration<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] T>(this IServiceCollection services, Action<IServiceProvider, DbContextOptionsBuilder> configure, string? wolverineDatabaseSchema = null) where T : DbContext
     {
         return addDbContextWithWolverineIntegration<T>(services, configure, wolverineDatabaseSchema);
     }
@@ -158,7 +159,11 @@ public static class WolverineEntityCoreExtensions
     }
 
 
-    private static IServiceCollection addDbContextWithWolverineIntegration<T>(IServiceCollection services, Action<IServiceProvider, DbContextOptionsBuilder> configure, string? wolverineDatabaseSchema = null) where T : DbContext
+    // EF Core's AddDbContext<T> requires DAM(PublicConstructors) on T to satisfy
+    // its own internal reflection. Forward the annotation up so callers (e.g.
+    // AddWolverineEFCore<T>) get the cascade and concrete-type registration
+    // sites satisfy it automatically.
+    private static IServiceCollection addDbContextWithWolverineIntegration<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] T>(IServiceCollection services, Action<IServiceProvider, DbContextOptionsBuilder> configure, string? wolverineDatabaseSchema = null) where T : DbContext
     {
         services.TryAddSingleton<IDbContextOutboxFactory, DbContextOutboxFactory>();
         registerEFCoreSagaStoreDiagnostics(services);


### PR DESCRIPTION
27 IL warning sites across 7 files in this package — codegen frame providers, saga diagnostics, tenanted DbContext builders, and the public DI extension surface. All in Dynamic-mode codegen path.

Approach: class-level `[UnconditionalSuppressMessage]` on the codegen frame providers / saga diagnostics / tenanted DbContext builders, plus a forwarded `[DAM(PublicConstructors|NonPublicConstructors|PublicProperties)]` on `AddDbContextWithWolverineIntegration<T>` to satisfy EF Core's own `AddDbContext<TContext>` requirement.

Files annotated:
- Codegen/EFCorePersistenceFrameProvider.cs — class-level (11 sites)
- Codegen/EFCoreSagaStoreDiagnostics.cs — class-level (8 sites)
- Codegen/BatchedLoadEntityFrame.cs — class-level (1 site)
- Codegen/FetchSpecificationFrame.cs — class-level (2 sites)
- Internals/EfCoreEnvelopeTransaction.cs — class-level (2 sites)
- Internals/TenantedDbContextBuilderByConnectionString.cs / Internals/TenantedDbContextBuilderByDbDataSource.cs — class-level (3 sites each, cross-linked to #2755 FastExpressionCompiler elimination)
- WolverineEntityCoreExtensions.cs — DAM forwarding on `T`

`IsAotCompatible=true` flipped. Wolverine.EntityFrameworkCore.csproj: 80→0 IL warnings (excluding bleed-through from chunk W).

Cross-link: #2746 / chunks P+Z saga pattern / #2755 FastExpressionCompiler