### PR TITLE
Fix CosmosDb durability agent URI scheme ('cosmosdb' → 'wolverinedb') (#2845) [5.0]

### DIFF
--- a/src/Persistence/CosmosDbTests/durability_agent_lifecycle.cs
+++ b/src/Persistence/CosmosDbTests/durability_agent_lifecycle.cs
@@ -9,12 +9,12 @@ using Wolverine.Runtime.Agents;
 
 namespace CosmosDbTests;
 
-// Companion guard for the CosmosDb side of #2623. RavenDb had a duplicate-poller bug
-// because RavenDbMessageStore.BuildAgentFamily registered a competing
-// wolverinedb://ravendb/durability agent and StartScheduledJobs *also* started its own.
-// CosmosDbMessageStore.BuildAgentFamily returns null, so only the one returned from
-// StartScheduledJobs polls — but if anyone ever wires a CosmosDb agent family in the
-// future, this test will fail loudly the first time two pollers appear.
+// Companion guard for the CosmosDb side of #2623 and the #2845 scheme fix. The CosmosDb
+// durability agent is cluster-managed via the wolverinedb://cosmosdb/durability URI
+// (MessageStoreCollection.BuildAgentAsync), and NodeAgentController calls StartAsync on it
+// — that is the single poller. CosmosDbMessageStore.StartScheduledJobs must NOT also call
+// StartTimers(), or two pollers would share this store and race (the #2623 bug). This test
+// asserts exactly one polling agent across both sources and fails loudly if that regresses.
 [Collection("cosmosdb")]
 [Trait("Category", "Flaky")]
 public class durability_agent_lifecycle : IAsyncLifetime

--- a/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.cs
@@ -4,6 +4,7 @@ using JasperFx.Descriptors;
 using Microsoft.Azure.Cosmos;
 using Wolverine.CosmosDb.Internals.Durability;
 using Wolverine.CosmosDb.Internals.Transport;
+using Wolverine.Persistence;
 using Wolverine.Persistence.Durability;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Agents;
@@ -52,7 +53,7 @@ public partial class CosmosDbMessageStore : IMessageStoreWithAgentSupport
 
     public string Name => _databaseName;
 
-    public Uri Uri => new("cosmosdb://durability");
+    public Uri Uri => new($"{PersistenceConstants.AgentScheme}://cosmosdb/durability");
 
     public string IdentityFor(Envelope envelope) => _identity(envelope);
 
@@ -107,15 +108,14 @@ public partial class CosmosDbMessageStore : IMessageStoreWithAgentSupport
         _scheduledLockId = $"lock|scheduled|{runtime.Options.ServiceName.ToLowerInvariant()}";
         _runtime = runtime;
 
-        // Unlike the RavenDb message store, CosmosDb returns null from BuildAgentFamily,
-        // so NodeAgentController never registers a second durability agent. The agent
-        // built and started here is the only one polling — leaving the eager
-        // StartTimers() call intact is correct. See #2623 for the matching RavenDb fix
-        // that DID need to drop StartTimers because RavenDb has a competing
-        // wolverinedb://ravendb/durability agent registered through IAgentFamily.
-        var agent = BuildAgent(runtime);
-        agent.As<CosmosDbDurabilityAgent>().StartTimers();
-        return agent;
+        // NodeAgentController owns the durability agent lifecycle via the
+        // wolverinedb://cosmosdb/durability URI (built through
+        // MessageStoreCollection.BuildAgentAsync and started with StartAsync); do not
+        // start a second instance here. The agent built here is held by
+        // WolverineRuntime.DurableScheduledJobs purely for its disposal-time StopAsync,
+        // which is null-safe on the unstarted task fields. Eagerly calling StartTimers()
+        // would produce two concurrent pollers sharing this store — the #2623 bug.
+        return BuildAgent(runtime);
     }
 
     public IAgent BuildAgent(IWolverineRuntime runtime)

--- a/src/Persistence/Wolverine.CosmosDb/Internals/Durability/CosmosDbDurabilityAgent.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/Durability/CosmosDbDurabilityAgent.cs
@@ -40,7 +40,7 @@ public partial class CosmosDbDurabilityAgent : IAgent
         _localQueue = (ILocalQueue)runtime.Endpoints.AgentForLocalQueue(TransportConstants.Scheduled);
         _settings = runtime.DurabilitySettings;
 
-        Uri = new Uri("cosmosdb://durability");
+        Uri = new Uri($"{PersistenceConstants.AgentScheme}://cosmosdb/durability");
 
         _logger = runtime.LoggerFactory.CreateLogger<CosmosDbDurabilityAgent>();
 


### PR DESCRIPTION
## Summary

Closes #2845 on the **5.0** maintenance branch (reported against WolverineFx.CosmosDb 5.35.1). Cherry-pick of the `main` fix — the affected code is identical on both branches.

With CosmosDB persistence, every poll cycle logged `ArgumentOutOfRangeException: Unrecognized agent scheme 'cosmosdb'`. `CosmosDbMessageStore.Uri` / `CosmosDbDurabilityAgent.Uri` were `cosmosdb://durability`, but `MessageStoreCollection` advertises and distributes store URIs under the `wolverinedb` scheme, so `NodeAgentController.findAgentAsync` couldn't resolve the `cosmosdb` scheme. Same class as the RavenDb #2261 fix.

### Fix

- Both URIs → `wolverinedb://cosmosdb/durability` (routes to `MessageStoreCollection.BuildAgentAsync` → store `BuildAgent`).
- Dropped the eager `StartTimers()` in `StartScheduledJobs` — now that the agent is cluster-managed via `NodeAgentController.StartAsync`, keeping it would create two pollers racing on the same store (#2623). The agent built there is retained only for disposal.

## Test plan

- [x] `Wolverine.CosmosDb` + `CosmosDbTests` build clean on 5.0
- [x] `durability_agent_lifecycle` guard asserts exactly one polling agent
- [ ] Full CosmosDb test run pending in CI (local Testcontainers Cosmos emulator did not start)

Companion `main` PR: #2863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)