### PR TITLE
Promote Mode + IsListener to typed EndpointDescriptor fields; drop redundant Http Sets.Routes (#3009)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/http_capability_descriptor_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/http_capability_descriptor_tests.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.Configuration.Capabilities;
+using Xunit;
+
+namespace Wolverine.Http.Tests;
+
+public class http_capability_descriptor_tests : IntegrationContext
+{
+    public http_capability_descriptor_tests(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public void does_not_emit_the_redundant_routes_set()
+    {
+        // Precondition: the app really does have routes, so the dropped "Routes" set
+        // would otherwise have been populated — this proves the assertion has teeth.
+        HttpChains.Chains.ShouldNotBeEmpty();
+
+        var description = Host.Services.GetServices<ICapabilityDescriptor>()
+            .Select(x => x.Describe())
+            .Single(x => x.Subject == "Wolverine.Http");
+
+        // GH-3009: the per-route "Routes" set (~96 KB on a Topicus-scale graph) is dropped —
+        // it was fully redundant with HttpGraphs[*].Chains, which the SPA already reads.
+        description.Sets.ContainsKey("Routes").ShouldBeFalse();
+
+        // ...but the small core capability content is unaffected.
+        description.Tags.ShouldContain("http");
+        description.Properties.ShouldContain(x => x.Name == nameof(WolverineHttpOptions.WarmUpRoutes));
+    }
+}

--- a/src/Http/Wolverine.Http/HttpCapabilityDescriptor.cs
+++ b/src/Http/Wolverine.Http/HttpCapabilityDescriptor.cs
@@ -1,8 +1,5 @@
-using JasperFx.Core;
-using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
 using Wolverine.Configuration.Capabilities;
-using Wolverine.Http.CodeGen;
 
 namespace Wolverine.Http;
 
@@ -31,28 +28,10 @@ public class HttpCapabilityDescriptor : ICapabilityDescriptor
         description.AddValue(nameof(_options.WarmUpRoutes), _options.WarmUpRoutes);
         description.AddValue(nameof(_options.ServiceProviderSource), _options.ServiceProviderSource);
 
-        var endpoints = _options.Endpoints;
-        if (endpoints != null)
-        {
-            var routeSet = description.AddChildSet("Routes");
-            routeSet.SummaryColumns = ["HttpMethods", "Route", "Endpoint"];
-
-            foreach (var chain in endpoints.Chains.OrderBy(c => c.RoutePattern?.RawText ?? string.Empty))
-            {
-                var routeDescription = new OptionsDescription
-                {
-                    Subject = chain.RoutePattern?.RawText ?? string.Empty,
-                    Title = chain.RoutePattern?.RawText ?? string.Empty
-                };
-
-                routeDescription.AddValue("HttpMethods", chain.HttpMethods.Join(", "));
-                routeDescription.AddValue("Route", chain.RoutePattern?.RawText ?? string.Empty);
-                routeDescription.AddValue("Endpoint",
-                    $"{chain.Method.HandlerType.FullNameInCode()}.{chain.Method.Method.Name}");
-
-                routeSet.Rows.Add(routeDescription);
-            }
-        }
+        // Intentionally no "Routes" child set (GH-3009): it summarized every route
+        // (~96 KB on a Topicus-scale graph) and was fully redundant with
+        // HttpGraphs[*].Chains, which the SPA already reads. The Sets collection on
+        // this capability has no other consumer.
 
         return description;
     }

--- a/src/Testing/CoreTests/Configuration/endpoint_descriptor_mode_tests.cs
+++ b/src/Testing/CoreTests/Configuration/endpoint_descriptor_mode_tests.cs
@@ -1,0 +1,63 @@
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Transports.Local;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+/// <summary>
+/// Locks down GH-3009: <see cref="Endpoint.Mode"/> and <see cref="Endpoint.IsListener"/>
+/// are lifted onto <see cref="EndpointDescriptor"/> as first-class typed fields (the same
+/// shape as BrokerRole / EndpointRole), and the duplicate generic Properties rows the base
+/// OptionsDescription ctor reflects off the Endpoint are dropped so the payload doesn't
+/// ship them twice. CritterWatch reads the typed fields at the service-overview level.
+/// </summary>
+public class endpoint_descriptor_mode_tests
+{
+    [Fact]
+    public void lifts_mode_and_is_listener_as_typed_fields()
+    {
+        var queue = new LocalQueue("queue-mode")
+        {
+            Mode = EndpointMode.Durable,
+            IsListener = true
+        };
+
+        var descriptor = new EndpointDescriptor(queue);
+
+        descriptor.Mode.ShouldBe(EndpointMode.Durable);
+        descriptor.IsListener.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void reflects_buffered_and_non_listener_values()
+    {
+        var queue = new LocalQueue("queue-buffered")
+        {
+            Mode = EndpointMode.BufferedInMemory,
+            IsListener = false
+        };
+
+        var descriptor = new EndpointDescriptor(queue);
+
+        descriptor.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+        descriptor.IsListener.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void does_not_duplicate_mode_and_is_listener_in_properties()
+    {
+        var queue = new LocalQueue("queue-no-dupes")
+        {
+            Mode = EndpointMode.Durable,
+            IsListener = true
+        };
+
+        var descriptor = new EndpointDescriptor(queue);
+
+        // Promoted to typed fields — the generic Properties rows must be gone so we don't double-ship.
+        descriptor.Properties.ShouldNotContain(x => x.Name == nameof(Endpoint.Mode));
+        descriptor.Properties.ShouldNotContain(x => x.Name == nameof(Endpoint.IsListener));
+    }
+}

--- a/src/Wolverine/Configuration/Capabilities/EndpointDescriptor.cs
+++ b/src/Wolverine/Configuration/Capabilities/EndpointDescriptor.cs
@@ -40,6 +40,14 @@ public class EndpointDescriptor : OptionsDescription
                         || endpoint.Uri?.Scheme.Equals("local", StringComparison.OrdinalIgnoreCase) == true;
         EndpointRole = endpoint.Role;
         BrokerRole = endpoint.BrokerRole;
+        Mode = endpoint.Mode;
+        IsListener = endpoint.IsListener;
+
+        // Mode and IsListener are now first-class typed fields (GH-3009). Drop the generic
+        // OptionsDescription rows the base ctor reflected off the Endpoint so we don't ship
+        // them twice — CritterWatch reads the typed fields at the service-overview level, and
+        // Properties is becoming lazy-fetchable downstream.
+        Properties.RemoveAll(x => x.Name is nameof(Endpoint.Mode) or nameof(Endpoint.IsListener));
     }
 
     public Uri Uri { get; set; } = null!;
@@ -95,6 +103,22 @@ public class EndpointDescriptor : OptionsDescription
     /// mapping. See GH-2601.
     /// </summary>
     public string? BrokerRole { get; init; }
+
+    /// <summary>
+    /// How this endpoint processes messages — <c>Durable</c> (persistence-backed inbox/outbox),
+    /// <c>BufferedInMemory</c>, or <c>Inline</c>. Lifted from <see cref="Endpoint.Mode"/> into a
+    /// first-class typed field (GH-3009) so CritterWatch and other UIs can read it at the
+    /// service-overview level without walking <see cref="OptionsDescription.Properties"/>.
+    /// </summary>
+    public EndpointMode Mode { get; init; }
+
+    /// <summary>
+    /// Whether this endpoint is actively listening for (receiving) messages. Lifted from
+    /// <see cref="Endpoint.IsListener"/> into a first-class typed field (GH-3009) so monitoring
+    /// tools can read it at the service-overview level without walking
+    /// <see cref="OptionsDescription.Properties"/>.
+    /// </summary>
+    public bool IsListener { get; init; }
 
     internal static string? ResolveInteropMode(Endpoint endpoint)
     {


### PR DESCRIPTION
Closes #3009.

Two payload-shrink changes on the `ServiceCapabilities` snapshot, building on the HTTP descriptor cleanup in jasperfx#411 / #3008.

## 1. `Mode` + `IsListener` → typed fields on `EndpointDescriptor`
Today these ride along as generic `OptionsDescription` rows under `EndpointDescriptor.Properties`. CritterWatch consumes both at the **service-overview** level, so they can't simply ride along once `Properties` becomes lazy-fetchable downstream.

- Added `Mode` (`EndpointMode`) and `IsListener` (`bool`) as first-class typed properties, lifted from the underlying `Endpoint` — same shape as the existing `BrokerRole` / `EndpointRole` / `TransportType` / `SerializerType` fields.
- Drop the duplicate `Mode` / `IsListener` rows from the `Properties` enumeration (the base `OptionsDescription` ctor reflects them off the `Endpoint`) so we don't double-ship.

## 2. Drop `Sets.Routes` from the `Wolverine.Http` capability
`HttpCapabilityDescriptor` no longer emits the per-route `Routes` child set (**~96 KB on a Topicus-scale graph**). It was fully redundant with `HttpGraphs[*].Chains`, which the SPA already reads; the `Sets` collection on this capability has no other consumer. The remaining `Properties` / `Tags` on the entry are tiny and unaffected.

## Tests
- **CoreTests** `endpoint_descriptor_mode_tests` — typed fields populated from the endpoint (`Durable`/listener and `BufferedInMemory`/non-listener), and no duplicate `Mode`/`IsListener` rows left in `Properties`.
- **Http** `http_capability_descriptor_tests` — against the real WolverineWebApi host (which has routes, so the old `Routes` set *would* have been populated): asserts no `Routes` set, with the core capability content (`http` tag, `WarmUpRoutes`) intact.

Full `wolverine.slnx` Release build clean (0 warnings / 0 errors); adjacent descriptor/capability suite (61 tests) green.

## Payload impact
- `Sets.Routes` drop: ~96 KB raw.
- Typed `Mode`/`IsListener` unblocks the CritterWatch follow-up that makes `MessagingEndpoints[].Properties`/`Children` lazy-fetchable: ~570 KB raw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)