### PR TITLE
DCB: Marten boundary-model test fix + Polecat parity suite + foundation re-pin

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,7 @@
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
     <PackageVersion Include="Marten" Version="9.0.0-alpha.4" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="4.0.0-alpha.8" />
+    <PackageVersion Include="Polecat" Version="4.0.0-alpha.10" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageVersion Include="Marten.AspNetCore" Version="9.0.0-alpha.4" />
     <PackageVersion Include="Marten.Newtonsoft" Version="9.0.0-alpha.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,9 +31,9 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.17" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.16" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.9" />
+    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.20" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.21" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.13" />
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-alpha.5" />
     <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.6" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
@@ -107,13 +107,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.0.0-alpha.6" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.6" />
-    <PackageVersion Include="Weasel.MySql" Version="9.0.0-alpha.6" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.0.0-alpha.6" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-alpha.6" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.0.0-alpha.6" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.0.0-alpha.6" />
+    <PackageVersion Include="Weasel.Core" Version="9.0.0-alpha.7" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.7" />
+    <PackageVersion Include="Weasel.MySql" Version="9.0.0-alpha.7" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.0.0-alpha.7" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-alpha.7" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.0.0-alpha.7" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.0.0-alpha.7" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/Persistence/MartenTests/Dcb/University/SubscriptionState.cs
+++ b/src/Persistence/MartenTests/Dcb/University/SubscriptionState.cs
@@ -6,8 +6,14 @@ namespace MartenTests.Dcb.University;
 /// Ported from the Axon SubscribeStudentToCourseCommandHandler.State which uses
 /// EventCriteria.either() to load events matching CourseId OR StudentId.
 /// </summary>
-public class SubscriptionState
+public partial class SubscriptionState
 {
+    // Required so the aggregate can be registered as a single-stream projection
+    // (LiveStreamAggregation), which is what makes the JasperFx.Events source generator
+    // emit the dispatcher that FetchForWritingByTags<SubscriptionState> resolves. For the
+    // boundary (tag-query) path this Id is not stream-bound — it just satisfies the
+    // single-stream projection shape, the same way Marten's own DCB aggregates carry one.
+    public string Id { get; set; } = null!;
     public CourseId? CourseId { get; private set; }
     public int CourseCapacity { get; private set; }
     public int StudentsSubscribedToCourse { get; private set; }

--- a/src/Persistence/MartenTests/Dcb/boundary_model_workflow_tests.cs
+++ b/src/Persistence/MartenTests/Dcb/boundary_model_workflow_tests.cs
@@ -46,6 +46,14 @@ public class boundary_model_workflow_tests : PostgresqlContext, IAsyncLifetime
                             .ForAggregate<SubscriptionState>();
                         m.Events.RegisterTagType<FacultyId>("faculty");
 
+                        // FetchForWritingByTags<T> resolves its aggregator via the JasperFx.Events
+                        // source generator, which only emits a dispatcher for an aggregate that is
+                        // registered as a single-stream projection. Registering SubscriptionState as a
+                        // live aggregation (it also carries an Id) gives the SG something to generate
+                        // for; without it the boundary fetch throws InvalidProjectionException. This
+                        // mirrors Marten's own DCB tests (StudentCourseEnrollment / HsTicketSummary).
+                        m.Projections.LiveStreamAggregation<SubscriptionState>();
+
                         // Register event types
                         m.Events.AddEventType<CourseCreated>();
                         m.Events.AddEventType<CourseCapacityChanged>();

--- a/src/Persistence/MySql/Wolverine.MySql/MySqlAdvisoryLock.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlAdvisoryLock.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using JasperFx.Events.Daemon;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
 using MySqlConnector;

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleAdvisoryLock.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleAdvisoryLock.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using JasperFx.Events.Daemon;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
 using Oracle.ManagedDataAccess.Client;

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using JasperFx.Events.Daemon;
 using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx;

--- a/src/Persistence/PolecatTests/Dcb/University/BoundaryModelSubscribeStudentToCourse.cs
+++ b/src/Persistence/PolecatTests/Dcb/University/BoundaryModelSubscribeStudentToCourse.cs
@@ -1,0 +1,41 @@
+using JasperFx.Events.Tags;
+using Wolverine.Polecat;
+
+namespace PolecatTests.Dcb.University;
+
+public record BoundaryModelSubscribeStudentToCourse(StudentId StudentId, CourseId CourseId);
+
+public static class BoundaryModelSubscribeStudentHandler
+{
+    public const int MaxCoursesPerStudent = 3;
+
+    public static EventTagQuery Load(BoundaryModelSubscribeStudentToCourse command)
+        => EventTagQuery
+            .For(command.CourseId)
+            .AndEventsOfType<CourseCreated, CourseCapacityChanged, StudentSubscribedToCourse, StudentUnsubscribedFromCourse>()
+            .Or(command.StudentId)
+            .AndEventsOfType<StudentEnrolledInFaculty, StudentSubscribedToCourse, StudentUnsubscribedFromCourse>();
+
+    public static StudentSubscribedToCourse Handle(
+        BoundaryModelSubscribeStudentToCourse command,
+        [BoundaryModel]
+        SubscriptionState state)
+    {
+        if (state.StudentId == null)
+            throw new InvalidOperationException("Student with given id never enrolled the faculty");
+
+        if (state.CoursesStudentSubscribed >= MaxCoursesPerStudent)
+            throw new InvalidOperationException("Student subscribed to too many courses");
+
+        if (state.CourseId == null)
+            throw new InvalidOperationException("Course with given id does not exist");
+
+        if (state.StudentsSubscribedToCourse >= state.CourseCapacity)
+            throw new InvalidOperationException("Course is fully booked");
+
+        if (state.AlreadySubscribed)
+            throw new InvalidOperationException("Student already subscribed to this course");
+
+        return new StudentSubscribedToCourse(FacultyId.Default, command.StudentId, command.CourseId);
+    }
+}

--- a/src/Persistence/PolecatTests/Dcb/University/SubscriptionState.cs
+++ b/src/Persistence/PolecatTests/Dcb/University/SubscriptionState.cs
@@ -1,0 +1,61 @@
+namespace PolecatTests.Dcb.University;
+
+/// <summary>
+/// Built from events tagged with BOTH CourseId and StudentId.
+/// This is the core DCB pattern — the consistency boundary spans multiple streams.
+///
+/// Ported from the Axon SubscribeStudentToCourseCommandHandler.State which uses
+/// EventCriteria.either() to load events matching CourseId OR StudentId.
+/// </summary>
+public partial class SubscriptionState
+{
+    // Required so the aggregate can be registered as a single-stream projection
+    // (LiveStreamAggregation), which is what makes the JasperFx.Events source generator
+    // emit the dispatcher that FetchForWritingByTags<SubscriptionState> resolves. For the
+    // boundary (tag-query) path this Id is not stream-bound — it just satisfies the
+    // single-stream projection shape, the same way Marten's own DCB aggregates carry one.
+    public string Id { get; set; } = null!;
+    public CourseId? CourseId { get; private set; }
+    public int CourseCapacity { get; private set; }
+    public int StudentsSubscribedToCourse { get; private set; }
+
+    public StudentId? StudentId { get; private set; }
+    public int CoursesStudentSubscribed { get; private set; }
+    public bool AlreadySubscribed { get; private set; }
+
+    public void Apply(CourseCreated e)
+    {
+        CourseId = e.CourseId;
+        CourseCapacity = e.Capacity;
+    }
+
+    public void Apply(CourseCapacityChanged e)
+    {
+        CourseCapacity = e.Capacity;
+    }
+
+    public void Apply(StudentEnrolledInFaculty e)
+    {
+        StudentId = e.StudentId;
+    }
+
+    public void Apply(StudentSubscribedToCourse e)
+    {
+        if (e.CourseId == CourseId)
+            StudentsSubscribedToCourse++;
+        if (e.StudentId == StudentId)
+            CoursesStudentSubscribed++;
+        if (e.StudentId == StudentId && e.CourseId == CourseId)
+            AlreadySubscribed = true;
+    }
+
+    public void Apply(StudentUnsubscribedFromCourse e)
+    {
+        if (e.CourseId == CourseId)
+            StudentsSubscribedToCourse--;
+        if (e.StudentId == StudentId)
+            CoursesStudentSubscribed--;
+        if (e.StudentId == StudentId && e.CourseId == CourseId)
+            AlreadySubscribed = false;
+    }
+}

--- a/src/Persistence/PolecatTests/Dcb/University/SubscriptionStateProjection.cs
+++ b/src/Persistence/PolecatTests/Dcb/University/SubscriptionStateProjection.cs
@@ -1,0 +1,15 @@
+using Polecat.Projections;
+
+namespace PolecatTests.Dcb.University;
+
+/// <summary>
+/// Empty single-stream projection over <see cref="SubscriptionState"/>. Its only purpose is to give
+/// the JasperFx.Events source generator a partial SingleStreamProjection&lt;,&gt; subclass to emit an
+/// aggregator dispatcher for, which FetchForWritingByTags&lt;SubscriptionState&gt; then resolves. The
+/// apply logic lives on SubscriptionState's conventional Apply methods. Registered with
+/// ProjectionLifecycle.Live so nothing is persisted — this is Polecat's equivalent of the Marten DCB
+/// test's LiveStreamAggregation&lt;SubscriptionState&gt;().
+/// </summary>
+public partial class SubscriptionStateProjection : SingleStreamProjection<SubscriptionState, string>
+{
+}

--- a/src/Persistence/PolecatTests/Dcb/University/UniversityEvents.cs
+++ b/src/Persistence/PolecatTests/Dcb/University/UniversityEvents.cs
@@ -1,0 +1,15 @@
+namespace PolecatTests.Dcb.University;
+
+public record CourseCreated(FacultyId FacultyId, CourseId CourseId, string Name, int Capacity);
+
+public record CourseRenamed(FacultyId FacultyId, CourseId CourseId, string Name);
+
+public record CourseCapacityChanged(FacultyId FacultyId, CourseId CourseId, int Capacity);
+
+public record StudentEnrolledInFaculty(FacultyId FacultyId, StudentId StudentId, string FirstName, string LastName);
+
+public record StudentSubscribedToCourse(FacultyId FacultyId, StudentId StudentId, CourseId CourseId);
+
+public record StudentUnsubscribedFromCourse(FacultyId FacultyId, StudentId StudentId, CourseId CourseId);
+
+public record AllCoursesFullyBookedNotificationSent(FacultyId FacultyId);

--- a/src/Persistence/PolecatTests/Dcb/University/UniversityIds.cs
+++ b/src/Persistence/PolecatTests/Dcb/University/UniversityIds.cs
@@ -1,0 +1,36 @@
+namespace PolecatTests.Dcb.University;
+
+/// <summary>
+/// Strong-typed ID for a course. Uses string value with "Course:" prefix.
+/// </summary>
+public record CourseId(string Value)
+{
+    public static CourseId Random() => new($"Course:{Guid.NewGuid()}");
+    public static CourseId Of(string raw) => new(raw.StartsWith("Course:") ? raw : $"Course:{raw}");
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Strong-typed ID for a student. Uses string value with "Student:" prefix.
+/// </summary>
+public record StudentId(string Value)
+{
+    public static StudentId Random() => new($"Student:{Guid.NewGuid()}");
+    public static StudentId Of(string raw) => new(raw.StartsWith("Student:") ? raw : $"Student:{raw}");
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Strong-typed ID for the faculty. Single-instance in this demo.
+/// </summary>
+public record FacultyId(string Value)
+{
+    public static readonly FacultyId Default = new("Faculty:ONLY_FACULTY_ID");
+    public static FacultyId Of(string raw) => new(raw.StartsWith("Faculty:") ? raw : $"Faculty:{raw}");
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Composite ID for a student-course subscription.
+/// </summary>
+public record SubscriptionId(CourseId CourseId, StudentId StudentId);

--- a/src/Persistence/PolecatTests/Dcb/boundary_model_workflow_tests.cs
+++ b/src/Persistence/PolecatTests/Dcb/boundary_model_workflow_tests.cs
@@ -1,0 +1,216 @@
+using IntegrationTests;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Tags;
+using JasperFx.Resources;
+using Polecat;
+using Polecat.Events;
+using Polecat.Projections;
+using PolecatTests.Dcb.University;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Polecat;
+using Wolverine.Tracking;
+
+namespace PolecatTests.Dcb;
+
+// Parity port of MartenTests.Dcb.boundary_model_workflow_tests — same DCB scenarios run against
+// Polecat (SQL Server) to guarantee the Wolverine + Polecat boundary-model integration covers the
+// same cases as the Wolverine + Marten one.
+//
+// KNOWN FAILING (visible TODO) as of Polecat 4.0.0-alpha.8 — fixed by JasperFx/polecat#123, pending a
+// published Polecat release. Two Polecat-side defects, both verified resolved against a local Polecat
+// build of that PR (the full suite goes 5/5):
+//   1. Multi-condition EventTagQuery returned zero rows. A single tag condition (Or<TTag>) worked, but
+//      any query OR-combining distinct tag types returned nothing because Polecat INNER JOINed every
+//      tag-type table (requiring each event to carry all queried tags). can_fetch_..._multiple_tag_types
+//      hits this directly via session.Events — no Wolverine code involved.
+//   2. Boundary append to an existing tag-derived stream threw ExistingStreamIdCollisionException
+//      (Polecat used StreamAction.Start instead of Append). This breaks the [BoundaryModel] handler save.
+// Both are fixed to match Marten's behavior in polecat#123. These tests go green once Polecat ships it.
+public class boundary_model_workflow_tests : IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddPolecat(m =>
+                    {
+                        m.ConnectionString = Servers.SqlServerConnectionString;
+                        m.DatabaseSchemaName = "dcb_boundary_tests";
+
+                        // Register tag types for DCB
+                        m.Events.RegisterTagType<StudentId>("student")
+                            .ForAggregate<SubscriptionState>();
+                        m.Events.RegisterTagType<CourseId>("course")
+                            .ForAggregate<SubscriptionState>();
+                        m.Events.RegisterTagType<FacultyId>("faculty");
+
+                        // FetchForWritingByTags<T> resolves its aggregator via the JasperFx.Events
+                        // source generator, which only emits a dispatcher for an aggregate backed by a
+                        // single-stream projection. SubscriptionStateProjection is that partial
+                        // SingleStreamProjection<SubscriptionState, string> subclass; registered Live it
+                        // is computed on demand with no snapshot table. This is Polecat's equivalent of
+                        // the Marten DCB test's LiveStreamAggregation<SubscriptionState>(); without it
+                        // the boundary fetch throws InvalidProjectionException.
+                        m.Projections.Add<SubscriptionStateProjection>(ProjectionLifecycle.Live);
+
+                        m.Events.StreamIdentity = StreamIdentity.AsString;
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        theStore = theHost.Services.GetRequiredService<IDocumentStore>();
+        await ((DocumentStore)theStore).Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await theStore.Advanced.CleanAllEventDataAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private async Task SeedCourseAndStudent(CourseId courseId, StudentId studentId, int capacity = 10)
+    {
+        await using var session = theStore.LightweightSession();
+
+        var courseCreated = session.Events.BuildEvent(
+            new CourseCreated(FacultyId.Default, courseId, "Math 101", capacity));
+        courseCreated.WithTag(courseId);
+        var courseStreamKey = courseId.Value;
+        session.Events.Append(courseStreamKey, courseCreated);
+
+        var enrolled = session.Events.BuildEvent(
+            new StudentEnrolledInFaculty(FacultyId.Default, studentId, "Alice", "Smith"));
+        enrolled.WithTag(studentId);
+        var studentStreamKey = studentId.Value;
+        session.Events.Append(studentStreamKey, enrolled);
+
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task can_fetch_for_writing_by_tags_across_multiple_tag_types()
+    {
+        var courseId = CourseId.Random();
+        var studentId = StudentId.Random();
+
+        await SeedCourseAndStudent(courseId, studentId);
+
+        await using var session = theStore.LightweightSession();
+
+        var query = new EventTagQuery()
+            .Or<CourseCreated, CourseId>(courseId)
+            .Or<StudentEnrolledInFaculty, StudentId>(studentId);
+
+        var boundary = await session.Events.FetchForWritingByTags<SubscriptionState>(query);
+        boundary.Events.Count.ShouldBe(2);
+        boundary.Aggregate.ShouldNotBeNull();
+        boundary.Aggregate.CourseId.ShouldBe(courseId);
+        boundary.Aggregate.StudentId.ShouldBe(studentId);
+    }
+
+    [Fact]
+    public async Task boundary_model_handler_subscribes_student_to_course()
+    {
+        var courseId = CourseId.Random();
+        var studentId = StudentId.Random();
+
+        await SeedCourseAndStudent(courseId, studentId);
+
+        // Invoke the [BoundaryModel] handler
+        await theHost.InvokeMessageAndWaitAsync(
+            new BoundaryModelSubscribeStudentToCourse(studentId, courseId));
+
+        // Verify the subscription event was appended and discoverable by tag
+        await using var session = theStore.LightweightSession();
+        var events = await session.Events.QueryByTagsAsync(
+            new EventTagQuery().Or<StudentId>(studentId));
+
+        events.ShouldContain(e => e.Data is StudentSubscribedToCourse);
+    }
+
+    [Fact]
+    public async Task boundary_model_handler_throws_when_student_not_enrolled()
+    {
+        var courseId = CourseId.Random();
+        var studentId = StudentId.Random();
+
+        // Only seed the course, NOT the student
+        await using var session = theStore.LightweightSession();
+        var courseCreated = session.Events.BuildEvent(
+            new CourseCreated(FacultyId.Default, courseId, "Math 101", 10));
+        courseCreated.WithTag(courseId);
+        session.Events.Append(courseId.Value, courseCreated);
+        await session.SaveChangesAsync();
+
+        // The handler should throw because student is not enrolled
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            await theHost.InvokeMessageAndWaitAsync(
+                new BoundaryModelSubscribeStudentToCourse(studentId, courseId));
+        });
+    }
+
+    [Fact]
+    public async Task boundary_model_handler_throws_when_course_does_not_exist()
+    {
+        var courseId = CourseId.Random();
+        var studentId = StudentId.Random();
+
+        // Only seed the student, NOT the course
+        await using var session = theStore.LightweightSession();
+        var enrolled = session.Events.BuildEvent(
+            new StudentEnrolledInFaculty(FacultyId.Default, studentId, "Alice", "Smith"));
+        enrolled.WithTag(studentId);
+        session.Events.Append(studentId.Value, enrolled);
+        await session.SaveChangesAsync();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            await theHost.InvokeMessageAndWaitAsync(
+                new BoundaryModelSubscribeStudentToCourse(studentId, courseId));
+        });
+    }
+
+    [Fact]
+    public async Task boundary_model_handler_throws_when_course_is_fully_booked()
+    {
+        var courseId = CourseId.Random();
+        var studentId = StudentId.Random();
+
+        // Create course with capacity = 1 and fill it
+        await SeedCourseAndStudent(courseId, studentId, capacity: 1);
+
+        // Subscribe a different student first to fill the course
+        var otherStudentId = StudentId.Random();
+        await using var session = theStore.LightweightSession();
+        var otherEnrolled = session.Events.BuildEvent(
+            new StudentEnrolledInFaculty(FacultyId.Default, otherStudentId, "Bob", "Jones"));
+        otherEnrolled.WithTag(otherStudentId);
+        session.Events.Append(otherStudentId.Value, otherEnrolled);
+
+        var subscribed = session.Events.BuildEvent(
+            new StudentSubscribedToCourse(FacultyId.Default, otherStudentId, courseId));
+        subscribed.WithTag(otherStudentId, courseId);
+        session.Events.Append(otherStudentId.Value, subscribed);
+        await session.SaveChangesAsync();
+
+        // Now try to subscribe our student — should fail because course is full
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            await theHost.InvokeMessageAndWaitAsync(
+                new BoundaryModelSubscribeStudentToCourse(studentId, courseId));
+        });
+    }
+}

--- a/src/Persistence/PolecatTests/Dcb/boundary_model_workflow_tests.cs
+++ b/src/Persistence/PolecatTests/Dcb/boundary_model_workflow_tests.cs
@@ -18,18 +18,9 @@ namespace PolecatTests.Dcb;
 
 // Parity port of MartenTests.Dcb.boundary_model_workflow_tests — same DCB scenarios run against
 // Polecat (SQL Server) to guarantee the Wolverine + Polecat boundary-model integration covers the
-// same cases as the Wolverine + Marten one.
-//
-// KNOWN FAILING (visible TODO) as of Polecat 4.0.0-alpha.8 — fixed by JasperFx/polecat#123, pending a
-// published Polecat release. Two Polecat-side defects, both verified resolved against a local Polecat
-// build of that PR (the full suite goes 5/5):
-//   1. Multi-condition EventTagQuery returned zero rows. A single tag condition (Or<TTag>) worked, but
-//      any query OR-combining distinct tag types returned nothing because Polecat INNER JOINed every
-//      tag-type table (requiring each event to carry all queried tags). can_fetch_..._multiple_tag_types
-//      hits this directly via session.Events — no Wolverine code involved.
-//   2. Boundary append to an existing tag-derived stream threw ExistingStreamIdCollisionException
-//      (Polecat used StreamAction.Start instead of Append). This breaks the [BoundaryModel] handler save.
-// Both are fixed to match Marten's behavior in polecat#123. These tests go green once Polecat ships it.
+// same cases as the Wolverine + Marten one. Requires the two DCB fixes from JasperFx/polecat#123
+// (cross-tag-type EventTagQuery LEFT JOIN; boundary append via StreamAction.Append), shipped in
+// Polecat 4.0.0-alpha.10.
 public class boundary_model_workflow_tests : IAsyncLifetime
 {
     private IHost theHost = null!;

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlNodePersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlNodePersistence.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using JasperFx.Events.Daemon;
 using System.Data.Common;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;

--- a/src/Persistence/Wolverine.RDBMS/IMessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/IMessageDatabase.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using JasperFx.Events.Daemon;
 using JasperFx.MultiTenancy;
 using Microsoft.Extensions.Logging;
 using Weasel.Core;

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using JasperFx.Events.Daemon;
 using System.Data.Common;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerAdvisoryLock.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerAdvisoryLock.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using JasperFx.Events.Daemon;
 using JasperFx.Core;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;

--- a/src/Persistence/Wolverine.Sqlite/SqliteAdvisoryLock.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteAdvisoryLock.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using JasperFx.Events.Daemon;
 using System.Data.Common;
 using Microsoft.Extensions.Logging;
 using Weasel.Core;


### PR DESCRIPTION
## Summary

Brings the Wolverine ↔ **Polecat** DCB boundary-model integration up to parity with the Wolverine ↔ **Marten** one, fixes the Marten DCB test to the supported recipe, and re-pins the foundation to the latest JasperFx/Weasel/Polecat alphas.

### 1. Foundation re-pin
- JasperFx.Events `alpha.16 → alpha.21`, JasperFx `alpha.17 → alpha.20`, JasperFx.Events.SourceGenerator `alpha.9 → alpha.13`, Weasel `alpha.6 → alpha.7`, **Polecat `alpha.8 → alpha.10`**.
- `IAdvisoryLock` moved to the `JasperFx.Events.Daemon` namespace; the RDBMS advisory-lock implementations + consumers add that using.
- Verified: full `wolverine.slnx` Release build clean (net9.0 + net10.0); CoreTests **1707/1707**.

### 2. Marten DCB test fix
`FetchForWritingByTags<T>` resolves its aggregator via the JasperFx.Events source generator, which only emits a dispatcher for an aggregate registered as a single-stream projection. `SubscriptionState` had no `Id` and was registered only via `ForAggregate`, so the boundary fetch threw `InvalidProjectionException`. Made it `partial` with an `Id` and registered it via `LiveStreamAggregation` (live = computed on demand, no snapshot table), matching Marten's own DCB tests → all 5 cases pass.

### 3. Polecat DCB parity suite
`PolecatTests/Dcb/boundary_model_workflow_tests` mirrors the Marten suite against Polecat (SQL Server). It surfaced two Polecat-side DCB defects — cross-tag-type queries returning zero rows (`INNER JOIN` over every tag table) and boundary append colliding (`StreamAction.Start` instead of `Append`) — both fixed in **JasperFx/polecat#123** and shipped in **Polecat 4.0.0-alpha.10**. With that release pinned, the parity suite passes **5/5**, matching the Marten side.

## Test plan

- [x] `wolverine.slnx` Release build clean (net9.0 + net10.0)
- [x] CoreTests green (1707/1707)
- [x] Marten `boundary_model_workflow_tests` 5/5
- [x] Polecat `boundary_model_workflow_tests` 5/5 against published Polecat 4.0.0-alpha.10

Incorporates JasperFx/polecat#123 (released as Polecat 4.0.0-alpha.10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)