### PR TITLE
Bump JasperFx to 2.2.5; adopt built-in Variable.FSharpUsage (GH-2969)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,13 +32,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.2.4" />
-    <PackageVersion Include="JasperFx.Events" Version="2.2.4" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.4" />
+    <PackageVersion Include="JasperFx" Version="2.2.5" />
+    <PackageVersion Include="JasperFx.Events" Version="2.2.5" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.5" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.4" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.5" />
     <PackageVersion Include="Marten" Version="9.2.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.2.1" />

--- a/src/Wolverine/Configuration/FSharpEmitHelpers.cs
+++ b/src/Wolverine/Configuration/FSharpEmitHelpers.cs
@@ -1,14 +1,12 @@
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
-using JasperFx.CodeGeneration.Model;
-using JasperFx.Core.Reflection;
 
 namespace Wolverine.Configuration;
 
 /// <summary>
-///     Small shared helpers for emitting F# from Wolverine frames (issue GH-2969). These cover gaps in
-///     the JasperFx-layer model where a value's C# rendering is not valid F#, plus the recurring
-///     "abort-or-continue" continuation shape.
+///     Small shared helper for emitting F# from Wolverine frames (issue GH-2969): the recurring
+///     "abort-or-continue" continuation shape. (The former CastVariable workaround was retired once
+///     JasperFx 2.2.5 added the built-in <c>Variable.FSharpUsage</c>; frames now use that directly.)
 /// </summary>
 internal static class FSharpEmitHelpers
 {
@@ -39,22 +37,5 @@ internal static class FSharpEmitHelpers
         }
 
         writer.FinishBlock();
-    }
-
-    /// <summary>
-    ///     The F# rendering of a variable's usage. F# has no C-style cast, but
-    ///     <see cref="CastVariable" /> bakes a C# <c>((Type)x)</c> cast into its <see cref="Variable.Usage" />
-    ///     (e.g. the injected <c>ILogger&lt;TMessage&gt;</c> handed to validation frames as <c>ILogger</c>).
-    ///     Rewrite that as an F# upcast <c>(x :&gt; Type)</c>; everything else uses its usage verbatim.
-    /// </summary>
-    /// <remarks>
-    ///     The proper fix is an F#-aware usage on JasperFx's <c>CastVariable</c> itself; tracked as an
-    ///     upstream JasperFx gap. Until then this keeps the audit moving without leaving Wolverine.
-    /// </remarks>
-    public static string FSharpUsage(Variable variable)
-    {
-        return variable is CastVariable cast
-            ? $"({cast.Inner.Usage} :> {cast.VariableType.FSharpName()})"
-            : variable.Usage;
     }
 }

--- a/src/Wolverine/Logging/AuditToActivityFrame.cs
+++ b/src/Wolverine/Logging/AuditToActivityFrame.cs
@@ -51,7 +51,7 @@ public class AuditToActivityFrame : SyncFrame
             foreach (var member in _members)
             {
                 writer.Write(
-                    $"{current}.{nameof(Activity.SetTag)}(\"{member.OpenTelemetryName}\", {FSharpEmitHelpers.FSharpUsage(_input!)}.{member.Member.Name}) |> ignore");
+                    $"{current}.{nameof(Activity.SetTag)}(\"{member.OpenTelemetryName}\", {_input!.FSharpUsage}.{member.Member.Name}) |> ignore");
             }
 
             writer.FinishBlock();

--- a/src/Wolverine/Middleware/RequirementResultContinuationPolicy.cs
+++ b/src/Wolverine/Middleware/RequirementResultContinuationPolicy.cs
@@ -120,7 +120,7 @@ internal class RequirementResultHandlerFrame : SyncFrame
         // F# has no early `return`; render the remainder of the chain inside the `else` branch.
         writer.WriteComment("Check RequirementResult and abort if Branch == Stop");
         var condition =
-            $"{typeof(RequirementResultContinuationPolicy).FSharpName()}.{nameof(RequirementResultContinuationPolicy.ShouldStop)}({FSharpEmitHelpers.FSharpUsage(_logger!)}, {_variable.Usage})";
+            $"{typeof(RequirementResultContinuationPolicy).FSharpName()}.{nameof(RequirementResultContinuationPolicy.ShouldStop)}({_logger!.FSharpUsage}, {_variable.Usage})";
         FSharpEmitHelpers.WriteAbortGuard(writer, method, condition, Next);
     }
 }

--- a/src/Wolverine/Middleware/SimpleValidationContinuationPolicy.cs
+++ b/src/Wolverine/Middleware/SimpleValidationContinuationPolicy.cs
@@ -140,7 +140,7 @@ internal class SimpleValidationHandlerFrame : SyncFrame
         // `else` branch so the abort path simply yields the method's result.
         writer.WriteComment("Check for any simple validation messages and abort if any exist");
         var condition =
-            $"{typeof(SimpleValidationContinuationPolicy).FSharpName()}.{nameof(SimpleValidationContinuationPolicy.LogValidationMessages)}({FSharpEmitHelpers.FSharpUsage(_logger!)}, {_variable.Usage})";
+            $"{typeof(SimpleValidationContinuationPolicy).FSharpName()}.{nameof(SimpleValidationContinuationPolicy.LogValidationMessages)}({_logger!.FSharpUsage}, {_variable.Usage})";
         FSharpEmitHelpers.WriteAbortGuard(writer, method, condition, Next);
     }
 }

--- a/src/Wolverine/Persistence/Sagas/SetSagaIdFrame.cs
+++ b/src/Wolverine/Persistence/Sagas/SetSagaIdFrame.cs
@@ -45,7 +45,7 @@ internal class SetSagaIdFrame : SyncFrame
 
     public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
     {
-        var sagaId = FSharpEmitHelpers.FSharpUsage(_sagaId);
+        var sagaId = _sagaId.FSharpUsage;
         writer.Write($"{_context!.Usage}.{nameof(MessageContext.SetSagaId)}({sagaId})");
 
         // F# has no null-conditional `?.`, and SetTag returns the Activity; guard once and pipe to ignore.


### PR DESCRIPTION
JasperFx **2.2.5** ([jasperfx#395](https://github.com/JasperFx/jasperfx/pull/396)) adds a built-in F#-aware `Variable.FSharpUsage` that renders a `CastVariable` as an F# `:>`/`:?>` cast. This adopts it and retires Wolverine's local workaround.

## Changes
- **Bump** `JasperFx` / `.Events` / `.Events.SourceGenerator` / `.SourceGenerator` **2.2.4 → 2.2.5** (RuntimeCompiler stays on its 5.x line).
- Replace the four `FSharpEmitHelpers.FSharpUsage(x)` call sites (RequirementResult/SimpleValidation logger, `SetSagaIdFrame` sagaId, `AuditToActivityFrame` input) with the built-in `x.FSharpUsage` property.
- Remove `FSharpEmitHelpers.FSharpUsage` (keep `WriteAbortGuard`).

## Verification
- **Behaviour-preserving**: the regenerated F# fixtures are byte-identical (the logger still renders `(_loggerForMessage :> ILogger)`), so the diff is purely the pin + call-site swap.
- Both F# surface gates pass; `fsharp-coverage` unchanged (Core 25/2/17, HTTP-loaded 28/2/51).
- Full `dotnet build wolverine.slnx -c Release` regression on 2.2.5 — 0 warnings, 0 errors.

Part of #2969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)