### PR TITLE
feat: add support for constructor injection in middleware exception handling

### DIFF
--- a/src/Testing/CoreTests/Acceptance/on_exception_convention.cs
+++ b/src/Testing/CoreTests/Acceptance/on_exception_convention.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Shouldly;
 using Wolverine.Attributes;
 using Wolverine.ComplianceTests;
@@ -106,6 +107,99 @@ public class on_exception_convention
         await host.StopAsync();
 
         recorder.Actions.ShouldContain("MiddlewareOnException:middleware test");
+    }
+
+    [Fact]
+    public async Task non_static_middleware_on_exception_with_constructor_injection()
+    {
+        var recorder = new OnExceptionRecorder();
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(recorder);
+                opts.Discovery.IncludeType(typeof(MessageForInstanceMiddlewareHandler));
+                opts.Policies.AddMiddleware(typeof(InstanceOnExceptionMiddleware));
+            }).StartAsync();
+
+        await host.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .PublishMessageAndWaitAsync(new MessageForInstanceMiddleware("ctor inject test"));
+
+        foreach (var action in recorder.Actions) _output.WriteLine($"\"{action}\"");
+
+        await host.StopAsync();
+
+        recorder.Actions.ShouldContain("InstanceMiddlewareOnException:ctor inject test");
+    }
+
+    [Fact]
+    public async Task middleware_with_ilogger_injection()
+    {
+        var recorder = new OnExceptionRecorder();
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(recorder);
+                opts.Discovery.IncludeType(typeof(MessageForLoggerMiddlewareHandler));
+                opts.Policies.AddMiddleware(typeof(LoggerOnExceptionMiddleware));
+            }).StartAsync();
+
+        await host.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .PublishMessageAndWaitAsync(new MessageForLoggerMiddleware("logger test"));
+
+        foreach (var action in recorder.Actions) _output.WriteLine($"\"{action}\"");
+
+        await host.StopAsync();
+
+        recorder.Actions.ShouldContain("LoggerOnException:logger test");
+    }
+
+    [Fact]
+    public async Task static_middleware_on_exception_with_additional_injected_parameters()
+    {
+        var recorder = new OnExceptionRecorder();
+        var probe = new StaticMiddlewareDependencyProbe();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(recorder);
+                opts.Services.AddSingleton(probe);
+                opts.Discovery.IncludeType(typeof(MessageForStaticMiddlewareDependencyHandler));
+                opts.Policies.AddMiddleware(typeof(StaticMiddlewareWithDependencyOnException));
+            }).StartAsync();
+
+        await host.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .PublishMessageAndWaitAsync(new MessageForStaticMiddlewareDependency("static dependency test"));
+
+        foreach (var action in recorder.Actions) _output.WriteLine($"\"{action}\"");
+
+        await host.StopAsync();
+
+        recorder.Actions.ShouldContain("StaticDependencyOnException:static dependency test");
+        probe.WasCalled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task non_static_middleware_with_before_and_on_exception()
+    {
+        var recorder = new OnExceptionRecorder();
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(recorder);
+                opts.Discovery.IncludeType(typeof(MessageForBeforeAndOnExceptionHandler));
+                opts.Policies.AddMiddleware(typeof(BeforeAndOnExceptionMiddleware));
+            }).StartAsync();
+
+        await host.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .PublishMessageAndWaitAsync(new MessageForBeforeAndOnException("before+onexception test"));
+
+        foreach (var action in recorder.Actions) _output.WriteLine($"\"{action}\"");
+
+        await host.StopAsync();
+
+        recorder.Actions.ShouldContain("BeforeMiddleware:before+onexception test");
+        recorder.Actions.ShouldContain("BeforeAndOnExceptionMiddleware:before+onexception test");
     }
 }
 
@@ -218,5 +312,126 @@ public static class GlobalOnExceptionMiddleware
     public static void OnException(TestAppException ex, OnExceptionRecorder recorder)
     {
         recorder.Actions.Add($"MiddlewareOnException:{ex.Message}");
+    }
+}
+
+// Support types for the instance middleware ctor-injection test
+public record MessageForInstanceMiddleware(string Text);
+
+public static class MessageForInstanceMiddlewareHandler
+{
+    public static void Handle(MessageForInstanceMiddleware message, OnExceptionRecorder recorder)
+    {
+        throw new TestAppException(message.Text);
+    }
+}
+
+/// <summary>
+/// Non-static middleware whose dependency (OnExceptionRecorder) is injected via the constructor.
+/// Exercises constructor-injection support for OnException handlers.
+/// </summary>
+public class InstanceOnExceptionMiddleware
+{
+    private readonly OnExceptionRecorder _recorder;
+
+    public InstanceOnExceptionMiddleware(OnExceptionRecorder recorder)
+    {
+        _recorder = recorder;
+    }
+
+    public void OnException(TestAppException ex)
+    {
+        _recorder.Actions.Add($"InstanceMiddlewareOnException:{ex.Message}");
+    }
+}
+
+// Support types for the ILogger injection test
+public record MessageForLoggerMiddleware(string Text);
+
+public static class MessageForLoggerMiddlewareHandler
+{
+    public static void Handle(MessageForLoggerMiddleware message, OnExceptionRecorder recorder)
+    {
+        throw new TestAppException(message.Text);
+    }
+}
+
+/// <summary>
+/// Middleware that receives an ILogger via constructor injection and an OnExceptionRecorder
+/// via the OnException parameter list — mirrors the documented usage example.
+/// </summary>
+public class LoggerOnExceptionMiddleware
+{
+    private readonly ILogger<LoggerOnExceptionMiddleware> _logger;
+
+    public LoggerOnExceptionMiddleware(ILogger<LoggerOnExceptionMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    public void OnException(TestAppException ex, OnExceptionRecorder recorder)
+    {
+        _logger.LogError(ex, "Unhandled exception in message handler: {Message}", ex.Message);
+        recorder.Actions.Add($"LoggerOnException:{ex.Message}");
+    }
+}
+
+public record MessageForStaticMiddlewareDependency(string Text);
+
+public static class MessageForStaticMiddlewareDependencyHandler
+{
+    public static void Handle(MessageForStaticMiddlewareDependency message, OnExceptionRecorder recorder)
+    {
+        throw new TestAppException(message.Text);
+    }
+}
+
+public class StaticMiddlewareDependencyProbe
+{
+    public bool WasCalled { get; set; }
+}
+
+public static class StaticMiddlewareWithDependencyOnException
+{
+    public static void OnException(TestAppException ex, StaticMiddlewareDependencyProbe probe, OnExceptionRecorder recorder)
+    {
+        probe.WasCalled = true;
+        recorder.Actions.Add($"StaticDependencyOnException:{ex.Message}");
+    }
+}
+
+// Support types for the Before + OnException test (exercises the "move existing ConstructorFrame" path)
+public record MessageForBeforeAndOnException(string Text);
+
+public static class MessageForBeforeAndOnExceptionHandler
+{
+    public static void Handle(MessageForBeforeAndOnException message, OnExceptionRecorder recorder)
+    {
+        throw new TestAppException(message.Text);
+    }
+}
+
+/// <summary>
+/// Non-static middleware that has BOTH a Before method and an OnException method.
+/// Exercises the code path where the existing ConstructorFrame (created by BuildBeforeCalls)
+/// is moved before TryCatchFinallyFrame so the same instance is reachable in catch blocks.
+/// </summary>
+public class BeforeAndOnExceptionMiddleware
+{
+    private readonly OnExceptionRecorder _recorder;
+
+    public BeforeAndOnExceptionMiddleware(OnExceptionRecorder recorder)
+    {
+        _recorder = recorder;
+    }
+
+    public void Before(MessageForBeforeAndOnException message)
+    {
+        _recorder.Actions.Add($"BeforeMiddleware:{message.Text}");
+    }
+
+    public void OnException(TestAppException ex)
+    {
+        _recorder.Actions.Add($"BeforeAndOnExceptionMiddleware:{ex.Message}");
     }
 }

--- a/src/Wolverine/Middleware/MiddlewarePolicy.cs
+++ b/src/Wolverine/Middleware/MiddlewarePolicy.cs
@@ -103,39 +103,79 @@ public class MiddlewarePolicy : IChainPolicy
 
     internal static void ApplyExceptionHandling(List<Application> applications, GenerationRules rules, IChain chain)
     {
-        var exceptionHandlers = applications
-            .Where(x => x.HasOnExceptions)
-            .SelectMany(x => x.BuildOnExceptionCalls(chain, rules))
-            .ToArray();
+        var applicationsWithHandlers = applications.Where(x => x.HasOnExceptions).ToArray();
 
-        if (exceptionHandlers.Length == 0 && !applications.Any(x => x.HasFinally))
+        if (applicationsWithHandlers.Length == 0 && !applications.Any(x => x.HasFinally))
         {
             return;
         }
 
         // Only create TryCatchFinallyFrame if there are exception handlers
         // (TryFinallyWrapperFrame already handles finally-only cases)
-        if (exceptionHandlers.Length == 0) return;
+        if (applicationsWithHandlers.Length == 0) return;
 
         var tryCatchFinally = chain.GetOrCreateTryCatchFinallyFrame();
 
-        foreach (var (exceptionType, call) in exceptionHandlers)
+        // For non-static middleware, the ConstructorFrame must be placed BEFORE the
+        // TryCatchFinallyFrame in chain.Middleware so that the middleware instance variable
+        // is declared in outer scope and accessible inside catch blocks (C# scoping rules).
+        //
+        // • Exception-only middleware (no Before methods): no ConstructorFrame exists yet —
+        //   create one and insert it before TryCatchFinallyFrame.
+        // • Middleware with both Before and OnException: its ConstructorFrame was placed
+        //   inside the try block by BuildBeforeCalls; move it before TryCatchFinallyFrame
+        //   so the same instance is reachable in catch blocks.
+        var insertIndex = chain.Middleware.IndexOf(tryCatchFinally);
+        if (insertIndex < 0) insertIndex = 0; // defensive fallback
+
+        foreach (var application in applicationsWithHandlers)
         {
-            var frames = new List<Frame> { call };
+            var ctorFrame = application.BuildConstructorFrame();
+            if (ctorFrame == null) continue; // static middleware — no instance needed
 
-            // Handle return values from OnException methods — same as Before methods
-            var outgoings = call.Creates.Where(x => x.VariableType == typeof(OutgoingMessages)).ToArray();
-            foreach (var outgoing in outgoings)
+            var existing = chain.Middleware.OfType<ConstructorFrame>()
+                .FirstOrDefault(x => x.Variable.VariableType == application.MiddlewareType);
+
+            if (existing != null)
             {
-                frames.Add(new CaptureCascadingMessages(outgoing));
+                // Move the existing ConstructorFrame to before the TryCatchFinallyFrame
+                // (it currently sits inside the try block at a higher index).
+                var existingIndex = chain.Middleware.IndexOf(existing);
+                if (existingIndex > insertIndex)
+                {
+                    chain.Middleware.RemoveAt(existingIndex);
+                    chain.Middleware.Insert(insertIndex, existing);
+                    insertIndex++;
+                }
             }
-
-            if (rules.TryFindContinuationHandler(chain, call, out var continuation))
+            else
             {
-                frames.Add(continuation!);
+                // No prior ConstructorFrame — insert one before the TryCatchFinallyFrame.
+                chain.Middleware.Insert(insertIndex, ctorFrame);
+                insertIndex++;
             }
+        }
 
-            tryCatchFinally.AddCatchBlock(exceptionType, frames.ToArray());
+        foreach (var application in applicationsWithHandlers)
+        {
+            foreach (var (exceptionType, call) in application.BuildOnExceptionCalls(chain, rules))
+            {
+                var frames = new List<Frame> { call };
+
+                // Handle return values from OnException methods — same as Before methods
+                var outgoings = call.Creates.Where(x => x.VariableType == typeof(OutgoingMessages)).ToArray();
+                foreach (var outgoing in outgoings)
+                {
+                    frames.Add(new CaptureCascadingMessages(outgoing));
+                }
+
+                if (rules.TryFindContinuationHandler(chain, call, out var continuation))
+                {
+                    frames.Add(continuation!);
+                }
+
+                tryCatchFinally.AddCatchBlock(exceptionType, frames.ToArray());
+            }
         }
     }
 
@@ -367,6 +407,26 @@ public class MiddlewarePolicy : IChainPolicy
 
         public bool HasOnExceptions => _onExceptions.Length > 0;
         public bool HasFinally => _finals.Length > 0;
+
+        /// <summary>
+        /// Returns a <see cref="ConstructorFrame"/> for non-static middleware types, or null for static types.
+        /// Used to instantiate the middleware inside a catch block so constructor-injected dependencies
+        /// (e.g. ILogger) are available to OnException handlers.
+        /// </summary>
+        /// <remarks>
+        /// The IDisposable/IAsyncDisposable handling mirrors <see cref="BuildBeforeCalls"/> —
+        /// keep both in sync when changing constructor frame creation logic.
+        /// </remarks>
+        internal Frame? BuildConstructorFrame()
+        {
+            if (MiddlewareType.IsStatic() || _constructor == null) return null;
+            var frame = new ConstructorFrame(MiddlewareType, _constructor);
+            if (MiddlewareType.CanBeCastTo<IDisposable>() || MiddlewareType.CanBeCastTo<IAsyncDisposable>())
+            {
+                frame.Mode = ConstructorCallMode.UsingNestedVariable;
+            }
+            return frame;
+        }
 
         private IEnumerable<Frame> buildAfters(IChain chain)
         {


### PR DESCRIPTION
I posted the following question to discord but haven't gotten an answer yet

As I am not deep enough into the wolverine source generation, I can only offer a Claude generated solution for the problem; maybe it helps, otherwise please reject.

---

Hi,

I saw that there has been an IExceptionFilter equivalent introduced recently
https://github.com/JasperFx/wolverine/issues/2410

From the documentation and also my experiments, I was unable to inject anything else than the excption into the handler

My goal would be to log the exception / stack trace, is there a way to achieve something like

```
public static class LoggingExceptionMiddleware
{
    public static ProblemDetails OnException(DomainException exception)
        => ApiExceptionMapper.CreateDomainExceptionProblemDetails(exception);

    // public static ProblemDetails OnException(DomainException exception, ILogger logger)
    // {
    //     // logger.LogWarning(exception, "HandleDomainException");
    //     return ApiExceptionMapper.CreateDomainExceptionProblemDetails(exception);
    // }
}
```