### PR TITLE
Bump JasperFx 2.3.0: fix HTTP codegen-write service location (GH-2991)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,13 +32,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.2.7" />
-    <PackageVersion Include="JasperFx.Events" Version="2.2.7" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.7" />
+    <PackageVersion Include="JasperFx" Version="2.3.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.3.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.3.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.7" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.3.0" />
     <PackageVersion Include="Marten" Version="9.2.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.2.1" />

--- a/src/Http/Wolverine.Http.Tests/using_efcore.cs
+++ b/src/Http/Wolverine.Http.Tests/using_efcore.cs
@@ -16,7 +16,7 @@ public class using_efcore : IntegrationContext
     public using_efcore(AppFixture fixture) : base(fixture)
     {
     }
-    
+
     
 
     [Fact]
@@ -65,7 +65,9 @@ public class using_efcore : IntegrationContext
     private async Task cleanItems()
     {
         await Host.ResetResourceState();
-        
+        EfCoreEndpoints.DbContext = null;
+        EfCoreEndpoints.NestedDbContext = null;
+
         var table = new Table("items");
         table.AddColumn<Guid>("Id").AsPrimaryKey();
         table.AddColumn<string>("Name");
@@ -148,5 +150,21 @@ public class using_efcore : IntegrationContext
         var scheduledMessage = tracked.Scheduled.SingleEnvelope<ItemCreated>();
         scheduledMessage.ScheduleDelay.ShouldNotBeNull();
         scheduledMessage.Message.ShouldBeOfType<ItemCreated>();
+    }
+
+    [Fact]
+    public async Task http_handler_with_http_context_sourced_gets_the_same_service()
+    {
+        await cleanItems();
+
+        var _ = await TrackedHttpCall(x =>
+        {
+            x.Post.Json(new CreateItemCommand()).ToUrl("/ef/servicelocation");
+            x.StatusCodeShouldBe(204);
+        });
+
+        EfCoreEndpoints.DbContext.ShouldNotBeNull();
+        EfCoreEndpoints.NestedDbContext.ShouldNotBeNull();
+        EfCoreEndpoints.DbContext.ShouldBe(EfCoreEndpoints.NestedDbContext);
     }
 }

--- a/src/Http/WolverineWebApi/EfCoreEndpoints.cs
+++ b/src/Http/WolverineWebApi/EfCoreEndpoints.cs
@@ -4,6 +4,29 @@ using Wolverine.Http;
 
 namespace WolverineWebApi;
 
+public interface IServiceWithDbContextReference
+{
+    ItemsDbContext DbContext { get; }
+}
+
+public interface IRandomService
+{
+    double Next();
+}
+
+public class RandomService : IRandomService
+{
+    private readonly Random _random = new();
+
+    public double Next() => _random.NextDouble();
+}
+
+public class ServiceWithDbContextReference(IRandomService randomService, ItemsDbContext dbContext) : IServiceWithDbContextReference
+{
+    public ItemsDbContext DbContext { get; } = dbContext;
+    public IRandomService RandomService { get; } = randomService;
+}
+
 public class EfCoreEndpoints
 {
     [WolverinePost("/ef/create")]
@@ -19,13 +42,13 @@ public class EfCoreEndpoints
         db.Items.Add(item);
         await bus.PublishAsync(new ItemCreated { Id = item.Id });
     }
-    
+
     [WolverinePost("/ef/schedule")]
     public async Task ScheduleItem(CreateItemCommand command, ItemsDbContext db, IMessageBus bus)
     {
-        await bus.PublishAsync(new ItemCreated { Id = Guid.NewGuid() }, new(){ ScheduleDelay = 5.Days()});
+        await bus.PublishAsync(new ItemCreated { Id = Guid.NewGuid() }, new() { ScheduleDelay = 5.Days() });
     }
-    
+
     [WolverinePost("/ef/schedule2"), EmptyResponse]
     public static object ScheduleItem2(CreateItemCommand command)
     {
@@ -36,5 +59,14 @@ public class EfCoreEndpoints
     public async Task ScheduleItem_NoDb(CreateItemCommand command, IMessageBus bus)
     {
         await bus.PublishAsync(new ItemCreated { Id = Guid.NewGuid() }, new() { ScheduleDelay = 5.Days() });
+    }
+
+    public static ItemsDbContext? DbContext { get; set; }
+    public static ItemsDbContext? NestedDbContext { get; set; }
+    [WolverinePost("/ef/servicelocation")]
+    public static void Handle(CreateItemCommand command, ItemsDbContext dbContext, IServiceWithDbContextReference serviceWrapper)
+    {
+        DbContext = dbContext;
+        NestedDbContext = serviceWrapper.DbContext;
     }
 }

--- a/src/Http/WolverineWebApi/Program.cs
+++ b/src/Http/WolverineWebApi/Program.cs
@@ -108,6 +108,8 @@ public class Program
         builder.Services.AddKeyedSingleton<IThing, RedThing>("Red");
         builder.Services.AddKeyedScoped<IThing, BlueThing>("Blue");
         builder.Services.AddKeyedTransient<IThing, GreenThing>("Green");
+        builder.Services.AddScoped<IRandomService>(_ => new RandomService());
+        builder.Services.AddScoped<IServiceWithDbContextReference, ServiceWithDbContextReference>();
 
         builder.Services.AddMarten(opts =>
         {
@@ -140,6 +142,8 @@ public class Program
 // Need this.
         builder.Host.UseWolverine(opts =>
         {
+            opts.ServiceLocationPolicy = JasperFx.CodeGeneration.Model.ServiceLocationPolicy.AllowedButWarn;
+
             opts.Durability.MessageStorageSchemaName = "wolverine";
 
             // I'm speeding this up a lot for faster tests
@@ -377,6 +381,8 @@ public class Program
             opts.AddParameterHandlingStrategy<NowParameterStrategy>();
 
             #endregion
+
+            opts.ServiceProviderSource = ServiceProviderSource.FromHttpContextRequestServices;
         });
 
         #region sample_mapwolverinehttptransportendpoints


### PR DESCRIPTION
Closes #2991. Supersedes #2992 (carries its reproduction, with @perchr's authorship preserved).

## Problem
With `WolverineHttpOptions.ServiceProviderSource = FromHttpContextRequestServices`, the **runtime** generated correct code (service-located deps from `httpContext.RequestServices`), but **`dotnet run -- codegen write`** generated *different and wrong* code: an opaque scoped lambda-factory dependency was service-located from an isolated `serviceScope` while a sibling `DbContext` used `httpContext.RequestServices` → two different scoped instances for one logical request.

## Root cause + fix (JasperFx)
The CLI codegen paths (`DynamicCodeBuilder`) never applied the per-file `TryReplaceServiceProvider`/`ReplaceServiceProvider` step that the runtime `DynamicTypeLoader` does. Fixed in **[jasperfx#401](https://github.com/JasperFx/jasperfx/pull/401) → JasperFx 2.3.0**, including a new `IServiceVariableSource.ResetServiceProvider()` so the override is isolated per file on the CLI's shared source (otherwise it would leak `httpContext.RequestServices` into every following file). That PR carries the precise `DynamicCodeBuilder` regression test.

## This PR
- Bumps JasperFx 2.2.7 → **2.3.0** (consumes the fix).
- Carries the **#2992 reproduction** (`EfCoreEndpoints` `/ef/servicelocation` + `http_handler_with_http_context_sourced_gets_the_same_service`). Note: that test exercises the **runtime** path, which was always correct, so it passes pre- and post-fix — it documents the scenario and guards against a runtime regression; the codegen-write defect itself is guarded by the JasperFx test.

## Verification
- Manually confirmed against this repro: regenerating `WolverineWebApi` with 2.3.0 via `codegen write` now resolves the opaque scoped service **and** the `DbContext` both from `httpContext.RequestServices`, with no leak of `httpContext.RequestServices` into non-HTTP `MessageHandler` files.
- `using_efcore` suite green on 2.3.0.

> This bump changes `codegen write`/preview output for any consumer using a `ServiceProviderSource` override, so the **full Wolverine CI** here is the regression net — please watch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)