### PR TITLE
Docs: AOT callout for FluentValidation in HTTP validation guide (addresses #2910)

### DIFF
--- a/docs/guide/http/validation.md
+++ b/docs/guide/http/validation.md
@@ -350,6 +350,19 @@ request types of your HTTP endpoints -- and the [UseFluentValidation](/guide/han
 `WolverineFx.FluentValidation` package will help find these validators and register them in a way that optimizes this
 middleware usage.
 
+::: tip AOT publishing
+`UseFluentValidation()` defaults to `RegistrationBehavior.DiscoverAndRegisterValidators`, which runs FluentValidation's
+`AssemblyScanner` at bootstrap and is **not trim/AOT-safe**. For AOT publishing, opt out of the scan and register your
+validators explicitly:
+
+```csharp
+opts.UseFluentValidation(RegistrationBehavior.ExplicitRegistration);
+opts.Services.AddScoped<IValidator<CreateCustomer>, CreateCustomerValidator>();
+```
+
+See [Validation and AOT](/guide/aot.html#validation-and-aot) for the full story.
+:::
+
 Next, add this one single line of code to your Wolverine.Http bootstrapping:
 
 ```csharp


### PR DESCRIPTION
Single-file docs change addressing the HTTP-side gap surfaced by #2910.

## What

Adds a brief `::: tip AOT publishing` callout to `docs/guide/http/validation.md` immediately after the paragraph that introduces `UseFluentValidation()`. The callout notes that the default `RegistrationBehavior.DiscoverAndRegisterValidators` runs FluentValidation's `AssemblyScanner` (not trim/AOT-safe), shows the `ExplicitRegistration` opt-out + a manual `AddScoped<IValidator<...>, ...>()` example, and links to [Validation and AOT](/guide/aot.html#validation-and-aot) for the full story.

## Why

The AOT story for FluentValidation was already covered in:

- `docs/guide/aot.md` → `## Validation and AOT`
- `docs/guide/handlers/fluent-validation.md` → `## Trimming / AOT`

…but a reader who lands on the HTTP-side FluentValidation section had no breadcrumb to it. This patches that single missing entry point. Wording mirrors the handler-side note for consistency.

## Scope

- One file, +13 lines, additive only.
- No source / behavior changes.
- Source-generation possibility from #2910 is **intentionally out of scope**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)