### PR TITLE
AOT chunk AK: flip IsAotCompatible=true on Wolverine.DataAnnotationsValidation (#2746)

### DIFF
--- a/src/Extensions/Wolverine.DataAnnotationsValidation/Internals/DataAnnotationsValidationExecutor.cs
+++ b/src/Extensions/Wolverine.DataAnnotationsValidation/Internals/DataAnnotationsValidationExecutor.cs
@@ -1,11 +1,21 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Wolverine.DataAnnotationsValidation.Internals;
 
 public static class DataAnnotationsValidationExecutor
 {
+    // ValidationContext + Validator.TryValidateObject reflect over the runtime
+    // type's [Validation*] attribute graph. T is the user-defined message type
+    // that handler discovery already roots (and DataAnnotationsValidationPolicy
+    // closes Validate<T> at codegen time, so trim-walkers can see the closed
+    // generic instantiations). AOT consumers preserve message types via
+    // TrimmerRootDescriptor or by relying on Wolverine's TypeLoadMode.Static
+    // codegen pipeline. See AOT guide.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "ValidationContext / Validator.TryValidateObject reflect over the runtime message type's DataAnnotations attributes; T is handler-rooted. AOT consumers preserve via TrimmerRootDescriptor. See AOT guide.")]
     public static void Validate<T>(T message, IServiceProvider services, IFailureAction<T> failureAction)
     {
         ArgumentNullException.ThrowIfNull(message);

--- a/src/Extensions/Wolverine.DataAnnotationsValidation/Internals/DataAnnotationsValidationPolicy.cs
+++ b/src/Extensions/Wolverine.DataAnnotationsValidation/Internals/DataAnnotationsValidationPolicy.cs
@@ -1,4 +1,5 @@
-﻿using JasperFx;
+﻿using System.Diagnostics.CodeAnalysis;
+using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using Wolverine.Configuration;
@@ -13,6 +14,15 @@ public class DataAnnotationsValidationPolicy : IHandlerPolicy
         foreach (var chain in chains) Apply(chain, container);
     }
 
+    // chain.MessageType! is the user-defined message type that handler discovery
+    // already roots. MakeGenericMethod here is the standard chunk D / I / J / K
+    // codegen-time pattern: AOT consumers in TypeLoadMode.Static pre-generate
+    // the closed Validate<T> call sites at codegen time, so the reflective
+    // close never fires in steady state.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "MakeGenericMethod closes DataAnnotationsValidationExecutor.Validate<T> over a handler-rooted message type at codegen time; AOT consumers pre-generate via TypeLoadMode.Static. See AOT guide / #2769.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "MakeGenericMethod closes DataAnnotationsValidationExecutor.Validate<T> over a handler-rooted message type at codegen time; AOT consumers pre-generate via TypeLoadMode.Static. See AOT guide / #2769.")]
     public void Apply(HandlerChain chain, IServiceContainer container)
     {
         var method =

--- a/src/Extensions/Wolverine.DataAnnotationsValidation/Wolverine.DataAnnotationsValidation.csproj
+++ b/src/Extensions/Wolverine.DataAnnotationsValidation/Wolverine.DataAnnotationsValidation.csproj
@@ -8,10 +8,20 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <!--
+      AOT-compatible (#2746). DataAnnotations validation runs against
+      message types that the user already roots through Wolverine's
+      handler discovery, so the validator's reflection over property
+      attributes resolves against trim-rooted members. See per-site
+      justifications in source if any IL warnings surface.
+    -->
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Wolverine\Wolverine.csproj" />
   </ItemGroup>
+
+  <Import Project="../../../Analysis.Build.props" />
 
 </Project>


### PR DESCRIPTION
## Summary

Flips `<IsAotCompatible>true</IsAotCompatible>` on `Wolverine.DataAnnotationsValidation.csproj` and imports `Analysis.Build.props`. Two reflective sites suppressed at the leaf.

## Suppressions

- **`DataAnnotationsValidationPolicy.Apply`**: `MakeGenericMethod` closes `DataAnnotationsValidationExecutor.Validate<T>` over `chain.MessageType` at codegen time. Standard chunk D / I / J / K codegen-time pattern; AOT consumers in `TypeLoadMode.Static` pre-generate the closed `Validate<T>` call sites at codegen time, so the reflective close never fires in steady state.
- **`DataAnnotationsValidationExecutor.Validate<T>`**: method-level `[UnconditionalSuppressMessage(IL2026)]` for `ValidationContext` + `Validator.TryValidateObject` reflecting over the runtime type's `[Validation*]` attribute graph. `T` is the user-defined message type that handler discovery already roots (and the policy closes `Validate<T>` at codegen time, so trim-walkers can see the closed generic instantiations).

AOT consumers preserve message types via `TrimmerRootDescriptor`.

## Files touched

- `src/Extensions/Wolverine.DataAnnotationsValidation/Wolverine.DataAnnotationsValidation.csproj` — flip + Analysis.Build.props import.
- `src/Extensions/Wolverine.DataAnnotationsValidation/Internals/DataAnnotationsValidationPolicy.cs` — method-level codegen-time suppression.
- `src/Extensions/Wolverine.DataAnnotationsValidation/Internals/DataAnnotationsValidationExecutor.cs` — method-level Validator.TryValidateObject suppression.

## Test plan

- [x] `dotnet build src/Extensions/Wolverine.DataAnnotationsValidation/Wolverine.DataAnnotationsValidation.csproj -c Debug -f net9.0` — 0 warnings, 0 errors.
- [x] Same on `-f net10.0`.
- [ ] Full CI suite via this PR. **Will fail on the VSTHRD103 break in `DbContextUsageSource.cs` (#2792 fixes it); rerun after #2792 lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
