### PR TITLE
Persist single IMartenOp side-effect returns; bump 6.4.4 (GH-3025)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.4.3</Version>
+        <Version>6.4.4</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Persistence/MartenTests/single_marten_op_side_effect_persists.cs
+++ b/src/Persistence/MartenTests/single_marten_op_side_effect_persists.cs
@@ -1,0 +1,103 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests;
+
+// GH-3025: a handler returning a SINGLE IMartenOp (e.g. MartenOps.StartStream / MartenOps.Store)
+// must persist even without opts.Policies.AutoApplyTransactions(). Previously MartenOpPolicy only
+// applied Marten transaction support (the SaveChangesAsync postprocessor) for IEnumerable<IMartenOp>
+// returns, so a single op was Execute()'d onto the session and then silently dropped.
+public class single_marten_op_side_effect_persists : PostgresqlContext, IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "single_op_3025";
+                        m.DisableNpgsqlLogging = true;
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                // Deliberately NO opts.Policies.AutoApplyTransactions().
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(StartViaOpHandler))
+                    .IncludeType(typeof(StoreViaOpHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        theStore = theHost.Services.GetRequiredService<IDocumentStore>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task single_start_stream_op_persists_without_auto_transactions()
+    {
+        var id = Guid.NewGuid();
+        await theHost.InvokeMessageAndWaitAsync(new StartViaOp(id));
+
+        await using var session = theStore.LightweightSession();
+        var events = await session.Events.FetchStreamAsync(id);
+        events.Count.ShouldBe(1); // was 0 (op dropped) before GH-3025
+    }
+
+    [Fact]
+    public async Task single_store_op_persists_without_auto_transactions()
+    {
+        var id = Guid.NewGuid();
+        await theHost.InvokeMessageAndWaitAsync(new StoreViaOp(id));
+
+        await using var session = theStore.LightweightSession();
+        (await session.LoadAsync<OpDoc>(id)).ShouldNotBeNull();
+    }
+}
+
+public record StartViaOp(Guid Id);
+
+public record OpStarted(string Name);
+
+public class OpTally
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public void Apply(OpStarted e) => Name = e.Name;
+}
+
+public static class StartViaOpHandler
+{
+    public static IMartenOp Handle(StartViaOp command)
+        => MartenOps.StartStream<OpTally>(command.Id, new OpStarted("created"));
+}
+
+public record StoreViaOp(Guid Id);
+
+public class OpDoc
+{
+    public Guid Id { get; set; }
+}
+
+public static class StoreViaOpHandler
+{
+    public static IMartenOp Handle(StoreViaOp command)
+        => MartenOps.Store(new OpDoc { Id = command.Id });
+}

--- a/src/Persistence/Wolverine.Marten/IMartenOp.cs
+++ b/src/Persistence/Wolverine.Marten/IMartenOp.cs
@@ -33,13 +33,25 @@ internal class MartenOpPolicy : IChainPolicy
     {
         foreach (var chain in chains)
         {
-            var candidates = chain.ReturnVariablesOfType<IEnumerable<IMartenOp>>().ToArray();
-            if (candidates.Any())
+            var collections = chain.ReturnVariablesOfType<IEnumerable<IMartenOp>>().ToArray();
+
+            // A single IMartenOp return is an ISideEffect — Wolverine already generates the Execute()
+            // call — but it still needs Marten transaction support so SaveChangesAsync actually runs.
+            // Without it the op is applied to the session and then silently dropped unless the app
+            // happens to have AutoApplyTransactions enabled. Collections were already handled below;
+            // single returns were not, so e.g. a handler returning MartenOps.StartStream(...) never
+            // persisted. ApplyTransactionSupport is idempotent, so this composes with aggregate
+            // handlers / AutoApplyTransactions. GH-3025.
+            var singles = chain.ReturnVariablesOfType<IMartenOp>().ToArray();
+
+            if (collections.Any() || singles.Any())
             {
                 new MartenPersistenceFrameProvider().ApplyTransactionSupport(chain, container);
             }
-            
-            foreach (var collection in candidates)
+
+            // Only collections need the explicit foreach-Execute frame; single IMartenOp returns are
+            // executed by the ISideEffect machinery (adding a frame here would double-execute).
+            foreach (var collection in collections)
             {
                 collection.UseReturnAction(v => new ForEachMartenOpFrame(v));
             }


### PR DESCRIPTION
Closes #3025.

## Problem

A handler that returns a single `IMartenOp` — e.g. `MartenOps.StartStream<T>(...)` or `MartenOps.Store(doc)` — silently dropped its work unless the app happened to enable `Policies.AutoApplyTransactions()`. No events/documents persisted, no exception. A direct `session.Events.StartStream(...)` persisted fine.

Surfaced via per-tenant event partitioning (`Events.UseTenantPartitionedEvents`), but **not** partitioning-specific — it reproduces on any plain Marten host without `AutoApplyTransactions`.

## Root cause

A single `IMartenOp` return is an `ISideEffect`, so Wolverine generates the `Execute()` call onto the document session — but `MartenOpPolicy` only applied Marten transaction support (the `SaveChangesAsync` postprocessor via `MartenPersistenceFrameProvider.ApplyTransactionSupport`) for `IEnumerable<IMartenOp>` returns. So a single op was executed onto the session and then never committed.

## Fix

`MartenOpPolicy.Apply` now also detects single `IMartenOp` returns and applies transaction support for them. `ApplyTransactionSupport` is idempotent (guards on `CreateDocumentSessionFrame` + `DocumentSessionSaveChanges`), so this composes cleanly with aggregate handlers and with `AutoApplyTransactions`. The single op's `Execute()` stays with the `ISideEffect` machinery — no `ForEachMartenOpFrame` is added for singles, so there's no double-execute.

## Tests

New `single_marten_op_side_effect_persists` (MartenTests) — a host **without** `AutoApplyTransactions` invokes a handler returning a single `MartenOps.StartStream` and a single `MartenOps.Store`; both assert the data persisted. Both fail without the fix (stream count 0 / document null), pass with it.

- Full `wolverine.slnx` Release build: 0 warnings, 0 errors.
- Full MartenTests suite: **477 passing**.

> Carries the version bump to **6.4.4**. Companion fix #3027 (PR #3028) has no bump; both should land before the next NuGet so 6.4.4 ships with both fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)