### PR TITLE
F# codegen: HTTP route/query binding — string + typed (GH-2969)

### DIFF
--- a/.github/workflows/fsharp.yml
+++ b/.github/workflows/fsharp.yml
@@ -51,7 +51,12 @@ jobs:
       - name: Build the F# solution
         run: dotnet build wolverine_fsharp.slnx -c "$config" --nologo
 
-      - name: Compile-gate + fsharp-coverage (Core + Http surfaces)
-        # Each gate test regenerates its Generated.fs, recompiles the F# fixture (retrying once on the
-        # transient FS0193 internal-compiler crash), and runs the fsharp-coverage report.
-        run: dotnet test wolverine_fsharp.slnx -c "$config" --nologo
+      # Run the two surface gates SEQUENTIALLY (not `dotnet test wolverine_fsharp.slnx`, which runs the
+      # test assemblies in parallel). Each gate shells a nested `dotnet build` of its F# fixture, and
+      # both fixtures transitively build Debug Wolverine.dll — concurrent nested builds race on
+      # obj/Debug/.../refint/Wolverine.dll (IOException "used by another process"). Serializing avoids it.
+      - name: Compile-gate + fsharp-coverage (Core surface)
+        run: dotnet test src/Testing/Wolverine.Core.FSharpTests/Wolverine.Core.FSharpTests.csproj -c "$config" --nologo
+
+      - name: Compile-gate + fsharp-coverage (Http surface)
+        run: dotnet test src/Testing/Wolverine.Http.FSharpTests/Wolverine.Http.FSharpTests.csproj -c "$config" --nologo

--- a/src/Http/Wolverine.Http/CodeGen/IReadHttpFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/IReadHttpFrame.cs
@@ -105,6 +105,71 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
         Next?.GenerateCode(method, writer);
     }
 
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        // F# emit currently covers string binding to a method argument. The parsed/out-var path and
+        // property binding (AsParameters) are deferred (GH-2969).
+        if (Mode != AssignMode.WriteToVariable)
+        {
+            throw new NotSupportedException(
+                "F# code generation for ReadHttpFrame supports method-argument binding only (not property/AsParameters binding) yet.");
+        }
+
+        if (_rawType != typeof(string))
+        {
+            throw new NotSupportedException(
+                $"F# code generation for ReadHttpFrame does not yet support parsed (non-string) binding (was {_rawType.FullNameInCode()}).");
+        }
+
+        writer.Write($"{Variable.FSharpAssignmentUsage} = {fsharpRawValueSource()}");
+
+        if (_source == BindingSource.RouteValue && !_isOptional)
+        {
+            // A missing required route value 404s and aborts. F# has no early return, so the rest of
+            // the chain renders inside the else branch.
+            writer.Write($"BLOCK:if isNull {Variable.Usage} then");
+            writer.Write($"httpContext.Response.{nameof(HttpResponse.StatusCode)} <- 404");
+            writer.Write("()");
+            writer.FinishBlock();
+            writer.Write("BLOCK:else");
+            if (Next != null)
+            {
+                Next.GenerateFSharpCode(method, writer);
+            }
+            else
+            {
+                writer.Write("()");
+            }
+
+            writer.FinishBlock();
+        }
+        else
+        {
+            Next?.GenerateFSharpCode(method, writer);
+        }
+    }
+
+    private string fsharpRawValueSource()
+    {
+        switch (_source)
+        {
+            case BindingSource.Form:
+                return $"httpContext.Request.Form.[\"{Key}\"].ToString()";
+
+            case BindingSource.Header:
+                return $"{typeof(HttpHandler).FSharpName()}.{nameof(HttpHandler.ReadSingleHeaderValue)}(httpContext, \"{Key}\")";
+
+            case BindingSource.QueryString:
+                return $"httpContext.Request.Query.[\"{Key}\"].ToString()";
+
+            case BindingSource.RouteValue:
+                return $"(httpContext.GetRouteValue(\"{Key}\") :?> string)";
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
     private void writeStringValue(ISourceWriter writer, GeneratedMethod method)
     {
         var assignTo = Mode == AssignMode.WriteToVariable ? $"var {Variable.Usage}" : _property;

--- a/src/Http/Wolverine.Http/CodeGen/IReadHttpFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/IReadHttpFrame.cs
@@ -107,20 +107,25 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
 
     public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
     {
-        // F# emit currently covers string binding to a method argument. The parsed/out-var path and
-        // property binding (AsParameters) are deferred (GH-2969).
+        // F# emit covers binding to a method argument. Property binding (AsParameters) is deferred.
         if (Mode != AssignMode.WriteToVariable)
         {
             throw new NotSupportedException(
                 "F# code generation for ReadHttpFrame supports method-argument binding only (not property/AsParameters binding) yet.");
         }
 
-        if (_rawType != typeof(string))
+        if (_rawType == typeof(string))
         {
-            throw new NotSupportedException(
-                $"F# code generation for ReadHttpFrame does not yet support parsed (non-string) binding (was {_rawType.FullNameInCode()}).");
+            writeStringValueFSharp(method, writer);
         }
+        else
+        {
+            writeParsedValueFSharp(method, writer);
+        }
+    }
 
+    private void writeStringValueFSharp(GeneratedMethod method, ISourceWriter writer)
+    {
         writer.Write($"{Variable.FSharpAssignmentUsage} = {fsharpRawValueSource()}");
 
         if (_source == BindingSource.RouteValue && !_isOptional)
@@ -128,25 +133,89 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
             // A missing required route value 404s and aborts. F# has no early return, so the rest of
             // the chain renders inside the else branch.
             writer.Write($"BLOCK:if isNull {Variable.Usage} then");
-            writer.Write($"httpContext.Response.{nameof(HttpResponse.StatusCode)} <- 404");
-            writer.Write("()");
+            writeStatusAbort(writer);
             writer.FinishBlock();
             writer.Write("BLOCK:else");
-            if (Next != null)
-            {
-                Next.GenerateFSharpCode(method, writer);
-            }
-            else
-            {
-                writer.Write("()");
-            }
-
+            WriteNextOrUnit(method, writer);
             writer.FinishBlock();
         }
         else
         {
             Next?.GenerateFSharpCode(method, writer);
         }
+    }
+
+    private void writeParsedValueFSharp(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_isNullable || _isOptional)
+        {
+            throw new NotSupportedException(
+                $"F# code generation does not yet support nullable/optional parsed binding ({_rawType.FullNameInCode()}).");
+        }
+
+        if (_rawType.IsEnum)
+        {
+            throw new NotSupportedException(
+                $"F# code generation does not yet support enum binding ({_rawType.FullNameInCode()}).");
+        }
+
+        var raw = $"{Variable.Usage}_rawValue";
+        writer.Write($"let {raw} = {fsharpRawValueSource()}");
+
+        if (_source == BindingSource.RouteValue)
+        {
+            // Required route value: null or parse-failure 404s + aborts; success binds the variable and
+            // renders the rest of the chain in the success match arm (no F# early return).
+            writer.Write($"BLOCK:if isNull {raw} then");
+            writeStatusAbort(writer);
+            writer.FinishBlock();
+            writer.Write("BLOCK:else");
+            writer.Write($"BLOCK:match {fsharpTryParse(raw)} with");
+            writer.Write($"BLOCK:| true, {Variable.Usage} ->");
+            WriteNextOrUnit(method, writer);
+            writer.FinishBlock();
+            writer.Write("BLOCK:| _ ->");
+            writeStatusAbort(writer);
+            writer.FinishBlock();
+            writer.FinishBlock(); // match
+            writer.FinishBlock(); // else
+        }
+        else
+        {
+            // Query/form/header: bind the parsed value, or the default when parsing fails, then continue.
+            writer.Write(
+                $"{Variable.FSharpAssignmentUsage} = match {fsharpTryParse(raw)} with | true, v -> v | _ -> Unchecked.defaultof<{_rawType.FSharpName()}>");
+            Next?.GenerateFSharpCode(method, writer);
+        }
+    }
+
+    private void WriteNextOrUnit(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (Next != null)
+        {
+            Next.GenerateFSharpCode(method, writer);
+        }
+        else
+        {
+            writer.Write("()");
+        }
+    }
+
+    private static void writeStatusAbort(ISourceWriter writer)
+    {
+        writer.Write($"httpContext.Response.{nameof(HttpResponse.StatusCode)} <- 404");
+        writer.Write("()");
+    }
+
+    // The F# tuple form of the C# out-parameter TryParse (F# auto-tuples the out arg).
+    private string fsharpTryParse(string raw)
+    {
+        if (_rawType.IsBoolean())
+        {
+            return $"System.Boolean.TryParse({raw})";
+        }
+
+        return $"{_rawType.FullName}.TryParse({raw}, System.Globalization.CultureInfo.InvariantCulture)";
     }
 
     private string fsharpRawValueSource()

--- a/src/Testing/Wolverine.Core.FSharpTests/FSharpCompileGate.cs
+++ b/src/Testing/Wolverine.Core.FSharpTests/FSharpCompileGate.cs
@@ -39,9 +39,12 @@ public class FSharpCompileGate
 
         // A nested `dotnet build` (build-inside-test) can occasionally trip an internal F# compiler
         // crash (e.g. FS0193 in the auto-generated AssemblyAttributes.fs) that has nothing to do with
-        // the generated source. Retry once on that specific signature only — a genuine F# error in
-        // Generated.fs is deterministic and would persist across the retry, so this can't mask it.
-        if (exitCode != 0 && (output.Contains("FS0193") || output.Contains("internal error")))
+        // the generated source, or a concurrent-build file lock on a shared ref assembly (MSB3883 /
+        // "used by another process"). Retry once on those transient signatures only — a genuine F#
+        // error in Generated.fs is deterministic and would persist across the retry, so this can't mask it.
+        if (exitCode != 0 && (output.Contains("FS0193") || output.Contains("internal error")
+                                                        || output.Contains("being used by another process")
+                                                        || output.Contains("MSB3883")))
         {
             (exitCode, output) = RunDotnet($"build \"{fixtureProject}\" -c Debug --nologo");
         }

--- a/src/Testing/Wolverine.Http.FSharpContracts/Endpoints.cs
+++ b/src/Testing/Wolverine.Http.FSharpContracts/Endpoints.cs
@@ -45,4 +45,11 @@ public class ThingEndpoints
     {
         return $"searching {q}";
     }
+
+    // Typed query-string binding: page is an int bound from the query string (default when absent/unparseable).
+    [WolverineGet("/fsharp/paged")]
+    public string Paged(int page)
+    {
+        return $"page {page}";
+    }
 }

--- a/src/Testing/Wolverine.Http.FSharpContracts/Endpoints.cs
+++ b/src/Testing/Wolverine.Http.FSharpContracts/Endpoints.cs
@@ -25,4 +25,24 @@ public class ThingEndpoints
     {
         return new ThingCreated(command.Name);
     }
+
+    // Route-value binding: {id} is bound from the route. {count} is a typed (int) route value.
+    [WolverineGet("/fsharp/things/{id}")]
+    public string GetById(string id)
+    {
+        return $"thing {id}";
+    }
+
+    [WolverineGet("/fsharp/things/{id}/items/{count}")]
+    public string GetItems(string id, int count)
+    {
+        return $"{count} items for {id}";
+    }
+
+    // Query-string binding: q has no matching route token, so it binds from the query string.
+    [WolverineGet("/fsharp/search")]
+    public string Search(string q)
+    {
+        return $"searching {q}";
+    }
 }

--- a/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
+++ b/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
@@ -43,3 +43,37 @@ type POST_fsharp_things(wolverineHttpOptions: Wolverine.Http.WolverineHttpOption
                 do! this.WriteJsonAsync(httpContext, thingCreated_response)
         }
 
+type GET_fsharp_things_id(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions) =
+    inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
+    let _wolverineHttpOptions = wolverineHttpOptions
+
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+        task {
+            let id = (httpContext.GetRouteValue("id") :?> string)
+            if isNull id then
+                httpContext.Response.StatusCode <- 404
+                ()
+            else
+                let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
+                
+                // The actual HTTP request handler execution
+                let result_of_GetById = thingEndpoints.GetById(id)
+
+                do! Wolverine.Http.HttpHandler.WriteString(httpContext, result_of_GetById)
+        }
+
+type GET_fsharp_search(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions) =
+    inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
+    let _wolverineHttpOptions = wolverineHttpOptions
+
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+        task {
+            let q = httpContext.Request.Query.["q"].ToString()
+            let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
+            
+            // The actual HTTP request handler execution
+            let result_of_Search = thingEndpoints.Search(q)
+
+            do! Wolverine.Http.HttpHandler.WriteString(httpContext, result_of_Search)
+        }
+

--- a/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
+++ b/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
@@ -77,3 +77,48 @@ type GET_fsharp_search(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions
             do! Wolverine.Http.HttpHandler.WriteString(httpContext, result_of_Search)
         }
 
+type GET_fsharp_things_id_items_count(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions) =
+    inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
+    let _wolverineHttpOptions = wolverineHttpOptions
+
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+        task {
+            let id = (httpContext.GetRouteValue("id") :?> string)
+            if isNull id then
+                httpContext.Response.StatusCode <- 404
+                ()
+            else
+                let count_rawValue = (httpContext.GetRouteValue("count") :?> string)
+                if isNull count_rawValue then
+                    httpContext.Response.StatusCode <- 404
+                    ()
+                else
+                    match System.Int32.TryParse(count_rawValue, System.Globalization.CultureInfo.InvariantCulture) with
+                        | true, count ->
+                            let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
+                            
+                            // The actual HTTP request handler execution
+                            let result_of_GetItems = thingEndpoints.GetItems(id, count)
+
+                            do! Wolverine.Http.HttpHandler.WriteString(httpContext, result_of_GetItems)
+                        | _ ->
+                            httpContext.Response.StatusCode <- 404
+                            ()
+        }
+
+type GET_fsharp_paged(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions) =
+    inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
+    let _wolverineHttpOptions = wolverineHttpOptions
+
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+        task {
+            let page_rawValue = httpContext.Request.Query.["page"].ToString()
+            let page = match System.Int32.TryParse(page_rawValue, System.Globalization.CultureInfo.InvariantCulture) with | true, v -> v | _ -> Unchecked.defaultof<int>
+            let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
+            
+            // The actual HTTP request handler execution
+            let result_of_Paged = thingEndpoints.Paged(page)
+
+            do! Wolverine.Http.HttpHandler.WriteString(httpContext, result_of_Paged)
+        }
+

--- a/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCodegenSample.cs
+++ b/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCodegenSample.cs
@@ -35,9 +35,9 @@ public static class HttpFSharpCodegenSample
             HttpChain.ChainFor<ThingEndpoints>(x => x.Hello(), httpGraph),
             HttpChain.ChainFor<ThingEndpoints>(x => x.Create(null!), httpGraph),
             HttpChain.ChainFor<ThingEndpoints>(x => x.GetById(null!), httpGraph),
-            HttpChain.ChainFor<ThingEndpoints>(x => x.Search(null!), httpGraph)
-            // GetItems (typed int route value) is deferred — ReadHttpFrame's parsed/out-var path
-            // isn't emitted to F# yet; only the string binding path is.
+            HttpChain.ChainFor<ThingEndpoints>(x => x.Search(null!), httpGraph),
+            HttpChain.ChainFor<ThingEndpoints>(x => x.GetItems(null!, 0), httpGraph), // typed int route value
+            HttpChain.ChainFor<ThingEndpoints>(x => x.Paged(0), httpGraph)            // typed int query value
         };
 
         var generatedAssembly = httpGraph.StartAssembly(httpGraph.Rules);

--- a/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCodegenSample.cs
+++ b/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCodegenSample.cs
@@ -33,7 +33,11 @@ public static class HttpFSharpCodegenSample
         var chains = new[]
         {
             HttpChain.ChainFor<ThingEndpoints>(x => x.Hello(), httpGraph),
-            HttpChain.ChainFor<ThingEndpoints>(x => x.Create(null!), httpGraph)
+            HttpChain.ChainFor<ThingEndpoints>(x => x.Create(null!), httpGraph),
+            HttpChain.ChainFor<ThingEndpoints>(x => x.GetById(null!), httpGraph),
+            HttpChain.ChainFor<ThingEndpoints>(x => x.Search(null!), httpGraph)
+            // GetItems (typed int route value) is deferred — ReadHttpFrame's parsed/out-var path
+            // isn't emitted to F# yet; only the string binding path is.
         };
 
         var generatedAssembly = httpGraph.StartAssembly(httpGraph.Rules);

--- a/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCompileGate.cs
+++ b/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCompileGate.cs
@@ -33,8 +33,11 @@ public class HttpFSharpCompileGate
         var fixtureProject = HttpFSharpCodegenSample.FixtureProjectPath();
         var (exitCode, output) = RunDotnet($"build \"{fixtureProject}\" -c Debug --nologo");
 
-        // Retry once on the transient FS0193 internal-compiler crash (see the Core surface gate).
-        if (exitCode != 0 && (output.Contains("FS0193") || output.Contains("internal error")))
+        // Retry once on the transient FS0193 internal-compiler crash, or a concurrent-build file lock
+        // on a shared ref assembly (MSB3883 / "used by another process") if gates ever overlap.
+        if (exitCode != 0 && (output.Contains("FS0193") || output.Contains("internal error")
+                                                        || output.Contains("being used by another process")
+                                                        || output.Contains("MSB3883")))
         {
             (exitCode, output) = RunDotnet($"build \"{fixtureProject}\" -c Debug --nologo");
         }


### PR DESCRIPTION
Extends `ReadHttpFrame` F# emit to **typed (parsed) HTTP binding** for method arguments, on top of the string binding.

> ⚠️ **Includes the route/query *string* binding from #2980**, which merged into the stacked #2979 branch and **never reached `main`** (the stacked-merge gotcha — base was the #2979 branch, not main). This PR re-lands that commit plus the new typed binding, both against `main`.

## Typed binding
- `writeParsedValueFSharp`: F# auto-tuples the C# `out`-parameter `TryParse` into `match Type.TryParse(raw, InvariantCulture) with | true, v -> … | _ -> …`.
  - **Route value**: null or parse-failure 404s + aborts; success binds the variable and renders the rest of the chain in the success arm (no F# early return).
  - **Query/form/header**: binds the parsed value, or `Unchecked.defaultof<T>` on failure, then continues.
- Nullable/optional and enum parsed binding still throw `NotSupported` (deferred).

### Generated F#
```fsharp
// GET /fsharp/things/{id}/items/{count}  (string + int route values)
let count_rawValue = (httpContext.GetRouteValue("count") :?> string)
if isNull count_rawValue then
    httpContext.Response.StatusCode <- 404
    ()
else
    match System.Int32.TryParse(count_rawValue, System.Globalization.CultureInfo.InvariantCulture) with
    | true, count -> ... thingEndpoints.GetItems(id, count) ...
    | _ -> httpContext.Response.StatusCode <- 404; ()

// GET /fsharp/paged?page=  (int query)
let page = match System.Int32.TryParse(page_rawValue, ...) with | true, v -> v | _ -> Unchecked.defaultof<int>
```

## Verification
- Fixture renders + compiles GET `/things/{id}` (string route), `/search` (string query), `/things/{id}/items/{count}` (string + **int** route), `/paged` (**int** query), plus the existing string/JSON endpoints.
- Both F# gates green; full `wolverine.slnx` Release regression — 0 warnings, 0 errors.

Part of #2969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)