### PR TITLE
Fix #2896 (mixed-lifetime IEnumerable<T> singleton support) + remove Lamar from CoreTests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,6 @@
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
     <PackageVersion Include="JasperFx.SourceGenerator" Version="2.1.3" />
-    <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
     <PackageVersion Include="Marten" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.1.1" />

--- a/build/build.cs
+++ b/build/build.cs
@@ -510,7 +510,6 @@ partial class Build : NukeBuild
     {
         { "jasperfx", ["JasperFx", "JasperFx.Events", "EventTests", "JasperFx.RuntimeCompiler"] },
         { "weasel", ["Weasel.Core", "Weasel.Postgresql", "Weasel.SqlServer"] },
-        {"lamar", ["Lamar", "Lamar.Microsoft.DependencyInjection"]},
         {"marten", ["Marten"]},
         {"polecat", ["Polecat"]}
     };

--- a/docs/guide/codegen.md
+++ b/docs/guide/codegen.md
@@ -388,7 +388,7 @@ Here's some facts you do need to know about this whole process:
   lifetime is either an `internal` type or uses an "opaque" Lambda registration (think `IServiceCollection.AddScoped(s => {})`)
 
 ::: tip
-The code generation using IoC configuration is tested with both the built in .NET `ServiceProvider` and [Lamar](https://jasperfx.github.io/lamar). It 
+The code generation using IoC configuration is tested with the built in .NET `ServiceProvider`. It
 is theoretically possible to use other IoC tools with Wolverine, but only if you are *only* using `IServiceCollection`
 for your IoC configuration.
 :::

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,10 +1,9 @@
 # Configuration
 
 ::: info
-As of 3.0,  Wolverine **does not require the usage of the [Lamar](https://jasperfx.github.io/lamar) IoC container**, and will no longer replace the built in .NET container with Lamar.
-
-Wolverine 3.0 *is* tested with both the built in `ServiceProvider` and Lamar. It's theoretically possible to use other
-IoC containers now as long as they conform to the .NET conforming container, but this isn't tested by the Wolverine team.
+Wolverine uses the built in .NET `ServiceProvider` as its IoC container and does not replace it. It's
+theoretically possible to use other IoC containers as long as they conform to the .NET conforming container,
+but this isn't tested by the Wolverine team.
 :::
 
 ::: warning Wolverine 6.0: IoC registrations need to be transparent to codegen

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -158,47 +158,6 @@ await host.StartAsync();
 
 And lastly, you can just use `IServiceCollection.AddWolverine()` by itself.
 
-## Replacing ServiceProvider with Lamar
-
-If you run into any trouble whatsoever with code generation after upgrading to Wolverine 3.0, please:
-
-1. Please [raise a GitHub issue in Wolverine](https://github.com/JasperFx/wolverine/issues/new/choose) with some description of the offending message handler or http endpoint
-2. Fall back to Lamar for your IoC tool
-
-To use Lamar, add this Nuget to your main project:
-
-```bash
-dotnet add package Lamar.Microsoft.DependencyInjection
-```
-
-If you're using `IHostBuilder` like you might for a simple console app, it's:
-
-<!-- snippet: sample_use_lamar_with_host_builder -->
-<a id='snippet-sample_use_lamar_with_host_builder'></a>
-```cs
-// With IHostBuilder
-var builder = Host.CreateDefaultBuilder();
-builder.UseLamar();
-```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Configuration/DocumentationSamples.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_use_lamar_with_host_builder' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-In a web application, it's:
-
-```csharp
-var builder = WebApplication.CreateBuilder(args);
-builder.Host.UseLamar();
-```
-
-and with `HostApplicationBuilder`, try:
-
-```csharp
-var builder = Host.CreateApplicationBuilder();
-
-// Little ugly, and Lamar *should* have a helper for this...
-builder.ConfigureContainer<ServiceRegistry>(new LamarServiceProviderFactory());
-```
-
 ## Splitting Configuration Across Modules <Badge type="tip" text="5.0" />
 
 To keep your `UseWolverine()` configuration from becoming too huge or to keep specific configuration maybe

--- a/docs/guide/durability/efcore/domain-events.md
+++ b/docs/guide/durability/efcore/domain-events.md
@@ -257,7 +257,7 @@ the EF Core transactional middleware, the domain events published to that interf
 
 Likewise, if you are using `IDbContextOutbox<T>`, the domain events published to `IEventPublisher` will be correctly piped to Wolverine if you:
 
-1. Pull both `IEventPublisher` and `IDbContextOutbox<T>` from the same scoped service provider (nested container in Lamar / StructureMap parlance)
+1. Pull both `IEventPublisher` and `IDbContextOutbox<T>` from the same scoped service provider
 2. Call `IDbContextOutbox<T>.SaveChangesAndFlushMessagesAsync()`
 
 3. So, we’re going to have to do some sleight of hand to keep your domain entities synchronous

--- a/docs/guide/durability/efcore/transactional-middleware.md
+++ b/docs/guide/durability/efcore/transactional-middleware.md
@@ -25,7 +25,7 @@ builder.Host.UseWolverine(opts =>
 <!-- endSnippet -->
 
 ::: tip
-When using the opt in `Handlers.AutoApplyTransactions()` option, Wolverine (really Lamar) can detect that your handler method uses a `DbContext` if it's a method argument,
+When using the opt in `Handlers.AutoApplyTransactions()` option, Wolverine can detect that your handler method uses a `DbContext` if it's a method argument,
 a dependency of any service injected as a method argument, or a dependency of any service injected as a constructor
 argument of the handler class.
 :::

--- a/docs/guide/extensions.md
+++ b/docs/guide/extensions.md
@@ -1,9 +1,8 @@
 # Configuration Extensions
 
 ::: warning
-As of Wolverine 3.0 and our move to directly support non-Lamar IoC containers, it is no longer
-possible to alter service registrations through Wolverine extensions that are themselves registered
-in the IoC container at bootstrapping time.
+As of Wolverine 3.0, it is no longer possible to alter service registrations through Wolverine
+extensions that are themselves registered in the IoC container at bootstrapping time.
 :::
 
 Wolverine supports the concept of extensions for modularizing Wolverine configuration with implementations of the `IWolverineExtension` interface:

--- a/docs/guide/http/endpoints.md
+++ b/docs/guide/http/endpoints.md
@@ -246,7 +246,7 @@ types that are known in the IoC container. If there's any potential for confusio
 between the request type argument and what should be coming from the IoC
 container, you can decorate parameters with the `[FromServices]` attribute
 from ASP.Net Core to give Wolverine a hint. Otherwise, Wolverine is asking the underlying
-Lamar container if it knows how to resolve the service from the parameter argument.
+IoC container if it knows how to resolve the service from the parameter argument.
 
 
 ## Accessing HttpContext

--- a/docs/guide/http/index.md
+++ b/docs/guide/http/index.md
@@ -216,7 +216,7 @@ by MVC Core or Minimal API or even some other kind of AspNetCore `Endpoint`.
 :::
 
 By default, any time [Wolverine has to revert to using a service locator](/guide/codegen.html#wolverine-code-generation-and-ioc) 
-to generate the adapter code for an HTTP endpoint, Wolverine is using an isolated `IServiceScope` (or Lamar `INestedContainer`) within the generated code.
+to generate the adapter code for an HTTP endpoint, Wolverine is using an isolated `IServiceScope` within the generated code.
 
 But, with Wolverine 5.0+ you can opt into Wolverine just using the `HttpContext.RequestServices` so that you
 can share services with AspNetCore middleware. You can also configure *some* service types to be pulled from

--- a/docs/guide/http/multi-tenancy.md
+++ b/docs/guide/http/multi-tenancy.md
@@ -390,10 +390,9 @@ app.MapWolverineEndpoints(opts =>
 <!-- endSnippet -->
 
 Just note that if you are having the IoC container for your Wolverine application resolve your
-custom `ITenantDetection` strategy that it's going to be effectively `Singleton`-scoped. Wolverine
-depends on using [Lamar](https://jasperfx.github.io/lamar) as the underlying IoC container, and Lamar does
-not require prior registrations to directly resolve a concrete type as long as it can select a public
-constructor with dependencies that it "knows" how to resolve in turn.
+custom `ITenantDetection` strategy that it's going to be effectively `Singleton`-scoped. Wolverine can
+resolve your `ITenantDetection` as a concrete type even without an explicit registration, as long as it has
+a public constructor whose dependencies are themselves resolvable.
 
 
 

--- a/docs/guide/messaging/message-bus.md
+++ b/docs/guide/messaging/message-bus.md
@@ -70,9 +70,8 @@ the root container or injected into a `Singleton` scoped service.
 
 Not to worry! You have a couple options:
 
-1. Switch to using [Lamar](https://jasperfx.github.io/lamar) as your IoC container that doesn't have the fussy, whiney limitations about scoping that `ServiceProvider` does and generally works a little better with Wolverine anyway
-2. Follow the admittedly annoying steps in [this article about using `Scoped` services from `Singleton` services](https://learn.microsoft.com/en-us/dotnet/core/extensions/scoped-service)
-3. Inject `IWolverineRuntime`, and build `new MessageBus(runtime)` instances at will.
+1. Follow the admittedly annoying steps in [this article about using `Scoped` services from `Singleton` services](https://learn.microsoft.com/en-us/dotnet/core/extensions/scoped-service)
+2. Inject `IWolverineRuntime`, and build `new MessageBus(runtime)` instances at will.
 
 ## Invoking Message Execution
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -355,28 +355,21 @@ By and large, we've *tried* to replace any API nomenclature using "master" with 
 The 3.0 release did not have any breaking changes to the public API, but does come with some significant internal
 changes.
 
-### Lamar Removal
+### Built-in IoC Container
+
+The biggest change is that Wolverine no longer automatically replaces the built in `ServiceProvider` and
+uses the .NET conforming container directly. At this point it is theoretically possible to use Wolverine with
+any IoC library that fully supports the ASP.Net Core DI conformance behavior, but Wolverine has only been
+tested against the default `ServiceProvider`.
+
+Do be aware that `ServiceProvider` is stricter than some third-party containers about service resolution and
+lifetime scoping, so there might be some hiccups. See the [Configuration Guide](/guide/configuration) for more
+information. Wolverine uses the IoC configuration to generate code that inlines dependency creation in a way
+that's more efficient than resolving through an IoC tool at runtime when it can.
 
 ::: tip
-Lamar is more "forgiving" than the built in `ServiceProvider`. If after converting to Wolverine 3.0, you receive
-messages from `ServiceProvider` about not being able to resolve this, that, or the other, just go back to Lamar with
-the steps in this guide.
-:::
-
-The biggest change is that Wolverine is no longer directly coupled to the [Lamar IoC library](https://jasperfx.github.io/lamar) and
-Wolverine will no longer automatically replace the built in `ServiceProvider` with Lamar. At this point it is theoretically
-possible to use Wolverine with any IoC library that fully supports the ASP.Net Core DI conformance behavior, but Wolverine
-has only been tested against the default `ServiceProvider` and Lamar IoC containers. 
-
-Do be aware if moving to Wolverine 3.0 that Lamar is more forgiving than `ServiceProvider`, so there might be some hiccups
-if you choose to forgo Lamar. See the [Configuration Guide](/guide/configuration) for more information. Lamar does still have a little more
-robust support for the code generation abilities in Wolverine (Wolverine uses the IoC configuration to generate code to inline
-dependency creation in a way that's more efficient than an IoC tool at runtime -- when it can).
-
-::: tip
-If you have any issues with Wolverine's code generation about your message handlers or HTTP endpoints after upgrading to Wolverine 3.0,
-please open a GitHub issue with Wolverine, but just know that you can probably fall back to using Lamar as the IoC tool
-to "fix" those issues with code generation planning.
+If you have any issues with Wolverine's code generation about your message handlers or HTTP endpoints after
+upgrading, please open a GitHub issue with Wolverine.
 :::
 
 Wolverine 3.0 can now be bootstrapped with the `HostApplicationBuilder` or any standard .NET bootstrapping mechanism through
@@ -448,9 +441,9 @@ schema for the queues.
 
 ### Wolverine.Http
 
-For [Wolverine.Http usage](/guide/http/), the Wolverine 3.0 usage of the less capable `ServiceProvider` instead of the previously
-mandated [Lamar](https://jasperfx.github.io/lamar) library necessitates the usage of this API to register necessary
-services for Wolverine.HTTP in addition to adding the Wolverine endpoints:
+For [Wolverine.Http usage](/guide/http/), the Wolverine 3.0 usage of the built in `ServiceProvider`
+necessitates the usage of this API to register necessary services for Wolverine.HTTP in addition to
+adding the Wolverine endpoints:
 
 <!-- snippet: sample_adding_http_services -->
 <a id='snippet-sample_adding_http_services'></a>

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -428,8 +428,8 @@ Built in examples of the agent and agent family are:
 ## IoC Container Integration
 
 ::: info
-Wolverine has been tested with both the built in `ServiceProvider` and [Lamar](https://jasperfx.github.io/lamar), which was originally built
-specifically to support what ended up becoming Wolverine. The previous limitation to only supporting Lamar was lifted in Wolverine 3.0.
+Wolverine uses the built in .NET `ServiceProvider` as its IoC container. It's theoretically possible to use
+other conforming containers, but only the built in `ServiceProvider` is tested by the Wolverine team.
 :::
 
 Wolverine is a significantly different animal than other .NET frameworks, and uses the IoC container quite differently than most

--- a/docs/tutorials/cqrs-with-marten.md
+++ b/docs/tutorials/cqrs-with-marten.md
@@ -62,9 +62,8 @@ builder.Services.AddWolverineHttp();
 ```
 
 ::: info
-We had to separate the IoC service registrations from the addition of the 
-Wolverine endpoints when Wolverine was decoupled from Lamar as its only
-IoC tool. Two steps forward, one step back.
+The IoC service registrations are separate from the addition of the Wolverine
+endpoints because Wolverine uses the built in .NET `ServiceProvider`.
 :::
 
 Next, let's add support for [Wolverine.HTTP]() endpoints:

--- a/src/Testing/CoreTests/Acceptance/using_with_keyed_services.cs
+++ b/src/Testing/CoreTests/Acceptance/using_with_keyed_services.cs
@@ -1,4 +1,3 @@
-using Lamar.Microsoft.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Wolverine.Attributes;
@@ -14,62 +13,6 @@ public class using_with_keyed_services : IAsyncLifetime
     public async Task InitializeAsync()
     {
         _host = await Host.CreateDefaultBuilder()
-            .UseWolverine(opts =>
-            {
-                opts.Discovery.DisableConventionalDiscovery().IncludeType<ThingHandler>();
-
-                opts.Services.AddKeyedSingleton<IThing, RedThing>("Red");
-                opts.Services.AddKeyedScoped<IThing, BlueThing>("Blue");
-                opts.Services.AddKeyedSingleton<IThing, GreenThing>("Green");
-
-                opts.Services.AddTransient<ThingUser>();
-                opts.Services.AddTransient<ThingUserHolder>();
-            }).StartAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        await _host.StopAsync();
-        _host.Dispose();
-    }
-
-    [Fact]
-    public async Task use_inside_of_deep_dependency_chain()
-    {
-        var container = _host.Services.GetRequiredService<IServiceContainer>();
-        var holder = container.QuickBuild<ThingUserHolder>();
-        holder.ThingUser.Thing.ShouldBeOfType<RedThing>();
-
-        await _host.InvokeAsync(new UseThingHolder());
-    }
-
-    [Fact]
-    public async Task use_as_single_parameter_on_handler()
-    {
-        await _host.InvokeAsync(new UseThingDirectly());
-    }
-
-    [Fact]
-    public async Task use_as_singleton_parameter_on_handler()
-    {
-        await _host.InvokeAsync(new UseSingletonThingDirectly());
-    }
-
-    [Fact]
-    public async Task use_multiple_parameters_on_handler()
-    {
-        await _host.InvokeAsync(new UseMultipleThings());
-    }
-}
-
-public class using_with_keyed_services_and_lamar : IAsyncLifetime
-{
-    private IHost _host = null!;
-
-    public async Task InitializeAsync()
-    {
-        _host = await Host.CreateDefaultBuilder()
-            .UseLamar()
             .UseWolverine(opts =>
             {
                 opts.Discovery.DisableConventionalDiscovery().IncludeType<ThingHandler>();

--- a/src/Testing/CoreTests/Bugs/Bug_2896_mixed_lifetime_enumerable_dependency.cs
+++ b/src/Testing/CoreTests/Bugs/Bug_2896_mixed_lifetime_enumerable_dependency.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+/// <summary>
+/// Regression for GitHub issue #2896: a handler that depends on an IEnumerable&lt;T&gt; whose
+/// registrations mix DI lifetimes (one singleton + one scoped of the same interface) used to
+/// receive a null for the singleton element. JasperFx's inline IEnumerable codegen injects the
+/// singleton element via [FromKeyedServices]; Wolverine now calls AddJasperFxEnumerableSingletonSupport()
+/// at bootstrap so the keyed "mirror" registration exists and the singleton element is non-null.
+/// </summary>
+public class Bug_2896_mixed_lifetime_enumerable_dependency
+{
+    [Fact]
+    public async Task mixed_lifetime_enumerable_dependency_resolves_every_element()
+    {
+        Bug2896Handler.Received = null;
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton<IBug2896Thing, Bug2896Singleton>();
+                opts.Services.AddScoped<IBug2896Thing, Bug2896Scoped>();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(Bug2896Handler));
+            })
+            .StartAsync();
+
+        await host.MessageBus().InvokeAsync(new Bug2896Message());
+
+        var received = Bug2896Handler.Received.ShouldNotBeNull();
+        received.Length.ShouldBe(2);
+
+        // The crux of #2896: the singleton element must not be null, and both lifetimes are present.
+        received.OfType<Bug2896Singleton>().ShouldHaveSingleItem();
+        received.OfType<Bug2896Scoped>().ShouldHaveSingleItem();
+
+        // The singleton element shares the container's singleton instance.
+        var containerSingleton = host.Services.GetServices<IBug2896Thing>().OfType<Bug2896Singleton>().Single();
+        received.OfType<Bug2896Singleton>().Single().ShouldBeSameAs(containerSingleton);
+    }
+}
+
+public record Bug2896Message;
+
+public interface IBug2896Thing;
+
+public class Bug2896Singleton : IBug2896Thing;
+
+public class Bug2896Scoped : IBug2896Thing;
+
+public static class Bug2896Handler
+{
+    public static IBug2896Thing[]? Received;
+
+    public static void Handle(Bug2896Message message, IEnumerable<IBug2896Thing> things)
+    {
+        Received = things.ToArray();
+    }
+}

--- a/src/Testing/CoreTests/Configuration/DocumentationSamples.cs
+++ b/src/Testing/CoreTests/Configuration/DocumentationSamples.cs
@@ -1,6 +1,4 @@
 using JasperFx.Core;
-using Lamar;
-using Lamar.Microsoft.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Wolverine.Tracking;
 using Xunit;
@@ -9,27 +7,6 @@ namespace CoreTests.Configuration;
 
 public static class DocumentationSamples
 {
-    public static async Task bootstrap_with_lamar()
-    {
-        #region sample_use_lamar_with_host_builder
-        // With IHostBuilder
-        var builder = Host.CreateDefaultBuilder();
-        builder.UseLamar();
-
-        #endregion
-        
-        
-    }
-
-    public static async Task bootstrap_with_lamar_using_web_app()
-    {
-        var builder = Host.CreateApplicationBuilder();
-        
-        // Little ugly, and Lamar *should* have a helper for this...
-        builder.ConfigureContainer<ServiceRegistry>(new LamarServiceProviderFactory());
-    }
-
-
     #region sample_using_tracked_sessions_end_to_end
     // Personally, I prefer to reuse the IHost between tests and
     // do something to clear off any dirty state, but other folks

--- a/src/Testing/CoreTests/CoreTests.csproj
+++ b/src/Testing/CoreTests/CoreTests.csproj
@@ -5,7 +5,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
         <PackageReference Include="Microsoft.FeatureManagement"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="OpenTelemetry.Exporter.Console"/>

--- a/src/Testing/CoreTests/IntegrationContext.cs
+++ b/src/Testing/CoreTests/IntegrationContext.cs
@@ -2,7 +2,6 @@
 using CoreTests.Bugs;
 using CoreTests.Shims;
 using JasperFx.Core.Reflection;
-using Lamar.Microsoft.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -22,7 +21,6 @@ public class DefaultApp : IDisposable
     public DefaultApp()
     {
         Host = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
-            .UseLamar()
             .UseWolverine(opts =>
             {
                 opts.Policies.MessageExecutionLogLevel(LogLevel.Information);

--- a/src/Wolverine/HostBuilderExtensions.cs
+++ b/src/Wolverine/HostBuilderExtensions.cs
@@ -268,6 +268,15 @@ public static class HostBuilderExtensions
 
         options.ApplyLazyConfiguration();
 
+        // JasperFx's inline IEnumerable<T> codegen needs keyed "mirror" singletons registered for any
+        // service family that mixes a singleton with non-singleton registrations (e.g. one AddSingleton
+        // + one AddScoped of the same interface). The generated code injects the singleton element via
+        // [FromKeyedServices(key)]; without the mirror the singleton element resolves as null at runtime
+        // (resolves #2896). The mirror keys are ordinal-based, so this MUST run as the last registration
+        // step Wolverine controls — after the configure callback and ApplyLazyConfiguration, and before
+        // the host builds the service provider. It is idempotent and only touches mixed-lifetime families.
+        services.AddJasperFxEnumerableSingletonSupport();
+
         return services;
     }
 


### PR DESCRIPTION
## Part 1 — Fix #2896

JasperFx 2.1.3's inline `IEnumerable<T>` codegen injects the **singleton** element of a *mixed-lifetime* service family (e.g. one `AddSingleton` + one `AddScoped` of the same interface) via `[FromKeyedServices]`. For that to resolve, the host must register keyed "mirror" singletons **before** `BuildServiceProvider()` by calling `AddJasperFxEnumerableSingletonSupport()`. Wolverine wasn't doing this, so such an `IEnumerable<T>` handler dependency received **null** for the singleton element at runtime.

`AddWolverine` now calls `AddJasperFxEnumerableSingletonSupport()` as the **last registration step it controls** (after the `configure` callback + `ApplyLazyConfiguration()`, before the provider is built). Mirror keys are ordinal-based, so this placement keeps them in sync with the codegen. The call is idempotent and only touches mixed-lifetime families.

Adds `Bug_2896_mixed_lifetime_enumerable_dependency` regression test.

## Part 2 — Remove Lamar (build stabilization + drop unsupported container)

The keyed-mirror mechanism assumes **Microsoft DI** semantics: `GetServices<T>` excludes keyed registrations. **Lamar** instead pulls the keyed mirror back into `IEnumerable<T>`, so the mirror factory's `GetServices<T>` call recurses infinitely → **`StackOverflowException` on `StartAsync()`**. The triggering family is a Wolverine-*internal* mixed-lifetime registration, so **every** Lamar host crashes on startup — and it can't be guarded at `AddWolverine` time because the provider factory isn't knowable during `ConfigureServices`.

Wolverine core has been Lamar-free since 3.0; Lamar survived only in CoreTests and the docs. This drops Lamar entirely so everything runs on the built-in container (the 6.0 default and the mechanism the #2896 fix targets):

**Code / build:**
- `IntegrationContext`/`DefaultApp`: drop `.UseLamar()`
- `using_with_keyed_services`: delete the Lamar-only duplicate class
- `DocumentationSamples`: drop the two Lamar bootstrap samples
- `CoreTests.csproj` + `Directory.Packages.props`: drop the Lamar package
- `build/build.cs`: drop the orphaned `lamar` Attach/Detach entry

**Docs (now Lamar-free):**
- Remove the "Replacing ServiceProvider with Lamar" section and the now-invalid "fall back to / switch to Lamar" guidance (`configuration`, `migration`, `message-bus`).
- Correct "tested with both ServiceProvider and Lamar" claims to just the built-in `ServiceProvider` (`configuration`, `runtime`, `codegen`).
- Reword stale/incidental Lamar mentions to be container-agnostic (`multi-tenancy` "depends on Lamar" was already untrue since 3.0; efcore, http endpoints/index, cqrs-with-marten asides).
- Rename migration's "Lamar Removal" section to "Built-in IoC Container", keeping the still-relevant "`ServiceProvider` is stricter" guidance.

> This effectively makes Wolverine 6.0 **not support Lamar** as an IoC container — by design, since the #2896 fix makes Lamar crash at runtime.

## Verification

- New #2896 regression test passes.
- **CoreTests: 1711 passed** (previously the entire run aborted on the stack overflow).
- `dotnet build wolverine.slnx -c Release` — 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)