### PR TITLE
Per-tenant-partitioned-events Phase 1 (cont.): required-write isolation, optimistic version, cascading tenant inheritance (#3021)

### DIFF
--- a/src/Persistence/MartenTests/AggregateHandlerWorkflow/tenant_partitioned_aggregate_matrix.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerWorkflow/tenant_partitioned_aggregate_matrix.cs
@@ -1,3 +1,4 @@
+using JasperFx;
 using JasperFx.Events;
 using JasperFx.Events.Projections;
 using Marten;
@@ -6,15 +7,20 @@ using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Wolverine;
 using Wolverine.Marten;
+using Wolverine.Persistence;
 using Wolverine.Tracking;
 
 namespace MartenTests.AggregateHandlerWorkflow;
 
 // Phase 1 of the per-tenant-partitioned-events matrix (follow-up #3021): the single-store
-// aggregate-handler scenarios beyond the foundational slice — [ReadAggregate], every append
-// return shape, and [WriteAggregate] — each scoped by tenant against a Conjoined + Quick +
+// aggregate-handler scenarios beyond the foundational slice — [ReadAggregate], every append return
+// shape, [WriteAggregate] (optimistic + required-with-throw isolation), optimistic version checks,
+// and cascading-message tenant inheritance — each scoped by tenant against a Conjoined + Quick +
 // UseTenantPartitionedEvents store (string identity). Reuses TenantTally / PartitionedTenancyHost
 // from tenant_partitioned_events_aggregate_workflow.cs.
+//
+// Streams are seeded via a direct tenant session because MartenOps.StartStream from a handler is
+// silently dropped under UseTenantPartitionedEvents (GH-3025).
 public class tenant_partitioned_aggregate_matrix : PostgresqlContext, IAsyncLifetime
 {
     private IHost theHost = null!;
@@ -29,7 +35,7 @@ public class tenant_partitioned_aggregate_matrix : PostgresqlContext, IAsyncLife
                 m.Schema.For<TenantTally>().MultiTenanted();
                 m.Projections.Snapshot<TenantTally>(SnapshotLifecycle.Inline);
             },
-            typeof(TenantTallyHandler), typeof(PhaseOneMatrixHandlers));
+            typeof(TenantTallyHandler), typeof(PhaseOneMatrixHandlers), typeof(RequiredTallyHandler), typeof(VersionedTallyHandler), typeof(CascadingTallyHandler));
 
         theStore = theHost.Services.GetRequiredService<IDocumentStore>();
     }
@@ -40,8 +46,15 @@ public class tenant_partitioned_aggregate_matrix : PostgresqlContext, IAsyncLife
         theHost.Dispose();
     }
 
-    private Task SeedAsync(string tenant, string id)
-        => theHost.InvokeMessageAndWaitAsync(new StartTally(id), tenant);
+    // Seed via a direct tenant session. NOT via the StartTally handler / MartenOps.StartStream — that
+    // side-effect is silently dropped under UseTenantPartitionedEvents (GH-3025), so it would leave no
+    // stream and the version/required scenarios below could not see a pre-existing aggregate.
+    private async Task SeedAsync(string tenant, string id)
+    {
+        await using var session = theStore.LightweightSession(tenant);
+        session.Events.StartStream<TenantTally>(id, new TallyIncremented(0));
+        await session.SaveChangesAsync();
+    }
 
     private async Task<TenantTally?> LoadAsync(string tenant, string id)
     {
@@ -123,6 +136,58 @@ public class tenant_partitioned_aggregate_matrix : PostgresqlContext, IAsyncLife
         // The same stream id, routed to tenant2, sees no aggregate (separate partition).
         (await LoadAsync("tenant2", id)).ShouldBeNull();
     }
+
+    [Fact]
+    public async Task required_write_aggregate_missing_in_the_routed_tenant_throws()
+    {
+        // Aggregate exists in tenant1; the same Required=true command routed to tenant2 must not find
+        // it there (partition isolation) and must raise RequiredDataMissingException rather than
+        // silently starting a tenant2 stream.
+        var id = UniqueId("req");
+        await SeedAsync("tenant1", id);
+
+        await theHost.InvokeMessageAndWaitAsync(new RequireAppendTally(id, 3), "tenant1");
+        (await LoadAsync("tenant1", id))!.Total.ShouldBe(3);
+
+        await Should.ThrowAsync<RequiredDataMissingException>(() =>
+            theHost.MessageBus().InvokeForTenantAsync("tenant2", new RequireAppendTally(id, 3)));
+        (await LoadAsync("tenant2", id)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task optimistic_version_check_is_scoped_to_the_tenant_partition()
+    {
+        // StartTally appends one event, so each tenant's stream is at version 1.
+        var id = UniqueId("ver");
+        await SeedAsync("tenant1", id);
+        await SeedAsync("tenant2", id);
+
+        await theHost.InvokeMessageAndWaitAsync(new IncrementWithVersion(id, 1, 5), "tenant1");
+        (await LoadAsync("tenant1", id))!.Total.ShouldBe(5);
+        (await LoadAsync("tenant2", id))!.Total.ShouldBe(0);
+
+        await Should.ThrowAsync<ConcurrencyException>(() =>
+            theHost.MessageBus().InvokeForTenantAsync("tenant1", new IncrementWithVersion(id, 99, 1)));
+
+        await theHost.InvokeMessageAndWaitAsync(new IncrementWithVersion(id, 1, 7), "tenant2");
+        (await LoadAsync("tenant2", id))!.Total.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task cascaded_message_inherits_the_routed_tenant()
+    {
+        // A message cascaded from an aggregate handler must carry the handler's tenant (the outbox
+        // session is tenant-scoped) — otherwise per-tenant follow-on work silently misroutes.
+        var id = UniqueId("casc");
+        await SeedAsync("tenant1", id);
+
+        var marker = Guid.NewGuid();
+        await theHost.InvokeMessageAndWaitAsync(new AppendAndCascade(id, 4, marker), "tenant1");
+
+        (await LoadAsync("tenant1", id))!.Total.ShouldBe(4);
+        CascadingTallyHandler.CascadeTenants.TryGetValue(marker, out var tenant);
+        tenant.ShouldBe("tenant1");
+    }
 }
 
 public record ViewTally(string TenantTallyId);
@@ -165,4 +230,39 @@ public static class PhaseOneMatrixHandlers
 
     public static Events Handle(AppendToTally command, [WriteAggregate(Required = false)] TenantTally? tally)
         => new Events(new object[] { new TallyIncremented(command.Amount) });
+}
+
+public record RequireAppendTally(string TenantTallyId, int Amount);
+
+public static class RequiredTallyHandler
+{
+    public static Events Handle(RequireAppendTally command,
+        [WriteAggregate(Required = true, OnMissing = OnMissing.ThrowException)] TenantTally tally)
+        => new Events(new object[] { new TallyIncremented(command.Amount) });
+}
+
+public record IncrementWithVersion(string TenantTallyId, long ExpectedVersion, int Amount);
+
+[AggregateHandler(VersionSource = nameof(IncrementWithVersion.ExpectedVersion))]
+public static class VersionedTallyHandler
+{
+    public static TallyIncremented Handle(IncrementWithVersion command, TenantTally tally)
+        => new(command.Amount);
+}
+
+public record AppendAndCascade(string TenantTallyId, int Amount, Guid Marker);
+
+public record TallyCascaded(Guid Marker);
+
+public static class CascadingTallyHandler
+{
+    public static readonly System.Collections.Concurrent.ConcurrentDictionary<Guid, string?> CascadeTenants = new();
+
+    [AggregateHandler]
+    public static (Events, OutgoingMessages) Handle(AppendAndCascade command, TenantTally tally)
+        => (new Events(new object[] { new TallyIncremented(command.Amount) }),
+            new OutgoingMessages { new TallyCascaded(command.Marker) });
+
+    public static void Handle(TallyCascaded message, Envelope envelope)
+        => CascadeTenants[message.Marker] = envelope.TenantId;
 }


### PR DESCRIPTION
Advances #3021. Test-only (no shippable change). Builds on the merged Phase-1 slice (#3022) with three more single-store, tenant-scoped aggregate-handler scenarios against a `Conjoined + Quick + UseTenantPartitionedEvents` store:

- **`[WriteAggregate(Required=true, OnMissing=ThrowException)]` isolation** — aggregate present in tenant1 but routed to tenant2 → `RequiredDataMissingException` (not a silently-started tenant2 stream).
- **Optimistic version check** (`[AggregateHandler(VersionSource=...)]`) **scoped to the tenant partition** — correct version appends in the routed tenant only; stale version → `ConcurrencyException`; sibling tenant's version unaffected.
- **Cascading-message tenant inheritance** — a message cascaded from an aggregate handler carries the handler's tenant (outbox session is tenant-scoped).

### Bug found + filed: #3025
While building these I found that **`MartenOps.StartStream` returned from a handler is silently dropped under `UseTenantPartitionedEvents`** (0 events persisted), whereas a direct `session.Events.StartStream` persists. The earlier tests masked this because aggregate handlers start-if-missing — these version/required scenarios are the first that need a genuinely pre-existing stream. The seed therefore uses a direct tenant session, with a comment pointing at #3025.

### Verification
Full `MartenTests/AggregateHandlerWorkflow` folder green (80, +3).

### Still on #3021 (deferred)
Natural-key aggregate, `MartenOps` document tenant overloads, event-as-message, ancillary stores, the HTTP `[Aggregate]`/`[WriteAggregate]`/`[ReadAggregate]` cluster (needs an Alba host), and all of Phase 2 (multi-node projection/subscription distribution) + Phase 3 (sharded DBs). The single-PR goal hit two practical limits: the #3025 StartStream bug (worked around), and the HTTP/multi-node clusters needing separate harnesses — so those are tracked rather than forced in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)