### PR TITLE
Release Wolverine 6.0.0 (Critter Stack 2026)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -82,7 +82,7 @@
                      Polecat                           rc.1 -> 4.0.0-rc.2
                      Weasel.* (7 packages)             unchanged (9.0.0-rc.1 is latest)
         -->
-        <Version>6.0.0-rc.2</Version>
+        <Version>6.0.0</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,18 +31,18 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-rc.3" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-rc.3" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-rc.3" />
-    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-rc.3" />
-    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-rc.3" />
+    <PackageVersion Include="JasperFx" Version="2.0.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0" />
+    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
+    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-    <PackageVersion Include="Marten" Version="9.0.0-rc.3" />
+    <PackageVersion Include="Marten" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="4.0.0-rc.2" />
+    <PackageVersion Include="Polecat" Version="4.0.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.0.0-rc.3" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.0.0-rc.3" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.0.0" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.0.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />
@@ -113,13 +113,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Weasel.MySql" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Weasel.Core" Version="9.0.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0" />
+    <PackageVersion Include="Weasel.MySql" Version="9.0.0" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.0.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.0.0" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />


### PR DESCRIPTION
The bottom-of-the-stack release: bump **all** foundation refs to final + WolverineFx 6.0.0.

| Package(s) | From | To |
|---|---|---|
| JasperFx (+ Events / Events.SourceGenerator / SourceGeneration) | 2.0.0-rc.3 | **2.0.0** |
| JasperFx.RuntimeCompiler | 5.0.0-rc.3 | **5.0.0** |
| Marten / Marten.AspNetCore / Marten.Newtonsoft | 9.0.0-rc.3 | **9.0.0** |
| Polecat | 4.0.0-rc.2 | **4.0.0** |
| Weasel.* (7) | 9.0.0-rc.1 | **9.0.0** |
| WolverineFx.* | 6.0.0-rc.2 | **6.0.0** |

All foundation packages are live on nuget.org. Wolverine core + Wolverine.Marten + Wolverine.Polecat build clean (0 errors) against them.

After merge: tag `V6.0.0`, GitHub release, then trigger NuGet publish + docs deploy. (Release-sequence items from #2745.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)