### PR TITLE
F# codegen: JSON HTTP path + causation via JasperFx 2.2.4 (GH-2969)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,13 +32,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.2.3" />
-    <PackageVersion Include="JasperFx.Events" Version="2.2.3" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.3" />
+    <PackageVersion Include="JasperFx" Version="2.2.4" />
+    <PackageVersion Include="JasperFx.Events" Version="2.2.4" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.4" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.3" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.4" />
     <PackageVersion Include="Marten" Version="9.2.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.2.1" />

--- a/src/Http/Wolverine.Http/CodeGen/JsonHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/JsonHandling.cs
@@ -6,6 +6,7 @@ using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Wolverine.Configuration;
 using Wolverine.Runtime;
 
 namespace Wolverine.Http.CodeGen;
@@ -39,6 +40,20 @@ internal class ReadJsonBody : AsyncFrame
             $"if (jsonContinue == {typeof(HandlerContinuation).FullNameInCode()}.{nameof(HandlerContinuation.Stop)}) return;");
 
         Next?.GenerateCode(method, writer);
+    }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment("Reading the request body via JSON deserialization");
+
+        // ReadJsonAsync is an inherited *instance* method on HttpHandler (qualified with the member's
+        // `this` self identifier, jasperfx#393) returning (body, continuation). F# has no early
+        // `return`, so the abort guard renders the rest of the chain inside its `else` branch.
+        writer.Write(
+            $"let! ({Variable.Usage}, jsonContinue) = this.{nameof(HttpHandler.ReadJsonAsync)}<{Variable.VariableType.FSharpName()}>(httpContext)");
+
+        var condition = $"jsonContinue = {typeof(HandlerContinuation).FSharpName()}.{nameof(HandlerContinuation.Stop)}";
+        FSharpEmitHelpers.WriteAbortGuard(writer, method, condition, Next);
     }
 }
 

--- a/src/Http/Wolverine.Http/CodeGen/WriteJsonFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/WriteJsonFrame.cs
@@ -20,4 +20,16 @@ public class WriteJsonFrame : AsyncFrame
         writer.Write($"await {nameof(HttpHandler.WriteJsonAsync)}(httpContext, {_resourceVariable.Usage});");
         Next?.GenerateCode(method, writer);
     }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment("Writing the response body to JSON because this was the first 'return variable' in the method signature");
+
+        // WriteJsonAsync is an inherited *instance* method on HttpHandler, so it must be qualified with
+        // the generated member's `this` self identifier (jasperfx#393).
+        var call = $"this.{nameof(HttpHandler.WriteJsonAsync)}(httpContext, {_resourceVariable.Usage})";
+        writer.Write(method.AsyncMode == AsyncMode.AsyncTask ? $"do! {call}" : call);
+
+        Next?.GenerateFSharpCode(method, writer);
+    }
 }

--- a/src/Testing/Wolverine.Core.FSharpFixture/Generated.fs
+++ b/src/Testing/Wolverine.Core.FSharpFixture/Generated.fs
@@ -14,7 +14,7 @@ type CheckThingHandler649476295(loggerForMessage: Microsoft.Extensions.Logging.I
     inherit Wolverine.Runtime.Handlers.MessageHandler()
     let _loggerForMessage = loggerForMessage
 
-    override _.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
         // The actual message body
         let checkThing = context.Envelope.Message :?> Wolverine.Core.FSharpContracts.CheckThing
 
@@ -32,13 +32,14 @@ type CheckThingHandler649476295(loggerForMessage: Microsoft.Extensions.Logging.I
             // The actual message execution
             checkThingHandler.Handle(checkThing)
 
+            this.RecordCauseAndEffect(context, context.Runtime.Observer)
         System.Threading.Tasks.Task.CompletedTask
 
 type CreateNameHandler1923366998(loggerForMessage: Microsoft.Extensions.Logging.ILogger<Wolverine.Core.FSharpContracts.CreateName>) =
     inherit Wolverine.Runtime.Handlers.MessageHandler()
     let _loggerForMessage = loggerForMessage
 
-    override _.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
         task {
             // The actual message body
             let createName = context.Envelope.Message :?> Wolverine.Core.FSharpContracts.CreateName
@@ -64,11 +65,12 @@ type CreateNameHandler1923366998(loggerForMessage: Microsoft.Extensions.Logging.
                 // Outgoing, cascaded message
                 do! context.EnqueueCascadingAsync(outgoing1)
 
+                this.RecordCauseAndEffect(context, context.Runtime.Observer)
         }
 
 type GateHandler1696712162() =
     inherit Wolverine.Runtime.Handlers.MessageHandler()
-    override _.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
         // The actual message body
         let gate = context.Envelope.Message :?> Wolverine.Core.FSharpContracts.Gate
 
@@ -86,13 +88,14 @@ type GateHandler1696712162() =
             // The actual message execution
             gateHandler.Handle(gate)
 
+            this.RecordCauseAndEffect(context, context.Runtime.Observer)
         System.Threading.Tasks.Task.CompletedTask
 
 type IncrementCountHandler540640831(inMemorySagaPersistor: Wolverine.Persistence.Sagas.InMemorySagaPersistor) =
     inherit Wolverine.Runtime.Handlers.MessageHandler()
     let _inMemorySagaPersistor = inMemorySagaPersistor
 
-    override _.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
         // The actual message body
         let incrementCount = context.Envelope.Message :?> Wolverine.Core.FSharpContracts.IncrementCount
 
@@ -126,7 +129,7 @@ type StartCountHandler1561563330(inMemorySagaPersistor: Wolverine.Persistence.Sa
     inherit Wolverine.Runtime.Handlers.MessageHandler()
     let _inMemorySagaPersistor = inMemorySagaPersistor
 
-    override _.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
         // The actual message body
         let startCount = context.Envelope.Message :?> Wolverine.Core.FSharpContracts.StartCount
 

--- a/src/Testing/Wolverine.Core.FSharpTests/FSharpCodegenSample.cs
+++ b/src/Testing/Wolverine.Core.FSharpTests/FSharpCodegenSample.cs
@@ -38,6 +38,10 @@ public static class FSharpCodegenSample
 
                     // Inserts ApplyExecutionDiagnosticTagsFrame at the head of every chain.
                     opts.Tracking.HandlerExecutionDiagnosticsEnabled = true;
+
+                    // Inserts RecordMessageCausationFrame after the handler call (a `this.`-qualified
+                    // inherited instance call, now resolvable per JasperFx 2.2.4 / jasperfx#393).
+                    opts.Tracking.EnableMessageCausationTracking = true;
                 })
                 .Build();
 

--- a/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
+++ b/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
@@ -13,7 +13,7 @@ type GET_fsharp_hello(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions)
     inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
     let _wolverineHttpOptions = wolverineHttpOptions
 
-    override _.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
         task {
             let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
             
@@ -21,5 +21,25 @@ type GET_fsharp_hello(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions)
             let result_of_Hello = thingEndpoints.Hello()
 
             do! Wolverine.Http.HttpHandler.WriteString(httpContext, result_of_Hello)
+        }
+
+type POST_fsharp_things(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions) =
+    inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
+    let _wolverineHttpOptions = wolverineHttpOptions
+
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+        task {
+            // Reading the request body via JSON deserialization
+            let! (command, jsonContinue) = this.ReadJsonAsync<Wolverine.Http.FSharpContracts.CreateThing>(httpContext)
+            if jsonContinue = Wolverine.HandlerContinuation.Stop then
+                ()
+            else
+                let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
+                
+                // The actual HTTP request handler execution
+                let thingCreated_response = thingEndpoints.Create(command)
+
+                // Writing the response body to JSON because this was the first 'return variable' in the method signature
+                do! this.WriteJsonAsync(httpContext, thingCreated_response)
         }
 

--- a/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCodegenSample.cs
+++ b/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCodegenSample.cs
@@ -27,14 +27,13 @@ public static class HttpFSharpCodegenSample
         var container = new ServiceContainer(registry, registry.BuildServiceProvider());
         var httpGraph = new HttpGraph(new WolverineOptions { ApplicationAssembly = typeof(ThingEndpoints).Assembly }, container);
 
-        // Phase C increment 1 renders the static-response GET endpoint. The JSON POST endpoint
-        // (ReadJsonBody / WriteJsonFrame) calls *instance* HttpHandler methods unqualified, which F#
-        // cannot resolve from a `member _.Handle` body — blocked on the JasperFx F# self-identifier
-        // gap (tracked upstream; same gap as RecordMessageCausationFrame). Add it back once JasperFx
-        // emits a named self for generated members.
+        // GET (static string response) + POST (JSON body bind + JSON response). The JSON path calls
+        // the inherited instance HttpHandler methods ReadJsonAsync/WriteJsonAsync, now qualified with
+        // the generated member's `this` self identifier (JasperFx 2.2.4 / jasperfx#393).
         var chains = new[]
         {
-            HttpChain.ChainFor<ThingEndpoints>(x => x.Hello(), httpGraph)
+            HttpChain.ChainFor<ThingEndpoints>(x => x.Hello(), httpGraph),
+            HttpChain.ChainFor<ThingEndpoints>(x => x.Create(null!), httpGraph)
         };
 
         var generatedAssembly = httpGraph.StartAssembly(httpGraph.Rules);

--- a/src/Wolverine/Runtime/RecordMessageCausationFrame.cs
+++ b/src/Wolverine/Runtime/RecordMessageCausationFrame.cs
@@ -45,4 +45,14 @@ internal class RecordMessageCausationFrame : Frame
 
         Next?.GenerateCode(method, writer);
     }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        // RecordCauseAndEffect is an inherited instance method on the generated MessageHandler subclass,
+        // so it must be qualified with the member's `this` self identifier (jasperfx#393).
+        writer.Write(
+            $"this.{nameof(MessageHandler.RecordCauseAndEffect)}({_context!.Usage}, {_context!.Usage}.Runtime.Observer)");
+
+        Next?.GenerateFSharpCode(method, writer);
+    }
 }


### PR DESCRIPTION
Picks up the F# self-identifier fix ([jasperfx#393](https://github.com/JasperFx/jasperfx/pull/394), shipped in **JasperFx 2.2.4**) and uses it to unblock the inherited-instance-method frames F# couldn't emit before — completing the **Wolverine.Http JSON request/response path** (Phase C) and **message-causation tracking**.

## Changes
- **Bump JasperFx 2.2.3 → 2.2.4** (`JasperFx`, `.Events`, `.Events.SourceGenerator`, `.SourceGenerator`; `RuntimeCompiler` stays on its 5.x line). 2.2.4 emits `member this.` for generated F# members, so inherited instance calls resolve.
- **`WriteJsonFrame`** → `do! this.WriteJsonAsync(httpContext, result)`
- **`ReadJsonBody`** → `let! (body, jsonContinue) = this.ReadJsonAsync<T>(httpContext)` + `FSharpEmitHelpers.WriteAbortGuard` for the no-early-return stop check (the helper is reachable from `Wolverine.Http` via the existing `[InternalsVisibleTo]`).
- **`RecordMessageCausationFrame`** → `this.RecordCauseAndEffect(context, context.Runtime.Observer)`
- Re-enabled the POST/JSON endpoint in the Http F# driver and turned on `EnableMessageCausationTracking` in the Core driver, so all three frames are compile-gated.

### Generated F# (the JSON POST endpoint)
```fsharp
override this.Handle(httpContext: HttpContext) : Task =
    task {
        let! (command, jsonContinue) = this.ReadJsonAsync<CreateThing>(httpContext)
        if jsonContinue = Wolverine.HandlerContinuation.Stop then
            ()
        else
            let thingCreated_response = thingEndpoints.Create(command)
            do! this.WriteJsonAsync(httpContext, thingCreated_response)
    }
```

## Verification
- Both F# surface gates compile (Core: GET + validation + cascade + saga chains; Http: GET **and POST/JSON**).
- `fsharp-coverage`: Core **25 / 2 / 17** of 44; with `Wolverine.Http` loaded **28 / 2 / 51** of 81.
- `dotnet build wolverine_fsharp.slnx -c Release` + all 4 gate/coverage tests — green.
- Full `dotnet build wolverine.slnx -c Release` regression (whole solution on 2.2.4) — 0 warnings, 0 errors.

Part of #2969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)