### PR TITLE
Fix NuGet pack failure: migrate PackageIconUrl to PackageIcon

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,10 @@
     <PropertyGroup>
         <LangVersion>12</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee;</Authors>
-        <PackageIconUrl>https://github.com/JasperFx/wolverine/blob/main/docs/public/logo.png?raw=true</PackageIconUrl>
+        <!-- PackageIconUrl is deprecated and trips NU5048 as a build-break under
+             TreatWarningsAsErrors on .NET SDK 10.0.300+. Use PackageIcon with an
+             embedded file instead. The icon is packed in via the ItemGroup below. -->
+        <PackageIcon>logo.png</PackageIcon>
         <PackageProjectUrl>http://github.com/jasperfx/wolverine</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
@@ -40,6 +43,14 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- Embed the package icon referenced by <PackageIcon> above. Pack=true
+             puts the file inside every produced .nupkg; PackagePath="\" places it
+             at the package root so PackageIcon's relative resolution finds it. -->
+        <None Include="$(MSBuildThisFileDirectory)docs/public/logo.png"
+              Pack="true" PackagePath="\" Visible="false" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

The [6.0.0-alpha.2 publish run](https://github.com/JasperFx/wolverine/actions/runs/25917830973) failed at the Pack step with **NU5048**:

> error NU5048: Warning As Error: The 'PackageIconUrl'/'iconUrl' element is deprecated. Consider using the 'PackageIcon'/'icon' element instead.

.NET SDK 10.0.300 enforces NU5048; combined with project-wide `TreatWarningsAsErrors=true`, that turns into a build break that aborts pack across every WolverineFx.* project. The previous publish on May 10 ran on an older 10.0.x SDK that didn't enforce it.

## Fix

- Replace `<PackageIconUrl>` with `<PackageIcon>logo.png</PackageIcon>` in `Directory.Build.props`.
- Add an `<ItemGroup>` that packs `docs/public/logo.png` into every produced `.nupkg` at the package root.
  - `$(MSBuildThisFileDirectory)docs/public/logo.png` anchors the include at the repo root so each project picks up the file from the same place rather than its own directory.
  - `Pack=true PackagePath="\" Visible=false` puts the file inside the `.nupkg` at the root (where `<PackageIcon>` resolves) and hides it from the IDE's solution explorer.

## Verified locally

```bash
$ dotnet pack src/Wolverine/Wolverine.csproj -c Release -o /tmp/pack
Successfully created package '/tmp/pack/WolverineFx.6.0.0-alpha.2.nupkg'.

$ unzip -l /tmp/pack/WolverineFx.6.0.0-alpha.2.nupkg | grep logo
   129350  05-15-2026 08:04   logo.png

$ unzip -p /tmp/pack/WolverineFx.6.0.0-alpha.2.nupkg WolverineFx.nuspec | grep icon
    <icon>logo.png</icon>
```

## Next steps after merge

1. Re-trigger the `Publish Wolverine Nugets` workflow_dispatch.
2. Verify alpha.2 packages land on nuget.org.

## Test plan

- [ ] CI green
- [ ] After merge: trigger publish workflow
- [ ] Confirm `WolverineFx 6.0.0-alpha.2` (and the rest of the matrix) reach nuget.org with the embedded icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)