### PR TITLE
Upgrade Marten family to 9.2.0; release 6.1.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -100,8 +100,27 @@
                      JasperFx.SourceGenerator           2.0.1 -> 2.1.3
                      JasperFx.RuntimeCompiler          unchanged (own 5.x line)
                      Marten / Weasel.* / Polecat       unchanged
+
+          6.1.0: Marten family upgrade for the 6.1 minor release:
+                     Marten (+ .AspNetCore / .Newtonsoft)  9.0.1 -> 9.2.0
+                     Polecat                               unchanged (4.1.1, already latest)
+                     JasperFx.* (non-RuntimeCompiler)      2.1.3 -> 2.2.0 (#2938)
+                   Marten 9.2.0 now bundles JasperFx.Events.SourceGenerator as an
+                   analyzer (analyzers/dotnet/cs/), whereas 9.0.1 did not. Projects
+                   that reference Wolverine.Marten therefore receive the generator
+                   transitively, so the explicit
+                     <PackageReference Include="JasperFx.Events.SourceGenerator"
+                       OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+                   ref was redundant and ran the generator a SECOND time -> CS0111/
+                   CS0101 duplicate-Evolve/duplicate-*Evolver errors. Dropped that
+                   ref from the 8 Marten-referencing projects (MartenTests,
+                   WolverineWebApi, LoadTesting, Orders, TeleHealth.Common,
+                   Wolverine.{RabbitMQ,Kafka,AmazonSqs}.Tests). PolecatTests KEEPS
+                   the explicit ref: Polecat 4.1.1 does not bundle the analyzer and
+                   PolecatTests does not reference Marten, so its explicit ref is the
+                   sole (single) generator instance there.
         -->
-        <Version>6.0.3</Version>
+        <Version>6.1.0</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,12 +38,12 @@
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
     <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.0" />
-    <PackageVersion Include="Marten" Version="9.0.1" />
+    <PackageVersion Include="Marten" Version="9.2.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.1.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.0.1" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.0.1" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.2.0" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.2.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />

--- a/src/Http/WolverineWebApi/WolverineWebApi.csproj
+++ b/src/Http/WolverineWebApi/WolverineWebApi.csproj
@@ -13,7 +13,6 @@
         <PackageReference Include="Shouldly" />
         <PackageReference Include="StronglyTypedId" />
         <PackageReference Include="Swashbuckle.AspNetCore" />
-        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Persistence/LoadTesting/LoadTesting.csproj
+++ b/src/Persistence/LoadTesting/LoadTesting.csproj
@@ -9,7 +9,6 @@
     <ItemGroup>
       <ProjectReference Include="..\..\Transports\RabbitMQ\Wolverine.RabbitMQ\Wolverine.RabbitMQ.csproj" />
       <ProjectReference Include="..\Wolverine.Marten\Wolverine.Marten.csproj" />
-      <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Persistence/MartenTests/MartenTests.csproj
+++ b/src/Persistence/MartenTests/MartenTests.csproj
@@ -22,7 +22,6 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="StronglyTypedId" />
-        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/CQRSWithMarten/TeleHealth.Common/TeleHealth.Common.csproj
+++ b/src/Samples/CQRSWithMarten/TeleHealth.Common/TeleHealth.Common.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
       <ProjectReference Include="..\..\..\Persistence\Wolverine.Marten\Wolverine.Marten.csproj" />
-      <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 </Project>

--- a/src/Samples/OrderManagement/Orders/Orders.csproj
+++ b/src/Samples/OrderManagement/Orders/Orders.csproj
@@ -11,7 +11,6 @@
         <ProjectReference Include="..\..\..\Persistence\Wolverine.Marten\Wolverine.Marten.csproj"/>
         <ProjectReference Include="..\..\..\Transports\RabbitMQ\Wolverine.RabbitMQ\Wolverine.RabbitMQ.csproj"/>
         <ProjectReference Include="..\Messages\Messages.csproj"/>
-        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
@@ -10,7 +10,6 @@
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
         <PackageReference Include="coverlet.collector" PrivateAssets="All" />
-        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
@@ -21,7 +21,6 @@
         <PackageReference Include="Alba" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
-        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
@@ -12,7 +12,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
-        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## What

6.1.0 minor release.

- **Marten** / **Marten.AspNetCore** / **Marten.Newtonsoft**: `9.0.1` → `9.2.0`
- **Polecat**: unchanged (`4.1.1`, already latest)
- **JasperFx.\*** (non-RuntimeCompiler): already `2.2.0` from #2938
- **Version**: `6.0.3` → `6.1.0`

## Double-generation fix (analyzer collision)

Marten 9.2.0 now bundles `JasperFx.Events.SourceGenerator` as an analyzer (`analyzers/dotnet/cs/`), whereas 9.0.1 did not. Any project that references `Wolverine.Marten` therefore receives the generator **transitively**, so the explicit

```xml
<PackageReference Include="JasperFx.Events.SourceGenerator"
    OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
```

ref became redundant and ran the generator a **second** time — producing `CS0111`/`CS0101` duplicate `Evolve`/`*Evolver` build errors.

Dropped that explicit ref from the **8 Marten-referencing projects** (`MartenTests`, `WolverineWebApi`, `LoadTesting`, `Orders`, `TeleHealth.Common`, `Wolverine.RabbitMQ.Tests`, `Wolverine.Kafka.Tests`, `Wolverine.AmazonSqs.Tests`).

`PolecatTests` **keeps** its explicit ref: Polecat 4.1.1 does not bundle the analyzer, and `PolecatTests` does not reference Marten, so its explicit ref is the sole (single) generator instance there.

## Verification

`dotnet build wolverine.slnx -c Release` — clean (net9.0 + net10.0, **0 warnings, 0 errors**); single generation confirmed across all projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)