### PR TITLE
fix(kafka): ReceiveRawJson honors wolverine-ping infrastructure messages (#2838)

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/Bugs/Bug_2838_receive_raw_json_honors_wolverine_ping.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/Bugs/Bug_2838_receive_raw_json_honors_wolverine_ping.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using Confluent.Kafka;
+using Shouldly;
+using Wolverine.Kafka.Internals;
+
+namespace Wolverine.Kafka.Tests.Bugs;
+
+// Regression for https://github.com/JasperFx/wolverine/issues/2838.
+// JsonOnlyMapper used to unconditionally stamp _messageTypeName on every incoming
+// message, so the wolverine-ping envelope emitted by InlineKafkaSender.PingAsync
+// was routed to the user's handler as a Msg and System.Text.Json blew up on the
+// 0x01 first byte of the ping body.
+public class Bug_2838_receive_raw_json_honors_wolverine_ping
+{
+    [Fact]
+    public void wolverine_ping_header_is_honored_by_json_only_mapper()
+    {
+        var topic = new KafkaTopic(
+            new KafkaTransport(),
+            "ping-regression",
+            Wolverine.Configuration.EndpointRole.Application)
+        {
+            MessageType = typeof(Msg2838)
+        };
+
+        var mapper = new JsonOnlyMapper(topic, new System.Text.Json.JsonSerializerOptions());
+
+        var incoming = new Message<string, byte[]>
+        {
+            Value = [1, 2, 3, 4], // mirrors Envelope.ForPing's body bytes
+            Headers = new Headers
+            {
+                { EnvelopeConstants.MessageTypeKey, Encoding.UTF8.GetBytes(Envelope.PingMessageType) }
+            }
+        };
+
+        var envelope = new Envelope();
+        mapper.MapIncomingToEnvelope(envelope, incoming);
+
+        envelope.MessageType.ShouldBe(Envelope.PingMessageType);
+        envelope.IsPing().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void non_ping_payload_still_uses_default_message_type()
+    {
+        var topic = new KafkaTopic(
+            new KafkaTransport(),
+            "json-regression",
+            Wolverine.Configuration.EndpointRole.Application)
+        {
+            MessageType = typeof(Msg2838)
+        };
+
+        var mapper = new JsonOnlyMapper(topic, new System.Text.Json.JsonSerializerOptions());
+
+        var payload = Encoding.UTF8.GetBytes("{\"name\":\"hi\"}");
+        var incoming = new Message<string, byte[]>
+        {
+            Value = payload
+            // No headers — external producer.
+        };
+
+        var envelope = new Envelope();
+        mapper.MapIncomingToEnvelope(envelope, incoming);
+
+        envelope.IsPing().ShouldBeFalse();
+        envelope.MessageType.ShouldNotBe(Envelope.PingMessageType);
+        envelope.Data.ShouldBe(payload);
+    }
+
+    public record Msg2838(string Name);
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
@@ -44,7 +44,33 @@ internal class JsonOnlyMapper : IKafkaEnvelopeMapper
 
     public void MapIncomingToEnvelope(Envelope envelope, Message<string, byte[]> incoming)
     {
+        // Honor Wolverine's own infrastructure messages (currently just ping) even when this
+        // listener is configured for raw JSON. InlineKafkaSender.PingAsync produces a
+        // wolverine-ping envelope on the topic for sender liveness checks; without this guard
+        // the raw-JSON mapper would stamp the user's message type on it, and the four-byte
+        // ping body would blow up the JSON deserializer with "0x01 is an invalid start of a
+        // value." See https://github.com/JasperFx/wolverine/issues/2838.
+        if (TryReadHeader(incoming, EnvelopeConstants.MessageTypeKey, out var incomingMessageType)
+            && incomingMessageType == Envelope.PingMessageType)
+        {
+            envelope.MessageType = Envelope.PingMessageType;
+            envelope.Data = incoming.Value;
+            return;
+        }
+
         envelope.Data = incoming.Value;
         envelope.MessageType = _messageTypeName;
+    }
+
+    private static bool TryReadHeader(Message<string, byte[]> incoming, string key, out string value)
+    {
+        if (incoming.Headers != null && incoming.Headers.TryGetLastBytes(key, out var bytes))
+        {
+            value = Encoding.UTF8.GetString(bytes);
+            return true;
+        }
+
+        value = default!;
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
Closes #2838.

`JsonOnlyMapper.MapIncomingToEnvelope` unconditionally stamped the listener's configured message type and discarded all Kafka headers:

```csharp
public void MapIncomingToEnvelope(Envelope envelope, Message<string, byte[]> incoming)
{
    envelope.Data = incoming.Value;
    envelope.MessageType = _messageTypeName;
}
```

`InlineKafkaSender.PingAsync` publishes a wolverine-ping envelope (`Data = {1,2,3,4}`, `MessageType = wolverine-ping`) to the topic as part of the sender's liveness check (`src/Transports/Kafka/Wolverine.Kafka/Internals/InlineKafkaSender.cs:25-36`). On a listener configured with `ReceiveRawJson<T>()`, that envelope arrived at the user's handler, `System.Text.Json` choked on the leading 0x01 byte (`'0x01' is an invalid start of a value`), and Wolverine shunted it to the error queue.

## Fix
Detect the `wolverine-ping` marker via the standard `message-type` Kafka header in `MapIncomingToEnvelope` and short-circuit: stamp the envelope's `MessageType` as `PingMessageType` so `BufferedReceiver.Enqueue`/`EnqueueAsync` (`src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs:172,184`) drops it before handler dispatch. Other headers/payloads still flow through the raw-JSON path unchanged.

## Test plan
- [x] New `Bug_2838_receive_raw_json_honors_wolverine_ping.wolverine_ping_header_is_honored_by_json_only_mapper` — feeds the mapper a Kafka message stamped with `message-type: wolverine-ping` + the four-byte ping body, asserts `envelope.IsPing()` is true.
- [x] New `…_non_ping_payload_still_uses_default_message_type` — confirms a header-less external producer payload still gets `Data = incoming.Value` and the listener's configured message type via the existing fallback in `KafkaListener.cs:50` (`envelope.MessageType ??= _messageTypeName`).
- [x] Verified pre-fix: stashed the mapper change, the ping test fails on baseline (`MessageType` becomes the user's type) while the non-ping test still passes. Restored fix; both pass.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)