### PR TITLE
Fix master-table multi-tenancy on SqlServer (DB-agnostic tenant SQL); bump 6.4.3 (#3023)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.4.2</Version>
+        <Version>6.4.3</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Persistence/PostgresqlTests/master_table_tenancy_di_registration.cs
+++ b/src/Persistence/PostgresqlTests/master_table_tenancy_di_registration.cs
@@ -73,4 +73,38 @@ public class master_table_tenancy_di_registration : PostgresqlContext
         // Reaching a started host without throwing is the assertion; the registration still lights up.
         host.Services.GetServices<IDynamicTenantSource<string>>().ShouldNotBeEmpty();
     }
+
+    [Fact]
+    public async Task dynamic_tenant_lifecycle_round_trip()
+    {
+        // GH-3023: confirm the master-table tenant-registry write/read/disable paths still work on
+        // PostgreSQL after the shared SQL was made DB-agnostic (parameterized booleans +
+        // delete-then-insert instead of ON CONFLICT) to fix SqlServer.
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "mt_lifecycle_3023")
+                    .UseMasterTableTenancy(_ => { });
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        var source = host.Services.GetServices<IDynamicTenantSource<string>>()
+            .OfType<MasterTenantSource>().Single();
+
+        var tenant = "life-" + Guid.NewGuid().ToString("N")[..8];
+        var conn = Servers.PostgresConnectionString;
+
+        await source.AddTenantAsync(tenant, conn);            // AddTenantRecordAsync (delete-then-insert)
+        await source.RefreshAsync();                          // LoadAllTenantConnectionStrings
+        source.AllActiveByTenant().ShouldContain(a => a.TenantId == tenant);
+
+        await source.DisableTenantAsync(tenant);
+        (await source.AllDisabledAsync()).ShouldContain(tenant);   // LoadDisabledTenantIdsAsync
+
+        await source.EnableTenantAsync(tenant);
+        (await source.AllDisabledAsync()).ShouldNotContain(tenant);
+
+        await source.AddTenantAsync(tenant, conn);            // upsert path again
+        await source.RemoveTenantAsync(tenant);
+    }
 }

--- a/src/Persistence/SqlServerTests/master_table_tenancy_dynamic_lifecycle.cs
+++ b/src/Persistence/SqlServerTests/master_table_tenancy_dynamic_lifecycle.cs
@@ -1,0 +1,73 @@
+using IntegrationTests;
+using JasperFx.MultiTenancy;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.RDBMS.MultiTenancy;
+using Wolverine.SqlServer;
+
+namespace SqlServerTests;
+
+// GH-3023: master-table multi-tenancy on SqlServer. The shared tenant-table queries used
+// PostgreSQL-only SQL (boolean `false`/`true` literals + ON CONFLICT upsert) that SqlServer
+// rejects ("Invalid column name 'false'"), so this whole path was broken on SqlServer. These
+// exercise the read + write + disable/enable paths end-to-end through the (now DI-registered,
+// parity with GH-3016) IDynamicTenantSource<string> abstraction.
+public class master_table_tenancy_dynamic_lifecycle
+{
+    [Fact]
+    public async Task master_tenant_source_is_registered_as_dynamic_tenant_source()
+    {
+        using var host = Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "mt_di_3023")
+                    .UseMasterTableTenancy(tenants => tenants.Register("seed", Servers.SqlServerConnectionString));
+            })
+            .Build();
+
+        host.Services.GetServices<IDynamicTenantSource<string>>().OfType<MasterTenantSource>()
+            .ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task dynamic_tenant_lifecycle_round_trip()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "mt_lifecycle_3023")
+                    .UseMasterTableTenancy(_ => { });
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        var source = host.Services.GetServices<IDynamicTenantSource<string>>()
+            .OfType<MasterTenantSource>().Single();
+
+        var tenant = "life-" + Guid.NewGuid().ToString("N")[..8];
+        var conn = Servers.SqlServerConnectionString;
+
+        // Add — AddTenantRecordAsync (portable delete-then-insert; was PostgreSQL-only ON CONFLICT + `false` literal)
+        await source.AddTenantAsync(tenant, conn);
+
+        // Read — LoadAllTenantConnectionStrings (was `where disabled = false`)
+        await source.RefreshAsync();
+        source.AllActiveByTenant().ShouldContain(a => a.TenantId == tenant);
+
+        // Disable — shows up in the disabled list (LoadDisabledTenantIdsAsync; was `where disabled = true`)
+        await source.DisableTenantAsync(tenant);
+        (await source.AllDisabledAsync()).ShouldContain(tenant);
+
+        // Enable — no longer disabled
+        await source.EnableTenantAsync(tenant);
+        (await source.AllDisabledAsync()).ShouldNotContain(tenant);
+
+        // Re-add must not throw (upsert path)
+        await source.AddTenantAsync(tenant, conn);
+
+        // Remove
+        await source.RemoveTenantAsync(tenant);
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Tenants.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Tenants.cs
@@ -102,7 +102,8 @@ public abstract partial class MessageDatabase<T>
         {
             await using var reader =
                 await conn.CreateCommand(
-                        $"select {StorageConstants.TenantIdColumn}, {StorageConstants.ConnectionStringColumn} from {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} where {DatabaseConstants.DisabledColumn} = false")
+                        $"select {StorageConstants.TenantIdColumn}, {StorageConstants.ConnectionStringColumn} from {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} where {DatabaseConstants.DisabledColumn} = @disabled")
+                    .With("disabled", false)
                     .ExecuteReaderAsync(_cancellation);
 
             while (await reader.ReadAsync(_cancellation))
@@ -132,10 +133,15 @@ public abstract partial class MessageDatabase<T>
         await conn.OpenAsync(_cancellation);
         try
         {
+            // Upsert + (re-)enable. Uses a portable delete-then-insert rather than PostgreSQL's
+            // ON CONFLICT (which SqlServer rejects), and a bool parameter rather than a `false`
+            // literal (SqlServer has no boolean literal — it parses `false` as a column name). GH-3023.
             await conn.CreateCommand(
-                    $"insert into {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} ({StorageConstants.TenantIdColumn}, {StorageConstants.ConnectionStringColumn}, {DatabaseConstants.DisabledColumn}) values (@id, @connection, false) on conflict ({StorageConstants.TenantIdColumn}) do update set {StorageConstants.ConnectionStringColumn} = @connection, {DatabaseConstants.DisabledColumn} = false")
+                    $"delete from {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} where {StorageConstants.TenantIdColumn} = @id;" +
+                    $"insert into {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} ({StorageConstants.TenantIdColumn}, {StorageConstants.ConnectionStringColumn}, {DatabaseConstants.DisabledColumn}) values (@id, @connection, @disabled)")
                 .With("id", tenantId)
                 .With("connection", connectionString)
+                .With("disabled", false)
                 .ExecuteNonQueryAsync(_cancellation);
         }
         finally
@@ -187,7 +193,8 @@ public abstract partial class MessageDatabase<T>
         try
         {
             await using var reader = await conn.CreateCommand(
-                    $"select {StorageConstants.TenantIdColumn} from {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} where {DatabaseConstants.DisabledColumn} = true")
+                    $"select {StorageConstants.TenantIdColumn} from {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} where {DatabaseConstants.DisabledColumn} = @disabled")
+                .With("disabled", true)
                 .ExecuteReaderAsync(_cancellation);
 
             while (await reader.ReadAsync(_cancellation))

--- a/src/Persistence/Wolverine.SqlServer/SqlServerBackedPersistence.cs
+++ b/src/Persistence/Wolverine.SqlServer/SqlServerBackedPersistence.cs
@@ -325,6 +325,18 @@ internal class SqlServerBackedPersistence : IWolverineExtension, ISqlServerBacke
         configure(source);
 
         TenantConnections = source;
+
+        // GH-3023: surface the MasterTenantSource through DI as IDynamicTenantSource<string> so
+        // store-agnostic admin consumers can drive the dynamic-tenancy lifecycle through the
+        // abstraction — parity with the PostgreSQL provider (GH-3016). Registered at config time
+        // (before the container is built); the factory defers to IMessageStore resolution, which is
+        // what constructs the MasterTenantSource and assigns ConnectionStringTenancy.
+        _options.Services.AddSingleton<IDynamicTenantSource<string>>(s =>
+        {
+            _ = s.GetRequiredService<IMessageStore>();
+            return (IDynamicTenantSource<string>)ConnectionStringTenancy!;
+        });
+
         return this;
     }
 


### PR DESCRIPTION
Closes #3023. Found during the persistence/EF-Core compliance survey.

## The bug
`UseMasterTableTenancy()` was completely broken on SqlServer — `EfCoreTests.MultiTenancy.multi_tenancy_with_master_table_approach_sqlserver` failed **16/16** (incl. `can_build_a_db_context_at_all`) with `SqlException: Invalid column name 'false'` during multi-tenanted resource setup.

The shared tenant-registry queries in `MessageDatabase<T>` (`Wolverine.RDBMS/MessageDatabase.Tenants.cs`, used by **both** the Postgres and SqlServer stores) were written with PostgreSQL-only SQL:
- `where {disabled} = false` / `= true` — SqlServer has no boolean literal, so it parses `false`/`true` as **column names**.
- `AddTenantRecordAsync`: `insert ... values (..., false) on conflict (...) do update ...` — `ON CONFLICT` is PostgreSQL-only (plus the same `false`).

(The `shared-database` and `static-connection-strings` SqlServer variants pass — this is specific to the master-table path. Postgres passes because it accepts all of the above.)

## The fix
- Boolean literals → a **bool parameter** (`@disabled`), which the driver maps to `boolean`/`bit` — matching the existing `SetTenantDisabledAsync` pattern.
- `ON CONFLICT` upsert → the portable **delete-then-insert** already used by `SeedDatabasesAsync`.
- Registered `MasterTenantSource` as `IDynamicTenantSource<string>` in the **SqlServer** provider — parity with the Postgres gap closed in #3016 (it had the same omission), so store-agnostic admin consumers can drive the lifecycle on SqlServer too.

## Tests
- **SqlServerTests** `master_table_tenancy_dynamic_lifecycle`: DI registration + a full lifecycle round-trip (add → refresh/read → disable → list-disabled → enable → re-add upsert → remove) — exercises all three fixed statements.
- **PostgresqlTests**: mirrored Postgres lifecycle test (regression guard for the shared SQL change).

## Verification (Postgres + SqlServer both up)
- `multi_tenancy_with_master_table_approach_sqlserver`: **16/16 pass** (was 16/16 fail).
- `multi_tenancy_with_master_table_approach_postgresql`: **16/16 pass** (no regression).
- SqlServer lifecycle 2/2; Postgres master-table DI/lifecycle 4/4.
- Full `wolverine.slnx` Release build clean (0/0).

Bumps to **6.4.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)