### PR TITLE
Fix NRE from null-Sender routes built during description mode (GH-2897)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Routing/description_mode_routes_are_not_cached.cs
+++ b/src/Testing/CoreTests/Runtime/Routing/description_mode_routes_are_not_cached.cs
@@ -1,0 +1,65 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Runtime.Routing;
+
+// GH-2897: routes built while WolverineSystemPart.WithinDescription is true are allowed to take a
+// null MessageRoute.Sender (the endpoint's sending agent may not exist yet during
+// FindResources/resource-setup-on-startup). If such a route is cached in the runtime's router
+// cache, it later escapes onto the send path and NREs inside CreateForSending (the Envelope ctor
+// dereferences agent.Endpoint). The fix: never cache description-mode routes.
+public class description_mode_routes_are_not_cached
+{
+    [Fact]
+    public async Task within_description_routing_is_not_cached_but_normal_routing_is()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<Bug2897RoutingHandler>();
+            }).StartAsync();
+
+        var runtime = host.GetRuntime();
+
+        // Baseline: normal-mode routing caches, so repeated lookups return the same router instance.
+        runtime.ClearRoutingFor(typeof(Bug2897RoutedMessage));
+        var normal1 = runtime.RoutingFor(typeof(Bug2897RoutedMessage));
+        var normal2 = runtime.RoutingFor(typeof(Bug2897RoutedMessage));
+        normal2.ShouldBeSameAs(normal1);
+
+        // Description mode: routing must NOT be cached, so each lookup rebuilds a fresh router
+        // and the (potentially null-Sender) description route can never poison the runtime cache.
+        runtime.ClearRoutingFor(typeof(Bug2897RoutedMessage));
+        WolverineSystemPart.WithinDescription = true;
+        try
+        {
+            var d1 = runtime.RoutingFor(typeof(Bug2897RoutedMessage));
+            var d2 = runtime.RoutingFor(typeof(Bug2897RoutedMessage));
+            d2.ShouldNotBeSameAs(d1);
+        }
+        finally
+        {
+            WolverineSystemPart.WithinDescription = false;
+        }
+
+        // After description mode, the cache repopulates normally with live agents.
+        runtime.ClearRoutingFor(typeof(Bug2897RoutedMessage));
+        var after1 = runtime.RoutingFor(typeof(Bug2897RoutedMessage));
+        runtime.RoutingFor(typeof(Bug2897RoutedMessage)).ShouldBeSameAs(after1);
+
+        // And a real publish still works (the local route has a live, non-null Sender).
+        await host.SendMessageAndWaitAsync(new Bug2897RoutedMessage("ok"));
+    }
+}
+
+public record Bug2897RoutedMessage(string Text);
+
+public class Bug2897RoutingHandler
+{
+    public void Handle(Bug2897RoutedMessage message) => _ = message;
+}

--- a/src/Wolverine/Runtime/Routing/MessageRoute.cs
+++ b/src/Wolverine/Runtime/Routing/MessageRoute.cs
@@ -106,7 +106,16 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
     public Envelope CreateForSending(object message, DeliveryOptions? options, ISendingAgent localDurableQueue,
         WolverineRuntime runtime, string? topicName)
     {
-        var envelope = new Envelope(message, Sender)
+        // GH-2897 defense-in-depth: a route can carry a null Sender if it was built during
+        // description mode (WithinDescription) before the endpoint's sending agent existed.
+        // Such routes are no longer cached, so this should never trip — but resolve the live
+        // agent on demand rather than NRE inside the Envelope ctor (which dereferences
+        // agent.Endpoint) if one ever reaches the send path.
+        var sender = Sender ?? runtime.Endpoints.GetOrBuildSendingAgent(_endpoint.Uri)
+            ?? throw new InvalidOperationException(
+                $"Endpoint {_endpoint.Uri} does not have an active sending agent. Message type: {MessageType.FullNameInCode()}");
+
+        var envelope = new Envelope(message, sender)
         {
             Serializer = Serializer,
             ContentType = Serializer?.ContentType,
@@ -116,7 +125,7 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
             GroupId = options?.GroupId
         };
 
-        if (Sender.Endpoint is LocalQueue)
+        if (sender.Endpoint is LocalQueue)
         {
             envelope.Status = EnvelopeStatus.Incoming;
         }
@@ -138,7 +147,7 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
         options?.Override(envelope);
 
         // Will need the topic persisted, see https://github.com/JasperFx/wolverine/issues/1100
-        if (Sender.Endpoint.RoutingType == RoutingMode.ByTopic && envelope.TopicName.IsEmpty())
+        if (sender.Endpoint.RoutingType == RoutingMode.ByTopic && envelope.TopicName.IsEmpty())
         {
             envelope.TopicName = TopicRouting.DetermineTopicName(envelope);
         }
@@ -151,7 +160,7 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
                 envelope.OwnerId = TransportConstants.AnyNode;
                 runtime.Logger.LogDebug("Envelope {EnvelopeId} ({MessageType}) marked as Scheduled for local execution at {Destination}", envelope.Id, envelope.MessageType, envelope.Destination);
             }
-            else if (!Sender.SupportsNativeScheduledSend)
+            else if (!sender.SupportsNativeScheduledSend)
             {
                 runtime.Logger.LogDebug("Envelope {EnvelopeId} ({MessageType}) wrapped for durable scheduled send to {Destination} (transport does not support native scheduling)", envelope.Id, envelope.MessageType, envelope.Destination);
                 return envelope.ForScheduledSend(localDurableQueue);

--- a/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
@@ -224,7 +224,18 @@ public partial class WolverineRuntime
             Observer.MessageRouted(messageType, router);
         }
 
-        _messageTypeRouting = _messageTypeRouting.AddOrUpdate(messageType, router);
+        // Never cache routes built during "description" mode. While
+        // WolverineSystemPart.WithinDescription is true, MessageRoute is allowed to take a
+        // null Sender (the endpoint's sending agent may not be built yet — e.g. during
+        // FindResources()/resource-setup-on-startup, before transports start). Caching such a
+        // route would let a null Sender escape onto the runtime hot path and NRE inside
+        // CreateForSending (the Envelope ctor dereferences agent.Endpoint). Routes requested
+        // during description are display-only and ephemeral; the real cache is populated later
+        // with live agents. See GH-2897.
+        if (!WolverineSystemPart.WithinDescription)
+        {
+            _messageTypeRouting = _messageTypeRouting.AddOrUpdate(messageType, router);
+        }
 
         return router;
     }

--- a/src/Wolverine/WolverineSystemPart.cs
+++ b/src/Wolverine/WolverineSystemPart.cs
@@ -18,8 +18,20 @@ namespace Wolverine;
 
 internal class WolverineSystemPart : SystemPartBase
 {
-    public static bool WithinDescription = false;
-    
+    // Scoped to the current async flow (AsyncLocal) rather than a process-global mutable field.
+    // A description pass (FindResources / describe) sets this true so MessageRoute may take a
+    // null Sender for display-only routing. As a global static, that "null Sender is OK" state
+    // could bleed across an await into concurrent route building on another task — or another
+    // host in the same process — and poison the runtime cache, NRE'ing on send. AsyncLocal keeps
+    // it confined to the description call tree that set it. See GH-2897.
+    private static readonly AsyncLocal<bool> _withinDescription = new();
+
+    public static bool WithinDescription
+    {
+        get => _withinDescription.Value;
+        set => _withinDescription.Value = value;
+    }
+
     private readonly WolverineRuntime _runtime;
 
     public WolverineSystemPart(IWolverineRuntime runtime) : base("Wolverine", new Uri("wolverine://" + runtime.Options.ServiceName))
@@ -34,21 +46,29 @@ internal class WolverineSystemPart : SystemPartBase
     public override async Task WriteToConsole()
     {
         WithinDescription = true;
-        await _runtime.StartLightweightAsync();
-        
-        _runtime.Options.WriteToConsole();
-        
-        AnsiConsole.WriteLine();
-        
-        await _runtime.Options.HandlerGraph.WriteToConsole();
-        AnsiConsole.WriteLine();
-        WriteMessageSubscriptions();
-        AnsiConsole.WriteLine();
-        WriteSendingEndpoints();
-        AnsiConsole.WriteLine();
-        WriteListeners();
-        AnsiConsole.WriteLine();
-        WriteErrorHandling();
+        try
+        {
+            await _runtime.StartLightweightAsync();
+
+            _runtime.Options.WriteToConsole();
+
+            AnsiConsole.WriteLine();
+
+            await _runtime.Options.HandlerGraph.WriteToConsole();
+            AnsiConsole.WriteLine();
+            WriteMessageSubscriptions();
+            AnsiConsole.WriteLine();
+            WriteSendingEndpoints();
+            AnsiConsole.WriteLine();
+            WriteListeners();
+            AnsiConsole.WriteLine();
+            WriteErrorHandling();
+        }
+        finally
+        {
+            // Don't leave the description flag set for anything that reuses this flow.
+            WithinDescription = false;
+        }
     }
     
     public void WriteMessageSubscriptions()


### PR DESCRIPTION
Fixes #2897.

## Problem

With durable policies active (`UseDurableLocalQueues` / `UseDurableOutboxOnAllSendingEndpoints` / `UseDurableInboxOnAllListeners`), hosts can NRE on startup:

```
System.NullReferenceException
   at Wolverine.Envelope..ctor(...)          // agent.Endpoint.DefaultSerializer, agent == null
   at Wolverine.Runtime.Routing.MessageRoute.CreateForSending(...)
```

`MessageRoute.Sender` is a get-only property set once in the ctor. While `WolverineSystemPart.WithinDescription` is `true`, the ctor takes `Sender = endpoint.Agent!` — and the agent can be **null** (it isn't built until transports start, which is *after* `FindResources()`/resource-setup-on-startup). If that null-`Sender` route gets cached and reused for an actual send, `CreateForSending` → `new Envelope(message, Sender)` dereferences `agent.Endpoint` and throws.

**Why it's a 6.0-line regression (worked in v5):** v5 built routes lazily on first send — always with a live agent, so `Sender` was never null. 6.0 added eager `PrepopulateRoutingCache` at startup (#2769 / #2794) alongside the description-phase mechanism, which created the window. `FindResources()` already tries to compensate by clearing those routes (`ClearRoutingFor`), but that manual dance is order/concurrency-fragile and the bug slips past it under test/ASP.NET host startup (the reporter sees it only under Alba; the workaround is to disable the durable policies in the test host).

## Fix (three layers)

1. **(primary) Don't cache description-mode routes** — `RoutingFor` skips the cache write while `WithinDescription` is true, so a null-`Sender` route can never poison the runtime router cache. This enforces the invariant the manual `ClearRoutingFor()` was groping for, independent of startup ordering.
2. **De-globalize the flag** — `WithinDescription` is now `AsyncLocal`-scoped rather than a process-global mutable static, so a description pass on one task/host can't bleed its "null Sender is OK" state across an `await` into concurrent route building on another flow or another host in the same process. `WriteToConsole` now resets it in a `finally` (it previously leaked).
3. **(defense-in-depth) Resilient `CreateForSending`** — if a route's `Sender` is somehow null, resolve the live agent on demand via `GetOrBuildSendingAgent` instead of NRE'ing in the `Envelope` ctor.

## Tests

Adds `CoreTests/Runtime/Routing/description_mode_routes_are_not_cached.cs` asserting that routing requested under `WithinDescription` is **not** cached (each lookup rebuilds) while normal routing is cached. Verified it **fails** before fix #1 and **passes** after. Existing `WithinDescription`/routing tests (`global_partitioning`, `WolverineDiagnosticsCommand`, `system_message_type_filtering`) all still pass.

`dotnet build wolverine.slnx -c Release` is clean (0/0); routing/describe/bugs slice green.

> Note on reproduction: I confirmed the exact crash chain and the precondition, but could not deterministically reproduce the *trigger* in a minimal generic host (the `FindResources` clear self-heals there) — it needs the reporter's Alba/ASP.NET host wiring. These fixes close the null-`Sender` class structurally regardless of the exact startup ordering, so they don't depend on reproducing that specific window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)