### PR TITLE
fix(tests): partial aggregates + SG analyzer for live FetchForWriting under Marten 9

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
@@ -10,6 +10,7 @@
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
         <PackageReference Include="coverlet.collector" PrivateAssets="All" />
+        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/concurrency_resilient_sharded_processing.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/concurrency_resilient_sharded_processing.cs
@@ -155,7 +155,7 @@ public static class LetterMessageHandler
 
 }
 
-public class SimpleAggregate : IRevisioned
+public partial class SimpleAggregate : IRevisioned
 {
     // This will be the aggregate version
     public int Version { get; set; }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
@@ -21,6 +21,7 @@
         <PackageReference Include="Alba" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/global_partitioned_aggregate_concurrency.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/global_partitioned_aggregate_concurrency.cs
@@ -223,7 +223,7 @@ public record GpStreamEventB(string Data);
 public record GpStreamEventCascaded(string Source);
 
 // --- Aggregate ---
-public class GpStreamAggregate : IRevisioned
+public partial class GpStreamAggregate : IRevisioned
 {
     public Guid Id { get; set; }
     public long Version { get; set; }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/global_partitioned_sharded_processing.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/global_partitioned_sharded_processing.cs
@@ -137,7 +137,7 @@ public static class GLetterMessageHandler
     }
 }
 
-public class GSimpleAggregate : IRevisioned
+public partial class GSimpleAggregate : IRevisioned
 {
     public long Version { get; set; }
     public Guid Id { get; set; }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
@@ -12,6 +12,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/concurrency_resilient_sharded_processing.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/concurrency_resilient_sharded_processing.cs
@@ -277,7 +277,7 @@ public static class LetterMessageHandler
 
 }
 
-public class SimpleAggregate : IRevisioned
+public partial class SimpleAggregate : IRevisioned
 {
     // This will be the aggregate version
     public int Version { get; set; }


### PR DESCRIPTION
## Summary

`global_partitioned_sharded_processing.hammer_it_with_lots_of_messages_global_partitioned` has been **failing on `main` across all three transport CI jobs (AWS / Kafka / RabbitMQ)** for 3+ commits. Despite the "hammer_it … lots_of_messages" name, this is **not a timing flake** — it's a hard `InvalidProjectionException` introduced by the Marten 9 / JasperFx.Events 2.0 foundation re-pin.

## Root cause

Marten 9 / JasperFx.Events 2.0 Phase 2 ([jasperfx#276](https://github.com/JasperFx/jasperfx)) replaced runtime-reflective aggregate dispatch with a **source-generated dispatcher** emitted into the partial aggregate/projection class.

The `[AggregateHandler]` workflow's live `FetchForWriting<T>` builds a `FetchLivePlan` that calls `ProjectionGraph.AggregatorFor<T>()` → `JasperFxAggregationProjectionBase.AssembleAndAssertValidity()`. Under Marten 9 that now throws when the aggregate has conventional `Apply` methods but **no SG-emitted dispatcher and isn't `partial`**:

```
JasperFx.Events.Projections.InvalidProjectionException
  at JasperFxAggregationProjectionBase`4.AssembleAndAssertValidity() : line 304
  at ProjectionGraph`3.AggregatorFor[T]() : line 267
  at Marten.Events.Fetching.FetchLivePlan`2..ctor(...)
  at Marten.Events.EventStore.FetchForWriting[T](Guid id, ...)
  at Internal.Generated.WolverineHandlers.LogAHandler….HandleAsync(...)
```

This is the same contract the [foundation re-align (#2848)](https://github.com/JasperFx/wolverine/pull/2848) adopted for *registered* projection classes — but these aggregates are fetched **live** via `[AggregateHandler]`, so they were missed in that pass.

## Fix

For each transport test project's live-aggregated aggregate (`SimpleAggregate`, `GSimpleAggregate`, `GpStreamAggregate`):

1. Mark the aggregate class `partial` so the SG can emit the evolve dispatcher into a sibling partial.
2. Reference `JasperFx.Events.SourceGenerator` (analyzer-only, `OutputItemType="Analyzer" ReferenceOutputAssembly="false"`) in the test project so the SG actually runs — matching the pattern used in #2848 and #2851.

| Test project | Aggregate(s) made partial | SG ref added |
|---|---|---|
| Wolverine.RabbitMQ.Tests | `SimpleAggregate` | ✓ |
| Wolverine.AmazonSqs.Tests | `SimpleAggregate` | ✓ |
| Wolverine.Kafka.Tests | `GSimpleAggregate`, `GpStreamAggregate` | ✓ |

## Verification

Run locally against live infrastructure (Docker Postgres / RabbitMQ / Kafka / LocalStack):

| Test | Transport | Before | After |
|---|---|---|---|
| `global_partitioned_sharded_processing.hammer_it_with_lots_of_messages_global_partitioned` | RabbitMQ | ❌ InvalidProjectionException | ✓ pass (1s) |
| `global_partitioned_sharded_processing.hammer_it_with_lots_of_messages_global_partitioned` | Kafka | ❌ InvalidProjectionException | ✓ pass (3s) |
| `global_partitioned_sharded_processing.hammer_it_with_lots_of_messages_global_partitioned` | SQS | ❌ InvalidProjectionException | ✓ pass (1s) |
| `global_partitioned_aggregate_concurrency.should_not_have_concurrency_exceptions_for_same_stream` | Kafka | (latent) | ✓ pass (45s) |

The ~1-3s pass times confirm the original failure was a hard exception at handler dispatch, not load-related timeout. The RabbitMQ/SQS `concurrency_resilient_sharded_processing` tests are `//[Fact]` (commented out — "times out very easily") so they don't run in CI, but their `SimpleAggregate` is covered by the same change if re-enabled.

## Scope

Independent of the AOT flag-flip PRs (#2851 / #2852) — this is a Marten 9 test-domain adoption fix that was pre-existing on `main`. Once merged, the transport CI jobs go green and #2852 rebases onto a clean baseline.

A broader audit of *other* live-aggregated aggregates (e.g. in MartenTests / samples) is deferred to the planned Marten-test run.

Refs #2715 (Wolverine 6.0 master plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)