### PR TITLE
docs(dcb): document [BoundaryAggregate] for identity-less DCB aggregates (#2859)

### DIFF
--- a/docs/guide/durability/marten/event-sourcing.md
+++ b/docs/guide/durability/marten/event-sourcing.md
@@ -1476,6 +1476,43 @@ public class SubscriptionState
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Dcb/University/SubscriptionState.cs#L1-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_dcb_subscription_state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### Identity-less Boundary Aggregates with `[BoundaryAggregate]`
+
+A boundary aggregate is built from `Apply` / `Create` methods, and the source generator emits the evolver that `FetchForWritingByTags<T>()` (and `AggregateByTagsAsync<T>()`) resolve at runtime. The generator normally discovers the aggregate's identity (`TId`) from an `Id` property or an `[AggregateIdentity]` member. A *true* boundary aggregate, though, has **no single-stream identity** — it spans multiple streams by tag — so the generator cannot infer a `TId`, emits nothing, and the DCB fetch throws:
+
+```
+JasperFx.Events.Projections.InvalidProjectionException : No source-generated dispatcher found for ...
+```
+
+Mark such an identity-less aggregate with `[BoundaryAggregate]` (from `JasperFx.Events.Aggregation`) to opt it into evolver generation:
+
+```cs
+using JasperFx.Events.Aggregation;
+
+[BoundaryAggregate]
+public partial class SubscriptionState
+{
+    // No Id property, no [AggregateIdentity] — spans streams by tag only
+    public CourseId? CourseId { get; private set; }
+    public StudentId? StudentId { get; private set; }
+
+    public void Apply(StudentEnrolledInFaculty e) => StudentId = e.StudentId;
+    public void Apply(CourseCreated e) => CourseId = e.CourseId;
+    // ... remaining Apply methods
+}
+```
+
+Requirements:
+
+- The aggregate must be `partial` and live in an assembly that references the `JasperFx.Events.SourceGenerator` analyzer.
+- The `[BoundaryAggregate]` attribute must sit on the type **in its own defining assembly** — that is the compilation the generator emits into and the assembly the runtime scans (`typeof(T).Assembly`) when resolving the evolver.
+
+::: tip
+This is only needed for the **identity-less** case. An aggregate that carries an `Id` (or an `[AggregateIdentity]` member) — like the `SubscriptionState` shown above, which keeps an `Id` and is registered as a live single-stream projection — already gets an evolver and needs no marker.
+:::
+
+The `[BoundaryAggregate]` marker comes from JasperFx.Events 2.0.0-alpha.21 / JasperFx.Events.SourceGenerator 2.0.0-alpha.13 ([jasperfx#324](https://github.com/JasperFx/jasperfx/issues/324)). See the [Marten DCB documentation](https://github.com/JasperFx/marten/issues/4513) for the canonical attribute reference; the note here covers the Wolverine handler-side workflow.
+
 ### Using the `[BoundaryModel]` Attribute
 
 The `[BoundaryModel]` attribute on a handler parameter triggers the DCB workflow. Your handler class must include a `Load()` (or `LoadAsync()`, `Before()`, `BeforeAsync()`) method that returns an `EventTagQuery`:

--- a/docs/guide/durability/polecat/event-sourcing.md
+++ b/docs/guide/durability/polecat/event-sourcing.md
@@ -761,6 +761,43 @@ public class SubscriptionState
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Dcb/University/SubscriptionState.cs#L1-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_dcb_subscription_state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### Identity-less Boundary Aggregates with `[BoundaryAggregate]`
+
+A boundary aggregate is built from `Apply` / `Create` methods, and the source generator emits the evolver that `FetchForWritingByTags<T>()` (and `AggregateByTagsAsync<T>()`) resolve at runtime. The generator normally discovers the aggregate's identity (`TId`) from an `Id` property or an `[AggregateIdentity]` member. A *true* boundary aggregate, though, has **no single-stream identity** — it spans multiple streams by tag — so the generator cannot infer a `TId`, emits nothing, and the DCB fetch throws:
+
+```
+JasperFx.Events.Projections.InvalidProjectionException : No source-generated dispatcher found for ...
+```
+
+Mark such an identity-less aggregate with `[BoundaryAggregate]` (from `JasperFx.Events.Aggregation`) to opt it into evolver generation:
+
+```cs
+using JasperFx.Events.Aggregation;
+
+[BoundaryAggregate]
+public partial class SubscriptionState
+{
+    // No Id property, no [AggregateIdentity] — spans streams by tag only
+    public CourseId? CourseId { get; private set; }
+    public StudentId? StudentId { get; private set; }
+
+    public void Apply(StudentEnrolledInFaculty e) => StudentId = e.StudentId;
+    public void Apply(CourseCreated e) => CourseId = e.CourseId;
+    // ... remaining Apply methods
+}
+```
+
+Requirements:
+
+- The aggregate must be `partial` and live in an assembly that references the `JasperFx.Events.SourceGenerator` analyzer.
+- The `[BoundaryAggregate]` attribute must sit on the type **in its own defining assembly** — that is the compilation the generator emits into and the assembly the runtime scans (`typeof(T).Assembly`) when resolving the evolver.
+
+::: tip
+This is only needed for the **identity-less** case. An aggregate that carries an `Id` (or an `[AggregateIdentity]` member) — like the `SubscriptionState` shown above, which keeps an `Id` and is registered as a live single-stream projection — already gets an evolver and needs no marker.
+:::
+
+The `[BoundaryAggregate]` marker comes from JasperFx.Events 2.0.0-alpha.21 / JasperFx.Events.SourceGenerator 2.0.0-alpha.13 ([jasperfx#324](https://github.com/JasperFx/jasperfx/issues/324)). See the [Polecat DCB documentation](https://github.com/JasperFx/polecat/issues/122) for the canonical attribute reference; the note here covers the Wolverine handler-side workflow.
+
 ### Using the `[BoundaryModel]` Attribute
 
 The `[BoundaryModel]` attribute on a handler parameter triggers the DCB workflow. Your handler class must include a `Load()` (or `LoadAsync()`, `Before()`, `BeforeAsync()`) method that returns an `EventTagQuery`:


### PR DESCRIPTION
## Summary

Closes #2859. Documents the `[BoundaryAggregate]` marker (from [jasperfx#324](https://github.com/JasperFx/jasperfx/issues/324), in JasperFx.Events 2.0.0-alpha.21 / JasperFx.Events.SourceGenerator 2.0.0-alpha.13) in Wolverine's DCB-facing event-sourcing guides.

When a handler fetches/aggregates a **boundary aggregate with no single-stream identity** (no `Id`, no `[AggregateIdentity]`) via the DCB surface (`FetchForWritingByTags<T>` / `AggregateByTagsAsync<T>`), the source generator can't infer a `TId`, emits no evolver, and the fetch throws `InvalidProjectionException: No source-generated dispatcher found`. Marking the (partial) aggregate `[BoundaryAggregate]` in its own assembly opts it into evolver generation.

### Changes

A new **"Identity-less Boundary Aggregates with `[BoundaryAggregate]`"** subsection added to both:
- `docs/guide/durability/marten/event-sourcing.md`
- `docs/guide/durability/polecat/event-sourcing.md`

Each covers: the failure mode, the marker + its own-defining-assembly requirement, a `::: tip` clarifying that aggregates carrying an `Id` (like the example `SubscriptionState`, which keeps an `Id` and registers as a live single-stream projection) need **no** marker, and cross-links to the canonical event-store DCB references — Marten ([marten#4513](https://github.com/JasperFx/marten/issues/4513)) / Polecat ([polecat#122](https://github.com/JasperFx/polecat/issues/122)) — plus jasperfx#324.

Docs-only; no code change. The `[BoundaryAggregate]` shape was taken from the attribute's source in JasperFx.Events 2.0.0-alpha.21 (the version `main` is pinned to).

### Note for reviewer

The embedded `sample_wolverine_dcb_subscription_state` example aggregate currently uses the `Id` + live-single-stream-projection approach (from the DCB parity work), so it's the "needs no marker" case and is consistent with the new tip. Migrating that example to actually use `[BoundaryAggregate]` would be a separate code change beyond this docs issue — happy to do it as a follow-up if you'd prefer the example showcase the marker directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)