### PR TITLE
Codegen scope priming for service-located MessageContext (GH-3001, core slice)

### DIFF
--- a/src/Testing/CoreTests/Runtime/service_location_message_context.cs
+++ b/src/Testing/CoreTests/Runtime/service_location_message_context.cs
@@ -13,10 +13,12 @@ using Xunit;
 namespace CoreTests.Runtime;
 
 /// <summary>
-/// Verifies the AsyncLocal-based handoff that keeps service-located <see cref="IMessageBus"/>
-/// / <see cref="IMessageContext"/> instances pointed at the same MessageContext the handler
-/// itself received. Without this, a bus pulled from a constructor on a service the user
-/// injects bypasses the active outbox. See issue #2583.
+/// Verifies the structural scope-priming (GH-3001) that keeps service-located <see cref="IMessageBus"/>
+/// / <see cref="IMessageContext"/> instances pointed at the same MessageContext the handler itself
+/// received. When a chain falls back to service location, the generated code primes the child scope's
+/// <c>ScopedMessageContextHolder</c> with the handler's context, so a bus/context pulled from a
+/// service-located dependency enrols with the active outbox instead of a duplicate. This replaced the
+/// earlier AsyncLocal <c>MessageContext.Current</c> handoff (GH-2583).
 /// </summary>
 public class service_location_message_context
 {
@@ -48,15 +50,15 @@ public class service_location_message_context
     }
 
     [Fact]
-    public async Task chain_without_service_location_does_not_set_message_context_current()
+    public async Task clean_chain_still_runs_and_does_not_force_service_location()
     {
-        // A chain that doesn't service-locate must not touch MessageContext.Current during
-        // invocation — that's how we keep AsyncLocal overhead off the hot path. Verified
-        // by capturing Current from inside the handler; it must be null.
+        // A chain that doesn't service-locate must still run normally — the scope-priming activator
+        // is non-forcing (it never injects an IServiceProvider that would flag the chain as using
+        // service location, which would otherwise fail under ServiceLocationPolicy.NotAllowed).
         using var host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.ServiceLocationPolicy = ServiceLocationPolicy.AllowedButWarn;
+                opts.ServiceLocationPolicy = ServiceLocationPolicy.NotAllowed;
             }).StartAsync();
 
         CleanCommandProbe.Reset();
@@ -64,16 +66,13 @@ public class service_location_message_context
         await host.InvokeMessageAndWaitAsync(new CleanCommand());
 
         CleanCommandProbe.WasInvoked.ShouldBeTrue();
-        CleanCommandProbe.CurrentDuringInvocation.ShouldBeNull();
     }
 
     [Fact]
-    public async Task message_context_current_is_null_outside_handler_invocation()
+    public async Task message_bus_resolves_outside_handler_invocation()
     {
-        // Sanity check: the AsyncLocal default is null, so service resolution outside any
-        // handler invocation must hit the fall-back factory branch.
-        MessageContext.Current.ShouldBeNull();
-
+        // Outside any handler invocation the scope holder is empty, so IMessageBus falls back to a
+        // fresh MessageContext — resolution must still succeed for hosted services / admin tools.
         using var host = await Host.CreateDefaultBuilder()
             .UseWolverine().StartAsync();
 
@@ -152,12 +151,10 @@ public record CleanCommand;
 public static class CleanCommandProbe
 {
     public static bool WasInvoked;
-    public static MessageContext? CurrentDuringInvocation;
 
     public static void Reset()
     {
         WasInvoked = false;
-        CurrentDuringInvocation = null;
     }
 }
 
@@ -166,7 +163,6 @@ public static class CleanCommandHandler
     public static void Handle(CleanCommand cmd)
     {
         CleanCommandProbe.WasInvoked = true;
-        CleanCommandProbe.CurrentDuringInvocation = MessageContext.Current;
     }
 }
 

--- a/src/Wolverine/Configuration/Chain.cs
+++ b/src/Wolverine/Configuration/Chain.cs
@@ -495,12 +495,11 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
     /// rather than receiving the dependency through a constructor / handler-method parameter).
     /// Recorded at codegen time by <see cref="AssertServiceLocationsAreAllowed"/>.
     ///
-    /// At runtime, the executor factory consults this flag to decide whether to wrap the chain's
-    /// <see cref="Wolverine.Runtime.Handlers.IExecutor"/> with the <see cref="System.Threading.AsyncLocal{T}"/>-based
-    /// <see cref="Wolverine.Runtime.MessageContext.Current"/> handoff that keeps service-located
-    /// <see cref="IMessageContext"/> / <see cref="IMessageBus"/> instances pointed at the same
-    /// <see cref="Wolverine.Runtime.MessageContext"/> the handler itself received. Chains that don't
-    /// service-locate skip the wrap and pay zero AsyncLocal overhead per message. See issue #2583.
+    /// When a chain service-locates, the generated code creates a child scope, and Wolverine primes
+    /// that scope so a service-located <see cref="IMessageContext"/> / <see cref="IMessageBus"/>
+    /// (and <see cref="IRequireScopingFrame"/> contributors such as Marten's
+    /// <c>IDocumentSession</c>) resolves to the same instance the handler received rather than a
+    /// duplicate. See GH-3001 (which replaced the earlier AsyncLocal handoff from GH-2583).
     /// </summary>
     public bool UsesServiceLocation { get; private set; }
 

--- a/src/Wolverine/Configuration/IChain.cs
+++ b/src/Wolverine/Configuration/IChain.cs
@@ -134,11 +134,9 @@ public interface IChain
     /// <summary>
     /// <see langword="true"/> when this chain's compiled code resolves at least one
     /// dependency via service location rather than constructor / parameter injection.
-    /// Recorded at codegen time. Consumed by the executor factory to opt into the
-    /// AsyncLocal-based <see cref="Wolverine.Runtime.MessageContext.Current"/> handoff
-    /// that keeps service-located <see cref="IMessageContext"/> / <see cref="IMessageBus"/>
-    /// pointed at the same context the handler itself received. Chains where this is
-    /// <see langword="false"/> incur zero AsyncLocal overhead per invocation. See issue #2583.
+    /// Recorded at codegen time. When set, the generated code creates a child scope that
+    /// Wolverine primes so service-located <see cref="IMessageContext"/> / <see cref="IMessageBus"/>
+    /// resolve to the same context the handler received rather than a duplicate. See GH-3001.
     /// </summary>
     bool UsesServiceLocation { get; }
 

--- a/src/Wolverine/Configuration/IRequireScopingFrame.cs
+++ b/src/Wolverine/Configuration/IRequireScopingFrame.cs
@@ -1,0 +1,20 @@
+using JasperFx.CodeGeneration.Frames;
+
+namespace Wolverine.Configuration;
+
+/// <summary>
+/// Implemented by codegen frames whose work resolves a "should-be-singleton-per-message" instance
+/// (e.g. an outbox-enrolled <c>IDocumentSession</c>) that must also be seen by any service-located
+/// dependency. When a chain falls back to service location, Wolverine collects a scoping frame from
+/// every <see cref="IRequireScopingFrame"/> in the chain and emits it immediately after the child
+/// service-location scope is created, so service location returns the already-resolved instance
+/// rather than a duplicate. See GH-3001.
+/// </summary>
+public interface IRequireScopingFrame
+{
+    /// <summary>
+    /// Build the frame that primes the service-location scope with this frame's already-resolved
+    /// instance. Returns null when, for the current configuration, no priming is required.
+    /// </summary>
+    SyncFrame? BuildScopingFrame();
+}

--- a/src/Wolverine/HostBuilderExtensions.cs
+++ b/src/Wolverine/HostBuilderExtensions.cs
@@ -213,17 +213,18 @@ public static class HostBuilderExtensions
         services.AddOptions();
         services.AddLogging();
 
-        // The scoped factories prefer MessageContext.Current when it has been set by the
-        // ServiceLocationAwareExecutor (chains compiled with service location in play). That
-        // routes any service-located IMessageContext / IMessageBus through the same instance
-        // the handler itself received, so writes through a service-located bus enrol with the
-        // active outbox instead of being silently lost. The fall-back to a fresh MessageContext
-        // preserves resolution for non-handler scopes (hosted services, admin tools, tests
-        // that resolve IMessageBus directly from the root provider). See issue #2583.
+        // GH-3001: structural scope priming. When a handler falls back to service location, the
+        // generated code creates a child scope and primes its ScopedMessageContextHolder with the
+        // handler's MessageContext (PrimeScopedMessageContextFrame). These factories prefer that
+        // primed instance, so a service-located IMessageContext / IMessageBus is the SAME context the
+        // handler uses (enrolled with the active outbox) rather than a duplicate. Non-handler scopes
+        // (hosted services, admin tools, raw resolution) leave the holder empty and fall back to a
+        // fresh MessageContext. Replaces the AsyncLocal MessageContext.Current handoff (GH-2583).
+        services.AddScoped<ScopedMessageContextHolder>();
         services.AddScoped<IMessageBus>(sp =>
-            Wolverine.Runtime.MessageContext.Current ?? sp.GetRequiredService<MessageContext>());
+            sp.GetRequiredService<ScopedMessageContextHolder>().Context ?? sp.GetRequiredService<MessageContext>());
         services.AddScoped<IMessageContext>(sp =>
-            Wolverine.Runtime.MessageContext.Current ?? sp.GetRequiredService<MessageContext>());
+            sp.GetRequiredService<ScopedMessageContextHolder>().Context ?? sp.GetRequiredService<MessageContext>());
         services.AddScoped<MessageContext>();
 
         services.AddSingleton<ObjectPoolProvider>(new DefaultObjectPoolProvider());

--- a/src/Wolverine/Runtime/Handlers/Executor.cs
+++ b/src/Wolverine/Runtime/Handlers/Executor.cs
@@ -57,17 +57,6 @@ internal class Executor : IExecutor
     private readonly IMessageTracker _tracker;
     private readonly IWolverineRuntime? _runtime;
 
-    /// <summary>
-    /// When <see langword="true"/>, the executor publishes the in-flight <see cref="MessageContext"/>
-    /// through <see cref="MessageContext.Current"/> for the duration of each invocation, so
-    /// service-located <see cref="IMessageContext"/> / <see cref="IMessageBus"/> see the same
-    /// instance the handler itself received. Set only when the
-    /// chain's compiled code resolves at least one dependency via service location, so chains
-    /// that don't service-locate pay zero <see cref="System.Threading.AsyncLocal{T}"/> overhead
-    /// per message. See issue #2583.
-    /// </summary>
-    private bool _capturesContextForServiceLocation;
-
     public Executor(ObjectPool<MessageContext> contextPool, IWolverineRuntime runtime, IMessageHandler handler,
         FailureRuleCollection rules, TimeSpan timeout)
         : this(contextPool, runtime.LoggerFactory.CreateLogger(handler.MessageType), handler, runtime.MessageTracking, rules, timeout)
@@ -238,15 +227,6 @@ internal class Executor : IExecutor
         using var timeout = new CancellationTokenSource(_timeout);
         using var combined = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellation);
 
-        // Publish the in-flight context for service location only when the chain's codegen
-        // reported at least one service-located dependency. Pure-codegen chains skip the
-        // AsyncLocal touch entirely. See #2583 / ServiceLocationAwareExecutor docs.
-        var previousAmbient = _capturesContextForServiceLocation ? MessageContext.Current : null;
-        if (_capturesContextForServiceLocation)
-        {
-            MessageContext.Current = context;
-        }
-
         try
         {
             await Handler.HandleAsync(context, combined.Token).ConfigureAwait(false);
@@ -279,10 +259,6 @@ internal class Executor : IExecutor
         }
         finally
         {
-            if (_capturesContextForServiceLocation)
-            {
-                MessageContext.Current = previousAmbient;
-            }
             _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
         }
     }
@@ -292,12 +268,6 @@ internal class Executor : IExecutor
         if (context.Envelope == null)
         {
             throw new ArgumentOutOfRangeException(nameof(context.Envelope));
-        }
-
-        var previousAmbient = _capturesContextForServiceLocation ? MessageContext.Current : null;
-        if (_capturesContextForServiceLocation)
-        {
-            MessageContext.Current = context;
         }
 
         try
@@ -323,13 +293,6 @@ internal class Executor : IExecutor
             return await retry
                 .ExecuteInlineAsync(context, context.Runtime, DateTimeOffset.UtcNow, Activity.Current, cancellation)
                 .ConfigureAwait(false);
-        }
-        finally
-        {
-            if (_capturesContextForServiceLocation)
-            {
-                MessageContext.Current = previousAmbient;
-            }
         }
     }
 
@@ -427,15 +390,6 @@ internal class Executor : IExecutor
             _rules, _timeout);
     }
 
-    /// <summary>
-    /// Set when the chain's compiled code is known to resolve a
-    /// dependency via service location. Toggles the per-invocation
-    /// <see cref="MessageContext.Current"/> publish/restore so service-located
-    /// <see cref="IMessageContext"/> / <see cref="IMessageBus"/> see the same instance the
-    /// handler received. See issue #2583.
-    /// </summary>
-    internal void EnableServiceLocationContextCapture() => _capturesContextForServiceLocation = true;
-
     public static IExecutor Build(IWolverineRuntime runtime, ObjectPool<MessageContext> contextPool,
         HandlerGraph handlerGraph, Type messageType)
     {
@@ -460,20 +414,10 @@ internal class Executor : IExecutor
 
         if (runtime.Options.InvokeTracing == InvokeTracingMode.Full)
         {
-            var tracingExecutor = new TracingExecutor(contextPool, runtime, handler, rules, timeoutSpan);
-            if (chain?.UsesServiceLocation == true)
-            {
-                tracingExecutor.EnableServiceLocationContextCapture();
-            }
-            return tracingExecutor;
+            return new TracingExecutor(contextPool, runtime, handler, rules, timeoutSpan);
         }
 
-        var executor = new Executor(contextPool, runtime, handler, rules, timeoutSpan);
-        if (chain?.UsesServiceLocation == true)
-        {
-            executor.EnableServiceLocationContextCapture();
-        }
-        return executor;
+        return new Executor(contextPool, runtime, handler, rules, timeoutSpan);
     }
 
     public static IExecutor Build(IWolverineRuntime runtime, ObjectPool<MessageContext> contextPool,
@@ -487,19 +431,9 @@ internal class Executor : IExecutor
 
         if (runtime.Options.InvokeTracing == InvokeTracingMode.Full)
         {
-            var tracingExecutor = new TracingExecutor(contextPool, logger, handler, tracker, rules, timeoutSpan);
-            if (chain?.UsesServiceLocation == true)
-            {
-                tracingExecutor.EnableServiceLocationContextCapture();
-            }
-            return tracingExecutor;
+            return new TracingExecutor(contextPool, logger, handler, tracker, rules, timeoutSpan);
         }
 
-        var executor = new Executor(contextPool, logger, handler, tracker, rules, timeoutSpan);
-        if (chain?.UsesServiceLocation == true)
-        {
-            executor.EnableServiceLocationContextCapture();
-        }
-        return executor;
+        return new Executor(contextPool, logger, handler, tracker, rules, timeoutSpan);
     }
 }

--- a/src/Wolverine/Runtime/Handlers/HandlerChain.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerChain.cs
@@ -673,8 +673,18 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
             ? new Frame[] { new RecordMessageCausationFrame() }
             : Array.Empty<Frame>();
 
+        // GH-3001: when this chain falls back to service location, prime the child scope so
+        // service-located IMessageContext / IMessageBus (and any IRequireScopingFrame contributor)
+        // resolve to the same instances the handler uses instead of duplicates. The activator emits
+        // nothing unless a service-location scope is actually created for the chain.
+        var scopingFrames = new List<SyncFrame> { new PrimeScopedMessageContextFrame() };
+        scopingFrames.AddRange(collectScopingFrames(handlerReturnValueFrames));
+        var scopeActivator = new ScopePrimingActivatorFrame(scopingFrames);
+
         // The Enqueue cascading needs to happen before the post processors because of the
-        // transactional & outbox support
+        // transactional & outbox support. The scope-priming activator runs LAST so it arranges after
+        // the service-location scope (if any) has been created — it emits no code, it only registers
+        // postprocessors on that scope.
         return preamble
             .Concat(Middleware)
             .Concat(container.TryCreateConstructorFrames(Handlers))
@@ -682,7 +692,31 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
             .Concat(handlerReturnValueFrames)
             .Concat(causation)
             .Concat(Postprocessors)
+            .Append(scopeActivator)
             .ToList();
+    }
+
+    // GH-3001: collect a scoping frame from every IRequireScopingFrame in the chain (persistence
+    // providers contribute IDocumentSession / IQuerySession priming), de-duplicated so two frames
+    // never prime the same type. The MessageContext priming frame is added unconditionally by the
+    // caller, so it is excluded here.
+    private IEnumerable<SyncFrame> collectScopingFrames(IEnumerable<Frame> handlerReturnValueFrames)
+    {
+        var candidates = Middleware
+            .Concat(Handlers)
+            .Concat(handlerReturnValueFrames)
+            .Concat(Postprocessors)
+            .OfType<IRequireScopingFrame>();
+
+        var seen = new HashSet<Type>();
+        foreach (var candidate in candidates)
+        {
+            var frame = candidate.BuildScopingFrame();
+            if (frame != null && seen.Add(candidate.GetType()))
+            {
+                yield return frame;
+            }
+        }
     }
 
     protected void applyCustomizations(GenerationRules rules, IServiceContainer container)

--- a/src/Wolverine/Runtime/Handlers/PrimeScopedMessageContextFrame.cs
+++ b/src/Wolverine/Runtime/Handlers/PrimeScopedMessageContextFrame.cs
@@ -1,0 +1,39 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.CodeGeneration.Services;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Wolverine.Runtime.Handlers;
+
+/// <summary>
+/// Emitted (via <c>IScopedContainerCreation.AddPostProcessor</c>) immediately after a handler's
+/// service-location child scope is created. Primes that scope's <see cref="ScopedMessageContextHolder"/>
+/// with the handler's <see cref="MessageContext"/>, so any service-located
+/// <see cref="IMessageContext"/> / <see cref="IMessageBus"/> resolves to that single context (enrolled
+/// with the active outbox) rather than a duplicate. See GH-3001.
+/// </summary>
+internal sealed class PrimeScopedMessageContextFrame : SyncFrame, IUsesServiceProviderFrame
+{
+    private Variable? _context;
+    private Variable? _scopedProvider;
+
+    // The parent ScopedContainerCreation hands us its scoped IServiceProvider variable BEFORE we
+    // resolve our other variables, so we never ask the arranger for an IServiceProvider (which would
+    // create a bi-directional dependency with the scope line that creates it).
+    public void UseServiceProvider(Variable serviceProvider) => _scopedProvider = serviceProvider;
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _context = chain.FindVariable(typeof(MessageContext));
+        yield return _context;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write(
+            $"{typeof(ServiceProviderServiceExtensions).FullNameInCode()}.{nameof(ServiceProviderServiceExtensions.GetRequiredService)}<{typeof(ScopedMessageContextHolder).FullNameInCode()}>({_scopedProvider!.Usage}).{nameof(ScopedMessageContextHolder.Context)} = {_context!.Usage};");
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Wolverine/Runtime/Handlers/PrimeScopedMessageContextFrame.cs
+++ b/src/Wolverine/Runtime/Handlers/PrimeScopedMessageContextFrame.cs
@@ -36,4 +36,12 @@ internal sealed class PrimeScopedMessageContextFrame : SyncFrame, IUsesServicePr
             $"{typeof(ServiceProviderServiceExtensions).FullNameInCode()}.{nameof(ServiceProviderServiceExtensions.GetRequiredService)}<{typeof(ScopedMessageContextHolder).FullNameInCode()}>({_scopedProvider!.Usage}).{nameof(ScopedMessageContextHolder.Context)} = {_context!.Usage};");
         Next?.GenerateCode(method, writer);
     }
+
+    // F#: mutable property assignment uses `<-` and no trailing semicolon.
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write(
+            $"{typeof(ServiceProviderServiceExtensions).FSharpName()}.{nameof(ServiceProviderServiceExtensions.GetRequiredService)}<{typeof(ScopedMessageContextHolder).FSharpName()}>({_scopedProvider!.Usage}).{nameof(ScopedMessageContextHolder.Context)} <- {_context!.Usage}");
+        Next?.GenerateFSharpCode(method, writer);
+    }
 }

--- a/src/Wolverine/Runtime/Handlers/ScopePrimingActivatorFrame.cs
+++ b/src/Wolverine/Runtime/Handlers/ScopePrimingActivatorFrame.cs
@@ -1,0 +1,50 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.CodeGeneration.Services;
+
+namespace Wolverine.Runtime.Handlers;
+
+/// <summary>
+/// Codegen-time activator (GH-3001). When a chain falls back to service location, the generated code
+/// creates a child <c>IServiceScope</c> off the root provider. This frame detects that scope at
+/// arrangement time and registers scoping postprocessors on it — always the
+/// <see cref="PrimeScopedMessageContextFrame"/>, plus one from every collected
+/// <see cref="Wolverine.Configuration.IRequireScopingFrame"/> — so they run immediately after the
+/// scope is created and prime it with the correct already-resolved instances. Emits no code itself.
+///
+/// If no service-location scope is created for the chain (the IServiceProvider variable's Creator is
+/// not an <see cref="IScopedContainerCreation"/>), nothing is attached.
+/// </summary>
+internal sealed class ScopePrimingActivatorFrame : SyncFrame
+{
+    private readonly IReadOnlyList<SyncFrame> _scopingFrames;
+
+    public ScopePrimingActivatorFrame(IReadOnlyList<SyncFrame> scopingFrames)
+    {
+        _scopingFrames = scopingFrames;
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        // Non-forcing: only finds the scoped IServiceProvider that the service-location machinery
+        // already created. Using FindVariable here would *inject* a root IServiceProvider into every
+        // handler (flagging it as service location — which would fail under ServiceLocationPolicy.NotAllowed).
+        var provider = chain.TryFindVariable(typeof(IServiceProvider), VariableSource.NotServices);
+        if (provider?.Creator is IScopedContainerCreation scoped)
+        {
+            foreach (var frame in _scopingFrames)
+            {
+                scoped.AddPostProcessor(frame);
+            }
+
+            yield return provider;
+        }
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        // No-op: the work is registering postprocessors on the scope during FindVariables.
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Wolverine/Runtime/Handlers/ScopePrimingActivatorFrame.cs
+++ b/src/Wolverine/Runtime/Handlers/ScopePrimingActivatorFrame.cs
@@ -47,4 +47,11 @@ internal sealed class ScopePrimingActivatorFrame : SyncFrame
         // No-op: the work is registering postprocessors on the scope during FindVariables.
         Next?.GenerateCode(method, writer);
     }
+
+    // No-op for F# too — this frame emits no code in either language (it only registers postprocessors
+    // during arrangement). Required so it doesn't hit the base Frame.GenerateFSharpCode which throws.
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        Next?.GenerateFSharpCode(method, writer);
+    }
 }

--- a/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
+++ b/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
@@ -35,13 +35,6 @@ internal class TracingExecutor : IExecutor
     private readonly Action<ILogger, string, Guid, string, Exception?> _messageSucceeded;
     private readonly Action<ILogger, string, Guid, string, Exception> _messageFailed;
 
-    /// <summary>
-    /// Mirror of the same flag on <see cref="Executor"/>; see issue #2583.
-    /// </summary>
-    private bool _capturesContextForServiceLocation;
-
-    internal void EnableServiceLocationContextCapture() => _capturesContextForServiceLocation = true;
-
     public TracingExecutor(ObjectPool<MessageContext> contextPool, IWolverineRuntime runtime,
         IMessageHandler handler, FailureRuleCollection rules, TimeSpan timeout)
         : this(contextPool, runtime.LoggerFactory.CreateLogger(handler.MessageType), handler,
@@ -171,12 +164,6 @@ internal class TracingExecutor : IExecutor
         using var timeout = new CancellationTokenSource(_timeout);
         using var combined = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellation);
 
-        var previousAmbient = _capturesContextForServiceLocation ? MessageContext.Current : null;
-        if (_capturesContextForServiceLocation)
-        {
-            MessageContext.Current = context;
-        }
-
         try
         {
             await Handler.HandleAsync(context, combined.Token);
@@ -208,10 +195,6 @@ internal class TracingExecutor : IExecutor
         }
         finally
         {
-            if (_capturesContextForServiceLocation)
-            {
-                MessageContext.Current = previousAmbient;
-            }
             _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
         }
     }
@@ -221,12 +204,6 @@ internal class TracingExecutor : IExecutor
         if (context.Envelope == null)
         {
             throw new ArgumentOutOfRangeException(nameof(context.Envelope));
-        }
-
-        var previousAmbient = _capturesContextForServiceLocation ? MessageContext.Current : null;
-        if (_capturesContextForServiceLocation)
-        {
-            MessageContext.Current = context;
         }
 
         try
@@ -252,13 +229,6 @@ internal class TracingExecutor : IExecutor
             return await retry
                 .ExecuteInlineAsync(context, context.Runtime, DateTimeOffset.UtcNow, Activity.Current, cancellation)
                 .ConfigureAwait(false);
-        }
-        finally
-        {
-            if (_capturesContextForServiceLocation)
-            {
-                MessageContext.Current = previousAmbient;
-            }
         }
     }
 

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -36,32 +36,6 @@ public enum MultiFlushMode
 
 public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelopeTransaction, IEnvelopeLifecycle
 {
-    /// <summary>
-    /// Ambient holder for the <see cref="MessageContext"/> currently driving the in-flight
-    /// handler invocation on this async flow. Set by <c>ServiceLocationAwareExecutor</c> when
-    /// a chain is known (at codegen time) to use service location, and consulted by the
-    /// <see cref="IMessageContext"/> / <see cref="IMessageBus"/> scoped DI registrations so
-    /// that service-located instances see the same <see cref="MessageContext"/> the handler
-    /// itself received — preserving outbox semantics.
-    ///
-    /// Chains that do not use service location never set this value, so the per-message
-    /// <see cref="System.Threading.AsyncLocal{T}"/> machinery and ExecutionContext clone
-    /// cost are avoided on the hot path. See issue #2583.
-    /// </summary>
-    private static readonly System.Threading.AsyncLocal<MessageContext?> _current = new();
-
-    /// <summary>
-    /// The <see cref="MessageContext"/> driving the current handler invocation, if any.
-    /// Set by <c>ServiceLocationAwareExecutor</c>; <see langword="null"/> outside of a
-    /// service-location-aware handler invocation. Public so that custom service registrations
-    /// can opt into the same ambient handoff.
-    /// </summary>
-    public static MessageContext? Current
-    {
-        get => _current.Value;
-        internal set => _current.Value = value;
-    }
-
     private IChannelCallback? _channel;
 
     private bool _hasFlushed;

--- a/src/Wolverine/Runtime/ScopedMessageContextHolder.cs
+++ b/src/Wolverine/Runtime/ScopedMessageContextHolder.cs
@@ -1,0 +1,17 @@
+namespace Wolverine.Runtime;
+
+/// <summary>
+/// Scope-local carrier for the active <see cref="MessageContext"/>. When a handler falls back to
+/// service location, Wolverine's generated code creates a child <see cref="IServiceScope"/> off the
+/// root provider; that scope does not share the per-message scope's <see cref="MessageContext"/>.
+/// The codegen scoping frame primes this holder in the child scope immediately after it is created,
+/// so any service-located <see cref="IMessageContext"/> / <see cref="IMessageBus"/> resolves to the
+/// SAME context the handler received (enrolled with the active outbox) instead of a duplicate.
+///
+/// This replaces the AsyncLocal <c>MessageContext.Current</c> handoff (GH-2583) with a structural,
+/// scope-local mechanism that does not depend on async-flow propagation.
+/// </summary>
+public sealed class ScopedMessageContextHolder
+{
+    public MessageContext? Context { get; set; }
+}


### PR DESCRIPTION
Addresses [#3001](https://github.com/JasperFx/wolverine/issues/3001) — the **core `MessageContext` slice**. When a handler chain falls back to service location, the generated code creates a child `IServiceScope` off the root provider, which previously resolved a **second** `MessageContext`; a service-located `IMessageBus`/`IMessageContext` then enrolled with a different (or no) outbox and cascaded messages could silently drop.

This replaces the AsyncLocal `MessageContext.Current` handoff (#2583) with a **structural, codegen-time** fix built on JasperFx 2.4.1's `IScopedContainerCreation.AddPostProcessor` hook.

## How it works
- **`ScopedMessageContextHolder`** (scoped) + `IMessageBus`/`IMessageContext` registrations that prefer the primed instance, falling back to a fresh `MessageContext` for non-handler scopes (hosted services, admin tools).
- **`PrimeScopedMessageContextFrame`** — an `IUsesServiceProviderFrame` emitted immediately after the child scope is created; primes the holder with the handler's `MessageContext`.
- **`ScopePrimingActivatorFrame`** — detects the service-location scope at arrangement time via a **non-forcing** `TryFindVariable(IServiceProvider, VariableSource.NotServices)`. This is the key correctness point: a forcing lookup would inject `IServiceProvider` into *every* handler and flag it as service-locating — which would fail under `ServiceLocationPolicy.NotAllowed`. Clean chains are untouched.
- **`IRequireScopingFrame`** — extension seam so persistence providers can contribute `IDocumentSession`/`IQuerySession` scoping frames; `HandlerChain` collects + de-dupes them. The `MessageContext` frame is always added.
- **Removed the AsyncLocal mechanism** entirely: `MessageContext.Current`, the `Executor`/`TracingExecutor` publish/restore, and `EnableServiceLocationContextCapture`.

## Scope (this PR)
`MessageContext` / `IMessageBus` / `IMessageContext` over **handler chains** — the core slice. Per the issue triage with the maintainer, the following are **deliberate follow-ups** (the `IRequireScopingFrame` seam is in place for them):
- Marten / Polecat `IDocumentSession` / `IQuerySession` scoping frames + registration overrides.
- HTTP + gRPC chains (they have their own `DetermineFrames`; they never consumed the AsyncLocal, so removing it doesn't regress them).
- The ancillary-message-store test matrix.

## Verification
- `service_location_message_context` proves exactly one `MessageContext` flows through a service-located object graph (`ReferenceEquals`), and that the service-located bus publishes through the active outbox — now via the structural mechanism, no AsyncLocal.
- A non-forcing-activator test runs a clean chain under `ServiceLocationPolicy.NotAllowed` (would fail if the activator forced service location).
- **541** Compilation/Runtime/Bugs tests pass; `dotnet build wolverine.slnx -c Release` clean.

Requires JasperFx ≥ 2.4.1 (already pinned on `main` via 6.3.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)