### PR TITLE
Drop HttpChainDescriptor pipeline-introspection fields; bump JasperFx 2.8.0 + Marten 9.4.0 (#3008)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,19 +32,19 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.4.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.4.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.4.1" />
+    <PackageVersion Include="JasperFx" Version="2.8.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.8.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.8.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.4.1" />
-    <PackageVersion Include="Marten" Version="9.2.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.8.0" />
+    <PackageVersion Include="Marten" Version="9.4.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.2.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.2.0" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.2.0" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.4.0" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.4.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />
@@ -114,13 +114,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.0.1" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.1" />
-    <PackageVersion Include="Weasel.MySql" Version="9.0.1" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.0.1" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.1" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.0.1" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.0.1" />
+    <PackageVersion Include="Weasel.Core" Version="9.0.2" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.2" />
+    <PackageVersion Include="Weasel.MySql" Version="9.0.2" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.0.2" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.0.2" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.0.2" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.0.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/Http/Wolverine.Http/Diagnostics/HttpGraphUsageSource.cs
+++ b/src/Http/Wolverine.Http/Diagnostics/HttpGraphUsageSource.cs
@@ -1,7 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
 using JasperFx;
-using JasperFx.CodeGeneration.Frames;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
@@ -101,7 +100,7 @@ internal sealed class HttpGraphUsageSource : IHttpGraphUsageSource
         foreach (var group in collapsed.OrderBy(g => g.Key.RawText))
         {
             var primary = group.First();
-            var descriptor = buildChainDescriptor(primary, group.ToArray(), apiDescriptions, services);
+            var descriptor = buildChainDescriptor(primary, group.ToArray(), apiDescriptions);
             usage.Chains.Add(descriptor);
         }
 
@@ -131,8 +130,7 @@ internal sealed class HttpGraphUsageSource : IHttpGraphUsageSource
     private HttpChainDescriptor buildChainDescriptor(
         HttpChain chain,
         HttpChain[] versionGroup,
-        IApiDescriptionGroupCollectionProvider? apiDescriptions,
-        IServiceProvider services)
+        IApiDescriptionGroupCollectionProvider? apiDescriptions)
     {
         var route = chain.RoutePattern!.RawText ?? string.Empty;
         var methods = chain.HttpMethods.ToList();
@@ -184,11 +182,10 @@ internal sealed class HttpGraphUsageSource : IHttpGraphUsageSource
             .ToArray();
         descriptor.CascadingMessageTypes = cascading.Select(TypeDescriptor.For).ToList();
 
-        // Service dependencies — surface what the chain resolves at runtime.
-        descriptor.ServiceDependencies = readServiceDependencies(chain, services);
-
-        descriptor.Middleware = describeFrames(chain.Middleware, "Middleware");
-        descriptor.Postprocessors = describeFrames(chain.Postprocessors, "Postprocessor");
+        // Pipeline-introspection fields (Middleware / Postprocessors / ServiceDependencies) are no
+        // longer populated (GH-3008 / jasperfx#411) — they were removed from HttpChainDescriptor. The
+        // CritterWatch Pipeline tab now points at the RequestHandlerSourceCode lazy fetch, which
+        // returns the actual compiled pipeline, so no operator-facing information is lost.
 
         // API version info. When versionGroup has >1 entries, this is a
         // collapsed multi-version chain; collect every version + sunset.
@@ -201,53 +198,6 @@ internal sealed class HttpGraphUsageSource : IHttpGraphUsageSource
         }
 
         return descriptor;
-    }
-
-    private List<TypeDescriptor> readServiceDependencies(HttpChain chain, IServiceProvider services)
-    {
-        try
-        {
-            var container = services.GetService<IServiceContainer>();
-            if (container is null) return new List<TypeDescriptor>();
-
-            return chain
-                .ServiceDependencies(container, Type.EmptyTypes)
-                .Where(t => t != typeof(IServiceProvider))
-                .Distinct()
-                .Select(TypeDescriptor.For)
-                .ToList();
-        }
-        catch
-        {
-            return new List<TypeDescriptor>();
-        }
-    }
-
-    private static List<MiddlewareStepDescriptor> describeFrames(IEnumerable<Frame> frames, string kind)
-    {
-        var list = new List<MiddlewareStepDescriptor>();
-        foreach (var frame in frames)
-        {
-            var step = new MiddlewareStepDescriptor
-            {
-                Kind = kind,
-                Description = frame.ToString() ?? frame.GetType().FullNameInCode()
-            };
-
-            if (frame is MethodCall call)
-            {
-                step.TypeFullName = call.HandlerType.FullNameInCode();
-                step.MethodName = call.Method.Name;
-            }
-            else
-            {
-                step.TypeFullName = frame.GetType().FullNameInCode();
-            }
-
-            list.Add(step);
-        }
-
-        return list;
     }
 
     private static ApiVersionDescriptor? buildApiVersionDescriptor(HttpChain chain, HttpChain[] versionGroup)


### PR DESCRIPTION
Closes #3008. Producer side of the JasperFx descriptor cleanup (jasperfx#411).

## Status check first
Nothing for #3008 had landed on `main` (the population code + helpers were intact, JasperFx still 2.4.1). jasperfx#411 **is** now closed/shipped — but the property removal only exists in **JasperFx 2.8.0**, so the issue is *still open and was newly unblocked*, not closeable. The prescribed "bump JasperFx" therefore became a 2.4.1 → 2.8.0 jump coupled to the Marten family.

## Coordinated dependency bump
`HttpChainDescriptor.Middleware` / `ServiceDependencies` / `Postprocessors` (and `MiddlewareStepDescriptor`) are removed only in JasperFx 2.8.0 (still present in 2.5.0 / 2.6.x). So:
- **JasperFx family 2.4.1 → 2.8.0** (RuntimeCompiler stays on its 5.x line)
- **Marten family 9.2.0 → 9.4.0** — Marten 9.4.0's JasperFx floor is 2.5.0 (vs 9.2.0's 2.2.0), keeping the compiled-against vs runtime gap to 2.8.0 as small as published Marten allows
- **Weasel.\* 9.0.1 → 9.0.2** — required by Marten 9.4.0
- **Polecat stays 4.2.1** — floor 2.2.0, satisfied by 2.8.0

## Code change
In `HttpGraphUsageSource`: stop populating the three fields and delete the now-dead `describeFrames` / `readServiceDependencies` helpers (plus the now-unused `buildChainDescriptor` `services` parameter and the `JasperFx.CodeGeneration.Frames` using). Per the issue, the CritterWatch Pipeline tab moves to the existing `RequestHandlerSourceCode` lazy fetch, which returns the actual compiled pipeline — no operator-facing information is lost. `CascadingMessageTypes` (added in 2.8.0) is unaffected.

## Validation
- Full `wolverine.slnx` Release build clean (net9.0 + net10.0), 0 warnings / 0 errors — i.e. no test references the removed JasperFx members.
- **CoreTests 1735**, **MartenTests 461**, **Wolverine.Http.Tests 777**, **PolecatTests 216** — all green against the live infra. This exercises JasperFx 2.8.0 codegen, Marten 9.4.0 event-sourcing, and Polecat-on-2.8.0 runtime.

## Notes
- No dedicated test exists for `HttpGraphUsageSource`, and the descriptor fields are gone from the type, so there's nothing to assert-negative on the producer side.
- I did **not** bump the Wolverine package version — left for you as a release decision (the precedent Marten bump landed alongside a version bump in a release commit).
- Downstream CritterWatch follow-up (Pipeline-tab UI removal) is tracked separately per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)