### PR TITLE
Persist IEventStream<T> compound-handler appends without AutoApplyTransactions (#3032)

### DIFF
--- a/src/Persistence/MartenTests/event_stream_append_persists.cs
+++ b/src/Persistence/MartenTests/event_stream_append_persists.cs
@@ -1,0 +1,84 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Marten;
+using JasperFx.Events;
+using Marten.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests;
+
+// GH-3032: a compound handler that loads an IEventStream<T> via FetchForWriting and appends to it must
+// persist even without opts.Policies.AutoApplyTransactions() - consistent with single IMartenOp returns
+// (GH-3025) and [AggregateHandler]. Previously the append was silently dropped (no SaveChangesAsync).
+public class event_stream_append_persists : PostgresqlContext, IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "event_stream_3032";
+                        m.DisableNpgsqlLogging = true;
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                // Deliberately NO opts.Policies.AutoApplyTransactions().
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(AppendViaStreamHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        theStore = theHost.Services.GetRequiredService<IDocumentStore>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task compound_handler_event_stream_append_persists_without_auto_transactions()
+    {
+        var id = Guid.NewGuid();
+        await theHost.InvokeMessageAndWaitAsync(new AppendViaStreamCommand(id));
+
+        await using var session = theStore.LightweightSession();
+        var events = await session.Events.FetchStreamAsync(id);
+        events.Count.ShouldBe(1); // was 0 (append dropped) before GH-3032
+    }
+}
+
+public record AppendViaStreamCommand(Guid Id);
+
+public record StreamThingHappened(int Amount);
+
+public class StreamThing
+{
+    public Guid Id { get; set; }
+    public int Total { get; set; }
+    public void Apply(StreamThingHappened e) => Total += e.Amount;
+}
+
+public static class AppendViaStreamHandler
+{
+    public static Task<IEventStream<StreamThing>> LoadAsync(
+        AppendViaStreamCommand command, IDocumentSession session, CancellationToken cancellation)
+        => session.Events.FetchForWriting<StreamThing>(command.Id, cancellation);
+
+    public static void Handle(AppendViaStreamCommand command, IEventStream<StreamThing> stream)
+        => stream.AppendOne(new StreamThingHappened(5));
+}

--- a/src/Persistence/Wolverine.Marten/IMartenOp.cs
+++ b/src/Persistence/Wolverine.Marten/IMartenOp.cs
@@ -4,6 +4,7 @@ using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core;
+using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using Marten;
 using Marten.Events;
@@ -44,7 +45,17 @@ internal class MartenOpPolicy : IChainPolicy
             // handlers / AutoApplyTransactions. GH-3025.
             var singles = chain.ReturnVariablesOfType<IMartenOp>().ToArray();
 
-            if (collections.Any() || singles.Any())
+            // A compound handler that loads an IEventStream<T> (typically via FetchForWriting in a
+            // Load/LoadAsync method) and appends to it needs Marten transaction support so SaveChangesAsync
+            // flushes the appended events. Without it the append is silently dropped unless the app has
+            // AutoApplyTransactions enabled — inconsistent with single IMartenOp returns (above) and
+            // [AggregateHandler]. Detect by an IEventStream<T> handler parameter. ApplyTransactionSupport is
+            // idempotent, so this composes with the aggregate workflow (which also uses IEventStream<T>) and
+            // with AutoApplyTransactions. GH-3032.
+            var appendsToEventStream = chain.HandlerCalls()
+                .Any(call => call.Method.GetParameters().Any(p => p.ParameterType.Closes(typeof(IEventStream<>))));
+
+            if (collections.Any() || singles.Any() || appendsToEventStream)
             {
                 new MartenPersistenceFrameProvider().ApplyTransactionSupport(chain, container);
             }


### PR DESCRIPTION
Closes #3032.

## Problem
A compound handler that obtains an `IEventStream<T>` via the `Load`/`LoadAsync` convention (`FetchForWriting<T>`) and appends to it got **no Marten transaction support** unless `opts.Policies.AutoApplyTransactions()` was enabled — `SaveChangesAsync` was never generated and the appended events were **silently dropped** (no exception). This was inconsistent with the other handler-side Marten effects that self-persist: single/collection `IMartenOp` returns (fixed in #3025) and `[AggregateHandler]`.

## Fix
`MartenOpPolicy` now also detects a handler that takes an `IEventStream<T>` parameter (the append shape) and applies the same idempotent Marten transaction support it already applies for `IMartenOp` returns. `ApplyTransactionSupport` guards on `CreateDocumentSessionFrame` + `DocumentSessionSaveChanges`, so it composes with the aggregate workflow (which also uses `IEventStream<T>` via `[WriteAggregate]`) and with `AutoApplyTransactions`.

```csharp
var appendsToEventStream = chain.HandlerCalls()
    .Any(call => call.Method.GetParameters().Any(p => p.ParameterType.Closes(typeof(IEventStream<>))));
```

## Tests
New `event_stream_append_persists` — a compound handler (`LoadAsync` → `FetchForWriting<T>`, `Handle` appends) on a host **without** `AutoApplyTransactions` now persists the append (`FetchStreamAsync` count 1). **Verified it fails (count 0, dropped) without the fix.**

- Bug_225 (the `AutoApplyTransactions`-on compound path), the aggregate-handler workflow, and the single-`IMartenOp` suites stay green (94 targeted).
- Full MartenTests suite: **494/494**.

> No version bump — `main` is unpublished 6.4.4 (latest tag `V6.4.1`); rides the pending release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)