### PR TITLE
Route remaining ad-hoc discovery scans through JasperFx TypeQuery (GH-2909)

### DIFF
--- a/src/Http/Wolverine.Http/HttpChainSource.cs
+++ b/src/Http/Wolverine.Http/HttpChainSource.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.Core.Reflection;
+using JasperFx.Core.TypeScanning;
 using Wolverine.Attributes;
 
 namespace Wolverine.Http;
@@ -24,13 +26,20 @@ internal class HttpChainSource
         _typeFilters.Excludes += type => type.HasAttribute<WolverineIgnoreAttribute>();
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification =
+            "Endpoint discovery scan routed through JasperFx TypeQuery — the single annotated scanning entry point (GH-2909). AOT/TypeLoadMode.Static consumers use the pre-generated HttpEndpointRegistry (the FindActions(types) overload) and never reach this scan. See GH-2925.")]
     internal MethodCall[] FindActions()
     {
-        var discovered = _assemblies.SelectMany(x => x.ExportedTypes)
-            .Where(x => _typeFilters.Matches(x))
-            .Where(x => x.IsPublic && x.GetGenericArguments().Length == 0);
+        // Route the endpoint type scan through JasperFx's central TypeQuery (GH-2909) rather than an
+        // ad-hoc Assembly.ExportedTypes walk; the endpoint-specific include/exclude rules stay in
+        // _typeFilters, so discovery semantics are unchanged. TypeClassification.All keeps every
+        // non-trimmed type (e.g. static endpoint classes) that the previous scan considered.
+        var query = new TypeQuery(TypeClassification.All);
+        query.Includes.WithCondition("Wolverine HTTP endpoint type",
+            x => _typeFilters.Matches(x) && x.IsPublic && x.GetGenericArguments().Length == 0);
 
-        return discovered
+        return query.Find(_assemblies)
             .Distinct()
             .SelectMany(actionsFromType).ToArray();
     }

--- a/src/Testing/CoreTests/Runtime/Serialization/forwarder_discovery_scan.cs
+++ b/src/Testing/CoreTests/Runtime/Serialization/forwarder_discovery_scan.cs
@@ -1,0 +1,22 @@
+using CoreTests.Transports.Tcp;
+using Shouldly;
+using Wolverine.Runtime.Serialization;
+using Xunit;
+
+namespace CoreTests.Runtime.Serialization;
+
+// GH-2909: Forwarders.FindForwards now routes its scan through JasperFx's central TypeQuery instead
+// of an ad-hoc Assembly.ExportedTypes walk. This pins that it still discovers IForwardsTo<>
+// implementations (OriginalMessage : IForwardsTo<NewMessage> lives in this test assembly).
+public class forwarder_discovery_scan
+{
+    [Fact]
+    public void find_forwards_still_discovers_IForwardsTo_implementations()
+    {
+        var forwarders = new Forwarders();
+        forwarders.FindForwards(typeof(OriginalMessage).Assembly);
+
+        forwarders.Relationships.ContainsKey(typeof(OriginalMessage)).ShouldBeTrue();
+        forwarders.Relationships[typeof(OriginalMessage)].ShouldBe(typeof(NewMessage));
+    }
+}

--- a/src/Wolverine/Runtime/Serialization/Forwarders.cs
+++ b/src/Wolverine/Runtime/Serialization/Forwarders.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.Core.Reflection;
+using JasperFx.Core.TypeScanning;
 
 namespace Wolverine.Runtime.Serialization;
 
@@ -26,7 +27,12 @@ internal class Forwarders
         "have the forwards baked into pre-generated code and don't reach this path.")]
     public void FindForwards(Assembly assembly)
     {
-        var candidates = assembly.ExportedTypes.Where(x => x.IsConcrete() && !x.IsOpenGeneric());
-        foreach (var type in candidates.Where(t => t.Closes(typeof(IForwardsTo<>)))) Add(type);
+        // Route the scan through JasperFx's central TypeQuery (GH-2909) instead of an ad-hoc
+        // Assembly.ExportedTypes walk. Concretes|Closed reproduces the previous
+        // IsConcrete() && !IsOpenGeneric() candidate filter; the IForwardsTo<> closure check is unchanged.
+        var query = new TypeQuery(TypeClassification.Concretes | TypeClassification.Closed);
+        query.Includes.WithCondition("Closes IForwardsTo<>", t => t.Closes(typeof(IForwardsTo<>)));
+
+        foreach (var type in query.Find([assembly])) Add(type);
     }
 }


### PR DESCRIPTION
Part of #2909 (route remaining runtime scanning through JasperFx's central helpers).

## Audit

| Site | Kind | Through JasperFx? | Owner |
|------|------|-------------------|-------|
| `HandlerDiscovery` `HandlerQuery`/`_messageQuery.Find` | handler+message discovery | ✅ already `TypeQuery` | #2906 (merged) |
| **`HttpChainSource.FindActions`** | HTTP endpoint discovery | ❌ → ✅ **this PR** | unowned |
| **`Forwarders.FindForwards`** | forwarder discovery | ❌ → ✅ **this PR** | unowned |
| `GrpcGraph.Find*` / `WolverineGrpcExtensions` | gRPC service discovery | ❌ | #2907 (open) |
| `…ExportedTypes.First(x.Name==TypeName)` (Handler/Http/Grpc) | generated-type *attachment* by name | n/a | #2908 (open) |
| `DiscoverHandlerModules` `AppDomain…GetAssemblies` | handler-module assembly enum | partial | #2905 (open) |
| `WolverineDiagnosticsCommand` / `OpenApiDocumentProvider` | CLI diagnostics tooling | n/a | not a production discovery path |

The primary discovery surface (handler/message) already routes through JasperFx `TypeQuery`. gRPC discovery (#2907), generated-type attachment (#2908), and the handler-module scan (#2905) are each tracked by their own open issues — routing them there avoids duplicating that work. That left **two unowned, ad-hoc production discovery scans**, which this PR routes through `TypeQuery` so the `ExportedTypes` enumeration + trim annotation live in one audited place.

## Changes
- **`HttpChainSource.FindActions`** — enumerate via `TypeQuery(All).Find(...)` instead of a raw `Assembly.ExportedTypes` walk. The endpoint include/exclude rules stay in `_typeFilters`, so discovery semantics are unchanged; `TypeClassification.All` still includes the static endpoint classes the previous scan considered.
- **`Forwarders.FindForwards`** — `TypeQuery(Concretes | Closed)` reproduces the prior `IsConcrete() && !IsOpenGeneric()` candidate filter; the `IForwardsTo<>` closure check is unchanged.

Both keep their existing trim annotations (`TypeQuery.Find` itself carries `[RequiresUnreferencedCode]`, the centralized entry point this issue is about).

## Tests
New `forwarder_discovery_scan` (the existing forwarder test used explicit registration per #2757). HTTP endpoint discovery is covered by the existing endpoint smoke tests (full app boots through the rerouted scan). Full `wolverine.slnx` build clean (net9.0 + net10.0).

Leaving #2909 open since the gRPC/attachment/module scans are still tracked by #2907/#2908/#2905.
