### PR TITLE
AOT chunk AJ: flip IsAotCompatible=true on Wolverine.Newtonsoft (#2746)

### DIFF
--- a/src/Extensions/Wolverine.Newtonsoft/Wolverine.Newtonsoft.csproj
+++ b/src/Extensions/Wolverine.Newtonsoft/Wolverine.Newtonsoft.csproj
@@ -8,6 +8,19 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          AOT-compatible (#2746). Wolverine's NewtonsoftSerializer /
+          NewtonsoftEnvelopeSerializer wrappers themselves are AOT-clean —
+          they don't perform reflection over user types; that's done by
+          Newtonsoft.Json internally, and Newtonsoft already carries its own
+          [RequiresUnreferencedCode] disclaimers on its public Serialize /
+          Deserialize methods. The IL warnings only surface when user code
+          calls Newtonsoft against trim-unsafe types. Net result for this
+          package: zero leaf suppressions needed. AOT consumers should
+          prefer System.Text.Json (Wolverine's default since 5.0) and only
+          opt back into Newtonsoft if they need 5.x wire-format compat.
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,5 +30,7 @@
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" />
     </ItemGroup>
+
+    <Import Project="../../../Analysis.Build.props" />
 
 </Project>


### PR DESCRIPTION
## Summary

Flips `<IsAotCompatible>true</IsAotCompatible>` on `Wolverine.Newtonsoft.csproj` and imports `Analysis.Build.props` to bring the package into line with the other satellites.

## Surprise: zero suppressions needed

Wolverine's `NewtonsoftSerializer` / `NewtonsoftEnvelopeSerializer` wrappers themselves are AOT-clean — they don't perform reflection over user types; that's done by Newtonsoft.Json internally, and Newtonsoft already carries its own `[RequiresUnreferencedCode]` disclaimers on its public `Serialize` / `Deserialize` methods. The IL warnings only surface at user call sites where the user code passes trim-unsafe message types to `JsonConvert` / `JsonSerializer` — which is the user's responsibility, not this package's.

Net result for this package: just the csproj flip + Analysis.Build.props import. No source-code changes.

## Files touched

- `src/Extensions/Wolverine.Newtonsoft/Wolverine.Newtonsoft.csproj` — flip + Analysis.Build.props import + comment.

## Test plan

- [x] `dotnet build src/Extensions/Wolverine.Newtonsoft/Wolverine.Newtonsoft.csproj -c Debug -f net9.0` — 0 warnings, 0 errors.
- [x] Same on `-f net10.0`.
- [ ] Full CI suite via this PR. **Will fail on the VSTHRD103 break in `DbContextUsageSource.cs` (#2792 fixes it); rerun after #2792 lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
