### PR TITLE
Pack + publish WolverineFx.RuntimeCompilation

### DIFF
--- a/build/build.cs
+++ b/build/build.cs
@@ -321,6 +321,7 @@ partial class Build : NukeBuild
             var nugetProjects = new[]
             {
                 Solution.Wolverine,
+                Solution.Wolverine_RuntimeCompilation,
                 Solution.Wolverine_HealthChecks,
                 Solution.Transports.RabbitMQ.Wolverine_RabbitMQ,
                 Solution.Transports.Azure.Wolverine_AzureServiceBus,


### PR DESCRIPTION
`Wolverine.RuntimeCompilation` (PackageId **`WolverineFx.RuntimeCompilation`** — the opt-in runtime-Roslyn compilation package with `opts.UseRuntimeCompilation()`) was missing from the `Pack` target's `nugetProjects` list in `build/build.cs`, so it has **never been published to NuGet** (zero versions there today).

This PR adds it to the pack/publish set.

- **Harmless for current releases** — core `WolverineFx` still bundles `JasperFx.RuntimeCompiler`, so `TypeLoadMode.Dynamic` apps work without this package.
- **Prerequisite for the RuntimeCompiler decoupling (#2876 / PR #2877)** — that change tells apps to reference `WolverineFx.RuntimeCompilation`, which is impossible until it's on NuGet.

Verified: the Nuke build project compiles with the new `Solution.Wolverine_RuntimeCompilation` accessor, and the project packs to `WolverineFx.RuntimeCompilation.6.0.0-rc.2.nupkg`.

Once merged, the next publish run (with `--skip-duplicate`) pushes this package while the already-published `6.0.0-rc.2` packages skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)