### PR TITLE
F# codegen: HTTP route + query string binding (GH-2969)

### DIFF
--- a/src/Http/Wolverine.Http/CodeGen/IReadHttpFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/IReadHttpFrame.cs
@@ -105,6 +105,71 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
         Next?.GenerateCode(method, writer);
     }
 
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        // F# emit currently covers string binding to a method argument. The parsed/out-var path and
+        // property binding (AsParameters) are deferred (GH-2969).
+        if (Mode != AssignMode.WriteToVariable)
+        {
+            throw new NotSupportedException(
+                "F# code generation for ReadHttpFrame supports method-argument binding only (not property/AsParameters binding) yet.");
+        }
+
+        if (_rawType != typeof(string))
+        {
+            throw new NotSupportedException(
+                $"F# code generation for ReadHttpFrame does not yet support parsed (non-string) binding (was {_rawType.FullNameInCode()}).");
+        }
+
+        writer.Write($"{Variable.FSharpAssignmentUsage} = {fsharpRawValueSource()}");
+
+        if (_source == BindingSource.RouteValue && !_isOptional)
+        {
+            // A missing required route value 404s and aborts. F# has no early return, so the rest of
+            // the chain renders inside the else branch.
+            writer.Write($"BLOCK:if isNull {Variable.Usage} then");
+            writer.Write($"httpContext.Response.{nameof(HttpResponse.StatusCode)} <- 404");
+            writer.Write("()");
+            writer.FinishBlock();
+            writer.Write("BLOCK:else");
+            if (Next != null)
+            {
+                Next.GenerateFSharpCode(method, writer);
+            }
+            else
+            {
+                writer.Write("()");
+            }
+
+            writer.FinishBlock();
+        }
+        else
+        {
+            Next?.GenerateFSharpCode(method, writer);
+        }
+    }
+
+    private string fsharpRawValueSource()
+    {
+        switch (_source)
+        {
+            case BindingSource.Form:
+                return $"httpContext.Request.Form.[\"{Key}\"].ToString()";
+
+            case BindingSource.Header:
+                return $"{typeof(HttpHandler).FSharpName()}.{nameof(HttpHandler.ReadSingleHeaderValue)}(httpContext, \"{Key}\")";
+
+            case BindingSource.QueryString:
+                return $"httpContext.Request.Query.[\"{Key}\"].ToString()";
+
+            case BindingSource.RouteValue:
+                return $"(httpContext.GetRouteValue(\"{Key}\") :?> string)";
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
     private void writeStringValue(ISourceWriter writer, GeneratedMethod method)
     {
         var assignTo = Mode == AssignMode.WriteToVariable ? $"var {Variable.Usage}" : _property;

--- a/src/Testing/Wolverine.Http.FSharpContracts/Endpoints.cs
+++ b/src/Testing/Wolverine.Http.FSharpContracts/Endpoints.cs
@@ -25,4 +25,24 @@ public class ThingEndpoints
     {
         return new ThingCreated(command.Name);
     }
+
+    // Route-value binding: {id} is bound from the route. {count} is a typed (int) route value.
+    [WolverineGet("/fsharp/things/{id}")]
+    public string GetById(string id)
+    {
+        return $"thing {id}";
+    }
+
+    [WolverineGet("/fsharp/things/{id}/items/{count}")]
+    public string GetItems(string id, int count)
+    {
+        return $"{count} items for {id}";
+    }
+
+    // Query-string binding: q has no matching route token, so it binds from the query string.
+    [WolverineGet("/fsharp/search")]
+    public string Search(string q)
+    {
+        return $"searching {q}";
+    }
 }

--- a/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
+++ b/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
@@ -43,3 +43,37 @@ type POST_fsharp_things(wolverineHttpOptions: Wolverine.Http.WolverineHttpOption
                 do! this.WriteJsonAsync(httpContext, thingCreated_response)
         }
 
+type GET_fsharp_things_id(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions) =
+    inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
+    let _wolverineHttpOptions = wolverineHttpOptions
+
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+        task {
+            let id = (httpContext.GetRouteValue("id") :?> string)
+            if isNull id then
+                httpContext.Response.StatusCode <- 404
+                ()
+            else
+                let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
+                
+                // The actual HTTP request handler execution
+                let result_of_GetById = thingEndpoints.GetById(id)
+
+                do! Wolverine.Http.HttpHandler.WriteString(httpContext, result_of_GetById)
+        }
+
+type GET_fsharp_search(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions) =
+    inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
+    let _wolverineHttpOptions = wolverineHttpOptions
+
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+        task {
+            let q = httpContext.Request.Query.["q"].ToString()
+            let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
+            
+            // The actual HTTP request handler execution
+            let result_of_Search = thingEndpoints.Search(q)
+
+            do! Wolverine.Http.HttpHandler.WriteString(httpContext, result_of_Search)
+        }
+

--- a/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCodegenSample.cs
+++ b/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCodegenSample.cs
@@ -33,7 +33,11 @@ public static class HttpFSharpCodegenSample
         var chains = new[]
         {
             HttpChain.ChainFor<ThingEndpoints>(x => x.Hello(), httpGraph),
-            HttpChain.ChainFor<ThingEndpoints>(x => x.Create(null!), httpGraph)
+            HttpChain.ChainFor<ThingEndpoints>(x => x.Create(null!), httpGraph),
+            HttpChain.ChainFor<ThingEndpoints>(x => x.GetById(null!), httpGraph),
+            HttpChain.ChainFor<ThingEndpoints>(x => x.Search(null!), httpGraph)
+            // GetItems (typed int route value) is deferred — ReadHttpFrame's parsed/out-var path
+            // isn't emitted to F# yet; only the string binding path is.
         };
 
         var generatedAssembly = httpGraph.StartAssembly(httpGraph.Rules);


### PR DESCRIPTION
Phase C long tail — teaches `ReadHttpFrame` to emit F# for **string binding to a method argument** (route values + query string).

> Stacked on #2979 (the 2.2.5 bump). Base is `feat-2969-fsharp-jasperfx-2.2.5`; rebases onto main once that merges.

## Changes
- `ReadHttpFrame.GenerateFSharpCode` covers the string path:
  - **Route value** → `let id = (httpContext.GetRouteValue("id") :?> string)`, with the required-value 404 guard rendered as `if isNull id then (set 404; ()) else <rest of chain>` — F# has no early return, so `Next` renders inside the `else`.
  - **Query string** → `let q = httpContext.Request.Query.["q"].ToString()`.
  - **Header/Form** string sources via the static `ReadSingleHeaderValue` / form lookup.
- Parsed (non-string, `out var` `TryParse`) binding and property/AsParameters binding throw a clear `NotSupportedException` for now (deferred — the `out var`/`default` path is the next chunk).

### Generated F#
```fsharp
// GET /fsharp/things/{id}
let id = (httpContext.GetRouteValue("id") :?> string)
if isNull id then
    httpContext.Response.StatusCode <- 404
    ()
else
    let result_of_GetById = thingEndpoints.GetById(id)
    do! Wolverine.Http.HttpHandler.WriteString(httpContext, result_of_GetById)

// GET /fsharp/search
let q = httpContext.Request.Query.["q"].ToString()
```

## Verification
- Fixture renders + compiles GET `/things/{id}` (route) and GET `/search` (query) alongside the existing endpoints.
- `fsharp-coverage` (Wolverine.Http loaded): **29 / 2 / 50** (ReadHttpFrame now implemented).
- Both F# gates green; full `wolverine.slnx` Release regression — 0 warnings, 0 errors.

Part of #2969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)