### PR TITLE
Fix 6.4.0 NRE on empty system envelope (BufferedReceiver + MoveToErrorQueue null guards); bump 6.4.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.4.0</Version>
+        <Version>6.4.1</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Testing/CoreTests/Runtime/MoveToErrorQueueTester.cs
+++ b/src/Testing/CoreTests/Runtime/MoveToErrorQueueTester.cs
@@ -70,4 +70,21 @@ public class MoveToErrorQueueTester
         theRuntime.MessageTracking.Received().MessageFailed(theEnvelope, theException);
         theRuntime.MessageTracking.Received().MovedToErrorQueue(theEnvelope, theException);
     }
+
+    [Fact]
+    public async Task does_not_NRE_when_envelope_has_no_destination()
+    {
+        // GH-3013: a malformed system envelope (no Destination) must not NRE on the
+        // `lifecycle.Envelope!.Destination!.Scheme` read before EnableAutomaticFailureAcks
+        // even gets a chance to short-circuit. Enabling acks reproduces the pre-fix bug.
+        theRuntime.Options.EnableAutomaticFailureAcks = true;
+        theEnvelope.Destination = null;
+
+        // A throw here fails the test — pre-fix this NRE'd at the `scheme` variable init.
+        await theContinuation.ExecuteAsync(theLifecycle, theRuntime, DateTimeOffset.Now, null);
+
+        // No scheme → no failure ack attempted, and the move-to-DLQ still happens.
+        await theLifecycle.DidNotReceive().SendFailureAcknowledgementAsync(Arg.Any<string>());
+        await theLifecycle.Received().MoveToDeadLetterQueueAsync(theException);
+    }
 }

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/buffered_receiver_null_listener_guard_3013.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/buffered_receiver_null_listener_guard_3013.cs
@@ -1,0 +1,97 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using JasperFx.Blocks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Wolverine;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports.Local;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+public class buffered_receiver_null_listener_guard_3013
+{
+    [Fact]
+    public async Task listenerless_envelope_does_not_NRE_in_defer_or_complete_blocks()
+    {
+        // GH-3013: the empty all-zero startup / agent-handshake envelope reaches the buffered
+        // receiver's defer/complete retry blocks with Listener == null. Pre-fix the unguarded
+        // env.Listener! deref NRE'd inside the retry loop; RetryBlock catches + logs it (and retries),
+        // so the failure surfaces only as logged errors that aggregate into tracked-session failures
+        // across the consumer's whole integration sweep — not as a thrown exception here.
+        var captor = new CapturingLoggerProvider();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.AddProvider(captor))
+            .UseWolverine(opts => { opts.LocalQueue("buffered-3013"); })
+            .StartAsync();
+
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        var endpoint = (LocalQueue?)runtime.Endpoints.EndpointByName("buffered-3013")
+                       ?? throw new InvalidOperationException("buffered-3013 not found");
+        var receiver = (BufferedReceiver)endpoint.Agent!;
+
+        captor.Errors.Clear(); // ignore anything logged during bootstrap
+
+        var deferBlock = retryBlock(receiver, "_deferBlock");
+        var completeBlock = retryBlock(receiver, "_completeBlock");
+
+        // The malformed system envelope: no Listener, no Destination.
+        var empty = new Envelope();
+
+        await deferBlock.PostAsync(empty);
+        await completeBlock.PostAsync(empty);
+        await deferBlock.DrainAsync();
+        await completeBlock.DrainAsync();
+
+        captor.Errors.ShouldNotContain(e => e is NullReferenceException);
+    }
+
+    private static RetryBlock<Envelope> retryBlock(BufferedReceiver receiver, string field)
+    {
+        var info = typeof(BufferedReceiver).GetField(field, BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (RetryBlock<Envelope>)info.GetValue(receiver)!;
+    }
+}
+
+/// <summary>
+/// Minimal <see cref="ILoggerProvider"/> that records the exceptions passed to any log call,
+/// so a test can assert no <see cref="NullReferenceException"/> was logged (the GH-3013 symptom,
+/// which <c>RetryBlock</c> swallows and logs rather than re-throwing).
+/// </summary>
+public sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    public ConcurrentBag<Exception> Errors { get; } = new();
+
+    public ILogger CreateLogger(string categoryName) => new CapturingLogger(Errors);
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class CapturingLogger(ConcurrentBag<Exception> errors) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (exception != null)
+            {
+                errors.Add(exception);
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/Wolverine/ErrorHandling/MoveToErrorQueue.cs
+++ b/src/Wolverine/ErrorHandling/MoveToErrorQueue.cs
@@ -30,8 +30,11 @@ internal class MoveToErrorQueue : IContinuation
         DateTimeOffset now, Activity? activity)
     {
         // TODO -- at some point, we need a more systematic way of doing this
-        var scheme = lifecycle.Envelope!.Destination!.Scheme;
-        if (runtime.Options.EnableAutomaticFailureAcks && scheme != TransportConstants.Local && scheme != "external-table")
+        // Defensive: a malformed system envelope (no Destination) shouldn't NRE here before
+        // EnableAutomaticFailureAcks even gets a chance to short-circuit. The envelope itself is
+        // always present (the block below already relies on it); only Destination can be null. GH-3013.
+        var scheme = lifecycle.Envelope!.Destination?.Scheme;
+        if (scheme is not null && runtime.Options.EnableAutomaticFailureAcks && scheme != TransportConstants.Local && scheme != "external-table")
         {
             await lifecycle.SendFailureAcknowledgementAsync(
                 $"Moved message {lifecycle.Envelope!.Id} to the Error Queue.\n{Exception}");

--- a/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
@@ -38,9 +38,14 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
 
         _scheduler = new InMemoryScheduledJobProcessor(this, _logger);
 
-        _deferBlock = new RetryBlock<Envelope>((env, _) => env.Listener!.DeferAsync(env).AsTask(), runtime.Logger,
+        // Guard against a listener-less envelope (e.g. the empty all-zero system/agent-handshake
+        // envelope produced during startup) reaching either retry block — env.Listener is null in
+        // that case, and an unguarded deref NREs into the retry loop. GH-3013.
+        _deferBlock = new RetryBlock<Envelope>(
+            (env, _) => env.Listener is { } l ? l.DeferAsync(env).AsTask() : Task.CompletedTask, runtime.Logger,
             runtime.Cancellation);
-        _completeBlock = new RetryBlock<Envelope>((env, _) => env.Listener!.CompleteAsync(env).AsTask(), runtime.Logger,
+        _completeBlock = new RetryBlock<Envelope>(
+            (env, _) => env.Listener is { } l ? l.CompleteAsync(env).AsTask() : Task.CompletedTask, runtime.Logger,
             runtime.Cancellation);
 
         _receivingBlock = endpoint.GroupShardingSlotNumber == null  


### PR DESCRIPTION
Fixes #3013.

The empty all-zero (`#00000000-0000-0000-0000-000000000000`) system / agent-handshake envelope that the 6.4.0 startup path emits tripped two unguarded null-forgiving derefs (introduced in e0b67fb28 "Fix compiler warnings"), producing cascading `NullReferenceException`s that aggregated into **every** consumer integration test going through a `TrackedSession` — even when the test's own assertions would have passed.

## Fixes
- **`BufferedReceiver.cs`** — `_deferBlock` / `_completeBlock` retry lambdas dereferenced `env.Listener!`. Now `env.Listener is { } l ? l.DeferAsync(...) : Task.CompletedTask` — a listener-less envelope no-ops instead of NRE-ing into the retry loop.
- **`MoveToErrorQueue.cs`** — `var scheme = lifecycle.Envelope!.Destination!.Scheme;` was evaluated **before** the `EnableAutomaticFailureAcks` guard, so consumers who explicitly disable failure acks still NRE'd. Now `lifecycle.Envelope!.Destination?.Scheme` + a `scheme is not null` guard. (Only `Destination` is guarded — the envelope itself is always present, as the block just below already relies on; guarding `Envelope` too would trip CS8602 on those derefs.)

Steady-state behaviour is unchanged — both guards only no-op the malformed pre-init envelope.

## Regression tests
Both **fail without the fix and pass with it** (verified by reverting the two source files):
- `MoveToErrorQueueTester.does_not_NRE_when_envelope_has_no_destination` — destination-less envelope with failure acks enabled completes without NRE, sends no failure ack, still moves to DLQ.
- `buffered_receiver_null_listener_guard_3013` — real host + a capturing `ILoggerProvider`; posts a listener-less envelope to both retry blocks and asserts no `NullReferenceException` is **logged** (RetryBlock swallows + logs + retries the exception rather than rethrowing, so a "does not throw" assertion wouldn't catch it).

## Release
Bumps `Directory.Build.props` to **6.4.1**. Full `wolverine.slnx` Release build clean (0/0); CoreTests serialization/error-handling suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)