### PR TITLE
Remove obsolete RedisTransport.BuildRedisStreamUri helpers (refs wolverine#2745)

### DIFF
--- a/docs/guide/messaging/transports/redis.md
+++ b/docs/guide/messaging/transports/redis.md
@@ -273,7 +273,3 @@ using Wolverine.Redis;
 
 var uri = RedisEndpointUri.Stream("orders", databaseId: 3);
 ```
-
-::: tip
-`RedisTransport.BuildRedisStreamUri` is deprecated. Use `RedisEndpointUri.Stream` instead.
-:::

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -29,6 +29,7 @@ The table below is the **complete inventory** of changed defaults, removed APIs,
 | Critter-stack package versions | 1.x line | 2.0-alpha line | Bump in lockstep across JasperFx, Marten, Polecat — full table below |
 | `IForwardsTo<T>` discovery | implicit assembly scan at startup | **explicit `opts.RegisterMessageForwarder<TFrom, TTo>()`** *(BREAKING)* | Register each forwarder explicitly; or temporarily call [`opts.UseAutomaticForwarderDiscovery()`](#iforwardsto-discovery-is-now-explicit-breaking) (`[Obsolete]`, removed in 7.0) |
 | `MartenConfigurationExpression.EventForwardingToWolverine(...)` | extension method on the Marten configuration expression *(both overloads `[Obsolete]` since 3.x)* | **removed** *(BREAKING)* | Move the flag into the `IntegrateWithWolverine` callback: [`IntegrateWithWolverine(x => x.UseFastEventForwarding = true)`](#eventforwardingtowolverine-removed-breaking) |
+| `RedisTransport.BuildRedisStreamUri(...)` | static helper on `RedisTransport` *(`[Obsolete]`)* | **removed** *(BREAKING)* | Call [`RedisEndpointUri.Stream(...)`](#redistransport-buildredisstreamuri-removed-breaking) — identical signature, drop the helper |
 | `Saga.Version` property type | `int` | `long` | Typically none — `int` widens implicitly to `long`. Only affects code that stores `saga.Version` in an `int` variable, casts it explicitly, or binds it to a column typed `int`. Tracks the matching `IRevisioned.Version` widening in Marten 9.0. |
 | **One-line full revert** | n/a | [`opts.RestoreV5Defaults()`](#one-line-revert-restorev5defaults) | Flip every runtime default this method covers back to its 5.x value |
 
@@ -231,6 +232,26 @@ services.AddMarten(opts => opts.Connection(connString))
             .TransformedTo(e => new SecondMessage(e.StreamId, e.Sequence));
     });
 ```
+
+### `RedisTransport.BuildRedisStreamUri(...)` removed (BREAKING)
+
+Both `RedisTransport.BuildRedisStreamUri(...)` overloads (the 2-param `(streamKey, databaseId)` form and the 3-param `(streamKey, databaseId, consumerGroup)` form) were marked `[Obsolete]` and were thin forwarders to `RedisEndpointUri.Stream(...)`. They're now removed in 6.0.
+
+Replace any call to `RedisTransport.BuildRedisStreamUri(...)` with the identical-signature `RedisEndpointUri.Stream(...)`:
+
+**Before:**
+
+```csharp
+var uri = RedisTransport.BuildRedisStreamUri("orders", databaseId: 3);
+```
+
+**After:**
+
+```csharp
+var uri = RedisEndpointUri.Stream("orders", databaseId: 3);
+```
+
+If you never called these helpers directly (most users don't — Wolverine builds these URIs internally from `ListenToRedisStream(...)` / `PublishToRedisStream(...)`), no change is needed.
 
 ### Performance: per-endpoint serializer cache pre-population
 

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
@@ -299,29 +299,4 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
 
         _streams[cacheKey] = replyEndpoint;
     }
-    
-    /// <summary>
-    /// Helper method to create a Redis stream URI with database ID.
-    /// </summary>
-    /// <param name="streamKey">Redis stream key name</param>
-    /// <param name="databaseId">Redis database ID</param>
-    /// <returns>Formatted Redis stream URI</returns>
-    [Obsolete("Use RedisEndpointUri.Stream instead. This helper will be removed in a future version.")]
-    public static Uri BuildRedisStreamUri(string streamKey, int databaseId = 0)
-    {
-        return RedisEndpointUri.Stream(streamKey, databaseId);
-    }
-
-    /// <summary>
-    /// Helper method to create a Redis stream URI with database ID and consumer group.
-    /// </summary>
-    /// <param name="streamKey">Redis stream key name</param>
-    /// <param name="databaseId">Redis database ID</param>
-    /// <param name="consumerGroup">Consumer group name</param>
-    /// <returns>Formatted Redis stream URI</returns>
-    [Obsolete("Use RedisEndpointUri.Stream instead. This helper will be removed in a future version.")]
-    public static Uri BuildRedisStreamUri(string streamKey, int databaseId, string consumerGroup)
-    {
-        return RedisEndpointUri.Stream(streamKey, databaseId, consumerGroup);
-    }
 }


### PR DESCRIPTION
Next item from the Wolverine 6.0 API-cleanup pillar (goal #6 in #2715), following on from the merged [Obsolete] removal in #2815.

## Summary

- Removes both `RedisTransport.BuildRedisStreamUri(...)` overloads — thin `[Obsolete]` forwarders to `RedisEndpointUri.Stream(...)` with identical signatures and behavior.
- Zero call sites in the repo (production, tests, samples all clean), so no code migrations needed.
- Removes the now-redundant deprecation tip from the Redis transport docs.
- Adds the row + long-form section to the 6.0 migration guide alongside the `EventForwardingToWolverine` entry from #2815.

## Migration shape

Identical signature — drop the `RedisTransport.` prefix and switch to `RedisEndpointUri.Stream(...)`:

```csharp
// Before
var uri = RedisTransport.BuildRedisStreamUri("orders", databaseId: 3);

// After
var uri = RedisEndpointUri.Stream("orders", databaseId: 3);
```

## Test plan

- [x] `dotnet build wolverine.slnx` — clean, 0 warnings, 0 errors
- [x] No call sites to migrate, so no test surface to re-run beyond compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)