### PR TITLE
Repoint JasperFx.SourceGeneration → JasperFx.SourceGenerator 2.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0" />
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.0.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
     <PackageVersion Include="Marten" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/src/Wolverine/Wolverine.csproj
+++ b/src/Wolverine/Wolverine.csproj
@@ -58,7 +58,7 @@
         <!-- JasperFx.RuntimeCompiler (Roslyn) is intentionally NOT referenced by core
              WolverineFx. It ships only in the opt-in WolverineFx.RuntimeCompilation package
              so TypeLoadMode.Static / AOT apps don't carry Roslyn. See #2876. -->
-        <PackageReference Include="JasperFx.SourceGeneration"
+        <PackageReference Include="JasperFx.SourceGenerator"
                           OutputItemType="Analyzer"
                           ReferenceOutputAssembly="false" />
     </ItemGroup>


### PR DESCRIPTION
Repoints core WolverineFx off the retired `JasperFx.SourceGeneration` (noun) package onto the merged **`JasperFx.SourceGenerator`** (singular) `2.0.1`, per [JasperFx/jasperfx#365](https://github.com/JasperFx/jasperfx/issues/365).

The two JasperFx source-generator packages were combined into one: the CLI command-discovery + input-parser generators Wolverine consumes now ship in `JasperFx.SourceGenerator` alongside the OptionsDescription generator. The package versions in lockstep with the `JasperFx` core package, starting at `2.0.1` (`2.0.0` of the singular package predates the merge and lacks the command generators, so `2.0.1` is required).

## Changes
- `Directory.Packages.props` — `JasperFx.SourceGeneration` `2.0.0` → `JasperFx.SourceGenerator` `2.0.1`
- `src/Wolverine/Wolverine.csproj` — `PackageReference` id renamed (analyzer wiring `OutputItemType="Analyzer"` / `ReferenceOutputAssembly="false"` unchanged)

The historical changelog comment in `Directory.Build.props` that mentions `JasperFx.SourceGeneration` was intentionally left as-is (it's an accurate record of the alpha.5 bump).

## Verification
- `dotnet build wolverine.slnx` — **0 errors, 0 warnings** (live `2.0.1` analyzer resolves and generated code compiles across the solution).
- `src/Testing/CoreTests` — green: net10.0 1713/1713; net9.0 1712/1713 with one flaky `TrackedSession` timeout (`envelope_username_tracking`) that passes on isolated re-run and is unrelated to source generation.

Closes #2890.
