### PR TITLE
docs(marten): warn injecting IDocumentSession without transactional middleware silently drops writes (#2860)

### DIFF
--- a/docs/guide/durability/marten/transactional-middleware.md
+++ b/docs/guide/durability/marten/transactional-middleware.md
@@ -33,6 +33,12 @@ With this enabled, Wolverine will automatically use the Marten
 transactional middleware for handlers that have a dependency on `IDocumentSession` (meaning the method takes in `IDocumentSession` or has
 some dependency that itself depends on `IDocumentSession`) as long as the `IntegrateWithWolverine()` call was used in application bootstrapping.
 
+::: danger
+If a handler takes in `IDocumentSession` and writes to it (appending events, `Store`, `Insert`, etc.) but the chain has **no** transactional middleware — i.e. `AutoApplyTransactions()` is not enabled, the method has no `[Transactional]` attribute, it does not return an [`IMartenOp`](/guide/durability/marten/operations), and it is not a saga — then Wolverine opens the managed `IDocumentSession` to satisfy the parameter but **never calls `SaveChangesAsync()`**. The session is disposed at the end of the handler and **all writes are silently discarded with no exception**.
+
+This is the most common cause of "my event/document was not persisted and I got no error" reports. If you inject `IDocumentSession` and rely on Wolverine to commit, you **must** opt into the transactional middleware via `AutoApplyTransactions()` or `[Transactional]` (or return an `IMartenOp`). Alternatively, if you intend to own the lifecycle, call `IDocumentSession.SaveChangesAsync()` yourself — but note the outbox caveat in the warning at the top of this page.
+:::
+
 ### Opting Out with [NonTransactional]
 
 When using `AutoApplyTransactions()`, there may be specific handlers or HTTP endpoints where you want to explicitly opt out of

--- a/src/Persistence/MartenTests/Bugs/Bug_2860_inline_projection_null_apply.cs
+++ b/src/Persistence/MartenTests/Bugs/Bug_2860_inline_projection_null_apply.cs
@@ -1,0 +1,108 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Marten;
+
+namespace MartenTests.Bugs;
+
+// Regression guard for GH-2860. The issue was reported as an inline MultiStreamProjection with a
+// null Apply silently aborting SaveChanges under a Wolverine-managed session, but the projection is
+// a red herring: the real cause is that a handler which injects IDocumentSession, writes to it, and
+// relies on Wolverine to persist will silently drop the writes UNLESS the chain has transactional
+// middleware (AutoApplyTransactions(), [Transactional], an IMartenOp return, or a saga). Without it
+// Wolverine opens the managed session to satisfy the parameter but never calls SaveChangesAsync, so
+// the session is disposed with the writes discarded — no save, no exception. These guards pin the
+// supported "Wolverine saves it" recipes. (Reproduces with or without the projection.)
+
+public record Bug2860ItemRegistered(string Category);
+public record Bug2860ItemRemoved(string Category);
+
+public class Bug2860ItemStream
+{
+    public Guid Id { get; set; }
+    public List<string> Categories { get; set; } = [];
+    public void Apply(Bug2860ItemRegistered e) => Categories.Add(e.Category);
+    public void Apply(Bug2860ItemRemoved e) => Categories.Remove(e.Category);
+}
+
+public record Bug2860RemoveItemCommand(Guid StreamId, string Category);
+
+public static class Bug2860AutoApplyHandler
+{
+    public static async Task Handle(Bug2860RemoveItemCommand cmd, IDocumentSession session)
+    {
+        var stream = await session.Events.FetchForWriting<Bug2860ItemStream>(cmd.StreamId);
+        stream.AppendMany(new Bug2860ItemRemoved(cmd.Category));
+    }
+}
+
+public static class Bug2860TransactionalHandler
+{
+    [Transactional]
+    public static async Task Handle(Bug2860RemoveItemCommand cmd, IDocumentSession session)
+    {
+        var stream = await session.Events.FetchForWriting<Bug2860ItemStream>(cmd.StreamId);
+        stream.AppendMany(new Bug2860ItemRemoved(cmd.Category));
+    }
+}
+
+public class Bug_2860_inline_projection_null_apply : PostgresqlContext
+{
+    private async Task<int> seedThenRemoveThroughWolverine(Type handlerType, bool autoApplyTransactions)
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(handlerType);
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "bug2860";
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine();
+
+                if (autoApplyTransactions)
+                {
+                    opts.Policies.AutoApplyTransactions();
+                }
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamId = Guid.NewGuid();
+        await using (var seed = store.LightweightSession())
+        {
+            seed.Events.StartStream<Bug2860ItemStream>(streamId, new Bug2860ItemRegistered("Electronics"));
+            await seed.SaveChangesAsync();
+        }
+
+        await host.MessageBus().InvokeAsync(new Bug2860RemoveItemCommand(streamId, "Other"));
+
+        await using var query = store.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+        return events.Count;
+    }
+
+    [Fact]
+    public async Task auto_apply_transactions_persists_the_appended_event()
+    {
+        var count = await seedThenRemoveThroughWolverine(typeof(Bug2860AutoApplyHandler), autoApplyTransactions: true);
+        count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task transactional_attribute_persists_the_appended_event()
+    {
+        var count = await seedThenRemoveThroughWolverine(typeof(Bug2860TransactionalHandler), autoApplyTransactions: false);
+        count.ShouldBe(2);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2860 as **by-design** with a documentation fix + regression guards.

The issue was reported as: an inline `MultiStreamProjection` with a null `Apply` silently aborts `SaveChangesAsync` under a Wolverine-managed session. Investigation showed the **projection is a red herring** — the bug reproduces with or without it.

### Real root cause

A handler that injects `IDocumentSession`, writes to it, and relies on Wolverine to persist will silently drop the writes **unless the chain has transactional middleware** — i.e. `AutoApplyTransactions()`, `[Transactional]`, an `IMartenOp` return, or a saga. Without one of those, Wolverine's `SessionVariableSource` → `OpenMartenSessionFrame` opens the managed (outbox) `IDocumentSession` to satisfy the parameter, the handler appends/stores, and then the `await using` disposes the session **without ever calling `SaveChangesAsync()`**. The writes are discarded — no save, no exception.

The reporter's "works with a plain `LightweightSession`" evidence called `SaveChangesAsync()` explicitly, which is why the failure only appeared under Wolverine and got mis-attributed to the projection.

I confirmed the diagnosis on current `main` (Marten 9 alpha):

| Scenario | Result |
|---|---|
| No transactional middleware, **with** projection | event dropped (count 1) |
| No transactional middleware, **no** projection | event dropped (count 1) |
| `AutoApplyTransactions()` | persisted (count 2) |
| `[Transactional]` | persisted (count 2) |

### Changes

- **Docs**: a `::: danger` callout in `docs/guide/durability/marten/transactional-middleware.md` explaining the silent-no-save behavior and that injecting `IDocumentSession` and relying on Wolverine to commit requires opting into the transactional middleware (or owning `SaveChangesAsync()` yourself).
- **Tests**: `Bug_2860_inline_projection_null_apply` with two guards proving the `AutoApplyTransactions()` and `[Transactional]` recipes persist the appended event.

No production behavior change — the silent-no-save is the intended "you didn't opt into transactions" path; this PR makes it discoverable.

## Test plan

- [x] `auto_apply_transactions_persists_the_appended_event` (2/2 green)
- [x] `transactional_attribute_persists_the_appended_event`

🤖 Generated with [Claude Code](https://claude.com/claude-code)