### PR TITLE
Attach generated HTTP/gRPC types by full name instead of a GetTypes() scan (GH-2908)

### DIFF
--- a/src/Http/Wolverine.Http/HttpChain.Codegen.cs
+++ b/src/Http/Wolverine.Http/HttpChain.Codegen.cs
@@ -96,7 +96,10 @@ public partial class HttpChain
     {
         Debug.WriteLine(_generatedType?.SourceCode);
 
-        _handlerType = assembly.ExportedTypes.FirstOrDefault(x => x.Name == _fileName)
+        // GH-2908: resolve the generated handler by its full name (a targeted lookup, no GetTypes()
+        // enumeration in the pre-generated/Static case); fall back to the reflective scan only if it misses.
+        _handlerType = assembly.GetType($"{containingNamespace}.{_fileName}")
+            ?? assembly.ExportedTypes.FirstOrDefault(x => x.Name == _fileName)
             ?? assembly.GetTypes().FirstOrDefault(x => x.Name == _fileName);
 
         return _handlerType != null;

--- a/src/Wolverine.Grpc/CodeFirstGrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/CodeFirstGrpcServiceChain.cs
@@ -254,7 +254,10 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
     bool ICodeFile.AttachTypesSynchronously(GenerationRules rules, Assembly assembly, IServiceProvider? services,
         string containingNamespace)
     {
-        _generatedRuntimeType = assembly.ExportedTypes.FirstOrDefault(x => x.Name == TypeName)
+        // GH-2908: resolve the generated wrapper by its full name (a targeted lookup, no GetTypes()
+        // enumeration in the pre-generated/Static case); fall back to the reflective scan only if it misses.
+        _generatedRuntimeType = assembly.GetType($"{containingNamespace}.{TypeName}")
+                                ?? assembly.ExportedTypes.FirstOrDefault(x => x.Name == TypeName)
                                 ?? assembly.GetTypes().FirstOrDefault(x => x.Name == TypeName);
 
         return _generatedRuntimeType != null;

--- a/src/Wolverine.Grpc/GrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/GrpcServiceChain.cs
@@ -283,7 +283,10 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
     bool ICodeFile.AttachTypesSynchronously(GenerationRules rules, Assembly assembly, IServiceProvider? services,
         string containingNamespace)
     {
-        _generatedRuntimeType = assembly.ExportedTypes.FirstOrDefault(x => x.Name == TypeName)
+        // GH-2908: resolve the generated wrapper by its full name (a targeted lookup, no GetTypes()
+        // enumeration in the pre-generated/Static case); fall back to the reflective scan only if it misses.
+        _generatedRuntimeType = assembly.GetType($"{containingNamespace}.{TypeName}")
+                                ?? assembly.ExportedTypes.FirstOrDefault(x => x.Name == TypeName)
                                 ?? assembly.GetTypes().FirstOrDefault(x => x.Name == TypeName);
 
         return _generatedRuntimeType != null;

--- a/src/Wolverine.Grpc/HandWrittenGrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/HandWrittenGrpcServiceChain.cs
@@ -202,7 +202,10 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
     bool ICodeFile.AttachTypesSynchronously(GenerationRules rules, Assembly assembly, IServiceProvider? services,
         string containingNamespace)
     {
-        _generatedRuntimeType = assembly.ExportedTypes.FirstOrDefault(x => x.Name == TypeName)
+        // GH-2908: resolve the generated wrapper by its full name (a targeted lookup, no GetTypes()
+        // enumeration in the pre-generated/Static case); fall back to the reflective scan only if it misses.
+        _generatedRuntimeType = assembly.GetType($"{containingNamespace}.{TypeName}")
+                                ?? assembly.ExportedTypes.FirstOrDefault(x => x.Name == TypeName)
                                 ?? assembly.GetTypes().FirstOrDefault(x => x.Name == TypeName);
 
         return _generatedRuntimeType != null;


### PR DESCRIPTION
Closes #2908.

`ICodeFile.AttachTypesSynchronously` in `HttpChain` and the three gRPC service chains located their generated type via `assembly.ExportedTypes`/`GetTypes()` enumeration — materializing every type in the assembly (trim/AOT-hostile, slow), for what is a single known-name lookup.

## Change
Resolve the generated type with a **targeted `assembly.GetType($"{containingNamespace}.{TypeName}")`** — the exact `{containingNamespace}.{TypeName}` full name JasperFx's own `AttachTypes` reference generators use — so the pre-generated/Static case is an O(1) lookup with **no enumeration**. The `ExportedTypes`/`GetTypes` scan is kept only as a fallback if the targeted lookup misses.

Four sites: `HttpChain.Codegen.cs`, `GrpcServiceChain.cs`, `CodeFirstGrpcServiceChain.cs`, `HandWrittenGrpcServiceChain.cs`.

## Validation
- HTTP + gRPC codegen/attach suites pass unchanged (no regression).
- **Strip validation**: temporarily removing the fallback (leaving *only* `GetType(fullName)`) still passed the HTTP smoke + gRPC code-first/proto-first/hand-written codegen tests — proving the primary lookup resolves the generated type for every chain type, so the enumeration is genuinely avoided in the common case (not silently falling back).
- Full `wolverine.slnx` build clean (net9.0 + net10.0).

## Acceptance criteria
- [x] HTTP + gRPC generated-type attachment performs no `assembly.GetTypes()` enumeration in Static/pre-generated mode.
- [x] Reflective fallback retained for the rare miss / runtime-compilation edge.
- [x] Parity on the HTTP and gRPC test suites.

## Scope note
This is the self-contained Wolverine fix. The issue also floated a JasperFx-level generated-type *manifest* (name→Type dictionary) shared by all `AttachTypes` consumers as the AOT-purest option; that remains a possible future cross-repo enhancement, but the targeted lookup removes the enumeration the issue targets without a JasperFx dependency.

With this, the AOT discovery/attachment roadmap's primary paths are all done (#2902, #2905, #2906, #2907, #2925, #2926, #2908) — **#2909** (the scanning-governance catch-all) can be reassessed for closing.
