### PR TITLE
[jasperfx#273] Rename SubscriptionVersion -> Version in Wolverine.Polecat

### DIFF
--- a/src/Persistence/Wolverine.Polecat/Subscriptions/BatchSubscription.cs
+++ b/src/Persistence/Wolverine.Polecat/Subscriptions/BatchSubscription.cs
@@ -36,7 +36,7 @@ public abstract class BatchSubscription : IWolverineSubscription, IEventFilterab
 
     public string SubscriptionName { get; protected set; }
 
-    public uint SubscriptionVersion { get; set; } = 1;
+    public uint Version { get; set; } = 1;
 
     void IWolverineSubscription.Filter(IEventFilterable filterable)
     {

--- a/src/Persistence/Wolverine.Polecat/Subscriptions/IWolverineSubscription.cs
+++ b/src/Persistence/Wolverine.Polecat/Subscriptions/IWolverineSubscription.cs
@@ -17,7 +17,7 @@ public interface IWolverineSubscription
     /// <summary>
     /// Apply versioning if you need blue/green subscriptions for new versions to catch up from the beginning
     /// </summary>
-    public uint SubscriptionVersion { get; set; }
+    public uint Version { get; set; }
 
     /// <summary>
     /// Apply filters on event data for better runtime efficiency

--- a/src/Persistence/Wolverine.Polecat/Subscriptions/PublishingRelay.cs
+++ b/src/Persistence/Wolverine.Polecat/Subscriptions/PublishingRelay.cs
@@ -28,7 +28,7 @@ public interface IPublishingRelay
     /// </summary>
     void PublishEvent(Type eventType);
 
-    uint SubscriptionVersion { get; set; }
+    uint Version { get; set; }
 
     /// <summary>
     /// Should this subscription be applied to archived events? The default is false

--- a/src/Persistence/Wolverine.Polecat/Subscriptions/ScopedWolverineSubscriptionRunner.cs
+++ b/src/Persistence/Wolverine.Polecat/Subscriptions/ScopedWolverineSubscriptionRunner.cs
@@ -21,7 +21,7 @@ internal class ScopedWolverineSubscriptionRunner<T> : SubscriptionBase where T :
         using var scope = services.CreateScope();
         var subscription = scope.ServiceProvider.GetRequiredService<T>();
         Name = subscription.SubscriptionName;
-        Version = subscription.SubscriptionVersion;
+        Version = subscription.Version;
         subscription.Filter(this);
         Options = subscription.Options;
     }

--- a/src/Persistence/Wolverine.Polecat/Subscriptions/WolverineSubscriptionRunner.cs
+++ b/src/Persistence/Wolverine.Polecat/Subscriptions/WolverineSubscriptionRunner.cs
@@ -17,7 +17,7 @@ internal class WolverineSubscriptionRunner : SubscriptionBase
         _subscription = subscription;
         _runtime = runtime;
         Name = subscription.SubscriptionName;
-        Version = subscription.SubscriptionVersion;
+        Version = subscription.Version;
         subscription.Filter(this);
         Options = subscription.Options;
     }


### PR DESCRIPTION
Row 4 of the [jasperfx#273](https://github.com/JasperFx/jasperfx/issues/273) rename-pair umbrella — the only row that's fully Marten-free. Unblocks the JasperFx-side `[Obsolete]` removal once a new JasperFx.Events alpha publishes.

## Changes

Renames the Wolverine-side `SubscriptionVersion` property to `Version` so the Wolverine.Polecat surface stays aligned with the JasperFx.Events rename. Pure property rename, no behavior change.

- `IWolverineSubscription.SubscriptionVersion` → `Version`
- `BatchSubscription.SubscriptionVersion` → `Version`
- `IPublishingRelay.SubscriptionVersion` → `Version`
- `WolverineSubscriptionRunner` + `ScopedWolverineSubscriptionRunner`: pass-through now reads `subscription.Version` instead of `subscription.SubscriptionVersion`. The `Version =` LHS is `Polecat.SubscriptionBase.Version` (inherited from `JasperFxSubscriptionBase`), which already adopted the new name.

## Out of scope

- Marten-side consumer migrations (other 5 rows of jasperfx#273) — held by another agent.
- The JasperFx.Events `[Obsolete]` alias removal — follow-up JasperFx PR after this lands and a new JasperFx.Events alpha publishes.

## Test plan

- [x] `dotnet build wolverine.slnx` — 0 errors, 0 warnings
- [ ] `dotnet test src/Persistence/PolecatTests --filter "FullyQualifiedName~Subscription"` — blocked locally by a port-1434 conflict with an unrelated `CritterStackScalability` SQL Server container (different SA password). CI should run cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)