### PR TITLE
Emit PersistNodeRecord SQL with unquoted schema name (closes #2940)

### DIFF
--- a/src/Persistence/MySql/MySqlTests/Bug_2940_persist_node_record_unquoted_schema.cs
+++ b/src/Persistence/MySql/MySqlTests/Bug_2940_persist_node_record_unquoted_schema.cs
@@ -1,0 +1,73 @@
+using MySqlConnector;
+using Shouldly;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Durability;
+using Wolverine.Runtime.Agents;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace MySqlTests;
+
+// Regression for GH-2940. PersistNodeRecord.ConfigureCommand used to interpolate
+// DatabaseSettings.QuotedSchemaName, which hard-codes ANSI double quotes around the schema name
+// (`"wolverine"`). MySQL/MariaDB under the default sql_mode reject double-quoted identifiers
+// (they expect backticks), so node-lifecycle persistence failed with a SQL syntax error every
+// time. This was the lone hold-out using QuotedSchemaName - every other durability SQL builder
+// in Wolverine.RDBMS uses the (unquoted) MessageDatabase.QuotedSchemaName, which is just
+// SchemaName.
+//
+// The test inspects the generated SQL string directly so it runs without MySQL connectivity
+// (only the DbCommand instance type pins the dialect, and a "wolverine" schema name is a valid
+// unquoted identifier in every provider Wolverine supports).
+public class Bug_2940_persist_node_record_unquoted_schema
+{
+    [Fact]
+    public void persist_node_record_does_not_wrap_schema_name_in_ansi_double_quotes()
+    {
+        var settings = new DatabaseSettings { SchemaName = "wolverine" };
+        var op = new PersistNodeRecord(settings,
+        [
+            new NodeRecord
+            {
+                NodeNumber = 1,
+                RecordType = NodeRecordType.NodeStarted,
+                Description = "test"
+            }
+        ]);
+
+        var builder = new DbCommandBuilder(new MySqlCommand());
+        op.ConfigureCommand(builder);
+
+        var sql = builder.ToString();
+
+        // The exact bug surface: MySQL parser saw `"wolverine"` and rejected it.
+        sql.ShouldNotContain("\"wolverine\"");
+        sql.ShouldContain("wolverine.wolverine_node_records");
+    }
+
+    [Fact]
+    public void persist_node_record_with_null_schema_name_emits_unprefixed_table()
+    {
+        // Defensive: DatabaseSettings.SchemaName is nullable. The original
+        // QuotedSchemaName getter returned "" for null, producing `.wolverine_node_records`
+        // (a stray leading dot - also a syntax error). Verify the unquoted path skips the
+        // schema prefix entirely when the schema name is absent.
+        var settings = new DatabaseSettings { SchemaName = null };
+        var op = new PersistNodeRecord(settings,
+        [
+            new NodeRecord
+            {
+                NodeNumber = 1,
+                RecordType = NodeRecordType.NodeStarted,
+                Description = "test"
+            }
+        ]);
+
+        var builder = new DbCommandBuilder(new MySqlCommand());
+        op.ConfigureCommand(builder);
+
+        var sql = builder.ToString();
+
+        sql.ShouldNotContain(".wolverine_node_records");
+        sql.ShouldContain("insert into wolverine_node_records");
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/Durability/PersistNodeRecord.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/PersistNodeRecord.cs
@@ -24,8 +24,24 @@ public class PersistNodeRecord : IDatabaseOperation, IDoNotReturnData
         foreach (var @event in _events)
         {
             builder.Append("insert into ");
-            builder.Append(_settings.QuotedSchemaName);
-            builder.Append('.');
+
+            // GH-2940: emit the schema identifier unquoted, matching every other durability SQL
+            // builder in Wolverine.RDBMS (MessageDatabase.{Incoming,Outgoing,Scheduled,Admin,
+            // DeadLetterAdminService,ScheduledMessages}.cs all interpolate
+            // MessageDatabase.QuotedSchemaName, which is `protected virtual SchemaName` -
+            // unquoted). PersistNodeRecord was the lone hold-out using
+            // DatabaseSettings.QuotedSchemaName, which hard-codes ANSI double quotes
+            // (`"wolverine"`). PostgreSQL and SQL Server accept that, but MySQL/MariaDB under
+            // the default sql_mode reject double-quoted identifiers, so node-lifecycle
+            // persistence failed with "SQL syntax error... near
+            // '\"wolverine\".wolverine_node_records'". Unquoted matches what the rest of the
+            // provider already does (and works for every dialect with a default schema name).
+            if (!string.IsNullOrEmpty(_settings.SchemaName))
+            {
+                builder.Append(_settings.SchemaName);
+                builder.Append('.');
+            }
+
             builder.Append(DatabaseConstants.NodeRecordTableName);
             builder.Append(" (node_number, event_name, description) values (");
             builder.AppendParameter(@event.NodeNumber);


### PR DESCRIPTION
Closes #2940.

## The bug

MySQL/MariaDB durability operations failed on startup and during agent assignment with:

```
Wolverine.RDBMS.Polling.DatabaseBatchCommandException: Database operation batch failure:
1. Wolverine.RDBMS.Durability.PersistNodeRecord
insert into "wolverine".wolverine_node_records (...) ...
---> MySqlException: You have an error in your SQL syntax... near '"wolverine".wolverine_node_records...'
```

Root cause: `PersistNodeRecord.ConfigureCommand` interpolated `DatabaseSettings.QuotedSchemaName`, which hard-codes ANSI double quotes (`"wolverine"`). PostgreSQL and SQL Server accept that; MySQL/MariaDB under the default `sql_mode` reject double-quoted identifiers (they expect backticks). So the generated SQL was rejected by MySQL's parser and every node-lifecycle event (`NodeStarted`, `LeadershipAssumed`, `AssignmentChanged`, `AgentStarted`) failed.

`PersistNodeRecord` was the **lone hold-out** using `DatabaseSettings.QuotedSchemaName`. Every other durability SQL builder in `Wolverine.RDBMS` interpolates `MessageDatabase.QuotedSchemaName`, which is just `SchemaName` (unquoted, `protected virtual string QuotedSchemaName => SchemaName`).

## Fix

Align `PersistNodeRecord` with the rest of `Wolverine.RDBMS`: emit the schema identifier **unquoted**. The change is a no-op for PostgreSQL and SQL Server with conventional schema names — both parse `wolverine.wolverine_node_records` identically with or without the double quotes — and matches what every other Wolverine durability operation already does. Also guards the null/empty-schema case (the old `QuotedSchemaName` getter returned `""` for null, producing a stray `.wolverine_node_records` which would also have been a syntax error).

## Tests

`MySqlTests/Bug_2940_persist_node_record_unquoted_schema.cs` (no DB required; inspects the generated SQL string directly):

- `persist_node_record_does_not_wrap_schema_name_in_ansi_double_quotes` — the regression: SQL must not contain `"wolverine"`.
- `persist_node_record_with_null_schema_name_emits_unprefixed_table` — guard against the stray-leading-dot case.

## Verification

- New tests: 2/2 pass (net9.0 + net10.0).
- Negative-control: reverting the change makes both new tests fail — confirms they exercise the specific bug.
- Existing `PostgresqlMessageStoreTests` (**48/48** pass) and `SqliteMessageStoreTests` (**48/48** pass): no regression on the other dialects.
- Full `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)