### PR TITLE
Honor policy-set TransactionMiddlewareMode for storage-action saga chains (#3039)

### DIFF
--- a/src/Persistence/EfCoreTests/transaction_middleware_mode_tests.cs
+++ b/src/Persistence/EfCoreTests/transaction_middleware_mode_tests.cs
@@ -1,4 +1,6 @@
 using IntegrationTests;
+using JasperFx;
+using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
@@ -6,9 +8,11 @@ using SharedPersistenceModels.Items;
 using Shouldly;
 using Wolverine;
 using Wolverine.Attributes;
+using Wolverine.Configuration;
 using Wolverine.EntityFrameworkCore;
 using Wolverine.EntityFrameworkCore.Codegen;
 using Wolverine.Persistence;
+using Wolverine.Runtime.Handlers;
 using Wolverine.SqlServer;
 using Wolverine.Tracking;
 
@@ -242,6 +246,93 @@ public class transaction_middleware_mode_tests
 
         // Default should be Eager
         chain.Middleware.OfType<EnrollDbContextInTransaction>().ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task handler_policy_eager_mode_is_honored_for_storage_action_saga_chains()
+    {
+        // GH-3039: global Lightweight, but a marker-interface IHandlerPolicy opts specific messages into
+        // Eager by setting chain.Tags["TransactionMiddlewareMode"]. A saga handler returning a storage
+        // action (Insert<T>) must honor that policy-set mode - previously it was silently ignored because
+        // SideEffectPolicy applied the (Lightweight) transaction support before the user policy ran.
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<EagerPolicySagaDbContext>(x =>
+                    x.UseSqlServer(Servers.SqlServerConnectionString));
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "txmode");
+                opts.UseEntityFrameworkCoreTransactions(TransactionMiddlewareMode.Lightweight);
+                opts.Policies.AutoApplyTransactions();
+
+                // Opt the marker-interface messages into Eager from a policy, the natural per-message way.
+                opts.Policies.Add<EagerTransactionForMessagePolicy<IRequiresEagerTransaction>>();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<EagerPolicySaga>();
+            }).StartAsync();
+
+        host.GetRuntime().Handlers.HandlerFor<StartEagerPolicySaga>();
+        var chain = host.GetRuntime().Handlers.ChainFor<StartEagerPolicySaga>()!;
+
+        // The policy set Eager, so the storage-action saga chain must get the eager transaction frames.
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ShouldNotBeEmpty();
+
+        chain.Postprocessors.OfType<MethodCall>()
+            .Any(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
+            .ShouldBeTrue();
+    }
+}
+
+public interface IRequiresEagerTransaction;
+
+// Mirrors the marker-interface policy from GH-3039: opt every message of a given type into eager
+// transactions from a single IHandlerPolicy rather than per-method [Transactional] attributes.
+public class EagerTransactionForMessagePolicy<TMessage> : IHandlerPolicy
+{
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        foreach (var chain in chains.Where(c => typeof(TMessage).IsAssignableFrom(c.MessageType)))
+        {
+            chain.Tags["TransactionMiddlewareMode"] = TransactionMiddlewareMode.Eager;
+        }
+    }
+}
+
+public record StartEagerPolicySaga(Guid Id) : IRequiresEagerTransaction;
+
+public class EagerPolicySaga : Saga
+{
+    public Guid Id { get; set; }
+
+    // Saga start whose return value is a storage action for another entity - the GH-3039 shape.
+    public Insert<Item> Start(StartEagerPolicySaga message)
+    {
+        return Storage.Insert(new Item { Id = Guid.NewGuid(), Name = "from-saga" });
+    }
+}
+
+public class EagerPolicySagaDbContext : DbContext
+{
+    public EagerPolicySagaDbContext(DbContextOptions<EagerPolicySagaDbContext> options) : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Item>(map =>
+        {
+            map.ToTable("policy_items");
+            map.HasKey(x => x.Id);
+            map.Property(x => x.Name);
+        });
+
+        modelBuilder.Entity<EagerPolicySaga>(map =>
+        {
+            map.ToTable("policy_saga");
+            map.HasKey(x => x.Id);
+        });
     }
 }
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -317,6 +317,17 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 
     public void ApplyTransactionSupport(IChain chain, IServiceContainer container, Type entityType)
     {
+        // GH-3039: For saga chains, defer to the saga's own transaction-support application at codegen
+        // time (SagaChain.DetermineFrames -> the no-entity ApplyTransactionSupport below). That runs
+        // AFTER every IHandlerPolicy, so a transaction mode set on the chain by a user policy
+        // (chain.Tags["TransactionMiddlewareMode"]) is honored. This entity overload is otherwise
+        // invoked by SideEffectPolicy when a handler returns a storage action (Insert<T>/Update<T>/
+        // UnitOfWork<T>/...), which happens DURING policy application - before a marker-interface
+        // IHandlerPolicy has had a chance to set the mode tag. Applying it here would lock in DefaultMode
+        // and the UsingEfCoreTransaction idempotency guard would then block the later, correctly-moded
+        // application - silently dropping the eager transaction for storage-action saga handlers.
+        if (chain is SagaChain) return;
+
         if (chain.Tags.ContainsKey(UsingEfCoreTransaction)) return;
         chain.Tags.Add(UsingEfCoreTransaction, true);
 


### PR DESCRIPTION
Closes #3039.

## Problem
A handler chain returning an EF Core storage action (`Insert<T>` / `Update<T>` / `UnitOfWork<T>`) silently ignored `TransactionMiddlewareMode.Eager` set from an `IHandlerPolicy` via `chain.Tags["TransactionMiddlewareMode"]`. The generated handler got no outbox enrollment and no `BeginTransactionAsync` — only a trailing `SaveChangesAsync` — so handler-spanning row locks were released immediately and concurrency protection silently disappeared. Sibling chains for the same message type that returned only cascading messages got the full eager pattern.

## Root cause
`Storage`/`SideEffectPolicy` apply EF transaction support **during policy application** (when a handler returns a storage action), which runs **before** a user `IHandlerPolicy` has set the mode tag. The mode therefore resolved to the default (Lightweight), and the `UsingEfCoreTransaction` idempotency guard then blocked the later, correctly-moded application from `SagaChain.DetermineFrames` (codegen time, after all policies). A per-method `[Transactional(Mode = Eager)]` worked because `ResolveEffectiveMode` reads attributes directly; a marker-interface `IHandlerPolicy` did not.

## Fix
`EFCorePersistenceFrameProvider.ApplyTransactionSupport(chain, container, entityType)` now defers to the saga's own application for `SagaChain`. `SagaChain.DetermineFrames` calls the no-entity `ApplyTransactionSupport` **after** every `IHandlerPolicy` has run, so the policy-set mode tag is honored. The storage-action return frame is still emitted by `SideEffectPolicy` exactly as before. One guard line; no behavior change for non-saga chains or for the attribute path.

## Tests
New `handler_policy_eager_mode_is_honored_for_storage_action_saga_chains` — a saga whose `Start` returns `Insert<Item>`, global mode Lightweight, with a marker-interface `IHandlerPolicy` (the exact pattern from the issue) setting the chain to Eager. The chain now gets `EnrollDbContextInTransaction`. Verified it **fails** (no eager frame) without the fix.

- `transaction_middleware_mode_tests` + EF Core saga suites: 50/50.
- (The full `EfCoreTests` run showed unrelated outbox/idempotency/domain-event failures only under full-suite SQL Server contention against a freshly-started container; every one passes in isolation and none touch saga transaction-mode resolution.)

> No version bump: `main` is `6.4.4` and unpublished (latest tag is `V6.4.1`), so this fix rides the pending 6.4.4 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)