### PR TITLE
AOT chunk AE: flip IsAotCompatible=true on Wolverine.Postgresql (#2746)

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx;
 using JasperFx.Core;
@@ -59,6 +60,14 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>
         return dataSource;
     }
 
+    // typeof(DatabaseSagaSchema<,>).CloseAndBuildAs<IDatabaseSagaSchema>(...) at L89
+    // closes the saga schema generic over (sagaType, idType) at startup. Same
+    // chunk D / I / J / K CloseAndBuildAs pattern: AOT-clean apps preserve
+    // saga state types via TrimmerRootDescriptor. Cross-link to #2769.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "DatabaseSagaSchema<,> closed over runtime saga / id types at startup; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide / #2769.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "DatabaseSagaSchema<,> closed over runtime saga / id types at startup; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide / #2769.")]
     public PostgresqlMessageStore(DatabaseSettings databaseSettings, DurabilitySettings settings, NpgsqlDataSource dataSource,
         ILogger<PostgresqlMessageStore> logger, IEnumerable<SagaTableDefinition> sagaTypes) : base(databaseSettings, dataSource,
         settings, logger, new PostgresqlMigrator(), PostgresqlProvider.Instance)

--- a/src/Persistence/Wolverine.Postgresql/Sagas/DatabaseSagaSchema.cs
+++ b/src/Persistence/Wolverine.Postgresql/Sagas/DatabaseSagaSchema.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using JasperFx;
 using JasperFx.Core.Reflection;
@@ -12,6 +13,15 @@ using Wolverine.Postgresql;
 using Wolverine.RDBMS;
 using Wolverine.RDBMS.Sagas;
 
+// AOT note (#2746): Reflection-based STJ over runtime saga state type T.
+// Same chunk D / chunk Z (RavenDb) pattern: AOT consumers using lightweight
+// Postgres saga storage supply a JsonSerializerContext for their saga state
+// types or preserve via TrimmerRootDescriptor. T is statically rooted via
+// the saga registration (SagaTableDefinition).
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Reflection-based STJ over runtime saga state type; AOT consumers supply a JsonSerializerContext. See AOT guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Reflection-based STJ over runtime saga state type; AOT consumers supply a JsonSerializerContext. See AOT guide.")]
 public class DatabaseSagaSchema<T, TId> : IDatabaseSagaSchema<TId, T> where T : Saga
 {
     private readonly DatabaseSettings _settings;

--- a/src/Persistence/Wolverine.Postgresql/Wolverine.Postgresql.csproj
+++ b/src/Persistence/Wolverine.Postgresql/Wolverine.Postgresql.csproj
@@ -8,6 +8,16 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          AOT-compatible (#2746). Two reflective sites suppressed:
+          - PostgresqlMessageStore ctor: typeof(DatabaseSagaSchema<,>)
+            .CloseAndBuildAs over runtime saga / id types at startup
+          - DatabaseSagaSchema<T,TId>: reflection-based STJ over runtime
+            saga state type T (chunk D / chunk Z pattern)
+          AOT consumers preserve saga state types via TrimmerRootDescriptor
+          or supply a JsonSerializerContext.
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Two reflective sites in this package:

- `PostgresqlMessageStore` ctor: `typeof(DatabaseSagaSchema<,>).CloseAndBuildAs` over runtime saga / id types at startup. Same chunk D/I/J/K CloseAndBuildAs pattern.
- `DatabaseSagaSchema<T,TId>`: class-level `[UnconditionalSuppressMessage(IL2026, IL3050)]` for reflection-based JsonSerializer over the runtime saga state type T (Insert, Update, Load methods). Same chunk D / chunk Z (RavenDb) pattern.

AOT consumers preserve saga state types via `TrimmerRootDescriptor` or supply a `JsonSerializerContext`.

`IsAotCompatible=true` flipped. Wolverine.Postgresql.csproj: 8→0 IL warnings (excluding bleed-through from chunk W).

Cross-link: #2746 / chunk D pattern / #2769