### PR TITLE
Adds ExtendConsumerConfiguration for KafkaListenerConfiguration

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs
@@ -104,7 +104,18 @@ public class DocumentationSamples
 
                         // Other configuration
                     })
-                    
+                    // Extends the consumer configuration for this topic only.
+                    // Unlike ConfigureConsumer(), this preserves any existing topic-level
+                    // ConsumerConfig and only applies the changes below.
+                    .ExtendConsumerConfiguration(config =>
+                    {
+                        // This also sets Envelope.GroupId for any messages received
+                        // from this topic.
+                        config.GroupId = "foo";
+                        config.BootstrapServers = KafkaContainerFixture.ConnectionString;
+
+                        // Other additive configuration
+                    })
                     // Configure circuit breaker behavior for
                     // this specific Kafka listener
                     .CircuitBreaker(cb =>
@@ -112,7 +123,6 @@ public class DocumentationSamples
                         cb.MinimumThreshold = 10;
                         cb.PauseTime = TimeSpan.FromMinutes(1);
                     })
-                    
                     // Fine tune how the Kafka Topic is declared by Wolverine
                     .Specification(spec =>
                     {

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaTransportTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaTransportTests.cs
@@ -127,6 +127,45 @@ public class KafkaTransportTests
     }
 }
 
+public class KafkaListenerConfigurationTests
+{
+    private static KafkaTopic BuildTopic()
+    {
+        var transport = new KafkaTransport();
+        return new KafkaTopic(transport, "topic-a", EndpointRole.Application);
+    }
+
+    [Fact]
+    public void extend_consumer_configuration_creates_topic_consumer_configuration()
+    {
+        var topic = BuildTopic();
+
+        var config = new KafkaListenerConfiguration(topic)
+            .ExtendConsumerConfiguration(consumer => consumer.GroupId = "topic");
+
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        topic.ConsumerConfig.ShouldNotBeNull();
+        topic.ConsumerConfig.GroupId.ShouldBe("topic");
+    }
+
+    [Fact]
+    public void extend_consumer_configuration_preserves_existing_topic_consumer_configuration()
+    {
+        var topic = BuildTopic();
+
+        var config = new KafkaListenerConfiguration(topic)
+            .ConfigureConsumer(consumer => consumer.GroupId = "topic")
+            .ExtendConsumerConfiguration(consumer => consumer.ClientId = "topic-client");
+
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        topic.ConsumerConfig.ShouldNotBeNull();
+        topic.ConsumerConfig.GroupId.ShouldBe("topic");
+        topic.ConsumerConfig.ClientId.ShouldBe("topic-client");
+    }
+}
+
 public class UseKafkaUsingNamedConnectionTests
 {
     [Fact]

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -158,4 +158,20 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
         });
         return this;
     }
+    /// <summary>
+    /// Extends the Kafka consumer settings for this topic without replacing the
+    /// existing topic-level configuration. If no topic-specific configuration exists,
+    /// a new <see cref="ConsumerConfig"/> is created before applying the changes.
+    /// </summary>
+    /// <param name="configuration">An action that adds or updates consumer settings for this topic.</param>
+    /// <returns>The current <see cref="KafkaListenerConfiguration"/> for fluent chaining.</returns>
+    public KafkaListenerConfiguration ExtendConsumerConfiguration(Action<ConsumerConfig> configuration)
+    {
+        add(topic =>
+        {
+            topic.ConsumerConfig ??= new ConsumerConfig();
+            configuration(topic.ConsumerConfig);
+        });
+        return this;
+    }
 }


### PR DESCRIPTION
### Adds coverage for topic-level Kafka consumer configuration behavior

This PR adds test coverage for the difference between `ConfigureConsumer()` and `ExtendConsumerConfiguration()` on Kafka topic listeners.

`ConfigureConsumer()` intentionally creates a new topic-level `ConsumerConfig` and replaces the transport-level consumer configuration. This is useful when a topic needs a completely separate consumer configuration.

`ExtendConsumerConfiguration()` is intended for the more common case where Kafka client settings are configured globally, and an individual topic only needs to adjust a small number of consumer-specific options without losing the shared configuration.

For example, an application may configure SSL once at the transport level:

```csharp
kafka.ConfigureClient(config => config.ConfigureClientConfig(settings));

public static class ConfluentKafkaExtensions
{
    public static void ConfigureClientConfig(this ClientConfig config, KafkaSettings settings)
    {
        if (settings.UseSsl)
        {
            config.SecurityProtocol = SecurityProtocol.Ssl;
            config.SslKeystoreLocation = Path.Combine(AppContext.BaseDirectory, settings.Ssl.KeystoreLocation);
            config.SslKeystorePassword = settings.Ssl.KeystorePassword;
            config.SslCaLocation = Path.Combine(AppContext.BaseDirectory, settings.Ssl.SslCaLocation);
            config.SslKeyPassword = settings.Ssl.KeyPassword;
            config.EnableSslCertificateVerification = settings.Ssl.EnableCertificateVerification;
        }
    }
}
```

Then a specific topic may only need to override the consumer group:

```csharp
opts.ListenToKafkaTopic("orders")
    .ExtendConsumerConfiguration(config =>
    {
        config.GroupId = "orders-service";
    });
```

In this case, the topic should keep the shared SSL/client settings while applying the topic-specific consumer setting.

Using `ConfigureConsumer()` for this scenario would be easy to misuse, because it replaces the topic consumer config entirely:

```csharp
opts.ListenToKafkaTopic("orders")
    .ConfigureConsumer(config =>
    {
        config.GroupId = "orders-service";
    });
```
