### PR TITLE
Fix #2780: propagate OverrideAutoCreateResources to DatabaseSettings (5 providers)

### DIFF
--- a/src/Persistence/MySql/Wolverine.MySql/MySqlBackedPersistence.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlBackedPersistence.cs
@@ -242,7 +242,9 @@ internal class MySqlBackedPersistence : IMySqlBackedPersistence, IWolverineExten
             ScheduledJobLockId = ScheduledJobLockId,
             SchemaName = EnvelopeStorageSchemaName,
             AddTenantLookupTable = UseMasterTableTenancy,
-            TenantConnections = TenantConnections
+            TenantConnections = TenantConnections,
+            // Propagate the AutoCreate override (see #2780).
+            AutoCreate = AutoCreate
         };
         return settings;
     }

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleBackedPersistence.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleBackedPersistence.cs
@@ -201,7 +201,9 @@ internal class OracleBackedPersistence : IOracleBackedPersistence, IWolverineExt
             ScheduledJobLockId = ScheduledJobLockId,
             SchemaName = EnvelopeStorageSchemaName,
             AddTenantLookupTable = UseMasterTableTenancy,
-            TenantConnections = TenantConnections
+            TenantConnections = TenantConnections,
+            // Propagate the AutoCreate override (see #2780).
+            AutoCreate = AutoCreate
         };
         return settings;
     }

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
@@ -284,7 +284,13 @@ internal class PostgresqlBackedPersistence : IPostgresqlBackedPersistence, IWolv
             MigrationLockId = MigrationLockId,
             SchemaName = EnvelopeStorageSchemaName,
             AddTenantLookupTable = UseMasterTableTenancy,
-            TenantConnections = TenantConnections
+            TenantConnections = TenantConnections,
+            // Propagate the AutoCreate override (see #2780). Without this,
+            // OverrideAutoCreateResources(autoCreate) mutated the wrapper's
+            // own field but never made it into DatabaseSettings, which is
+            // what MessageDatabase.Admin / MessageDatabase.Tenants /
+            // Migrator.ApplyAllAsync actually read.
+            AutoCreate = AutoCreate
         };
         return settings;
     }

--- a/src/Persistence/Wolverine.SqlServer/SqlServerBackedPersistence.cs
+++ b/src/Persistence/Wolverine.SqlServer/SqlServerBackedPersistence.cs
@@ -265,7 +265,9 @@ internal class SqlServerBackedPersistence : IWolverineExtension, ISqlServerBacke
             ScheduledJobLockId = ScheduledJobLockId,
             SchemaName = EnvelopeStorageSchemaName,
             AddTenantLookupTable = UseMasterTableTenancy,
-            TenantConnections = TenantConnections
+            TenantConnections = TenantConnections,
+            // Propagate the AutoCreate override (see #2780).
+            AutoCreate = AutoCreate
         };
     }
 

--- a/src/Persistence/Wolverine.Sqlite/SqliteBackedPersistence.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteBackedPersistence.cs
@@ -226,7 +226,9 @@ internal class SqliteBackedPersistence : ISqliteBackedPersistence, IWolverineExt
             ScheduledJobLockId = ScheduledJobLockId,
             SchemaName = EnvelopeStorageSchemaName,
             AddTenantLookupTable = UseMasterTableTenancy,
-            TenantConnections = TenantConnections
+            TenantConnections = TenantConnections,
+            // Propagate the AutoCreate override (see #2780).
+            AutoCreate = AutoCreate
         };
         return settings;
     }


### PR DESCRIPTION
## Summary

Fix #2780. The wrapper's `OverrideAutoCreateResources(autoCreate)` method correctly mutated `PostgresqlBackedPersistence.AutoCreate` — but `buildMainDatabaseSettings()` never copied that value into the `DatabaseSettings` instance that the downstream migration / admin / tenants code actually reads. Net effect: the override was dead code, a field nothing read.

Reported against Postgresql but the identical pattern exists in **all five RDBMS providers** (Postgresql, SqlServer, MySql, Oracle, Sqlite). One-line fix per file: add `AutoCreate = AutoCreate,` to the `DatabaseSettings` initializer in each `buildMainDatabaseSettings()`.

## Where the value was being read but never set

- `MessageDatabase` ctor — `RDBMS/MessageDatabase.cs:37` passes `databaseSettings.AutoCreate` to the base.
- `MessageDatabase.Admin.cs:190` — `Migrator.ApplyAllAsync(conn, migration, _settings.AutoCreate, ...)`.
- `MessageDatabase.Tenants.cs:45, 80` — per-tenant migration guard.

## Behavior

- **No API surface change**: the public `IXxxBackedPersistence.OverrideAutoCreateResources(autoCreate)` signature is unchanged.
- **No change for users who never call the override**: both `XxxBackedPersistence.AutoCreate` and `DatabaseSettings.AutoCreate` already defaulted to `AutoCreate.CreateOrUpdate`, so users who hadn't been calling the override see exactly the same migration behavior as before.
- **Users who DO call the override now see it take effect** — the documented behavior finally matches the runtime behavior.

## Test plan

- [x] All five fixed projects build clean on net9.0:
  - Wolverine.Postgresql ✅
  - Wolverine.SqlServer ✅
  - Wolverine.MySql ✅
  - Wolverine.Oracle ✅
  - Wolverine.Sqlite ✅
- [ ] Full CI suite via this PR.

Closes #2780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
