### PR TITLE
Polecat IDocumentSession scope priming (GH-3001, Polecat slice)

### DIFF
--- a/src/Persistence/PolecatTests/service_location_document_session.cs
+++ b/src/Persistence/PolecatTests/service_location_document_session.cs
@@ -1,0 +1,99 @@
+using IntegrationTests;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Shouldly;
+using Wolverine;
+using Wolverine.Polecat;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace PolecatTests;
+
+/// <summary>
+/// GH-3001: when a handler chain falls back to service location, a dependency that takes Polecat's
+/// <see cref="IDocumentSession"/> must receive the SAME outbox-enrolled session the handler is using
+/// — not a separate, un-enrolled one (which would defeat the transaction boundary). Proven via
+/// reference equality against the handler's own session.
+/// </summary>
+public class service_location_document_session : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(SessionProbeCommandHandler));
+
+                opts.Services.AddPolecat(m =>
+                    {
+                        m.ConnectionString = Servers.SqlServerConnectionString;
+                        m.DatabaseSchemaName = "scope_priming";
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                opts.Services.AddResourceSetupOnStartup();
+
+                opts.ServiceLocationPolicy = ServiceLocationPolicy.AllowedButWarn;
+                opts.Services.AddScoped<SessionCapturingService>();
+
+                // Force the capturing service to be resolved via service location so the chain creates
+                // a child scope — the path GH-3001 primes.
+                opts.CodeGeneration.AlwaysUseServiceLocationFor<SessionCapturingService>();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync() => await _host.StopAsync();
+
+    [Fact]
+    public async Task service_located_session_is_same_instance_as_the_handler_session()
+    {
+        SessionIdentityProbe.Reset();
+
+        await _host.InvokeMessageAndWaitAsync(new SessionProbeCommand());
+
+        SessionIdentityProbe.HandlerSession.ShouldNotBeNull();
+        SessionIdentityProbe.ServiceLocatedSession.ShouldNotBeNull();
+
+        // Reference equality — the service-located session IS the handler's outbox-enrolled session.
+        ReferenceEquals(SessionIdentityProbe.HandlerSession, SessionIdentityProbe.ServiceLocatedSession)
+            .ShouldBeTrue();
+    }
+}
+
+public record SessionProbeCommand;
+
+public static class SessionIdentityProbe
+{
+    public static IDocumentSession? HandlerSession;
+    public static IDocumentSession? ServiceLocatedSession;
+
+    public static void Reset()
+    {
+        HandlerSession = null;
+        ServiceLocatedSession = null;
+    }
+}
+
+public class SessionCapturingService(IDocumentSession session)
+{
+    public IDocumentSession Capture() => session;
+}
+
+public static class SessionProbeCommandHandler
+{
+    public static void Handle(SessionProbeCommand command, IDocumentSession handlerSession, IServiceProvider services)
+    {
+        SessionIdentityProbe.HandlerSession = handlerSession;
+        SessionIdentityProbe.ServiceLocatedSession = services
+            .GetRequiredService<SessionCapturingService>()
+            .Capture();
+    }
+}

--- a/src/Persistence/Wolverine.Polecat/Codegen/PrimeScopedDocumentSessionFrame.cs
+++ b/src/Persistence/Wolverine.Polecat/Codegen/PrimeScopedDocumentSessionFrame.cs
@@ -1,0 +1,59 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.CodeGeneration.Services;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Polecat;
+
+namespace Wolverine.Polecat.Codegen;
+
+/// <summary>
+/// Emitted (via <c>IScopedContainerCreation.AddPostProcessor</c>) immediately after a handler's
+/// service-location child scope is created. Primes that scope's <see cref="ScopedDocumentSessionHolder"/>
+/// with the handler's outbox-enrolled <see cref="IDocumentSession"/>, so any service-located
+/// <see cref="IDocumentSession"/> / <see cref="IQuerySession"/> resolves to that single enrolled
+/// session rather than a separate one. See GH-3001.
+/// </summary>
+internal sealed class PrimeScopedDocumentSessionFrame : SyncFrame, IUsesServiceProviderFrame
+{
+    private Variable? _session;
+    private Variable? _scopedProvider;
+
+    // The parent ScopedContainerCreation hands us the scoped IServiceProvider variable before we
+    // resolve our other variables (avoiding a bi-directional dependency with the scope line).
+    public void UseServiceProvider(Variable serviceProvider) => _scopedProvider = serviceProvider;
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        // The enrolled session created by CreateDocumentSessionFrame (NotServices: never the
+        // container's own scoped IDocumentSession registration).
+        _session = chain.TryFindVariable(typeof(IDocumentSession), VariableSource.NotServices);
+        if (_session != null)
+        {
+            yield return _session;
+        }
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_session != null)
+        {
+            writer.Write(
+                $"{typeof(ServiceProviderServiceExtensions).FullNameInCode()}.{nameof(ServiceProviderServiceExtensions.GetRequiredService)}<{typeof(ScopedDocumentSessionHolder).FullNameInCode()}>({_scopedProvider!.Usage}).{nameof(ScopedDocumentSessionHolder.Session)} = {_session.Usage};");
+        }
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_session != null)
+        {
+            writer.Write(
+                $"{typeof(ServiceProviderServiceExtensions).FSharpName()}.{nameof(ServiceProviderServiceExtensions.GetRequiredService)}<{typeof(ScopedDocumentSessionHolder).FSharpName()}>({_scopedProvider!.Usage}).{nameof(ScopedDocumentSessionHolder.Session)} <- {_session.Usage}");
+        }
+
+        Next?.GenerateFSharpCode(method, writer);
+    }
+}

--- a/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
@@ -48,6 +48,11 @@ public class PolecatIntegration : IWolverineExtension, IEventForwarding
 
         options.CodeGeneration.Sources.Add(new PolecatBackedPersistenceMarker());
 
+        // GH-3001: prime the service-location child scope with the handler's outbox-enrolled
+        // IDocumentSession so a service-located IDocumentSession / IQuerySession resolves to that same
+        // session. The frame self-guards (no-op when the chain has no Polecat session).
+        options.ScopingFrameSources.Add(() => new Codegen.PrimeScopedDocumentSessionFrame());
+
         options.CodeGeneration.InsertFirstPersistenceStrategy<PolecatPersistenceFrameProvider>();
         options.CodeGeneration.Sources.Add(new SessionVariableSource());
         options.CodeGeneration.Sources.Add(new DocumentOperationsSource());

--- a/src/Persistence/Wolverine.Polecat/ScopedDocumentSessionHolder.cs
+++ b/src/Persistence/Wolverine.Polecat/ScopedDocumentSessionHolder.cs
@@ -1,0 +1,19 @@
+using Polecat;
+
+namespace Wolverine.Polecat;
+
+/// <summary>
+/// Scope-local carrier for the outbox-enrolled <see cref="IDocumentSession"/> a handler is using.
+/// When a handler falls back to service location, Wolverine's generated code creates a child
+/// <see cref="IServiceScope"/> off the root provider; the Polecat scoping frame primes this holder in
+/// that scope so a service-located <see cref="IDocumentSession"/> / <see cref="IQuerySession"/>
+/// resolves to the SAME session enrolled with the active outbox instead of a separate, un-enrolled
+/// one (which would defeat the transaction boundary). See GH-3001.
+///
+/// The holder is empty in non-handler scopes (hosted services, admin tools, raw resolution), where
+/// the decorated registration falls back to Polecat's own session factory.
+/// </summary>
+public sealed class ScopedDocumentSessionHolder
+{
+    public IDocumentSession? Session { get; set; }
+}

--- a/src/Persistence/Wolverine.Polecat/WolverineOptionsPolecatExtensions.cs
+++ b/src/Persistence/Wolverine.Polecat/WolverineOptionsPolecatExtensions.cs
@@ -57,6 +57,16 @@ public static class WolverineOptionsPolecatExtensions
 
         expression.Services.AddScoped<IPolecatOutbox, PolecatOutbox>();
 
+        // GH-3001: structural scope priming for Polecat sessions. When a handler falls back to service
+        // location, the generated code primes the child scope's ScopedDocumentSessionHolder with the
+        // handler's outbox-enrolled IDocumentSession (PrimeScopedDocumentSessionFrame). Decorate
+        // Polecat's own IDocumentSession / IQuerySession scoped registrations so service-located
+        // resolution prefers that primed session instead of a separate, un-enrolled one. Non-handler
+        // scopes (the holder is empty) fall back to Polecat's original session factory.
+        expression.Services.AddScoped<ScopedDocumentSessionHolder>();
+        preferScopedSession<IDocumentSession>(expression.Services);
+        preferScopedSession<IQuerySession>(expression.Services);
+
         expression.Services.AddSingleton<DatabaseSettings>(s =>
         {
             var store = s.GetRequiredService<IMessageStore>() as IMessageDatabase;
@@ -101,6 +111,48 @@ public static class WolverineOptionsPolecatExtensions
         }
 
         return expression;
+    }
+
+    // GH-3001: replace Polecat's scoped session registration with one that prefers a scope-primed
+    // session (the outbox-enrolled session the handler is using), falling back to Polecat's original
+    // factory when the holder is empty (non-handler scopes). Preserving the original factory keeps
+    // Polecat's exact session-building for the fall-back path.
+    private static void preferScopedSession<T>(IServiceCollection services) where T : class
+    {
+        var descriptor = services.LastOrDefault(x => x.ServiceType == typeof(T));
+        if (descriptor == null)
+        {
+            return;
+        }
+
+        Func<IServiceProvider, object> original;
+        if (descriptor.ImplementationFactory != null)
+        {
+            original = descriptor.ImplementationFactory;
+        }
+        else if (descriptor.ImplementationInstance != null)
+        {
+            original = _ => descriptor.ImplementationInstance;
+        }
+        else if (descriptor.ImplementationType != null)
+        {
+            original = sp => ActivatorUtilities.CreateInstance(sp, descriptor.ImplementationType);
+        }
+        else
+        {
+            return;
+        }
+
+        services.Remove(descriptor);
+        services.AddScoped<T>(sp =>
+        {
+            if (sp.GetRequiredService<ScopedDocumentSessionHolder>().Session is T primed)
+            {
+                return primed;
+            }
+
+            return (T)original(sp);
+        });
     }
 
     internal static IMessageStore BuildSqlServerMessageStore(


### PR DESCRIPTION
The Polecat slice of [#3001](https://github.com/JasperFx/wolverine/issues/3001), mirroring the Marten slice (#3003). When a handler falls back to service location, a service-located Polecat `IDocumentSession` / `IQuerySession` now resolves to the **same outbox-enrolled session** the handler is using — not a separate, un-enrolled one.

## How it works (mirror of #3003)
- **`ScopedDocumentSessionHolder`** + **`PrimeScopedDocumentSessionFrame`** for Polecat's `IDocumentSession`, registered via the **`WolverineOptions.ScopingFrameSources`** seam (from #3003) in `PolecatIntegration`.
- **`IntegrateWithWolverine`** decorates Polecat's own `IDocumentSession` / `IQuerySession` scoped registrations to prefer the primed session, delegating to Polecat's original factory for non-handler scopes.

**No core changes** — this slice purely reuses the registry introduced in #3003.

## Verification
- New `PolecatTests.service_location_document_session` proves one `IDocumentSession` flows through a service-located object graph (`ReferenceEquals`, SQL Server).
- **70** Polecat aggregate/outbox/read-aggregate/service-location tests pass; `dotnet build wolverine.slnx -c Release` clean.

## ⚠️ Stacked on #3003
Based on `feat-3001-marten-scope-priming` (#3003) because it depends on the `ScopingFrameSources` registry that lives there. **Merge #3002 → #3003 → this**, in order, to avoid the registry being absent. Once #3003 merges to main, this PR retargets to main.

## Remaining follow-ups
HTTP + gRPC chains; the ancillary-store matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)