### PR TITLE
#2742: extract WolverineFx.Http.Newtonsoft package

### DIFF
--- a/build/build.cs
+++ b/build/build.cs
@@ -347,6 +347,7 @@ partial class Build : NukeBuild
                 Solution.Extensions.Wolverine_Newtonsoft,
                 Solution.Extensions.Wolverine_Protobuf,
                 Solution.Http.Wolverine_Http,
+                Solution.Http.Wolverine_Http_Newtonsoft,
                 Solution.Http.Wolverine_Http_FluentValidation,
                 Solution.Http.Wolverine_Http_Marten,
                 Solution.Persistence.Polecat.Wolverine_Http_Polecat,

--- a/docs/guide/http/json.md
+++ b/docs/guide/http/json.md
@@ -88,8 +88,20 @@ to drop back to Newtonsoft.Json for various scenarios. This feature was added sp
 at the request of F# developers.
 :::
 
-To opt into using Newtonsoft.Json for the JSON serialization of *HTTP endpoints*, you have this option within the call
-to the `MapWolverineEndpoints()` configuration:
+::: tip
+As of **Wolverine 6.0**, Newtonsoft.Json support for Wolverine.Http lives in a separate `WolverineFx.Http.Newtonsoft` NuGet package. The core `WolverineFx.Http` package no longer depends on Newtonsoft.Json; install `WolverineFx.Http.Newtonsoft` alongside it to opt in. This mirrors the symmetric core extraction in `WolverineFx.Newtonsoft` (see [the migration guide](/guide/migration.html#wolverine-http-newtonsoft-moved-to-wolverinefx-http-newtonsoft-package-breaking)).
+:::
+
+To install:
+
+```bash
+dotnet add package WolverineFx.Http.Newtonsoft
+```
+
+The `WolverineFx.Http.Newtonsoft` package provides the same `UseNewtonsoftJsonForSerialization`
+API as Wolverine 5.x, now exposed as an extension method on `WolverineHttpOptions`. Add the
+`using Wolverine.Http.Newtonsoft;` directive to bring the extensions into scope, and register
+the package's services on the `IServiceCollection` alongside `AddWolverineHttp()`:
 
 <!-- snippet: sample_use_newtonsoft_for_http_serialization -->
 <a id='snippet-sample_use_newtonsoft_for_http_serialization'></a>
@@ -106,16 +118,22 @@ builder.Host.UseWolverine(opts =>
 });
 
 builder.Services.AddWolverineHttp();
+// As of Wolverine 6.0, Newtonsoft.Json HTTP support lives in the
+// separate WolverineFx.Http.Newtonsoft package — register its
+// services here, then opt in via UseNewtonsoftJsonForSerialization()
+// below.
+builder.Services.AddWolverineHttpNewtonsoft();
 
 await using var host = await AlbaHost.For(builder, app =>
 {
     app.MapWolverineEndpoints(opts =>
     {
         // Opt into using Newtonsoft.Json for JSON serialization just with Wolverine.HTTP routes
-        // Configuring the JSON serialization is optional
+        // Configuring the JSON serialization is optional. This extension method comes from
+        // the WolverineFx.Http.Newtonsoft package (using Wolverine.Http.Newtonsoft;).
         opts.UseNewtonsoftJsonForSerialization(settings => settings.TypeNameHandling = TypeNameHandling.All);
     });
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/using_newtonsoft_for_serialization.cs#L18-L42' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_use_newtonsoft_for_http_serialization' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/using_newtonsoft_for_serialization.cs#L19-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_use_newtonsoft_for_http_serialization' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/messages.md
+++ b/docs/guide/messages.md
@@ -203,6 +203,12 @@ The `WolverineFx.Newtonsoft` package provides the same `UseNewtonsoftForSerializ
 `WolverineOptions` and per-endpoint configuration. Add the `using Wolverine.Newtonsoft;` directive
 to bring the extensions into scope.
 
+::: tip
+For HTTP-endpoint JSON serialization, there's a parallel `WolverineFx.Http.Newtonsoft` package that
+extracts the HTTP-side Newtonsoft surface (`WolverineHttpOptions.UseNewtonsoftJsonForSerialization`) from
+core `WolverineFx.Http` in 6.0. See [the HTTP JSON docs](/guide/http/json.html#using-newtonsoft-json) for setup.
+:::
+
 The default configuration is:
 
 ```cs

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -20,6 +20,9 @@ The table below is the **complete inventory** of changed defaults, removed APIs,
 | `IMassTransitInterop.UseNewtonsoftForSerialization(...)` | interface method | extension method in `WolverineFx.Newtonsoft` *(BREAKING)* | Same |
 | `NewtonsoftSerializer` type | `Wolverine.Runtime.Serialization` namespace | `Wolverine.Newtonsoft` namespace *(BREAKING)* | Update `using` |
 | `Subscription.Scope` JSON converter attribute | `[StringEnumConverter]` (Newtonsoft) | `[JsonStringEnumConverter]` (STJ) | Wire format unchanged; if you serialize `Subscription` yourself with Newtonsoft and rely on string-named scopes, configure `StringEnumConverter` on your own settings |
+| `WolverineHttpOptions.UseNewtonsoftJsonForSerialization(...)` | instance method on core `WolverineFx.Http` | extension method in `WolverineFx.Http.Newtonsoft` *(BREAKING)* | Install `WolverineFx.Http.Newtonsoft`; call `services.AddWolverineHttpNewtonsoft();` alongside `AddWolverineHttp()`; add `using Wolverine.Http.Newtonsoft;` |
+| `NewtonsoftHttpSerialization` type | `Wolverine.Http` namespace in core `WolverineFx.Http` | `Wolverine.Http.Newtonsoft` namespace in `WolverineFx.Http.Newtonsoft` *(BREAKING)* | Update `using` |
+| `ProblemDetailsContinuationPolicy.WriteProblems` diagnostic logger dump | `JsonConvert.SerializeObject` (Newtonsoft) | `JsonSerializer.Serialize` (STJ) | None — diagnostic-only log line; output shape unchanged |
 | `SnapshotLifecycle` namespace | `Marten.Events.Projections` | `JasperFx.Events.Projections` *(BREAKING)* | Add `using JasperFx.Events.Projections;` |
 | `OperationRole` namespace | `Marten.Internal.Operations` | `Weasel.Core` *(BREAKING)* | Add `using Weasel.Core;` |
 | Target framework | `net8.0;net9.0;net10.0` | `net9.0;net10.0` *(BREAKING)* | Move to .NET 9+ or pin Wolverine 5.x |
@@ -140,6 +143,31 @@ The call surface itself is unchanged — `opts.UseNewtonsoftForSerialization(set
 Transports that pin a `NewtonsoftSerializer` internally for NServiceBus / MassTransit wire-compat (RabbitMQ's `UseNServiceBusInterop()`, the AWS SQS and SNS NServiceBus mappers, Azure Service Bus listeners) carry the `WolverineFx.Newtonsoft` dependency for you. You don't need to install it explicitly unless you call one of the Newtonsoft APIs from your own code.
 
 In a related cleanup, `Subscription.Scope` no longer carries a `[Newtonsoft.Json.Converters.StringEnumConverter]` attribute — it's now annotated with `[System.Text.Json.Serialization.JsonStringEnumConverter]`. Wire format is unchanged (still string-named scopes). If you serialize `Subscription` instances yourself with Newtonsoft and rely on the string-named scope shape, configure `StringEnumConverter` on your own settings explicitly.
+
+### `Wolverine.Http` Newtonsoft moved to `WolverineFx.Http.Newtonsoft` package (BREAKING)
+
+Mirrors the core extraction above: the `WolverineFx.Http` NuGet package no longer depends on Newtonsoft.Json. All Newtonsoft-flavored HTTP serialization moved to a separate `WolverineFx.Http.Newtonsoft` package and is exposed as an **extension method** rather than an instance method on `WolverineHttpOptions`.
+
+If you call the following 5.x API:
+
+- `WolverineHttpOptions.UseNewtonsoftJsonForSerialization(...)`
+- `new NewtonsoftHttpSerialization(...)` directly (rare — it was an internal-feeling singleton)
+
+you must:
+
+1. **Install the new package**: `dotnet add package WolverineFx.Http.Newtonsoft`
+2. **Register the package's services** alongside `AddWolverineHttp()`:
+   ```csharp
+   builder.Services.AddWolverineHttp();
+   builder.Services.AddWolverineHttpNewtonsoft();   // new
+   ```
+3. **Add `using Wolverine.Http.Newtonsoft;`** to bring the extension method (and the `NewtonsoftHttpSerialization` type) into scope.
+
+The call surface itself is unchanged — `opts.UseNewtonsoftJsonForSerialization(settings => …)` works exactly as before, it's just an extension method now. See the [HTTP JSON serialization docs](/guide/http/json.html#using-newtonsoft-json) for the full example.
+
+Core `WolverineFx.Http` retains the `JsonUsage.NewtonsoftJson` enum value so the public switch shape doesn't change. The codegen path inside `JsonResourceWriterPolicy` / `JsonBodyParameterStrategy` now dispatches through an internal `INewtonsoftHttpCodeGen` seam implemented in the new package; selecting `JsonUsage.NewtonsoftJson` without the package installed throws an `InvalidOperationException` at codegen time pointing you at `dotnet add package WolverineFx.Http.Newtonsoft`.
+
+In a related cleanup, `ProblemDetailsContinuationPolicy.WriteProblems` (which dumps the `ProblemDetails` payload into the log line for the "found problems with this message" diagnostic) switched from `Newtonsoft.Json.JsonConvert.SerializeObject` to `System.Text.Json.JsonSerializer.Serialize`. This is a logging dump only — `ProblemDetails` round-trips cleanly through STJ; there is no observable output-format change.
 
 ### `IForwardsTo<T>` discovery is now explicit (BREAKING)
 

--- a/src/Extensions/Wolverine.Http.Newtonsoft/CodeGen/NewtonsoftHttpCodeGen.cs
+++ b/src/Extensions/Wolverine.Http.Newtonsoft/CodeGen/NewtonsoftHttpCodeGen.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using Wolverine.Http.CodeGen;
+
+namespace Wolverine.Http.Newtonsoft.CodeGen;
+
+/// <summary>
+///     <see cref="INewtonsoftHttpCodeGen"/> implementation registered by
+///     <see cref="WolverineHttpNewtonsoftExtensions.UseNewtonsoftJsonForSerialization"/>.
+///     Produces the same Newtonsoft-flavored request-deserialization and
+///     response-serialization codegen frames the Wolverine 5.x core
+///     Wolverine.Http package emitted inline.
+/// </summary>
+internal sealed class NewtonsoftHttpCodeGen : INewtonsoftHttpCodeGen
+{
+    public Variable CreateReadJsonBodyVariable(ParameterInfo parameter)
+    {
+        return new ReadJsonBodyWithNewtonsoft(parameter).ReturnVariable!;
+    }
+
+    public Variable CreateReadJsonBodyVariable(Type requestType)
+    {
+        return new ReadJsonBodyWithNewtonsoft(requestType).ReturnVariable!;
+    }
+
+    public Frame CreateWriteJsonFrame(Variable resourceVariable)
+    {
+        var frame = new MethodCall(typeof(NewtonsoftHttpSerialization),
+            nameof(NewtonsoftHttpSerialization.WriteJsonAsync));
+        frame.Arguments[1] = resourceVariable;
+        return frame;
+    }
+}

--- a/src/Extensions/Wolverine.Http.Newtonsoft/CodeGen/ReadJsonBodyWithNewtonsoft.cs
+++ b/src/Extensions/Wolverine.Http.Newtonsoft/CodeGen/ReadJsonBodyWithNewtonsoft.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+
+namespace Wolverine.Http.Newtonsoft.CodeGen;
+
+internal class ReadJsonBodyWithNewtonsoft : MethodCall
+{
+    private static MethodInfo findMethodForType(Type parameterType)
+    {
+        return typeof(NewtonsoftHttpSerialization).GetMethod(nameof(NewtonsoftHttpSerialization.ReadFromJsonAsync))!
+            .MakeGenericMethod(parameterType);
+    }
+
+    public ReadJsonBodyWithNewtonsoft(ParameterInfo parameter) : base(typeof(NewtonsoftHttpSerialization), findMethodForType(parameter.ParameterType))
+    {
+        var parameterName = parameter.Name!;
+        if (parameterName == "_")
+        {
+            parameterName = Variable.DefaultArgName(parameter.ParameterType);
+        }
+
+        ReturnVariable!.OverrideName(parameterName);
+
+        CommentText = "Reading the request body with JSON deserialization";
+    }
+
+    public ReadJsonBodyWithNewtonsoft(Type requestType) : base(typeof(NewtonsoftHttpSerialization), findMethodForType(requestType))
+    {
+        var parameterName = Variable.DefaultArgName(requestType);
+        if (parameterName == "_")
+        {
+            parameterName = Variable.DefaultArgName(requestType);
+        }
+
+        ReturnVariable!.OverrideName(parameterName);
+
+        CommentText = "Reading the request body with JSON deserialization";
+    }
+}

--- a/src/Extensions/Wolverine.Http.Newtonsoft/GlobalSuppressions.cs
+++ b/src/Extensions/Wolverine.Http.Newtonsoft/GlobalSuppressions.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics.CodeAnalysis;
+
+// AOT-pillar suppressions for Wolverine.Http.Newtonsoft (#2742 / #2746).
+//
+// Mirrors the namespace-scoped pattern in Wolverine.Http's GlobalSuppressions.cs.
+// This package re-introduces the Newtonsoft-flavored HTTP codegen frames that
+// previously lived in core Wolverine.Http; the IL warnings come from the same
+// codegen-time MakeGenericMethod / generic-arg flow over user endpoint /
+// parameter / JSON-body types that Wolverine.Http already suppresses for the
+// System.Text.Json branch. Same justification: user types are statically rooted
+// via endpoint discovery, AOT consumers run pre-generated frames in
+// TypeLoadMode.Static.
+
+[assembly: UnconditionalSuppressMessage("AOT", "IL3050",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http.Newtonsoft",
+    Justification = "Wolverine.Http.Newtonsoft codegen — closed generics over runtime endpoint / parameter types at codegen time. See AOT guide.")]

--- a/src/Extensions/Wolverine.Http.Newtonsoft/NewtonsoftHttpSerialization.cs
+++ b/src/Extensions/Wolverine.Http.Newtonsoft/NewtonsoftHttpSerialization.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
 using Newtonsoft.Json;
 
-namespace Wolverine.Http;
+namespace Wolverine.Http.Newtonsoft;
 
 public class NewtonsoftHttpSerialization
 {
@@ -15,13 +15,13 @@ public class NewtonsoftHttpSerialization
     private readonly ArrayPool<char> _charPool;
     private readonly JsonSerializer _serializer;
 
-    public NewtonsoftHttpSerialization(WolverineHttpOptions options)
+    public NewtonsoftHttpSerialization(JsonSerializerSettings settings)
     {
         _bytePool = ArrayPool<byte>.Shared;
         _charPool = ArrayPool<char>.Shared;
         _jsonCharPool = new JsonArrayPool<char>(_charPool);
 
-        Settings = options.NewtonsoftSerializerSettings;
+        Settings = settings ?? new JsonSerializerSettings();
         _serializer = JsonSerializer.Create(Settings);
     }
 

--- a/src/Extensions/Wolverine.Http.Newtonsoft/Wolverine.Http.Newtonsoft.csproj
+++ b/src/Extensions/Wolverine.Http.Newtonsoft/Wolverine.Http.Newtonsoft.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Newtonsoft.Json (Json.NET) serialization support for Wolverine.Http. Provides Wolverine 5.x-compatible Newtonsoft.Json wire-format opt-in via UseNewtonsoftJsonForSerialization() extension methods on WolverineHttpOptions. As of Wolverine 6.0, the core WolverineFx.Http package no longer depends on Newtonsoft.Json — install this package alongside it if you need Newtonsoft.Json instead of System.Text.Json for HTTP endpoints.</Description>
+        <PackageId>WolverineFx.Http.Newtonsoft</PackageId>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          AOT-compatible (#2746). Mirrors WolverineFx.Newtonsoft: the
+          NewtonsoftHttpSerialization wrappers themselves are AOT-clean,
+          and Newtonsoft.Json already carries its own
+          [RequiresUnreferencedCode] disclaimers on its public Serialize /
+          Deserialize methods. The IL warnings only surface when user code
+          calls Newtonsoft against trim-unsafe types. Net result for this
+          package: zero leaf suppressions needed. AOT consumers of
+          Wolverine.Http should prefer System.Text.Json (the default) and
+          only opt back into Newtonsoft if they need 5.x wire-format compat.
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <ProjectReference Include="..\..\Http\Wolverine.Http\Wolverine.Http.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Newtonsoft.Json" />
+    </ItemGroup>
+
+    <Import Project="../../../Analysis.Build.props" />
+
+</Project>

--- a/src/Extensions/Wolverine.Http.Newtonsoft/WolverineHttpNewtonsoftExtensions.cs
+++ b/src/Extensions/Wolverine.Http.Newtonsoft/WolverineHttpNewtonsoftExtensions.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Wolverine.Http.Newtonsoft.CodeGen;
+
+namespace Wolverine.Http.Newtonsoft;
+
+/// <summary>
+///     Wolverine 6.0 extension methods that wire Newtonsoft.Json into the
+///     Wolverine.Http JSON serialization pipeline. The Newtonsoft surface
+///     lived inline on <see cref="WolverineHttpOptions"/> in Wolverine 5.x;
+///     it moved to this separate package in 6.0 so the core
+///     <c>WolverineFx.Http</c> NuGet package no longer carries a
+///     Newtonsoft.Json dependency. Mirrors the symmetric extraction of
+///     core Wolverine to <c>WolverineFx.Newtonsoft</c> (PR #2743).
+///     See the Wolverine 6.0 migration guide.
+/// </summary>
+public static class WolverineHttpNewtonsoftExtensions
+{
+    /// <summary>
+    ///     Register the Newtonsoft.Json HTTP-serialization singleton
+    ///     (<c>NewtonsoftHttpSerialization</c>) used by the codegen frames
+    ///     emitted when <see cref="WolverineHttpOptions"/> is opted into
+    ///     <see cref="JsonUsage.NewtonsoftJson"/>. Call this alongside
+    ///     <c>AddWolverineHttp()</c> on your <see cref="IServiceCollection"/>
+    ///     when you intend to call
+    ///     <see cref="UseNewtonsoftJsonForSerialization"/> later inside
+    ///     <c>MapWolverineEndpoints</c>.
+    /// </summary>
+    /// <param name="services">The service collection to register against.</param>
+    /// <returns>The same service collection, for chaining.</returns>
+    public static IServiceCollection AddWolverineHttpNewtonsoft(this IServiceCollection services)
+    {
+        services.AddSingleton<NewtonsoftHttpSerialization>(sp =>
+        {
+            var options = sp.GetRequiredService<WolverineHttpOptions>();
+            var settings = new JsonSerializerSettings();
+            if (options.NewtonsoftSettingsConfiguration is Action<JsonSerializerSettings> configure)
+            {
+                configure(settings);
+            }
+            return new NewtonsoftHttpSerialization(settings);
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    ///     Opt into using Newtonsoft.Json for all JSON serialization in the Wolverine
+    ///     Http handlers. Mirrors the Wolverine 5.x
+    ///     <c>WolverineHttpOptions.UseNewtonsoftJsonForSerialization</c> instance method.
+    ///     Requires the <c>WolverineFx.Http.Newtonsoft</c> NuGet package and a prior
+    ///     call to <see cref="AddWolverineHttpNewtonsoft"/> on the IServiceCollection.
+    /// </summary>
+    /// <param name="options">The Wolverine HTTP options.</param>
+    /// <param name="configure">Optional callback to customize the Newtonsoft settings.</param>
+    public static void UseNewtonsoftJsonForSerialization(this WolverineHttpOptions options,
+        Action<JsonSerializerSettings>? configure = null)
+    {
+        if (options.Endpoints is null)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(UseNewtonsoftJsonForSerialization)} must be called inside the " +
+                "MapWolverineEndpoints configuration callback so the HttpGraph is initialized.");
+        }
+
+        // Stash the user's settings callback on the (untyped) options slot.
+        // AddWolverineHttpNewtonsoft()'s singleton factory reads it back when
+        // the DI container first resolves NewtonsoftHttpSerialization at
+        // request time.
+        if (configure != null)
+        {
+            options.NewtonsoftSettingsConfiguration = configure;
+        }
+
+        options.Endpoints.UseNewtonsoftJson(new NewtonsoftHttpCodeGen());
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/Wolverine.Http.Tests.csproj
+++ b/src/Http/Wolverine.Http.Tests/Wolverine.Http.Tests.csproj
@@ -27,6 +27,8 @@
         <ProjectReference Include="..\..\Testing\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj" />
         <ProjectReference Include="..\Wolverine.Http.Tests.DifferentAssembly\Wolverine.Http.Tests.DifferentAssembly.csproj" />
         <ProjectReference Include="..\Wolverine.Http\Wolverine.Http.csproj" />
+        <!-- using_newtonsoft_for_serialization.cs exercises the moved Newtonsoft HTTP surface. -->
+        <ProjectReference Include="..\..\Extensions\Wolverine.Http.Newtonsoft\Wolverine.Http.Newtonsoft.csproj" />
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <ProjectReference Include="..\WolverineWebApi\WolverineWebApi.csproj" />
     </ItemGroup>

--- a/src/Http/Wolverine.Http.Tests/using_newtonsoft_for_serialization.cs
+++ b/src/Http/Wolverine.Http.Tests/using_newtonsoft_for_serialization.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Shouldly;
+using Wolverine.Http.Newtonsoft;
 using Wolverine.Http.Tests.Bugs;
 using Wolverine.Marten;
 
@@ -28,13 +29,19 @@ public class using_newtonsoft_for_serialization
         });
 
         builder.Services.AddWolverineHttp();
+        // As of Wolverine 6.0, Newtonsoft.Json HTTP support lives in the
+        // separate WolverineFx.Http.Newtonsoft package — register its
+        // services here, then opt in via UseNewtonsoftJsonForSerialization()
+        // below.
+        builder.Services.AddWolverineHttpNewtonsoft();
 
         await using var host = await AlbaHost.For(builder, app =>
         {
             app.MapWolverineEndpoints(opts =>
             {
                 // Opt into using Newtonsoft.Json for JSON serialization just with Wolverine.HTTP routes
-                // Configuring the JSON serialization is optional
+                // Configuring the JSON serialization is optional. This extension method comes from
+                // the WolverineFx.Http.Newtonsoft package (using Wolverine.Http.Newtonsoft;).
                 opts.UseNewtonsoftJsonForSerialization(settings => settings.TypeNameHandling = TypeNameHandling.All);
             });
         });

--- a/src/Http/Wolverine.Http/AssemblyAttributes.cs
+++ b/src/Http/Wolverine.Http/AssemblyAttributes.cs
@@ -2,4 +2,10 @@ using System.Runtime.CompilerServices;
 using JasperFx.Core.TypeScanning;
 
 [assembly: InternalsVisibleTo("Wolverine.Http.Tests")]
+// WolverineFx.Http.Newtonsoft's UseNewtonsoftJsonForSerialization extension
+// needs to call HttpGraph.UseNewtonsoftJson(INewtonsoftHttpCodeGen) and
+// implement INewtonsoftHttpCodeGen — both internal so the public surface
+// only acknowledges the System.Text.Json default. The grant is intentional
+// and scoped to this one consumer.
+[assembly: InternalsVisibleTo("Wolverine.Http.Newtonsoft")]
 [assembly: IgnoreAssembly]

--- a/src/Http/Wolverine.Http/CodeGen/INewtonsoftHttpCodeGen.cs
+++ b/src/Http/Wolverine.Http/CodeGen/INewtonsoftHttpCodeGen.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+
+namespace Wolverine.Http.CodeGen;
+
+/// <summary>
+///     Internal seam used by the WolverineFx.Http.Newtonsoft companion package
+///     to plug Newtonsoft-flavored JSON request / response codegen frames into
+///     the core Wolverine.Http pipeline. As of Wolverine 6.0 the Newtonsoft
+///     surface (NewtonsoftHttpSerialization, the codegen frames that target it,
+///     UseNewtonsoftJsonForSerialization extension) lives in a separate NuGet
+///     package; core only carries the <see cref="JsonUsage.NewtonsoftJson"/>
+///     enum value and this hook so user code can flip the switch with the
+///     extension package installed. Without an implementation registered (which
+///     happens automatically when WolverineFx.Http.Newtonsoft is wired in via
+///     <c>UseNewtonsoftJsonForSerialization()</c>), selecting
+///     <see cref="JsonUsage.NewtonsoftJson"/> throws at codegen time.
+/// </summary>
+internal interface INewtonsoftHttpCodeGen
+{
+    /// <summary>
+    ///     Build the codegen variable that reads the request body via Newtonsoft.Json
+    ///     deserialization for a parameter on the endpoint method.
+    /// </summary>
+    Variable CreateReadJsonBodyVariable(ParameterInfo parameter);
+
+    /// <summary>
+    ///     Build the codegen variable that reads the request body via Newtonsoft.Json
+    ///     deserialization for a request type already discovered by the chain.
+    /// </summary>
+    Variable CreateReadJsonBodyVariable(Type requestType);
+
+    /// <summary>
+    ///     Build the codegen frame that writes the resource value to the response body
+    ///     via Newtonsoft.Json serialization.
+    /// </summary>
+    Frame CreateWriteJsonFrame(Variable resourceVariable);
+}

--- a/src/Http/Wolverine.Http/CodeGen/JsonHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/JsonHandling.cs
@@ -42,41 +42,6 @@ internal class ReadJsonBody : AsyncFrame
     }
 }
 
-internal class ReadJsonBodyWithNewtonsoft : MethodCall
-{
-    private static MethodInfo findMethodForType(Type parameterType)
-    {
-        return typeof(NewtonsoftHttpSerialization).GetMethod(nameof(NewtonsoftHttpSerialization.ReadFromJsonAsync))!
-            .MakeGenericMethod(parameterType);
-    }
-
-    public ReadJsonBodyWithNewtonsoft(ParameterInfo parameter) : base(typeof(NewtonsoftHttpSerialization), findMethodForType(parameter.ParameterType))
-    {
-        var parameterName = parameter.Name!;
-        if (parameterName == "_")
-        {
-            parameterName = Variable.DefaultArgName(parameter.ParameterType);
-        }
-
-        ReturnVariable!.OverrideName(parameterName);
-
-        CommentText = "Reading the request body with JSON deserialization";
-    }
-    
-    public ReadJsonBodyWithNewtonsoft(Type requestType) : base(typeof(NewtonsoftHttpSerialization), findMethodForType(requestType))
-    {
-        var parameterName = Variable.DefaultArgName(requestType);
-        if (parameterName == "_")
-        {
-            parameterName = Variable.DefaultArgName(requestType);
-        }
-
-        ReturnVariable!.OverrideName(parameterName);
-
-        CommentText = "Reading the request body with JSON deserialization";
-    }
-}
-
 internal class JsonBodyParameterStrategy : IParameterStrategy
 {
     public bool TryMatch(HttpChain chain, IServiceContainer container, ParameterInfo parameter, out Variable? variable)
@@ -107,7 +72,7 @@ internal class JsonBodyParameterStrategy : IParameterStrategy
             // It *could* be used twice, so let's watch out for this!
             chain.RequestBodyVariable ??= Usage == JsonUsage.SystemTextJson
                 ? new ReadJsonBody(parameter).Variable
-                : new ReadJsonBodyWithNewtonsoft(parameter).ReturnVariable!;
+                : RequireNewtonsoftCodeGen().CreateReadJsonBodyVariable(parameter);
 
             variable = chain.RequestBodyVariable;
 
@@ -121,6 +86,13 @@ internal class JsonBodyParameterStrategy : IParameterStrategy
 
     public JsonUsage Usage { get; set; } = JsonUsage.SystemTextJson;
 
+    /// <summary>
+    ///     Set by <see cref="HttpGraph.UseNewtonsoftJson"/> when the WolverineFx.Http.Newtonsoft
+    ///     companion package is wired up. Required when <see cref="Usage"/> is
+    ///     <see cref="JsonUsage.NewtonsoftJson"/>.
+    /// </summary>
+    internal INewtonsoftHttpCodeGen? NewtonsoftCodeGen { get; set; }
+
     public bool TryBuildVariable(HttpChain chain, out Variable variable)
     {
         if (chain.RequestType.IsConcrete())
@@ -128,7 +100,7 @@ internal class JsonBodyParameterStrategy : IParameterStrategy
             // It *could* be used twice, so let's watch out for this!
             chain.RequestBodyVariable ??= Usage == JsonUsage.SystemTextJson
                 ? new ReadJsonBody(chain.RequestType!).Variable
-                : new ReadJsonBodyWithNewtonsoft(chain.RequestType!).ReturnVariable!;
+                : RequireNewtonsoftCodeGen().CreateReadJsonBodyVariable(chain.RequestType!);
 
             variable = chain.RequestBodyVariable;
 
@@ -137,5 +109,19 @@ internal class JsonBodyParameterStrategy : IParameterStrategy
 
         variable = default!;
         return false;
+    }
+
+    private INewtonsoftHttpCodeGen RequireNewtonsoftCodeGen()
+    {
+        if (NewtonsoftCodeGen is null)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(JsonUsage)}.{nameof(JsonUsage.NewtonsoftJson)} is selected for HTTP JSON serialization, " +
+                "but no Newtonsoft codegen hook is registered. Install the WolverineFx.Http.Newtonsoft NuGet package " +
+                "and call opts.UseNewtonsoftJsonForSerialization() inside MapWolverineEndpoints. " +
+                "See https://wolverinefx.net/guide/http/json.html#using-newtonsoft-json.");
+        }
+
+        return NewtonsoftCodeGen;
     }
 }

--- a/src/Http/Wolverine.Http/CodeGen/ProblemDetailsContinuationPolicy.cs
+++ b/src/Http/Wolverine.Http/CodeGen/ProblemDetailsContinuationPolicy.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
@@ -6,7 +7,6 @@ using JasperFx.Core.Reflection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Wolverine.Configuration;
 using Wolverine.Middleware;
 
@@ -35,7 +35,11 @@ public class ProblemDetailsContinuationPolicy : IContinuationStrategy
 {
     public static void WriteProblems(ILogger logger, ProblemDetails details)
     {
-        var json = JsonConvert.SerializeObject(details, Formatting.None);
+        // Diagnostic-only logging dump; switched from Newtonsoft.Json's
+        // JsonConvert.SerializeObject to System.Text.Json in 6.0 alongside
+        // the Newtonsoft.Json extraction (#2742 / WolverineFx.Http.Newtonsoft).
+        // ProblemDetails round-trips cleanly through STJ; no observable change.
+        var json = JsonSerializer.Serialize(details);
         logger.LogInformation("Found problems with this message: {Problems}", json);
     }
     

--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -151,9 +151,25 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
         return chain;
     }
 
-    internal void UseNewtonsoftJson()
+    internal INewtonsoftHttpCodeGen? NewtonsoftCodeGen { get; private set; }
+
+    /// <summary>
+    ///     Wire the Newtonsoft.Json HTTP codegen path. Called by the WolverineFx.Http.Newtonsoft
+    ///     extension package's <c>UseNewtonsoftJsonForSerialization()</c> extension method;
+    ///     core <see cref="JsonResourceWriterPolicy"/> / <see cref="JsonBodyParameterStrategy"/>
+    ///     dispatch through the supplied hook when <see cref="JsonUsage.NewtonsoftJson"/>
+    ///     is selected.
+    /// </summary>
+    internal void UseNewtonsoftJson(INewtonsoftHttpCodeGen codeGen)
     {
-        _builtInWriterPolicies.OfType<JsonResourceWriterPolicy>().Single().Usage = JsonUsage.NewtonsoftJson;
-        _strategies.OfType<JsonBodyParameterStrategy>().Single().Usage = JsonUsage.NewtonsoftJson;
+        NewtonsoftCodeGen = codeGen ?? throw new ArgumentNullException(nameof(codeGen));
+
+        var writerPolicy = _builtInWriterPolicies.OfType<JsonResourceWriterPolicy>().Single();
+        writerPolicy.Usage = JsonUsage.NewtonsoftJson;
+        writerPolicy.NewtonsoftCodeGen = codeGen;
+
+        var bodyStrategy = _strategies.OfType<JsonBodyParameterStrategy>().Single();
+        bodyStrategy.Usage = JsonUsage.NewtonsoftJson;
+        bodyStrategy.NewtonsoftCodeGen = codeGen;
     }
 }

--- a/src/Http/Wolverine.Http/Resources/JsonResourceWriterPolicy.cs
+++ b/src/Http/Wolverine.Http/Resources/JsonResourceWriterPolicy.cs
@@ -1,4 +1,3 @@
-using JasperFx.CodeGeneration.Frames;
 using Wolverine.Http.CodeGen;
 
 namespace Wolverine.Http.Resources;
@@ -18,11 +17,16 @@ internal class JsonResourceWriterPolicy : IResourceWriterPolicy
             }
             else
             {
-                var frame = new MethodCall(typeof(NewtonsoftHttpSerialization),
-                    nameof(NewtonsoftHttpSerialization.WriteJsonAsync));
-                frame.Arguments[1] = resourceVariable;
+                if (NewtonsoftCodeGen is null)
+                {
+                    throw new InvalidOperationException(
+                        $"{nameof(JsonUsage)}.{nameof(JsonUsage.NewtonsoftJson)} is selected for HTTP JSON serialization, " +
+                        "but no Newtonsoft codegen hook is registered. Install the WolverineFx.Http.Newtonsoft NuGet package " +
+                        "and call opts.UseNewtonsoftJsonForSerialization() inside MapWolverineEndpoints. " +
+                        "See https://wolverinefx.net/guide/http/json.html#using-newtonsoft-json.");
+                }
 
-                chain.Postprocessors.Add(frame);
+                chain.Postprocessors.Add(NewtonsoftCodeGen.CreateWriteJsonFrame(resourceVariable));
             }
 
             return true;
@@ -32,4 +36,11 @@ internal class JsonResourceWriterPolicy : IResourceWriterPolicy
     }
 
     public JsonUsage Usage { get; set; } = JsonUsage.SystemTextJson;
+
+    /// <summary>
+    ///     Set by <see cref="HttpGraph.UseNewtonsoftJson"/> when the WolverineFx.Http.Newtonsoft
+    ///     companion package is wired up. Required when <see cref="Usage"/> is
+    ///     <see cref="JsonUsage.NewtonsoftJson"/>.
+    /// </summary>
+    internal INewtonsoftHttpCodeGen? NewtonsoftCodeGen { get; set; }
 }

--- a/src/Http/Wolverine.Http/Wolverine.Http.csproj
+++ b/src/Http/Wolverine.Http/Wolverine.Http.csproj
@@ -21,16 +21,15 @@
         <ProjectReference Include="..\..\Wolverine\Wolverine.csproj"/>
         <PackageReference Include="Asp.Versioning.Abstractions"/>
         <!--
-          Wolverine.Http carries its own Newtonsoft.Json surface
-          (NewtonsoftHttpSerialization, WolverineHttpOptions.UseNewtonsoftJsonForSerialization,
-          JsonStyle.NewtonsoftJson, the ProblemDetailsContinuationPolicy converter).
-          In 5.x this came in transitively via core Wolverine; that dependency
-          moved out of core in 6.0 (see WolverineFx.Newtonsoft / migration.md).
-          Wolverine.Http now declares the direct dependency. A future cleanup
-          (#2742) may extract this whole surface to a WolverineFx.Http.Newtonsoft
-          companion package.
+          Newtonsoft.Json was removed from WolverineFx.Http in 6.0 (#2742).
+          The Newtonsoft surface (NewtonsoftHttpSerialization,
+          UseNewtonsoftJsonForSerialization, the codegen frames that target
+          NewtonsoftHttpSerialization) moved to the WolverineFx.Http.Newtonsoft
+          companion package. Core retains the JsonUsage.NewtonsoftJson enum
+          value and an internal INewtonsoftHttpCodeGen seam; selecting the
+          enum without the extension package installed throws a useful
+          codegen-time exception. See docs/guide/migration.md.
         -->
-        <PackageReference Include="Newtonsoft.Json"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Http/Wolverine.Http/WolverineHttpEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpEndpointRouteBuilderExtensions.cs
@@ -164,7 +164,10 @@ public static class WolverineHttpEndpointRouteBuilderExtensions
         services.AddType(typeof(IApiDescriptionProvider), typeof(WolverineApiDescriptionProvider),
             ServiceLifetime.Singleton);
         services.AddSingleton<WolverineHttpOptions>();
-        services.AddSingleton<NewtonsoftHttpSerialization>();
+        // NewtonsoftHttpSerialization moved to the WolverineFx.Http.Newtonsoft
+        // companion package in 6.0. The package's AddWolverineHttpNewtonsoft()
+        // service-collection extension registers the singleton on demand; only
+        // apps that call UseNewtonsoftJsonForSerialization() pay for it now.
         services.AddSingleton<HttpTransportExecutor>();
 
         services.AddSingleton(typeof(IProblemDetailSource<>), typeof(ProblemDetailSource<>));

--- a/src/Http/Wolverine.Http/WolverineHttpOptions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpOptions.cs
@@ -5,7 +5,6 @@ using JasperFx.Core.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Wolverine.Http.Antiforgery;
 using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json;
 using Wolverine.Configuration;
 using Wolverine.Http.ApiVersioning;
 using Wolverine.Http.CodeGen;
@@ -204,7 +203,17 @@ public class WolverineHttpOptions
 
     internal Lazy<JsonSerializerOptions> JsonSerializerOptions { get; set; } = new(() => new JsonSerializerOptions());
 
-    internal JsonSerializerSettings NewtonsoftSerializerSettings { get; set; } = new();
+    /// <summary>
+    ///     Set by the WolverineFx.Http.Newtonsoft companion package's
+    ///     <c>UseNewtonsoftJsonForSerialization()</c> extension method to
+    ///     thread the user's <c>JsonSerializerSettings</c> customization
+    ///     into the singleton <c>NewtonsoftHttpSerialization</c> the
+    ///     extension package's <c>AddWolverineHttpNewtonsoft()</c>
+    ///     IServiceCollection extension registers. Untyped (object) so the
+    ///     core Wolverine.Http assembly does not have to reference
+    ///     Newtonsoft.Json.
+    /// </summary>
+    internal object? NewtonsoftSettingsConfiguration { get; set; }
 
     internal HttpGraph? Endpoints { get; set; }
 
@@ -259,17 +268,12 @@ public class WolverineHttpOptions
         Endpoints!.Rules.Sources.Add(source);
     }
 
-    /// <summary>
-    /// Opt into using Newtonsoft.Json for all JSON serialization in the Wolverine
-    /// Http handlers
-    /// </summary>
-    /// <param name="configure"></param>
-    public void UseNewtonsoftJsonForSerialization(Action<JsonSerializerSettings>? configure = null)
-    {
-        configure?.Invoke(NewtonsoftSerializerSettings);
-        Endpoints!.UseNewtonsoftJson();
-
-    }
+    // Newtonsoft.Json HTTP serialization moved to the WolverineFx.Http.Newtonsoft
+    // companion package in 6.0. The 5.x instance method
+    // WolverineHttpOptions.UseNewtonsoftJsonForSerialization(...) is now an
+    // extension method declared in that package; install it and add
+    // `using Wolverine.Http.Newtonsoft;` to bring the same call surface back
+    // into scope. See docs/guide/migration.md.
 
     /// <summary>
     ///     Customize Wolverine's handling of parameters to HTTP endpoint methods

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -37,6 +37,7 @@
     <Project Path="src/Extensions/Wolverine.Protobuf/Wolverine.Protobuf.csproj" />
   </Folder>
   <Folder Name="/Http/">
+    <Project Path="src/Extensions/Wolverine.Http.Newtonsoft/Wolverine.Http.Newtonsoft.csproj" />
     <Project Path="src/Http/CrazyStartingWebApp/CrazyStartingWebApp.csproj" />
     <Project Path="src/Http/DeepMiddlewareUsage/DeepMiddlewareUsage.csproj" />
     <Project Path="src/Http/NSwagDemonstrator/NSwagDemonstrator.csproj" />


### PR DESCRIPTION
Wolverine 6.0 breaking change. Removes the Newtonsoft.Json dependency from the core `WolverineFx.Http` NuGet package and moves the Newtonsoft HTTP surface to a new `WolverineFx.Http.Newtonsoft` companion package — direct mirror of #2743 (which did the same extraction for the core `WolverineFx` package).

Closes #2742.

## What moves

| 5.x API                                                              | 6.0 location                                            |
|---------------------------------------------------------------------- |---------------------------------------------------------|
| `WolverineHttpOptions.UseNewtonsoftJsonForSerialization(...)`        | extension method in `WolverineFx.Http.Newtonsoft`      |
| `Wolverine.Http.NewtonsoftHttpSerialization`                         | `Wolverine.Http.Newtonsoft.NewtonsoftHttpSerialization` |
| `ReadJsonBodyWithNewtonsoft` codegen frame                           | `Wolverine.Http.Newtonsoft.CodeGen` (internal)          |

Migrate by:
1. `dotnet add package WolverineFx.Http.Newtonsoft`
2. Add `builder.Services.AddWolverineHttpNewtonsoft();` alongside `AddWolverineHttp();`
3. Add `using Wolverine.Http.Newtonsoft;` wherever the old APIs are called
4. The call signature of `UseNewtonsoftJsonForSerialization` itself doesn't change

## What stays in core `Wolverine.Http`

- The `JsonUsage` enum, including `JsonUsage.NewtonsoftJson`. Per the issue's open question #1, the enum stays public on core; selecting `NewtonsoftJson` without the extension package installed throws an `InvalidOperationException` at codegen time pointing the user at `dotnet add package WolverineFx.Http.Newtonsoft`.
- The codegen branches in `JsonResourceWriterPolicy` / `JsonBodyParameterStrategy` that dispatch on `JsonUsage`. They route through a new internal `INewtonsoftHttpCodeGen` seam when `JsonUsage.NewtonsoftJson` is selected; the seam is implemented in the extension package.

## Branch points / decisions not pre-dictated by #2743

#2743 was an entirely-internal extraction (no public enum referenced the moved types). #2742 had to deal with `JsonUsage.NewtonsoftJson` being a *public enum value* on core that codegen branches on. Decisions made in this PR:

1. **Service registration is explicit, not transitive.** Wolverine 5.x's `AddWolverineHttp()` registered `NewtonsoftHttpSerialization` unconditionally as a singleton — an over-allocation paid by every app whether it used Newtonsoft or not. This PR removes that registration from core and ships an `AddWolverineHttpNewtonsoft()` extension on `IServiceCollection` in the new package. Users opting in now make two calls (`AddWolverineHttp().AddWolverineHttpNewtonsoft()`) instead of one — explicit and pay-for-play.
2. **Settings flow through an `internal object?` slot.** `UseNewtonsoftJsonForSerialization` is called inside `MapWolverineEndpoints` (after the DI container is built), so the user's `Action<JsonSerializerSettings>` callback can't be passed to the singleton at construction time directly. The extension stashes the callback on a new `WolverineHttpOptions.NewtonsoftSettingsConfiguration` (typed as `object?` so core stays Newtonsoft-free), and the new package's singleton factory reads it back on first DI resolve.
3. **`ProblemDetailsContinuationPolicy.WriteProblems` switched from Newtonsoft to STJ.** Symmetric to #2743's `Subscription.Scope` swap (`StringEnumConverter` → `JsonStringEnumConverter`). This is a diagnostic-only log-line dump of `ProblemDetails`; `ProblemDetails` round-trips cleanly through STJ. No observable output-format change.
4. **AOT.** The new package mirrors the `IsAotCompatible=true` + suppressions pattern from `WolverineFx.Newtonsoft` (chunk AJ #2801, merged). One namespace-scoped IL3050 suppression covering the codegen `MakeGenericMethod` path; same justification as the parallel STJ branch in core Wolverine.Http.

## Transports / other extensions

No transport changes. Wolverine.Http.Marten / Wolverine.Http.FluentValidation build clean against the slimmer core. Tests in `Wolverine.Http.Tests` get an explicit `ProjectReference` to the new package and the one affected test (`using_newtonsoft_for_serialization`) gets its `using` directive updated; no test logic changes.

## Test plan

- [x] `WolverineFx.Http.Newtonsoft` builds clean on net9.0 and net10.0 (0 warnings / 0 errors)
- [x] `WolverineFx.Http` builds clean on net9.0 and net10.0 with no Newtonsoft transitive dependency
- [x] `Wolverine.Http.Marten`, `Wolverine.Http.FluentValidation` build clean
- [ ] CI matrix validates the whole tree (kicking off with this PR)
- [ ] `using_newtonsoft_for_serialization.end_to_end` end-to-end test — blocked locally by pre-existing AOT errors in `Wolverine.EntityFrameworkCore` (the test project's transitive dep), unrelated to this PR; will fall out of CI

## Documentation

- `docs/guide/http/json.md`: replaced the inline Newtonsoft setup snippet with a "WolverineFx.Http.Newtonsoft" subsection that calls out the package install + `AddWolverineHttpNewtonsoft()` registration + `using Wolverine.Http.Newtonsoft;` directive
- `docs/guide/messages.md`: cross-reference tip directing HTTP-serialization users to the HTTP-specific package
- `docs/guide/migration.md`: 3 new at-a-glance table rows + a full "Wolverine.Http Newtonsoft moved to WolverineFx.Http.Newtonsoft package (BREAKING)" section mirroring the prose pattern from #2743's section

## Build wiring

- `wolverine.slnx`: new `Wolverine.Http.Newtonsoft` project added to the `/Http/` folder
- `build/build.cs` nugetProjects: `WolverineFx.Http.Newtonsoft` added to the pack list so it ships alongside core
- `Wolverine.Http.csproj`: `PackageReference Newtonsoft.Json` removed; replaced with a pointer comment + `InternalsVisibleTo` grant for `Wolverine.Http.Newtonsoft` (so the extension can call internal `HttpGraph.UseNewtonsoftJson(INewtonsoftHttpCodeGen)`)

Closes #2742; closes the Newtonsoft-extraction conversation from #2743 with the HTTP-side follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
