### PR TITLE
Lock in custom-serializer-on-send guarantee (CritterWatch#261 H1 analysis)

### DIFF
--- a/src/Testing/CoreTests/Serialization/serialization_configuration.cs
+++ b/src/Testing/CoreTests/Serialization/serialization_configuration.cs
@@ -158,6 +158,70 @@ public class serialization_configuration
             .DefaultSerializer.ShouldBe(fooSerializer);
     }
 
+    [Fact]
+    public async Task custom_serializer_on_sender_is_used_to_produce_outgoing_envelopes()
+    {
+        // Regression for CritterWatch#261 (H1): a custom IMessageSerializer attached at the
+        // rule/endpoint level via .DefaultSerializer(...) must be the serializer that actually
+        // produces the outgoing envelope — and therefore the wire bytes — rather than being
+        // silently replaced by the global System.Text.Json default at Compile() time.
+        var custom = new RecordingSerializer();
+
+        using var host = await Host.CreateDefaultBuilder().UseWolverine(opts =>
+        {
+            opts.PublishMessage<CustomSerializedMessage>().To("stub://custom")
+                .DefaultSerializer(custom);
+
+            // Sibling sender with no override — must stay on the global STJ default.
+            opts.PublishMessage<CustomSerializedMessage>().To("stub://plain");
+        }).StartAsync();
+
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        var router = runtime.RoutingFor(typeof(CustomSerializedMessage));
+
+        var envelopes = router.RouteForSend(new CustomSerializedMessage("hi"), null);
+        envelopes.Length.ShouldBe(2);
+
+        // The route to the overridden endpoint carries the custom serializer + its content type.
+        var customEnvelope = envelopes.Single(e => ReferenceEquals(e.Serializer, custom));
+        customEnvelope.ContentType.ShouldBe("text/recording");
+
+        // ...and the wire payload is produced by that custom serializer, exactly as the sending
+        // agent does (envelope.Serializer.Write(envelope)).
+        customEnvelope.Serializer!.Write(customEnvelope).ShouldBe(RecordingSerializer.Sentinel);
+        custom.WriteCount.ShouldBeGreaterThan(0);
+
+        // Isolation: the un-overridden sibling endpoint still uses the global System.Text.Json default.
+        envelopes.ShouldContain(e => e.Serializer is SystemTextJsonSerializer);
+    }
+
+    public record CustomSerializedMessage(string Name);
+
+    // A custom serializer with a working Write so we can prove the *actual wire bytes* come from it.
+    public class RecordingSerializer : IMessageSerializer
+    {
+        public static readonly byte[] Sentinel = [9, 8, 7, 6];
+        public int WriteCount { get; private set; }
+
+        public string ContentType => "text/recording";
+
+        public byte[] WriteMessage(object message)
+        {
+            WriteCount++;
+            return Sentinel;
+        }
+
+        public byte[] Write(Envelope envelope)
+        {
+            WriteCount++;
+            return Sentinel;
+        }
+
+        public object ReadFromData(byte[] data) => throw new NotImplementedException();
+
+        public object ReadFromData(Type messageType, Envelope envelope) => throw new NotImplementedException();
+    }
+
     public class FooSerializer : IMessageSerializer
     {
         public string ContentType => "text/foo";


### PR DESCRIPTION
Pre-release verification for the H1 hypothesis in [CritterWatch#261](https://github.com/JasperFx/CritterWatch/issues/261#issuecomment-4606596734): *"Wolverine SQS endpoint not honoring the rule-level `DefaultSerializer`."*

## Conclusion: the framework honors custom serializers
Traced the send path end to end — the mechanism is sound, no production bug:

1. `x.To(uri).DefaultSerializer(custom)` → `SubscriberConfiguration` delays `e.DefaultSerializer = custom`, whose setter `RegisterSerializer(custom)`s it (keyed by `custom.ContentType`) and stores it on the **Endpoint**.
2. `Endpoint.Compile()` uses `DefaultSerializer ??= runtime.Options.DefaultSerializer` — so an endpoint-level custom serializer is **not** overwritten by the global STJ default.
3. `MessageRoute` captures `Serializer = endpoint.DefaultSerializer`, and `CreateForSending` sets `envelope.Serializer = Serializer` + `envelope.ContentType = Serializer.ContentType`. The sending agent then writes the wire bytes via `envelope.Serializer.Write(envelope)`.

So a custom `IMessageSerializer` (e.g. a Brotli-compressing one) **is** the serializer that produces the wire payload — provided the rule lands on the endpoint the message routes to.

### On the URI-mismatch sub-hypothesis (H2)
`AmazonSqsTransport.findEndpointByUri` falls back to `Queues[uri.OriginalString.Split("//")[1].TrimEnd('/')]`, so `sqs://critterwatch` and `sqs://critterwatch/` resolve to the **same** queue endpoint — the trailing-slash difference seen in the logs does not split the serializer onto a phantom endpoint at the framework level.

The #261 symptom is therefore most likely on the CritterWatch-extension / host-config side (H3 host-level `DefaultSerializer` override after `AddCritterWatchMonitoring`, H4 `Wolverine.CritterWatch 0.7.0` version regression, or H5 strip not running) — the diagnostic logging in that comment will localize it. Not a Wolverine framework defect.

## What this PR adds
The existing `serialization_configuration` tests only assert the serializer is *attached* to the endpoint. This adds a **send-path** regression test that routes a message through `runtime.RoutingFor(...).RouteForSend(...)` and asserts:
- the outgoing envelope for the overridden endpoint carries the custom serializer + its content type,
- `envelope.Serializer.Write(envelope)` is what produces the payload,
- a sibling endpoint with no override stays on the global `SystemTextJsonSerializer`.

No production code change — this locks in the guarantee so a future regression (e.g. a `Compile()` ordering change that lets the global default clobber an endpoint override) is caught. `serialization_configuration` suite green (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)