### PR TITLE
Un-obsolete Use{SqlServer,MySql,Postgresql}PersistenceAndTransport (refs wolverine#2745)

### DIFF
--- a/src/Persistence/MySql/Wolverine.MySql/MySqlConfigurationExtensions.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlConfigurationExtensions.cs
@@ -89,7 +89,6 @@ public static class MySqlConfigurationExtensions
     /// <param name="schema"></param>
     /// <param name="transportSchema"></param>
     /// <returns></returns>
-    [Obsolete("Prefer PersistMessagesWithMySql().EnableMessageTransport()")]
     public static MySqlPersistenceExpression UseMySqlPersistenceAndTransport(this WolverineOptions options,
         string connectionString,
         string? schema = null,

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlConfigurationExtensions.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlConfigurationExtensions.cs
@@ -100,7 +100,6 @@ public static class PostgresqlConfigurationExtensions
     /// <param name="connectionString"></param>
     /// <param name="schema"></param>
     /// <returns></returns>
-    [Obsolete("Prefer PersistMessagesWithPostgresql().EnableMessageTransport()")]
     public static PostgresqlPersistenceExpression UsePostgresqlPersistenceAndTransport(this WolverineOptions options,
         string connectionString,
         string? schema = null,

--- a/src/Persistence/Wolverine.SqlServer/SqlServerConfigurationExtensions.cs
+++ b/src/Persistence/Wolverine.SqlServer/SqlServerConfigurationExtensions.cs
@@ -80,7 +80,6 @@ public static class SqlServerConfigurationExtensions
     /// <param name="connectionString"></param>
     /// <param name="schema"></param>
     /// <returns></returns>
-    [Obsolete("Prefer PersistMessagesWithSqlServer().EnableMessageTransport()")]
     public static SqlServerPersistenceExpression UseSqlServerPersistenceAndTransport(this WolverineOptions options,
         string connectionString,
         string? schema = null,


### PR DESCRIPTION
Next item from the Wolverine 6.0 API-cleanup pillar (goal #6 in #2715). Per Jeremy's call: leave these three helpers alone and just clear the `[Obsolete]` deprecation rather than remove the API.

## Summary

- `WolverineOptions.UseSqlServerPersistenceAndTransport(...)`
- `WolverineOptions.UseMySqlPersistenceAndTransport(...)`
- `WolverineOptions.UsePostgresqlPersistenceAndTransport(...)`

All three were marked `[Obsolete("Prefer PersistMessagesWith{X}().EnableMessageTransport()")]`. They have ~40 active call sites across `SqlServerTests`/`PostgresqlTests`/`MySqlTests` plus the durability docs — the combined "persistence + transport at the same connection string" shape is a useful one-liner that won't actually get migrated away from. Reverting the deprecation rather than churning the call sites.

## Test plan

- [x] `dotnet build wolverine.slnx` — clean, 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)