### PR TITLE
AOT #2757: explicit IForwardsTo<T> registration replaces assembly scan (BREAKING)

### DIFF
--- a/docs/guide/messages.md
+++ b/docs/guide/messages.md
@@ -421,6 +421,19 @@ Using this strategy, other systems could still send your system the original `ap
 message, and on the receiving end, Wolverine would know to deserialize the Json data into the `PersonBorn` object, then call its
 `Transform()` method to build out the `PersonBornV2` type that matches up with your message handler.
 
+::: warning Wolverine 6.0 breaking change
+Prior to 6.0, Wolverine scanned the application assembly at startup for `IForwardsTo<T>` implementations and registered them
+automatically. That scan is gone in 6.0 because it is not trim/AOT-clean. Register your forwarders explicitly:
+
+```csharp
+opts.RegisterMessageForwarder<PersonBorn, PersonBornV2>();
+```
+
+If you need the legacy behavior temporarily while migrating, opt back into the assembly scan with
+`opts.UseAutomaticForwarderDiscovery()`. That method is `[Obsolete]` and slated for removal in 7.0; new code should prefer
+the explicit `RegisterMessageForwarder<TFrom, TTo>()` API. See `docs/guide/migration.md` and issue #2757.
+:::
+
 ## "Self Serializing" Messages
 
 ::: info

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -24,6 +24,7 @@ The table below is the **complete inventory** of changed defaults, removed APIs,
 | `OperationRole` namespace | `Marten.Internal.Operations` | `Weasel.Core` *(BREAKING)* | Add `using Weasel.Core;` |
 | Target framework | `net8.0;net9.0;net10.0` | `net9.0;net10.0` *(BREAKING)* | Move to .NET 9+ or pin Wolverine 5.x |
 | Critter-stack package versions | 1.x line | 2.0-alpha line | Bump in lockstep across JasperFx, Marten, Polecat — full table below |
+| `IForwardsTo<T>` discovery | implicit assembly scan at startup | **explicit `opts.RegisterMessageForwarder<TFrom, TTo>()`** *(BREAKING)* | Register each forwarder explicitly; or temporarily call [`opts.UseAutomaticForwarderDiscovery()`](#iforwardsto-discovery-is-now-explicit-breaking) (`[Obsolete]`, removed in 7.0) |
 | **One-line full revert** | n/a | [`opts.RestoreV5Defaults()`](#one-line-revert-restorev5defaults) | Flip every runtime default this method covers back to its 5.x value |
 
 ::: tip
@@ -139,6 +140,34 @@ The call surface itself is unchanged — `opts.UseNewtonsoftForSerialization(set
 Transports that pin a `NewtonsoftSerializer` internally for NServiceBus / MassTransit wire-compat (RabbitMQ's `UseNServiceBusInterop()`, the AWS SQS and SNS NServiceBus mappers, Azure Service Bus listeners) carry the `WolverineFx.Newtonsoft` dependency for you. You don't need to install it explicitly unless you call one of the Newtonsoft APIs from your own code.
 
 In a related cleanup, `Subscription.Scope` no longer carries a `[Newtonsoft.Json.Converters.StringEnumConverter]` attribute — it's now annotated with `[System.Text.Json.Serialization.JsonStringEnumConverter]`. Wire format is unchanged (still string-named scopes). If you serialize `Subscription` instances yourself with Newtonsoft and rely on the string-named scope shape, configure `StringEnumConverter` on your own settings explicitly.
+
+### `IForwardsTo<T>` discovery is now explicit (BREAKING)
+
+Wolverine 5.x scanned the application assembly at handler-graph compile time for every concrete type that implemented `IForwardsTo<T>` and wired the source-type → target-type forwarding automatically. That scan walks `Assembly.ExportedTypes` and is **not trim/AOT-clean** — so 6.0 removes it from the default startup path as part of the [AOT pillar](https://github.com/JasperFx/wolverine/issues/2746). Any application that relied on the implicit scan needs to opt in to one of two paths:
+
+**Preferred upgrade path** — register each `IForwardsTo<T>` pair explicitly in your `UseWolverine` lambda:
+
+```csharp
+opts.RegisterMessageForwarder<PersonBorn, PersonBornV2>();
+```
+
+There's also a single-type-argument overload that derives the target type from the `IForwardsTo<>` closure (handy for attribute-driven helpers):
+
+```csharp
+opts.RegisterMessageForwarder<PersonBorn>(); // resolves to <PersonBorn, PersonBornV2>
+```
+
+Both forms feed `WolverineOptions.ExplicitMessageForwarders`, which is drained inside `HandlerGraph.Compile` — exactly where `Forwarders.FindForwards(Assembly)` used to run. The on-the-wire dispatch behavior (the older message type's `Transform()` builds the newer message, the newer message's handler runs) is unchanged.
+
+**Escape hatch — opt back into the legacy scan:**
+
+```csharp
+opts.UseAutomaticForwarderDiscovery();
+```
+
+This re-enables the 5.x assembly scan against `WolverineOptions.ApplicationAssembly`. It is marked `[Obsolete]` and `[RequiresUnreferencedCode]` because the underlying scan walks exported types and the trimmer cannot prove which forwarder types are reachable. It is provided as a backward-compatibility escape valve for the 6.0 release cycle and is **slated for removal in 7.0** — migrate to `RegisterMessageForwarder<TFrom, TTo>()` before then.
+
+If you don't use `IForwardsTo<T>` at all, no change is needed.
 
 ### Performance: per-endpoint serializer cache pre-population
 

--- a/src/Testing/CoreTests/Transports/Tcp/message_forwarding.cs
+++ b/src/Testing/CoreTests/Transports/Tcp/message_forwarding.cs
@@ -17,6 +17,10 @@ public class message_forwarding
             opts.DisableConventionalDiscovery();
             opts.IncludeType<NewMessageHandler>();
 
+            // 6.0: forwarders are no longer auto-discovered from the application
+            // assembly — register the IForwardsTo pair explicitly. See #2757.
+            opts.RegisterMessageForwarder<OriginalMessage, NewMessage>();
+
             opts.Publish(x =>
             {
                 x.Message<OriginalMessage>();

--- a/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
@@ -322,16 +322,17 @@ public partial class HandlerGraph : ICodeFileCollectionWithServices, IWithFailur
         return handler;
     }
 
-    // Compile is the bootstrap-time handler-graph build. The IL2026 here comes
-    // from the call to Forwarders.FindForwards (which carries
-    // [RequiresUnreferencedCode]) plus registerMessageTypes' MakeGenericType
-    // /GetInterfaces walks. Pre-population of _messageTypes / _handlers caches
-    // would close most of these — tracked in #2769 (CloseAndBuildAs elimination)
-    // and the IForwardsTo follow-up #2757. Until those land, suppress at the
-    // Compile boundary: a single annotation here keeps WolverineRuntime
-    // .StartAsync (the public bootstrap entry point) free of the cascade.
+    // Compile is the bootstrap-time handler-graph build. The remaining IL2026
+    // here comes from registerMessageTypes' MakeGenericType / GetInterfaces walks
+    // (pre-population work tracked in #2769) and from the opt-in
+    // Forwarders.FindForwards path that runs only when
+    // options.AutomaticForwarderDiscoveryEnabled is true (the 6.0 explicit
+    // RegisterMessageForwarder API replaced the unconditional scan — see #2757).
+    // Suppress at the Compile boundary: a single annotation here keeps
+    // WolverineRuntime.StartAsync (the public bootstrap entry point) free of
+    // the cascade.
     [UnconditionalSuppressMessage("Trimming", "IL2026",
-        Justification = "Bootstrap-time handler-graph build; Forwarders.FindForwards assembly scan + per-message-type cache population. Pre-population work tracked in #2769 / #2757. See AOT guide.")]
+        Justification = "Bootstrap-time handler-graph build; per-message-type cache population (#2769) plus opt-in Forwarders.FindForwards assembly scan (#2757). See AOT guide.")]
     internal void Compile(WolverineOptions options, IServiceContainer container)
     {
         if (_hasCompiled)
@@ -383,8 +384,24 @@ public partial class HandlerGraph : ICodeFileCollectionWithServices, IWithFailur
 
         Container = container;
 
+        // 6.0 forwarder registration: drain the explicit
+        // WolverineOptions.RegisterMessageForwarder<TFrom, TTo>() registrations
+        // first (AOT-clean — no reflective assembly walk), then optionally
+        // run the legacy Forwarders.FindForwards(ApplicationAssembly) scan
+        // when the user opted in via UseAutomaticForwarderDiscovery(). The
+        // pre-6.0 unconditional scan is gone — see #2757 and
+        // docs/guide/migration.md.
         var forwarders = new Forwarders();
-        forwarders.FindForwards(options.ApplicationAssembly!);
+        foreach (var pair in options.ExplicitMessageForwarders)
+        {
+            forwarders.Relationships[pair.Key] = pair.Value;
+        }
+
+        if (options.AutomaticForwarderDiscoveryEnabled && options.ApplicationAssembly is not null)
+        {
+            forwarders.FindForwards(options.ApplicationAssembly);
+        }
+
         AddForwarders(forwarders);
 
         foreach (var configuration in _configurations) configuration();

--- a/src/Wolverine/WolverineOptions.Forwarders.cs
+++ b/src/Wolverine/WolverineOptions.Forwarders.cs
@@ -1,0 +1,124 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine;
+
+public sealed partial class WolverineOptions
+{
+    /// <summary>
+    /// Explicit (TForwarder, TForwarded) message-forwarder registrations made via
+    /// <see cref="RegisterMessageForwarder{TFrom, TTo}"/> or
+    /// <see cref="RegisterMessageForwarder{TForwarder}"/>. Replaces the
+    /// pre-6.0 <c>Forwarders.FindForwards(Assembly)</c> assembly scan, which is
+    /// now opt-in via <see cref="UseAutomaticForwarderDiscovery"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Drained at <c>HandlerGraph.Compile</c> time and merged into the
+    /// runtime <see cref="Wolverine.Runtime.Serialization.Forwarders"/>
+    /// instance — the on-the-wire behavior of <c>IForwardsTo&lt;T&gt;</c>
+    /// dispatch (the old type forwards to the new type's handler) is
+    /// unchanged from 5.x.
+    /// </para>
+    /// </remarks>
+    internal Dictionary<Type, Type> ExplicitMessageForwarders { get; } = new();
+
+    /// <summary>
+    /// When <see langword="true"/>, <c>HandlerGraph.Compile</c> will scan
+    /// <see cref="ApplicationAssembly"/>'s exported types for concrete
+    /// <c>IForwardsTo&lt;T&gt;</c> implementations and register them as
+    /// message forwarders — the 5.x behavior. Default in 6.0 is
+    /// <see langword="false"/>; existing apps that relied on the implicit
+    /// scan should either call <see cref="UseAutomaticForwarderDiscovery"/>
+    /// or migrate to <see cref="RegisterMessageForwarder{TFrom, TTo}"/>
+    /// (recommended; see docs/guide/migration.md).
+    /// </summary>
+    internal bool AutomaticForwarderDiscoveryEnabled { get; set; }
+
+    /// <summary>
+    /// Register a message forwarder so that incoming messages of type
+    /// <typeparamref name="TFrom"/> are transformed into
+    /// <typeparamref name="TTo"/> via <see cref="IForwardsTo{T}.Transform"/>
+    /// before being dispatched to a <typeparamref name="TTo"/> handler.
+    /// </summary>
+    /// <typeparam name="TFrom">
+    /// The source message type. Must implement <see cref="IForwardsTo{TTo}"/>.
+    /// </typeparam>
+    /// <typeparam name="TTo">The target message type after transformation.</typeparam>
+    /// <returns>This <see cref="WolverineOptions"/> for fluent chaining.</returns>
+    /// <remarks>
+    /// 6.0 explicit-registration replacement for the pre-6.0
+    /// <c>Forwarders.FindForwards(Assembly)</c> assembly scan. See #2757 and
+    /// docs/guide/migration.md for the migration story.
+    /// </remarks>
+    public WolverineOptions RegisterMessageForwarder<TFrom, TTo>() where TFrom : IForwardsTo<TTo>
+    {
+        ExplicitMessageForwarders[typeof(TFrom)] = typeof(TTo);
+        return this;
+    }
+
+    /// <summary>
+    /// Register a message forwarder by inspecting the supplied type's
+    /// <see cref="IForwardsTo{T}"/> closure to derive the forwarded-to type.
+    /// Equivalent to calling
+    /// <see cref="RegisterMessageForwarder{TFrom, TTo}"/> with the resolved
+    /// pair — useful when only the source type is known statically (e.g.,
+    /// generic helper code or attribute-driven registration).
+    /// </summary>
+    /// <typeparam name="TForwarder">
+    /// A concrete type that implements <see cref="IForwardsTo{T}"/>.
+    /// </typeparam>
+    /// <returns>This <see cref="WolverineOptions"/> for fluent chaining.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <typeparamref name="TForwarder"/> doesn't implement
+    /// <see cref="IForwardsTo{T}"/>.
+    /// </exception>
+    public WolverineOptions RegisterMessageForwarder<TForwarder>()
+    {
+        var forwardingInterface = typeof(TForwarder).FindInterfaceThatCloses(typeof(IForwardsTo<>));
+        if (forwardingInterface is null)
+        {
+            throw new ArgumentException(
+                $"Type {typeof(TForwarder).FullName} does not implement {typeof(IForwardsTo<>).FullName}. " +
+                $"Use RegisterMessageForwarder<TFrom, TTo>() to specify both types explicitly.",
+                nameof(TForwarder));
+        }
+
+        var forwardedType = forwardingInterface.GetGenericArguments().Single();
+        ExplicitMessageForwarders[typeof(TForwarder)] = forwardedType;
+        return this;
+    }
+
+    /// <summary>
+    /// Re-enable the pre-6.0 behavior of scanning
+    /// <see cref="ApplicationAssembly"/>'s exported types for concrete
+    /// <see cref="IForwardsTo{T}"/> implementations at startup. Provided as
+    /// a backward-compatibility escape valve while apps migrate to the
+    /// explicit <see cref="RegisterMessageForwarder{TFrom, TTo}"/> API.
+    /// </summary>
+    /// <returns>This <see cref="WolverineOptions"/> for fluent chaining.</returns>
+    /// <remarks>
+    /// Marked <c>[Obsolete]</c> as a migration nudge and
+    /// <c>[RequiresUnreferencedCode]</c> because the underlying assembly
+    /// scan walks <see cref="System.Reflection.Assembly.ExportedTypes"/>
+    /// and trimming may remove forwarder types that are only reached
+    /// reflectively here. The explicit
+    /// <see cref="RegisterMessageForwarder{TFrom, TTo}"/> API is AOT-clean
+    /// and should be preferred for new code. Targeted for removal in 7.0.
+    /// </remarks>
+    [Obsolete(
+        "Migrate to the explicit RegisterMessageForwarder<TFrom, TTo>() API. " +
+        "UseAutomaticForwarderDiscovery() is provided as a backward-compatibility " +
+        "escape valve for the 6.0 release cycle and is targeted for removal in 7.0. " +
+        "See docs/guide/migration.md for the migration recipe.")]
+    [RequiresUnreferencedCode(
+        "UseAutomaticForwarderDiscovery() walks ApplicationAssembly.ExportedTypes for " +
+        "IForwardsTo<> implementations at HandlerGraph.Compile time. Trimming may remove " +
+        "forwarder types that are only reached reflectively. Migrate to " +
+        "RegisterMessageForwarder<TFrom, TTo>() — see docs/guide/migration.md.")]
+    public WolverineOptions UseAutomaticForwarderDiscovery()
+    {
+        AutomaticForwarderDiscoveryEnabled = true;
+        return this;
+    }
+}


### PR DESCRIPTION
## Summary

- Removes the unconditional `Forwarders.FindForwards(ApplicationAssembly)` assembly scan from `HandlerGraph.Compile` — the scan walks `Assembly.ExportedTypes` and is not trim/AOT-clean (carries `[RequiresUnreferencedCode]`).
- Adds explicit replacement APIs on `WolverineOptions`:
  - `RegisterMessageForwarder<TFrom, TTo>() where TFrom : IForwardsTo<TTo>` — AOT-clean explicit registration.
  - `RegisterMessageForwarder<TForwarder>()` — convenience overload that derives `TTo` from the `IForwardsTo<>` interface closure.
  - `UseAutomaticForwarderDiscovery()` — `[Obsolete]` + `[RequiresUnreferencedCode]` opt-in escape valve that re-enables the legacy 5.x scan. Targeted for removal in 7.0.
- `HandlerGraph.Compile` now drains `options.ExplicitMessageForwarders` unconditionally and only runs `Forwarders.FindForwards` when `options.AutomaticForwarderDiscoveryEnabled` is true.

This is a **breaking change** for any 5.x application that relied on the implicit assembly scan. Migration is one line per pair: `opts.RegisterMessageForwarder<PersonBorn, PersonBornV2>()`. The dispatch behavior (`Transform()` builds the new message, the new message's handler runs) is unchanged.

## Why

This is the third architectural follow-up under the AOT pillar (#2746) — alongside #2755 (FastExpressionCompiler removal) and #2769 (CloseAndBuildAs cache pre-population). The Forwarders scan was the last remaining `[RequiresUnreferencedCode]` call inside the Wolverine-core `HandlerGraph.Compile` path that we couldn't justify keeping on by default.

## Files touched

- `src/Wolverine/WolverineOptions.Forwarders.cs` — new partial; public API + internal state.
- `src/Wolverine/Runtime/Handlers/HandlerGraph.cs` — replaces the unconditional scan with the drain + opt-in path; updates the IL2026 leaf-suppression justification.
- `src/Testing/CoreTests/Transports/Tcp/message_forwarding.cs` — the only existing test that depended on the implicit scan; now calls `RegisterMessageForwarder<OriginalMessage, NewMessage>()`.
- `docs/guide/messages.md` — 6.0-breaking-change callout in the versioning section.
- `docs/guide/migration.md` — at-a-glance table row + full "IForwardsTo<T> discovery is now explicit" section covering both the explicit registration path and the obsolete escape valve.

## Test plan

- [x] `dotnet build src/Wolverine/Wolverine.csproj -f net9.0` — 0 warnings, 0 errors under `IsAotCompatible=true`.
- [x] `send_message_via_forwarding` test passes against the new explicit-registration call path.
- [x] Adjacent HandlerGraph / naming tests (29) continue to pass.
- [x] `DocumentationSamples` builds clean.
- [ ] Full CI suite via this PR (pending #2792 — VSTHRD103 build break).

Closes #2757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
