### PR TITLE
Fix duplicate var messageContext codegen in Wolverine.Http (#2958)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Bug_marten_outbox_duplicate_message_context_codegen.cs
+++ b/src/Http/Wolverine.Http.Tests/Bug_marten_outbox_duplicate_message_context_codegen.cs
@@ -1,0 +1,89 @@
+using JasperFx.CodeGeneration;
+using JasperFx.Core.Reflection;
+using Shouldly;
+
+namespace Wolverine.Http.Tests;
+
+/// <summary>
+/// Reproducer for the duplicate <c>var messageContext = new MessageContext(_wolverineRuntime);</c>
+/// codegen bug surfaced by an HTTP endpoint that:
+///
+///   (1) takes an <c>IDocumentSession</c> parameter (triggers Wolverine.Marten's
+///       <c>OutboxedSessionFactory.OpenSession(messageContext)</c> contribution), AND
+///   (2) requires the post-save outbox flush per
+///       https://github.com/JasperFx/wolverine/issues/536 (a cascading message return,
+///       <c>IMessageBus</c>/<c>IMessageContext</c> dependency, or a post-processor that
+///       MaySendMessages), AND
+///   (3) does NOT participate in tenant-id detection (so the MessageContext is not
+///       pre-emitted by tenant-aware codegen at the top of the method).
+///
+/// In that combination, <c>CreateDocumentSessionFrame.FindVariables</c> resolves its
+/// context via <c>chain.TryFindVariable(typeof(IMessageContext), VariableSource.NotServices)</c>
+/// — request type IMessageContext. Wolverine.Http's
+/// <see cref="Wolverine.Http.CodeGen.MessageBusSource"/> matches IMessageBus /
+/// IMessageContext / MessageContext. Later in the same chain,
+/// <c>FlushOutgoingMessages : MethodCall(typeof(MessageContext), ...)</c> asks the
+/// chain for typeof(MessageContext) — a DIFFERENT request type — and the source
+/// previously returned <c>new CreateMessageContextWithMaybeTenantFrame().Variable</c>
+/// on every call, producing two distinct frame instances that each emitted
+/// <c>var messageContext = new MessageContext(_wolverineRuntime);</c>. CS0128 at
+/// compile time on the second declaration prevented the chain from ever booting.
+///
+/// JasperFx.CodeGeneration's MethodVariables caches resolved variables by REQUEST
+/// type, so requests for IMessageContext and MessageContext live in separate cache
+/// entries — even though MessageBusSource produces a variable typed as
+/// MessageContext in both cases. The fix caches the produced frame inside
+/// MessageBusSource so that any of the three matched types resolves to the same
+/// frame instance. The cache is per-source, and a fresh MessageBusSource is added
+/// to every HTTP chain in <c>HttpChain.Codegen.cs</c>, so the cache scope is
+/// exactly one generated handler method.
+///
+/// We assert on the compiled generated source code (forced by
+/// <see cref="JasperFx.CodeGeneration.CodeFileExtensions.InitializeSynchronously"/>)
+/// because the failing frame composition is only visible after the
+/// MethodFrameArranger pulls variable-producing frames in. The pre-arrangement
+/// <c>chain.DetermineFrames(...)</c> list never includes the duplicates, but the
+/// final SourceCode does.
+///
+/// Endpoint under test: <c>POST /todoitems</c> in WolverineWebApi.Samples.
+/// </summary>
+public class Bug_marten_outbox_duplicate_message_context_codegen : IntegrationContext
+{
+    public Bug_marten_outbox_duplicate_message_context_codegen(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public void http_chain_emits_exactly_one_message_context_declaration()
+    {
+        var chain = HttpChains.ChainFor("POST", "/todoitems");
+        chain.ShouldNotBeNull();
+        chain.As<ICodeFile>().InitializeSynchronously(
+            HttpChains.Rules,
+            HttpChains,
+            Host.Services);
+
+        var source = chain.SourceCode;
+        source.ShouldNotBeNull("Failed to generate the source code");
+        
+        const string declaration = "var messageContext = new Wolverine.Runtime.MessageContext(_wolverineRuntime);";
+        var count = TotalFound(source, declaration);
+
+        count.ShouldBe(1,
+            $"Expected exactly one `{declaration}` line in the generated source, found {count}. " +
+            "Two would produce CS0128 at compile time and prevent the chain from booting. " +
+            $"Source code follows:\n{source}");
+    }
+
+    private static int TotalFound(string lookin, string lookfor)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = lookin.IndexOf(lookfor, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += lookfor.Length;
+        }
+        return count;
+    }
+}

--- a/src/Http/Wolverine.Http/CodeGen/MessageBusSource.cs
+++ b/src/Http/Wolverine.Http/CodeGen/MessageBusSource.cs
@@ -9,6 +9,8 @@ namespace Wolverine.Http.CodeGen;
 
 internal class MessageBusSource : IVariableSource
 {
+    private CreateMessageContextWithMaybeTenantFrame? _frame;
+
     public bool Matches(Type type)
     {
         return type == typeof(IMessageBus) || type == typeof(IMessageContext) || type == typeof(MessageContext);
@@ -16,7 +18,24 @@ internal class MessageBusSource : IVariableSource
 
     public Variable Create(Type type)
     {
-        return new CreateMessageContextWithMaybeTenantFrame().Variable;
+        // Cache the frame so a chain that resolves both IMessageContext (e.g. from
+        // OpenMartenSessionFrame's non-tenant fallback) and MessageContext (e.g. from
+        // FlushOutgoingMessages' MethodCall target) shares a single frame instead of
+        // emitting `var messageContext = new MessageContext(_wolverineRuntime);` twice.
+        // The cache is per-source, and MessageBusSource is registered per HTTP chain in
+        // HttpChain.Codegen.cs, so the scope is exactly one generated handler method.
+        //
+        // We always return the concrete MessageContext variable rather than the
+        // CastVariable for the matched interface. The interface CastVariables exist for
+        // downstream parameter-strategy users (UseMessageBusFrame), but consumers via
+        // chain.TryFindVariable(IMessageContext) — including the Wolverine.Marten
+        // CreateDocumentSessionFrame — invoke methods on the concrete MessageContext
+        // (e.g. EnqueueCascadingAsync, FlushOutgoingMessagesAsync) that are not visible
+        // through the interface. Pre-fix behavior was equivalent because each Create
+        // call produced a fresh CreateMessageContextWithMaybeTenantFrame whose .Variable
+        // was the only thing ever handed out from this source.
+        _frame ??= new CreateMessageContextWithMaybeTenantFrame();
+        return _frame.Variable;
     }
 }
 


### PR DESCRIPTION
Closes #2958.

## Summary

When a Wolverine.Http chain takes an `IDocumentSession` parameter, requires the post-save outbox flush per #536, and does NOT participate in tenant-id detection, the generated handler declares `var messageContext = new MessageContext(_wolverineRuntime);` twice and fails to compile with CS0128.

Two consumers of `MessageContext` ask the chain for different request types: `CreateDocumentSessionFrame` requests `IMessageContext`, and `FlushOutgoingMessages` (a `MethodCall(typeof(MessageContext), ...)`) requests `MessageContext`. `MessageBusSource.Matches` accepts both, but `Create` returned a fresh `CreateMessageContextWithMaybeTenantFrame` per call.

## Why now?

The bug is latent on the 6.0.x line (JasperFx 2.0.1) because `MethodVariables` deduped on the produced Variable's actual type. JasperFx 2.1.3+ (bumped in 8206b9603, rolled into 6.1.0) keys the cache on the request type, so `IMessageContext` and `MessageContext` became separate cache entries even though `MessageBusSource` returns a `MessageContext`-typed Variable in both cases. The tenant-detection codepath happens to dedupe via a shared frame emitted at the top of the method, which is why the committed test handlers (`POST_todo_create`, `GET_todo_id`) never reproduced it.

## Fix

Cache the produced frame inside `MessageBusSource`. Scope is per-source, and `HttpChain.Codegen.cs` registers a fresh `MessageBusSource` per HTTP chain, so the cache is exactly one generated handler method. Always return the concrete `MessageContext` variable rather than a `CastVariable` for the interfaces, because downstream consumers like `CreateDocumentSessionFrame` invoke methods (`EnqueueCascadingAsync`, `FlushOutgoingMessagesAsync`) that are not visible through `IMessageContext` — matches the pre-fix behavior of the source always producing the concrete variable.

## Verification

`Bug_marten_outbox_duplicate_message_context_codegen` asserts on the compiled generated source for `POST /todoitems` (existing sample endpoint that matches the failing shape) — forces codegen via `InitializeSynchronously` and counts occurrences of the declaration line.

- PASSES against the 6.0.1 source tree (no fix) — 1 declaration
- FAILS against current main without the fix — CS0128, 2 declarations
- PASSES against current main with the fix — 1 declaration

Full `Wolverine.Http.Tests` suite with the fix: **773 passed, 10 skipped, 0 failed**.
