### PR TITLE
Upgrade JasperFx.* to 2.1.3; bump to 6.0.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -90,8 +90,18 @@
                      Polecat                           4.0.0 -> 4.1.1
                      Weasel.* (7 packages)             9.0.0 -> 9.0.1
                      JasperFx.RuntimeCompiler (5.0.0) / .SourceGeneration (2.0.0) unchanged
+          6.0.3:   JasperFx 2.1.x family -> 2.1.3. Picks up the source-generated extension/option
+                   discovery + DI-registration manifests (jasperfx #371/#374), the mixed-lifetime
+                   IEnumerable<T> codegen fix (jasperfx #376, resolves GH-2896), and the
+                   InputParserGenerator nullable-annotation fix (jasperfx #379) that this upgrade
+                   required on net10 + TreatWarningsAsErrors:
+                     JasperFx                          2.0.1 -> 2.1.3
+                     JasperFx.Events (+ .Events.SourceGenerator)  2.1.0 -> 2.1.3
+                     JasperFx.SourceGenerator           2.0.1 -> 2.1.3
+                     JasperFx.RuntimeCompiler          unchanged (own 5.x line)
+                     Marten / Weasel.* / Polecat       unchanged
         -->
-        <Version>6.0.2</Version>
+        <Version>6.0.3</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,11 +31,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.0.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.1.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.1.0" />
+    <PackageVersion Include="JasperFx" Version="2.1.3" />
+    <PackageVersion Include="JasperFx.Events" Version="2.1.3" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.1.3" />
+    <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
+         family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.0.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.1.3" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
     <PackageVersion Include="Marten" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />


### PR DESCRIPTION
Upgrades the JasperFx 2.1.x family to **2.1.3** and bumps Wolverine to **6.0.3**.

| Package(s) | From | To |
|---|---|---|
| `JasperFx` | 2.0.1 | **2.1.3** |
| `JasperFx.Events`, `JasperFx.Events.SourceGenerator` | 2.1.0 | **2.1.3** |
| `JasperFx.SourceGenerator` | 2.0.1 | **2.1.3** |
| `JasperFx.RuntimeCompiler` | 5.0.0 | **5.0.0** (unchanged — own 5.x line) |
| **Wolverine** | 6.0.2 | **6.0.3** |

`Marten` / `Weasel.*` / `Polecat` unchanged.

## Why
Picks up the JasperFx 2.1.x work:
- source-generated extension/option **discovery** + **DI-registration** manifests (jasperfx [#371](https://github.com/JasperFx/jasperfx/pull/371) / [#374](https://github.com/JasperFx/jasperfx/pull/374)) — the foundation for the Wolverine scanning-elimination set (#2902, #2905–#2909);
- the **mixed-lifetime `IEnumerable<T>`** codegen fix (jasperfx [#376](https://github.com/JasperFx/jasperfx/pull/376)) — **resolves #2896**;
- the **`InputParserGenerator` nullable fix** (jasperfx [#379](https://github.com/JasperFx/jasperfx/pull/379)) that this very upgrade required: JasperFx 2.1.2's generator emitted CS8619 on `Dictionary<string, string?>` flags, breaking the net10 + `TreatWarningsAsErrors` build. 2.1.3 contains the fix, so **no `WarningsNotAsErrors` shim is needed**.

## Verification
`dotnet build wolverine.slnx -c Release` — **clean (0 warnings, 0 errors)** across net9.0 + net10.0. CI runs the full test matrix.

> Follow-up (one at a time): verify #2896 end-to-end through Wolverine, then begin #2902 (eliminate `ExtensionLoader` via the manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)