### PR TITLE
Decouple JasperFx.RuntimeCompiler (Roslyn) from core WolverineFx (#2876)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,6 +53,12 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <!-- Pinned so the EF Core projects unify on the 4.14.0 Roslyn line. Core WolverineFx no
+         longer references JasperFx.RuntimeCompiler (#2876), which previously pulled
+         CodeAnalysis.CSharp.Workspaces 4.14.0 and masked EF Core Design's transitive 4.8.0
+         (conflicting with Workspaces.MSBuild 4.14.0). WolverineFx.EntityFrameworkCore
+         references this directly so the unification flows to all EF sample/test projects. -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
     <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.5" />
     <PackageVersion Include="Microsoft.FeatureManagement" Version="3.2.0" />

--- a/src/Extensions/Wolverine.DataAnnotationsValidation.Tests/Wolverine.DataAnnotationsValidation.Tests.csproj
+++ b/src/Extensions/Wolverine.DataAnnotationsValidation.Tests/Wolverine.DataAnnotationsValidation.Tests.csproj
@@ -21,4 +21,9 @@
     <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
+++ b/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
@@ -21,4 +21,9 @@
         <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
 
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Http/Wolverine.Http.Tests/Bugs/Bug_2182_unresolved_IProblemDetailSource.cs
+++ b/src/Http/Wolverine.Http.Tests/Bugs/Bug_2182_unresolved_IProblemDetailSource.cs
@@ -33,6 +33,9 @@ public class Bug_2182_unresolved_IProblemDetailSource
         {
             opts.Discovery.IncludeAssembly(typeof(Bug_2182_Endpoint.Request).Assembly);
             opts.UseFluentValidation(); // from Wolverine.FluentValidation
+            // ManualOnly discovery does not auto-load the WolverineFx.RuntimeCompilation module, so a
+            // Dynamic-mode app must opt into runtime compilation explicitly (#2876).
+            opts.UseRuntimeCompilation();
             // ExtensionDiscovery.ManualMode and Wolverine.Http.FluentValidation services are not registered
         });
 
@@ -74,6 +77,7 @@ public class Bug_2182_unresolved_IProblemDetailSource
             opts.Discovery.IncludeAssembly(typeof(Bug_2182_Endpoint.Request).Assembly);
             opts.UseFluentValidation(); // from Wolverine.FluentValidation
             opts.UseFluentValidationProblemDetail(); // from Wolverine.Http.FluentValidation
+            opts.UseRuntimeCompilation(); // ManualOnly discovery: opt into runtime codegen (#2876)
         });
 
         await using var host = await AlbaHost.For(_builder, app =>
@@ -128,6 +132,8 @@ public class Bug_2182_unresolved_IProblemDetailSource
             opts.UseFluentValidation();
             if (useFluentValidationProblemDetail)
                 opts.UseFluentValidationProblemDetail();
+            // Harmless/idempotent under Automatic discovery; required for the ManualOnly case (#2876).
+            opts.UseRuntimeCompilation();
         });
 
         await using var host = await AlbaHost.For(_builder, app =>

--- a/src/Persistence/MartenSubscriptionTests/MartenSubscriptionTests.csproj
+++ b/src/Persistence/MartenSubscriptionTests/MartenSubscriptionTests.csproj
@@ -33,4 +33,9 @@
 
 
 
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj
@@ -28,4 +28,9 @@
       <ProjectReference Include="..\Wolverine.ClaimCheck.AmazonS3\Wolverine.ClaimCheck.AmazonS3.csproj" />
     </ItemGroup>
 
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj
@@ -28,4 +28,9 @@
       <ProjectReference Include="..\Wolverine.ClaimCheck.AzureBlobStorage\Wolverine.ClaimCheck.AzureBlobStorage.csproj" />
     </ItemGroup>
 
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Wolverine.EntityFrameworkCore.csproj
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Wolverine.EntityFrameworkCore.csproj
@@ -30,6 +30,10 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
+        <!-- Unify EF Core Design's transitive Roslyn (CSharp.Workspaces 4.8.0) up to the
+             solution's 4.14.0 line. Previously masked by core WolverineFx's JasperFx.RuntimeCompiler
+             reference, removed in #2876. Flows transitively to the EF sample/test projects. -->
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
         <PackageReference Include="Microsoft.Build.Tasks.Core" />
     </ItemGroup>
 

--- a/src/Persistence/Wolverine.Marten/AggregateHandlerAttribute.cs
+++ b/src/Persistence/Wolverine.Marten/AggregateHandlerAttribute.cs
@@ -8,7 +8,6 @@ using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using Marten;
 using Marten.Events;
-using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Testing/BackPressureTests/BackPressureTests.csproj
+++ b/src/Testing/BackPressureTests/BackPressureTests.csproj
@@ -26,4 +26,9 @@
         <Link>Servers.cs</Link>
       </Compile>
     </ItemGroup>
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Testing/CoreTests/Configuration/bootstrapping_specs.cs
+++ b/src/Testing/CoreTests/Configuration/bootstrapping_specs.cs
@@ -69,6 +69,11 @@ public class bootstrapping_specs : IntegrationContext
             .UseWolverine(opts =>
             {
                 opts.DisableConventionalDiscovery();
+
+                // With ExtensionDiscovery.ManualOnly, Wolverine does not auto-load the
+                // WolverineFx.RuntimeCompilation module, so a TypeLoadMode.Dynamic app must
+                // opt into runtime Roslyn compilation explicitly (or pre-generate with Static).
+                opts.UseRuntimeCompilation();
             }, ExtensionDiscovery.ManualOnly)
             
             .StartAsync();

--- a/src/Testing/MessageRoutingTests/MessageRoutingTests.csproj
+++ b/src/Testing/MessageRoutingTests/MessageRoutingTests.csproj
@@ -20,4 +20,9 @@
     <ItemGroup>
       <ProjectReference Include="..\..\Transports\RabbitMQ\Wolverine.RabbitMQ\Wolverine.RabbitMQ.csproj" />
     </ItemGroup>
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Testing/MetricsTests/MetricsTests.csproj
+++ b/src/Testing/MetricsTests/MetricsTests.csproj
@@ -30,4 +30,9 @@
       <ProjectReference Include="..\..\Wolverine\Wolverine.csproj" />
     </ItemGroup>
 
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Testing/OpenTelemetry/TracingTests/TracingTests.csproj
+++ b/src/Testing/OpenTelemetry/TracingTests/TracingTests.csproj
@@ -37,4 +37,9 @@
     <ItemGroup>
         <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Testing/Wolverine.ComplianceTests/Wolverine.ComplianceTests.csproj
+++ b/src/Testing/Wolverine.ComplianceTests/Wolverine.ComplianceTests.csproj
@@ -9,6 +9,14 @@
         <ProjectReference Include="..\..\Wolverine\Wolverine.csproj"/>
         <ProjectReference Include="..\..\Persistence\Wolverine.RDBMS\Wolverine.RDBMS.csproj"/>
         <!--
+          Core WolverineFx no longer ships the Roslyn runtime compiler (#2876). Compliance
+          suites bootstrap Wolverine hosts in the default TypeLoadMode.Dynamic, so they need
+          the runtime compiler. Referencing WolverineFx.RuntimeCompilation here flows
+          transitively to the ~39 downstream test/sample projects and auto-registers
+          IAssemblyGenerator via its [WolverineModule] — no per-project change needed.
+        -->
+        <ProjectReference Include="..\..\Wolverine.RuntimeCompilation\Wolverine.RuntimeCompilation.csproj"/>
+        <!--
           TransportCompliance.cs exercises options.UseNewtonsoftForSerialization()
           against every transport. Newtonsoft moved to its own package in 6.0;
           the compliance harness carries the explicit dependency so transport

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/Wolverine.AmazonSns.Tests.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/Wolverine.AmazonSns.Tests.csproj
@@ -29,4 +29,9 @@
         <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
 
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
@@ -28,4 +28,9 @@
     <ItemGroup>
         <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Transports/SignalR/Wolverine.SignalR.Tests/Wolverine.SignalR.Tests.csproj
+++ b/src/Transports/SignalR/Wolverine.SignalR.Tests/Wolverine.SignalR.Tests.csproj
@@ -38,4 +38,9 @@
         <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
 
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Wolverine.HealthChecks.Tests/Wolverine.HealthChecks.Tests.csproj
+++ b/src/Wolverine.HealthChecks.Tests/Wolverine.HealthChecks.Tests.csproj
@@ -25,4 +25,9 @@
     <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Wolverine.RuntimeCompilation/RuntimeCompilationModule.cs
+++ b/src/Wolverine.RuntimeCompilation/RuntimeCompilationModule.cs
@@ -1,0 +1,30 @@
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.RuntimeCompilation;
+
+[assembly: WolverineModule<RuntimeCompilationModule>]
+
+namespace Wolverine.RuntimeCompilation;
+
+/// <summary>
+/// Auto-loaded Wolverine extension that activates whenever the
+/// <c>WolverineFx.RuntimeCompilation</c> package is referenced by the
+/// application. It registers the Roslyn-backed <c>IAssemblyGenerator</c> (via
+/// <see cref="RuntimeCompilationExtensions.UseRuntimeCompilation"/>) so that
+/// <c>TypeLoadMode.Dynamic</c>/<c>Auto</c> applications "just work" without an
+/// explicit <c>opts.UseRuntimeCompilation()</c> call.
+/// <para>
+/// Core <c>WolverineFx</c> no longer ships the Roslyn runtime compiler; apps
+/// that pre-generate everything with <c>TypeLoadMode.Static</c> simply don't
+/// reference this package and therefore ship without Roslyn (smaller binaries,
+/// faster cold start, AOT-friendliness). Calling <c>UseRuntimeCompilation()</c>
+/// explicitly remains supported and is idempotent with this auto-registration.
+/// </para>
+/// </summary>
+internal sealed class RuntimeCompilationModule : IWolverineExtension
+{
+    public void Configure(WolverineOptions options)
+    {
+        options.UseRuntimeCompilation();
+    }
+}

--- a/src/Wolverine/HostBuilderExtensions.cs
+++ b/src/Wolverine/HostBuilderExtensions.cs
@@ -18,7 +18,6 @@ using JasperFx.CodeGeneration.Services;
 using JasperFx.CommandLine;
 using JasperFx.CommandLine.Descriptions;
 using JasperFx.Resources;
-using JasperFx.RuntimeCompiler;
 using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.ErrorHandling;
@@ -108,26 +107,15 @@ public static class HostBuilderExtensions
 
         services.AddJasperFx();
         services.AddSingleton<MessageStoreCollection>();
-        // NOTE: this default registration is preserved in v5.x for backward compatibility
-        // so existing apps that rely on Wolverine compiling handler/middleware code at
-        // runtime continue to work without additional configuration. In v6, this line is
-        // expected to be removed: applications using TypeLoadMode.Dynamic / Auto fallback
-        // will need to install the WolverineFx.RuntimeCompilation package and call
-        // opts.UseRuntimeCompilation() inside UseWolverine(...). Production deployments
-        // that pre-generate code with TypeLoadMode.Static will then be able to ship
-        // without Roslyn at all (smaller binaries, faster cold start, AOT-readiness).
-        // See issue #1577 for the full cold-start optimization roadmap.
-        //
-        // The IL2026 warning on the AssemblyGenerator() constructor is intentional and
-        // suppressed here: AssemblyGenerator emits and loads runtime-generated types,
-        // which is fundamentally incompatible with trimming. The whole point of the
-        // v6 Static-mode story is to let AOT-compatible apps avoid this registration
-        // entirely via UseRuntimeCompilation() opt-in. See AOT pillar #2715 / #2746.
-        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-            Justification = "Wolverine's runtime-codegen default; Static-mode AOT apps avoid this registration. See #2715/#2746.")]
-        static IServiceCollection RegisterAssemblyGenerator(IServiceCollection s)
-            => s.AddSingleton<IAssemblyGenerator, AssemblyGenerator>();
-        RegisterAssemblyGenerator(services);
+
+        // The Roslyn runtime compiler (JasperFx.RuntimeCompiler / AssemblyGenerator) is no
+        // longer registered by, or referenced from, core WolverineFx. Apps running
+        // TypeLoadMode.Dynamic/Auto reference the WolverineFx.RuntimeCompilation package,
+        // which auto-registers IAssemblyGenerator via its [WolverineModule] (or an explicit
+        // opts.UseRuntimeCompilation() call). TypeLoadMode.Static apps pre-generate all code
+        // and ship without Roslyn — smaller binaries, faster cold start, AOT-readiness. A
+        // fail-fast guard at startup (WolverineRuntime.HostService.logCodeGenerationConfiguration)
+        // catches a Dynamic app that is missing the generator. See #2876 / #1577 / AOT pillar #2746.
 
         services.AddSingleton(typeof(AncillaryMessageStoreApplication<>));
         

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -268,6 +268,21 @@ public partial class WolverineRuntime
         switch (Options.CodeGeneration.TypeLoadMode)
         {
             case TypeLoadMode.Dynamic:
+                // Core WolverineFx no longer ships the Roslyn runtime compiler (#2876). Dynamic mode
+                // always compiles handler/middleware dispatch at runtime, so it requires an
+                // IAssemblyGenerator — auto-registered by referencing WolverineFx.RuntimeCompilation,
+                // or via an explicit opts.UseRuntimeCompilation(). Fail fast with guidance if absent.
+                if (!_container.HasRegistrationFor(typeof(IAssemblyGenerator)))
+                {
+                    throw new InvalidOperationException(
+                        "Wolverine is running in TypeLoadMode.Dynamic, which compiles handler/middleware code at runtime, " +
+                        "but no IAssemblyGenerator (Roslyn) is registered. Core WolverineFx no longer ships the runtime compiler. " +
+                        "Either add the 'WolverineFx.RuntimeCompilation' NuGet package (it auto-registers when referenced, or call " +
+                        "opts.UseRuntimeCompilation() in UseWolverine(...)), or pre-generate code with 'dotnet run -- codegen write' " +
+                        "and set opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Static. " +
+                        "See https://wolverinefx.net/guide/codegen.html (GH-2876).");
+                }
+
                 Logger.LogInformation(
                     $"The Wolverine code generation mode is {nameof(TypeLoadMode.Dynamic)}. This is suitable for development, but you may want to opt into other options for production usage to reduce start up time and resource utilization.");
                 Logger.LogInformation("See https://wolverine.netlify.app/guide/codegen.html for more information");

--- a/src/Wolverine/Wolverine.csproj
+++ b/src/Wolverine/Wolverine.csproj
@@ -55,7 +55,9 @@
     <ItemGroup>
         <PackageReference Include="JasperFx" />
         <PackageReference Include="JasperFx.Events" />
-        <PackageReference Include="JasperFx.RuntimeCompiler" />
+        <!-- JasperFx.RuntimeCompiler (Roslyn) is intentionally NOT referenced by core
+             WolverineFx. It ships only in the opt-in WolverineFx.RuntimeCompilation package
+             so TypeLoadMode.Static / AOT apps don't carry Roslyn. See #2876. -->
         <PackageReference Include="JasperFx.SourceGeneration"
                           OutputItemType="Analyzer"
                           ReferenceOutputAssembly="false" />


### PR DESCRIPTION
Draft implementing #2876. Makes the Roslyn runtime compiler an opt-in/dev-only dependency so `TypeLoadMode.Static` / AOT apps ship without Roslyn.

## Approach: auto-register on reference (the recommended model from #2876)

- Core `WolverineFx` no longer references `JasperFx.RuntimeCompiler` nor registers the `AssemblyGenerator` by default (it only needs the `IAssemblyGenerator` abstraction, which lives in `JasperFx`/`JasperFx.CodeGeneration`).
- `WolverineFx.RuntimeCompilation` ships a `[WolverineModule]` (`RuntimeCompilationModule`) that registers the generator via `UseRuntimeCompilation()`. **Referencing the package is enough** for `TypeLoadMode.Dynamic` to work — no explicit call needed. The explicit `opts.UseRuntimeCompilation()` stays supported and is required when extension auto-discovery is off (`ExtensionDiscovery.ManualOnly`).
- **Fail-fast** at runtime startup (`WolverineRuntime.logCodeGenerationConfiguration`): a `TypeLoadMode.Dynamic` app with no `IAssemblyGenerator` throws an actionable error (add the package / call `UseRuntimeCompilation()` / pre-generate with Static). Placed at startup, not `AddWolverine`, so registration-only callers aren't affected.

## Wiring done

- `Wolverine.ComplianceTests` references `WolverineFx.RuntimeCompilation` → flows transitively to its ~39 downstream test/sample projects (the auto-module loads everywhere).
- `ManualOnly` bootstraps opt in explicitly (`bootstrapping_specs`, `Bug_2182`).
- **EF Core packaging fallout (expected):** removing Roslyn from core exposed a pre-existing EF Core Design transitive conflict (`CodeAnalysis.CSharp.Workspaces 4.8.0` vs `Workspaces.MSBuild 4.14.0`) that core's `RuntimeCompiler` had been masking. Fixed by pinning `CSharp.Workspaces 4.14.0` and referencing it from `WolverineFx.EntityFrameworkCore`.
- Removed a spurious `using Microsoft.CodeAnalysis.VisualBasic;` in `Wolverine.Marten` that only compiled via the transitive Roslyn dep.

## Status

- ✅ Full `wolverine.slnx` builds **0 warnings / 0 errors** (net9.0 + net10.0).
- ✅ CoreTests bootstrapping + runtime-compilation slices green (auto-module registers the generator; fail-fast + ManualOnly opt-in validated).
- ⏳ **Remaining (why this is a draft):** ~13 test projects sit outside the ComplianceTests reference graph and may need the `WolverineFx.RuntimeCompilation` reference (some are likely covered transitively). Letting CI pinpoint the exact set rather than over-referencing. Will also confirm the docker-backed suites (Marten/transports) and the `aot`/`AotSmoke` guard (which must stay Roslyn-free).

## Open decisions (from #2876)

- **Timing**: this is a breaking default flip for Dynamic-mode apps — land in a 6.0 rc or hold for GA?
- Docs (`aot.md`/`codegen.md`/`migration.md`) + the `wolverine-migration-v5-to-v6` AI skill (JasperFx/ai-skills#59) update once the activation model + timing are locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)