### PR TITLE
Manifest the fourth gRPC discovery mode (direct-mapped services) — completes GH-2907

### DIFF
--- a/src/Wolverine.Grpc.Tests/grpc_direct_mapped_manifest.cs
+++ b/src/Wolverine.Grpc.Tests/grpc_direct_mapped_manifest.cs
@@ -1,0 +1,52 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.CodeGeneration.Services;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests;
+
+// GH-2907: the fourth gRPC discovery mode — direct-mapped hand-written services (mapped without a
+// generated wrapper by MapWolverineGrpcServices) — is now captured in the GrpcServiceRegistry manifest.
+// This compiles the registry code file and verifies the new DirectMappedServiceTypes() accessor
+// round-trips the captured types (emit -> compile -> read).
+public class grpc_direct_mapped_manifest
+{
+    [Fact]
+    public void registry_round_trips_direct_mapped_service_types()
+    {
+        // Same minimal codegen harness as the HTTP manifest test; AssemblyGenerator is qualified inline
+        // to avoid importing JasperFx.RuntimeCompiler (whose obsolete InitializeSynchronously extension
+        // would collide with the JasperFx.CodeGeneration one used below).
+        var registry = new ServiceCollection();
+        registry.AddTransient<IServiceVariableSource>(c =>
+            new ServiceCollectionServerVariableSource((ServiceContainer)c.GetRequiredService<IServiceContainer>()));
+        registry.AddSingleton<IServiceCollection>(registry);
+        registry.AddSingleton<IServiceContainer, ServiceContainer>();
+        registry.AddSingleton<IAssemblyGenerator, JasperFx.RuntimeCompiler.AssemblyGenerator>();
+
+        var container = registry.BuildServiceProvider().GetRequiredService<IServiceContainer>();
+        var parent = new GrpcGraph(new WolverineOptions { ApplicationAssembly = GetType().Assembly }, container);
+
+        // Only the direct-mapped slot is populated.
+        var codeFile = new GrpcServiceRegistryCodeFile([], [], [], [typeof(SampleManifestService)]);
+
+        codeFile.As<ICodeFile>().InitializeSynchronously(parent.Rules, parent, parent.Container.Services);
+
+        codeFile.RegistryType.ShouldNotBeNull();
+
+        var instance = (GrpcServiceRegistry)Activator.CreateInstance(codeFile.RegistryType!)!;
+
+        instance.DirectMappedServiceTypes().ShouldBe([typeof(SampleManifestService)]);
+        instance.ProtoFirstStubTypes().ShouldBeEmpty();
+        instance.CodeFirstContractTypes().ShouldBeEmpty();
+        instance.HandWrittenServiceTypes().ShouldBeEmpty();
+    }
+}
+
+// Plain type used only as a manifest payload — deliberately NOT named *GrpcService and not attributed,
+// so it is never picked up by gRPC service discovery in other tests.
+public class SampleManifestService;

--- a/src/Wolverine.Grpc.Tests/grpc_service_manifest.cs
+++ b/src/Wolverine.Grpc.Tests/grpc_service_manifest.cs
@@ -2,9 +2,11 @@ using GreeterProtoFirstGrpc.Server;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
+using Wolverine.Runtime;
 using Xunit;
 
 namespace Wolverine.Grpc.Tests;
@@ -46,13 +48,25 @@ public class grpc_service_manifest
             registryFile.AssembleTypes(generatedAssembly);
             var code = generatedAssembly.GenerateCode(serviceVariableSource);
 
-            // All three discovery flavors get their own accessor...
+            // All four discovery flavors get their own accessor (GH-2907 adds direct-mapped)...
             code.ShouldContain("ProtoFirstStubTypes()");
             code.ShouldContain("CodeFirstContractTypes()");
             code.ShouldContain("HandWrittenServiceTypes()");
+            code.ShouldContain("DirectMappedServiceTypes()");
 
             // ...and the discovered proto-first stub type is captured.
             code.ShouldContain(nameof(GreeterGrpcService));
+
+            // Satellite parity (GH-2907): every direct-mapped service the live map-time scan would find
+            // across the registered assemblies — including the referenced GreeterProtoFirstGrpc.Server
+            // satellite — is captured in the manifest, so MapWolverineGrpcServices can skip its scan
+            // under TypeLoadMode.Static.
+            var assemblies = ((WolverineRuntime)host.Services.GetRequiredService<IWolverineRuntime>())
+                .Options.Assemblies;
+            foreach (var type in WolverineGrpcExtensions.FindGrpcServiceTypes(assemblies, graph))
+            {
+                code.ShouldContain($"typeof({type.FullNameInCode()})");
+            }
         }
         finally
         {

--- a/src/Wolverine.Grpc/GrpcGraph.cs
+++ b/src/Wolverine.Grpc/GrpcGraph.cs
@@ -49,13 +49,21 @@ public class GrpcGraph : ICodeFileCollectionWithServices, IDescribeMyself
 
     public IReadOnlyList<ICodeFile> BuildFiles()
     {
-        // GH-2926: capture the discovered service types (across all three discovery flavors) so startup
-        // can skip the GetExportedTypes scans under TypeLoadMode.Static. The types come from the
-        // already-built chains, so no scan is needed to produce the manifest.
+        // GH-2926/GH-2907: capture the discovered service types (across all four discovery flavors) so
+        // startup can skip the GetExportedTypes scans under TypeLoadMode.Static. The first three come
+        // from the already-built chains (no scan). Direct-mapped services receive no chain, so — like
+        // the conventional message types in the handler manifest — they require a scan, performed only
+        // while actually generating code (BuildFiles is also enumerated during a Static-mode attach,
+        // where a scan would defeat the purpose).
+        var directMapped = DynamicCodeBuilder.WithinCodegenCommand
+            ? WolverineGrpcExtensions.FindGrpcServiceTypes(_options.Assemblies, this)
+            : [];
+
         var registry = new GrpcServiceRegistryCodeFile(
             _chains.Select(x => x.StubType),
             _codeFirstChains.Select(x => x.ServiceContractType),
-            _handWrittenChains.Select(x => x.ServiceClassType));
+            _handWrittenChains.Select(x => x.ServiceClassType),
+            directMapped);
 
         return [.._chains, .._codeFirstChains, .._handWrittenChains, registry];
     }

--- a/src/Wolverine.Grpc/GrpcServiceRegistry.cs
+++ b/src/Wolverine.Grpc/GrpcServiceRegistry.cs
@@ -31,6 +31,15 @@ public abstract class GrpcServiceRegistry
     /// <summary>Hand-written service class types discovered at <c>codegen write</c> time.</summary>
     public abstract Type[] HandWrittenServiceTypes();
 
+    /// <summary>
+    ///     Direct-mapped hand-written service class types discovered at <c>codegen write</c> time — the
+    ///     concrete <c>*GrpcService</c>/<c>[WolverineGrpcService]</c> classes that receive no generated
+    ///     wrapper and are mapped directly by <c>MapWolverineGrpcServices()</c> (see
+    ///     <c>WolverineGrpcExtensions.FindGrpcServiceTypes</c>). Captured so that map-time discovery can
+    ///     skip its assembly scan too.
+    /// </summary>
+    public abstract Type[] DirectMappedServiceTypes();
+
     // Locates the pre-generated GrpcServiceRegistry subclass in the application assembly. The
     // single-assembly ExportedTypes walk is far cheaper than service discovery's multi-assembly scans.
     [UnconditionalSuppressMessage("Trimming", "IL2026",
@@ -72,14 +81,17 @@ internal class GrpcServiceRegistryCodeFile : ICodeFile
     private readonly Type[] _protoFirstStubTypes;
     private readonly Type[] _codeFirstContractTypes;
     private readonly Type[] _handWrittenServiceTypes;
+    private readonly Type[] _directMappedServiceTypes;
     private GeneratedType? _generatedType;
 
     public GrpcServiceRegistryCodeFile(IEnumerable<Type> protoFirstStubTypes,
-        IEnumerable<Type> codeFirstContractTypes, IEnumerable<Type> handWrittenServiceTypes)
+        IEnumerable<Type> codeFirstContractTypes, IEnumerable<Type> handWrittenServiceTypes,
+        IEnumerable<Type> directMappedServiceTypes)
     {
         _protoFirstStubTypes = onlyPublic(protoFirstStubTypes);
         _codeFirstContractTypes = onlyPublic(codeFirstContractTypes);
         _handWrittenServiceTypes = onlyPublic(handWrittenServiceTypes);
+        _directMappedServiceTypes = onlyPublic(directMappedServiceTypes);
     }
 
     private static Type[] onlyPublic(IEnumerable<Type> types)
@@ -99,7 +111,8 @@ internal class GrpcServiceRegistryCodeFile : ICodeFile
     {
         _generatedType = assembly.AddType(GrpcServiceRegistry.GeneratedTypeName, typeof(GrpcServiceRegistry));
 
-        foreach (var type in _protoFirstStubTypes.Concat(_codeFirstContractTypes).Concat(_handWrittenServiceTypes))
+        foreach (var type in _protoFirstStubTypes.Concat(_codeFirstContractTypes)
+                     .Concat(_handWrittenServiceTypes).Concat(_directMappedServiceTypes))
         {
             assembly.ReferenceAssembly(type.Assembly);
         }
@@ -112,6 +125,9 @@ internal class GrpcServiceRegistryCodeFile : ICodeFile
 
         _generatedType.MethodFor(nameof(GrpcServiceRegistry.HandWrittenServiceTypes))
             .Frames.Add(new WriteServiceTypesFrame(_handWrittenServiceTypes));
+
+        _generatedType.MethodFor(nameof(GrpcServiceRegistry.DirectMappedServiceTypes))
+            .Frames.Add(new WriteServiceTypesFrame(_directMappedServiceTypes));
     }
 
     Task<bool> ICodeFile.AttachTypes(GenerationRules rules, Assembly assembly, IServiceProvider? services,

--- a/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
@@ -133,8 +133,9 @@ public static class WolverineGrpcExtensions
         }
 
         // Map hand-written classes that have NO generated wrapper directly (i.e. those not
-        // claimed by a HandWrittenGrpcServiceChain in the graph).
-        foreach (var type in FindDirectMappedServiceTypes(assemblies, graph))
+        // claimed by a HandWrittenGrpcServiceChain in the graph). Under TypeLoadMode.Static this reads
+        // the pre-generated manifest instead of scanning assemblies (GH-2907).
+        foreach (var type in ResolveDirectMappedServiceTypes(runtime, assemblies, graph))
         {
             MapGrpcServiceMethod.MakeGenericMethod(type).Invoke(null, [endpoints]);
         }
@@ -225,6 +226,23 @@ public static class WolverineGrpcExtensions
     public static IEnumerable<Type> FindGrpcServiceTypes(IEnumerable<Assembly> assemblies,
         GrpcGraph? graph = null)
     {
+        return FindDirectMappedServiceTypes(assemblies, graph);
+    }
+
+    // Cold-start fast path (GH-2907): in TypeLoadMode.Static, read the direct-mapped service types from
+    // the pre-generated GrpcServiceRegistry instead of scanning assemblies. The manifest already excludes
+    // wrapper-claimed types (it was captured via FindGrpcServiceTypes at codegen write time). Never
+    // applies during `codegen write` itself — that must run a fresh scan to regenerate the registry.
+    private static IEnumerable<Type> ResolveDirectMappedServiceTypes(WolverineRuntime runtime,
+        IEnumerable<Assembly> assemblies, GrpcGraph? graph)
+    {
+        if (!DynamicCodeBuilder.WithinCodegenCommand &&
+            runtime.Options.CodeGeneration.TypeLoadMode == TypeLoadMode.Static &&
+            GrpcServiceRegistry.TryLoad(runtime.Options.ApplicationAssembly, out var registry))
+        {
+            return registry!.DirectMappedServiceTypes();
+        }
+
         return FindDirectMappedServiceTypes(assemblies, graph);
     }
 


### PR DESCRIPTION
Closes #2907.

Completes gRPC service-discovery manifest coverage. #2926 already manifest-covered three of the four discovery modes in `GrpcGraph.DiscoverServices` (proto-first stubs, code-first contracts, hand-written services), consumed under `TypeLoadMode.Static`. This PR adds the **fourth** mode — `FindDirectMappedServiceTypes` in `WolverineGrpcExtensions` (the map-time scan for `*GrpcService`/`[WolverineGrpcService]` classes that receive no generated wrapper and are mapped directly).

## Changes
- **`GrpcServiceRegistry`** gains a `DirectMappedServiceTypes()` accessor; `GrpcServiceRegistryCodeFile` emits it alongside the other three.
- Unlike the other three modes, direct-mapped types produce **no chain** in the graph, so — like the conventional message types in the handler manifest (#2906) — they require a scan to capture. `GrpcGraph.BuildFiles` computes them via `WolverineGrpcExtensions.FindGrpcServiceTypes` **only while actually generating** (`DynamicCodeBuilder.WithinCodegenCommand`); `BuildFiles` is also enumerated during a Static-mode attach, where a scan would defeat the purpose.
- **`MapWolverineGrpcServices`** resolves direct-mapped types from the manifest under `TypeLoadMode.Static` (`ResolveDirectMappedServiceTypes`), falling back to the reflective scan otherwise. All four gRPC discovery modes are now manifest-covered.

## Tests
- Extends `grpc_service_manifest` with the 4th accessor and a **satellite parity** check — every direct-mapped service the live scan finds across the registered assemblies (including the referenced `GreeterProtoFirstGrpc.Server` satellite) is captured in the manifest.
- Adds `grpc_direct_mapped_manifest` for the emit → compile → read round-trip of the new accessor.
- gRPC discovery/codegen/map regression slice (28 tests) stays green; full `wolverine.slnx` build clean (net9.0 + net10.0).

## Acceptance criteria
- [x] All four gRPC discovery modes resolvable from a compile-time manifest with no `GetExportedTypes()` scan when present.
- [x] Parity with reflective discovery across proto-first / code-first / hand-written / direct-mapped.
- [x] gRPC services in satellite assemblies discovered identically (satellite parity test).
- [x] Reflective fallback for non-generator / non-Static apps.

Same runtime-codegen-from-the-built-graph approach as #2906/#2925/#2926.
