### PR TITLE
Expose the connection's ClaimsPrincipal on SignalREnvelope (GH-2927)

### DIFF
--- a/src/Transports/SignalR/Wolverine.SignalR.Tests/capturing_the_claims_principal.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR.Tests/capturing_the_claims_principal.cs
@@ -1,0 +1,43 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.SignalR;
+using NSubstitute;
+using Shouldly;
+using Wolverine.SignalR.Internals;
+
+namespace Wolverine.SignalR.Tests;
+
+// GH-2927: SignalREnvelope captures the connection's ClaimsPrincipal (HubCallerContext.User) so
+// Wolverine handlers/middleware can perform per-message authorization from the principal's claims.
+public class capturing_the_claims_principal
+{
+    [Fact]
+    public void captures_principal_connection_id_and_user_name_from_the_hub_context()
+    {
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.NameIdentifier, "wolverine"), new Claim(ClaimTypes.Role, "admin")], "test"));
+
+        var context = Substitute.For<HubCallerContext>();
+        context.ConnectionId.Returns("conn-1");
+        context.UserIdentifier.Returns("wolverine");
+        context.User.Returns(principal);
+
+        var envelope = new SignalREnvelope(context, Substitute.For<IHubContext<Hub>>());
+
+        envelope.Principal.ShouldBeSameAs(principal);
+        envelope.Principal!.IsInRole("admin").ShouldBeTrue();
+        envelope.ConnectionId.ShouldBe("conn-1");
+        envelope.UserName.ShouldBe("wolverine");
+    }
+
+    [Fact]
+    public void principal_is_null_for_an_unauthenticated_connection()
+    {
+        var context = Substitute.For<HubCallerContext>();
+        context.ConnectionId.Returns("conn-2");
+        context.User.Returns((ClaimsPrincipal?)null);
+
+        var envelope = new SignalREnvelope(context, Substitute.For<IHubContext<Hub>>());
+
+        envelope.Principal.ShouldBeNull();
+    }
+}

--- a/src/Transports/SignalR/Wolverine.SignalR/Internals/SignalREnvelope.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Internals/SignalREnvelope.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Wolverine.SignalR.Internals;
@@ -11,9 +12,18 @@ public class SignalREnvelope : Envelope
         HubContext = hubContext;
         ConnectionId = context.ConnectionId;
         UserName = context.UserIdentifier;
+        Principal = context.User;
     }
 
     public new string? UserName { get; set; }
 
     public string ConnectionId { get; set; }
+
+    /// <summary>
+    ///     The connecting client's <see cref="ClaimsPrincipal" /> (<c>HubCallerContext.User</c>), captured
+    ///     so Wolverine handlers/middleware can perform per-message authorization from the principal's
+    ///     claims — not just connection-time <c>[Authorize]</c> on the hub. Null if the connection is
+    ///     unauthenticated. See GH-2927.
+    /// </summary>
+    public ClaimsPrincipal? Principal { get; }
 }


### PR DESCRIPTION
Closes #2927.

`SignalREnvelope` carried the user identifier string (`HubCallerContext.UserIdentifier`) but not the `ClaimsPrincipal`, so role/claim-based **per-message** authorization wasn't possible in the Wolverine handler/middleware pipeline — `[Authorize]` on the hub only gates connection establishment.

## Change
Capture `HubCallerContext.User` as a new `public ClaimsPrincipal? Principal { get; }` on `SignalREnvelope` (mirrors the existing `ConnectionId`/`UserName` capture). Purely additive, backward compatible.

Consumers can now write a small Wolverine middleware that maps message type → required permission and authorizes from `envelope.Principal`'s claims (cast `IMessageContext.Envelope` to `SignalREnvelope`).

## Scope note
The principal flows on the live (inline/buffered) envelope that `Receiver.ReceivedAsync` dispatches — it is **not** persisted through a durable inbox (`ClaimsPrincipal` isn't serializable), which matches SignalR's real-time shape and the issue's use case (authorize at handling time). The "project claims into headers" variant the issue floated as an alternative for header-based/persisted access can be a follow-up if needed.

## Tests
`capturing_the_claims_principal` — verifies the principal (with roles), `ConnectionId`, and `UserName` are captured from the hub context, and that an unauthenticated connection yields a null `Principal`. Existing SignalR e2e tests stay green; full `wolverine.slnx` build clean.
