### PR TITLE
AOT chunk AG: flip IsAotCompatible=true on Wolverine.Sqlite (#2746)

### DIFF
--- a/src/Persistence/Wolverine.Sqlite/Sagas/DatabaseSagaSchema.cs
+++ b/src/Persistence/Wolverine.Sqlite/Sagas/DatabaseSagaSchema.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using JasperFx;
 using JasperFx.Core.Reflection;
@@ -13,6 +14,15 @@ using Wolverine.RDBMS.Sagas;
 
 namespace Wolverine.Sqlite.Sagas;
 
+// AOT note (#2746): Reflection-based STJ over runtime saga state type T.
+// Same chunk D / chunk AE (Postgresql) / AF (SqlServer) pattern: AOT consumers
+// using lightweight Sqlite saga storage supply a JsonSerializerContext for their
+// saga state types or preserve via TrimmerRootDescriptor. T is statically rooted
+// via the saga registration (SagaTableDefinition).
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Reflection-based STJ over runtime saga state type; AOT consumers supply a JsonSerializerContext. See AOT guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Reflection-based STJ over runtime saga state type; AOT consumers supply a JsonSerializerContext. See AOT guide.")]
 public class DatabaseSagaSchema<T, TId> : IDatabaseSagaSchema<TId, T> where T : Saga
 {
     private readonly DatabaseSettings _settings;

--- a/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx;
 using JasperFx.Core;
@@ -42,6 +43,14 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         Id = new DatabaseId(descriptor.ServerName, descriptor.DatabaseName);
     }
 
+    // typeof(DatabaseSagaSchema<,>).CloseAndBuildAs<IDatabaseSagaSchema>(...) at L67
+    // closes the saga schema generic over (sagaType, idType) at startup. Same
+    // chunk D / I / J / K / AE / AF CloseAndBuildAs pattern: AOT-clean apps
+    // preserve saga state types via TrimmerRootDescriptor. Cross-link to #2769.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "DatabaseSagaSchema<,> closed over runtime saga / id types at startup; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide / #2769.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "DatabaseSagaSchema<,> closed over runtime saga / id types at startup; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide / #2769.")]
     public SqliteMessageStore(DatabaseSettings databaseSettings, DurabilitySettings settings, DbDataSource dataSource,
         ILogger<SqliteMessageStore> logger, IEnumerable<SagaTableDefinition> sagaTypes) : base(databaseSettings, dataSource,
         settings, logger, new SqliteMigrator(), SqliteProvider.Instance)

--- a/src/Persistence/Wolverine.Sqlite/SqliteNodePersistence.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteNodePersistence.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Data.Common;
+using System.Text.Json.Serialization;
 using JasperFx.Core;
 using Weasel.Core;
 using Weasel.Sqlite;
@@ -46,7 +47,11 @@ internal class SqliteNodePersistence : DatabaseConstants, INodeAgentPersistence
     public async Task<int> PersistAsync(WolverineNode node, CancellationToken cancellationToken)
     {
         // SQLite doesn't have RETURNING clause in the same way, we need to use last_insert_rowid()
-        var capabilitiesJson = System.Text.Json.JsonSerializer.Serialize(node.Capabilities.Select(x => x.ToString()).ToArray());
+        // Use the source-generated JsonSerializerContext for string[] (chunk N pattern) so the
+        // round-trip through System.Text.Json is AOT-clean — no leaf-site IL2026/IL3050 suppression.
+        var capabilitiesJson = System.Text.Json.JsonSerializer.Serialize(
+            node.Capabilities.Select(x => x.ToString()).ToArray(),
+            SqliteNodeCapabilitiesJsonContext.Default.StringArray);
 
         await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
 
@@ -388,7 +393,8 @@ internal class SqliteNodePersistence : DatabaseConstants, INodeAgentPersistence
         if (!(await reader.IsDBNullAsync(7)))
         {
             var capabilitiesJson = await reader.GetFieldValueAsync<string>(7);
-            var capabilities = System.Text.Json.JsonSerializer.Deserialize<string[]>(capabilitiesJson);
+            var capabilities = System.Text.Json.JsonSerializer.Deserialize(
+                capabilitiesJson, SqliteNodeCapabilitiesJsonContext.Default.StringArray);
             if (capabilities != null)
             {
                 node.Capabilities.AddRange(capabilities.Select(x => new Uri(x)));
@@ -397,4 +403,17 @@ internal class SqliteNodePersistence : DatabaseConstants, INodeAgentPersistence
 
         return node;
     }
+}
+
+/// <summary>
+/// Source-generated JSON context for the WolverineNode.Capabilities round-trip in
+/// <see cref="SqliteNodePersistence"/>. Lets the Persist/Read paths use the AOT-friendly
+/// <c>JsonTypeInfo</c> overloads instead of the reflection-based defaults — clearing
+/// IL2026/IL3050 in trim/AOT builds without leaf-site suppression. Same chunk N
+/// (NodeRecord) pattern; the type set is statically known (just <c>string[]</c>),
+/// so the source generator can emit fully-typed serializers.
+/// </summary>
+[JsonSerializable(typeof(string[]))]
+internal partial class SqliteNodeCapabilitiesJsonContext : JsonSerializerContext
+{
 }

--- a/src/Persistence/Wolverine.Sqlite/Wolverine.Sqlite.csproj
+++ b/src/Persistence/Wolverine.Sqlite/Wolverine.Sqlite.csproj
@@ -8,6 +8,20 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          AOT-compatible (#2746). Mirrors the chunk AE / AF (Postgresql /
+          SqlServer) pattern. Two reflective sites suppressed:
+          - SqliteMessageStore ctor: typeof(DatabaseSagaSchema<,>)
+            .CloseAndBuildAs over runtime (sagaType, idType) tuples at
+            startup. Cross-link to #2769 (CloseAndBuildAs elimination).
+          - Wolverine.Sqlite.Sagas.DatabaseSagaSchema<TId, TSaga>:
+            class-level [UnconditionalSuppressMessage] for reflection-based
+            STJ over the runtime saga state type TSaga (Insert / Update /
+            Load methods). Same chunk D / AE pattern.
+          AOT consumers preserve saga state types via TrimmerRootDescriptor
+          or supply a JsonSerializerContext.
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

Flips `<IsAotCompatible>true</IsAotCompatible>` on `Wolverine.Sqlite.csproj` and addresses three reflective sites — two via leaf suppression (the saga schema, where `T` is user-defined), one via a proper source-generated `JsonSerializerContext` (the `WolverineNode.Capabilities` round-trip, where the type is statically known).

## Suppressions

- **`SqliteMessageStore` ctor** (the `IEnumerable<SagaTableDefinition>` overload): `typeof(DatabaseSagaSchema<,>).CloseAndBuildAs<IDatabaseSagaSchema>(...)` closes the saga schema generic over `(sagaType, idType)` at startup. Same chunk D / I / J / K / AE / AF `CloseAndBuildAs` pattern; cross-link to #2769.
- **`Wolverine.Sqlite.Sagas.DatabaseSagaSchema<T, TId>`**: class-level `[UnconditionalSuppressMessage(IL2026, IL3050)]` covers reflection-based STJ over the runtime saga state type `T` (`Insert` / `Update` / `Load`). Same chunk D / AE / AF pattern.

## Proper AOT fix (no suppression)

- **`SqliteNodePersistence.PersistAsync` / `Read`** previously round-tripped `WolverineNode.Capabilities` through `JsonSerializer.Serialize(string[])` / `Deserialize<string[]>(...)`. Type is statically known, so a source-generated `JsonSerializerContext` is the correct fix (matches chunk N's `NodeRecord` precedent). Added internal `SqliteNodeCapabilitiesJsonContext` with `[JsonSerializable(typeof(string[]))]`. No leaf suppression on these two methods.

## Files touched

- `src/Persistence/Wolverine.Sqlite/Wolverine.Sqlite.csproj` — flip + comment.
- `src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs` — ctor-level suppression.
- `src/Persistence/Wolverine.Sqlite/Sagas/DatabaseSagaSchema.cs` — class-level suppression.
- `src/Persistence/Wolverine.Sqlite/SqliteNodePersistence.cs` — JsonSerializerContext refactor.

## Test plan

- [x] `dotnet build src/Persistence/Wolverine.Sqlite/Wolverine.Sqlite.csproj -c Debug -f net9.0` — 0 warnings, 0 errors.
- [x] Same on `-f net10.0`.
- [ ] Full CI suite via this PR. **Will fail on the VSTHRD103 break in `DbContextUsageSource.cs` (#2792 fixes it); rerun after #2792 lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
