### PR TITLE
Flush EF Core outbox before writing the HTTP response (GH-2917)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/issue_2917_trackactivity_transactional_outbox.cs
+++ b/src/Http/Wolverine.Http.Tests/issue_2917_trackactivity_transactional_outbox.cs
@@ -7,12 +7,14 @@ using Xunit.Abstractions;
 
 namespace Wolverine.Http.Tests;
 
-// Reproduction for https://github.com/JasperFx/wolverine/issues/2917.
-// /issue2917 is [Transactional] (Marten outbox) and returns a cascading Issue2917Message.
-// Under the outbox that message is only sent in FlushOutgoingMessagesAsync, which the generated
-// endpoint runs AFTER WriteJsonAsync. With Alba the client receives the response before the flush
-// records the "sent" envelope, so a TrackActivity session that relies on the default
-// "wait until activity quiesces" behavior can finish empty.
+// Regression test for https://github.com/JasperFx/wolverine/issues/2917.
+// /issue2917 is an EF Core [Transactional] endpoint that returns a cascading Issue2917Message.
+// EF Core's Eager transaction middleware now commits the transaction and flushes the outbox (via
+// the CommitEfCoreEnvelopeTransaction postprocessor) BEFORE the HTTP response is written. Previously
+// the flush happened inside EnrollDbContextInTransaction.CommitAsync at the end of the wrap, AFTER
+// WriteJsonAsync wrote the response - so with Alba the client received the response before the
+// "sent" envelope was recorded and a TrackActivity session (with no explicit wait condition) could
+// finish empty.
 public class issue_2917_trackactivity_transactional_outbox : IntegrationContext
 {
     private readonly ITestOutputHelper _output;
@@ -23,7 +25,7 @@ public class issue_2917_trackactivity_transactional_outbox : IntegrationContext
     }
 
     [Fact]
-    public async Task tracked_session_should_capture_the_transactional_outbox_message()
+    public async Task tracked_session_captures_the_transactional_outbox_message()
     {
         var tracked = await Host
             .TrackActivity()
@@ -35,12 +37,10 @@ public class issue_2917_trackactivity_transactional_outbox : IntegrationContext
             .Name.ShouldBe("test");
     }
 
-    // Demonstrates the current workaround: an explicit wait condition keeps the tracked session
-    // open until the cascading message is actually received, past the HTTP response. If this PASSES
-    // while the test above FAILS, it proves the message IS sent — just after the response is
-    // written (and after ExecuteAndWaitAsync's default quiescence check has already returned).
+    // An explicit wait condition is no longer required (the test above passes without one), but it
+    // must of course still work.
     [Fact]
-    public async Task workaround_with_explicit_wait_condition()
+    public async Task tracked_session_with_explicit_wait_condition()
     {
         var tracked = await Host
             .TrackActivity()

--- a/src/Http/Wolverine.Http.Tests/issue_2917_trackactivity_transactional_outbox.cs
+++ b/src/Http/Wolverine.Http.Tests/issue_2917_trackactivity_transactional_outbox.cs
@@ -1,0 +1,53 @@
+using Alba;
+using Shouldly;
+using Wolverine.Tracking;
+using WolverineWebApi;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Wolverine.Http.Tests;
+
+// Reproduction for https://github.com/JasperFx/wolverine/issues/2917.
+// /issue2917 is [Transactional] (Marten outbox) and returns a cascading Issue2917Message.
+// Under the outbox that message is only sent in FlushOutgoingMessagesAsync, which the generated
+// endpoint runs AFTER WriteJsonAsync. With Alba the client receives the response before the flush
+// records the "sent" envelope, so a TrackActivity session that relies on the default
+// "wait until activity quiesces" behavior can finish empty.
+public class issue_2917_trackactivity_transactional_outbox : IntegrationContext
+{
+    private readonly ITestOutputHelper _output;
+
+    public issue_2917_trackactivity_transactional_outbox(AppFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task tracked_session_should_capture_the_transactional_outbox_message()
+    {
+        var tracked = await Host
+            .TrackActivity()
+            .ExecuteAndWaitAsync(_ => Host.Scenario(x => x.Post.Json(new Issue2917Request("test")).ToUrl("/issue2917")));
+
+        _output.WriteLine(tracked.ToString());
+
+        tracked.MessageSucceeded.SingleMessage<Issue2917Message>()
+            .Name.ShouldBe("test");
+    }
+
+    // Demonstrates the current workaround: an explicit wait condition keeps the tracked session
+    // open until the cascading message is actually received, past the HTTP response. If this PASSES
+    // while the test above FAILS, it proves the message IS sent — just after the response is
+    // written (and after ExecuteAndWaitAsync's default quiescence check has already returned).
+    [Fact]
+    public async Task workaround_with_explicit_wait_condition()
+    {
+        var tracked = await Host
+            .TrackActivity()
+            .WaitForMessageToBeReceivedAt<Issue2917Message>(Host)
+            .ExecuteAndWaitAsync(_ => Host.Scenario(x => x.Post.Json(new Issue2917Request("test")).ToUrl("/issue2917")));
+
+        tracked.MessageSucceeded.SingleMessage<Issue2917Message>()
+            .Name.ShouldBe("test");
+    }
+}

--- a/src/Http/WolverineWebApi/Issue2917Endpoint.cs
+++ b/src/Http/WolverineWebApi/Issue2917Endpoint.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Http;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Http;
+
+namespace WolverineWebApi;
+
+// Endpoint that reproduces https://github.com/JasperFx/wolverine/issues/2917 — a transactional
+// EF Core endpoint that returns a cascading message alongside its HTTP response. Under EF Core's
+// Eager transaction middleware the cascading Issue2917Message is only sent inside
+// EnrollDbContextInTransaction's CommitAsync(), which runs AFTER WriteJsonAsync writes the response.
+public record Issue2917Message(string Name);
+
+public record Issue2917Request(string Name);
+
+public static class Issue2917Endpoint
+{
+    // The ItemsDbContext dependency engages EF Core's Eager transaction middleware (the same as
+    // the user's AutoApplyTransactions setup).
+    [Transactional]
+    [WolverinePost("/issue2917")]
+    public static (IResult, OutgoingMessages) Post(Issue2917Request request, ItemsDbContext db)
+    {
+        return (Results.Ok("ok"), [new Issue2917Message(request.Name)]);
+    }
+}
+
+public class Issue2917Handler
+{
+    public void Handle(Issue2917Message message)
+    {
+        // no-op; we only care that the message is tracked
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -195,6 +195,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
         }
 
         var enrolledInTransaction = false;
+        var multiTenantTransaction = false;
         if (mode == TransactionMiddlewareMode.Eager)
         {
             if (isMultiTenanted(container, dbContextType))
@@ -203,6 +204,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 
                 chain.Middleware.Insert(0, createContext);
                 chain.Middleware.Insert(0, new StartDatabaseTransactionForDbContext(dbContextType, chain.Idempotency));
+                multiTenantTransaction = true;
             }
             else
             {
@@ -221,25 +223,33 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 
         chain.Postprocessors.Add(call);
 
-        applyEagerCommitOrLightweightFlush(chain, mode, enrolledInTransaction);
+        applyEagerCommitOrLightweightFlush(chain, mode, enrolledInTransaction, multiTenantTransaction, dbContextType);
     }
 
-    // Eager mode wraps the rest of the chain in EnrollDbContextInTransaction's try/catch. The
-    // commit + outbox flush is emitted as the CommitEfCoreEnvelopeTransaction postprocessor added
-    // here (right after SaveChanges), rather than at the end of the wrap, so it runs BEFORE the
-    // response writer that Wolverine.Http appends to Postprocessors during codegen. That keeps the
-    // transaction commit + MessageContext flush ahead of the HTTP response (GH-2917), while still
-    // committing AFTER SaveChanges and flushing AFTER the commit - so it does NOT reintroduce the
-    // flush-before-commit stranding bug (see Wolverine.Http.Tests/Bug_efcore_outbox_flush_before_commit.cs).
+    // Eager mode wraps the rest of the chain in a transaction middleware's try/catch. The commit +
+    // outbox flush is emitted as a postprocessor added here (right after SaveChanges), rather than at
+    // the end of the wrap, so it runs BEFORE the response writer that Wolverine.Http appends to
+    // Postprocessors during codegen. That keeps the transaction commit + MessageContext flush ahead of
+    // the HTTP response (GH-2917), while still committing AFTER SaveChanges and flushing AFTER the
+    // commit - so it does NOT reintroduce the flush-before-commit stranding bug (see
+    // Wolverine.Http.Tests/Bug_efcore_outbox_flush_before_commit.cs).
     //
-    // Lightweight mode skips EnrollDbContextInTransaction (no try-block wrap, no CommitAsync), so a
-    // standalone FlushOutgoingMessages postprocessor is the only flush trigger and must stay.
+    //  - Single DbContext (EnrollDbContextInTransaction): commit via the enlisted EfCoreEnvelopeTransaction.
+    //  - Multi-tenant (StartDatabaseTransactionForDbContext): commit the DbContext transaction directly,
+    //    then flush the MessageContext. The postprocessor is IFlushesMessages so the chain does not also
+    //    add a standalone FlushOutgoingMessages (which would flush after the response and before commit).
+    //  - Lightweight mode (no try-block wrap, no commit frame): a standalone FlushOutgoingMessages
+    //    postprocessor is the only flush trigger and must stay.
     private static void applyEagerCommitOrLightweightFlush(IChain chain, TransactionMiddlewareMode mode,
-        bool enrolledInTransaction)
+        bool enrolledInTransaction, bool multiTenantTransaction, Type dbContextType)
     {
         if (enrolledInTransaction)
         {
             chain.Postprocessors.Add(new CommitEfCoreEnvelopeTransaction());
+        }
+        else if (multiTenantTransaction)
+        {
+            chain.Postprocessors.Add(new CommitTenantedDbContextTransaction(dbContextType));
         }
         else if (mode != TransactionMiddlewareMode.Eager
                  && chain.RequiresOutbox() && chain.ShouldFlushOutgoingMessages())
@@ -303,6 +313,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
         var mode = ResolveEffectiveMode(chain);
 
         var enrolledInTransaction = false;
+        var multiTenantTransaction = false;
         if (mode == TransactionMiddlewareMode.Eager)
         {
             if (isMultiTenanted(container, dbType))
@@ -310,6 +321,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
                 var createContext = typeof(CreateTenantedDbContext<>).CloseAndBuildAs<Frame>(dbType);
                 chain.Middleware.Insert(0, createContext);
                 chain.Middleware.Insert(0, new StartDatabaseTransactionForDbContext(dbType, chain.Idempotency));
+                multiTenantTransaction = true;
             }
             else
             {
@@ -329,7 +341,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
         chain.Postprocessors.Add(call);
 
         // See applyEagerCommitOrLightweightFlush + the no-entity overload above (GH-2917).
-        applyEagerCommitOrLightweightFlush(chain, mode, enrolledInTransaction);
+        applyEagerCommitOrLightweightFlush(chain, mode, enrolledInTransaction, multiTenantTransaction, dbType);
     }
 
     public bool CanApply(IChain chain, IServiceContainer container)

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -194,6 +194,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
             chain.Middleware.Insert(0, frame);
         }
 
+        var enrolledInTransaction = false;
         if (mode == TransactionMiddlewareMode.Eager)
         {
             if (isMultiTenanted(container, dbContextType))
@@ -206,6 +207,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
             else
             {
                 chain.Middleware.Insert(0, new EnrollDbContextInTransaction(dbContextType, chain.Idempotency));
+                enrolledInTransaction = true;
             }
         }
 
@@ -219,23 +221,28 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 
         chain.Postprocessors.Add(call);
 
-        // Eager mode wraps the rest of the chain in EnrollDbContextInTransaction's
-        // try/catch and ends the try block with `efCoreEnvelopeTransaction.CommitAsync(...)`.
-        // EfCoreEnvelopeTransaction.CommitAsync commits the EF Core transaction and THEN
-        // flushes outgoing messages - that's the only ordering that lets the post-send
-        // outbox bookkeeping see the wolverine_outgoing row this chain just inserted.
-        // Adding a standalone FlushOutgoingMessages postprocessor here would inject the
-        // flush BEFORE the commit, and the post-send DELETE would no-op against the
-        // still-uncommitted INSERT, leaving the row stranded for the durability agent
-        // (at-least-once instead of exactly-once). See the dmytro-pryvedeniuk/outbox
-        // sample report and the failing HTTP test in
-        // Wolverine.Http.Tests/Bug_efcore_outbox_flush_before_commit.cs.
-        //
-        // Lightweight mode skips EnrollDbContextInTransaction (no try-block wrap, no
-        // CommitAsync), so the standalone FlushOutgoingMessages postprocessor is the
-        // only flush trigger and must stay.
-        if (mode != TransactionMiddlewareMode.Eager
-            && chain.RequiresOutbox() && chain.ShouldFlushOutgoingMessages())
+        applyEagerCommitOrLightweightFlush(chain, mode, enrolledInTransaction);
+    }
+
+    // Eager mode wraps the rest of the chain in EnrollDbContextInTransaction's try/catch. The
+    // commit + outbox flush is emitted as the CommitEfCoreEnvelopeTransaction postprocessor added
+    // here (right after SaveChanges), rather than at the end of the wrap, so it runs BEFORE the
+    // response writer that Wolverine.Http appends to Postprocessors during codegen. That keeps the
+    // transaction commit + MessageContext flush ahead of the HTTP response (GH-2917), while still
+    // committing AFTER SaveChanges and flushing AFTER the commit - so it does NOT reintroduce the
+    // flush-before-commit stranding bug (see Wolverine.Http.Tests/Bug_efcore_outbox_flush_before_commit.cs).
+    //
+    // Lightweight mode skips EnrollDbContextInTransaction (no try-block wrap, no CommitAsync), so a
+    // standalone FlushOutgoingMessages postprocessor is the only flush trigger and must stay.
+    private static void applyEagerCommitOrLightweightFlush(IChain chain, TransactionMiddlewareMode mode,
+        bool enrolledInTransaction)
+    {
+        if (enrolledInTransaction)
+        {
+            chain.Postprocessors.Add(new CommitEfCoreEnvelopeTransaction());
+        }
+        else if (mode != TransactionMiddlewareMode.Eager
+                 && chain.RequiresOutbox() && chain.ShouldFlushOutgoingMessages())
         {
 #pragma warning disable CS4014
             chain.Postprocessors.Add(new FlushOutgoingMessages());
@@ -295,6 +302,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 
         var mode = ResolveEffectiveMode(chain);
 
+        var enrolledInTransaction = false;
         if (mode == TransactionMiddlewareMode.Eager)
         {
             if (isMultiTenanted(container, dbType))
@@ -306,6 +314,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
             else
             {
                 chain.Middleware.Insert(0, new EnrollDbContextInTransaction(dbType, chain.Idempotency));
+                enrolledInTransaction = true;
             }
         }
 
@@ -319,17 +328,8 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 
         chain.Postprocessors.Add(call);
 
-        // See the rationale in the no-entity ApplyTransactionSupport overload above.
-        // Same constraint: in Eager mode, EnrollDbContextInTransaction's CommitAsync is
-        // the sole legitimate flush trigger; a standalone postprocessor would flush
-        // before the EF Core commit and strand the wolverine_outgoing row.
-        if (mode != TransactionMiddlewareMode.Eager
-            && chain.RequiresOutbox() && chain.ShouldFlushOutgoingMessages())
-        {
-#pragma warning disable CS4014
-            chain.Postprocessors.Add(new FlushOutgoingMessages());
-#pragma warning restore CS4014
-        }
+        // See applyEagerCommitOrLightweightFlush + the no-entity overload above (GH-2917).
+        applyEagerCommitOrLightweightFlush(chain, mode, enrolledInTransaction);
     }
 
     public bool CanApply(IChain chain, IServiceContainer container)

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EnrollDbContextInTransaction.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EnrollDbContextInTransaction.cs
@@ -48,9 +48,14 @@ internal class EnrollDbContextInTransaction : AsyncFrame, IFlushesMessages
             writer.Write($"await {_context.Usage}.{nameof(MessageContext.AssertEagerIdempotencyAsync)}({_cancellation.Usage}).ConfigureAwait(false);");
         }
         
+        // The commit + outbox flush is NOT emitted here anymore. It is emitted by the
+        // CommitEfCoreEnvelopeTransaction postprocessor (added by EFCorePersistenceFrameProvider),
+        // which is part of Next and runs BEFORE the HTTP response writer - while still inside this
+        // try/catch, so a failed commit rolls back and never produces a success response. This is
+        // what lets Wolverine's transactional outbox flush (and thus the TrackActivity "sent"
+        // bookkeeping) complete before the response is written. See GH-2917.
         Next?.GenerateCode(method, writer);
-        
-        writer.Write($"await {_envelopeTransaction.Usage}.CommitAsync({_cancellation.Usage}).ConfigureAwait(false);");
+
         writer.FinishBlock();
         writer.Write($"BLOCK:catch ({typeof(Exception).FullNameInCode()})");
         writer.Write($"await {_envelopeTransaction.Usage}.RollbackAsync().ConfigureAwait(false);");
@@ -62,12 +67,42 @@ internal class EnrollDbContextInTransaction : AsyncFrame, IFlushesMessages
     {
         _scrapers = chain.FindVariable(typeof(IEnumerable<IDomainEventScraper>));
         yield return _scrapers;
-        
+
         _context = chain.FindVariable(typeof(MessageContext));
         yield return _context;
 
         _dbContext = chain.FindVariable(_dbContextType);
         yield return _dbContext;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+    }
+}
+
+/// <summary>
+/// Commits the Ef Core envelope transaction (committing the EF Core database transaction and then
+/// flushing the MessageContext's outgoing messages). Emitted as a postprocessor so it runs before
+/// the HTTP response writer, ensuring the outbox is flushed before the response is sent (GH-2917).
+/// Pairs with <see cref="EnrollDbContextInTransaction" />, which begins the transaction and provides
+/// the try/catch (and the <see cref="EfCoreEnvelopeTransaction" /> variable this frame commits).
+/// </summary>
+internal class CommitEfCoreEnvelopeTransaction : AsyncFrame
+{
+    private Variable _envelopeTransaction = null!;
+    private Variable _cancellation = null!;
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment(
+            "Commit the EF Core transaction and flush outgoing messages before writing the response (GH-2917)");
+        writer.Write($"await {_envelopeTransaction.Usage}.CommitAsync({_cancellation.Usage}).ConfigureAwait(false);");
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _envelopeTransaction = chain.FindVariable(typeof(EfCoreEnvelopeTransaction));
+        yield return _envelopeTransaction;
 
         _cancellation = chain.FindVariable(typeof(CancellationToken));
         yield return _cancellation;

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/StartDatabaseTransactionForDbContext.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/StartDatabaseTransactionForDbContext.cs
@@ -9,6 +9,10 @@ using Wolverine.Runtime;
 
 namespace Wolverine.EntityFrameworkCore.Codegen;
 
+// Multi-tenant counterpart to EnrollDbContextInTransaction. Begins the transaction and provides the
+// try/catch rollback wrapper; the commit + outbox flush is emitted by the
+// CommitTenantedDbContextTransaction postprocessor (added by EFCorePersistenceFrameProvider) so it
+// runs before the HTTP response writer. See GH-2917.
 internal class StartDatabaseTransactionForDbContext : AsyncFrame
 {
     private readonly Type _dbContextType;
@@ -44,9 +48,12 @@ internal class StartDatabaseTransactionForDbContext : AsyncFrame
             writer.Write($"await {_context!.Usage}.{nameof(MessageContext.AssertEagerIdempotencyAsync)}({_cancellation.Usage}).ConfigureAwait(false);");
         }
 
+        // The commit + outbox flush is NOT emitted here anymore - see CommitTenantedDbContextTransaction
+        // (added as a postprocessor by EFCorePersistenceFrameProvider). It runs BEFORE the HTTP response
+        // writer while still inside this try/catch, so the commit + MessageContext flush complete before
+        // the response is written. See GH-2917.
         Next?.GenerateCode(method, writer);
 
-        writer.Write($"await {_dbContext.Usage}.Database.CommitTransactionAsync({_cancellation.Usage}).ConfigureAwait(false);");
         writer.FinishBlock();
         writer.Write($"BLOCK:catch ({typeof(Exception).FullNameInCode()})");
         writer.Write($"await {_dbContext.Usage}.Database.RollbackTransactionAsync({_cancellation.Usage}).ConfigureAwait(false);");
@@ -61,6 +68,49 @@ internal class StartDatabaseTransactionForDbContext : AsyncFrame
 
         _dbContext = chain.FindVariable(_dbContextType);
         yield return _dbContext;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+    }
+}
+
+/// <summary>
+/// Commits the multi-tenant EF Core database transaction started by
+/// <see cref="StartDatabaseTransactionForDbContext" /> and then flushes the MessageContext's outgoing
+/// messages. Emitted as a postprocessor so it runs before the HTTP response writer - committing
+/// before flushing (so the post-send outbox bookkeeping sees committed rows) and flushing before the
+/// response is written (so TrackActivity observes the sent envelopes). Implements
+/// <see cref="IFlushesMessages" /> so the chain does not also add a standalone FlushOutgoingMessages
+/// postprocessor (which would flush after the response, and before the commit). See GH-2917.
+/// </summary>
+internal class CommitTenantedDbContextTransaction : AsyncFrame, IFlushesMessages
+{
+    private readonly Type _dbContextType;
+    private Variable _dbContext = null!;
+    private Variable _context = null!;
+    private Variable _cancellation = null!;
+
+    public CommitTenantedDbContextTransaction(Type dbContextType)
+    {
+        _dbContextType = dbContextType;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment(
+            "Commit the EF Core transaction and flush outgoing messages before writing the response (GH-2917)");
+        writer.Write($"await {_dbContext.Usage}.Database.CommitTransactionAsync({_cancellation.Usage}).ConfigureAwait(false);");
+        writer.Write($"await {_context.Usage}.{nameof(MessageContext.FlushOutgoingMessagesAsync)}().ConfigureAwait(false);");
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _dbContext = chain.FindVariable(_dbContextType);
+        yield return _dbContext;
+
+        _context = chain.FindVariable(typeof(MessageContext));
+        yield return _context;
 
         _cancellation = chain.FindVariable(typeof(CancellationToken));
         yield return _cancellation;


### PR DESCRIPTION
Closes #2917.

## Problem

With Wolverine.Http + EF Core's transactional outbox, a transactional endpoint that returns cascading messages would leave an `IHost.TrackActivity().ExecuteAndWaitAsync(...)` session **empty** (no `Sent`/`MessageSucceeded` records) unless the caller added an explicit `WaitForMessageToBeReceivedAt` condition.

**Root cause (deterministic ordering, not a flaky race):** EF Core's Eager transaction middleware `EnrollDbContextInTransaction` wraps the rest of the chain in `try { … }` and emits `efCoreEnvelopeTransaction.CommitAsync()` at the **end** of the try block. `CommitAsync` commits the DB transaction and **then** flushes the outbox (sends the cascading messages). But the response-writing postprocessor (`WriteJsonAsync`) is *inside* that try block, **before** `CommitAsync`. So the generated endpoint wrote the HTTP response → the Alba client received it and `ExecuteAndWaitAsync` saw no in-flight activity and returned → *then* the outbox was flushed. Tracking missed the send. (Marten is unaffected because it flushes via a `SaveChanges` session listener, before the response.)

## Fix

Reorder so the transaction commit + outbox flush run **before** the response is written:

- `EnrollDbContextInTransaction` no longer emits `CommitAsync()` at the end of its wrap — it just begins the transaction and provides the `try/catch` rollback wrapper.
- A new `CommitEfCoreEnvelopeTransaction` postprocessor performs the commit + flush. `EFCorePersistenceFrameProvider` adds it **right after `SaveChanges`**, which is before the response writer Wolverine.Http appends during codegen. The generated try block now reads:

  ```
  try {
      handler;
      SaveChanges;
      commit + flush;     // CommitEfCoreEnvelopeTransaction (was at end of wrap)
      WriteResponse;       // now after commit + flush
  } catch { rollback; throw; }
  ```

This preserves existing guarantees:
- The flush still runs **after** the EF Core commit → does **not** reintroduce the flush-before-commit row-stranding bug (`Bug_efcore_outbox_flush_before_commit` stays green).
- A failed commit now rolls back and **never writes a success response** — strictly more correct than before (previously the client got `200` before the transaction committed). Rollback-after-commit is a no-op because EF Core clears `CurrentTransaction` on commit.

**Scope:** the non-multi-tenant Eager path (`EnrollDbContextInTransaction`). Lightweight mode (standalone `FlushOutgoingMessages`) and message-handler chains are unaffected. The multi-tenant `StartDatabaseTransactionForDbContext` path still has the old ordering — a follow-up commit will extend the same reordering there.

## Validation

- New regression test `issue_2917_trackactivity_transactional_outbox` passes deterministically (no explicit wait condition).
- `Bug_efcore_outbox_flush_before_commit` still passes (no flush-before-commit regression).
- Full **`Wolverine.Http.Tests`: 771 passed, 10 skipped, 0 failed** (EF Core + Marten HTTP).
- `EfCoreTests`, `EfCoreTests.MultiTenancy`, `PersistenceTests` compile clean.

> The SQL Server-backed EF Core **message-handler** suites couldn't be run locally (emulated SQL Server too slow) — relying on CI here. The change is functionally equivalent for handlers (no response writer, so the commit postprocessor remains the last frame).

🤖 Generated with [Claude Code](https://claude.com/claude-code)