### PR TITLE
fix(http): default tenant-id assertion to true when detection is configured

### DIFF
--- a/docs/guide/http/multi-tenancy.md
+++ b/docs/guide/http/multi-tenancy.md
@@ -246,24 +246,35 @@ See [Referencing the TenantId](/guide/handlers/multi-tenancy.html#referencing-th
 
 ## Requiring Tenant Id -- or Not!
 
-You can direct Wolverine.HTTP to verify that there is a non-null, non-empty tenant id on all requests with this syntax:
+Starting in Wolverine 6.0, the tenant id is **required by default** on any HTTP endpoint that participates in multi-tenancy whenever at least one detection strategy is registered (`IsRequestHeaderValue`, `IsQueryStringValue`, `IsClaimTypeNamed`, `IsRouteArgumentNamed`, `IsSubDomainName`, or `DetectWith(...)`). A request that omits the tenant id returns a 400 with a [ProblemDetails](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.problemdetails?view=aspnetcore-7.0) body stating that the tenant id was missing.
+
+The `AssertExists()` call is therefore now optional. It is still valid and documents intent:
 
 <!-- snippet: sample_assert_tenant_id_exists -->
-<a id='snippet-sample_assert_tenant_id_exists'></a>
-```cs
-app.MapWolverineEndpoints(opts =>
-{
-    // Configure your tenant id detection...
-
-    // Require tenant id some how, some way...
-    opts.TenantId.AssertExists();
-});
-```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/Samples/MultiTenancy.cs#L67-L76' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_assert_tenant_id_exists' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-At runtime, this is going to return a status code of 400 with a [ProblemDetails](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.problemdetails?view=aspnetcore-7.0) specification 
-response stating that the tenant id was missing. 
+There are two ways to opt out of this default:
+
+**Preferred — register a fallback tenant.** If your application has a meaningful default tenant for unauthenticated or header-omitted traffic, register it with `DefaultIs(...)`. When a `DefaultIs(...)` strategy is registered the framework treats it as your explicit fallback and does not assert:
+
+```csharp
+opts.TenantId.IsRequestHeaderValue("X-Tenant-Id");
+opts.TenantId.DefaultIs("public");
+```
+
+**Discouraged — disable the assertion.** For non-multi-tenant scenarios (or to restore the 5.x behavior of silently coercing missing tenant ids to the master tenant) call `DoNotAssertExists()`. This is a footgun in multi-tenant deployments because cascaded messages and downstream side effects will execute against the master tenant store:
+
+<!-- snippet: sample_do_not_assert_tenant_id_exists -->
+<!-- endSnippet -->
+
+### Migrating from 5.x
+
+In 5.x, `AssertExists()` was opt-in and missing tenant ids were silently coerced to the master tenant store. In 6.0 the default is reversed. If your 5.x deployment relied on the silent coercion, either:
+
+1. Register `opts.TenantId.DefaultIs(...)` with the tenant id you want missing-id traffic to land on, or
+2. Call `opts.TenantId.DoNotAssertExists()` to keep the old behavior verbatim.
+
+The framework otherwise leaves the `MessageBus.TenantId` null-to-`*DEFAULT*` coercion and the per-tenant database routing untouched — only the HTTP-layer assertion default has changed.
 
 But of course, you will frequently have *some* endpoints within your system that do **not** use any kind
 of multi-tenancy, so you can completely opt out of all tenant id detection and assertions through the

--- a/src/Http/Wolverine.Http.Tests/MultiTenancy/multi_tenancy_detection_and_integration.cs
+++ b/src/Http/Wolverine.Http.Tests/MultiTenancy/multi_tenancy_detection_and_integration.cs
@@ -276,6 +276,97 @@ public class multi_tenancy_detection_and_integration : IAsyncDisposable, IDispos
     }
 
     [Fact]
+    public async Task tenant_id_assertion_is_on_by_default_when_detection_is_registered()
+    {
+        await configure(opts =>
+        {
+            opts.TenantId.IsQueryStringValue("tenant");
+        });
+
+        var results = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/tenant");
+            x.StatusCodeShouldBe(400);
+        });
+
+        var details = results.ReadAsJson<ProblemDetails>();
+        details.Detail.ShouldBe(TenantIdDetection
+            .NoMandatoryTenantIdCouldBeDetectedForThisHttpRequest);
+    }
+
+    [Fact]
+    public async Task DefaultIs_suppresses_the_default_assertion()
+    {
+        await configure(opts =>
+        {
+            opts.TenantId.IsQueryStringValue("tenant");
+            opts.TenantId.DefaultIs("acme");
+        });
+
+        var result = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/tenant");
+            x.StatusCodeShouldBe(200);
+        });
+
+        result.ReadAsText().ShouldBe("acme");
+    }
+
+    [Fact]
+    public async Task DoNotAssertExists_opts_out_of_the_default()
+    {
+        await configure(opts =>
+        {
+            opts.TenantId.IsQueryStringValue("tenant");
+            opts.TenantId.DoNotAssertExists();
+        });
+
+        var result = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/tenant/raw");
+            x.StatusCodeShouldBe(200);
+        });
+
+        result.ReadAsText().ShouldBe(StorageConstants.DefaultTenantId);
+    }
+
+    [Fact]
+    public async Task DoNotAssertExists_then_AssertExists_resolves_to_assertion()
+    {
+        await configure(opts =>
+        {
+            opts.TenantId.IsQueryStringValue("tenant");
+            opts.TenantId.DoNotAssertExists();
+            opts.TenantId.AssertExists();
+        });
+
+        await theHost.Scenario(x =>
+        {
+            x.Get.Url("/tenant");
+            x.StatusCodeShouldBe(400);
+        });
+    }
+
+    [Fact]
+    public async Task AssertExists_then_DoNotAssertExists_resolves_to_opt_out()
+    {
+        await configure(opts =>
+        {
+            opts.TenantId.IsQueryStringValue("tenant");
+            opts.TenantId.AssertExists();
+            opts.TenantId.DoNotAssertExists();
+        });
+
+        var result = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/tenant/raw");
+            x.StatusCodeShouldBe(200);
+        });
+
+        result.ReadAsText().ShouldBe(StorageConstants.DefaultTenantId);
+    }
+
+    [Fact]
     public async Task end_to_end_through_marten()
     {
         await configure(opts =>
@@ -427,6 +518,14 @@ public static class TenantedEndpoints
         httpContext.Features.Set(CustomActivityFeature.FromHttpContext(httpContext));
         tenantId.Value.ShouldBe(bus.TenantId);
         return bus.TenantId!;
+    }
+
+    // Plain endpoint without invariant checks, registered with the default TenancyMode,
+    // so DoNotAssertExists tests can observe the request actually flowing through.
+    [WolverineGet("/tenant/raw")]
+    public static string RawTenantId(IMessageBus bus)
+    {
+        return bus.TenantId ?? "(none)";
     }
 
     [WolverineGet("/todo/{id}")]

--- a/src/Http/Wolverine.Http.Tests/Samples/MultiTenancy.cs
+++ b/src/Http/Wolverine.Http.Tests/Samples/MultiTenancy.cs
@@ -68,9 +68,28 @@ public static class MultiTenancy
         app.MapWolverineEndpoints(opts =>
         {
             // Configure your tenant id detection...
+            opts.TenantId.IsRequestHeaderValue("tenant");
 
-            // Require tenant id some how, some way...
+            // AssertExists() is the default in 6.0 whenever any detection strategy
+            // is registered. Calling it explicitly is still valid and documents intent.
             opts.TenantId.AssertExists();
+        });
+
+        #endregion
+    }
+
+    public static void do_not_assert_tenant(WebApplication app)
+    {
+        #region sample_do_not_assert_tenant_id_exists
+        app.MapWolverineEndpoints(opts =>
+        {
+            // Configure your tenant id detection...
+            opts.TenantId.IsRequestHeaderValue("tenant");
+
+            // Opt out of the 6.0 default fail-loud behavior. Missing tenant ids
+            // will fall through to the master ("default") tenant. Prefer DefaultIs(...)
+            // if you actually want a known fallback tenant.
+            opts.TenantId.DoNotAssertExists();
         });
 
         #endregion

--- a/src/Http/Wolverine.Http/Runtime/MultiTenancy/TenantIdDetection.cs
+++ b/src/Http/Wolverine.Http/Runtime/MultiTenancy/TenantIdDetection.cs
@@ -38,7 +38,12 @@ internal class TenantIdDetection : ITenantDetectionPolicies, IHttpPolicy
 
     public void AssertExists()
     {
-        AssertTenantExists = true;
+        _assertSetting = true;
+    }
+
+    public void DoNotAssertExists()
+    {
+        _assertSetting = false;
     }
 
     public void DetectWith(ITenantDetection detection)
@@ -60,11 +65,23 @@ internal class TenantIdDetection : ITenantDetectionPolicies, IHttpPolicy
         DetectWith(Services.GetRequiredService<IServiceContainer>().QuickBuild<T>());
     }
 
-    public bool AssertTenantExists { get; set; }
+    // null = no explicit choice; resolve via EffectiveAssertTenantExists.
+    private bool? _assertSetting;
+
+    private bool EffectiveAssertTenantExists
+    {
+        get
+        {
+            if (_assertSetting.HasValue) return _assertSetting.Value;
+            if (Strategies.Count == 0) return false;
+            if (Strategies.Any(s => s is FallbackDefault)) return false;
+            return true;
+        }
+    }
 
     public bool ShouldAssertTenantIdExists(HttpChain chain)
     {
-        if (!AssertTenantExists) return false;
+        if (!EffectiveAssertTenantExists) return false;
 
         if (chain.TenancyMode == null) return true;
 

--- a/src/Http/Wolverine.Http/WolverineHttpOptions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpOptions.cs
@@ -65,6 +65,14 @@ public interface ITenantDetectionPolicies
     void AssertExists();
 
     /// <summary>
+    /// Opt out of the default fail-loud behavior. When called, requests that omit the
+    /// tenant id will fall through to the master ("default") tenant instead of returning 400.
+    /// This is a safety footgun in multi-tenanted deployments — prefer DefaultIs(...) if you
+    /// actually want a fallback tenant, and reserve this for non-multi-tenant scenarios.
+    /// </summary>
+    void DoNotAssertExists();
+
+    /// <summary>
     /// Register a custom tenant detection strategy. Be aware though, this object
     /// will be resolved from your application container, but will be done as with Singleton
     /// scoping.


### PR DESCRIPTION
# fix(http): default tenant-id assertion to true when detection is configured

Closes #2841.

## Summary

Configuring tenant detection without calling `AssertExists()` previously let header-omitted requests fall through to the master ("default") tenant store, silently writing per-tenant outbox/saga/dead-letter rows into `Main`. The default in 6.0 is now to return `400 ProblemDetails` on a missing tenant id whenever any detection strategy is registered.

Opt-outs:

- **`DefaultIs(...)`** — register a fallback tenant for header-omitted requests (preferred when you actually want a fallback).
- **`DoNotAssertExists()`** — explicitly restore the prior fall-through behaviour. Documented as a footgun; reserved for non-multi-tenant scenarios.

The fix is scoped to `TenantIdDetection` and the HTTP options surface. `MessageBus.TenantId`'s null→`"*DEFAULT*"` coercion and the persistence-layer short-circuits on `"*DEFAULT*"`/`"default"`/`"Main"` are unchanged — the loud failure now happens earlier, before a null tenant reaches them.

## Behaviour

`TenantIdDetection.EffectiveAssertTenantExists` resolves like this:

1. If `AssertExists()` or `DoNotAssertExists()` was called explicitly, honour that (last-write-wins).
2. Otherwise, if no detection strategies are registered → `false` (single-tenant app, nothing to assert).
3. Otherwise, if a `FallbackDefault` strategy is registered (via `DefaultIs(...)`) → `false` (the fallback handles missing ids).
4. Otherwise → `true` (multi-tenant detection is configured, fail loud on missing id).

## Breaking change (6.0)

The public `AssertTenantExists` setter on `TenantIdDetection` is removed. Callers must use `AssertExists()` / `DoNotAssertExists()` instead. The 5.x to 6.0 migration note in `docs/guide/http/multi-tenancy.md` covers this.

## Files changed

- `src/Http/Wolverine.Http/Runtime/MultiTenancy/TenantIdDetection.cs` — replace public `AssertTenantExists` property with nullable `_assertSetting` + `EffectiveAssertTenantExists`; add `DoNotAssertExists()`.
- `src/Http/Wolverine.Http/WolverineHttpOptions.cs` — add `DoNotAssertExists()` to `ITenantDetectionPolicies` with a footgun-warning xmldoc.
- `docs/guide/http/multi-tenancy.md` — document the new default, `DefaultIs(...)` opt-out, `DoNotAssertExists()` opt-out, and 5.x → 6.0 migration note.
- `src/Testing/Wolverine.Http.Tests/Samples/MultiTenancy.cs` — sample updates.
- `src/Testing/Wolverine.Http.Tests/multi_tenancy_detection_and_integration.cs` — new tests covering the four resolution branches above.