### PR TITLE
F# codegen: AsyncMode-aware abort + terminal IResult endpoint (GH-2969)

### DIFF
--- a/src/Http/Wolverine.Http/CodeGen/IReadHttpFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/IReadHttpFrame.cs
@@ -3,6 +3,7 @@ using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
 using Microsoft.AspNetCore.Http;
+using Wolverine.Configuration;
 
 namespace Wolverine.Http.CodeGen;
 
@@ -133,7 +134,7 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
             // A missing required route value 404s and aborts. F# has no early return, so the rest of
             // the chain renders inside the else branch.
             writer.Write($"BLOCK:if isNull {Variable.Usage} then");
-            writeStatusAbort(writer);
+            writeStatusAbort(method, writer);
             writer.FinishBlock();
             writer.Write("BLOCK:else");
             WriteNextOrUnit(method, writer);
@@ -167,7 +168,7 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
             // Required route value: null or parse-failure 404s + aborts; success binds the variable and
             // renders the rest of the chain in the success match arm (no F# early return).
             writer.Write($"BLOCK:if isNull {raw} then");
-            writeStatusAbort(writer);
+            writeStatusAbort(method, writer);
             writer.FinishBlock();
             writer.Write("BLOCK:else");
             writer.Write($"BLOCK:match {fsharpTryParse(raw)} with");
@@ -175,7 +176,7 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
             WriteNextOrUnit(method, writer);
             writer.FinishBlock();
             writer.Write("BLOCK:| _ ->");
-            writeStatusAbort(writer);
+            writeStatusAbort(method, writer);
             writer.FinishBlock();
             writer.FinishBlock(); // match
             writer.FinishBlock(); // else
@@ -197,14 +198,14 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
         }
         else
         {
-            writer.Write("()");
+            writer.Write(FSharpEmitHelpers.AbortExpression(method));
         }
     }
 
-    private static void writeStatusAbort(ISourceWriter writer)
+    private static void writeStatusAbort(GeneratedMethod method, ISourceWriter writer)
     {
         writer.Write($"httpContext.Response.{nameof(HttpResponse.StatusCode)} <- 404");
-        writer.Write("()");
+        writer.Write(FSharpEmitHelpers.AbortExpression(method));
     }
 
     // The F# tuple form of the C# out-parameter TryParse (F# auto-tuples the out arg).

--- a/src/Http/Wolverine.Http/CodeGen/ResultContinuationPolicy.cs
+++ b/src/Http/Wolverine.Http/CodeGen/ResultContinuationPolicy.cs
@@ -73,4 +73,9 @@ public class MaybeEndWithResultFrame : AsyncFrame
 
         Next?.GenerateCode(method, writer);
     }
+
+    // NOTE: F# emit for MaybeEndWithResultFrame is deferred. The frame is added by ResultContinuationPolicy
+    // during a full endpoint compile (MapWolverineEndpoints); the no-host ChainFor harness used by the F#
+    // fixture doesn't apply continuation policies, so it can't exercise this frame yet. It will be done
+    // with the behavioural (host-based) harness (GH-2969).
 }

--- a/src/Testing/Wolverine.Http.FSharpContracts/Endpoints.cs
+++ b/src/Testing/Wolverine.Http.FSharpContracts/Endpoints.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Http;
+
 namespace Wolverine.Http.FSharpContracts;
 
 /// <summary>The JSON body bound by <see cref="ThingEndpoints.Create" />.</summary>
@@ -51,5 +53,14 @@ public class ThingEndpoints
     public string Paged(int page)
     {
         return $"page {page}";
+    }
+
+    // IResult return: a terminal IResult endpoint. The handler's IResult is executed directly as the
+    // returned Task (ReturnFromLastNode); combined with a route value it exercises the AsyncMode-aware
+    // abort (a missing route value yields Task.CompletedTask, not unit).
+    [WolverineGet("/fsharp/result/{id}")]
+    public IResult GetResult(string id)
+    {
+        return string.IsNullOrEmpty(id) ? Results.NotFound() : Results.Ok($"thing {id}");
     }
 }

--- a/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
+++ b/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
@@ -122,3 +122,20 @@ type GET_fsharp_paged(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions)
             do! Wolverine.Http.HttpHandler.WriteString(httpContext, result_of_Paged)
         }
 
+type GET_fsharp_result_id(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions) =
+    inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
+    let _wolverineHttpOptions = wolverineHttpOptions
+
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+        let id = (httpContext.GetRouteValue("id") :?> string)
+        if isNull id then
+            httpContext.Response.StatusCode <- 404
+            System.Threading.Tasks.Task.CompletedTask
+        else
+            let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
+            
+            // The actual HTTP request handler execution
+            let result = thingEndpoints.GetResult(id)
+
+            result.ExecuteAsync(httpContext)
+

--- a/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCodegenSample.cs
+++ b/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCodegenSample.cs
@@ -37,7 +37,8 @@ public static class HttpFSharpCodegenSample
             HttpChain.ChainFor<ThingEndpoints>(x => x.GetById(null!), httpGraph),
             HttpChain.ChainFor<ThingEndpoints>(x => x.Search(null!), httpGraph),
             HttpChain.ChainFor<ThingEndpoints>(x => x.GetItems(null!, 0), httpGraph), // typed int route value
-            HttpChain.ChainFor<ThingEndpoints>(x => x.Paged(0), httpGraph)            // typed int query value
+            HttpChain.ChainFor<ThingEndpoints>(x => x.Paged(0), httpGraph),           // typed int query value
+            HttpChain.ChainFor<ThingEndpoints>(x => x.GetResult(null!), httpGraph)    // terminal IResult + route value
         };
 
         var generatedAssembly = httpGraph.StartAssembly(httpGraph.Rules);

--- a/src/Wolverine/Configuration/FSharpEmitHelpers.cs
+++ b/src/Wolverine/Configuration/FSharpEmitHelpers.cs
@@ -1,5 +1,6 @@
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
 
 namespace Wolverine.Configuration;
 
@@ -22,8 +23,10 @@ internal static class FSharpEmitHelpers
     public static void WriteAbortGuard(ISourceWriter writer, GeneratedMethod method, string conditionExpression,
         Frame? next)
     {
+        var abort = AbortExpression(method);
+
         writer.Write($"BLOCK:if {conditionExpression} then");
-        writer.Write("()");
+        writer.Write(abort);
         writer.FinishBlock();
 
         writer.Write("BLOCK:else");
@@ -33,9 +36,23 @@ internal static class FSharpEmitHelpers
         }
         else
         {
-            writer.Write("()");
+            writer.Write(abort);
         }
 
         writer.FinishBlock();
+    }
+
+    /// <summary>
+    ///     The expression a branch yields when it does NOT continue the chain (abort / no-op). In a
+    ///     <c>task { }</c> body (AsyncMode.AsyncTask) or a synchronous-Task method (AsyncMode.None, where
+    ///     the machinery appends a trailing <c>Task.CompletedTask</c>) that's just <c>()</c>. But when the
+    ///     method body IS a bare trailing Task expression (AsyncMode.ReturnFromLastNode) every branch must
+    ///     itself be a <c>Task</c>, so the no-op branch yields <c>Task.CompletedTask</c>.
+    /// </summary>
+    public static string AbortExpression(GeneratedMethod method)
+    {
+        return method.AsyncMode == AsyncMode.ReturnFromLastNode
+            ? "System.Threading.Tasks.Task.CompletedTask"
+            : "()";
     }
 }


### PR DESCRIPTION
A route-bound endpoint whose handler returns `IResult` compiles to `AsyncMode.ReturnFromLastNode` — the `IResult`'s `ExecuteAsync` *is* the method's returned `Task`, with no `task { }` block. In that mode **every branch of the body must itself be a `Task`**, so the route-guard's abort can't be `()` — it must be `Task.CompletedTask`. This PR makes the abort expression AsyncMode-aware and adds the endpoint that exercises it.

## Changes
- **`FSharpEmitHelpers.AbortExpression(method)`** — `()` inside a `task { }` body or a synchronous-`Task` method (`None`, where the machinery appends a trailing `CompletedTask`), but **`Task.CompletedTask`** for `ReturnFromLastNode`. `WriteAbortGuard` and `ReadHttpFrame`'s route-value 404 guards now use it instead of a bare `()`.
- **Fixture**: `GET /fsharp/result/{id}` returns `IResult` with a route value, exercising the `ReturnFromLastNode` abort (a missing `id` yields `Task.CompletedTask`). The terminal `IResult` is executed directly — matching the C# path (no `MaybeEnd` guard for a terminal result).

### Generated F#
```fsharp
override this.Handle(httpContext: HttpContext) : Task =
    let id = (httpContext.GetRouteValue("id") :?> string)
    if isNull id then
        httpContext.Response.StatusCode <- 404
        System.Threading.Tasks.Task.CompletedTask   // <- was () before; ReturnFromLastNode needs Task
    else
        let result = thingEndpoints.GetResult(id)
        result.ExecuteAsync(httpContext)
```

## Deferred
`MaybeEndWithResultFrame` F# emit (the `WolverineContinue` short-circuit for *intermediate* IResults) is intentionally **not** done here: that frame is added by `ResultContinuationPolicy` during a full `MapWolverineEndpoints` compile, which the no-host `ChainFor` fixture harness doesn't run — so it can't be exercised until the behavioural (host-based) harness lands. Documented inline.

## Verification
- Both F# gates pass; `GET /fsharp/result/{id}` renders + compiles.
- Full `wolverine.slnx` Release regression — 0 warnings, 0 errors.

Part of #2969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)