### PR TITLE
Remove unused OnlyType<T> test helper (refs wolverine#2745)

### DIFF
--- a/src/Testing/Wolverine.ComplianceTests/HandlerConfigurationExtensions.cs
+++ b/src/Testing/Wolverine.ComplianceTests/HandlerConfigurationExtensions.cs
@@ -18,21 +18,6 @@ public static class HandlerConfigurationExtensions
     }
 
     /// <summary>
-    /// Testing usage to disable all automatic handler discovery and only use the supplied type
-    /// as the sole handler type for this application
-    /// </summary>
-    /// <param name="handlers"></param>
-    /// <typeparam name="T"></typeparam>
-    /// <returns></returns>
-    [Obsolete("This is a weird testing helper that's not used anymore and will be deleted in Wolverine 3")]
-    public static WolverineOptions OnlyType<T>(this WolverineOptions handlers)
-    {
-        handlers.Discovery.DisableConventionalDiscovery().IncludeType<T>();
-
-        return handlers;
-    }
-
-    /// <summary>
     /// Explicitly add this type to Wolverine as a handler type
     /// </summary>
     /// <param name="handlers"></param>


### PR DESCRIPTION
Next item from the Wolverine 6.0 API-cleanup pillar (goal #6 in #2715), following #2815 (EventForwarding) and #2817 (Redis URI helpers).

## Summary

- Removes `HandlerConfigurationExtensions.OnlyType<T>` from `Wolverine.ComplianceTests`. The `[Obsolete]` marker said *"This is a weird testing helper that's not used anymore and will be deleted in Wolverine 3"* — five major versions overdue.
- **Zero call sites** in the repo (production, tests, samples all clean).
- Test-internal helper that was never part of the public NuGet API surface, so no migration-guide entry needed.

## Test plan

- [x] `dotnet build wolverine.slnx` — clean, 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)