### PR TITLE
AOT chunk AL: flip IsAotCompatible=true on Wolverine.FluentValidation (#2746)

### DIFF
--- a/src/Extensions/Wolverine.FluentValidation/Internals/FluentValidationPolicy.cs
+++ b/src/Extensions/Wolverine.FluentValidation/Internals/FluentValidationPolicy.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using FluentValidation;
 using JasperFx;
 using JasperFx.CodeGeneration;
@@ -15,6 +16,16 @@ internal class FluentValidationPolicy : IHandlerPolicy
         foreach (var chain in chains) Apply(chain, container);
     }
 
+    // chain.MessageType is the user-defined message type that handler discovery
+    // already roots. The MakeGenericType (IValidator<T>) + MakeGenericMethod
+    // (ExecuteOne<T> / ExecuteMany<T>) pair here is the standard chunk D / I /
+    // J / K / AK codegen-time pattern: AOT consumers in TypeLoadMode.Static
+    // pre-generate the closed Validate<T> call sites at codegen time, so the
+    // reflective close never fires in steady state.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "MakeGenericType/MakeGenericMethod close FluentValidationExecutor.ExecuteOne<T>/ExecuteMany<T> over a handler-rooted message type at codegen time; AOT consumers pre-generate via TypeLoadMode.Static. See AOT guide / #2769.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "MakeGenericType/MakeGenericMethod close FluentValidationExecutor.ExecuteOne<T>/ExecuteMany<T> over a handler-rooted message type at codegen time; AOT consumers pre-generate via TypeLoadMode.Static. See AOT guide / #2769.")]
     public void Apply(HandlerChain chain, IServiceContainer container)
     {
         var validatorInterface = typeof(IValidator<>).MakeGenericType(chain.MessageType);

--- a/src/Extensions/Wolverine.FluentValidation/Wolverine.FluentValidation.csproj
+++ b/src/Extensions/Wolverine.FluentValidation/Wolverine.FluentValidation.csproj
@@ -8,6 +8,18 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          AOT-compatible (#2746). Single reflective site:
+          FluentValidationPolicy.Apply uses MakeGenericType (IValidator<T>)
+          + MakeGenericMethod (ExecuteOne<T> / ExecuteMany<T>) to wire
+          the FluentValidation middleware at codegen time. Same chunk AK
+          (DataAnnotationsValidation) / chunk D / I / J / K codegen-time
+          pattern; AOT consumers pre-generate via TypeLoadMode.Static.
+          FluentValidation itself is AOT-friendly for hand-written
+          AbstractValidator<T> classes (no reflection on T's properties
+          beyond what the user's validation rules explicitly reference).
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,5 +29,7 @@
     <ItemGroup>
         <PackageReference Include="FluentValidation" />
     </ItemGroup>
+
+    <Import Project="../../../Analysis.Build.props" />
 
 </Project>

--- a/src/Extensions/Wolverine.FluentValidation/WolverineFluentValidationExtensions.cs
+++ b/src/Extensions/Wolverine.FluentValidation/WolverineFluentValidationExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using FluentValidation;
 using JasperFx;
 using JasperFx.Core.IoC;
@@ -48,6 +49,17 @@ public static class WolverineFluentValidationExtensions
     /// <param name="behavior"></param>
     /// <param name="includeInternalTypes">When true, also discovers validators with internal visibility</param>
     /// <returns></returns>
+    // The DiscoverAndRegisterValidators path runs FluentValidation's
+    // AssemblyScanner over options.ApplicationAssembly. AssemblyScanResult
+    // .ValidatorType is `Type` without DAM annotations, so the trimmer cannot
+    // verify that ServiceDescriptor's ctor requirement (PublicConstructors)
+    // is satisfied. The scan path is inherently not AOT-friendly — AOT
+    // consumers should use RegistrationBehavior.ExplicitRegistration and
+    // wire validators by hand, which is fully trim-clean. See AOT guide.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "FluentValidation AssemblyScanner discovery path is non-AOT by design; AOT consumers use RegistrationBehavior.ExplicitRegistration. See AOT guide.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
+        Justification = "AssemblyScanResult.ValidatorType is not DAM-annotated by FluentValidation; the scan path is non-AOT by design. AOT consumers use RegistrationBehavior.ExplicitRegistration. See AOT guide.")]
     public static WolverineOptions UseFluentValidation(this WolverineOptions options,
         RegistrationBehavior behavior = RegistrationBehavior.DiscoverAndRegisterValidators,
         bool includeInternalTypes = false)


### PR DESCRIPTION
## Summary

Flips `<IsAotCompatible>true</IsAotCompatible>` on `Wolverine.FluentValidation.csproj` and imports `Analysis.Build.props`. Two suppression sites address the IL warnings that surface.

## Suppressions

- **`FluentValidationPolicy.Apply`**: `MakeGenericType` (`IValidator<T>`) + `MakeGenericMethod` (`FluentValidationExecutor.ExecuteOne<T>` / `ExecuteMany<T>`) at codegen time. Standard chunk D / I / J / K / AK codegen-time pattern; AOT consumers pre-generate via `TypeLoadMode.Static` so the reflective close never fires in steady state.
- **`WolverineFluentValidationExtensions.UseFluentValidation`** overload: the `DiscoverAndRegisterValidators` path runs FluentValidation's `AssemblyScanner` over `options.ApplicationAssembly`. `AssemblyScanner.AssemblyScanResult.ValidatorType` is plain `Type` without DAM annotations, so the trimmer cannot verify `ServiceDescriptor`'s `PublicConstructors` requirement. The scan path is inherently non-AOT by design; AOT consumers should opt into `RegistrationBehavior.ExplicitRegistration` and wire validators by hand, which is fully trim-clean.

FluentValidation itself is AOT-friendly for hand-written `AbstractValidator<T>` classes (no reflection on `T`'s properties beyond what the user's validation rules explicitly reference).

## Files touched

- `src/Extensions/Wolverine.FluentValidation/Wolverine.FluentValidation.csproj` — flip + Analysis.Build.props import.
- `src/Extensions/Wolverine.FluentValidation/Internals/FluentValidationPolicy.cs` — codegen-time policy suppression.
- `src/Extensions/Wolverine.FluentValidation/WolverineFluentValidationExtensions.cs` — UseFluentValidation extension method suppression (IL2026 + IL2072).

## Test plan

- [x] `dotnet build src/Extensions/Wolverine.FluentValidation/Wolverine.FluentValidation.csproj -c Debug -f net9.0` — 0 warnings, 0 errors.
- [x] Same on `-f net10.0`.
- [ ] Full CI suite via this PR. With #2792 merged, this should now build clean against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
