### PR TITLE
Fix #2874: guard MessageRoutingConvention sender registration against startup/publish race

### DIFF
--- a/src/Samples/ProcessManagerViaHandlers/ProcessManagerViaHandlers/ProcessManagerViaHandlers.csproj
+++ b/src/Samples/ProcessManagerViaHandlers/ProcessManagerViaHandlers/ProcessManagerViaHandlers.csproj
@@ -4,6 +4,12 @@
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <!-- This Microsoft.NET.Sdk.Web sample serves no static web assets (no wwwroot,
+             no Razor/Blazor). Disabling StaticWebAssets skips the DefineStaticWebAssets
+             task, which intermittently fails the CI build with an IOException on its
+             obj/.../rpswa.dswa.cache.json cache under parallel MSBuild ("being used by
+             another process"). Nothing here needs that pipeline. -->
+        <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wolverine/Transports/MessageRoutingConvention.cs
+++ b/src/Wolverine/Transports/MessageRoutingConvention.cs
@@ -33,6 +33,16 @@ public abstract class MessageRoutingConvention<[DynamicallyAccessedMembers(Dynam
     /// </summary>
     private readonly HashSet<Type> _configuredSenders = new();
 
+    /// <summary>
+    /// Guards the non-thread-safe sender-registration state (<see cref="_configuredSenders"/>
+    /// and the subscriber endpoint's Subscriptions list). <c>tryRegisterSenderConfiguration</c>
+    /// is reachable both from <see cref="PreregisterSenders"/> during host startup and from
+    /// the lazy <see cref="DiscoverSenders"/> on the first publish path; if a publish races
+    /// the tail of startup these run concurrently on the same convention instance and corrupt
+    /// the <see cref="HashSet{T}"/>. See GH-2874.
+    /// </summary>
+    private readonly object _senderRegistrationLock = new();
+
     void IMessageRoutingConvention.DiscoverListeners(IWolverineRuntime runtime, IReadOnlyList<Type> handledMessageTypes)
     {
         if(_onlyApplyToOutboundMessages)
@@ -232,43 +242,50 @@ public abstract class MessageRoutingConvention<[DynamicallyAccessedMembers(Dynam
             return null;
         }
 
-        var transport = runtime.Options.Transports.GetOrCreate<TTransport>();
-
         var destinationName = _identifierForSender(messageType);
         if (destinationName.IsEmpty())
         {
             return null;
         }
 
-        var corrected = transport.MaybeCorrectName(destinationName);
-
-        var (configuration, endpoint) = FindOrCreateSubscriber(corrected, transport);
-        endpoint.EndpointName = destinationName;
-
-        // Register the subscription so that endpoint policies like
-        // UseDurableOutboxOnAllSendingEndpoints() recognize this as a sender
-        // endpoint when Compile() applies policies. See GH-2304 / GH-2588.
-        //
-        // Marked IsFromConvention=true so ExplicitRouting (and the diagnostics command)
-        // don't mistake the conventional sender for a user-wired publish rule. Without
-        // this flag, ExplicitRouting picks up the conventional sender via
-        // Endpoint.ShouldSendMessage and short-circuits past LocalRouting — handled
-        // messages stop routing to their local handlers and explicit publish rules get
-        // duplicated against the conventional broker exchange. See the MessageRoutingTests
-        // regression that motivated splitting Subscription.ForType from
-        // Subscription.ForConventionalType.
-        if (!endpoint.Subscriptions.Any(s => s.Matches(messageType)))
+        // Serialize the mutation of _configuredSenders and the endpoint's Subscriptions
+        // list. This method runs both during startup (PreregisterSenders) and lazily on
+        // the first publish (DiscoverSenders); a publish racing the tail of startup would
+        // otherwise corrupt the non-thread-safe HashSet. See GH-2874.
+        lock (_senderRegistrationLock)
         {
-            endpoint.Subscriptions.Add(Subscription.ForConventionalType(messageType));
-        }
+            var transport = runtime.Options.Transports.GetOrCreate<TTransport>();
 
-        if (_configuredSenders.Add(messageType))
-        {
-            _configureSending(configuration, new MessageRoutingContext(messageType, runtime));
-            configuration.As<IDelayedEndpointConfiguration>().Apply();
-        }
+            var corrected = transport.MaybeCorrectName(destinationName);
 
-        return endpoint;
+            var (configuration, endpoint) = FindOrCreateSubscriber(corrected, transport);
+            endpoint.EndpointName = destinationName;
+
+            // Register the subscription so that endpoint policies like
+            // UseDurableOutboxOnAllSendingEndpoints() recognize this as a sender
+            // endpoint when Compile() applies policies. See GH-2304 / GH-2588.
+            //
+            // Marked IsFromConvention=true so ExplicitRouting (and the diagnostics command)
+            // don't mistake the conventional sender for a user-wired publish rule. Without
+            // this flag, ExplicitRouting picks up the conventional sender via
+            // Endpoint.ShouldSendMessage and short-circuits past LocalRouting — handled
+            // messages stop routing to their local handlers and explicit publish rules get
+            // duplicated against the conventional broker exchange. See the MessageRoutingTests
+            // regression that motivated splitting Subscription.ForType from
+            // Subscription.ForConventionalType.
+            if (!endpoint.Subscriptions.Any(s => s.Matches(messageType)))
+            {
+                endpoint.Subscriptions.Add(Subscription.ForConventionalType(messageType));
+            }
+
+            if (_configuredSenders.Add(messageType))
+            {
+                _configureSending(configuration, new MessageRoutingContext(messageType, runtime));
+                configuration.As<IDelayedEndpointConfiguration>().Apply();
+            }
+
+            return endpoint;
+        }
     }
 
     private bool _onlyApplyToOutboundMessages;


### PR DESCRIPTION
Fixes #2874.

## Problem

`MessageRoutingConvention<,,,>.tryRegisterSenderConfiguration(...)` mutates the non-thread-safe `_configuredSenders` `HashSet<Type>` (and the subscriber endpoint's `Subscriptions` list) with no synchronization. That method is reachable from two paths that can run on different threads simultaneously:

- **Startup**: `PreregisterSenders(...)` (called from `WolverineRuntime.discoverListenersFromConventions()` during `StartAsync`).
- **First publish (lazy)**: `DiscoverSenders(...)` (called from the routing path on the first publish of a message type).

If a message is published while host startup is still finishing convention pre-registration, both call `_configuredSenders.Add(messageType)` on the same convention instance and the `HashSet` self-corrupts:

```
System.InvalidOperationException : Operations that change non-concurrent collections must have exclusive access...
   at System.Collections.Generic.HashSet`1.AddIfNotPresent(...)
   at Wolverine.Transports.MessageRoutingConvention`4.tryRegisterSenderConfiguration(...)
   at Wolverine.Transports.MessageRoutingConvention`4.IMessageRoutingConvention.PreregisterSenders(...)
   at Wolverine.Runtime.WolverineRuntime.discoverListenersFromConventions()
```

The eager `PreregisterSenders` pass added for GH-2588 widened this window because the same state `DiscoverSenders` builds lazily is now also built during `StartAsync`.

## Fix

Serialize the mutating section of `tryRegisterSenderConfiguration` with a per-instance lock. The pure early-return filters stay outside the lock, and the method still short-circuits via `_configuredSenders` after the first call per message type, so the added contention is negligible.

## Testing

A deterministic regression test is awkward because the failure is timing-dependent (it requires a publish to land within the startup pre-registration window). Observed reliably under concurrent load in a downstream suite that boots several Wolverine services in parallel while their publishers emit on startup; passes after this change. Happy to add a stress test if you'd like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)