### PR TITLE
Wolverine AOT pass: HTTP + integration extension packages (5 packages)

### DIFF
--- a/src/Http/Wolverine.Http.FluentValidation/Internals/HttpChainFluentValidationPolicy.cs
+++ b/src/Http/Wolverine.Http.FluentValidation/Internals/HttpChainFluentValidationPolicy.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using FluentValidation;
 using JasperFx;
 using JasperFx.CodeGeneration;
@@ -34,6 +35,8 @@ internal class HttpChainFluentValidationPolicy : IHttpPolicy
         }
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "MakeGenericType/MakeGenericMethod close FluentValidationHttpExecutor.ExecuteOne<T>/ExecuteMany<T> over the HTTP chain's request type at codegen time; AOT consumers pre-generate via TypeLoadMode.Static. Same pattern as Wolverine.FluentValidation's FluentValidationPolicy. See AOT guide / #2769.")]
     private static void addValidationMiddleware(HttpChain chain, IServiceContainer container, Type validatedType)
     {
         var validatorInterface = typeof(IValidator<>).MakeGenericType(validatedType);

--- a/src/Http/Wolverine.Http.FluentValidation/Wolverine.Http.FluentValidation.csproj
+++ b/src/Http/Wolverine.Http.FluentValidation/Wolverine.Http.FluentValidation.csproj
@@ -8,6 +8,7 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Http/Wolverine.Http.Marten/GlobalSuppressions.cs
+++ b/src/Http/Wolverine.Http.Marten/GlobalSuppressions.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics.CodeAnalysis;
+
+// AOT-pillar suppressions for Wolverine.Http.Marten (#2746).
+//
+// Wolverine.Http.Marten extends Wolverine.Http codegen with Marten-aware
+// frame providers — CompiledQueryWriterPolicy reflects over runtime
+// IQueryHandler<T> implementations at codegen time to wire Marten compiled
+// queries into HTTP endpoint result-writing. Same shape as the parent
+// Wolverine.Marten + Wolverine.Http packages, both already AOT-flagged.
+//
+// All IL warnings in this package are codegen-time reflection over user
+// compiled-query / aggregate / event types that are statically rooted via:
+//   - app-level handler discovery (chunks Q HandlerDiscovery RUC propagation)
+//   - explicit Marten document-store registration
+//   - HTTP endpoint discovery in MapWolverineEndpoints
+//
+// AOT-clean apps in TypeLoadMode.Static use pre-generated HTTP handler code
+// from `dotnet run codegen write` and bypass these frame providers entirely.
+
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2026",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http.Marten",
+    Justification = "Wolverine.Http.Marten codegen — closed-generic compiled-query helpers over user query / response types statically rooted via Marten registration. AOT consumers run pre-generated frames. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2072",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http.Marten",
+    Justification = "Wolverine.Http.Marten codegen — Variable.VariableType flow into Closes/FindInterfaceThatCloses; query/handler types statically rooted via Marten registration. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("AOT", "IL3050",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Http.Marten",
+    Justification = "Wolverine.Http.Marten codegen — closed generics over runtime compiled-query types at codegen time. See AOT guide.")]

--- a/src/Http/Wolverine.Http.Marten/Wolverine.Http.Marten.csproj
+++ b/src/Http/Wolverine.Http.Marten/Wolverine.Http.Marten.csproj
@@ -8,6 +8,7 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Http/Wolverine.Http.Polecat/Wolverine.Http.Polecat.csproj
+++ b/src/Http/Wolverine.Http.Polecat/Wolverine.Http.Polecat.csproj
@@ -10,6 +10,7 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Persistence/Wolverine.Polecat/GlobalSuppressions.cs
+++ b/src/Persistence/Wolverine.Polecat/GlobalSuppressions.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics.CodeAnalysis;
+
+// AOT-pillar suppressions for Wolverine.Polecat (#2746).
+//
+// Wolverine.Polecat is the SQL Server counterpart to Wolverine.Marten and has
+// the same shape: WriteAggregateAttribute, the AggregateHandling codegen
+// frames, EventWrapperForwarder, and the Subscriptions / PublishingRelay /
+// InlineInvoker entry points reflect over user aggregate / event types at
+// codegen time to bind Polecat session operations into the generated handler
+// pipeline. UpdatedAggregate inspects user strong-typed-id types via
+// ValueTypeInfo.ForType to discover the id shape.
+//
+// All IL warnings in this package are codegen-time discovery walks over user
+// aggregate / saga / event types that are statically rooted via:
+//   - app-level handler discovery (chunks Q HandlerDiscovery RUC propagation)
+//   - explicit Polecat registration via opts.UsePolecat / IntegrateWithPolecat
+//
+// AOT-clean apps in TypeLoadMode.Static use pre-generated handler code from
+// `dotnet run codegen write` and bypass the codegen frame providers entirely.
+// Apps using Dynamic codegen must preserve their aggregate / saga state /
+// event types via TrimmerRootDescriptor.
+//
+// Same namespace-scoped pattern as Wolverine.Marten — keeps the suppressions
+// in one file and survives codegen frame additions / aggregate-handler
+// refactors without sprinkling attributes across the package.
+
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2026",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Polecat",
+    Justification = "Wolverine.Polecat codegen — reflection over user aggregate / event types statically rooted via handler discovery + Polecat registration. AOT consumers run pre-generated frames. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2060",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Polecat",
+    Justification = "Wolverine.Polecat codegen — generic Polecat APIs (event-stream load / aggregate fetch) invoked over runtime aggregate types at codegen time. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2065",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Polecat",
+    Justification = "Wolverine.Polecat codegen — 'this' arg flow on reflective member lookups over runtime aggregate / event types. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2067",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Polecat",
+    Justification = "Wolverine.Polecat codegen — aggregate / event types statically rooted via handler discovery + Polecat registration. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2070",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Polecat",
+    Justification = "Wolverine.Polecat codegen — GetMethods / GetProperties walks over user aggregate types statically rooted via handler discovery. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2072",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Polecat",
+    Justification = "Wolverine.Polecat codegen — return-type metadata flow through codegen helpers; user types statically rooted via handler discovery. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2075",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Polecat",
+    Justification = "Wolverine.Polecat codegen — member walks over runtime aggregate types at codegen time. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2091",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Polecat",
+    Justification = "Wolverine.Polecat codegen — generic argument T flows to a [DAM]-annotated target; T is statically rooted via Polecat registration. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("AOT", "IL3050",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Polecat",
+    Justification = "Wolverine.Polecat codegen — closed generics over runtime aggregate / event types at codegen time. See AOT guide.")]

--- a/src/Persistence/Wolverine.Polecat/Wolverine.Polecat.csproj
+++ b/src/Persistence/Wolverine.Polecat/Wolverine.Polecat.csproj
@@ -9,6 +9,7 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Wolverine.SqlServer\Wolverine.SqlServer.csproj" />

--- a/src/Wolverine.HealthChecks/Wolverine.HealthChecks.csproj
+++ b/src/Wolverine.HealthChecks/Wolverine.HealthChecks.csproj
@@ -9,6 +9,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Drops the smaller half of the remaining Wolverine AOT-flag pass — five extension packages where each is a sibling of an already-flagged package. Same shape, same precedent (Wolverine.Marten ✅, Wolverine.FluentValidation ✅, Wolverine.Http ✅, plus the earlier #2789–#2803 chunks AE–AL pass).

The larger half (serializer + transport extensions: MemoryPack, MessagePack, Protobuf, Grpc, ClaimCheck.AmazonS3 / AzureBlobStorage, CosmosDb) is the sibling chip and lands separately.

Sequenced after #2848 (foundation re-align) merged so the alpha matrix baseline is JasperFx.Events 2.0-alpha.16 / Marten 9.0-alpha.4 / Polecat 4.0-alpha.8 / Weasel 9.0-alpha.6.

## Per-package outcome

| Package | IsAotCompatible | Notes |
|---|---|---|
| Wolverine.HealthChecks | true | **Clean, no annotations.** Tiny shim over `Microsoft.Extensions.Diagnostics.HealthChecks` (themselves AOT-clean). No reflective surface. |
| Wolverine.Polecat | true (annotated) | 162 IL warnings across IL2026/IL2060/IL2065/IL2067/IL2070/IL2072/IL2075/IL2091/IL3050 — all codegen-time reflection over user aggregate / event types. Added `GlobalSuppressions.cs` with namespace-scoped `[UnconditionalSuppressMessage]` block targeting `~N:Wolverine.Polecat`, **mirroring Wolverine.Marten's GlobalSuppressions.cs pattern** verbatim. |
| Wolverine.Http.Marten | true (annotated) | 12 IL warnings across IL2026/IL2072/IL3050 in `CompiledQueryWriterPolicy` (HTTP codegen reflecting over Marten compiled-query types). Added `GlobalSuppressions.cs` with the same namespace-scoped pattern, target `~N:Wolverine.Http.Marten`. |
| Wolverine.Http.Polecat | true | **Clean, no annotations.** All reflective codegen lives in the referenced Wolverine.Polecat package which is suppressed at its own namespace. |
| Wolverine.Http.FluentValidation | true (annotated) | 6 IL3050 warnings on `HttpChainFluentValidationPolicy.addValidationMiddleware` where `IValidator<T>.MakeGenericType` + `ExecuteOne<T>/ExecuteMany<T>.MakeGenericMethod` close the validation middleware over the HTTP chain's request type. Method-level `[UnconditionalSuppressMessage(\"AOT\", \"IL3050\")]` matching the parent **Wolverine.FluentValidation's `FluentValidationPolicy` annotation style** (method-level rather than namespace-scoped). |

## Test plan

- [x] `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors)
- [x] `dotnet build src/Testing/Wolverine.AotSmoke` clean
- [x] `dotnet build src/Testing/Wolverine.AotSmoke.Static` clean
- [ ] CI / `./build.sh CIAotSmoke`

## Notes on style choice

Wolverine has two AOT-suppression precedents:
1. **Namespace-scoped `GlobalSuppressions.cs`** with `[UnconditionalSuppressMessage(Scope = \"namespaceanddescendants\", Target = \"~N:<Namespace>\")]` — used by Wolverine.Marten, Wolverine.Http, Wolverine.Http.Newtonsoft, Wolverine.AzureServiceBus/Emulator. Better when there are many distinct call sites across a package (e.g. Polecat's 162 warnings).
2. **Method-level `[UnconditionalSuppressMessage]`** on the specific reflective call site — used by Wolverine.FluentValidation's `FluentValidationPolicy`. Better when there's one concentrated reflective surface (e.g. Http.FluentValidation's 6 warnings all in one method).

This PR matches each package to its **parent's existing style** rather than picking one globally:
- Polecat / Http.Marten ← Wolverine.Marten style → namespace-scoped `GlobalSuppressions.cs`
- Http.FluentValidation ← Wolverine.FluentValidation style → method-level attribute

Note also: the chip recipe called for adding a per-csproj `<WarningsAsErrors>IL2026;…</WarningsAsErrors>` block, but `Directory.Build.props` already has `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` globally — that escalates every IL warning to error without a per-csproj declaration. Followed the chip's own \"don't duplicate if inheritance covers it\" guidance and skipped.

Refs #2715 (Wolverine 6.0 master plan), #2746 (AOT pillar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)