### PR TITLE
Phase 2 distribution under UseTenantPartitionedEvents: per-(shard×database) granularity + subscription tenant attribution (#3021)

### DIFF
--- a/src/Persistence/MartenTests/Distribution/tenant_partitioned_distribution_granularity.cs
+++ b/src/Persistence/MartenTests/Distribution/tenant_partitioned_distribution_granularity.cs
@@ -1,0 +1,163 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Events;
+using MartenTests.Distribution.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Marten.Distribution;
+using Wolverine.MessagePack;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MartenTests.Distribution;
+
+// Phase 2 of the per-tenant-partitioned-events matrix (#3021): projection/subscription distribution
+// granularity under a SINGLE database with Conjoined + Quick + UseTenantPartitionedEvents.
+//
+// The load-bearing caveat this pins: Wolverine-managed event-subscription agents are distributed per
+// (shard × DATABASE), NOT per tenant. With per-tenant *partitioning* the tenants all live in one
+// database, so a single async projection yields exactly ONE agent ("…/all") spanning every tenant
+// partition — not one agent per tenant. ("One agent per tenant" is only true under sharded databases,
+// which is Phase 3.) The single shard still processes every tenant's events into that tenant's own
+// projection document.
+public class tenant_partitioned_distribution_granularity(ITestOutputHelper output) : PostgresqlContext, IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
+    // Unique schema per run: managed partitions created in one run otherwise break the next run's
+    // resource-setup DDL reconciliation against the same schema.
+    private readonly string theSchema = "csp_tpe_" + Guid.NewGuid().ToString("N");
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.HealthCheckPollingTime = 1.Seconds();
+                opts.Durability.CheckAssignmentPeriod = 1.Seconds();
+                opts.UseMessagePackSerialization();
+
+                opts.Services.AddMarten(m =>
+                    {
+                        m.DisableNpgsqlLogging = true;
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = theSchema;
+
+                        m.Events.StreamIdentity = StreamIdentity.AsString;
+                        m.Events.TenancyStyle = TenancyStyle.Conjoined;
+                        m.Events.AppendMode = EventAppendMode.Quick;
+                        m.Events.UseTenantPartitionedEvents = true;
+                        m.Events.UseIdentityMapForAggregates = false;
+
+                        m.Schema.For<PartitionedCounter>().MultiTenanted();
+                        m.Projections.Snapshot<PartitionedCounter>(SnapshotLifecycle.Async);
+                    })
+                    .IntegrateWithWolverine(m => m.UseWolverineManagedEventSubscriptionDistribution = true);
+
+                opts.Services.AddSingleton<ILoggerProvider>(new OutputLoggerProvider(output));
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Auto;
+            }).StartAsync();
+
+        theStore = theHost.Services.GetRequiredService<IDocumentStore>();
+        await theStore.Advanced.AddMartenManagedTenantsAsync(default, new Dictionary<string, string>
+        {
+            ["tenant1"] = "tenant1",
+            ["tenant2"] = "tenant2",
+            [StorageConstants.DefaultTenantId] = "default"
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        theHost.GetRuntime().Agents.DisableHealthChecks();
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task one_async_projection_yields_one_agent_per_shard_not_per_tenant()
+    {
+        await theHost.WaitUntilAssumesLeadershipAsync(10.Seconds());
+
+        // One async projection over a single database => exactly ONE subscription agent, even though
+        // three tenants (tenant1/tenant2/*DEFAULT*) are registered. Per-tenant would be three.
+        await theHost.WaitUntilAssignmentsChangeTo(w =>
+        {
+            w.AgentScheme = EventSubscriptionAgentFamily.SchemeName;
+            w.ExpectRunningAgents(theHost, 1);
+        }, 60.Seconds());
+
+        var uris = await GetAgentUrisAsync(theHost);
+        uris.Length.ShouldBe(1);
+
+        // The agent Uri is keyed by (store/database/shard) — no tenant component.
+        var uri = uris.Single();
+        uri.ShouldContain("/all");
+        uri.ShouldNotContain("tenant1");
+        uri.ShouldNotContain("tenant2");
+    }
+
+    [Fact]
+    public async Task the_single_shard_projects_every_tenant_partition()
+    {
+        await theHost.WaitUntilAssumesLeadershipAsync(10.Seconds());
+        await theHost.WaitUntilAssignmentsChangeTo(w =>
+        {
+            w.AgentScheme = EventSubscriptionAgentFamily.SchemeName;
+            w.ExpectRunningAgents(theHost, 1);
+        }, 60.Seconds());
+
+        var id = "pc-" + Guid.NewGuid().ToString("N");
+        await AppendAsync("tenant1", id, 5);
+        await AppendAsync("tenant2", id, 11); // same stream id, different tenant partition
+
+        await theStore.WaitForNonStaleProjectionDataAsync(60.Seconds());
+
+        // The one shard processed both tenant partitions into each tenant's own projection doc.
+        (await LoadAsync("tenant1", id))!.Total.ShouldBe(5);
+        (await LoadAsync("tenant2", id))!.Total.ShouldBe(11);
+    }
+
+    private async Task AppendAsync(string tenant, string id, int amount)
+    {
+        await using var session = theStore.LightweightSession(tenant);
+        session.Events.StartStream<PartitionedCounter>(id, new CounterChanged(amount));
+        await session.SaveChangesAsync();
+    }
+
+    private async Task<PartitionedCounter?> LoadAsync(string tenant, string id)
+    {
+        await using var session = theStore.LightweightSession(tenant);
+        return await session.LoadAsync<PartitionedCounter>(id);
+    }
+
+    private static async Task<string[]> GetAgentUrisAsync(IHost host)
+    {
+        var family = host.Services.GetServices<IAgentFamily>()
+            .OfType<EventSubscriptionAgentFamily>().Single();
+        var agents = await family.AllKnownAgentsAsync();
+        return [.. agents.Select(x => x.AbsoluteUri)];
+    }
+}
+
+public record CounterChanged(int Amount);
+
+public class PartitionedCounter
+{
+    public string Id { get; set; } = null!;
+    public int Total { get; set; }
+    public void Apply(CounterChanged e) => Total += e.Amount;
+}

--- a/src/Persistence/MartenTests/Distribution/tenant_partitioned_subscription_attribution.cs
+++ b/src/Persistence/MartenTests/Distribution/tenant_partitioned_subscription_attribution.cs
@@ -1,0 +1,114 @@
+using System.Collections.Concurrent;
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using JasperFx.Resources;
+using Marten;
+using Marten.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace MartenTests.Distribution;
+
+// Phase 2 of #3021 (subscriptions slice): PublishEventsToWolverine under Conjoined + Quick +
+// UseTenantPartitionedEvents. Under conjoined tenancy the relay binds RelayWithEventTenant (GH-2675),
+// so each event reaches its Wolverine handler attributed with the event's own per-row TenantId — the
+// tenant lives in the row, not the database. This pins that an event appended in tenant1 is delivered
+// with TenantId "tenant1", tenant2 with "tenant2", and a default-tenant event with the literal
+// StorageConstants.DefaultTenantId (the case GH-2675 fixed against silent misrouting to the database id).
+// Also exercises the event-as-message (IEvent<T>) handler shape.
+public class tenant_partitioned_subscription_attribution : PostgresqlContext, IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
+    private readonly string theSchema = "tpe_sub_" + Guid.NewGuid().ToString("N");
+
+    public async Task InitializeAsync()
+    {
+        SubscribedCounterHandler.TenantByAmount.Clear();
+
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddMarten(m =>
+                    {
+                        m.DisableNpgsqlLogging = true;
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = theSchema;
+
+                        m.Events.StreamIdentity = StreamIdentity.AsString;
+                        m.Events.TenancyStyle = TenancyStyle.Conjoined;
+                        m.Events.AppendMode = EventAppendMode.Quick;
+                        m.Events.UseTenantPartitionedEvents = true;
+                    })
+                    .IntegrateWithWolverine()
+                    .UseLightweightSessions()
+                    .PublishEventsToWolverine("tenant_attribution", relay => relay.PublishEvent<CounterChanged>());
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(SubscribedCounterHandler));
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        theStore = theHost.Services.GetRequiredService<IDocumentStore>();
+        await theStore.Advanced.AddMartenManagedTenantsAsync(default, new Dictionary<string, string>
+        {
+            ["tenant1"] = "tenant1",
+            ["tenant2"] = "tenant2",
+            [StorageConstants.DefaultTenantId] = "default"
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task relayed_events_carry_their_own_per_row_tenant()
+    {
+        var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+
+        // Typed as Func<…, Task> to disambiguate the Task/ValueTask ExecuteAndWaitAsync overloads.
+        Func<IMessageContext, Task> append = async _ =>
+        {
+            await Append("tenant1", 5);
+            await Append("tenant2", 11);
+            await Append(StorageConstants.DefaultTenantId, 7);
+            await daemon.WaitForNonStaleData(30.Seconds());
+        };
+
+        await theHost.TrackActivity().Timeout(60.Seconds()).ExecuteAndWaitAsync(append);
+
+        SubscribedCounterHandler.TenantByAmount[5].ShouldBe("tenant1");
+        SubscribedCounterHandler.TenantByAmount[11].ShouldBe("tenant2");
+        SubscribedCounterHandler.TenantByAmount[7].ShouldBe(StorageConstants.DefaultTenantId);
+    }
+
+    private async Task Append(string tenant, int amount)
+    {
+        await using var session = theStore.LightweightSession(tenant);
+        session.Events.StartStream("c-" + Guid.NewGuid().ToString("N"), new CounterChanged(amount));
+        await session.SaveChangesAsync();
+    }
+}
+
+// Event-as-message handler: receives the relayed IEvent<CounterChanged> and records the tenant the
+// envelope was delivered under, keyed by the (unique-per-tenant) amount.
+public static class SubscribedCounterHandler
+{
+    public static readonly ConcurrentDictionary<int, string?> TenantByAmount = new();
+
+    public static void Handle(IEvent<CounterChanged> e, Envelope envelope)
+        => TenantByAmount[e.Data.Amount] = envelope.TenantId;
+}


### PR DESCRIPTION
Opens **Phase 2** (projection/subscription distribution) of the #3021 per-tenant-partitioned-events matrix. Test-only, no version bump. Both fixtures use a single database with Conjoined + Quick + `UseTenantPartitionedEvents` and three managed tenants.

## `tenant_partitioned_distribution_granularity`
Pins the load-bearing **granularity caveat**: Wolverine-managed event-subscription agents distribute per **(shard × DATABASE)**, not per tenant. With per-tenant *partitioning* all tenants live in one database, so:
- `one_async_projection_yields_one_agent_per_shard_not_per_tenant` — one async snapshot projection ⇒ exactly **one** `event-subscriptions://…/all` agent, even with three tenants registered (per-tenant would be three); the agent Uri carries (store/database/shard) with no tenant component.
- `the_single_shard_projects_every_tenant_partition` — that single shard projects each tenant's events into that tenant's own projection document (same stream id in two tenants stays isolated).

("One agent per tenant" is only valid under sharded databases — Phase 3.)

## `tenant_partitioned_subscription_attribution`
`PublishEventsToWolverine` under conjoined tenancy auto-binds `RelayWithEventTenant` (GH-2675), so each relayed event reaches its Wolverine handler attributed with the event's own per-row `TenantId`:
- `relayed_events_carry_their_own_per_row_tenant` — events appended in tenant1 / tenant2 / default are delivered to an `IEvent<CounterChanged>` handler with `TenantId` `"tenant1"` / `"tenant2"` / the literal `StorageConstants.DefaultTenantId` (the default-tenant case GH-2675 fixed against silent misrouting to the database identifier). Also exercises the **event-as-message** (`IEvent<T>`) handler shape.

## Findings
No bugs — distribution granularity and subscription tenant attribution both behave correctly under partitioning.

## Verification
- Each test stable across 3 repeated runs (daemon/agent timing).
- Full MartenTests suite **480/480**.

## Remaining Phase 2 (future)
Multi-node spread/failover & rebalance of the partitioned subscription, per-tenant high-water continuity, blue/green projection versioning under partitioning. **Phase 3** (sharded databases — where granularity becomes per-tenant) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)