### PR TITLE
Upgrade to JasperFx/Marten rc.3 + Polecat rc.2; cut Wolverine 6.0.0-rc.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -74,8 +74,15 @@
                    event-stream-versioned aggregates implement ILongVersioned. rc
                    namespace relocations absorbed across tests/samples (IRevisioned,
                    TenancyStyle, Identity/IdentityAttribute, ISoftDeleted).
+          rc.2:    Critter Stack 2026 rc refresh — bump to the latest published
+                   prerelease line:
+                     JasperFx / .RuntimeCompiler / .SourceGeneration / .Events
+                       (+ .Events.SourceGenerator)     rc.2 -> 2.0.0-rc.3 / 5.0.0-rc.3
+                     Marten / .AspNetCore / .Newtonsoft rc.2 -> 9.0.0-rc.3
+                     Polecat                           rc.1 -> 4.0.0-rc.2
+                     Weasel.* (7 packages)             unchanged (9.0.0-rc.1 is latest)
         -->
-        <Version>6.0.0-rc.1</Version>
+        <Version>6.0.0-rc.2</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,18 +31,18 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-rc.2" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-rc.2" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-rc.2" />
-    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-rc.2" />
-    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-rc.2" />
+    <PackageVersion Include="JasperFx" Version="2.0.0-rc.3" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0-rc.3" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-rc.3" />
+    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-rc.3" />
+    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-rc.3" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-    <PackageVersion Include="Marten" Version="9.0.0-rc.2" />
+    <PackageVersion Include="Marten" Version="9.0.0-rc.3" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="4.0.0-rc.1" />
+    <PackageVersion Include="Polecat" Version="4.0.0-rc.2" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.0.0-rc.2" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.0.0-rc.2" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.0.0-rc.3" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.0.0-rc.3" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />

--- a/src/Persistence/MartenTests/handler_actions_with_implied_marten_operations.cs
+++ b/src/Persistence/MartenTests/handler_actions_with_implied_marten_operations.cs
@@ -1,6 +1,9 @@
 ﻿using IntegrationTests;
 using Marten;
 using Marten.Exceptions;
+// JasperFx 2.0 rc.3 dedupe lifted DocumentAlreadyExistsException out of
+// Marten.Exceptions into the JasperFx namespace; Marten throws the lifted type.
+using DocumentAlreadyExistsException = JasperFx.DocumentAlreadyExistsException;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Wolverine;


### PR DESCRIPTION
Critter Stack 2026 rc refresh to the latest published prerelease line, and bumps the WolverineFx package version to `6.0.0-rc.2`.

| Package family | From | To |
|---|---|---|
| JasperFx / .RuntimeCompiler / .SourceGeneration / .Events (+ .Events.SourceGenerator) | `2.0.0-rc.2` / `5.0.0-rc.2` | **`2.0.0-rc.3`** / **`5.0.0-rc.3`** |
| Marten / .AspNetCore / .Newtonsoft | `9.0.0-rc.2` | **`9.0.0-rc.3`** |
| Polecat | `4.0.0-rc.1` | **`4.0.0-rc.2`** |
| Weasel.* (7 packages) | `9.0.0-rc.1` | _unchanged — `9.0.0-rc.1` is the latest_ |
| **WolverineFx version** | `6.0.0-rc.1` | **`6.0.0-rc.2`** |

## One source change

The JasperFx 2.0 **rc.3 dedupe lifted `DocumentAlreadyExistsException` out of `Marten.Exceptions` into the `JasperFx` namespace** (Marten now throws the lifted type). `MartenTests/handler_actions_with_implied_marten_operations.cs` aliases the lifted type:

```csharp
using DocumentAlreadyExistsException = JasperFx.DocumentAlreadyExistsException;
```

That was the only compile impact of the bump.

## Verification

`dotnet build wolverine.slnx -c Release` → **0 warnings, 0 errors** (net9.0 + net10.0).

On a green CI run: merge, then publish the `6.0.0-rc.2` Wolverine NuGets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)