### PR TITLE
Bump Polecat to 4.2.1 and unskip the three Polecat scheduled-cascade tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,7 +40,7 @@
     <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.0" />
     <PackageVersion Include="Marten" Version="9.2.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="4.1.1" />
+    <PackageVersion Include="Polecat" Version="4.2.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageVersion Include="Marten.AspNetCore" Version="9.2.0" />
     <PackageVersion Include="Marten.Newtonsoft" Version="9.2.0" />

--- a/src/Persistence/PolecatTests/Bugs/Bug_2941_document_exists_scheduled_cascade.cs
+++ b/src/Persistence/PolecatTests/Bugs/Bug_2941_document_exists_scheduled_cascade.cs
@@ -30,7 +30,7 @@ public class Bug_2941_document_exists_scheduled_cascade
 
     private IHost theHost => _context.Host;
 
-    [Fact(Skip = "Requires Polecat upstream fix: see Bug_2941_read_aggregate_scheduled_cascade for details. Same SaveChangesAsync-skips-participants root cause.")]
+    [Fact]
     public async Task document_exists_handler_schedules_its_cascading_message()
     {
         var tracked = await theHost
@@ -43,7 +43,7 @@ public class Bug_2941_document_exists_scheduled_cascade
         tracked.Received.MessagesOf<PcDocExistsScheduled>().Count().ShouldBe(1);
     }
 
-    [Fact(Skip = "Requires Polecat upstream fix: see Bug_2941_read_aggregate_scheduled_cascade for details.")]
+    [Fact]
     public async Task document_does_not_exist_handler_schedules_its_cascading_message()
     {
         var tracked = await theHost

--- a/src/Persistence/PolecatTests/Bugs/Bug_2941_read_aggregate_scheduled_cascade.cs
+++ b/src/Persistence/PolecatTests/Bugs/Bug_2941_read_aggregate_scheduled_cascade.cs
@@ -74,7 +74,7 @@ public class Bug_2941_read_aggregate_scheduled_cascade : IClassFixture<ReadAggre
         tracked.Received.MessagesOf<PcSomethingWasScheduled>().Count().ShouldBe(1);
     }
 
-    [Fact(Skip = "Requires Polecat upstream fix: DocumentSessionBase.SaveChangesAsync early-returns when _workTracker has no outstanding work, which silently skips StoreIncomingEnvelopeParticipant added via Session.StoreIncoming(...) for a [ReadAggregate] handler whose body emits only a scheduled cascade (no doc ops, no streams). The Wolverine-side CanApply fix is necessary but not sufficient on Polecat. Unskip when Polecat ships a SaveChangesAsync that runs participants even when no document/stream work is outstanding. GH-2941.")]
+    [Fact]
     public async Task read_aggregate_handler_schedules_its_cascading_message()
     {
         // The GH-2941 case. Without the CanApply fix this times out: the cascade is recorded as

--- a/src/Persistence/Wolverine.Polecat/Persistence/Sagas/PolecatPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.Polecat/Persistence/Sagas/PolecatPersistenceFrameProvider.cs
@@ -67,13 +67,11 @@ internal class PolecatPersistenceFrameProvider : IPersistenceFrameProvider
 
         // GH-2941: detect parameter attributes whose Modify() injects a non-MethodCall frame
         // depending on IDocumentSession. See MartenPersistenceFrameProvider.CanApply for the full
-        // explanation; Polecat mirrors the Marten path structurally. NOTE: this is necessary but
-        // not sufficient on the Polecat side - Polecat 4.1.1's DocumentSessionBase.SaveChangesAsync
-        // early-returns when _workTracker has no outstanding work, which skips transaction
-        // participants entirely. A handler that only adds a StoreIncomingEnvelopeParticipant via
-        // PolecatEnvelopeTransaction.PersistIncomingAsync therefore never gets its participant
-        // executed, even after this fix attaches the SaveChangesAsync postprocessor. The full
-        // Polecat fix is upstream in Polecat's SaveChangesAsync guard.
+        // explanation; Polecat mirrors the Marten path structurally. Pairs with the upstream
+        // Polecat fix (polecat#161, shipped in Polecat 4.2.1): DocumentSessionBase.SaveChangesAsync
+        // now also runs queued ITransactionParticipants when there are no document operations
+        // outstanding, so the StoreIncomingEnvelopeParticipant added via Session.StoreIncoming(...)
+        // for a scheduled cascade actually executes inside the chain's session transaction.
         if (ChainHasPolecatSessionAttributes(chain)) return true;
 
         var serviceDependencies = chain


### PR DESCRIPTION
Follow-up to #2943.

## What

[Polecat 4.2.1](https://www.nuget.org/packages/Polecat/4.2.1) ships [polecat#161](https://github.com/JasperFx/polecat/pull/161), the upstream companion fix to GH-2941. Its `DocumentSessionBase.SaveChangesAsync` no longer early-returns when only `ITransactionParticipant`s are queued, so the `StoreIncomingEnvelopeParticipant` added via `Session.StoreIncoming(...)` inside `PolecatEnvelopeTransaction.PersistIncomingAsync` actually runs for scheduled cascades from `[ReadAggregate]` / `[DocumentExists]` handlers that don't write any documents.

This PR:
- Bumps `Polecat` 4.1.1 → 4.2.1 in `Directory.Packages.props`.
- **Unskips** the three Polecat tests added in #2943 with `[Fact(Skip = "…polecat#161…")]`:
  - `Bug_2941_read_aggregate_scheduled_cascade.read_aggregate_handler_schedules_its_cascading_message`
  - `Bug_2941_document_exists_scheduled_cascade.document_exists_handler_schedules_its_cascading_message`
  - `Bug_2941_document_exists_scheduled_cascade.document_does_not_exist_handler_schedules_its_cascading_message`
- Tightens the `PolecatPersistenceFrameProvider.CanApply` comment so it documents the pairing with polecat#161 / Polecat 4.2.1 rather than the "necessary but not sufficient" caveat from #2943.

## Verification

- Full `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors).
- Local Marten Bugs sweep: 45/45 pass.
- Polecat tests will be validated by CI — the local SQL Server 2025 image on Apple Silicon is too slow to run them (existing Polecat durable tests time out the same way against it; this is unrelated to the change here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)