### PR TITLE
fix(http): scope SourceServiceFromHttpContext<T> to HTTP chains (#2831)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/CodeGeneration/service_location_assertions.cs
+++ b/src/Http/Wolverine.Http.Tests/CodeGeneration/service_location_assertions.cs
@@ -235,6 +235,28 @@ public class service_location_assertions
 
     }
 
+    // Regression for https://github.com/JasperFx/wolverine/issues/2831 — when
+    // SourceServiceFromHttpContext<IThing>() is configured, a non-HTTP handler whose
+    // parameter is IThing must still generate compilable code: it has no httpContext
+    // in scope, so the HTTP-shaped variable source must not leak in. The override of
+    // IThing to a typed registration keeps the handler chain on the constructor-injection
+    // path so the test asserts purely against codegen — independent of whatever the
+    // current ServiceLocationPolicy default is.
+    [Fact]
+    public async Task non_http_handler_with_http_context_sourced_type_is_resolved_through_normal_di()
+    {
+        await using var host = await buildHost(ServiceProviderSource.IsolatedAndScoped, opts =>
+        {
+            opts.Services.AddScoped<IThing, BigThing>();
+        });
+
+        UseThingHandler.LastSeen = null;
+
+        await host.InvokeAsync(new UseThing());
+
+        UseThingHandler.LastSeen.ShouldBeOfType<BigThing>();
+    }
+
     [Theory]
     [InlineData(ServiceLocationPolicy.AllowedButWarn, ServiceProviderSource.IsolatedAndScoped)]
     [InlineData(ServiceLocationPolicy.AlwaysAllowed, ServiceProviderSource.IsolatedAndScoped)]
@@ -305,6 +327,15 @@ public record UseWidget;
 public static class UseWidgetHandler
 {
     public static void Handle(UseWidget command, IWidget service) => Debug.WriteLine("Got me a widget to use");
+}
+
+public record UseThing;
+
+public static class UseThingHandler
+{
+    public static IThing? LastSeen { get; set; }
+
+    public static void Handle(UseThing command, IThing thing) => LastSeen = thing;
 }
 
 public class RecordingLogger : ILoggerFactory, ILogger

--- a/src/Http/Wolverine.Http/HttpChain.Codegen.cs
+++ b/src/Http/Wolverine.Http/HttpChain.Codegen.cs
@@ -61,6 +61,14 @@ public partial class HttpChain
             handleMethod.Sources.Add(new LoggerVariableSource(loggedType));
             handleMethod.Sources.Add(new MessageBusSource());
 
+            // Per-method scoping for SourceServiceFromHttpContext<T>(). Registering on the
+            // method (rather than WolverineOptions.CodeGeneration.Sources) keeps the
+            // httpContext-shaped frame out of non-HTTP message handler chains.
+            foreach (var serviceType in _parent.HttpContextSourcedTypes)
+            {
+                handleMethod.Sources.Add(new RequestServicesVariableSource(serviceType));
+            }
+
             handleMethod.Frames.AddRange(DetermineFrames(assembly.Rules));
         }
     }

--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -42,8 +42,14 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
         Container = container;
         Rules = _options.CodeGeneration;
     }
-    
+
     internal IServiceContainer Container { get; }
+
+    // Types registered via WolverineHttpOptions.SourceServiceFromHttpContext<T>().
+    // Stored on the HTTP graph so the RequestServicesVariableSource is only added to
+    // HTTP chains' per-method sources, never to the shared WolverineOptions.CodeGeneration.Sources
+    // that non-HTTP message-handler chains also read from.
+    internal HashSet<Type> HttpContextSourcedTypes { get; } = new();
 
     /// <summary>
     /// When true, automatically apply antiforgery metadata to form data and file upload endpoints.

--- a/src/Http/Wolverine.Http/WolverineHttpOptions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpOptions.cs
@@ -259,13 +259,13 @@ public class WolverineHttpOptions
     /// <summary>
     /// Tell Wolverine that services of type T should always be sourced from the HttpContext.RequestServices.
     /// This enables your system to use shared services with AspNetCore middleware while still allowing Wolverine
-    /// to generate inlined constructor invocation code otherwise
+    /// to generate inlined constructor invocation code otherwise. Scoped to HTTP chains — non-HTTP message
+    /// handlers that happen to consume the same service type continue to use normal constructor resolution.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public void SourceServiceFromHttpContext<T>()
     {
-        var source = new RequestServicesVariableSource(typeof(T));
-        Endpoints!.Rules.Sources.Add(source);
+        Endpoints!.HttpContextSourcedTypes.Add(typeof(T));
     }
 
     // Newtonsoft.Json HTTP serialization moved to the WolverineFx.Http.Newtonsoft


### PR DESCRIPTION
## Summary
- Cherry-pick of the same fix shipped to the `5.0` branch in #2833.
- Closes #2831: `WolverineHttpOptions.SourceServiceFromHttpContext<T>()` was registering its `RequestServicesVariableSource` on `WolverineOptions.CodeGeneration.Sources`, which `HandlerGraph` also reads from. Non-HTTP message handlers with a parameter of type `T` ended up generating `httpContext.RequestServices.GetRequiredService<T>(...)`, referencing an `httpContext` variable that doesn't exist in handler chains, and failing to compile.
- Fix: store the registered types on `HttpGraph` (`HttpContextSourcedTypes`) and inject the `RequestServicesVariableSource` into each `HttpChain`'s per-method `Sources` at codegen time. `MethodFrameArranger` consults the per-method sources before the shared `Rules.Sources`, so HTTP chains keep their existing resolution behavior while non-HTTP handler chains fall back to normal constructor / service-location resolution.
- Regression test in `service_location_assertions.cs` overrides the `IThing` registration to a typed scoped binding so the assertion is purely against codegen and independent of the 6.0 `ServiceLocationPolicy.NotAllowed` default.

## Test plan
- [x] `dotnet test src/Http/Wolverine.Http.Tests -f net9.0 --filter "FullyQualifiedName~service_location_assertions"` (23/23 passed on `main`, including the new `non_http_handler_with_http_context_sourced_type_is_resolved_through_normal_di`)
- [ ] CI (full `wolverine.slnx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)