### PR TITLE
Pre-populate chain.AncillaryStoreType in Phase A so the inbox-routing map sees [MartenStore] (closes #2944)

### DIFF
--- a/src/Persistence/Wolverine.Marten/MartenIntegration.cs
+++ b/src/Persistence/Wolverine.Marten/MartenIntegration.cs
@@ -69,6 +69,11 @@ public class MartenIntegration : IWolverineExtension, IEventForwarding
         options.CodeGeneration.Sources.Add(new EventStoreOperationsSource());
 
         options.Policies.Add<MartenAggregateHandlerStrategy>();
+
+        // GH-2944: pre-populate chain.AncillaryStoreType so the message-type-to-ancillary-store
+        // map built later in WolverineRuntime.HostService sees it. See MartenStoreEagerPolicy for
+        // the Phase A vs Phase B ordering trap this addresses.
+        options.Policies.Add<MartenStoreEagerPolicy>();
         
         // QuerySpecificationPolicy detects ICompiledQuery/IQueryPlan-typed variables
         // produced by Load/LoadAsync methods and injects FetchSpecificationFrames to

--- a/src/Persistence/Wolverine.Marten/MartenStoreEagerPolicy.cs
+++ b/src/Persistence/Wolverine.Marten/MartenStoreEagerPolicy.cs
@@ -1,0 +1,66 @@
+using System.Reflection;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.Marten;
+
+/// <summary>
+/// GH-2944: pre-populate <see cref="IChain.AncillaryStoreType"/> on every handler chain decorated
+/// with <see cref="MartenStoreAttribute"/> so the message-type-to-ancillary-store map that
+/// WolverineRuntime.HostService builds during startMessagingTransportsAsync sees the targeting.
+///
+/// MartenStoreAttribute is a ModifyChainAttribute, which means its Modify() runs LAZILY inside
+/// HandlerChain.applyCustomizations - i.e. at first-codegen time, when a message of that type
+/// arrives or the chain is otherwise compiled. WolverineRuntime.HostService runs the
+/// ancillary-store mapping loop ('Handlers.AllChains().Where(c =&gt; c.AncillaryStoreType != null)')
+/// EAGERLY during startMessagingTransportsAsync, long before any chain has had its
+/// applyCustomizations triggered - so the loop sees a null AncillaryStoreType on every chain and
+/// the map ends up empty. The downstream effect: a message arriving from an external system in
+/// interop mode (no Wolverine headers) lands in the MAIN store's inbox instead of the ancillary
+/// store's inbox, because DurableLocalQueue / DurableReceiver consult that map at receive time.
+///
+/// This policy is an IHandlerPolicy - which runs in Phase A (eager, at HandlerGraph.Compile) -
+/// and assigns just the AncillaryStoreType field. The Phase B MartenStoreAttribute.Modify still
+/// runs later and re-assigns the same value (idempotent) plus inserts AncillaryOutboxFactoryFrame,
+/// which has to stay lazy because middleware insertion participates in codegen.
+///
+/// Mirrors the discovery rules in Chain.applyAttributesAndConfigureMethods (handler-type and
+/// handler-method, not message-type). Also walks per-endpoint sticky child chains (ByEndpoint) so
+/// MultipleHandlerBehavior.Separated keeps working - matches the AllChains() iteration that the
+/// HostService loop already uses for the same reason (refs GH-2576).
+/// </summary>
+internal class MartenStoreEagerPolicy : IHandlerPolicy
+{
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        foreach (var chain in chains)
+        {
+            applyTo(chain);
+
+            foreach (var byEndpoint in chain.ByEndpoint)
+            {
+                applyTo(byEndpoint);
+            }
+        }
+    }
+
+    private static void applyTo(HandlerChain chain)
+    {
+        if (chain.AncillaryStoreType != null) return;
+
+        foreach (var call in chain.Handlers)
+        {
+            var att = call.Method.GetCustomAttribute<MartenStoreAttribute>(inherit: true)
+                      ?? call.HandlerType.GetCustomAttribute<MartenStoreAttribute>(inherit: true);
+
+            if (att != null)
+            {
+                chain.AncillaryStoreType = att.StoreType;
+                return;
+            }
+        }
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_2944_interop_ancillary_inbox.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_2944_interop_ancillary_inbox.cs
@@ -1,0 +1,151 @@
+using System.Text.Json;
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RabbitMQ.Client;
+using Shouldly;
+using Wolverine.Attributes;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+using Wolverine.Util;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests.Bugs;
+
+// Regression test for GH-2944. Reported by @fadrian23.
+//
+// A message arrives from an external system in INTEROP mode (i.e. published as raw JSON, with no
+// Wolverine envelope headers). Its handler targets an ancillary Marten store via [MartenStore].
+// Before the fix the durable inbox envelope ended up in the MAIN store's inbox instead of the
+// ancillary store's inbox.
+//
+// Root cause: [MartenStore] is a ModifyChainAttribute, so MartenStoreAttribute.Modify() runs in
+// Phase B (lazy, inside HandlerChain.applyCustomizations at first-codegen time). The
+// message-type-to-ancillary-store map that WolverineRuntime.HostService builds during
+// startMessagingTransportsAsync runs in Phase A (eager, at handler-graph compile). At that point
+// chain.AncillaryStoreType is still null on every chain, so the map is empty. When the interop
+// envelope arrives, DurableLocalQueue / DurableReceiver looks up the ancillary store by message
+// type and finds nothing, so it falls back to the main store.
+//
+// Fix: MartenStoreEagerPolicy (registered by MartenIntegration alongside the AggregateHandler
+// strategy) pre-populates chain.AncillaryStoreType in Phase A by walking the handler-type and
+// handler-method for [MartenStore] - matching the discovery rules in
+// Chain.applyAttributesAndConfigureMethods. The Phase B Modify() still runs later and is
+// idempotent for the AncillaryStoreType assignment plus inserts AncillaryOutboxFactoryFrame.
+
+public interface IAncillaryStore2944 : IDocumentStore;
+
+public record InteropMessage2944(Guid Id);
+
+public class InteropDoc2944
+{
+    public Guid Id { get; set; }
+}
+
+[MartenStore(typeof(IAncillaryStore2944))]
+public static class InteropMessage2944Handler
+{
+    [Transactional]
+    public static void Handle(InteropMessage2944 message, IDocumentSession session)
+    {
+        session.Store(new InteropDoc2944 { Id = message.Id });
+    }
+}
+
+public class Bug_2944_interop_ancillary_inbox : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private string _queueName = null!;
+
+    public async Task InitializeAsync()
+    {
+        _queueName = RabbitTesting.NextQueueName();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "bug2944_main";
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine(x => x.MessageStorageSchemaName = "bug2944_main");
+
+                opts.Services.AddMartenStore<IAncillaryStore2944>(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "bug2944_ancillary";
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine(x => x.SchemaName = "bug2944_ancillary");
+
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToRabbitQueue(_queueName)
+                    .DefaultIncomingMessage<InteropMessage2944>()
+                    .UseDurableInbox();
+
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        await _host.ResetResourceState();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task interop_message_should_be_persisted_in_ancillary_store_inbox()
+    {
+        var runtime = _host.GetRuntime();
+
+        var messageId = Guid.NewGuid();
+        var message = new InteropMessage2944(messageId);
+        var data = JsonSerializer.SerializeToUtf8Bytes(message);
+
+        var transport = runtime.Options.RabbitMqTransport();
+
+        // Publish raw JSON bytes — no Wolverine envelope headers, simulating an external producer.
+        var session = await _host.TrackActivity()
+            .Timeout(30.Seconds())
+            .IncludeExternalTransports()
+            .WaitForMessageToBeReceivedAt<InteropMessage2944>(_host)
+            .ExecuteAndWaitAsync(async Task (_) =>
+            {
+                await transport.WithAdminChannelAsync(async channel =>
+                {
+                    var props = new BasicProperties();
+                    await channel.BasicPublishAsync(string.Empty, _queueName, true, props, data);
+                });
+            });
+
+        session.Received.SingleEnvelope<InteropMessage2944>().ShouldNotBeNull();
+
+        // Brief settle so the inbox row commits before we query - the tracker fires on Received,
+        // not on inbox commit.
+        await Task.Delay(1000);
+
+        var ancillaryStore = runtime.Stores.FindAncillaryStore(typeof(IAncillaryStore2944));
+
+        var ancillaryIncoming = await ancillaryStore.Admin.AllIncomingAsync();
+        var messageTypeName = typeof(InteropMessage2944).ToMessageTypeName();
+
+        ancillaryIncoming.ShouldContain(
+            x => x.MessageType == messageTypeName,
+            "The interop message should have been persisted in the ancillary store's inbox");
+
+        var mainIncoming = await runtime.Storage.Admin.AllIncomingAsync();
+        mainIncoming.ShouldNotContain(
+            x => x.MessageType == messageTypeName,
+            "The interop message should NOT be persisted in the main store's inbox");
+    }
+}


### PR DESCRIPTION
Closes #2944. Reported by @fadrian23.

## The bug

A message arriving from an external system in **interop mode** (raw JSON, no Wolverine envelope headers) whose handler targets an ancillary Marten store via `[MartenStore]` had its durable-inbox envelope persisted in the **main** store's inbox instead of the **ancillary** store's. The handler still ran (Wolverine's message routing finds the chain fine), but the inbox row landed in the wrong place — so the reporter's downstream operational assertions about ancillary-store atomicity broke.

The reporter pinpointed the exact line in their issue:

```csharp
// WolverineRuntime.HostService.cs:447
foreach (var chain in Handlers.AllChains().Where(c => c.AncillaryStoreType != null))
```

returns **0 records**, because `chain.AncillaryStoreType` is still `null` at that point.

## Root cause

Same Phase A vs Phase B ordering trap as GH-2941:

- `[MartenStore]` derives from `ModifyChainAttribute`. `MartenStoreAttribute.Modify()` runs in **Phase B** (lazy, inside `HandlerChain.applyCustomizations` at first-codegen time).
- The map that `WolverineRuntime.HostService` builds during `startMessagingTransportsAsync` runs in **Phase A** (eager, at handler-graph compile).

At the time of the Phase A loop, no chain has had its `applyCustomizations` triggered yet — so `chain.AncillaryStoreType` is `null` on every chain and the map is built empty. When an interop message arrives, `DurableLocalQueue` / `DurableReceiver` calls `Stores.TryFindAncillaryStoreForMessageType(envelope.MessageType)`, hits an empty map, and falls back to the main store.

The prior fix at `HostService.cs:447` (`AllChains()` over `Chains`, [GH-2576](https://github.com/JasperFx/wolverine/issues/2576)) addressed per-endpoint sticky chains under `MultipleHandlerBehavior.Separated` — but didn't address the ordering trap. By the time it runs, the chains *still* have null `AncillaryStoreType`.

## Fix

A new internal `MartenStoreEagerPolicy : IHandlerPolicy` in `Wolverine.Marten`, registered by `MartenIntegration` alongside `MartenAggregateHandlerStrategy`. It runs in Phase A and pre-populates `chain.AncillaryStoreType` by walking each `HandlerChain`'s handler-type and handler-method for `[MartenStore]` — matching the discovery rules already used in `Chain.applyAttributesAndConfigureMethods` (handler-type + handler-method). Also walks the per-endpoint sticky child chains (`ByEndpoint`) so `Separated`-mode keeps working alongside #2576.

The Phase B `MartenStoreAttribute.Modify()` still runs later — the `AncillaryStoreType` reassignment is idempotent, and the `AncillaryOutboxFactoryFrame` middleware insertion stays where it has to be (it participates in codegen).

## Tests + verification

New regression: **`Bug_2944_interop_ancillary_inbox`** in `Wolverine.RabbitMQ.Tests/Bugs/` mirrors the reporter's repro — publishes a raw JSON message (no Wolverine headers) to a durable RabbitMQ queue whose default incoming type has a `[MartenStore]`-decorated handler, then asserts the inbox envelope landed in the ancillary store and **not** the main store.

| Suite | Result |
|---|---|
| `Bug_2944_interop_ancillary_inbox` (new) | **1/1 pass** |
| Marten ancillary + bug-family (`AncillaryStores` + `Bug_2318` + `Bug_2382` + `Bug_2576` + `Bug_2669` + `Bug_2887` + `Bug_ancillary` + `Distribution.with_ancillary`) | **30/30 pass** |
| `EfCoreTests.Bug_DurableLocalQueue_ancillary` | **3/3 pass** |
| `Wolverine.RabbitMQ.Tests.Bug_2155_ancillary` | **1/1 pass** |
| `Wolverine.Http.Tests.using_ancillary_stores` | **1/1 pass** |
| Full Marten Bugs | **45/45 pass** |
| Full AggregateHandlerWorkflow | **66/66 pass** |
| `dotnet build wolverine.slnx -c Release` | **0 warnings, 0 errors** |

**Negative-control:** commenting out the policy registration makes `Bug_2944_interop_ancillary_inbox` fail with exactly the assertion the reporter described — *"The interop message should have been persisted in the ancillary store's inbox"* — confirming the test exercises the bug.

`PersistenceTests.ModularMonoliths.end_to_end_modular_monolith` and `.registration_of_message_stores` could **not** be validated locally — their SQL-Server-touching fixtures time out under emulated SQL Server 2025 on Apple Silicon. The same tests fail the same way on the **baseline (no fix)** — this is a pre-existing local-environment limitation, not a regression introduced here. CI on native Linux SQL Server validates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)