### PR TITLE
FromHandlerType routing: create listeners for separated handler chains, not just the saga (#3041)

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/Bug_3041_saga_and_handler_with_handler_type_naming.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/Bug_3041_saga_and_handler_with_handler_type_naming.cs
@@ -1,0 +1,83 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Util;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests.ConventionalRouting;
+
+// GH-3041: with NamingSource.FromHandlerType + MultipleHandlerBehavior.Separated, a message handled by
+// BOTH a saga (e.g. a Start method) and a regular handler only created a listener queue for the saga -
+// the regular handler's separated chain lives in chain.ByEndpoint, which the FromHandlerType listener
+// discovery ignored. Result: the regular handler never received the message.
+public class Bug_3041_saga_and_handler_with_handler_type_naming : IAsyncLifetime, IDisposable
+{
+    private IHost _host = null!;
+    private IWolverineRuntime _runtime = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UseRabbitMq()
+                .AutoProvision()
+                .UseConventionalRouting(NamingSource.FromHandlerType);
+
+            opts.Policies.DisableConventionalLocalRouting();
+            opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+
+            opts.Discovery.DisableConventionalDiscovery()
+                .IncludeType(typeof(Bug3041Saga))
+                .IncludeType(typeof(Bug3041RegularHandler));
+        });
+
+        _runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+    }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void both_the_saga_and_the_regular_handler_get_listener_queues()
+    {
+        var transport = _runtime.Options.RabbitMqTransport();
+        var sagaQueue = typeof(Bug3041Saga).ToMessageTypeName();
+        var handlerQueue = typeof(Bug3041RegularHandler).ToMessageTypeName();
+        var all = string.Join(", ", transport.Queues.Select(q => q.EndpointName));
+
+        transport.Queues.Contains(sagaQueue).ShouldBeTrue($"saga queue '{sagaQueue}' missing. Queues: {all}");
+        transport.Queues.Contains(handlerQueue).ShouldBeTrue($"regular-handler queue '{handlerQueue}' missing. Queues: {all}");
+    }
+
+    [Fact]
+    public void both_handler_queues_have_active_listeners()
+    {
+        var saga = $"rabbitmq://queue/{typeof(Bug3041Saga).ToMessageTypeName()}".ToUri();
+        var handler = $"rabbitmq://queue/{typeof(Bug3041RegularHandler).ToMessageTypeName()}".ToUri();
+
+        var listeners = _runtime.Endpoints.ActiveListeners().Select(x => x.Uri).ToArray();
+        listeners.ShouldContain(saga);
+        listeners.ShouldContain(handler);
+    }
+
+    public void Dispose() => _host.Dispose();
+}
+
+public record Bug3041Message;
+
+public class Bug3041Saga : Saga
+{
+    public Guid Id { get; set; }
+    public void Start(Bug3041Message message) => Id = Guid.NewGuid();
+}
+
+public class Bug3041RegularHandler
+{
+    public void Handle(Bug3041Message message)
+    {
+    }
+}

--- a/src/Wolverine/Transports/MessageRoutingConvention.cs
+++ b/src/Wolverine/Transports/MessageRoutingConvention.cs
@@ -71,7 +71,7 @@ public abstract class MessageRoutingConvention<[DynamicallyAccessedMembers(Dynam
                 continue;
             }
 
-            if (_namingSource == NamingSource.FromHandlerType && chain.Handlers.Any())
+            if (_namingSource == NamingSource.FromHandlerType && (chain.Handlers.Any() || chain.ByEndpoint.Any()))
             {
                 foreach (var handler in chain.Handlers)
                 {
@@ -79,6 +79,22 @@ public abstract class MessageRoutingConvention<[DynamicallyAccessedMembers(Dynam
                     var endpoint = maybeCreateListenerForMessageOrHandlerType(transport, handlerType, runtime, messageType);
                     if (endpoint != null)
                     {
+                        endpoint.StickyHandlers.Add(handlerType);
+                    }
+                }
+
+                // Separated handler chains live in ByEndpoint, NOT chain.Handlers. When a message is
+                // handled by more than one handler under MultipleHandlerBehavior.Separated (e.g. a saga
+                // plus a regular handler), only the saga stays in chain.Handlers - the sibling handlers
+                // are moved to ByEndpoint. They each still need their own handler-named listener, or the
+                // message never reaches them and only chain.Handlers (the saga) is invoked. GH-3041.
+                foreach (var handlerChain in chain.ByEndpoint)
+                {
+                    var handlerType = handlerChain.Handlers.First().HandlerType;
+                    var endpoint = maybeCreateListenerForMessageOrHandlerType(transport, handlerType, runtime, messageType);
+                    if (endpoint != null)
+                    {
+                        handlerChain.RegisterEndpoint(endpoint);
                         endpoint.StickyHandlers.Add(handlerType);
                     }
                 }


### PR DESCRIPTION
Closes #3041.

## Reproduction
From the reporter's repo: RabbitMQ + `UseConventionalRouting(NamingSource.FromHandlerType)` + `DisableConventionalLocalRouting()` + `MultipleHandlerBehavior.Separated`, with a message handled by both a saga (a `Start` method) and a regular handler. Only the saga ran; the regular handler never received the message.

I reproduced it broker-free by inspecting the `SagaChain` for the shared message type:

```
chain type      : SagaChain
chain.Handlers  : [ReproSaga.Start]          // the saga only
chain.ByEndpoint: [ReproRegularHandler]      // the regular handler is a SEPARATED chain
```

(The reporter's own diagnostic — `runtime.RoutingFor(messageType).Routes` — points at the sender/exchange side; the actual missing piece is on the listener side, which the endpoint/queue diagnostics surface: only the saga's queue gets created.)

## Root cause
Under `MultipleHandlerBehavior.Separated`, when a message has multiple handlers and one is a saga, only the saga stays in `chain.Handlers` — the sibling handlers are moved to separated chains in `chain.ByEndpoint`. `MessageRoutingConvention.DiscoverListeners`' `FromHandlerType` branch iterated **only `chain.Handlers`**, so it created a handler-named listener queue for the saga but **none for the separated regular handler**. With conventional local routing disabled, that handler had no queue/listener and never received the message. (The `Separated` branch handles `ByEndpoint`, but `FromHandlerType` takes the earlier `if` and never reaches it.)

## Fix
The `FromHandlerType` branch now also creates a handler-named listener for each `chain.ByEndpoint` chain — registering the endpoint on that chain and marking it sticky, mirroring what the `Separated` branch already does — and is entered when there are only `ByEndpoint` chains too. One small change in `MessageRoutingConvention`.

## Tests
New RabbitMQ regression `Bug_3041_saga_and_handler_with_handler_type_naming` (mirrors the repro): asserts both the saga's and the regular handler's handler-named queues exist and have active listeners. Verified it **fails** (regular-handler queue missing) without the fix.

- RabbitMQ conventional-routing + separated suites: 34.
- MessageRoutingTests: 25. CoreTests saga/separated: 66.

> No version bump — `main` is unpublished 6.4.4 (latest tag `V6.4.1`); rides the pending release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)