### PR TITLE
Fix parallel build IO race

### DIFF
--- a/src/Samples/ProcessManagerViaHandlers/ProcessManagerViaHandlers/ProcessManagerViaHandlers.csproj
+++ b/src/Samples/ProcessManagerViaHandlers/ProcessManagerViaHandlers/ProcessManagerViaHandlers.csproj
@@ -1,18 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <!-- This Microsoft.NET.Sdk.Web sample serves no static web assets (no wwwroot,
-             no Razor/Blazor). Disabling StaticWebAssets skips the DefineStaticWebAssets
-             task, which intermittently fails the CI build with an IOException on its
-             obj/.../rpswa.dswa.cache.json cache under parallel MSBuild ("being used by
-             another process"). Nothing here needs that pipeline. -->
-        <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
+
     </PropertyGroup>
 
     <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <ProjectReference Include="..\..\..\Persistence\Wolverine.Marten\Wolverine.Marten.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
This PR switches ProcessManagerViaHandlers from Sdk.Web to Sdk + FrameworkReference

The sample has no Razor, Blazor, wwwroot, or static assets, so Microsoft.NET.Sdk.Web only adds unnecessary build tasks that touch shared obj/ artifacts. These sporadically race under parallel MSBuild in CI, producing hard-to-reproduce IOException failures.

Switching to Microsoft.NET.Sdk with an explicit
FrameworkReference Include="Microsoft.AspNetCore.App" eliminates the Web SDK build pipeline while keeping all ASP.NET Core APIs available.