### PR TITLE
Add Wolverine.Http `openapi` command for build-time OpenAPI generation (GH-2903)

### DIFF
--- a/.github/workflows/http.yml
+++ b/.github/workflows/http.yml
@@ -38,6 +38,13 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      # Exercises the `openapi` command (GH-2903) against the TodoWebService sample, which uses
+      # Marten/PostgreSQL-backed message persistence + AddOpenApi(). Runs *before* any database
+      # container is started to prove the command generates the OpenAPI document without database
+      # connectivity. Modeled on the command-line targets in the .NET CI target (./build.sh ci).
+      - name: Exercise the openapi command
+        run: ./build.sh OpenApiCommand --framework net9.0
+
       - name: Run HTTP Tests
         run: ./build.sh CIHttp --framework net9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### WolverineFx.Http
+
+- **New `openapi` command for build-time OpenAPI generation without starting the host.**
+  `dotnet run -- openapi` writes the application's OpenAPI document straight from endpoint metadata,
+  reusing the same `Microsoft.AspNetCore.OpenApi` document provider that Microsoft's
+  `GetDocument.Insider` tool uses, but **without** calling `IHost.StartAsync()`. This means the
+  document can be generated in build/CI pipelines for applications backed by database message
+  persistence (or external brokers) with no database or broker connectivity required. Requires
+  `builder.Services.AddOpenApi()`. Writes to standard output by default; supports `--document`,
+  `--output` (a file path), `--list`, and `--route` (a fuzzy route filter that emits only the matching
+  paths and the schema components they reference — handy for troubleshooting a single endpoint). See the
+  [HTTP metadata guide](https://wolverinefx.net/guide/http/metadata.html) (GH-2903).
+
 ## 6.0.1
 
 Patch release on the 6.0 line: a Critter Stack dependency refresh plus two

--- a/build/build.cs
+++ b/build/build.cs
@@ -193,7 +193,7 @@ partial class Build : NukeBuild
         });
     
     Target CodegenPreviewCommand => _ => _
-        .DependsOn(Compile)    
+        .DependsOn(Compile)
         .ProceedAfterFailure()
         .Executes(() =>
         {
@@ -206,7 +206,42 @@ partial class Build : NukeBuild
                 .AddApplicationArguments("codegen")
                 .AddApplicationArguments("preview"));
         });
-    
+
+    // Exercises the Wolverine.Http `openapi` command (GH-2903) against the TodoWebService sample,
+    // which uses Marten/PostgreSQL-backed message persistence and AddOpenApi(). Modeled on
+    // CodegenPreviewCommand above. This intentionally runs without a database (no docker services
+    // started) to prove the command generates the OpenAPI document straight from endpoint metadata
+    // without any database connectivity. Builds on demand so it can run as a standalone http CI step.
+    Target OpenApiCommand => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            var project = RootDirectory / "src" / "Samples" / "TodoWebService" / "TodoWebService" /
+                          "TodoWebService.csproj";
+
+            // Full document for the default "v1" document. --no-launch-profile keeps the host
+            // environment (e.g. ASPNETCORE_ENVIRONMENT=Development on CI) intact instead of letting
+            // launchSettings.json override it; Development turns on DI scope validation, which also
+            // guards the GH-2911 fix.
+            DotNetRun(c => c
+                .SetProjectFile(project)
+                .SetConfiguration(Configuration)
+                .EnableNoLaunchProfile()
+                .SetFramework(Framework)
+                .AddApplicationArguments("openapi"));
+
+            // The fuzzy --route filter, which emits only the matching paths and their schemas
+            DotNetRun(c => c
+                .SetProjectFile(project)
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoLaunchProfile()
+                .SetFramework(Framework)
+                .AddApplicationArguments("openapi")
+                .AddApplicationArguments("--route")
+                .AddApplicationArguments("todoitems"));
+        });
+
     Target SqliteTests => _ => _
         .DependsOn(Compile)
         .ProceedAfterFailure()

--- a/docs/guide/http/metadata.md
+++ b/docs/guide/http/metadata.md
@@ -222,7 +222,91 @@ public class ValidatedCompoundEndpoint2
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Validation/ValidatedCompoundEndpoint.cs#L33-L60' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_optional_iresult_with_openapi_metadata' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Generating the OpenAPI Document at the Command Line
+
+::: tip
+**Reach for this whenever Microsoft's built-in OpenAPI generation chokes on your infrastructure.**
+The standard build-time generators ([`Microsoft.Extensions.ApiDescription.Server`](#with-microsoft-extensions-apidescription-server)
+and NSwag's `GetDocument.Insider`) call `IHost.StartAsync()`, which boots Wolverine's hosted service and
+tries to connect to your database and/or message broker *before* a single line of JSON is written — so
+they routinely fail in build/CI environments that have no real database or broker. The `openapi` command
+was **purposefully designed to avoid that**: it never starts your host, so it never opens a database or
+broker connection just to emit a JSON file.
+:::
+
+Wolverine.HTTP adds an `openapi` command to the JasperFx command line (the same command line you already
+use for `dotnet run -- codegen`, `dotnet run -- check-env`, and friends). It reuses the host your
+application already builds — Wolverine added and `MapWolverineEndpoints()` already called — and asks the
+registered OpenAPI document provider (the `Microsoft.AspNetCore.OpenApi` service that Microsoft's own
+`GetDocument.Insider` tool uses) to serialize the document directly from your endpoint metadata. The
+host is never started, so the result is functionally equivalent to Microsoft's output without any of the
+startup connectivity.
+
+The only prerequisite is that your application registers the built-in OpenAPI services and maps the
+Wolverine endpoints before handing control to the JasperFx command line:
+
+```csharp
+builder.Services.AddOpenApi();      // Microsoft.AspNetCore.OpenApi
+builder.Services.AddWolverineHttp();
+
+var app = builder.Build();
+
+app.MapWolverineEndpoints();
+
+// The openapi command is dispatched from here
+return await app.RunJasperFxCommands(args);
+```
+
+Then generate the document:
+
+```bash
+# Write the default "v1" document to standard output
+dotnet run -- openapi
+
+# Write a specific document to a chosen file path
+dotnet run -- openapi --document v1 --output ./artifacts/openapi.json
+
+# List the OpenAPI documents this application exposes
+dotnet run -- openapi --list
+```
+
+### Inspecting a single route
+
+When you just want to look at the OpenAPI metadata for one endpoint — a great way to troubleshoot how
+Wolverine.HTTP is binding parameters, negotiating content, or shaping responses — use `--route`. It does
+a case-insensitive fuzzy match against the route templates (so it may match several related routes) and
+emits a document containing only those paths plus the schema components they reference:
+
+```bash
+# Only the routes whose template contains "todoitems", with their schemas
+dotnet run -- openapi --route /todoitems --output ./todoitems.json
+
+# Fuzzy match can return multiple related routes
+dotnet run -- openapi -r todoitems
+```
+
+| Flag | Alias | Description |
+| --- | --- | --- |
+| `--document` | `-d` | The named document to generate. Defaults to `v1`, the default document name registered by `AddOpenApi()`. |
+| `--output` | `-o` | File path for the generated JSON. When omitted (or set to `-`), the document is written to standard output. Use `--output` to capture a clean JSON file, since application and command-line logging is also written to the console. |
+| `--route` | `-r` | Fuzzy (case-insensitive, substring) filter on the route template. Only matching paths — and the schema components they reference — are written. |
+| `--list` | `-l` | List the document names this application exposes and exit. |
+
+::: warning
+Because the host is never started, the document reflects exactly the endpoints discovered at
+`MapWolverineEndpoints()` time. Endpoints that are only added during host startup (for example, by an
+asynchronous Wolverine extension) will not appear. This matches the goal of build-time generation, but
+is worth knowing if you add endpoints dynamically.
+:::
+
 ## With Microsoft.Extensions.ApiDescription.Server
+
+::: tip
+If you are hitting the problems described below, consider the
+[`openapi` command](#generating-the-openapi-document-at-the-command-line) instead — it was built
+specifically to avoid the full application startup that `Microsoft.Extensions.ApiDescription.Server`
+forces.
+:::
 
 Just a heads up, if you are trying to use [Microsoft.Extensions.ApiDescription.Server](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/aspnetcore-openapi?view=aspnetcore-9.0&tabs=net-cli%2Cvisual-studio-code#generate-openapi-documents-at-build-time) and
 you get an `ObjectDisposedException` error on compilation against the `IServiceProvider`, follow these steps to fix:

--- a/src/Http/Wolverine.Http.Tests/generate_openapi_without_database.cs
+++ b/src/Http/Wolverine.Http.Tests/generate_openapi_without_database.cs
@@ -1,0 +1,99 @@
+using Marten;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.Http.Commands;
+using Wolverine.Http.Tests.DifferentAssembly.Validation;
+using Wolverine.Marten;
+
+namespace Wolverine.Http.Tests;
+
+// Proves GH-2903: the `openapi` command can generate the server OpenAPI document straight from
+// endpoint metadata without starting the host — so an application backed by durable (database)
+// message persistence produces its document with no database connectivity whatsoever.
+public class generate_openapi_without_database
+{
+    [Fact]
+    public async Task generates_full_document_with_no_database_connection()
+    {
+        var json = await GenerateDocumentWithoutDatabaseAsync();
+
+        // A real OpenAPI document containing the discovered Wolverine endpoints.
+        json.ShouldContain("\"openapi\"");
+        json.ShouldContain("/validate2/customer");
+        json.ShouldContain("/validate2/user");
+    }
+
+    [Fact]
+    public async Task route_filter_keeps_only_matching_routes_and_their_schemas()
+    {
+        var json = await GenerateDocumentWithoutDatabaseAsync();
+
+        var filtered = OpenApiRouteFilter.Filter(json, "customer", out var matchedPaths);
+
+        // Only the fuzzy-matched route survives...
+        matchedPaths.ShouldBe(["/validate2/customer"]);
+        filtered.ShouldContain("/validate2/customer");
+        filtered.ShouldNotContain("/validate2/user");
+
+        // ...along with the schema it references, while the unrelated schema is pruned.
+        filtered.ShouldContain("CreateCustomer2");
+        filtered.ShouldNotContain("CreateUser2");
+    }
+
+    [Fact]
+    public async Task route_filter_with_no_match_reports_available_routes()
+    {
+        var json = await GenerateDocumentWithoutDatabaseAsync();
+
+        OpenApiRouteFilter.Filter(json, "does-not-exist", out var matchedPaths);
+        matchedPaths.ShouldBeEmpty();
+
+        OpenApiRouteFilter.ListPaths(json).ShouldContain("/validate2/customer");
+    }
+
+    private static async Task<string> GenerateDocumentWithoutDatabaseAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+
+        // Configure database-backed Wolverine message persistence (Marten/PostgreSQL) pointed at an
+        // unreachable database. Port 9999 has nothing listening, so if document generation ever
+        // attempted to open a connection this test would fail fast (or hang) rather than pass.
+        builder.Services
+            .AddMarten(opts =>
+            {
+                opts.Connection(
+                    "Host=localhost;Port=9999;Database=does_not_exist;Username=nobody;Password=nobody;Timeout=2;Command Timeout=2");
+            })
+            .IntegrateWithWolverine();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            // Pin endpoint discovery to the small, isolated "DifferentAssembly" so the test is
+            // deterministic and does not pick up the rest of the test suite's endpoints.
+            opts.ApplicationAssembly = typeof(Validated2Endpoint).Assembly;
+
+            // The durable-transaction policy is exactly the kind of database-coupled configuration
+            // that would otherwise force a connection during a full host start.
+            opts.Policies.AutoApplyTransactions();
+            opts.Policies.UseDurableLocalQueues();
+        });
+
+        // The Microsoft.AspNetCore.OpenApi document provider that the command reuses.
+        builder.Services.AddOpenApi();
+        builder.Services.AddWolverineHttp();
+
+        await using var app = builder.Build();
+        app.MapWolverineEndpoints();
+
+        // Exercise the exact no-startup path the `openapi` command uses. Note: no app.StartAsync().
+        var documentProvider = OpenApiCommand.PrepareDocumentProvider(app);
+        documentProvider.ShouldNotBeNull();
+
+        documentProvider!.GetDocumentNames().ShouldContain("v1");
+
+        var writer = new StringWriter();
+        await documentProvider.GenerateAsync("v1", writer);
+        return writer.ToString();
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/generate_openapi_without_database.cs
+++ b/src/Http/Wolverine.Http.Tests/generate_openapi_without_database.cs
@@ -54,7 +54,11 @@ public class generate_openapi_without_database
 
     private static async Task<string> GenerateDocumentWithoutDatabaseAsync()
     {
-        var builder = WebApplication.CreateBuilder([]);
+        // Build in the Development environment, which is what the CI runner uses and which turns on DI
+        // scope validation by default. This reproduces GH-2911: the Microsoft.AspNetCore.OpenApi
+        // document provider is a root-captured singleton, so the document must be generated without
+        // resolving a scoped service from the root provider.
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = "Development" });
 
         // Configure database-backed Wolverine message persistence (Marten/PostgreSQL) pointed at an
         // unreachable database. Port 9999 has nothing listening, so if document generation ever

--- a/src/Http/Wolverine.Http/AssemblyAttributes.cs
+++ b/src/Http/Wolverine.Http/AssemblyAttributes.cs
@@ -1,5 +1,11 @@
 using System.Runtime.CompilerServices;
+using JasperFx;
 using JasperFx.Core.TypeScanning;
+
+// Marks WolverineFx.Http as a JasperFx command-line extension assembly so the
+// 'openapi' command (and any future Wolverine.Http commands) are discovered by
+// RunJasperFxCommands() in consuming applications. See OpenApiCommand.
+[assembly: JasperFxAssembly]
 
 [assembly: InternalsVisibleTo("Wolverine.Http.Tests")]
 // WolverineFx.Http.Newtonsoft's UseNewtonsoftJsonForSerialization extension

--- a/src/Http/Wolverine.Http/Commands/OpenApiCommand.cs
+++ b/src/Http/Wolverine.Http/Commands/OpenApiCommand.cs
@@ -1,0 +1,265 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text;
+using JasperFx.CommandLine;
+using JasperFx.Core;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+using Wolverine.Http.Commands;
+
+namespace Wolverine.Http;
+
+public class OpenApiInput : NetCoreInput
+{
+    [Description(
+        "The named OpenAPI document to generate. Defaults to 'v1', which matches the default " +
+        "document name registered by AddOpenApi(). Use 'openapi --list' to see the documents this " +
+        "application exposes.")]
+    [FlagAlias("document", 'd')]
+    public string DocumentFlag { get; set; } = "v1";
+
+    [Description(
+        "File path to write the generated OpenAPI JSON to. When omitted (or set to '-'), the document " +
+        "is written to standard output. Note that application and command-line logging is also written " +
+        "to the console, so pass --output to capture a clean JSON file.")]
+    [FlagAlias("output", 'o')]
+    public string OutputFlag { get; set; } = string.Empty;
+
+    [Description("List the OpenAPI document names exposed by this application and exit without generating anything.")]
+    [FlagAlias("list", 'l')]
+    public bool ListFlag { get; set; }
+
+    [Description(
+        "Optional fuzzy filter on the HTTP route. When set, only paths whose route template contains " +
+        "this value (case-insensitive) are written, along with the schema components they reference. " +
+        "Handy for inspecting the OpenAPI metadata of a single endpoint when troubleshooting. " +
+        "Example: --route /todoitems")]
+    [FlagAlias("route", 'r')]
+    public string RouteFlag { get; set; } = string.Empty;
+}
+
+/// <summary>
+///     Generates the OpenAPI (Swagger) description document for a Wolverine.HTTP application
+///     <i>without</i> performing a full <see cref="Microsoft.Extensions.Hosting.IHost" /> startup.
+///     Microsoft's <c>Microsoft.Extensions.ApiDescription.Server</c> tooling (the
+///     <c>GetDocument.Insider</c> process used by <c>dotnet build</c> / NSwag) starts the host,
+///     which spins up Wolverine's hosted service and attempts to connect to the configured
+///     database and/or message broker before a single line of OpenAPI JSON is produced. That makes
+///     build-time / CI document generation fragile for any system backed by durable message storage.
+///
+///     This command instead reuses the host the application already built (Wolverine added,
+///     <c>MapWolverineEndpoints()</c> already invoked) and asks the registered OpenAPI document
+///     provider — the same <c>IDocumentProvider</c> service <c>GetDocument.Insider</c> resolves — to
+///     serialize the document straight from endpoint metadata. The host is never started, so no
+///     database or broker connection is ever attempted.
+/// </summary>
+[Description(
+    "Generate the OpenAPI document for this Wolverine.HTTP application without starting the host, " +
+    "so no database or message broker connectivity is required",
+    Name = "openapi")]
+public class OpenApiCommand : JasperFxAsyncCommand<OpenApiInput>
+{
+    public override async Task<bool> Execute(OpenApiInput input)
+    {
+        // BuildHost() returns the host the application already configured during bootstrapping.
+        // Crucially, MapWolverineEndpoints() runs *before* RunJasperFxCommands(args), so the
+        // Wolverine HTTP endpoints are already registered in the EndpointDataSource by the time
+        // this command executes. We deliberately do NOT call host.StartAsync(): starting the host
+        // is exactly what triggers the database / broker connectivity this command is meant to avoid.
+        using var host = input.BuildHost();
+
+        var documentProvider = PrepareDocumentProvider(host);
+        if (documentProvider == null)
+        {
+            AnsiConsole.MarkupLine(
+                "[red]No OpenAPI document provider is registered for this application.[/]");
+            AnsiConsole.MarkupLine(
+                "Add the [bold]Microsoft.AspNetCore.OpenApi[/] package and call " +
+                "[bold]builder.Services.AddOpenApi()[/] in your application bootstrapping to enable OpenAPI generation.");
+            return false;
+        }
+
+        var documentNames = documentProvider.GetDocumentNames();
+
+        if (input.ListFlag)
+        {
+            WriteDocumentNames(documentNames);
+            return true;
+        }
+
+        if (documentNames.Count == 0)
+        {
+            AnsiConsole.MarkupLine(
+                "[red]The registered OpenAPI document provider did not expose any documents.[/] " +
+                "Verify that [bold]AddOpenApi()[/] was called during application bootstrapping.");
+            return false;
+        }
+
+        if (!documentNames.Contains(input.DocumentFlag, StringComparer.OrdinalIgnoreCase))
+        {
+            AnsiConsole.MarkupLine(
+                $"[red]No OpenAPI document named '[bold]{Markup.Escape(input.DocumentFlag)}[/]' was found.[/]");
+            WriteDocumentNames(documentNames);
+            return false;
+        }
+
+        // A file is written only when an explicit path is given. Otherwise (no --output, or the "-"
+        // convention) the JSON goes to standard output.
+        var writeToFile = input.OutputFlag.IsNotEmpty() && input.OutputFlag != "-";
+
+        if (input.RouteFlag.IsEmpty())
+        {
+            // Stream the full document straight from the provider.
+            if (writeToFile)
+            {
+                var path = await WriteFileAsync(input.OutputFlag, w => documentProvider.GenerateAsync(input.DocumentFlag, w));
+                AnsiConsole.MarkupLine(
+                    $"[green]Wrote OpenAPI document '[bold]{Markup.Escape(input.DocumentFlag)}[/]' to [bold]{Markup.Escape(path)}[/][/]");
+            }
+            else
+            {
+                await documentProvider.GenerateAsync(input.DocumentFlag, Console.Out);
+                await Console.Out.FlushAsync();
+            }
+
+            return true;
+        }
+
+        // --route: generate the full document, then keep only the matching routes (plus the schema
+        // components they reference).
+        var buffer = new StringWriter();
+        await documentProvider.GenerateAsync(input.DocumentFlag, buffer);
+        var fullDocument = buffer.ToString();
+
+        var filtered = OpenApiRouteFilter.Filter(fullDocument, input.RouteFlag, out var matchedPaths);
+        if (matchedPaths.Count == 0)
+        {
+            AnsiConsole.MarkupLine(
+                $"[red]No HTTP routes matched '[bold]{Markup.Escape(input.RouteFlag)}[/]'.[/]");
+            WriteAvailableRoutes(OpenApiRouteFilter.ListPaths(fullDocument));
+            return false;
+        }
+
+        if (writeToFile)
+        {
+            var path = await WriteFileAsync(input.OutputFlag, w => w.WriteAsync(filtered));
+            AnsiConsole.MarkupLine(
+                $"[green]Wrote {matchedPaths.Count} matching route(s) from document '[bold]{Markup.Escape(input.DocumentFlag)}[/]' to [bold]{Markup.Escape(path)}[/]:[/]");
+            foreach (var matchedPath in matchedPaths)
+            {
+                AnsiConsole.MarkupLine($"  [grey]{Markup.Escape(matchedPath)}[/]");
+            }
+        }
+        else
+        {
+            await Console.Out.WriteAsync(filtered);
+            await Console.Out.FlushAsync();
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Make the application's mapped endpoints visible to the OpenAPI document service and
+    ///     resolve the registered provider — without starting the host. Shared by the command and
+    ///     by tests so both exercise the identical no-startup generation path. Returns null when no
+    ///     OpenAPI document provider is registered (i.e. AddOpenApi() was never called).
+    /// </summary>
+    internal static OpenApiDocumentProvider? PrepareDocumentProvider(IHost host)
+    {
+        // The application's endpoint data sources (e.g. the Wolverine HttpGraph added by
+        // MapWolverineEndpoints) are normally merged into the global EndpointDataSource by the
+        // routing middleware's UseEndpoints step, which only runs once the host starts. We replicate
+        // just that merge here so generation sees every endpoint while skipping host startup entirely.
+        ComposeEndpointDataSources(host);
+
+        return OpenApiDocumentProvider.Resolve(host.Services);
+    }
+
+    private static async Task<string> WriteFileAsync(string outputPath, Func<TextWriter, Task> writeBody)
+    {
+        var fullPath = Path.GetFullPath(outputPath);
+
+        var directory = Path.GetDirectoryName(fullPath);
+        if (directory.IsNotEmpty() && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        // UTF-8 without a BOM, matching what GetDocument.Insider writes for OpenAPI documents.
+        await using (var stream = new FileStream(fullPath, FileMode.Create, FileAccess.Write))
+        await using (var writer = new StreamWriter(stream, new UTF8Encoding(false)))
+        {
+            await writeBody(writer);
+            await writer.FlushAsync();
+        }
+
+        return fullPath;
+    }
+
+    private static void WriteAvailableRoutes(IReadOnlyList<string> paths)
+    {
+        if (paths.Count == 0)
+        {
+            return;
+        }
+
+        AnsiConsole.MarkupLine("[grey]Available routes:[/]");
+        foreach (var path in paths)
+        {
+            AnsiConsole.MarkupLine($"  [grey]{Markup.Escape(path)}[/]");
+        }
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "Dev/build-time 'openapi' CLI command. RouteOptions.EndpointDataSources is an internal collection populated identically by ASP.NET Core's own UseEndpoints; reflecting it here only runs interactively, never on an AOT-published hot path.")]
+    private static void ComposeEndpointDataSources(IHost host)
+    {
+        if (host is not IEndpointRouteBuilder routeBuilder || routeBuilder.DataSources.Count == 0)
+        {
+            return;
+        }
+
+        var routeOptions = host.Services.GetService<IOptions<RouteOptions>>();
+        if (routeOptions?.Value == null)
+        {
+            return;
+        }
+
+        var property = typeof(RouteOptions).GetProperty("EndpointDataSources",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        if (property?.GetValue(routeOptions.Value) is not ICollection<EndpointDataSource> sources)
+        {
+            return;
+        }
+
+        // Mirror EndpointRoutingApplicationBuilderExtensions.UseEndpoints: add every data source the
+        // application mapped, de-duplicating so a later real start (if any) stays correct.
+        foreach (var dataSource in routeBuilder.DataSources)
+        {
+            if (!sources.Contains(dataSource))
+            {
+                sources.Add(dataSource);
+            }
+        }
+    }
+
+    private static void WriteDocumentNames(IReadOnlyList<string> documentNames)
+    {
+        if (documentNames.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[grey]This application does not expose any OpenAPI documents.[/]");
+            return;
+        }
+
+        AnsiConsole.MarkupLine("[grey]Available OpenAPI documents:[/]");
+        foreach (var name in documentNames)
+        {
+            AnsiConsole.MarkupLine($"  [grey]{Markup.Escape(name)}[/]");
+        }
+    }
+}

--- a/src/Http/Wolverine.Http/Commands/OpenApiDocumentProvider.cs
+++ b/src/Http/Wolverine.Http/Commands/OpenApiDocumentProvider.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Wolverine.Http.Commands;
 
@@ -24,12 +25,19 @@ internal sealed class OpenApiDocumentProvider
     // keeps us decoupled from any one provider package.
     private const string DocumentProviderTypeName = "Microsoft.Extensions.ApiDescriptions.IDocumentProvider";
 
+    // The Microsoft.AspNetCore.OpenApi options type whose configured OpenApiVersion we read so we can
+    // invoke the scope-safe 3-argument GenerateAsync overload. See GenerateAsync below.
+    private const string OpenApiOptionsTypeName = "Microsoft.AspNetCore.OpenApi.OpenApiOptions";
+
+    private readonly IServiceProvider _services;
     private readonly object _service;
     private readonly MethodInfo _getDocumentNames;
     private readonly MethodInfo _generateAsync;
 
-    private OpenApiDocumentProvider(object service, MethodInfo getDocumentNames, MethodInfo generateAsync)
+    private OpenApiDocumentProvider(IServiceProvider services, object service, MethodInfo getDocumentNames,
+        MethodInfo generateAsync)
     {
+        _services = services;
         _service = service;
         _getDocumentNames = getDocumentNames;
         _generateAsync = generateAsync;
@@ -51,7 +59,7 @@ internal sealed class OpenApiDocumentProvider
         // despite the identical full name, so an application that references more than one (e.g. a test
         // project that pulls in both) can have several. Probe each and use the first whose service is
         // actually registered — that is the provider the application opted into via AddOpenApi()/etc.
-        foreach (var providerType in FindDocumentProviderTypes())
+        foreach (var providerType in FindTypes(DocumentProviderTypeName))
         {
             var service = services.GetService(providerType);
             if (service == null)
@@ -67,7 +75,7 @@ internal sealed class OpenApiDocumentProvider
                 continue;
             }
 
-            return new OpenApiDocumentProvider(service, getDocumentNames, generateAsync);
+            return new OpenApiDocumentProvider(services, service, getDocumentNames, generateAsync);
         }
 
         return null;
@@ -79,12 +87,77 @@ internal sealed class OpenApiDocumentProvider
         return result is IEnumerable<string> names ? names.ToArray() : [];
     }
 
-    public Task GenerateAsync(string documentName, TextWriter writer)
+    public async Task GenerateAsync(string documentName, TextWriter writer)
     {
-        return (Task)_generateAsync.Invoke(_service, [documentName, writer])!;
+        // Microsoft.AspNetCore.OpenApi's OpenApiDocumentProvider is a *singleton* that captures the
+        // *root* service provider. Its 2-argument GenerateAsync(name, writer) resolves the *scoped*
+        // IOptionsSnapshot<OpenApiOptions> directly from that root provider, which throws
+        // "Cannot resolve scoped service ... from root provider" under DI scope validation (the
+        // default in the Development environment).
+        //
+        // Its 3-argument overload, GenerateAsync(name, writer, OpenApiSpecVersion), takes the spec
+        // version explicitly and creates its own scope internally — it never resolves a scoped service
+        // from the root. So we read the configured version from the *singleton* IOptionsMonitor<OpenApiOptions>
+        // (safe from the root) and call that overload. This keeps the command working regardless of the
+        // host environment. Non-Microsoft providers (Swashbuckle/NSwag) fall back to the 2-arg overload.
+        if (TryInvokeScopeSafe(documentName, writer, out var scopeSafe))
+        {
+            await scopeSafe!;
+            return;
+        }
+
+        await (Task)_generateAsync.Invoke(_service, [documentName, writer])!;
     }
 
-    private static IEnumerable<Type> FindDocumentProviderTypes()
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Dev/build-time 'openapi' CLI command. Resolves the Microsoft.AspNetCore.OpenApi options/provider members reflectively to call the scope-safe GenerateAsync overload; never on an AOT-published hot path.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "OpenApiOptions.OpenApiVersion and the 3-arg GenerateAsync overload are public members of Microsoft.AspNetCore.OpenApi types; present whenever that package (and therefore this code path) is in play.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2055",
+        Justification = "IOptionsMonitor<OpenApiOptions> is closed over a public framework options type; only reached for the Microsoft.AspNetCore.OpenApi provider in a dev/build CLI.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2076",
+        Justification = "The reflectively-resolved OpenApiOptions type is a concrete public options class; closing IOptionsMonitor<TOptions> over it in this dev/build CLI cannot be trimmed away because the live registration keeps it.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "MakeGenericType over IOptionsMonitor<OpenApiOptions> only runs in the dev/build 'openapi' CLI, never on an AOT-published hot path.")]
+    private bool TryInvokeScopeSafe(string documentName, TextWriter writer, out Task? task)
+    {
+        task = null;
+
+        try
+        {
+            var optionsType = FindTypes(OpenApiOptionsTypeName).FirstOrDefault();
+            if (optionsType == null)
+            {
+                return false;
+            }
+
+            var monitor = _services.GetService(typeof(IOptionsMonitor<>).MakeGenericType(optionsType));
+            var namedOptions = monitor?.GetType().GetMethod("Get", [typeof(string)])?.Invoke(monitor, [documentName]);
+            var specVersion = namedOptions?.GetType().GetProperty("OpenApiVersion")?.GetValue(namedOptions);
+            if (specVersion == null)
+            {
+                return false;
+            }
+
+            var generateWithVersion = _service.GetType()
+                .GetMethod("GenerateAsync", [typeof(string), typeof(TextWriter), specVersion.GetType()]);
+            if (generateWithVersion == null)
+            {
+                return false;
+            }
+
+            task = (Task)generateWithVersion.Invoke(_service, [documentName, writer, specVersion])!;
+            return true;
+        }
+        catch (Exception)
+        {
+            // Any reflection mismatch (e.g. a non-Microsoft provider) falls back to the 2-arg overload.
+            task = null;
+            return false;
+        }
+    }
+
+    private static IEnumerable<Type> FindTypes(string fullName)
     {
         foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
         {
@@ -96,7 +169,7 @@ internal sealed class OpenApiDocumentProvider
             Type? type = null;
             try
             {
-                type = assembly.GetType(DocumentProviderTypeName, throwOnError: false);
+                type = assembly.GetType(fullName, throwOnError: false);
             }
             catch (Exception)
             {

--- a/src/Http/Wolverine.Http/Commands/OpenApiDocumentProvider.cs
+++ b/src/Http/Wolverine.Http/Commands/OpenApiDocumentProvider.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Wolverine.Http.Commands;
+
+/// <summary>
+/// Thin reflection wrapper around the <c>Microsoft.Extensions.ApiDescriptions.IDocumentProvider</c>
+/// service that <c>AddOpenApi()</c> (the <c>Microsoft.AspNetCore.OpenApi</c> package) registers.
+/// This is the very same service that Microsoft's <c>GetDocument.Insider</c> build tool resolves,
+/// so the document we emit is functionally equivalent to the one produced by
+/// <c>Microsoft.Extensions.ApiDescription.Server</c> — only without the full <c>IHost</c>
+/// startup that triggers database/broker connectivity.
+///
+/// The interface is internal to <c>Microsoft.AspNetCore.OpenApi</c> and is matched against by
+/// full type name across the loaded assemblies, exactly as <c>GetDocument.Insider</c> does it,
+/// rather than taking a compile-time dependency on a non-public type.
+/// </summary>
+internal sealed class OpenApiDocumentProvider
+{
+    // The well-known full name of the build-time document provider contract. This name is shared
+    // (by string match) between Microsoft.Extensions.ApiDescription.Server and the various
+    // implementations (Microsoft.AspNetCore.OpenApi, NSwag, Swashbuckle), so resolving by name
+    // keeps us decoupled from any one provider package.
+    private const string DocumentProviderTypeName = "Microsoft.Extensions.ApiDescriptions.IDocumentProvider";
+
+    private readonly object _service;
+    private readonly MethodInfo _getDocumentNames;
+    private readonly MethodInfo _generateAsync;
+
+    private OpenApiDocumentProvider(object service, MethodInfo getDocumentNames, MethodInfo generateAsync)
+    {
+        _service = service;
+        _getDocumentNames = getDocumentNames;
+        _generateAsync = generateAsync;
+    }
+
+    /// <summary>
+    /// Attempt to resolve the registered OpenAPI document provider out of the application's
+    /// service provider. Returns null when no provider is registered — typically because the
+    /// application never called <c>builder.Services.AddOpenApi()</c>.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Dev/build-time 'openapi' CLI command. The document provider contract is matched by full type name against loaded provider packages (Microsoft.AspNetCore.OpenApi/NSwag/Swashbuckle), mirroring Microsoft's own GetDocument.Insider tool. Never runs on an AOT-published hot path.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "GenerateAsync(string, TextWriter) and GetDocumentNames() are public members of the shared IDocumentProvider contract; they are present on every provider implementation that GetDocument.Insider also invokes.")]
+    public static OpenApiDocumentProvider? Resolve(IServiceProvider services)
+    {
+        // The IDocumentProvider contract is shared *source* compiled independently into each provider
+        // package (Microsoft.AspNetCore.OpenApi, Swashbuckle, NSwag). Those are distinct CLR types
+        // despite the identical full name, so an application that references more than one (e.g. a test
+        // project that pulls in both) can have several. Probe each and use the first whose service is
+        // actually registered — that is the provider the application opted into via AddOpenApi()/etc.
+        foreach (var providerType in FindDocumentProviderTypes())
+        {
+            var service = services.GetService(providerType);
+            if (service == null)
+            {
+                continue;
+            }
+
+            var getDocumentNames = providerType.GetMethod("GetDocumentNames", Type.EmptyTypes);
+            var generateAsync = providerType.GetMethod("GenerateAsync", [typeof(string), typeof(TextWriter)]);
+
+            if (getDocumentNames == null || generateAsync == null)
+            {
+                continue;
+            }
+
+            return new OpenApiDocumentProvider(service, getDocumentNames, generateAsync);
+        }
+
+        return null;
+    }
+
+    public IReadOnlyList<string> GetDocumentNames()
+    {
+        var result = _getDocumentNames.Invoke(_service, null);
+        return result is IEnumerable<string> names ? names.ToArray() : [];
+    }
+
+    public Task GenerateAsync(string documentName, TextWriter writer)
+    {
+        return (Task)_generateAsync.Invoke(_service, [documentName, writer])!;
+    }
+
+    private static IEnumerable<Type> FindDocumentProviderTypes()
+    {
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (assembly.IsDynamic)
+            {
+                continue;
+            }
+
+            Type? type = null;
+            try
+            {
+                type = assembly.GetType(DocumentProviderTypeName, throwOnError: false);
+            }
+            catch (Exception)
+            {
+                // Some assemblies can throw when probed for types (e.g. ReflectionTypeLoadException
+                // shapes). Those are never the OpenAPI provider package, so skip them.
+            }
+
+            if (type != null)
+            {
+                yield return type;
+            }
+        }
+    }
+}

--- a/src/Http/Wolverine.Http/Commands/OpenApiRouteFilter.cs
+++ b/src/Http/Wolverine.Http/Commands/OpenApiRouteFilter.cs
@@ -1,0 +1,188 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Wolverine.Http.Commands;
+
+/// <summary>
+/// Post-processes a generated OpenAPI document down to just the HTTP routes whose path template
+/// fuzzily matches a user-supplied search term. Used by the <c>openapi --route</c> option to make it
+/// easy to inspect the OpenAPI metadata for a single endpoint (or a small related set) when
+/// troubleshooting Wolverine.HTTP behavior. Schema components that the retained paths no longer
+/// reference are pruned (best-effort) so the output stays focused on the matching routes.
+/// </summary>
+internal static class OpenApiRouteFilter
+{
+    /// <summary>
+    /// The path templates ("/todoitems/{id}", ...) declared by the document, in document order.
+    /// </summary>
+    public static IReadOnlyList<string> ListPaths(string documentJson)
+    {
+        return JsonNode.Parse(documentJson) is JsonObject { } root && root["paths"] is JsonObject paths
+            ? paths.Select(pair => pair.Key).ToArray()
+            : [];
+    }
+
+    /// <summary>
+    /// Returns the document filtered to only the paths whose template contains <paramref name="routeSearch"/>
+    /// (case-insensitive). <paramref name="matchedPaths"/> reports which path templates were kept.
+    /// </summary>
+    public static string Filter(string documentJson, string routeSearch, out IReadOnlyList<string> matchedPaths)
+    {
+        var root = JsonNode.Parse(documentJson) as JsonObject
+                   ?? throw new InvalidOperationException("The generated OpenAPI document was not a JSON object.");
+
+        var search = routeSearch.Trim();
+        var matched = new List<string>();
+
+        if (root["paths"] is JsonObject paths)
+        {
+            var toRemove = new List<string>();
+            foreach (var entry in paths)
+            {
+                if (entry.Key.Contains(search, StringComparison.OrdinalIgnoreCase))
+                {
+                    matched.Add(entry.Key);
+                }
+                else
+                {
+                    toRemove.Add(entry.Key);
+                }
+            }
+
+            foreach (var key in toRemove)
+            {
+                paths.Remove(key);
+            }
+
+            if (matched.Count > 0)
+            {
+                try
+                {
+                    PruneUnreferencedComponents(root, paths);
+                }
+                catch (Exception)
+                {
+                    // Best-effort only: leave the components intact on any failure. An over-broad
+                    // components section is still a valid OpenAPI document.
+                }
+            }
+        }
+
+        matchedPaths = matched;
+        return root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static void PruneUnreferencedComponents(JsonObject root, JsonObject retainedPaths)
+    {
+        if (root["components"] is not JsonObject components)
+        {
+            return;
+        }
+
+        // Walk the retained paths and collect every "$ref" they reach, transitively through the
+        // components they point at, so component-to-component references are preserved.
+        var referenced = new HashSet<string>(StringComparer.Ordinal);
+        var toScan = new Queue<JsonNode>();
+        toScan.Enqueue(retainedPaths);
+
+        while (toScan.Count > 0)
+        {
+            foreach (var pointer in FindRefs(toScan.Dequeue()))
+            {
+                if (referenced.Add(pointer) && ResolvePointer(root, pointer) is { } resolved)
+                {
+                    toScan.Enqueue(resolved);
+                }
+            }
+        }
+
+        foreach (var section in components.ToList())
+        {
+            if (section.Value is not JsonObject sectionObject)
+            {
+                continue;
+            }
+
+            var unreferenced = sectionObject
+                .Where(item => !referenced.Contains($"#/components/{section.Key}/{item.Key}"))
+                .Select(item => item.Key)
+                .ToList();
+
+            foreach (var name in unreferenced)
+            {
+                sectionObject.Remove(name);
+            }
+
+            if (sectionObject.Count == 0)
+            {
+                components.Remove(section.Key);
+            }
+        }
+
+        if (components.Count == 0)
+        {
+            root.Remove("components");
+        }
+    }
+
+    private static IEnumerable<string> FindRefs(JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                foreach (var pair in obj)
+                {
+                    if (pair.Key == "$ref" && pair.Value is JsonValue value &&
+                        value.TryGetValue<string>(out var reference))
+                    {
+                        yield return reference;
+                    }
+                    else
+                    {
+                        foreach (var nested in FindRefs(pair.Value))
+                        {
+                            yield return nested;
+                        }
+                    }
+                }
+
+                break;
+
+            case JsonArray array:
+                foreach (var item in array)
+                {
+                    foreach (var nested in FindRefs(item))
+                    {
+                        yield return nested;
+                    }
+                }
+
+                break;
+        }
+    }
+
+    private static JsonNode? ResolvePointer(JsonObject root, string pointer)
+    {
+        if (!pointer.StartsWith("#/", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        JsonNode? current = root;
+        foreach (var rawSegment in pointer[2..].Split('/'))
+        {
+            // JSON Pointer escaping: ~1 => '/', ~0 => '~'
+            var segment = rawSegment.Replace("~1", "/").Replace("~0", "~");
+            if (current is JsonObject obj && obj.TryGetPropertyValue(segment, out var next))
+            {
+                current = next;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        return current;
+    }
+}

--- a/src/Http/Wolverine.Http/Wolverine.Http.csproj
+++ b/src/Http/Wolverine.Http/Wolverine.Http.csproj
@@ -21,6 +21,15 @@
         <ProjectReference Include="..\..\Wolverine\Wolverine.csproj"/>
         <PackageReference Include="Asp.Versioning.Abstractions"/>
         <!--
+          Emits the source-generated JasperFx DiscoveredCommands manifest for this
+          assembly so the 'openapi' command (and any future Wolverine.Http commands)
+          are discovered without a reflective assembly scan, keeping the AOT/trim
+          posture of WolverineFx.Http (IsAotCompatible) intact. Mirrors WolverineFx core.
+        -->
+        <PackageReference Include="JasperFx.SourceGenerator"
+                          OutputItemType="Analyzer"
+                          ReferenceOutputAssembly="false" />
+        <!--
           Newtonsoft.Json was removed from WolverineFx.Http in 6.0 (#2742).
           The Newtonsoft surface (NewtonsoftHttpSerialization,
           UseNewtonsoftJsonForSerialization, the codegen frames that target


### PR DESCRIPTION
Closes #2903.

## Problem

Microsoft's build-time OpenAPI generators — `Microsoft.Extensions.ApiDescription.Server` and NSwag's `GetDocument.Insider` — call `IHost.StartAsync()`, which boots Wolverine's hosted service and tries to connect to the configured database and/or message broker *before* a single line of OpenAPI JSON is written. For any app backed by durable (database) message persistence or external brokers, that makes build/CI document generation fragile or impossible without live infrastructure.

## Solution

A new `openapi` JasperFx command in **WolverineFx.Http** that generates the document **without starting the host**:

- It reuses the host the application already built (Wolverine added, `MapWolverineEndpoints()` already called — `RunJasperFxCommands` runs after that).
- It merges the application's mapped endpoint data sources into the global `EndpointDataSource` exactly the way `UseEndpoints` does, so the endpoints are visible **without** a host start.
- It resolves the same `Microsoft.AspNetCore.OpenApi` `IDocumentProvider` that `GetDocument.Insider` uses, so the output is **functionally equivalent** to Microsoft's — just with no startup connectivity.

```bash
# Full document to stdout (or --output <file> for a clean file)
dotnet run -- openapi

# List the OpenAPI documents the app exposes
dotnet run -- openapi --list

# Fuzzy-match a route (may match several) and emit ONLY those paths plus the
# schema components they reference — focused output for troubleshooting one endpoint
dotnet run -- openapi --route /todoitems --output ./todoitems.json
```

### Flags
| Flag | Alias | Description |
| --- | --- | --- |
| `--document` | `-d` | Named document to generate. Defaults to `v1`. |
| `--output` | `-o` | File path for the JSON. Omitted (or `-`) → stdout. |
| `--route` | `-r` | Fuzzy (case-insensitive substring) filter on the route template; emits only matching paths + the schema components they transitively reference. |
| `--list` | `-l` | List the document names the app exposes and exit. |

Requires `builder.Services.AddOpenApi()`. Discovery is wired via `[assembly: JasperFxAssembly]` plus the `JasperFx.SourceGenerator` manifest so it stays trim/AOT-clean (mirrors WolverineFx core). The command never starts the host, so the document reflects endpoints discovered at `MapWolverineEndpoints()` time (noted in the docs).

## Testing

- New `generate_openapi_without_database.cs` (3 tests): builds a Marten/Wolverine HTTP app pointed at an **unreachable** database, never starts it, and asserts a full document is produced — plus `--route` pruning and the no-match path. Completes in ~190ms.
- Manually verified with **no database running** against two samples covering both backends:
  - `TodoWebService` (PostgreSQL/Marten) — 5 paths, 7 schemas
  - `EFCoreSample/ItemService` (SQL Server/EFCore) — 4 paths
  - On both net9.0 (OpenAPI 3.0.1) and net10.0 (OpenAPI 3.1.1).
- Full `wolverine.slnx` Release build: 0 warnings, 0 errors.

## Docs & changelog
- `docs/guide/http/metadata.md`: new section framing this as the fix when Microsoft's generators choke on DB/broker infrastructure, with usage samples and the `--route` troubleshooting workflow.
- `CHANGELOG.md`: Unreleased entry under WolverineFx.Http.

## Follow-up
- AI-skills follow-up filed: JasperFx/ai-skills#64 (teach agents to use `openapi --route` for HTTP troubleshooting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)