### PR TITLE
Upgrade JasperFx.* 2.8.0→2.8.2 and Marten.* 9.5.2→9.6.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,19 +32,19 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.8.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.8.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.8.0" />
+    <PackageVersion Include="JasperFx" Version="2.8.2" />
+    <PackageVersion Include="JasperFx.Events" Version="2.8.2" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.8.2" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.8.0" />
-    <PackageVersion Include="Marten" Version="9.5.2" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.8.2" />
+    <PackageVersion Include="Marten" Version="9.6.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.2.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.5.2" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.5.2" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.6.0" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.6.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />


### PR DESCRIPTION
Bumps the JasperFx and Marten families to their latest stable releases.

| Package(s) | From | To |
|---|---|---|
| `JasperFx`, `JasperFx.Events`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator` | 2.8.0 | **2.8.2** |
| `Marten`, `Marten.AspNetCore`, `Marten.Newtonsoft` | 9.5.2 | **9.6.0** |
| `Weasel.*` | 9.0.3 | unchanged (already latest) |
| `JasperFx.RuntimeCompiler` | 5.0.0 | unchanged (pinned to 5.x, already latest) |

Marten 9.6.0's dependency set is exactly **JasperFx 2.8.2 + JasperFx.Events 2.8.2 + Weasel.Postgresql 9.0.3**, so the versions stay consistent (verified against the published nuspec).

## Verification
- Full `wolverine.slnx` Release build: **0 warnings, 0 errors** (compiles across Marten/Polecat/HTTP/EF/all extensions — no source-gen/analyzer double-emit or API breaks).
- Marten 9.6.0 runtime smoke (single-IMartenOp + tenant-partitioned-events foundational/matrix/unregistered-tenant): **21/21**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)