### PR TITLE
test(marten): fix AggregateHandler tests under Marten 9 UseIdentityMapForAggregates default

### DIFF
--- a/src/Persistence/MartenTests/AggregateHandlerWorkflow/aggregate_handler_workflow.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerWorkflow/aggregate_handler_workflow.cs
@@ -33,6 +33,14 @@ public class aggregate_handler_workflow: PostgresqlContext, IAsyncLifetime
                         m.Connection(Servers.PostgresConnectionString);
                         m.Projections.Snapshot<LetterAggregate>(SnapshotLifecycle.Inline);
 
+                        // These handlers intentionally mutate the FetchForWriting aggregate in place
+                        // (e.g. to compute the returned Response). Marten 9 defaults
+                        // UseIdentityMapForAggregates = true, which reuses that mutated instance as the
+                        // inline projection's apply baseline — double-counting the events. Opt back into
+                        // the Marten 8 round-trip behavior for this store so the snapshot rebuilds purely
+                        // from events. See JasperFx/wolverine#2857 and JasperFx/marten#4509.
+                        m.Events.UseIdentityMapForAggregates = false;
+
                         m.DisableNpgsqlLogging = true;
                     })
                     .UseLightweightSessions()


### PR DESCRIPTION
## Summary

Closes #2857. Fixes the 4 `[AggregateHandler]` tests in `aggregate_handler_workflow` that broke after re-pinning to Marten 9.

The handlers in these tests intentionally mutate the `FetchForWriting` aggregate in place (e.g. `aggregate.ACount++`) to compute the returned `Response`. Marten 9 defaults `StoreOptions.Events.UseIdentityMapForAggregates = true`, which reuses that mutated instance as the inline projection's apply baseline on `SaveChangesAsync` — double-counting the events, so the persisted snapshot diverges from the `AggregateStreamAsync` rebuild.

Marten considers this **by design** (JasperFx/marten#4509, #4439). Per the issue's documented alternative, this store opts back into the Marten 8 round-trip behavior:

```csharp
m.Events.UseIdentityMapForAggregates = false;
```

This keeps the existing mutate-then-respond test pattern valid without rewriting the handlers. Scoped to this one test store only.

## Test plan

- [x] `aggregate_handler_workflow` green (16/16, was 4 failing)
- [x] Broader AggregateHandler suite green (71/71: `AggregateHandlerWorkflow` + `using_an_aggregate_that_handles_commands` + `read_aggregate_attribute_usage`)

Refs JasperFx/marten#4509, JasperFx/marten#4512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)