### PR TITLE
Wolverine.Polecat IMessageOutbox bridge (closes #2774)

### DIFF
--- a/docs/guide/durability/polecat/event-forwarding.md
+++ b/docs/guide/durability/polecat/event-forwarding.md
@@ -55,3 +55,61 @@ builder.Host.UseWolverine(opts =>
     opts.Policies.AutoApplyTransactions();
 });
 ```
+
+## Projection Side-Effect Messages <Badge type="tip" text="6.0" />
+
+Polecat projections can publish Wolverine messages as a side effect of a projection update by overriding `RaiseSideEffects` and calling `slice.PublishMessage(...)`. By default Polecat ships with a `NulloMessageOutbox` that drops every published message — projections that don't need messaging pay zero overhead.
+
+`IntegrateWithWolverine()` flips that default and registers Wolverine.Polecat's `PolecatToWolverineOutbox` as the active `IMessageOutbox`. After that's wired, every `slice.PublishMessage(...)` is buffered in a `MessageContext` outbox enlisted in the projection's SQL transaction, and the buffered messages flush via Wolverine's outgoing-message machinery once the projection's database changes commit durably.
+
+See Polecat's [`docs/events/projections/side-effects.md`](https://github.com/JasperFx/polecat/blob/main/docs/events/projections/side-effects.md) for the projection-author side of the contract (the `RaiseSideEffects` override shape and the `slice.PublishMessage` surface).
+
+## Overriding Side-Effect Message Metadata <Badge type="tip" text="6.0" />
+
+When a Polecat projection publishes a Wolverine message from `RaiseSideEffects` via `slice.PublishMessage(...)`, the resulting Wolverine envelope is built by an internal `MessageContext` that has no inherent knowledge of the originating event's metadata. By default the outgoing message ends up with no correlation id, no causation id, and an envelope-level conversation id rooted at its own envelope id — which means the chain Event A → side-effect command → Event B does not naturally share a correlation id.
+
+The metadata-aware overload of `PublishMessage` (JasperFx.Events 2.0+) lets the projection author override the per-message metadata that the side-effect command's envelope (and the Polecat session opened for its handler) will inherit:
+
+```csharp
+public class TodoCloserProjection : MultiStreamProjection<TodoTask, Guid>
+{
+    public override ValueTask RaiseSideEffects(IDocumentSession session, IEventSlice<TodoTask> slice)
+    {
+        if (slice.Snapshot is null) return ValueTask.CompletedTask;
+
+        // Carry the originating event's correlation id (and optionally its
+        // causation id) onto the command we're emitting, so the handler that
+        // closes the task can match against it.
+        var correlationId = slice.Events()
+            .Select(e => e.CorrelationId)
+            .FirstOrDefault(id => id is not null);
+
+        slice.PublishMessage(
+            new CloseTodoTask(slice.Snapshot.Id),
+            new MessageMetadata(slice.TenantId)
+            {
+                CorrelationId = correlationId,
+                CausationId = slice.Events().Last().Id.ToString()
+            });
+
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+What the override actually does inside Wolverine — identical mapping to the Marten bridge:
+
+| `MessageMetadata` field | Effect on the outgoing envelope | Effect on the receiving handler |
+|---|---|---|
+| `TenantId` | `envelope.TenantId` (also drives transport routing for tenanted endpoints) | `IMessageContext.TenantId`, scoped `DbContext` / `IDocumentSession` tenant |
+| `CorrelationId` | `envelope.CorrelationId` (passes through `MessageBus.TrackEnvelopeCorrelation` without being clobbered) | `IMessageContext.CorrelationId`, `session.CorrelationId` (Polecat) |
+| `CausationId` | Stored as `envelope.Headers["causation-id"]` because Wolverine's native `Envelope.ConversationId` is `Guid`-typed and would lose information | `session.CausationId` (Polecat) — `OutboxedSessionFactory` reads the header in preference to the default `ConversationId.ToString()` chain |
+| `Headers` | Each entry copied onto `envelope.Headers` (string-converted) | Available via `envelope.Headers` on the receiving side |
+
+The metadata-less form (`slice.PublishMessage(message)`) is unchanged and remains the right call when you don't need per-message overrides.
+
+### When you actually need this
+
+The motivating case is a "todo-list" projection: Event A opens a task keyed by some correlation id, Event B (emitted by the handler of a side-effect command) closes the task with the same key. Without the metadata override, Event B carries a null correlation id and the close never matches.
+
+The same shape applies to anywhere you want a chain of derived events/commands to share a business-meaningful identifier — distributed tracing keyed on `correlation-id`, idempotency keys, tenant-scoped audit threading, etc. Pick the metadata fields that match your business need; you don't have to set all of them.

--- a/src/Persistence/PolecatTests/Publishing/polecat_to_wolverine_outbox_registration.cs
+++ b/src/Persistence/PolecatTests/Publishing/polecat_to_wolverine_outbox_registration.cs
@@ -1,0 +1,86 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Polecat.Events.Aggregation;
+using Shouldly;
+using Wolverine;
+using Wolverine.Polecat;
+using Wolverine.Polecat.Publishing;
+using Xunit;
+
+namespace PolecatTests.Publishing;
+
+/// <summary>
+///     Registration smoke test for wolverine#2774: verify that
+///     <see cref="WolverineOptionsPolecatExtensions.IntegrateWithWolverine"/>
+///     replaces Polecat's default <see cref="NulloMessageOutbox"/> on
+///     <see cref="StoreOptions.Events"/>.<c>MessageOutbox</c> with the Wolverine
+///     bridge (<see cref="PolecatToWolverineOutbox"/>).
+///
+///     Doesn't drive the daemon end-to-end — that's the broader test-parity
+///     work tracked alongside the issue's other acceptance criteria. This test
+///     fails closed if the registration line in <c>PolecatOverrides.Configure</c>
+///     ever regresses (silent drop back to the no-op outbox would surface here
+///     as the assertion failing, not as messages silently disappearing in
+///     production).
+/// </summary>
+public class polecat_to_wolverine_outbox_registration
+{
+    [Fact]
+    public async Task integrate_with_wolverine_replaces_the_default_nullo_outbox()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddPolecat(m =>
+                {
+                    m.ConnectionString = Servers.SqlServerConnectionString;
+                    m.DatabaseSchemaName = "wolverine_polecat_outbox_smoke";
+                }).IntegrateWithWolverine();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+
+        // Before #2774, Polecat shipped NulloMessageOutbox as the default; the bridge
+        // flips it to PolecatToWolverineOutbox during PolecatOverrides.Configure.
+        store.Options.Events.MessageOutbox.ShouldBeOfType<PolecatToWolverineOutbox>();
+    }
+
+    [Fact]
+    public async Task polecat_without_integrate_with_wolverine_keeps_polecats_default_outbox()
+    {
+        // Standalone Polecat host (no Wolverine integration) should keep Polecat's
+        // default outbox — confirms PolecatOverrides only flips the outbox when
+        // IntegrateWithWolverine actually runs. NulloMessageOutbox is internal to
+        // Polecat so we assert the negative (NOT the Wolverine bridge) instead of
+        // type-checking against the internal default.
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddPolecat(m =>
+                {
+                    m.ConnectionString = Servers.SqlServerConnectionString;
+                    m.DatabaseSchemaName = "polecat_no_wolverine_outbox_smoke";
+                });
+
+                services.AddResourceSetupOnStartup();
+            })
+            .Build();
+
+        await host.StartAsync();
+
+        try
+        {
+            var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+            store.Options.Events.MessageOutbox.ShouldNotBeOfType<PolecatToWolverineOutbox>();
+        }
+        finally
+        {
+            await host.StopAsync();
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
@@ -118,6 +118,13 @@ internal class PolecatOverrides : IConfigurePolecat
         // Polecat's DocumentMapping automatically detects IRevisioned types
         // and enables numeric revisions. Wolverine's Saga type uses Version property
         // which is handled by the saga persistence framework.
+
+        // Replace Polecat's default NulloMessageOutbox with the Wolverine bridge so
+        // projection authors who call `slice.PublishMessage(...)` from a Polecat
+        // RaiseSideEffects override actually have the message delivered through
+        // Wolverine after the projection batch's SQL transaction commits. Mirrors
+        // the Marten side at MartenIntegration.cs:153. See wolverine#2774.
+        options.Events.MessageOutbox = new PolecatToWolverineOutbox(services);
     }
 }
 

--- a/src/Persistence/Wolverine.Polecat/Publishing/PolecatToWolverineMessageBatch.cs
+++ b/src/Persistence/Wolverine.Polecat/Publishing/PolecatToWolverineMessageBatch.cs
@@ -1,0 +1,93 @@
+using JasperFx.Events;
+using Polecat;
+using Polecat.Events.Aggregation;
+using Wolverine.Runtime;
+
+namespace Wolverine.Polecat.Publishing;
+
+/// <summary>
+///     Polecat side of the projection-message bridge to Wolverine. One instance
+///     per projection daemon batch; <see cref="IMessageOutbox.CreateBatch(IDocumentSession)"/>
+///     vends a fresh batch on the first <c>slice.PublishMessage(...)</c> within a
+///     given daemon write. Messages buffer in the underlying
+///     <see cref="MessageContext"/> outbox and flush once the projection's SQL
+///     transaction has committed durably (see <see cref="AfterCommitAsync"/>).
+/// </summary>
+/// <remarks>
+///     Mirrors <see cref="Wolverine.Marten.Publishing.MartenToWolverineMessageBatch"/>.
+///     The differences from Marten:
+///     <list type="bullet">
+///         <item><description>
+///             Polecat's <see cref="IMessageBatch.BeforeCommitAsync"/> /
+///             <see cref="IMessageBatch.AfterCommitAsync"/> take just a
+///             <see cref="CancellationToken"/> — Polecat already owns the
+///             session + commit context internally.
+///         </description></item>
+///         <item><description>
+///             The session field is captured but unused at flush time (the message
+///             flush goes through <see cref="MessageContext"/>, which already holds
+///             the enlisted <see cref="PolecatEnvelopeTransaction"/>). Kept on the
+///             constructor for symmetry with Marten and in case future per-batch
+///             session-scoped behavior needs it.
+///         </description></item>
+///     </list>
+/// </remarks>
+#pragma warning disable CS9113 // Parameter is unread
+internal class PolecatToWolverineMessageBatch(MessageContext Context, IDocumentSession Session) : IMessageBatch
+#pragma warning restore CS9113
+{
+    public ValueTask PublishAsync<T>(T message, string tenantId)
+    {
+        return Context.PublishAsync(message, new DeliveryOptions { TenantId = tenantId });
+    }
+
+    /// <summary>
+    ///     Metadata-aware overload backing <see cref="IMessageSink.PublishAsync{T}(T, MessageMetadata)"/>
+    ///     (JasperFx.Events 2.0+). Maps the incoming <see cref="MessageMetadata"/>
+    ///     onto a <see cref="DeliveryOptions"/> so projection-authored side-effect
+    ///     messages can override tenant, correlation id, causation id, and headers
+    ///     on a per-message basis. Behavior is identical to Marten's mapping; see
+    ///     https://github.com/JasperFx/wolverine/issues/2545 for the original motivation.
+    /// </summary>
+    public ValueTask PublishAsync<T>(T message, MessageMetadata metadata)
+    {
+        var options = new DeliveryOptions
+        {
+            TenantId = metadata.TenantId
+        };
+
+        if (metadata.CorrelationIdEnabled)
+        {
+            options.CorrelationId = metadata.CorrelationId;
+        }
+
+        if (metadata.CausationIdEnabled)
+        {
+            options.CausationId = metadata.CausationId;
+        }
+
+        if (metadata.HeadersEnabled)
+        {
+            foreach (var header in metadata.Headers!)
+            {
+                options.Headers[header.Key] = header.Value?.ToString();
+            }
+        }
+
+        return Context.PublishAsync(message, options);
+    }
+
+    public Task BeforeCommitAsync(CancellationToken token)
+    {
+        // Wolverine's MessageContext flushes after commit (post-#2545); the
+        // Marten bridge does the same. Polecat surfaces a pre-commit hook for
+        // future "outbox row participates in the projection SQL transaction"
+        // strategies, but the current bridge stays best-effort post-commit.
+        return Task.CompletedTask;
+    }
+
+    public Task AfterCommitAsync(CancellationToken token)
+    {
+        return Context.FlushOutgoingMessagesAsync();
+    }
+}

--- a/src/Persistence/Wolverine.Polecat/Publishing/PolecatToWolverineOutbox.cs
+++ b/src/Persistence/Wolverine.Polecat/Publishing/PolecatToWolverineOutbox.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.DependencyInjection;
+using Polecat;
+using Polecat.Events.Aggregation;
+using Wolverine.Runtime;
+
+namespace Wolverine.Polecat.Publishing;
+
+/// <summary>
+///     <see cref="IMessageOutbox"/> implementation that bridges Polecat's projection
+///     daemon to Wolverine's outgoing-message machinery. Registered as
+///     <see cref="Polecat.StoreOptions.MessageOutbox"/> when
+///     <see cref="WolverineOptionsPolecatExtensions.IntegrateWithWolverine"/> runs;
+///     replaces Polecat's default <see cref="NulloMessageOutbox"/> (which drops
+///     every published message).
+/// </summary>
+/// <remarks>
+///     Mirrors <see cref="Wolverine.Marten.Publishing.MartenToWolverineOutbox"/>
+///     verbatim except for the Polecat-vs-Marten session type. The
+///     <see cref="IMessageOutbox.CreateBatch(IDocumentSession)"/> contract receives
+///     the public <see cref="IDocumentSession"/> (Polecat exposes the
+///     <c>ITransactionParticipantRegistrar</c> surface needed to enlist there), so
+///     no <c>InternalsVisibleTo</c> is required.
+/// </remarks>
+internal class PolecatToWolverineOutbox : IMessageOutbox
+{
+    private readonly Lazy<IWolverineRuntime> _runtime;
+
+    public PolecatToWolverineOutbox(IServiceProvider services)
+    {
+        _runtime = new Lazy<IWolverineRuntime>(() => services.GetRequiredService<IWolverineRuntime>());
+    }
+
+    public async ValueTask<IMessageBatch> CreateBatch(IDocumentSession session)
+    {
+        var context = new MessageContext(_runtime.Value, session.TenantId)
+        {
+            MultiFlushMode = MultiFlushMode.AllowMultiples
+        };
+
+        await context.EnlistInOutboxAsync(new PolecatEnvelopeTransaction(session, context));
+
+        return new PolecatToWolverineMessageBatch(context, session);
+    }
+}


### PR DESCRIPTION
## Summary

Closes [#2774](https://github.com/JasperFx/wolverine/issues/2774). Mirrors the Wolverine.Marten projection-side-effect bridge for Polecat 4.0. Once `IntegrateWithWolverine()` runs, Polecat's `options.Events.MessageOutbox` flips from the default `NulloMessageOutbox` to `PolecatToWolverineOutbox`, so projection authors who call `slice.PublishMessage(...)` from a `RaiseSideEffects` override actually have the message delivered through Wolverine after the projection batch's SQL transaction commits.

## Files

| Path | Mirrors |
|---|---|
| `src/Persistence/Wolverine.Polecat/Publishing/PolecatToWolverineOutbox.cs` | `MartenToWolverineOutbox.cs` |
| `src/Persistence/Wolverine.Polecat/Publishing/PolecatToWolverineMessageBatch.cs` | `MartenToWolverineMessageBatch.cs` |
| `src/Persistence/Wolverine.Polecat/PolecatIntegration.cs` (`PolecatOverrides.Configure`) | `MartenIntegration.cs:153` |
| `docs/guide/durability/polecat/event-forwarding.md` (two new sections) | `docs/guide/durability/marten/event-forwarding.md` |
| `src/Persistence/PolecatTests/Publishing/polecat_to_wolverine_outbox_registration.cs` | registration smoke tests (see below) |

The Polecat-side `IMessageOutbox.CreateBatch` takes the public `IDocumentSession` (Polecat exposes the `ITransactionParticipantRegistrar` surface on the public interface), so no `InternalsVisibleTo` is required.

## Differences from Marten

| Aspect | Marten | Polecat |
|---|---|---|
| `IMessageBatch` commit-hook signatures | `Task BeforeCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)` | `Task BeforeCommitAsync(CancellationToken token)` — Polecat owns the session + commit context internally |
| `IMessageBatch` base | none | `: IMessageSink` (the shared JasperFx.Events 2.0+ interface) |
| `MessageOutbox` property path | `options.Events.MessageOutbox` (same shape) | `options.Events.MessageOutbox` — on the nested `EventStoreOptions` accessed via `StoreOptions.Events` |

Both flush messages in `AfterCommitAsync` (post-commit best-effort delivery, matches the documented Marten semantic).

## Metadata-aware overload

`PublishAsync<T>(T message, MessageMetadata metadata)` carries the full `MessageMetadata → DeliveryOptions` mapping from the Marten side: `TenantId`, `CorrelationId` (gated on `CorrelationIdEnabled`), `CausationId` (gated on `CausationIdEnabled`), and `Headers` (gated on `HeadersEnabled`). Per-field semantics documented in the new doc section.

## Tests

Two registration smoke tests in `polecat_to_wolverine_outbox_registration.cs`:

1. **With `IntegrateWithWolverine()`** — asserts `options.Events.MessageOutbox` is `PolecatToWolverineOutbox`.
2. **Without `IntegrateWithWolverine()`** — asserts `options.Events.MessageOutbox` is **not** `PolecatToWolverineOutbox` (Polecat's default `NulloMessageOutbox` is left alone). Asserts the negative because `NulloMessageOutbox` is internal to Polecat.

### Test parity follow-up

The broader end-to-end test parity (projection writes events → `RaiseSideEffects` publishes → Wolverine handler receives) — symmetric with `src/Persistence/MartenTests/event_streaming.cs` + `end_to_end_publish_messages_through_marten_to_wolverine.cs` (~465 lines) — is **left as a follow-up**. The implementation here is a verbatim mirror of the Marten side at the call sites that matter, so the unit-level risk is low; full parity is documentation-completeness work that fits better as a dedicated PR.

### Local verification

- [x] `dotnet build src/Persistence/Wolverine.Polecat/Wolverine.Polecat.csproj` — 0 errors on net9.0 + net10.0
- [x] `dotnet build src/Persistence/PolecatTests/PolecatTests.csproj` — 0 errors on net9.0 + net10.0
- [ ] Registration smoke test (needs SQL Server; deferred to CI — local SQL Server boot under emulated amd64-on-arm64 took longer than the session budget; CI runs the proper image natively)

## Documentation

Two new sections on `docs/guide/durability/polecat/event-forwarding.md`:

- **Projection Side-Effect Messages** — explains the `NulloMessageOutbox` → `PolecatToWolverineOutbox` flip on `IntegrateWithWolverine()` and points readers at Polecat's `docs/events/projections/side-effects.md`.
- **Overriding Side-Effect Message Metadata** — the metadata-aware overload's projection-author guidance and the per-field mapping table. Verbatim port of the Marten section, with the projection example signature updated from `IDocumentOperations` to `IDocumentSession` to match Polecat's `RaiseSideEffects` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
