### PR TITLE
Fix Polecat event-forwarding doc to use real API (refs #2745)

### DIFF
--- a/docs/guide/durability/polecat/event-forwarding.md
+++ b/docs/guide/durability/polecat/event-forwarding.md
@@ -30,16 +30,34 @@ Timing wise, the "event forwarding" happens at the time of committing the transa
 new events, and the resulting event messages go out as cascading messages only after the original transaction succeeds -- just
 like any other outbox usage. **There is no guarantee about ordering in this case.**
 
-To opt into this feature, chain the `AddPolecat().EventForwardingToWolverine()` call as
-shown below:
+To opt into this feature, set `PolecatIntegration.UseFastEventForwarding = true` inside the
+configure callback on `IntegrateWithWolverine()` as shown below:
 
 ```cs
 builder.Services.AddPolecat(opts =>
     {
         opts.Connection(connectionString);
     })
-    .IntegrateWithWolverine()
-    .EventForwardingToWolverine();
+    // Enroll Polecat in the Wolverine outbox and opt into
+    // forwarding events to the Wolverine outbox on SaveChangesAsync()
+    .IntegrateWithWolverine(x => x.UseFastEventForwarding = true);
+```
+
+If you also need to transform events into a different message type before they hit Wolverine's
+routing rules, use `SubscribeToEvent<T>().TransformedTo(...)` on the same `PolecatIntegration`
+instance — exactly like the Marten side:
+
+```cs
+builder.Services.AddPolecat(opts =>
+    {
+        opts.Connection(connectionString);
+    })
+    .IntegrateWithWolverine(x =>
+    {
+        x.UseFastEventForwarding = true;
+        x.SubscribeToEvent<SecondEvent>()
+            .TransformedTo(e => new SecondMessage(e.StreamId, e.Sequence));
+    });
 ```
 
 This does need to be paired with Wolverine configuration to add


### PR DESCRIPTION
## Summary

- `docs/guide/durability/polecat/event-forwarding.md` told users to chain `AddPolecat().IntegrateWithWolverine().EventForwardingToWolverine()`. That extension method **does not exist** in `Wolverine.Polecat` — `grep -rn "EventForwardingToWolverine" src/Persistence/Wolverine.Polecat src/Persistence/PolecatTests` returns zero matches. The doc was aspirational, copied from the (now-also-removed) Marten shape.
- `PolecatIntegration` already exposes the right API: `UseFastEventForwarding` (the same flag the Marten side uses post-#2815) and `SubscribeToEvent<T>().TransformedTo(...)` via `IEventForwarding`. See [src/Persistence/Wolverine.Polecat/PolecatIntegration.cs:31](https://github.com/JasperFx/wolverine/blob/main/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs#L31) and [:108](https://github.com/JasperFx/wolverine/blob/main/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs#L108).
- This PR rewrites the opt-in section to use the real API (callback form on `IntegrateWithWolverine(...)`), and adds the transformation example, mirroring the Marten doc shape after [#2815](https://github.com/JasperFx/wolverine/pull/2815) cleaned up the obsolete extension on that side.
- Picks up the explicit out-of-scope note from #2815 ("`docs/guide/durability/polecat/event-forwarding.md` references `AddPolecat().EventForwardingToWolverine()`, which is **not** an extension method that exists in `Wolverine.Polecat`. That's a separate doc/API gap, not a `[Obsolete]` removal — should be its own issue.").

Refs the 6.0 release punchlist [#2745](https://github.com/JasperFx/wolverine/issues/2745).

## Test plan

- [x] Visually re-read the rewritten section in context — code samples align with `PolecatIntegration`'s actual surface (`UseFastEventForwarding`, `SubscribeToEvent<T>().TransformedTo(...)`).
- [ ] Docs build (`npm run docs`) renders the page cleanly — VitePress build is the only thing that meaningfully exercises this file.
- [ ] No snippet markers are introduced, so `npm run mdsnippets` is a no-op for this change.

## Out of scope

- No production C# changes — this is pure docs.
- The Marten-side equivalent doc fix already shipped in #2815; this is the parallel Polecat-side fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)