### PR TITLE
Follow-up to #2919: docs + extended scenario tests for DbContext abstractions

### DIFF
--- a/docs/guide/durability/efcore/transactional-middleware.md
+++ b/docs/guide/durability/efcore/transactional-middleware.md
@@ -223,3 +223,164 @@ public static void Handle(UpdateItemCommand command, ItemsDbContext db)
 }
 ```
 
+
+## DbContext Abstractions <Badge type="tip" text="6.2" />
+
+Sometimes the application code wants to depend on an interface that's implemented by a `DbContext`
+rather than on the concrete `DbContext` itself — a `DbContext` that doubles as a custom
+`IRepository`, an `IUnitOfWork`, or a similar abstraction. Wolverine's EF Core transactional
+middleware can be taught to recognise those abstractions at handler-graph compile time so the
+auto-applied transaction/outbox still wraps the handler. Register the abstraction with
+`WithDbContextAbstraction<TAbstraction, TDbContext>()`:
+
+<!-- snippet: sample_register_dbcontext_abstraction -->
+<a id='snippet-sample_register_dbcontext_abstraction'></a>
+```cs
+opts.Services.AddDbContextWithWolverineIntegration<OrdersDbContext>(x =>
+    x.UseNpgsql(connectionString));
+
+// Forward the abstraction to the SAME scoped DbContext via a factory. This keeps
+// `IOrderRepository` and `OrdersDbContext` pointing at one instance per scope, which is
+// what `AddScoped<TAbs, TImpl>()` does NOT do (it would create a separate one per
+// registered interface).
+opts.Services.AddScoped<IOrderRepository>(sp => sp.GetRequiredService<OrdersDbContext>());
+
+opts.PersistMessagesWithPostgresql(connectionString, "wolverine");
+
+opts.UseEntityFrameworkCoreTransactions()
+    .WithDbContextAbstraction<IOrderRepository, OrdersDbContext>();
+
+opts.Policies.AutoApplyTransactions();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests/dbContext_abstraction_scenarios.cs#L432-L450' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_register_dbcontext_abstraction' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: tip
+The generic constraint `where TDbContext : DbContext, TAbstraction` means the registration only
+covers abstractions that the `DbContext` implements **directly**. Wrappers around a `DbContext`
+are out of scope; declare the abstraction on the `DbContext` itself.
+:::
+
+Handlers depend on the abstraction the same way they'd depend on any other service. Wolverine
+emits a runtime cast at the top of the handler chain so `SaveChangesAsync` and the EF Core
+outbox enrolment fire against the concrete `DbContext` underneath:
+
+<!-- snippet: sample_handler_using_dbcontext_abstraction -->
+<a id='snippet-sample_handler_using_dbcontext_abstraction'></a>
+```cs
+public class PlaceOrderViaAbstractionHandler
+{
+    public static void Handle(PlaceOrderViaAbstraction cmd, IOrderRepository orders)
+    {
+        // The handler depends on the abstraction. Wolverine's transactional middleware
+        // recognises the chain as `DbContext`-backed via the registered abstraction and emits
+        // a runtime cast at the top of the chain so SaveChangesAsync + outbox enrolment fire
+        // against the concrete OrdersDbContext underneath.
+        orders.Orders.Add(new OrderEntity { Id = cmd.Id, Description = cmd.Description });
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests/dbContext_abstraction_scenarios.cs#L351-L365' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_handler_using_dbcontext_abstraction' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+### Multiple abstractions for the same DbContext
+
+A single `DbContext` can implement several abstractions, and a handler may depend on more than
+one of them. The contract Wolverine honours is: **both parameters resolve to the same scoped
+`DbContext` instance, just viewed through different interfaces**, so a single `SaveChangesAsync`
+commits all the writes the handler made through either parameter.
+
+To make this work the abstractions must forward to the same scoped `DbContext` in DI — use a
+factory registration, **not** `AddScoped<TAbstraction, TDbContext>()` (the latter would create a
+separate `DbContext` per registered abstraction):
+
+<!-- snippet: sample_register_multiple_dbcontext_abstractions -->
+<a id='snippet-sample_register_multiple_dbcontext_abstractions'></a>
+```cs
+opts.Services.AddDbContextWithWolverineIntegration<StoreDbContext>(x =>
+    x.UseNpgsql(Servers.PostgresConnectionString,
+        b => b.MigrationsHistoryTable("__EFMigrationsHistory", "store_abs_schema")));
+
+// Two abstractions forwarded to the SAME scoped DbContext instance via factory
+// lambdas. `AddScoped<TAbs, TImpl>()` would create *separate* instances per
+// registration; the factory form is the one users want when an abstraction is
+// just a view over a DbContext that's already in the scope.
+opts.Services.AddScoped<IItemRepository>(sp => sp.GetRequiredService<StoreDbContext>());
+opts.Services.AddScoped<IOrderInsightRepository>(sp => sp.GetRequiredService<StoreDbContext>());
+
+opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_abs");
+
+opts.UseEntityFrameworkCoreTransactions()
+    .WithDbContextAbstraction<IItemRepository, StoreDbContext>()
+    .WithDbContextAbstraction<IOrderInsightRepository, StoreDbContext>();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests/dbContext_abstraction_scenarios.cs#L130-L149' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_register_multiple_dbcontext_abstractions' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+A handler can take both abstractions; the casts inside the chain land on the single shared
+`DbContext` and one transaction commits everything atomically:
+
+<!-- snippet: sample_handler_using_multiple_abstractions -->
+<a id='snippet-sample_handler_using_multiple_abstractions'></a>
+```cs
+public class CrossAbstractionAuditHandler
+{
+    public static (bool SameInstance, Type ItemsType, Type OrdersType) LastSeen;
+
+    // The handler depends on TWO abstractions of the same `DbContext`. At runtime both
+    // parameters resolve to the same scoped `StoreDbContext`, just viewed through different
+    // interfaces — so a single `SaveChangesAsync` commits writes the handler made through
+    // either parameter atomically. The forwarding-factory DI registrations above are what
+    // make this work; without them you'd get two separate `DbContext` instances.
+    public static void Handle(CrossAbstractionAudit cmd, IItemRepository items, IOrderInsightRepository orders)
+    {
+        // Cast both back to the concrete DbContext - the cast must succeed (the constraint on
+        // WithDbContextAbstraction guarantees TDbContext : TAbstraction) and the resulting
+        // references must be the SAME instance. That's the contract Wolverine's
+        // CastDbContextFrame + the user's forwarding-factory DI registrations together provide:
+        // one DbContext in scope, viewed through different interfaces.
+        var itemsCtx = (StoreDbContext)items;
+        var ordersCtx = (StoreDbContext)orders;
+
+        LastSeen = (ReferenceEquals(itemsCtx, ordersCtx), itemsCtx.GetType(), ordersCtx.GetType());
+
+        // Both writes go through the single scoped DbContext - the EF Core middleware's
+        // SaveChangesAsync postprocessor commits them as one transaction.
+        items.Items.Add(new StoreItem { Id = cmd.ItemId, Name = "cross-abs" });
+        orders.StoreOrders.Add(new StoreOrder { Id = cmd.OrderId, Status = "audited" });
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests/dbContext_abstraction_scenarios.cs#L391-L421' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_handler_using_multiple_abstractions' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+### Multi-DbContext, mixed abstraction
+
+Each `DbContext` is independent — a host can mix abstracted and non-abstracted `DbContext`s
+freely. The middleware picks the right one for each handler based on its actual parameter
+dependencies:
+
+<!-- snippet: sample_register_mixed_dbcontexts -->
+<a id='snippet-sample_register_mixed_dbcontexts'></a>
+```cs
+// First DbContext: abstracted via IOrderRepository.
+opts.Services.AddDbContextWithWolverineIntegration<OrdersDbContext>(x =>
+    x.UseNpgsql(Servers.PostgresConnectionString,
+        b => b.MigrationsHistoryTable("__EFMigrationsHistory", "orders_abs_schema")));
+opts.Services.AddScoped<IOrderRepository>(sp => sp.GetRequiredService<OrdersDbContext>());
+
+// Second DbContext: used directly, no abstraction.
+opts.Services.AddDbContextWithWolverineIntegration<CustomersDbContext>(x =>
+    x.UseNpgsql(Servers.PostgresConnectionString,
+        b => b.MigrationsHistoryTable("__EFMigrationsHistory", "customers_abs_schema")));
+
+opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_abs");
+
+// Only OrdersDbContext is registered as having an abstraction — Wolverine's
+// transactional middleware still wraps handlers that depend on
+// CustomersDbContext directly.
+opts.UseEntityFrameworkCoreTransactions()
+    .WithDbContextAbstraction<IOrderRepository, OrdersDbContext>();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests/dbContext_abstraction_scenarios.cs#L62-L83' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_register_mixed_dbcontexts' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->

--- a/docs/guide/durability/marten/ancillary-stores.md
+++ b/docs/guide/durability/marten/ancillary-stores.md
@@ -26,7 +26,7 @@ public interface IPlayerStore : IDocumentStore;
 
 public interface IThingStore : IDocumentStore;
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AncillaryStores/bootstrapping_ancillary_marten_stores_with_wolverine.cs#L267-L272' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_separate_marten_stores' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AncillaryStores/bootstrapping_ancillary_marten_stores_with_wolverine.cs#L268-L273' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_separate_marten_stores' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 We can add Wolverine integration to both through a similar call to `IntegrateWithWolverine()` as normal as shown below:
@@ -74,11 +74,12 @@ theHost = await Host.CreateDefaultBuilder()
         {
             x.MainConnectionString = Servers.PostgresConnectionString;
         });
-
+        opts.Discovery.DisableConventionalDiscovery()
+            .IncludeType(typeof(PlayerMessageHandler));
         opts.Services.AddResourceSetupOnStartup();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AncillaryStores/bootstrapping_ancillary_marten_stores_with_wolverine.cs#L57-L105' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_with_ancillary_marten_stores' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AncillaryStores/bootstrapping_ancillary_marten_stores_with_wolverine.cs#L57-L106' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_with_ancillary_marten_stores' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Let's specifically zoom in on this code from within the big sample above:
@@ -118,7 +119,7 @@ public static class PlayerMessageHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AncillaryStores/bootstrapping_ancillary_marten_stores_with_wolverine.cs#L252-L265' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_playermessagehandler' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AncillaryStores/bootstrapping_ancillary_marten_stores_with_wolverine.cs#L253-L266' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_playermessagehandler' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: info

--- a/docs/guide/durability/marten/distribution.md
+++ b/docs/guide/durability/marten/distribution.md
@@ -26,7 +26,7 @@ opts.Services.AddMarten(m =>
         m.UseWolverineManagedEventSubscriptionDistribution = true;
     });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Distribution/Support/SingleTenantContext.cs#L71-L90' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opt_into_wolverine_managed_subscription_distribution' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Distribution/Support/SingleTenantContext.cs#L60-L79' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opt_into_wolverine_managed_subscription_distribution' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: tip
@@ -113,11 +113,11 @@ var host = await Host.CreateDefaultBuilder()
     {
         opts.Durability.HealthCheckPollingTime = 1.Seconds();
         opts.Durability.CheckAssignmentPeriod = 1.Seconds();
-        
+
         opts.UseMessagePackSerialization();
-        
+
         opts.UseSharedMemoryQueueing();
-        
+
         opts.Services.AddMarten(m =>
             {
                 m.DisableNpgsqlLogging = true;
@@ -135,8 +135,8 @@ var host = await Host.CreateDefaultBuilder()
                 // cluster
                 m.UseWolverineManagedEventSubscriptionDistribution = true;
             });
-        
-        opts.Services.AddSingleton<ILoggerProvider>(new OutputLoggerProvider(_output));
+
+        opts.Services.AddSingleton<ILoggerProvider>(new OutputLoggerProvider(output));
 
         opts.Services.AddMartenStore<ITripStore>(m =>
         {
@@ -149,9 +149,8 @@ var host = await Host.CreateDefaultBuilder()
             m.Projections.Add<DistanceProjection>(ProjectionLifecycle.Async);
         }).IntegrateWithWolverine();
 
-        opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Auto;
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Distribution/with_ancillary_stores.cs#L76-L121' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_distributed_projections_with_ancillary_stores' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Distribution/with_ancillary_stores.cs#L59-L103' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_distributed_projections_with_ancillary_stores' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 

--- a/docs/guide/durability/marten/event-forwarding.md
+++ b/docs/guide/durability/marten/event-forwarding.md
@@ -135,7 +135,7 @@ To be used in your tests such as this:
 [Fact]
 public async Task execution_of_forwarded_events_can_be_awaited_from_tests()
 {
-    var host = await Host.CreateDefaultBuilder()
+    using var host = await Host.CreateDefaultBuilder()
         .UseWolverine()
         .ConfigureServices(services =>
         {
@@ -162,7 +162,7 @@ public async Task execution_of_forwarded_events_can_be_awaited_from_tests()
     events[1].Data.ShouldBeOfType<FourthEvent>();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/event_streaming.cs#L144-L174' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_execution_of_forwarded_events_can_be_awaited_from_tests' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/event_streaming.cs#L149-L179' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_execution_of_forwarded_events_can_be_awaited_from_tests' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Where the result contains `FourthEvent` because `SecondEvent` was forwarded as `SecondMessage` and that persisted `FourthEvent` in a handler such as:
@@ -177,7 +177,7 @@ public static Task HandleAsync(SecondMessage message, IDocumentSession session)
     return session.SaveChangesAsync();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/event_streaming.cs#L222-L228' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_execution_of_forwarded_events_second_message_to_fourth_event' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/event_streaming.cs#L223-L229' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_execution_of_forwarded_events_second_message_to_fourth_event' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Overriding Side-Effect Message Metadata <Badge type="tip" text="5.x" />

--- a/docs/guide/durability/marten/event-sourcing.md
+++ b/docs/guide/durability/marten/event-sourcing.md
@@ -437,7 +437,7 @@ public static void Handle(OrderEventSourcingSample.MarkItemReady command, IEvent
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L26-L54' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemreadyhandler_with_explicit_stream' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L27-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemreadyhandler_with_explicit_stream' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Just as in other Wolverine [message handlers](/guide/handlers/), you can use
@@ -535,7 +535,7 @@ public class MarkItemReady
     public string ItemName { get; init; } = null!;
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L10-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemready_with_explicit_identity' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L11-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemready_with_explicit_identity' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Validation <Badge type="tip" text="4.8" />
@@ -644,7 +644,7 @@ public static (
     return (new UpdatedAggregate(), events);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L62-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemreadyhandler_with_response_for_updated_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L63-L100' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_markitemreadyhandler_with_response_for_updated_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note the usage of the `Wolverine.Marten.UpdatedAggregate` response in the handler. That type by itself is just a directive 
@@ -662,7 +662,7 @@ public static Task<Order> update_and_get_latest(IMessageBus bus, MarkItemReady c
     return bus.InvokeAsync<Order>(command);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L101-L110' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_updatedaggregate_with_invoke_async' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/OrderEventSourcingSample/Alternatives/Signatures.cs#L102-L111' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_updatedaggregate_with_invoke_async' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Likewise, you can use `UpdatedAggregate` as the response body of an HTTP endpoint with Wolverine.HTTP [as shown here](/guide/http/marten.html#responding-with-the-updated-aggregate~~~~).
@@ -697,7 +697,7 @@ public static class RaiseIfValidatedHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/aggregate_handler_workflow.cs#L436-L451' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_passing_aggregate_into_validate_method' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/aggregate_handler_workflow.cs#L448-L463' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_passing_aggregate_into_validate_method' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Archiving Streams
@@ -1146,7 +1146,7 @@ public class StrongLetterAggregate
     public void Apply(DEvent _) => DCount++;
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/strong_named_identifiers.cs#L184-L207' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_strong_typed_identifier_with_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/strong_named_identifiers.cs#L187-L210' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_strong_typed_identifier_with_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And now let's use that identifier type in message handlers:
@@ -1209,7 +1209,7 @@ public static class StrongLetterHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/strong_named_identifiers.cs#L124-L180' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_strong_typed_identifier_with_aggregate_handler_workflow' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/strong_named_identifiers.cs#L127-L183' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_strong_typed_identifier_with_aggregate_handler_workflow' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And also in some of the equivalent Wolverine.HTTP endpoints:
@@ -1279,7 +1279,7 @@ public record NkHandlerOrderCreated(NkHandlerOrderNumber OrderNumber, string Cus
 public record NkHandlerItemAdded(string ItemName, decimal Price);
 public record NkHandlerOrderCompleted;
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs#L125-L161' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_marten_natural_key_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs#L124-L160' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_marten_natural_key_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Using Natural Keys in Command Handlers
@@ -1293,7 +1293,7 @@ public record AddNkOrderItem(NkHandlerOrderNumber OrderNum, string ItemName, dec
 public record AddNkOrderItems(NkHandlerOrderNumber OrderNum, (string Name, decimal Price)[] Items);
 public record CompleteNkOrder(NkHandlerOrderNumber OrderNum);
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs#L163-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_marten_natural_key_commands' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs#L162-L167' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_marten_natural_key_commands' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Wolverine uses the natural key type on the command property to call `FetchForWriting<TAggregate, TNaturalKey>()` under the covers, resolving the stream by the natural key in a single database round-trip.
@@ -1329,7 +1329,7 @@ public static class NkOrderHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs#L170-L195' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_marten_natural_key_handlers' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs#L169-L194' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_marten_natural_key_handlers' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 For more details on how natural keys work at the Marten level, see the [Marten natural keys documentation](https://martendb.io/events/natural-keys).
@@ -1437,8 +1437,14 @@ namespace MartenTests.Dcb.University;
 /// Ported from the Axon SubscribeStudentToCourseCommandHandler.State which uses
 /// EventCriteria.either() to load events matching CourseId OR StudentId.
 /// </summary>
-public class SubscriptionState
+public partial class SubscriptionState
 {
+    // Required so the aggregate can be registered as a single-stream projection
+    // (LiveStreamAggregation), which is what makes the JasperFx.Events source generator
+    // emit the dispatcher that FetchForWritingByTags<SubscriptionState> resolves. For the
+    // boundary (tag-query) path this Id is not stream-bound — it just satisfies the
+    // single-stream projection shape, the same way Marten's own DCB aggregates carry one.
+    public string Id { get; set; } = null!;
     public CourseId? CourseId { get; private set; }
     public int CourseCapacity { get; private set; }
     public int StudentsSubscribedToCourse { get; private set; }
@@ -1484,7 +1490,7 @@ public class SubscriptionState
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Dcb/University/SubscriptionState.cs#L1-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_dcb_subscription_state' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Dcb/University/SubscriptionState.cs#L1-L61' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_dcb_subscription_state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Identity-less Boundary Aggregates with `[BoundaryAggregate]`

--- a/docs/guide/durability/marten/multi-tenancy.md
+++ b/docs/guide/durability/marten/multi-tenancy.md
@@ -151,7 +151,7 @@ public static class CreateTenantDocumentHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/MultiTenancy/conjoined_tenancy.cs#L85-L111' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_multi_tenancy_sample_code' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/MultiTenancy/conjoined_tenancy.cs#L87-L113' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_multi_tenancy_sample_code' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 For completeness, here's the Wolverine and Marten bootstrapping:
@@ -162,6 +162,8 @@ For completeness, here's the Wolverine and Marten bootstrapping:
 _host = await Host.CreateDefaultBuilder()
     .UseWolverine(opts =>
     {
+        opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(CreateTenantDocumentHandler));
+        opts.Durability.Mode = DurabilityMode.Solo;
         opts.Services.AddMarten(Servers.PostgresConnectionString)
             .IntegrateWithWolverine()
             .UseLightweightSessions();
@@ -170,7 +172,7 @@ _host = await Host.CreateDefaultBuilder()
 
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/MultiTenancy/conjoined_tenancy.cs#L19-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_setup_with_conjoined_tenancy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/MultiTenancy/conjoined_tenancy.cs#L19-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_setup_with_conjoined_tenancy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 and after that, the calls to [InvokeForTenantAsync()]() "just work" as you can see if you squint hard enough reading this test:
@@ -216,7 +218,7 @@ public async Task execute_with_tenancy()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/MultiTenancy/conjoined_tenancy.cs#L43-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_conjoined_tenancy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/MultiTenancy/conjoined_tenancy.cs#L45-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_conjoined_tenancy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/guide/durability/marten/operations.md
+++ b/docs/guide/durability/marten/operations.md
@@ -39,7 +39,7 @@ public static IMartenOp Pay([Document] Invoice invoice)
     return MartenOps.Store(invoice);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L41-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_marten_op_from_http_endpoint' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L42-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_marten_op_from_http_endpoint' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 There are existing Marten ops for storing, inserting, updating, and deleting a document.
@@ -169,7 +169,7 @@ public static IEnumerable<IMartenOp> Handle(AppendManyNamedDocuments command)
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/handler_actions_with_implied_marten_operations.cs#L342-L353' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_ienumerable_of_martenop_as_side_effect' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/handler_actions_with_implied_marten_operations.cs#L349-L360' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_ienumerable_of_martenop_as_side_effect' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Wolverine will pick up on any return type that can be cast to `IEnumerable<IMartenOp>`, so for example:

--- a/docs/guide/durability/marten/transactional-middleware.md
+++ b/docs/guide/durability/marten/transactional-middleware.md
@@ -19,6 +19,8 @@ It is no longer necessary to mark a handler method with `[Transactional]` if you
 using var host = await Host.CreateDefaultBuilder()
     .UseWolverine(opts =>
     {
+        opts.Discovery.DisableConventionalDiscovery();
+        opts.Durability.Mode = DurabilityMode.Solo;
         opts.Services.AddMarten("some connection string")
             .IntegrateWithWolverine();
 
@@ -26,7 +28,7 @@ using var host = await Host.CreateDefaultBuilder()
         opts.Policies.AutoApplyTransactions();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Sample/BootstrapWithAutoTransactions.cs#L12-L23' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_auto_apply_transactions_with_marten' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Sample/BootstrapWithAutoTransactions.cs#L12-L25' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_auto_apply_transactions_with_marten' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 With this enabled, Wolverine will automatically use the Marten
@@ -182,7 +184,7 @@ public class CommandsAreTransactional : IHandlerPolicy
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/transactional_frame_end_to_end.cs#L134-L147' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_commandsaretransactional' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/transactional_frame_end_to_end.cs#L136-L149' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_commandsaretransactional' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Then add the policy to your application like this:
@@ -193,11 +195,13 @@ Then add the policy to your application like this:
 using var host = await Host.CreateDefaultBuilder()
     .UseWolverine(opts =>
     {
+        opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(CreateDocCommand2Handler));
+        opts.Durability.Mode = DurabilityMode.Solo;
         // And actually use the policy
         opts.Policies.Add<CommandsAreTransactional>();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/transactional_frame_end_to_end.cs#L66-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_commandsaretransactional' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/transactional_frame_end_to_end.cs#L66-L76' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_commandsaretransactional' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Using IDocumentOperations <Badge type="tip" text="3.14" />
@@ -229,6 +233,6 @@ public class CreateDocCommand2Handler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/transactional_frame_end_to_end.cs#L90-L107' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_idocumentoperations' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/transactional_frame_end_to_end.cs#L92-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_idocumentoperations' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 

--- a/docs/guide/durability/polecat/event-sourcing.md
+++ b/docs/guide/durability/polecat/event-sourcing.md
@@ -711,8 +711,14 @@ namespace MartenTests.Dcb.University;
 /// Ported from the Axon SubscribeStudentToCourseCommandHandler.State which uses
 /// EventCriteria.either() to load events matching CourseId OR StudentId.
 /// </summary>
-public class SubscriptionState
+public partial class SubscriptionState
 {
+    // Required so the aggregate can be registered as a single-stream projection
+    // (LiveStreamAggregation), which is what makes the JasperFx.Events source generator
+    // emit the dispatcher that FetchForWritingByTags<SubscriptionState> resolves. For the
+    // boundary (tag-query) path this Id is not stream-bound — it just satisfies the
+    // single-stream projection shape, the same way Marten's own DCB aggregates carry one.
+    public string Id { get; set; } = null!;
     public CourseId? CourseId { get; private set; }
     public int CourseCapacity { get; private set; }
     public int StudentsSubscribedToCourse { get; private set; }
@@ -758,7 +764,7 @@ public class SubscriptionState
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Dcb/University/SubscriptionState.cs#L1-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_dcb_subscription_state' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Dcb/University/SubscriptionState.cs#L1-L61' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_dcb_subscription_state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Identity-less Boundary Aggregates with `[BoundaryAggregate]`

--- a/docs/guide/durability/sagas.md
+++ b/docs/guide/durability/sagas.md
@@ -695,7 +695,7 @@ public class RevisionedSaga : Wolverine.Saga
         chain.SuccessLogLevel = LogLevel.None;
     }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Saga/RevisionedSaga.cs#L80-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_overriding_logging_on_saga' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Saga/RevisionedSaga.cs#L82-L93' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_overriding_logging_on_saga' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or if you wanted to just do it globally, something like this approach:

--- a/docs/guide/extensions.md
+++ b/docs/guide/extensions.md
@@ -13,7 +13,7 @@ Wolverine supports the concept of extensions for modularizing Wolverine configur
 /// <summary>
 ///     Use to create loadable extensions to Wolverine applications
 /// </summary>
-public interface IWolverineExtension
+public interface IWolverineExtension : IJasperFxExtension
 {
     /// <summary>
     ///     Make any alterations to the WolverineOptions for the application
@@ -22,7 +22,7 @@ public interface IWolverineExtension
     void Configure(WolverineOptions options);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/IWolverineExtension.cs#L3-L16' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iwolverineextension' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/IWolverineExtension.cs#L5-L18' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iwolverineextension' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Here's a sample:
@@ -108,7 +108,7 @@ internal class DisableExternalTransports : IWolverineExtension
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/HostBuilderExtensions.cs#L464-L473' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disableexternaltransports' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/HostBuilderExtensions.cs#L461-L470' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disableexternaltransports' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And that extension is just added to the application's IoC container at test bootstrapping time like this:
@@ -122,7 +122,7 @@ public static IServiceCollection DisableAllExternalWolverineTransports(this ISer
     return services;
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/HostBuilderExtensions.cs#L440-L447' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_extension_method_to_disable_external_transports' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/HostBuilderExtensions.cs#L437-L444' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_extension_method_to_disable_external_transports' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In usage, the `IWolverineExtension` objects added to the IoC container are applied *after* the inner configuration
@@ -312,9 +312,14 @@ using var host = await Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
     .UseWolverine(opts =>
     {
         opts.DisableConventionalDiscovery();
+
+        // With ExtensionDiscovery.ManualOnly, Wolverine does not auto-load the
+        // WolverineFx.RuntimeCompilation module, so a TypeLoadMode.Dynamic app must
+        // opt into runtime Roslyn compilation explicitly (or pre-generate with Static).
+        opts.UseRuntimeCompilation();
     }, ExtensionDiscovery.ManualOnly)
     
     .StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Configuration/bootstrapping_specs.cs#L67-L76' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disabling_assembly_scanning' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Configuration/bootstrapping_specs.cs#L67-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disabling_assembly_scanning' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/http/index.md
+++ b/docs/guide/http/index.md
@@ -260,7 +260,7 @@ app.MapWolverineEndpoints(opts =>
 
 return await app.RunJasperFxCommands(args);
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/CodeGeneration/service_location_assertions.cs#L401-L436' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_with_httpcontext_request_services' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/Wolverine.Http.Tests/CodeGeneration/service_location_assertions.cs#L432-L467' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_with_httpcontext_request_services' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Notice the call to `SourceServiceFromHttpContext<T>()`. That directs Wolverine.HTTP to always pull the service

--- a/docs/guide/http/marten.md
+++ b/docs/guide/http/marten.md
@@ -42,7 +42,7 @@ look like this:
         return Results.Ok(invoice);
     }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L14-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_get_invoice_longhand' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L15-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_get_invoice_longhand' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Pretty straightforward, but it's a little annoying to have to scatter in all the attributes for OpenAPI and there's definitely
@@ -58,7 +58,7 @@ public static Invoice Get([Document] Invoice invoice)
     return invoice;
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L32-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_document_attribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L33-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_document_attribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Notice that the `[Document]` attribute was able to use the "id" route parameter. By default, Wolverine is looking first
@@ -75,7 +75,7 @@ public static IMartenOp Approve([Document("number")] Invoice invoice)
     return MartenOps.Store(invoice);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L51-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_overriding_route_argument_with_document_attribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L52-L60' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_overriding_route_argument_with_document_attribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In the code above, if the `Invoice` document does not exist, the route will stop and return a status code 404 for Not Found.  
@@ -101,7 +101,7 @@ public static Invoice GetSoftDeleted([Document(Required = true, MaybeSoftDeleted
     return invoice;
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L61-L67' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_document_with_maybesoftdeleted' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L62-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_document_with_maybesoftdeleted' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -378,7 +378,7 @@ public static class MakePurchaseHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/mixed_aggregate_handler_with_multiple_streams.cs#L88-L116' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_makepurchasehandler' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/AggregateHandlerWorkflow/mixed_aggregate_handler_with_multiple_streams.cs#L90-L118' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_makepurchasehandler' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: info
@@ -548,7 +548,7 @@ public static ApprovedInvoicedCompiledQuery GetApproved()
     return new ApprovedInvoicedCompiledQuery();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L69-L75' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiled_query_return_endpoint' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L70-L76' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiled_query_return_endpoint' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 <!-- snippet: sample_compiled_query_return_query -->
@@ -562,7 +562,7 @@ public class ApprovedInvoicedCompiledQuery : ICompiledListQuery<Invoice>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L105-L114' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiled_query_return_query' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L106-L115' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiled_query_return_query' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Streaming JSON Responses <Badge type="tip" text="5.32" />

--- a/docs/guide/http/streaming.md
+++ b/docs/guide/http/streaming.md
@@ -14,7 +14,7 @@ public static IResult GetSseEvents()
 {
     return Results.Stream(async stream =>
     {
-        var writer = new StreamWriter(stream);
+        await using var writer = new StreamWriter(stream);
         for (var i = 0; i < 3; i++)
         {
             await writer.WriteAsync($"data: Event {i}\n\n");
@@ -40,7 +40,7 @@ public static IResult GetStreamData()
 {
     return Results.Stream(async stream =>
     {
-        var writer = new StreamWriter(stream);
+        await using var writer = new StreamWriter(stream);
         for (var i = 0; i < 5; i++)
         {
             await writer.WriteLineAsync($"line {i}");

--- a/docs/guide/messaging/message-bus.md
+++ b/docs/guide/messaging/message-bus.md
@@ -190,7 +190,7 @@ public class CreateItemCommandHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Bugs/Bug_305_invoke_async_with_return_not_publishing_with_tuple_return_value.cs#L65-L85' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_alwayspublishresponse' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Bugs/Bug_305_invoke_async_with_return_not_publishing_with_tuple_return_value.cs#L77-L97' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_alwayspublishresponse' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Global Timeout Default for Request/Reply <Badge type="tip" text="5.11" />

--- a/docs/guide/messaging/partitioning.md
+++ b/docs/guide/messaging/partitioning.md
@@ -164,7 +164,7 @@ opts.MessagePartitioning
         });
     });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/concurrency_resilient_sharded_processing.cs#L112-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_inferred_message_group_id' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/concurrency_resilient_sharded_processing.cs#L114-L135' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_inferred_message_group_id' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The built in rules *at this point* include:

--- a/docs/guide/messaging/subscriptions.md
+++ b/docs/guide/messaging/subscriptions.md
@@ -365,9 +365,22 @@ public interface IMessageRoutingConvention
     void PreregisterSenders(IReadOnlyList<Type> handledMessageTypes, IWolverineRuntime runtime)
     {
     }
+
+    /// <summary>
+    /// Diagnostic description of this routing convention for routing explanations, the
+    /// describe-routing CLI, and service capabilities. The default implementation reports the
+    /// type name with no description; built-in and extension conventions should override to
+    /// supply a meaningful, AI-readable explanation (and, for broker conventions, the parent
+    /// transport's scheme/name/description).
+    /// </summary>
+    RoutingConventionDescriptor Describe(IWolverineRuntime runtime) => new()
+    {
+        Name = GetType().Name,
+        Description = string.Empty
+    };
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/Runtime/Routing/IMessageRoutingConvention.cs#L5-L46' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_imessageroutingconvention' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/Runtime/Routing/IMessageRoutingConvention.cs#L5-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_imessageroutingconvention' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 As a concrete example, the Wolverine team received [this request](https://github.com/JasperFx/wolverine/issues/1130) to conventionally route messages based on 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -498,5 +498,5 @@ public class CreateItemCommandHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Bugs/Bug_305_invoke_async_with_return_not_publishing_with_tuple_return_value.cs#L65-L85' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_alwayspublishresponse' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/MartenTests/Bugs/Bug_305_invoke_async_with_return_not_publishing_with_tuple_return_value.cs#L77-L97' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_alwayspublishresponse' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/tutorials/leader-election.md
+++ b/docs/tutorials/leader-election.md
@@ -491,12 +491,14 @@ public class SimpleSingularAgent : SingularAgent
     // This template method should be used to cleanly stop up your background service
     protected override Task stopAsync(CancellationToken cancellationToken)
     {
+        _cancellation.Cancel();
+        _cancellation.Dispose();
         _timer.SafeDispose();
         return Task.CompletedTask;
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/Wolverine.ComplianceTests/SimpleSingularAgent.cs#L1-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_simplesingularagent' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/Wolverine.ComplianceTests/SimpleSingularAgent.cs#L1-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_simplesingularagent' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To add that to your Wolverine system, we've added this convenience method:

--- a/docs/tutorials/modular-monolith.md
+++ b/docs/tutorials/modular-monolith.md
@@ -352,7 +352,7 @@ public static async Task run_end_to_end(IHost host)
     // command handler
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Configuration/DocumentationSamples.cs#L33-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_tracked_sessions_end_to_end' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Configuration/DocumentationSamples.cs#L10-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_tracked_sessions_end_to_end' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In the code sample above, the `InvokeAndMessageAndWaitAsync()` method puts the Wolverine runtime into a "tracked" mode
@@ -394,7 +394,7 @@ public static async Task run_end_to_end_with_external_transports(IHost host)
     // command handler
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Configuration/DocumentationSamples.cs#L63-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_external_brokers_with_tracked_sessions' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Configuration/DocumentationSamples.cs#L40-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_external_brokers_with_tracked_sessions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And to test the invocation of an event message to a specific handler, we can still do that by sending the message to a specific local queue:
@@ -410,7 +410,7 @@ public static async Task test_specific_handler(IHost host)
         c => c.EndpointFor("local queue name").SendAsync(new OrderPlaced("111")).AsTask());
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Configuration/DocumentationSamples.cs#L52-L61' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_test_specific_queue_end_to_end' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Configuration/DocumentationSamples.cs#L29-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_test_specific_queue_end_to_end' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## With EF Core

--- a/src/Persistence/EfCoreTests/dbContext_abstraction_scenarios.cs
+++ b/src/Persistence/EfCoreTests/dbContext_abstraction_scenarios.cs
@@ -1,0 +1,452 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Persistence;
+using Wolverine.Postgresql;
+using Wolverine.Tracking;
+
+// Sub-namespace so this file's `OrderEntity` / `IOrderRepository` / etc. don't collide with the
+// unrelated identically-named fixtures in `Bug_252_codegen_issue.cs` under the parent namespace.
+namespace EfCoreTests.DbContextAbstractionScenarios;
+
+// Follow-up coverage for PR #2919 (`WithDbContextAbstraction<TAbstraction, TDbContext>()`). The
+// scenarios in this file prove three contracts that aren't exercised by the original PR's tests:
+//
+//   1. Multi-DbContext, mixed abstraction — one DbContext is registered through an abstraction
+//      and another DbContext is used directly. Both handlers transact through Wolverine's
+//      EF Core middleware in the same host.
+//
+//   2. Multiple abstractions for the SAME DbContext — `StoreDbContext` implements both
+//      `IItemRepository` and `IOrderRepository`. Two separate handlers, each depending on a
+//      different abstraction, both successfully commit through the same physical DbContext.
+//
+//   3. Multiple abstractions used IN THE SAME handler — the handler depends on both
+//      `IItemRepository` and `IOrderRepository`. At runtime BOTH parameters must resolve to the
+//      *same scoped* `StoreDbContext` instance (just cast to the requested interface), so a
+//      single Save/transaction commits all writes atomically. This is the contract the
+//      DI-registration pattern (forwarding factories) is designed to honour, and the cast frame
+//      that the merged PR emits depends on.
+
+public class dbContext_abstraction_scenarios
+{
+    // --- Scenario 1: multi-DbContext, mixed abstraction ---------------------------------------
+
+    [Fact]
+    public async Task multiple_dbcontext_types_one_abstracted_one_direct()
+    {
+        await CreateSchemaAsync("""
+            CREATE TABLE orders_abs_schema.orders (
+                "Id" uuid PRIMARY KEY,
+                "Description" text NOT NULL
+            );
+            CREATE TABLE customers_abs_schema.customers (
+                "Id" uuid PRIMARY KEY,
+                "Name" text NOT NULL
+            );
+            """, "orders_abs_schema", "customers_abs_schema");
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                #region sample_register_mixed_dbcontexts
+
+                // First DbContext: abstracted via IOrderRepository.
+                opts.Services.AddDbContextWithWolverineIntegration<OrdersDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString,
+                        b => b.MigrationsHistoryTable("__EFMigrationsHistory", "orders_abs_schema")));
+                opts.Services.AddScoped<IOrderRepository>(sp => sp.GetRequiredService<OrdersDbContext>());
+
+                // Second DbContext: used directly, no abstraction.
+                opts.Services.AddDbContextWithWolverineIntegration<CustomersDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString,
+                        b => b.MigrationsHistoryTable("__EFMigrationsHistory", "customers_abs_schema")));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_abs");
+
+                // Only OrdersDbContext is registered as having an abstraction — Wolverine's
+                // transactional middleware still wraps handlers that depend on
+                // CustomersDbContext directly.
+                opts.UseEntityFrameworkCoreTransactions()
+                    .WithDbContextAbstraction<IOrderRepository, OrdersDbContext>();
+
+                #endregion
+
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<PlaceOrderViaAbstractionHandler>()
+                    .IncludeType<RegisterCustomerDirectHandler>();
+
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+            }).StartAsync();
+
+        var orderId = Guid.NewGuid();
+        var customerId = Guid.NewGuid();
+
+        await host.InvokeMessageAndWaitAsync(new PlaceOrderViaAbstraction(orderId, "abstracted"));
+        await host.InvokeMessageAndWaitAsync(new RegisterCustomerDirect(customerId, "direct"));
+
+        await using var scope = host.Services.CreateAsyncScope();
+        (await scope.ServiceProvider.GetRequiredService<OrdersDbContext>()
+                .Orders.AnyAsync(o => o.Id == orderId))
+            .ShouldBeTrue("abstracted handler must commit through the IOrderRepository transaction");
+        (await scope.ServiceProvider.GetRequiredService<CustomersDbContext>()
+                .Customers.AnyAsync(c => c.Id == customerId))
+            .ShouldBeTrue("direct handler must commit through the CustomersDbContext transaction");
+    }
+
+    // --- Scenario 2: multiple abstractions for the same DbContext ------------------------------
+
+    [Fact]
+    public async Task multiple_abstractions_for_same_dbcontext_each_used_independently()
+    {
+        await CreateSchemaAsync("""
+            CREATE TABLE store_abs_schema.items (
+                "Id" uuid PRIMARY KEY,
+                "Name" text NOT NULL
+            );
+            CREATE TABLE store_abs_schema.orders (
+                "Id" uuid PRIMARY KEY,
+                "Status" text NOT NULL
+            );
+            """, "store_abs_schema");
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                #region sample_register_multiple_dbcontext_abstractions
+
+                opts.Services.AddDbContextWithWolverineIntegration<StoreDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString,
+                        b => b.MigrationsHistoryTable("__EFMigrationsHistory", "store_abs_schema")));
+
+                // Two abstractions forwarded to the SAME scoped DbContext instance via factory
+                // lambdas. `AddScoped<TAbs, TImpl>()` would create *separate* instances per
+                // registration; the factory form is the one users want when an abstraction is
+                // just a view over a DbContext that's already in the scope.
+                opts.Services.AddScoped<IItemRepository>(sp => sp.GetRequiredService<StoreDbContext>());
+                opts.Services.AddScoped<IOrderInsightRepository>(sp => sp.GetRequiredService<StoreDbContext>());
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_abs");
+
+                opts.UseEntityFrameworkCoreTransactions()
+                    .WithDbContextAbstraction<IItemRepository, StoreDbContext>()
+                    .WithDbContextAbstraction<IOrderInsightRepository, StoreDbContext>();
+
+                #endregion
+
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<CreateStoreItemHandler>()
+                    .IncludeType<RecordStoreOrderHandler>();
+
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+            }).StartAsync();
+
+        var itemId = Guid.NewGuid();
+        var orderId = Guid.NewGuid();
+
+        await host.InvokeMessageAndWaitAsync(new CreateStoreItem(itemId, "phone"));
+        await host.InvokeMessageAndWaitAsync(new RecordStoreOrder(orderId, "shipped"));
+
+        await using var scope = host.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<StoreDbContext>();
+        (await db.Items.AnyAsync(i => i.Id == itemId)).ShouldBeTrue();
+        (await db.StoreOrders.AnyAsync(o => o.Id == orderId)).ShouldBeTrue();
+    }
+
+    // --- Scenario 3: same handler uses both abstractions; assert SAME DbContext instance -------
+
+    [Fact]
+    public async Task handler_using_two_abstractions_to_same_dbcontext_uses_one_scoped_instance()
+    {
+        await CreateSchemaAsync("""
+            CREATE TABLE store_abs_schema.items (
+                "Id" uuid PRIMARY KEY,
+                "Name" text NOT NULL
+            );
+            CREATE TABLE store_abs_schema.orders (
+                "Id" uuid PRIMARY KEY,
+                "Status" text NOT NULL
+            );
+            """, "store_abs_schema");
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<StoreDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString,
+                        b => b.MigrationsHistoryTable("__EFMigrationsHistory", "store_abs_schema")));
+
+                // Critical for the contract under test: both abstractions are factory-resolved
+                // from the same scoped StoreDbContext. Any other registration shape would defeat
+                // the "one DbContext in scope, viewed through different interfaces" guarantee.
+                opts.Services.AddScoped<IItemRepository>(sp => sp.GetRequiredService<StoreDbContext>());
+                opts.Services.AddScoped<IOrderInsightRepository>(sp => sp.GetRequiredService<StoreDbContext>());
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_abs");
+
+                opts.UseEntityFrameworkCoreTransactions()
+                    .WithDbContextAbstraction<IItemRepository, StoreDbContext>()
+                    .WithDbContextAbstraction<IOrderInsightRepository, StoreDbContext>();
+
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<CrossAbstractionAuditHandler>();
+
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+            }).StartAsync();
+
+        var itemId = Guid.NewGuid();
+        var orderId = Guid.NewGuid();
+
+        // Reset between scenarios so we observe only this command's writes.
+        CrossAbstractionAuditHandler.LastSeen = default;
+
+        await host.InvokeMessageAndWaitAsync(new CrossAbstractionAudit(itemId, orderId));
+
+        // The handler tested reference-equality between the two abstraction parameters cast back
+        // to the concrete DbContext; this assertion is the test's actual proof point.
+        CrossAbstractionAuditHandler.LastSeen.SameInstance
+            .ShouldBeTrue("both abstractions must resolve to the same scoped StoreDbContext");
+
+        // And both writes must have landed via that single context's single SaveChanges.
+        await using var scope = host.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<StoreDbContext>();
+        (await db.Items.AnyAsync(i => i.Id == itemId)).ShouldBeTrue();
+        (await db.StoreOrders.AnyAsync(o => o.Id == orderId)).ShouldBeTrue();
+    }
+
+    // EF Core's EnsureCreatedAsync is a no-op when the database already exists — and the shared
+    // Wolverine integration-tests Postgres always does. So we issue raw DDL for the user-defined
+    // tables, mirroring the workaround documented in `Bugs/Bug_DurableLocalQueue_ancillary_store_routing.cs`
+    // (see GH-2618). Schemas are dropped first so re-runs of these scenarios start clean.
+    private static async Task CreateSchemaAsync(string sql, params string[] schemas)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        foreach (var schema in schemas)
+        {
+            await conn.DropSchemaAsync(schema);
+            await conn.CreateCommand($"CREATE SCHEMA \"{schema}\"").ExecuteNonQueryAsync();
+        }
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+// === Entities + DbContexts + abstractions ====================================================
+
+public class OrderEntity
+{
+    public Guid Id { get; set; }
+    public string Description { get; set; } = string.Empty;
+}
+
+public class CustomerEntity
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class StoreItem
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class StoreOrder
+{
+    public Guid Id { get; set; }
+    public string Status { get; set; } = string.Empty;
+}
+
+public interface IOrderRepository
+{
+    DbSet<OrderEntity> Orders { get; }
+}
+
+public interface IItemRepository
+{
+    DbSet<StoreItem> Items { get; }
+}
+
+public interface IOrderInsightRepository
+{
+    DbSet<StoreOrder> StoreOrders { get; }
+}
+
+public class OrdersDbContext(DbContextOptions<OrdersDbContext> options) : DbContext(options), IOrderRepository
+{
+    public DbSet<OrderEntity> Orders => Set<OrderEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("orders_abs_schema");
+        modelBuilder.MapWolverineEnvelopeStorage("orders_abs_schema");
+        modelBuilder.Entity<OrderEntity>().ToTable("orders");
+    }
+}
+
+public class CustomersDbContext(DbContextOptions<CustomersDbContext> options) : DbContext(options)
+{
+    public DbSet<CustomerEntity> Customers => Set<CustomerEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("customers_abs_schema");
+        modelBuilder.MapWolverineEnvelopeStorage("customers_abs_schema");
+        modelBuilder.Entity<CustomerEntity>().ToTable("customers");
+    }
+}
+
+public class StoreDbContext(DbContextOptions<StoreDbContext> options) : DbContext(options),
+    IItemRepository, IOrderInsightRepository
+{
+    public DbSet<StoreItem> Items => Set<StoreItem>();
+    public DbSet<StoreOrder> StoreOrders => Set<StoreOrder>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("store_abs_schema");
+        modelBuilder.MapWolverineEnvelopeStorage("store_abs_schema");
+        modelBuilder.Entity<StoreItem>().ToTable("items");
+        modelBuilder.Entity<StoreOrder>().ToTable("orders");
+    }
+}
+
+// === Messages ================================================================================
+
+public record PlaceOrderViaAbstraction(Guid Id, string Description);
+
+public record RegisterCustomerDirect(Guid Id, string Name);
+
+public record CreateStoreItem(Guid Id, string Name);
+
+public record RecordStoreOrder(Guid Id, string Status);
+
+public record CrossAbstractionAudit(Guid ItemId, Guid OrderId);
+
+// === Handlers ================================================================================
+
+#region sample_handler_using_dbcontext_abstraction
+
+public class PlaceOrderViaAbstractionHandler
+{
+    public static void Handle(PlaceOrderViaAbstraction cmd, IOrderRepository orders)
+    {
+        // The handler depends on the abstraction. Wolverine's transactional middleware
+        // recognises the chain as `DbContext`-backed via the registered abstraction and emits
+        // a runtime cast at the top of the chain so SaveChangesAsync + outbox enrolment fire
+        // against the concrete OrdersDbContext underneath.
+        orders.Orders.Add(new OrderEntity { Id = cmd.Id, Description = cmd.Description });
+    }
+}
+
+#endregion
+
+public class RegisterCustomerDirectHandler
+{
+    public static void Handle(RegisterCustomerDirect cmd, CustomersDbContext db)
+    {
+        db.Customers.Add(new CustomerEntity { Id = cmd.Id, Name = cmd.Name });
+    }
+}
+
+public class CreateStoreItemHandler
+{
+    public static void Handle(CreateStoreItem cmd, IItemRepository items)
+    {
+        items.Items.Add(new StoreItem { Id = cmd.Id, Name = cmd.Name });
+    }
+}
+
+public class RecordStoreOrderHandler
+{
+    public static void Handle(RecordStoreOrder cmd, IOrderInsightRepository orders)
+    {
+        orders.StoreOrders.Add(new StoreOrder { Id = cmd.Id, Status = cmd.Status });
+    }
+}
+
+#region sample_handler_using_multiple_abstractions
+
+public class CrossAbstractionAuditHandler
+{
+    public static (bool SameInstance, Type ItemsType, Type OrdersType) LastSeen;
+
+    // The handler depends on TWO abstractions of the same `DbContext`. At runtime both
+    // parameters resolve to the same scoped `StoreDbContext`, just viewed through different
+    // interfaces — so a single `SaveChangesAsync` commits writes the handler made through
+    // either parameter atomically. The forwarding-factory DI registrations above are what
+    // make this work; without them you'd get two separate `DbContext` instances.
+    public static void Handle(CrossAbstractionAudit cmd, IItemRepository items, IOrderInsightRepository orders)
+    {
+        // Cast both back to the concrete DbContext - the cast must succeed (the constraint on
+        // WithDbContextAbstraction guarantees TDbContext : TAbstraction) and the resulting
+        // references must be the SAME instance. That's the contract Wolverine's
+        // CastDbContextFrame + the user's forwarding-factory DI registrations together provide:
+        // one DbContext in scope, viewed through different interfaces.
+        var itemsCtx = (StoreDbContext)items;
+        var ordersCtx = (StoreDbContext)orders;
+
+        LastSeen = (ReferenceEquals(itemsCtx, ordersCtx), itemsCtx.GetType(), ordersCtx.GetType());
+
+        // Both writes go through the single scoped DbContext - the EF Core middleware's
+        // SaveChangesAsync postprocessor commits them as one transaction.
+        items.Items.Add(new StoreItem { Id = cmd.ItemId, Name = "cross-abs" });
+        orders.StoreOrders.Add(new StoreOrder { Id = cmd.OrderId, Status = "audited" });
+    }
+}
+
+#endregion
+
+// === Doc-only sample: bare single-abstraction registration ====================================
+//
+// Existence-of-this-class proves the snippet below compiles; the dedicated tests above exercise
+// the actual runtime behaviour.
+
+public static class SingleAbstractionRegistrationSample
+{
+    public static void Configure(WolverineOptions opts, string connectionString)
+    {
+        #region sample_register_dbcontext_abstraction
+
+        opts.Services.AddDbContextWithWolverineIntegration<OrdersDbContext>(x =>
+            x.UseNpgsql(connectionString));
+
+        // Forward the abstraction to the SAME scoped DbContext via a factory. This keeps
+        // `IOrderRepository` and `OrdersDbContext` pointing at one instance per scope, which is
+        // what `AddScoped<TAbs, TImpl>()` does NOT do (it would create a separate one per
+        // registered interface).
+        opts.Services.AddScoped<IOrderRepository>(sp => sp.GetRequiredService<OrdersDbContext>());
+
+        opts.PersistMessagesWithPostgresql(connectionString, "wolverine");
+
+        opts.UseEntityFrameworkCoreTransactions()
+            .WithDbContextAbstraction<IOrderRepository, OrdersDbContext>();
+
+        opts.Policies.AutoApplyTransactions();
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Reviewer-requested follow-up to [#2919](https://github.com/JasperFx/wolverine/pull/2919) (DbContext abstractions support via `WithDbContextAbstraction<TAbstraction, TDbContext>()`).

## Three new test scenarios

A new file at `src/Persistence/EfCoreTests/dbContext_abstraction_scenarios.cs` covers contracts that the merged PR's tests don't reach:

1. **`multiple_dbcontext_types_one_abstracted_one_direct`** — one Wolverine host with two `DbContext`s: `OrdersDbContext` registered through an `IOrderRepository` abstraction and `CustomersDbContext` used directly. Both handlers transact correctly through the EF Core middleware in parallel.

2. **`multiple_abstractions_for_same_dbcontext_each_used_independently`** — `StoreDbContext` implements both `IItemRepository` and `IOrderInsightRepository`. Two separate handlers, each depending on a different abstraction, both successfully commit through the same physical `DbContext`.

3. **`handler_using_two_abstractions_to_same_dbcontext_uses_one_scoped_instance`** — the headline scenario. The handler takes BOTH `IItemRepository` and `IOrderInsightRepository`, casts both back to `StoreDbContext`, and asserts `ReferenceEquals(itemsCtx, ordersCtx)`. That's the contract the merged `CastDbContextFrame` depends on: at runtime, both parameters resolve to the *same* scoped `DbContext`, just viewed through different interfaces, so a single `SaveChangesAsync` commits all writes atomically.

A note about #3: the contract only holds when the abstractions forward to the same scoped `DbContext` in DI via a factory:

```csharp
services.AddScoped<IItemRepository>(sp => sp.GetRequiredService<StoreDbContext>());
services.AddScoped<IOrderInsightRepository>(sp => sp.GetRequiredService<StoreDbContext>());
```

`services.AddScoped<IItemRepository, StoreDbContext>()` (without the factory) would create a *separate* `DbContext` instance per registered interface, and the cast frame would land on whichever the codegen picked first while the handler's other reference points at a different one. The new docs section calls this out explicitly.

## Docs

New `DbContext Abstractions` section at the bottom of `docs/guide/durability/efcore/transactional-middleware.md`. Five `#region sample_*` blocks in the test file, expanded by `mdsnippets` so every code block in the doc lives in a passing test:

- `sample_register_dbcontext_abstraction` — the bare single-abstraction registration shape
- `sample_handler_using_dbcontext_abstraction` — handler depending on the abstraction
- `sample_register_multiple_dbcontext_abstractions` — two abstractions, factory-forwarded to the same scoped DbContext
- `sample_handler_using_multiple_abstractions` — handler taking both abstractions; ref-equality contract
- `sample_register_mixed_dbcontexts` — multi-DbContext, mixed abstraction registration

The rest of the doc diffs in this PR are mdsnippets regenerations of unrelated snippets it touched while running over the whole repo.

## Schema setup detail (mirrors the GH-2618 workaround)

EF Core's `EnsureCreatedAsync` is a no-op when the database already exists — and the shared Wolverine integration-tests Postgres always does. So each scenario drops + creates its test schemas and then issues raw `CREATE TABLE` DDL for the user-defined entity tables, the same pattern `Bug_DurableLocalQueue_ancillary_store_routing` uses for the same reason.

## Verification

- New scenario suite: 3/3 pass against Postgres on port 5433.
- Full `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors).
- `mdsnippets` expansion of the new doc anchors succeeded and is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)