### PR TITLE
Remove obsolete EventForwardingToWolverine() Marten extensions (refs wolverine#2745)

### DIFF
--- a/docs/guide/durability/marten/event-forwarding.md
+++ b/docs/guide/durability/marten/event-forwarding.md
@@ -31,8 +31,9 @@ new events, and the resulting event messages go out as cascading messages only a
 like any other outbox usage. **There is no guarantee about ordering in this case.** Instead, Wolverine is trying to have these
 events processed as soon as possible.
 
-To opt into this feature, chain the Wolverine `AddMarten().EventForwardingToWolverine()` call as
-shown in this application bootstrapping sample shown below:
+To opt into this feature, set `MartenIntegration.UseFastEventForwarding = true` inside the
+configure callback on `IntegrateWithWolverine()` as shown in this application bootstrapping
+sample below:
 
 <!-- snippet: sample_opting_into_wolverine_event_publishing -->
 <a id='snippet-sample_opting_into_wolverine_event_publishing'></a>
@@ -64,14 +65,11 @@ builder.Services.AddMarten(opts =>
     // asynchronous projections in a background process
     .AddAsyncDaemon(DaemonMode.HotCold)
 
-    // I added this to enroll Marten in the Wolverine outbox
-    .IntegrateWithWolverine()
-
-    // I also added this to opt into events being forward to
-    // the Wolverine outbox during SaveChangesAsync()
-    .EventForwardingToWolverine();
+    // Enroll Marten in the Wolverine outbox and opt into
+    // forwarding events to the Wolverine outbox on SaveChangesAsync()
+    .IntegrateWithWolverine(x => x.UseFastEventForwarding = true);
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/CQRSWithMarten/TeleHealth.WebApi/Program.cs#L57-L92' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opting_into_wolverine_event_publishing' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/CQRSWithMarten/TeleHealth.WebApi/Program.cs#L57-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opting_into_wolverine_event_publishing' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This does need to be paired with a little bit of Wolverine configuration to add
@@ -142,8 +140,9 @@ public async Task execution_of_forwarded_events_can_be_awaited_from_tests()
         .ConfigureServices(services =>
         {
             services.AddMarten(Servers.PostgresConnectionString)
-                .IntegrateWithWolverine().EventForwardingToWolverine(opts =>
+                .IntegrateWithWolverine(opts =>
                 {
+                    opts.UseFastEventForwarding = true;
                     opts.SubscribeToEvent<SecondEvent>().TransformedTo(e =>
                         new SecondMessage(e.StreamId, e.Sequence));
                 });
@@ -163,7 +162,7 @@ public async Task execution_of_forwarded_events_can_be_awaited_from_tests()
     events[1].Data.ShouldBeOfType<FourthEvent>();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/event_streaming.cs#L142-L171' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_execution_of_forwarded_events_can_be_awaited_from_tests' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/event_streaming.cs#L142-L172' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_execution_of_forwarded_events_can_be_awaited_from_tests' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Where the result contains `FourthEvent` because `SecondEvent` was forwarded as `SecondMessage` and that persisted `FourthEvent` in a handler such as:

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -28,6 +28,7 @@ The table below is the **complete inventory** of changed defaults, removed APIs,
 | Target framework | `net8.0;net9.0;net10.0` | `net9.0;net10.0` *(BREAKING)* | Move to .NET 9+ or pin Wolverine 5.x |
 | Critter-stack package versions | 1.x line | 2.0-alpha line | Bump in lockstep across JasperFx, Marten, Polecat — full table below |
 | `IForwardsTo<T>` discovery | implicit assembly scan at startup | **explicit `opts.RegisterMessageForwarder<TFrom, TTo>()`** *(BREAKING)* | Register each forwarder explicitly; or temporarily call [`opts.UseAutomaticForwarderDiscovery()`](#iforwardsto-discovery-is-now-explicit-breaking) (`[Obsolete]`, removed in 7.0) |
+| `MartenConfigurationExpression.EventForwardingToWolverine(...)` | extension method on the Marten configuration expression *(both overloads `[Obsolete]` since 3.x)* | **removed** *(BREAKING)* | Move the flag into the `IntegrateWithWolverine` callback: [`IntegrateWithWolverine(x => x.UseFastEventForwarding = true)`](#eventforwardingtowolverine-removed-breaking) |
 | `Saga.Version` property type | `int` | `long` | Typically none — `int` widens implicitly to `long`. Only affects code that stores `saga.Version` in an `int` variable, casts it explicitly, or binds it to a column typed `int`. Tracks the matching `IRevisioned.Version` widening in Marten 9.0. |
 | **One-line full revert** | n/a | [`opts.RestoreV5Defaults()`](#one-line-revert-restorev5defaults) | Flip every runtime default this method covers back to its 5.x value |
 
@@ -197,6 +198,39 @@ opts.UseAutomaticForwarderDiscovery();
 This re-enables the 5.x assembly scan against `WolverineOptions.ApplicationAssembly`. It is marked `[Obsolete]` and `[RequiresUnreferencedCode]` because the underlying scan walks exported types and the trimmer cannot prove which forwarder types are reachable. It is provided as a backward-compatibility escape valve for the 6.0 release cycle and is **slated for removal in 7.0** — migrate to `RegisterMessageForwarder<TFrom, TTo>()` before then.
 
 If you don't use `IForwardsTo<T>` at all, no change is needed.
+
+### `EventForwardingToWolverine()` removed (BREAKING)
+
+Both `MartenConfigurationExpression.EventForwardingToWolverine(...)` extension method overloads (parameterless and the one taking `Action<IEventForwarding>`) were marked `[Obsolete]` in the 3.x line with a "will be removed in Wolverine 4.0" notice. They are now actually removed in 6.0.
+
+The replacement has been available since 3.0: set `MartenIntegration.UseFastEventForwarding = true` inside the `IntegrateWithWolverine` configure callback. Event-subscription transformations (`SubscribeToEvent<T>().TransformedTo(...)`) live on the same `MartenIntegration` instance, so they move into the same callback.
+
+**Before (5.x):**
+
+```csharp
+services.AddMarten(opts => opts.Connection(connString))
+    .IntegrateWithWolverine()
+    .EventForwardingToWolverine();
+```
+
+**After (6.0):**
+
+```csharp
+services.AddMarten(opts => opts.Connection(connString))
+    .IntegrateWithWolverine(x => x.UseFastEventForwarding = true);
+```
+
+The `Action<IEventForwarding>` overload migrates to the same callback:
+
+```csharp
+services.AddMarten(opts => opts.Connection(connString))
+    .IntegrateWithWolverine(x =>
+    {
+        x.UseFastEventForwarding = true;
+        x.SubscribeToEvent<SecondEvent>()
+            .TransformedTo(e => new SecondMessage(e.StreamId, e.Sequence));
+    });
+```
 
 ### Performance: per-endpoint serializer cache pre-population
 

--- a/src/Persistence/MartenTests/Bugs/Bug_262_test_does_not_complete_with_timeout_message.cs
+++ b/src/Persistence/MartenTests/Bugs/Bug_262_test_does_not_complete_with_timeout_message.cs
@@ -23,8 +23,7 @@ public class saga_cannot_access_stream_just_persisted_in_immediate_timeout : Pos
                     {
                         m.Connection(Servers.PostgresConnectionString);
                     })
-                    .EventForwardingToWolverine()
-                    .IntegrateWithWolverine();
+                    .IntegrateWithWolverine(x => x.UseFastEventForwarding = true);
 
                 services.AddResourceSetupOnStartup();
             })

--- a/src/Persistence/MartenTests/Bugs/event_forwarding_bug.cs
+++ b/src/Persistence/MartenTests/Bugs/event_forwarding_bug.cs
@@ -32,8 +32,7 @@ public class event_forwarding_bug
                     m.Events.StreamIdentity = StreamIdentity.AsString;
                     m.Projections.LiveStreamAggregation<ShoppingList>();
                 }).UseLightweightSessions()
-                .IntegrateWithWolverine()
-                .EventForwardingToWolverine();;
+                .IntegrateWithWolverine(x => x.UseFastEventForwarding = true);
             }).StartAsync();
 
         var runtime = host.GetRuntime();

--- a/src/Persistence/MartenTests/Bugs/event_forwarding_routing_bug.cs
+++ b/src/Persistence/MartenTests/Bugs/event_forwarding_routing_bug.cs
@@ -27,8 +27,7 @@ public class event_forwarding_routing_bug
                         m.Connection(Servers.PostgresConnectionString);
                         m.DatabaseSchemaName = "forwarding_routing";
                     })
-                    .IntegrateWithWolverine()
-                    .EventForwardingToWolverine();
+                    .IntegrateWithWolverine(x => x.UseFastEventForwarding = true);
             })
             .StartAsync();
 

--- a/src/Persistence/MartenTests/event_streaming.cs
+++ b/src/Persistence/MartenTests/event_streaming.cs
@@ -79,9 +79,11 @@ public class event_streaming : PostgresqlContext, IAsyncLifetime
                         opts.Connection(Servers.PostgresConnectionString);
                         opts.Logger(new TestOutputMartenLogger(_output));
                     })
-                    .IntegrateWithWolverine(x => x.MessageStorageSchemaName = "sender").EventForwardingToWolverine(opts =>
+                    .IntegrateWithWolverine(x =>
                     {
-                        opts.SubscribeToEvent<SecondEvent>().TransformedTo(e => new SecondMessage(e.StreamId, e.Sequence));
+                        x.MessageStorageSchemaName = "sender";
+                        x.UseFastEventForwarding = true;
+                        x.SubscribeToEvent<SecondEvent>().TransformedTo(e => new SecondMessage(e.StreamId, e.Sequence));
                     });
 
                 services.AddResourceSetupOnStartup();
@@ -148,8 +150,9 @@ public class event_streaming : PostgresqlContext, IAsyncLifetime
             .ConfigureServices(services =>
             {
                 services.AddMarten(Servers.PostgresConnectionString)
-                    .IntegrateWithWolverine().EventForwardingToWolverine(opts =>
+                    .IntegrateWithWolverine(opts =>
                     {
+                        opts.UseFastEventForwarding = true;
                         opts.SubscribeToEvent<SecondEvent>().TransformedTo(e =>
                             new SecondMessage(e.StreamId, e.Sequence));
                     });

--- a/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
@@ -251,56 +251,6 @@ public static class WolverineOptionsMartenExtensions
     }
 
     /// <summary>
-    ///     Enable publishing of events to Wolverine message routing when captured in Marten sessions that are enrolled in a
-    ///     Wolverine outbox
-    /// </summary>
-    /// <param name="expression"></param>
-    /// <returns></returns>
-    [Obsolete(
-        $"Favor using the {nameof(MartenIntegration.UseFastEventForwarding)} property as part of {nameof(IntegrateWithWolverine)}. This will be removed in Wolverine 4.0")]
-    public static MartenServiceCollectionExtensions.MartenConfigurationExpression EventForwardingToWolverine(
-        this MartenServiceCollectionExtensions.MartenConfigurationExpression expression)
-    {
-        var integration = expression.Services.FindMartenIntegration();
-        if (integration == null)
-        {
-            expression.IntegrateWithWolverine();
-            integration = expression.Services.FindMartenIntegration();
-        }
-
-        integration!.UseFastEventForwarding = true;
-
-        return expression;
-    }
-
-    /// <summary>
-    ///     Enable publishing of events to Wolverine message routing when captured in Marten sessions that are enrolled in a
-    ///     Wolverine outbox. This requires usage of Marten transactional middleware within Wolverine, and makes no guarantees
-    ///     about ordering
-    /// </summary>
-    /// <param name="expression"></param>
-    /// <returns></returns>
-    [Obsolete(
-        $"All of these options are available within the {nameof(IntegrateWithWolverine)}() method. This will be removed in Wolverine 4.0")]
-    public static MartenServiceCollectionExtensions.MartenConfigurationExpression EventForwardingToWolverine(
-        this MartenServiceCollectionExtensions.MartenConfigurationExpression expression,
-        Action<IEventForwarding> configure)
-    {
-        var integration = expression.Services.FindMartenIntegration();
-        if (integration == null)
-        {
-            expression.IntegrateWithWolverine();
-            integration = expression.Services.FindMartenIntegration();
-        }
-
-        integration!.UseFastEventForwarding = true;
-
-        configure(integration);
-
-        return expression;
-    }
-
-    /// <summary>
     ///     Register a custom subscription that will process a batch of Marten events at a time with
     ///     a user defined action
     /// </summary>

--- a/src/Samples/CQRSWithMarten/TeleHealth.WebApi/Program.cs
+++ b/src/Samples/CQRSWithMarten/TeleHealth.WebApi/Program.cs
@@ -82,12 +82,9 @@ builder.Services.AddMarten(opts =>
     // asynchronous projections in a background process
     .AddAsyncDaemon(DaemonMode.HotCold)
 
-    // I added this to enroll Marten in the Wolverine outbox
-    .IntegrateWithWolverine()
-
-    // I also added this to opt into events being forward to
-    // the Wolverine outbox during SaveChangesAsync()
-    .EventForwardingToWolverine();
+    // Enroll Marten in the Wolverine outbox and opt into
+    // forwarding events to the Wolverine outbox on SaveChangesAsync()
+    .IntegrateWithWolverine(x => x.UseFastEventForwarding = true);
 
 #endregion
 


### PR DESCRIPTION
One item from the Wolverine 6.0 release punchlist (#2745) — specifically goal #6 from #2715 ("API cleanup — accumulated `[Obsolete]` APIs since Wolverine 5 are removed").

## Summary

- Removes both `MartenConfigurationExpression.EventForwardingToWolverine(...)` overloads from `Wolverine.Marten`. Both were marked `[Obsolete]` in the 3.x line with a "will be removed in Wolverine 4.0" notice — finally honored here.
- The replacement has been available since 3.0: set `MartenIntegration.UseFastEventForwarding = true` inside the `IntegrateWithWolverine` configure callback. The same callback also exposes `SubscribeToEvent<T>()` for event-forwarding transformations.
- Migrates 5 `MartenTests` call sites + the `TeleHealth.WebApi` sample to the nested-callback form.
- Updates `docs/guide/durability/marten/event-forwarding.md` (prose + snippet anchors) to the new API.
- Adds a row to the at-a-glance table in the 6.0 migration guide plus a long-form `### EventForwardingToWolverine() removed (BREAKING)` section with before/after snippets.

## Migration shape

Before (5.x):
```csharp
services.AddMarten(opts => opts.Connection(connString))
    .IntegrateWithWolverine()
    .EventForwardingToWolverine();
```

After (6.0):
```csharp
services.AddMarten(opts => opts.Connection(connString))
    .IntegrateWithWolverine(x => x.UseFastEventForwarding = true);
```

The `Action<IEventForwarding>` overload collapses into the same callback (see migration guide for the example with `SubscribeToEvent<T>().TransformedTo(...)`).

## Test plan

- [x] `dotnet build wolverine.slnx` — clean, 0 warnings, 0 errors
- [x] Targeted MartenTests on net9.0 (`event_streaming` + `event_forwarding_routing_bug` + `event_forwarding_bug` + `Bug_262_test_does_not_complete_with_timeout_message`): **7/7 passing** locally
- [x] Verified `event_streaming.event_should_be_published_from_sender_to_receiver` (the 8th of those tests) fails on plain `main` too — it's a pre-existing flake, not caused by this PR
- [ ] CI to confirm the full matrix

## Out of scope (deliberately not touched)

- `docs/guide/durability/polecat/event-forwarding.md` references `AddPolecat().EventForwardingToWolverine()`, which is **not** an extension method that exists in `Wolverine.Polecat`. That's a separate doc/API gap, not a `[Obsolete]` removal — should be its own issue.
- Other `[Obsolete]` markers in the tree (SqlServer/MySql/Postgres `Use*PersistenceAndTransport` extensions, the Redis/Pulsar URI helpers, etc.) — each is its own removal PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)