### PR TITLE
Remove obsolete PulsarEndpoint.UriFor overloads (refs wolverine#2745)

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -176,7 +176,3 @@ using Wolverine.Pulsar;
 
 var uri = PulsarEndpointUri.PersistentTopic("public", "default", "orders");
 ```
-
-::: tip
-`PulsarEndpoint.UriFor` is deprecated. Use `PulsarEndpointUri.Topic` (string overload) or `PersistentTopic`/`NonPersistentTopic` instead. The old `UriFor(bool, ...)` overload returned a Pulsar-native topic path, not a Wolverine endpoint URI — if you need that format, build the string directly.
-:::

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -29,6 +29,7 @@ The table below is the **complete inventory** of changed defaults, removed APIs,
 | Critter-stack package versions | 1.x line | 2.0-alpha line | Bump in lockstep across JasperFx, Marten, Polecat — full table below |
 | `IForwardsTo<T>` discovery | implicit assembly scan at startup | **explicit `opts.RegisterMessageForwarder<TFrom, TTo>()`** *(BREAKING)* | Register each forwarder explicitly; or temporarily call [`opts.UseAutomaticForwarderDiscovery()`](#iforwardsto-discovery-is-now-explicit-breaking) (`[Obsolete]`, removed in 7.0) |
 | `MartenConfigurationExpression.EventForwardingToWolverine(...)` | extension method on the Marten configuration expression *(both overloads `[Obsolete]` since 3.x)* | **removed** *(BREAKING)* | Move the flag into the `IntegrateWithWolverine` callback: [`IntegrateWithWolverine(x => x.UseFastEventForwarding = true)`](#eventforwardingtowolverine-removed-breaking) |
+| `PulsarEndpoint.UriFor(...)` | static helpers on `PulsarEndpoint` *(both overloads `[Obsolete]`)* | **removed** *(BREAKING)* | For the Wolverine-URI form, call [`PulsarEndpointUri.Topic(...)`](#pulsarendpoint-urifor-removed-breaking); the native-topic-path form (`persistent://...`) was an internal-only seam now covered by `PulsarEndpoint.NativeTopicPath` |
 | `Saga.Version` property type | `int` | `long` | Typically none — `int` widens implicitly to `long`. Only affects code that stores `saga.Version` in an `int` variable, casts it explicitly, or binds it to a column typed `int`. Tracks the matching `IRevisioned.Version` widening in Marten 9.0. |
 | **One-line full revert** | n/a | [`opts.RestoreV5Defaults()`](#one-line-revert-restorev5defaults) | Flip every runtime default this method covers back to its 5.x value |
 
@@ -231,6 +232,21 @@ services.AddMarten(opts => opts.Connection(connString))
             .TransformedTo(e => new SecondMessage(e.StreamId, e.Sequence));
     });
 ```
+
+### `PulsarEndpoint.UriFor(...)` removed (BREAKING)
+
+Both `PulsarEndpoint.UriFor(...)` overloads were `[Obsolete]` in the 5.x line and are now removed in 6.0:
+
+- **`UriFor(string topicPath)`** — was a thin forwarder to `PulsarEndpointUri.Topic(topicPath)`. Replace any caller with `PulsarEndpointUri.Topic(...)` directly. Same signature, same return shape.
+
+- **`UriFor(bool persistent, string tenant, string @namespace, string topicName)`** — returned a Pulsar-*native* topic path of the form `persistent://{tenant}/{ns}/{topic}` for hand-off to the native Pulsar client. That is NOT a Wolverine endpoint URI (`pulsar://...`); the two forms are deliberately not interchangeable. The internal Pulsar transport now uses a renamed helper `PulsarEndpoint.NativeTopicPath(...)` (also `internal`, same signature). External callers of the old `UriFor(bool, ...)` overload were rare-to-nonexistent — if you need this form for your own native-Pulsar interop, construct it directly:
+
+  ```csharp
+  var scheme = persistent ? "persistent" : "non-persistent";
+  var nativePath = new Uri($"{scheme}://{tenant}/{@namespace}/{topicName}");
+  ```
+
+If you only ever called `UriFor(string)`, this is a one-line `using`-already-imported rename.
 
 ### Performance: per-endpoint serializer cache pre-population
 

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarEndpointTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarEndpointTests.cs
@@ -56,16 +56,16 @@ public class PulsarEndpointTests
     }
 
     [Fact]
-    public void uri_for_all_props_and_persistent()
+    public void native_topic_path_all_props_and_persistent()
     {
-        var uri = PulsarEndpoint.UriFor(true, "public", "default", "aaa");
+        var uri = PulsarEndpoint.NativeTopicPath(true, "public", "default", "aaa");
         uri.ShouldBe(new Uri("persistent://public/default/aaa"));
     }
 
     [Fact]
-    public void uri_for_all_props_and_non_persistent()
+    public void native_topic_path_all_props_and_non_persistent()
     {
-        var uri = PulsarEndpoint.UriFor(false, "public", "default", "aaa");
+        var uri = PulsarEndpoint.NativeTopicPath(false, "public", "default", "aaa");
         uri.ShouldBe(new Uri("non-persistent://public/default/aaa"));
     }
 
@@ -73,7 +73,7 @@ public class PulsarEndpointTests
     public void uri_for_topic_string()
     {
         var topicPath = "persistent://t1/ns1/aaa";
-        var uri = PulsarEndpoint.UriFor(topicPath);
+        var uri = PulsarEndpointUri.Topic(topicPath);
         var endpoint = new PulsarEndpoint(uri, null!);
 
         endpoint.Persistence.ShouldBe(PulsarEndpoint.Persistent);
@@ -85,7 +85,7 @@ public class PulsarEndpointTests
     [Fact]
     public void uri_for_topic_string_handles_non_persistent_scheme()
     {
-        var uri = PulsarEndpoint.UriFor("non-persistent://t1/ns1/aaa");
+        var uri = PulsarEndpointUri.Topic("non-persistent://t1/ns1/aaa");
         var endpoint = new PulsarEndpoint(uri, null!);
 
         endpoint.Persistence.ShouldBe(PulsarEndpoint.NonPersistent);
@@ -97,7 +97,7 @@ public class PulsarEndpointTests
     [Fact]
     public void uri_for_topic_string_preserves_realistic_topic_names()
     {
-        var uri = PulsarEndpoint.UriFor("persistent://my-tenant/my-namespace/order.created.v2");
+        var uri = PulsarEndpointUri.Topic("persistent://my-tenant/my-namespace/order.created.v2");
         var endpoint = new PulsarEndpoint(uri, null!);
 
         endpoint.Persistence.ShouldBe(PulsarEndpoint.Persistent);
@@ -107,20 +107,20 @@ public class PulsarEndpointTests
     }
 
     [Fact]
-    public void uri_for_bool_produces_retry_suffix_path_used_by_pulsar_listener()
+    public void native_topic_path_produces_retry_suffix_used_by_pulsar_listener()
     {
         // Mirrors the call pattern in PulsarListener.getRetryLetterTopicUri:
-        // PulsarEndpoint.UriFor(isPersistent, tenant, namespace, "{topic}-RETRY").
-        var uri = PulsarEndpoint.UriFor(true, "public", "default", "orders-RETRY");
+        // PulsarEndpoint.NativeTopicPath(isPersistent, tenant, namespace, "{topic}-RETRY").
+        var uri = PulsarEndpoint.NativeTopicPath(true, "public", "default", "orders-RETRY");
         uri.ShouldBe(new Uri("persistent://public/default/orders-RETRY"));
     }
 
     [Fact]
-    public void uri_for_bool_produces_dlq_suffix_path_used_by_pulsar_listener()
+    public void native_topic_path_produces_dlq_suffix_used_by_pulsar_listener()
     {
         // Mirrors the call pattern in PulsarListener.getDeadLetteredTopicUri:
-        // PulsarEndpoint.UriFor(isPersistent, tenant, namespace, "{topic}-DLQ").
-        var uri = PulsarEndpoint.UriFor(true, "public", "default", "orders-DLQ");
+        // PulsarEndpoint.NativeTopicPath(isPersistent, tenant, namespace, "{topic}-DLQ").
+        var uri = PulsarEndpoint.NativeTopicPath(true, "public", "default", "orders-DLQ");
         uri.ShouldBe(new Uri("persistent://public/default/orders-DLQ"));
     }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -49,17 +49,16 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
 
     public bool IsPersistent => Persistence.Equals(Persistent);
 
-    [Obsolete("This overload returns a Pulsar-native topic path (persistent://...), not a Wolverine endpoint URI (pulsar://...). The native Pulsar client requires the former; PulsarEndpointUri produces the latter — they are NOT interchangeable, which is why this overload is not delegated. Build Pulsar-native topic paths directly. This helper will be removed in a future version.")]
-    public static Uri UriFor(bool persistent, string tenant, string @namespace, string topicName)
+    /// <summary>
+    /// Build a Pulsar-native topic-path URI of the form
+    /// <c>persistent://{tenant}/{namespace}/{topic}</c> (or <c>non-persistent://...</c>) for
+    /// hand-off to the native Pulsar client. This is NOT a Wolverine endpoint URI —
+    /// for those, use <see cref="PulsarEndpointUri"/>.
+    /// </summary>
+    internal static Uri NativeTopicPath(bool persistent, string tenant, string @namespace, string topicName)
     {
-        var scheme = persistent ? "persistent" : "non-persistent";
+        var scheme = persistent ? Persistent : NonPersistent;
         return new Uri($"{scheme}://{tenant}/{@namespace}/{topicName}");
-    }
-
-    [Obsolete("Use PulsarEndpointUri.Topic instead. This helper will be removed in a future version.")]
-    public static Uri UriFor(string topicPath)
-    {
-        return PulsarEndpointUri.Topic(topicPath);
     }
 
     public override IDictionary<string, object> DescribeProperties()

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -138,22 +138,16 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
 
     private Uri? getRetryLetterTopicUri(PulsarEndpoint endpoint)
     {
-#pragma warning disable CS0618 // Pulsar-native topic-path form is required by the Pulsar client
         return NativeRetryLetterQueueEnabled
-            ? PulsarEndpoint.UriFor(endpoint.IsPersistent, endpoint.Tenant, endpoint.Namespace,
+            ? PulsarEndpoint.NativeTopicPath(endpoint.IsPersistent, endpoint.Tenant, endpoint.Namespace,
                 endpoint.RetryLetterTopic?.TopicName ?? $"{endpoint.TopicName}-RETRY")
             : null;
-#pragma warning restore CS0618
     }
 
     private Uri getDeadLetteredTopicUri(PulsarEndpoint endpoint)
     {
-#pragma warning disable CS0618 // Pulsar-native topic-path form is required by the Pulsar client
-        var topicDql = PulsarEndpoint.UriFor(endpoint.IsPersistent, endpoint.Tenant, endpoint.Namespace,
+        return PulsarEndpoint.NativeTopicPath(endpoint.IsPersistent, endpoint.Tenant, endpoint.Namespace,
             endpoint.DeadLetterTopic?.TopicName ?? $"{endpoint.TopicName}-DLQ");
-#pragma warning restore CS0618
-
-        return topicDql;
     }
 
     public ValueTask CompleteAsync(Envelope envelope)


### PR DESCRIPTION
Next item from the Wolverine 6.0 API-cleanup pillar (goal #6 in #2715), following #2815 (EventForwarding), #2817 (Redis URI helpers), and #2818 (`OnlyType<T>` test helper).

## Summary

Removes both `[Obsolete]` `PulsarEndpoint.UriFor(...)` overloads. They were two semantically different APIs sharing a name — splitting their replacements cleanly:

- **`UriFor(string topicPath)`** was a thin forwarder to `PulsarEndpointUri.Topic(topicPath)`. Pulsar.Tests call sites switched directly to `PulsarEndpointUri.Topic`.

- **`UriFor(bool persistent, string tenant, string namespace, string topicName)`** produced a Pulsar-*native* topic path (`persistent://{tenant}/{ns}/{topic}`) for hand-off to the native Pulsar client — deliberately **not** interchangeable with `PulsarEndpointUri` (which produces Wolverine `pulsar://...` URIs). The Pulsar transport's two internal call sites (`PulsarListener.cs:139,149`) were already wrapped in `#pragma warning disable CS0618` blocks because they had no public replacement. This PR introduces a renamed `internal static PulsarEndpoint.NativeTopicPath(...)` helper (same signature) and switches both production call sites to it — dropping the `#pragma`s.

## Migration shape

```csharp
// Before — Wolverine-URI form
var uri = PulsarEndpoint.UriFor("persistent://tenant/ns/topic");
// After
var uri = PulsarEndpointUri.Topic("persistent://tenant/ns/topic");

// Before — native-topic-path form (rare; was always internal-feeling)
var nativePath = PulsarEndpoint.UriFor(true, "public", "default", "orders");
// After — build directly, or use the new internal helper if you're inside the Pulsar package
var scheme = persistent ? "persistent" : "non-persistent";
var nativePath = new Uri($"{scheme}://{tenant}/{ns}/{topic}");
```

## Changes

- Removed both overloads from `src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs`.
- Added internal `PulsarEndpoint.NativeTopicPath(bool, string, string, string)` helper with an XmlDoc explaining the native-vs-Wolverine-URI distinction.
- Migrated `PulsarListener.cs` (2 production call sites) and `PulsarEndpointTests.cs` (7 test call sites). The two `#pragma warning disable CS0618` blocks in `PulsarListener` are gone.
- Removed the deprecation tip from the Pulsar transport docs.
- Added a row + long-form section to the 6.0 migration guide.

## Test plan

- [x] `dotnet build wolverine.slnx` — clean, 0 warnings, 0 errors
- [x] `Wolverine.Pulsar.Tests.PulsarEndpointTests` — **12/12 passing** on both net9.0 and net10.0 (URI unit tests, no broker required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)