### PR TITLE
Wolverine AOT pass: serializer + transport extension packages (8 packages)

### DIFF
--- a/src/Extensions/Wolverine.FluentValidation.Grpc/Wolverine.FluentValidation.Grpc.csproj
+++ b/src/Extensions/Wolverine.FluentValidation.Grpc/Wolverine.FluentValidation.Grpc.csproj
@@ -8,6 +8,7 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Extensions/Wolverine.MemoryPack/Wolverine.MemoryPack.csproj
+++ b/src/Extensions/Wolverine.MemoryPack/Wolverine.MemoryPack.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Description>MemoryPack serialization for Wolverine Applications</Description>
         <PackageId>WolverineFx.MemoryPack</PackageId>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Extensions/Wolverine.MessagePack/Wolverine.MessagePack.csproj
+++ b/src/Extensions/Wolverine.MessagePack/Wolverine.MessagePack.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Description>MessagePack serialization for Wolverine Applications</Description>
         <PackageId>WolverineFx.MessagePack</PackageId>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Extensions/Wolverine.Protobuf/Internal/ProtobufMessageSerializer.cs
+++ b/src/Extensions/Wolverine.Protobuf/Internal/ProtobufMessageSerializer.cs
@@ -1,4 +1,5 @@
-﻿using Google.Protobuf;
+﻿using System.Diagnostics.CodeAnalysis;
+using Google.Protobuf;
 
 using Wolverine.Runtime.Serialization;
 
@@ -10,6 +11,8 @@ internal class ProtobufMessageSerializer(ProtobufSerializerOptions options) : IM
     private readonly ProtobufSerializerOptions _options = options;
     public string ContentType => "binary/protobuf";
 
+    [UnconditionalSuppressMessage("Trimming", "IL2067",
+        Justification = "messageType is a Wolverine-handler-discovered IMessage type — statically rooted via HandlerDiscovery + the registration boundary. Generated protobuf message classes have a public parameterless constructor by design (Google.Protobuf code-gen contract).")]
     public object ReadFromData(Type messageType, Envelope envelope)
     {
         if (envelope?.Data == null || envelope.Data.Length == 0)

--- a/src/Extensions/Wolverine.Protobuf/Wolverine.Protobuf.csproj
+++ b/src/Extensions/Wolverine.Protobuf/Wolverine.Protobuf.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<Description>Protobuf serialization for Wolverine Applications</Description>
 		<PackageId>WolverineFx.Protobuf</PackageId>
+		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Persistence/Wolverine.ClaimCheck.AmazonS3/Wolverine.ClaimCheck.AmazonS3.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.AmazonS3/Wolverine.ClaimCheck.AmazonS3.csproj
@@ -8,6 +8,7 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage/Wolverine.ClaimCheck.AzureBlobStorage.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage/Wolverine.ClaimCheck.AzureBlobStorage.csproj
@@ -8,6 +8,7 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Persistence/Wolverine.CosmosDb/Wolverine.CosmosDb.csproj
+++ b/src/Persistence/Wolverine.CosmosDb/Wolverine.CosmosDb.csproj
@@ -8,6 +8,30 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          NOT AOT-compatible (#2746).
+
+          Wolverine.CosmosDb is built around the C# `dynamic` keyword for
+          interacting with Cosmos DB's flexible-schema documents — the
+          MessageStore admin and durability agent flows use Container.
+          GetItemQueryIterator<dynamic> + per-item member access via the
+          DLR (Microsoft.CSharp.RuntimeBinder.Binder.GetMember/SetMember/
+          InvokeMember). `dynamic` requires runtime call-site generation,
+          which is fundamentally incompatible with Native AOT — there is
+          no annotation that makes this surface AOT-clean.
+
+          Flag-off matches the precedent set by Marten.Newtonsoft
+          (Marten PR #4468): when a wrapper's whole purpose is the
+          AOT-hostile upstream/runtime feature and there's no meaningful
+          AOT-clean subset, the honest answer is unflagged + documented
+          rather than suppressed-into-silence.
+
+          AOT-publishing applications that need Cosmos DB envelope storage
+          should either (a) shape envelope persistence around the typed
+          Microsoft.Azure.Cosmos<T> APIs instead of dynamic, or (b) use
+          one of the typed RDBMS / Marten / Polecat persistence packages
+          which are AOT-flagged.
+        -->
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wolverine.Grpc/GlobalSuppressions.cs
+++ b/src/Wolverine.Grpc/GlobalSuppressions.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics.CodeAnalysis;
+
+// AOT-pillar suppressions for Wolverine.Grpc (#2746).
+//
+// Wolverine.Grpc is a runtime-codegen + service-discovery package:
+//   - CodeFirstGrpcServiceChain / HandWrittenGrpcServiceChain / GrpcServiceChain
+//     close gRPC service-contract types over user message types at codegen
+//     time, emitting stub classes via JasperFx.CodeGeneration's
+//     GeneratedAssembly.AddType(name, baseType).
+//   - WolverineGrpcExtensions uses MakeGenericMethod to wire transport
+//     registration over discovered service-contract types.
+//   - GrpcGraph builds OptionsDescription instances for diagnostic surfaces
+//     (reflects over property metadata of user contract types).
+//
+// All IL warnings in this package are codegen-time / service-discovery
+// reflection over user gRPC service-contract types that are statically rooted
+// via:
+//   - explicit MapWolverineGrpc / AddGrpcEndpoints registration
+//   - the protobuf-net.Grpc + Grpc.AspNetCore code-first / contract-first
+//     service definitions (themselves AOT-friendly when consumers follow
+//     the Grpc.Tools source-gen path)
+//
+// AOT-clean apps in TypeLoadMode.Static use pre-generated service stubs from
+// `dotnet run codegen write` and bypass these chain providers entirely.
+// Apps using Dynamic codegen must preserve their gRPC service-contract types
+// + their generated message classes via TrimmerRootDescriptor.
+//
+// Same namespace-scoped pattern as Wolverine.Marten / Wolverine.Polecat —
+// keeps the suppressions in one file rather than sprinkling attributes
+// across the codegen chain providers.
+
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2026",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Grpc",
+    Justification = "Wolverine.Grpc codegen — JasperFx OptionsDescription diagnostic surface reflects over service-contract properties; service types statically rooted via gRPC registration. AOT consumers run pre-generated frames. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2060",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Grpc",
+    Justification = "Wolverine.Grpc codegen — MakeGenericMethod closes transport-registration helpers over user service-contract types statically rooted via registration. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2070",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Grpc",
+    Justification = "Wolverine.Grpc codegen — GetMethods walks over user service-contract types statically rooted via gRPC registration. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2072",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Grpc",
+    Justification = "Wolverine.Grpc codegen — service-contract Type flow into GeneratedAssembly.AddType(name, baseType); base types statically rooted via gRPC registration. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2075",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Grpc",
+    Justification = "Wolverine.Grpc codegen — member walks over runtime service-contract types at codegen time. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2091",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Grpc",
+    Justification = "Wolverine.Grpc codegen — generic argument T flows to a [DAM]-annotated target; T is statically rooted via gRPC service registration. See AOT guide.")]
+[assembly: UnconditionalSuppressMessage("AOT", "IL3050",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Wolverine.Grpc",
+    Justification = "Wolverine.Grpc codegen — MakeGenericMethod over runtime service-contract types at codegen time. See AOT guide.")]

--- a/src/Wolverine.Grpc/Wolverine.Grpc.csproj
+++ b/src/Wolverine.Grpc/Wolverine.Grpc.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Description>Code-first and proto-first gRPC service support for Wolverine, including gRPC message transport</Description>
         <PackageId>WolverineFx.Grpc</PackageId>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Closes the bulk of the remaining Wolverine AOT-flag pass — the harder cohort of 8 extension packages. Pair to PR #2851 (HTTP + integrations, just merged). After this lands, **`Wolverine.RuntimeCompilation` is the only intentionally unflagged packaged lib** (it depends on Roslyn — AOT-hostile by design, opt-in for production drop).

## Per-package outcome

| Package | IsAotCompatible | Notes |
|---|---|---|
| Wolverine.MemoryPack | true | **Clean, no annotations.** MemoryPack is source-generator-driven; AOT-friendly by design. |
| Wolverine.MessagePack | true | **Clean, no wrapper annotations needed.** Thin IMessageSerializer over MessagePackSerializer's typed API. MessagePack-CSharp's reflection-based path carries its own [RequiresDynamicCode] and propagates through the standard chain. |
| Wolverine.Protobuf | true (annotated) | 2 IL2067 warnings on `ProtobufMessageSerializer.ReadFromData` where `Activator.CreateInstance(messageType)` is invoked over an unannotated `Type` parameter (the `IMessageSerializer` interface signature doesn't carry `[DAM]`). Method-level `[UnconditionalSuppressMessage("Trimming", "IL2067")]` with a justification naming Wolverine handler discovery + the Google.Protobuf code-gen contract (generated message classes have a public parameterless constructor). |
| Wolverine.Grpc | true (annotated) | 82 IL warnings across IL2026/IL2060/IL2070/IL2072/IL2075/IL2091/IL3050 in CodeFirstGrpcServiceChain / HandWrittenGrpcServiceChain / GrpcServiceChain / WolverineGrpcExtensions / GrpcGraph — all codegen-time reflection over user gRPC service-contract types. Namespace-scoped `GlobalSuppressions.cs` targeting `~N:Wolverine.Grpc`, matching the Wolverine.Marten / Wolverine.Polecat pattern. |
| Wolverine.FluentValidation.Grpc | true | **Clean, no annotations.** Bridge package that wires FluentValidation rule discovery into gRPC rich error details. Both referenced packages (Wolverine.Grpc, Wolverine.FluentValidation) handle their own AOT contracts. |
| **Wolverine.CosmosDb** | **false (documented)** | **Flag-off, with rationale.** Trial flag-on surfaced 31 IL2026/IL3050 warnings from `Microsoft.CSharp.RuntimeBinder.Binder.GetMember/SetMember/InvokeMember` — the wrapper uses `dynamic` throughout `CosmosDbMessageStore.Admin` + `CosmosDbDurabilityAgent.{Incoming,Outgoing}` to interact with Cosmos DB's flexible-schema documents. `dynamic` requires runtime call-site generation and is structurally incompatible with Native AOT — there is no annotation that makes this surface AOT-clean. Csproj carries a documented `<!-- NOT AOT-compatible -->` block matching the Marten.Newtonsoft precedent (Marten PR #4468). |
| Wolverine.ClaimCheck.AmazonS3 | true | **Clean, no annotations.** Thin claim-check store over typed AWSSDK.S3 GetObject/PutObject/DeleteObject calls (`byte[]` payloads keyed by string). |
| Wolverine.ClaimCheck.AzureBlobStorage | true | **Clean, no annotations.** Same shape as the AmazonS3 sibling; typed Azure.Storage.Blobs BlobClient Upload/Download/Delete. |

**7 packages flagged on (3 with annotations), 1 explicitly flagged off with documented rationale.**

## Style choices

Followed the parent-precedent pattern set in PR #2851:

- **Namespace-scoped `GlobalSuppressions.cs`** when a package has substantial reflective surface across multiple files (Wolverine.Grpc — 82 warnings across 5 files).
- **Method-level `[UnconditionalSuppressMessage]`** when a package has a single concentrated reflective site (Wolverine.Protobuf — 2 warnings in one method on the `IMessageSerializer.ReadFromData(Type, …)` interface seam).

The flag-off precedent (Wolverine.CosmosDb) follows Marten.Newtonsoft's posture verbatim: a wrapper whose entire purpose is the AOT-hostile feature (here, `dynamic` member access over Cosmos DB's flexible-schema documents) gets unflagged with a documented `<!-- NOT AOT-compatible -->` comment block and a forward pointer to AOT-friendly alternatives (typed RDBMS/Marten/Polecat persistence) for downstream consumers.

## Test plan

- [x] `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors)
- [x] `dotnet build src/Testing/Wolverine.AotSmoke -c Release` clean
- [x] `dotnet build src/Testing/Wolverine.AotSmoke.Static -c Release` clean
- [ ] CI / `./build.sh CIAotSmoke`

## Sequencing note

The chip specified \"drop this chip after the foundation re-pin merges AND after the HTTP+integrations chip lands.\" Both are satisfied — #2848 merged as `ee1dcf47f`, #2851 merged as `7c27bd659`. This work was built against that combined baseline (JasperFx 2.0-alpha.17 / Marten 9.0-alpha.4 / Polecat 4.0-alpha.8 / Weasel 9.0-alpha.6 + 5 newly-flagged HTTP+integration packages).

## State after this PR

| Packaged lib | IsAotCompatible | When flagged |
|---|---|---|
| All other libraries (~27 packages) | true | This chip + #2851 + prior #2789–#2803 |
| Wolverine.CosmosDb | **false (documented)** | This chip — `dynamic` is structurally AOT-incompatible |
| Wolverine.RuntimeCompilation | **false (documented)** | Intentional from day one — Roslyn dependency, opt-in for production drop |

The full AOT-flag pass is now complete.

Refs #2715 (Wolverine 6.0 master plan), #2746 (AOT pillar tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)