### PR TITLE
Upgrade JasperFx.* packages to 2.2.0 (RuntimeCompiler stays on 5.x)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,13 +31,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.1.3" />
-    <PackageVersion Include="JasperFx.Events" Version="2.1.3" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.1.3" />
+    <PackageVersion Include="JasperFx" Version="2.2.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.2.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.1.3" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.0" />
     <PackageVersion Include="Marten" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.1.1" />


### PR DESCRIPTION
Upgrade the JasperFx 2.x package family from **2.1.3 → 2.2.0**:

- `JasperFx`
- `JasperFx.Events`
- `JasperFx.Events.SourceGenerator`
- `JasperFx.SourceGenerator`

**`JasperFx.RuntimeCompiler` is intentionally left at `5.0.0`** — it's on its own 5.x line (the Roslyn runtime-compiler package), not the 2.1.x family, per the existing pin + comment in `Directory.Packages.props`.

Single-line-per-package change in `Directory.Packages.props` (central package management). Full `wolverine.slnx` Release build is clean on net9.0 + net10.0 with no API changes; local discovery/codegen/manifest/extension-discovery/handler-chain-ordering smoke tests pass. Opening as a PR so CI exercises the full transport/persistence/AOT-smoke matrix.
