### PR TITLE
Pulsar: Fix KeyNotFoundException ACKing batch messages on partitioned topics

### DIFF
--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/FixMessageIdTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/FixMessageIdTests.cs
@@ -1,0 +1,44 @@
+using DotPulsar;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+public class FixMessageIdTests
+{
+    private const string TopicUri = "persistent://public/default/events";
+
+    [Fact]
+    public void FixMessageId_BatchMessageMissingTopic_ReconstructsPartitionTopic()
+    {
+        var messageId = new MessageId(1UL, 2UL, partition: 3, batchIndex: 0);
+
+        var result = PulsarListener.FixMessageId(messageId, TopicUri);
+
+        result.Topic.ShouldBe($"{TopicUri}-partition-3");
+        result.LedgerId.ShouldBe(1UL);
+        result.EntryId.ShouldBe(2UL);
+        result.Partition.ShouldBe(3);
+        result.BatchIndex.ShouldBe(0);
+    }
+
+    [Fact]
+    public void FixMessageId_TopicAlreadySet_ReturnsOriginal()
+    {
+        var messageId = new MessageId(1UL, 2UL, partition: 3, batchIndex: 0, topic: $"{TopicUri}-partition-3");
+
+        var result = PulsarListener.FixMessageId(messageId, TopicUri);
+
+        result.ShouldBeSameAs(messageId);
+    }
+
+    [Fact]
+    public void FixMessageId_NonPartitionedMessage_ReturnsOriginal()
+    {
+        var messageId = new MessageId(1UL, 2UL, partition: -1, batchIndex: -1);
+
+        var result = PulsarListener.FixMessageId(messageId, TopicUri);
+
+        result.ShouldBeSameAs(messageId);
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -158,7 +158,7 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
             var consumer = e.IsFromRetryConsumer && _retryConsumer != null ? _retryConsumer : _consumer;
             if (consumer != null)
             {
-                return consumer.Acknowledge(e.MessageData, _cancellation);
+                return consumer.Acknowledge(FixMessageId(e.MessageData.MessageId, _endpoint.PulsarTopic()), _cancellation);
             }
         }
 
@@ -172,7 +172,7 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
         if (_enableRequeue && _sender is not null && envelope is PulsarEnvelope e)
         {
             var consumer = e.IsFromRetryConsumer && _retryConsumer != null ? _retryConsumer : _consumer;
-            await consumer!.Acknowledge(e.MessageData, _cancellation);
+            await consumer!.Acknowledge(FixMessageId(e.MessageData.MessageId, _endpoint.PulsarTopic()), _cancellation);
             await _sender.SendAsync(envelope);
         }
     }
@@ -297,12 +297,29 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
             }
 
             // Acknowledge the original message
-            await sourceConsumer!.Acknowledge(e.MessageData, _cancellation);
+            await sourceConsumer!.Acknowledge(FixMessageId(e.MessageData.MessageId, _endpoint.PulsarTopic()), _cancellation);
 
             // Send copy to retry/DLQ topic
             await targetProducer.Send(messageMetadata, e.MessageData.Data, _cancellation)
                 .ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// DotPulsar BatchHandler.Add creates MessageId objects without the topic for messages
+    /// inside a batch (https://github.com/apache/pulsar-dotpulsar/issues/287), so
+    /// Consumer._subConsumers[messageId.Topic] throws KeyNotFoundException on partitioned topics.
+    /// Reconstruct the MessageId with the correct partition sub-topic URI when it is missing.
+    /// </summary>
+    internal static MessageId FixMessageId(MessageId messageId, string topicUri)
+    {
+        if (string.IsNullOrEmpty(messageId.Topic) && messageId.Partition >= 0)
+        {
+            return new MessageId(messageId.LedgerId, messageId.EntryId, messageId.Partition,
+                messageId.BatchIndex, $"{topicUri}-partition-{messageId.Partition}");
+        }
+
+        return messageId;
     }
 
     private MessageMetadata BuildMessageMetadata(Envelope envelope, PulsarEnvelope e, Exception? exception,


### PR DESCRIPTION
Workaround apache/pulsar-dotpulsar#287: `BatchHandler.Add` constructs `MessageId` objects for each message inside a batch without setting the Topic field (it defaults to ""). `Consumer.Acknowledge()` does `_subConsumers[messageId.Topic]` to route the ACK to the correct partition sub-consumer — on a partitioned topic `""` is never a valid key, so the lookup throws `KeyNotFoundException` and the message is never acknowledged, causing infinite redelivery.

Non-batch messages are unaffected: `ConsumerChannel` uses `ToMessageId(topic)` for those, which correctly populates `Topic`.

The new `FixMessageId()` helper reconstructs the `MessageId` with the correct partition sub-topic URI (`{topic}-partition-{partition}`) when Topic is empty and Partition >= 0. Applied at all three `Acknowledge` call sites in `PulsarListener`.