### PR TITLE
Wolverine 6.0 punchlist sweep batch 2 (refs #2745)

### DIFF
--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -236,7 +236,7 @@ partial class Build
             var postgresqlTests = RootDirectory / "src" / "Persistence" / "PostgresqlTests" / "PostgresqlTests.csproj";
 
             BuildTestProjects(postgresqlTests);
-            // PersistenceTests only targets net8.0/net9.0
+            // Pin PersistenceTests to net9.0 in CI; csproj targets net9.0;net10.0.
             BuildTestProjectsWithFramework("net9.0", persistenceTests);
             StartDockerServices("postgresql", "sqlserver", "rabbitmq");
 

--- a/docs/guide/diagnostics.md
+++ b/docs/guide/diagnostics.md
@@ -151,7 +151,7 @@ be helpful:
 <!-- snippet: sample_using_preview_subscriptions -->
 <a id='snippet-sample_using_preview_subscriptions'></a>
 ```cs
-public static void using_preview_subscriptions(IMessageBus bus)
+private static void using_preview_subscriptions(IMessageBus bus)
 {
     // Preview where Wolverine is wanting to send a message
     var outgoing = bus.PreviewSubscriptions(new BlueMessage());

--- a/docs/guide/durability/marten/event-forwarding.md
+++ b/docs/guide/durability/marten/event-forwarding.md
@@ -58,7 +58,7 @@ builder.Services.AddMarten(opts =>
 
         opts.Projections.Add<AppointmentProjection>(ProjectionLifecycle.Inline);
         opts.Projections
-            .Snapshot<ProviderShift>(SnapshotLifecycle.Async);
+            .Snapshot<ProviderShift>(JasperFx.Events.Projections.SnapshotLifecycle.Async);
     })
 
     // This adds a hosted service to run
@@ -69,7 +69,7 @@ builder.Services.AddMarten(opts =>
     // forwarding events to the Wolverine outbox on SaveChangesAsync()
     .IntegrateWithWolverine(x => x.UseFastEventForwarding = true);
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/CQRSWithMarten/TeleHealth.WebApi/Program.cs#L57-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opting_into_wolverine_event_publishing' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/CQRSWithMarten/TeleHealth.WebApi/Program.cs#L57-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opting_into_wolverine_event_publishing' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This does need to be paired with a little bit of Wolverine configuration to add
@@ -162,7 +162,7 @@ public async Task execution_of_forwarded_events_can_be_awaited_from_tests()
     events[1].Data.ShouldBeOfType<FourthEvent>();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/event_streaming.cs#L142-L172' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_execution_of_forwarded_events_can_be_awaited_from_tests' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/event_streaming.cs#L144-L174' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_execution_of_forwarded_events_can_be_awaited_from_tests' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Where the result contains `FourthEvent` because `SecondEvent` was forwarded as `SecondMessage` and that persisted `FourthEvent` in a handler such as:
@@ -177,7 +177,7 @@ public static Task HandleAsync(SecondMessage message, IDocumentSession session)
     return session.SaveChangesAsync();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/event_streaming.cs#L219-L225' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_execution_of_forwarded_events_second_message_to_fourth_event' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/event_streaming.cs#L222-L228' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_execution_of_forwarded_events_second_message_to_fourth_event' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Overriding Side-Effect Message Metadata <Badge type="tip" text="5.x" />

--- a/docs/guide/durability/marten/event-sourcing.md
+++ b/docs/guide/durability/marten/event-sourcing.md
@@ -437,7 +437,7 @@ public static void Handle(OrderEventSourcingSample.MarkItemReady command, IEvent
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L25-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemreadyhandler_with_explicit_stream' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L26-L54' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemreadyhandler_with_explicit_stream' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Just as in other Wolverine [message handlers](/guide/handlers/), you can use
@@ -535,7 +535,7 @@ public class MarkItemReady
     public string ItemName { get; init; } = null!;
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L9-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemready_with_explicit_identity' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L10-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemready_with_explicit_identity' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Validation <Badge type="tip" text="4.8" />
@@ -561,7 +561,7 @@ public static string GetLetter2([ReadAggregate(Required = false)] LetterAggregat
 [WolverineGet("/letters3/{id}")]
 public static LetterAggregate GetLetter3([ReadAggregate(OnMissing = OnMissing.ProblemDetailsWith404)] LetterAggregate letters) => letters;
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/Marten/reacting_to_read_aggregate.cs#L150-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_read_aggregate_fine_grained_validation_control' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/Marten/reacting_to_read_aggregate.cs#L151-L169' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_read_aggregate_fine_grained_validation_control' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Forwarding Events
@@ -644,7 +644,7 @@ public static (
     return (new UpdatedAggregate(), events);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L61-L98' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemreadyhandler_with_response_for_updated_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L62-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemreadyhandler_with_response_for_updated_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note the usage of the `Wolverine.Marten.UpdatedAggregate` response in the handler. That type by itself is just a directive 
@@ -662,7 +662,7 @@ public static Task<Order> update_and_get_latest(IMessageBus bus, MarkItemReady c
     return bus.InvokeAsync<Order>(command);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L100-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_updatedaggregate_with_invoke_async' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L101-L110' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_updatedaggregate_with_invoke_async' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Likewise, you can use `UpdatedAggregate` as the response body of an HTTP endpoint with Wolverine.HTTP [as shown here](/guide/http/marten.html#responding-with-the-updated-aggregate~~~~).
@@ -697,7 +697,7 @@ public static class RaiseIfValidatedHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/aggregate_handler_workflow.cs#L435-L450' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_passing_aggregate_into_validate_method' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/aggregate_handler_workflow.cs#L436-L451' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_passing_aggregate_into_validate_method' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Archiving Streams
@@ -741,7 +741,7 @@ public static class FindLettersHandler
     */
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/read_aggregate_attribute_usage.cs#L80-L104' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_readaggregate_in_messsage_handlers' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/read_aggregate_attribute_usage.cs#L81-L105' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_readaggregate_in_messsage_handlers' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If the aggregate doesn't exist, the HTTP request will stop with a 404 status code.
@@ -772,7 +772,7 @@ public static string GetLetter2([ReadAggregate(Required = false)] LetterAggregat
 [WolverineGet("/letters3/{id}")]
 public static LetterAggregate GetLetter3([ReadAggregate(OnMissing = OnMissing.ProblemDetailsWith404)] LetterAggregate letters) => letters;
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/Marten/reacting_to_read_aggregate.cs#L150-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_read_aggregate_fine_grained_validation_control' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/Marten/reacting_to_read_aggregate.cs#L151-L169' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_read_aggregate_fine_grained_validation_control' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 There is also an option with `OnMissing` to throw a `RequiredDataMissingException` exception if a required data element
@@ -1215,7 +1215,7 @@ public static async ValueTask<StrongLetterAggregate> Handle2(LetterId id, IDocum
 public static StrongLetterAggregate Handle(
     [ReadAggregate] StrongLetterAggregate aggregate) => aggregate;
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/StrongTypedIdentifiers.cs#L11-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_strong_typed_id_as_route_argument' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/StrongTypedIdentifiers.cs#L12-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_strong_typed_id_as_route_argument' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -1268,7 +1268,7 @@ public record NkHandlerOrderCreated(NkHandlerOrderNumber OrderNumber, string Cus
 public record NkHandlerItemAdded(string ItemName, decimal Price);
 public record NkHandlerOrderCompleted;
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs#L118-L154' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_marten_natural_key_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs#L125-L161' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_marten_natural_key_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Using Natural Keys in Command Handlers
@@ -1282,7 +1282,7 @@ public record AddNkOrderItem(NkHandlerOrderNumber OrderNum, string ItemName, dec
 public record AddNkOrderItems(NkHandlerOrderNumber OrderNum, (string Name, decimal Price)[] Items);
 public record CompleteNkOrder(NkHandlerOrderNumber OrderNum);
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs#L156-L161' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_marten_natural_key_commands' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs#L163-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_marten_natural_key_commands' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Wolverine uses the natural key type on the command property to call `FetchForWriting<TAggregate, TNaturalKey>()` under the covers, resolving the stream by the natural key in a single database round-trip.
@@ -1318,7 +1318,7 @@ public static class NkOrderHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs#L163-L188' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_marten_natural_key_handlers' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs#L170-L195' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_marten_natural_key_handlers' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 For more details on how natural keys work at the Marten level, see the [Marten natural keys documentation](https://martendb.io/events/natural-keys).

--- a/docs/guide/durability/polecat/event-sourcing.md
+++ b/docs/guide/durability/polecat/event-sourcing.md
@@ -553,7 +553,7 @@ public record PcNkOrderCreated(PcNkOrderNumber OrderNumber, string CustomerName)
 public record PcNkItemAdded(string ItemName, decimal Price);
 public record PcNkOrderCompleted;
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PolecatTests/natural_key_aggregate_handler_workflow.cs#L123-L159' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_polecat_natural_key_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PolecatTests/natural_key_aggregate_handler_workflow.cs#L125-L161' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_polecat_natural_key_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Using Natural Keys in Command Handlers
@@ -567,7 +567,7 @@ public record AddPcNkOrderItem(PcNkOrderNumber OrderNum, string ItemName, decima
 public record AddPcNkOrderItems(PcNkOrderNumber OrderNum, (string Name, decimal Price)[] Items);
 public record CompletePcNkOrder(PcNkOrderNumber OrderNum);
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PolecatTests/natural_key_aggregate_handler_workflow.cs#L161-L166' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_polecat_natural_key_commands' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PolecatTests/natural_key_aggregate_handler_workflow.cs#L163-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_polecat_natural_key_commands' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Wolverine uses the natural key type on the command property to call `FetchForWriting<TAggregate, TNaturalKey>()` under the covers, resolving the stream by the natural key in a single database round-trip.
@@ -603,7 +603,7 @@ public static class PcNkOrderHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PolecatTests/natural_key_aggregate_handler_workflow.cs#L168-L193' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_polecat_natural_key_handlers' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PolecatTests/natural_key_aggregate_handler_workflow.cs#L170-L195' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_polecat_natural_key_handlers' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 For more details on how natural keys work at the Polecat level, see the [Polecat natural keys documentation](/events/natural-keys).

--- a/docs/guide/extensions.md
+++ b/docs/guide/extensions.md
@@ -44,7 +44,7 @@ public class SampleExtension : IWolverineExtension
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/ExtensionSamples.cs#L9-L23' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sampleextension' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/ExtensionSamples.cs#L10-L24' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sampleextension' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Extensions can be applied programmatically against the `WolverineOptions` like this:
@@ -73,7 +73,7 @@ using var host = await Host.CreateDefaultBuilder()
 
     .StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/ExtensionSamples.cs#L50-L72' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_including_extension' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/ExtensionSamples.cs#L51-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_including_extension' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Lastly, you can also add `IWolverineExtension` types to your IoC container registration that will be applied to `WolverineOptions` just
@@ -109,7 +109,7 @@ internal class DisableExternalTransports : IWolverineExtension
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/HostBuilderExtensions.cs#L460-L469' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disableexternaltransports' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/HostBuilderExtensions.cs#L480-L489' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disableexternaltransports' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And that extension is just added to the application's IoC container at test bootstrapping time like this:
@@ -123,7 +123,7 @@ public static IServiceCollection DisableAllExternalWolverineTransports(this ISer
     return services;
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/HostBuilderExtensions.cs#L436-L443' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_extension_method_to_disable_external_transports' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/HostBuilderExtensions.cs#L456-L463' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_extension_method_to_disable_external_transports' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In usage, the `IWolverineExtension` objects added to the IoC container are applied *after* the inner configuration
@@ -152,7 +152,7 @@ public class ConfigurationUsingExtension : IWolverineExtension
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/ExtensionSamples.cs#L25-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuration_using_extension' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/ExtensionSamples.cs#L26-L44' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuration_using_extension' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 There's also a small helper method to register Wolverine extensions like so:

--- a/docs/guide/extensions.md
+++ b/docs/guide/extensions.md
@@ -109,7 +109,7 @@ internal class DisableExternalTransports : IWolverineExtension
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/HostBuilderExtensions.cs#L480-L489' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disableexternaltransports' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/HostBuilderExtensions.cs#L464-L473' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disableexternaltransports' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And that extension is just added to the application's IoC container at test bootstrapping time like this:
@@ -123,7 +123,7 @@ public static IServiceCollection DisableAllExternalWolverineTransports(this ISer
     return services;
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/HostBuilderExtensions.cs#L456-L463' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_extension_method_to_disable_external_transports' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/HostBuilderExtensions.cs#L440-L447' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_extension_method_to_disable_external_transports' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In usage, the `IWolverineExtension` objects added to the IoC container are applied *after* the inner configuration

--- a/docs/guide/handlers/multi-tenancy.md
+++ b/docs/guide/handlers/multi-tenancy.md
@@ -10,7 +10,7 @@ inline, you can execute that message for a specific tenant with this syntax:
 <!-- snippet: sample_invoking_by_tenant -->
 <a id='snippet-sample_invoking_by_tenant'></a>
 ```cs
-public static async Task invoking_by_tenant(IMessageBus bus)
+private static async Task invoking_by_tenant(IMessageBus bus)
 {
     // Invoke inline
     await bus.InvokeForTenantAsync("tenant1", new CreateTodo("Release Wolverine 1.0"));
@@ -33,7 +33,7 @@ the `DeliveryOptions` approach:
 <!-- snippet: sample_publish_by_tenant -->
 <a id='snippet-sample_publish_by_tenant'></a>
 ```cs
-public static async Task publish_by_tenant(IMessageBus bus)
+private static async Task publish_by_tenant(IMessageBus bus)
 {
     await bus.PublishAsync(new CreateTodo("Fix that last broken test"),
         new DeliveryOptions { TenantId = "tenant3" });

--- a/docs/guide/http/json.md
+++ b/docs/guide/http/json.md
@@ -135,5 +135,5 @@ await using var host = await AlbaHost.For(builder, app =>
     });
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/using_newtonsoft_for_serialization.cs#L19-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_use_newtonsoft_for_http_serialization' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/using_newtonsoft_for_serialization.cs#L19-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_use_newtonsoft_for_http_serialization' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/http/marten.md
+++ b/docs/guide/http/marten.md
@@ -378,7 +378,7 @@ public static class MakePurchaseHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/mixed_aggregate_handler_with_multiple_streams.cs#L86-L114' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_makepurchasehandler' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/mixed_aggregate_handler_with_multiple_streams.cs#L88-L116' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_makepurchasehandler' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: info

--- a/docs/guide/http/routing.md
+++ b/docs/guide/http/routing.md
@@ -90,7 +90,7 @@ uses StronglyTypedId:
 [StronglyTypedId(Template.Guid)]
 public readonly partial struct LetterId;
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/StrongTypedIdentifiers.cs#L84-L88' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_letter_id' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/StrongTypedIdentifiers.cs#L85-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_letter_id' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can use the `LetterId` type as a route argument as this example shows:
@@ -107,7 +107,7 @@ public static async ValueTask<StrongLetterAggregate> Handle2(LetterId id, IDocum
 public static StrongLetterAggregate Handle(
     [ReadAggregate] StrongLetterAggregate aggregate) => aggregate;
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/StrongTypedIdentifiers.cs#L11-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_strong_typed_id_as_route_argument' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/StrongTypedIdentifiers.cs#L12-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_strong_typed_id_as_route_argument' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Route Prefixes <Badge type="tip" text="5.14" />

--- a/docs/guide/http/security.md
+++ b/docs/guide/http/security.md
@@ -26,7 +26,7 @@ public void RequireAuthorizeOnAll()
     ConfigureEndpoints(e => e.RequireAuthorization());
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http/WolverineHttpOptions.cs#L293-L302' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_requireauthorizeonall' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http/WolverineHttpOptions.cs#L297-L306' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_requireauthorizeonall' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Tracking User Name

--- a/docs/guide/messages.md
+++ b/docs/guide/messages.md
@@ -33,7 +33,7 @@ public class PersonBorn
     public int Year { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L13-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_personborn1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L14-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_personborn1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 By default, Wolverine will identify this type by just using the .NET full name like so:
@@ -48,7 +48,7 @@ public void message_alias_is_fullname_by_default()
         .MessageType.ShouldBe(typeof(PersonBorn).FullName);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L31-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ootb_message_alias' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L32-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ootb_message_alias' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 However, if you want to explicitly control the message type because you aren't sharing the DTO types or for some
@@ -67,7 +67,7 @@ public class PersonBorn
     public int Year { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L45-L56' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_override_message_alias' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L46-L57' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_override_message_alias' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Which now gives you different behavior:
@@ -82,7 +82,7 @@ public void message_alias_is_fullname_by_default()
         .MessageType.ShouldBe("person-born");
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L60-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_explicit_message_alias' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L61-L69' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_explicit_message_alias' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Message Discovery
@@ -153,7 +153,7 @@ public class PersonBornV2
     public DateTime Birthday { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L74-L83' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_personborn_v2' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L75-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_personborn_v2' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `[MessageIdentity("person-born", Version = 2)]` attribute usage tells Wolverine that this class is "Version 2" for the `message-type` = "person-born."
@@ -233,7 +233,7 @@ using var host = await Host.CreateDefaultBuilder()
         });
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L154-L164' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customizingjsonserialization' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L155-L165' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customizingjsonserialization' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### MessagePack Serialization
@@ -376,7 +376,7 @@ public class PersonCreatedHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L107-L121' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_personcreatedhandler' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L108-L122' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_personcreatedhandler' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or you could use a custom `IMessageDeserializer` to read incoming messages from V1 into the new V2 message type, or you can take advantage of message forwarding
@@ -404,7 +404,7 @@ public class PersonBorn : IForwardsTo<PersonBornV2>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L85-L105' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iforwardsto_personbornv2' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L86-L106' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iforwardsto_personbornv2' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Which forwards to the current message type:
@@ -420,7 +420,7 @@ public class PersonBornV2
     public DateTime Birthday { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L74-L83' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_personborn_v2' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MessageVersioning.cs#L75-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_personborn_v2' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Using this strategy, other systems could still send your system the original `application/vnd.person-born.v1+json` formatted

--- a/docs/guide/messaging/broadcast-to-topic.md
+++ b/docs/guide/messaging/broadcast-to-topic.md
@@ -49,7 +49,7 @@ var publisher = theSender.Services
 
 await publisher.BroadcastToTopicAsync("color.purple", new Message1());
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/send_by_topics.cs#L364-L370' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_send_to_topic-1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/send_by_topics.cs#L371-L377' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_send_to_topic-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/guide/messaging/transports/azureservicebus/interoperability.md
+++ b/docs/guide/messaging/transports/azureservicebus/interoperability.md
@@ -36,7 +36,7 @@ public class CustomAzureServiceBusMapper : IAzureServiceBusEnvelopeMapper
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L185-L209' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_custom_azure_service_bus_mapper' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L193-L217' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_custom_azure_service_bus_mapper' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To apply that mapper to specific endpoints, use this syntax on any type of Azure Service Bus endpoint:
@@ -55,5 +55,5 @@ using var host = await Host.CreateDefaultBuilder()
             .ConfigureSenders(s => s.InteropWith(new CustomAzureServiceBusMapper()));
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L102-L114' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_custom_envelope_mapper_for_azure_service_bus' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L110-L122' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_custom_envelope_mapper_for_azure_service_bus' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/messaging/transports/azureservicebus/multi-tenancy.md
+++ b/docs/guide/messaging/transports/azureservicebus/multi-tenancy.md
@@ -78,7 +78,7 @@ builder.UseWolverine(opts =>
         .GlobalSender();
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L122-L180' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_azure_service_bus_for_multi_tenancy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L130-L188' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_azure_service_bus_for_multi_tenancy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: warning
@@ -222,6 +222,7 @@ internal sealed class TopicPerTenantRoute(IReadOnlyDictionary<string, AzureServi
     }
 }
 ```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L226-L304' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_topic_per_tenant_route' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### The extension method
@@ -273,6 +274,7 @@ public static class TopicPerTenantWolverineOptionsExtensions
     }
 }
 ```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L306-L347' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_topic_per_tenant_route_extension' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Wiring it up
@@ -305,6 +307,7 @@ await bus.PublishAsync(
     new TenantBoundMessage("hello"),
     new DeliveryOptions { TenantId = "tenant-b" });
 ```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L353-L378' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_topic_per_tenant_route' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Behavior notes

--- a/docs/guide/messaging/transports/azureservicebus/object-management.md
+++ b/docs/guide/messaging/transports/azureservicebus/object-management.md
@@ -24,7 +24,7 @@ using var host = await Host.CreateDefaultBuilder()
         opts.Services.AddResourceSetupOnStartup();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L56-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_resource_setup_with_azure_service_bus' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L64-L76' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_resource_setup_with_azure_service_bus' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also direct Wolverine to build out Azure Service Bus object on demand as needed with:
@@ -42,7 +42,7 @@ using var host = await Host.CreateDefaultBuilder()
             .AutoProvision();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L73-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_auto_provision_with_azure_service_bus' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L81-L92' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_auto_provision_with_azure_service_bus' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also opt to auto-purge all queues (there's also an option to do this queue by queue) on application
@@ -58,7 +58,7 @@ using var host = await Host.CreateDefaultBuilder()
             .AutoPurgeOnStartup();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L89-L97' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_auto_purge_with_azure_service_bus' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L97-L105' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_auto_purge_with_azure_service_bus' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Identifier Prefixing for Shared Brokers

--- a/docs/guide/messaging/transports/azureservicebus/scheduled.md
+++ b/docs/guide/messaging/transports/azureservicebus/scheduled.md
@@ -12,7 +12,7 @@ So for message types that are routed to Azure Service Bus queues or topics, you 
 <!-- snippet: sample_send_delayed_message -->
 <a id='snippet-sample_send_delayed_message'></a>
 ```cs
-public async Task SendScheduledMessage(IMessageContext bus, Guid invoiceId)
+private async Task SendScheduledMessage(IMessageContext bus, Guid invoiceId)
 {
     var message = new ValidateInvoiceIsNotLate
     {

--- a/docs/guide/messaging/transports/azureservicebus/topics.md
+++ b/docs/guide/messaging/transports/azureservicebus/topics.md
@@ -39,7 +39,7 @@ using var host = await Host.CreateDefaultBuilder()
             });
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L17-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_azure_service_bus_subscriptions_and_topics' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Samples.cs#L25-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_azure_service_bus_subscriptions_and_topics' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To fully utilize subscription listening, be careful with using [Requeue error handling](/guide/handlers/error-handling) actions. In order to truly make

--- a/docs/guide/messaging/transports/local.md
+++ b/docs/guide/messaging/transports/local.md
@@ -63,7 +63,7 @@ The "scheduled execution" feature can be used with local execution within the sa
 <!-- snippet: sample_schedule_job_locally -->
 <a id='snippet-sample_schedule_job_locally'></a>
 ```cs
-public async Task ScheduleLocally(IMessageContext bus, Guid invoiceId)
+private async Task ScheduleLocally(IMessageContext bus, Guid invoiceId)
 {
     var message = new ValidateInvoiceIsNotLate
     {

--- a/docs/guide/messaging/transports/mqtt.md
+++ b/docs/guide/messaging/transports/mqtt.md
@@ -137,7 +137,7 @@ public class FirstMessage
     public Guid Id { get; set; } = Guid.NewGuid();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/send_by_topics.cs#L493-L500' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_topic_attribute-1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/send_by_topics.cs#L500-L507' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_topic_attribute-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Publishing by Topic Rules

--- a/docs/guide/messaging/transports/rabbitmq/conventional-routing.md
+++ b/docs/guide/messaging/transports/rabbitmq/conventional-routing.md
@@ -84,7 +84,7 @@ This keeps existing naming conventions intact and avoids the need to drop down t
 <!-- snippet: sample_conventional_routing_exchange_conventions -->
 <a id='snippet-sample_conventional_routing_exchange_conventions'></a>
 ```cs
-var sender = WolverineHost.For(opts =>
+var sender = await WolverineHost.ForAsync(opts =>
 {
     opts.UseRabbitMq()
         .UseConventionalRouting(conventions =>
@@ -101,7 +101,7 @@ var sender = WolverineHost.For(opts =>
         });
 });
 
-var receiver = WolverineHost.For(opts =>
+var receiver = await WolverineHost.ForAsync(opts =>
 {
     opts.UseRabbitMq()
         .UseConventionalRouting(conventions =>

--- a/docs/guide/messaging/transports/rabbitmq/topics.md
+++ b/docs/guide/messaging/transports/rabbitmq/topics.md
@@ -60,7 +60,7 @@ public class FirstMessage
     public Guid Id { get; set; } = Guid.NewGuid();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/send_by_topics.cs#L493-L500' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_topic_attribute-1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/send_by_topics.cs#L500-L507' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_topic_attribute-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Of course, you can always explicitly send a message to a specific topic with this syntax:

--- a/docs/guide/messaging/transports/signalr.md
+++ b/docs/guide/messaging/transports/signalr.md
@@ -94,15 +94,9 @@ app.UseRouting();
 
 app.UseAuthorization();
 
-#if NET9_0_OR_GREATER
 app.MapStaticAssets();
 app.MapRazorPages()
     .WithStaticAssets();
-#endif
-#if NET8_0
-app.UseStaticFiles();
-app.MapRazorPages();
-#endif
 
 // This line puts the SignalR hub for Wolverine at the 
 // designated route for your clients
@@ -110,7 +104,7 @@ app.MapWolverineSignalRHub("/api/messages");
 
 return await app.RunJasperFxCommands(args);
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/WolverineChat/Program.cs#L62-L86' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_map_wolverine_signalrhub' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/WolverineChat/Program.cs#L62-L80' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_map_wolverine_signalrhub' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Custom hubs

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -275,7 +275,7 @@ public interface IAgent : IHostedService, IHealthCheck
     /// </summary>
     Task<HealthCheckResult> IHealthCheck.CheckHealthAsync(
         HealthCheckContext context,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         return Task.FromResult(Status == AgentStatus.Running
             ? HealthCheckResult.Healthy()
@@ -320,7 +320,7 @@ public interface IAgent : IHostedService, IHealthCheck
     /// </summary>
     Task<HealthCheckResult> IHealthCheck.CheckHealthAsync(
         HealthCheckContext context,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         return Task.FromResult(Status == AgentStatus.Running
             ? HealthCheckResult.Healthy()

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -106,7 +106,7 @@ shown below:
 <!-- snippet: sample_advanced_tracked_session_usage -->
 <a id='snippet-sample_advanced_tracked_session_usage'></a>
 ```cs
-public async Task using_tracked_sessions_advanced(IHost otherWolverineSystem)
+private static async Task using_tracked_sessions_advanced(IHost otherWolverineSystem)
 {
     // The point here is just that you somehow have
     // an IHost for your application

--- a/docs/tutorials/cqrs-with-marten.md
+++ b/docs/tutorials/cqrs-with-marten.md
@@ -347,7 +347,7 @@ As a little tip, I've added this bit of marker code to the very bottom of our `P
 // application in a test harness project. Only a convenience
 public partial class Program{}
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/IncidentService/IncidentService/Program.cs#L67-L72' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_program_marker' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/IncidentService/IncidentService/Program.cs#L68-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_program_marker' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Having that above, I'll switch to the test harness project and create a shared fixture to bootstrap

--- a/docs/tutorials/leader-election.md
+++ b/docs/tutorials/leader-election.md
@@ -253,7 +253,7 @@ public interface IAgent : IHostedService, IHealthCheck
     /// </summary>
     Task<HealthCheckResult> IHealthCheck.CheckHealthAsync(
         HealthCheckContext context,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         return Task.FromResult(Status == AgentStatus.Running
             ? HealthCheckResult.Healthy()
@@ -298,7 +298,7 @@ public interface IAgent : IHostedService, IHealthCheck
     /// </summary>
     Task<HealthCheckResult> IHealthCheck.CheckHealthAsync(
         HealthCheckContext context,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         return Task.FromResult(Status == AgentStatus.Running
             ? HealthCheckResult.Healthy()

--- a/src/Persistence/EfCoreTests/Bug_661_postgresql_with_ef_core.cs
+++ b/src/Persistence/EfCoreTests/Bug_661_postgresql_with_ef_core.cs
@@ -12,7 +12,6 @@ namespace EfCoreTests;
 
 public class Bug_661_postgresql_with_ef_core
 {
-#if NET8_0_OR_GREATER
     [Fact]
     public async Task can_set_up_with_default_schema_name()
     {
@@ -23,11 +22,10 @@ public class Bug_661_postgresql_with_ef_core
                 {
                     o.UseNpgsql(Servers.PostgresConnectionString);
                 });
-                
+
                 opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString);
                 opts.Services.AddResourceSetupOnStartup();
                 opts.Services.AddDbContext<AppDbContext>(opt => opt.UseNpgsql(Servers.PostgresConnectionString));
             }).StartAsync();
     }
-#endif
 }

--- a/src/Persistence/Wolverine.CosmosDb/Internals/Transport/CosmosDbControlListener.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/Transport/CosmosDbControlListener.cs
@@ -62,11 +62,7 @@ internal class CosmosDbControlListener : IListener
 
     public async ValueTask DisposeAsync()
     {
-#if NET8_0_OR_GREATER
         await _cancellation.CancelAsync();
-#else
-        _cancellation.Cancel();
-#endif
         _receivingLoop.SafeDispose();
     }
 
@@ -74,11 +70,7 @@ internal class CosmosDbControlListener : IListener
 
     public async ValueTask StopAsync()
     {
-#if NET8_0_OR_GREATER
         await _cancellation.CancelAsync();
-#else
-        _cancellation.Cancel();
-#endif
         if (_receivingLoop != null)
         {
             await _receivingLoop;

--- a/src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlListener.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlListener.cs
@@ -68,13 +68,7 @@ internal class DatabaseControlListener : IListener
 
     public async ValueTask DisposeAsync()
     {
-#if NET8_0_OR_GREATER
         await _cancellation.CancelAsync();
-
-
-#else
-        _cancellation.Cancel();
-#endif
         _receivingLoop.SafeDispose();
     }
 
@@ -82,13 +76,7 @@ internal class DatabaseControlListener : IListener
 
     public async ValueTask StopAsync()
     {
-#if NET8_0_OR_GREATER
         await _cancellation.CancelAsync();
-
-
-#else
-        _cancellation.Cancel();
-#endif
         if (_receivingLoop != null)
         {
 #pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks

--- a/src/Samples/WolverineChat/Program.cs
+++ b/src/Samples/WolverineChat/Program.cs
@@ -66,15 +66,9 @@ app.UseRouting();
 
 app.UseAuthorization();
 
-#if NET9_0_OR_GREATER
 app.MapStaticAssets();
 app.MapRazorPages()
     .WithStaticAssets();
-#endif
-#if NET8_0
-app.UseStaticFiles();
-app.MapRazorPages();
-#endif
 
 
 // This line puts the SignalR hub for Wolverine at the 

--- a/src/Testing/CoreTests/envelope_id_generation.cs
+++ b/src/Testing/CoreTests/envelope_id_generation.cs
@@ -32,7 +32,6 @@ public class envelope_id_generation : IDisposable
         envelope.Id.ShouldNotBe(Guid.Empty);
     }
 
-#if NET9_0_OR_GREATER
     [Fact]
     public void guid_v7_mode_produces_version_7_guids()
     {
@@ -99,7 +98,6 @@ public class envelope_id_generation : IDisposable
 
         GuidV7TestHandler.LastReceived.ShouldBe("hello");
     }
-#endif
 
     [Fact]
     public void all_newid_usages_respect_id_generator()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqBrokerHealthProbe.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqBrokerHealthProbe.cs
@@ -141,16 +141,8 @@ public partial class RabbitMqTransport : IBrokerHealthProbe
 
     private static X509Certificate2 LoadCertificate(string certPath, string? passphrase)
     {
-#if NET9_0_OR_GREATER
         return string.IsNullOrEmpty(passphrase)
             ? X509CertificateLoader.LoadCertificateFromFile(certPath)
             : X509CertificateLoader.LoadPkcs12FromFile(certPath, passphrase);
-#else
-#pragma warning disable SYSLIB0057
-        return string.IsNullOrEmpty(passphrase)
-            ? new X509Certificate2(certPath)
-            : new X509Certificate2(certPath, passphrase);
-#pragma warning restore SYSLIB0057
-#endif
     }
 }

--- a/src/Wolverine/HostBuilderExtensions.cs
+++ b/src/Wolverine/HostBuilderExtensions.cs
@@ -283,7 +283,6 @@ public static class HostBuilderExtensions
         return services;
     }
 
-#if NET8_0_OR_GREATER
     /// <summary>
     /// Bootstrap Wolverine into a HostApplicationBuilder
     /// </summary>
@@ -297,21 +296,6 @@ public static class HostBuilderExtensions
 
         return builder;
     }
-    #else
-    /// <summary>
-    /// Bootstrap Wolverine into a HostApplicationBuilder
-    /// </summary>
-    /// <param name="builder"></param>
-    /// <param name="configure"></param>
-    /// <returns></returns>
-    public static HostApplicationBuilder UseWolverine(this HostApplicationBuilder builder,
-        Action<WolverineOptions>? configure)
-    {
-        builder.Services.AddWolverine(configure);
-
-        return builder;
-    }
-#endif
 
     internal static void MessagingRootService<T>(this IServiceCollection services,
         Func<IWolverineRuntime, T> expression)

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.cs
@@ -250,11 +250,7 @@ public partial class NodeAgentController
 
         await _persistence.ReleaseLeadershipLockAsync();
 
-#if NET8_0_OR_GREATER
         await _cancellation.CancelAsync();
-#else
-        _cancellation.Cancel();
-#endif
     }
 }
 

--- a/src/Wolverine/Runtime/WolverineRuntime.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.cs
@@ -48,15 +48,9 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IWolverineRunt
         Options = options;
         Handlers = options.HandlerGraph;
 
-        // Set the envelope ID generation strategy based on configuration
         Envelope.IdGenerator = options.EnvelopeIdGeneration switch
         {
-#if NET9_0_OR_GREATER
             EnvelopeIdGeneration.GuidV7 => Guid.CreateVersion7,
-#else
-            EnvelopeIdGeneration.GuidV7 => throw new NotSupportedException(
-                "EnvelopeIdGeneration.GuidV7 requires .NET 9 or later. Guid.CreateVersion7 is not available on .NET 8."),
-#endif
             _ => MassTransit.NewId.NextSequentialGuid
         };
 


### PR DESCRIPTION
Continuation of the [batch-1 sweep](https://github.com/JasperFx/wolverine/pulls?q=is%3Apr+is%3Amerged+%22refs+%232745%22) — JasperFx/wolverine#2815 / JasperFx/wolverine#2816 / JasperFx/wolverine#2817 / JasperFx/wolverine#2818 / JasperFx/wolverine#2819 / JasperFx/wolverine#2820 / JasperFx/wolverine#2821. Each item picked is independent, none gated by cross-stack alpha bumps, none with open design questions.

## Items picked

### 1. Refresh doc snippets via `mdsnippets` (commit 1)

Listed explicitly in the [#2745](https://github.com/JasperFx/wolverine/issues/2745) punchlist under *Pre-release validation → Run the docs snippet refresh*. Pure mechanical sync of markdown snippet blocks against their upstream source files.

Substantive content changes (beyond line-number drift):

- `WolverineHost.For(...)` → `await WolverineHost.ForAsync(...)` in `docs/guide/messaging/transports/rabbitmq/conventional-routing.md`, picking up the source-side conversion from JasperFx/wolverine#2821.
- `SnapshotLifecycle.Async` in `docs/guide/durability/marten/event-forwarding.md` now qualified as `JasperFx.Events.Projections.SnapshotLifecycle.Async`, matching the namespace move documented in `migration.md`.
- Three Azure Service Bus snippet blocks in `docs/guide/messaging/transports/azureservicebus/multi-tenancy.md` now correctly carry their `<sup>snippet source</sup>` link footers (mdsnippets had emitted them open-ended before).

25 files, +64 / -61.

### 2. Drop dead net8.0 / pre-net9.0 conditional compilation (commit 2)

Net8.0 was dropped in 6.0 (`Directory.Build.props` → `net9.0;net10.0`). That makes a handful of `#if NET8_0_OR_GREATER` and `#if NET9_0_OR_GREATER` blocks always-true and their `#else` branches dead code; one `#if NET8_0` block in the WolverineChat sample is now always-false dead code. All collapsed in place:

- `src/Wolverine/HostBuilderExtensions.cs` — drop the `IHostApplicationBuilder` vs `HostApplicationBuilder` fork.
- `src/Wolverine/Runtime/Agents/NodeAgentController.cs`, `src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlListener.cs`, `src/Persistence/Wolverine.CosmosDb/Internals/Transport/CosmosDbControlListener.cs` — drop the `CancelAsync()` vs `Cancel()` fork.
- `src/Wolverine/Runtime/WolverineRuntime.cs` — drop the `Guid.CreateVersion7` `NotSupportedException` net8.0 fallback.
- `src/Testing/CoreTests/envelope_id_generation.cs` — un-gate the GuidV7 tests.
- `src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqBrokerHealthProbe.cs` — drop the obsolete `X509Certificate2` ctor fallback (and its `SYSLIB0057` warning suppression).
- `src/Persistence/EfCoreTests/Bug_661_postgresql_with_ef_core.cs` — un-gate the `[Fact]`.
- `src/Samples/WolverineChat/Program.cs` — drop the dead `#if NET8_0` `UseStaticFiles()` branch and un-gate the `MapStaticAssets()` block. mdsnippets re-run so `signalr.md` / `extensions.md` pick up the source-line shifts.
- `build/CITargets.cs` — stale comment ("PersistenceTests only targets net8.0/net9.0") corrected; the csproj targets `net9.0;net10.0` and the framework override stays so CI runs net9.0 only.

12 files, +9 / -79.

## Items considered but skipped

- **`WolverineHost.Basic()` removal + class-level `[Obsolete]`** — punchlist explicitly says *"Decide whether to retire the class entirely for 6.0 or push that to 6.x"*. Design call.
- **`WolverineOptions.EnableMessageCausationTracking` `[Obsolete]` shim** — the property pre-dates 6.0 (added in 5.x's `c1fc27448`, moved to `TrackingOptions` during 6.0 dev). Removing it would break 5.x → 6.0 upgrade paths; the shim looks intentional and permanent.
- **`UseAutomaticForwarderDiscovery()` `[Obsolete]`** — already correctly marked *"Targeted for removal in 7.0"*, no action.
- **`IncidentResponse` sample type with `[Obsolete("Get rid of this")]`** — actively used by sample handlers; removal is sample-internal cleanup, not a 6.0 punchlist item.
- **`SubscriptionVersion` → `Version` on Wolverine.Marten side** — out-of-scope per [#2826](https://github.com/JasperFx/wolverine/pull/2826) ("held by another agent"); cross-stack jasperfx#273 umbrella.
- **Pulsar test `using Oakton;` stale import** — single dangling line; not worth a batch slot on its own. Whole-codebase Oakton → JasperFx sweep is a separate, larger workstream.
- **Other `#if NET9_0_OR_GREATER` guards still in source** — kept conservatively. Always-true with current TFMs but plausibly meaningful intent markers; net8.0 cleanup is the unambiguous case.

## Verify

```
dotnet build wolverine.slnx  →  0 warnings, 0 errors
dotnet test src/Testing/CoreTests --no-build --framework net9.0 \
  --filter "FullyQualifiedName~envelope_id_generation"  →  7/7 passing
```

## Estimated remaining scope on JasperFx/wolverine#2745

Almost everything left on the punchlist is **Jeremy-action** (running interop suites, scalability seeding, AOT smoke test, version bump from `6.0.0-alpha.N` to `6.0.0`, tagging, NuGet publish, GitHub Release, blog post, Discord announcement, master tracker JasperFx/wolverine#2715 close) or **decision items** (#2742 Wolverine.Http Newtonsoft for 6.0-final?, JasperFx/wolverine#2728 cold-start applicator, JasperFx/CritterWatch#239 Quartz/TickerQ, JasperFx/wolverine#2221 Result pattern, retire `WolverineHost` entirely?). The auto-mergeable sweep surface is largely picked clean — a hypothetical batch 3 would be small and would probably need broader scope expansion (e.g. Oakton → JasperFx import-sweep, or `#if NET9_0_OR_GREATER` un-gating).

## Items that look like they need design discussion

- **`WolverineHost.Basic()` retirement** — 6 callers; punchlist flags as "decide".
- **`EnableMessageCausationTracking` shim** — lifecycle (keep permanent? Mark for 7.0 removal?) is a judgement call.
- **Per-broker `ConventionalRoutingContext` async pattern (post-#2821)** — the test-infrastructure async conversion was thorough but the user-visible doc samples (`Samples.cs` files) that use it could benefit from a once-over for `Task` propagation correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)