### PR TITLE
AOT chunk AC: flip IsAotCompatible=true on Wolverine.Http (#2746)

### DIFF
--- a/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
@@ -13,6 +14,14 @@ using Wolverine.Runtime;
 
 internal class AsParamatersAttributeUsage : IParameterStrategy
 {
+    // parameter.ParameterType flows into AsParametersBindingFrame's
+    // [DAM(PublicConstructors|PublicProperties)]-annotated ctor parameter;
+    // ParameterInfo.ParameterType doesn't carry the DAM annotation. Suppress
+    // at the call site — the user's [AsParameters] type is statically rooted
+    // via endpoint discovery (which carries [RequiresUnreferencedCode]
+    // upstream after the chunk Q HandlerDiscovery work).
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
+        Justification = "User [AsParameters] type statically rooted via endpoint discovery; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide.")]
     public bool TryMatch(HttpChain chain, IServiceContainer container, ParameterInfo parameter, out Variable? variable)
     {
         variable = default;
@@ -78,7 +87,7 @@ internal class AsParametersBindingFrame : SyncFrame
     private bool _hasForms = false;
     private bool _hasJsonBody = false;
 
-    public AsParametersBindingFrame(Type queryType, HttpChain chain, IServiceContainer container)
+    public AsParametersBindingFrame([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] Type queryType, HttpChain chain, IServiceContainer container)
     {
         Variable = new Variable(queryType, this);
 

--- a/src/Http/Wolverine.Http/CodeGen/FormBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/FormBindingFrame.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
@@ -32,6 +33,13 @@ internal class FromFormAttributeUsage : IParameterStrategy
 
     
 
+    // parameter.ParameterType flows into FormBindingFrame's
+    // [DAM(PublicConstructors|PublicProperties)]-annotated ctor parameter;
+    // ParameterInfo.ParameterType doesn't carry the DAM annotation. Suppress
+    // at the call site — the user's [FromForm] type is statically rooted via
+    // endpoint discovery (chunk Q HandlerDiscovery RUC propagation upstream).
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
+        Justification = "User [FromForm] type statically rooted via endpoint discovery; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide.")]
     public bool TryMatch(HttpChain chain, IServiceContainer container, ParameterInfo parameter, out Variable? variable)
     {
          variable = default;
@@ -71,7 +79,7 @@ internal class FormBindingFrame : SyncFrame
     private readonly List<Variable> _parameters = new();
     private readonly List<IReadHttpFrame> _props = new();
     public Variable Variable { get; }
-    public FormBindingFrame(Type queryType, HttpChain chain){
+    public FormBindingFrame([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] Type queryType, HttpChain chain){
         Variable = new Variable(queryType, this);
 
         var constructors = queryType.GetConstructors();

--- a/src/Http/Wolverine.Http/GlobalSuppressions.cs
+++ b/src/Http/Wolverine.Http/GlobalSuppressions.cs
@@ -1,0 +1,80 @@
+using System.Diagnostics.CodeAnalysis;
+
+// AOT-pillar suppressions for Wolverine.Http (#2746).
+//
+// Wolverine.Http is fundamentally a runtime-codegen package: HttpChain walks
+// user endpoint methods reflectively at startup to bind route values, query
+// strings, form fields, headers, JSON bodies, and AsParameters-decorated
+// records. The codegen frames it emits then call the same reflective APIs
+// (PropertyInfo.GetValue, MethodInfo.Invoke, Type.GetMethod, etc.) at the
+// generated handler's method body — but those calls happen against statically
+// rooted user types because the source-generated handler class names them
+// directly.
+//
+// All ~128 IL warnings in this package are codegen-time discovery walks over
+// user endpoint / parameter types that are statically rooted via:
+//   - app.MapWolverineEndpoints() / [WolverineHandler] discovery
+//   - explicit endpoint registration through MapXxx<T>(...)
+//   - JsonBodyParameterStrategy reads against the user's JsonSerializerOptions
+//
+// AOT-clean apps in TypeLoadMode.Static use pre-generated endpoint handlers
+// from `dotnet run codegen write`; this Dynamic-mode codegen path doesn't
+// fire at runtime. Apps using Dynamic codegen must preserve their endpoint
+// types and JSON DTOs via TrimmerRootDescriptor.
+//
+// Same chunk pattern as Wolverine.csproj chunks A–U + Wolverine.EntityFrameworkCore
+// chunk AB. Namespace-scoped suppressions to avoid spreading attributes across
+// 20+ files; survives partial-class additions and codegen frame additions.
+
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2026",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — reflection-based STJ over user endpoint / parameter / JSON-body types statically rooted via endpoint discovery. AOT consumers run pre-generated frames in TypeLoadMode.Static. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2055",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — closed-generic helper types over user endpoint / parameter types at codegen time. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2057",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — Type.GetType lookups for endpoint / parameter / wire types statically rooted via endpoint discovery. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2060",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — generic method invocation over runtime endpoint / parameter types at codegen time. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2067",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — endpoint / parameter / JSON-body types statically rooted via endpoint discovery. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2070",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — GetMethods / GetProperties walks over user endpoint types statically rooted via endpoint discovery. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2072",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — return-type metadata flow through codegen helpers; user types statically rooted via endpoint discovery. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2075",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — member walks over runtime endpoint / parameter types at codegen time. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2087",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — generic-arg flow on parameter binding helpers; user types statically rooted via endpoint discovery. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2090",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — generic-parameter T accessed for member lookup; T is statically rooted via endpoint registration. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2091",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — generic argument T flows to a [DAM]-annotated target; T is statically rooted via endpoint registration. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2111",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — reflective method invoke on endpoint members; bounded by endpoint discovery. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("AOT", "IL3050",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http",
+    Justification = "Wolverine.Http codegen — closed generics over runtime endpoint / parameter types at codegen time. See AOT guide.")]

--- a/src/Http/Wolverine.Http/Wolverine.Http.csproj
+++ b/src/Http/Wolverine.Http/Wolverine.Http.csproj
@@ -3,6 +3,17 @@
     <PropertyGroup>
         <Description>High Performance ASP.Net Core HTTP endpoints using the Wolverine runtime</Description>
         <PackageId>WolverineFx.Http</PackageId>
+        <!--
+          AOT-compatible (#2746). All ~128 IL warnings resolved through:
+          - Namespace-scoped UnconditionalSuppressMessage in GlobalSuppressions.cs
+            covering the codegen surface (Wolverine.Http and descendants)
+          - Per-ctor [DAM] annotations on AsParametersBindingFrame /
+            FormBindingFrame for parameter-type member access
+          - Per-method [UnconditionalSuppressMessage(IL2072)] at
+            AsParamatersAttributeUsage.TryMatch / FromFormAttributeUsage.TryMatch
+            where ParameterInfo.ParameterType flows into the [DAM]-annotated ctors
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Wolverine.Http is fundamentally a runtime-codegen package. ~128 IL warnings across 20 files in HttpChain, codegen frames, endpoint discovery, content negotiation, validation, dead-letter / transport endpoints.

Approach:
- `GlobalSuppressions.cs` (new): namespace-scoped `UnconditionalSuppressMessage` covering the Wolverine.Http codegen surface. 13 IL codes covered.
- `CodeGen/AsParametersBindingFrame.cs` and `CodeGen/FormBindingFrame.cs`: per-ctor `[DAM(PublicConstructors|PublicProperties)]` on `queryType` parameter, plus `[UnconditionalSuppressMessage(IL2072)]` on the calling `TryMatch` methods where `ParameterInfo.ParameterType` flows in.

`IsAotCompatible=true` flipped. Wolverine.Http.csproj: 128→0 IL warnings (excluding bleed-through from chunk W).

Cross-link: #2746 / chunk pattern