### PR TITLE
Use SQL Server 2025

### DIFF
--- a/.github/workflows/polecat.yml
+++ b/.github/workflows/polecat.yml
@@ -37,20 +37,6 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      # Polecat 2.0+ defaults UseNativeJsonType=true, which requires the native
-      # `json` column type introduced in SQL Server 2025. The repo-wide
-      # docker-compose.yml pins sqlserver to 2022-latest because 2025-latest
-      # crashes on first boot under Apple Silicon (Windows build paths in
-      # master.mdf — see comment in docker-compose.yml). On the GitHub Linux
-      # x64 runner, 2025-latest works fine, so override the image just here.
-      - name: Override SQL Server image to 2025-latest for Polecat
-        run: |
-          cat > docker-compose.override.yml <<'EOF'
-          services:
-            sqlserver:
-              image: mcr.microsoft.com/mssql/server:2025-latest
-          EOF
-
       - name: Run Polecat Tests
         run: ./build.sh CIPolecat --framework net9.0
 

--- a/docker-compose.azure-sql-edge.yml
+++ b/docker-compose.azure-sql-edge.yml
@@ -1,0 +1,3 @@
+services:
+  sqlserver:
+    image: mcr.microsoft.com/azure-sql-edge:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,20 +52,10 @@ services:
   # SQL Server 2025 is required by Polecat 2.0+ (UseNativeJsonType defaults to true,
   # which uses the native `json` column type introduced in SQL Server 2025).
   #
-  # If you're working locally on ARM and don't need Polecat tests, you can
-  # override this service to use `mcr.microsoft.com/azure-sql-edge:latest` via
-  # a docker-compose.override.yml — but Polecat integration tests will fail
-  # against Azure SQL Edge unless you also set `m.UseNativeJsonType = false`
-  # in the test fixture.
-  #
-  # Pinned to 2022-latest (May 2026): mcr.microsoft.com/mssql/server:2025-latest
-  # ships with Windows build-server paths embedded in the master.mdf template
-  # (F:\dbs\sh\5uj5\…\model.mdf), causing first-boot to crash with
-  # "FCB::Open failed" / "Database 'model' cannot be opened" — error 5120/945.
-  # 2022-latest has a clean Linux build, runs reliably under Rosetta on Apple
-  # Silicon, and Wolverine doesn't depend on any 2025-only T-SQL surface.
+  # If you're working locally on ARM and don't need Polecat tests, you can override this service 
+  # using `docker-compose -f docker-compose.yml -f docker-compose.azure-sql-edge.yml up -d`
   sqlserver:
-    image: "mcr.microsoft.com/mssql/server:2022-latest"
+    image: mcr.microsoft.com/mssql/server:2025-latest
     ports:
       - "1434:1433"
     environment:


### PR DESCRIPTION
Currently `docker-compose.yml` uses SQL Server 2022 while CI uses 2025. It means the difference between local and CI configuration. Also, the tests running against 2022 fail by default.

This PR synchronizes both environments (by using 2025) and lets overriding version if needed using `docker-compose -f docker-compose.yml -f docker-compose.azure-sql-edge.yml up -d`. Here azure-sql-edge is used instead of 2022, just to be in sync with polecat repo.