### PR TITLE
Upgrade to JasperFx/Marten/Weasel rc (Polecat held); Saga.Version permanently int

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,18 +31,18 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.20" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.21" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.13" />
-    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-alpha.5" />
-    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.6" />
+    <PackageVersion Include="JasperFx" Version="2.0.0-rc.2" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0-rc.2" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-rc.2" />
+    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-rc.2" />
+    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-rc.2" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-    <PackageVersion Include="Marten" Version="9.0.0-alpha.4" />
+    <PackageVersion Include="Marten" Version="9.0.0-rc.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.0.0-alpha.10" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.0.0-alpha.4" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.0.0-alpha.4" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.0.0-rc.1" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />
@@ -107,13 +107,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.0.0-alpha.7" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.7" />
-    <PackageVersion Include="Weasel.MySql" Version="9.0.0-alpha.7" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.0.0-alpha.7" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-alpha.7" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.0.0-alpha.7" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.0.0-alpha.7" />
+    <PackageVersion Include="Weasel.Core" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Weasel.MySql" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.0.0-rc.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/Http/WolverineWebApi/Marten/Documents.cs
+++ b/src/Http/WolverineWebApi/Marten/Documents.cs
@@ -2,6 +2,7 @@ using System.Linq.Expressions;
 using Marten;
 using Marten.Linq;
 using Marten.Metadata;
+using JasperFx.Metadata;
 using Microsoft.AspNetCore.Mvc;
 using Wolverine.Http;
 using Wolverine.Http.Marten;

--- a/src/Persistence/MartenSubscriptionTests/subscriptions_end_to_end.cs
+++ b/src/Persistence/MartenSubscriptionTests/subscriptions_end_to_end.cs
@@ -423,7 +423,7 @@ public class subscriptions_end_to_end
                         m.DisableNpgsqlLogging = true;
                         m.Connection(Servers.PostgresConnectionString);
                         m.DatabaseSchemaName = "subscriptions";
-                        m.Events.TenancyStyle = Marten.Storage.TenancyStyle.Conjoined;
+                        m.Events.TenancyStyle = JasperFx.MultiTenancy.TenancyStyle.Conjoined;
                     }).IntegrateWithWolverine()
                     .UseLightweightSessions()
                     .PublishEventsToWolverine("Publish", x =>

--- a/src/Persistence/MartenTests/Bugs/Bug_1175_schema_name_with_queues.cs
+++ b/src/Persistence/MartenTests/Bugs/Bug_1175_schema_name_with_queues.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using IntegrationTests;
 using JasperFx;
 using JasperFx.Core;
+using JasperFx.MultiTenancy;
 using Marten;
 using Marten.Storage;
 using Microsoft.Extensions.Hosting;

--- a/src/Persistence/MartenTests/Bugs/Bug_4268_inline_side_effects_should_not_unpartition_envelope.cs
+++ b/src/Persistence/MartenTests/Bugs/Bug_4268_inline_side_effects_should_not_unpartition_envelope.cs
@@ -1,6 +1,7 @@
 using IntegrationTests;
 using JasperFx;
 using JasperFx.Core;
+using JasperFx.MultiTenancy;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;

--- a/src/Persistence/MartenTests/Distribution/TripDomain/DayProjection.cs
+++ b/src/Persistence/MartenTests/Distribution/TripDomain/DayProjection.cs
@@ -1,3 +1,4 @@
+using JasperFx;
 using JasperFx.Events.Projections;
 using Marten.Events.Projections;
 using Marten.Schema;

--- a/src/Persistence/MartenTests/MultiTenancy/using_tenant_specific_queues_and_subscriptions.cs
+++ b/src/Persistence/MartenTests/MultiTenancy/using_tenant_specific_queues_and_subscriptions.cs
@@ -1,3 +1,4 @@
+using JasperFx;
 using IntegrationTests;
 using JasperFx.Core;
 using JasperFx.Events.Daemon;

--- a/src/Persistence/MartenTests/Saga/UserRegistrationSaga.cs
+++ b/src/Persistence/MartenTests/Saga/UserRegistrationSaga.cs
@@ -1,4 +1,5 @@
 using Marten.Metadata;
+using JasperFx;
 using Wolverine.Persistence.Sagas;
 
 namespace MartenTests.Saga;

--- a/src/Persistence/MartenTests/Sample/SampleApp.cs
+++ b/src/Persistence/MartenTests/Sample/SampleApp.cs
@@ -1,3 +1,4 @@
+using JasperFx;
 using IntegrationTests;
 using Marten;
 using Marten.Schema;

--- a/src/Persistence/MartenTests/end_to_end_publish_messages_through_marten_to_wolverine.cs
+++ b/src/Persistence/MartenTests/end_to_end_publish_messages_through_marten_to_wolverine.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using IntegrationTests;
 using JasperFx;
 using JasperFx.Core;
+using JasperFx.MultiTenancy;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Grouping;
@@ -21,7 +22,7 @@ using Weasel.Postgresql;
 using Wolverine;
 using Wolverine.Marten;
 using Wolverine.Tracking;
-using IRevisioned = Marten.Metadata.IRevisioned;
+using IRevisioned = JasperFx.IRevisioned;
 
 namespace MartenTests;
 
@@ -250,13 +251,15 @@ public static class GotBHandler
     }
 }
 
-public class SideEffects1 : IRevisioned
+public class SideEffects1 : JasperFx.ILongVersioned
 {
     public Guid Id { get; set; }
     public int A { get; set; }
     public int B { get; set; }
     public int C { get; set; }
     public int D { get; set; }
+    // ILongVersioned (long), not IRevisioned (int): JasperFx 2.0 rc split numeric
+    // versioning, and this document tracks a long stream version.
     public long Version { get; set; }
 }
 

--- a/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs
+++ b/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs
@@ -1,3 +1,4 @@
+using JasperFx;
 using JasperFx.Events;
 using Marten.Events;
 using Marten.Schema;

--- a/src/Persistence/PolecatTests/AggregateHandlerWorkflow/AggregateHandlerAttributeTests.cs
+++ b/src/Persistence/PolecatTests/AggregateHandlerWorkflow/AggregateHandlerAttributeTests.cs
@@ -8,6 +8,12 @@ using Wolverine.Configuration;
 using Wolverine.Polecat;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Handlers;
+// JasperFx rc lifted its own IdentityAttribute (JasperFx.IdentityAttribute),
+// which now collides with Wolverine.Polecat.IdentityAttribute under the
+// `using Wolverine.Polecat;` import above. These tests exercise Polecat's
+// aggregate-handler attribute recognition (Polecat stays on alpha.10), so
+// pin [Identity] to the Polecat attribute the way it resolved pre-bump.
+using IdentityAttribute = Wolverine.Polecat.IdentityAttribute;
 
 namespace PolecatTests.AggregateHandlerWorkflow;
 

--- a/src/Persistence/Wolverine.Marten/MartenIntegration.cs
+++ b/src/Persistence/Wolverine.Marten/MartenIntegration.cs
@@ -175,19 +175,15 @@ internal class MartenOverrides : IConfigureMarten
             {
                 mapping.UseNumericRevisions = true;
                 // GetProperty(name, returnType) — not GetProperty(name) — because
-                // saga subclasses in the wild (pre-6.0) sometimes declare
-                // `public new int Version` to work around the 5.x mismatch
-                // between Saga.Version: int and Marten's IRevisioned.Version:
-                // long. After the 6.0 widening of Saga.Version to long
-                // (matching Marten 9.0.0-alpha.2's IRevisioned.Version), the
-                // single-arg overload throws AmbiguousMatchException on those
-                // subclasses because the inherited long and the derived int
-                // are two distinct properties. Filtering by return type picks
-                // the inherited long property unambiguously and treats the
-                // derived shadow as harmless dead code (which it now is, per
-                // the Saga.Version XML doc).
+                // saga subclasses in the wild sometimes declare a shadowing
+                // `public new ... Version` property. Saga.Version is permanently
+                // an int (it aligns with JasperFx 2.0 rc's IRevisioned.Version,
+                // which is an int; the long-versioned event-sourcing case is a
+                // separate ILongVersioned.Version). Filtering by the int return
+                // type picks the canonical Saga.Version revision property and
+                // ignores any derived shadow of a different type.
                 mapping.Metadata.Revision.Member = mapping.DocumentType.GetProperty(
-                    nameof(Saga.Version), typeof(long))!;
+                    nameof(Saga.Version), typeof(int))!;
             }
         });
     }

--- a/src/Persistence/Wolverine.Marten/Persistence/Sagas/LoadDocumentFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Persistence/Sagas/LoadDocumentFrame.cs
@@ -5,6 +5,7 @@ using JasperFx.Core.Reflection;
 using Marten;
 using Marten.Metadata;
 using Wolverine.Marten.Codegen;
+using IRevisioned = JasperFx.IRevisioned;
 
 namespace Wolverine.Marten.Persistence.Sagas;
 
@@ -98,8 +99,9 @@ internal class LoadDocumentFrame : AsyncFrame, IBatchableFrame
         if (Saga.VariableType.CanBeCastTo<IRevisioned>() && Saga.VariableType.CanBeCastTo<Saga>())
         {
             writer.WriteComment($"{Saga.VariableType.FullNameInCode()} implements {typeof(IRevisioned).FullNameInCode()}, so Wolverine will try to update based on the revision as a concurrency protection");
-            // 0L because IRevisioned.Version is long in Marten 9.0; the saga.Version + 1 assignment
-            // below must land in a long variable to avoid CS0266 in generated code.
+            // 0L because IDocumentOperations.UpdateRevision(entity, long revision) takes a long
+            // revision parameter, even though IRevisioned.Version is an int. The int saga.Version + 1
+            // below widens into this long variable, which then flows to UpdateRevision unchanged.
             writer.Write($"var {ExpectedSagaRevision} = 0L;");
             writer.Write($"BLOCK:if ({Saga.Usage} != null)");
             writer.Write($"{ExpectedSagaRevision} = {Saga.Usage}.{nameof(IRevisioned.Version)} + 1;");

--- a/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenPersistenceFrameProvider.cs
@@ -14,7 +14,7 @@ using Wolverine.Marten.Codegen;
 using Wolverine.Persistence;
 using Wolverine.Persistence.Sagas;
 using Wolverine.Runtime;
-using IRevisioned = Marten.Metadata.IRevisioned;
+using IRevisioned = JasperFx.IRevisioned;
 
 namespace Wolverine.Marten.Persistence.Sagas;
 

--- a/src/Persistence/Wolverine.Marten/Subscriptions/PublishingRelay.cs
+++ b/src/Persistence/Wolverine.Marten/Subscriptions/PublishingRelay.cs
@@ -3,6 +3,7 @@ using JasperFx;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Events;
+using JasperFx.MultiTenancy;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten;

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/global_partitioned_aggregate_concurrency.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/global_partitioned_aggregate_concurrency.cs
@@ -5,6 +5,7 @@ using JasperFx.Resources;
 using JasperFx.Events;
 using Marten;
 using Marten.Metadata;
+using JasperFx;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
@@ -223,9 +224,11 @@ public record GpStreamEventB(string Data);
 public record GpStreamEventCascaded(string Source);
 
 // --- Aggregate ---
-public partial class GpStreamAggregate : IRevisioned
+public partial class GpStreamAggregate : JasperFx.ILongVersioned
 {
     public Guid Id { get; set; }
+    // ILongVersioned (long), not IRevisioned (int): this is an event-sourced
+    // aggregate tracking a long stream version under JasperFx 2.0 rc.
     public long Version { get; set; }
     public int ACount { get; set; }
     public int BCount { get; set; }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/global_partitioned_sharded_processing.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/global_partitioned_sharded_processing.cs
@@ -4,6 +4,7 @@ using JasperFx.Core;
 using JasperFx.Events;
 using Marten;
 using Marten.Metadata;
+using JasperFx;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Wolverine.Configuration;
@@ -137,8 +138,10 @@ public static class GLetterMessageHandler
     }
 }
 
-public partial class GSimpleAggregate : IRevisioned
+public partial class GSimpleAggregate : JasperFx.ILongVersioned
 {
+    // ILongVersioned (long), not IRevisioned (int): this is an event-sourced
+    // aggregate tracking a long stream version under JasperFx 2.0 rc.
     public long Version { get; set; }
     public Guid Id { get; set; }
 

--- a/src/Wolverine/Saga.cs
+++ b/src/Wolverine/Saga.cs
@@ -30,12 +30,13 @@ public abstract class Saga
     /// For saga providers that support this, this is a version of the saga to help enforce optimistic concurrency
     /// protections. This value is the current version that is stored by saga storage and will
     /// be incremented upon save.
-    /// Widened to <see cref="long"/> in 6.0 to align with Marten's
-    /// <c>Marten.Metadata.IRevisioned.Version</c> (which is <see cref="long"/>
-    /// from Marten 9.0.0-alpha.2 onward), so sagas can implement <c>IRevisioned</c>
-    /// without a shadow override.
+    /// Typed as <see cref="int"/> to align with <c>JasperFx.IRevisioned.Version</c>
+    /// (an <see cref="int"/>), so sagas can implement <c>IRevisioned</c> directly
+    /// without a shadow override. (JasperFx 2.0 rc split versioning into
+    /// <c>IRevisioned</c> = <see cref="int"/> and <c>ILongVersioned</c> = <see cref="long"/>;
+    /// sagas use the <see cref="int"/> revision.)
     /// </summary>
-    public long Version { get; set; }
+    public int Version { get; set; }
 }
 
 #endregion


### PR DESCRIPTION
## Summary

Bumps the critter-stack dependencies to their **rc** lines ahead of the Wolverine 6.0 rc.1 release. **Polecat is intentionally held** at `4.0.0-alpha.10` because it has no rc published yet.

| Package family | From | To |
|---|---|---|
| JasperFx / RuntimeCompiler / SourceGeneration / Events(.SourceGenerator) | `2.0.0-alpha.*` / `5.0.0-alpha.5` | `2.0.0-rc.2` / `5.0.0-rc.2` |
| Marten / Marten.AspNetCore / Marten.Newtonsoft | `9.0.0-alpha.4` | `9.0.0-rc.1` |
| Weasel.* (Core, EFCore, MySql, Oracle, Postgresql, SqlServer, Sqlite) | `9.0.0-alpha.7` | `9.0.0-rc.1` |
| Polecat | `4.0.0-alpha.10` | _held_ |

## `Saga.Version` is permanently `int`

JasperFx 2.0 rc split numeric versioning into two interfaces:

- `IRevisioned.Version` → `int` (optimistic-concurrency revision)
- `ILongVersioned.Version` → `long` (event-stream version)

So `Saga.Version` reverts from `long` back to `int` (a deliberate, permanent design decision), letting sagas implement `IRevisioned` directly without a shadow override.

- `MartenIntegration` resolves the saga revision member via `GetProperty(nameof(Saga.Version), typeof(int))`.
- `LoadDocumentFrame` keeps the generated `expectedSagaRevision` as a `long` because `IDocumentOperations.UpdateRevision(entity, long)` takes a `long`; the `int` `Saga.Version + 1` widens into it. (Stale comment corrected.)
- Event-sourced aggregate test types that legitimately track a `long` stream version (`SideEffects1`, `GpStreamAggregate`, `GSimpleAggregate`) now implement `ILongVersioned` instead of `IRevisioned`.

## rc namespace relocations (test/sample compile fixes)

- `IRevisioned`: `Marten.Metadata` → `JasperFx`
- `TenancyStyle`: `Marten.Storage` → `JasperFx.MultiTenancy`
- `Identity` / `IdentityAttribute`: `Marten.Schema` → `JasperFx`
- `ISoftDeleted`: `Marten.Metadata` → `JasperFx.Metadata`
- PolecatTests: alias `[Identity]` to `Wolverine.Polecat.IdentityAttribute` to disambiguate from the lifted `JasperFx.IdentityAttribute` (Polecat stays on alpha.10)

## Verification

`dotnet build wolverine.slnx -c Release` → **0 warnings, 0 errors** across net9.0/net10.0.

## Follow-up

Polecat upgrade to `4.0.0-rc.1` (when published) and the Wolverine 6.0 rc.1 NuGet publish are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)