### PR TITLE
AOT chunk AI: flip IsAotCompatible=true on Wolverine.Oracle (#2746)

### DIFF
--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx;
 using JasperFx.Core;
@@ -53,6 +54,15 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
     {
     }
 
+    // typeof(OracleSagaSchema<,>).CloseAndBuildAs<IDatabaseSagaSchema>(...) at L74
+    // closes the saga schema generic over (sagaType, idType) at startup. Same
+    // chunk D / I / J / K / AE / AF / AG / AH CloseAndBuildAs pattern: AOT-clean
+    // apps preserve saga state types via TrimmerRootDescriptor. Cross-link to
+    // #2769.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "OracleSagaSchema<,> closed over runtime saga / id types at startup; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide / #2769.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "OracleSagaSchema<,> closed over runtime saga / id types at startup; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide / #2769.")]
     public OracleMessageStore(DatabaseSettings databaseSettings, DurabilitySettings durability,
         OracleDataSource dataSource, ILogger logger, IEnumerable<SagaTableDefinition> sagaTypes)
     {

--- a/src/Persistence/Oracle/Wolverine.Oracle/Sagas/OracleSagaSchema.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Sagas/OracleSagaSchema.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using JasperFx;
 using JasperFx.Core.Reflection;
@@ -12,6 +13,15 @@ using Wolverine.RDBMS.Sagas;
 
 namespace Wolverine.Oracle.Sagas;
 
+// AOT note (#2746): Reflection-based STJ over runtime saga state type T.
+// Same chunk D / chunk AE / AF / AG / AH pattern: AOT consumers using
+// lightweight Oracle saga storage supply a JsonSerializerContext for their
+// saga state types or preserve via TrimmerRootDescriptor. T is statically
+// rooted via the saga registration (SagaTableDefinition).
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Reflection-based STJ over runtime saga state type; AOT consumers supply a JsonSerializerContext. See AOT guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Reflection-based STJ over runtime saga state type; AOT consumers supply a JsonSerializerContext. See AOT guide.")]
 public class OracleSagaSchema<T, TId> : IDatabaseSagaSchema<TId, T> where T : Saga
 {
     private readonly DatabaseSettings _settings;

--- a/src/Persistence/Oracle/Wolverine.Oracle/Wolverine.Oracle.csproj
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Wolverine.Oracle.csproj
@@ -8,6 +8,20 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          AOT-compatible (#2746). Mirrors the chunk AE / AF / AG / AH
+          pattern. Two reflective sites suppressed:
+          - OracleMessageStore ctor: typeof(OracleSagaSchema<,>)
+            .CloseAndBuildAs over runtime (sagaType, idType) tuples at
+            startup. Cross-link to #2769 (CloseAndBuildAs elimination).
+          - Wolverine.Oracle.Sagas.OracleSagaSchema<T, TId>: class-level
+            [UnconditionalSuppressMessage] for reflection-based STJ over
+            the runtime saga state type T (Insert / Update / Load).
+            Same chunk D / AE pattern.
+          AOT consumers preserve saga state types via TrimmerRootDescriptor
+          or supply a JsonSerializerContext.
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

Flips `<IsAotCompatible>true</IsAotCompatible>` on `Wolverine.Oracle.csproj`. Mirrors the chunk AE / AF / AH pattern, with a schema-class-name variation: Oracle ships its saga schema as `Wolverine.Oracle.Sagas.OracleSagaSchema<T, TId>` rather than `DatabaseSagaSchema<,>`.

## Suppressions

- **`OracleMessageStore` second ctor** (the one that takes `IEnumerable<SagaTableDefinition>`): `typeof(OracleSagaSchema<,>).CloseAndBuildAs<IDatabaseSagaSchema>(...)` closes the saga schema generic over `(sagaType, idType)` at startup. Same chunk D / I / J / K / AE / AF / AG / AH `CloseAndBuildAs` pattern; cross-link to #2769.
- **`Wolverine.Oracle.Sagas.OracleSagaSchema<T, TId>`**: class-level `[UnconditionalSuppressMessage(IL2026, IL3050)]` covers reflection-based STJ over the runtime saga state type `T` (`Insert` / `Update` / `Load`).

`T` is statically rooted via the `SagaTableDefinition` registration. AOT consumers using lightweight Oracle saga storage preserve saga state types via `TrimmerRootDescriptor` or supply a `JsonSerializerContext`.

## Files touched

- `src/Persistence/Oracle/Wolverine.Oracle/Wolverine.Oracle.csproj` — flip + comment.
- `src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs` — ctor-level suppression.
- `src/Persistence/Oracle/Wolverine.Oracle/Sagas/OracleSagaSchema.cs` — class-level suppression.

## Test plan

- [x] `dotnet build src/Persistence/Oracle/Wolverine.Oracle/Wolverine.Oracle.csproj -c Debug -f net9.0` — 0 warnings, 0 errors.
- [x] Same on `-f net10.0`.
- [ ] Full CI suite via this PR. **Will fail on the VSTHRD103 break in `DbContextUsageSource.cs` (#2792 fixes it); rerun after #2792 lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
