### PR TITLE
fix(rdbms): upsert in RescheduleExistingEnvelopeForRetryAsync (#2823)

### DIFF
--- a/src/Persistence/Oracle/OracleTests/Bug_2823_reschedule_existing_envelope_for_retry_oracle.cs
+++ b/src/Persistence/Oracle/OracleTests/Bug_2823_reschedule_existing_envelope_for_retry_oracle.cs
@@ -1,0 +1,64 @@
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.ComplianceTests.Compliance;
+using Wolverine.Oracle;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.Transports;
+
+namespace OracleTests;
+
+// Oracle mirror of the regression for https://github.com/JasperFx/wolverine/issues/2823.
+// The Oracle inbox previously did UPDATE-only on retry, which silently no-op'd when
+// no row existed (ProcessInline retry #1), and never matched the same column shape
+// as ScheduleExecutionAsync. RescheduleExistingEnvelopeForRetryAsync is now an upsert
+// aligned with MessageDatabase<T>.
+[Collection("oracle")]
+public class Bug_2823_reschedule_existing_envelope_for_retry_oracle
+{
+    [Fact]
+    public async Task two_consecutive_reschedules_do_not_throw_duplicate()
+    {
+        var dataSource = new OracleDataSource(Servers.OracleConnectionString);
+        var settings = new DatabaseSettings
+        {
+            SchemaName = "WOLVERINE",
+            CommandQueuesEnabled = true,
+            Role = MessageStoreRole.Main
+        };
+        var store = new OracleMessageStore(settings, new DurabilitySettings(), dataSource,
+            NullLogger<OracleMessageStore>.Instance);
+
+        await store.Admin.MigrateAsync();
+        await store.Admin.ClearAllAsync();
+
+        var envelope = ObjectMother.Envelope();
+        envelope.Message = new Message1();
+        envelope.ScheduledTime = DateTimeOffset.UtcNow.AddMinutes(1);
+        envelope.Attempts = 1;
+
+        // Retry #1: no pre-existing row — UPDATE affects 0 rows, INSERT fallback runs.
+        await store.Inbox.RescheduleExistingEnvelopeForRetryAsync(envelope);
+
+        // Retry #2: row from #1 already exists — UPDATE succeeds.
+        envelope.ScheduledTime = DateTimeOffset.UtcNow.AddMinutes(5);
+        envelope.Attempts = 2;
+        await store.Inbox.RescheduleExistingEnvelopeForRetryAsync(envelope);
+
+        var rows = (await store.Admin.AllIncomingAsync())
+            .Where(x => x.Id == envelope.Id)
+            .ToList();
+
+        rows.Count.ShouldBe(1);
+
+        var persisted = rows[0];
+        persisted.Attempts.ShouldBe(2);
+        persisted.ScheduledTime!.Value.ShouldBe(envelope.ScheduledTime.Value, TimeSpan.FromSeconds(2));
+        persisted.OwnerId.ShouldBe(TransportConstants.AnyNode);
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Incoming.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Incoming.cs
@@ -125,16 +125,34 @@ internal partial class OracleMessageStore
 
     public async Task RescheduleExistingEnvelopeForRetryAsync(Envelope envelope)
     {
-        await using var conn = await _dataSource.OpenConnectionAsync(_cancellation);
-        var cmd = conn.CreateCommand(
-            $"UPDATE {SchemaName}.{DatabaseConstants.IncomingTable} SET " +
-            $"{DatabaseConstants.ExecutionTime} = :time, {DatabaseConstants.Attempts} = :attempts " +
-            "WHERE id = :id");
-        cmd.With("id", envelope.Id);
-        cmd.Parameters.Add(new OracleParameter("time", OracleDbType.TimeStampTZ) { Value = envelope.ScheduledTime });
-        cmd.With("attempts", envelope.Attempts);
-        await cmd.ExecuteNonQueryAsync(_cancellation);
-        await conn.CloseAsync();
+        envelope.Status = EnvelopeStatus.Scheduled;
+        envelope.OwnerId = TransportConstants.AnyNode;
+
+        // Upsert, aligned with MessageDatabase<T>.RescheduleExistingEnvelopeForRetryAsync.
+        // Try the same UPDATE shape ScheduleExecutionAsync uses; if no row exists
+        // (ProcessInline retry #1, BufferedLocalQueue's scheduled-publish path) fall back
+        // to an INSERT via StoreIncomingAsync. See #2823 for the unconditional-INSERT
+        // failure mode this replaces in the SQL Server / Postgres providers.
+        int rowsAffected;
+        await using (var conn = await _dataSource.OpenConnectionAsync(_cancellation))
+        {
+            var cmd = conn.CreateCommand(
+                $"UPDATE {SchemaName}.{DatabaseConstants.IncomingTable} SET " +
+                $"{DatabaseConstants.ExecutionTime} = :time, {DatabaseConstants.Status} = '{EnvelopeStatus.Scheduled}', " +
+                $"{DatabaseConstants.Attempts} = :attempts, {DatabaseConstants.OwnerId} = {TransportConstants.AnyNode} " +
+                $"WHERE id = :id AND {DatabaseConstants.ReceivedAt} = :uri");
+            cmd.With("id", envelope.Id);
+            cmd.Parameters.Add(new OracleParameter("time", OracleDbType.TimeStampTZ) { Value = envelope.ScheduledTime!.Value });
+            cmd.With("attempts", envelope.Attempts);
+            cmd.With("uri", envelope.Destination?.ToString() ?? string.Empty);
+            rowsAffected = await cmd.ExecuteNonQueryAsync(_cancellation);
+            await conn.CloseAsync();
+        }
+
+        if (rowsAffected == 0)
+        {
+            await StoreIncomingAsync(envelope);
+        }
     }
 
     public async Task ScheduleExecutionAsync(Envelope envelope)

--- a/src/Persistence/SqlServerTests/Persistence/Bug_2823_reschedule_existing_envelope_for_retry.cs
+++ b/src/Persistence/SqlServerTests/Persistence/Bug_2823_reschedule_existing_envelope_for_retry.cs
@@ -1,0 +1,45 @@
+using JasperFx.Core.Reflection;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.ComplianceTests.Compliance;
+using Wolverine.SqlServer.Persistence;
+using Wolverine.Transports;
+
+namespace SqlServerTests.Persistence;
+
+// Regression for https://github.com/JasperFx/wolverine/issues/2823.
+// With ProcessInline + ScheduleRetry(RetryCount > 1), the second retry called
+// RescheduleExistingEnvelopeForRetryAsync against a row that had already been
+// inserted by the first retry, blowing up on the primary key (id, received_at)
+// with DuplicateIncomingEnvelopeException. RescheduleExistingEnvelopeForRetryAsync
+// now upserts: UPDATE first, INSERT fallback if no row exists.
+public class Bug_2823_reschedule_existing_envelope_for_retry : SqlServerContext
+{
+    [Fact]
+    public async Task two_consecutive_reschedules_do_not_throw_duplicate()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Message = new Message1();
+        envelope.ScheduledTime = DateTimeOffset.UtcNow.AddMinutes(1);
+        envelope.Attempts = 1;
+
+        // Retry #1: no pre-existing row — UPDATE affects 0 rows, INSERT fallback runs.
+        await thePersistence.Inbox.RescheduleExistingEnvelopeForRetryAsync(envelope);
+
+        // Retry #2: row from #1 already exists — UPDATE succeeds, no INSERT.
+        envelope.ScheduledTime = DateTimeOffset.UtcNow.AddMinutes(5);
+        envelope.Attempts = 2;
+        await thePersistence.Inbox.RescheduleExistingEnvelopeForRetryAsync(envelope);
+
+        var rows = (await thePersistence.As<SqlServerMessageStore>().Admin.AllIncomingAsync())
+            .Where(x => x.Id == envelope.Id)
+            .ToList();
+
+        rows.Count.ShouldBe(1);
+
+        var persisted = rows[0];
+        persisted.Attempts.ShouldBe(2);
+        persisted.ScheduledTime!.Value.ShouldBe(envelope.ScheduledTime.Value, TimeSpan.FromSeconds(2));
+        persisted.OwnerId.ShouldBe(TransportConstants.AnyNode);
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Scheduled.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Scheduled.cs
@@ -20,12 +20,31 @@ public abstract partial class MessageDatabase<T>
             .ExecuteNonQueryAsync(_cancellation);
     }
 
-    public Task RescheduleExistingEnvelopeForRetryAsync(Envelope envelope)
+    public async Task RescheduleExistingEnvelopeForRetryAsync(Envelope envelope)
     {
         Logger.LogDebug("Rescheduling envelope {EnvelopeId} ({MessageType}) for retry in database inbox at {Destination}", envelope.Id, envelope.MessageType, envelope.Destination);
         envelope.Status = EnvelopeStatus.Scheduled;
         envelope.OwnerId = TransportConstants.AnyNode;
 
-        return StoreIncomingAsync(envelope);
+        // Try UPDATE first so we don't collide with a row left by an earlier reschedule.
+        // The same call services two scenarios:
+        //   * UseDurableInbox — the inbox row was inserted on arrival (issue #2462).
+        //   * ProcessInline   — retry #1 inserts, retry #2+ finds the previous Scheduled row
+        //                       (issue #2823).
+        // INSERT-only blew up on the existing row's primary key in both. When no row exists
+        // (e.g. ProcessInline retry #1, or BufferedLocalQueue's scheduled-publish path),
+        // UPDATE affects 0 rows and we fall back to StoreIncomingAsync.
+        var rowsAffected = await CreateCommand(
+                $"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} set execution_time = @time, status = \'{EnvelopeStatus.Scheduled}\', attempts = @attempts, owner_id = {TransportConstants.AnyNode} where id = @id and {DatabaseConstants.ReceivedAt} = @uri;")
+            .With("time", envelope.ScheduledTime!.Value)
+            .With("attempts", envelope.Attempts)
+            .With("id", envelope.Id)
+            .With("uri", envelope.Destination!.ToString())
+            .ExecuteNonQueryAsync(_cancellation);
+
+        if (rowsAffected == 0)
+        {
+            await StoreIncomingAsync(envelope);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Closes #2823. Same root cause as #2462 (this fix resolves both).

`MessageDatabase<T>.RescheduleExistingEnvelopeForRetryAsync` in `src/Persistence/Wolverine.RDBMS/MessageDatabase.Scheduled.cs` unconditionally went through `StoreIncomingAsync` (INSERT). The failure mode reported by @kakins:

| Config | Symptom |
|---|---|
| ProcessInline + `ScheduleRetry(RetryCount > 1)` | Retry #1 inserts a Scheduled row; durability agent redelivers; retry #2 collides on `(id, received_at)` PK with `DuplicateIncomingEnvelopeException`. (#2823) |
| UseDurableInbox + `ScheduleRetry` | Inbox row exists from arrival; retry #1 already collides. (#2462) |

Why this is ProcessInline-specific in the #2823 form: with `UseDurableInbox` the `IChannelCallback` is `DurableReceiver`, which implements `ISupportNativeScheduling`, so `MessageContext.tryGetRescheduler` routes through `DurableReceiver.MoveToScheduledUntilAsync` → `ScheduleExecutionAsync` (UPDATE-only). With `ProcessInline` the callback is `RabbitMqChannelCallback` which doesn't implement `ISupportNativeScheduling`, so reschedules fall through to `RescheduleExistingEnvelopeForRetryAsync`'s INSERT path.

The existing comment at `src/Wolverine/Transports/Local/BufferedLocalQueue.cs:80-85` already described this method as an upsert ("misnamed-but-correct API ... it sets Status=Scheduled + OwnerId=AnyNode, then upserts via StoreIncomingAsync") — the upsert behavior was aspirational; this PR makes it real.

## Fix
Try the same UPDATE SQL that `ScheduleExecutionAsync` already uses; fall back to `StoreIncomingAsync` only when 0 rows are affected. That covers:

| Caller / scenario | Pre-fix | Post-fix |
|---|---|---|
| `BufferedLocalQueue.ScheduleAsync` — no existing row | INSERT ✓ | UPDATE 0 → INSERT ✓ |
| ProcessInline retry #1 — no existing row | INSERT ✓ | UPDATE 0 → INSERT ✓ |
| ProcessInline retry #2+ — row exists from #1 | INSERT 💥 | UPDATE ✓ |
| UseDurableInbox retry #1 — row exists from arrival | INSERT 💥 | UPDATE ✓ |

Body bytes are not rewritten on the UPDATE path — `DatabasePersistence.ReadIncomingAsync` (line 96-109) already overrides `Status`, `OwnerId`, `Attempts`, `ScheduledTime` from the column values after deserializing the body, so the UPDATE state is what the runtime sees on the next dequeue.

## Test plan
- [x] New regression `Bug_2823_reschedule_existing_envelope_for_retry.two_consecutive_reschedules_do_not_throw_duplicate` (`src/Persistence/SqlServerTests/Persistence/`) — calls `RescheduleExistingEnvelopeForRetryAsync` twice on the same envelope, asserts no duplicate exception, exactly one row, with `Attempts` and `ScheduledTime` from the second call.
- [x] Verified pre-fix: the new test fails on baseline `main` with `DuplicateIncomingEnvelopeException` at `MessageDatabase.Incoming.cs:167` — the path #2823 reports.
- [x] `dotnet test src/Persistence/SqlServerTests -f net9.0 --filter "FullyQualifiedName~Bug_2823|SqlServerBackedMessageStoreTests"` — 5/5 pass (covers the new test + the existing reschedule round-trip in `SqlServerBackedMessageStoreTests`).
- [x] `dotnet test src/Persistence/PostgresqlTests -f net9.0 --filter "FullyQualifiedName~PostgresqlMessageStoreTests"` — 48/48 pass; fix lives in shared `MessageDatabase<T>` so the Postgres path benefits identically.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)