### PR TITLE
docs(codegen): recover Marten DevOps Dockerfile + 'codegen write' guidance (#2846)

### DIFF
--- a/docs/guide/codegen.md
+++ b/docs/guide/codegen.md
@@ -193,11 +193,68 @@ Adopting `opts.UseRuntimeCompilation()` today makes the v6 upgrade a no-op for y
 
 ## Embedding Codegen in Docker
 
-This blog post from Oskar Dudycz will apply to Wolverine as well: [How to create a Docker image for the Marten application](https://event-driven.io/en/marten_and_docker/)
+The sweet spot for production deployments is `Dynamic` codegen at development time, then pre-generated code artifacts baked into the production image so cold start never pays the runtime-codegen cost. A multi-stage Dockerfile that runs `dotnet run -- codegen write` in the build stage gets you there.
 
-At this point, the most successful mechanism and sweet spot is to run the codegen as `Dynamic` at development time, but generating
-the code artifacts just in time for production deployments. From Wolverine's sibling project Marten, see this section on [Application project setup](https://martendb.io/devops/devops.html#application-project-set-up)
-for embedding the code generation directly into your Docker images for deployment.
+### Wire up the CLI command
+
+`dotnet run -- codegen write` is provided by the JasperFx command-line integration that ships with Wolverine. The last line of your `Program.cs` needs to hand control to it:
+
+```csharp
+return await app.RunJasperFxCommands(args);
+```
+
+Without this, the `codegen write` verb is unreachable and the build-stage step below will fail.
+
+### A multi-stage Dockerfile
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
+WORKDIR /src
+
+COPY ["Application/Application.csproj", "Application/"]
+
+# Add more COPY lines for any project references your app needs
+# COPY ["Shared/Shared.csproj", "Shared/"]
+
+COPY . .
+WORKDIR "/src/Application"
+
+# Pre-generate Wolverine handler / endpoint adapter code into
+# Application/Internal/Generated/ so the production image ships static C#
+# instead of compiling at boot. Pair with TypeLoadMode.Static in production.
+RUN dotnet run -- codegen write
+RUN dotnet publish "Application.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine AS runtime
+ENV DOTNET_RUNNING_IN_CONTAINER=1
+ENV DOTNET_NOLOGO=1
+ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+RUN addgroup -g 1001 -S nonroot && adduser -u 1001 -S nonroot -G nonroot
+RUN mkdir /app
+RUN chown nonroot:nonroot /app
+WORKDIR /app
+COPY --chown=nonroot:nonroot --from=build /app/publish .
+
+FROM runtime
+EXPOSE 5000
+USER nonroot
+ENTRYPOINT ["dotnet", "Application.dll"]
+```
+
+The base image tags above (`9.0-alpine`) match Wolverine 6.0's minimum TFM (`net9.0`). Pick whichever LTS your app targets — `10.0-alpine` works the same way once you're on `net10.0`.
+
+### The `codegen write` step has no runtime resources
+
+This is the constraint that bites people: `dotnet run -- codegen write` boots the host far enough to discover handlers and HTTP endpoints, then exits before serving traffic. If anything in your `Program.cs` reaches out to a database, broker, or other external resource _before_ control reaches `RunJasperFxCommands(args)`, the build-stage step will block or fail because none of that infrastructure is reachable from inside the Dockerfile's build container.
+
+Two ways to dodge it:
+
+1. **Defer infrastructure to hosted services / DI factories.** Things like `PersistMessagesWithPostgresql(...)`, transport listener registrations, and resource-setup-on-startup all defer their actual I/O to host startup — they're already safe. The trap is custom code in `Program.cs` that eagerly connects (e.g. an inline `await dataSource.OpenConnectionAsync()` before `app.Run()` / `RunJasperFxCommands`).
+2. **Detect the codegen verb and short-circuit external wiring.** Same pattern that works for Aspire — see [the Aspire / OpenAPI codegen section](#handling-code-generation-with-wolverine-when-using-aspire-or-microsoft-extensions-apidescription-server) below — wrap conditionally-disabled transports / persistence inside `if (CodeGeneration.IsRunningGeneration())` so the build-stage run skips them.
+
+### Beyond Static: Native AOT
+
+Pre-generated codegen is the prerequisite for publishing the app with Native AOT (`dotnet publish /p:PublishAot=true`). Once the Dockerfile above is producing a `Static`-mode image, the [AOT publishing guide](/guide/aot.md) covers the additional `IsAotCompatible` / trimmer-annotation pieces needed to shrink the production image further and skip the runtime-compilation pipeline entirely.
 
 ## Troubleshooting Code Generation Issues
 


### PR DESCRIPTION
## Summary

Closes #2846.

Marten 9.0 [removed its runtime code-generation pipeline entirely](https://github.com/JasperFx/marten/pull/4461), and the Marten 9.0 docs cleanup ([marten#4498](https://github.com/JasperFx/marten/pull/4498)) followed up by stripping the `dotnet run -- codegen write` Dockerfile section from Marten's DevOps page. That guidance no longer applies to Marten, but Wolverine still ships its own runtime codegen, so the multi-stage build pattern (pre-generate handler/endpoint adapters into `Internal/Generated/`, ship static C# in the production image) is directly applicable to Wolverine apps.

Replaces the placeholder \"Embedding Codegen in Docker\" section in `docs/guide/codegen.md` (which previously pointed at the now-removed Marten page) with the recovered guidance adapted for Wolverine.

## What the new section covers

- **Wire up the CLI command** — note that `return await app.RunJasperFxCommands(args);` is the last-line requirement to make `dotnet run -- codegen write` reachable.
- **Multi-stage Dockerfile** — full SDK → publish → runtime layout, base images bumped to `mcr.microsoft.com/dotnet/sdk:9.0-alpine` / `aspnet:9.0-alpine` to match Wolverine 6.0's minimum TFM. Includes the non-root user + `EXPOSE 5000` hygiene the Marten original had.
- **Caveat the issue called out** — \"The `codegen write` step has no runtime resources.\" Explains why eager DB/broker connections in `Program.cs` break the build-stage step, with two mitigations: defer to hosted services / DI factories, or use the `CodeGeneration.IsRunningGeneration()` short-circuit pattern that already lives further down the same page (cross-linked).
- **Cross-link to AOT** — points at `docs/guide/aot.md` for the trim/AOT follow-on once a `Static`-mode image is in place.

## Doc home

Picked option #2 from the issue (\"new section inside existing `docs/guide/codegen.md`\") because:

1. The existing `## Embedding Codegen in Docker` H2 anchor was already cross-referenced from the `WolverineFx.RuntimeCompilation` section earlier in the page (`see [Embedding Codegen in Docker](#embedding-codegen-in-docker) below`). Replacing the section in place keeps that link working.
2. No new file means no Vitepress sidebar/nav change.
3. The topic is squarely a codegen-deployment concern, as the issue notes.

## Test plan
- [x] `git diff` clean — pure content swap inside the existing `## Embedding Codegen in Docker` section.
- [x] Existing cross-reference from line 182 still resolves to the same anchor (`#embedding-codegen-in-docker`).
- [ ] CI / docs preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)