### PR TITLE
Marten 9.5.2; register MasterTenantSource in DI (#3016); empty master-table seed fix (#3019); foundational per-tenant-partitioned-events tests (#3018)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.4.1</Version>
+        <Version>6.4.2</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,12 +39,12 @@
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
     <PackageVersion Include="JasperFx.SourceGenerator" Version="2.8.0" />
-    <PackageVersion Include="Marten" Version="9.4.0" />
+    <PackageVersion Include="Marten" Version="9.5.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.2.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.4.0" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.4.0" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.5.2" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.5.2" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />

--- a/src/Persistence/MartenTests/AggregateHandlerWorkflow/tenant_partitioned_events_aggregate_workflow.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerWorkflow/tenant_partitioned_events_aggregate_workflow.cs
@@ -1,0 +1,255 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using JasperFx.Resources;
+using Marten;
+using Marten.Events;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests.AggregateHandlerWorkflow;
+
+// Foundational slice of GH-3018: exercise the Wolverine aggregate-handler workflow against a Marten
+// event store using per-tenant event partitioning (Events.UseTenantPartitionedEvents) — Conjoined
+// tenancy + Quick append, on both string and guid stream identity.
+//
+// Load-bearing facts pinned here:
+//   * Tenant is the partition selector — a handler command routed to a tenant appends to that
+//     tenant's partition; the same stream-id value in two tenants stays isolated.
+//   * A command with no tenant falls to the default-tenant partition, isolated from the others.
+//   * Marten 9.5.2 uses MANAGED partitions: a tenant must be registered via
+//     AddMartenManagedTenantsAsync before its first append, otherwise MT002 (this is NOT the lazy
+//     42P01 provisioning the issue originally assumed — see the PR notes / issue checklist).
+internal static class PartitionedTenancyHost
+{
+    public static async Task<IHost> StartAsync(StreamIdentity identity, string schema, Action<StoreOptions> configureAggregate, params Type[] handlers)
+    {
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = schema;
+
+                        m.Events.StreamIdentity = identity;
+                        m.Events.TenancyStyle = TenancyStyle.Conjoined; // required by UseTenantPartitionedEvents
+                        m.Events.AppendMode = EventAppendMode.Quick;    // QuickAppend-only
+                        m.Events.UseTenantPartitionedEvents = true;
+                        m.Events.UseIdentityMapForAggregates = false;
+
+                        configureAggregate(m);
+                        m.DisableNpgsqlLogging = true;
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                var discovery = opts.Discovery.DisableConventionalDiscovery();
+                foreach (var handler in handlers) discovery.IncludeType(handler);
+
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        // Managed partitions — register the known tenants (and the default tenant, with a
+        // table-safe suffix since "*DEFAULT*" is not a legal partition suffix) before any append.
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+        await store.Advanced.AddMartenManagedTenantsAsync(default, new Dictionary<string, string>
+        {
+            ["tenant1"] = "tenant1",
+            ["tenant2"] = "tenant2",
+            [StorageConstants.DefaultTenantId] = "default"
+        });
+
+        return host;
+    }
+}
+
+public class tenant_partitioned_events_string_identity : PostgresqlContext, IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
+
+    public async Task InitializeAsync()
+    {
+        // Unique schema per run: managed partitions created in one run otherwise break the next
+        // run's resource-setup DDL reconciliation against the same schema.
+        theHost = await PartitionedTenancyHost.StartAsync(StreamIdentity.AsString, "tpe_str_" + Guid.NewGuid().ToString("N"),
+            m =>
+            {
+                m.Schema.For<TenantTally>().MultiTenanted();
+                m.Projections.Snapshot<TenantTally>(SnapshotLifecycle.Inline);
+            }, typeof(TenantTallyHandler));
+
+        theStore = theHost.Services.GetRequiredService<IDocumentStore>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private async Task<TenantTally?> LoadAsync(string tenantId, string id)
+    {
+        await using var session = theStore.LightweightSession(tenantId);
+        return await session.LoadAsync<TenantTally>(id);
+    }
+
+    // Unique per run — the shared schema is not reset between runs, so fixed ids would accumulate.
+    private static string UniqueId(string prefix) => $"{prefix}-{Guid.NewGuid():N}";
+
+    [Fact]
+    public async Task append_lands_in_the_routed_tenant_partition()
+    {
+        var id = UniqueId("tally");
+        await theHost.InvokeMessageAndWaitAsync(new StartTally(id), "tenant1");
+        await theHost.InvokeMessageAndWaitAsync(new IncrementTally(id, 5), "tenant1");
+        await theHost.InvokeMessageAndWaitAsync(new IncrementTally(id, 2), "tenant1");
+
+        (await LoadAsync("tenant1", id))!.Total.ShouldBe(7);
+        // Not visible in another tenant's partition.
+        (await LoadAsync("tenant2", id)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task same_stream_id_in_two_tenants_stays_isolated()
+    {
+        var id = UniqueId("shared");
+        await theHost.InvokeMessageAndWaitAsync(new StartTally(id), "tenant1");
+        await theHost.InvokeMessageAndWaitAsync(new IncrementTally(id, 5), "tenant1");
+
+        await theHost.InvokeMessageAndWaitAsync(new StartTally(id), "tenant2");
+        await theHost.InvokeMessageAndWaitAsync(new IncrementTally(id, 100), "tenant2");
+
+        (await LoadAsync("tenant1", id))!.Total.ShouldBe(5);
+        (await LoadAsync("tenant2", id))!.Total.ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task no_tenant_falls_to_the_default_partition_isolated()
+    {
+        var id = UniqueId("def");
+        await theHost.InvokeMessageAndWaitAsync(new StartTally(id));
+        await theHost.InvokeMessageAndWaitAsync(new IncrementTally(id, 9));
+
+        // Landed in the default-tenant partition...
+        await using (var session = theStore.LightweightSession())
+        {
+            (await session.LoadAsync<TenantTally>(id))!.Total.ShouldBe(9);
+        }
+
+        // ...and is invisible to the named-tenant partitions.
+        (await LoadAsync("tenant1", id)).ShouldBeNull();
+        (await LoadAsync("tenant2", id)).ShouldBeNull();
+    }
+}
+
+public class tenant_partitioned_events_guid_identity : PostgresqlContext, IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
+
+    public async Task InitializeAsync()
+    {
+        theHost = await PartitionedTenancyHost.StartAsync(StreamIdentity.AsGuid, "tpe_guid_" + Guid.NewGuid().ToString("N"),
+            m =>
+            {
+                m.Schema.For<GuidTally>().MultiTenanted();
+                m.Projections.Snapshot<GuidTally>(SnapshotLifecycle.Inline);
+            }, typeof(GuidTallyHandler));
+
+        theStore = theHost.Services.GetRequiredService<IDocumentStore>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private async Task<GuidTally?> LoadAsync(string tenantId, Guid id)
+    {
+        await using var session = theStore.LightweightSession(tenantId);
+        return await session.LoadAsync<GuidTally>(id);
+    }
+
+    [Fact]
+    public async Task append_lands_in_the_routed_tenant_partition()
+    {
+        var id = Guid.NewGuid();
+        await theHost.InvokeMessageAndWaitAsync(new StartGuidTally(id), "tenant1");
+        await theHost.InvokeMessageAndWaitAsync(new IncrementGuidTally(id, 3), "tenant1");
+
+        (await LoadAsync("tenant1", id))!.Total.ShouldBe(3);
+        (await LoadAsync("tenant2", id)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task same_stream_id_in_two_tenants_stays_isolated()
+    {
+        var id = Guid.NewGuid();
+        await theHost.InvokeMessageAndWaitAsync(new StartGuidTally(id), "tenant1");
+        await theHost.InvokeMessageAndWaitAsync(new IncrementGuidTally(id, 5), "tenant1");
+
+        await theHost.InvokeMessageAndWaitAsync(new StartGuidTally(id), "tenant2");
+        await theHost.InvokeMessageAndWaitAsync(new IncrementGuidTally(id, 50), "tenant2");
+
+        (await LoadAsync("tenant1", id))!.Total.ShouldBe(5);
+        (await LoadAsync("tenant2", id))!.Total.ShouldBe(50);
+    }
+}
+
+public record TallyIncremented(int Amount);
+
+public class TenantTally
+{
+    public string Id { get; set; } = null!;
+    public int Total { get; set; }
+    public void Apply(TallyIncremented e) => Total += e.Amount;
+}
+
+public record StartTally(string TenantTallyId);
+
+public record IncrementTally(string TenantTallyId, int Amount);
+
+public static class TenantTallyHandler
+{
+    public static IMartenOp Handle(StartTally command)
+        => MartenOps.StartStream<TenantTally>(command.TenantTallyId, new TallyIncremented(0));
+
+    [AggregateHandler]
+    public static IEnumerable<object> Handle(IncrementTally command, TenantTally tally)
+    {
+        yield return new TallyIncremented(command.Amount);
+    }
+}
+
+public class GuidTally
+{
+    public Guid Id { get; set; }
+    public int Total { get; set; }
+    public void Apply(TallyIncremented e) => Total += e.Amount;
+}
+
+public record StartGuidTally(Guid GuidTallyId);
+
+public record IncrementGuidTally(Guid GuidTallyId, int Amount);
+
+public static class GuidTallyHandler
+{
+    public static IMartenOp Handle(StartGuidTally command)
+        => MartenOps.StartStream<GuidTally>(command.GuidTallyId, new TallyIncremented(0));
+
+    [AggregateHandler]
+    public static IEnumerable<object> Handle(IncrementGuidTally command, GuidTally tally)
+    {
+        yield return new TallyIncremented(command.Amount);
+    }
+}

--- a/src/Persistence/PostgresqlTests/master_table_tenancy_di_registration.cs
+++ b/src/Persistence/PostgresqlTests/master_table_tenancy_di_registration.cs
@@ -1,0 +1,76 @@
+using IntegrationTests;
+using JasperFx.MultiTenancy;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.RDBMS.MultiTenancy;
+
+namespace PostgresqlTests;
+
+// GH-3016: when UseMasterTableTenancy() is configured, the resulting MasterTenantSource must be
+// resolvable from DI as IDynamicTenantSource<string> so store-agnostic admin consumers can drive
+// the dynamic-tenancy lifecycle through the abstraction (no concrete-type sniffing).
+//
+// These resolve services from a *built* (not started) host on purpose: the registration is a
+// config-time concern, and skipping StartAsync avoids tenant-database provisioning and the
+// unrelated empty-master-table SeedDatabasesAsync path (filed separately).
+public class master_table_tenancy_di_registration : PostgresqlContext
+{
+    [Fact]
+    public void master_tenant_source_is_registered_as_dynamic_tenant_source()
+    {
+        using var host = Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "mt_di_3016")
+                    .UseMasterTableTenancy(tenants =>
+                    {
+                        // The target is irrelevant to this DI-registration assertion; a seeded tenant
+                        // keeps the master-table boot path off the empty-table SeedDatabasesAsync branch.
+                        tenants.Register("tenant1", Servers.PostgresConnectionString);
+                    });
+            })
+            .Build();
+
+        var sources = host.Services.GetServices<IDynamicTenantSource<string>>().ToArray();
+
+        sources.ShouldNotBeEmpty();
+        sources[0].ShouldBeOfType<MasterTenantSource>();
+    }
+
+    [Fact]
+    public void no_dynamic_tenant_source_registered_without_master_table_tenancy()
+    {
+        using var host = Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "mt_di_3016_negative");
+            })
+            .Build();
+
+        // A plain Postgres-backed host exposes no dynamic tenant source — graceful no-op for
+        // abstraction-agnostic admin consumers.
+        host.Services.GetServices<IDynamicTenantSource<string>>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task starts_cleanly_with_an_empty_master_tenant_table()
+    {
+        // GH-3019: an empty master tenant table (no seeded tenants) must not throw
+        // "CommandText property has not been initialized" out of SeedDatabasesAsync during startup.
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "mt_empty_seed_3019")
+                    .UseMasterTableTenancy(_ => { }); // intentionally no seeded tenants
+                opts.Services.AddResourceSetupOnStartup();
+            })
+            .StartAsync();
+
+        // Reaching a started host without throwing is the assertion; the registration still lights up.
+        host.Services.GetServices<IDynamicTenantSource<string>>().ShouldNotBeEmpty();
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
@@ -401,6 +401,23 @@ internal class PostgresqlBackedPersistence : IPostgresqlBackedPersistence, IWolv
         configure(source);
 
         TenantConnections = source;
+
+        // GH-3016: surface the MasterTenantSource through DI so store-agnostic admin consumers
+        // (e.g. CritterWatch's tenant-management handler set) can drive the Add/Disable/Enable/
+        // Remove lifecycle via GetServices<IDynamicTenantSource<string>>() without sniffing for
+        // the concrete MasterTenantSource type. This must be registered here — at config time,
+        // before the container is built — rather than in BuildMessageStore (which runs lazily off
+        // the IMessageStore factory, after the container is built) or in Configure() (which
+        // Include() invokes eagerly, before this fluent call sets UseMasterTableTenancy). The
+        // factory defers to IMessageStore resolution, which is what constructs the
+        // MasterTenantSource and assigns it to ConnectionStringTenancy. Mirrors the conditional
+        // shape Marten landed in JasperFx/marten#4605.
+        _options.Services.AddSingleton<IDynamicTenantSource<string>>(s =>
+        {
+            _ = s.GetRequiredService<IMessageStore>();
+            return (IDynamicTenantSource<string>)ConnectionStringTenancy!;
+        });
+
         return this;
     }
 

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Tenants.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Tenants.cs
@@ -13,9 +13,19 @@ public abstract partial class MessageDatabase<T>
         // Gotta make sure the database state is in good shape first...
         // TODO -- might have to latch this w/ AutoCreate
         await ApplyAllConfiguredChangesToDatabaseAsync(ct: _cancellation);
-        
+
+        var assignments = tenantConnectionStrings.AllActiveByTenant().ToArray();
+        if (assignments.Length == 0)
+        {
+            // Nothing to seed. An empty master tenant table is valid — tenants may be registered
+            // later at runtime (e.g. via the master-table tenancy source). Compiling/executing a
+            // command with no SQL appended throws "CommandText property has not been initialized".
+            // GH-3019.
+            return;
+        }
+
         var builder = ToCommandBuilder();
-        foreach (var assignment in tenantConnectionStrings.AllActiveByTenant())
+        foreach (var assignment in assignments)
         {
             builder.Append($"delete from  {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} where {StorageConstants.TenantIdColumn} = ");
             builder.AppendParameter(assignment.TenantId);


### PR DESCRIPTION
Closes #3016. Closes #3019. Starts #3018 (foundational slice; deferred matrix tracked on the issue). Bumps to **6.4.2**.

## Marten 9.5.2
Bumps the Marten family 9.4.0 → 9.5.2. Its floors (JasperFx 2.8.0, Weasel 9.0.2) are already on main, so this is a Marten-only bump. Validated by a full `wolverine.slnx` Release build + the Marten test runs below.

## #3016 — register `MasterTenantSource` as `IDynamicTenantSource<string>`
When `UseMasterTableTenancy()` is configured, the `MasterTenantSource` is now resolvable from DI as `IDynamicTenantSource<string>`, so store-agnostic admin consumers (e.g. CritterWatch's tenant-management handlers) can drive Add/Disable/Enable/Remove through the abstraction without sniffing the concrete type.

**Registration point matters.** The issue suggested registering inside `BuildMessageStore`, but that runs lazily off the `AddSingleton<IMessageStore>(s => ...)` factory — *after* the container is built — so it would never reach `host.Services`. And `Configure()` runs *eagerly* via `Include()`, *before* the fluent `.UseMasterTableTenancy()` sets the flag. So the registration goes in the fluent `UseMasterTableTenancy()` method itself (config time, pre-build); the factory defers to `IMessageStore` resolution, which constructs the `MasterTenantSource` and assigns `ConnectionStringTenancy`.

Tests (positive resolves `MasterTenantSource`; negative — no `UseMasterTableTenancy` → empty). Both verified fail-without/pass-with.

## #3019 — empty master-table seed crash
`SeedDatabasesAsync` threw `"CommandText property has not been initialized"` when the master tenant table starts empty (no seeded tenants): the empty assignment set appended no SQL, so the compiled command had no `CommandText`. Now it skips execution when there is nothing to seed (an empty master table is valid — tenants can be registered at runtime). Regression test boots a host with `UseMasterTableTenancy(_ => {})` and `StartAsync` — verified fail-without/pass-with.

## #3018 — foundational per-tenant-partitioned-events test slice
First Wolverine tests exercising the aggregate-handler workflow against `Events.UseTenantPartitionedEvents` (Conjoined + Quick), on **string and guid** stream identity:
- tenant-routed append lands in the correct tenant partition (and is invisible to other tenants);
- the same stream-id value in two tenants stays isolated;
- a no-tenant command falls to the default-tenant partition, isolated from named tenants.

### Findings (these correct the issue's premises — see the issue checklist comment)
- **Managed partitions, not lazy 42P01.** Marten 9.5.2 requires `store.Advanced.AddMartenManagedTenantsAsync(...)` before a tenant's first append, else `MT002` — there is no lazy 42P01 provisioning. The "fresh tenant 42P01" item is therefore reframed.
- The projected aggregate must be `MultiTenanted()` to match conjoined events ("Tenancy storage style mismatch" otherwise).
- The **default** tenant also needs an explicit partition, registered with a table-safe suffix (`*DEFAULT*` is not a legal suffix).
- Observation for follow-up: an append for a never-registered tenant via Wolverine's invoke path did **not** surface `MT002` — left out of this slice pending investigation.

The full 2a/2b matrix (multi-node distribution, sharded DBs, HTTP endpoints, exclusive concurrency, blue/green, subscriptions/`RelayWithEventTenant`) remains deferred — checklist on #3018.

## Validation
- Full `wolverine.slnx` Release build clean (net9.0 + net10.0), 0 warnings / 0 errors.
- `PostgresqlTests` (#3016 + #3019): green (1 unrelated RabbitMQ replay flake in the broader run).
- `MartenTests/AggregateHandlerWorkflow` (71 incl. the new 5): green — confirms Marten 9.5.2 runtime + no discovery collisions from the new aggregate/handler types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)