### PR TITLE
Bound attacker-controlled length fields in EnvelopeSerializer and TCP transport

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Transport/HttpTransportExecutorTests.cs
+++ b/src/Http/Wolverine.Http.Tests/Transport/HttpTransportExecutorTests.cs
@@ -53,6 +53,55 @@ public class HttpTransportExecutorTests : IntegrationContext
     }
 
     [Fact]
+    public async Task execute_batch_returns_400_for_oversize_envelope_batch_claim()
+    {
+        // Wire-claim of int.MaxValue envelopes in a 4-byte payload — well over
+        // the configured MaxIncomingEnvelopeBatchSize cap.
+        var body = BitConverter.GetBytes(int.MaxValue);
+
+        await Scenario(s =>
+        {
+            s.Post.ByteArray(body).ToUrl("/_wolverine/batch/test")
+                .ContentType(HttpTransport.EnvelopeBatchContentType);
+            s.StatusCodeShouldBe(400);
+        });
+    }
+
+    [Fact]
+    public async Task invoke_returns_400_for_oversize_envelope_data_claim()
+    {
+        // Construct a minimal binary envelope that claims int.MaxValue bytes of
+        // payload data — well over the configured MaxIncomingEnvelopeDataSize cap.
+        // Layout: SentAt (int64) + headerCount=0 (int32) + byteCount=int.MaxValue (int32).
+        using var ms = new MemoryStream();
+        using (var bw = new BinaryWriter(ms, System.Text.Encoding.UTF8, leaveOpen: true))
+        {
+            bw.Write(DateTime.UtcNow.ToBinary());
+            bw.Write(0);            // headerCount
+            bw.Write(int.MaxValue); // byteCount
+        }
+        var body = ms.ToArray();
+
+        await Scenario(s =>
+        {
+            s.Post.ByteArray(body).ToUrl("/_wolverine/invoke")
+                .ContentType(HttpTransport.EnvelopeContentType);
+            s.StatusCodeShouldBe(400);
+        });
+    }
+
+    [Fact]
+    public async Task invoke_returns_500_for_invalid_envelope_data()
+    {
+        await Scenario(s =>
+        {
+            s.Post.ByteArray(new byte[] { 0xFF, 0xFF, 0xFF }).ToUrl("/_wolverine/invoke")
+                .ContentType(HttpTransport.EnvelopeContentType);
+            s.StatusCodeShouldBe(500);
+        });
+    }
+
+    [Fact]
     public async Task invoke_returns_415_for_wrong_content_type()
     {
         var result = await Scenario(s =>

--- a/src/Http/Wolverine.Http/Transport/HttpTransportExecutor.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpTransportExecutor.cs
@@ -46,6 +46,11 @@ internal class HttpTransportExecutor
         {
             envelopes = EnvelopeSerializer.ReadMany(data);
         }
+        catch (InvalidEnvelopeException e)
+        {
+            _logger.LogWarning(e, "Rejected malformed envelope batch in Http Transport ExecuteBatchAsync()");
+            return Results.Problem($"Invalid envelope: {e.Message}", statusCode: 400);
+        }
         catch (Exception e)
         {
             _logger.LogError(e, "Error trying to read Envelope[] in the Http Transport ExecuteBatchAsync()");
@@ -87,7 +92,21 @@ internal class HttpTransportExecutor
         Envelope? envelope = null;
         if (values[0] == HttpTransport.EnvelopeContentType)
         {
-            var data = await httpContext.Request.Body.ReadAllBytesAsync(); envelope = EnvelopeSerializer.Deserialize(data);
+            var data = await httpContext.Request.Body.ReadAllBytesAsync();
+            try
+            {
+                envelope = EnvelopeSerializer.Deserialize(data);
+            }
+            catch (InvalidEnvelopeException e)
+            {
+                _logger.LogWarning(e, "Rejected malformed envelope in Http Transport InvokeAsync()");
+                return Results.Problem($"Invalid envelope: {e.Message}", statusCode: 400);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error trying to deserialize envelope in Http Transport InvokeAsync()");
+                return Results.Problem("Error trying to deserialize envelope", statusCode: 500);
+            }
         }
         else
         {

--- a/src/Testing/CoreTests/Serialization/EnvelopeSerializerGuardTests.cs
+++ b/src/Testing/CoreTests/Serialization/EnvelopeSerializerGuardTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace CoreTests.Serialization;
 
+[Collection("EnvelopeSerializerLimits")]
 public class EnvelopeSerializerGuardTests
 {
     [Fact]

--- a/src/Testing/CoreTests/Serialization/EnvelopeSerializerGuardTests.cs
+++ b/src/Testing/CoreTests/Serialization/EnvelopeSerializerGuardTests.cs
@@ -1,0 +1,99 @@
+using System.IO;
+using Shouldly;
+using Wolverine.Runtime.Serialization;
+using Xunit;
+
+namespace CoreTests.Serialization;
+
+public class EnvelopeSerializerGuardTests
+{
+    [Fact]
+    public void default_limits_have_expected_values()
+    {
+        var defaults = EnvelopeReaderLimits.Default;
+        defaults.MaxBatchSize.ShouldBe(1_000);
+        defaults.MaxDataSize.ShouldBe(4 * 1024 * 1024);
+        defaults.MaxHeaderCount.ShouldBe(128);
+    }
+
+    [Fact]
+    public void envelope_serializer_limits_default_to_envelope_reader_limits_default()
+    {
+        EnvelopeSerializer.Limits.ShouldBe(EnvelopeReaderLimits.Default);
+    }
+
+    [Fact]
+    public void read_many_rejects_oversize_batch_count()
+    {
+        var buffer = WriteInt32(EnvelopeReaderLimits.Default.MaxBatchSize + 1);
+        Should.Throw<InvalidEnvelopeException>(() => EnvelopeSerializer.ReadMany(buffer))
+            .Message.ShouldContain("batch size");
+    }
+
+    [Fact]
+    public void read_many_rejects_negative_batch_count()
+    {
+        var buffer = WriteInt32(-1);
+        Should.Throw<InvalidEnvelopeException>(() => EnvelopeSerializer.ReadMany(buffer))
+            .Message.ShouldContain("range");
+    }
+
+    [Fact]
+    public void read_many_rejects_batch_count_impossible_for_buffer()
+    {
+        // 500 envelopes claimed (well under MaxBatchSize) but the buffer contains
+        // only the 4-byte count itself — impossible to fit 500 envelopes.
+        var buffer = WriteInt32(500);
+        Should.Throw<InvalidEnvelopeException>(() => EnvelopeSerializer.ReadMany(buffer))
+            .Message.ShouldContain("impossible");
+    }
+
+    [Fact]
+    public void deserialize_rejects_oversize_data_byte_count()
+    {
+        var buffer = WriteSingleEnvelopePrefix(
+            headerCount: 0,
+            byteCount: EnvelopeReaderLimits.Default.MaxDataSize + 1);
+        Should.Throw<InvalidEnvelopeException>(() => EnvelopeSerializer.Deserialize(buffer))
+            .Message.ShouldContain("data size");
+    }
+
+    [Fact]
+    public void deserialize_rejects_byte_count_beyond_remaining_buffer()
+    {
+        // byteCount is under the data-size cap but the buffer carries no trailing data bytes.
+        var buffer = WriteSingleEnvelopePrefix(headerCount: 0, byteCount: 1024);
+        Should.Throw<InvalidEnvelopeException>(() => EnvelopeSerializer.Deserialize(buffer))
+            .Message.ShouldContain("remain in the buffer");
+    }
+
+    [Fact]
+    public void deserialize_rejects_oversize_header_count()
+    {
+        var buffer = WriteSingleEnvelopePrefix(
+            headerCount: EnvelopeReaderLimits.Default.MaxHeaderCount + 1,
+            byteCount: 0);
+        Should.Throw<InvalidEnvelopeException>(() => EnvelopeSerializer.Deserialize(buffer))
+            .Message.ShouldContain("header count");
+    }
+
+    private static byte[] WriteInt32(int value)
+    {
+        using var ms = new MemoryStream();
+        using var bw = new BinaryWriter(ms);
+        bw.Write(value);
+        bw.Flush();
+        return ms.ToArray();
+    }
+
+    private static byte[] WriteSingleEnvelopePrefix(int headerCount, int byteCount)
+    {
+        using var ms = new MemoryStream();
+        using var bw = new BinaryWriter(ms);
+        bw.Write(DateTime.UtcNow.ToBinary()); // SentAt (int64)
+        bw.Write(headerCount);
+        bw.Write(byteCount);
+        bw.Flush();
+        return ms.ToArray();
+    }
+}

--- a/src/Testing/CoreTests/Serialization/EnvelopeSerializerGuardTests.cs
+++ b/src/Testing/CoreTests/Serialization/EnvelopeSerializerGuardTests.cs
@@ -6,8 +6,15 @@ using Xunit;
 namespace CoreTests.Serialization;
 
 [Collection("EnvelopeSerializerLimits")]
-public class EnvelopeSerializerGuardTests
+public class EnvelopeSerializerGuardTests : IDisposable
 {
+    public void Dispose()
+    {
+        // Reset so a test that mutates Limits cannot leak state to other tests
+        // in the collection.
+        EnvelopeSerializer.Limits = EnvelopeReaderLimits.Default;
+    }
+
     [Fact]
     public void default_limits_have_expected_values()
     {

--- a/src/Testing/CoreTests/Serialization/EnvelopeSerializerLimitsCollection.cs
+++ b/src/Testing/CoreTests/Serialization/EnvelopeSerializerLimitsCollection.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+namespace CoreTests.Serialization;
+
+[CollectionDefinition("EnvelopeSerializerLimits", DisableParallelization = true)]
+public class EnvelopeSerializerLimitsCollection;

--- a/src/Testing/CoreTests/Serialization/WolverineRuntimeLimitsWireupTests.cs
+++ b/src/Testing/CoreTests/Serialization/WolverineRuntimeLimitsWireupTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Runtime.Serialization;
+using Xunit;
+
+namespace CoreTests.Serialization;
+
+public class WolverineRuntimeLimitsWireupTests : IAsyncLifetime
+{
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync()
+    {
+        EnvelopeSerializer.Limits = EnvelopeReaderLimits.Default;
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task host_startup_publishes_configured_limits_to_envelope_serializer()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.MaxIncomingEnvelopeBatchSize = 4242;
+                opts.MaxIncomingEnvelopeDataSize = 9 * 1024 * 1024;
+                opts.MaxIncomingEnvelopeHeaderCount = 256;
+            })
+            .StartAsync();
+
+        EnvelopeSerializer.Limits.MaxBatchSize.ShouldBe(4242);
+        EnvelopeSerializer.Limits.MaxDataSize.ShouldBe(9 * 1024 * 1024);
+        EnvelopeSerializer.Limits.MaxHeaderCount.ShouldBe(256);
+    }
+
+    [Fact]
+    public async Task host_startup_with_default_options_leaves_default_limits()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(_ => { })
+            .StartAsync();
+
+        EnvelopeSerializer.Limits.ShouldBe(EnvelopeReaderLimits.Default);
+    }
+}

--- a/src/Testing/CoreTests/Serialization/WolverineRuntimeLimitsWireupTests.cs
+++ b/src/Testing/CoreTests/Serialization/WolverineRuntimeLimitsWireupTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace CoreTests.Serialization;
 
+[Collection("EnvelopeSerializerLimits")]
 public class WolverineRuntimeLimitsWireupTests : IAsyncLifetime
 {
     public Task InitializeAsync() => Task.CompletedTask;

--- a/src/Testing/CoreTests/Serialization/WolverineRuntimeLimitsWireupTests.cs
+++ b/src/Testing/CoreTests/Serialization/WolverineRuntimeLimitsWireupTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Wolverine.Runtime.Serialization;
+using Wolverine.Transports.Tcp;
 using Xunit;
 
 namespace CoreTests.Serialization;
@@ -13,6 +14,7 @@ public class WolverineRuntimeLimitsWireupTests : IAsyncLifetime
     public Task DisposeAsync()
     {
         EnvelopeSerializer.Limits = EnvelopeReaderLimits.Default;
+        WireProtocol.MaxFrameSize = WireProtocol.DefaultMaxFrameSize;
         return Task.CompletedTask;
     }
 
@@ -41,5 +43,19 @@ public class WolverineRuntimeLimitsWireupTests : IAsyncLifetime
             .StartAsync();
 
         EnvelopeSerializer.Limits.ShouldBe(EnvelopeReaderLimits.Default);
+        WireProtocol.MaxFrameSize.ShouldBe(WireProtocol.DefaultMaxFrameSize);
+    }
+
+    [Fact]
+    public async Task host_startup_publishes_configured_tcp_frame_size_to_wire_protocol()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.MaxIncomingTcpFrameSize = 7 * 1024 * 1024;
+            })
+            .StartAsync();
+
+        WireProtocol.MaxFrameSize.ShouldBe(7 * 1024 * 1024);
     }
 }

--- a/src/Testing/CoreTests/Transports/Tcp/WireProtocolFrameLimitTests.cs
+++ b/src/Testing/CoreTests/Transports/Tcp/WireProtocolFrameLimitTests.cs
@@ -1,0 +1,97 @@
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine.Runtime.Serialization;
+using Wolverine.Transports.Tcp;
+using Xunit;
+
+namespace CoreTests.Transports.Tcp;
+
+[Collection("EnvelopeSerializerLimits")]
+public class WireProtocolFrameLimitTests
+{
+    [Fact]
+    public async Task receive_async_rejects_oversize_frame_length()
+    {
+        // Arrange: a stream whose first 4 bytes encode int.MaxValue —
+        // well above WireProtocol.MaxFrameSize (32 MiB).
+        // ReceiveAsync should catch the InvalidEnvelopeException thrown by the
+        // guard, write SerializationFailureBuffer to the stream, and return
+        // normally — without ever attempting to allocate int.MaxValue bytes.
+        var originalMaxFrameSize = WireProtocol.MaxFrameSize;
+        try
+        {
+            WireProtocol.MaxFrameSize = 32 * 1024 * 1024; // explicit 32 MiB for this test
+
+            var ms = new MemoryStream();
+            var writer = new BinaryWriter(ms);
+            writer.Write(int.MaxValue); // 4-byte hostile length prefix
+            writer.Flush();
+            ms.Position = 0;
+
+            var receiver = new Protocol.StubReceiverCallback();
+
+            // Act: should NOT throw — the catch block handles InvalidEnvelopeException
+            // and writes SerializationFailureBuffer before returning.
+            await WireProtocol.ReceiveAsync(null!, NullLogger.Instance, ms, receiver);
+
+            // Assert: the bytes written after the initial 4-byte read are
+            // SerializationFailureBuffer.
+            var written = ms.ToArray().Skip(sizeof(int)).ToArray();
+            written.ShouldBe(WireProtocol.SerializationFailureBuffer);
+        }
+        finally
+        {
+            WireProtocol.MaxFrameSize = originalMaxFrameSize;
+        }
+    }
+
+    [Fact]
+    public async Task receive_async_rejects_negative_frame_length()
+    {
+        // Negative lengths (bit-pattern trick) must also be rejected.
+        var originalMaxFrameSize = WireProtocol.MaxFrameSize;
+        try
+        {
+            WireProtocol.MaxFrameSize = 32 * 1024 * 1024;
+
+            var ms = new MemoryStream();
+            var writer = new BinaryWriter(ms);
+            writer.Write(-1); // negative length
+            writer.Flush();
+            ms.Position = 0;
+
+            var receiver = new Protocol.StubReceiverCallback();
+
+            await WireProtocol.ReceiveAsync(null!, NullLogger.Instance, ms, receiver);
+
+            var written = ms.ToArray().Skip(sizeof(int)).ToArray();
+            written.ShouldBe(WireProtocol.SerializationFailureBuffer);
+        }
+        finally
+        {
+            WireProtocol.MaxFrameSize = originalMaxFrameSize;
+        }
+    }
+
+    [Fact]
+    public async Task receive_async_accepts_zero_length_frame()
+    {
+        // A zero-length frame is a valid ping / no-op that ReceiveAsync handles
+        // by returning immediately without error.
+        var ms = new MemoryStream();
+        var writer = new BinaryWriter(ms);
+        writer.Write(0); // zero length
+        writer.Flush();
+        ms.Position = 0;
+
+        var receiver = new Protocol.StubReceiverCallback();
+
+        // Should return without writing any response bytes.
+        await WireProtocol.ReceiveAsync(null!, NullLogger.Instance, ms, receiver);
+
+        // No response written — only the original 4 bytes exist.
+        ms.ToArray().Length.ShouldBe(sizeof(int));
+    }
+}

--- a/src/Testing/CoreTests/WolverineOptionsTests.cs
+++ b/src/Testing/CoreTests/WolverineOptionsTests.cs
@@ -11,9 +11,11 @@ using Wolverine.Configuration;
 using Wolverine.Configuration.Capabilities;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Routing;
+using Wolverine.Runtime.Serialization;
 using Wolverine.Transports;
 using Wolverine.Transports.Local;
 using Wolverine.Transports.Sending;
+using Wolverine.Transports.Tcp;
 using Xunit;
 
 namespace CoreTests;
@@ -26,6 +28,16 @@ public class WolverineOptionsTests
     public void publish_agent_events_should_be_false_by_default()
     {
         new WolverineOptions().Policies.PublishAgentEvents.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void envelope_reader_limit_defaults_match_the_record()
+    {
+        var opts = new WolverineOptions();
+        opts.MaxIncomingEnvelopeBatchSize.ShouldBe(EnvelopeReaderLimits.Default.MaxBatchSize);
+        opts.MaxIncomingEnvelopeDataSize.ShouldBe(EnvelopeReaderLimits.Default.MaxDataSize);
+        opts.MaxIncomingEnvelopeHeaderCount.ShouldBe(EnvelopeReaderLimits.Default.MaxHeaderCount);
+        opts.MaxIncomingTcpFrameSize.ShouldBe(WireProtocol.DefaultMaxFrameSize);
     }
 
     [Fact]

--- a/src/Wolverine/Runtime/Serialization/EnvelopeReaderLimits.cs
+++ b/src/Wolverine/Runtime/Serialization/EnvelopeReaderLimits.cs
@@ -1,0 +1,17 @@
+namespace Wolverine.Runtime.Serialization;
+
+/// <summary>
+/// Per-host caps applied by <see cref="EnvelopeSerializer"/> when reading
+/// inbound envelopes off the wire. The caps prevent attacker-controlled
+/// 32-bit length fields from driving multi-gigabyte allocations.
+/// </summary>
+public sealed record EnvelopeReaderLimits(
+    int MaxBatchSize,
+    int MaxDataSize,
+    int MaxHeaderCount)
+{
+    public static EnvelopeReaderLimits Default { get; } = new(
+        MaxBatchSize: 1_000,
+        MaxDataSize: 4 * 1024 * 1024,
+        MaxHeaderCount: 128);
+}

--- a/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
@@ -5,6 +5,12 @@ namespace Wolverine.Runtime.Serialization;
 
 public static class EnvelopeSerializer
 {
+    /// <summary>
+    /// Caps applied to inbound envelopes during deserialization. Defaults to
+    /// <see cref="EnvelopeReaderLimits.Default"/>.
+    /// </summary>
+    public static EnvelopeReaderLimits Limits { get; set; } = EnvelopeReaderLimits.Default;
+
     public static void ReadDataElement(Envelope env, string key, string value)
     {
         try
@@ -152,7 +158,24 @@ public static class EnvelopeSerializer
     {
         using var ms = new MemoryStream(buffer);
         using var br = new BinaryReader(ms);
+        var limits = Limits;
         var numberOfMessages = br.ReadInt32();
+        if (numberOfMessages < 0 || numberOfMessages > limits.MaxBatchSize)
+        {
+            throw new InvalidEnvelopeException(
+                $"Envelope batch size {numberOfMessages} is outside the allowed range [0..{limits.MaxBatchSize}].");
+        }
+
+        // Each envelope is at least ~16 bytes on the wire (SentAt int64 +
+        // headerCount int32 + byteCount int32). Reject claims that can't fit
+        // in the buffer we actually received.
+        const int MinBytesPerEnvelope = 16;
+        if ((long)numberOfMessages * MinBytesPerEnvelope > buffer.Length)
+        {
+            throw new InvalidEnvelopeException(
+                $"Envelope batch size {numberOfMessages} is impossible for a {buffer.Length}-byte buffer.");
+        }
+
         var messages = new Envelope[numberOfMessages];
         for (var i = 0; i < numberOfMessages; i++)
         {
@@ -174,15 +197,7 @@ public static class EnvelopeSerializer
         using var ms = new MemoryStream(buffer);
         using var br = new BinaryReader(ms);
         envelope.SentAt = DateTime.FromBinary(br.ReadInt64());
-        var headerCount = br.ReadInt32();
-
-        for (var j = 0; j < headerCount; j++)
-        {
-            ReadDataElement(envelope, br.ReadString(), br.ReadString());
-        }
-
-        var byteCount = br.ReadInt32();
-        envelope.Data = br.ReadBytes(byteCount);
+        readEnvelopeBody(br, envelope, Limits);
     }
 
     private static Envelope readSingle(BinaryReader br)
@@ -191,18 +206,39 @@ public static class EnvelopeSerializer
         {
             SentAt = DateTime.FromBinary(br.ReadInt64())
         };
+        readEnvelopeBody(br, msg, Limits);
+        return msg;
+    }
 
+    private static void readEnvelopeBody(BinaryReader br, Envelope envelope, EnvelopeReaderLimits limits)
+    {
         var headerCount = br.ReadInt32();
+        if (headerCount < 0 || headerCount > limits.MaxHeaderCount)
+        {
+            throw new InvalidEnvelopeException(
+                $"Envelope header count {headerCount} is outside the allowed range [0..{limits.MaxHeaderCount}].");
+        }
 
         for (var j = 0; j < headerCount; j++)
         {
-            ReadDataElement(msg, br.ReadString(), br.ReadString());
+            ReadDataElement(envelope, br.ReadString(), br.ReadString());
         }
 
         var byteCount = br.ReadInt32();
-        msg.Data = br.ReadBytes(byteCount);
+        if (byteCount < 0 || byteCount > limits.MaxDataSize)
+        {
+            throw new InvalidEnvelopeException(
+                $"Envelope data size {byteCount} bytes is outside the allowed range [0..{limits.MaxDataSize}].");
+        }
 
-        return msg;
+        var remaining = br.BaseStream.Length - br.BaseStream.Position;
+        if (byteCount > remaining)
+        {
+            throw new InvalidEnvelopeException(
+                $"Envelope claims {byteCount} bytes of data but only {remaining} remain in the buffer.");
+        }
+
+        envelope.Data = br.ReadBytes(byteCount);
     }
 
     public static byte[] Serialize(IList<Envelope> messages)

--- a/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
@@ -7,7 +7,11 @@ public static class EnvelopeSerializer
 {
     /// <summary>
     /// Caps applied to inbound envelopes during deserialization. Defaults to
-    /// <see cref="EnvelopeReaderLimits.Default"/>.
+    /// <see cref="EnvelopeReaderLimits.Default"/>. Wolverine publishes the
+    /// configured <see cref="WolverineOptions"/> values into this property
+    /// at host startup. The slot is process-global; when several Wolverine
+    /// hosts run in the same process, the last one to start determines the
+    /// active limits.
     /// </summary>
     public static EnvelopeReaderLimits Limits { get; set; } = EnvelopeReaderLimits.Default;
 

--- a/src/Wolverine/Runtime/Serialization/InvalidEnvelopeException.cs
+++ b/src/Wolverine/Runtime/Serialization/InvalidEnvelopeException.cs
@@ -1,0 +1,14 @@
+namespace Wolverine.Runtime.Serialization;
+
+/// <summary>
+/// Thrown by <see cref="EnvelopeSerializer"/> when an inbound payload declares
+/// a wire-format length that exceeds the configured limits or is otherwise
+/// inconsistent with the buffer. Transports map this to a deterministic
+/// 4xx-style failure rather than allowing an unbounded allocation to crash
+/// the host.
+/// </summary>
+public sealed class InvalidEnvelopeException : Exception
+{
+    public InvalidEnvelopeException(string message) : base(message) { }
+    public InvalidEnvelopeException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -10,6 +10,7 @@ using Wolverine.Configuration;
 using Wolverine.Persistence.Durability;
 using Wolverine.Runtime.Agents;
 using Wolverine.Runtime.Scheduled;
+using Wolverine.Runtime.Serialization;
 using Wolverine.Runtime.WorkerQueues;
 using Wolverine.Transports;
 using Wolverine.Transports.Local;
@@ -60,6 +61,14 @@ public partial class WolverineRuntime
             logCodeGenerationConfiguration();
 
             await ApplyAsyncExtensions();
+
+            // Run after async extensions (which may mutate the options) and
+            // before any listener is started so an early-arriving message
+            // can't race the publish.
+            EnvelopeSerializer.Limits = new EnvelopeReaderLimits(
+                MaxBatchSize: Options.MaxIncomingEnvelopeBatchSize,
+                MaxDataSize: Options.MaxIncomingEnvelopeDataSize,
+                MaxHeaderCount: Options.MaxIncomingEnvelopeHeaderCount);
 
             await _stores.Value.InitializeAsync();
 

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -14,6 +14,7 @@ using Wolverine.Runtime.Serialization;
 using Wolverine.Runtime.WorkerQueues;
 using Wolverine.Transports;
 using Wolverine.Transports.Local;
+using Wolverine.Transports.Tcp;
 using Wolverine.Util;
 
 namespace Wolverine.Runtime;
@@ -69,6 +70,7 @@ public partial class WolverineRuntime
                 MaxBatchSize: Options.MaxIncomingEnvelopeBatchSize,
                 MaxDataSize: Options.MaxIncomingEnvelopeDataSize,
                 MaxHeaderCount: Options.MaxIncomingEnvelopeHeaderCount);
+            WireProtocol.MaxFrameSize = Options.MaxIncomingTcpFrameSize;
 
             await _stores.Value.InitializeAsync();
 

--- a/src/Wolverine/Transports/Tcp/WireProtocol.cs
+++ b/src/Wolverine/Transports/Tcp/WireProtocol.cs
@@ -28,13 +28,20 @@ public static class WireProtocol
     public static byte[] RevertBuffer = Encoding.Unicode.GetBytes(Revert);
 
     /// <summary>
+    /// Default value for <see cref="MaxFrameSize"/> and
+    /// <see cref="WolverineOptions.MaxIncomingTcpFrameSize"/> — 32 MiB.
+    /// Sourcing both initializers from this constant prevents drift.
+    /// </summary>
+    public const int DefaultMaxFrameSize = 32 * 1024 * 1024;
+
+    /// <summary>
     /// Maximum total byte size of a single inbound TCP frame. Defaults to
     /// 32 MiB. Wolverine publishes the configured
     /// <see cref="WolverineOptions.MaxIncomingTcpFrameSize"/> value into this
     /// property at host startup. Process-global; in a multi-host process the
     /// last host to start determines the active cap.
     /// </summary>
-    public static int MaxFrameSize { get; set; } = 32 * 1024 * 1024;
+    public static int MaxFrameSize { get; set; } = DefaultMaxFrameSize;
 
     // Nothing but actually sending here. Worry about timeouts and retries somewhere
     // else

--- a/src/Wolverine/Transports/Tcp/WireProtocol.cs
+++ b/src/Wolverine/Transports/Tcp/WireProtocol.cs
@@ -27,6 +27,15 @@ public static class WireProtocol
     public static byte[] AcknowledgedBuffer = Encoding.Unicode.GetBytes(Acknowledged);
     public static byte[] RevertBuffer = Encoding.Unicode.GetBytes(Revert);
 
+    /// <summary>
+    /// Maximum total byte size of a single inbound TCP frame. Defaults to
+    /// 32 MiB. Wolverine publishes the configured
+    /// <see cref="WolverineOptions.MaxIncomingTcpFrameSize"/> value into this
+    /// property at host startup. Process-global; in a multi-host process the
+    /// last host to start determines the active cap.
+    /// </summary>
+    public static int MaxFrameSize { get; set; } = 32 * 1024 * 1024;
+
     // Nothing but actually sending here. Worry about timeouts and retries somewhere
     // else
     public static async Task SendAsync(Stream stream, OutgoingMessageBatch batch, byte[]? messageBytes,
@@ -69,6 +78,12 @@ public static class WireProtocol
         {
             var lengthBytes = await stream.ReadBytesAsync(sizeof(int));
             var length = BitConverter.ToInt32(lengthBytes, 0);
+            if (length < 0 || length > MaxFrameSize)
+            {
+                throw new InvalidEnvelopeException(
+                    $"TCP frame length {length} is outside the allowed range [0..{MaxFrameSize}].");
+            }
+
             if (length == 0)
             {
                 return;

--- a/src/Wolverine/WolverineOptions.Serialization.cs
+++ b/src/Wolverine/WolverineOptions.Serialization.cs
@@ -38,6 +38,16 @@ public sealed partial class WolverineOptions
         = EnvelopeReaderLimits.Default.MaxHeaderCount;
 
     /// <summary>
+    /// Maximum total byte size of a single inbound TCP transport frame
+    /// (one batch of envelopes). Defaults to 32 MiB. The TCP receive path
+    /// reads a 4-byte length prefix and allocates that many bytes before
+    /// individual envelope contents are parsed; the cap prevents an
+    /// attacker-controlled length from driving a multi-gigabyte allocation
+    /// before the per-envelope guards can fire.
+    /// </summary>
+    public int MaxIncomingTcpFrameSize { get; set; } = 32 * 1024 * 1024;
+
+    /// <summary>
     ///     Override or get the default message serializer for the application. The default is
     ///     <see cref="SystemTextJsonSerializer"/> (wired in the <see cref="WolverineOptions"/>
     ///     constructor via <see cref="UseSystemTextJsonForSerialization"/>). To restore the

--- a/src/Wolverine/WolverineOptions.Serialization.cs
+++ b/src/Wolverine/WolverineOptions.Serialization.cs
@@ -12,6 +12,32 @@ public sealed partial class WolverineOptions
     private IMessageSerializer? _defaultSerializer;
 
     /// <summary>
+    /// Maximum number of envelopes accepted in a single inbound batch payload
+    /// (HTTP batch endpoint, TCP wire protocol, Pub/Sub batch, etc.). Defaults
+    /// to 1000. Raise this for high-throughput batch consumers that legitimately
+    /// move batches larger than the default.
+    /// </summary>
+    public int MaxIncomingEnvelopeBatchSize { get; set; }
+        = EnvelopeReaderLimits.Default.MaxBatchSize;
+
+    /// <summary>
+    /// Maximum size in bytes of an individual envelope's payload data segment.
+    /// Defaults to 4 MiB. Raise this if you legitimately move large payloads
+    /// (e.g. embedded blobs) over the wire protocol.
+    /// </summary>
+    public int MaxIncomingEnvelopeDataSize { get; set; }
+        = EnvelopeReaderLimits.Default.MaxDataSize;
+
+    /// <summary>
+    /// Maximum number of headers an inbound envelope may declare. Defaults to
+    /// 128. Headers are key/value string pairs read off the wire; the cap
+    /// prevents an attacker-controlled count from driving an unbounded loop
+    /// of small allocations.
+    /// </summary>
+    public int MaxIncomingEnvelopeHeaderCount { get; set; }
+        = EnvelopeReaderLimits.Default.MaxHeaderCount;
+
+    /// <summary>
     ///     Override or get the default message serializer for the application. The default is
     ///     <see cref="SystemTextJsonSerializer"/> (wired in the <see cref="WolverineOptions"/>
     ///     constructor via <see cref="UseSystemTextJsonForSerialization"/>). To restore the

--- a/src/Wolverine/WolverineOptions.Serialization.cs
+++ b/src/Wolverine/WolverineOptions.Serialization.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using JasperFx.Core;
 using Wolverine.Runtime.Serialization;
+using Wolverine.Transports.Tcp;
 
 namespace Wolverine;
 
@@ -45,7 +46,7 @@ public sealed partial class WolverineOptions
     /// attacker-controlled length from driving a multi-gigabyte allocation
     /// before the per-envelope guards can fire.
     /// </summary>
-    public int MaxIncomingTcpFrameSize { get; set; } = 32 * 1024 * 1024;
+    public int MaxIncomingTcpFrameSize { get; set; } = WireProtocol.DefaultMaxFrameSize;
 
     /// <summary>
     ///     Override or get the default message serializer for the application. The default is


### PR DESCRIPTION
# Bound attacker-controlled length fields in `EnvelopeSerializer` and TCP transport

Closes #2843.

## Summary

Three deserialize sinks in `EnvelopeSerializer` (`ReadMany`, `readSingle`, `ReadEnvelopeData`) and the outer TCP-frame read in `WireProtocol.ReceiveAsync` each took a 32-bit signed length straight off the wire and allocated against it with no bound check, so a 4–17 byte payload could request a multi-GiB allocation and crash the host with `OutOfMemoryException`. This PR validates each of those length fields against a configurable ceiling before the allocation, throws `InvalidEnvelopeException` on violation, exposes the ceilings on `WolverineOptions`, and maps malformed transport input to HTTP 400 / the existing TCP serialization-failure response instead of letting the deserializer crash the request. The serialize path is unchanged.

## What this PR changes

**Core guards in `EnvelopeSerializer`** (`src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs`)

Validates `numberOfMessages` (batch count), per-envelope `byteCount` (data length), and per-envelope `headerCount` against configurable caps before any size-dependent allocation. Cross-checks `numberOfMessages` against `data.Length / minBytesPerEnvelope` so a forged-but-under-cap value cannot allocate beyond the buffer that was actually received; cross-checks `byteCount` against bytes remaining in the buffer. Violations throw `InvalidEnvelopeException` rather than letting `new Envelope[…]` / `new byte[…]` fail with OOM. The active caps live on a single struct `EnvelopeReaderLimits` exposed through `EnvelopeSerializer.Limits`.

**Configurable limits on `WolverineOptions`** (`src/Wolverine/WolverineOptions.Serialization.cs`)

Four new properties:

- `MaxIncomingEnvelopeBatchSize` — default `1000` envelopes per batch
- `MaxIncomingEnvelopeDataSize` — default `4 * 1024 * 1024` (4 MiB) per envelope data segment
- `MaxIncomingEnvelopeHeaderCount` — default `128` headers per envelope
- `MaxIncomingTcpFrameSize` — default `32 * 1024 * 1024` (32 MiB) per outer TCP frame

`WolverineRuntime.HostService.StartAsync` publishes the configured values into `EnvelopeSerializer.Limits` and `WireProtocol.MaxFrameSize` after async extensions have had a chance to mutate options and before any listener is activated, so high-throughput batch consumers can raise the caps without touching the statics directly. The statics are process-global; the property docs call out that in a multi-host process the last host to start wins.

**HTTP 400 for malformed envelopes** (`src/Http/Wolverine.Http/Transport/HttpTransportExecutor.cs`)

`ExecuteBatchAsync` and `InvokeAsync` previously caught every deserialize exception and returned 500. Malformed payloads from external callers are client errors, so `InvalidEnvelopeException` now maps to 400 with a sanitized `"Invalid envelope: <reason>"` body and is logged at Warning. Genuine server-side deserialization failures continue to log at Error and return 500. The previously unwrapped `EnvelopeSerializer.Deserialize` call in `InvokeAsync` is now inside the same try/catch so it cannot escape into the ASP.NET pipeline.

**TCP outer-frame guard** (`src/Wolverine/Transports/Tcp/WireProtocol.cs`)

`ReceiveAsync` reads its 4-byte length prefix before `EnvelopeSerializer` ever sees the bytes, so the central guards above cannot protect it. The wire-supplied length is now validated against `WireProtocol.MaxFrameSize` (sourced from `WolverineOptions.MaxIncomingTcpFrameSize`) before `stream.ReadBytesAsync(length)`; out-of-range values throw `InvalidEnvelopeException`, which the existing `catch` in `ReceiveAsync` handles by returning the standard `SerializationFailureBuffer` to the sender — no protocol change, no new client-visible failure code. A new `WireProtocol.DefaultMaxFrameSize` const keeps the option's initializer and the static's default in sync so they can't drift.

**Test hardening**

Tests that touch the process-global `EnvelopeSerializer.Limits` and `WireProtocol.MaxFrameSize` are pinned into a single non-parallel xUnit collection (`EnvelopeSerializerLimitsCollection`) so they cannot race each other under default cross-class parallelism. `EnvelopeSerializerGuardTests` implements `IDisposable` to restore `Limits` after each test so a future test that lowers the caps cannot leak state to its neighbours in the collection.

## Configuration example

```csharp
builder.UseWolverine(opts =>
{
    // Raise caps for a high-throughput batch consumer
    opts.MaxIncomingEnvelopeBatchSize = 10_000;
    opts.MaxIncomingEnvelopeDataSize = 16 * 1024 * 1024; // 16 MiB
    opts.MaxIncomingTcpFrameSize     = 256 * 1024 * 1024; // 256 MiB
});
```

## Behaviour changes (potentially user-visible)

- Inbound envelope batches with `numberOfMessages > MaxIncomingEnvelopeBatchSize`, envelope data segments larger than `MaxIncomingEnvelopeDataSize`, or envelopes with more than `MaxIncomingEnvelopeHeaderCount` headers are now rejected with `InvalidEnvelopeException` rather than being deserialized. Existing applications that exchanged envelopes above these defaults need to raise the corresponding option.
- The HTTP transport endpoints `POST /_wolverine/batch/{queue}` and `POST /_wolverine/invoke` now return `400 Bad Request` (instead of `500 Internal Server Error`) when the body is not a valid envelope.
- TCP frames whose 4-byte length prefix exceeds `MaxIncomingTcpFrameSize` (default 32 MiB) cause the listener to return the standard `FailDesr` response to the sender instead of crashing. Hosts that previously relied on accepting larger frames need to raise the option.

## Out of scope

- The serialize side of `EnvelopeSerializer` is intentionally untouched — sending hosts continue to write whatever shape they did before, so the change is wire-compatible.
- No transport protocol bump and no new client-visible failure codes; existing senders see the existing failure responses.