### PR TITLE
Convert WolverineHost.For -> ForAsync; remove sync For (refs wolverine#2745)

### DIFF
--- a/src/Persistence/CosmosDbTests/saga_storage_compliance.cs
+++ b/src/Persistence/CosmosDbTests/saga_storage_compliance.cs
@@ -19,7 +19,7 @@ public class CosmosDbSagaHost : ISagaHost
         _fixture.InitializeAsync().GetAwaiter().GetResult();
     }
 
-    public IHost BuildHost<TSaga>()
+    public Task<IHost> BuildHostAsync<TSaga>()
     {
         return Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
@@ -35,7 +35,7 @@ public class CosmosDbSagaHost : ISagaHost
 
                 opts.Services.AddSingleton(_fixture.Client);
                 opts.UseCosmosDbPersistence(AppFixture.DatabaseName);
-            }).Start();
+            }).StartAsync();
     }
 
     public Task<T?> LoadState<T>(Guid id) where T : Saga

--- a/src/Persistence/EfCoreTests/EfCoreCompilationScenarios.cs
+++ b/src/Persistence/EfCoreTests/EfCoreCompilationScenarios.cs
@@ -14,13 +14,13 @@ public class EfCoreCompilationScenarios
     [Fact]
     public async Task ef_context_is_scoped_and_options_are_scoped()
     {
-        using var host = WolverineHost.For(opts =>
+        using var host = await WolverineHost.ForAsync(opts =>
         {
             opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(CreateItemHandler));
 
             // Default of both is scoped
             opts.Services.AddDbContext<SampleDbContext>();
-            
+
             opts.UseEntityFrameworkCoreTransactions();
         });
 
@@ -47,7 +47,7 @@ public class EfCoreCompilationScenarios
     [Fact]
     public async Task ef_context_is_singleton_and_options_are_singleton()
     {
-        using var host = WolverineHost.For(opts =>
+        using var host = await WolverineHost.ForAsync(opts =>
         {
             opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(CreateItemHandler));
             

--- a/src/Persistence/EfCoreTests/Sagas/EfCoreSagaHost.cs
+++ b/src/Persistence/EfCoreTests/Sagas/EfCoreSagaHost.cs
@@ -16,9 +16,9 @@ public class EfCoreSagaHost : ISagaHost
 {
     private IHost _host = null!;
 
-    public IHost BuildHost<TSaga>()
+    public async Task<IHost> BuildHostAsync<TSaga>()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.DisableConventionalDiscovery().IncludeType<TSaga>();
 
@@ -32,7 +32,7 @@ public class EfCoreSagaHost : ISagaHost
             opts.PublishAllMessages().Locally();
         });
 
-        _host.ResetResourceState().GetAwaiter().GetResult();
+        await _host.ResetResourceState();
 
         return _host;
     }

--- a/src/Persistence/EfCoreTests/Sagas/efcore_saga_store_diagnostics_tests.cs
+++ b/src/Persistence/EfCoreTests/Sagas/efcore_saga_store_diagnostics_tests.cs
@@ -31,7 +31,7 @@ public class efcore_saga_store_diagnostics_tests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             // Pin discovery to one workflow saga the SagaDbContext
             // maps. The compliance fixtures share a WildcardStart

--- a/src/Persistence/MartenTests/AggregateHandlerWorkflow/marten_command_workflow_middleware.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerWorkflow/marten_command_workflow_middleware.cs
@@ -19,15 +19,15 @@ using Wolverine.Tracking;
 
 namespace MartenTests.AggregateHandlerWorkflow;
 
-public class marten_command_workflow_middleware : PostgresqlContext, IDisposable
+public class marten_command_workflow_middleware : PostgresqlContext, IAsyncLifetime, IDisposable
 {
-    private readonly IHost theHost;
-    private readonly IDocumentStore theStore;
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
     private Guid theStreamId;
 
-    public marten_command_workflow_middleware()
+    public async Task InitializeAsync()
     {
-        theHost = WolverineHost.For(opts =>
+        theHost = await WolverineHost.ForAsync(opts =>
         {
             opts.Services.AddMarten(opts =>
                 {
@@ -44,6 +44,8 @@ public class marten_command_workflow_middleware : PostgresqlContext, IDisposable
 
         theStore = theHost.Services.GetRequiredService<IDocumentStore>();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs
@@ -18,14 +18,14 @@ using Wolverine.Tracking;
 
 namespace MartenTests.AggregateHandlerWorkflow;
 
-public class natural_key_aggregate_handler_workflow : PostgresqlContext, IAsyncDisposable
+public class natural_key_aggregate_handler_workflow : PostgresqlContext, IAsyncLifetime, IAsyncDisposable
 {
-    private readonly IHost _host;
-    private readonly IDocumentStore _store;
+    private IHost _host = null!;
+    private IDocumentStore _store = null!;
 
-    public natural_key_aggregate_handler_workflow()
+    public async Task InitializeAsync()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.Services.AddMarten(m =>
                 {
@@ -43,10 +43,15 @@ public class natural_key_aggregate_handler_workflow : PostgresqlContext, IAsyncD
         _store = _host.Services.GetRequiredService<IDocumentStore>();
     }
 
+    Task IAsyncLifetime.DisposeAsync() => DisposeAsync().AsTask();
+
     public async ValueTask DisposeAsync()
     {
-        await _host.StopAsync();
-        _host.Dispose();
+        if (_host != null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
     }
 
     [Fact]

--- a/src/Persistence/MartenTests/Persistence/MartenBackedMessagePersistenceTests.cs
+++ b/src/Persistence/MartenTests/Persistence/MartenBackedMessagePersistenceTests.cs
@@ -20,18 +20,11 @@ public class MartenBackedMessagePersistenceTests : PostgresqlContext, IDisposabl
 {
     private readonly Envelope theEnvelope;
 
-    private readonly IHost theHost;
+    private IHost theHost = null!;
     private Envelope persisted = null!;
 
     public MartenBackedMessagePersistenceTests()
     {
-        theHost = WolverineHost.For(opts =>
-        {
-            opts.Services.AddMarten(x => { x.Connection(Servers.PostgresConnectionString); })
-                .IntegrateWithWolverine();
-        });
-
-
         theEnvelope = ObjectMother.Envelope();
         theEnvelope.Message = new Message1();
         theEnvelope.ScheduledTime = DateTime.Today.ToUniversalTime().AddDays(1);
@@ -45,6 +38,12 @@ public class MartenBackedMessagePersistenceTests : PostgresqlContext, IDisposabl
 
     public async Task InitializeAsync()
     {
+        theHost = await WolverineHost.ForAsync(opts =>
+        {
+            opts.Services.AddMarten(x => { x.Connection(Servers.PostgresConnectionString); })
+                .IntegrateWithWolverine();
+        });
+
         var persistence = theHost.Get<IMessageStore>();
 
         await persistence.Admin.RebuildAsync();

--- a/src/Persistence/MartenTests/Persistence/Sagas/MartenSagaHost.cs
+++ b/src/Persistence/MartenTests/Persistence/Sagas/MartenSagaHost.cs
@@ -14,9 +14,9 @@ public class MartenSagaHost : ISagaHost
 {
     private IHost _host = null!;
 
-    public IHost BuildHost<TSaga>()
+    public async Task<IHost> BuildHostAsync<TSaga>()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.DisableConventionalDiscovery().IncludeType<TSaga>();
 

--- a/src/Persistence/MartenTests/Persistence/end_to_end_with_persistence.cs
+++ b/src/Persistence/MartenTests/Persistence/end_to_end_with_persistence.cs
@@ -19,14 +19,18 @@ namespace MartenTests.Persistence;
 public class end_to_end_with_persistence : PostgresqlContext, IDisposable, IAsyncLifetime
 {
     private readonly ITestOutputHelper _output;
-    private readonly IHost theReceiver;
+    private IHost theReceiver = null!;
 
-    private readonly IHost theSender;
+    private IHost theSender = null!;
 
     public end_to_end_with_persistence(ITestOutputHelper output)
     {
         _output = output;
-        theSender = WolverineHost.For(opts =>
+    }
+
+    public async Task InitializeAsync()
+    {
+        theSender = await WolverineHost.ForAsync(opts =>
         {
             opts.Publish(x =>
             {
@@ -45,7 +49,7 @@ public class end_to_end_with_persistence : PostgresqlContext, IDisposable, IAsyn
             opts.ListenAtPort(2567);
         });
 
-        theReceiver = WolverineHost.For(opts =>
+        theReceiver = await WolverineHost.ForAsync(opts =>
         {
             opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "receiver");
 
@@ -58,10 +62,7 @@ public class end_to_end_with_persistence : PostgresqlContext, IDisposable, IAsyn
                 x.DatabaseSchemaName = "receiver";
             }).IntegrateWithWolverine();
         });
-    }
 
-    public async Task InitializeAsync()
-    {
         await theSender.ResetResourceState();
         await theReceiver.ResetResourceState();
     }

--- a/src/Persistence/MartenTests/Sample/SampleApp.cs
+++ b/src/Persistence/MartenTests/Sample/SampleApp.cs
@@ -18,7 +18,7 @@ public class MessageInvocationTests : PostgresqlContext, IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        theHost = WolverineHost.For(opts =>
+        theHost = await WolverineHost.ForAsync(opts =>
         {
             opts.PublishAllMessages().Locally();
 

--- a/src/Persistence/MartenTests/transactional_frame_end_to_end.cs
+++ b/src/Persistence/MartenTests/transactional_frame_end_to_end.cs
@@ -23,7 +23,7 @@ public class transactional_frame_end_to_end : PostgresqlContext
     [Fact]
     public async Task the_transactional_middleware_works()
     {
-        using var host = WolverineHost.For(opts =>
+        using var host = await WolverineHost.ForAsync(opts =>
         {
             opts.Services.AddMarten(o =>
             {
@@ -43,7 +43,7 @@ public class transactional_frame_end_to_end : PostgresqlContext
     [Fact]
     public async Task the_transactional_middleware_works_with_document_operations()
     {
-        using var host = WolverineHost.For(opts =>
+        using var host = await WolverineHost.ForAsync(opts =>
         {
             opts.Services.AddMarten(o =>
             {

--- a/src/Persistence/PersistenceTests/DurableFixture.cs
+++ b/src/Persistence/PersistenceTests/DurableFixture.cs
@@ -23,7 +23,7 @@ public abstract class DurableFixture<TTriggerHandler, TItemCreatedHandler> : IAs
         var receiverPort = PortFinder.GetAvailablePort();
         var senderPort = PortFinder.GetAvailablePort();
         
-        theSender = WolverineHost.For(senderRegistry =>
+        theSender = await WolverineHost.ForAsync(senderRegistry =>
         {
             senderRegistry
                 .DisableConventionalDiscovery()
@@ -48,7 +48,7 @@ public abstract class DurableFixture<TTriggerHandler, TItemCreatedHandler> : IAs
         
         await theSender.ResetResourceState();
 
-        theReceiver = WolverineHost.For(receiverRegistry =>
+        theReceiver = await WolverineHost.ForAsync(receiverRegistry =>
         {
             receiverRegistry.DisableConventionalDiscovery()
                 .IncludeType<TTriggerHandler>()

--- a/src/Persistence/PolecatTests/AggregateHandlerWorkflow/polecat_command_workflow_middleware.cs
+++ b/src/Persistence/PolecatTests/AggregateHandlerWorkflow/polecat_command_workflow_middleware.cs
@@ -18,15 +18,15 @@ using Wolverine.Tracking;
 
 namespace PolecatTests.AggregateHandlerWorkflow;
 
-public class polecat_command_workflow_middleware : IDisposable
+public class polecat_command_workflow_middleware : IAsyncLifetime, IDisposable
 {
-    private readonly IHost theHost;
-    private readonly IDocumentStore theStore;
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
     private Guid theStreamId;
 
-    public polecat_command_workflow_middleware()
+    public async Task InitializeAsync()
     {
-        theHost = WolverineHost.For(opts =>
+        theHost = await WolverineHost.ForAsync(opts =>
         {
             opts.Services.AddPolecat(m =>
                 {
@@ -43,8 +43,10 @@ public class polecat_command_workflow_middleware : IDisposable
         });
 
         theStore = theHost.Services.GetRequiredService<IDocumentStore>();
-        ((DocumentStore)theStore).Database.ApplyAllConfiguredChangesToDatabaseAsync().GetAwaiter().GetResult();
+        await ((DocumentStore)theStore).Database.ApplyAllConfiguredChangesToDatabaseAsync();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Persistence/PolecatTests/Sagas/PolecatSagaHost.cs
+++ b/src/Persistence/PolecatTests/Sagas/PolecatSagaHost.cs
@@ -13,9 +13,9 @@ public class PolecatSagaHost : ISagaHost
 {
     private IHost _host = null!;
 
-    public IHost BuildHost<TSaga>()
+    public async Task<IHost> BuildHostAsync<TSaga>()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.DisableConventionalDiscovery().IncludeType<TSaga>();
 

--- a/src/Persistence/PostgresqlTests/Sagas/lightweight_saga_persistence.cs
+++ b/src/Persistence/PostgresqlTests/Sagas/lightweight_saga_persistence.cs
@@ -15,15 +15,15 @@ public class PostgresqlSagaHost : ISagaHost
 {
     private IHost _host = null!;
 
-    public IHost BuildHost<TSaga>()
+    public async Task<IHost> BuildHostAsync<TSaga>()
     {
-        _host =  Host.CreateDefaultBuilder()
+        _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
                 opts.DisableConventionalDiscovery().IncludeType<TSaga>();
 
                 opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "sagas");
-            }).Start();
+            }).StartAsync();
 
         return _host;
     }

--- a/src/Persistence/PostgresqlTests/configuration_extension_methods.cs
+++ b/src/Persistence/PostgresqlTests/configuration_extension_methods.cs
@@ -14,9 +14,9 @@ namespace PostgresqlTests;
 public class configuration_extension_methods : PostgresqlContext
 {
     [Fact]
-    public void bootstrap_with_connection_string()
+    public async Task bootstrap_with_connection_string()
     {
-        using var host = WolverineHost.For(x =>
+        using var host = await WolverineHost.ForAsync(x =>
             x.PersistMessagesWithPostgresql(Servers.PostgresConnectionString));
         host.Services.GetRequiredService<IMessageStore>().ShouldBeOfType<PostgresqlMessageStore>()
             .Settings.ConnectionString.ShouldBe(Servers.PostgresConnectionString);

--- a/src/Persistence/PostgresqlTests/extension_registrations.cs
+++ b/src/Persistence/PostgresqlTests/extension_registrations.cs
@@ -12,9 +12,9 @@ namespace PostgresqlTests;
 public class extension_registrations : PostgresqlContext
 {
     [Fact]
-    public void registrations()
+    public async Task registrations()
     {
-        using var runtime = WolverineHost.For(x =>
+        using var runtime = await WolverineHost.ForAsync(x =>
             x.PersistMessagesWithPostgresql(Servers.PostgresConnectionString));
 
         var container = runtime.Get<IServiceContainer>();

--- a/src/Persistence/RavenDbTests/saga_storage_compliance.cs
+++ b/src/Persistence/RavenDbTests/saga_storage_compliance.cs
@@ -15,7 +15,7 @@ public class RavenDbSagaHost : RavenTestDriver, ISagaHost
 {
     private IDocumentStore _store = null!;
 
-    public IHost BuildHost<TSaga>()
+    public Task<IHost> BuildHostAsync<TSaga>()
     {
         DatabaseFixture.EnsureServerConfigured();
         _store = GetDocumentStore();
@@ -35,7 +35,7 @@ public class RavenDbSagaHost : RavenTestDriver, ISagaHost
 
                 opts.Services.AddSingleton(_store);
                 opts.UseRavenDbPersistence();
-            }).Start();
+            }).StartAsync();
     }
 
     public Task<T?> LoadState<T>(Guid id) where T : Saga

--- a/src/Persistence/SqlServerTests/Persistence/SqlServerBackedMessageStoreTests.cs
+++ b/src/Persistence/SqlServerTests/Persistence/SqlServerBackedMessageStoreTests.cs
@@ -30,7 +30,7 @@ public class SqlServerBackedMessageStoreTests : SqlServerContext, IAsyncLifetime
 
     protected override async Task initialize()
     {
-        theHost = WolverineHost.For(opts => { opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString); });
+        theHost = await WolverineHost.ForAsync(opts => { opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString); });
 
         await theHost.ResetResourceState();
 

--- a/src/Persistence/SqlServerTests/Sagas/lightweight_saga_persistence.cs
+++ b/src/Persistence/SqlServerTests/Sagas/lightweight_saga_persistence.cs
@@ -16,15 +16,15 @@ public class SqlServerSagaHost : ISagaHost
 {
     private IHost _host = null!;
 
-    public IHost BuildHost<TSaga>()
+    public async Task<IHost> BuildHostAsync<TSaga>()
     {
-        _host =  Host.CreateDefaultBuilder()
+        _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
                 opts.DisableConventionalDiscovery().IncludeType<TSaga>();
 
                 opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "sagas");
-            }).Start();
+            }).StartAsync();
 
         return _host;
     }

--- a/src/Persistence/SqlServerTests/configuration_extension_methods.cs
+++ b/src/Persistence/SqlServerTests/configuration_extension_methods.cs
@@ -16,11 +16,11 @@ namespace SqlServerTests;
 public class configuration_extension_methods : SqlServerContext
 {
     [Fact]
-    public void bootstrap_with_connection_string()
+    public async Task bootstrap_with_connection_string()
     {
-        using var host = WolverineHost.For(x =>
+        using var host = await WolverineHost.ForAsync(x =>
             x.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString));
-        
+
         host.GetRuntime().Storage.As<SqlServerMessageStore>()
             .Settings.ConnectionString.ShouldBe(Servers.SqlServerConnectionString);
     }

--- a/src/Persistence/SqlServerTests/extension_registrations.cs
+++ b/src/Persistence/SqlServerTests/extension_registrations.cs
@@ -12,9 +12,9 @@ namespace SqlServerTests;
 public class extension_registrations : SqlServerContext
 {
     [Fact]
-    public void registrations()
+    public async Task registrations()
     {
-        using var runtime = WolverineHost.For(x =>
+        using var runtime = await WolverineHost.ForAsync(x =>
             x.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString));
         var container = runtime.Get<IServiceContainer>();
 

--- a/src/Testing/CoreTests/Acceptance/discarding_expired_envelopes.cs
+++ b/src/Testing/CoreTests/Acceptance/discarding_expired_envelopes.cs
@@ -16,7 +16,7 @@ public class discarding_expired_envelopes
     {
         var logger = Substitute.For<IMessageTracker>();
 
-        using var runtime = WolverineHost.For(x =>
+        using var runtime = await WolverineHost.ForAsync(x =>
         {
             x.DisableConventionalDiscovery();
             x.Services.AddSingleton(logger);

--- a/src/Testing/CoreTests/Acceptance/endpoint_specific_customizations.cs
+++ b/src/Testing/CoreTests/Acceptance/endpoint_specific_customizations.cs
@@ -9,9 +9,9 @@ namespace CoreTests.Acceptance;
 public class endpoint_specific_customizations : SendingContext
 {
     [Fact]
-    public void apply_customizations_to_certain_message_types_for_specific_type()
+    public async Task apply_customizations_to_certain_message_types_for_specific_type()
     {
-        using var host = WolverineHost.For(opts =>
+        using var host = await WolverineHost.ForAsync(opts =>
         {
             opts.PublishMessage<SpecialMessage>().To("stub://one")
                 .CustomizeOutgoing(e => e.Headers.Add("a", "one"))

--- a/src/Testing/CoreTests/Acceptance/logging_configuration.cs
+++ b/src/Testing/CoreTests/Acceptance/logging_configuration.cs
@@ -26,20 +26,20 @@ public class logging_configuration : IntegrationContext
     }
 
     [Fact]
-    public void set_log_message_activity_from_attribute_no_global_policy()
+    public async Task set_log_message_activity_from_attribute_no_global_policy()
     {
         // Not configuration
-        with(opts => { });
+        await with(opts => { });
 
         chainFor<AuditedMessage3>().Middleware.OfType<LogStartingActivity>()
             .Single().Level.ShouldBe(LogLevel.Information);
     }
-    
+
     [Fact]
-    public void override_starting_message_activity_from_attribute_over_global_policy()
+    public async Task override_starting_message_activity_from_attribute_over_global_policy()
     {
         // Not configuration
-        with(opts =>
+        await with(opts =>
         {
             opts.Policies.LogMessageStarting(LogLevel.Debug);
         });
@@ -47,21 +47,21 @@ public class logging_configuration : IntegrationContext
         // Still Information!
         chainFor<AuditedMessage3>().Middleware.OfType<LogStartingActivity>()
             .Single().Level.ShouldBe(LogLevel.Information);
-        
+
         // The default is still from the global policy
         chainFor<NormalMessage>().Middleware.OfType<LogStartingActivity>()
             .Single().Level.ShouldBe(LogLevel.Debug);
     }
 
     [Fact]
-    public void override_the_log_start_messaging_to_off()
+    public async Task override_the_log_start_messaging_to_off()
     {
         // Not configuration
-        with(opts =>
+        await with(opts =>
         {
             opts.Policies.LogMessageStarting(LogLevel.Debug);
         });
-        
+
         // Attribute says None, so it's None!!!
         chainFor<QuietMessage2>().Middleware.OfType<LogStartingActivity>()
             .Any().ShouldBeFalse();

--- a/src/Testing/CoreTests/Acceptance/missing_handlers.cs
+++ b/src/Testing/CoreTests/Acceptance/missing_handlers.cs
@@ -11,7 +11,7 @@ public class missing_handlers
     [Fact]
     public async Task calls_all_the_missing_handlers()
     {
-        using var host = WolverineHost.For(x =>
+        using var host = await WolverineHost.ForAsync(x =>
         {
             x.PublishMessage<MessageWithNoHandler>().ToLocalQueue("foo");
             x.Services.AddSingleton<IMissingHandler, RecordingMissingHandler>();

--- a/src/Testing/CoreTests/Acceptance/overriding_delivery_options_when_sending.cs
+++ b/src/Testing/CoreTests/Acceptance/overriding_delivery_options_when_sending.cs
@@ -10,18 +10,18 @@ namespace CoreTests.Acceptance;
 public class overriding_delivery_options_when_sending : SendingContext
 {
     [Fact]
-    public void apply_message_type_rules_from_attributes()
+    public async Task apply_message_type_rules_from_attributes()
     {
-        var envelope = theSendingRuntime.RoutingFor(typeof(MessageWithSpecialAttribute))
+        var envelope = (await theSendingRuntime()).RoutingFor(typeof(MessageWithSpecialAttribute))
             .RouteForPublish(new MessageWithSpecialAttribute(), null).Single();
 
         envelope.Headers["special"].ShouldBe("true");
     }
 
     [Fact]
-    public void deliver_by_mechanics()
+    public async Task deliver_by_mechanics()
     {
-        var envelope = theSendingRuntime.RoutingFor(typeof(MessageWithSpecialAttribute))
+        var envelope = (await theSendingRuntime()).RoutingFor(typeof(MessageWithSpecialAttribute))
             .RouteForPublish(new MessageWithSpecialAttribute(), null).Single();
 
         envelope.DeliverBy!.Value.ShouldBeGreaterThan(DateTimeOffset.UtcNow);
@@ -30,9 +30,10 @@ public class overriding_delivery_options_when_sending : SendingContext
     [Fact]
     public async Task honor_customization_attributes_on_message_type()
     {
-        var session = await theSender.TrackActivity()
+        var sender = await theSender();
+        var session = await sender.TrackActivity()
             .IncludeExternalTransports()
-            .AlsoTrack(theReceiver)
+            .AlsoTrack(await theReceiver())
             .SendMessageAndWaitAsync(new MessageWithSpecialAttribute());
 
         var outgoing = session
@@ -42,32 +43,32 @@ public class overriding_delivery_options_when_sending : SendingContext
     }
 
     [Fact]
-    public void message_type_rules_override_endpoint_rules()
+    public async Task message_type_rules_override_endpoint_rules()
     {
-        SenderOptions(opts =>
+        await SenderOptions(opts =>
         {
             opts.PublishMessage<MessageWithSpecialAttribute>()
                 .ToPort(ReceiverPort)
                 .CustomizeOutgoing(e => e.Headers["special"] = "different");
         });
 
-        var outgoing = theSendingRuntime
+        var outgoing = (await theSendingRuntime())
             .RouteForSend(new MessageWithSpecialAttribute(), null).Single();
 
         outgoing.Headers["special"].ShouldBe("true");
     }
 
     [Fact]
-    public void delivery_options_trumps_all_other_rules()
+    public async Task delivery_options_trumps_all_other_rules()
     {
-        SenderOptions(opts =>
+        await SenderOptions(opts =>
         {
             opts.PublishMessage<MessageWithSpecialAttribute>()
                 .ToPort(ReceiverPort)
                 .CustomizeOutgoing(e => e.Headers["special"] = "different");
         });
 
-        var outgoing = theSendingRuntime
+        var outgoing = (await theSendingRuntime())
             .RouteForSend(new MessageWithSpecialAttribute(), new DeliveryOptions().WithHeader("special", "explicit"))
             .Single();
 
@@ -77,10 +78,11 @@ public class overriding_delivery_options_when_sending : SendingContext
     [Fact]
     public async Task can_use_delivery_options_on_send()
     {
-        var session = await theSender
+        var sender = await theSender();
+        var session = await sender
             .TrackActivity()
             .IncludeExternalTransports()
-            .AlsoTrack(theReceiver)
+            .AlsoTrack(await theReceiver())
             .SendMessageAndWaitAsync(new StatusMessage(), new DeliveryOptions
             {
                 AckRequested = true
@@ -95,10 +97,11 @@ public class overriding_delivery_options_when_sending : SendingContext
     {
         var uri = $"tcp://localhost:{ReceiverPort}".ToUri();
 
-        var session = await theSender
+        var sender = await theSender();
+        var session = await sender
             .TrackActivity()
             .IncludeExternalTransports()
-            .AlsoTrack(theReceiver)
+            .AlsoTrack(await theReceiver())
             .SendMessageAndWaitAsync(uri, new StatusMessage(), new DeliveryOptions
             {
                 AckRequested = true
@@ -111,10 +114,11 @@ public class overriding_delivery_options_when_sending : SendingContext
     [Fact]
     public async Task can_use_delivery_options_on_publish()
     {
-        var session = await theSender
+        var sender = await theSender();
+        var session = await sender
             .TrackActivity()
             .IncludeExternalTransports()
-            .AlsoTrack(theReceiver)
+            .AlsoTrack(await theReceiver())
             .PublishMessageAndWaitAsync(new StatusMessage(), new DeliveryOptions
             {
                 AckRequested = true

--- a/src/Testing/CoreTests/Acceptance/publish_versus_send_mechanics.cs
+++ b/src/Testing/CoreTests/Acceptance/publish_versus_send_mechanics.cs
@@ -7,11 +7,15 @@ using Xunit;
 
 namespace CoreTests.Acceptance;
 
-public class publish_versus_send_mechanics : IntegrationContext
+public class publish_versus_send_mechanics : IntegrationContext, IAsyncLifetime
 {
     public publish_versus_send_mechanics(DefaultApp @default) : base(@default)
     {
-        with(opts =>
+    }
+
+    public Task InitializeAsync()
+    {
+        return with(opts =>
         {
             opts.DisableConventionalDiscovery();
 
@@ -23,6 +27,8 @@ public class publish_versus_send_mechanics : IntegrationContext
             opts.Publish(x => x.Message<Message2>().ToLocalQueue("two"));
         });
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public async Task publish_message_with_no_known_subscribers()

--- a/src/Testing/CoreTests/Acceptance/sending_messages_to_named_endpoints.cs
+++ b/src/Testing/CoreTests/Acceptance/sending_messages_to_named_endpoints.cs
@@ -9,44 +9,46 @@ using Xunit;
 
 namespace CoreTests.Acceptance;
 
-public class sending_messages_to_named_endpoints : IDisposable
+public class sending_messages_to_named_endpoints : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _receiver1;
-    private readonly IHost _receiver2;
-    private readonly IHost _receiver3;
-    private readonly IHost _sender;
+    private IHost _receiver1 = null!;
+    private IHost _receiver2 = null!;
+    private IHost _receiver3 = null!;
+    private IHost _sender = null!;
 
-    public sending_messages_to_named_endpoints()
+    public async Task InitializeAsync()
     {
         var port1 = PortFinder.GetAvailablePort();
         var port2 = PortFinder.GetAvailablePort();
         var port3 = PortFinder.GetAvailablePort();
 
-        _sender = WolverineHost.For(opts =>
+        _sender = await WolverineHost.ForAsync(opts =>
         {
             opts.Publish().ToPort(port1).Named("one");
             opts.Publish().ToPort(port2).Named("two");
             opts.Publish().ToPort(port3).Named("three");
         });
 
-        _receiver1 = WolverineHost.For(opts =>
+        _receiver1 = await WolverineHost.ForAsync(opts =>
         {
             opts.ListenAtPort(port1);
             opts.ServiceName = "one";
         });
 
-        _receiver2 = WolverineHost.For(opts =>
+        _receiver2 = await WolverineHost.ForAsync(opts =>
         {
             opts.ListenAtPort(port2);
             opts.ServiceName = "two";
         });
 
-        _receiver3 = WolverineHost.For(opts =>
+        _receiver3 = await WolverineHost.ForAsync(opts =>
         {
             opts.ListenAtPort(port3);
             opts.ServiceName = "three";
         });
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Testing/CoreTests/Acceptance/using_ISendMyself_as_cascading_message.cs
+++ b/src/Testing/CoreTests/Acceptance/using_ISendMyself_as_cascading_message.cs
@@ -47,14 +47,14 @@ public class using_ISendMyself_as_cascading_message : IntegrationContext
         var receiverPort = PortFinder.GetAvailablePort();
         var senderPort = PortFinder.GetAvailablePort();
 
-        using var sender = WolverineHost.For(opts =>
+        using var sender = await WolverineHost.ForAsync(opts =>
         {
             opts.PublishMessage<RequestTrigger>().ToPort(receiverPort);
             opts.ListenAtPort(senderPort);
             opts.ServiceName = "Sender";
         });
 
-        using var receiver = WolverineHost.For(opts =>
+        using var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.ServiceName = "Receiver";
             opts.ListenAtPort(receiverPort);

--- a/src/Testing/CoreTests/Acceptance/wolverine_as_command_bus.cs
+++ b/src/Testing/CoreTests/Acceptance/wolverine_as_command_bus.cs
@@ -17,9 +17,9 @@ public class wolverine_as_command_bus : IntegrationContext
     {
     }
 
-    private void configure()
+    private Task configure()
     {
-        with(opts =>
+        return with(opts =>
         {
             opts.Services.AddSingleton(theTracker);
 
@@ -37,20 +37,20 @@ public class wolverine_as_command_bus : IntegrationContext
     [Fact]
     public async Task exceptions_will_be_thrown_to_caller()
     {
-        configure();
+        await configure();
 
         var message = new Message5
         {
             FailThisManyTimes = 1
         };
-        
+
         await Should.ThrowAsync<DivideByZeroException>(() => Publisher.InvokeAsync(message));
     }
 
     [Fact]
     public async Task will_process_inline()
     {
-        configure();
+        await configure();
 
         var message = new Message5();
 
@@ -62,7 +62,7 @@ public class wolverine_as_command_bus : IntegrationContext
     [Fact]
     public async Task use_retry_in_invoke()
     {
-        configure();
+        await configure();
         var message = new InvokedMessage { FailThisManyTimes = 2 };
 
         await Publisher.InvokeAsync(message);
@@ -71,7 +71,7 @@ public class wolverine_as_command_bus : IntegrationContext
     [Fact]
     public async Task will_send_cascading_messages()
     {
-        configure();
+        await configure();
 
         var message = new Message5();
 

--- a/src/Testing/CoreTests/Compilation/CompilationContext.cs
+++ b/src/Testing/CoreTests/Compilation/CompilationContext.cs
@@ -24,19 +24,19 @@ public abstract class CompilationContext : IDisposable
         _host = Host.CreateDefaultBuilder().UseWolverine(configure).Start();
     }
 
-    protected void AllHandlersCompileSuccessfully(Action<WolverineOptions>? configure = null)
+    protected async Task AllHandlersCompileSuccessfully(Action<WolverineOptions>? configure = null)
     {
         configure ??= _ => { };
-        using var host = WolverineHost.For(configure);
+        using var host = await WolverineHost.ForAsync(configure);
         host.Get<HandlerGraph>().Chains.Length.ShouldBeGreaterThan(0);
     }
 
-    public MessageHandler HandlerFor<TMessage>(Action<WolverineOptions>? configure = null)
+    public async Task<MessageHandler> HandlerFor<TMessage>(Action<WolverineOptions>? configure = null)
     {
         if (_host == null)
         {
             configure ??= _ => { };
-            _host = WolverineHost.For(configure);
+            _host = await WolverineHost.ForAsync(configure);
         }
 
         return _host.Get<HandlerGraph>().HandlerFor(typeof(TMessage))!.As<MessageHandler>();
@@ -44,7 +44,7 @@ public abstract class CompilationContext : IDisposable
 
     public async Task<IMessageContext> Execute<TMessage>(TMessage message)
     {
-        var handler = HandlerFor<TMessage>();
+        var handler = await HandlerFor<TMessage>();
         theEnvelope = new Envelope(message!);
         var context = new MessageContext(_host.Get<IWolverineRuntime>());
         context.ReadEnvelope(theEnvelope, InvocationCallback.Instance);
@@ -55,8 +55,8 @@ public abstract class CompilationContext : IDisposable
     }
 
     [Fact]
-    public void can_compile_all()
+    public async Task can_compile_all()
     {
-        AllHandlersCompileSuccessfully();
+        await AllHandlersCompileSuccessfully();
     }
 }

--- a/src/Testing/CoreTests/Compilation/can_customize_handler_chains_with_attributes.cs
+++ b/src/Testing/CoreTests/Compilation/can_customize_handler_chains_with_attributes.cs
@@ -11,9 +11,9 @@ namespace CoreTests.Compilation;
 
 public class can_customize_handler_chains_with_attributes
 {
-    private void forMessage<T>(Action<HandlerChain> action)
+    private async Task forMessage<T>(Action<HandlerChain> action)
     {
-        using var runtime = WolverineHost.For(opts =>
+        using var runtime = await WolverineHost.ForAsync(opts =>
         {
             opts.DisableConventionalDiscovery();
             opts.IncludeType<FakeHandler1>();
@@ -24,15 +24,15 @@ public class can_customize_handler_chains_with_attributes
     }
 
     [Fact]
-    public void apply_attribute_on_class()
+    public async Task apply_attribute_on_class()
     {
-        forMessage<Message2>(chain => chain.SourceCode!.ShouldContain("// fake frame here"));
+        await forMessage<Message2>(chain => chain.SourceCode!.ShouldContain("// fake frame here"));
     }
 
     [Fact]
-    public void apply_attribute_on_message_type()
+    public async Task apply_attribute_on_message_type()
     {
-        forMessage<ErrorHandledMessage>(chain =>
+        await forMessage<ErrorHandledMessage>(chain =>
         {
             chain.SourceCode!.ShouldContain("// fake frame here");
             chain.Failures.MaximumAttempts.ShouldBe(5);
@@ -40,9 +40,9 @@ public class can_customize_handler_chains_with_attributes
     }
 
     [Fact]
-    public void apply_attribute_on_method()
+    public async Task apply_attribute_on_method()
     {
-        forMessage<Message1>(chain => chain.SourceCode!.ShouldContain("// fake frame here"));
+        await forMessage<Message1>(chain => chain.SourceCode!.ShouldContain("// fake frame here"));
     }
 }
 

--- a/src/Testing/CoreTests/Configuration/auditing_determination.cs
+++ b/src/Testing/CoreTests/Configuration/auditing_determination.cs
@@ -39,9 +39,9 @@ public class auditing_determination : IntegrationContext
     }
 
     [Fact]
-    public void adds_the_log_start_message_to_code()
+    public async Task adds_the_log_start_message_to_code()
     {
-        with(opts =>
+        await with(opts =>
         {
             opts.Policies.LogMessageStarting(LogLevel.Information);
         });
@@ -57,7 +57,7 @@ public class auditing_determination : IntegrationContext
     [Fact]
     public async Task execute_to_prove_it_does_not_blow_up()
     {
-        with(opts =>
+        await with(opts =>
         {
             opts.Policies.LogMessageStarting(LogLevel.Information);
         });
@@ -66,9 +66,9 @@ public class auditing_determination : IntegrationContext
     }
 
     [Fact]
-    public void use_audit_members_from_explicit_interface_adds()
+    public async Task use_audit_members_from_explicit_interface_adds()
     {
-        with(opts =>
+        await with(opts =>
         {
             #region sample_explicit_registration_of_audit_properties
             // opts is WolverineOptions inside of a UseWolverine() call
@@ -82,10 +82,10 @@ public class auditing_determination : IntegrationContext
     }
 
     [Fact]
-    public void use_audit_member_named_id_and_disambiguate()
+    public async Task use_audit_member_named_id_and_disambiguate()
     {
-        with(opts => opts.Policies.LogMessageStarting(LogLevel.Information));
-        
+        await with(opts => opts.Policies.LogMessageStarting(LogLevel.Information));
+
         var chain = chainFor<AuditedMessage2>();
         
         

--- a/src/Testing/CoreTests/Configuration/bootstrapping_specs.cs
+++ b/src/Testing/CoreTests/Configuration/bootstrapping_specs.cs
@@ -25,9 +25,9 @@ public class bootstrapping_specs : IntegrationContext
     }
 
     [Fact]
-    public void registers_the_supplemental_code_files()
+    public async Task registers_the_supplemental_code_files()
     {
-        with(_ => {});
+        await with(_ => {});
 
         var container = Host.Services.GetRequiredService<IServiceContainer>();
         container.DefaultFor<WolverineSupplementalCodeFiles>()!
@@ -40,17 +40,17 @@ public class bootstrapping_specs : IntegrationContext
     }
 
     [Fact]
-    public void can_apply_a_wrapper_to_all_chains()
+    public async Task can_apply_a_wrapper_to_all_chains()
     {
-        with(opts => opts.Policies.Add<WrapWithSimple>());
+        await with(opts => opts.Policies.Add<WrapWithSimple>());
 
         chainFor<MovieAdded>().Middleware.OfType<SimpleWrapper>().Any().ShouldBeTrue();
     }
 
     [Fact]
-    public void can_customize_source_code_generation()
+    public async Task can_customize_source_code_generation()
     {
-        with(opts =>
+        await with(opts =>
         {
             opts.CodeGeneration.Sources.Add(new SpecialServiceSource());
             opts.IncludeType<SpecialServiceUsingThing>();

--- a/src/Testing/CoreTests/Configuration/extension_loading_and_discovery.cs
+++ b/src/Testing/CoreTests/Configuration/extension_loading_and_discovery.cs
@@ -14,9 +14,9 @@ public class extension_loading_and_discovery : IntegrationContext
     }
 
     [Fact]
-    public void the_application_still_wins()
+    public async Task the_application_still_wins()
     {
-        using var host = WolverineHost.For(options =>
+        using var host = await WolverineHost.ForAsync(options =>
         {
             options.DisableConventionalDiscovery();
             options.Include<OptionalExtension>();
@@ -24,32 +24,32 @@ public class extension_loading_and_discovery : IntegrationContext
         });
 
         using var scope = host.Services.CreateScope();
-        
+
         scope.ServiceProvider.GetRequiredService<IColorService>()
             .ShouldBeOfType<BlueService>();
     }
 
     [Fact]
-    public void try_find_extension_miss()
+    public async Task try_find_extension_miss()
     {
-        using var host = WolverineHost.For(options =>
+        using var host = await WolverineHost.ForAsync(options =>
         {
             options.DisableConventionalDiscovery();
         });
-        
+
         var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
         runtime.TryFindExtension<OptionalExtension>().ShouldBeNull();
     }
 
     [Fact]
-    public void try_find_extension_hit()
+    public async Task try_find_extension_hit()
     {
-        using var host = WolverineHost.For(options =>
+        using var host = await WolverineHost.ForAsync(options =>
         {
             options.DisableConventionalDiscovery();
             options.Include<OptionalExtension>();
         });
-        
+
         var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
         runtime.TryFindExtension<OptionalExtension>().ShouldBeOfType<OptionalExtension>().ShouldNotBeNull();
     }
@@ -71,9 +71,9 @@ public class extension_loading_and_discovery : IntegrationContext
     }
 
     [Fact]
-    public void will_apply_an_extension()
+    public async Task will_apply_an_extension()
     {
-        using var runtime = WolverineHost.For(opts =>
+        using var runtime = await WolverineHost.ForAsync(opts =>
         {
             #region sample_explicitly_add_extension
             opts.Include<OptionalExtension>();
@@ -83,30 +83,30 @@ public class extension_loading_and_discovery : IntegrationContext
         });
 
         using var scope = runtime.Services.CreateScope();
-        
+
         scope.ServiceProvider.GetRequiredService<IColorService>()
             .ShouldBeOfType<RedService>();
     }
 
     [Fact]
-    public void will_only_apply_extension_once()
+    public async Task will_only_apply_extension_once()
     {
-        using var host = WolverineHost.For(registry =>
+        using var host = await WolverineHost.ForAsync(registry =>
         {
             registry.Include<OptionalExtension>();
             registry.Include<OptionalExtension>();
             registry.Include<OptionalExtension>();
             registry.Include<OptionalExtension>();
         });
-        
+
         host.Get<IServiceContainer>().RegistrationsFor<IColorService>()
             .Count().ShouldBe(1);
     }
 
     [Fact]
-    public void picks_up_on_handlers_from_extension()
+    public async Task picks_up_on_handlers_from_extension()
     {
-        with(x => x.Include<MyExtension>());
+        await with(x => x.Include<MyExtension>());
 
         var handlerChain = chainFor<ExtensionMessage>();
         handlerChain.Handlers.Single()

--- a/src/Testing/CoreTests/Configuration/find_handlers_with_the_default_handler_discovery.cs
+++ b/src/Testing/CoreTests/Configuration/find_handlers_with_the_default_handler_discovery.cs
@@ -59,9 +59,9 @@ public class find_handlers_with_the_default_handler_discovery : IntegrationConte
     }
 
     [Fact]
-    public void ignore_method_marked_as_NotHandler()
+    public async Task ignore_method_marked_as_NotHandler()
     {
-        with(x => x.DisableConventionalDiscovery().IncludeType<NetflixHandler>());
+        await with(x => x.DisableConventionalDiscovery().IncludeType<NetflixHandler>());
         //withAllDefaults();
         chainFor<MovieAdded>()
             .ShouldNotHaveHandler<NetflixHandler>(x => x.Handles(new MovieAdded()));
@@ -121,26 +121,26 @@ public class customized_finding : IntegrationContext
     {
     }
 
-    private void withTypeDiscovery(Action<TypeQuery> customize)
+    private Task withTypeDiscovery(Action<TypeQuery> customize)
     {
-        with(opts =>
+        return with(opts =>
         {
             opts.Discovery.CustomizeHandlerDiscovery(customize);
         });
     }
 
     [Fact]
-    public void extra_suffix()
+    public async Task extra_suffix()
     {
-        withTypeDiscovery(x => x.Includes.WithNameSuffix("Watcher"));
+        await withTypeDiscovery(x => x.Includes.WithNameSuffix("Watcher"));
 
         chainFor<MovieAdded>().ShouldHaveHandler<MovieWatcher>(x => x.Handle(null!));
     }
 
     [Fact]
-    public void handler_types_from_a_marker_interface()
+    public async Task handler_types_from_a_marker_interface()
     {
-        withTypeDiscovery(x => x.Includes.Implements<IMovieThing>());
+        await withTypeDiscovery(x => x.Includes.Implements<IMovieThing>());
 
         chainFor<MovieAdded>().ShouldHaveHandler<EpisodeWatcher>(x => x.Handle(new MovieAdded()));
     }
@@ -164,9 +164,9 @@ public class customized_finding : IntegrationContext
     }
 
     [Fact]
-    public void find_handlers_from_included_assembly()
+    public async Task find_handlers_from_included_assembly()
     {
-        with(opts =>
+        await with(opts =>
         {
             opts.Discovery.IncludeAssembly(typeof(Module2Message1).Assembly);
         });
@@ -178,9 +178,9 @@ public class customized_finding : IntegrationContext
     }
 
     [Fact]
-    public void find_handlers_from_handler_module_assemblies()
+    public async Task find_handlers_from_handler_module_assemblies()
     {
-        with(opts =>
+        await with(opts =>
         {
             opts.Discovery.IncludeHandlerModules = true;
         });

--- a/src/Testing/CoreTests/IntegrationContext.cs
+++ b/src/Testing/CoreTests/IntegrationContext.cs
@@ -89,9 +89,9 @@ public class IntegrationContext : IDisposable, IClassFixture<DefaultApp>
         _default.Dispose();
     }
 
-    protected void with(Action<WolverineOptions> configuration)
+    protected async Task with(Action<WolverineOptions> configuration)
     {
-        Host = WolverineHost.For(configuration);
+        Host = await WolverineHost.ForAsync(configuration);
     }
 
     protected HandlerChain chainFor<T>()

--- a/src/Testing/CoreTests/Persistence/Sagas/in_memory_saga.cs
+++ b/src/Testing/CoreTests/Persistence/Sagas/in_memory_saga.cs
@@ -11,9 +11,9 @@ public class InMemorySagaHost : ISagaHost
 {
     private IHost _host = null!;
 
-    public IHost BuildHost<TSaga>()
+    public async Task<IHost> BuildHostAsync<TSaga>()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.DisableConventionalDiscovery().IncludeType<TSaga>();
 

--- a/src/Testing/CoreTests/Persistence/Sagas/saga_not_found_usages.cs
+++ b/src/Testing/CoreTests/Persistence/Sagas/saga_not_found_usages.cs
@@ -17,9 +17,9 @@ public class saga_not_found_usages : SagaTestHarness<SteppedSaga>
     [Fact]
     public async Task call_not_found_when_saga_does_not_exist()
     {
-        withApplication();
+        await withApplication();
 
-        _output.WriteLine(codeFor<CompleteOne>());
+        _output.WriteLine(await codeFor<CompleteOne>());
 
         var completeOne = new CompleteOne();
         await send(completeOne, Guid.NewGuid());
@@ -30,7 +30,7 @@ public class saga_not_found_usages : SagaTestHarness<SteppedSaga>
     [Fact]
     public async Task not_found_not_called_if_the_saga_is_found()
     {
-        withApplication();
+        await withApplication();
 
         SteppedSaga.NotFoundCommand = null!;
 
@@ -46,7 +46,7 @@ public class saga_not_found_usages : SagaTestHarness<SteppedSaga>
     [Fact]
     public async Task should_throw_exception_on_saga_not_found_with_no_alternative_handler()
     {
-        withApplication();
+        await withApplication();
 
         var sagaId = Guid.NewGuid();
 
@@ -64,7 +64,7 @@ public class saga_not_found_usages : SagaTestHarness<SteppedSaga>
     [Fact]
     public async Task StartOrHandle_works_if_new()
     {
-        withApplication();
+        await withApplication();
 
         var id = Guid.NewGuid();
         await send(new CompleteTwo(), id);

--- a/src/Testing/CoreTests/Runtime/MessageContextTests.cs
+++ b/src/Testing/CoreTests/Runtime/MessageContextTests.cs
@@ -244,7 +244,7 @@ public class MessageContextTests
     [Fact]
     public async Task clear_all_cleans_out_outstanding_messages()
     {
-        using var host = WolverineHost.For(opts =>
+        using var host = await WolverineHost.ForAsync(opts =>
         {
             opts.PublishAllMessages().ToPort(PortFinder.GetAvailablePort());
         });

--- a/src/Testing/CoreTests/SendingContext.cs
+++ b/src/Testing/CoreTests/SendingContext.cs
@@ -21,36 +21,30 @@ public abstract class SendingContext : IAsyncDisposable
 
     public int ReceiverPort { get; }
 
-    internal IWolverineRuntime theSendingRuntime => theSender.Services.GetRequiredService<IWolverineRuntime>();
+    internal async Task<IWolverineRuntime> theSendingRuntime() => (await theSender()).Services.GetRequiredService<IWolverineRuntime>();
 
-    internal IHost theSender
+    internal async Task<IHost> theSender()
     {
-        get
+        if (_sender == null)
         {
-            if (_sender == null)
+            _sender = await WolverineHost.ForAsync(opts =>
             {
-                _sender = WolverineHost.For(opts =>
-                {
-                    opts.PublishAllMessages().ToPort(ReceiverPort);
-                    opts.ListenAtPort(_senderPort);
-                });
-            }
-
-            return _sender;
+                opts.PublishAllMessages().ToPort(ReceiverPort);
+                opts.ListenAtPort(_senderPort);
+            });
         }
+
+        return _sender;
     }
 
-    internal IHost theReceiver
+    internal async Task<IHost> theReceiver()
     {
-        get
+        if (_receiver == null)
         {
-            if (_receiver == null)
-            {
-                _receiver = WolverineHost.For(opts => opts.ListenAtPort(ReceiverPort));
-            }
-
-            return _receiver;
+            _receiver = await WolverineHost.ForAsync(opts => opts.ListenAtPort(ReceiverPort));
         }
+
+        return _receiver;
     }
 
     public async ValueTask DisposeAsync()
@@ -68,9 +62,9 @@ public abstract class SendingContext : IAsyncDisposable
         }
     }
 
-    internal void SenderOptions(Action<WolverineOptions> configure)
+    internal async Task SenderOptions(Action<WolverineOptions> configure)
     {
-        _sender = WolverineHost.For(opts =>
+        _sender = await WolverineHost.ForAsync(opts =>
         {
             configure(opts);
             opts.ListenAtPort(_senderPort);

--- a/src/Testing/CoreTests/Transports/Local/local_integration_specs.cs
+++ b/src/Testing/CoreTests/Transports/Local/local_integration_specs.cs
@@ -16,9 +16,9 @@ public class local_integration_specs : IntegrationContext
     {
     }
 
-    private void configure()
+    private Task configure()
     {
-        with(opts =>
+        return with(opts =>
         {
             opts.Publish(x => x.Message<Message1>()
                 .ToLocalQueue("incoming"));
@@ -36,7 +36,7 @@ public class local_integration_specs : IntegrationContext
     [Fact]
     public async Task send_a_message_and_get_the_response()
     {
-        configure();
+        await configure();
 
         var message1 = new Message1();
         var session = await Host.SendMessageAndWaitAsync(message1, timeoutInMilliseconds: 15000);
@@ -47,9 +47,9 @@ public class local_integration_specs : IntegrationContext
     }
 
     [Fact]
-    public void no_circuit_breaker()
+    public async Task no_circuit_breaker()
     {
-        with(opts => { opts.LocalQueue("foo").UseDurableInbox(); });
+        await with(opts => { opts.LocalQueue("foo").UseDurableInbox(); });
 
         var runtime = Host.GetRuntime();
         var agent = runtime
@@ -63,9 +63,9 @@ public class local_integration_specs : IntegrationContext
     }
 
     [Fact]
-    public void build_isolated_watched_handler_pipeline_when_durable_and_circuit_breaker()
+    public async Task build_isolated_watched_handler_pipeline_when_durable_and_circuit_breaker()
     {
-        with(opts =>
+        await with(opts =>
         {
             opts.LocalQueue("foo")
                 .UseDurableInbox()
@@ -86,9 +86,9 @@ public class local_integration_specs : IntegrationContext
     }
 
     [Fact]
-    public void individual_configuration_by_queue()
+    public async Task individual_configuration_by_queue()
     {
-        with(opts =>
+        await with(opts =>
         {
             opts.LocalQueueFor<Message1>().MaximumParallelMessages(6);
         });
@@ -100,9 +100,9 @@ public class local_integration_specs : IntegrationContext
     }
 
     [Fact]
-    public void individual_configuration_by_queue_2()
+    public async Task individual_configuration_by_queue_2()
     {
-        with(opts =>
+        await with(opts =>
         {
             opts.LocalQueueFor<Message1>().MaximumParallelMessages(6);
         });
@@ -114,11 +114,11 @@ public class local_integration_specs : IntegrationContext
     }
 
     [Fact]
-    public void not_allowed_to_use_strict_ordering()
+    public async Task not_allowed_to_use_strict_ordering()
     {
-        Should.Throw<NotSupportedException>(() =>
+        await Should.ThrowAsync<NotSupportedException>(async () =>
         {
-            with(o => o.LocalQueue("one").ListenWithStrictOrdering());
+            await with(o => o.LocalQueue("one").ListenWithStrictOrdering());
         });
     }
 }

--- a/src/Testing/CoreTests/Transports/Tcp/message_forwarding.cs
+++ b/src/Testing/CoreTests/Transports/Tcp/message_forwarding.cs
@@ -12,7 +12,7 @@ public class message_forwarding
     [Fact]
     public async Task send_message_via_forwarding()
     {
-        using var host = WolverineHost.For(opts =>
+        using var host = await WolverineHost.ForAsync(opts =>
         {
             opts.DisableConventionalDiscovery();
             opts.IncludeType<NewMessageHandler>();

--- a/src/Testing/CoreTests/Transports/Tcp/using_stubbed_listeners.cs
+++ b/src/Testing/CoreTests/Transports/Tcp/using_stubbed_listeners.cs
@@ -12,7 +12,7 @@ public class using_stubbed_listeners
     [Fact]
     public async Task track_outgoing_to_tcp_when_stubbed()
     {
-        using var host = WolverineHost.For(options =>
+        using var host = await WolverineHost.ForAsync(options =>
         {
             options.PublishAllMessages().ToPort(7777);
             options.StubAllExternalTransports();

--- a/src/Testing/CoreTests/Transports/envelope_username_tracking.cs
+++ b/src/Testing/CoreTests/Transports/envelope_username_tracking.cs
@@ -11,7 +11,7 @@ public class envelope_username_tracking
     [Fact]
     public async Task username_is_propagated_through_tcp_transport()
     {
-        using var host = WolverineHost.For(opts =>
+        using var host = await WolverineHost.ForAsync(opts =>
         {
             opts.DisableConventionalDiscovery();
             opts.IncludeType(typeof(UserNameTrackingHandler));
@@ -49,7 +49,7 @@ public class envelope_username_tracking
     [Fact]
     public async Task username_is_not_propagated_when_relay_disabled()
     {
-        using var host = WolverineHost.For(opts =>
+        using var host = await WolverineHost.ForAsync(opts =>
         {
             opts.DisableConventionalDiscovery();
             opts.IncludeType(typeof(UserNameTrackingHandler));

--- a/src/Testing/CoreTests/WolverineOptionsTests.cs
+++ b/src/Testing/CoreTests/WolverineOptionsTests.cs
@@ -125,9 +125,9 @@ public class WolverineOptionsTests
     }
 
     [Fact]
-    public void sets_up_the_container_with_services()
+    public async Task sets_up_the_container_with_services()
     {
-        using var runtime = WolverineHost.For(registry =>
+        using var runtime = await WolverineHost.ForAsync(registry =>
         {
             registry.DisableConventionalDiscovery();
             registry.Services.AddScoped<IFoo, Foo>();

--- a/src/Testing/SlowTests/message_timeout_mechanics.cs
+++ b/src/Testing/SlowTests/message_timeout_mechanics.cs
@@ -50,7 +50,7 @@ public class message_timeout_mechanics
     {
         PotentiallySlowMessageHandler.DidTimeout = false; // start clean
 
-        using var host = WolverineHost.For(
+        using var host = await WolverineHost.ForAsync(
             opts => { opts.DefaultExecutionTimeout = 50.Milliseconds(); });
 
         var session = await host

--- a/src/Testing/SlowTests/ping_handling.cs
+++ b/src/Testing/SlowTests/ping_handling.cs
@@ -14,7 +14,7 @@ public class ping_handling
     [Fact]
     public async Task ping_happy_path_with_tcp()
     {
-        using (var runtime = WolverineHost.For(opts => { opts.ListenAtPort(2222); }))
+        using (var runtime = await WolverineHost.ForAsync(opts => { opts.ListenAtPort(2222); }))
         {
             var sender = new BatchedSender(new TcpEndpoint(2222), new SocketSenderProtocol(),
                 CancellationToken.None, NullLogger.Instance);

--- a/src/Testing/Wolverine.ComplianceTests/Sagas/GuidIdentifiedSagaComplianceSpecs.cs
+++ b/src/Testing/Wolverine.ComplianceTests/Sagas/GuidIdentifiedSagaComplianceSpecs.cs
@@ -58,8 +58,8 @@ public class GuidIdentifiedSagaComplianceSpecs<T> : SagaTestHarness<GuidBasicWor
             Name = "Croaker"
         });
 
-        Debug.WriteLine(codeFor<GuidStart>());
-        Debug.WriteLine(codeFor<CompleteOne>());
+        Debug.WriteLine(await codeFor<GuidStart>());
+        Debug.WriteLine(await codeFor<CompleteOne>());
 
         await send(new CompleteOne(), stateId);
 

--- a/src/Testing/Wolverine.ComplianceTests/Sagas/ISagaHost.cs
+++ b/src/Testing/Wolverine.ComplianceTests/Sagas/ISagaHost.cs
@@ -4,7 +4,7 @@ namespace Wolverine.ComplianceTests.Sagas;
 
 public interface ISagaHost
 {
-    IHost BuildHost<TSaga>();
+    Task<IHost> BuildHostAsync<TSaga>();
 
     Task<T?> LoadState<T>(Guid id) where T : Saga;
     Task<T?> LoadState<T>(int id) where T : Saga;

--- a/src/Testing/Wolverine.ComplianceTests/Sagas/SagaTestHarness.cs
+++ b/src/Testing/Wolverine.ComplianceTests/Sagas/SagaTestHarness.cs
@@ -24,13 +24,18 @@ public class SagaTestHarness<T> : IDisposable
         _host?.Dispose();
     }
 
-    protected void withApplication()
+    protected async Task withApplication()
     {
-        _host = SagaHost.BuildHost<T>();
+        _host = await SagaHost.BuildHostAsync<T>();
     }
 
-    protected string codeFor<TMessage>()
+    protected async Task<string> codeFor<TMessage>()
     {
+        if (_host == null)
+        {
+            await withApplication();
+        }
+
         return _host!.Get<HandlerGraph>().HandlerFor<TMessage>()!.As<MessageHandler>().Chain!.SourceCode!;
     }
 
@@ -38,7 +43,7 @@ public class SagaTestHarness<T> : IDisposable
     {
         if (_host == null)
         {
-            withApplication();
+            await withApplication();
         }
 
         await _host!.InvokeMessageAndWaitAsync(message!);
@@ -48,7 +53,7 @@ public class SagaTestHarness<T> : IDisposable
     {
         if (_host == null)
         {
-            withApplication();
+            await withApplication();
         }
 
         await _host!.ExecuteAndWaitValueTaskAsync(x => x.SendAsync(message!));

--- a/src/Testing/Wolverine.ComplianceTests/Scheduling/DurabilityComplianceContext.cs
+++ b/src/Testing/Wolverine.ComplianceTests/Scheduling/DurabilityComplianceContext.cs
@@ -25,7 +25,7 @@ public abstract class DurabilityComplianceContext<TTriggerHandler, TItemCreatedH
         var receiverPort = PortFinder.GetAvailablePort();
         var senderPort = PortFinder.GetAvailablePort();
         
-        theSender = WolverineHost.For(senderRegistry =>
+        theSender = await WolverineHost.ForAsync(senderRegistry =>
         {
             senderRegistry.Durability.Mode = DurabilityMode.Solo;
             senderRegistry.Durability.ScheduledJobFirstExecution = 0.Seconds(); // Start immediately!
@@ -53,7 +53,7 @@ public abstract class DurabilityComplianceContext<TTriggerHandler, TItemCreatedH
 
         await theSender.ClearAllPersistedWolverineDataAsync();
 
-        theReceiver = WolverineHost.For(receiverRegistry =>
+        theReceiver = await WolverineHost.ForAsync(receiverRegistry =>
         {
             receiverRegistry.Durability.Mode = DurabilityMode.Solo;
             receiverRegistry.Services.AddSingleton<ILogger>(NullLogger.Instance);

--- a/src/Testing/Wolverine.ComplianceTests/WolverineHost.cs
+++ b/src/Testing/Wolverine.ComplianceTests/WolverineHost.cs
@@ -25,12 +25,6 @@ public static class WolverineHost
         return bootstrap(_ => {});
     }
 
-    [Obsolete("Try to eliminate this")]
-    public static IHost For(Action<WolverineOptions> configure)
-    {
-        return bootstrap(configure);
-    }
-
     public static Task<IHost> ForAsync(Action<WolverineOptions> configure)
     {
         return bootstrapAsync(configure);

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Bugs/Bug_2588_durable_outbox_with_handler_and_conventional_routing.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Bugs/Bug_2588_durable_outbox_with_handler_and_conventional_routing.cs
@@ -20,13 +20,13 @@ namespace Wolverine.AmazonSqs.Tests.Bugs;
 /// <c>endpoint.Subscriptions.Any() == false</c> and never upgrade the endpoint
 /// mode to Durable.
 /// </summary>
-public class Bug_2588_durable_outbox_with_handler_and_conventional_routing : IDisposable
+public class Bug_2588_durable_outbox_with_handler_and_conventional_routing : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _host;
+    private IHost _host = null!;
 
-    public Bug_2588_durable_outbox_with_handler_and_conventional_routing()
+    public async Task InitializeAsync()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.UseAmazonSqsTransportLocally()
                 .UseConventionalRouting()
@@ -62,6 +62,8 @@ public class Bug_2588_durable_outbox_with_handler_and_conventional_routing : IDi
 
         brokerEndpoint.Mode.ShouldBe(EndpointMode.Durable);
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/ConventionalRoutingContext.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/ConventionalRoutingContext.cs
@@ -9,21 +9,14 @@ namespace Wolverine.AmazonSqs.Tests.ConventionalRouting;
 
 public abstract class ConventionalRoutingContext : IDisposable
 {
-    private readonly object _hostLock = new();
     private IHost _host = null!;
 
-    internal IWolverineRuntime theRuntime
+    internal async Task<IWolverineRuntime> theRuntime()
     {
-        get
-        {
-            lock (_hostLock)
-            {
-                _host ??= WolverineHost.For(opts =>
-                    opts.UseAmazonSqsTransport().UseConventionalRouting().AutoProvision().AutoPurgeOnStartup());
-            }
+        _host ??= await WolverineHost.ForAsync(opts =>
+            opts.UseAmazonSqsTransport().UseConventionalRouting().AutoProvision().AutoPurgeOnStartup());
 
-            return _host.Services.GetRequiredService<IWolverineRuntime>();
-        }
+        return _host.Services.GetRequiredService<IWolverineRuntime>();
     }
 
     public void Dispose()
@@ -31,28 +24,28 @@ public abstract class ConventionalRoutingContext : IDisposable
         _host?.Dispose();
     }
 
-    internal void ConfigureConventions(Action<AmazonSqsMessageRoutingConvention> configure)
+    internal async Task ConfigureConventions(Action<AmazonSqsMessageRoutingConvention> configure)
     {
-        _host = Host.CreateDefaultBuilder()
+        _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
                 opts.UseAmazonSqsTransport().UseConventionalRouting(configure).AutoProvision()
                     .AutoPurgeOnStartup();
-            }).Start();
+            }).StartAsync();
     }
 
-    internal IMessageRouter RoutingFor<T>()
+    internal async Task<IMessageRouter> RoutingFor<T>()
     {
-        return theRuntime.RoutingFor(typeof(T));
+        return (await theRuntime()).RoutingFor(typeof(T));
     }
 
-    internal void AssertNoRoutes<T>()
+    internal async Task AssertNoRoutes<T>()
     {
-        RoutingFor<T>().ShouldBeOfType<EmptyMessageRouter<T>>();
+        (await RoutingFor<T>()).ShouldBeOfType<EmptyMessageRouter<T>>();
     }
 
-    internal IMessageRoute[] PublishingRoutesFor<T>()
+    internal async Task<IMessageRoute[]> PublishingRoutesFor<T>()
     {
-        return RoutingFor<T>().ShouldBeOfType<MessageRouter<T>>().Routes;
+        return (await RoutingFor<T>()).ShouldBeOfType<MessageRouter<T>>().Routes;
     }
 }

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/conventional_listener_discovery.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/conventional_listener_discovery.cs
@@ -13,9 +13,9 @@ namespace Wolverine.AmazonSqs.Tests.ConventionalRouting;
 public class conventional_listener_discovery : ConventionalRoutingContext
 {
     [Fact]
-    public void disable_sender_with_lambda()
+    public async Task disable_sender_with_lambda()
     {
-        ConfigureConventions(c => c.QueueNameForSender(t =>
+        await ConfigureConventions(c => c.QueueNameForSender(t =>
         {
             if (t == typeof(PublishedMessage))
             {
@@ -25,56 +25,58 @@ public class conventional_listener_discovery : ConventionalRoutingContext
             return t.ToMessageTypeName().Replace('.', '-');
         }));
 
-        AssertNoRoutes<PublishedMessage>();
+        await AssertNoRoutes<PublishedMessage>();
     }
 
     [Fact]
-    public void exclude_types()
+    public async Task exclude_types()
     {
-        ConfigureConventions(c => { c.ExcludeTypes(t => t == typeof(PublishedMessage)); });
+        await ConfigureConventions(c => { c.ExcludeTypes(t => t == typeof(PublishedMessage)); });
 
-        AssertNoRoutes<PublishedMessage>();
+        await AssertNoRoutes<PublishedMessage>();
 
         var uri = "sqs://published.message".ToUri();
-        var endpoint = theRuntime.Endpoints.EndpointFor(uri);
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor(uri);
         endpoint.ShouldBeNull();
 
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
+        runtime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void include_types()
+    public async Task include_types()
     {
-        ConfigureConventions(c => { c.IncludeTypes(t => t == typeof(PublishedMessage)); });
+        await ConfigureConventions(c => { c.IncludeTypes(t => t == typeof(PublishedMessage)); });
 
-        AssertNoRoutes<Message1>();
+        await AssertNoRoutes<Message1>();
 
-        PublishingRoutesFor<PublishedMessage>().Any().ShouldBeTrue();
+        (await PublishingRoutesFor<PublishedMessage>()).Any().ShouldBeTrue();
 
         var uri = "sqs://Message1".ToUri();
-        var endpoint = theRuntime.Endpoints.EndpointFor(uri);
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor(uri);
         endpoint.ShouldBeNull();
 
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
+        runtime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void configure_sender_overrides()
+    public async Task configure_sender_overrides()
     {
-        ConfigureConventions(c => c.ConfigureSending((c, _) => c.AddOutgoingRule(new FakeEnvelopeRule())));
+        await ConfigureConventions(c => c.ConfigureSending((c, _) => c.AddOutgoingRule(new FakeEnvelopeRule())));
 
-        var route = PublishingRoutesFor<PublishedMessage>().Single().As<MessageRoute>().Sender.Endpoint
+        var route = (await PublishingRoutesFor<PublishedMessage>()).Single().As<MessageRoute>().Sender.Endpoint
             .ShouldBeOfType<AmazonSqsQueue>();
 
         route.OutgoingRules.Single().ShouldBeOfType<FakeEnvelopeRule>();
     }
 
     [Fact]
-    public void disable_listener_by_lambda()
+    public async Task disable_listener_by_lambda()
     {
-        ConfigureConventions(c => c.QueueNameForListener(t =>
+        await ConfigureConventions(c => c.QueueNameForListener(t =>
         {
             if (t == typeof(RoutedMessage))
             {
@@ -85,7 +87,8 @@ public class conventional_listener_discovery : ConventionalRoutingContext
         }));
 
         var uri = "sqs://routed".ToUri();
-        var endpoint = theRuntime.Endpoints.EndpointFor(uri);
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor(uri);
 
         // An endpoint may exist at this URI as a SENDER (since a handler is
         // registered for RoutedMessage and the framework eagerly pre-registers
@@ -93,16 +96,17 @@ public class conventional_listener_discovery : ConventionalRoutingContext
         // the listener side must NOT have been created.
         if (endpoint != null) endpoint.IsListener.ShouldBeFalse();
 
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
+        runtime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void configure_listener()
+    public async Task configure_listener()
     {
-        ConfigureConventions(c => c.ConfigureListeners((x, _) => { x.UseDurableInbox(); }));
+        await ConfigureConventions(c => c.ConfigureListeners((x, _) => { x.UseDurableInbox(); }));
 
-        var endpoint = theRuntime.Endpoints.EndpointFor("sqs://routed".ToUri())
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor("sqs://routed".ToUri())
             .ShouldBeOfType<AmazonSqsQueue>();
 
         endpoint.Mode.ShouldBe(EndpointMode.Durable);

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/end_to_end_with_conventional_routing.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/end_to_end_with_conventional_routing.cs
@@ -7,26 +7,28 @@ using Wolverine.Tracking;
 namespace Wolverine.AmazonSqs.Tests.ConventionalRouting;
 
 [Trait("Category", "Flaky")]
-public class end_to_end_with_conventional_routing : IDisposable
+public class end_to_end_with_conventional_routing : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _receiver;
-    private readonly IHost _sender;
+    private IHost _receiver = null!;
+    private IHost _sender = null!;
 
-    public end_to_end_with_conventional_routing()
+    public async Task InitializeAsync()
     {
-        _sender = WolverineHost.For(opts =>
+        _sender = await WolverineHost.ForAsync(opts =>
         {
             opts.UseAmazonSqsTransport().UseConventionalRouting().AutoProvision().AutoPurgeOnStartup();
             opts.DisableConventionalDiscovery();
             opts.ServiceName = "Sender";
         });
 
-        _receiver = WolverineHost.For(opts =>
+        _receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseAmazonSqsTransport().UseConventionalRouting().AutoProvision().AutoPurgeOnStartup();
             opts.ServiceName = "Receiver";
         });
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/end_to_end_with_conventional_routing_with_prefix.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/end_to_end_with_conventional_routing_with_prefix.cs
@@ -7,14 +7,14 @@ using Wolverine.Tracking;
 namespace Wolverine.AmazonSqs.Tests.ConventionalRouting;
 
 [Trait("Category", "Flaky")]
-public class end_to_end_with_conventional_routing_with_prefix : IDisposable
+public class end_to_end_with_conventional_routing_with_prefix : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _receiver;
-    private readonly IHost _sender;
+    private IHost _receiver = null!;
+    private IHost _sender = null!;
 
-    public end_to_end_with_conventional_routing_with_prefix()
+    public async Task InitializeAsync()
     {
-        _sender = WolverineHost.For(opts =>
+        _sender = await WolverineHost.ForAsync(opts =>
         {
             opts.UseAmazonSqsTransport()
                 .PrefixIdentifiers("shazaam")
@@ -23,7 +23,7 @@ public class end_to_end_with_conventional_routing_with_prefix : IDisposable
             opts.ServiceName = "Sender";
         });
 
-        _receiver = WolverineHost.For(opts =>
+        _receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseAmazonSqsTransport()
                 .PrefixIdentifiers("shazaam")
@@ -31,6 +31,8 @@ public class end_to_end_with_conventional_routing_with_prefix : IDisposable
             opts.ServiceName = "Receiver";
         });
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
@@ -6,15 +6,17 @@ using Wolverine.Configuration;
 namespace Wolverine.AmazonSqs.Tests.ConventionalRouting;
 
 [Trait("Category", "Flaky")]
-public class when_discovering_a_listening_endpoint_with_all_defaults : ConventionalRoutingContext
+public class when_discovering_a_listening_endpoint_with_all_defaults : ConventionalRoutingContext, IAsyncLifetime
 {
     private readonly Uri theExpectedUri = "sqs://routed".ToUri();
-    private readonly AmazonSqsQueue theQueue;
+    private AmazonSqsQueue theQueue = null!;
 
-    public when_discovering_a_listening_endpoint_with_all_defaults()
+    public async Task InitializeAsync()
     {
-        theQueue = theRuntime.Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AmazonSqsQueue>();
+        theQueue = (await theRuntime()).Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AmazonSqsQueue>();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void endpoint_should_be_a_listener()
@@ -35,9 +37,9 @@ public class when_discovering_a_listening_endpoint_with_all_defaults : Conventio
     }
 
     [Fact]
-    public void should_be_an_active_listener()
+    public async Task should_be_an_active_listener()
     {
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
+        (await theRuntime()).Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
             .ShouldBeTrue();
     }
 }

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
@@ -5,18 +5,21 @@ using Wolverine.AmazonSqs.Internal;
 namespace Wolverine.AmazonSqs.Tests.ConventionalRouting;
 
 [Trait("Category", "Flaky")]
-public class when_discovering_a_listening_endpoint_with_overridden_queue_naming : ConventionalRoutingContext
+public class when_discovering_a_listening_endpoint_with_overridden_queue_naming : ConventionalRoutingContext, IAsyncLifetime
 {
     private readonly Uri theExpectedUri = "sqs://routedmessage2".ToUri();
-    private readonly AmazonSqsQueue theQueue;
+    private AmazonSqsQueue theQueue = null!;
 
-    public when_discovering_a_listening_endpoint_with_overridden_queue_naming()
+    public async Task InitializeAsync()
     {
-        ConfigureConventions(c => c.QueueNameForListener(t => t.Name.ToLower() + "2"));
+        await ConfigureConventions(c => c.QueueNameForListener(t => t.Name.ToLower() + "2"));
 
-        var theRuntimeEndpoints = theRuntime.Endpoints.ActiveListeners().ToArray();
-        theQueue = theRuntime.Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AmazonSqsQueue>();
+        var runtime = await theRuntime();
+        var theRuntimeEndpoints = runtime.Endpoints.ActiveListeners().ToArray();
+        theQueue = runtime.Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AmazonSqsQueue>();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void endpoint_should_be_a_listener()
@@ -31,9 +34,9 @@ public class when_discovering_a_listening_endpoint_with_overridden_queue_naming 
     }
 
     [Fact]
-    public void should_be_an_active_listener()
+    public async Task should_be_an_active_listener()
     {
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
+        (await theRuntime()).Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
             .ShouldBeTrue();
     }
 }

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
@@ -7,14 +7,16 @@ using Wolverine.Runtime.Routing;
 namespace Wolverine.AmazonSqs.Tests.ConventionalRouting;
 
 [Trait("Category", "Flaky")]
-public class when_discovering_a_sender_with_all_defaults : ConventionalRoutingContext
+public class when_discovering_a_sender_with_all_defaults : ConventionalRoutingContext, IAsyncLifetime
 {
-    private readonly MessageRoute theRoute;
+    private MessageRoute theRoute = null!;
 
-    public when_discovering_a_sender_with_all_defaults()
+    public async Task InitializeAsync()
     {
-        theRoute = PublishingRoutesFor<PublishedMessage>().Single().As<MessageRoute>();
+        theRoute = (await PublishingRoutesFor<PublishedMessage>()).Single().As<MessageRoute>();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void should_have_exactly_one_route()

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/when_using_handler_type_naming.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/ConventionalRouting/when_using_handler_type_naming.cs
@@ -11,14 +11,14 @@ using Xunit;
 namespace Wolverine.AmazonSqs.Tests.ConventionalRouting;
 
 [Trait("Category", "Flaky")]
-public class when_using_handler_type_naming : IDisposable
+public class when_using_handler_type_naming : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _host;
-    private readonly IWolverineRuntime _runtime;
+    private IHost _host = null!;
+    private IWolverineRuntime _runtime = null!;
 
-    public when_using_handler_type_naming()
+    public async Task InitializeAsync()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.UseAmazonSqsTransport()
                 .UseConventionalRouting(NamingSource.FromHandlerType)
@@ -51,6 +51,8 @@ public class when_using_handler_type_naming : IDisposable
         _runtime.Endpoints.ActiveListeners().Any(x => x.Uri.ToString().Contains(expectedName, StringComparison.OrdinalIgnoreCase))
             .ShouldBeTrue($"Expected active listener containing '{expectedName}'");
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/end_to_end_with_named_broker.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/end_to_end_with_named_broker.cs
@@ -20,7 +20,7 @@ public class end_to_end_with_named_broker
     public async Task send_message_to_and_receive_through_kafka_with_inline_receivers()
     {
         var queueName = Guid.NewGuid().ToString();
-        using var publisher = WolverineHost.For(opts =>
+        using var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.UseAmazonSqsTransportLocallyAsNamedBroker(theName).AutoProvision().AutoPurgeOnStartup();
 
@@ -30,7 +30,7 @@ public class end_to_end_with_named_broker
         });
 
 
-        using var receiver = WolverineHost.For(opts =>
+        using var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseAmazonSqsTransportLocallyAsNamedBroker(theName).AutoProvision();
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/Broadcasting/end_to_end_with_conventional_routing.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/Broadcasting/end_to_end_with_conventional_routing.cs
@@ -13,9 +13,9 @@ public class end_to_end_with_conventional_routing : IAsyncLifetime
     private IHost _receiver = null!;
     private IHost _sender = null!;
 
-    public Task InitializeAsync()
+    public async Task InitializeAsync()
     {
-        _sender = WolverineHost.For(opts =>
+        _sender = await WolverineHost.ForAsync(opts =>
         {
             opts.UseAzureServiceBusTesting().UseTopicAndSubscriptionConventionalRouting(x =>
             {
@@ -28,7 +28,7 @@ public class end_to_end_with_conventional_routing : IAsyncLifetime
             opts.ServiceName = "Sender";
         });
 
-        _receiver = WolverineHost.For(opts =>
+        _receiver = await WolverineHost.ForAsync(opts =>
         {
             #region sample_using_topic_and_subscription_conventional_routing_with_azure_service_bus
             opts.UseAzureServiceBusTesting()
@@ -52,8 +52,6 @@ public class end_to_end_with_conventional_routing : IAsyncLifetime
 
             opts.ServiceName = "Receiver";
         });
-
-        return Task.CompletedTask;
     }
 
     public async Task DisposeAsync()

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/ConventionalRoutingContext.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/ConventionalRoutingContext.cs
@@ -10,57 +10,50 @@ namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 
 public abstract class ConventionalRoutingContext : IAsyncLifetime
 {
-    private readonly object _hostLock = new();
     private IHost _host = null!;
 
-    internal IWolverineRuntime theRuntime
+    internal async Task<IWolverineRuntime> theRuntime()
     {
-        get
-        {
-            lock (_hostLock)
-            {
-                _host ??= WolverineHost.For(opts =>
-                    opts.UseAzureServiceBusTesting().UseConventionalRouting().AutoProvision().AutoPurgeOnStartup());
-            }
+        _host ??= await WolverineHost.ForAsync(opts =>
+            opts.UseAzureServiceBusTesting().UseConventionalRouting().AutoProvision().AutoPurgeOnStartup());
 
-            return _host.Services.GetRequiredService<IWolverineRuntime>();
-        }
+        return _host.Services.GetRequiredService<IWolverineRuntime>();
     }
 
-    public Task InitializeAsync()
+    public virtual Task InitializeAsync()
     {
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public virtual async Task DisposeAsync()
     {
         if (_host != null) await _host.StopAsync();
         _host?.Dispose();
         await AzureServiceBusTesting.DeleteAllEmulatorObjectsAsync();
     }
 
-    internal void ConfigureConventions(Action<AzureServiceBusMessageRoutingConvention> configure)
+    internal async Task ConfigureConventions(Action<AzureServiceBusMessageRoutingConvention> configure)
     {
-        _host = Host.CreateDefaultBuilder()
+        _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
                 opts.UseAzureServiceBusTesting().UseConventionalRouting(configure).AutoProvision()
                     .AutoPurgeOnStartup();
-            }).Start();
+            }).StartAsync();
     }
 
-    internal IMessageRouter RoutingFor<T>()
+    internal async Task<IMessageRouter> RoutingFor<T>()
     {
-        return theRuntime.RoutingFor(typeof(T));
+        return (await theRuntime()).RoutingFor(typeof(T));
     }
 
-    internal void AssertNoRoutes<T>()
+    internal async Task AssertNoRoutes<T>()
     {
-        RoutingFor<T>().ShouldBeOfType<EmptyMessageRouter<T>>();
+        (await RoutingFor<T>()).ShouldBeOfType<EmptyMessageRouter<T>>();
     }
 
-    internal IMessageRoute[] PublishingRoutesFor<T>()
+    internal async Task<IMessageRoute[]> PublishingRoutesFor<T>()
     {
-        return RoutingFor<T>().ShouldBeOfType<MessageRouter<T>>().Routes;
+        return (await RoutingFor<T>()).ShouldBeOfType<MessageRouter<T>>().Routes;
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/conventional_listener_discovery.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/conventional_listener_discovery.cs
@@ -14,9 +14,9 @@ namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 public class conventional_listener_discovery : ConventionalRoutingContext
 {
     [Fact]
-    public void disable_sender_with_lambda()
+    public async Task disable_sender_with_lambda()
     {
-        ConfigureConventions(c => c.QueueNameForSender(t =>
+        await ConfigureConventions(c => c.QueueNameForSender(t =>
         {
             if (t == typeof(PublishedMessage))
             {
@@ -26,56 +26,58 @@ public class conventional_listener_discovery : ConventionalRoutingContext
             return t.ToMessageTypeName().Replace('.', '-');
         }));
 
-        AssertNoRoutes<PublishedMessage>();
+        await AssertNoRoutes<PublishedMessage>();
     }
 
     [Fact]
-    public void exclude_types()
+    public async Task exclude_types()
     {
-        ConfigureConventions(c => { c.ExcludeTypes(t => t == typeof(PublishedMessage)); });
+        await ConfigureConventions(c => { c.ExcludeTypes(t => t == typeof(PublishedMessage)); });
 
-        AssertNoRoutes<PublishedMessage>();
+        await AssertNoRoutes<PublishedMessage>();
 
         var uri = "sqs://published.message".ToUri();
-        var endpoint = theRuntime.Endpoints.EndpointFor(uri);
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor(uri);
         endpoint.ShouldBeNull();
 
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
+        runtime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void include_types()
+    public async Task include_types()
     {
-        ConfigureConventions(c => { c.IncludeTypes(t => t == typeof(PublishedMessage)); });
+        await ConfigureConventions(c => { c.IncludeTypes(t => t == typeof(PublishedMessage)); });
 
-        AssertNoRoutes<Message1>();
+        await AssertNoRoutes<Message1>();
 
-        PublishingRoutesFor<PublishedMessage>().Any().ShouldBeTrue();
+        (await PublishingRoutesFor<PublishedMessage>()).Any().ShouldBeTrue();
 
         var uri = "sqs://Message1".ToUri();
-        var endpoint = theRuntime.Endpoints.EndpointFor(uri);
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor(uri);
         endpoint.ShouldBeNull();
 
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
+        runtime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void configure_sender_overrides()
+    public async Task configure_sender_overrides()
     {
-        ConfigureConventions(c => c.ConfigureSending((c, _) => c.AddOutgoingRule(new FakeEnvelopeRule())));
+        await ConfigureConventions(c => c.ConfigureSending((c, _) => c.AddOutgoingRule(new FakeEnvelopeRule())));
 
-        var route = PublishingRoutesFor<PublishedMessage>().Single().As<MessageRoute>().Sender.Endpoint
+        var route = (await PublishingRoutesFor<PublishedMessage>()).Single().As<MessageRoute>().Sender.Endpoint
             .ShouldBeOfType<AzureServiceBusQueue>();
 
         route.OutgoingRules.Single().ShouldBeOfType<FakeEnvelopeRule>();
     }
 
     [Fact]
-    public void disable_listener_by_lambda()
+    public async Task disable_listener_by_lambda()
     {
-        ConfigureConventions(c => c.QueueNameForListener(t =>
+        await ConfigureConventions(c => c.QueueNameForListener(t =>
         {
             if (t == typeof(RoutedMessage))
             {
@@ -86,7 +88,8 @@ public class conventional_listener_discovery : ConventionalRoutingContext
         }));
 
         var uri = "sqs://routed".ToUri();
-        var endpoint = theRuntime.Endpoints.EndpointFor(uri);
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor(uri);
 
         // An endpoint may exist at this URI as a SENDER (since a handler is
         // registered for RoutedMessage and the framework eagerly pre-registers
@@ -94,19 +97,20 @@ public class conventional_listener_discovery : ConventionalRoutingContext
         // the listener side must NOT have been created.
         if (endpoint != null) endpoint.IsListener.ShouldBeFalse();
 
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
+        runtime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void configure_listener()
+    public async Task configure_listener()
     {
-        ConfigureConventions(c => c.ConfigureListeners((x, _) =>
+        await ConfigureConventions(c => c.ConfigureListeners((x, _) =>
         {
             x.UseDurableInbox();
         }));
 
-        var endpoint = theRuntime.Endpoints.EndpointFor("asb://queue/routed".ToUri())
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor("asb://queue/routed".ToUri())
             .ShouldBeOfType<AzureServiceBusQueue>();
 
         endpoint.Mode.ShouldBe(EndpointMode.Durable);

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/end_to_end_with_conventional_routing_with_prefix.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/end_to_end_with_conventional_routing_with_prefix.cs
@@ -13,9 +13,9 @@ public class end_to_end_with_conventional_routing_with_prefix : IAsyncLifetime
     private IHost _receiver = null!;
     private IHost _sender = null!;
 
-    public Task InitializeAsync()
+    public async Task InitializeAsync()
     {
-        _sender = WolverineHost.For(opts =>
+        _sender = await WolverineHost.ForAsync(opts =>
         {
             opts.UseAzureServiceBusTesting()
                 .PrefixIdentifiers("shazaam")
@@ -24,15 +24,13 @@ public class end_to_end_with_conventional_routing_with_prefix : IAsyncLifetime
             opts.ServiceName = "Sender";
         });
 
-        _receiver = WolverineHost.For(opts =>
+        _receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseAzureServiceBusTesting()
                 .PrefixIdentifiers("shazaam")
                 .UseConventionalRouting().AutoProvision().AutoPurgeOnStartup();
             opts.ServiceName = "Receiver";
         });
-
-        return Task.CompletedTask;
     }
 
     public async Task DisposeAsync()

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
@@ -10,35 +10,32 @@ namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 public class when_discovering_a_listening_endpoint_with_all_defaults : ConventionalRoutingContext
 {
     private readonly Uri theExpectedUri = "asb://queue/routed2".ToUri();
-    private readonly AzureServiceBusQueue theQueue;
-
-    public when_discovering_a_listening_endpoint_with_all_defaults()
-    {
-        theQueue = theRuntime.Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AzureServiceBusQueue>();
-    }
 
     [Fact]
-    public void endpoint_should_be_a_listener()
+    public async Task endpoint_should_be_a_listener()
     {
+        var theQueue = (await theRuntime()).Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AzureServiceBusQueue>();
         theQueue.IsListener.ShouldBeTrue();
     }
 
     [Fact]
-    public void endpoint_should_not_be_null()
+    public async Task endpoint_should_not_be_null()
     {
+        var theQueue = (await theRuntime()).Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AzureServiceBusQueue>();
         theQueue.ShouldNotBeNull();
     }
 
     [Fact]
-    public void mode_is_buffered_by_default()
+    public async Task mode_is_buffered_by_default()
     {
+        var theQueue = (await theRuntime()).Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AzureServiceBusQueue>();
         theQueue.Mode.ShouldBe(EndpointMode.BufferedInMemory);
     }
 
     [Fact]
-    public void should_be_an_active_listener()
+    public async Task should_be_an_active_listener()
     {
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
+        (await theRuntime()).Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
             .ShouldBeTrue();
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
@@ -9,14 +9,16 @@ namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 public class when_discovering_a_listening_endpoint_with_overridden_queue_naming : ConventionalRoutingContext
 {
     private readonly Uri theExpectedUri = "asb://queue/routedmessage2".ToUri();
-    private readonly AzureServiceBusQueue theQueue;
+    private AzureServiceBusQueue theQueue = null!;
 
-    public when_discovering_a_listening_endpoint_with_overridden_queue_naming()
+    public override async Task InitializeAsync()
     {
-        ConfigureConventions(c => c.QueueNameForListener(t => t.Name.ToLower() + "2"));
+        await base.InitializeAsync();
+        await ConfigureConventions(c => c.QueueNameForListener(t => t.Name.ToLower() + "2"));
 
-        var theRuntimeEndpoints = theRuntime.Endpoints.ActiveListeners().ToArray();
-        theQueue = theRuntime.Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AzureServiceBusQueue>();
+        var runtime = await theRuntime();
+        var theRuntimeEndpoints = runtime.Endpoints.ActiveListeners().ToArray();
+        theQueue = runtime.Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AzureServiceBusQueue>();
     }
 
     [Fact]
@@ -32,9 +34,9 @@ public class when_discovering_a_listening_endpoint_with_overridden_queue_naming 
     }
 
     [Fact]
-    public void should_be_an_active_listener()
+    public async Task should_be_an_active_listener()
     {
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
+        (await theRuntime()).Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
             .ShouldBeTrue();
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
@@ -10,11 +10,12 @@ namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 [Trait("Category", "Flaky")]
 public class when_discovering_a_sender_with_all_defaults : ConventionalRoutingContext
 {
-    private readonly MessageRoute theRoute;
+    private MessageRoute theRoute = null!;
 
-    public when_discovering_a_sender_with_all_defaults()
+    public override async Task InitializeAsync()
     {
-        theRoute = PublishingRoutesFor<PublishedMessage>().Single().As<MessageRoute>();
+        await base.InitializeAsync();
+        theRoute = (await PublishingRoutesFor<PublishedMessage>()).Single().As<MessageRoute>();
     }
 
     [Fact]

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end_with_named_broker.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end_with_named_broker.cs
@@ -55,7 +55,7 @@ public class end_to_end_with_named_broker : IAsyncLifetime
     public async Task correct_scheme_on_reply_uri()
     {
         var queueName = Guid.NewGuid().ToString();
-        using var publisher = WolverineHost.For(opts =>
+        using var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.ServiceName = "Publisher";
             opts.Discovery.DisableConventionalDiscovery();
@@ -74,7 +74,7 @@ public class end_to_end_with_named_broker : IAsyncLifetime
         });
 
 
-        using var receiver = WolverineHost.For(opts =>
+        using var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.ServiceName = "Receiver";
             opts.UseAzureServiceBusTesting().AutoProvision();

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/ConventionalRoutingContext.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/ConventionalRoutingContext.cs
@@ -11,21 +11,18 @@ public abstract class ConventionalRoutingContext : IDisposable
 {
     private IHost _host = default!;
 
-    internal IWolverineRuntime theRuntime
+    internal async Task<IWolverineRuntime> theRuntime()
     {
-        get
-        {
-            _host ??= WolverineHost.For(opts => opts
-                .UsePubsubTesting()
-                .AutoProvision()
-                .AutoPurgeOnStartup()
-                .EnableDeadLettering()
-                .EnableSystemEndpoints()
-                .UseConventionalRouting()
-            );
+        _host ??= await WolverineHost.ForAsync(opts => opts
+            .UsePubsubTesting()
+            .AutoProvision()
+            .AutoPurgeOnStartup()
+            .EnableDeadLettering()
+            .EnableSystemEndpoints()
+            .UseConventionalRouting()
+        );
 
-            return _host.Services.GetRequiredService<IWolverineRuntime>();
-        }
+        return _host.Services.GetRequiredService<IWolverineRuntime>();
     }
 
     public void Dispose()
@@ -33,9 +30,9 @@ public abstract class ConventionalRoutingContext : IDisposable
         _host?.Dispose();
     }
 
-    internal void ConfigureConventions(Action<PubsubMessageRoutingConvention> configure)
+    internal async Task ConfigureConventions(Action<PubsubMessageRoutingConvention> configure)
     {
-        _host = Host
+        _host = await Host
             .CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
@@ -46,21 +43,21 @@ public abstract class ConventionalRoutingContext : IDisposable
                     .EnableDeadLettering()
                     .EnableSystemEndpoints()
                     .UseConventionalRouting(configure);
-            }).Start();
+            }).StartAsync();
     }
 
-    internal IMessageRouter RoutingFor<T>()
+    internal async Task<IMessageRouter> RoutingFor<T>()
     {
-        return theRuntime.RoutingFor(typeof(T));
+        return (await theRuntime()).RoutingFor(typeof(T));
     }
 
-    internal void AssertNoRoutes<T>()
+    internal async Task AssertNoRoutes<T>()
     {
-        RoutingFor<T>().ShouldBeOfType<EmptyMessageRouter<T>>();
+        (await RoutingFor<T>()).ShouldBeOfType<EmptyMessageRouter<T>>();
     }
 
-    internal IMessageRoute[] PublishingRoutesFor<T>()
+    internal async Task<IMessageRoute[]> PublishingRoutesFor<T>()
     {
-        return RoutingFor<T>().ShouldBeOfType<MessageRouter<T>>().Routes;
+        return (await RoutingFor<T>()).ShouldBeOfType<MessageRouter<T>>().Routes;
     }
 }

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/conventional_listener_discovery.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/conventional_listener_discovery.cs
@@ -12,9 +12,9 @@ namespace Wolverine.Pubsub.Tests.ConventionalRouting;
 public class conventional_listener_discovery : ConventionalRoutingContext
 {
     [Fact]
-    public void disable_sender_with_lambda()
+    public async Task disable_sender_with_lambda()
     {
-        ConfigureConventions(c => c.TopicNameForSender(t =>
+        await ConfigureConventions(c => c.TopicNameForSender(t =>
         {
             if (t == typeof(PublishedMessage))
             {
@@ -24,60 +24,62 @@ public class conventional_listener_discovery : ConventionalRoutingContext
             return t.ToMessageTypeName();
         }));
 
-        AssertNoRoutes<PublishedMessage>();
+        await AssertNoRoutes<PublishedMessage>();
     }
 
     [Fact]
-    public void exclude_types()
+    public async Task exclude_types()
     {
-        ConfigureConventions(c => { c.ExcludeTypes(t => t == typeof(PublishedMessage)); });
+        await ConfigureConventions(c => { c.ExcludeTypes(t => t == typeof(PublishedMessage)); });
 
-        AssertNoRoutes<PublishedMessage>();
+        await AssertNoRoutes<PublishedMessage>();
 
         var uri = $"{PubsubTransport.ProtocolName}://wolverine/published-message".ToUri();
-        var endpoint = theRuntime.Endpoints.EndpointFor(uri);
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor(uri);
 
         endpoint.ShouldBeNull();
 
-        theRuntime.Endpoints.ActiveListeners()
+        runtime.Endpoints.ActiveListeners()
             .Any(x => x.Uri == uri)
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void include_types()
+    public async Task include_types()
     {
-        ConfigureConventions(c => { c.IncludeTypes(t => t == typeof(PublishedMessage)); });
+        await ConfigureConventions(c => { c.IncludeTypes(t => t == typeof(PublishedMessage)); });
 
-        AssertNoRoutes<Message1>();
+        await AssertNoRoutes<Message1>();
 
-        PublishingRoutesFor<PublishedMessage>().Any().ShouldBeTrue();
+        (await PublishingRoutesFor<PublishedMessage>()).Any().ShouldBeTrue();
 
         var uri = $"{PubsubTransport.ProtocolName}://wolverine/Message1".ToUri();
-        var endpoint = theRuntime.Endpoints.EndpointFor(uri);
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor(uri);
 
         endpoint.ShouldBeNull();
 
-        theRuntime.Endpoints.ActiveListeners()
+        runtime.Endpoints.ActiveListeners()
             .Any(x => x.Uri == uri)
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void configure_sender_overrides()
+    public async Task configure_sender_overrides()
     {
-        ConfigureConventions(c => c.ConfigureSending((c, _) => c.AddOutgoingRule(new FakeEnvelopeRule())));
+        await ConfigureConventions(c => c.ConfigureSending((c, _) => c.AddOutgoingRule(new FakeEnvelopeRule())));
 
-        var route = PublishingRoutesFor<PublishedMessage>().Single().As<MessageRoute>().Sender.Endpoint
+        var route = (await PublishingRoutesFor<PublishedMessage>()).Single().As<MessageRoute>().Sender.Endpoint
             .ShouldBeOfType<PubsubEndpoint>();
 
         route.OutgoingRules.Single().ShouldBeOfType<FakeEnvelopeRule>();
     }
 
     [Fact]
-    public void disable_listener_by_lambda()
+    public async Task disable_listener_by_lambda()
     {
-        ConfigureConventions(c => c.QueueNameForListener(t =>
+        await ConfigureConventions(c => c.QueueNameForListener(t =>
         {
             if (t == typeof(RoutedMessage))
             {
@@ -88,7 +90,8 @@ public class conventional_listener_discovery : ConventionalRoutingContext
         }));
 
         var uri = $"{PubsubTransport.ProtocolName}://wolverine/routed".ToUri();
-        var endpoint = theRuntime.Endpoints.EndpointFor(uri);
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor(uri);
 
         // An endpoint may exist at this URI as a SENDER (since a handler is
         // registered for RoutedMessage and the framework eagerly pre-registers
@@ -96,17 +99,18 @@ public class conventional_listener_discovery : ConventionalRoutingContext
         // the listener side must NOT have been created.
         if (endpoint != null) endpoint.IsListener.ShouldBeFalse();
 
-        theRuntime.Endpoints.ActiveListeners()
+        runtime.Endpoints.ActiveListeners()
             .Any(x => x.Uri == uri)
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void configure_listener()
+    public async Task configure_listener()
     {
-        ConfigureConventions(c => c.ConfigureListeners((x, _) => { x.UseDurableInbox(); }));
+        await ConfigureConventions(c => c.ConfigureListeners((x, _) => { x.UseDurableInbox(); }));
 
-        var endpoint = theRuntime.Endpoints.EndpointFor($"{PubsubTransport.ProtocolName}://wolverine/routed".ToUri())
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor($"{PubsubTransport.ProtocolName}://wolverine/routed".ToUri())
             .ShouldBeOfType<PubsubEndpoint>();
 
         endpoint.Mode.ShouldBe(EndpointMode.Durable);

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/end_to_end_with_conventional_routing_with_prefix.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/end_to_end_with_conventional_routing_with_prefix.cs
@@ -7,14 +7,14 @@ using Xunit;
 
 namespace Wolverine.Pubsub.Tests.ConventionalRouting;
 
-public class end_to_end_with_conventional_routing_with_prefix : IDisposable
+public class end_to_end_with_conventional_routing_with_prefix : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _receiver;
-    private readonly IHost _sender;
+    private IHost _receiver = null!;
+    private IHost _sender = null!;
 
-    public end_to_end_with_conventional_routing_with_prefix()
+    public async Task InitializeAsync()
     {
-        _sender = WolverineHost.For(opts =>
+        _sender = await WolverineHost.ForAsync(opts =>
         {
             opts
                 .UsePubsubTesting()
@@ -30,7 +30,7 @@ public class end_to_end_with_conventional_routing_with_prefix : IDisposable
             opts.ServiceName = "Sender";
         });
 
-        _receiver = WolverineHost.For(opts =>
+        _receiver = await WolverineHost.ForAsync(opts =>
         {
             opts
                 .UsePubsubTesting()
@@ -44,6 +44,8 @@ public class end_to_end_with_conventional_routing_with_prefix : IDisposable
             opts.ServiceName = "Receiver";
         });
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
@@ -5,15 +5,17 @@ using Xunit;
 
 namespace Wolverine.Pubsub.Tests.ConventionalRouting;
 
-public class when_discovering_a_listening_endpoint_with_all_defaults : ConventionalRoutingContext
+public class when_discovering_a_listening_endpoint_with_all_defaults : ConventionalRoutingContext, IAsyncLifetime
 {
-    private readonly PubsubEndpoint theEndpoint;
+    private PubsubEndpoint theEndpoint = null!;
     private readonly Uri theExpectedUri = $"{PubsubTransport.ProtocolName}://wolverine/routed".ToUri();
 
-    public when_discovering_a_listening_endpoint_with_all_defaults()
+    public async Task InitializeAsync()
     {
-        theEndpoint = theRuntime.Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<PubsubEndpoint>();
+        theEndpoint = (await theRuntime()).Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<PubsubEndpoint>();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void endpoint_should_be_a_listener()
@@ -34,9 +36,9 @@ public class when_discovering_a_listening_endpoint_with_all_defaults : Conventio
     }
 
     [Fact]
-    public void should_be_an_active_listener()
+    public async Task should_be_an_active_listener()
     {
-        theRuntime.Endpoints
+        (await theRuntime()).Endpoints
             .ActiveListeners()
             .Any(x => x.Uri == theExpectedUri)
             .ShouldBeTrue();

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
@@ -4,19 +4,22 @@ using Xunit;
 
 namespace Wolverine.Pubsub.Tests.ConventionalRouting;
 
-public class when_discovering_a_listening_endpoint_with_overridden_queue_naming : ConventionalRoutingContext
+public class when_discovering_a_listening_endpoint_with_overridden_queue_naming : ConventionalRoutingContext, IAsyncLifetime
 {
-    private readonly PubsubEndpoint theEndpoint;
+    private PubsubEndpoint theEndpoint = null!;
     private readonly Uri theExpectedUri = $"{PubsubTransport.ProtocolName}://wolverine/routedmessage2".ToUri();
 
-    public when_discovering_a_listening_endpoint_with_overridden_queue_naming()
+    public async Task InitializeAsync()
     {
-        ConfigureConventions(c => c.QueueNameForListener(t => t.Name.ToLower() + "2"));
+        await ConfigureConventions(c => c.QueueNameForListener(t => t.Name.ToLower() + "2"));
 
-        var theRuntimeEndpoints = theRuntime.Endpoints.ActiveListeners().ToArray();
+        var runtime = await theRuntime();
+        var theRuntimeEndpoints = runtime.Endpoints.ActiveListeners().ToArray();
 
-        theEndpoint = theRuntime.Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<PubsubEndpoint>();
+        theEndpoint = runtime.Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<PubsubEndpoint>();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void endpoint_should_be_a_listener()
@@ -31,9 +34,9 @@ public class when_discovering_a_listening_endpoint_with_overridden_queue_naming 
     }
 
     [Fact]
-    public void should_be_an_active_listener()
+    public async Task should_be_an_active_listener()
     {
-        theRuntime.Endpoints
+        (await theRuntime()).Endpoints
             .ActiveListeners()
             .Any(x => x.Uri == theExpectedUri)
             .ShouldBeTrue();

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
@@ -6,14 +6,16 @@ using Xunit;
 
 namespace Wolverine.Pubsub.Tests.ConventionalRouting;
 
-public class when_discovering_a_sender_with_all_defaults : ConventionalRoutingContext
+public class when_discovering_a_sender_with_all_defaults : ConventionalRoutingContext, IAsyncLifetime
 {
-    private readonly MessageRoute theRoute;
+    private MessageRoute theRoute = null!;
 
-    public when_discovering_a_sender_with_all_defaults()
+    public async Task InitializeAsync()
     {
-        theRoute = PublishingRoutesFor<PublishedMessage>().Single().As<MessageRoute>();
+        theRoute = (await PublishingRoutesFor<PublishedMessage>()).Single().As<MessageRoute>();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void should_have_exactly_one_route()

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/when_using_handler_type_naming.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/ConventionalRouting/when_using_handler_type_naming.cs
@@ -10,14 +10,14 @@ using Xunit;
 
 namespace Wolverine.Pubsub.Tests.ConventionalRouting;
 
-public class when_using_handler_type_naming : IDisposable
+public class when_using_handler_type_naming : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _host;
-    private readonly IWolverineRuntime _runtime;
+    private IHost _host = null!;
+    private IWolverineRuntime _runtime = null!;
 
-    public when_using_handler_type_naming()
+    public async Task InitializeAsync()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.UsePubsubTesting()
                 .AutoProvision()
@@ -41,6 +41,8 @@ public class when_using_handler_type_naming : IDisposable
         _runtime.Endpoints.ActiveListeners().Any(x => x.Uri.ToString().Contains(expectedName))
             .ShouldBeTrue($"Expected active listener containing '{expectedName}' for handler type");
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/end_to_end_with_named_broker.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/end_to_end_with_named_broker.cs
@@ -24,7 +24,7 @@ public class end_to_end_with_named_broker
     public async Task send_message_to_and_receive_through_kafka_with_inline_receivers()
     {
         var topicName = Guid.NewGuid().ToString();
-        using var publisher = WolverineHost.For(opts =>
+        using var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.AddNamedKafkaBroker(theName, KafkaContainerFixture.ConnectionString).AutoProvision().AutoPurgeOnStartup();
 
@@ -34,7 +34,7 @@ public class end_to_end_with_named_broker
         });
 
 
-        using var receiver = WolverineHost.For(opts =>
+        using var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.AddNamedKafkaBroker(theName, KafkaContainerFixture.ConnectionString).AutoProvision();
 

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/stopping_and_starting_listeners.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/stopping_and_starting_listeners.cs
@@ -18,20 +18,20 @@ using Wolverine.Util;
 
 namespace CircuitBreakingTests;
 
-public class stopping_and_starting_listeners : IDisposable
+public class stopping_and_starting_listeners : IAsyncLifetime, IDisposable
 {
-    private readonly int _port1;
-    private readonly int _port2;
-    private readonly int _port3;
-    private readonly IHost theListener;
+    private int _port1;
+    private int _port2;
+    private int _port3;
+    private IHost theListener = null!;
 
-    public stopping_and_starting_listeners()
+    public async Task InitializeAsync()
     {
         _port1 = PortFinder.GetAvailablePort();
         _port2 = PortFinder.GetAvailablePort();
         _port3 = PortFinder.GetAvailablePort();
 
-        theListener = WolverineHost.For(opts =>
+        theListener = await WolverineHost.ForAsync(opts =>
         {
             opts.Durability.Mode = DurabilityMode.Solo;
 
@@ -51,6 +51,8 @@ public class stopping_and_starting_listeners : IDisposable
                 .Requeue().AndPauseProcessing(5.Seconds());
         });
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_2304_conventional_routing_ignores_durable_outbox_policy.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_2304_conventional_routing_ignores_durable_outbox_policy.cs
@@ -12,13 +12,13 @@ using Xunit;
 
 namespace Wolverine.RabbitMQ.Tests.Bugs;
 
-public class Bug_2304_conventional_routing_ignores_durable_outbox_policy : IDisposable
+public class Bug_2304_conventional_routing_ignores_durable_outbox_policy : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _host;
+    private IHost _host = null!;
 
-    public Bug_2304_conventional_routing_ignores_durable_outbox_policy()
+    public async Task InitializeAsync()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.Services.AddMarten(m =>
                 {
@@ -55,6 +55,8 @@ public class Bug_2304_conventional_routing_ignores_durable_outbox_policy : IDisp
         // The endpoint should be Durable because of UseDurableOutboxOnAllSendingEndpoints()
         endpoint.Mode.ShouldBe(EndpointMode.Durable);
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_2588_durable_outbox_with_handler_and_conventional_routing.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_2588_durable_outbox_with_handler_and_conventional_routing.cs
@@ -25,13 +25,13 @@ namespace Wolverine.RabbitMQ.Tests.Bugs;
 /// in <c>WolverineRuntime.discoverListenersFromConventions</c> /
 /// <c>MessageRoutingConvention.PreregisterSenders</c>. See GH-2588.
 /// </summary>
-public class Bug_2588_durable_outbox_with_handler_and_conventional_routing : IDisposable
+public class Bug_2588_durable_outbox_with_handler_and_conventional_routing : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _host;
+    private IHost _host = null!;
 
-    public Bug_2588_durable_outbox_with_handler_and_conventional_routing()
+    public async Task InitializeAsync()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.Services.AddMarten(m =>
                 {
@@ -53,6 +53,8 @@ public class Bug_2588_durable_outbox_with_handler_and_conventional_routing : IDi
             opts.DisableConventionalDiscovery().IncludeType<Bug2588Handler>();
         });
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void conventionally_routed_sender_should_be_durable_when_handler_is_also_registered()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/Bug_2681_handler_type_naming_binds_all_exchanges.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/Bug_2681_handler_type_naming_binds_all_exchanges.cs
@@ -26,14 +26,14 @@ namespace Wolverine.RabbitMQ.Tests.ConventionalRouting;
 /// The reporter has a candidate fix; this test pins down the expected behaviour
 /// independently so the contract is verifiable from outside the convention.
 /// </summary>
-public class Bug_2681_handler_type_naming_binds_all_exchanges : IDisposable
+public class Bug_2681_handler_type_naming_binds_all_exchanges : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _host;
-    private readonly IWolverineRuntime _runtime;
+    private IHost _host = null!;
+    private IWolverineRuntime _runtime = null!;
 
-    public Bug_2681_handler_type_naming_binds_all_exchanges()
+    public async Task InitializeAsync()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq()
                 .AutoProvision()
@@ -45,6 +45,8 @@ public class Bug_2681_handler_type_naming_binds_all_exchanges : IDisposable
 
         _runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void handler_queue_is_bound_to_every_handled_message_exchange()
@@ -94,14 +96,14 @@ public class Bug_2681_handler_type_naming_binds_all_exchanges : IDisposable
 /// message-type exchange via a custom configuration must not be bound a second
 /// time.
 /// </summary>
-public class Bug_2681_custom_bindings_are_not_double_added : IDisposable
+public class Bug_2681_custom_bindings_are_not_double_added : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _host;
-    private readonly IWolverineRuntime _runtime;
+    private IHost _host = null!;
+    private IWolverineRuntime _runtime = null!;
 
-    public Bug_2681_custom_bindings_are_not_double_added()
+    public async Task InitializeAsync()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq()
                 .AutoProvision()
@@ -124,6 +126,8 @@ public class Bug_2681_custom_bindings_are_not_double_added : IDisposable
 
         _runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void user_custom_binding_is_not_double_added_by_the_convention()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/ConventionalRoutingContext.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/ConventionalRoutingContext.cs
@@ -17,43 +17,37 @@ public static class ConventionalRoutingTestDefaults
 public abstract class ConventionalRoutingContext : IDisposable
 {
     private IHost _host = null!;
-    
+
     internal bool DisableListenerDiscovery { get; set; }
-    
-    internal IWolverineRuntime theRuntime
+
+    internal async Task<IWolverineRuntime> theRuntime()
     {
-        get
+        if (_host == null)
         {
-            if (_host == null)
+            _host = await WolverineHost.ForAsync(opts =>
             {
-                _host = WolverineHost.For(opts =>
+                opts.UseRabbitMq().UseConventionalRouting().AutoProvision().AutoPurgeOnStartup();
+
+                if (DisableListenerDiscovery)
                 {
-                    opts.UseRabbitMq().UseConventionalRouting().AutoProvision().AutoPurgeOnStartup();
-
-                    if (DisableListenerDiscovery)
-                    {
-                        opts.Discovery.DisableConventionalDiscovery();
-                    }
-                });
-            }
-
-            return _host.Services.GetRequiredService<IWolverineRuntime>();
+                    opts.Discovery.DisableConventionalDiscovery();
+                }
+            });
         }
+
+        return _host.Services.GetRequiredService<IWolverineRuntime>();
     }
 
-    internal RabbitMqTransport theTransport
+    internal async Task<RabbitMqTransport> theTransport()
     {
-        get
+        if (_host == null)
         {
-            if (_host == null)
-            {
-                _host = WolverineHost.For(opts => opts.UseRabbitMq().UseConventionalRouting());
-            }
-
-            var options = _host.Services.GetRequiredService<IWolverineRuntime>().Options;
-
-            return options.RabbitMqTransport();
+            _host = await WolverineHost.ForAsync(opts => opts.UseRabbitMq().UseConventionalRouting());
         }
+
+        var options = _host.Services.GetRequiredService<IWolverineRuntime>().Options;
+
+        return options.RabbitMqTransport();
     }
 
     public void Dispose()
@@ -61,31 +55,31 @@ public abstract class ConventionalRoutingContext : IDisposable
         _host?.Dispose();
     }
 
-    internal void ConfigureConventions(Action<RabbitMqMessageRoutingConvention> configure)
+    internal async Task ConfigureConventions(Action<RabbitMqMessageRoutingConvention> configure)
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             if (DisableListenerDiscovery)
             {
                 opts.Discovery.DisableConventionalDiscovery();
             }
-            
+
             opts.UseRabbitMq().UseConventionalRouting(configure).AutoProvision().AutoPurgeOnStartup();
         });
     }
 
-    internal IMessageRouter RoutingFor<T>()
+    internal async Task<IMessageRouter> RoutingFor<T>()
     {
-        return theRuntime.RoutingFor(typeof(T));
+        return (await theRuntime()).RoutingFor(typeof(T));
     }
 
-    internal void AssertNoRoutes<T>()
+    internal async Task AssertNoRoutes<T>()
     {
-        RoutingFor<T>().ShouldBeOfType<EmptyMessageRouter<T>>();
+        (await RoutingFor<T>()).ShouldBeOfType<EmptyMessageRouter<T>>();
     }
 
-    internal IMessageRoute[] PublishingRoutesFor<T>()
+    internal async Task<IMessageRoute[]> PublishingRoutesFor<T>()
     {
-        return RoutingFor<T>().ShouldBeOfType<MessageRouter<T>>().Routes;
+        return (await RoutingFor<T>()).ShouldBeOfType<MessageRouter<T>>().Routes;
     }
 }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/conventional_listener_discovery.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/conventional_listener_discovery.cs
@@ -12,9 +12,9 @@ namespace Wolverine.RabbitMQ.Tests.ConventionalRouting;
 public class conventional_listener_discovery : ConventionalRoutingContext
 {
     [Fact]
-    public void disable_sender_with_lambda()
+    public async Task disable_sender_with_lambda()
     {
-        ConfigureConventions(c =>
+        await ConfigureConventions(c =>
             {
                 c.IncludeTypes(c => c == typeof(PublishedMessage));
                 c.ExchangeNameForSending(t =>
@@ -29,64 +29,66 @@ public class conventional_listener_discovery : ConventionalRoutingContext
             }
           );
 
-        AssertNoRoutes<PublishedMessage>();
+        await AssertNoRoutes<PublishedMessage>();
     }
 
     [Fact]
-    public void exclude_types()
+    public async Task exclude_types()
     {
-        ConfigureConventions(c =>
+        await ConfigureConventions(c =>
         {
             c.ExcludeTypes(t => t == typeof(PublishedMessage) || t == typeof(HeadersMessage));
         });
 
-        AssertNoRoutes<PublishedMessage>();
+        await AssertNoRoutes<PublishedMessage>();
 
         var uri = "rabbitmq://queue/published.message".ToUri();
-        var endpoint = theRuntime.Endpoints.EndpointFor(uri);
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor(uri);
         endpoint.ShouldBeNull();
 
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
+        runtime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void include_types()
+    public async Task include_types()
     {
-        ConfigureConventions(c => { c.IncludeTypes(t => t == typeof(PublishedMessage)); });
+        await ConfigureConventions(c => { c.IncludeTypes(t => t == typeof(PublishedMessage)); });
 
-        AssertNoRoutes<Message1>();
+        await AssertNoRoutes<Message1>();
 
-        PublishingRoutesFor<PublishedMessage>().Any().ShouldBeTrue();
+        (await PublishingRoutesFor<PublishedMessage>()).Any().ShouldBeTrue();
 
         var uri = "rabbitmq://queue/Message1".ToUri();
-        var endpoint = theRuntime.Endpoints.EndpointFor(uri);
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor(uri);
         endpoint.ShouldBeNull();
 
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
+        runtime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void configure_sender_overrides()
+    public async Task configure_sender_overrides()
     {
-        ConfigureConventions(c =>
+        await ConfigureConventions(c =>
             {
                 c.IncludeTypes(t => t == typeof(PublishedMessage));
                 c.ConfigureSending((c, _) => c.AddOutgoingRule(new FakeEnvelopeRule()));
             }
            );
 
-        var route = PublishingRoutesFor<PublishedMessage>().Single().As<MessageRoute>().Sender.Endpoint
+        var route = (await PublishingRoutesFor<PublishedMessage>()).Single().As<MessageRoute>().Sender.Endpoint
             .ShouldBeOfType<RabbitMqExchange>();
 
         route.OutgoingRules.Single().ShouldBeOfType<FakeEnvelopeRule>();
     }
 
     [Fact]
-    public void disable_listener_by_lambda()
+    public async Task disable_listener_by_lambda()
     {
-        ConfigureConventions(c =>
+        await ConfigureConventions(c =>
         {
             c.IncludeTypes(t => t == typeof(ConventionallyRoutedMessage));
             c.QueueNameForListener(t =>
@@ -101,23 +103,25 @@ public class conventional_listener_discovery : ConventionalRoutingContext
         });
 
         var uri = "rabbitmq://queue/routed".ToUri();
-        var endpoint = theRuntime.Endpoints.EndpointFor(uri);
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor(uri);
         endpoint.ShouldBeNull();
 
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
+        runtime.Endpoints.ActiveListeners().Any(x => x.Uri == uri)
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void configure_listener()
+    public async Task configure_listener()
     {
-        ConfigureConventions(c =>
+        await ConfigureConventions(c =>
         {
             c.IncludeTypes(t => t == typeof(ConventionallyRoutedMessage));
             c.ConfigureListeners((x, _) => { x.ListenerCount(6); });
         });
 
-        var endpoint = theRuntime.Endpoints.EndpointFor("rabbitmq://queue/routed".ToUri())
+        var runtime = await theRuntime();
+        var endpoint = runtime.Endpoints.EndpointFor("rabbitmq://queue/routed".ToUri())
             .ShouldBeOfType<RabbitMqQueue>();
 
         endpoint.ListenerCount.ShouldBe(6);

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/end_to_end_with_conventional_routing.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/end_to_end_with_conventional_routing.cs
@@ -6,26 +6,28 @@ using Xunit;
 
 namespace Wolverine.RabbitMQ.Tests.ConventionalRouting;
 
-public class end_to_end_with_conventional_routing : IDisposable
+public class end_to_end_with_conventional_routing : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _receiver;
-    private readonly IHost _sender;
+    private IHost _receiver = null!;
+    private IHost _sender = null!;
 
-    public end_to_end_with_conventional_routing()
+    public async Task InitializeAsync()
     {
-        _sender = WolverineHost.For(opts =>
+        _sender = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().UseConventionalRouting(x=> x.IncludeTypes(ConventionalRoutingTestDefaults.RoutingMessageOnly)).AutoProvision().AutoPurgeOnStartup();
             opts.DisableConventionalDiscovery();
             opts.ServiceName = "Sender";
         });
 
-        _receiver = WolverineHost.For(opts =>
+        _receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().UseConventionalRouting(x=> x.IncludeTypes(ConventionalRoutingTestDefaults.RoutingMessageOnly)).AutoProvision().AutoPurgeOnStartup();
             opts.ServiceName = "Receiver";
         });
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/end_to_end_with_conventional_routing_custom_exchange.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/end_to_end_with_conventional_routing_custom_exchange.cs
@@ -7,14 +7,14 @@ using Xunit;
 
 namespace Wolverine.RabbitMQ.Tests.ConventionalRouting;
 
-public class end_to_end_with_conventional_routing_custom_exchange : IDisposable
+public class end_to_end_with_conventional_routing_custom_exchange : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _receiver;
-    private readonly IHost _sender;
+    private IHost _receiver = null!;
+    private IHost _sender = null!;
 
-    public end_to_end_with_conventional_routing_custom_exchange()
+    public async Task InitializeAsync()
     {
-        _receiver = WolverineHost.For(opts =>
+        _receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().UseConventionalRouting(conventions =>
                 {
@@ -35,7 +35,7 @@ public class end_to_end_with_conventional_routing_custom_exchange : IDisposable
             opts.ServiceName = "Receiver";
         });
         
-        _sender = WolverineHost.For(opts =>
+        _sender = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().UseConventionalRouting(conventions =>
                 {
@@ -56,6 +56,8 @@ public class end_to_end_with_conventional_routing_custom_exchange : IDisposable
 
 
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/end_to_end_with_conventional_routing_with_prefix.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/end_to_end_with_conventional_routing_with_prefix.cs
@@ -7,14 +7,14 @@ using Xunit;
 
 namespace Wolverine.RabbitMQ.Tests.ConventionalRouting;
 
-public class end_to_end_with_conventional_routing_with_prefix : IDisposable
+public class end_to_end_with_conventional_routing_with_prefix : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _receiver;
-    private readonly IHost _sender;
+    private IHost _receiver = null!;
+    private IHost _sender = null!;
 
-    public end_to_end_with_conventional_routing_with_prefix()
+    public async Task InitializeAsync()
     {
-        _sender = WolverineHost.For(opts =>
+        _sender = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq()
                 .PrefixIdentifiers("shazaam")
@@ -26,7 +26,7 @@ public class end_to_end_with_conventional_routing_with_prefix : IDisposable
             opts.ServiceName = "Sender";
         });
 
-        _receiver = WolverineHost.For(opts =>
+        _receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq()
                 .PrefixIdentifiers("shazaam")
@@ -37,6 +37,8 @@ public class end_to_end_with_conventional_routing_with_prefix : IDisposable
             opts.ServiceName = "Receiver";
         });
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
@@ -6,16 +6,18 @@ using Xunit;
 
 namespace Wolverine.RabbitMQ.Tests.ConventionalRouting;
 
-public class when_discovering_a_listening_endpoint_with_all_defaults : ConventionalRoutingContext
+public class when_discovering_a_listening_endpoint_with_all_defaults : ConventionalRoutingContext, IAsyncLifetime
 {
-    private readonly RabbitMqEndpoint theEndpoint;
+    private RabbitMqEndpoint theEndpoint = null!;
     private readonly Uri theExpectedUri = "rabbitmq://queue/routed".ToUri();
 
-    public when_discovering_a_listening_endpoint_with_all_defaults()
+    public async Task InitializeAsync()
     {
-        ConfigureConventions(x=> x.IncludeTypes(ConventionalRoutingTestDefaults.RoutingMessageOnly));
-        theEndpoint = theRuntime.Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<RabbitMqQueue>();
+        await ConfigureConventions(x=> x.IncludeTypes(ConventionalRoutingTestDefaults.RoutingMessageOnly));
+        theEndpoint = (await theRuntime()).Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<RabbitMqQueue>();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void endpoint_should_be_a_listener()
@@ -36,16 +38,17 @@ public class when_discovering_a_listening_endpoint_with_all_defaults : Conventio
     }
 
     [Fact]
-    public void should_be_an_active_listener()
+    public async Task should_be_an_active_listener()
     {
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
+        (await theRuntime()).Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
             .ShouldBeTrue();
     }
 
     [Fact]
-    public void the_queue_was_declared()
+    public async Task the_queue_was_declared()
     {
-        theTransport.Queues.Contains("routed").ShouldBeTrue();
-        theTransport.Queues["routed"].HasDeclared.ShouldBeTrue();
+        var transport = await theTransport();
+        transport.Queues.Contains("routed").ShouldBeTrue();
+        transport.Queues["routed"].HasDeclared.ShouldBeTrue();
     }
 }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
@@ -6,21 +6,23 @@ using Xunit;
 
 namespace Wolverine.RabbitMQ.Tests.ConventionalRouting;
 
-public class when_discovering_a_listening_endpoint_with_overridden_queue_naming : ConventionalRoutingContext
+public class when_discovering_a_listening_endpoint_with_overridden_queue_naming : ConventionalRoutingContext, IAsyncLifetime
 {
-    private readonly RabbitMqEndpoint theEndpoint;
+    private RabbitMqEndpoint theEndpoint = null!;
     private readonly Uri theExpectedUri = "rabbitmq://queue/routed2".ToUri();
 
-    public when_discovering_a_listening_endpoint_with_overridden_queue_naming()
+    public async Task InitializeAsync()
     {
-        ConfigureConventions(c =>
+        await ConfigureConventions(c =>
         {
             c.IncludeTypes(ConventionalRoutingTestDefaults.RoutingMessageOnly);
             c.QueueNameForListener(t => t.ToMessageTypeName() + "2");
         });
 
-        theEndpoint = theRuntime.Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<RabbitMqQueue>();
+        theEndpoint = (await theRuntime()).Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<RabbitMqQueue>();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void endpoint_should_be_a_listener()
@@ -35,16 +37,17 @@ public class when_discovering_a_listening_endpoint_with_overridden_queue_naming 
     }
 
     [Fact]
-    public void should_be_an_active_listener()
+    public async Task should_be_an_active_listener()
     {
-        theRuntime.Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
+        (await theRuntime()).Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
             .ShouldBeTrue();
     }
 
     [Fact]
-    public void the_queue_was_declared()
+    public async Task the_queue_was_declared()
     {
-        theTransport.Queues.Contains("routed2").ShouldBeTrue();
-        theTransport.Queues["routed2"].HasDeclared.ShouldBeTrue();
+        var transport = await theTransport();
+        transport.Queues.Contains("routed2").ShouldBeTrue();
+        transport.Queues["routed2"].HasDeclared.ShouldBeTrue();
     }
 }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
@@ -9,15 +9,18 @@ using Xunit;
 
 namespace Wolverine.RabbitMQ.Tests.ConventionalRouting;
 
-public class when_discovering_a_sender_with_all_defaults : ConventionalRoutingContext
+public class when_discovering_a_sender_with_all_defaults : ConventionalRoutingContext, IAsyncLifetime
 {
-    private readonly MessageRoute theRoute = null!;
-    public when_discovering_a_sender_with_all_defaults()
+    private MessageRoute theRoute = null!;
+
+    public async Task InitializeAsync()
     {
         DisableListenerDiscovery = true;
-        ConfigureConventions(x=> x.IncludeTypes(ConventionalRoutingTestDefaults.RoutingMessageOnly));
-        theRoute = (PublishingRoutesFor<ConventionallyRoutedMessage>().Single() as MessageRoute)!;
+        await ConfigureConventions(x=> x.IncludeTypes(ConventionalRoutingTestDefaults.RoutingMessageOnly));
+        theRoute = ((await PublishingRoutesFor<ConventionallyRoutedMessage>()).Single() as MessageRoute)!;
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void should_have_exactly_one_route()
@@ -43,11 +46,12 @@ public class when_discovering_a_sender_with_all_defaults : ConventionalRoutingCo
     public async Task has_declared_exchange()
     {
         // The rabbit object construction is lazy, so force it to happen
-        await new MessageBus(theRuntime).SendAsync(new ConventionallyRoutedMessage());
+        await new MessageBus(await theRuntime()).SendAsync(new ConventionallyRoutedMessage());
 
         var endpoint = theRoute.Sender.Endpoint.ShouldBeOfType<RabbitMqExchange>();
-        theTransport.Exchanges.Contains(endpoint.ExchangeName).ShouldBeTrue();
-        var theExchange = theTransport.Exchanges[endpoint.ExchangeName];
+        var transport = await theTransport();
+        transport.Exchanges.Contains(endpoint.ExchangeName).ShouldBeTrue();
+        var theExchange = transport.Exchanges[endpoint.ExchangeName];
         theExchange.HasDeclared.ShouldBeTrue();
     }
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_using_handler_type_naming.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_using_handler_type_naming.cs
@@ -11,14 +11,14 @@ using Xunit;
 
 namespace Wolverine.RabbitMQ.Tests.ConventionalRouting;
 
-public class when_using_handler_type_naming : IDisposable
+public class when_using_handler_type_naming : IAsyncLifetime, IDisposable
 {
-    private readonly IHost _host;
-    private readonly IWolverineRuntime _runtime;
+    private IHost _host = null!;
+    private IWolverineRuntime _runtime = null!;
 
-    public when_using_handler_type_naming()
+    public async Task InitializeAsync()
     {
-        _host = WolverineHost.For(opts =>
+        _host = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq()
                 .AutoProvision()
@@ -30,6 +30,8 @@ public class when_using_handler_type_naming : IDisposable
 
         _runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
     }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void listener_endpoint_should_be_named_after_handler_type()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitMqBrokerHealthProbe_tests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitMqBrokerHealthProbe_tests.cs
@@ -30,7 +30,7 @@ public class RabbitMqBrokerHealthProbe_tests
     [Fact]
     public async Task probe_returns_healthy_for_a_running_transport()
     {
-        using var host = WolverineHost.For(opts =>
+        using var host = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().AutoProvision();
         });
@@ -55,7 +55,7 @@ public class RabbitMqBrokerHealthProbe_tests
     [Fact]
     public async Task probe_returns_unhealthy_when_underlying_connection_is_closed()
     {
-        using var host = WolverineHost.For(opts =>
+        using var host = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().AutoProvision();
         });

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Samples.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Samples.cs
@@ -594,10 +594,10 @@ public class Samples
         #endregion
     }
 
-    public static void configure_routing_conventions()
+    public static async Task configure_routing_conventions()
     {
         #region sample_conventional_routing_exchange_conventions
-        var sender = WolverineHost.For(opts =>
+        var sender = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq()
                 .UseConventionalRouting(conventions =>
@@ -613,8 +613,8 @@ public class Samples
                     });
                 });
         });
-        
-        var receiver = WolverineHost.For(opts =>
+
+        var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq()
                 .UseConventionalRouting(conventions =>
@@ -635,7 +635,7 @@ public class Samples
                 });
         });
         #endregion
-      
+
     }
 
     #region sample_rabbitmq_configuration_in_wolverine_extension

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/end_to_end.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/end_to_end.cs
@@ -52,7 +52,7 @@ public class end_to_end
     public async Task rabbitmq_transport_is_exposed_as_a_resource()
     {
         var queueName = RabbitTesting.NextQueueName();
-        using var publisher = WolverineHost.For(opts =>
+        using var publisher = await WolverineHost.ForAsync(opts =>
         {
 
             opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
@@ -108,7 +108,7 @@ public class end_to_end
     public async Task rabbitmq_transport_is_NOT_exposed_as_a_resource_if_external_transports_are_stubbed()
     {
         var queueName = RabbitTesting.NextQueueName();
-        using var publisher = WolverineHost.For(opts =>
+        using var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
 
@@ -140,7 +140,7 @@ public class end_to_end
     public async Task send_message_to_and_receive_through_rabbitmq_with_durable_transport_option()
     {
         var queueName = "durable_test_queue_no_dlq";
-        using var publisher = WolverineHost.For(opts =>
+        using var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().DisableDeadLetterQueueing().AutoProvision().AutoPurgeOnStartup();
 
@@ -159,7 +159,7 @@ public class end_to_end
         });
 
 
-        using var receiver = WolverineHost.For(opts =>
+        using var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().AutoProvision().DisableDeadLetterQueueing();
 
@@ -195,7 +195,7 @@ public class end_to_end
     public async Task send_message_to_and_receive_through_rabbitmq_with_inline_receivers()
     {
         var queueName = RabbitTesting.NextQueueName();
-        using var publisher = WolverineHost.For(opts =>
+        using var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
 
@@ -207,7 +207,7 @@ public class end_to_end
         });
 
 
-        using var receiver = WolverineHost.For(opts =>
+        using var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().AutoProvision();
 
@@ -242,7 +242,7 @@ public class end_to_end
     public async Task send_message_to_and_receive_through_rabbitmq_with_inline_receivers_and_with_CloudEvents()
     {
         var queueName = RabbitTesting.NextQueueName();
-        using var publisher = WolverineHost.For(opts =>
+        using var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
 
@@ -254,7 +254,7 @@ public class end_to_end
         });
 
 
-        using var receiver = WolverineHost.For(opts =>
+        using var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().AutoProvision();
 
@@ -446,7 +446,7 @@ public class end_to_end
         var queueName = RabbitTesting.NextQueueName();
         var exchangeName = RabbitTesting.NextExchangeName();
 
-        var publisher = WolverineHost.For(opts =>
+        var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq()
                 .AutoProvision()
@@ -458,7 +458,7 @@ public class end_to_end
             opts.Services.AddResourceSetupOnStartup();
         });
 
-        var receiver = WolverineHost.For(opts =>
+        var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq()
                 .AutoProvision()
@@ -494,7 +494,7 @@ public class end_to_end
     {
         var queueName = RabbitTesting.NextQueueName();
 
-        var publisher = WolverineHost.For(opts =>
+        var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.Durability.ScheduledJobFirstExecution = 1.Seconds();
             opts.Durability.ScheduledJobPollingTime = 1.Seconds();
@@ -514,7 +514,7 @@ public class end_to_end
 
         await publisher.ResetResourceState();
 
-        var receiver = WolverineHost.For(opts =>
+        var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.ServiceName = "Receiver";
 
@@ -560,7 +560,7 @@ public class end_to_end
         var queueName3 = RabbitTesting.NextQueueName() + "e23";
 
 
-        var publisher = WolverineHost.For(opts =>
+        var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().AutoProvision()
                 .BindExchange(exchangeName).ToQueue(queueName1)
@@ -570,7 +570,7 @@ public class end_to_end
             opts.PublishAllMessages().ToRabbitExchange(exchangeName);
         });
 
-        var receiver1 = WolverineHost.For(opts =>
+        var receiver1 = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq();
 
@@ -578,7 +578,7 @@ public class end_to_end
             opts.Services.AddSingleton<ColorHistory>();
         });
 
-        var receiver2 = WolverineHost.For(opts =>
+        var receiver2 = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq();
 
@@ -586,7 +586,7 @@ public class end_to_end
             opts.Services.AddSingleton<ColorHistory>();
         });
 
-        var receiver3 = WolverineHost.For(opts =>
+        var receiver3 = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq();
 
@@ -624,7 +624,7 @@ public class end_to_end
     {
         var queueName = RabbitTesting.NextQueueName();
 
-        var publisher = WolverineHost.For(opts =>
+        var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().AutoProvision()
                 .BindExchange("topics", ExchangeType.Topic)
@@ -635,7 +635,7 @@ public class end_to_end
             opts.DisableConventionalDiscovery();
         });
 
-        var receiver = WolverineHost.For(opts =>
+        var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq();
 
@@ -841,7 +841,7 @@ public class end_to_end
     public async Task request_reply_from_within_handler()
     {
         var queueName = RabbitTesting.NextQueueName();
-        using var publisher = WolverineHost.For(opts =>
+        using var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().DisableDeadLetterQueueing().AutoProvision().AutoPurgeOnStartup();
 
@@ -856,7 +856,7 @@ public class end_to_end
         });
 
 
-        using var receiver = WolverineHost.For(opts =>
+        using var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.DisableConventionalDiscovery()
                 .IncludeType(typeof(ColorRequestHandler));

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/end_to_end_with_named_broker.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/end_to_end_with_named_broker.cs
@@ -25,7 +25,7 @@ public class end_to_end_with_named_broker
     public async Task send_message_to_and_receive_through_rabbitmq_with_inline_receivers()
     {
         var queueName = RabbitTesting.NextQueueName();
-        using var publisher = WolverineHost.For(opts =>
+        using var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.AddNamedRabbitMqBroker(theName, factory => {}).AutoProvision().AutoPurgeOnStartup();
 
@@ -37,7 +37,7 @@ public class end_to_end_with_named_broker
         });
 
 
-        using var receiver = WolverineHost.For(opts =>
+        using var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.AddNamedRabbitMqBroker(theName, factory => { }).AutoProvision();
 
@@ -71,7 +71,7 @@ public class end_to_end_with_named_broker
     public async Task correct_scheme_on_reply_uri()
     {
         var queueName = RabbitTesting.NextQueueName();
-        using var publisher = WolverineHost.For(opts =>
+        using var publisher = await WolverineHost.ForAsync(opts =>
         {
             opts.Discovery.DisableConventionalDiscovery();
             
@@ -85,7 +85,7 @@ public class end_to_end_with_named_broker
         });
 
 
-        using var receiver = WolverineHost.For(opts =>
+        using var receiver = await WolverineHost.ForAsync(opts =>
         {
             opts.UseRabbitMq().AutoProvision();
 


### PR DESCRIPTION
Per Jeremy's call on the Wolverine 6.0 API-cleanup pillar (goal #6 in #2715): instead of trying to remove the `WolverineHost` test base class entirely, honor its `[Obsolete("Try to eliminate this")]` marker on the sync `For(...)` method by converting every caller to the async `ForAsync(...)` form and deleting the sync method.

Scope deliberately excludes `WolverineHost.Basic()` (the 0-arg sync helper with 6 callers — separate cleanup if wanted).

## Summary

- **119 call sites** of `WolverineHost.For(...)` across **96 test files** converted to `await WolverineHost.ForAsync(...)`.
- Sync test methods (`public void Test_x()`) flipped to `public async Task Test_x()` where needed. xUnit accepts both.
- Test contexts that lazy-init a host in a sync property getter / constructor restructured to eager-init via `IAsyncLifetime.InitializeAsync()` or to async helper methods. Notable signature changes (all internal-to-tests):
  - `Wolverine.ComplianceTests.ISagaHost.BuildHost<T>` → `BuildHostAsync<T>` — propagated to 7 implementations (InMemory, CosmosDb, RavenDb, Postgresql, SqlServer, Polecat, EfCore, Marten).
  - `IntegrationContext.with`, `SendingContext` (`theSender`/`theReceiver`/`theSendingRuntime`/`SenderOptions`), `CompilationContext` (`AllHandlersCompileSuccessfully`/`HandlerFor<T>`/`Execute<T>`) all changed from sync members to async methods/`Task`-returning members.
  - The per-broker `ConventionalRoutingContext` base classes (Azure / RabbitMQ / AWS SQS / GCP Pub/Sub) — `theRuntime` / `theTransport` / `ConfigureConventions` / `RoutingFor<T>` / `AssertNoRoutes<T>` / `PublishingRoutesFor<T>` all moved to async. Subclass test files updated accordingly.
- Removed the sync `For` method (and its `[Obsolete]` marker) from `src/Testing/Wolverine.ComplianceTests/WolverineHost.cs`.

## Out of scope

- The class itself still carries `[Obsolete("This should have gone away a long time ago")]` at the type level. That class-level [Obsolete] stays as-is — its removal would be a larger effort to retire `WolverineHost` entirely.
- `WolverineHost.Basic()` (sync 0-arg, 6 callers) is untouched.

## Test plan

- [x] `dotnet build wolverine.slnx` — clean, 0 warnings, 0 errors
- [x] `CoreTests` on net9.0 (skipping DB-dependent filters): **1691/1691 passing** in 2m07s
- [ ] CI to confirm broker-integration tests (Azure / RabbitMQ / AWS / GCP / Pulsar / Kafka) that need actual broker infra

## Stats

- 97 files changed, 733 insertions, 676 deletions
- Net +57 lines (`await` keywords + a few `Task`-wrapping type signature changes outweighed by the per-call-site savings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)