### PR TITLE
Optimized inline request/reply over the Wolverine.Http transport (GH-2966)

### DIFF
--- a/docs/guide/http/transport.md
+++ b/docs/guide/http/transport.md
@@ -159,6 +159,58 @@ When using `.UseDurableOutbox()`, messages are first persisted to your configure
 (PostgreSQL, SQL Server, etc.) and then delivered in the background. This guarantees that messages
 are never lost, even if the sending application crashes or the receiver is temporarily unavailable.
 
+## Inline Request/Reply
+
+When you call `IMessageBus.InvokeAsync<T>(message)` and the message is routed to an HTTP transport
+endpoint, Wolverine uses the HTTP response body **as** the reply. The request envelope is POSTed to the
+receiver's `/_wolverine/invoke` endpoint and the response envelope is read straight back off the HTTP
+response:
+
+```cs
+// Sender — route the request to the receiver's /_wolverine/invoke endpoint
+opts.PublishMessage<PriceQuoteRequest>()
+    .ToHttpEndpoint("https://pricing.example.com/_wolverine/invoke");
+```
+
+```cs
+// Anywhere with an IMessageBus
+var quote = await bus.InvokeAsync<PriceQuote>(new PriceQuoteRequest("SKU-123"));
+```
+
+This is materially cheaper than request/reply over a brokered transport (Rabbit MQ, SQS, Azure Service
+Bus): because HTTP already provides a response slot, there is
+
+- **no `ReplyListener` and no listener loop on the sender** — the reply is the HTTP response, not a
+  separate correlated message, so the sender does not need to run a listening endpoint just to receive
+  its own replies;
+- **no cross-loop `TaskCompletionSource`** allocated per call.
+
+The optimization is **structural and automatic** — there is no opt-in flag. Any `InvokeAsync<T>` routed
+to an HTTP endpoint takes this path; the decision is baked into the route when it is compiled, so there
+is no per-message branching. Fire-and-forget sends (`PublishAsync` / `SendAsync`) continue to use the
+batched/inline send path described above.
+
+### Failure semantics
+
+If the receiver's handler throws, the receiver responds with HTTP 500 and an envelope-shaped error
+body, and the sender re-throws a `WolverineRequestReplyException` — exactly the same caller-visible
+behavior as brokered request/reply:
+
+```cs
+try
+{
+    var quote = await bus.InvokeAsync<PriceQuote>(new PriceQuoteRequest("SKU-123"));
+}
+catch (WolverineRequestReplyException e)
+{
+    // The receiver's handler failed; e.Message carries the failure detail.
+}
+```
+
+When the receiver is configured with a transactional outbox, the HTTP response is held until the outbox
+commits, so any cascading messages emitted by the handler are part of the same transactional unit
+before the caller observes the reply.
+
 ## CloudEvents Support
 
 The HTTP transport supports the [CloudEvents](https://cloudevents.io/) specification for

--- a/src/Http/Wolverine.Http.Tests/Transport/HttpScheduledMessageTests.cs
+++ b/src/Http/Wolverine.Http.Tests/Transport/HttpScheduledMessageTests.cs
@@ -101,6 +101,11 @@ public class TestWolverineHttpTransportClient : IWolverineHttpTransportClient
 
         return Task.CompletedTask;
     }
+
+    public Task<InlineHttpReply> InvokeAsync(string uri, Envelope envelope, JsonSerializerOptions serializerOptions)
+    {
+        return Task.FromResult(new InlineHttpReply(200, Array.Empty<byte>()));
+    }
 }
 
 public record ScheduledTestCommand(string Id);

--- a/src/Http/Wolverine.Http.Tests/Transport/inline_request_reply_sender.cs
+++ b/src/Http/Wolverine.Http.Tests/Transport/inline_request_reply_sender.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Http.Transport;
+using Wolverine.Runtime.RemoteInvocation;
+using Wolverine.Runtime.Serialization;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.Http.Tests.Transport;
+
+// GH-2966: the sender side of optimized inline request/reply over the Wolverine.Http transport.
+// The message has NO local handler and the host configures NO listening endpoint and registers NO
+// ReplyListener — so the only way InvokeAsync<T> can return (rather than time out) is by reading the
+// reply straight off the HTTP transport's response slot, which is what HttpEndpoint
+// (IInlineRequestReplyEndpoint) does. A fake IWolverineHttpTransportClient stands in for the receiver.
+public record InlineProbeRequest(string Name);
+
+public record InlineProbeResponse(string Name);
+
+public class inline_request_reply_sender
+{
+    private static IHostBuilder ConfigureSender(IWolverineHttpTransportClient client)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.PublishAllMessages().ToHttpEndpoint("https://receiver.test/_wolverine/invoke");
+                opts.Services.AddSingleton(client);
+            });
+    }
+
+    [Fact]
+    public async Task invoke_reads_reply_from_the_http_response_slot()
+    {
+        using var host = await ConfigureSender(new EchoingInlineClient()).StartAsync();
+
+        var response = await host.MessageBus().InvokeAsync<InlineProbeResponse>(new InlineProbeRequest("Egwene"));
+
+        response.ShouldNotBeNull();
+        response.Name.ShouldBe("Egwene");
+    }
+
+    [Fact]
+    public async Task handler_failure_surfaces_as_request_reply_exception()
+    {
+        using var host = await ConfigureSender(new FailingInlineClient()).StartAsync();
+
+        var ex = await Should.ThrowAsync<WolverineRequestReplyException>(async () =>
+            await host.MessageBus().InvokeAsync<InlineProbeResponse>(new InlineProbeRequest("Nynaeve")));
+
+        ex.Message.ShouldContain("kaboom");
+    }
+
+    // Simulates the receiver: echoes the request name back as an InlineProbeResponse reply envelope.
+    private class EchoingInlineClient : IWolverineHttpTransportClient
+    {
+        public Task SendBatchAsync(string uri, OutgoingMessageBatch batch) => Task.CompletedTask;
+        public Task SendAsync(string uri, Envelope envelope, JsonSerializerOptions serializerOptions) => Task.CompletedTask;
+
+        public Task<InlineHttpReply> InvokeAsync(string uri, Envelope envelope, JsonSerializerOptions serializerOptions)
+        {
+            var request = JsonSerializer.Deserialize<InlineProbeRequest>(envelope.Data!,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+            var serializer = new SystemTextJsonSerializer(new JsonSerializerOptions());
+            var response = new InlineProbeResponse(request.Name);
+            var reply = new Envelope(response) { Serializer = serializer, ContentType = serializer.ContentType };
+            reply.Data = serializer.WriteMessage(response);
+
+            var bytes = EnvelopeSerializer.Serialize(reply);
+            return Task.FromResult(new InlineHttpReply(200, bytes));
+        }
+    }
+
+    // Simulates a receiver whose handler threw: replies 500 with an envelope-shaped FailureAcknowledgement.
+    private class FailingInlineClient : IWolverineHttpTransportClient
+    {
+        public Task SendBatchAsync(string uri, OutgoingMessageBatch batch) => Task.CompletedTask;
+        public Task SendAsync(string uri, Envelope envelope, JsonSerializerOptions serializerOptions) => Task.CompletedTask;
+
+        public Task<InlineHttpReply> InvokeAsync(string uri, Envelope envelope, JsonSerializerOptions serializerOptions)
+        {
+            var failure = new FailureAcknowledgement { RequestId = envelope.Id, Message = "kaboom" };
+            var reply = new Envelope(failure) { Serializer = IntrinsicSerializer.Instance, ContentType = IntrinsicSerializer.Instance.ContentType };
+            reply.Data = IntrinsicSerializer.Instance.Write(reply);
+
+            var bytes = EnvelopeSerializer.Serialize(reply);
+            return Task.FromResult(new InlineHttpReply(500, bytes));
+        }
+    }
+}

--- a/src/Http/Wolverine.Http/Transport/HttpEndpoint.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpEndpoint.cs
@@ -1,18 +1,55 @@
 using System.Text.Json;
 using JasperFx.Descriptors;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
+using Wolverine.Runtime.RemoteInvocation;
+using Wolverine.Runtime.Serialization;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
 
 namespace Wolverine.Http.Transport;
 
-public class HttpEndpoint : Endpoint
+public class HttpEndpoint : Endpoint, IInlineRequestReplyEndpoint
 {
     public HttpEndpoint(Uri uri, EndpointRole role) : base(uri, role)
     {
         BrokerRole = "route";
+    }
+
+    // GH-2966: HTTP carries the reply in the same response, so InvokeAsync<T> reads the reply envelope
+    // straight off the HTTP response body — no ReplyListener, no listening endpoint on the sender.
+    public async Task<Envelope> InvokeRemoteAsync(Envelope request, IWolverineRuntime runtime, CancellationToken cancellation)
+    {
+        if (request.Data == null && request.Message != null)
+        {
+            request.Serializer ??= DefaultSerializer;
+            request.Data = request.Serializer!.Write(request);
+            request.ContentType ??= request.Serializer!.ContentType;
+        }
+
+        using var scope = runtime.Services.CreateScope();
+        var client = scope.ServiceProvider.GetRequiredService<IWolverineHttpTransportClient>()
+                     ?? throw new InvalidOperationException(
+                         "IWolverineHttpTransportClient is not registered in the service container");
+
+        var reply = await client.InvokeAsync(OutboundUri, request, SerializerOptions);
+
+        if (reply.Body is { Length: > 0 })
+        {
+            return EnvelopeSerializer.Deserialize(reply.Body);
+        }
+
+        // Receiver returned no envelope body (infrastructure error); surface as a failure reply so the
+        // caller gets the usual WolverineRequestReplyException.
+        var ack = new FailureAcknowledgement
+        {
+            RequestId = request.Id,
+            Message =
+                $"Inline HTTP request/reply to {OutboundUri} failed with status code {reply.StatusCode} and no reply body"
+        };
+        return new Envelope { Message = ack };
     }
 
     internal bool SupportsNativeScheduledSend { get; set; }

--- a/src/Http/Wolverine.Http/Transport/HttpTransportExecutor.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpTransportExecutor.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Wolverine.ErrorHandling;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Handlers;
+using Wolverine.Runtime.RemoteInvocation;
 using Wolverine.Runtime.Interop;
 using Wolverine.Runtime.Serialization;
 using Wolverine.Runtime.WorkerQueues;
@@ -175,9 +176,27 @@ internal class HttpTransportExecutor
         {
             await executor.InvokeInlineAsync(envelope, httpContext.RequestAborted);
         }
-        catch (Exception)
+        catch (Exception e)
         {
-            return Results.Problem("Execution failed", statusCode: 500);
+            _logger.LogError(e, "Inline HTTP invoke failed for message type {MessageType}", envelope.MessageType);
+
+            // GH-2966: surface the handler failure as an envelope-shaped FailureAcknowledgement on a
+            // 500 so the inline-request/reply sender re-throws WolverineRequestReplyException — the
+            // same caller-visible semantics as the brokered request/reply path.
+            var failure = new FailureAcknowledgement { RequestId = envelope.Id, Message = e.Message };
+            var failureEnvelope = envelope.CreateForResponse(failure);
+            failureEnvelope.Serializer ??= IntrinsicSerializer.Instance;
+            // IntrinsicSerializer only implements Write(Envelope) (it reads envelope.Message);
+            // WriteMessage(object) intentionally throws. The Message was set by CreateForResponse.
+            failureEnvelope.Data = failureEnvelope.Serializer.Write(failureEnvelope);
+            failureEnvelope.ContentType = failureEnvelope.Serializer.ContentType;
+
+            httpContext.Response.StatusCode = 500;
+            httpContext.Response.ContentType = "binary/wolverine-envelope";
+            var failureData = EnvelopeSerializer.Serialize(failureEnvelope);
+            httpContext.Response.ContentLength = failureData.Length;
+            await httpContext.Response.Body.WriteAsync(failureData);
+            return Results.Empty;
         }
 
         if (envelope.Response != null)

--- a/src/Http/Wolverine.Http/Transport/IWolverineHttpTransportClient.cs
+++ b/src/Http/Wolverine.Http/Transport/IWolverineHttpTransportClient.cs
@@ -7,4 +7,15 @@ public interface IWolverineHttpTransportClient
 {
     Task SendBatchAsync(string uri, OutgoingMessageBatch batch);
     Task SendAsync(string uri, Envelope envelope, JsonSerializerOptions serializerOptions);
+
+    /// <summary>
+    /// GH-2966 inline request/reply: POST a single request envelope and read the raw response
+    /// (status + body) back. The body is read regardless of status so a 500 carrying an
+    /// envelope-shaped error reply can be surfaced to the caller. Returns an empty body when the
+    /// response has none.
+    /// </summary>
+    Task<InlineHttpReply> InvokeAsync(string uri, Envelope envelope, JsonSerializerOptions serializerOptions);
 }
+
+/// <summary>The raw HTTP response of an inline request/reply send (GH-2966).</summary>
+public record InlineHttpReply(int StatusCode, byte[] Body);

--- a/src/Http/Wolverine.Http/Transport/WolverineHttpTransportClient.cs
+++ b/src/Http/Wolverine.Http/Transport/WolverineHttpTransportClient.cs
@@ -23,6 +23,16 @@ public class WolverineHttpTransportClient(IHttpClientFactory clientFactory) : IW
         content.Headers.ContentType = new MediaTypeHeaderValue(HttpTransport.EnvelopeContentType);
         await client.PostAsync(client.BaseAddress, content);
     }
+
+    public async Task<InlineHttpReply> InvokeAsync(string uri, Envelope envelope, JsonSerializerOptions? options = null)
+    {
+        var client = clientFactory.CreateClient(uri);
+        var content = new ByteArrayContent(EnvelopeSerializer.Serialize(envelope));
+        content.Headers.ContentType = new MediaTypeHeaderValue(HttpTransport.EnvelopeContentType);
+        var response = await client.PostAsync(client.BaseAddress, content);
+        var body = await response.Content.ReadAsByteArrayAsync();
+        return new InlineHttpReply((int)response.StatusCode, body);
+    }
 }
 
 public class WolverineHttpTransportClientCloudEvents(IHttpClientFactory clientFactory) : IWolverineHttpTransportClient
@@ -42,5 +52,17 @@ public class WolverineHttpTransportClientCloudEvents(IHttpClientFactory clientFa
         var content = new StringContent(JsonSerializer.Serialize(ce, options));
         content.Headers.ContentType = new MediaTypeHeaderValue(HttpTransport.CloudEventsContentType);
         await client.PostAsync(client.BaseAddress, content);
+    }
+
+    public async Task<InlineHttpReply> InvokeAsync(string uri, Envelope envelope, JsonSerializerOptions? options = null)
+    {
+        // The reply is always a binary Wolverine envelope regardless of the request encoding, so the
+        // inline request/reply send uses the binary envelope format both ways (see GH-2966).
+        var client = clientFactory.CreateClient(uri);
+        var content = new ByteArrayContent(EnvelopeSerializer.Serialize(envelope));
+        content.Headers.ContentType = new MediaTypeHeaderValue(HttpTransport.EnvelopeContentType);
+        var response = await client.PostAsync(client.BaseAddress, content);
+        var body = await response.Content.ReadAsByteArrayAsync();
+        return new InlineHttpReply((int)response.StatusCode, body);
     }
 }

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -473,7 +473,7 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
             return route;
         }
 
-        route = new MessageRoute(messageType, this, runtime);
+        route = MessageRoute.For(messageType, this, runtime);
 
         Routes = Routes.AddOrUpdate(messageType, route);
 

--- a/src/Wolverine/Runtime/Partitioning/GlobalPartitionedMessageTopology.cs
+++ b/src/Wolverine/Runtime/Partitioning/GlobalPartitionedMessageTopology.cs
@@ -208,11 +208,11 @@ public class GlobalPartitionedMessageTopology
         }
 
         var externalRoutes = _externalTopology.Slots
-            .Select(x => (IMessageRoute)new MessageRoute(messageType, x, runtime))
+            .Select(x => (IMessageRoute)MessageRoute.For(messageType, x, runtime))
             .ToArray();
 
         var localRoutes = _localTopology.Slots
-            .Select(x => (IMessageRoute)new MessageRoute(messageType, x, runtime))
+            .Select(x => (IMessageRoute)MessageRoute.For(messageType, x, runtime))
             .ToArray();
 
         var externalEndpoints = _externalTopology.Slots.ToArray();

--- a/src/Wolverine/Runtime/Partitioning/PartitionedMessageTopology.cs
+++ b/src/Wolverine/Runtime/Partitioning/PartitionedMessageTopology.cs
@@ -110,7 +110,7 @@ public abstract class PartitionedMessageTopology
 
         if (Matches(messageType))
         {
-            var innerRoutes = _slots.Select(x => new MessageRoute(messageType, x, runtime)).ToArray();
+            var innerRoutes = _slots.Select(x => MessageRoute.For(messageType, x, runtime)).ToArray();
             
             route = new ShardedMessageRoute(Uri, runtime.Options.MessagePartitioning, innerRoutes);
             

--- a/src/Wolverine/Runtime/Routing/MessageRoute.cs
+++ b/src/Wolverine/Runtime/Routing/MessageRoute.cs
@@ -22,9 +22,16 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
     private static ImHashMap<Type, IList<IEnvelopeRule>> _rulesByMessageType =
         ImHashMap<Type, IList<IEnvelopeRule>>.Empty;
 
+    private static readonly string _failureAckTypeName = typeof(FailureAcknowledgement).ToMessageTypeName();
+
     private readonly IReplyTracker _replyTracker;
     private readonly MessagePartitioningRules _partitioning;
     private readonly Endpoint _endpoint;
+
+    // GH-2966: cached once at construction (routing-compile time), so InvokeAsync<T> on an
+    // inline-request/reply transport (e.g. HTTP) takes the protocol's response slot instead of the
+    // reply-tracker/listener round trip. Null for every other transport — no per-message branching.
+    private readonly IInlineRequestReplyEndpoint? _inlineRequestReply;
 
     // CloseAndBuildAs<IMessageSerializer> on typeof(IntrinsicSerializer<>) closes
     // over the runtime-resolved message type when the type implements
@@ -74,6 +81,7 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
         MessageType = messageType;
 
         _endpoint = endpoint;
+        _inlineRequestReply = endpoint as IInlineRequestReplyEndpoint;
     }
 
     public Uri Uri => _endpoint.Uri;
@@ -248,11 +256,62 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
         // for proper tracking. See https://github.com/JasperFx/wolverine/issues/1176
         envelope.ConversationId = envelope.Id;
 
+        // GH-2966: HTTP (and other inline-request/reply transports) carry the reply in the same
+        // response slot, so skip the reply-tracker/listener round trip entirely — no ReplyListener<T>,
+        // no listening endpoint on the sender. The capability was resolved once at construction.
+        if (_inlineRequestReply != null)
+        {
+            envelope.Serializer ??= Serializer;
+            var reply = await _inlineRequestReply.InvokeRemoteAsync(envelope, bus.Runtime, cancellation)
+                .ConfigureAwait(false);
+            return CompleteInlineReply<T>(reply, bus.Runtime);
+        }
+
         var waiter = _replyTracker.RegisterListener<T>(envelope, cancellation, timeout.Value);
 
         await Sender.EnqueueOutgoingAsync(envelope);
 
         return await waiter;
+    }
+
+    // GH-2966: translate the reply envelope read straight off the HTTP response into the caller's T,
+    // preserving the existing broker request/reply semantics — a receiver handler failure comes back
+    // as a FailureAcknowledgement and is rethrown as WolverineRequestReplyException.
+    private T CompleteInlineReply<T>(Envelope reply, IWolverineRuntime runtime)
+    {
+        if (reply.Message is FailureAcknowledgement directAck)
+        {
+            throw new WolverineRequestReplyException(directAck.Message);
+        }
+
+        if (reply.MessageType == _failureAckTypeName)
+        {
+            var ack = (FailureAcknowledgement)IntrinsicSerializer.Instance.ReadFromData(typeof(FailureAcknowledgement), reply);
+            throw new WolverineRequestReplyException(ack.Message);
+        }
+
+        if (typeof(T) == typeof(Acknowledgement))
+        {
+            return (T)(object)new Acknowledgement { RequestId = reply.ConversationId };
+        }
+
+        if (reply.Message is T alreadyTyped)
+        {
+            return alreadyTyped;
+        }
+
+        var serializer = reply.ContentType.IsNotEmpty()
+            ? runtime.Options.FindSerializer(reply.ContentType)
+            : Serializer;
+
+        var message = serializer.ReadFromData(typeof(T), reply);
+        if (message is T typed)
+        {
+            return typed;
+        }
+
+        throw new WolverineRequestReplyException(
+            $"Inline request/reply to {_endpoint.Uri} returned a '{reply.MessageType}' reply that could not be read as {typeof(T).FullNameInCode()}");
     }
 
     public static IEnumerable<IEnvelopeRule> RulesForMessageType(Type type)

--- a/src/Wolverine/Runtime/Routing/MessageRoute.cs
+++ b/src/Wolverine/Runtime/Routing/MessageRoute.cs
@@ -22,16 +22,22 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
     private static ImHashMap<Type, IList<IEnvelopeRule>> _rulesByMessageType =
         ImHashMap<Type, IList<IEnvelopeRule>>.Empty;
 
-    private static readonly string _failureAckTypeName = typeof(FailureAcknowledgement).ToMessageTypeName();
-
     private readonly IReplyTracker _replyTracker;
     private readonly MessagePartitioningRules _partitioning;
-    private readonly Endpoint _endpoint;
+    private protected readonly Endpoint _endpoint;
 
-    // GH-2966: cached once at construction (routing-compile time), so InvokeAsync<T> on an
-    // inline-request/reply transport (e.g. HTTP) takes the protocol's response slot instead of the
-    // reply-tracker/listener round trip. Null for every other transport — no per-message branching.
-    private readonly IInlineRequestReplyEndpoint? _inlineRequestReply;
+    /// <summary>
+    /// GH-2966: construct the right MessageRoute shape for an endpoint. Transports that carry the reply
+    /// in the same request/response exchange (HTTP) get <see cref="InlineReplyMessageRoute"/>, which reads
+    /// the reply straight off the protocol response instead of the reply-tracker/listener round trip.
+    /// The shape is chosen once here at routing-compile time, so there is no per-message branching.
+    /// </summary>
+    public static MessageRoute For(Type messageType, Endpoint endpoint, IWolverineRuntime runtime)
+    {
+        return endpoint is IInlineRequestReplyEndpoint
+            ? new InlineReplyMessageRoute(messageType, endpoint, runtime)
+            : new MessageRoute(messageType, endpoint, runtime);
+    }
 
     // CloseAndBuildAs<IMessageSerializer> on typeof(IntrinsicSerializer<>) closes
     // over the runtime-resolved message type when the type implements
@@ -81,7 +87,6 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
         MessageType = messageType;
 
         _endpoint = endpoint;
-        _inlineRequestReply = endpoint as IInlineRequestReplyEndpoint;
     }
 
     public Uri Uri => _endpoint.Uri;
@@ -256,28 +261,74 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
         // for proper tracking. See https://github.com/JasperFx/wolverine/issues/1176
         envelope.ConversationId = envelope.Id;
 
-        // GH-2966: HTTP (and other inline-request/reply transports) carry the reply in the same
-        // response slot, so skip the reply-tracker/listener round trip entirely — no ReplyListener<T>,
-        // no listening endpoint on the sender. The capability was resolved once at construction.
-        if (_inlineRequestReply != null)
-        {
-            envelope.Serializer ??= Serializer;
-            var reply = await _inlineRequestReply.InvokeRemoteAsync(envelope, bus.Runtime, cancellation)
-                .ConfigureAwait(false);
-            return CompleteInlineReply<T>(reply, bus.Runtime);
-        }
+        return await sendAndAwaitReplyAsync<T>(envelope, bus, cancellation, timeout.Value).ConfigureAwait(false);
+    }
 
-        var waiter = _replyTracker.RegisterListener<T>(envelope, cancellation, timeout.Value);
+    /// <summary>
+    /// Send the request envelope and resolve the reply. The default (brokered) shape registers a
+    /// <c>ReplyListener&lt;T&gt;</c> with the reply tracker and awaits the correlated reply envelope on the
+    /// sender's listener loop. <see cref="InlineReplyMessageRoute"/> overrides this for transports whose
+    /// protocol carries the reply in the same exchange (HTTP) — see GH-2966.
+    /// </summary>
+    protected virtual async Task<T> sendAndAwaitReplyAsync<T>(Envelope envelope, MessageBus bus,
+        CancellationToken cancellation, TimeSpan timeout)
+    {
+        var waiter = _replyTracker.RegisterListener<T>(envelope, cancellation, timeout);
 
         await Sender.EnqueueOutgoingAsync(envelope);
 
         return await waiter;
     }
 
-    // GH-2966: translate the reply envelope read straight off the HTTP response into the caller's T,
-    // preserving the existing broker request/reply semantics — a receiver handler failure comes back
-    // as a FailureAcknowledgement and is rethrown as WolverineRequestReplyException.
-    private T CompleteInlineReply<T>(Envelope reply, IWolverineRuntime runtime)
+    public static IEnumerable<IEnvelopeRule> RulesForMessageType(Type type)
+    {
+        if (_rulesByMessageType.TryFind(type, out var rules))
+        {
+            return rules;
+        }
+
+        rules = type.GetAllAttributes<ModifyEnvelopeAttribute>().OfType<IEnvelopeRule>().ToList();
+        _rulesByMessageType = _rulesByMessageType.AddOrUpdate(type, rules);
+
+        return rules;
+    }
+
+    public override string ToString()
+    {
+        return $"Send to {Sender.Destination}";
+    }
+}
+
+/// <summary>
+/// GH-2966: <see cref="MessageRoute"/> for transports that carry the reply in the same request/response
+/// exchange (e.g. HTTP). <c>InvokeAsync&lt;T&gt;</c> reads the reply straight off the protocol response —
+/// no <c>ReplyListener&lt;T&gt;</c>, no listener loop on the sender, no cross-loop
+/// <c>TaskCompletionSource</c>. Selected at routing-compile time by <see cref="MessageRoute.For"/> when
+/// the endpoint implements <see cref="IInlineRequestReplyEndpoint"/>, so there is no per-message branching.
+/// </summary>
+internal class InlineReplyMessageRoute : MessageRoute
+{
+    private static readonly string _failureAckTypeName = typeof(FailureAcknowledgement).ToMessageTypeName();
+    private readonly IInlineRequestReplyEndpoint _inline;
+
+    public InlineReplyMessageRoute(Type messageType, Endpoint endpoint, IWolverineRuntime runtime)
+        : base(messageType, endpoint, runtime)
+    {
+        _inline = (IInlineRequestReplyEndpoint)endpoint;
+    }
+
+    protected override async Task<T> sendAndAwaitReplyAsync<T>(Envelope envelope, MessageBus bus,
+        CancellationToken cancellation, TimeSpan timeout)
+    {
+        envelope.Serializer ??= Serializer;
+        var reply = await _inline.InvokeRemoteAsync(envelope, bus.Runtime, cancellation).ConfigureAwait(false);
+        return completeReply<T>(reply, bus.Runtime);
+    }
+
+    // Translate the reply envelope read straight off the transport response into the caller's T,
+    // preserving the brokered request/reply semantics — a receiver handler failure comes back as a
+    // FailureAcknowledgement and is rethrown as WolverineRequestReplyException.
+    private T completeReply<T>(Envelope reply, IWolverineRuntime runtime)
     {
         if (reply.Message is FailureAcknowledgement directAck)
         {
@@ -311,24 +362,6 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
         }
 
         throw new WolverineRequestReplyException(
-            $"Inline request/reply to {_endpoint.Uri} returned a '{reply.MessageType}' reply that could not be read as {typeof(T).FullNameInCode()}");
-    }
-
-    public static IEnumerable<IEnvelopeRule> RulesForMessageType(Type type)
-    {
-        if (_rulesByMessageType.TryFind(type, out var rules))
-        {
-            return rules;
-        }
-
-        rules = type.GetAllAttributes<ModifyEnvelopeAttribute>().OfType<IEnvelopeRule>().ToList();
-        _rulesByMessageType = _rulesByMessageType.AddOrUpdate(type, rules);
-
-        return rules;
-    }
-
-    public override string ToString()
-    {
-        return $"Send to {Sender.Destination}";
+            $"Inline request/reply to {Uri} returned a '{reply.MessageType}' reply that could not be read as {typeof(T).FullNameInCode()}");
     }
 }

--- a/src/Wolverine/Runtime/Routing/MessageRouterBase.cs
+++ b/src/Wolverine/Runtime/Routing/MessageRouterBase.cs
@@ -52,7 +52,7 @@ public abstract class MessageRouterBase<T> : IMessageRouter
         {
             if (endpoint.RoutingType == RoutingMode.ByTopic)
             {
-                topicRouteList.Add(new MessageRoute(typeof(T), endpoint, runtime));
+                topicRouteList.Add(MessageRoute.For(typeof(T), endpoint, runtime));
             }
         }
 
@@ -112,7 +112,7 @@ public abstract class MessageRouterBase<T> : IMessageRouter
         }
 
         var agent = Runtime.Endpoints.GetOrBuildSendingAgent(destination);
-        route = new MessageRoute(typeof(T), agent.Endpoint, Runtime);
+        route = MessageRoute.For(typeof(T), agent.Endpoint, Runtime);
         _specificRoutes = _specificRoutes.AddOrUpdate(destination, route);
 
         return route;

--- a/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Routing.cs
@@ -62,7 +62,7 @@ internal class AgentMessages : IMessageRouteSource
         if (messageType.CanBeCastTo<IAgentCommand>())
         {
             var queue = runtime.Endpoints.AgentForLocalQueue(TransportConstants.Agents);
-            yield return new MessageRoute(messageType, queue.Endpoint, runtime);
+            yield return MessageRoute.For(messageType, queue.Endpoint, runtime);
         }
     }
 
@@ -85,7 +85,7 @@ internal class ExplicitRouting : IMessageRouteSource
             .Transports
             .AllEndpoints()
             .Where(x => x.ShouldSendMessage(messageType))
-            .Select(x => new MessageRoute(messageType, x, runtime));
+            .Select(x => MessageRoute.For(messageType, x, runtime));
 
         foreach (var explicitRoute in explicitRoutes)
         {
@@ -129,7 +129,7 @@ internal class LocalRouting : IMessageRouteSource
         if (options.HandlerGraph.CanHandle(messageType))
         {
             var endpoints = options.LocalRouting.DiscoverSenders(messageType, runtime).ToArray();
-            return endpoints.Select(e => new MessageRoute(messageType, e, runtime));
+            return endpoints.Select(e => MessageRoute.For(messageType, e, runtime));
         }
 
         var batching = options.BatchDefinitions.FirstOrDefault(x => x.ElementType == messageType);
@@ -141,7 +141,7 @@ internal class LocalRouting : IMessageRouteSource
         var endpoint = options.Transports.GetOrCreate<LocalTransport>()
             .QueueFor(batching.LocalExecutionQueueName!);
 
-        return [new MessageRoute(messageType, endpoint, runtime)];
+        return [MessageRoute.For(messageType, endpoint, runtime)];
 
     }
 
@@ -160,7 +160,7 @@ internal class MessageRoutingConventions : IMessageRouteSource
     public IEnumerable<IMessageRoute> FindRoutes(Type messageType, IWolverineRuntime runtime)
     {
         return runtime.Options.RoutingConventions.SelectMany(x => x.DiscoverSenders(messageType, runtime))
-            .Select(e => new MessageRoute(messageType, e, runtime));
+            .Select(e => MessageRoute.For(messageType, e, runtime));
     }
 
     public bool IsAdditive => true;

--- a/src/Wolverine/Transports/IInlineRequestReplyEndpoint.cs
+++ b/src/Wolverine/Transports/IInlineRequestReplyEndpoint.cs
@@ -1,0 +1,24 @@
+using Wolverine.Runtime;
+
+namespace Wolverine.Transports;
+
+/// <summary>
+/// Capability marker for transports whose underlying protocol carries the reply in the same
+/// request/response exchange (e.g. HTTP). When an <see cref="Wolverine.Configuration.Endpoint"/>
+/// implements this, <c>IMessageBus.InvokeAsync&lt;T&gt;</c> routed to that endpoint skips the
+/// listener-loop + reply-tracker round trip (no <c>ReplyListener&lt;T&gt;</c>, no listening endpoint
+/// on the sender) and instead sends the request and reads the reply envelope straight back from the
+/// protocol's response slot. The routing decision is structural — <see cref="Wolverine.Runtime.Routing.MessageRoute"/>
+/// detects the capability once at construction, so there is no per-message branching on the hot path.
+/// See GH-2966.
+/// </summary>
+public interface IInlineRequestReplyEndpoint
+{
+    /// <summary>
+    /// Send the request envelope and return the reply envelope read directly from the transport's
+    /// response slot. A handler failure on the receiver is returned as a reply envelope whose Message
+    /// is a <see cref="Wolverine.Runtime.RemoteInvocation.FailureAcknowledgement"/>, which the caller
+    /// translates into the usual <see cref="Wolverine.Runtime.RemoteInvocation.WolverineRequestReplyException"/>.
+    /// </summary>
+    Task<Envelope> InvokeRemoteAsync(Envelope request, IWolverineRuntime runtime, CancellationToken cancellation);
+}

--- a/src/Wolverine/Transports/Stub/StubTransport.cs
+++ b/src/Wolverine/Transports/Stub/StubTransport.cs
@@ -78,7 +78,7 @@ internal class StubTransport : TransportBase<StubEndpoint>, IStubHandlers, IMess
         {
             var sendingAgent = runtime.Endpoints.GetOrBuildSendingAgent(TransportConstants.LocalStubs, e => e.Mode = EndpointMode.BufferedInMemory);
             
-            yield return new MessageRoute(messageType, sendingAgent.Endpoint, runtime);
+            yield return MessageRoute.For(messageType, sendingAgent.Endpoint, runtime);
         }
     }
 


### PR DESCRIPTION
Closes #2966.

When `IMessageBus.InvokeAsync<T>(message)` routes to a Wolverine.Http transport endpoint, the HTTP response body **is** the reply — no `ReplyListener`, no listener loop on the sender, no cross-loop `TaskCompletionSource`.

## Sender
- **New `IInlineRequestReplyEndpoint` capability** (Wolverine core). `MessageRoute` caches `endpoint as IInlineRequestReplyEndpoint` once **at construction** (routing-compile time); when present, `RemoteInvokeAsync<T>` sends the request and reads the reply envelope straight back instead of registering a `ReplyListener` — **no per-message branching**, null for every other transport.
- **`HttpEndpoint`** implements the capability: serializes the request, POSTs to its `OutboundUri`, deserializes the reply envelope from the HTTP response body.
- **`IWolverineHttpTransportClient.InvokeAsync`** returns `(status, body)` so a 500 carrying an envelope-shaped error reply is read regardless of status.
- A receiver handler failure comes back as a `FailureAcknowledgement` reply and is rethrown as **`WolverineRequestReplyException`** — identical caller semantics to brokered request/reply.

## Receiver
The existing `/_wolverine/invoke` endpoint already ran the handler and wrote `Envelope.Response` to the body. Now a handler exception maps to **HTTP 500 + a `FailureAcknowledgement` envelope body** (using `IntrinsicSerializer.Write` — `WriteMessage` intentionally throws). Outbox commit already happens (via `InvokeInlineAsync`'s flush) before the response is written.

## Design notes
- **Auto-activates per endpoint** via the transport capability — no user-facing opt-in flag, since the routing decision is structural.
- The brokered request/reply path is untouched (`_inlineRequestReply` is null for non-HTTP endpoints).
- Fire-and-forget HTTP sends (batch/inline publish) are unchanged.

## Tests
`inline_request_reply_sender` drives the full sender path (`InvokeAsync<T>` → `MessageRoute` inline branch → `HttpEndpoint` → reply) with a fake transport client standing in for the receiver. The host configures **no listening endpoint**, so the tests only pass because the reply is read off the response slot (otherwise they'd time out):
- happy path returns the typed reply;
- a receiver-side failure surfaces as `WolverineRequestReplyException`.

(Pre-existing unrelated flake noted: `HttpTransportExecutorTests.batch_with_multiple_queues_routes_to_correct_queue` fails on clean `main` too.)

## Verification
- New sender tests green; HTTP transport suite otherwise green.
- `dotnet build wolverine.slnx -c Release` clean.

## Docs & follow-up
- Docs: new **"Inline Request/Reply"** section in `guide/http/transport.md`.
- **#2989** tracks the remaining hardening — full cross-process (Kestrel) integration + compliance-suite coverage, the outbox-commit-before-response assertion, `Result<T>` composition (#2221), and **documenting/using this as the control mechanism for CritterWatch against HTTP-only services**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)