### PR TITLE
AOT #2769 Option A: pre-populate per-message-type CloseAndBuildAs caches

### DIFF
--- a/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
@@ -394,6 +394,17 @@ public partial class HandlerGraph : ICodeFileCollectionWithServices, IWithFailur
         tryApplyLocalQueueConfiguration(options);
 
         options.MessagePartitioning.MaybeInferGrouping(this);
+
+        // Pre-populate the per-message-type cascading-async-enumerable cache on
+        // MessageContext so the reflective lazy-init in
+        // MessageContext.ResolveTypedAsyncEnumerableCascader never fires at
+        // steady state. AOT pillar follow-up #2769 (Option A).
+        var allMessageTypes = AllMessageTypes().ToArray();
+        MessageContext.PrepopulateCascadeCache(allMessageTypes);
+
+        // Same Option A pre-population for the IntrinsicSerializer<T> cache so
+        // ISerializable message types skip the first-occurrence CloseAndBuildAs.
+        Wolverine.Runtime.Serialization.IntrinsicSerializer.Instance.Prepopulate(allMessageTypes);
     }
 
     private void compileWithRuntimeScanning(WolverineOptions options, ILogger logger)

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -765,6 +765,43 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
         return method;
     }
 
+    /// <summary>
+    /// Pre-populate the typed-enumerable cascader cache with the supplied message
+    /// types. Called from <see cref="Wolverine.Runtime.Handlers.HandlerGraph.Compile"/>
+    /// after handler-graph compilation so the per-message
+    /// <see cref="ResolveTypedAsyncEnumerableCascader"/> hot path never pays the
+    /// first-occurrence reflection cost (GetInterfaces walk + MakeGenericMethod).
+    /// Closes the AOT story for the cascading-async-enumerable resolution from
+    /// AOT pillar issue #2769 — at steady state the cache is pre-warmed and the
+    /// reflective miss path inside <see cref="ResolveTypedAsyncEnumerableCascader"/>
+    /// never fires.
+    /// </summary>
+    /// <remarks>
+    /// Tolerates duplicates; the underlying <c>ImHashMap.AddOrUpdate</c> is idempotent.
+    /// Tolerates a null source for defensive callers.
+    /// </remarks>
+    /// <param name="messageTypes">Message types to resolve and cache.</param>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Pre-populating the typed-enumerable cache at handler-graph compile time; same suppression as ResolveTypedAsyncEnumerableCascader. See AOT guide / #2769.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2060",
+        Justification = "Pre-populating the typed-enumerable cache at handler-graph compile time; same suppression as ResolveTypedAsyncEnumerableCascader. See AOT guide / #2769.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Pre-populating the typed-enumerable cache at handler-graph compile time; same suppression as ResolveTypedAsyncEnumerableCascader. See AOT guide / #2769.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Pre-populating the typed-enumerable cache at handler-graph compile time; same suppression as ResolveTypedAsyncEnumerableCascader. See AOT guide / #2769.")]
+    internal static void PrepopulateCascadeCache(IEnumerable<Type>? messageTypes)
+    {
+        if (messageTypes == null) return;
+
+        foreach (var messageType in messageTypes)
+        {
+            if (messageType == null) continue;
+            if (_typedEnumerableCascadeMethods.TryFind(messageType, out _)) continue;
+
+            ResolveTypedAsyncEnumerableCascader(messageType);
+        }
+    }
+
     private static async Task CascadeTypedItemsAsync<T>(IAsyncEnumerable<T> source, MessageContext context)
     {
         await foreach (var item in source)

--- a/src/Wolverine/Runtime/Serialization/IntrinsicSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/IntrinsicSerializer.cs
@@ -68,6 +68,40 @@ public class IntrinsicSerializer : IMessageSerializer
     {
         throw new NotSupportedException();
     }
+
+    /// <summary>
+    /// Pre-populate the per-message-type IntrinsicSerializer&lt;T&gt; cache with the
+    /// supplied message types that implement <see cref="ISerializable"/>. Called
+    /// from <see cref="Wolverine.Runtime.Handlers.HandlerGraph.Compile"/> after
+    /// handler-graph compilation so the per-message Write/ReadFromData hot path
+    /// never pays the first-occurrence CloseAndBuildAs over
+    /// IntrinsicSerializer&lt;T&gt;. Closes the AOT story for ISerializable
+    /// dispatch from AOT pillar issue #2769.
+    /// </summary>
+    /// <remarks>
+    /// Skips message types that don't implement ISerializable — those are served
+    /// by the default JSON serializer (or whatever the endpoint configures).
+    /// Tolerates duplicates and a null source.
+    /// </remarks>
+    /// <param name="messageTypes">Message types to resolve and cache.</param>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Pre-populating the IntrinsicSerializer<T> cache at handler-graph compile time; same suppression as Write/ReadFromData. See AOT guide / #2769.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Pre-populating the IntrinsicSerializer<T> cache at handler-graph compile time; same suppression as Write/ReadFromData. See AOT guide / #2769.")]
+    internal void Prepopulate(IEnumerable<Type>? messageTypes)
+    {
+        if (messageTypes == null) return;
+
+        foreach (var messageType in messageTypes)
+        {
+            if (messageType == null) continue;
+            if (!messageType.CanBeCastTo(typeof(ISerializable))) continue;
+            if (_inner.TryFind(messageType, out _)) continue;
+
+            var serializer = typeof(IntrinsicSerializer<>).CloseAndBuildAs<IMessageSerializer>(messageType);
+            _inner = _inner.AddOrUpdate(messageType, serializer);
+        }
+    }
 }
 
 internal class IntrinsicSerializer<T> : IMessageSerializer where T : ISerializable

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -148,6 +148,15 @@ public partial class WolverineRuntime
                     break;
             }
 
+            // Pre-populate the per-message-type router cache so the per-message
+            // RoutingFor() hot path never pays the first-occurrence
+            // CloseAndBuildAs over MessageRouter<T> / EmptyMessageRouter<T>.
+            // Must happen AFTER the messaging transports start (so external-
+            // transport route sources can resolve their endpoints), but
+            // before RuntimeIsFullyStarted observers run. AOT pillar follow-up
+            // #2769 (Option A).
+            PrepopulateRoutingCache(Handlers.AllMessageTypes());
+
             await Observer.RuntimeIsFullyStarted();
             _hasStarted = true;
 

--- a/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
@@ -200,6 +200,42 @@ public partial class WolverineRuntime
         return routes;
     }
 
+    /// <summary>
+    /// Pre-populate the per-message-type router cache with the supplied message
+    /// types. Called from <see cref="WolverineRuntime.HostService.StartAsync"/>
+    /// after the handler graph has compiled and the route sources are wired up,
+    /// so the per-message <see cref="RoutingFor"/> hot path never pays the
+    /// first-occurrence reflection cost (CloseAndBuildAs over MessageRouter&lt;T&gt;
+    /// / EmptyMessageRouter&lt;T&gt;). Closes the AOT story for the per-message
+    /// router resolution from AOT pillar issue #2769.
+    /// </summary>
+    /// <remarks>
+    /// Tolerates duplicates and the typeof(object) sentinel; <see cref="RoutingFor"/>
+    /// itself filters those. <see cref="System.IsSystemMessageType"/>-flagged types
+    /// are still visited so framework-internal routers get cached too — the
+    /// cache lookup is the same dictionary either way.
+    /// </remarks>
+    /// <param name="messageTypes">Message types to resolve and cache.</param>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Pre-populating the message-router cache at host startup; same suppression as RoutingFor. See AOT guide / #2769.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Pre-populating the message-router cache at host startup; same suppression as RoutingFor. See AOT guide / #2769.")]
+    internal void PrepopulateRoutingCache(IEnumerable<Type>? messageTypes)
+    {
+        if (messageTypes == null) return;
+
+        foreach (var messageType in messageTypes)
+        {
+            if (messageType == null) continue;
+            if (messageType == typeof(object)) continue;
+            if (_messageTypeRouting.TryFind(messageType, out _)) continue;
+
+            // RoutingFor populates _messageTypeRouting as a side effect of the
+            // cache-miss path. Just drop the result.
+            _ = RoutingFor(messageType);
+        }
+    }
+
     internal ISendingAgent? DetermineLocalSendingAgent(Type messageType)
     {
         if (Options.LocalRouting.Assignments.TryGetValue(messageType, out var endpoint))


### PR DESCRIPTION
## Summary

Implements Option A from #2769: pre-populate three per-message-type `ImHashMap` caches at bootstrap time so the leaf-suppressed `CloseAndBuildAs` miss paths never fire at steady state.

Caches pre-populated:

1. `MessageContext._typedEnumerableCascadeMethods` — closes `ResolveTypedAsyncEnumerableCascader<T>` per message type. New internal `MessageContext.PrepopulateCascadeCache(IEnumerable<Type>?)` walks each type and seeds.
2. `WolverineRuntime._messageTypeRouting` — closes `MessageRouter<T>` / `EmptyMessageRouter<T>` per message type. New internal `WolverineRuntime.PrepopulateRoutingCache(IEnumerable<Type>?)` walks types and calls `RoutingFor(messageType)` to seed as a side effect.
3. `IntrinsicSerializer._inner` — closes `IntrinsicSerializer<T>` per `ISerializable` message type. New internal `IntrinsicSerializer.Prepopulate(IEnumerable<Type>?)` filters to `ISerializable` and seeds.

Wiring:

- `HandlerGraph.Compile` calls `MessageContext.PrepopulateCascadeCache(allMessageTypes)` and `IntrinsicSerializer.Instance.Prepopulate(allMessageTypes)` at the end of compile.
- `WolverineRuntime.HostService.StartAsync` calls `PrepopulateRoutingCache(Handlers.AllMessageTypes())` just before `RuntimeIsFullyStarted`.

## Why

Continuation of the AOT pillar (#2746). The three reflective `CloseAndBuildAs` paths carry leaf `[UnconditionalSuppressMessage]` annotations because they fall on hot dispatch / send paths — annotating up the call graph would cascade into every public send/publish API. AOT-clean apps in `TypeLoadMode.Static` now pre-populate at startup so the leaf miss paths never fire in steady state. Trim-only apps without source generation still need `MessageRouter<>` etc. preserved via `TrimmerRootDescriptor` — see the AOT publishing guide.

## Files touched

- `src/Wolverine/Runtime/MessageContext.cs` — new `PrepopulateCascadeCache` + 4 `[UnconditionalSuppressMessage]` justifications cross-linked to #2769.
- `src/Wolverine/Runtime/WolverineRuntime.Routing.cs` — new `PrepopulateRoutingCache`.
- `src/Wolverine/Runtime/Serialization/IntrinsicSerializer.cs` — new `Prepopulate(IEnumerable<Type>?)`.
- `src/Wolverine/Runtime/Handlers/HandlerGraph.cs` — wires the two compile-time pre-populators.
- `src/Wolverine/Runtime/WolverineRuntime.HostService.cs` — wires the bootstrap-time routing pre-populator.

## Test plan

- [x] `dotnet build src/Wolverine/Wolverine.csproj -f net9.0` — 0 warnings, 0 errors.
- [x] 138/138 tests pass on Routing + Cascade + Saga slices.
- [ ] Full CI suite via this PR (pending #2792 — VSTHRD103 build break).

Closes #2769.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
