### PR TITLE
AOT chunk AH: flip IsAotCompatible=true on Wolverine.MySql (#2746)

### DIFF
--- a/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx;
 using JasperFx.Core;
@@ -41,6 +42,14 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
         Id = new DatabaseId(descriptor.ServerName, descriptor.DatabaseName);
     }
 
+    // typeof(DatabaseSagaSchema<,>).CloseAndBuildAs<IDatabaseSagaSchema>(...) at L59
+    // closes the saga schema generic over (sagaType, idType) at startup. Same
+    // chunk D / I / J / K / AE / AF / AG CloseAndBuildAs pattern: AOT-clean apps
+    // preserve saga state types via TrimmerRootDescriptor. Cross-link to #2769.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "DatabaseSagaSchema<,> closed over runtime saga / id types at startup; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide / #2769.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "DatabaseSagaSchema<,> closed over runtime saga / id types at startup; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide / #2769.")]
     public MySqlMessageStore(DatabaseSettings databaseSettings, DurabilitySettings settings,
         MySqlDataSource dataSource,
         ILogger<MySqlMessageStore> logger, IEnumerable<SagaTableDefinition> sagaTypes) : base(databaseSettings,

--- a/src/Persistence/MySql/Wolverine.MySql/Sagas/DatabaseSagaSchema.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Sagas/DatabaseSagaSchema.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using JasperFx;
 using JasperFx.Core.Reflection;
@@ -11,6 +12,15 @@ using Wolverine.RDBMS.Sagas;
 
 namespace Wolverine.MySql.Sagas;
 
+// AOT note (#2746): Reflection-based STJ over runtime saga state type T.
+// Same chunk D / chunk AE / AF / AG pattern: AOT consumers using lightweight
+// MySQL saga storage supply a JsonSerializerContext for their saga state types
+// or preserve via TrimmerRootDescriptor. T is statically rooted via the
+// saga registration (SagaTableDefinition).
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Reflection-based STJ over runtime saga state type; AOT consumers supply a JsonSerializerContext. See AOT guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Reflection-based STJ over runtime saga state type; AOT consumers supply a JsonSerializerContext. See AOT guide.")]
 public class DatabaseSagaSchema<T, TId> : IDatabaseSagaSchema<TId, T> where T : Saga
 {
     private readonly DatabaseSettings _settings;

--- a/src/Persistence/MySql/Wolverine.MySql/Wolverine.MySql.csproj
+++ b/src/Persistence/MySql/Wolverine.MySql/Wolverine.MySql.csproj
@@ -8,6 +8,20 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          AOT-compatible (#2746). Mirrors the chunk AE / AF / AG pattern.
+          Two reflective sites suppressed:
+          - MySqlMessageStore ctor: typeof(DatabaseSagaSchema<,>)
+            .CloseAndBuildAs over runtime (sagaType, idType) tuples at
+            startup. Cross-link to #2769 (CloseAndBuildAs elimination).
+          - Wolverine.MySql.Sagas.DatabaseSagaSchema<T, TId>: class-level
+            [UnconditionalSuppressMessage] for reflection-based STJ over
+            the runtime saga state type T (Insert / Update / Load).
+            Same chunk D / AE pattern.
+          AOT consumers preserve saga state types via TrimmerRootDescriptor
+          or supply a JsonSerializerContext.
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

Flips `<IsAotCompatible>true</IsAotCompatible>` on `Wolverine.MySql.csproj`. Mirrors the chunk AE / AF / AG pattern — `Wolverine.MySql` ships its own copy of `DatabaseSagaSchema<T, TId>` alongside its own `MySqlMessageStore`. No `NodePersistence` STJ to address (the Sqlite-specific source-gen step from #2797 doesn't apply here).

## Suppressions

- **`MySqlMessageStore` ctor** (the `IEnumerable<SagaTableDefinition>` overload): `typeof(DatabaseSagaSchema<,>).CloseAndBuildAs<IDatabaseSagaSchema>(...)` closes the saga schema generic over `(sagaType, idType)` at startup. Same chunk D / I / J / K / AE / AF / AG `CloseAndBuildAs` pattern; cross-link to #2769.
- **`Wolverine.MySql.Sagas.DatabaseSagaSchema<T, TId>`**: class-level `[UnconditionalSuppressMessage(IL2026, IL3050)]` covers reflection-based STJ over the runtime saga state type `T` (`Insert` / `Update` / `Load`).

`T` is statically rooted via the `SagaTableDefinition` registration. AOT consumers using lightweight MySQL saga storage preserve saga state types via `TrimmerRootDescriptor` or supply a `JsonSerializerContext`.

## Files touched

- `src/Persistence/MySql/Wolverine.MySql/Wolverine.MySql.csproj` — flip + comment.
- `src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs` — ctor-level suppression.
- `src/Persistence/MySql/Wolverine.MySql/Sagas/DatabaseSagaSchema.cs` — class-level suppression.

## Test plan

- [x] `dotnet build src/Persistence/MySql/Wolverine.MySql/Wolverine.MySql.csproj -c Debug -f net9.0` — 0 warnings, 0 errors.
- [x] Same on `-f net10.0`.
- [ ] Full CI suite via this PR. **Will fail on the VSTHRD103 break in `DbContextUsageSource.cs` (#2792 fixes it); rerun after #2792 lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
