### PR TITLE
Fix Saga.Version reflection ambiguity for subclasses with 'new int Version' shadow

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -31,7 +31,7 @@ The table below is the **complete inventory** of changed defaults, removed APIs,
 | `MartenConfigurationExpression.EventForwardingToWolverine(...)` | extension method on the Marten configuration expression *(both overloads `[Obsolete]` since 3.x)* | **removed** *(BREAKING)* | Move the flag into the `IntegrateWithWolverine` callback: [`IntegrateWithWolverine(x => x.UseFastEventForwarding = true)`](#eventforwardingtowolverine-removed-breaking) |
 | `RedisTransport.BuildRedisStreamUri(...)` | static helper on `RedisTransport` *(`[Obsolete]`)* | **removed** *(BREAKING)* | Call [`RedisEndpointUri.Stream(...)`](#redistransport-buildredisstreamuri-removed-breaking) — identical signature, drop the helper |
 | `PulsarEndpoint.UriFor(...)` | static helpers on `PulsarEndpoint` *(both overloads `[Obsolete]`)* | **removed** *(BREAKING)* | For the Wolverine-URI form, call [`PulsarEndpointUri.Topic(...)`](#pulsarendpoint-urifor-removed-breaking); the native-topic-path form (`persistent://...`) was an internal-only seam now covered by `PulsarEndpoint.NativeTopicPath` |
-| `Saga.Version` property type | `int` | `long` | Typically none — `int` widens implicitly to `long`. Only affects code that stores `saga.Version` in an `int` variable, casts it explicitly, or binds it to a column typed `int`. Tracks the matching `IRevisioned.Version` widening in Marten 9.0. |
+| `Saga.Version` property type | `int` | `long` | Typically none — `int` widens implicitly to `long`. Tracks the matching `IRevisioned.Version` widening in Marten 9.0. **Sagas that hand-rolled `public new int Version` to work around the 5.x type mismatch with `IRevisioned.Version: long` must drop that shadow on upgrade** — see [`Saga.Version` widening: drop any `new int Version` shadow on saga subclasses](#sagaversion-widening-drop-any-new-int-version-shadow-on-saga-subclasses). |
 | **One-line full revert** | n/a | [`opts.RestoreV5Defaults()`](#one-line-revert-restorev5defaults) | Flip every runtime default this method covers back to its 5.x value |
 
 ::: tip
@@ -267,6 +267,27 @@ Both `PulsarEndpoint.UriFor(...)` overloads were `[Obsolete]` in the 5.x line an
   ```
 
 If you only ever called `UriFor(string)`, this is a one-line `using`-already-imported rename.
+
+### `Saga.Version` widening: drop any `new int Version` shadow on saga subclasses
+
+`Wolverine.Saga.Version` widened from `int` to `long` in 6.0 to match `Marten.Metadata.IRevisioned.Version` (which itself widened to `long` in Marten 9.0.0-alpha.2). For the vast majority of saga code, this is an invisible change — `int` widens implicitly to `long`.
+
+There is **one upgrade hazard** worth a callout: sagas in the wild sometimes hand-rolled a `public new int Version` shadow on a Wolverine 5.x saga subclass to work around the 5.x type mismatch with `IRevisioned`. For example:
+
+```csharp
+public class OrderSaga : Wolverine.Saga
+{
+    public string Id { get; set; }
+    public new int Version { get; set; }  // ← drop this on upgrade
+    // ...
+}
+```
+
+In 6.0, that shadow is no longer needed (the base `Saga.Version: long` aligns with `IRevisioned.Version: long` by default) and is actively harmful: it leaves two `Version` properties on the type with different return types, which makes `Type.GetProperty("Version")` ambiguous in any reflective lookup. Wolverine's own Marten integration uses the typed `GetProperty(name, typeof(long))` overload to avoid this, but other consumers (Marten metadata customization, user-written diagnostics, model-binding frameworks) may still trip on the ambiguity at startup with `System.Reflection.AmbiguousMatchException`.
+
+Recommended action on upgrade: **search your saga types for `new int Version` and delete the shadow.** The inherited `Saga.Version` does the right thing.
+
+If you'd rather keep the shadow for backward compatibility (e.g. a column already typed `int`), change its return type to `long` (`public new long Version`) so it doesn't conflict with the inherited property type. That's a wire-format change; the simpler upgrade is to drop the shadow and let the inherited `long` handle it.
 
 ### Performance: per-endpoint serializer cache pre-population
 

--- a/src/Persistence/MartenTests/Saga/RevisionedSaga.cs
+++ b/src/Persistence/MartenTests/Saga/RevisionedSaga.cs
@@ -95,9 +95,12 @@ public class RevisionedSaga : Wolverine.Saga
     public static RevisionedSaga Start(StartNewRevisionedSaga command) => new RevisionedSaga { Id = command.Id };
     
     public Guid Id { get; set; }
-    
-    public new int Version { get; set; }
-    
+
+    // No `new Version` shadow needed in 6.0 — Wolverine.Saga.Version was
+    // widened from int to long to match Marten 9's IRevisioned.Version, so
+    // the base property is now the saga's revision tracker by default.
+    // See docs/guide/migration.md.
+
     public bool One { get; set; }
     public bool Two { get; set; }
     public bool Three { get; set; }

--- a/src/Persistence/Wolverine.Marten/MartenIntegration.cs
+++ b/src/Persistence/Wolverine.Marten/MartenIntegration.cs
@@ -174,7 +174,20 @@ internal class MartenOverrides : IConfigureMarten
             if (mapping.DocumentType.CanBeCastTo<Saga>())
             {
                 mapping.UseNumericRevisions = true;
-                mapping.Metadata.Revision.Member = mapping.DocumentType.GetProperty(nameof(Saga.Version))!;
+                // GetProperty(name, returnType) — not GetProperty(name) — because
+                // saga subclasses in the wild (pre-6.0) sometimes declare
+                // `public new int Version` to work around the 5.x mismatch
+                // between Saga.Version: int and Marten's IRevisioned.Version:
+                // long. After the 6.0 widening of Saga.Version to long
+                // (matching Marten 9.0.0-alpha.2's IRevisioned.Version), the
+                // single-arg overload throws AmbiguousMatchException on those
+                // subclasses because the inherited long and the derived int
+                // are two distinct properties. Filtering by return type picks
+                // the inherited long property unambiguously and treats the
+                // derived shadow as harmless dead code (which it now is, per
+                // the Saga.Version XML doc).
+                mapping.Metadata.Revision.Member = mapping.DocumentType.GetProperty(
+                    nameof(Saga.Version), typeof(long))!;
             }
         });
     }


### PR DESCRIPTION
## Summary

`Wolverine.Saga.Version` was widened from `int` to `long` in 6.0 (matching Marten 9's `IRevisioned.Version: long`). For most saga code that's invisible — `int` widens implicitly to `long` — but it interacts badly with one upgrade-time pattern: saga subclasses that hand-rolled `public new int Version` to bridge the 5.x type mismatch with `IRevisioned`.

Once the inherited `Version` is `long` and the derived shadow is `int`, `Type.GetProperty("Version")` sees two distinct properties with the same name and throws `AmbiguousMatchException` from `Wolverine.Marten.MartenOverrides` at `DocumentMapping` construction time — surfaces during host startup as a confusing reflection error with no upgrade hint.

Surfaced as a deterministic 1/1 failure in `MartenTests.Saga.using_revisioned_sagas.execute_using_update_revision`.

## Three-part fix

### 1. Wolverine fix — `MartenIntegration.cs:177`

Swap `GetProperty(name)` for `GetProperty(name, typeof(long))`:

```diff
- mapping.Metadata.Revision.Member = mapping.DocumentType.GetProperty(nameof(Saga.Version))!;
+ mapping.Metadata.Revision.Member = mapping.DocumentType.GetProperty(
+     nameof(Saga.Version), typeof(long))!;
```

The typed overload filters by return type, picks the inherited base `Saga.Version` unambiguously, and treats any derived `new int Version` shadow as harmless dead code. Single line change in Wolverine internals; no public API surface change.

### 2. Test fixture cleanup — `MartenTests/Saga/RevisionedSaga.cs:99`

Drop the now-redundant `public new int Version { get; set; }` shadow. The base `Wolverine.Saga.Version` (long) is the saga's revision-tracker by default in 6.0 — that's exactly what the widening enables, per the `Saga.Version` XML doc which says *"so sagas can implement `IRevisioned` without a shadow override."*

### 3. Migration guide — long-form section + table-row pointer

Adds a new section `Saga.Version widening: drop any new int Version shadow on saga subclasses` calling out the upgrade hazard for 5.x users with the same shadow pattern in their own saga code. Tells the user to either delete the shadow (recommended) or change the shadow's return type to `long` if they need backward-compat with a column already typed `int`.

Updates the at-a-glance table row to point at the new section so anyone skimming the upgrade notes catches it.

## Test plan

- [x] `dotnet build src/Persistence/Wolverine.Marten/Wolverine.Marten.csproj -c Debug -f net9.0` — 0 warnings, 0 errors.
- [x] `dotnet build src/Persistence/MartenTests/MartenTests.csproj -c Debug -f net9.0` — clean.
- [x] `dotnet test ... --filter "FullyQualifiedName=MartenTests.Saga.using_revisioned_sagas.execute_using_update_revision"` — passes (previously failed deterministically, 3/3 attempts before the fix).
- [x] `dotnet test ... --filter "FullyQualifiedName~MartenTests.Saga."` — 29/29 pass (was 28/29).
- [x] `grep -rn "public new.*Version\|new int Version\|new long Version" src/` — only the one test file had the shadow pattern. No other repo code needs updating.
- [ ] Full CI suite via this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
