### PR TITLE
fix(marten): emit ancillary OutboxedSessionFactory cast at codegen time

### DIFF
--- a/src/Persistence/MartenTests/Bugs/Bug_ancillary_outbox_factory_late_rename_codegen.cs
+++ b/src/Persistence/MartenTests/Bugs/Bug_ancillary_outbox_factory_late_rename_codegen.cs
@@ -1,0 +1,94 @@
+using System.Reflection;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using Marten;
+using Shouldly;
+using Wolverine.Marten.Codegen;
+using Wolverine.Marten.Publishing;
+using Xunit;
+
+namespace MartenTests.Bugs;
+
+// Regression: when Lamar provides the IServiceVariableSource, an injected service
+// field returned for OutboxedSessionFactory<TStore> can be renamed to its short
+// form (e.g. "_outboxedSessionFactoryOfCodeListStore") *after* AncillaryOutboxFactoryFrame
+// has captured it in FindVariables — Lamar.IoC.Frames.InjectedServiceField.IsOnlyOne
+// flips the field's Usage during ServiceVariableSource.useInlineConstruction.
+//
+// The pre-fix frame returned its public Factory as a CastVariable, whose Usage is
+// baked into a string at construction time. After Lamar's rename, downstream frames
+// emitted that stale name and the generated handler failed to compile with CS0103.
+//
+// The fix is to defer the cast to GenerateCode so parent.Usage is read live.
+public class Bug_ancillary_outbox_factory_late_rename_codegen
+{
+    [Fact]
+    public void factory_emits_cast_against_live_parent_usage_after_rename()
+    {
+        var frame = new AncillaryOutboxFactoryFrame(typeof(IAncillaryLateRenameStore));
+
+        // Stand in for Lamar's InjectedServiceField. The seed name mirrors what
+        // Lamar.Instance.DefaultArgName produces on JasperFx 1.20+ — the JasperFx
+        // "Of<TypeArg>" suffix doubled by Lamar's own "_of_<TypeArg>" suffix.
+        var parent = new InjectedField(
+            typeof(OutboxedSessionFactory<IAncillaryLateRenameStore>),
+            "outboxedSessionFactoryOfAncillaryLateRenameStore_of_IAncillaryLateRenameStore");
+
+        var variables = new StubMethodVariables();
+        variables.Store(parent);
+
+        // Drain FindVariables the way MethodFrameArranger would during chain arrangement.
+        frame.FindVariables(variables).ToList();
+
+        // After arrangement, Lamar renames the InjectedServiceField to the short form
+        // via its IsOnlyOne setter (which calls Variable.OverrideName with the
+        // already-prefixed underscore name).
+        parent.OverrideName("_outboxedSessionFactoryOfAncillaryLateRenameStore");
+
+        using var writer = new SourceWriter();
+        frame.GenerateCode(null!, writer);
+        var code = writer.Code();
+
+        code.ShouldContain("_outboxedSessionFactoryOfAncillaryLateRenameStore");
+        code.ShouldNotContain("_of_IAncillaryLateRenameStore");
+    }
+
+    public interface IAncillaryLateRenameStore : IDocumentStore;
+
+    private sealed class StubMethodVariables : IMethodVariables
+    {
+        private readonly List<Variable> _extras = new();
+        private readonly Dictionary<Type, Variable> _byType = new();
+
+        public Variable FindVariable(Type type) => _byType[type];
+
+        public Variable FindVariable(ParameterInfo parameter)
+        {
+            if (TryFindVariableByName(parameter.ParameterType, parameter.Name!, out var v))
+                return v;
+            return FindVariable(parameter.ParameterType);
+        }
+
+        public Variable FindVariableByName(Type dependency, string name)
+        {
+            if (TryFindVariableByName(dependency, name, out var v)) return v;
+            throw new InvalidOperationException($"No known variable for {dependency} named {name}");
+        }
+
+        public bool TryFindVariableByName(Type dependency, string name, out Variable variable)
+        {
+            variable = _byType.Values.Concat(_extras)
+                .FirstOrDefault(x => x.Usage == name && x.VariableType == dependency)!;
+            return variable != null;
+        }
+
+        public Variable? TryFindVariable(Type type, VariableSource source)
+            => _byType.TryGetValue(type, out var v) ? v : null;
+
+        public void Store(Variable variable)
+        {
+            _byType[variable.VariableType] = variable;
+            _extras.Add(variable);
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Marten/Codegen/AncillaryOutboxFactoryFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/AncillaryOutboxFactoryFrame.cs
@@ -19,12 +19,12 @@ internal class AncillaryOutboxFactoryFrame : SyncFrame
         {
             throw new ArgumentOutOfRangeException(nameof(storeType), "Must be an IDocumentStore type");
         }
-        
+
         _storeType = storeType;
         _factoryType = typeof(OutboxedSessionFactory<>).MakeGenericType(storeType);
-        
+
     }
-    
+
     public Variable? Factory { get; private set; }
 
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
@@ -32,14 +32,21 @@ internal class AncillaryOutboxFactoryFrame : SyncFrame
         _outerFactory = chain.FindVariable(_factoryType);
         yield return _outerFactory;
 
-        Factory = new CastVariable(_outerFactory, typeof(OutboxedSessionFactory));
+        // A plain Variable assigned via a cast emitted in GenerateCode below — not a
+        // CastVariable. CastVariable snapshots parent.Usage at construction time, but
+        // Lamar's InjectedServiceField renames itself to the short form after FindVariables
+        // when IsOnlyOne is detected. That left CastVariable.Usage holding the pre-rename
+        // (Lamar-internal "_of_<TypeArg>") name, producing CS0103 references to a field
+        // the host never declared. Emitting the cast at code-emit time always reads the
+        // current parent.Usage.
+        Factory = new Variable(typeof(OutboxedSessionFactory), this);
         creates.Add(Factory);
         yield return Factory;
     }
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
-        // This only exists to resolve the variables
+        writer.Write($"var {Factory!.Usage} = ({typeof(OutboxedSessionFactory).FullNameInCode()}){_outerFactory.Usage};");
         Next?.GenerateCode(method, writer);
     }
 }

--- a/src/Persistence/Wolverine.Polecat/Codegen/AncillaryOutboxFactoryFrame.cs
+++ b/src/Persistence/Wolverine.Polecat/Codegen/AncillaryOutboxFactoryFrame.cs
@@ -34,14 +34,17 @@ internal class AncillaryOutboxFactoryFrame : SyncFrame
         _outerFactory = chain.FindVariable(_factoryType);
         yield return _outerFactory;
 
-        Factory = new CastVariable(_outerFactory, typeof(OutboxedSessionFactory));
+        // See Wolverine.Marten's mirror of this frame: CastVariable snapshots parent.Usage
+        // at construction time, which breaks under Lamar's post-FindVariables IsOnlyOne
+        // rename. Plain Variable + cast emitted in GenerateCode reads the live parent.Usage.
+        Factory = new Variable(typeof(OutboxedSessionFactory), this);
         creates.Add(Factory);
         yield return Factory;
     }
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
-        // This only exists to resolve the variables
+        writer.Write($"var {Factory!.Usage} = ({typeof(OutboxedSessionFactory).FullNameInCode()}){_outerFactory.Usage};");
         Next?.GenerateCode(method, writer);
     }
 }


### PR DESCRIPTION
## Summary
Addresses a user-reported codegen failure on Wolverine 5.39.1 + Lamar 15.x + JasperFx 1.31:

```
JasperFx.CodeGeneration.GeneratorCompilationFailureException: Failure when
trying to generate code for Wolverine.Runtime.Handlers.HandlerGraph
  CS0103: The name '_outboxedSessionFactoryOfCodeListStore_of_ICodeListStore'
  does not exist in the current context
```

### Root cause
`AncillaryOutboxFactoryFrame.FindVariables` set `Factory = new CastVariable(_outerFactory, typeof(OutboxedSessionFactory))`. `CastVariable.Usage` is a string baked in at construction time:

```csharp
$"(({specificType.FullNameInCode()}){parent.Usage})"
```

When the IoC container is Lamar, the `_outerFactory` returned for `OutboxedSessionFactory<TStore>` is a `Lamar.IoC.Frames.InjectedServiceField`. JasperFx 1.20 (Feb 2026) added an `Of<TypeArg>` suffix to `Variable.DefaultArgName` for closed generics; Lamar's `Instance.DefaultArgName` still also appends `"_of_<TypeArg>"`, so the field is initially named `_outboxedSessionFactoryOfCodeListStore_of_ICodeListStore`. Then `ServiceVariableSource.useInlineConstruction` flips `IsOnlyOne = true` after `FindVariables`, which calls `OverrideName` to the short form `_outboxedSessionFactoryOfCodeListStore` — *after* `CastVariable` already captured the long form. The handler chain emits the stale long name, which no longer matches the declared field.

### Fix
Replace the `CastVariable` with a plain `Variable` and emit the cast in `GenerateCode`, where `_outerFactory.Usage` is read live — after Lamar's post-arrangement rename. Mirror the same change in the (currently `#if`-guarded) Polecat copy.

## Test plan
- [x] New focused unit test `Bug_ancillary_outbox_factory_late_rename_codegen` exercises `AncillaryOutboxFactoryFrame` directly: stubs a parent `InjectedField` with the doubled name, drains `FindVariables`, renames the parent (simulating Lamar's `IsOnlyOne` rename), then asserts the frame's `GenerateCode` output contains the short post-rename name and not the pre-rename suffix.
- [x] Existing `Bug_2669_ancillary_marten_store_local_message_from_main_store` integration test still passes (`dotnet test ... --filter Bug_2669_ancillary` ✓).
- [x] Wider ancillary set (`Bug_2576|Bug_2382|Bug_2318|AncillaryStores`) — 21/23 pass; the 2 failures (`multi_stream_projection_with_side_effects_on_ancillary_store`) reproduce on the unmodified 5.0 baseline as `WeaselDatabase` setup errors, unrelated to this change.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)