### PR TITLE
Clarify + guard the *AggregateHandler naming convention vs [ReadAggregate] (supersedes #2922)

### DIFF
--- a/docs/guide/durability/marten/event-sourcing.md
+++ b/docs/guide/durability/marten/event-sourcing.md
@@ -402,7 +402,7 @@ like `[Entity]` or `[WriteAggregate]` or `[ReadAggregate]`.
 
 The Marten workflow command handler method signature needs to follow these rules:
 
-* Either explicitly use the `[AggregateHandler]` attribute on the handler method **or use the `AggregateHandler` suffix** on the message handler type to tell Wolverine to opt into the aggregate command workflow.
+* Either explicitly use the `[AggregateHandler]` attribute on the handler method **or use the `AggregateHandler` suffix** on the message handler type to tell Wolverine to opt into the aggregate command workflow. Note that the suffix opts in _by name alone_: a handler type that happens to end in `AggregateHandler` is promoted into this workflow, so its return values are appended to the event stream as events instead of being published as cascading messages. See the warning under [Reading the Latest Version of an Aggregate](#reading-the-latest-version-of-an-aggregate) if that surprises you.
 * The first argument should be the command type, just like any other Wolverine message handler
 * The 2nd argument should be the aggregate -- either the aggregate itself (`Order`) or wrapped
   in the Marten `IEventStream<T>` type (`IEventStream<Order>`). There is an example of that usage below:
@@ -743,6 +743,17 @@ public static class FindLettersHandler
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/read_aggregate_attribute_usage.cs#L81-L105' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_readaggregate_in_messsage_handlers' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+::: warning
+`[ReadAggregate]` only _loads_ the aggregate; on its own it does **not** opt the handler into the
+heavier aggregate event-sourcing workflow. But remember that Wolverine _also_ opts a handler into that
+workflow when its **type name ends with `AggregateHandler`** (see [Handler Method Signatures](#handler-method-signatures)).
+If both are true, the handler's return value is **appended to the aggregate's event stream as an event**
+rather than published as a cascading message — almost never what you want for a read-only handler, and it
+can look like the message simply vanished. Wolverine logs a startup warning when it detects this
+combination. If you intend the return value to be published as a message, rename the handler type so it
+does **not** end in `AggregateHandler`. See [JasperFx/wolverine#2922](https://github.com/JasperFx/wolverine/pull/2922).
+:::
 
 If the aggregate doesn't exist, the HTTP request will stop with a 404 status code.
 The aggregate/stream identity is found with the same rules as the `[Entity]` or `[Aggregate]` attributes:

--- a/src/Persistence/MartenTests/Bugs/Bug_aggregate_should_still_publish.cs
+++ b/src/Persistence/MartenTests/Bugs/Bug_aggregate_should_still_publish.cs
@@ -1,0 +1,220 @@
+using System.Collections.Concurrent;
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Events.Projections;
+using JasperFx.Resources;
+using Marten;
+using MartenTests.AggregateHandlerWorkflow;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests.Bugs;
+
+// Originally reported by JurJean in https://github.com/JasperFx/wolverine/pull/2922: a handler that
+// loads an aggregate with [ReadAggregate] appeared to "lose" its cascading message. The root cause
+// is NOT a bug in the outbox - it is the *AggregateHandler naming convention. A handler whose type
+// name ends with "AggregateHandler" is automatically promoted into Marten's aggregate event-sourcing
+// workflow (MartenAggregateHandlerStrategy), where the return value is appended to the aggregate's
+// event stream rather than published as a cascading message. Rename the handler and the return value
+// is published normally.
+//
+// These tests pin that contract deterministically (the original repro counted the inbox table
+// immediately after PublishAsync, before the async processing had run, which is racy).
+public class Bug_aggregate_should_still_publish : PostgresqlContext, IClassFixture<AggregatePublishContext>
+{
+    private readonly AggregatePublishContext _context;
+
+    public Bug_aggregate_should_still_publish(AggregatePublishContext context)
+    {
+        _context = context;
+    }
+
+    private IHost theHost => _context.Host;
+
+    [Fact]
+    public async Task normal_handler_publishes_its_cascading_message()
+    {
+        var tracked = await theHost
+            .TrackActivity()
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<SomethingWasScheduled>(theHost)
+            .ExecuteAndWaitAsync(_ => theHost.MessageBus().PublishAsync(new ScheduleSomething(Guid.NewGuid())));
+
+        tracked.Received.MessagesOf<SomethingWasScheduled>().Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task read_aggregate_handler_with_safe_name_publishes_its_cascading_message()
+    {
+        // ScheduleReader uses [ReadAggregate] exactly like the original repro, but its type name does
+        // NOT end with "AggregateHandler", so the return value is published as a cascading message.
+        var tracked = await theHost
+            .TrackActivity()
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<SomethingWasScheduled>(theHost)
+            .ExecuteAndWaitAsync(_ => theHost.MessageBus().PublishAsync(new ScheduleViaReader(Guid.NewGuid())));
+
+        tracked.Received.MessagesOf<SomethingWasScheduled>().Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task aggregate_named_handler_captures_the_return_value_as_an_event_not_a_message()
+    {
+        // The original repro's handler was named "AggregateHandler", which opts it into the aggregate
+        // event-sourcing workflow: the return value is appended to the event stream, NOT published. So
+        // no SomethingWasScheduled message is ever produced.
+        var tracked = await theHost
+            .TrackActivity()
+            .Timeout(30.Seconds())
+            .ExecuteAndWaitAsync(_ =>
+                theHost.MessageBus().PublishAsync(new ScheduleSomethingUsingAggregate(Guid.NewGuid())));
+
+        tracked.Received.MessagesOf<ScheduleSomethingUsingAggregate>().Count().ShouldBe(1);
+        tracked.Received.MessagesOf<SomethingWasScheduled>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void warns_when_a_readaggregate_handler_is_promoted_by_the_aggregatehandler_naming_convention()
+    {
+        // GH-2922 guardrail: bootstrapping should have logged a warning for AggregateHandler, which uses
+        // [ReadAggregate] and is auto-promoted into the aggregate workflow purely by its name.
+        _context.Warnings.ShouldContain(w =>
+            w.Contains(typeof(AggregateHandler).FullName!) && w.Contains("AggregateHandler"));
+    }
+}
+
+public class AggregatePublishContext : PostgresqlContext, IAsyncLifetime
+{
+    private const string Schema = "publish_2922";
+
+    public IHost Host { get; private set; } = null!;
+
+    public ConcurrentBag<string> Warnings { get; } = new();
+
+    public async Task InitializeAsync()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync(Schema);
+            await conn.CloseAsync();
+        }
+
+        Host = await Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Policies.UseDurableLocalQueues();
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(AggregateHandler))
+                    .IncludeType(typeof(ScheduleReader))
+                    .IncludeType(typeof(SomeOtherHandler));
+
+                opts.Services.AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.Projections.Snapshot<LetterAggregate>(SnapshotLifecycle.Inline);
+
+                        m.DatabaseSchemaName = Schema;
+                        m.DisableNpgsqlLogging = true;
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                opts.Services.AddResourceSetupOnStartup();
+
+                opts.Services.AddLogging(b => b.AddProvider(new CapturingLoggerProvider(Warnings)));
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await Host.StopAsync();
+        Host.Dispose();
+    }
+}
+
+internal sealed class CapturingLoggerProvider(ConcurrentBag<string> warnings) : ILoggerProvider
+{
+    public ILogger CreateLogger(string categoryName) => new CapturingLogger(warnings);
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class CapturingLogger(ConcurrentBag<string> warnings) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NoopDisposable.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel >= LogLevel.Warning)
+            {
+                warnings.Add(formatter(state, exception));
+            }
+        }
+
+        private sealed class NoopDisposable : IDisposable
+        {
+            public static readonly NoopDisposable Instance = new();
+            public void Dispose() { }
+        }
+    }
+}
+
+public record ScheduleSomething(Guid Id);
+
+public record ScheduleSomethingUsingAggregate(Guid Id);
+
+public record ScheduleViaReader(Guid Id);
+
+public record SomethingWasScheduled(Guid Id);
+
+// Name ends with "AggregateHandler" -> auto-promoted into the Marten aggregate event-sourcing
+// workflow, so the return value is appended to the LetterAggregate stream as an event.
+public static class AggregateHandler
+{
+    public static SomethingWasScheduled Handle(
+        ScheduleSomethingUsingAggregate command,
+        [ReadAggregate(Required = false)] LetterAggregate aggregate)
+    {
+        return new SomethingWasScheduled(command.Id);
+    }
+}
+
+// Same [ReadAggregate] usage, but the type name does not end with "AggregateHandler", so the return
+// value is published as a cascading message.
+public static class ScheduleReader
+{
+    public static SomethingWasScheduled Handle(
+        ScheduleViaReader command,
+        [ReadAggregate(Required = false)] LetterAggregate aggregate)
+    {
+        return new SomethingWasScheduled(command.Id);
+    }
+}
+
+public static class SomeOtherHandler
+{
+    public static SomethingWasScheduled Handle(ScheduleSomething command)
+    {
+        return new SomethingWasScheduled(command.Id);
+    }
+
+    public static void Handle(SomethingWasScheduled message)
+    {
+    }
+}

--- a/src/Persistence/Wolverine.Marten/MartenAggregateHandlerStrategy.cs
+++ b/src/Persistence/Wolverine.Marten/MartenAggregateHandlerStrategy.cs
@@ -1,6 +1,10 @@
+using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Handlers;
@@ -11,6 +15,8 @@ internal class MartenAggregateHandlerStrategy : IHandlerPolicy
 {
     public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
     {
+        ILogger? logger = null;
+
         foreach (var chain in chains.Where(x =>
                      x.Handlers.Any(call => call.HandlerType.Name.EndsWith("AggregateHandler"))))
         {
@@ -21,7 +27,30 @@ internal class MartenAggregateHandlerStrategy : IHandlerPolicy
 
             if (chain.Handlers.SelectMany(x => x.Creates).Any(x => x.VariableType.CanBeCastTo<IStartStream>())) continue;
 
+            // GH-2922: this chain is being promoted into the Marten aggregate event-sourcing workflow
+            // purely because its handler type name ends with "AggregateHandler" (there is no explicit
+            // [AggregateHandler] attribute). In that workflow the handler's return value(s) are appended
+            // to the aggregate's event stream rather than published as cascading messages. If the handler
+            // also declares a [ReadAggregate] parameter (read-only intent), the author very likely meant
+            // the return value to be published as a message, so warn rather than silently turning it into
+            // an event.
+            if (UsesReadAggregate(chain))
+            {
+                logger ??= container.Services.GetService<ILoggerFactory>()?.CreateLogger<MartenAggregateHandlerStrategy>()
+                    ?? NullLogger<MartenAggregateHandlerStrategy>.Instance;
+
+                logger.LogWarning(
+                    "Handler {HandlerType} is being treated as a Marten aggregate handler because its type name ends with \"AggregateHandler\", so its return value is appended to the aggregate's event stream instead of being published as a cascading message. The handler also declares a [ReadAggregate] parameter, which suggests read-only intent. If you meant to publish the return value as a message, rename the handler type so it does not end in \"AggregateHandler\". See https://wolverinefx.net/guide/durability/marten/event-sourcing (GH-2922).",
+                    chain.Handlers.First().HandlerType.FullNameInCode());
+            }
+
             new AggregateHandlerAttribute(ConcurrencyStyle.Optimistic).Modify(chain, rules, container);
         }
+    }
+
+    private static bool UsesReadAggregate(HandlerChain chain)
+    {
+        return chain.Handlers.Any(call =>
+            call.Method.GetParameters().Any(p => p.GetCustomAttribute<ReadAggregateAttribute>() != null));
     }
 }


### PR DESCRIPTION
Supersedes #2922 (retaining @JurJean's co-authorship).

## Investigation

@JurJean reported in #2922 that a `[ReadAggregate]` handler's cascading message never appeared in `wolverine_incoming_envelopes`. **It's not an outbox bug — it's the `*AggregateHandler` naming convention.**

`MartenAggregateHandlerStrategy` auto-promotes any handler whose **type name ends with `AggregateHandler`** into Marten's aggregate event-sourcing workflow:
```csharp
chains.Where(x => x.Handlers.Any(call => call.HandlerType.Name.EndsWith("AggregateHandler")))
    → new AggregateHandlerAttribute().Modify(chain, …)
```
The repro's handler class was literally named `AggregateHandler`, so it was promoted, and in that workflow the **return value is appended to the aggregate's event stream** (`stream.AppendOne(...)`) rather than **published** (`context.EnqueueCascadingAsync(...)`). I confirmed this by dumping the generated code: an identical `[ReadAggregate]` handler with a non-colliding type name generates `EnqueueCascadingAsync`. The `[ReadAggregate]` parameter only loads the aggregate; the **class name** is what triggers event capture.

The original repro test was also racy — it counted the inbox table immediately after `PublishAsync`, before async processing ran (locally that test's "normal=2" case actually failed with 1).

## What this PR does (config/usability sharp edge, not a defect)

1. **Deterministic regression test** (`Bug_aggregate_should_still_publish`, building on @JurJean's repro): uses `TrackActivity` to pin the contract — a normal handler and a `[ReadAggregate]` handler whose name does **not** end in `AggregateHandler` both publish their cascading message; an `AggregateHandler`-named one captures the return as an event instead.
2. **Guardrail** (`MartenAggregateHandlerStrategy`): logs a warning when a chain is promoted into the aggregate workflow purely by the `AggregateHandler` name convention **and** declares a `[ReadAggregate]` parameter — since the return value silently becomes an event. (No behavior change; warning only. The test asserts it's emitted.)
3. **Docs** (`marten/event-sourcing.md`): document that the `AggregateHandler` suffix opts in by name alone, with a warning about the `[ReadAggregate]` + naming-convention interaction.

## Validation
- New tests pass (4/4, deterministic).
- No regressions: `AggregateHandlerWorkflow` suite (66) + `read_aggregate` suite (5) green; `Wolverine.Marten` + `MartenTests` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)