### PR TITLE
Add 6.0.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## Unreleased
 
+## 6.0.1
+
+Patch release on the 6.0 line: a Critter Stack dependency refresh plus two
+targeted fixes and one new opt-in transport feature. No breaking changes.
+
+### WolverineFx (core)
+
+- **Keyed services now resolve correctly when code generation falls back to
+  service location.** When a handler dependency injected `IServiceProvider`
+  directly or used an opaque lambda registration (such as the ones the MS Graph
+  SDK adds), the generated code dropped the service key and emitted
+  `GetRequiredService<T>` instead of `GetRequiredKeyedService<T>`, throwing at
+  runtime. Fixed upstream in the JasperFx 2.0.1 code generation
+  (jasperfx GH-2878) and pulled in via the dependency bump below.
+
+### WolverineFx.AmazonSqs
+
+- **Amazon SQS standard queues can opt into [fair queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html)**
+  via `EnableFairQueueMessageGroups()`, which maps `Envelope.GroupId` to the SQS
+  `MessageGroupId` on outgoing messages to improve fairness for multi-tenant
+  workloads. Opt-in per endpoint, no ordering/deduplication semantics, and no
+  effect on FIFO queues (which always map `MessageGroupId`). (#2886)
+
+### WolverineFx.Marten
+
+- **Ancillary store outbox honors the per-store envelope schema.** Projection
+  side-effect messages published from an ancillary Marten store integrated via
+  `IntegrateWithWolverine(x => x.SchemaName = ...)` on a separate database now
+  write envelopes to that store's own schema instead of the main store's,
+  fixing `42P01: relation "public.wolverine_incoming_envelopes" does not exist`
+  in modular-monolith setups. (#2887)
+
+### Dependencies
+
+- JasperFx `2.0.0` → `2.0.1`
+- JasperFx.Events (and `.Events.SourceGenerator`) `2.0.0` → `2.1.0`
+- JasperFx source-generator package repointed to `JasperFx.SourceGenerator` `2.0.1` (#2891)
+- Marten (and `.AspNetCore` / `.Newtonsoft`) `9.0.0` → `9.0.1`
+- Polecat `4.0.0` → `4.1.1`
+- Weasel.* (7 packages) `9.0.0` → `9.0.1`
+
 ## 6.0.0-alpha.1
 
 First explicitly-versioned 6.0 alpha. Cumulative work since 5.39.0 on the `main`


### PR DESCRIPTION
Release notes for **WolverineFx 6.0.1** (patch on the 6.0 line; nuget.org is currently at 6.0.0).

Covers everything merged since the `8570541b6` 6.0.0 GA commit:

- **Core:** keyed services resolve correctly when codegen falls back to service location (via JasperFx 2.0.1, jasperfx GH-2878).
- **AmazonSqs:** `EnableFairQueueMessageGroups()` opt-in for SQS standard fair queues (#2886).
- **Marten:** ancillary-store outbox writes projection side-effect envelopes to the per-store schema (#2887).
- **Dependencies:** JasperFx 2.0.1, JasperFx.Events 2.1.0, source-generator repoint to `JasperFx.SourceGenerator` 2.0.1 (#2891), Marten 9.0.1, Polecat 4.1.1, Weasel.* 9.0.1 (#2892).

The `<Version>` is already at `6.0.1` on main (bumped in #2892); this PR only adds the changelog. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)