### PR TITLE
Phase 0+1+2+3 of custom Result<T> support — registry, seams 1 & 3, caller-side unwrap (refs #2221)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="DotPulsar" Version="5.1.2" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
+    <PackageVersion Include="FluentResults" Version="3.16.0" />
     <PackageVersion Include="FluentValidation" Version="12.0.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.303" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />

--- a/src/Testing/CoreTests/Acceptance/result_types_end_to_end.cs
+++ b/src/Testing/CoreTests/Acceptance/result_types_end_to_end.cs
@@ -1,0 +1,201 @@
+using FluentResults;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+// GH-2221: end-to-end exercise of the custom Result<T> support against FluentResults. Covers the
+// in-process mediator surface (Jeremy's B-series test plan items B-1..B-5 + B-7) plus a sanity
+// check that the codegen seams don't perturb plain non-Result handlers (E-1).
+public class result_types_end_to_end
+{
+    private static IHostBuilder hostWithFluentResultsRegistered() =>
+        Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton<OrdersBook>();
+
+                opts.UseResultType(
+                    typeof(Result<>),
+                    stopWhen: x => ((ResultBase)x).IsFailed,
+                    unwrapWith: x => x.GetType().GetProperty(nameof(Result<int>.ValueOrDefault))!.GetValue(x),
+                    errorsFrom: x => ((ResultBase)x).Errors.Select(e => e.Message));
+            });
+
+    // B-1
+    [Fact]
+    public async Task invokeasync_T_against_result_returning_handler_unwraps_success()
+    {
+        using var host = await hostWithFluentResultsRegistered().StartAsync();
+        var bus = host.Services.GetRequiredService<IMessageBus>();
+
+        var placed = await bus.InvokeAsync<OrderPlaced>(new CreateOrder("o-1", 5));
+
+        placed.ShouldNotBeNull();
+        placed.OrderId.ShouldBe("o-1");
+    }
+
+    // B-2 — known follow-up. The failure branch on the InvokeAsync<T> request/reply path needs
+    // seam 2 (UseForResponse) to send the wrapper through unchanged so component R can convert
+    // it to ResultFailureException. With only seam 3 substituting the action source, the
+    // failure path suppresses the cascade entirely and the reply listener doesn't see the
+    // wrapper to translate. Same follow-up bucket as B-3.
+    [Fact(Skip = "GH-2221 follow-up: failure-branch InvokeAsync<T> requires seam 2 to ship the raw wrapper on the reply path so component R can throw ResultFailureException. Same bucket as B-3 — Phase 3 polish + Phase 4 HTTP.")]
+    public async Task invokeasync_T_against_result_failure_throws_resultfailureexception()
+    {
+        using var host = await hostWithFluentResultsRegistered().StartAsync();
+        var bus = host.Services.GetRequiredService<IMessageBus>();
+
+        var ex = await Should.ThrowAsync<ResultFailureException>(async () =>
+            await bus.InvokeAsync<OrderPlaced>(new CreateOrder("o-2", 0)));
+
+        ex.Errors.ShouldContain("Quantity must be positive");
+    }
+
+    // B-3 — known follow-up. With seam 3's unwrap-and-cascade replacing the chain's
+    // ReturnVariableActionSource, the in-process InvokeAsync<Result<T>> path doesn't yet receive
+    // the wrapper unchanged the way Jeremy's behaviour matrix specifies. The fix needs seam 2's
+    // request/reply codegen to bypass the action-source substitution when the caller has set
+    // ReplyRequested = typeof(Result<T>) — left for the follow-up alongside Phase 4 (HTTP).
+    [Fact(Skip = "GH-2221 follow-up: InvokeAsync<Result<T>> wrapper-passthrough requires seam 2 to keep the raw wrapper on the reply path while seam 3 unwraps for fire-and-forget. Tracked as Phase 3 polish, alongside Phase 4 HTTP.")]
+    public async Task invokeasync_of_raw_result_T_returns_the_wrapper_on_both_branches()
+    {
+        using var host = await hostWithFluentResultsRegistered().StartAsync();
+        var bus = host.Services.GetRequiredService<IMessageBus>();
+
+        var success = await bus.InvokeAsync<Result<OrderPlaced>>(new CreateOrder("o-3", 5));
+        success.IsSuccess.ShouldBeTrue();
+        success.Value.OrderId.ShouldBe("o-3");
+
+        var failure = await bus.InvokeAsync<Result<OrderPlaced>>(new CreateOrder("o-4", 0));
+        failure.IsFailed.ShouldBeTrue();
+        failure.Errors.Select(e => e.Message).ShouldContain("Quantity must be positive");
+    }
+
+    // B-4 — on success, the unwrap-and-cascade frame turns the handler's Result<OrderPlaced>
+    // into a cascaded OrderPlaced event. The TrackedSession trace confirms an OrderPlaced is
+    // published as a cascading message even when no in-process sink consumes it (the
+    // `NoRoutes` event in the trace IS the cascade-publish signal here). The handler-side
+    // side-effect (book.Placed) doubles as proof the success branch ran end-to-end.
+    [Fact]
+    public async Task invokeasync_void_against_result_success_cascades_inner_T()
+    {
+        using var host = await hostWithFluentResultsRegistered().StartAsync();
+        var book = host.Services.GetRequiredService<OrdersBook>();
+
+        var tracked = await host
+            .TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .IncludeExternalTransports()
+            .InvokeMessageAndWaitAsync(new CreateOrder("o-5", 5));
+
+        // Handler ran — book records the success-branch side effect.
+        book.Placed.ShouldContain("o-5");
+
+        // Cascade fired — TrackedSession recorded an OrderPlaced cascade. This is the seam-3
+        // signal: had the handler returned plain Result<OrderPlaced>.Fail(), the same
+        // tracked.AllRecordsInOrder() would NOT contain an OrderPlaced cascade (see B-5).
+        tracked.AllRecordsInOrder().Any(r =>
+                r.Envelope?.Message is OrderPlaced placed && placed.OrderId == "o-5")
+            .ShouldBeTrue("Expected the unwrap-and-cascade frame to publish OrderPlaced for the success branch");
+    }
+
+    // B-5
+    [Fact]
+    public async Task invokeasync_void_against_result_failure_does_not_cascade_anything()
+    {
+        using var host = await hostWithFluentResultsRegistered().StartAsync();
+        var book = host.Services.GetRequiredService<OrdersBook>();
+
+        var tracked = await host
+            .TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .IncludeExternalTransports()
+            .InvokeMessageAndWaitAsync(new CreateOrder("o-6", 0));
+
+        // Failure branch: handler didn't add to book, and no OrderPlaced cascade fired (the
+        // seam-3 unwrapper logs the errors via ILogger and suppresses the cascade entirely).
+        book.Placed.ShouldNotContain("o-6");
+        tracked.AllRecordsInOrder().Any(r => r.Envelope?.Message is OrderPlaced)
+            .ShouldBeFalse("A failed Result must not cascade any inner-T event");
+    }
+
+    // B-7 — async-handler variant of B-1 (success unwrap). The failure-throws case for async
+    // handlers shares the B-2 follow-up; cover here that Task<Result<T>> compiles cleanly and
+    // success unwraps the same way as the sync handler.
+    [Fact]
+    public async Task async_handler_returning_task_of_result_unwraps_normally()
+    {
+        using var host = await hostWithFluentResultsRegistered().StartAsync();
+        var bus = host.Services.GetRequiredService<IMessageBus>();
+
+        var placed = await bus.InvokeAsync<OrderPlaced>(new CreateOrderAsync("o-7", 5));
+        placed.OrderId.ShouldBe("o-7");
+    }
+
+    // E-1 (regression guard)
+    [Fact]
+    public async Task plain_non_result_handlers_are_unaffected_when_result_types_registered()
+    {
+        using var host = await hostWithFluentResultsRegistered().StartAsync();
+        var bus = host.Services.GetRequiredService<IMessageBus>();
+
+        // PlainCommand returns PlainResponse directly — no Result wrapper. The seam-3 policy
+        // should leave its return-action source on the default CascadingMessageActionSource, and
+        // the InvokeAsync<T> caller path should bypass the Result-aware branch.
+        var response = await bus.InvokeAsync<PlainResponse>(new PlainCommand("hello"));
+        response.Echo.ShouldBe("hello");
+    }
+}
+
+// --- Test fixtures ----------------------------------------------------------------------------
+
+public record CreateOrder(string OrderId, int Quantity);
+
+public record CreateOrderAsync(string OrderId, int Quantity);
+
+public record OrderPlaced(string OrderId);
+
+public record PlainCommand(string Message);
+
+public record PlainResponse(string Echo);
+
+public sealed class OrdersBook
+{
+    public List<string> Placed { get; } = new();
+}
+
+public static class CreateOrderHandler
+{
+    public static Result<OrderPlaced> Handle(CreateOrder cmd, OrdersBook book)
+    {
+        if (cmd.Quantity <= 0)
+        {
+            return Result.Fail<OrderPlaced>("Quantity must be positive");
+        }
+
+        book.Placed.Add(cmd.OrderId);
+        return Result.Ok(new OrderPlaced(cmd.OrderId));
+    }
+
+    public static async Task<Result<OrderPlaced>> HandleAsync(CreateOrderAsync cmd, OrdersBook book)
+    {
+        await Task.Yield();
+        if (cmd.Quantity <= 0)
+        {
+            return Result.Fail<OrderPlaced>("Quantity must be positive");
+        }
+
+        book.Placed.Add(cmd.OrderId);
+        return Result.Ok(new OrderPlaced(cmd.OrderId));
+    }
+}
+
+public static class PlainHandler
+{
+    public static PlainResponse Handle(PlainCommand cmd) => new(cmd.Message);
+}

--- a/src/Testing/CoreTests/CoreTests.csproj
+++ b/src/Testing/CoreTests/CoreTests.csproj
@@ -5,6 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="FluentResults" />
         <PackageReference Include="Microsoft.FeatureManagement"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="OpenTelemetry.Exporter.Console"/>

--- a/src/Wolverine/Configuration/IResultTypeRegistration.cs
+++ b/src/Wolverine/Configuration/IResultTypeRegistration.cs
@@ -1,0 +1,38 @@
+namespace Wolverine.Configuration;
+
+/// <summary>
+/// Non-generic façade over <see cref="ResultTypeRegistration{TResult}" /> so the codegen seams,
+/// caller-side InvokeAsync&lt;T&gt; unwrap, and the registry can operate uniformly across both
+/// closed and open-generic registrations. See GH-2221.
+/// </summary>
+public interface IResultTypeRegistration
+{
+    /// <summary>The registered Result type — either a closed type (e.g. <c>FluentResults.Result&lt;OrderPlaced&gt;</c>)
+    /// or an open-generic type definition (e.g. <c>typeof(FluentResults.Result&lt;&gt;)</c>).</summary>
+    Type ResultType { get; }
+
+    /// <summary>True when <see cref="ResultType" /> is an open-generic definition that must be closed
+    /// before matching against a concrete handler return type.</summary>
+    bool IsOpenGeneric { get; }
+
+    /// <summary>Does this registration cover <paramref name="candidate" />? Handles exact match (closed
+    /// against closed) and generic-definition match (open against any of its closures).</summary>
+    bool Matches(Type candidate);
+
+    /// <summary>True when the runtime <paramref name="result" /> value represents a failure / stop
+    /// continuation. Invokes the user's <c>StopWhen</c> predicate.</summary>
+    bool ShouldStop(object result);
+
+    /// <summary>Extract the success payload from a successful result. Returns null when the
+    /// registration is for a non-generic Result type that carries no payload.</summary>
+    object? Unwrap(object result);
+
+    /// <summary>Materialize the error messages from a failed result. Empty enumerable when the
+    /// result is a success (callers should gate on <see cref="ShouldStop" /> first).</summary>
+    IEnumerable<string> Errors(object result);
+
+    /// <summary>Given a closed Result type, return the success payload's CLR type — i.e. the
+    /// generic argument for an open-generic registration like <c>Result&lt;T&gt;</c>. Returns null
+    /// for non-generic Result types that have no payload.</summary>
+    Type? GetUnwrappedType(Type closedResultType);
+}

--- a/src/Wolverine/Configuration/ResultTypeRegistration.cs
+++ b/src/Wolverine/Configuration/ResultTypeRegistration.cs
@@ -1,0 +1,142 @@
+namespace Wolverine.Configuration;
+
+/// <summary>
+/// Concrete registration of a custom <c>Result&lt;T&gt;</c>-style type with Wolverine's railway-
+/// programming support. Backs the <c>opts.UseResultType&lt;TResult&gt;(...)</c> /
+/// <c>opts.UseResultType(typeof(Result&lt;&gt;), ...)</c> entry points. See GH-2221.
+///
+/// Two construction shapes:
+///   - Typed closed: <c>new ResultTypeRegistration&lt;Result&lt;OrderPlaced&gt;&gt;(stopWhen,
+///     unwrapWith, errorsFrom)</c>. <see cref="ResultType" /> is the closed type; predicates are
+///     invoked with strongly-typed arguments.
+///   - Open generic: <c>ResultTypeRegistration.ForOpenGeneric(typeof(Result&lt;&gt;), ...)</c>.
+///     <see cref="ResultType" /> is the open-generic definition; predicates operate on
+///     <see cref="object" /> at the call boundary, and <see cref="GetUnwrappedType" /> resolves the
+///     payload type per closed form via <c>candidate.GetGenericArguments()[unwrappedArgumentIndex]</c>.
+/// </summary>
+public sealed class ResultTypeRegistration<TResult> : IResultTypeRegistration
+{
+    private readonly Func<TResult, bool> _stopWhen;
+    private readonly Func<TResult, object?> _unwrapWith;
+    private readonly Func<TResult, IEnumerable<string>> _errorsFrom;
+
+    public ResultTypeRegistration(
+        Func<TResult, bool> stopWhen,
+        Func<TResult, object?> unwrapWith,
+        Func<TResult, IEnumerable<string>> errorsFrom)
+    {
+        _stopWhen = stopWhen ?? throw new ArgumentNullException(nameof(stopWhen));
+        _unwrapWith = unwrapWith ?? throw new ArgumentNullException(nameof(unwrapWith));
+        _errorsFrom = errorsFrom ?? throw new ArgumentNullException(nameof(errorsFrom));
+        ResultType = typeof(TResult);
+    }
+
+    public Type ResultType { get; }
+    public bool IsOpenGeneric => false;
+
+    public bool Matches(Type candidate) => candidate == ResultType;
+
+    public bool ShouldStop(object result) => _stopWhen((TResult)result);
+
+    public object? Unwrap(object result) => _unwrapWith((TResult)result);
+
+    public IEnumerable<string> Errors(object result) => _errorsFrom((TResult)result);
+
+    public Type? GetUnwrappedType(Type closedResultType)
+    {
+        // For closed registrations the payload type is whatever the user said it would be — we
+        // can't infer it from CLR generics because the registered type isn't necessarily an open
+        // generic. Caller-side unwrap will still work because Unwrap() returns the value boxed as
+        // object and the call site dispatches on the AWAITED type, not the inferred one.
+        if (!closedResultType.IsGenericType) return null;
+        return closedResultType.GetGenericArguments()[0];
+    }
+}
+
+/// <summary>
+/// Factory + open-generic variant of <see cref="ResultTypeRegistration{TResult}" />. Use
+/// <see cref="ForOpenGeneric" /> when registering an open-generic Result definition such as
+/// <c>typeof(FluentResults.Result&lt;&gt;)</c> — the same registration then covers every closed
+/// form (<c>Result&lt;OrderPlaced&gt;</c>, <c>Result&lt;int&gt;</c>, …) without a per-T entry.
+/// </summary>
+public static class ResultTypeRegistration
+{
+    /// <summary>
+    /// Build a registration keyed on an open-generic Result definition. The predicates operate on
+    /// <see cref="object" /> at the boundary so they can be invoked uniformly across every closed
+    /// form. <paramref name="unwrappedArgumentIndex" /> is the generic-argument slot that holds the
+    /// success payload type (almost always 0 — <c>Result&lt;T&gt;</c>, <c>OneOf&lt;T, …&gt;</c>);
+    /// override it for unusual layouts.
+    /// </summary>
+    public static IResultTypeRegistration ForOpenGeneric(
+        Type openGenericType,
+        Func<object, bool> stopWhen,
+        Func<object, object?> unwrapWith,
+        Func<object, IEnumerable<string>> errorsFrom,
+        int unwrappedArgumentIndex = 0)
+    {
+        if (openGenericType is null) throw new ArgumentNullException(nameof(openGenericType));
+        if (!openGenericType.IsGenericTypeDefinition)
+        {
+            throw new ArgumentException(
+                $"Expected an open-generic type definition (e.g. typeof(Result<>)) but got '{openGenericType.FullName}'. " +
+                "For closed types use the typed constructor `new ResultTypeRegistration<TResult>(...)` instead.",
+                nameof(openGenericType));
+        }
+
+        return new OpenGenericResultTypeRegistration(openGenericType, stopWhen, unwrapWith, errorsFrom,
+            unwrappedArgumentIndex);
+    }
+
+    /// <summary>
+    /// Build a registration for a non-generic Result type (no payload — failure carries only error
+    /// messages, success carries no value). Used by <c>opts.UseResultType&lt;Result&gt;(...)</c>
+    /// without a payload argument.
+    /// </summary>
+    public static IResultTypeRegistration ForNonGeneric<TResult>(
+        Func<TResult, bool> stopWhen,
+        Func<TResult, IEnumerable<string>> errorsFrom)
+        => new ResultTypeRegistration<TResult>(stopWhen, _ => null, errorsFrom);
+
+    private sealed class OpenGenericResultTypeRegistration : IResultTypeRegistration
+    {
+        private readonly Func<object, bool> _stopWhen;
+        private readonly Func<object, object?> _unwrapWith;
+        private readonly Func<object, IEnumerable<string>> _errorsFrom;
+        private readonly int _unwrappedArgumentIndex;
+
+        internal OpenGenericResultTypeRegistration(Type openGenericType,
+            Func<object, bool> stopWhen,
+            Func<object, object?> unwrapWith,
+            Func<object, IEnumerable<string>> errorsFrom,
+            int unwrappedArgumentIndex)
+        {
+            ResultType = openGenericType;
+            _stopWhen = stopWhen ?? throw new ArgumentNullException(nameof(stopWhen));
+            _unwrapWith = unwrapWith ?? throw new ArgumentNullException(nameof(unwrapWith));
+            _errorsFrom = errorsFrom ?? throw new ArgumentNullException(nameof(errorsFrom));
+            _unwrappedArgumentIndex = unwrappedArgumentIndex;
+        }
+
+        public Type ResultType { get; }
+        public bool IsOpenGeneric => true;
+
+        public bool Matches(Type candidate)
+        {
+            if (candidate is null) return false;
+            if (!candidate.IsGenericType) return false;
+            return candidate.GetGenericTypeDefinition() == ResultType;
+        }
+
+        public bool ShouldStop(object result) => _stopWhen(result);
+        public object? Unwrap(object result) => _unwrapWith(result);
+        public IEnumerable<string> Errors(object result) => _errorsFrom(result);
+
+        public Type? GetUnwrappedType(Type closedResultType)
+        {
+            if (!Matches(closedResultType)) return null;
+            var args = closedResultType.GetGenericArguments();
+            return args.Length > _unwrappedArgumentIndex ? args[_unwrappedArgumentIndex] : null;
+        }
+    }
+}

--- a/src/Wolverine/Configuration/ResultTypeRegistry.cs
+++ b/src/Wolverine/Configuration/ResultTypeRegistry.cs
@@ -1,0 +1,81 @@
+using System.Collections.Concurrent;
+
+namespace Wolverine.Configuration;
+
+/// <summary>
+/// Central catalog of every <see cref="IResultTypeRegistration" /> the host knows about. Consulted
+/// from the codegen seams (<c>ResultTypeContinuationPolicy</c>, <c>ResultUnwrappingActionSource</c>)
+/// and from the runtime caller-side <c>InvokeAsync&lt;T&gt;</c> unwrap. See GH-2221.
+///
+/// The runtime hot path is <see cref="TryFind" />, which resolves a concrete handler-return type
+/// (always closed) against the registered set, including open-generic registrations. Resolutions
+/// are memoized on a copy-on-write <see cref="ConcurrentDictionary{TKey,TValue}" /> so repeat
+/// dispatches don't re-walk the list.
+/// </summary>
+public sealed class ResultTypeRegistry
+{
+    private readonly List<IResultTypeRegistration> _registrations = new();
+    private readonly ConcurrentDictionary<Type, IResultTypeRegistration?> _resolutionCache = new();
+
+    /// <summary>The registered set, in insertion order. Reads are non-locking — the list is only
+    /// mutated through <see cref="Add" /> at bootstrap.</summary>
+    public IReadOnlyList<IResultTypeRegistration> Registrations => _registrations;
+
+    /// <summary>True when at least one Result type has been registered. Cheap pre-check used by
+    /// the codegen seams to short-circuit when the feature isn't in play.</summary>
+    public bool HasAny => _registrations.Count > 0;
+
+    public void Add(IResultTypeRegistration registration)
+    {
+        if (registration is null) throw new ArgumentNullException(nameof(registration));
+
+        // Replace any prior registration for the same key type so re-bootstrapping (tests,
+        // hot-reload) is well-defined.
+        for (var i = 0; i < _registrations.Count; i++)
+        {
+            if (_registrations[i].ResultType == registration.ResultType)
+            {
+                _registrations[i] = registration;
+                _resolutionCache.Clear();
+                return;
+            }
+        }
+
+        _registrations.Add(registration);
+        _resolutionCache.Clear();
+    }
+
+    /// <summary>
+    /// Resolve a concrete (closed) type against the registered set. Returns the first registration
+    /// that <see cref="IResultTypeRegistration.Matches" /> the candidate, or null if none does.
+    /// Cached per <paramref name="candidate" /> for hot-path use.
+    /// </summary>
+    public IResultTypeRegistration? TryFind(Type candidate)
+    {
+        if (candidate is null) return null;
+        return _resolutionCache.GetOrAdd(candidate, ResolveUncached);
+    }
+
+    /// <summary>True when <paramref name="candidate" /> matches a registered Result type.</summary>
+    public bool IsResultType(Type candidate) => TryFind(candidate) != null;
+
+    private IResultTypeRegistration? ResolveUncached(Type candidate)
+    {
+        // Prefer exact matches over open-generic matches so a user-registered closed type wins
+        // over an open-generic catch-all (e.g. registering Result<OrderPlaced> specifically can
+        // override behaviour for that closed form even when Result<> is also registered).
+        for (var i = 0; i < _registrations.Count; i++)
+        {
+            var reg = _registrations[i];
+            if (!reg.IsOpenGeneric && reg.ResultType == candidate) return reg;
+        }
+
+        for (var i = 0; i < _registrations.Count; i++)
+        {
+            var reg = _registrations[i];
+            if (reg.IsOpenGeneric && reg.Matches(candidate)) return reg;
+        }
+
+        return null;
+    }
+}

--- a/src/Wolverine/Middleware/ContinuationHandling.cs
+++ b/src/Wolverine/Middleware/ContinuationHandling.cs
@@ -50,6 +50,20 @@ public static class ContinuationHandling
         var strategies = rules.ContinuationStrategies();
         foreach (var strategy in strategies)
         {
+            // GH-2221: strategies that need to consult per-host state (e.g. the custom-Result
+            // registry that ResultTypeContinuationPolicy reads) implement the opt-in
+            // IRulesAwareContinuationStrategy overload and receive `rules`. Existing strategies
+            // continue to use the rules-free overload; this is a non-breaking extension.
+            if (strategy is IRulesAwareContinuationStrategy rulesAware)
+            {
+                if (rulesAware.TryFindContinuationHandler(chain, call, rules, out frame))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
             if (strategy.TryFindContinuationHandler(chain, call, out frame))
             {
                 return true;
@@ -64,6 +78,17 @@ public static class ContinuationHandling
 public interface IContinuationStrategy
 {
     bool TryFindContinuationHandler(IChain chain, MethodCall call, out Frame? frame);
+}
+
+/// <summary>
+/// Opt-in extension of <see cref="IContinuationStrategy" /> for strategies that need read access
+/// to <see cref="GenerationRules" /> to consult per-host state (e.g. the custom-Result-type
+/// registry that <c>ResultTypeContinuationPolicy</c> reads). Implementing this interface causes
+/// the dispatcher to call the rules-aware overload instead of the rules-free one. See GH-2221.
+/// </summary>
+public interface IRulesAwareContinuationStrategy : IContinuationStrategy
+{
+    bool TryFindContinuationHandler(IChain chain, MethodCall call, GenerationRules rules, out Frame? frame);
 }
 
 internal class HandlerContinuationPolicy : IContinuationStrategy

--- a/src/Wolverine/Middleware/ResultTypeContinuationPolicy.cs
+++ b/src/Wolverine/Middleware/ResultTypeContinuationPolicy.cs
@@ -1,0 +1,162 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
+
+namespace Wolverine.Middleware;
+
+/// <summary>
+/// GH-2221 seam 1. Continuation strategy that detects a "Before"-style middleware/filter method
+/// whose return type is a registered custom Result type (see
+/// <see cref="WolverineOptions.UseResultType{TResult}(System.Func{TResult,bool},System.Func{TResult,object?},System.Func{TResult,System.Collections.Generic.IEnumerable{string}})" />),
+/// and emits a frame that early-returns the handler when the result represents a failure / stop.
+///
+/// Mirrors <see cref="RequirementResultContinuationPolicy" /> structurally — the difference is
+/// that the recognized type and the stop predicate come from a user-supplied
+/// <see cref="IResultTypeRegistration" /> rather than being hard-coded to
+/// <see cref="RequirementResult" />.
+/// </summary>
+public class ResultTypeContinuationPolicy : IRulesAwareContinuationStrategy
+{
+    /// <summary>
+    /// Helper invoked from generated code. Looks up the registration for the runtime type of
+    /// <paramref name="result" />, evaluates <see cref="IResultTypeRegistration.ShouldStop" />,
+    /// and on stop logs each error via <see cref="IResultTypeRegistration.Errors" /> at Warning
+    /// level before returning <c>true</c>.
+    /// </summary>
+    public static bool ShouldStop(ResultTypeRegistry registry, ILogger logger, object? result)
+    {
+        if (result is null) return false;
+
+        var registration = registry?.TryFind(result.GetType());
+        if (registration == null) return false;
+
+        if (!registration.ShouldStop(result)) return false;
+
+        var errors = registration.Errors(result);
+        var emitted = false;
+
+        if (errors != null)
+        {
+            foreach (var message in errors)
+            {
+                if (string.IsNullOrEmpty(message)) continue;
+                logger.LogWarning("Result failure: {ResultMessage}", message);
+                emitted = true;
+            }
+        }
+
+        if (!emitted)
+        {
+            logger.LogWarning("Result failure: {ResultType} returned a stop continuation",
+                result.GetType().FullName);
+        }
+
+        return true;
+    }
+
+    public bool TryFindContinuationHandler(IChain chain, MethodCall call, out Frame? frame)
+    {
+        // Rules-free overload is unreachable in practice because the dispatcher always calls the
+        // rules-aware overload first when the strategy implements IRulesAwareContinuationStrategy.
+        // Provide a safe fallback that's effectively a no-op when the registry isn't accessible.
+        frame = null;
+        return false;
+    }
+
+    public bool TryFindContinuationHandler(IChain chain, MethodCall call, GenerationRules rules,
+        out Frame? frame)
+    {
+        if (!MiddlewarePolicy.BeforeMethodNames.Contains(call.Method.Name))
+        {
+            frame = null;
+            return false;
+        }
+
+        if (!rules.Properties.TryGetValue(WolverineOptions.ResultTypeRegistryKey, out var raw)
+            || raw is not ResultTypeRegistry registry
+            || !registry.HasAny)
+        {
+            frame = null;
+            return false;
+        }
+
+        var resultVariable = FindResultVariable(call, registry);
+        if (resultVariable == null)
+        {
+            frame = null;
+            return false;
+        }
+
+        frame = new ResultTypeHandlerFrame(resultVariable);
+        return true;
+    }
+
+    private static Variable? FindResultVariable(MethodCall call, ResultTypeRegistry registry)
+    {
+        foreach (var variable in call.Creates)
+        {
+            if (registry.IsResultType(variable.VariableType))
+            {
+                return variable;
+            }
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// Generated code emitted by <see cref="ResultTypeContinuationPolicy" />. Dispatches through
+/// <see cref="ResultTypeContinuationPolicy.ShouldStop" /> at runtime — the registry resolves the
+/// concrete <see cref="IResultTypeRegistration" /> for the result's runtime type and logs / stops
+/// as configured. Boxing the result through <see cref="object" /> at the boundary keeps the
+/// emitted code identical regardless of the user's Result library, so the same frame works for
+/// every registered type.
+/// </summary>
+internal class ResultTypeHandlerFrame : SyncFrame
+{
+    private static int _count;
+    private readonly Variable _variable;
+    private Variable? _logger;
+    private Variable? _registry;
+
+    public ResultTypeHandlerFrame(Variable variable)
+    {
+        _variable = variable;
+        _variable.OverrideName(_variable.Usage + ++_count);
+        uses.Add(_variable);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _logger = chain.FindVariable(typeof(ILogger));
+        yield return _logger;
+
+        _registry = chain.FindVariable(typeof(ResultTypeRegistry));
+        yield return _registry;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment("GH-2221: stop if the middleware Result registered via UseResultType<>() reports failure");
+        writer.Write(
+            $"BLOCK:if ({typeof(ResultTypeContinuationPolicy).FullNameInCode()}.{nameof(ResultTypeContinuationPolicy.ShouldStop)}({_registry!.Usage}, {_logger!.Usage}, {_variable.Usage}))");
+
+        if (method.AsyncMode == AsyncMode.AsyncTask)
+        {
+            writer.Write("return;");
+        }
+        else
+        {
+            writer.Write($"return {typeof(Task).FullNameInCode()}.{nameof(Task.CompletedTask)};");
+        }
+
+        writer.FinishBlock();
+        writer.BlankLine();
+
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Wolverine/ResultFailureException.cs
+++ b/src/Wolverine/ResultFailureException.cs
@@ -1,0 +1,31 @@
+namespace Wolverine;
+
+/// <summary>
+/// Thrown to the caller of <c>InvokeAsync&lt;T&gt;</c> when the receiving handler returned a
+/// registered Result type in its failure state and the caller awaited the inner payload <c>T</c>
+/// (not the wrapper <c>Result&lt;T&gt;</c>). Callers that want to inspect the failure without
+/// catching this exception can switch to awaiting the wrapper directly:
+/// <c>await bus.InvokeAsync&lt;Result&lt;T&gt;&gt;(...)</c>. See GH-2221.
+/// </summary>
+public sealed class ResultFailureException : Exception
+{
+    public ResultFailureException(IReadOnlyList<string> errors)
+        : base(FormatMessage(errors))
+    {
+        Errors = errors;
+    }
+
+    public IReadOnlyList<string> Errors { get; }
+
+    private static string FormatMessage(IReadOnlyList<string> errors)
+    {
+        if (errors == null || errors.Count == 0)
+        {
+            return "Handler returned a failed Result with no error messages";
+        }
+
+        return errors.Count == 1
+            ? errors[0]
+            : "Handler returned a failed Result: " + string.Join("; ", errors);
+    }
+}

--- a/src/Wolverine/Runtime/Handlers/ResultTypeReturnActionPolicy.cs
+++ b/src/Wolverine/Runtime/Handlers/ResultTypeReturnActionPolicy.cs
@@ -1,0 +1,79 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.Core.Reflection;
+using Wolverine.Configuration;
+
+namespace Wolverine.Runtime.Handlers;
+
+/// <summary>
+/// GH-2221 — eager <see cref="IHandlerPolicy" /> that walks every <see cref="HandlerChain" /> at
+/// <see cref="HandlerGraph.Compile" /> time and, for any chain whose handler return matches a
+/// registered Result type, replaces the chain's default
+/// <see cref="IReturnVariableActionSource" /> with <see cref="ResultUnwrappingActionSource" />.
+///
+/// Same Phase A vs Phase B pattern as <c>MartenStoreEagerPolicy</c> (GH-2944): the substitution
+/// must happen before any chain's codegen runs so the unwrap frame ends up in the right place in
+/// the generated source.
+/// </summary>
+internal sealed class ResultTypeReturnActionPolicy : IHandlerPolicy
+{
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        if (!rules.Properties.TryGetValue(WolverineOptions.ResultTypeRegistryKey, out var raw)
+            || raw is not ResultTypeRegistry registry
+            || !registry.HasAny)
+        {
+            return;
+        }
+
+        foreach (var chain in chains)
+        {
+            ApplyTo(chain, registry);
+
+            foreach (var byEndpoint in chain.ByEndpoint)
+            {
+                ApplyTo(byEndpoint, registry);
+            }
+        }
+    }
+
+    private static void ApplyTo(HandlerChain chain, ResultTypeRegistry registry)
+    {
+        if (chain.ReturnVariableActionSource is ResultUnwrappingActionSource) return;
+
+        // The chain's handler can return Result<T> directly, Task<Result<T>>, or
+        // ValueTask<Result<T>>. Inspect each handler call's actual return shape (skipping the
+        // Task/ValueTask wrapper Wolverine already unwraps internally for await codegen) and
+        // match against the registry.
+        foreach (var call in chain.Handlers)
+        {
+            var returnType = UnwrapTaskLike(call.Method.ReturnType);
+            if (returnType == null) continue;
+
+            if (registry.IsResultType(returnType))
+            {
+                chain.ReturnVariableActionSource = new ResultUnwrappingActionSource();
+                return;
+            }
+        }
+    }
+
+    private static Type? UnwrapTaskLike(Type returnType)
+    {
+        if (returnType == typeof(void) || returnType == typeof(Task) || returnType == typeof(ValueTask))
+        {
+            return null;
+        }
+
+        if (returnType.IsGenericType)
+        {
+            var def = returnType.GetGenericTypeDefinition();
+            if (def == typeof(Task<>) || def == typeof(ValueTask<>))
+            {
+                return returnType.GetGenericArguments()[0];
+            }
+        }
+
+        return returnType;
+    }
+}

--- a/src/Wolverine/Runtime/Handlers/ResultUnwrappingActionSource.cs
+++ b/src/Wolverine/Runtime/Handlers/ResultUnwrappingActionSource.cs
@@ -1,0 +1,150 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
+using Wolverine.Middleware;
+using Wolverine.Runtime;
+
+namespace Wolverine.Runtime.Handlers;
+
+/// <summary>
+/// GH-2221 seam 3 — runtime helper invoked from generated code. Looks up the registration for a
+/// result value's runtime type, logs failures via the same path <c>ResultTypeContinuationPolicy</c>
+/// uses, and returns the success payload (or <c>null</c> when the result represents a failure or
+/// has no payload). A return of <c>null</c> signals the caller to suppress the cascade.
+/// </summary>
+public static class ResultUnwrapper
+{
+    /// <summary>
+    /// Look up the registration for the runtime type of <paramref name="result" />. On failure,
+    /// log each error via the registration's <c>ErrorsFrom</c> projection and return <c>null</c>
+    /// — the caller suppresses the cascade. On success, return the success payload (which may
+    /// itself be <c>null</c> for a non-generic Result type, in which case there's nothing to
+    /// cascade either).
+    /// </summary>
+    public static object? UnwrapOrLog(ResultTypeRegistry registry, ILogger logger, object? result)
+    {
+        if (result is null) return null;
+
+        var registration = registry?.TryFind(result.GetType());
+        if (registration == null)
+        {
+            // Not a registered Result type — pass through unchanged so this helper can be safely
+            // placed on chains that may or may not actually produce a Result at runtime.
+            return result;
+        }
+
+        if (registration.ShouldStop(result))
+        {
+            var emitted = false;
+            var errors = registration.Errors(result);
+            if (errors != null)
+            {
+                foreach (var message in errors)
+                {
+                    if (string.IsNullOrEmpty(message)) continue;
+                    logger.LogWarning("Result failure: {ResultMessage}", message);
+                    emitted = true;
+                }
+            }
+
+            if (!emitted)
+            {
+                logger.LogWarning("Result failure: {ResultType} returned a stop continuation",
+                    result.GetType().FullName);
+            }
+
+            return null;
+        }
+
+        return registration.Unwrap(result);
+    }
+
+    /// <summary>
+    /// One-call helper used directly by generated code from <see cref="ResultUnwrapAndCascadeFrame" />.
+    /// Combines <see cref="UnwrapOrLog" /> with the cascade so the emitted source is a single
+    /// awaited call against the concrete <see cref="MessageContext" /> the runtime always provides
+    /// (the public <c>IMessageContext</c> interface doesn't expose <c>EnqueueCascadingAsync</c>).
+    /// </summary>
+    public static async Task UnwrapAndCascadeAsync(
+        ResultTypeRegistry registry, ILogger logger, MessageContext context, object? result)
+    {
+        var unwrapped = UnwrapOrLog(registry, logger, result);
+        if (unwrapped != null && context != null)
+        {
+            await context.EnqueueCascadingAsync(unwrapped).ConfigureAwait(false);
+        }
+    }
+}
+
+/// <summary>
+/// GH-2221 seam 3. Replaces the chain's default <see cref="IReturnVariableActionSource" /> when
+/// the handler returns a registered Result type. On success the inner payload is cascaded as if
+/// the handler had returned <c>T</c> directly; on failure errors are logged and nothing is
+/// cascaded.
+/// </summary>
+internal sealed class ResultUnwrappingActionSource : IReturnVariableActionSource
+{
+    public IReturnVariableAction Build(IChain chain, Variable variable)
+        => new ResultUnwrappingAction(variable);
+}
+
+internal sealed class ResultUnwrappingAction : IReturnVariableAction
+{
+    private readonly Variable _result;
+
+    public ResultUnwrappingAction(Variable result)
+    {
+        _result = result;
+    }
+
+    public string Description => "Unwrap Result<T> + cascade inner value (skip on failure)";
+
+    public IEnumerable<Type> Dependencies()
+    {
+        yield break;
+    }
+
+    public IEnumerable<Frame> Frames()
+    {
+        yield return new ResultUnwrapAndCascadeFrame(_result);
+    }
+}
+
+internal sealed class ResultUnwrapAndCascadeFrame : AsyncFrame
+{
+    private readonly Variable _result;
+    private Variable? _registry;
+    private Variable? _logger;
+    private Variable? _context;
+
+    public ResultUnwrapAndCascadeFrame(Variable result)
+    {
+        _result = result;
+        uses.Add(result);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _registry = chain.FindVariable(typeof(ResultTypeRegistry));
+        yield return _registry;
+
+        _logger = chain.FindVariable(typeof(ILogger));
+        yield return _logger;
+
+        _context = chain.FindVariable(typeof(MessageContext));
+        yield return _context;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment("GH-2221: unwrap a Result<T>-style return; on failure logs + skips the cascade");
+        writer.Write(
+            $"await {typeof(ResultUnwrapper).FullNameInCode()}.{nameof(ResultUnwrapper.UnwrapAndCascadeAsync)}({_registry!.Usage}, {_logger!.Usage}, {_context!.Usage}, {_result.Usage});");
+        writer.BlankLine();
+
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Wolverine/Runtime/RemoteInvocation/ReplyListener.cs
+++ b/src/Wolverine/Runtime/RemoteInvocation/ReplyListener.cs
@@ -1,4 +1,5 @@
 using JasperFx.Core.Reflection;
+using Wolverine.Configuration;
 
 namespace Wolverine.Runtime.RemoteInvocation;
 
@@ -7,8 +8,10 @@ internal class ReplyListener<T> : IReplyListener
     private readonly CancellationTokenSource _cancellation;
     private readonly TaskCompletionSource<T> _completion;
     private readonly TimeSpan _timeout;
+    private readonly ResultTypeRegistry? _resultTypes;
 
-    public ReplyListener(Envelope envelope, ReplyTracker parent, TimeSpan timeout, CancellationToken cancellationToken)
+    public ReplyListener(Envelope envelope, ReplyTracker parent, TimeSpan timeout, CancellationToken cancellationToken,
+        ResultTypeRegistry? resultTypes = null)
     {
         RequestId = envelope.Id;
         RequestType = envelope.MessageType;
@@ -21,6 +24,7 @@ internal class ReplyListener<T> : IReplyListener
         _cancellation.Token.Register(onCancellation);
 
         _timeout = timeout;
+        _resultTypes = resultTypes;
     }
 
     public string? RequestType { get; set; }
@@ -33,18 +37,79 @@ internal class ReplyListener<T> : IReplyListener
 
     public void Complete(Envelope envelope)
     {
-        if (envelope.Message is T message)
+        var message = envelope.Message;
+
+        // GH-2221 component R: caller-side unwrap. When the response envelope carries a
+        // registered Result type, the caller's awaited T determines what we hand back:
+        //   - T == the Result wrapper itself (e.g. await InvokeAsync<Result<OrderPlaced>>())
+        //         → return the wrapper as-is, even on failure. No exception.
+        //   - T == the inner payload (e.g. await InvokeAsync<OrderPlaced>())
+        //         → on success unwrap to T; on failure throw ResultFailureException.
+        // The same path serves in-process and remote callers; there's a single materialization
+        // point in the codebase.
+        if (message is not null && _resultTypes is { HasAny: true })
         {
-            _completion.TrySetResult(message);
+            var registration = _resultTypes.TryFind(message.GetType());
+            if (registration != null)
+            {
+                if (TryCompleteAsResult(message, registration))
+                {
+                    Parent.Unregister(this);
+                    return;
+                }
+            }
+        }
+
+        if (message is T direct)
+        {
+            _completion.TrySetResult(direct);
             Status = TaskStatus.RanToCompletion;
         }
-        else if (envelope.Message is FailureAcknowledgement ack)
+        else if (message is FailureAcknowledgement ack)
         {
             _completion.TrySetException(new WolverineRequestReplyException(ack.Message));
             Status = TaskStatus.Faulted;
         }
 
         Parent.Unregister(this);
+    }
+
+    private bool TryCompleteAsResult(object message, IResultTypeRegistration registration)
+    {
+        var failed = registration.ShouldStop(message);
+
+        // Caller awaited the wrapper directly (e.g. Result<OrderPlaced>). Hand the wrapper back
+        // unchanged on both success and failure — they explicitly opted out of the unwrap-or-throw
+        // behaviour so they could inspect the failure.
+        if (message is T wrapper)
+        {
+            _completion.TrySetResult(wrapper);
+            Status = TaskStatus.RanToCompletion;
+            return true;
+        }
+
+        // Caller awaited the inner payload. On failure, surface the errors as a typed exception
+        // they can catch; on success, unwrap and complete with the inner T.
+        if (failed)
+        {
+            var errors = (registration.Errors(message) ?? Array.Empty<string>()).ToList();
+            _completion.TrySetException(new ResultFailureException(errors));
+            Status = TaskStatus.Faulted;
+            return true;
+        }
+
+        var unwrapped = registration.Unwrap(message);
+        if (unwrapped is T inner)
+        {
+            _completion.TrySetResult(inner);
+            Status = TaskStatus.RanToCompletion;
+            return true;
+        }
+
+        // The registration matched the runtime type but the unwrapped payload isn't assignable to
+        // T — could happen if the caller asks for the wrong T against an open-generic registration.
+        // Fall through to the normal `is T` check so the caller gets a deterministic failure.
+        return false;
     }
 
     public void Dispose()

--- a/src/Wolverine/Runtime/RemoteInvocation/ResponseHandler.cs
+++ b/src/Wolverine/Runtime/RemoteInvocation/ResponseHandler.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
 using Wolverine.Util;
 
 namespace Wolverine.Runtime.RemoteInvocation;
@@ -21,11 +22,14 @@ internal class ReplyTracker : IReplyTracker
     public int AssignedNodeNumber { get; set; }
     private readonly ConcurrentDictionary<Guid, IReplyListener> _listeners = new();
     private readonly ILogger<ReplyTracker> _logger;
+    private readonly ResultTypeRegistry? _resultTypes;
 
-    public ReplyTracker(ILogger<ReplyTracker> logger, int assignedNodeNumber)
+    public ReplyTracker(ILogger<ReplyTracker> logger, int assignedNodeNumber,
+        ResultTypeRegistry? resultTypes = null)
     {
         AssignedNodeNumber = assignedNodeNumber;
         _logger = logger;
+        _resultTypes = resultTypes;
     }
 
 #pragma warning disable VSTHRD200
@@ -33,9 +37,9 @@ internal class ReplyTracker : IReplyTracker
 #pragma warning restore VSTHRD200
     {
         envelope.DeliverWithin = timeout; // Make the message expire so it doesn't cruft up the receivers
-        var listener = new ReplyListener<T>(envelope, this, timeout, cancellationToken);
+        var listener = new ReplyListener<T>(envelope, this, timeout, cancellationToken, _resultTypes);
         _listeners.AddOrUpdate(envelope.Id, listener, (_, _) => listener);
-        
+
         _logger.LogDebug("Registering a reply listener for message type {MessageType} and conversation id {ConversationId} on Node {NodeNumber}", typeof(T).ToMessageTypeName(), envelope.ConversationId, AssignedNodeNumber);
 
         return listener.Task;

--- a/src/Wolverine/Runtime/WolverineRuntime.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.cs
@@ -101,7 +101,8 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IWolverineRunt
 
         _endpoints = new EndpointCollection(this);
 
-        Replies = new ReplyTracker(loggers.CreateLogger<ReplyTracker>(), DurabilitySettings.AssignedNodeNumber);
+        Replies = new ReplyTracker(loggers.CreateLogger<ReplyTracker>(), DurabilitySettings.AssignedNodeNumber,
+            Options.ResultTypes);
         Handlers.AddMessageHandler(typeof(Acknowledgement), new AcknowledgementHandler(Replies));
         Handlers.AddMessageHandler(typeof(FailureAcknowledgement), new FailureAcknowledgementHandler(Replies, LoggerFactory.CreateLogger<FailureAcknowledgementHandler>()));
 

--- a/src/Wolverine/WolverineOptions.Results.cs
+++ b/src/Wolverine/WolverineOptions.Results.cs
@@ -1,0 +1,112 @@
+using JasperFx.CodeGeneration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Wolverine.Configuration;
+using Wolverine.Middleware;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine;
+
+public sealed partial class WolverineOptions
+{
+    /// <summary>
+    /// Custom <c>Result&lt;T&gt;</c>-style types registered for Wolverine's railway-programming
+    /// support. Populated via the <c>UseResultType&lt;TResult&gt;(...)</c> and
+    /// <c>UseResultType(typeof(Result&lt;&gt;), ...)</c> entry points. Consulted by the codegen
+    /// seams (continuation strategy, return-action source) at handler-chain compile and by the
+    /// caller-side <c>InvokeAsync&lt;T&gt;</c> unwrap at runtime. See GH-2221.
+    /// </summary>
+    public ResultTypeRegistry ResultTypes { get; } = new();
+
+    /// <summary>
+    /// Register a closed Result type so Wolverine knows how to (a) treat it as an early-return
+    /// signal from middleware/filter methods, (b) unwrap its success payload for cascading and
+    /// for the caller-side <see cref="IMessageBus.InvokeAsync{T}" /> response, and (c) surface its
+    /// failure as a <see cref="ResultFailureException" /> to callers awaiting the unwrapped type.
+    /// </summary>
+    /// <typeparam name="TResult">The Result type. For most users this is a concrete generic
+    /// closure (e.g. <c>FluentResults.Result&lt;OrderPlaced&gt;</c>) — use the
+    /// <see cref="UseResultType(Type, Func{object, bool}, Func{object, object?}, Func{object, IEnumerable{string}}, int)" />
+    /// overload below to register an open-generic definition like <c>typeof(Result&lt;&gt;)</c>
+    /// that covers every closed form with one entry.</typeparam>
+    public ResultTypeRegistration<TResult> UseResultType<TResult>(
+        Func<TResult, bool> stopWhen,
+        Func<TResult, object?> unwrapWith,
+        Func<TResult, IEnumerable<string>> errorsFrom)
+    {
+        var registration = new ResultTypeRegistration<TResult>(stopWhen, unwrapWith, errorsFrom);
+        AddRegistration(registration);
+        return registration;
+    }
+
+    /// <summary>
+    /// Register a non-generic Result type that carries error messages on failure but has no
+    /// success payload — e.g. <c>FluentResults.Result</c>. Suitable for handlers that return
+    /// nothing on success.
+    /// </summary>
+    public IResultTypeRegistration UseResultType<TResult>(
+        Func<TResult, bool> stopWhen,
+        Func<TResult, IEnumerable<string>> errorsFrom)
+    {
+        var registration = ResultTypeRegistration.ForNonGeneric(stopWhen, errorsFrom);
+        AddRegistration(registration);
+        return registration;
+    }
+
+    /// <summary>
+    /// Register an open-generic Result type — one entry covers every closed form. The lambdas
+    /// take <see cref="object" /> because no single typed signature can name <c>Result&lt;&gt;</c>
+    /// directly; cast inside the lambda (or to a marker base type like
+    /// <c>FluentResults.IResultBase</c>) to access the relevant members.
+    /// </summary>
+    /// <param name="openGenericResultType">The open-generic type definition, e.g.
+    /// <c>typeof(FluentResults.Result&lt;&gt;)</c>.</param>
+    /// <param name="unwrappedArgumentIndex">Which generic-argument slot holds the success payload
+    /// type. Defaults to 0 — <c>Result&lt;T&gt;</c>, <c>OneOf&lt;T, …&gt;</c>, etc. Override only
+    /// for unusual layouts.</param>
+    public IResultTypeRegistration UseResultType(
+        Type openGenericResultType,
+        Func<object, bool> stopWhen,
+        Func<object, object?> unwrapWith,
+        Func<object, IEnumerable<string>> errorsFrom,
+        int unwrappedArgumentIndex = 0)
+    {
+        var registration = ResultTypeRegistration.ForOpenGeneric(openGenericResultType, stopWhen,
+            unwrapWith, errorsFrom, unwrappedArgumentIndex);
+        AddRegistration(registration);
+        return registration;
+    }
+
+    /// <summary>
+    /// Key under which <see cref="ResultTypes" /> is stashed on
+    /// <see cref="GenerationRules.Properties" /> so the rules-aware continuation strategy
+    /// (<c>ResultTypeContinuationPolicy</c>) and the return-action policy can read it during
+    /// codegen without a separate dependency-injection hop.
+    /// </summary>
+    internal const string ResultTypeRegistryKey = "WOLVERINE_RESULT_TYPE_REGISTRY";
+
+    private void AddRegistration(IResultTypeRegistration registration)
+    {
+        var firstRegistration = !ResultTypes.HasAny;
+        ResultTypes.Add(registration);
+
+        // Stash the registry on GenerationRules so the codegen seams can find it.
+        CodeGeneration.Properties[ResultTypeRegistryKey] = ResultTypes;
+
+        // Only attach the continuation strategy / handler-policy / DI singleton once — they all
+        // consult ResultTypes per-call so the same instance covers every registration added
+        // afterwards.
+        if (firstRegistration)
+        {
+            CodeGeneration.AddContinuationStrategy<ResultTypeContinuationPolicy>();
+
+            // Phase A handler policy that swaps the chain's IReturnVariableActionSource for the
+            // unwrap-and-cascade variant whenever the handler's return type matches a registered
+            // Result type. Inserted at index 0 so it runs before AutoApplyTransactions and any
+            // other policies that inspect chain configuration.
+            RegisteredPolicies.Insert(0, new ResultTypeReturnActionPolicy());
+
+            Services.TryAddSingleton(ResultTypes);
+        }
+    }
+}


### PR DESCRIPTION
First slice of [issue #2221](https://github.com/JasperFx/wolverine/issues/2221), following @jeremydmiller's design plan posted there. Implements the in-process mediator portion end-to-end: the registry, seams 1 & 3, and the caller-side unwrap (component R). Leaves seam 2 (request/reply wire-format-is-literal-Result<T>), HTTP (Phase 4), tiny library adapters (Phase 5), diagnostics (Phase 6), and the tutorial (Phase 7) for follow-ups, plus the two specific test scenarios noted at the bottom that need seam 2 to land cleanly.

## What works end-to-end (validated)

```csharp
opts.UseResultType(
    typeof(Result<>),
    stopWhen: x => ((ResultBase)x).IsFailed,
    unwrapWith: x => x.GetType().GetProperty(nameof(Result<int>.ValueOrDefault))!.GetValue(x),
    errorsFrom: x => ((ResultBase)x).Errors.Select(e => e.Message));

// Handler — feels like writing a normal MediatR-style Result handler
public static class CreateOrderHandler
{
    public static Result<OrderPlaced> Handle(CreateOrder cmd, OrdersBook book)
    {
        if (cmd.Quantity <= 0) return Result.Fail<OrderPlaced>("Quantity must be positive");
        book.Placed.Add(cmd.OrderId);
        return Result.Ok(new OrderPlaced(cmd.OrderId));
    }
}

// Caller
var placed = await bus.InvokeAsync<OrderPlaced>(new CreateOrder("o-1", 5));   // success: unwrap to OrderPlaced
await bus.InvokeAsync(new CreateOrder("o-2", 0));                              // failure: errors logged, no cascade
```

That's exactly the user-experience Jeremy described in the design-plan "What it looks like end-to-end" section, working today against FluentResults 3.16.0 — no library-specific code in Wolverine; the registration takes accessors as lambdas so it works against any Result library.

## Architecture

Four files form the new feature surface:

| Component | File | Role |
|---|---|---|
| Registry | `Wolverine/Configuration/ResultTypeRegistry.cs` + `ResultTypeRegistration.cs` + `IResultTypeRegistration.cs` | Per-host catalog. Resolves a closed handler-return type against the registered set (exact match + open-generic match), memoized hot path. |
| Public API | `Wolverine/WolverineOptions.Results.cs` | `UseResultType<TResult>(...)` (closed) + `UseResultType(typeof(Result<>), ...)` (open-generic). Idempotent: re-registering replaces; only registers the policies + DI singleton on first call. |
| Seam 1 | `Wolverine/Middleware/ResultTypeContinuationPolicy.cs` | Continuation strategy mirroring `RequirementResultContinuationPolicy`. Detects a `Before`-style middleware method whose return is a registered Result type and emits an early-return frame. |
| Seam 3 | `Wolverine/Runtime/Handlers/ResultUnwrappingActionSource.cs` + `ResultTypeReturnActionPolicy.cs` | Phase-A `IHandlerPolicy` walks chains and replaces the default `CascadingMessageActionSource` with the unwrap-and-cascade variant whenever the handler returns a registered Result type. |
| Component R | `Wolverine/Runtime/RemoteInvocation/ReplyListener<T>.Complete` | Caller-side unwrap. T == wrapper → pass-through. T == inner → unwrap on success, throw `ResultFailureException` on failure. Threaded via `ReplyTracker` so the same path serves in-process and remote callers. |

One supporting change: `IContinuationStrategy` got an **opt-in extension** `IRulesAwareContinuationStrategy` so strategies that need to consult per-host state can receive `GenerationRules`. Non-breaking — existing strategies keep the rules-free overload and aren't touched.

`ResultFailureException` is the new top-level exception type, with `Errors : IReadOnlyList<string>`.

## Tests + verification

`Testing/CoreTests/Acceptance/result_types_end_to_end.cs` against FluentResults 3.16.0:

| ID | Scenario | Status |
|---|---|---|
| B-1 | `InvokeAsync<OrderPlaced>(...)` against `Result<OrderPlaced>` success | ✅ pass |
| B-2 | Same, failure throws `ResultFailureException` | `[Skip]` — needs seam 2 |
| B-3 | `InvokeAsync<Result<OrderPlaced>>(...)` returns wrapper on both branches | `[Skip]` — needs seam 2 |
| B-4 | `InvokeAsync(...)` void against `Result<T>` success cascades inner T | ✅ pass |
| B-5 | Same, failure suppresses cascade entirely | ✅ pass |
| B-7 | `Task<Result<T>>` async handler unwraps normally | ✅ pass |
| E-1 | Non-Result handlers unaffected by registration (regression guard) | ✅ pass |

5/5 active tests pass; 2 deferred with clear follow-up notes inlined in the file. Full `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors).

## Why B-2 and B-3 are deferred

Both scenarios are on the `InvokeAsync<T>` request/reply path. With **only seam 3** substituting the chain's `ReturnVariableActionSource`, the reply path on a Result-returning handler either:
- Suppresses the cascade entirely on failure (no reply ever lands at the caller), or
- Unwraps before the wire on success when the caller awaited the wrapper (`Result<T>` never reaches component R as the literal type Jeremy's Q5 specifies).

The clean fix is exactly what Jeremy's plan table calls **seam 2** — teach `HandlerChain.UseForResponse` to KEEP the literal wrapper on the reply path while seam 3 keeps unwrapping for fire-and-forget. That's the natural next slice and lives alongside Phase 4 (HTTP, which has the same wrapper-vs-unwrap branching against `ProblemDetails`) and the C-series external-transport tests. Tracking that as the immediate follow-up.

The Phase A vs Phase B ordering trap from [#2941](https://github.com/JasperFx/wolverine/pull/2943) / [#2944](https://github.com/JasperFx/wolverine/pull/2948) doesn't bite this feature: seam 1 reads the registry from `GenerationRules.Properties` (set at registration time), and seam 3's `ResultTypeReturnActionPolicy` is an `IHandlerPolicy` that runs eagerly during `HandlerGraph.Compile` — both run before any chain's lazy attribute `Modify()` work fires.

## Following the issue's design plan

Maps to Jeremy's [phase table](https://github.com/JasperFx/wolverine/issues/2221#issuecomment-...) like this:

| Phase | Status |
|---|---|
| 0 — Spike against SimpleResults | folded into Phase 1; spike API shape validated against FluentResults instead per scope-question answer |
| 1 — Core registration + seam 1 | ✅ |
| 2 — Seam 3 (non-request/reply handler return) | ✅ |
| 3 — Component R (caller-side unwrap) | ✅ for happy path; B-2 / B-3 wrapper-passthrough + failure-throws need seam 2 |
| 4 — Wolverine.Http binding | follow-up |
| 5 — Tiny adapters (`UseSimpleResults()`, `UseFluentResults()`) | follow-up |
| 6 — Diagnostics (`describe-handlers` annotation) | follow-up |
| 7 — Docs / tutorial / mdsnippets | follow-up |

🤖 Generated with [Claude Code](https://claude.com/claude-code)