### PR TITLE
Capture message types in the handler manifest + pin customization ordering (GH-2906)

### DIFF
--- a/src/Testing/CoreTests/Configuration/handler_chain_customization_ordering.cs
+++ b/src/Testing/CoreTests/Configuration/handler_chain_customization_ordering.cs
@@ -3,8 +3,10 @@ using JasperFx.CodeGeneration;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Wolverine;
+using Wolverine.Attributes;
 using Wolverine.Configuration;
 using Wolverine.ErrorHandling;
+using Wolverine.Persistence.Sagas;
 using Wolverine.Runtime.Handlers;
 using Wolverine.Tracking;
 using Xunit;
@@ -19,9 +21,10 @@ namespace CoreTests.Configuration;
 // FailureRuleCollection is first-rule-wins — must stay identical.
 //
 // Sources, in the order established here:
-//   1. IHandlerPolicy.Apply              (HandlerGraph.Compile, runs first)
-//   2. ConfigureHandlerForMessage lambdas (HandlerGraph.Compile, after policies)
-//   3. static Configure(HandlerChain)     (applyCustomizations, during codegen, last)
+//   1. IHandlerPolicy.Apply               (HandlerGraph.Compile, eager, runs first)
+//   2. ConfigureHandlerForMessage lambdas (HandlerGraph.Compile, eager, after policies)
+//   3. ModifyHandlerChainAttribute        (applyCustomizations during codegen, HandlerChain.cs:694)
+//   4. static Configure(HandlerChain)     (applyCustomizations during codegen, HandlerChain.cs:705, last)
 //
 // Because chain.Failures matches the FIRST rule that fits, a rule contributed by an earlier
 // source takes precedence over a later one for the same exception.
@@ -70,38 +73,202 @@ public class handler_chain_customization_ordering
             _output.WriteLine(rule.ToString());
         }
 
+        AssertCustomizationOrder(rules);
+    }
+
+    [Fact]
+    public async Task ordering_is_preserved_for_saga_chains()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(OrderingSaga));
+
+                opts.HandlerGraph.ConfigureHandlerForMessage<StartOrderingSaga>(chain =>
+                {
+                    chain.OnException<LambdaAddedException>().Discard();
+                });
+
+                opts.Policies.Add<ChainErrorPolicy>();
+            }).StartAsync();
+
+        var handlers = host.GetRuntime().Handlers;
+        handlers.HandlerFor<StartOrderingSaga>().ShouldNotBeNull();
+
+        var chain = handlers.ChainFor<StartOrderingSaga>();
+        chain.ShouldNotBeNull();
+
+        // Confirm we really exercised the saga emit path, not a plain HandlerChain.
+        chain.ShouldBeOfType<SagaChain>();
+
+        var rules = chain.Failures.ToList();
+        foreach (var rule in rules)
+        {
+            _output.WriteLine(rule.ToString());
+        }
+
+        // SagaChain.DetermineFrames calls applyCustomizations FIRST (SagaChain.cs:245), before
+        // building its saga-specific frames, so the customization ordering is identical to a plain
+        // HandlerChain. GH-2906, Q3: the generated saga emit path must run this same sequence.
+        AssertCustomizationOrder(rules);
+    }
+
+    [Fact]
+    public async Task ordering_is_preserved_for_sticky_endpoint_chains()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Two sticky handlers so the chain splits into per-endpoint child chains
+                // (the split only happens when more than one handler targets the message type).
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(OrangeStickyHandler))
+                    .IncludeType(typeof(PurpleStickyHandler));
+
+                opts.Policies.Add<ChainErrorPolicy>();
+            }).StartAsync();
+
+        var handlers = host.GetRuntime().Handlers;
+
+        var parent = handlers.ChainFor<StickyOrderingMessage>();
+        parent.ShouldNotBeNull();
+
+        // Both sticky handlers are split out into their own per-endpoint child chains; the parent
+        // keeps no default handlers.
+        parent.ByEndpoint.Count.ShouldBe(2);
+        parent.Handlers.ShouldBeEmpty();
+
+        var sticky = parent.ByEndpoint.Single(c => c.Handlers.Single().HandlerType == typeof(OrangeStickyHandler));
+
+        // Q4: the child chain's endpoint is resolved (to a local queue named after the attribute)
+        // by the time the chain is built — the contract behind "emit Uris, resolve post-transport-config".
+        var endpoint = sticky.Endpoints.ShouldHaveSingleItem();
+        endpoint.EndpointName.ShouldBe("orange");
+
+        // Force the child chain to compile so its applyCustomizations (attribute + Configure) runs.
+        handlers.HandlerFor(typeof(StickyOrderingMessage), endpoint).ShouldNotBeNull();
+
+        var rules = sticky.Failures.ToList();
+        foreach (var rule in rules)
+        {
+            _output.WriteLine(rule.ToString());
+        }
+
+        var policyIndex = rules.FindIndex(r => r.Match.Matches(new PolicyAddedException()));
+        var attributeIndex = rules.FindIndex(r => r.Match.Matches(new AttributeAddedException()));
+        var configureIndex = rules.FindIndex(r => r.Match.Matches(new ConfigureAddedException()));
+
+        policyIndex.ShouldBeGreaterThanOrEqualTo(0, "IHandlerPolicy error rule should reach the sticky child chain");
+        attributeIndex.ShouldBeGreaterThanOrEqualTo(0, "ModifyHandlerChainAttribute error rule should reach the sticky child chain");
+        configureIndex.ShouldBeGreaterThanOrEqualTo(0, "static Configure(HandlerChain) error rule should reach the sticky child chain");
+
+        // GH-2906, Q4: generated code must apply customizations to each per-endpoint child chain,
+        // preserving the same relative order: policy -> attribute -> static Configure.
+        policyIndex.ShouldBeLessThan(attributeIndex);
+        attributeIndex.ShouldBeLessThan(configureIndex);
+    }
+
+    // GH-2906 contract (first-rule-wins => earlier source has precedence):
+    //   policy -> ConfigureHandlerForMessage lambda -> ModifyHandlerChainAttribute -> static Configure.
+    // The attribute and Configure both run inside applyCustomizations, but the attribute pass
+    // (HandlerChain.cs:694) precedes the static Configure pass (HandlerChain.cs:705).
+    private static void AssertCustomizationOrder(List<FailureRule> rules)
+    {
         var policyIndex = rules.FindIndex(r => r.Match.Matches(new PolicyAddedException()));
         var lambdaIndex = rules.FindIndex(r => r.Match.Matches(new LambdaAddedException()));
+        var attributeIndex = rules.FindIndex(r => r.Match.Matches(new AttributeAddedException()));
         var configureIndex = rules.FindIndex(r => r.Match.Matches(new ConfigureAddedException()));
 
         policyIndex.ShouldBeGreaterThanOrEqualTo(0, "IHandlerPolicy error rule should be present");
         lambdaIndex.ShouldBeGreaterThanOrEqualTo(0, "ConfigureHandlerForMessage error rule should be present");
+        attributeIndex.ShouldBeGreaterThanOrEqualTo(0, "ModifyHandlerChainAttribute error rule should be present");
         configureIndex.ShouldBeGreaterThanOrEqualTo(0, "static Configure(HandlerChain) error rule should be present");
 
-        // GH-2906 contract: policies first, then per-message lambdas, then the handler type's
-        // static Configure(HandlerChain). First-rule-wins => earlier source has precedence.
         policyIndex.ShouldBeLessThan(lambdaIndex);
-        lambdaIndex.ShouldBeLessThan(configureIndex);
+        lambdaIndex.ShouldBeLessThan(attributeIndex);
+        attributeIndex.ShouldBeLessThan(configureIndex);
     }
 }
 
+[AddAttributeErrorRule]
 public record OrderingMessage;
 
 public class PolicyAddedException : Exception;
 
 public class LambdaAddedException : Exception;
 
+public class AttributeAddedException : Exception;
+
 public class ConfigureAddedException : Exception;
+
+// (3) A ModifyHandlerChainAttribute on the message type. Applied inside applyCustomizations
+// (HandlerChain.cs:694), before the static Configure(HandlerChain) pass (HandlerChain.cs:705).
+public class AddAttributeErrorRuleAttribute : ModifyHandlerChainAttribute
+{
+    public override void Modify(HandlerChain chain, GenerationRules rules)
+    {
+        chain.OnException<AttributeAddedException>().Discard();
+    }
+}
 
 public static class OrderingMessageHandler
 {
-    // (3) Convention-discovered explicit configuration. Runs during codegen, after Compile.
+    // (4) Convention-discovered explicit configuration. Runs during codegen, last.
     public static void Configure(HandlerChain chain)
     {
         chain.OnException<ConfigureAddedException>().Discard();
     }
 
     public static void Handle(OrderingMessage message)
+    {
+    }
+}
+
+// Saga variant — the same four sources applied to a Saga, whose chain is a SagaChain with its
+// own DetermineFrames emit path (which still calls applyCustomizations first; SagaChain.cs:245).
+[AddAttributeErrorRule]
+public record StartOrderingSaga(Guid Id);
+
+public class OrderingSaga : Saga
+{
+    public Guid Id { get; set; }
+
+    public static OrderingSaga Start(StartOrderingSaga command)
+    {
+        return new OrderingSaga { Id = command.Id };
+    }
+
+    // (4) static Configure(HandlerChain) on the saga type.
+    public static void Configure(HandlerChain chain)
+    {
+        chain.OnException<ConfigureAddedException>().Discard();
+    }
+}
+
+// Sticky variant — the handler is bound to a named endpoint, so its chain is split into a
+// per-endpoint child chain (HandlerChain.ByEndpoint) that must receive the same customizations.
+[AddAttributeErrorRule]
+public record StickyOrderingMessage;
+
+[StickyHandler("orange")]
+public static class OrangeStickyHandler
+{
+    // (4) static Configure(HandlerChain) on the sticky handler type.
+    public static void Configure(HandlerChain chain)
+    {
+        chain.OnException<ConfigureAddedException>().Discard();
+    }
+
+    public static void Handle(StickyOrderingMessage message)
+    {
+    }
+}
+
+// Second sticky handler — present only so the chain splits into per-endpoint child chains.
+[StickyHandler("purple")]
+public static class PurpleStickyHandler
+{
+    public static void Handle(StickyOrderingMessage message)
     {
     }
 }

--- a/src/Testing/CoreTests/Configuration/handler_chain_customization_ordering.cs
+++ b/src/Testing/CoreTests/Configuration/handler_chain_customization_ordering.cs
@@ -1,0 +1,120 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+using Wolverine.Runtime.Handlers;
+using Wolverine.Tracking;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreTests.Configuration;
+
+// Characterization tests that PIN the order in which the various HandlerChain customization
+// sources are applied during Compile/codegen. This is the contract the future source-generated
+// handler manifest (GH-2906) must reproduce: the manifest will re-invoke policies + per-message
+// configuration at startup, so the ordering — especially for error handling, where
+// FailureRuleCollection is first-rule-wins — must stay identical.
+//
+// Sources, in the order established here:
+//   1. IHandlerPolicy.Apply              (HandlerGraph.Compile, runs first)
+//   2. ConfigureHandlerForMessage lambdas (HandlerGraph.Compile, after policies)
+//   3. static Configure(HandlerChain)     (applyCustomizations, during codegen, last)
+//
+// Because chain.Failures matches the FIRST rule that fits, a rule contributed by an earlier
+// source takes precedence over a later one for the same exception.
+public class handler_chain_customization_ordering
+{
+    private readonly ITestOutputHelper _output;
+
+    public handler_chain_customization_ordering(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task policies_are_applied_before_explicit_chain_configuration()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(OrderingMessageHandler));
+
+                // (2) per-message explicit config
+                opts.HandlerGraph.ConfigureHandlerForMessage<OrderingMessage>(chain =>
+                {
+                    chain.OnException<LambdaAddedException>().Discard();
+                });
+
+                // (1) handler policy
+                opts.Policies.Add<ChainErrorPolicy>();
+            }).StartAsync();
+
+        var handlers = host.GetRuntime().Handlers;
+
+        // ModifyChainAttribute / static Configure(HandlerChain) are applied during codegen
+        // (HandlerChain.applyCustomizations), which is LAZY — it does not run at host StartAsync,
+        // only when the chain is first compiled. Force that compile so the full, final ordering is
+        // observable. This lazy timing is itself part of what GH-2906's eager generated manifest
+        // must preserve as an equivalent final order.
+        handlers.HandlerFor<OrderingMessage>().ShouldNotBeNull();
+
+        var chain = handlers.ChainFor<OrderingMessage>();
+        chain.ShouldNotBeNull();
+
+        var rules = chain.Failures.ToList();
+        foreach (var rule in rules)
+        {
+            _output.WriteLine(rule.ToString());
+        }
+
+        var policyIndex = rules.FindIndex(r => r.Match.Matches(new PolicyAddedException()));
+        var lambdaIndex = rules.FindIndex(r => r.Match.Matches(new LambdaAddedException()));
+        var configureIndex = rules.FindIndex(r => r.Match.Matches(new ConfigureAddedException()));
+
+        policyIndex.ShouldBeGreaterThanOrEqualTo(0, "IHandlerPolicy error rule should be present");
+        lambdaIndex.ShouldBeGreaterThanOrEqualTo(0, "ConfigureHandlerForMessage error rule should be present");
+        configureIndex.ShouldBeGreaterThanOrEqualTo(0, "static Configure(HandlerChain) error rule should be present");
+
+        // GH-2906 contract: policies first, then per-message lambdas, then the handler type's
+        // static Configure(HandlerChain). First-rule-wins => earlier source has precedence.
+        policyIndex.ShouldBeLessThan(lambdaIndex);
+        lambdaIndex.ShouldBeLessThan(configureIndex);
+    }
+}
+
+public record OrderingMessage;
+
+public class PolicyAddedException : Exception;
+
+public class LambdaAddedException : Exception;
+
+public class ConfigureAddedException : Exception;
+
+public static class OrderingMessageHandler
+{
+    // (3) Convention-discovered explicit configuration. Runs during codegen, after Compile.
+    public static void Configure(HandlerChain chain)
+    {
+        chain.OnException<ConfigureAddedException>().Discard();
+    }
+
+    public static void Handle(OrderingMessage message)
+    {
+    }
+}
+
+// (1) A handler policy that contributes a chain-level error rule, the same way framework
+// policies (e.g. AutoApplyTransactions, MartenAggregateHandlerStrategy) mutate chains.
+public class ChainErrorPolicy : IHandlerPolicy
+{
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        foreach (var chain in chains)
+        {
+            chain.OnException<PolicyAddedException>().Discard();
+        }
+    }
+}

--- a/src/Testing/CoreTests/Configuration/handler_manifest_message_types.cs
+++ b/src/Testing/CoreTests/Configuration/handler_manifest_message_types.cs
@@ -1,0 +1,75 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+// GH-2906: the generated HandlerRegistry manifest also captures the conventional message types
+// (IMessage implementations + [WolverineMessage]) discovered at `codegen write` time, so that
+// message-type discovery — like handler discovery — can skip the assembly scan under
+// TypeLoadMode.Static.
+public class handler_manifest_message_types
+{
+    [Fact]
+    public void generated_handler_registry_captures_handler_and_message_types()
+    {
+        // The conventional message-type scan that feeds the manifest is only performed while actually
+        // generating code (codegen write); BuildFiles is otherwise enumerated during a Static-mode
+        // attach, where scanning would defeat the purpose.
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+        try
+        {
+            using var host = Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    // Only our handler produces a chain; IncludeAssembly puts this test assembly into
+                    // the message-type scan so the orphan [WolverineMessage] below is discovered.
+                    opts.Discovery.DisableConventionalDiscovery()
+                        .IncludeType(typeof(ManifestSampleHandler))
+                        .IncludeAssembly(typeof(OrphanManifestMessage).Assembly);
+                })
+                .Build();
+
+            var collections = host.Services.GetServices<ICodeFileCollection>().ToArray();
+            var builder = new DynamicCodeBuilder(host.Services, collections)
+            {
+                ServiceVariableSource = host.Services.GetService<IServiceVariableSource>()
+            };
+
+            var code = builder.GenerateAllCode();
+
+            // The registry now emits a MessageTypes() accessor alongside HandlerTypes()...
+            code.ShouldContain("public override System.Type[] MessageTypes()");
+
+            // ...capturing a conventional [WolverineMessage] type that has NO handler, so it can only
+            // have come from the message-type scan being folded into the manifest.
+            code.ShouldContain(nameof(OrphanManifestMessage));
+
+            // ...and the handler types are still captured.
+            code.ShouldContain(nameof(ManifestSampleHandler));
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+}
+
+public record ManifestSampleMessage;
+
+public static class ManifestSampleHandler
+{
+    public static void Handle(ManifestSampleMessage message)
+    {
+    }
+}
+
+// A conventional message type with no handler — discovered only by the IMessage/[WolverineMessage] scan.
+[WolverineMessage]
+public record OrphanManifestMessage;

--- a/src/Testing/Wolverine.AotSmoke.Static/Internal/Generated/WolverineHandlers/GeneratedHandlerRegistry.cs
+++ b/src/Testing/Wolverine.AotSmoke.Static/Internal/Generated/WolverineHandlers/GeneratedHandlerRegistry.cs
@@ -14,6 +14,12 @@ namespace Internal.Generated.WolverineHandlers
             return new System.Type[] { typeof(AotSmokeHandler) };
         }
 
+
+        public override System.Type[] MessageTypes()
+        {
+            return System.Array.Empty<System.Type>();
+        }
+
     }
 
     // END: GeneratedHandlerRegistry

--- a/src/Wolverine/Configuration/HandlerDiscovery.cs
+++ b/src/Wolverine/Configuration/HandlerDiscovery.cs
@@ -24,6 +24,10 @@ public sealed partial class HandlerDiscovery
 
     private bool _conventionalDiscoveryDisabled;
 
+    // Set (only) by TryLoadStaticHandlerRegistry from the generated manifest's MessageTypes(); when
+    // non-null, findAllMessages uses it instead of scanning assemblies. See GH-2906.
+    private Type[]? _staticMessageTypes;
+
     public HandlerDiscovery()
     {
         specifyHandlerMethodRules();
@@ -163,8 +167,21 @@ public sealed partial class HandlerDiscovery
             yield return messageType;
         }
 
-        var discovered = _messageQuery.Find(Assemblies);
+        // In TypeLoadMode.Static the conventional message types were captured into the generated
+        // HandlerRegistry at codegen write time (cached by TryLoadStaticHandlerRegistry), so we skip
+        // the IMessage/[WolverineMessage] assembly scan entirely. Falls back to the scan otherwise.
+        var discovered = _staticMessageTypes ?? _messageQuery.Find(Assemblies);
         foreach (var type in discovered) yield return type;
+    }
+
+    // The conventional message types (IMessage implementations + [WolverineMessage]) found by scanning
+    // the discovery assemblies. Used only at `codegen write` time to capture them into the generated
+    // HandlerRegistry; at runtime under TypeLoadMode.Static they are read back from the manifest instead.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Conventional message-type scan executed at `codegen write` time to populate the static manifest; runtime TypeLoadMode.Static reads the captured typeof(...) literals and never calls this. See AOT guide.")]
+    internal Type[] DiscoverConventionalMessageTypes()
+    {
+        return _messageQuery.Find(Assemblies).ToArray();
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026",
@@ -239,6 +256,11 @@ public sealed partial class HandlerDiscovery
 
         var registry = (HandlerRegistry)Activator.CreateInstance(registryType)!;
         handlerTypes = registry.HandlerTypes();
+
+        // Cache the conventional message types captured in the manifest so findAllMessages can skip its
+        // own IMessage/[WolverineMessage] assembly scan (GH-2906). Only set on this Static-mode path,
+        // so a null _staticMessageTypes means "fall back to scanning".
+        _staticMessageTypes = registry.MessageTypes();
         return true;
     }
 

--- a/src/Wolverine/Runtime/Handlers/HandlerGraph.GeneratesCode.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerGraph.GeneratesCode.cs
@@ -37,8 +37,19 @@ public partial class HandlerGraph
             }
         }
 
-        // Pre-generated handler registry for TypeLoadMode.Static cold-start (Wolverine#1577 Tier 1):
-        // capture the discovered handler types so startup can skip the conventional assembly scan.
-        yield return new HandlerRegistryCodeFile(handlerTypes);
+        // Pre-generated handler registry for TypeLoadMode.Static cold-start (Wolverine#1577 Tier 1,
+        // GH-2906): capture the discovered handler types AND the conventional message types so startup
+        // can skip both assembly scans.
+        //
+        // The conventional message-type scan is only performed while actually generating code
+        // (`codegen write`); BuildFiles is also enumerated during TypeLoadMode.Static *attach*, where a
+        // scan here would defeat the purpose. Same WithinCodegenCommand guard as
+        // HandlerGraph.shouldConsumeStaticRegistry. (Handler types come from the already-built chains,
+        // so they never need a scan.)
+        var messageTypes = DynamicCodeBuilder.WithinCodegenCommand
+            ? Discovery.DiscoverConventionalMessageTypes()
+            : [];
+
+        yield return new HandlerRegistryCodeFile(handlerTypes, messageTypes);
     }
 }

--- a/src/Wolverine/Runtime/Handlers/HandlerRegistry.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerRegistry.cs
@@ -27,6 +27,15 @@ public abstract class HandlerRegistry
     ///     normal handler-method selection to exactly these types instead of scanning assemblies.
     /// </summary>
     public abstract Type[] HandlerTypes();
+
+    /// <summary>
+    ///     The conventional message types discovered at <c>codegen write</c> time — the result of
+    ///     the <c>IMessage</c>/<c>[WolverineMessage]</c> assembly scan (see
+    ///     <c>HandlerDiscovery.findAllMessages</c>). Captured so message-type discovery can also skip
+    ///     the assembly scan in <see cref="TypeLoadMode.Static" />. Empty when the application declares
+    ///     no such message types (handler-derived message types are still resolved from the handler graph).
+    /// </summary>
+    public abstract Type[] MessageTypes();
 }
 
 /// <summary>
@@ -38,11 +47,18 @@ public abstract class HandlerRegistry
 internal class HandlerRegistryCodeFile : ICodeFile
 {
     private readonly Type[] _handlerTypes;
+    private readonly Type[] _messageTypes;
     private GeneratedType? _generatedType;
 
-    public HandlerRegistryCodeFile(IEnumerable<Type> handlerTypes)
+    public HandlerRegistryCodeFile(IEnumerable<Type> handlerTypes, IEnumerable<Type> messageTypes)
     {
-        _handlerTypes = handlerTypes
+        _handlerTypes = onlyPublic(handlerTypes);
+        _messageTypes = onlyPublic(messageTypes);
+    }
+
+    private static Type[] onlyPublic(IEnumerable<Type> types)
+    {
+        return types
             .Where(x => x is { IsPublic: true } or { IsNestedPublic: true })
             .Distinct()
             .OrderBy(x => x.FullName, StringComparer.Ordinal)
@@ -57,13 +73,16 @@ internal class HandlerRegistryCodeFile : ICodeFile
     {
         _generatedType = assembly.AddType(HandlerRegistry.GeneratedTypeName, typeof(HandlerRegistry));
 
-        foreach (var type in _handlerTypes)
+        foreach (var type in _handlerTypes.Concat(_messageTypes))
         {
             assembly.ReferenceAssembly(type.Assembly);
         }
 
-        var method = _generatedType.MethodFor(nameof(HandlerRegistry.HandlerTypes));
-        method.Frames.Add(new WriteHandlerTypesFrame(_handlerTypes));
+        _generatedType.MethodFor(nameof(HandlerRegistry.HandlerTypes))
+            .Frames.Add(new WriteTypeArrayFrame(_handlerTypes));
+
+        _generatedType.MethodFor(nameof(HandlerRegistry.MessageTypes))
+            .Frames.Add(new WriteTypeArrayFrame(_messageTypes));
     }
 
     Task<bool> ICodeFile.AttachTypes(GenerationRules rules, Assembly assembly, IServiceProvider? services,
@@ -85,14 +104,15 @@ internal class HandlerRegistryCodeFile : ICodeFile
 }
 
 /// <summary>
-///     Writes the body of <see cref="HandlerRegistry.HandlerTypes" /> as a single
-///     <c>typeof(...)</c> array literal — fully resolved at codegen time, no reflection at runtime.
+///     Writes the body of a <see cref="HandlerRegistry" /> type-array accessor
+///     (<see cref="HandlerRegistry.HandlerTypes" /> / <see cref="HandlerRegistry.MessageTypes" />) as a
+///     single <c>typeof(...)</c> array literal — fully resolved at codegen time, no reflection at runtime.
 /// </summary>
-internal class WriteHandlerTypesFrame : SyncFrame
+internal class WriteTypeArrayFrame : SyncFrame
 {
     private readonly Type[] _types;
 
-    public WriteHandlerTypesFrame(Type[] types)
+    public WriteTypeArrayFrame(Type[] types)
     {
         _types = types;
     }


### PR DESCRIPTION
Closes #2906.

Conventional handler discovery already skips the assembly scan in `TypeLoadMode.Static` via the pre-generated `HandlerRegistry` (handler *types*). This completes #2906 by folding **message-type discovery** into that same manifest, and pins the customization-ordering contract that the future generated config path must preserve.

See the [consolidated design](https://github.com/JasperFx/wolverine/issues/2906#issuecomment-4557318737) for the full rationale (runtime-codegen `ICodeFile` reading the built graph, single manifest in the application assembly, consumed under Static — not a Roslyn source generator).

### Message types in the manifest
- `HandlerRegistry` gains an abstract `MessageTypes()` alongside `HandlerTypes()`; `HandlerRegistryCodeFile` emits both as `typeof(...)` literals (the type-array frame is reused, renamed `WriteHandlerTypesFrame` → `WriteTypeArrayFrame`).
- `HandlerGraph.explodeAllFiles` captures the conventional message types into the manifest, but **only while generating** (`DynamicCodeBuilder.WithinCodegenCommand`) — `BuildFiles` is also enumerated during Static-mode attach, where a scan would defeat the purpose. Handler types still come from the built chains (no scan).
- `HandlerDiscovery.findAllMessages` consumes the manifest's `MessageTypes()` under Static instead of the `IMessage`/`[WolverineMessage]` scan; a null cache falls back to scanning, so non-Static behavior is unchanged.
- The committed AOT-smoke registry fixture is updated with the new `MessageTypes()` override.

### Customization-ordering characterization tests
`handler_chain_customization_ordering` pins the order in which a `HandlerChain`'s error-handling customizations are applied — `IHandlerPolicy` → `ConfigureHandlerForMessage` lambda → `ModifyHandlerChainAttribute` → `static Configure(HandlerChain)` — across plain handler chains, `SagaChain`, and sticky `ByEndpoint` chains. `FailureRuleCollection` is first-rule-wins, so this order *is* the precedence; it's the contract the future generated/re-invoked config path must reproduce.

### Tests
New `handler_manifest_message_types` (asserts a handler-less `[WolverineMessage]` type is captured) + the three ordering tests, all green. Full `wolverine.slnx` build clean (net9.0 + net10.0).
