### PR TITLE
Polecat 4.0.0-rc.1 + cut 6.0.0-rc.1 + fix EF Core saga concurrency test (follow-up to #2872)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -61,8 +61,21 @@
                      IEventSlice<T>.Aggregate -> IEventSlice<T>.Snapshot
                      ProjectionBase.ProjectionName -> Name
                      ProjectionBase.CacheLimitPerTenant -> Options.CacheLimitPerTenant
+          rc.1:    First 6.0 release candidate. Critter Stack 2026 rc pin matrix
+                   (PR #2872):
+                     JasperFx / .RuntimeCompiler / .SourceGeneration / .Events
+                       (+ .Events.SourceGenerator)     alpha.* -> 2.0.0-rc.2 / 5.0.0-rc.2
+                     Marten / .AspNetCore / .Newtonsoft alpha.4 -> 9.0.0-rc.1
+                     Weasel.* (7 packages)             alpha.7 -> 9.0.0-rc.1
+                     Polecat                           alpha.10 -> 4.0.0-rc.1
+                   JasperFx 2.0 rc split numeric versioning into IRevisioned.Version
+                   (int) and ILongVersioned.Version (long); Saga.Version reverts to
+                   int (permanent) so sagas implement IRevisioned directly, and
+                   event-stream-versioned aggregates implement ILongVersioned. rc
+                   namespace relocations absorbed across tests/samples (IRevisioned,
+                   TenancyStyle, Identity/IdentityAttribute, ISoftDeleted).
         -->
-        <Version>6.0.0-alpha.5</Version>
+        <Version>6.0.0-rc.1</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,12 +37,12 @@
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-rc.2" />
     <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-rc.2" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-    <PackageVersion Include="Marten" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Marten" Version="9.0.0-rc.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.0.0-rc.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.0.0-rc.2" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.0.0-rc.2" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,7 @@
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
     <PackageVersion Include="Marten" Version="9.0.0-rc.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="4.0.0-alpha.10" />
+    <PackageVersion Include="Polecat" Version="4.0.0-rc.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageVersion Include="Marten.AspNetCore" Version="9.0.0-rc.1" />
     <PackageVersion Include="Marten.Newtonsoft" Version="9.0.0-rc.1" />

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -31,7 +31,6 @@ The table below is the **complete inventory** of changed defaults, removed APIs,
 | `MartenConfigurationExpression.EventForwardingToWolverine(...)` | extension method on the Marten configuration expression *(both overloads `[Obsolete]` since 3.x)* | **removed** *(BREAKING)* | Move the flag into the `IntegrateWithWolverine` callback: [`IntegrateWithWolverine(x => x.UseFastEventForwarding = true)`](#eventforwardingtowolverine-removed-breaking) |
 | `RedisTransport.BuildRedisStreamUri(...)` | static helper on `RedisTransport` *(`[Obsolete]`)* | **removed** *(BREAKING)* | Call [`RedisEndpointUri.Stream(...)`](#redistransport-buildredisstreamuri-removed-breaking) — identical signature, drop the helper |
 | `PulsarEndpoint.UriFor(...)` | static helpers on `PulsarEndpoint` *(both overloads `[Obsolete]`)* | **removed** *(BREAKING)* | For the Wolverine-URI form, call [`PulsarEndpointUri.Topic(...)`](#pulsarendpoint-urifor-removed-breaking); the native-topic-path form (`persistent://...`) was an internal-only seam now covered by `PulsarEndpoint.NativeTopicPath` |
-| `Saga.Version` property type | `int` | `long` | Typically none — `int` widens implicitly to `long`. Tracks the matching `IRevisioned.Version` widening in Marten 9.0. **Sagas that hand-rolled `public new int Version` to work around the 5.x type mismatch with `IRevisioned.Version: long` must drop that shadow on upgrade** — see [`Saga.Version` widening: drop any `new int Version` shadow on saga subclasses](#sagaversion-widening-drop-any-new-int-version-shadow-on-saga-subclasses). |
 | **One-line full revert** | n/a | [`opts.RestoreV5Defaults()`](#one-line-revert-restorev5defaults) | Flip every runtime default this method covers back to its 5.x value |
 
 ::: tip
@@ -267,27 +266,6 @@ Both `PulsarEndpoint.UriFor(...)` overloads were `[Obsolete]` in the 5.x line an
   ```
 
 If you only ever called `UriFor(string)`, this is a one-line `using`-already-imported rename.
-
-### `Saga.Version` widening: drop any `new int Version` shadow on saga subclasses
-
-`Wolverine.Saga.Version` widened from `int` to `long` in 6.0 to match `Marten.Metadata.IRevisioned.Version` (which itself widened to `long` in Marten 9.0.0-alpha.2). For the vast majority of saga code, this is an invisible change — `int` widens implicitly to `long`.
-
-There is **one upgrade hazard** worth a callout: sagas in the wild sometimes hand-rolled a `public new int Version` shadow on a Wolverine 5.x saga subclass to work around the 5.x type mismatch with `IRevisioned`. For example:
-
-```csharp
-public class OrderSaga : Wolverine.Saga
-{
-    public string Id { get; set; }
-    public new int Version { get; set; }  // ← drop this on upgrade
-    // ...
-}
-```
-
-In 6.0, that shadow is no longer needed (the base `Saga.Version: long` aligns with `IRevisioned.Version: long` by default) and is actively harmful: it leaves two `Version` properties on the type with different return types, which makes `Type.GetProperty("Version")` ambiguous in any reflective lookup. Wolverine's own Marten integration uses the typed `GetProperty(name, typeof(long))` overload to avoid this, but other consumers (Marten metadata customization, user-written diagnostics, model-binding frameworks) may still trip on the ambiguity at startup with `System.Reflection.AmbiguousMatchException`.
-
-Recommended action on upgrade: **search your saga types for `new int Version` and delete the shadow.** The inherited `Saga.Version` does the right thing.
-
-If you'd rather keep the shadow for backward compatibility (e.g. a column already typed `int`), change its return type to `long` (`public new long Version`) so it doesn't conflict with the inherited property type. That's a wire-format change; the simpler upgrade is to drop the shadow and let the inherited `long` handle it.
 
 ### Performance: per-endpoint serializer cache pre-population
 

--- a/src/Persistence/EfCoreTests/Optimistic_concurrency_with_ef_core.cs
+++ b/src/Persistence/EfCoreTests/Optimistic_concurrency_with_ef_core.cs
@@ -109,9 +109,10 @@ public class ConcurrencyTestSaga : Saga
     public void Handle(UpdateConcurrencyTestSaga order, OptConcurrencyDbContext ctx)
     {
         // Fake 999 updates of the saga while this event is being handled. Literal must
-        // be `long` so the boxed value unboxes cleanly inside EF Core's concurrency-token
-        // comparator now that Saga.Version is `long` (was `int` pre-Marten-9).
-        ctx.ConcurrencyTestSagas.Entry(this).Property("Version").OriginalValue = 999L;
+        // be `int` so the boxed value unboxes cleanly inside EF Core's concurrency-token
+        // comparator: Saga.Version is `int` (it aligns with JasperFx 2.0 rc's
+        // IRevisioned.Version, an int).
+        ctx.ConcurrencyTestSagas.Entry(this).Property("Version").OriginalValue = 999;
 
         Value = order.NewValue;
     }

--- a/src/Persistence/MartenTests/Saga/RevisionedSaga.cs
+++ b/src/Persistence/MartenTests/Saga/RevisionedSaga.cs
@@ -96,9 +96,9 @@ public class RevisionedSaga : Wolverine.Saga
     
     public Guid Id { get; set; }
 
-    // No `new Version` shadow needed in 6.0 — Wolverine.Saga.Version was
-    // widened from int to long to match Marten 9's IRevisioned.Version, so
-    // the base property is now the saga's revision tracker by default.
+    // No `new Version` shadow needed in 6.0 — Wolverine.Saga.Version (an int)
+    // matches JasperFx 2.0 rc's IRevisioned.Version (also an int), so the base
+    // property is the saga's revision tracker by default.
     // See docs/guide/migration.md.
 
     public bool One { get; set; }

--- a/src/Persistence/Wolverine.Polecat/Subscriptions/PublishingRelay.cs
+++ b/src/Persistence/Wolverine.Polecat/Subscriptions/PublishingRelay.cs
@@ -83,7 +83,7 @@ internal class PublishingRelay : BatchSubscription, IPublishingRelay
             }
             else
             {
-                if (e.TenantId != global::Polecat.Tenancy.DefaultTenantId)
+                if (e.TenantId != JasperFx.StorageConstants.DefaultTenantId)
                 {
                     await bus.PublishAsync(e, new DeliveryOptions{TenantId = e.TenantId});
                 }

--- a/src/Persistence/Wolverine.Polecat/Subscriptions/WolverineSubscriptionRunner.cs
+++ b/src/Persistence/Wolverine.Polecat/Subscriptions/WolverineSubscriptionRunner.cs
@@ -29,7 +29,7 @@ internal class WolverineSubscriptionRunner : SubscriptionBase
 
         // Use the session's tenant id for multi-tenant support
         var tenantId = operations.TenantId;
-        if (tenantId.IsNotEmpty() && tenantId != global::Polecat.Tenancy.DefaultTenantId)
+        if (tenantId.IsNotEmpty() && tenantId != JasperFx.StorageConstants.DefaultTenantId)
         {
             context.TenantId = tenantId;
         }


### PR DESCRIPTION
## Why

PR #2872 was merged at its **first commit only**, before three follow-up fixes landed. This PR carries the stranded work and fixes `main`'s currently-red `efcore` CI.

## Contents

1. **Polecat `4.0.0-alpha.10` → `4.0.0-rc.1`** + version cut to **`6.0.0-rc.1`** (first 6.0 release candidate; changelog entry added in `Directory.Build.props`). Polecat rc.1 carries the same constant relocation as the rest of the stack — `Polecat.Tenancy.DefaultTenantId` is gone, so both `Wolverine.Polecat` subscription relays now use `JasperFx.StorageConstants.DefaultTenantId`.

2. **Fix `EfCoreTests.Optimistic_concurrency_with_ef_core`** (currently failing on `main`). The test set the concurrency-token `OriginalValue` to a boxed `long` (`999L`); EF Core unboxes against the property's CLR type, which is `int` again after the permanent `Saga.Version` revert, so the `long` failed to unbox. Reverted to `999`. Verified passing locally against SQL Server.

3. **Migration-docs correction.** `docs/guide/migration.md` documented a `Saga.Version` int→long widening and told users to drop `new int Version` shadows / make wire-format changes. `Saga.Version` is `int` in both 5.x and 6.0 — no type change — so the table row and section were removed and the stale `RevisionedSaga.cs` comment fixed.

## ⚠️ Known blocker (NOT fixed here — lives in Marten)

The `marten` CI job fails on a **Marten 9.0.0-rc.1 regression**, independent of this PR:

```
System.ArgumentNullException: Value cannot be null. (Parameter 'distributor')
  at JasperFx.Events.Daemon.ProjectionCoordinatorBase..ctor(IProjectionDistributor distributor, ...)
  at Marten.Events.Daemon.Coordination.ProjectionCoordinator..ctor(DocumentStore store, ILogger logger)
  at MartenTests.AncillaryStores.bootstrapping_ancillary_marten_stores_with_wolverine.projection_coordinator_from_marten()
```

Resolving `IProjectionCoordinator<TAncillaryStore>` constructs Marten's `ProjectionCoordinator` with a null `IProjectionDistributor`. Deterministic (fails both retries), and `9.0.0-rc.1` is the newest Marten rc, so there's no published fix. **This blocks the 6.0.0-rc.1 NuGet publish** until Marten ships a fix.

Full `wolverine.slnx` builds clean (0/0). `efcore` goes green with this PR; `marten` stays red on the dependency bug above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)