### PR TITLE
Docs: WolverineFx.RuntimeCompilation is required in 6.0 (decoupling shipped)

### DIFF
--- a/docs/guide/codegen.md
+++ b/docs/guide/codegen.md
@@ -115,10 +115,10 @@ Most of the facilities shown here will require the [Oakton command line integrat
 
 Runtime code generation requires a Roslyn-backed `IAssemblyGenerator` to compile the generated C# source into an assembly that Wolverine can load. That implementation ships in `JasperFx.RuntimeCompiler`, which pulls in roughly 100 MB of Roslyn assemblies. For applications that pre-generate all of their handler / middleware code with `TypeLoadMode.Static` and never recompile at runtime, those assemblies are dead weight — bigger deployment, slower cold start, and incompatible with Native AOT.
 
-The `WolverineFx.RuntimeCompilation` package isolates that runtime-compilation dependency behind an opt-in extension method, so production deployments that don't need it can drop it (in a future major version) and ship without Roslyn.
+The `WolverineFx.RuntimeCompilation` package isolates that runtime-compilation dependency in a separate package, so production deployments that don't need it ship without Roslyn.
 
-::: info
-This package is the first deliverable in [issue #1577](https://github.com/JasperFx/wolverine/issues/1577) — the broader cold-start optimization and AOT-readiness roadmap. The opt-in API exists today on v5.x; the actual decoupling of `JasperFx.RuntimeCompiler` from the core `WolverineFx` package is planned for v6.0. Adopt the `opts.UseRuntimeCompilation()` call today and your app will be future-proof against the v6 cleanup.
+::: warning Changed in 6.0
+**As of Wolverine 6.0, core `WolverineFx` no longer references `JasperFx.RuntimeCompiler` or registers a default `IAssemblyGenerator`.** Applications running `TypeLoadMode.Dynamic` (the default) or `Auto` now **must** reference `WolverineFx.RuntimeCompilation` — simply referencing the package is enough (it auto-registers the Roslyn `IAssemblyGenerator` via a `[WolverineModule]`). `TypeLoadMode.Static` apps that pre-generate all of their code need nothing and ship without Roslyn. See [Migrating from 5 to 6](/guide/migration). On 5.x this package was an optional, forward-looking opt-in; in 6.0 it is required for runtime code generation. Part of the cold-start / AOT-readiness work in [#1577](https://github.com/JasperFx/wolverine/issues/1577) / [#2876](https://github.com/JasperFx/wolverine/issues/2876).
 :::
 
 ### When you need it
@@ -127,7 +127,7 @@ This package is the first deliverable in [issue #1577](https://github.com/Jasper
 |----------|-------------------|
 | Local development with `TypeLoadMode.Dynamic` (the default) | **Yes** — runtime compilation runs every time. |
 | `TypeLoadMode.Auto` with the source-code fall-back | **Yes** — compilation runs the first time a missing handler is invoked. |
-| Production with `TypeLoadMode.Static` and all generated code pre-built into the application assembly | **No** — runtime compilation is never invoked. (Currently the package's bits ride along with `WolverineFx`; in v6.0 it will be opt-in and you can drop it for a smaller deployment.) |
+| Production with `TypeLoadMode.Static` and all generated code pre-built into the application assembly | **No** — runtime compilation is never invoked. In 6.0 core `WolverineFx` no longer carries Roslyn, so a Static-mode deployment ships without it automatically. |
 | Running `dotnet run -- codegen write` from a CI build agent | **Yes** — that command emits the generated source by compiling it once. |
 
 ### Installation
@@ -140,7 +140,9 @@ The package depends on `JasperFx.RuntimeCompiler`. It does not pull in any other
 
 ### Configuration
 
-Inside `UseWolverine(...)`, opt in via the `UseRuntimeCompilation()` extension method:
+In 6.0, **referencing the package is usually all you need**: `WolverineFx.RuntimeCompilation` ships a `[WolverineModule]` that Wolverine auto-discovers at startup and which registers the Roslyn `IAssemblyGenerator` for you. With the default extension auto-discovery on, `TypeLoadMode.Dynamic`/`Auto` "just works" once the package is referenced — no code change required.
+
+You can also register it explicitly inside `UseWolverine(...)` via the `UseRuntimeCompilation()` extension method. This is **required** if you've turned extension auto-discovery off (`ExtensionDiscovery.ManualOnly`), and is handy when you want to gate it by environment (see below):
 
 ```csharp
 using Wolverine;
@@ -153,7 +155,7 @@ builder.Host.UseWolverine(opts =>
 });
 ```
 
-`UseRuntimeCompilation()` is idempotent — calling it twice does nothing on the second call. It registers `IAssemblyGenerator` as a singleton in DI using `TryAddSingleton`, so a custom registration you've already added wins.
+`UseRuntimeCompilation()` is idempotent — calling it twice (or alongside the auto-registering module) does nothing on the second call. It registers `IAssemblyGenerator` as a singleton in DI using `TryAddSingleton`, so a custom registration you've already added wins.
 
 For advanced scenarios where you need to register the runtime compiler outside of `UseWolverine(...)` (e.g., from a hosted-service registration ordering), the `IServiceCollection` overload is available:
 
@@ -183,13 +185,13 @@ Combine that with `TypeLoadMode.Static` in production and the `dotnet run -- cod
 
 ### What happens if you forget?
 
-On v5.x today, `WolverineFx` itself still registers a default `IAssemblyGenerator` for backward compatibility, so omitting `opts.UseRuntimeCompilation()` is harmless — your app keeps working exactly as before. The opt-in is forward-looking.
+In 6.0, core `WolverineFx` no longer registers a default `IAssemblyGenerator`. A `TypeLoadMode.Dynamic`/`Auto` app that starts without the runtime compiler available fails fast at startup with:
 
-In v6.0, the default registration goes away. Apps that hit a runtime-compilation code path without the package installed will see a startup error along the lines of:
+> Wolverine is running in TypeLoadMode.Dynamic, which compiles handler/middleware code at runtime, but no IAssemblyGenerator (Roslyn) is registered. Core WolverineFx no longer ships the runtime compiler. Either add the 'WolverineFx.RuntimeCompilation' NuGet package (it auto-registers when referenced, or call opts.UseRuntimeCompilation() in UseWolverine(...)), or pre-generate code with 'dotnet run -- codegen write' and set opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Static.
 
-> No `IAssemblyGenerator` is registered in the application's service provider, but runtime code generation was requested. Either: (a) install the `WolverineFx.RuntimeCompilation` package and call `opts.UseRuntimeCompilation()` inside `UseWolverine(...)` for dev-time codegen, or (b) pre-generate all code (typically with `dotnet run -- codegen write`) and set `GenerationRules.TypeLoadMode = TypeLoadMode.Static` so runtime compilation is never invoked.
+To resolve it: reference `WolverineFx.RuntimeCompilation` (Dynamic/Auto mode), or move to `TypeLoadMode.Static` with pre-generated code (production, Roslyn-free).
 
-Adopting `opts.UseRuntimeCompilation()` today makes the v6 upgrade a no-op for you.
+(On 5.x, `WolverineFx` registered a default `IAssemblyGenerator`, so the package was an optional forward-looking opt-in. 6.0 removed that default — hence the requirement above.)
 
 ## Embedding Codegen in Docker
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -31,6 +31,7 @@ The table below is the **complete inventory** of changed defaults, removed APIs,
 | `MartenConfigurationExpression.EventForwardingToWolverine(...)` | extension method on the Marten configuration expression *(both overloads `[Obsolete]` since 3.x)* | **removed** *(BREAKING)* | Move the flag into the `IntegrateWithWolverine` callback: [`IntegrateWithWolverine(x => x.UseFastEventForwarding = true)`](#eventforwardingtowolverine-removed-breaking) |
 | `RedisTransport.BuildRedisStreamUri(...)` | static helper on `RedisTransport` *(`[Obsolete]`)* | **removed** *(BREAKING)* | Call [`RedisEndpointUri.Stream(...)`](#redistransport-buildredisstreamuri-removed-breaking) — identical signature, drop the helper |
 | `PulsarEndpoint.UriFor(...)` | static helpers on `PulsarEndpoint` *(both overloads `[Obsolete]`)* | **removed** *(BREAKING)* | For the Wolverine-URI form, call [`PulsarEndpointUri.Topic(...)`](#pulsarendpoint-urifor-removed-breaking); the native-topic-path form (`persistent://...`) was an internal-only seam now covered by `PulsarEndpoint.NativeTopicPath` |
+| Runtime code generation (Roslyn) | bundled in core `WolverineFx` (via `JasperFx.RuntimeCompiler`) | **moved to the opt-in `WolverineFx.RuntimeCompilation` package** *(BREAKING for `TypeLoadMode.Dynamic`/`Auto`)* | Reference [`WolverineFx.RuntimeCompilation`](#runtime-code-generation-moved-to-the-wolverinefxruntimecompilation-package-breaking) (it auto-registers), or pre-generate with `TypeLoadMode.Static` |
 | **One-line full revert** | n/a | [`opts.RestoreV5Defaults()`](#one-line-revert-restorev5defaults) | Flip every runtime default this method covers back to its 5.x value |
 
 ::: tip
@@ -171,6 +172,26 @@ The call surface itself is unchanged — `opts.UseNewtonsoftJsonForSerialization
 Core `WolverineFx.Http` retains the `JsonUsage.NewtonsoftJson` enum value so the public switch shape doesn't change. The codegen path inside `JsonResourceWriterPolicy` / `JsonBodyParameterStrategy` now dispatches through an internal `INewtonsoftHttpCodeGen` seam implemented in the new package; selecting `JsonUsage.NewtonsoftJson` without the package installed throws an `InvalidOperationException` at codegen time pointing you at `dotnet add package WolverineFx.Http.Newtonsoft`.
 
 In a related cleanup, `ProblemDetailsContinuationPolicy.WriteProblems` (which dumps the `ProblemDetails` payload into the log line for the "found problems with this message" diagnostic) switched from `Newtonsoft.Json.JsonConvert.SerializeObject` to `System.Text.Json.JsonSerializer.Serialize`. This is a logging dump only — `ProblemDetails` round-trips cleanly through STJ; there is no observable output-format change.
+
+### Runtime code generation moved to the `WolverineFx.RuntimeCompilation` package (BREAKING)
+
+In 5.x, core `WolverineFx` referenced `JasperFx.RuntimeCompiler` (≈100 MB of Roslyn assemblies) and registered a default `IAssemblyGenerator`, so runtime code generation always "just worked." In 6.0 that dependency is **removed from core** and lives only in the opt-in **`WolverineFx.RuntimeCompilation`** package. This lets `TypeLoadMode.Static` / Native-AOT deployments ship without Roslyn — smaller binaries, faster cold start — but it is a breaking change for apps that compile at runtime.
+
+**Who is affected:** any app running `TypeLoadMode.Dynamic` (the default) or `TypeLoadMode.Auto`. Such an app now fails fast at startup with an error telling you to add the package or switch to Static:
+
+> Wolverine is running in TypeLoadMode.Dynamic, which compiles handler/middleware code at runtime, but no IAssemblyGenerator (Roslyn) is registered. Core WolverineFx no longer ships the runtime compiler. Either add the 'WolverineFx.RuntimeCompilation' NuGet package (it auto-registers when referenced, or call opts.UseRuntimeCompilation() in UseWolverine(...)), or pre-generate code with 'dotnet run -- codegen write' and set opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Static.
+
+**Migration — pick one:**
+
+1. **Keep runtime codegen (simplest).** Reference the package; that's all — its `[WolverineModule]` auto-registers the Roslyn `IAssemblyGenerator` at bootstrap:
+   ```sh
+   dotnet add package WolverineFx.RuntimeCompilation
+   ```
+   If you've disabled extension auto-discovery (`ExtensionDiscovery.ManualOnly`), the module won't load automatically — call `opts.UseRuntimeCompilation()` inside `UseWolverine(...)` instead.
+
+2. **Go Roslyn-free in production (recommended for AOT / fast cold start).** Pre-generate code with `dotnet run -- codegen write`, commit `Internal/Generated`, and set `opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Static`. Reference `WolverineFx.RuntimeCompilation` only as a dev/build-time dependency (for `codegen write`); production ships without Roslyn. See the [Code Generation guide](/guide/codegen).
+
+`WolverineFx.RuntimeCompilation` is available from `6.0.0-rc.2` onward.
 
 ### `IForwardsTo<T>` discovery is now explicit (BREAKING)
 


### PR DESCRIPTION
The RuntimeCompiler decoupling (#2876) shipped in **6.0.0-rc.2**, but the docs still described it as *planned for v6.0* and the migration guide didn't mention it. Since it affects the **default** `TypeLoadMode.Dynamic`, this corrects both.

**`docs/guide/codegen.md`** — the `WolverineFx.RuntimeCompilation` section now reflects shipped reality:
- Core `WolverineFx` no longer references `JasperFx.RuntimeCompiler` / registers a default `IAssemblyGenerator` (was "planned for v6.0 / bits ride along / harmless to omit").
- Dynamic/Auto apps **must** reference the package — and **referencing it is enough** (auto-registers via `[WolverineModule]`); explicit `UseRuntimeCompilation()` only needed under `ExtensionDiscovery.ManualOnly`.
- "What happens if you forget" updated to the actual startup fail-fast message.

**`docs/guide/migration.md`** — adds an at-a-glance row + a dedicated **BREAKING** section ("Runtime code generation moved to the `WolverineFx.RuntimeCompilation` package") with the two migration paths (reference the package, or go `TypeLoadMode.Static` Roslyn-free).

Companion to the just-published `WolverineFx.RuntimeCompilation 6.0.0-rc.2` package (#2880). The matching AI-skill update is committed separately (JasperFx/ai-skills#59).