### PR TITLE
Cascade messages returned from OnException middleware (supersedes #3000)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/OnExceptionTests.cs
+++ b/src/Http/Wolverine.Http.Tests/OnExceptionTests.cs
@@ -152,4 +152,23 @@ public class OnExceptionTests : IntegrationContext
         problem.ShouldNotBeNull();
         problem!.Title.ShouldBe("Global Error Handler");
     }
+
+    // PR #3000 regression: an HTTP-endpoint OnException with an *extra* injected parameter
+    // (the author's literal ILogger example) alongside the exception still resolves the
+    // parameter and returns its ProblemDetails response.
+    [Fact]
+    public async Task on_exception_with_extra_injected_parameter()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Get.Url("/on-exception/injected-parameter");
+            x.StatusCodeShouldBe(500);
+            x.ContentTypeShouldBe("application/problem+json");
+        });
+
+        var problem = await result.ReadAsJsonAsync<Microsoft.AspNetCore.Mvc.ProblemDetails>();
+        problem.ShouldNotBeNull();
+        problem!.Title.ShouldBe("Injected Parameter Error");
+        problem.Detail.ShouldBe("Injected parameter error");
+    }
 }

--- a/src/Http/WolverineWebApi/OnExceptionEndpoints.cs
+++ b/src/Http/WolverineWebApi/OnExceptionEndpoints.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Wolverine.Http;
 
 namespace WolverineWebApi;
@@ -197,6 +198,30 @@ public static class NoErrorEndpoints
 }
 
 #endregion
+
+// Probe (PR #3000 regression): does an HTTP-endpoint OnException support an *extra*
+// injected parameter alongside the exception (the author's literal ILogger example),
+// returning a ProblemDetails response?
+public static class InjectedParameterExceptionEndpoints
+{
+    [WolverineGet("/on-exception/injected-parameter")]
+    public static string EndpointThatThrowsForInjection()
+    {
+        throw new CustomHttpException("Injected parameter error");
+    }
+
+    public static ProblemDetails OnException(CustomHttpException ex,
+        ILogger<CustomHttpException> logger)
+    {
+        logger.LogError(ex, "Handled in OnException with an injected logger");
+        return new ProblemDetails
+        {
+            Status = 500,
+            Detail = ex.Message,
+            Title = "Injected Parameter Error"
+        };
+    }
+}
 
 #region sample_on_exception_void_return
 /// <summary>

--- a/src/Testing/CoreTests/Acceptance/on_exception_convention.cs
+++ b/src/Testing/CoreTests/Acceptance/on_exception_convention.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Shouldly;
 using Wolverine.Attributes;
 using Wolverine.ComplianceTests;
@@ -106,6 +107,123 @@ public class on_exception_convention
         await host.StopAsync();
 
         recorder.Actions.ShouldContain("MiddlewareOnException:middleware test");
+    }
+
+    [Fact]
+    public async Task non_static_middleware_on_exception_with_constructor_injection()
+    {
+        var recorder = new OnExceptionRecorder();
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(recorder);
+                opts.Discovery.IncludeType(typeof(MessageForInstanceMiddlewareHandler));
+                opts.Policies.AddMiddleware(typeof(InstanceOnExceptionMiddleware));
+            }).StartAsync();
+
+        await host.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .PublishMessageAndWaitAsync(new MessageForInstanceMiddleware("ctor inject test"));
+
+        foreach (var action in recorder.Actions) _output.WriteLine($"\"{action}\"");
+
+        await host.StopAsync();
+
+        recorder.Actions.ShouldContain("InstanceMiddlewareOnException:ctor inject test");
+    }
+
+    [Fact]
+    public async Task middleware_with_ilogger_injection()
+    {
+        var recorder = new OnExceptionRecorder();
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(recorder);
+                opts.Discovery.IncludeType(typeof(MessageForLoggerMiddlewareHandler));
+                opts.Policies.AddMiddleware(typeof(LoggerOnExceptionMiddleware));
+            }).StartAsync();
+
+        await host.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .PublishMessageAndWaitAsync(new MessageForLoggerMiddleware("logger test"));
+
+        foreach (var action in recorder.Actions) _output.WriteLine($"\"{action}\"");
+
+        await host.StopAsync();
+
+        recorder.Actions.ShouldContain("LoggerOnException:logger test");
+    }
+
+    [Fact]
+    public async Task static_middleware_on_exception_with_additional_injected_parameters()
+    {
+        var recorder = new OnExceptionRecorder();
+        var probe = new StaticMiddlewareDependencyProbe();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(recorder);
+                opts.Services.AddSingleton(probe);
+                opts.Discovery.IncludeType(typeof(MessageForStaticMiddlewareDependencyHandler));
+                opts.Policies.AddMiddleware(typeof(StaticMiddlewareWithDependencyOnException));
+            }).StartAsync();
+
+        await host.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .PublishMessageAndWaitAsync(new MessageForStaticMiddlewareDependency("static dependency test"));
+
+        foreach (var action in recorder.Actions) _output.WriteLine($"\"{action}\"");
+
+        await host.StopAsync();
+
+        recorder.Actions.ShouldContain("StaticDependencyOnException:static dependency test");
+        probe.WasCalled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task non_static_middleware_with_before_and_on_exception()
+    {
+        var recorder = new OnExceptionRecorder();
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(recorder);
+                opts.Discovery.IncludeType(typeof(MessageForBeforeAndOnExceptionHandler));
+                opts.Policies.AddMiddleware(typeof(BeforeAndOnExceptionMiddleware));
+            }).StartAsync();
+
+        await host.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .PublishMessageAndWaitAsync(new MessageForBeforeAndOnException("before+onexception test"));
+
+        foreach (var action in recorder.Actions) _output.WriteLine($"\"{action}\"");
+
+        await host.StopAsync();
+
+        recorder.Actions.ShouldContain("BeforeMiddleware:before+onexception test");
+        recorder.Actions.ShouldContain("BeforeAndOnExceptionMiddleware:before+onexception test");
+    }
+
+    [Fact]
+    public async Task non_static_middleware_shares_instance_state_between_before_and_on_exception()
+    {
+        var recorder = new OnExceptionRecorder();
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(recorder);
+                opts.Discovery.IncludeType(typeof(MessageForSharedInstanceStateHandler));
+                opts.Policies.AddMiddleware(typeof(SharedInstanceStateMiddleware));
+            }).StartAsync();
+
+        await host.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .PublishMessageAndWaitAsync(new MessageForSharedInstanceState("shared state"));
+
+        foreach (var action in recorder.Actions) _output.WriteLine($"\"{action}\"");
+
+        await host.StopAsync();
+
+        // The SAME middleware instance must be used for Before and OnException, so the state set in
+        // Before is visible in OnException. A fresh catch-block instance would record "<lost>".
+        recorder.Actions.ShouldContain("SharedState:shared state");
     }
 }
 
@@ -218,5 +336,161 @@ public static class GlobalOnExceptionMiddleware
     public static void OnException(TestAppException ex, OnExceptionRecorder recorder)
     {
         recorder.Actions.Add($"MiddlewareOnException:{ex.Message}");
+    }
+}
+
+// Support types for the instance middleware ctor-injection test
+public record MessageForInstanceMiddleware(string Text);
+
+public static class MessageForInstanceMiddlewareHandler
+{
+    public static void Handle(MessageForInstanceMiddleware message, OnExceptionRecorder recorder)
+    {
+        throw new TestAppException(message.Text);
+    }
+}
+
+/// <summary>
+/// Non-static middleware whose dependency (OnExceptionRecorder) is injected via the constructor.
+/// Exercises constructor-injection support for OnException handlers.
+/// </summary>
+public class InstanceOnExceptionMiddleware
+{
+    private readonly OnExceptionRecorder _recorder;
+
+    public InstanceOnExceptionMiddleware(OnExceptionRecorder recorder)
+    {
+        _recorder = recorder;
+    }
+
+    public void OnException(TestAppException ex)
+    {
+        _recorder.Actions.Add($"InstanceMiddlewareOnException:{ex.Message}");
+    }
+}
+
+// Support types for the ILogger injection test
+public record MessageForLoggerMiddleware(string Text);
+
+public static class MessageForLoggerMiddlewareHandler
+{
+    public static void Handle(MessageForLoggerMiddleware message, OnExceptionRecorder recorder)
+    {
+        throw new TestAppException(message.Text);
+    }
+}
+
+/// <summary>
+/// Middleware that receives an ILogger via constructor injection and an OnExceptionRecorder
+/// via the OnException parameter list — mirrors the documented usage example.
+/// </summary>
+public class LoggerOnExceptionMiddleware
+{
+    private readonly ILogger<LoggerOnExceptionMiddleware> _logger;
+
+    public LoggerOnExceptionMiddleware(ILogger<LoggerOnExceptionMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    public void OnException(TestAppException ex, OnExceptionRecorder recorder)
+    {
+        _logger.LogError(ex, "Unhandled exception in message handler: {Message}", ex.Message);
+        recorder.Actions.Add($"LoggerOnException:{ex.Message}");
+    }
+}
+
+public record MessageForStaticMiddlewareDependency(string Text);
+
+public static class MessageForStaticMiddlewareDependencyHandler
+{
+    public static void Handle(MessageForStaticMiddlewareDependency message, OnExceptionRecorder recorder)
+    {
+        throw new TestAppException(message.Text);
+    }
+}
+
+public class StaticMiddlewareDependencyProbe
+{
+    public bool WasCalled { get; set; }
+}
+
+public static class StaticMiddlewareWithDependencyOnException
+{
+    public static void OnException(TestAppException ex, StaticMiddlewareDependencyProbe probe, OnExceptionRecorder recorder)
+    {
+        probe.WasCalled = true;
+        recorder.Actions.Add($"StaticDependencyOnException:{ex.Message}");
+    }
+}
+
+// Support types for the Before + OnException test (exercises the "move existing ConstructorFrame" path)
+public record MessageForBeforeAndOnException(string Text);
+
+public static class MessageForBeforeAndOnExceptionHandler
+{
+    public static void Handle(MessageForBeforeAndOnException message, OnExceptionRecorder recorder)
+    {
+        throw new TestAppException(message.Text);
+    }
+}
+
+/// <summary>
+/// Non-static middleware that has BOTH a Before method and an OnException method.
+/// Exercises the code path where the existing ConstructorFrame (created by BuildBeforeCalls)
+/// is moved before TryCatchFinallyFrame so the same instance is reachable in catch blocks.
+/// </summary>
+public class BeforeAndOnExceptionMiddleware
+{
+    private readonly OnExceptionRecorder _recorder;
+
+    public BeforeAndOnExceptionMiddleware(OnExceptionRecorder recorder)
+    {
+        _recorder = recorder;
+    }
+
+    public void Before(MessageForBeforeAndOnException message)
+    {
+        _recorder.Actions.Add($"BeforeMiddleware:{message.Text}");
+    }
+
+    public void OnException(TestAppException ex)
+    {
+        _recorder.Actions.Add($"BeforeAndOnExceptionMiddleware:{ex.Message}");
+    }
+}
+
+// GH-3000 analysis: the genuine gap the PR targets — INSTANCE STATE set in Before and read in
+// OnException requires the SAME middleware instance in both. On main the catch block constructs a
+// fresh instance, so the state is lost. This test should FAIL on main and pass with the fix.
+public record MessageForSharedInstanceState(string Text);
+
+public static class MessageForSharedInstanceStateHandler
+{
+    public static void Handle(MessageForSharedInstanceState message, OnExceptionRecorder recorder)
+    {
+        throw new TestAppException(message.Text);
+    }
+}
+
+public class SharedInstanceStateMiddleware
+{
+    private readonly OnExceptionRecorder _recorder;
+    private string? _stateFromBefore;
+
+    public SharedInstanceStateMiddleware(OnExceptionRecorder recorder)
+    {
+        _recorder = recorder;
+    }
+
+    public void Before(MessageForSharedInstanceState message)
+    {
+        _stateFromBefore = message.Text;
+    }
+
+    public void OnException(TestAppException ex)
+    {
+        // If a fresh instance was constructed for the catch block, _stateFromBefore is null.
+        _recorder.Actions.Add($"SharedState:{_stateFromBefore ?? "<lost>"}");
     }
 }

--- a/src/Testing/CoreTests/Acceptance/on_exception_convention.cs
+++ b/src/Testing/CoreTests/Acceptance/on_exception_convention.cs
@@ -225,6 +225,57 @@ public class on_exception_convention
         // Before is visible in OnException. A fresh catch-block instance would record "<lost>".
         recorder.Actions.ShouldContain("SharedState:shared state");
     }
+
+    [Fact]
+    public async Task static_on_exception_return_value_is_cascaded()
+    {
+        var recorder = new OnExceptionRecorder();
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(recorder);
+                opts.Discovery.IncludeType(typeof(MessageForReturningOnExceptionHandler));
+                opts.Discovery.IncludeType(typeof(CascadedFromOnExceptionHandler));
+                opts.Policies.AddMiddleware(typeof(ReturningOnExceptionMiddleware));
+            }).StartAsync();
+
+        var session = await host.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .PublishMessageAndWaitAsync(new MessageForReturningOnException("ret"));
+
+        foreach (var action in recorder.Actions) _output.WriteLine($"\"{action}\"");
+        await host.StopAsync();
+
+        recorder.Actions.ShouldContain("ReturningOnException:ret");
+        // The message RETURNED from OnException must be cascaded/published.
+        session.Sent.SingleEnvelope<CascadedFromOnException>().Message
+            .ShouldBeOfType<CascadedFromOnException>()
+            .Text.ShouldBe("cascaded:ret");
+    }
+
+    [Fact]
+    public async Task instance_on_exception_return_value_is_cascaded()
+    {
+        var recorder = new OnExceptionRecorder();
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(recorder);
+                opts.Discovery.IncludeType(typeof(MessageForInstanceReturningOnExceptionHandler));
+                opts.Discovery.IncludeType(typeof(CascadedFromOnExceptionHandler));
+                opts.Policies.AddMiddleware(typeof(InstanceReturningOnExceptionMiddleware));
+            }).StartAsync();
+
+        var session = await host.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .PublishMessageAndWaitAsync(new MessageForInstanceReturningOnException("ret"));
+
+        foreach (var action in recorder.Actions) _output.WriteLine($"\"{action}\"");
+        await host.StopAsync();
+
+        recorder.Actions.ShouldContain("InstanceReturningOnException:ret");
+        session.Sent.SingleEnvelope<CascadedFromOnException>().Message
+            .ShouldBeOfType<CascadedFromOnException>()
+            .Text.ShouldBe("instance-cascaded:ret");
+    }
 }
 
 // Support types
@@ -492,5 +543,59 @@ public class SharedInstanceStateMiddleware
     {
         // If a fresh instance was constructed for the catch block, _stateFromBefore is null.
         _recorder.Actions.Add($"SharedState:{_stateFromBefore ?? "<lost>"}");
+    }
+}
+
+// GH-3000 return-value probe: does an OnException that RETURNS a cascading message actually publish
+// it? (The author's goal returns a value from OnException.) Static + extra-param variant.
+public record MessageForReturningOnException(string Text);
+public record CascadedFromOnException(string Text);
+
+// Local handler so the cascaded message has a route and is tracked/delivered.
+public static class CascadedFromOnExceptionHandler
+{
+    public static void Handle(CascadedFromOnException message, OnExceptionRecorder recorder)
+    {
+        recorder.Actions.Add($"Handled:{message.Text}");
+    }
+}
+
+public static class MessageForReturningOnExceptionHandler
+{
+    public static void Handle(MessageForReturningOnException message, OnExceptionRecorder recorder)
+    {
+        throw new TestAppException(message.Text);
+    }
+}
+
+public static class ReturningOnExceptionMiddleware
+{
+    public static CascadedFromOnException OnException(TestAppException ex, OnExceptionRecorder recorder)
+    {
+        recorder.Actions.Add($"ReturningOnException:{ex.Message}");
+        return new CascadedFromOnException($"cascaded:{ex.Message}");
+    }
+}
+
+// Non-static + ctor-injected variant returning a cascading message.
+public record MessageForInstanceReturningOnException(string Text);
+
+public static class MessageForInstanceReturningOnExceptionHandler
+{
+    public static void Handle(MessageForInstanceReturningOnException message, OnExceptionRecorder recorder)
+    {
+        throw new TestAppException(message.Text);
+    }
+}
+
+public class InstanceReturningOnExceptionMiddleware
+{
+    private readonly OnExceptionRecorder _recorder;
+    public InstanceReturningOnExceptionMiddleware(OnExceptionRecorder recorder) => _recorder = recorder;
+
+    public CascadedFromOnException OnException(TestAppException ex)
+    {
+        _recorder.Actions.Add($"InstanceReturningOnException:{ex.Message}");
+        return new CascadedFromOnException($"instance-cascaded:{ex.Message}");
     }
 }

--- a/src/Wolverine/Middleware/MiddlewarePolicy.cs
+++ b/src/Wolverine/Middleware/MiddlewarePolicy.cs
@@ -123,16 +123,22 @@ public class MiddlewarePolicy : IChainPolicy
         {
             var frames = new List<Frame> { call };
 
-            // Handle return values from OnException methods — same as Before methods
-            var outgoings = call.Creates.Where(x => x.VariableType == typeof(OutgoingMessages)).ToArray();
-            foreach (var outgoing in outgoings)
-            {
-                frames.Add(new CaptureCascadingMessages(outgoing));
-            }
-
+            // A continuation strategy (IResult, HandlerContinuation, HTTP ProblemDetails response, ...)
+            // gets first claim on the return value. If one claims it, that frame *is* the handling of
+            // the return value and we must not also cascade it as a message.
             if (rules.TryFindContinuationHandler(chain, call, out var continuation))
             {
                 frames.Add(continuation!);
+            }
+            else if (call.ReturnVariable != null)
+            {
+                // Otherwise a value returned from OnException is published as a cascading message,
+                // mirroring the return-value semantics of handler methods (GH-3000). void/Task returns
+                // have no ReturnVariable; EnqueueCascadingAsync unwraps OutgoingMessages/IEnumerable too.
+                // Must be the catch-safe frame: CaptureCascadingMessages is a MethodCall whose
+                // FindVariables would expose the dependency on the OnException call's return variable,
+                // making the arranger pre-link the catch frames and collide with TryCatchFinallyFrame.
+                frames.Add(new CaptureCascadingMessagesInCatch(call.ReturnVariable));
             }
 
             tryCatchFinally.AddCatchBlock(exceptionType, frames.ToArray());

--- a/src/Wolverine/Runtime/Handlers/CaptureCascadingMessages.cs
+++ b/src/Wolverine/Runtime/Handlers/CaptureCascadingMessages.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
@@ -24,5 +25,44 @@ public class CaptureCascadingMessages : MethodCall
     {
         Arguments[0] = messages;
         CommentText = "Outgoing, cascaded message";
+    }
+}
+
+/// <summary>
+/// Publishes a value produced inside a try/catch catch block — e.g. a message (or OutgoingMessages,
+/// or IEnumerable of messages) returned from an OnException middleware method — as a cascading message.
+/// </summary>
+/// <remarks>
+/// This mirrors <see cref="CaptureCascadingMessages"/> but, like the HTTP ProblemDetails catch frame,
+/// deliberately does NOT yield the captured variable from <see cref="FindVariables"/>. That variable is
+/// created by an earlier frame in the same catch block (the OnException call); exposing the dependency
+/// would make the code-gen arranger pre-link the two frames' <c>Next</c> pointers, which then collides
+/// with <see cref="Wolverine.Middleware.TryCatchFinallyFrame"/>'s own manual chaining and throws
+/// "Frame chain is being re-arranged". <see cref="MessageContext.EnqueueCascadingAsync"/> already
+/// unwraps OutgoingMessages and IEnumerable internally, so a single frame covers every return shape.
+/// </remarks>
+internal sealed class CaptureCascadingMessagesInCatch : AsyncFrame
+{
+    private readonly Variable _cascaded;
+    private Variable? _context;
+
+    public CaptureCascadingMessagesInCatch(Variable cascaded)
+    {
+        _cascaded = cascaded;
+        uses.Add(cascaded);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _context = chain.FindVariable(typeof(MessageContext));
+        yield return _context;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment("Cascade the message returned from the exception handler");
+        writer.Write(
+            $"await {_context!.Usage}.{nameof(MessageContext.EnqueueCascadingAsync)}({_cascaded.Usage}).ConfigureAwait(false);");
+        Next?.GenerateCode(method, writer);
     }
 }


### PR DESCRIPTION
Supersedes #3000 (credit retained: co-authored with @danielwinkler).

## What #3000 set out to fix already works on `main`
Starting from #3000, I reproduced its scenarios as tests on a fresh branch. All of them pass **without** the PR's change:

- non-static `OnException` middleware with constructor injection
- `ILogger` constructor injection
- static middleware with extra injected parameters
- non-static `Before` + `OnException` sharing instance state (added a stronger test asserting the *same instance's* field set in `Before` is visible in `OnException`)

So a test in #3000 cannot fail without #3000's own code, and its `BuildConstructorFrame()` duplication (author-flagged "keep in sync") addresses a problem that isn't present. HTTP has no gap either — a probe with `OnException(CustomHttpException, ILogger<…>) => ProblemDetails` (the original ILogger example) passes.

## The real, unaddressed gap (fixed here)
A value **returned** from an `OnException` method was silently dropped instead of being published as a cascading message — unlike a handler method's return value. Neither `main` nor #3000 handled this.

`MiddlewarePolicy.ApplyExceptionHandling` now cascades the `OnException` return value when no continuation strategy (`IResult` / `HandlerContinuation` / HTTP `ProblemDetails`) claims it. `EnqueueCascadingAsync` already unwraps `OutgoingMessages`/`IEnumerable`, so one path covers every return shape.

### Codegen note
The cascade uses a **catch-safe** frame. `CaptureCascadingMessages` is a `MethodCall` whose `FindVariables` exposes its dependency on the `OnException` call's return variable, which makes the codegen arranger pre-link the catch frames' `Next` pointers and collide with `TryCatchFinallyFrame`'s manual chaining (`"Frame chain is being re-arranged"`). The new `CaptureCascadingMessagesInCatch` mirrors the HTTP ProblemDetails catch frame: it takes the variable in its ctor but does not yield it from `FindVariables`. (The pre-existing `OutgoingMessages`-from-`OnException` path had the same latent bug, now also covered.)

## Tests (kept as regression regardless)
- **CoreTests** `on_exception_convention` — ported #3000 scenarios + shared-instance-state test + static/instance `OnException`-return-value-cascaded tests (13 total).
- **HTTP** `OnExceptionTests` — extra-injected-parameter (`ILogger`) probe.

Full `wolverine.slnx` Release build clean (0 warnings / 0 errors); broader middleware/exception suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)