### PR TITLE
Routing diagnostics: ExplainRoutingFor + describe-routing --explain/--json (#2809)

### DIFF
--- a/docs/guide/command-line.md
+++ b/docs/guide/command-line.md
@@ -233,6 +233,31 @@ The output for a single message type includes:
 - **Message-level attributes** — any `ModifyEnvelopeAttribute`-derived attributes (e.g.,
   `[DeliverWithin]`) applied to the message class
 
+**Explain *why* a message routes where it does** <Badge type="tip" text="6.0" /> — add `--explain`
+(`-e`) to print the route source chain in the order Wolverine consults it, what each source
+produced, and which **terminating** source short-circuited the rest:
+
+```bash
+dotnet run -- wolverine-diagnostics describe-routing CreateOrder --explain
+```
+
+The explanation lists each route source (`MessageTransformations`, `AgentCommands`,
+`ExplicitRouting`, `LocalRouting`, `ConventionalRouting`, plus any custom sources) with a short
+description, whether it is additive or terminating, the routes it produced, and a skip reason when
+an earlier terminating source already produced routes. Conventional broker routing also reports the
+broker scheme/name and the transport's own description, so named brokers of the same transport type
+can be told apart. This is the CLI surface over the `IWolverineRuntime.ExplainRoutingFor(Type)` API
+(see [Troubleshooting Message Routing](/guide/diagnostics#troubleshooting-message-routing)).
+
+For machine or AI-agent consumption, add `--json` (`-j`) to emit the same explanation as JSON:
+
+```bash
+dotnet run -- wolverine-diagnostics describe-routing CreateOrder --json
+```
+
+The text output is intentionally stable and labeled so it reads well for humans *and* parses cleanly
+for AI agents; `--json` gives a fully structured form.
+
 **Show the complete routing topology** (all message types):
 
 ```bash

--- a/docs/guide/diagnostics.md
+++ b/docs/guide/diagnostics.md
@@ -205,6 +205,9 @@ sources keep contributing. `RoutingExplanation` makes that precedence visible:
   (`IInternalMessage` / `IAgentCommand` / `INotToBeRouted`, or types from an
   `[ExcludeFromServiceCapabilities]` assembly), which are filtered out of observers and service
   capabilities.
+- `LocalRoutingConventionDisabled` — the current value of
+  `WolverineOptions.LocalRoutingConventionDisabled`; when `true` the `LocalRouting` source is
+  short-circuited, so it explains why a locally-handled message routes nowhere locally.
 - `Steps` — one `RouteSourceStep` per route source consulted, in order, each carrying the source's
   descriptor, the routes it produced, and a `SkipReason` when a prior terminating source had
   already short-circuited the chain.

--- a/docs/guide/diagnostics.md
+++ b/docs/guide/diagnostics.md
@@ -166,3 +166,53 @@ private static void using_preview_subscriptions(IMessageBus bus)
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Runtime/Routing/routing_rules.cs#L102-L115' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_preview_subscriptions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### Explaining *Why* a Message Routes Where It Does <Badge type="tip" text="6.0" />
+
+`PreviewSubscriptions` tells you *where* a message goes; `IWolverineRuntime.ExplainRoutingFor(Type)`
+tells you *why*. It returns a structured `RoutingExplanation` that walks Wolverine's route source
+chain in order and records what each source did:
+
+```csharp
+var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+RoutingExplanation explanation = runtime.ExplainRoutingFor(typeof(CreateOrder));
+
+// Human- and AI-readable text rendering
+Console.WriteLine(explanation.ToText());
+
+// Or inspect the structure directly
+foreach (var step in explanation.Steps)
+{
+    // step.Source is a RouteSourceDescriptor (Name, Description, IsAdditive, Conventions)
+    if (step.SkipReason is not null)
+    {
+        // an earlier *terminating* source already produced routes, so this one never ran
+        Console.WriteLine($"{step.Source.Name}: skipped — {step.SkipReason}");
+    }
+    else
+    {
+        Console.WriteLine($"{step.Source.Name}: produced {step.Produced.Count} route(s)");
+    }
+}
+```
+
+Wolverine consults its route sources in a fixed order, and a **terminating** source (e.g.
+`ExplicitRouting`, `AgentCommands`) short-circuits the rest of the chain once any routes have been
+accumulated, while **additive** sources (e.g. `LocalRouting`, `ConventionalRouting`) let later
+sources keep contributing. `RoutingExplanation` makes that precedence visible:
+
+- `MessageType` and `IsSystemMessageType` — the latter is `true` for framework-internal types
+  (`IInternalMessage` / `IAgentCommand` / `INotToBeRouted`, or types from an
+  `[ExcludeFromServiceCapabilities]` assembly), which are filtered out of observers and service
+  capabilities.
+- `Steps` — one `RouteSourceStep` per route source consulted, in order, each carrying the source's
+  descriptor, the routes it produced, and a `SkipReason` when a prior terminating source had
+  already short-circuited the chain.
+- `FinalRoutes` — the final, de-duplicated route set actually used.
+
+The same information is also available from the command line — see
+[`describe-routing --explain`](/guide/command-line#describe-routing) — and the route-source
+descriptors are surfaced in Wolverine's service capabilities so external tooling (e.g. CritterWatch)
+can reason about routing decisions. The text output is deliberately stable and labeled so it is
+useful for both humans and AI agents.
+

--- a/src/Testing/CoreTests/Runtime/MockWolverineRuntime.cs
+++ b/src/Testing/CoreTests/Runtime/MockWolverineRuntime.cs
@@ -103,6 +103,14 @@ public class MockWolverineRuntime : IWolverineRuntime, IObserver<IWolverineEvent
         return Routers.TryGetValue(messageType, out var router) ? router : Substitute.For<IMessageRouter>();
     }
 
+    public Wolverine.Runtime.Routing.RoutingExplanation ExplainRoutingFor(Type messageType)
+    {
+        return new Wolverine.Runtime.Routing.RoutingExplanation
+        {
+            MessageType = messageType.FullName ?? messageType.Name
+        };
+    }
+
     public T? TryFindExtension<T>() where T : class
     {
         throw new NotImplementedException();

--- a/src/Testing/CoreTests/Runtime/Routing/explain_routing.cs
+++ b/src/Testing/CoreTests/Runtime/Routing/explain_routing.cs
@@ -77,6 +77,28 @@ public class explain_routing
     }
 
     [Fact]
+    public async Task reports_local_routing_convention_disabled_flag()
+    {
+        using var enabled = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType(typeof(ExplainLocalHandler)))
+            .StartAsync();
+        enabled.GetRuntime().ExplainRoutingFor(typeof(ExplainLocalMessage))
+            .LocalRoutingConventionDisabled.ShouldBeFalse();
+
+        using var disabled = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.IncludeType(typeof(ExplainLocalHandler));
+                opts.Policies.DisableConventionalLocalRouting();
+            })
+            .StartAsync();
+
+        var explanation = disabled.GetRuntime().ExplainRoutingFor(typeof(ExplainLocalMessage));
+        explanation.LocalRoutingConventionDisabled.ShouldBeTrue();
+        explanation.ToText().ShouldContain("LOCAL-ROUTING-CONVENTION-DISABLED: true");
+    }
+
+    [Fact]
     public async Task flags_system_message_types()
     {
         using var host = await Host.CreateDefaultBuilder().UseWolverine().StartAsync();

--- a/src/Testing/CoreTests/Runtime/Routing/explain_routing.cs
+++ b/src/Testing/CoreTests/Runtime/Routing/explain_routing.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+using Wolverine.Transports.Tcp;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Runtime.Routing;
+
+public class explain_routing
+{
+    public record ExplainLocalMessage(Guid Id);
+    public record ExplainPublishedMessage(Guid Id);
+    public record ExplainUnroutedMessage(Guid Id);
+
+    public static class ExplainLocalHandler
+    {
+        public static void Handle(ExplainLocalMessage message) { }
+        public static void Handle(ExplainPublishedMessage message) { }
+    }
+
+    [Fact]
+    public async Task explains_local_routing()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType(typeof(ExplainLocalHandler)))
+            .StartAsync();
+
+        var explanation = host.GetRuntime().ExplainRoutingFor(typeof(ExplainLocalMessage));
+
+        explanation.IsSystemMessageType.ShouldBeFalse();
+        explanation.FinalRoutes.ShouldNotBeEmpty();
+
+        var local = explanation.Steps.Single(x => x.Source.Name == "LocalRouting");
+        local.SkipReason.ShouldBeNull();
+        local.Produced.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task explicit_routing_terminates_and_later_sources_are_skipped()
+    {
+        var port = PortFinder.GetAvailablePort();
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.IncludeType(typeof(ExplainLocalHandler));
+                // Explicit publishing rule — ExplicitRouting is terminating
+                opts.PublishMessage<ExplainPublishedMessage>().ToPort(port);
+            })
+            .StartAsync();
+
+        var explanation = host.GetRuntime().ExplainRoutingFor(typeof(ExplainPublishedMessage));
+
+        var explicitStep = explanation.Steps.Single(x => x.Source.Name == "ExplicitRouting");
+        explicitStep.Source.IsAdditive.ShouldBeFalse();
+        explicitStep.Produced.ShouldNotBeEmpty();
+
+        // LocalRouting comes after the terminating ExplicitRouting and must be reported as skipped
+        var localStep = explanation.Steps.Single(x => x.Source.Name == "LocalRouting");
+        localStep.SkipReason.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task explains_a_message_routed_nowhere()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType(typeof(ExplainLocalHandler)))
+            .StartAsync();
+
+        var explanation = host.GetRuntime().ExplainRoutingFor(typeof(ExplainUnroutedMessage));
+
+        explanation.FinalRoutes.ShouldBeEmpty();
+        explanation.Steps.ShouldAllBe(x => x.Produced.Count == 0 || x.SkipReason != null);
+    }
+
+    [Fact]
+    public async Task flags_system_message_types()
+    {
+        using var host = await Host.CreateDefaultBuilder().UseWolverine().StartAsync();
+
+        var explanation = host.GetRuntime().ExplainRoutingFor(typeof(ExplainAgentCommand));
+        explanation.IsSystemMessageType.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task text_output_carries_stable_labels_for_humans_and_agents()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType(typeof(ExplainLocalHandler)))
+            .StartAsync();
+
+        var text = host.GetRuntime().ExplainRoutingFor(typeof(ExplainLocalMessage)).ToText();
+
+        text.ShouldContain("MESSAGE:");
+        text.ShouldContain("SYSTEM-MESSAGE-TYPE:");
+        text.ShouldContain("ROUTE SOURCES");
+        text.ShouldContain("SOURCE: LocalRouting");
+        text.ShouldContain("FINAL ROUTES:");
+    }
+}
+
+public record ExplainAgentCommand : IAgentCommand
+{
+    public Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
+        => Task.FromResult(AgentCommands.Empty);
+}

--- a/src/Wolverine/Configuration/Capabilities/MessageDescriptor.cs
+++ b/src/Wolverine/Configuration/Capabilities/MessageDescriptor.cs
@@ -29,6 +29,13 @@ public class MessageDescriptor
         var routes = runtime.RoutingFor(messageType).Routes;
         Subscriptions.AddRange(routes.Select(x => x.Describe()));
 
+        // The route sources / conventions that actually contributed this message's routes, so
+        // tooling (and AI agents) can see *why* it routes where it does, not just the destinations.
+        var explanation = runtime.ExplainRoutingFor(messageType);
+        RouteSources.AddRange(explanation.Steps
+            .Where(x => x.SkipReason is null && x.Produced.Count != 0)
+            .Select(x => x.Source));
+
         var chain = runtime.Options.HandlerGraph.ChainFor(messageType);
         if (chain != null)
         {
@@ -58,4 +65,11 @@ public class MessageDescriptor
     public List<MessageHandlerDescriptor> Handlers { get; set; } = new();
 
     public List<MessageSubscriptionDescriptor> Subscriptions { get; set; } = new();
+
+    /// <summary>
+    /// The route sources and conventions that contributed this message type's routes — the "why"
+    /// behind <see cref="Subscriptions"/>. Surfaced so external tooling (e.g. CritterWatch) and AI
+    /// agents can reason about routing decisions, not just the resulting destinations.
+    /// </summary>
+    public List<RouteSourceDescriptor> RouteSources { get; set; } = new();
 }

--- a/src/Wolverine/Diagnostics/WolverineDiagnosticsCommand.cs
+++ b/src/Wolverine/Diagnostics/WolverineDiagnosticsCommand.cs
@@ -47,6 +47,15 @@ public class WolverineDiagnosticsInput : NetCoreInput
     [FlagAlias("all", 'a')]
     [Description("For describe-routing: show complete routing topology for all known message types.")]
     public bool AllFlag { get; set; }
+
+    [FlagAlias("explain", 'e')]
+    [Description("For describe-routing <MessageType>: explain why the type routes where it does — " +
+                 "each route source consulted, what it produced, and which terminating source short-circuited the rest.")]
+    public bool ExplainFlag { get; set; }
+
+    [FlagAlias("json", 'j')]
+    [Description("For describe-routing <MessageType>: emit the routing explanation as JSON for machine / AI-agent consumption.")]
+    public bool JsonFlag { get; set; }
 }
 
 /// <summary>
@@ -471,6 +480,11 @@ public class WolverineDiagnosticsCommand : JasperFxAsyncCommand<WolverineDiagnos
                     return true;
                 }
 
+                if (input.ExplainFlag || input.JsonFlag)
+                {
+                    return ExplainSingleTypeRouting(input.MessageTypeArg, runtime, input.JsonFlag);
+                }
+
                 return DescribeSingleTypeRouting(input.MessageTypeArg, runtime);
             }
             finally
@@ -651,6 +665,39 @@ public class WolverineDiagnosticsCommand : JasperFxAsyncCommand<WolverineDiagnos
 
             AnsiConsole.Write(senderTable);
         }
+    }
+
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Dev-time describe-routing diagnostics CLI; reflection-based JSON of the RoutingExplanation runs interactively, never on an AOT-published hot path.")]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Dev-time describe-routing diagnostics CLI; reflection-based JSON of the RoutingExplanation runs interactively, never on an AOT-published hot path.")]
+    private static bool ExplainSingleTypeRouting(string search, IWolverineRuntime runtime, bool asJson)
+    {
+        var options = runtime.Options;
+        var messageTypes = options.Discovery.FindAllMessages(options.HandlerGraph).ToArray();
+        var messageType = FindMessageType(search, messageTypes, options.HandlerGraph);
+
+        if (messageType == null)
+        {
+            AnsiConsole.MarkupLine($"[red]No message type found matching '[bold]{Markup.Escape(search)}[/]'.[/]");
+            return false;
+        }
+
+        var explanation = runtime.ExplainRoutingFor(messageType);
+
+        if (asJson)
+        {
+            // Plain Console.WriteLine (not AnsiConsole markup) so the JSON is emitted verbatim
+            // for machine / AI-agent consumption.
+            Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(explanation,
+                new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
+        }
+        else
+        {
+            Console.WriteLine(explanation.ToText());
+        }
+
+        return true;
     }
 
     private static bool DescribeSingleTypeRouting(string search, IWolverineRuntime runtime)

--- a/src/Wolverine/Runtime/IWolverineRuntime.cs
+++ b/src/Wolverine/Runtime/IWolverineRuntime.cs
@@ -72,6 +72,15 @@ public interface IWolverineRuntime
     IMessageRouter RoutingFor(Type messageType);
 
     /// <summary>
+    ///     Produce a structured, on-demand explanation of how a message type is routed: which
+    ///     <see cref="IMessageRouteSource"/>s were consulted (in order), what each produced, whether
+    ///     a terminating source short-circuited the chain, the final routes, and whether the type is
+    ///     a framework system message type. Intended for diagnostics — the describe-routing CLI and
+    ///     external tooling — and runs against the live route sources with no steady-state cost.
+    /// </summary>
+    RoutingExplanation ExplainRoutingFor(Type messageType);
+
+    /// <summary>
     ///     Try to find an applied extension of type T
     /// </summary>
     /// <typeparam name="T"></typeparam>

--- a/src/Wolverine/Runtime/Routing/IMessageRoute.cs
+++ b/src/Wolverine/Runtime/Routing/IMessageRoute.cs
@@ -75,4 +75,11 @@ internal class TransformedMessageRouteSource : IMessageRouteSource
     }
 
     public bool IsAdditive => true;
+
+    public RouteSourceDescriptor Describe(IWolverineRuntime runtime) => new()
+    {
+        Name = "MessageTransformations",
+        Description = "Routes a registered transformed message type to wherever its destination type routes, applying the transformation when sending. Additive: transformed routes are combined with any others.",
+        IsAdditive = IsAdditive
+    };
 }

--- a/src/Wolverine/Runtime/Routing/IMessageRoutingConvention.cs
+++ b/src/Wolverine/Runtime/Routing/IMessageRoutingConvention.cs
@@ -41,6 +41,19 @@ public interface IMessageRoutingConvention
     void PreregisterSenders(IReadOnlyList<Type> handledMessageTypes, IWolverineRuntime runtime)
     {
     }
+
+    /// <summary>
+    /// Diagnostic description of this routing convention for routing explanations, the
+    /// describe-routing CLI, and service capabilities. The default implementation reports the
+    /// type name with no description; built-in and extension conventions should override to
+    /// supply a meaningful, AI-readable explanation (and, for broker conventions, the parent
+    /// transport's scheme/name/description).
+    /// </summary>
+    RoutingConventionDescriptor Describe(IWolverineRuntime runtime) => new()
+    {
+        Name = GetType().Name,
+        Description = string.Empty
+    };
 }
 
 #endregion

--- a/src/Wolverine/Runtime/Routing/RouteSourceDescriptor.cs
+++ b/src/Wolverine/Runtime/Routing/RouteSourceDescriptor.cs
@@ -1,0 +1,85 @@
+namespace Wolverine.Runtime.Routing;
+
+/// <summary>
+/// Diagnostic description of an <see cref="IMessageRouteSource"/> — what it is, what it
+/// matches, and whether it is additive (lets later sources contribute) or terminating
+/// (short-circuits the route source chain once it produces any routes). Surfaced through
+/// <see cref="IWolverineRuntime.ExplainRoutingFor"/>, the <c>describe-routing</c> CLI, and the
+/// expanded service capabilities so both humans and AI agents can reason about routing.
+/// </summary>
+public class RouteSourceDescriptor
+{
+    /// <summary>
+    /// Short, stable identifier for the route source (e.g. "LocalRouting",
+    /// "RabbitMqConventionalRouting"). Defaults to the implementing type name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Human- and AI-readable explanation of what this source matches and how it decides.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// True when this source lets subsequent route sources also contribute routes; false when
+    /// producing any route terminates the route source chain.
+    /// </summary>
+    public bool IsAdditive { get; set; }
+
+    /// <summary>
+    /// For sources that delegate to routing conventions (the conventional-routing source and
+    /// broker conventions), the conventions consulted by this source.
+    /// </summary>
+    public RoutingConventionDescriptor[] Conventions { get; set; } = [];
+
+    public override string ToString()
+    {
+        var additive = IsAdditive ? "additive" : "terminating";
+        return $"{Name} ({additive}): {Description}";
+    }
+}
+
+/// <summary>
+/// Diagnostic description of an <see cref="Wolverine.Runtime.Routing.IMessageRoutingConvention"/>.
+/// For broker conventions the shared <see cref="Description"/> is combined with the parent
+/// transport's own <see cref="TransportDescription"/>, plus the broker <see cref="TransportScheme"/>
+/// and <see cref="TransportName"/> so that named brokers of the same transport type in a single
+/// application can be told apart.
+/// </summary>
+public class RoutingConventionDescriptor
+{
+    /// <summary>
+    /// Short, stable identifier for the convention. Defaults to the implementing type name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Human- and AI-readable explanation of what this convention does (shared across all brokers
+    /// using the same convention base).
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The parent transport's broker scheme/protocol (e.g. "rabbitmq"). Disambiguates named brokers
+    /// of the same transport type within a single application.
+    /// </summary>
+    public string TransportScheme { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The parent transport's name. For multiple named brokers of the same transport type, this
+    /// distinguishes them.
+    /// </summary>
+    public string TransportName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The parent transport's own description, folded into the routing explanation alongside the
+    /// shared convention <see cref="Description"/>.
+    /// </summary>
+    public string TransportDescription { get; set; } = string.Empty;
+
+    public override string ToString()
+    {
+        var scheme = string.IsNullOrEmpty(TransportScheme) ? "" : $" [{TransportScheme}]";
+        return $"{Name}{scheme}: {Description}".Trim();
+    }
+}

--- a/src/Wolverine/Runtime/Routing/RoutingExplanation.cs
+++ b/src/Wolverine/Runtime/Routing/RoutingExplanation.cs
@@ -1,0 +1,124 @@
+using System.Text;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.Runtime.Routing;
+
+/// <summary>
+/// A structured, on-demand explanation of how a single message type is routed by Wolverine:
+/// which <see cref="IMessageRouteSource"/>s were consulted, what each produced, whether a
+/// terminating source short-circuited the chain, and the final route set. Produced by
+/// <see cref="IWolverineRuntime.ExplainRoutingFor"/>.
+///
+/// The <see cref="ToText"/> rendering is intended to be read by both humans and AI agents: it
+/// uses stable, labeled lines so an agent can parse "why is X routed here / why nowhere" without
+/// scraping free-form prose.
+/// </summary>
+public class RoutingExplanation
+{
+    /// <summary>The fully-qualified message type name this explanation describes.</summary>
+    public string MessageType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// True when the type is a Wolverine framework "system message type"
+    /// (IInternalMessage / IAgentCommand / INotToBeRouted, or from an
+    /// [ExcludeFromServiceCapabilities] assembly) and is therefore filtered out of
+    /// observer hooks and service capabilities.
+    /// </summary>
+    public bool IsSystemMessageType { get; set; }
+
+    /// <summary>Each route source consulted, in the order Wolverine consulted them.</summary>
+    public List<RouteSourceStep> Steps { get; set; } = new();
+
+    /// <summary>The final, combined route set produced for this message type.</summary>
+    public List<MessageSubscriptionDescriptor> FinalRoutes { get; set; } = new();
+
+    /// <summary>
+    /// Render a deterministic, labeled text block that is both human-readable and friendly for an
+    /// AI agent to consume. Stable line prefixes (MESSAGE / SYSTEM / SOURCE / produces / skipped /
+    /// ROUTE) let tooling parse the trace without natural-language scraping.
+    /// </summary>
+    public string ToText()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"MESSAGE: {MessageType}");
+        sb.AppendLine($"SYSTEM-MESSAGE-TYPE: {IsSystemMessageType.ToString().ToLowerInvariant()}");
+        sb.AppendLine();
+        sb.AppendLine("ROUTE SOURCES (in order consulted):");
+        if (Steps.Count == 0)
+        {
+            sb.AppendLine("  (none)");
+        }
+        foreach (var step in Steps)
+        {
+            var kind = step.Source.IsAdditive ? "additive" : "terminating";
+            sb.AppendLine($"  SOURCE: {step.Source.Name} [{kind}]");
+            if (!string.IsNullOrWhiteSpace(step.Source.Description))
+            {
+                sb.AppendLine($"    about: {step.Source.Description}");
+            }
+
+            if (step.SkipReason is not null)
+            {
+                sb.AppendLine($"    skipped: {step.SkipReason}");
+            }
+            else if (step.Produced.Count == 0)
+            {
+                sb.AppendLine("    produces: (no routes — no match)");
+            }
+            else
+            {
+                foreach (var route in step.Produced)
+                {
+                    sb.AppendLine($"    produces: {route.Endpoint} ({route.ContentType})");
+                }
+            }
+
+            foreach (var convention in step.Source.Conventions)
+            {
+                var scheme = string.IsNullOrEmpty(convention.TransportScheme)
+                    ? ""
+                    : $" [{convention.TransportScheme}{(string.IsNullOrEmpty(convention.TransportName) || convention.TransportName == convention.TransportScheme ? "" : "/" + convention.TransportName)}]";
+                sb.AppendLine($"    convention: {convention.Name}{scheme} — {convention.Description}");
+                if (!string.IsNullOrWhiteSpace(convention.TransportDescription))
+                {
+                    sb.AppendLine($"      transport: {convention.TransportDescription}");
+                }
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"FINAL ROUTES: {FinalRoutes.Count}");
+        if (FinalRoutes.Count == 0)
+        {
+            sb.AppendLine("  (this message type is routed nowhere)");
+        }
+        foreach (var route in FinalRoutes)
+        {
+            sb.AppendLine($"  ROUTE: {route.Endpoint} ({route.ContentType})");
+        }
+
+        return sb.ToString();
+    }
+
+    public override string ToString() => ToText();
+}
+
+/// <summary>
+/// One <see cref="IMessageRouteSource"/>'s contribution to a <see cref="RoutingExplanation"/>:
+/// the source's descriptor, the routes it produced, and — if a prior terminating source already
+/// short-circuited the chain — why it was skipped.
+/// </summary>
+public class RouteSourceStep
+{
+    /// <summary>Descriptor (name, description, additive/terminating, conventions) for the source.</summary>
+    public RouteSourceDescriptor Source { get; set; } = new();
+
+    /// <summary>The routes this source produced for the message type (empty if it produced none).</summary>
+    public List<MessageSubscriptionDescriptor> Produced { get; set; } = new();
+
+    /// <summary>
+    /// Null when this source actually ran. Populated when an earlier terminating source already
+    /// produced routes, so Wolverine never consulted this source for the message type.
+    /// </summary>
+    public string? SkipReason { get; set; }
+}

--- a/src/Wolverine/Runtime/Routing/RoutingExplanation.cs
+++ b/src/Wolverine/Runtime/Routing/RoutingExplanation.cs
@@ -26,6 +26,13 @@ public class RoutingExplanation
     /// </summary>
     public bool IsSystemMessageType { get; set; }
 
+    /// <summary>
+    /// The current value of <see cref="WolverineOptions.LocalRoutingConventionDisabled"/>. When true,
+    /// the LocalRouting source is short-circuited and never routes any message to a local in-process
+    /// queue — surfaced here so it's obvious why local routing produced nothing.
+    /// </summary>
+    public bool LocalRoutingConventionDisabled { get; set; }
+
     /// <summary>Each route source consulted, in the order Wolverine consulted them.</summary>
     public List<RouteSourceStep> Steps { get; set; } = new();
 
@@ -42,6 +49,7 @@ public class RoutingExplanation
         var sb = new StringBuilder();
         sb.AppendLine($"MESSAGE: {MessageType}");
         sb.AppendLine($"SYSTEM-MESSAGE-TYPE: {IsSystemMessageType.ToString().ToLowerInvariant()}");
+        sb.AppendLine($"LOCAL-ROUTING-CONVENTION-DISABLED: {LocalRoutingConventionDisabled.ToString().ToLowerInvariant()}");
         sb.AppendLine();
         sb.AppendLine("ROUTE SOURCES (in order consulted):");
         if (Steps.Count == 0)

--- a/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
@@ -247,7 +247,8 @@ public partial class WolverineRuntime
         var explanation = new RoutingExplanation
         {
             MessageType = messageType.FullNameInCode(),
-            IsSystemMessageType = messageType.IsSystemMessageType()
+            IsSystemMessageType = messageType.IsSystemMessageType(),
+            LocalRoutingConventionDisabled = Options.LocalRoutingConventionDisabled
         };
 
         // Mirror findRoutes() exactly so the explanation matches real routing behavior: routes

--- a/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
@@ -28,6 +28,19 @@ public interface IMessageRouteSource
     /// to add more routes from the subsequent routing sources?
     /// </summary>
     bool IsAdditive { get; }
+
+    /// <summary>
+    /// Diagnostic description of this route source for routing explanations, the
+    /// describe-routing CLI, and service capabilities. The default implementation reports the
+    /// type name and IsAdditive with no description; built-in and extension sources should
+    /// override to supply a meaningful, AI-readable explanation (and any conventions consulted).
+    /// </summary>
+    RouteSourceDescriptor Describe(IWolverineRuntime runtime) => new()
+    {
+        Name = GetType().Name,
+        Description = string.Empty,
+        IsAdditive = IsAdditive
+    };
 }
 
 #endregion
@@ -54,6 +67,13 @@ internal class AgentMessages : IMessageRouteSource
     }
 
     public bool IsAdditive => false;
+
+    public RouteSourceDescriptor Describe(IWolverineRuntime runtime) => new()
+    {
+        Name = "AgentCommands",
+        Description = "Routes Wolverine agent command messages (types implementing IAgentCommand) to the internal agent local queue. Terminating: nothing else routes an agent command.",
+        IsAdditive = IsAdditive
+    };
 }
 
 internal class ExplicitRouting : IMessageRouteSource
@@ -90,6 +110,13 @@ internal class ExplicitRouting : IMessageRouteSource
     }
 
     public bool IsAdditive => false;
+
+    public RouteSourceDescriptor Describe(IWolverineRuntime runtime) => new()
+    {
+        Name = "ExplicitRouting",
+        Description = "Routes to endpoints with explicit publishing rules (PublishMessage/PublishAllMessages/To...) that match this message type, plus any sharded or globally-partitioned message topologies. Terminating: when an explicit rule matches, conventional and local routing are skipped.",
+        IsAdditive = IsAdditive
+    };
 }
 
 internal class LocalRouting : IMessageRouteSource
@@ -119,6 +146,13 @@ internal class LocalRouting : IMessageRouteSource
     }
 
     public bool IsAdditive { get; set; }
+
+    public RouteSourceDescriptor Describe(IWolverineRuntime runtime) => new()
+    {
+        Name = "LocalRouting",
+        Description = "Routes a message to a local in-process queue when the application has a handler for it (or a registered message batch). This is how commands handled in the same process are dispatched. Disabled by LocalRoutingConventionDisabled.",
+        IsAdditive = IsAdditive
+    };
 }
 
 internal class MessageRoutingConventions : IMessageRouteSource
@@ -130,6 +164,14 @@ internal class MessageRoutingConventions : IMessageRouteSource
     }
 
     public bool IsAdditive => true;
+
+    public RouteSourceDescriptor Describe(IWolverineRuntime runtime) => new()
+    {
+        Name = "ConventionalRouting",
+        Description = "Routes via registered message routing conventions — including broker conventions (e.g. RabbitMQ/Kafka topic-or-queue-per-message-type) configured with UseConventionalRouting. Additive: convention routes are combined with any others.",
+        IsAdditive = IsAdditive,
+        Conventions = runtime.Options.RoutingConventions.Select(x => x.Describe(runtime)).ToArray()
+    };
 }
 
 public partial class WolverineRuntime
@@ -198,6 +240,53 @@ public partial class WolverineRuntime
         }
 
         return routes;
+    }
+
+    public RoutingExplanation ExplainRoutingFor(Type messageType)
+    {
+        var explanation = new RoutingExplanation
+        {
+            MessageType = messageType.FullNameInCode(),
+            IsSystemMessageType = messageType.IsSystemMessageType()
+        };
+
+        // Mirror findRoutes() exactly so the explanation matches real routing behavior: routes
+        // accumulate across sources, and a non-additive (terminating) source short-circuits the
+        // chain once the accumulated set is non-empty — even if that source itself produced none.
+        var accumulated = new List<IMessageRoute>();
+        var terminated = false;
+        string? terminatingSourceName = null;
+
+        foreach (var source in Options.RouteSources())
+        {
+            var step = new RouteSourceStep { Source = source.Describe(this) };
+
+            if (terminated)
+            {
+                step.SkipReason =
+                    $"not consulted — terminating source '{terminatingSourceName}' had already produced routes";
+                explanation.Steps.Add(step);
+                continue;
+            }
+
+            var produced = source.FindRoutes(messageType, this).ToList();
+            step.Produced = produced.Select(x => x.Describe()).ToList();
+            explanation.Steps.Add(step);
+
+            accumulated.AddRange(produced);
+
+            if (accumulated.Count != 0 && !source.IsAdditive)
+            {
+                terminated = true;
+                terminatingSourceName = step.Source.Name;
+            }
+        }
+
+        // The authoritative final route set (with any de-duplication applied) is whatever
+        // RoutingFor produces and caches.
+        explanation.FinalRoutes = RoutingFor(messageType).Routes.Select(x => x.Describe()).ToList();
+
+        return explanation;
     }
 
     /// <summary>

--- a/src/Wolverine/Transports/ITransport.cs
+++ b/src/Wolverine/Transports/ITransport.cs
@@ -33,6 +33,14 @@ public interface ITransport
     /// </summary>
     public string Name { get; }
 
+    /// <summary>
+    ///     Human- and AI-readable description of this transport, folded into routing explanations
+    ///     for conventional (broker) routing. The default reports the name and scheme; individual
+    ///     transports should override to explain what the broker is and how conventional routing
+    ///     maps message types onto it.
+    /// </summary>
+    string Describe() => $"{Name} broker (scheme '{Protocol}')";
+
     Endpoint? ReplyEndpoint();
 
     Endpoint GetOrCreateEndpoint(Uri uri);

--- a/src/Wolverine/Transports/MessageRoutingConvention.cs
+++ b/src/Wolverine/Transports/MessageRoutingConvention.cs
@@ -157,6 +157,19 @@ public abstract class MessageRoutingConvention<[DynamicallyAccessedMembers(Dynam
         return endpoint;
     }
 
+    RoutingConventionDescriptor IMessageRoutingConvention.Describe(IWolverineRuntime runtime)
+    {
+        var transport = runtime.Options.Transports.GetOrCreate<TTransport>();
+        return new RoutingConventionDescriptor
+        {
+            Name = GetType().Name,
+            Description = "Conventional broker routing: maps each message type to a broker destination (queue/topic/exchange) by naming convention, so messages publish to the broker without an explicit per-type rule.",
+            TransportScheme = transport.Protocol,
+            TransportName = transport.Name,
+            TransportDescription = transport.Describe()
+        };
+    }
+
     IEnumerable<Endpoint> IMessageRoutingConvention.DiscoverSenders(Type messageType, IWolverineRuntime runtime)
     {
         var endpoint = tryRegisterSenderConfiguration(messageType, runtime);


### PR DESCRIPTION
## Summary

Closes #2809 (Tier: message routing diagnostics, 6.0). Adds an on-demand, structured way to answer "why is this message routed where it is / why nowhere?" — for both humans and AI agents — with no steady-state cost.

### What's added

- **`IWolverineRuntime.ExplainRoutingFor(Type) → RoutingExplanation`** — re-runs the route source chain off-cache, capturing per-source `RouteSourceStep`s (the source's descriptor, the routes it produced, and a `SkipReason` when an earlier **terminating** source short-circuited the rest), the `IsSystemMessageType` flag, the current `LocalRoutingConventionDisabled` value, and the final de-duplicated route set. `RoutingExplanation.ToText()` renders a stable, labeled block that reads well for humans and parses cleanly for AI agents.
- **Rich `Describe()`** as default-interface methods on `IMessageRouteSource` (`RouteSourceDescriptor`) and `IMessageRoutingConvention` (`RoutingConventionDescriptor`), overridden on the built-in sources/conventions. Conventional broker routing folds in the parent transport's own `ITransport.Describe()` plus the broker **scheme + name**, so named brokers of the same transport type can be told apart.
- **CLI**: `describe-routing <MessageType>` gains `--explain` (`-e`) and `--json` (`-j`).
- **ServiceCapabilities**: `MessageDescriptor` gains a `RouteSources` list (the sources/conventions that contributed each message's routes) so external tooling can reason about routing.
- **Docs**: `diagnostics.md` (API) + `command-line.md` (CLI).

### Design notes

- Additive — no restructuring of the `IMessageRouteSource` chain; the explanation mirrors `findRoutes` exactly (including that a terminating source short-circuits once the accumulated set is non-empty).
- AOT/trim clean: `Wolverine.csproj` builds `IsAotCompatible=true` with warnings-as-errors and the only suppression needed was on the dev-time CLI JSON serialize; the runtime API + descriptors need none.
- No HTTP admin page (out of scope by design).

## Test plan

- [x] `explain_routing` tests (6/6): local routing, explicit-terminating short-circuit, routed-nowhere, system-message flag, `LocalRoutingConventionDisabled`, and stable text labels
- [x] Broader routing/capabilities suite green (54 tests)
- [x] Full `wolverine.slnx` Release build clean (net9.0 + net10.0, 0 warnings)

## Follow-ups (filed)

- CritterWatch: JasperFx/CritterWatch#210 (routing explanation in UI), JasperFx/CritterWatch#211 (capabilities descriptors in UI)
- ai-skills: JasperFx/ai-skills#57 (routing-explanation CLI skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)