### PR TITLE
Generate an HTTP endpoint manifest to skip discovery scanning under Static (GH-2925)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/http_endpoint_manifest.cs
+++ b/src/Http/Wolverine.Http.Tests/http_endpoint_manifest.cs
@@ -1,0 +1,45 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.CodeGeneration.Services;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using WolverineWebApi;
+using Xunit;
+
+namespace Wolverine.Http.Tests;
+
+// GH-2925: the generated HttpEndpointRegistry manifest captures the discovered endpoint types at
+// `codegen write` time so that, under TypeLoadMode.Static, HTTP endpoint discovery can skip the
+// HttpChainSource.FindActions ExportedTypes scan (the Wolverine.Http counterpart to GH-2906).
+public class http_endpoint_manifest
+{
+    [Fact]
+    public void generated_endpoint_registry_captures_endpoint_types()
+    {
+        // Same minimal codegen harness as smoke_test_code_generation_of_endpoints_with_no_service_dependencies.
+        // AssemblyGenerator is qualified inline to avoid importing JasperFx.RuntimeCompiler (whose obsolete
+        // InitializeSynchronously extension would collide with the JasperFx.CodeGeneration one used below).
+        var registry = new ServiceCollection();
+        registry.AddSingleton<WolverineHttpOptions>();
+        registry.AddTransient<IServiceVariableSource>(c =>
+            new ServiceCollectionServerVariableSource((ServiceContainer)c.GetRequiredService<IServiceContainer>()));
+        registry.AddSingleton<IServiceCollection>(registry);
+        registry.AddSingleton<IServiceContainer, ServiceContainer>();
+        registry.AddSingleton<IAssemblyGenerator, JasperFx.RuntimeCompiler.AssemblyGenerator>();
+
+        var container = registry.BuildServiceProvider().GetRequiredService<IServiceContainer>();
+        var parent = new HttpGraph(new WolverineOptions { ApplicationAssembly = GetType().Assembly }, container);
+
+        var codeFile = new HttpEndpointRegistryCodeFile([typeof(FakeEndpoint)]);
+
+        // Generate + compile + attach just the registry code file.
+        codeFile.As<ICodeFile>().InitializeSynchronously(parent.Rules, parent, parent.Container.Services);
+
+        codeFile.RegistryType.ShouldNotBeNull();
+
+        var instance = (HttpEndpointRegistry)Activator.CreateInstance(codeFile.RegistryType!)!;
+        instance.EndpointTypes().ShouldContain(typeof(FakeEndpoint));
+    }
+}

--- a/src/Http/Wolverine.Http/HttpChainSource.cs
+++ b/src/Http/Wolverine.Http/HttpChainSource.cs
@@ -35,6 +35,16 @@ internal class HttpChainSource
             .SelectMany(actionsFromType).ToArray();
     }
 
+    // Static-mode counterpart to FindActions(): the endpoint types were already discovered and
+    // captured into the generated HttpEndpointRegistry at codegen write time, so we apply the normal
+    // endpoint-method selection to exactly those types instead of scanning assemblies. See GH-2925.
+    internal MethodCall[] FindActions(IReadOnlyList<Type> endpointTypes)
+    {
+        return endpointTypes
+            .Distinct()
+            .SelectMany(actionsFromType).ToArray();
+    }
+
     private IEnumerable<MethodCall> actionsFromType(Type type)
     {
         return type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.Static)

--- a/src/Http/Wolverine.Http/HttpEndpointRegistry.cs
+++ b/src/Http/Wolverine.Http/HttpEndpointRegistry.cs
@@ -1,0 +1,145 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.Http;
+
+/// <summary>
+///     Base class for the pre-generated HTTP endpoint registry emitted by <c>codegen write</c>
+///     (GH-2925, the Wolverine.Http counterpart to the handler manifest in GH-2906). In
+///     <see cref="TypeLoadMode.Static" />, Wolverine.Http consumes the generated subclass to skip the
+///     <see cref="HttpChainSource.FindActions()" /> assembly scan that endpoint discovery would
+///     otherwise perform.
+/// </summary>
+public abstract class HttpEndpointRegistry
+{
+    /// <summary>
+    ///     The C# identifier of the generated subclass. Lives under
+    ///     <c>Internal.Generated.WolverineHandlers</c> after <c>codegen write</c>.
+    /// </summary>
+    public const string GeneratedTypeName = "GeneratedHttpEndpointRegistry";
+
+    /// <summary>
+    ///     The endpoint-declaring types discovered at <c>codegen write</c> time. Wolverine.Http applies
+    ///     its normal endpoint-method selection to exactly these types instead of scanning assemblies.
+    /// </summary>
+    public abstract Type[] EndpointTypes();
+
+    // Locates the pre-generated HttpEndpointRegistry subclass in the application assembly and returns
+    // its captured endpoint types. The single-assembly ExportedTypes walk is far cheaper than endpoint
+    // discovery's multi-assembly scan + convention filtering.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification =
+            "ExportedTypes walk over the application assembly to find the codegen-emitted HttpEndpointRegistry; the type is rooted by construction. See AOT guide.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
+        Justification =
+            "Activator.CreateInstance over the generated HttpEndpointRegistry subclass; the type carries its codegen-emitted public parameterless constructor. See AOT guide.")]
+    internal static bool TryLoad(Assembly? applicationAssembly, out IReadOnlyList<Type> endpointTypes)
+    {
+        endpointTypes = Array.Empty<Type>();
+
+        if (applicationAssembly == null)
+        {
+            return false;
+        }
+
+        var registryType = applicationAssembly.ExportedTypes.FirstOrDefault(t =>
+            t is { IsClass: true, IsAbstract: false } && typeof(HttpEndpointRegistry).IsAssignableFrom(t));
+
+        if (registryType == null)
+        {
+            return false;
+        }
+
+        var registry = (HttpEndpointRegistry)Activator.CreateInstance(registryType)!;
+        endpointTypes = registry.EndpointTypes();
+        return true;
+    }
+}
+
+/// <summary>
+///     <see cref="ICodeFile" /> that emits the <see cref="HttpEndpointRegistry.GeneratedTypeName" />
+///     subclass of <see cref="HttpEndpointRegistry" /> during <c>codegen write</c>, capturing the
+///     discovered endpoint types as a compile-time <c>typeof(...)</c> array so no reflection-based
+///     assembly scan is needed in <see cref="TypeLoadMode.Static" />.
+/// </summary>
+internal class HttpEndpointRegistryCodeFile : ICodeFile
+{
+    private readonly Type[] _endpointTypes;
+    private GeneratedType? _generatedType;
+
+    public HttpEndpointRegistryCodeFile(IEnumerable<Type> endpointTypes)
+    {
+        _endpointTypes = endpointTypes
+            .Where(x => x is { IsPublic: true } or { IsNestedPublic: true })
+            .Distinct()
+            .OrderBy(x => x.FullName, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    public Type? RegistryType { get; private set; }
+
+    string ICodeFile.FileName => HttpEndpointRegistry.GeneratedTypeName;
+
+    void ICodeFile.AssembleTypes(GeneratedAssembly assembly)
+    {
+        _generatedType = assembly.AddType(HttpEndpointRegistry.GeneratedTypeName, typeof(HttpEndpointRegistry));
+
+        foreach (var type in _endpointTypes)
+        {
+            assembly.ReferenceAssembly(type.Assembly);
+        }
+
+        _generatedType.MethodFor(nameof(HttpEndpointRegistry.EndpointTypes))
+            .Frames.Add(new WriteEndpointTypesFrame(_endpointTypes));
+    }
+
+    Task<bool> ICodeFile.AttachTypes(GenerationRules rules, Assembly assembly, IServiceProvider? services,
+        string containingNamespace)
+    {
+        var found = this.As<ICodeFile>().AttachTypesSynchronously(rules, assembly, services, containingNamespace);
+        return Task.FromResult(found);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification =
+            "ExportedTypes walk over the generated assembly to attach the generated registry type; the type is known by construction at codegen time. See AOT guide.")]
+    bool ICodeFile.AttachTypesSynchronously(GenerationRules rules, Assembly assembly, IServiceProvider? services,
+        string containingNamespace)
+    {
+        RegistryType = assembly.ExportedTypes.FirstOrDefault(x => x.Name == HttpEndpointRegistry.GeneratedTypeName);
+        return RegistryType != null;
+    }
+}
+
+/// <summary>
+///     Writes the body of <see cref="HttpEndpointRegistry.EndpointTypes" /> as a single
+///     <c>typeof(...)</c> array literal — fully resolved at codegen time, no reflection at runtime.
+/// </summary>
+internal class WriteEndpointTypesFrame : SyncFrame
+{
+    private readonly Type[] _types;
+
+    public WriteEndpointTypesFrame(Type[] types)
+    {
+        _types = types;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_types.Length == 0)
+        {
+            writer.Write("return System.Array.Empty<System.Type>();");
+        }
+        else
+        {
+            var literals = string.Join(", ", _types.Select(t => $"typeof({t.FullNameInCode()})"));
+            writer.Write($"return new System.Type[] {{ {literals} }};");
+        }
+
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -74,7 +74,16 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
 
     public IReadOnlyList<ICodeFile> BuildFiles()
     {
-        return _chains;
+        // Pre-generated endpoint registry for TypeLoadMode.Static cold-start (GH-2925, the Wolverine.Http
+        // counterpart to the GH-2906 handler manifest): capture the discovered endpoint types so startup
+        // can skip the HttpChainSource.FindActions ExportedTypes scan. The types come from the already-built
+        // chains (chain.EndpointType), so no scan is needed to produce the manifest.
+        var files = new List<ICodeFile>(_chains)
+        {
+            new HttpEndpointRegistryCodeFile(_chains.Select(x => x.EndpointType))
+        };
+
+        return files;
     }
 
     public string ChildNamespace => "WolverineHandlers";
@@ -104,7 +113,23 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
         var source = new HttpChainSource(_options.Assemblies);
         var logger = Container.GetInstance<ILogger<HttpGraph>>();
 
-        var calls = source.FindActions();
+        // Cold-start fast path (GH-2925): in TypeLoadMode.Static, consume the pre-generated
+        // HttpEndpointRegistry instead of scanning assemblies. Never applies during `codegen write`
+        // itself — that must run a fresh scan to regenerate the registry accurately.
+        MethodCall[] calls;
+        if (!DynamicCodeBuilder.WithinCodegenCommand && Rules.TypeLoadMode == TypeLoadMode.Static &&
+            HttpEndpointRegistry.TryLoad(_options.ApplicationAssembly, out var endpointTypes))
+        {
+            logger.LogInformation(
+                "Using pre-generated Wolverine HTTP endpoint registry ({Count} endpoint types); skipping assembly scan",
+                endpointTypes.Count);
+            calls = source.FindActions(endpointTypes);
+        }
+        else
+        {
+            calls = source.FindActions();
+        }
+
         logger.LogInformation("Found {Count} Wolverine HTTP endpoints in assemblies {Assemblies}", calls.Length,
             _options.Assemblies.Select(x => x.GetName().Name!).Join(", "));
         if (calls.Length == 0)


### PR DESCRIPTION
Closes #2925. Wolverine.Http counterpart to the GH-2906 handler manifest.

`HttpGraph` always scanned `ExportedTypes` (`HttpChainSource.FindActions`) to discover endpoints, even in `TypeLoadMode.Static`. This generates an endpoint manifest at `codegen write` time and consumes it under Static to skip that scan.

- New `HttpEndpointRegistry` (+ `HttpEndpointRegistryCodeFile`): an `ICodeFile` that emits the discovered endpoint types as `typeof(...)` literals. The types come from the already-built chains (`HttpChain.EndpointType`), so no scan is needed to produce the manifest; `HttpGraph.BuildFiles` yields it alongside the chains.
- `HttpChainSource` gains a `FindActions(IReadOnlyList<Type>)` overload that applies the normal endpoint-method selection to the manifest types instead of scanning.
- `HttpGraph.DiscoverEndpoints` consumes the registry under `TypeLoadMode.Static` (and not `WithinCodegenCommand`, so `codegen write` still rescans fresh), falling back to the assembly scan otherwise.

Test compiles the registry code file and verifies `EndpointTypes()` captures the endpoint type; the integration smoke test confirms the full app still boots with the registry added to `BuildFiles`. Same approach as #2906; parent design at #2906.
