### PR TITLE
Bump remote-node agent InvokeAsync<T> reply timeout 10s → 30s (closes #2949)

### DIFF
--- a/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
@@ -66,15 +66,23 @@ public partial class WolverineRuntime : IAgentRuntime
     public async Task<T> InvokeAsync<T>(NodeDestination destination, IAgentCommand command) where T : class
     {
         var messageBus = new MessageBus(this);
-        
+
         if (Options.UniqueNodeId == destination.NodeId)
         {
             return await messageBus.InvokeAsync<T>(command, _agentCancellation.Token, 30.Seconds());
         }
 
+        // GH-2949: remote-node InvokeAsync<T> used to wait only 10s for the typed reply while
+        // the same-node path above gets 30s. The asymmetry is backwards - a remote
+        // request-reply traverses the control endpoint + serialization + network, so it needs
+        // at least as much budget as a same-node in-memory call, not less. The 10s ceiling was
+        // tight enough that loaded CI runners (especially the RavenDb leader-election tests
+        // that chain `StartAgents` -> `AgentsStarted` during leadership takeover) hit it on a
+        // real timing race and surfaced 'Timed out waiting for expected response
+        // Wolverine.Runtime.Agents.AgentsStarted ... configured timeout of 10000 milliseconds'.
         return await messageBus
             .EndpointFor(destination.ControlUri)
-            .InvokeAsync<T>(command, _agentCancellation.Token, 10.Seconds());
+            .InvokeAsync<T>(command, _agentCancellation.Token, 30.Seconds());
     }
 
     public Uri[] AllRunningAgentUris()


### PR DESCRIPTION
Closes #2949. Mitigates the chronic `RavenDbTests.LeaderElection.leadership_election_compliance.*` flake that hit three consecutive PRs in May 2026 (#2943, #2947, #2948).

## Root cause

`WolverineRuntime.Agents.InvokeAsync<T>(NodeDestination, IAgentCommand)` had an asymmetric timeout:

```csharp
if (Options.UniqueNodeId == destination.NodeId)
{
    return await messageBus.InvokeAsync<T>(command, _agentCancellation.Token, 30.Seconds());  // same-node: 30s
}

return await messageBus
    .EndpointFor(destination.ControlUri)
    .InvokeAsync<T>(command, _agentCancellation.Token, 10.Seconds());                          // remote: 10s
```

The asymmetry is **backwards.** A remote request-reply traverses the control endpoint + serialization + network — it needs *at least* as much budget as a same-node in-memory invocation, not less. The 10s ceiling was tight enough that loaded CI runners hit it on a real timing race during the cross-node leadership-takeover scenarios the failing tests exercise (`StartAgents` → `AgentsStarted` ack between nodes).

The failure trace surfaces the exact constant: *"configured timeout of 10000 milliseconds"*.

## Fix

Align the remote timeout with the same-node timeout at 30s. Same constant the in-process path already accepts, so no new ceiling is introduced — just removes the asymmetry.

This is a **production change**, not a test-only mitigation. The same flake would (rarely) bite users on busy multi-node Wolverine clusters whose leadership takeover triggers `StartAgents` → `AgentsStarted` under network/CPU pressure — they'd see a `TimeoutException` percolate up from `Agents.InvokeAsync<T>` and the leadership-handoff would abort. The fix gives those handoffs the same budget they already have when the local node is the target.

## Why this approach over the alternatives in #2949

The issue listed two options:
1. **Bump the explicit timeouts in the two flaky test cases.** Considered but test-only — leaves the same race on real multi-node deployments.
2. **`[Trait("Category", "Flaky")]` on the two failing tests.** Loses leader-election coverage on every CI run; the tests are *correct*, the system-under-test's timeout is too tight.

Both miss the actual fix, which is to address the asymmetric production constant. The patch is one line of executable code + a comment.

## Verification

Full `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors). The two failing leader-election tests need RavenDb + multi-node hosting which doesn't run locally on this machine; CI on Linux runners will validate that the bump resolves the flake on the standard CI runners. Worst case if CI still flakes after this change, that's a real signal the timing is more broken than a budget bump can paper over and deserves a deeper look at the leader-election sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)