### PR TITLE
test(marten): align MartenTests with Marten 9 async-only LINQ and Quick append mode

### DIFF
--- a/src/Persistence/MartenTests/Bugs/ConsumerFeature1/MyEventConsumer.cs
+++ b/src/Persistence/MartenTests/Bugs/ConsumerFeature1/MyEventConsumer.cs
@@ -6,9 +6,9 @@ namespace MartenTests.Bugs.ConsumerFeature1;
 
 public class MyEventConsumer
 {
-    public DomainObjectX LoadAsync(IDocumentSession session) =>
+    public Task<DomainObjectX> LoadAsync(IDocumentSession session) =>
         // force to write the same document which has an opt-in for optimistic concurrency
-        session.Query<DomainObjectX>().First();
+        session.Query<DomainObjectX>().FirstAsync();
     
     public static IMartenOp Consume(MyEvent @event, DomainObjectX domainObjectX, ILogger<MyEventConsumer> logger)
     {

--- a/src/Persistence/MartenTests/Persistence/marten_durability_end_to_end.cs
+++ b/src/Persistence/MartenTests/Persistence/marten_durability_end_to_end.cs
@@ -166,10 +166,10 @@ public class marten_durability_end_to_end : IAsyncLifetime
         }
     }
 
-    protected int ReceivedMessageCount()
+    protected async Task<int> ReceivedMessageCount()
     {
-        using var session = _receiverStore.LightweightSession();
-        return session.Query<TraceDoc>().Count();
+        await using var session = _receiverStore.LightweightSession();
+        return await session.Query<TraceDoc>().CountAsync();
     }
 
     protected async Task WaitForMessagesToBeProcessed(int count)
@@ -177,7 +177,7 @@ public class marten_durability_end_to_end : IAsyncLifetime
         await using var session = _receiverStore.QuerySession();
         for (var i = 0; i < 480; i++)
         {
-            var actual = session.Query<TraceDoc>().Count();
+            var actual = await session.Query<TraceDoc>().CountAsync();
             var envelopeCount = PersistedIncomingCount();
 
 
@@ -240,7 +240,7 @@ public class marten_durability_end_to_end : IAsyncLifetime
         await WaitForMessagesToBeProcessed(10);
         PersistedIncomingCount().ShouldBe(0);
         PersistedOutgoingCount().ShouldBe(0);
-        ReceivedMessageCount().ShouldBe(10);
+        (await ReceivedMessageCount()).ShouldBe(10);
     }
 
     [Fact]
@@ -252,7 +252,7 @@ public class marten_durability_end_to_end : IAsyncLifetime
         await WaitForMessagesToBeProcessed(5);
         PersistedIncomingCount().ShouldBe(0);
         PersistedOutgoingCount().ShouldBe(0);
-        ReceivedMessageCount().ShouldBe(5);
+        (await ReceivedMessageCount()).ShouldBe(5);
     }
 }
 

--- a/src/Persistence/MartenTests/event_streaming.cs
+++ b/src/Persistence/MartenTests/event_streaming.cs
@@ -78,6 +78,11 @@ public class event_streaming : PostgresqlContext, IAsyncLifetime
                     {
                         opts.Connection(Servers.PostgresConnectionString);
                         opts.Logger(new TestOutputMartenLogger(_output));
+
+                        // Fast event forwarding publishes events in BeforeSaveChanges, before commit.
+                        // Marten's default Quick append mode does not assign IEvent.Sequence until the
+                        // server-side INSERT, so Rich mode is required for the forwarded events to carry a sequence.
+                        opts.Events.AppendMode = EventAppendMode.Rich;
                     })
                     .IntegrateWithWolverine(x =>
                     {


### PR DESCRIPTION
## Summary

Fixes 4 `MartenTests` failures that are genuinely Wolverine-side (test code that hadn't caught up to Marten 9 behavior). Part of a broader MartenTests triage against the `Marten 9.0.0-alpha.4` foundation re-align.

- **Sync data access (3 tests)** — Marten 9 removed synchronous LINQ data access (`"As of Marten 9.0, only asynchronous data access is supported"`). Test helpers that called `.Count()` / `.First()` now throw. Converted to `CountAsync()` / `FirstAsync()`:
  - `marten_durability_end_to_end` — `ReceivedMessageCount()` is now `async Task<int>` (callers awaited), and the wait-loop uses `await ...CountAsync()`.
  - `Bug_1427` — `MyEventConsumer.LoadAsync` uses `FirstAsync()`.
- **Fast event forwarding `Sequence == 0` (1 test)** — `event_streaming` relies on `IEvent.Sequence` being populated on the forwarded event. Wolverine's fast event forwarding publishes in `BeforeSaveChanges` (before commit), and Marten's default *Quick* append mode does not assign sequences until the server-side INSERT. The sender now opts into `EventAppendMode.Rich` so the forwarded event carries a sequence.

## Out of scope (tracked upstream)

The remaining MartenTests failures are **not** Wolverine bugs and are filed as upstream issues:

- **AggregateHandler double-count (4 tests)** — `FetchForWriting` + inline snapshot persists in-memory mutations to the fetched aggregate *plus* the appended events, diverging from the event-sourced rebuild. Isolated with a raw-Marten repro (no Wolverine handler). → Marten.
- **DCB `FetchForWritingByTags` (5 tests)** — `InvalidProjectionException: No source-generated dispatcher found for SingleStreamProjection<SubscriptionState, string>` for a pure boundary aggregate. No supported way to get the SG to emit a dispatcher for a DCB-only `ForAggregate<T>` type. → Marten/JasperFx.Events.

The 2 `basic_agent_mechanics_versioned_composition` distribution timeouts are already `[Trait("Category","Flaky")]` and excluded from CI.

## Test plan

- [x] `marten_durability_end_to_end` (both methods) pass locally
- [x] `Bug_1427_no_endpoint_error_on_retries` passes locally
- [x] `event_streaming.event_should_be_published_from_sender_to_receiver` passes locally
- [ ] CI green on full MartenTests

🤖 Generated with [Claude Code](https://claude.com/claude-code)