### PR TITLE
No message in wolverine_incoming_envelopes table when using aggregate handler

### DIFF
--- a/src/Persistence/MartenTests/Bugs/Bug_aggregate_does_not_publish.cs
+++ b/src/Persistence/MartenTests/Bugs/Bug_aggregate_does_not_publish.cs
@@ -1,0 +1,129 @@
+﻿using IntegrationTests;
+using JasperFx.Resources;
+using Marten;
+using JasperFx.Events.Projections;
+using MartenTests.AggregateHandlerWorkflow;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.RDBMS;
+
+namespace MartenTests.Bugs;
+
+public class Bug_aggregate_does_not_publish : PostgresqlContext, IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
+
+    public async Task InitializeAsync()
+    {
+        await dropSchema();
+        
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                
+                opts.Policies.UseDurableLocalQueues();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(AggregateHandler));
+
+                opts.Services.AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.Projections.Snapshot<LetterAggregate>(SnapshotLifecycle.Async);
+
+                        m.DatabaseSchemaName = "nopublish";
+                        m.DisableNpgsqlLogging = true;
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        theStore = theHost.Services.GetRequiredService<IDocumentStore>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+    
+    private static async Task dropSchema()
+    {
+        using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync("nopublish");
+        await conn.CloseAsync();
+    }
+
+    private async Task<long> PersistedIncomingCount()
+    {
+        await using var session = theStore.QuerySession();
+
+        var command = session.Connection.CreateCommand(
+            $"select count(*) from nopublish.{DatabaseConstants.IncomingTable}");
+
+        var count = await command.ExecuteScalarAsync();
+        return Convert.ToInt64(count);
+    }
+
+    [Fact]
+    public async Task envelope_is_stored()
+    {
+        await theHost.MessageBus()
+            .PublishAsync(new ScheduleSomething(Guid.NewGuid()));
+
+        var count = await PersistedIncomingCount();
+        count.ShouldBe(2); // ScheduleSomething + SomethingWasScheduled
+    }
+
+    [Fact]
+    public async Task envelope_is_not_stored()
+    {
+        await theHost.MessageBus()
+            .PublishAsync(new ScheduleSomethingUsingAggregate(Guid.NewGuid()));
+
+        var count = await PersistedIncomingCount();
+        count.ShouldBe(1); // ScheduleSomething, SomethingWasScheduled is missing
+    }
+}
+
+public record ScheduleSomething(Guid Id);
+
+public record ScheduleSomethingUsingAggregate(Guid Id);
+
+public record SomethingWasScheduled(Guid Id);
+
+public record AggregateCreated(Guid Id);
+
+public sealed partial class Aggregate
+{
+    public static Aggregate Create(AggregateCreated @event)
+    {
+        return new Aggregate();
+    }
+}
+
+public static class AggregateHandler
+{
+    public static SomethingWasScheduled Handle(ScheduleSomething command)
+    {
+        return new SomethingWasScheduled(command.Id);
+    }
+    
+    public static SomethingWasScheduled Handle(ScheduleSomethingUsingAggregate command, [ReadAggregate(Required = false)] LetterAggregate aggregate)
+    {
+        return new SomethingWasScheduled(command.Id);
+    }
+    
+    public static void Handle(SomethingWasScheduled message)
+    {
+    }
+}

--- a/src/Persistence/MartenTests/Bugs/Bug_aggregate_should_still_publish.cs
+++ b/src/Persistence/MartenTests/Bugs/Bug_aggregate_should_still_publish.cs
@@ -14,30 +14,36 @@ using Wolverine.RDBMS;
 
 namespace MartenTests.Bugs;
 
-public class Bug_aggregate_does_not_publish : PostgresqlContext, IAsyncLifetime
+public abstract class Bug_aggregate_should_still_publish : PostgresqlContext, IAsyncLifetime
 {
+    protected abstract string Schema { get; }
+
     private IHost theHost = null!;
+
     private IDocumentStore theStore = null!;
 
     public async Task InitializeAsync()
     {
         await dropSchema();
-        
+
         theHost = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
                 opts.Durability.Mode = DurabilityMode.Solo;
-                
-                opts.Policies.UseDurableLocalQueues();
 
-                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(AggregateHandler));
+                opts.Policies.UseDurableLocalQueues();
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(AggregateHandler))
+                    .IncludeType(typeof(SomeOtherHandler));
 
                 opts.Services.AddMarten(m =>
                     {
                         m.Connection(Servers.PostgresConnectionString);
                         m.Projections.Snapshot<LetterAggregate>(SnapshotLifecycle.Async);
 
-                        m.DatabaseSchemaName = "nopublish";
+                        m.DatabaseSchemaName = Schema;
                         m.DisableNpgsqlLogging = true;
                     })
                     .UseLightweightSessions()
@@ -54,12 +60,12 @@ public class Bug_aggregate_does_not_publish : PostgresqlContext, IAsyncLifetime
         await theHost.StopAsync();
         theHost.Dispose();
     }
-    
-    private static async Task dropSchema()
+
+    private async Task dropSchema()
     {
-        using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
         await conn.OpenAsync();
-        await conn.DropSchemaAsync("nopublish");
+        await conn.DropSchemaAsync(Schema);
         await conn.CloseAsync();
     }
 
@@ -68,30 +74,41 @@ public class Bug_aggregate_does_not_publish : PostgresqlContext, IAsyncLifetime
         await using var session = theStore.QuerySession();
 
         var command = session.Connection.CreateCommand(
-            $"select count(*) from nopublish.{DatabaseConstants.IncomingTable}");
+            $"select count(*) from {Schema}.{DatabaseConstants.IncomingTable}");
 
         var count = await command.ExecuteScalarAsync();
         return Convert.ToInt64(count);
     }
 
-    [Fact]
-    public async Task envelope_is_stored()
+    public class Using_normal_handler : Bug_aggregate_should_still_publish
     {
-        await theHost.MessageBus()
-            .PublishAsync(new ScheduleSomething(Guid.NewGuid()));
+        protected override string Schema => "publish_normal";
+        
+        [Fact]
+        public async Task the_envelope_is_stored()
+        {
+            await theHost.MessageBus()
+                .PublishAsync(new ScheduleSomething(Guid.NewGuid()));
 
-        var count = await PersistedIncomingCount();
-        count.ShouldBe(2); // ScheduleSomething + SomethingWasScheduled
+            var count = await PersistedIncomingCount();
+            count.ShouldBe(2); // ScheduleSomething + SomethingWasScheduled
+        }
     }
 
-    [Fact]
-    public async Task envelope_is_not_stored()
+    public class Using_aggregate_handler : Bug_aggregate_should_still_publish
     {
-        await theHost.MessageBus()
-            .PublishAsync(new ScheduleSomethingUsingAggregate(Guid.NewGuid()));
+        protected override string Schema => "publish_aggregate";
+        
+        [Fact]
+        public async Task envelope_is_not_stored()
+        {
+            await theHost.MessageBus()
+                .PublishAsync(new ScheduleSomethingUsingAggregate(Guid.NewGuid()));
 
-        var count = await PersistedIncomingCount();
-        count.ShouldBe(1); // ScheduleSomething, SomethingWasScheduled is missing
+            var count = await PersistedIncomingCount();
+            count.ShouldBe(1); // ScheduleSomething, SomethingWasScheduled is missing
+            //count.ShouldBe(2);
+        }
     }
 }
 
@@ -101,28 +118,23 @@ public record ScheduleSomethingUsingAggregate(Guid Id);
 
 public record SomethingWasScheduled(Guid Id);
 
-public record AggregateCreated(Guid Id);
-
-public sealed partial class Aggregate
+public static class AggregateHandler
 {
-    public static Aggregate Create(AggregateCreated @event)
+    public static SomethingWasScheduled Handle(
+        ScheduleSomethingUsingAggregate command,
+        [ReadAggregate(Required = false)] LetterAggregate aggregate)
     {
-        return new Aggregate();
+        return new SomethingWasScheduled(command.Id);
     }
 }
 
-public static class AggregateHandler
+public static class SomeOtherHandler
 {
     public static SomethingWasScheduled Handle(ScheduleSomething command)
     {
         return new SomethingWasScheduled(command.Id);
     }
-    
-    public static SomethingWasScheduled Handle(ScheduleSomethingUsingAggregate command, [ReadAggregate(Required = false)] LetterAggregate aggregate)
-    {
-        return new SomethingWasScheduled(command.Id);
-    }
-    
+
     public static void Handle(SomethingWasScheduled message)
     {
     }


### PR DESCRIPTION
I think I found a bug where no message is stored in wolverine_incoming_envelopes when using an aggregate handler using the marten integration. I have reproduced my expectation in a unit test.

My colleague found out that when you put `await documentSession.SaveChangesAsync().ConfigureAwait()` at the end of the generated handler, the message is does actually appear in the table.