### PR TITLE
Discover [WolverineHandlerModule] assemblies without a filesystem probe (GH-2905)

### DIFF
--- a/src/Testing/CoreTests/Configuration/handler_module_discovery.cs
+++ b/src/Testing/CoreTests/Configuration/handler_module_discovery.cs
@@ -1,0 +1,22 @@
+using Module2;
+using Shouldly;
+using Wolverine.Configuration;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+// GH-2905: [WolverineHandlerModule] assemblies are discovered via the shared deployment-list module
+// loader (ModuleAssemblyLoader) + an enumeration of loaded assemblies, with no AssemblyFinder
+// filesystem probe. Module2 is marked [assembly: WolverineHandlerModule].
+public class handler_module_discovery
+{
+    [Fact]
+    public void discovers_handler_module_assemblies_without_a_filesystem_probe()
+    {
+        var discovery = new HandlerDiscovery();
+
+        discovery.DiscoverHandlerModules(typeof(handler_module_discovery).Assembly);
+
+        discovery.Assemblies.ShouldContain(typeof(Module2Message1).Assembly);
+    }
+}

--- a/src/Wolverine/Configuration/HandlerDiscovery.cs
+++ b/src/Wolverine/Configuration/HandlerDiscovery.cs
@@ -5,6 +5,7 @@ using JasperFx.Core;
 using JasperFx.Core.TypeScanning;
 using Wolverine.Attributes;
 using Wolverine.Persistence.Sagas;
+using Wolverine.Runtime;
 using Wolverine.Runtime.Handlers;
 
 namespace Wolverine.Configuration;
@@ -269,17 +270,18 @@ public sealed partial class HandlerDiscovery
     /// <summary>
     /// Discovers and includes all assemblies marked with [WolverineHandlerModule] attribute.
     /// </summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2026",
-        Justification = "AssemblyFinder.FindAssemblies scans the application base directory and inspects the referenced-assembly graph for [WolverineHandlerModule]. AOT-published apps either skip this discovery (no handler-module attributes) or pre-register their handlers explicitly per the AOT publishing guide.")]
-    internal HandlerDiscovery DiscoverHandlerModules()
+    internal HandlerDiscovery DiscoverHandlerModules(Assembly? applicationAssembly)
     {
-        var handlerModuleAssemblies = AssemblyFinder
-            .FindAssemblies(a => a.HasAttribute<WolverineHandlerModuleAttribute>())
-            .Concat(AppDomain.CurrentDomain.GetAssemblies())
+        // GH-2905: load the deployed module assemblies via the runtime's deployment list (shared with
+        // extension discovery, GH-2902) instead of the AssemblyFinder.FindAssemblies bin-directory probe,
+        // then pick out the [WolverineHandlerModule]-marked ones from the loaded set. No filesystem scan.
+        ModuleAssemblyLoader.EnsureDeployedModuleAssembliesAreLoaded(applicationAssembly);
+
+        var handlerModuleAssemblies = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && a.HasAttribute<WolverineHandlerModuleAttribute>())
             .Distinct()
-            .Where(a => a.HasAttribute<WolverineHandlerModuleAttribute>())
             .ToArray();
-        
+
         Assemblies.AddRange(handlerModuleAssemblies);
         return this;
     }

--- a/src/Wolverine/HostBuilderExtensions.cs
+++ b/src/Wolverine/HostBuilderExtensions.cs
@@ -263,7 +263,7 @@ public static class HostBuilderExtensions
 
         if (options.Discovery.IncludeHandlerModules)
         {
-            options.HandlerGraph.Discovery.DiscoverHandlerModules();
+            options.HandlerGraph.Discovery.DiscoverHandlerModules(options.ApplicationAssembly);
         }
 
         options.ApplyLazyConfiguration();

--- a/src/Wolverine/Runtime/ModuleAssemblyLoader.cs
+++ b/src/Wolverine/Runtime/ModuleAssemblyLoader.cs
@@ -1,0 +1,147 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using JasperFx.Core;
+
+namespace Wolverine.Runtime;
+
+/// <summary>
+///     Loads the deployed module assemblies — those declaring a <c>[JasperFxAssembly]</c>-derived marker
+///     such as <c>[WolverineModule]</c> or <c>[WolverineHandlerModule]</c> — so their attributes and
+///     source-generated manifests can be read without an <c>AssemblyFinder</c> filesystem probe. Shared by
+///     extension discovery (GH-2902) and handler-module discovery (GH-2905).
+/// </summary>
+internal static class ModuleAssemblyLoader
+{
+    // Framework assembly name prefixes we never need to walk into. No Wolverine extension/module
+    // assembly uses these prefixes, so skipping them keeps the reference-graph walk from loading
+    // the whole BCL closure.
+    private static readonly string[] _nonModulePrefixes =
+        ["System.", "System,", "Microsoft.", "netstandard", "mscorlib", "WindowsBase", "Newtonsoft."];
+
+    // Make sure every deployed module assembly is loaded so its attributes / source-generated manifest
+    // can be inspected. This intentionally replaces AssemblyFinder.FindAssemblies'
+    // Directory.EnumerateFiles bin-directory probe.
+    //
+    // It does NOT just walk Assembly.GetReferencedAssemblies(): the C# compiler prunes a referenced
+    // assembly whose types the application never uses directly, so a "reference the package and it
+    // auto-activates" module like WolverineFx.RuntimeCompilation is absent from the metadata reference
+    // graph even though it is deployed. Instead we use the runtime's resolved deployment list
+    // (TRUSTED_PLATFORM_ASSEMBLIES) - not a recursive filesystem scan - which DOES include those
+    // pruned-but-deployed assemblies. The reference-graph walk is kept as a fallback for hosts that
+    // don't surface that list (e.g. single-file deployments).
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Loads assemblies from the runtime's resolved deployment list / declared reference graph (Assembly.Load), not a filesystem probe. AOT/trim-published apps reference their module assemblies statically and register explicitly (ExtensionDiscovery.ManualOnly); see GH-2902 / GH-2905 / AOT guide.")]
+    public static void EnsureDeployedModuleAssembliesAreLoaded(Assembly? applicationAssembly)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic))
+        {
+            var name = assembly.GetName().Name;
+            if (name != null)
+            {
+                seen.Add(name);
+            }
+        }
+
+        if (!tryLoadFromDeploymentList(seen))
+        {
+            walkReferenceGraph(seen, applicationAssembly);
+        }
+    }
+
+    // Load the non-framework assemblies the runtime resolved for this app (the deployment closure),
+    // which includes referenced module packages whose types the app doesn't use directly. Returns
+    // false when the host doesn't expose TRUSTED_PLATFORM_ASSEMBLIES so the caller can fall back.
+    private static bool tryLoadFromDeploymentList(HashSet<string> seen)
+    {
+        if (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is not string list || list.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (var path in list.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var name = Path.GetFileNameWithoutExtension(path);
+            if (name.IsEmpty() || isNonModuleAssembly(name) || !seen.Add(name))
+            {
+                continue;
+            }
+
+            try
+            {
+                Assembly.Load(new AssemblyName(name));
+            }
+            catch (Exception)
+            {
+                // Not loadable by simple name (native image, resource/satellite assembly, …); skip.
+            }
+        }
+
+        return true;
+    }
+
+    // Fallback: walk the reference graph from the application assembly plus everything already loaded,
+    // loading each non-framework referenced assembly. Misses compiler-pruned references, but better
+    // than nothing when no deployment list is available.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Reference-graph fallback (Assembly.GetReferencedAssemblies/Assembly.Load) used only when the runtime deployment list is unavailable. AOT/trim-published apps register modules explicitly (ExtensionDiscovery.ManualOnly); see GH-2902 / GH-2905 / AOT guide.")]
+    private static void walkReferenceGraph(HashSet<string> seen, Assembly? applicationAssembly)
+    {
+        var queue = new Queue<Assembly>();
+
+        void enqueue(Assembly assembly)
+        {
+            var name = assembly.GetName().Name;
+            if (name != null && seen.Add(name))
+            {
+                queue.Enqueue(assembly);
+            }
+        }
+
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic).ToArray())
+        {
+            // Already in `seen` from the caller; enqueue for walking without re-adding.
+            queue.Enqueue(assembly);
+        }
+
+        if (applicationAssembly != null)
+        {
+            enqueue(applicationAssembly);
+        }
+
+        while (queue.Count > 0)
+        {
+            foreach (var reference in queue.Dequeue().GetReferencedAssemblies())
+            {
+                var name = reference.Name;
+                if (name == null || seen.Contains(name) || isNonModuleAssembly(name))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    enqueue(Assembly.Load(reference));
+                }
+                catch (Exception)
+                {
+                    // A reference we can't resolve can't be a discoverable module; ignore it.
+                    seen.Add(name);
+                }
+            }
+        }
+    }
+
+    private static bool isNonModuleAssembly(string name)
+    {
+        foreach (var prefix in _nonModulePrefixes)
+        {
+            if (name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Wolverine/WolverineOptions.Extensions.cs
+++ b/src/Wolverine/WolverineOptions.Extensions.cs
@@ -25,7 +25,7 @@ public sealed partial class WolverineOptions
         // deployed [WolverineModule] assemblies so "reference the package and it auto-activates"
         // still works — using the runtime's resolved deployment list, not the old bin-directory
         // glob (Directory.EnumerateFiles) that AssemblyFinder.FindAssemblies used.
-        ensureReferencedModuleAssembliesAreLoaded();
+        Wolverine.Runtime.ModuleAssemblyLoader.EnsureDeployedModuleAssembliesAreLoaded(ApplicationAssembly);
 
         // Include any [WolverineModule]-marked assembly that is now loaded so its handlers
         // participate in discovery, exactly as the old ExtensionLoader.IncludeExtensionAssemblies
@@ -67,139 +67,6 @@ public sealed partial class WolverineOptions
     private static bool isDeclaredModuleExtension(Type type)
     {
         return type == type.Assembly.GetAttribute<WolverineModuleAttribute>()?.WolverineExtensionType;
-    }
-
-    // Framework assembly name prefixes we never need to walk into. No Wolverine extension/module
-    // assembly uses these prefixes, so skipping them keeps the reference-graph walk from loading
-    // the whole BCL closure.
-    private static readonly string[] _nonModulePrefixes =
-        ["System.", "System,", "Microsoft.", "netstandard", "mscorlib", "WindowsBase", "Newtonsoft."];
-
-    // Make sure every deployed [WolverineModule] assembly is loaded so its source-generated manifest
-    // can be read below. This intentionally replaces AssemblyFinder.FindAssemblies'
-    // Directory.EnumerateFiles bin-directory probe.
-    //
-    // It does NOT just walk Assembly.GetReferencedAssemblies(): the C# compiler prunes a referenced
-    // assembly whose types the application never uses directly, so a "reference the package and it
-    // auto-activates" module like WolverineFx.RuntimeCompilation is absent from the metadata
-    // reference graph even though it is deployed. Instead we use the runtime's resolved deployment
-    // list (TRUSTED_PLATFORM_ASSEMBLIES) - not a recursive filesystem scan - which DOES include those
-    // pruned-but-deployed assemblies. The reference-graph walk is kept as a fallback for hosts that
-    // don't surface that list (e.g. single-file deployments).
-    [UnconditionalSuppressMessage("Trimming", "IL2026",
-        Justification = "Loads assemblies from the runtime's resolved deployment list / declared reference graph (Assembly.Load), not a filesystem probe. AOT/trim-published apps reference their extension assemblies statically and register extensions explicitly (ExtensionDiscovery.ManualOnly); see GH-2902 / AOT guide.")]
-    private void ensureReferencedModuleAssembliesAreLoaded()
-    {
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic))
-        {
-            var name = assembly.GetName().Name;
-            if (name != null)
-            {
-                seen.Add(name);
-            }
-        }
-
-        if (!tryLoadFromDeploymentList(seen))
-        {
-            walkReferenceGraph(seen);
-        }
-    }
-
-    // Load the non-framework assemblies the runtime resolved for this app (the deployment closure),
-    // which includes referenced module packages whose types the app doesn't use directly. Returns
-    // false when the host doesn't expose TRUSTED_PLATFORM_ASSEMBLIES so the caller can fall back.
-    private bool tryLoadFromDeploymentList(HashSet<string> seen)
-    {
-        if (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is not string list || list.Length == 0)
-        {
-            return false;
-        }
-
-        foreach (var path in list.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            var name = Path.GetFileNameWithoutExtension(path);
-            if (name.IsEmpty() || isNonModuleAssembly(name) || !seen.Add(name))
-            {
-                continue;
-            }
-
-            try
-            {
-                Assembly.Load(new AssemblyName(name));
-            }
-            catch (Exception)
-            {
-                // Not loadable by simple name (native image, resource/satellite assembly, …); skip.
-            }
-        }
-
-        return true;
-    }
-
-    // Fallback: walk the reference graph from the application assembly plus everything already loaded,
-    // loading each non-framework referenced assembly. Misses compiler-pruned references, but better
-    // than nothing when no deployment list is available.
-    [UnconditionalSuppressMessage("Trimming", "IL2026",
-        Justification = "Reference-graph fallback (Assembly.GetReferencedAssemblies/Assembly.Load) used only when the runtime deployment list is unavailable. AOT/trim-published apps register extensions explicitly (ExtensionDiscovery.ManualOnly); see GH-2902 / AOT guide.")]
-    private void walkReferenceGraph(HashSet<string> seen)
-    {
-        var queue = new Queue<Assembly>();
-
-        void enqueue(Assembly assembly)
-        {
-            var name = assembly.GetName().Name;
-            if (name != null && seen.Add(name))
-            {
-                queue.Enqueue(assembly);
-            }
-        }
-
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic).ToArray())
-        {
-            // Already in `seen` from the caller; enqueue for walking without re-adding.
-            queue.Enqueue(assembly);
-        }
-
-        if (ApplicationAssembly != null)
-        {
-            enqueue(ApplicationAssembly);
-        }
-
-        while (queue.Count > 0)
-        {
-            foreach (var reference in queue.Dequeue().GetReferencedAssemblies())
-            {
-                var name = reference.Name;
-                if (name == null || seen.Contains(name) || isNonModuleAssembly(name))
-                {
-                    continue;
-                }
-
-                try
-                {
-                    enqueue(Assembly.Load(reference));
-                }
-                catch (Exception)
-                {
-                    // A reference we can't resolve can't be a discoverable module; ignore it.
-                    seen.Add(name);
-                }
-            }
-        }
-    }
-
-    private static bool isNonModuleAssembly(string name)
-    {
-        foreach (var prefix in _nonModulePrefixes)
-        {
-            if (name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     // The manifest stores extension types as a DAM-less Type[] (typeof(...) literals emitted by the


### PR DESCRIPTION
Closes #2905.

`HandlerDiscovery.DiscoverHandlerModules` used `AssemblyFinder.FindAssemblies` — a `Directory.EnumerateFiles` bin-directory probe — to find `[WolverineHandlerModule]` assemblies, which is trim/AOT-hostile and slow at cold start.

This takes **approach 2** from the issue (the unblocked one), using the **robust** variant: reuse the deployment-list loader built for #2902 rather than a naive "enumerate already-loaded" check. (Approach 1 — a JasperFx-side assembly-marker manifest — remains a possible future enhancement; it's blocked on a JasperFx publish and isn't required to remove the probe.)

## Changes
- Extracted the #2902 deployment-list loader (`TRUSTED_PLATFORM_ASSEMBLIES`, with a reference-graph fallback for hosts that don't surface it) into a shared **`ModuleAssemblyLoader`**, now used by both extension discovery and handler-module discovery.
- `DiscoverHandlerModules(applicationAssembly)` ensures the deployed module assemblies are loaded via that shared loader, then selects the `[WolverineHandlerModule]`-marked ones from the loaded set — **no `AssemblyFinder` filesystem probe**. (`[WolverineHandlerModule]` derives from `[JasperFxAssembly]`, the same eligibility as `[WolverineModule]`.)

## Why robust over naive enumeration
A naive "enumerate `AppDomain` assemblies" would miss a deployed-but-unloaded handler module (referenced package whose types the app doesn't use directly). The shared deployment-list loader loads those (the same reason #2902 added it for `WolverineFx.RuntimeCompilation`), so this is robust across `Automatic`/`ManualOnly` modes and ordering — and consistent with the extension path.

## Tests
- The existing `IncludeHandlerModules = true` test (Module2 is `[assembly: WolverineHandlerModule]`) still passes on the new path.
- Adds `handler_module_discovery` calling `DiscoverHandlerModules` directly.
- Module1 (`[WolverineModule]` extension) + Module2 (handler module) both flow through the shared loader; extension-discovery tests stay green. Full `wolverine.slnx` build clean (net9.0 + net10.0).

## Acceptance criteria
- [x] No `AssemblyFinder.FindAssemblies` filesystem probe for handler-module discovery.
- [x] `[WolverineHandlerModule]` assemblies still added to handler discovery identically.
- [x] Reflective fallback retained (the reference-graph walk, when the deployment list is unavailable).
- [x] Regression coverage for `IncludeHandlerModules = true`.

With this and #2908 (attachment lookups) done, **#2909** (the catch-all) can close.
