### PR TITLE
Upgrade Critter Stack deps (Marten 9.0.1 / Polecat 4.1.1 / JasperFx 2.0.1) and bump to 6.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -81,8 +81,17 @@
                      Marten / .AspNetCore / .Newtonsoft rc.2 -> 9.0.0-rc.3
                      Polecat                           rc.1 -> 4.0.0-rc.2
                      Weasel.* (7 packages)             unchanged (9.0.0-rc.1 is latest)
+          6.0.1:   First 6.0 patch. Critter Stack GA patch refresh; pulls in the
+                   JasperFx keyed-service-location codegen fix (jasperfx GH-2878,
+                   shipped in JasperFx 2.0.1). Latest-published pin matrix:
+                     JasperFx                          2.0.0 -> 2.0.1
+                     JasperFx.Events (+ .Events.SourceGenerator)  2.0.0 -> 2.1.0
+                     Marten / .AspNetCore / .Newtonsoft 9.0.0 -> 9.0.1
+                     Polecat                           4.0.0 -> 4.1.1
+                     Weasel.* (7 packages)             9.0.0 -> 9.0.1
+                     JasperFx.RuntimeCompiler (5.0.0) / .SourceGeneration (2.0.0) unchanged
         -->
-        <Version>6.0.0</Version>
+        <Version>6.0.1</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,18 +31,18 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.0.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0" />
+    <PackageVersion Include="JasperFx" Version="2.0.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.1.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.1.0" />
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
     <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-    <PackageVersion Include="Marten" Version="9.0.0" />
+    <PackageVersion Include="Marten" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="4.0.0" />
+    <PackageVersion Include="Polecat" Version="4.1.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.0.0" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.0.0" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.0.1" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.0.1" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />
@@ -113,13 +113,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.0.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0" />
-    <PackageVersion Include="Weasel.MySql" Version="9.0.0" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.0.0" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.0.0" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.0.0" />
+    <PackageVersion Include="Weasel.Core" Version="9.0.1" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.1" />
+    <PackageVersion Include="Weasel.MySql" Version="9.0.1" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.0.1" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.0.1" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.0.1" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />


### PR DESCRIPTION
## What

Upgrades the Critter Stack dependencies to their latest published stable versions and bumps Wolverine's own fix version.

| Package(s) | From | To |
|---|---|---|
| `JasperFx` | 2.0.0 | **2.0.1** |
| `JasperFx.Events`, `JasperFx.Events.SourceGenerator` | 2.0.0 | **2.1.0** |
| `Marten`, `Marten.AspNetCore`, `Marten.Newtonsoft` | 9.0.0 | **9.0.1** |
| `Polecat` | 4.0.0 | **4.1.1** |
| `Weasel.Core/.EntityFrameworkCore/.MySql/.Oracle/.Postgresql/.SqlServer/.Sqlite` | 9.0.0 | **9.0.1** |
| **Wolverine** (own version) | 6.0.0 | **6.0.1** |

`JasperFx.RuntimeCompiler` (5.0.0) and `JasperFx.SourceGeneration` (2.0.0) are already at their latest published stable, so they're left unchanged.

## Why

Picks up the latest GA patch line, notably the **keyed-service-location codegen fix** that shipped in `JasperFx 2.0.1` ([jasperfx GH-2878](https://github.com/JasperFx/wolverine/issues/2878)) — keyed services now resolve correctly when a sibling opaque/lambda registration forces a handler onto the service-location path.

## Verification

`dotnet build wolverine.slnx -c Release` — clean (**0 warnings, 0 errors**, with `TreatWarningsAsErrors=true`), so the upgrade — including the `JasperFx.Events` 2.0→2.1 minor bump — compiles across the entire solution. CI runs the full test matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)