### PR TITLE
Pulsar: fix KeyNotFoundException acking batch messages on partitioned topics (supersedes #2883)

### DIFF
--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/FixMessageIdTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/FixMessageIdTests.cs
@@ -1,0 +1,73 @@
+using DotPulsar;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+// Regression for the DotPulsar batch-handler partitioned-topic bug
+// (https://github.com/apache/pulsar-dotpulsar/issues/287). Builds on @patrick-cloke-simplisafe's
+// original repro in PR #2883; the only structural difference here is that PulsarListener now
+// reconstructs the partition sub-topic URI from the source consumer's own Topic
+// (IConsumer.Topic) rather than from _endpoint.PulsarTopic(). That additionally covers the
+// retry-consumer ack path - the retry consumer is subscribed to {baseTopic}-RETRY (or a
+// user-configured retry topic), so reusing the listener's base endpoint URI would have
+// reconstructed wrong sub-topic names and produced the same KeyNotFoundException on partitioned
+// retry topics.
+public class FixMessageIdTests
+{
+    private const string TopicUri = "persistent://public/default/events";
+    private const string RetryTopicUri = "persistent://public/default/events-RETRY";
+
+    [Fact]
+    public void FixMessageId_BatchMessageMissingTopic_ReconstructsPartitionTopic()
+    {
+        var messageId = new MessageId(1UL, 2UL, partition: 3, batchIndex: 0);
+
+        var result = PulsarListener.FixMessageId(messageId, TopicUri);
+
+        result.Topic.ShouldBe($"{TopicUri}-partition-3");
+        result.LedgerId.ShouldBe(1UL);
+        result.EntryId.ShouldBe(2UL);
+        result.Partition.ShouldBe(3);
+        result.BatchIndex.ShouldBe(0);
+    }
+
+    [Fact]
+    public void FixMessageId_TopicAlreadySet_ReturnsOriginal()
+    {
+        var messageId = new MessageId(1UL, 2UL, partition: 3, batchIndex: 0, topic: $"{TopicUri}-partition-3");
+
+        var result = PulsarListener.FixMessageId(messageId, TopicUri);
+
+        result.ShouldBeSameAs(messageId);
+    }
+
+    [Fact]
+    public void FixMessageId_NonPartitionedMessage_ReturnsOriginal()
+    {
+        var messageId = new MessageId(1UL, 2UL, partition: -1, batchIndex: -1);
+
+        var result = PulsarListener.FixMessageId(messageId, TopicUri);
+
+        result.ShouldBeSameAs(messageId);
+    }
+
+    [Fact]
+    public void FixMessageId_BatchMessageOnPartitionedRetryTopic_UsesRetryTopicForReconstruction()
+    {
+        // When the source consumer is the retry consumer, the listener passes that consumer's
+        // Topic - which is the retry topic URI, not the base topic URI. The reconstruction must
+        // therefore key the partition sub-topic off the retry topic so the ack lands on the
+        // correct sub-consumer inside DotPulsar's IConsumer._subConsumers map. Passing the base
+        // topic URI here (as the prior reconstruction did) would produce
+        // "events-partition-3" — a key the retry consumer's sub-consumers map does not contain —
+        // and re-trigger the same KeyNotFoundException the original bug reported on the main
+        // ack path.
+        var messageId = new MessageId(1UL, 2UL, partition: 3, batchIndex: 0);
+
+        var result = PulsarListener.FixMessageId(messageId, RetryTopicUri);
+
+        result.Topic.ShouldBe($"{RetryTopicUri}-partition-3");
+        result.Partition.ShouldBe(3);
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -158,7 +158,7 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
             var consumer = e.IsFromRetryConsumer && _retryConsumer != null ? _retryConsumer : _consumer;
             if (consumer != null)
             {
-                return consumer.Acknowledge(e.MessageData, _cancellation);
+                return consumer.Acknowledge(FixMessageId(e.MessageData.MessageId, consumer.Topic), _cancellation);
             }
         }
 
@@ -172,7 +172,7 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
         if (_enableRequeue && _sender is not null && envelope is PulsarEnvelope e)
         {
             var consumer = e.IsFromRetryConsumer && _retryConsumer != null ? _retryConsumer : _consumer;
-            await consumer!.Acknowledge(e.MessageData, _cancellation);
+            await consumer!.Acknowledge(FixMessageId(e.MessageData.MessageId, consumer.Topic), _cancellation);
             await _sender.SendAsync(envelope);
         }
     }
@@ -297,12 +297,35 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
             }
 
             // Acknowledge the original message
-            await sourceConsumer!.Acknowledge(e.MessageData, _cancellation);
+            await sourceConsumer!.Acknowledge(FixMessageId(e.MessageData.MessageId, sourceConsumer.Topic), _cancellation);
 
             // Send copy to retry/DLQ topic
             await targetProducer.Send(messageMetadata, e.MessageData.Data, _cancellation)
                 .ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Workaround for https://github.com/apache/pulsar-dotpulsar/issues/287. DotPulsar's
+    /// <c>BatchHandler.Add</c> constructs the inner <see cref="MessageId" /> for each message of a
+    /// batch via the four-arg ctor and never sets <see cref="MessageId.Topic" />, so
+    /// <c>Consumer.Acknowledge</c> hits <c>_subConsumers[messageId.Topic]</c> with the empty
+    /// string and throws <see cref="System.Collections.Generic.KeyNotFoundException" /> on
+    /// partitioned topics. Reconstruct the <see cref="MessageId" /> with the partition sub-topic
+    /// URI built from the <see cref="IConsumer.Topic" /> the source consumer was subscribed to.
+    /// Using <c>consumer.Topic</c> rather than <c>_endpoint.PulsarTopic()</c> means the same
+    /// helper works for the retry consumer (which subscribes to <c>{baseTopic}-RETRY</c>) without
+    /// any branching — DotPulsar reports the actual subscribed topic per consumer.
+    /// </summary>
+    internal static MessageId FixMessageId(MessageId messageId, string consumerTopic)
+    {
+        if (string.IsNullOrEmpty(messageId.Topic) && messageId.Partition >= 0)
+        {
+            return new MessageId(messageId.LedgerId, messageId.EntryId, messageId.Partition,
+                messageId.BatchIndex, $"{consumerTopic}-partition-{messageId.Partition}");
+        }
+
+        return messageId;
     }
 
     private MessageMetadata BuildMessageMetadata(Envelope envelope, PulsarEnvelope e, Exception? exception,


### PR DESCRIPTION
Supersedes [#2883](https://github.com/JasperFx/wolverine/pull/2883). Co-authored with @patrick-cloke-simplisafe, who diagnosed the upstream DotPulsar bug and wrote the original fix.

## The bug

DotPulsar's `BatchHandler.Add` ([apache/pulsar-dotpulsar#287](https://github.com/apache/pulsar-dotpulsar/issues/287)) constructs the inner `MessageId` for each message of a batch via the four-arg ctor and never sets `MessageId.Topic`. `Consumer.Acknowledge` then does `_subConsumers[messageId.Topic]` with the empty string and throws `KeyNotFoundException` on partitioned topics, so batched messages on partitioned topics are never acked → infinite redelivery.

Non-batched messages are unaffected: `ConsumerChannel` uses `ToMessageId(topic)` for those, which correctly populates `Topic`.

## Fix

`PulsarListener.FixMessageId` reconstructs the `MessageId` with the partition sub-topic URI (`{topic}-partition-{N}`) when `Topic` is empty and `Partition >= 0`. Short-circuits and returns the original `MessageId` instance otherwise (forward-compat for when the upstream DotPulsar fix lands; non-partitioned messages pass through unchanged). Applied at the three `Acknowledge` call sites in `PulsarListener`: `CompleteAsync`, `DeferAsync`, and `moveToQueueAsync` (the DLQ / retry-letter path).

## Difference from #2883

One substantive change: each ack call site uses **the source consumer's own `IConsumer.Topic`** (`consumer.Topic` / `sourceConsumer.Topic`) rather than `_endpoint.PulsarTopic()`. DotPulsar exposes `Topic` on the `IConsumer` abstraction (verified in `DotPulsar/Abstractions/IConsumer.cs`; stable since 3.x), so the same helper works correctly for the retry consumer without any branching. The retry consumer is subscribed to `{baseTopic}-RETRY` (or a user-configured retry topic), so the original `_endpoint.PulsarTopic()`-based reconstruction would have produced wrong sub-topic names (`{baseTopic}-partition-N` instead of `{baseTopic}-RETRY-partition-N`) and re-triggered the same `KeyNotFoundException` on the retry path for users with partitioned retry topics. Latent in the original PR; addressed here.

Carries Patrick's three unit tests verbatim, plus one new test (`FixMessageId_BatchMessageOnPartitionedRetryTopic_UsesRetryTopicForReconstruction`) that pins the retry-topic reconstruction contract.

## On `Envelope.TopicName`

@jeremydmiller asked on #2883 whether `Envelope.TopicName` could carry the topic and avoid URI reconstruction entirely. **It can't.** DotPulsar's `IMessage<T>` has no `Topic` property — the concrete `Message<T>` ctor takes no `topic` parameter, and `MessageFactory<T>` doesn't even know the topic it's constructing for. The only sources for the partition sub-topic at the ack site are (a) `MessageId.Topic` when set (works for non-batched) and (b) reconstruction from the consumer's base topic + `MessageId.Partition`. Populating `Envelope.TopicName` from that same reconstruction would just centralize the formatting in `PulsarEnvelopeMapper`; it doesn't eliminate it.

A separate enhancement to surface topic info to user handlers via `Envelope.TopicName` on incoming Pulsar messages is worth pursuing in its own PR — but it's out of scope for the bug fix here.

## Verification

- `FixMessageIdTests`: 4/4 pass locally (net9.0).
- Full `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors).
- The wider Pulsar compliance suite (`PulsarTransportComplianceTests`, `InlinePulsarTransportComplianceTests`, `with_cloud_events`) has 11 pre-existing local failures around retry/DLQ — verified that **the same tests fail identically on baseline `origin/main` with my fix stashed** (`BadImageFormatException` during handler load → Wolverine runtime-codegen issue with Apple-Silicon macOS, unrelated to this change). CI on Linux x64 validates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)