### PR TITLE
AOT chunk AF: flip IsAotCompatible=true on Wolverine.SqlServer (#2746)

### DIFF
--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx;
 using JasperFx.Core;
@@ -37,6 +38,14 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>
     
     private readonly List<ISchemaObject> _externalTables = new();
     
+    // typeof(DatabaseSagaSchema<,>).CloseAndBuildAs<IDatabaseSagaSchema>(...) at L56
+    // closes the saga schema generic over (sagaType, idType) at startup. Same
+    // chunk D / I / J / K / AE CloseAndBuildAs pattern: AOT-clean apps preserve
+    // saga state types via TrimmerRootDescriptor. Cross-link to #2769.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "DatabaseSagaSchema<,> closed over runtime saga / id types at startup; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide / #2769.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "DatabaseSagaSchema<,> closed over runtime saga / id types at startup; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide / #2769.")]
     public SqlServerMessageStore(DatabaseSettings database, DurabilitySettings settings,
         ILogger<SqlServerMessageStore> logger, IEnumerable<SagaTableDefinition> sagaTypes)
         : base(database, SqlClientFactory.Instance.CreateDataSource(database.ConnectionString!), settings, logger, new SqlServerMigrator(), SqlServerProvider.Instance)

--- a/src/Persistence/Wolverine.SqlServer/Sagas/DatabaseSagaSchema.cs
+++ b/src/Persistence/Wolverine.SqlServer/Sagas/DatabaseSagaSchema.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using JasperFx;
 using JasperFx.Core.Reflection;
@@ -11,6 +12,15 @@ using Wolverine.RDBMS.Sagas;
 
 namespace Wolverine.SqlServer.Sagas;
 
+// AOT note (#2746): Reflection-based STJ over runtime saga state type TSaga.
+// Same chunk D / chunk AE (Postgresql) pattern: AOT consumers using lightweight
+// SQL Server saga storage supply a JsonSerializerContext for their saga state
+// types or preserve via TrimmerRootDescriptor. TSaga is statically rooted via
+// the saga registration (SagaTableDefinition).
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Reflection-based STJ over runtime saga state type; AOT consumers supply a JsonSerializerContext. See AOT guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Reflection-based STJ over runtime saga state type; AOT consumers supply a JsonSerializerContext. See AOT guide.")]
 public class DatabaseSagaSchema<TId, TSaga> : IDatabaseSagaSchema<TId, TSaga> where TSaga : Saga
 {
     private readonly DatabaseSettings _settings;

--- a/src/Persistence/Wolverine.SqlServer/Wolverine.SqlServer.csproj
+++ b/src/Persistence/Wolverine.SqlServer/Wolverine.SqlServer.csproj
@@ -7,6 +7,20 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          AOT-compatible (#2746). Mirrors the chunk AE / Postgresql pattern.
+          Two reflective sites suppressed:
+          - SqlServerMessageStore ctor: typeof(DatabaseSagaSchema<,>)
+            .CloseAndBuildAs over runtime saga / id types at startup.
+            Cross-link to #2769 (CloseAndBuildAs elimination).
+          - Wolverine.SqlServer.Sagas.DatabaseSagaSchema<TId, TSaga>:
+            class-level [UnconditionalSuppressMessage] for reflection-based
+            STJ over the runtime saga state type T (Insert / Update / Load
+            methods). Same chunk D / chunk AE pattern.
+          AOT consumers preserve saga state types via TrimmerRootDescriptor
+          or supply a JsonSerializerContext.
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Wolverine.RDBMS\Wolverine.RDBMS.csproj" />


### PR DESCRIPTION
## Summary

Flips `<IsAotCompatible>true</IsAotCompatible>` on `Wolverine.SqlServer.csproj` and suppresses the two reflective sites that surface under the AOT analyzers. Mirrors the chunk AE / Postgresql pattern (#2789) almost exactly — `Wolverine.SqlServer` ships its own copy of `DatabaseSagaSchema<TId, TSaga>` alongside its own `SqlServerMessageStore`.

## Suppressions

- **`SqlServerMessageStore` ctor**: `typeof(DatabaseSagaSchema<,>).CloseAndBuildAs<IDatabaseSagaSchema>(...)` closes the saga schema generic over `(sagaType, idType)` at startup. Same chunk D / I / J / K / AE `CloseAndBuildAs` pattern; cross-link to #2769 (CloseAndBuildAs elimination tracked separately).
- **`Wolverine.SqlServer.Sagas.DatabaseSagaSchema<TId, TSaga>`**: class-level `[UnconditionalSuppressMessage(IL2026, IL3050)]` covers reflection-based STJ over the runtime saga state type `TSaga` (`Insert` / `Update` / `Load` methods).

`TSaga` is statically rooted via the `SagaTableDefinition` registration. AOT consumers using lightweight SQL Server saga storage preserve saga state types via `TrimmerRootDescriptor` or supply a `JsonSerializerContext`.

## Files touched

- `src/Persistence/Wolverine.SqlServer/Wolverine.SqlServer.csproj` — flip + comment.
- `src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs` — ctor-level suppression (line ~56 reflective site).
- `src/Persistence/Wolverine.SqlServer/Sagas/DatabaseSagaSchema.cs` — class-level suppression.

## Test plan

- [x] `dotnet build src/Persistence/Wolverine.SqlServer/Wolverine.SqlServer.csproj -c Debug -f net9.0` — 0 warnings, 0 errors.
- [x] Same on `-f net10.0`.
- [ ] Full CI suite via this PR. **Will currently fail on the VSTHRD103 break in `DbContextUsageSource.cs` (#2792 fixes it); rerun this PR after #2792 lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
