### PR TITLE
Remove TPL Dataflow leftovers from Wolverine core

### DIFF
--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -1,7 +1,6 @@
 #nullable enable
 
 using System.Text.Json;
-using System.Threading.Tasks.Dataflow;
 using ImTools;
 using JasperFx.CommandLine.Descriptions;
 using JasperFx.Core;

--- a/src/Wolverine/Configuration/IListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/IListenerConfiguration.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks.Dataflow;
-using Wolverine.Runtime.Serialization;
+﻿using Wolverine.Runtime.Serialization;
 using Wolverine.Runtime.Serialization.Encryption;
 using Wolverine.Transports;
 

--- a/src/Wolverine/Configuration/ListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/ListenerConfiguration.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Threading.Tasks.Dataflow;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Wolverine.Runtime;

--- a/src/Wolverine/Transports/Sending/SendingAgent.cs
+++ b/src/Wolverine/Transports/Sending/SendingAgent.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks.Dataflow;
 using JasperFx.Blocks;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
@@ -46,7 +45,7 @@ public abstract class SendingAgent : ISendingAgent, ISenderCallback, ISenderCirc
             ? sendWithCallbackHandlingAsync
             : sendWithExplicitHandlingAsync;
 
-        _sending = new RetryBlock<Envelope>(senderDelegate, logger, _settings.Cancellation, new ExecutionDataflowBlockOptions());
+        _sending = new RetryBlock<Envelope>(senderDelegate, logger, _settings.Cancellation);
     }
 
     public ISender Sender => _sender;


### PR DESCRIPTION
## Summary

Per Critter Stack 2026 direction, TPL Dataflow is not used in this release wave. The explicit \`<PackageReference Include=\"System.Threading.Tasks.Dataflow\" />\` was already dropped from \`Wolverine.csproj\` in an earlier AOT chunk; this PR clears the four orphaned \`using\` directives plus the one remaining usage.

## Changes

| File | Change |
|---|---|
| \`src/Wolverine/Configuration/IListenerConfiguration.cs\` | Drop leftover \`using System.Threading.Tasks.Dataflow;\` — file references no Dataflow API surface |
| \`src/Wolverine/Configuration/ListenerConfiguration.cs\` | Same |
| \`src/Wolverine/Configuration/Endpoint.cs\` | Same (\`MaxDegreeOfParallelism\` here is a plain \`int\`, not a Dataflow type) |
| \`src/Wolverine/Transports/Sending/SendingAgent.cs\` | Drop leftover \`using\` + drop \`new ExecutionDataflowBlockOptions()\` argument from the \`RetryBlock<Envelope>\` construction. Options object was empty and the constructor it bound to is being removed in [jasperfx#272](https://github.com/JasperFx/jasperfx/pull/272) |

## Verification

- [x] \`grep\` confirms zero remaining references to \`System.Threading.Tasks.Dataflow\`, \`ExecutionDataflowBlockOptions\`, \`ActionBlock\`, \`BatchBlock\`, \`BufferBlock\`, \`TransformBlock\`, \`ITargetBlock\`, \`ISourceBlock\` across \`src/Wolverine/\`
- [x] \`dotnet build src/Wolverine/Wolverine.csproj -c Debug\` — 0 errors, 0 warnings
- [ ] CI passes

## Companion to

- **jasperfx#272** — JasperFx-side TPL Dataflow removal + [Obsolete] sweep. Drops the \`RetryBlock\` constructor overloads that took \`ExecutionDataflowBlockOptions\`, which is why \`SendingAgent.cs:49\` needs to drop its argument here.
- Marten companion PR follows for the one Dataflow site in the EventPublisher sample.

Stats: \`4 files changed, 2 insertions(+), 6 deletions(-)\`.