### PR TITLE
Fix VSTHRD103 build break in DbContextUsageSource (blocks all open PRs)

### DIFF
--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/DbContextUsageSource.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/DbContextUsageSource.cs
@@ -126,14 +126,13 @@ public sealed class TenantedDbContextUsageSource<T> : IDbContextUsageSource wher
             }
             finally
             {
-                if (mainContext is IAsyncDisposable ad)
-                {
-                    await ad.DisposeAsync();
-                }
-                else
-                {
-                    mainContext.Dispose();
-                }
+                // DbContext implements IAsyncDisposable since EF Core 3.0 — and
+                // mainContext is statically typed T : DbContext — so always
+                // prefer DisposeAsync() to satisfy VSTHRD103 and avoid
+                // unnecessarily blocking on synchronous Dispose() in this
+                // async snapshot path. The previous if/else split was dead
+                // code: every concrete T reachable here is IAsyncDisposable.
+                await mainContext.DisposeAsync();
             }
         }
         catch


### PR DESCRIPTION
## Summary

Fix `VSTHRD103: Dispose synchronously blocks. Await DisposeAsync instead.` in `TenantedDbContextUsageSource<T>.TryCreateUsage`. The previous if/else split in the `finally` clause was dead code: `mainContext` is statically typed `T : DbContext`, and `DbContext` has implemented `IAsyncDisposable` since EF Core 3.0 — so the synchronous `Dispose()` branch was never reachable. Replace with a single `await mainContext.DisposeAsync()`.

## Why this is urgent

This is currently a hard build break against `main`. `TreatWarningsAsErrors=true` is set globally in `Directory.Build.props`, so the analyzer error on this one line fails the `Compile` target and blocks every in-flight PR's CI run that builds the full solution:

- AOT chunks W–AE: #2781, #2782, #2783, #2784, #2785, #2786, #2787, #2788, #2789 — all `feature/aot-chunk-*` branches.
- Architectural follow-ups: #2755, #2769, #2757 (queued behind these).

The break landed in #2720 (CritterWatch unification), which added `DbContextUsageSource.cs` with the if/else block. This single-line fix unblocks every pending PR's next CI run.

## Behavior

No change. `DbContext.DisposeAsync()` is the right disposer for any concrete `T` reachable here.

## Test plan

- [x] `dotnet build src/Persistence/Wolverine.EntityFrameworkCore/Wolverine.EntityFrameworkCore.csproj -c Release -f net9.0` — 0 warnings, 0 errors.
- [x] Same build clean for `-f net10.0`.
- [x] Reproduces the original failure on `main` before the fix; passes after.
- [ ] Full CI suite via this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
