### PR TITLE
Fix CosmosDb durability agent URI scheme ('cosmosdb' → 'wolverinedb') (#2845)

### DIFF
--- a/src/Persistence/CosmosDbTests/durability_agent_lifecycle.cs
+++ b/src/Persistence/CosmosDbTests/durability_agent_lifecycle.cs
@@ -9,12 +9,12 @@ using Wolverine.Runtime.Agents;
 
 namespace CosmosDbTests;
 
-// Companion guard for the CosmosDb side of #2623. RavenDb had a duplicate-poller bug
-// because RavenDbMessageStore.BuildAgentFamily registered a competing
-// wolverinedb://ravendb/durability agent and StartScheduledJobs *also* started its own.
-// CosmosDbMessageStore.BuildAgentFamily returns null, so only the one returned from
-// StartScheduledJobs polls — but if anyone ever wires a CosmosDb agent family in the
-// future, this test will fail loudly the first time two pollers appear.
+// Companion guard for the CosmosDb side of #2623 and the #2845 scheme fix. The CosmosDb
+// durability agent is cluster-managed via the wolverinedb://cosmosdb/durability URI
+// (MessageStoreCollection.BuildAgentAsync), and NodeAgentController calls StartAsync on it
+// — that is the single poller. CosmosDbMessageStore.StartScheduledJobs must NOT also call
+// StartTimers(), or two pollers would share this store and race (the #2623 bug). This test
+// asserts exactly one polling agent across both sources and fails loudly if that regresses.
 [Collection("cosmosdb")]
 [Trait("Category", "Flaky")]
 public class durability_agent_lifecycle : IAsyncLifetime

--- a/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.cs
@@ -4,6 +4,7 @@ using JasperFx.Descriptors;
 using Microsoft.Azure.Cosmos;
 using Wolverine.CosmosDb.Internals.Durability;
 using Wolverine.CosmosDb.Internals.Transport;
+using Wolverine.Persistence;
 using Wolverine.Persistence.Durability;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Agents;
@@ -52,7 +53,7 @@ public partial class CosmosDbMessageStore : IMessageStoreWithAgentSupport
 
     public string Name => _databaseName;
 
-    public Uri Uri => new("cosmosdb://durability");
+    public Uri Uri => new($"{PersistenceConstants.AgentScheme}://cosmosdb/durability");
 
     public string IdentityFor(Envelope envelope) => _identity(envelope);
 
@@ -107,15 +108,14 @@ public partial class CosmosDbMessageStore : IMessageStoreWithAgentSupport
         _scheduledLockId = $"lock|scheduled|{runtime.Options.ServiceName.ToLowerInvariant()}";
         _runtime = runtime;
 
-        // Unlike the RavenDb message store, CosmosDb returns null from BuildAgentFamily,
-        // so NodeAgentController never registers a second durability agent. The agent
-        // built and started here is the only one polling — leaving the eager
-        // StartTimers() call intact is correct. See #2623 for the matching RavenDb fix
-        // that DID need to drop StartTimers because RavenDb has a competing
-        // wolverinedb://ravendb/durability agent registered through IAgentFamily.
-        var agent = BuildAgent(runtime);
-        agent.As<CosmosDbDurabilityAgent>().StartTimers();
-        return agent;
+        // NodeAgentController owns the durability agent lifecycle via the
+        // wolverinedb://cosmosdb/durability URI (built through
+        // MessageStoreCollection.BuildAgentAsync and started with StartAsync); do not
+        // start a second instance here. The agent built here is held by
+        // WolverineRuntime.DurableScheduledJobs purely for its disposal-time StopAsync,
+        // which is null-safe on the unstarted task fields. Eagerly calling StartTimers()
+        // would produce two concurrent pollers sharing this store — the #2623 bug.
+        return BuildAgent(runtime);
     }
 
     public IAgent BuildAgent(IWolverineRuntime runtime)

--- a/src/Persistence/Wolverine.CosmosDb/Internals/Durability/CosmosDbDurabilityAgent.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/Durability/CosmosDbDurabilityAgent.cs
@@ -40,7 +40,7 @@ public partial class CosmosDbDurabilityAgent : IAgent
         _localQueue = (ILocalQueue)runtime.Endpoints.AgentForLocalQueue(TransportConstants.Scheduled);
         _settings = runtime.DurabilitySettings;
 
-        Uri = new Uri("cosmosdb://durability");
+        Uri = new Uri($"{PersistenceConstants.AgentScheme}://cosmosdb/durability");
 
         _logger = runtime.LoggerFactory.CreateLogger<CosmosDbDurabilityAgent>();
 


### PR DESCRIPTION
## Summary

Closes #2845. With CosmosDB persistence, every `NodeReassignmentPollingTime` cycle logged:

```
Error trying to reevaluate agent assignments for 'wolverinedb' agents
System.ArgumentOutOfRangeException: Unrecognized agent scheme 'cosmosdb' (Parameter 'uri')
   at Wolverine.Runtime.Agents.NodeAgentController.findAgentAsync(Uri uri)
```

### Root cause

`CosmosDbMessageStore.Uri` and `CosmosDbDurabilityAgent.Uri` were built as `cosmosdb://durability`. `MessageStoreCollection` (the central `wolverinedb` agent family) advertises every store's `Uri` via `AllKnownAgentsAsync()` and distributes them under the `wolverinedb` scheme. So `cosmosdb://durability` entered the assignment set, and when `NodeAgentController` tried to start it, `findAgentAsync` keyed on the URI's own scheme (`cosmosdb`), which isn't registered → threw every poll cycle. This is the same class of bug as the RavenDb fix in #2261.

### Fix

- Both URIs → `wolverinedb://cosmosdb/durability`, so the scheme resolves to `MessageStoreCollection`, which builds the durability agent via the store's `BuildAgent` (mirrors RavenDb).
- Because the agent is now **cluster-managed** (`NodeAgentController` calls `StartAsync` → `StartTimers`), `CosmosDbMessageStore.StartScheduledJobs` no longer eagerly calls `StartTimers()`. Keeping it would leave two pollers racing on the same store — the #2623 duplicate-poller bug. The agent built there is retained only for disposal-time `StopAsync`.

This makes CosmosDb consistent with the RavenDb post-#2261/#2623 design.

## Test plan

- [x] `Wolverine.CosmosDb` + `CosmosDbTests` build clean
- [x] Existing `durability_agent_lifecycle.only_one_durability_agent_polls_after_host_start` guard already asserts exactly one polling agent across both the NodeController and StartScheduledJobs sources — comment updated to reflect the cluster-managed agent is now the poller
- [ ] Full CosmosDb test run pending in CI (the Testcontainers Cosmos emulator did not start in my local environment)

Companion 5.0 PR: same fix cherry-picked to the `5.0` maintenance branch (reported against WolverineFx.CosmosDb 5.35.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)