### PR TITLE
Add 'wolverine-diagnostics describe-handlers' command + CLI smoke test

### DIFF
--- a/.github/workflows/command-line.yml
+++ b/.github/workflows/command-line.yml
@@ -1,0 +1,71 @@
+name: command-line
+
+# Smoke test for the Wolverine command-line diagnostics surface. Builds the
+# Quickstart sample (which opts into RunJasperFxCommands) and exercises the
+# `wolverine-diagnostics describe-handlers` command end to end: it must discover
+# a known handler and emit the expected DescribeHandlerMatch report, and it must
+# exit non-zero for an unknown type. No database or message broker is required —
+# the command builds the host and compiles the handler graph without starting it.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  config: Release
+
+jobs:
+  describe-handlers-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: wolverine-diagnostics describe-handlers smoke test
+        run: |
+          set -euo pipefail
+
+          echo "::group::Positive case — known handler is discovered"
+          output=$(dotnet run --project src/Samples/Quickstart --framework net9.0 -- \
+            wolverine-diagnostics describe-handlers CreateIssueHandler)
+          echo "$output"
+          echo "$output" | grep -q "Handler discovery report: Quickstart.CreateIssueHandler"
+          echo "$output" | grep -q "Successfully found Quickstart.CreateIssueHandler during scanning."
+          echo "$output" | grep -q "HIT -- Method name is 'Handle'"
+          echo "::endgroup::"
+
+          echo "::group::Fuzzy case — a partial name matches multiple types"
+          fuzzy=$(dotnet run --project src/Samples/Quickstart --framework net9.0 -- \
+            wolverine-diagnostics describe-handlers Create)
+          echo "$fuzzy"
+          count=$(echo "$fuzzy" | grep -c "Handler discovery report:")
+          echo "matched report count = $count"
+          test "$count" -ge 2
+          echo "::endgroup::"
+
+          echo "::group::Negative case — unknown type exits non-zero"
+          if dotnet run --project src/Samples/Quickstart --framework net9.0 -- \
+               wolverine-diagnostics describe-handlers ZzzNoSuchHandler > /dev/null 2>&1; then
+            echo "Expected describe-handlers to exit non-zero for an unknown type"
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          echo "describe-handlers smoke test passed"

--- a/docs/guide/command-line.md
+++ b/docs/guide/command-line.md
@@ -272,6 +272,29 @@ The `--all` output includes:
 - **Listeners** — all configured listening endpoints with name, mode, and parallelism
 - **Senders** — all configured sending endpoints with name, mode, and subscription count
 
+### describe-handlers <Badge type="tip" text="6.0" />
+
+Explain *why* a candidate type is — or is not — discovered as a message handler. This is the command-line
+surface over [`WolverineOptions.DescribeHandlerMatch(Type)`](/guide/diagnostics#troubleshooting-handler-discovery),
+so you no longer have to drop a temporary `Console.WriteLine(...)` into your bootstrapping code.
+
+```bash
+# By handler class name
+dotnet run -- wolverine-diagnostics describe-handlers CreateOrderHandler
+
+# By fully-qualified name
+dotnet run -- wolverine-diagnostics describe-handlers MyApp.Orders.CreateOrderHandler
+```
+
+The argument is matched against the types in your application — exact full name, then exact short name, then
+a fuzzy "contains" match. If the term matches **more than one** type, Wolverine prints a discovery report for
+*each* match. For every matched type the report shows whether its assembly is being scanned, which type-level
+include/exclude rules HIT or MISS, and — for each method — whether it satisfies the handler naming and
+signature conventions.
+
+Like the other diagnostics commands, this builds the host and compiles the handler graph but does **not**
+start it, so no database or message-broker connections are opened.
+
 ## Other Highlights
 
 * See the [code generation support](./codegen)

--- a/docs/guide/diagnostics.md
+++ b/docs/guide/diagnostics.md
@@ -133,6 +133,17 @@ using var host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/HandlerDiscoverySamples.cs#L140-L151' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_describe_handler_match' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+You can get the same report from the command line without editing any code, using the
+[`describe-handlers`](/guide/command-line#describe-handlers) diagnostics command <Badge type="tip" text="6.0" />:
+
+```bash
+dotnet run -- wolverine-diagnostics describe-handlers MyMissingMessageHandler
+```
+
+The type name is fuzzy-matched against the types in your application, so if more than one type matches you
+get a report for each. The command builds the host and compiles the handler graph without starting it, so
+no database or broker connection is required.
+
 ## Troubleshooting Message Routing
 
 Among other information, you can find a preview of how Wolverine will route known message types through the command line

--- a/docs/guide/messaging/subscriptions.md
+++ b/docs/guide/messaging/subscriptions.md
@@ -111,6 +111,17 @@ form for tooling or AI agents. See the [Command Line Diagnostics](/tutorials/com
 tutorial for a guided tour and the [Command Line Integration](/guide/command-line#describe-routing)
 reference for every flag.
 
+If a message has no local handler when you expected one — which leaves it with no local route — the cause is
+usually handler discovery rather than routing. The
+[`describe-handlers`](/guide/command-line#describe-handlers) command <Badge type="tip" text="6.0" /> explains
+why a given type is (or isn't) discovered as a handler:
+
+```bash
+dotnet run -- wolverine-diagnostics describe-handlers CreateOrderHandler
+```
+
+See [Troubleshooting Handler Discovery](/guide/diagnostics#troubleshooting-handler-discovery) for more.
+
 ## Explicit Subscriptions
 
 To route messages to specific endpoints, we can apply static message routing rules by using a routing rule as shown below:

--- a/docs/tutorials/command-line-diagnostics.md
+++ b/docs/tutorials/command-line-diagnostics.md
@@ -114,7 +114,24 @@ is deliberately stable and labeled so it reads well for humans *and* parses clea
 See [Troubleshooting Message Routing](/guide/diagnostics#troubleshooting-message-routing) for the
 programmatic side.
 
-## Step 4: Check Your Infrastructure
+## Step 4: Troubleshoot Handler Discovery
+
+If you expected Wolverine to find a handler but it isn't running, ask Wolverine to explain its discovery
+decision for that type:
+
+```bash
+# By handler class name (also accepts a fully-qualified name or a fuzzy partial match)
+dotnet run -- wolverine-diagnostics describe-handlers CreateOrderHandler
+```
+
+The argument is matched against the types in your application, and if it matches more than one type you get
+a report for *each*. Every report tells you whether the type's assembly is being scanned, which type-level
+include/exclude rules HIT or MISS, and — per method — whether it satisfies the handler naming and signature
+conventions. It's the command-line surface over `WolverineOptions.DescribeHandlerMatch(Type)`, so you don't
+have to drop a temporary `Console.WriteLine(...)` into your bootstrapping code (see
+[Troubleshooting Handler Discovery](/guide/diagnostics#troubleshooting-handler-discovery)).
+
+## Step 5: Check Your Infrastructure
 
 Wolverine's transports and the durable inbox/outbox register self-diagnosing environment checks — can I
 reach the database? the broker? are the IoC registrations valid?
@@ -131,7 +148,7 @@ dotnet run -- resources setup     # also: check, list, teardown, statistics
 
 `resources setup` is a great way to provision a clean environment before a test run.
 
-## Step 5: Inspect and Recover Message Storage
+## Step 6: Inspect and Recover Message Storage
 
 For applications using the durable inbox/outbox, the `storage` command administers the message store:
 
@@ -149,7 +166,7 @@ envelopes (optionally filtered to a single exception type). To purge inbox rows 
 dotnet run -- clear-handled
 ```
 
-## Step 6: Export a Full Snapshot with `capabilities`
+## Step 7: Export a Full Snapshot with `capabilities`
 
 <Badge type="tip" text="5.8" />
 
@@ -180,6 +197,7 @@ dotnet run -- openapi --route "GET /orders/{id}"
 | `codegen write` / `preview` | What code is Wolverine generating? |
 | `wolverine-diagnostics codegen-preview` | …for *one* handler / endpoint / gRPC service |
 | `wolverine-diagnostics describe-routing [--explain] [--json]` | Where — and *why* — does a message route? |
+| `wolverine-diagnostics describe-handlers <TypeName>` | Why is (or isn't) a type discovered as a handler? |
 | `check-env` | Can I connect to my infrastructure? |
 | `resources setup / check / teardown` | Provision or inspect stateful resources |
 | `storage counts / clear / rebuild / release` | Inbox/outbox state and recovery |

--- a/src/Wolverine/Diagnostics/WolverineDiagnosticsCommand.cs
+++ b/src/Wolverine/Diagnostics/WolverineDiagnosticsCommand.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Model;
@@ -17,11 +18,11 @@ namespace Wolverine.Diagnostics;
 
 public class WolverineDiagnosticsInput : NetCoreInput
 {
-    [Description("Diagnostics sub-command to execute. Valid values: codegen-preview, describe-routing")]
+    [Description("Diagnostics sub-command to execute. Valid values: codegen-preview, describe-routing, describe-handlers")]
     public string Action { get; set; } = "codegen-preview";
 
-    [Description("For describe-routing: the message type name to inspect. " +
-                 "Accepts full name, short name, or alias.")]
+    [Description("For describe-routing / describe-handlers: the type name to inspect. " +
+                 "Accepts full name, short name, or a fuzzy match.")]
     public string MessageTypeArg { get; set; } = string.Empty;
 
     [FlagAlias("handler", 'h')]
@@ -76,6 +77,9 @@ public class WolverineDiagnosticsInput : NetCoreInput
 ///         <item>
 ///             <c>describe-routing --all</c> — show complete routing topology
 ///         </item>
+///         <item>
+///             <c>describe-handlers &lt;TypeName&gt;</c> — explain why a candidate type is (or is not) discovered as a message handler
+///         </item>
 ///     </list>
 /// </summary>
 [Description("Wolverine diagnostics tools for inspecting generated code and runtime behavior",
@@ -102,9 +106,12 @@ public class WolverineDiagnosticsCommand : JasperFxAsyncCommand<WolverineDiagnos
             case "describe-routing":
                 return await RunDescribeRoutingAsync(input);
 
+            case "describe-handlers":
+                return await RunDescribeHandlersAsync(input);
+
             default:
                 AnsiConsole.MarkupLine(
-                    $"[red]Unknown sub-command '{input.Action}'. Valid sub-commands: codegen-preview, describe-routing[/]");
+                    $"[red]Unknown sub-command '{input.Action}'. Valid sub-commands: codegen-preview, describe-routing, describe-handlers[/]");
                 return false;
         }
     }
@@ -891,5 +898,206 @@ public class WolverineDiagnosticsCommand : JasperFxAsyncCommand<WolverineDiagnos
         }
 
         return "Transport routing convention";
+    }
+
+    // -------------------------------------------------------------------------
+    // describe-handlers implementation
+    // -------------------------------------------------------------------------
+
+    private static Task<bool> RunDescribeHandlersAsync(WolverineDiagnosticsInput input)
+    {
+        if (input.MessageTypeArg.IsEmpty())
+        {
+            AnsiConsole.MarkupLine("[red]describe-handlers requires a type name argument.[/]");
+            AnsiConsole.MarkupLine("[grey]Usage: wolverine-diagnostics describe-handlers <TypeName>[/]");
+            return Task.FromResult(false);
+        }
+
+        // Set codegen mode BEFORE building the host so Wolverine applies lightweight startup
+        // (transports stubbed, durability disabled — no database or message-broker connections).
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+
+        try
+        {
+            using var host = input.BuildHost();
+
+            var options = host.Services.GetRequiredService<WolverineOptions>();
+
+            // Force HandlerGraph.Compile() to run *without starting the host*. Starting would
+            // require Roslyn (WolverineFx.RuntimeCompilation) for TypeLoadMode.Dynamic apps and
+            // would open transport/persistence connections. Resolving the code file collections
+            // compiles the handler graph, which is what populates the conventional handler-discovery
+            // include/exclude rules that DescribeHandlerMatch reports against.
+            _ = host.Services.GetServices<ICodeFileCollection>().ToArray();
+
+            // Prefer the assemblies Wolverine actually scans (plus the application assembly) so a
+            // fuzzy search returns the user's own types rather than framework internals. Only if
+            // nothing matches there do we broaden to every loaded non-framework assembly — that still
+            // lets DescribeHandlerMatch find (and explain) a handler whose assembly is not scanned.
+            var matches = FindCandidateHandlerTypes(input.MessageTypeArg, CandidateTypes(ScannedAssemblies(options)));
+            if (matches.Length == 0)
+            {
+                matches = FindCandidateHandlerTypes(input.MessageTypeArg,
+                    CandidateTypes(AllLoadedApplicationAssemblies(options)));
+            }
+
+            if (matches.Length == 0)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[red]No type found matching '[bold]{Markup.Escape(input.MessageTypeArg)}[/]'.[/]");
+                AnsiConsole.MarkupLine("[grey]Assemblies searched:[/]");
+                foreach (var name in AllLoadedApplicationAssemblies(options)
+                             .Select(a => a.GetName().Name)
+                             .Where(n => n != null)
+                             .Distinct()
+                             .OrderBy(n => n))
+                {
+                    AnsiConsole.MarkupLine($"  [grey]{Markup.Escape(name!)}[/]");
+                }
+
+                return Task.FromResult(false);
+            }
+
+            // Guard against a pathologically broad fuzzy term dumping dozens of reports.
+            const int maxReports = 25;
+            if (matches.Length > maxReports)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[yellow]'{Markup.Escape(input.MessageTypeArg)}' matched {matches.Length} types. Please be more specific. Matches:[/]");
+                foreach (var t in matches.OrderBy(t => t.FullName))
+                {
+                    AnsiConsole.MarkupLine($"  [yellow]{(t.FullName ?? t.Name).EscapeMarkup()}[/]");
+                }
+
+                return Task.FromResult(false);
+            }
+
+            var first = true;
+            foreach (var type in matches.OrderBy(t => t.FullName))
+            {
+                if (!first)
+                {
+                    AnsiConsole.WriteLine();
+                    AnsiConsole.Write(new Rule());
+                }
+
+                first = false;
+
+                AnsiConsole.MarkupLine(
+                    $"[bold green]Handler discovery report: {type.FullNameInCode().EscapeMarkup()}[/]");
+                AnsiConsole.WriteLine();
+
+                // Print the raw DescribeHandlerMatch output (no markup) so it is copy-pasteable
+                // and identical to WolverineOptions.DescribeHandlerMatch used in code.
+                Console.WriteLine(options.DescribeHandlerMatch(type));
+            }
+
+            return Task.FromResult(true);
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+
+    // The assemblies Wolverine actually scans for handlers, plus the application assembly. This is
+    // the primary search scope so a fuzzy match returns the user's own types.
+    private static IEnumerable<Assembly> ScannedAssemblies(WolverineOptions options)
+    {
+        foreach (var assembly in options.Discovery.Assemblies)
+        {
+            yield return assembly;
+        }
+
+        if (options.ApplicationAssembly != null)
+        {
+            yield return options.ApplicationAssembly;
+        }
+    }
+
+    // The scanned assemblies plus every other non-framework assembly loaded into the app. Used as a
+    // fallback so we can still locate — and have DescribeHandlerMatch explain — a candidate handler
+    // type whose assembly is NOT currently being scanned.
+    private static IEnumerable<Assembly> AllLoadedApplicationAssemblies(WolverineOptions options)
+    {
+        foreach (var assembly in ScannedAssemblies(options))
+        {
+            yield return assembly;
+        }
+
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (!assembly.IsDynamic && IsLikelyApplicationAssembly(assembly))
+            {
+                yield return assembly;
+            }
+        }
+    }
+
+    private static bool IsLikelyApplicationAssembly(Assembly assembly)
+    {
+        var name = assembly.GetName().Name ?? string.Empty;
+        return !name.StartsWith("System", StringComparison.OrdinalIgnoreCase)
+               && !name.StartsWith("Microsoft", StringComparison.OrdinalIgnoreCase)
+               && !name.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase)
+               && !name.Equals("mscorlib", StringComparison.OrdinalIgnoreCase)
+               && !name.StartsWith("Spectre", StringComparison.OrdinalIgnoreCase)
+               && !name.StartsWith("JasperFx", StringComparison.OrdinalIgnoreCase)
+               && !name.StartsWith("Newtonsoft", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Dev-time describe-handlers diagnostics CLI; reflection over loaded assemblies' types runs interactively, never on an AOT-published hot path.")]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Dev-time describe-handlers diagnostics CLI; reflection over loaded assemblies' types runs interactively, never on an AOT-published hot path.")]
+    private static IReadOnlyList<Type> CandidateTypes(IEnumerable<Assembly> assemblies)
+    {
+        return assemblies
+            .Distinct()
+            .SelectMany(SafeGetTypes)
+            // Skip compiler-generated types (async state machines, display classes, etc.) — they
+            // are never what a user means by a handler type name.
+            .Where(t => !t.IsDefined(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute), false))
+            .Distinct()
+            .ToArray();
+    }
+
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Dev-time describe-handlers diagnostics CLI; reflection over loaded assemblies' types runs interactively, never on an AOT-published hot path.")]
+    private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException e)
+        {
+            return e.Types.Where(t => t != null).Select(t => t!);
+        }
+        catch
+        {
+            return Array.Empty<Type>();
+        }
+    }
+
+    internal static Type[] FindCandidateHandlerTypes(string search, IReadOnlyList<Type> candidates)
+    {
+        // 1. Exact full name match
+        var exactFull = candidates
+            .Where(t => string.Equals(t.FullName, search, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (exactFull.Length > 0) return exactFull;
+
+        // 2. Exact short name match
+        var exactShort = candidates
+            .Where(t => string.Equals(t.Name, search, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (exactShort.Length > 0) return exactShort;
+
+        // 3. Fuzzy "contains" match on full or short name (may match several types)
+        return candidates
+            .Where(t => (t.FullName?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false)
+                        || t.Name.Contains(search, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
     }
 }


### PR DESCRIPTION
Follow-up to #2921, which merged the Command Line Diagnostics tutorial but not this commit (the `describe-handlers` command + its CI smoke test + the incremental docs). This re-lands that outstanding work off the current `main`.

## New command: `wolverine-diagnostics describe-handlers <TypeName>`

Runs `WolverineOptions.DescribeHandlerMatch(Type)` from the command line so you can troubleshoot handler discovery without dropping a temporary `Console.WriteLine(...)` into bootstrap:

```bash
dotnet run -- wolverine-diagnostics describe-handlers CreateOrderHandler
```

- Fuzzy-matches the argument against the application's types (exact full name → exact short name → "contains"); if **more than one** type matches, a discovery report is printed for *each*.
- Prefers the **scanned** assemblies (`Discovery.Assemblies` + application assembly) so results are the user's own types; falls back to all loaded non-framework assemblies so a handler in an **un-scanned** assembly is still found — and `DescribeHandlerMatch` then explains that. Compiler-generated types are filtered out.
- **Builds** the host and forces `HandlerGraph.Compile()` (by resolving the `ICodeFileCollection` registrations) **without starting it**. That populates the conventional include/exclude discovery rules the report needs, while opening no DB/broker connections and requiring no Roslyn (works on `TypeLoadMode.Dynamic` apps — `StartAsync` would have fail-fasted there per GH-2876).

## CI smoke test

New `.github/workflows/command-line.yml` builds the Quickstart sample and asserts: known handler is discovered (`HIT -- Method name is 'Handle'`), a fuzzy term returns multiple reports, and an unknown type exits non-zero.

## Docs

- `command-line.md` — new `describe-handlers` reference section.
- `diagnostics.md` — CLI alternative to the `DescribeHandlerMatch` snippet.
- `tutorials/command-line-diagnostics.md` — "Troubleshoot Handler Discovery" step + cheat-sheet row.
- `messaging/subscriptions.md` — note that a missing local route is usually a discovery issue → `describe-handlers`.

## Verification

- `dotnet build wolverine.slnx -c Release` — 0 warnings / 0 errors.
- Local smoke: `CreateIssueHandler` → 1 report; `Create` → 4 reports; `Handler` → the 4 Quickstart handlers (no framework noise); unknown type → exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)