### PR TITLE
Bump JasperFx.* 2.2.0 -> 2.2.1 and Wolverine 6.2.0 -> 6.2.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -133,8 +133,15 @@
                    Pulsar batched-partition acks (#2883/#2950), and the remote-node
                    agent reply timeout (#2949). See the GitHub release notes for
                    the full PR list.
+
+          6.2.1: Patch release picking up upstream JasperFx 2.2.1 fixes:
+                     JasperFx (+ .Events / .Events.SourceGenerator
+                                / .SourceGenerator)        2.2.0 -> 2.2.1
+                     JasperFx.RuntimeCompiler              unchanged (own 5.x line, stays 5.0.0)
+                     Marten / Polecat                      unchanged (9.2.0 / 4.2.1)
+                   No Wolverine code changes — pure dependency bump.
         -->
-        <Version>6.2.0</Version>
+        <Version>6.2.1</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,13 +32,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.2.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.2.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.0" />
+    <PackageVersion Include="JasperFx" Version="2.2.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.2.1" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.1" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.1" />
     <PackageVersion Include="Marten" Version="9.2.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.2.1" />


### PR DESCRIPTION
Patch release picking up upstream JasperFx 2.2.1 fixes. No Wolverine code changes — pure dependency bump on the JasperFx 2.x family.

## Bumped pins

| Package | From | To |
|---|---|---|
| `JasperFx` | 2.2.0 | **2.2.1** |
| `JasperFx.Events` | 2.2.0 | **2.2.1** |
| `JasperFx.Events.SourceGenerator` | 2.2.0 | **2.2.1** |
| `JasperFx.SourceGenerator` | 2.2.0 | **2.2.1** |

## Unchanged

| Package | Version | Reason |
|---|---|---|
| `JasperFx.RuntimeCompiler` | 5.0.0 | Own 5.x line — the Roslyn runtime-compiler package was decoupled from the JasperFx 2.x family in #2876. |
| Marten family | 9.2.0 | Latest. |
| Polecat | 4.2.1 | Latest (bumped in 6.2.0 via #2947). |

`Directory.Build.props` `<Version>` bumped 6.2.0 → 6.2.1, with a matching changelog entry in the comment block above.

## Test plan

- `dotnet build wolverine.slnx -c Release` — clean locally (0 warnings, 0 errors, ~28 s).
- CI `dotnet.yml` gates merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
