### PR TITLE
Add `IDeadLetterInterceptor`: an exception-handling seam for durable dead letters

### DIFF
--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Incoming.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Incoming.cs
@@ -215,8 +215,8 @@ internal partial class OracleMessageStore
         insertCmd.With("messageType", envelope.MessageType ?? string.Empty);
         insertCmd.With("receivedAt", envelope.Destination?.ToString() ?? string.Empty);
         insertCmd.With("source", envelope.Source ?? string.Empty);
-        insertCmd.With("exceptionType", exception?.GetType().FullNameInCode() ?? string.Empty);
-        insertCmd.With("exceptionMessage", exception?.Message ?? string.Empty);
+        insertCmd.With("exceptionType", exception.DeadLetterExceptionType() ?? string.Empty);
+        insertCmd.With("exceptionMessage", exception.DeadLetterExceptionMessage() ?? string.Empty);
         insertCmd.Parameters.Add(new OracleParameter("sentAt", OracleDbType.TimeStampTZ) { Value = envelope.SentAt.ToUniversalTime() });
         insertCmd.With("replayable", 0); // Oracle stores bool as NUMBER(1)
 

--- a/src/Persistence/Wolverine.CosmosDb/Internals/DeadLetterMessage.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/DeadLetterMessage.cs
@@ -21,8 +21,8 @@ public class DeadLetterMessage
         SentAt = envelope.SentAt;
         ScheduledTime = envelope.ScheduledTime;
         Source = envelope.Source;
-        ExceptionType = exception?.GetType().FullNameInCode();
-        ExceptionMessage = exception?.Message;
+        ExceptionType = exception.DeadLetterExceptionType();
+        ExceptionMessage = exception.DeadLetterExceptionMessage();
         Body = EnvelopeSerializer.Serialize(envelope);
         PartitionKey = DocumentTypes.DeadLetterPartition;
     }

--- a/src/Persistence/Wolverine.RDBMS/DatabasePersistence.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabasePersistence.cs
@@ -165,8 +165,8 @@ public static class DatabasePersistence
             builder.AddParameter(envelope.MessageType ?? "unknown"),
             builder.AddParameter(envelope.Destination?.ToString()),
             builder.AddParameter(envelope.Source ?? "unknown"),
-            builder.AddParameter(exception?.GetType().FullNameInCode()),
-            builder.AddParameter(exception?.Message),
+            builder.AddParameter(exception.DeadLetterExceptionType()),
+            builder.AddParameter(exception.DeadLetterExceptionMessage()),
             builder.AddParameter(envelope.SentAt.ToUniversalTime()),
             builder.AddParameter(false)
         };

--- a/src/Persistence/Wolverine.RavenDb/Internals/DeadLetterMessage.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/DeadLetterMessage.cs
@@ -19,8 +19,8 @@ public class DeadLetterMessage
         SentAt = envelope.SentAt;
         ScheduledTime = envelope.ScheduledTime;
         Source = envelope.Source!;
-        ExceptionType = exception?.GetType().FullNameInCode()!;
-        ExceptionMessage = exception?.Message!;
+        ExceptionType = exception.DeadLetterExceptionType()!;
+        ExceptionMessage = exception.DeadLetterExceptionMessage()!;
 
         // TODO -- need to harden this one
         Body = EnvelopeSerializer.Serialize(envelope);

--- a/src/Testing/CoreTests/ErrorHandling/dead_letter_exception_info.cs
+++ b/src/Testing/CoreTests/ErrorHandling/dead_letter_exception_info.cs
@@ -1,0 +1,50 @@
+using JasperFx.Core.Reflection;
+using Shouldly;
+using Wolverine.Persistence.Durability;
+using Xunit;
+
+namespace CoreTests.ErrorHandling;
+
+public class dead_letter_exception_info
+{
+    [Fact]
+    public void falls_back_to_runtime_type_and_message_for_a_normal_exception()
+    {
+        var ex = new InvalidOperationException("boom");
+
+        ex.DeadLetterExceptionType().ShouldBe(ex.GetType().FullNameInCode());
+        ex.DeadLetterExceptionMessage().ShouldBe("boom");
+    }
+
+    [Fact]
+    public void honors_marker_to_preserve_type_while_redacting_message()
+    {
+        var original = new InvalidOperationException("secret PII: alice@example.com");
+        Exception redacted = new RedactingException(original);
+
+        // The persisted type stays the ORIGINAL type (so operators can still filter/triage by it),
+        // even though the runtime type handed to the store is RedactingException.
+        redacted.DeadLetterExceptionType().ShouldBe(original.GetType().FullNameInCode());
+
+        // ...while the message is redacted.
+        redacted.DeadLetterExceptionMessage().ShouldBe("redacted");
+    }
+
+    [Fact]
+    public void null_exception_yields_null_strings()
+    {
+        ((Exception?)null).DeadLetterExceptionType().ShouldBeNull();
+        ((Exception?)null).DeadLetterExceptionMessage().ShouldBeNull();
+    }
+
+    private sealed class RedactingException : Exception, IDeadLetterExceptionInfo
+    {
+        public RedactingException(Exception original) : base("redacted")
+        {
+            ExceptionType = original.GetType().FullNameInCode();
+        }
+
+        public string ExceptionType { get; }
+        public string ExceptionMessage => "redacted";
+    }
+}

--- a/src/Testing/CoreTests/ErrorHandling/dead_letter_interceptor.cs
+++ b/src/Testing/CoreTests/ErrorHandling/dead_letter_interceptor.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.ComplianceTests.ErrorHandling;
+using Wolverine.ErrorHandling;
+using Wolverine.Persistence.Durability;
+using Xunit;
+
+namespace CoreTests.ErrorHandling;
+
+public class dead_letter_interceptor : ErrorHandlingContext
+{
+    private readonly RecordingDeadLetterInterceptor _first;
+    private readonly RecordingDeadLetterInterceptor _second;
+
+    public dead_letter_interceptor()
+    {
+        // The first interceptor swaps in a replacement exception; the second just records what it
+        // receives - which proves both that interceptors run and that the return value is threaded
+        // from one to the next before the envelope is handed to durable storage.
+        _first = new RecordingDeadLetterInterceptor(replaceWith: new RedactedException());
+        _second = new RecordingDeadLetterInterceptor();
+
+        ConfigureOptions(opts =>
+        {
+            opts.Services.AddSingleton<IDeadLetterInterceptor>(_first);
+            opts.Services.AddSingleton<IDeadLetterInterceptor>(_second);
+
+            opts.HandlerGraph.ConfigureHandlerForMessage<ErrorCausingMessage>(chain =>
+            {
+                chain.OnException<DivideByZeroException>().MoveToErrorQueue();
+                chain.Failures.MaximumAttempts = 3;
+            });
+        });
+    }
+
+    [Fact]
+    public async Task interceptors_run_before_storage_and_chain_the_exception()
+    {
+        throwOnAttempt<DivideByZeroException>(1);
+
+        await shouldMoveToErrorQueueOnAttempt(1);
+
+        // Both registered interceptors were invoked on the dead-letter path.
+        _first.Invoked.ShouldBeTrue();
+        _second.Invoked.ShouldBeTrue();
+
+        // The first interceptor sees the original failure exception and the failed envelope.
+        _first.ReceivedException.ShouldBeOfType<DivideByZeroException>();
+        _first.ReceivedEnvelope!.Message.ShouldBeOfType<ErrorCausingMessage>();
+
+        // The replacement returned by the first interceptor is what the second one receives,
+        // i.e. the return value is threaded through and would be persisted in place of the original.
+        _second.ReceivedException.ShouldBeOfType<RedactedException>();
+    }
+}
+
+internal sealed class RedactedException : Exception
+{
+    public RedactedException() : base("redacted")
+    {
+    }
+}
+
+internal sealed class RecordingDeadLetterInterceptor : IDeadLetterInterceptor
+{
+    private readonly Exception? _replaceWith;
+
+    public RecordingDeadLetterInterceptor(Exception? replaceWith = null)
+    {
+        _replaceWith = replaceWith;
+    }
+
+    public bool Invoked { get; private set; }
+    public Envelope? ReceivedEnvelope { get; private set; }
+    public Exception? ReceivedException { get; private set; }
+
+    public ValueTask<Exception?> BeforeStoreAsync(Envelope envelope, Exception? exception, CancellationToken cancellation)
+    {
+        Invoked = true;
+        ReceivedEnvelope = envelope;
+        ReceivedException = exception;
+        return new ValueTask<Exception?>(_replaceWith ?? exception);
+    }
+}

--- a/src/Wolverine/Persistence/Durability/IDeadLetterExceptionInfo.cs
+++ b/src/Wolverine/Persistence/Durability/IDeadLetterExceptionInfo.cs
@@ -1,0 +1,38 @@
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.Persistence.Durability;
+
+/// <summary>
+/// Optional contract an exception can implement to control the exception type and message that are
+/// written to dead-letter storage, independently of the exception's runtime type. This lets an
+/// <see cref="IDeadLetterInterceptor"/> redact the message while still reporting the original
+/// exception type, so operators keep the ability to filter and triage dead letters by type.
+/// </summary>
+public interface IDeadLetterExceptionInfo
+{
+    /// <summary>The exception type name to persist (for example, the original thrown type).</summary>
+    string ExceptionType { get; }
+
+    /// <summary>The exception message to persist.</summary>
+    string ExceptionMessage { get; }
+}
+
+/// <summary>
+/// Resolves the exception type and message strings that stores persist to dead-letter storage.
+/// </summary>
+public static class DeadLetterExceptionExtensions
+{
+    /// <summary>
+    /// The exception type name to persist. Honors <see cref="IDeadLetterExceptionInfo"/> when the
+    /// exception implements it; otherwise the runtime type's code-friendly full name.
+    /// </summary>
+    public static string? DeadLetterExceptionType(this Exception? exception) =>
+        exception is IDeadLetterExceptionInfo info ? info.ExceptionType : exception?.GetType().FullNameInCode();
+
+    /// <summary>
+    /// The exception message to persist. Honors <see cref="IDeadLetterExceptionInfo"/> when the
+    /// exception implements it; otherwise <see cref="Exception.Message"/>.
+    /// </summary>
+    public static string? DeadLetterExceptionMessage(this Exception? exception) =>
+        exception is IDeadLetterExceptionInfo info ? info.ExceptionMessage : exception?.Message;
+}

--- a/src/Wolverine/Persistence/Durability/IDeadLetterInterceptor.cs
+++ b/src/Wolverine/Persistence/Durability/IDeadLetterInterceptor.cs
@@ -1,0 +1,30 @@
+namespace Wolverine.Persistence.Durability;
+
+/// <summary>
+/// Hook invoked for each envelope immediately before it is written to Wolverine's durable
+/// (database-backed) dead-letter storage. Implementations may mutate the envelope in place - for
+/// example re-serialize a redacted or encrypted body by editing <see cref="Envelope.Message"/> and
+/// setting <see cref="Envelope.Data"/> to <c>null</c> so the store re-serializes it - and/or return
+/// a replacement exception whose type and message are persisted in place of the original.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Interceptors are resolved from the application container and invoked in registration order; each
+/// receives the exception returned by the previous one. Register them in DI, e.g.
+/// <c>services.AddSingleton&lt;IDeadLetterInterceptor, MyInterceptor&gt;()</c>.
+/// </para>
+/// <para>
+/// This hook is a transformation seam for durable dead letters - useful for redacting PII or secrets,
+/// encrypting dead-letter payloads at rest, or scrubbing sensitive exception text before it is stored.
+/// It is not invoked for broker-native dead-lettering, where the original payload bytes are handled by
+/// the broker rather than persisted by Wolverine.
+/// </para>
+/// </remarks>
+public interface IDeadLetterInterceptor
+{
+    /// <param name="envelope">The failed envelope about to be stored. May be mutated in place.</param>
+    /// <param name="exception">The exception associated with the failure, if any.</param>
+    /// <param name="cancellation">The runtime cancellation token.</param>
+    /// <returns>The exception to persist; return <paramref name="exception"/> to leave it unchanged.</returns>
+    ValueTask<Exception?> BeforeStoreAsync(Envelope envelope, Exception? exception, CancellationToken cancellation);
+}

--- a/src/Wolverine/Persistence/Durability/IDeadLetterInterceptor.cs
+++ b/src/Wolverine/Persistence/Durability/IDeadLetterInterceptor.cs
@@ -14,10 +14,22 @@ namespace Wolverine.Persistence.Durability;
 /// <c>services.AddSingleton&lt;IDeadLetterInterceptor, MyInterceptor&gt;()</c>.
 /// </para>
 /// <para>
-/// This hook is a transformation seam for durable dead letters - useful for redacting PII or secrets,
-/// encrypting dead-letter payloads at rest, or scrubbing sensitive exception text before it is stored.
-/// It is not invoked for broker-native dead-lettering, where the original payload bytes are handled by
-/// the broker rather than persisted by Wolverine.
+/// The distinctive use is scrubbing or replacing the <b>exception</b> recorded with a dead letter -
+/// handlers sometimes interpolate sensitive data into exception messages, and the exception type and
+/// message are stored outside the message serializer. Return a replacement exception (optionally one
+/// implementing <see cref="IDeadLetterExceptionInfo"/> to keep the original type while redacting the
+/// message) to control what is persisted.
+/// </para>
+/// <para>
+/// For encrypting or redacting the message <b>body</b> at rest, a custom <c>IMessageSerializer</c> is
+/// usually the better seam: it covers the wire and the durable inbox/outbox as well, not just dead
+/// letters, and avoids re-serialization here. This hook can still mutate the envelope body (edit
+/// <see cref="Envelope.Message"/> and set <see cref="Envelope.Data"/> to <c>null</c>) when a
+/// dead-letter-only transform is needed.
+/// </para>
+/// <para>
+/// Not invoked for broker-native dead-lettering, where the original payload bytes are handled by the
+/// broker rather than persisted by Wolverine.
 /// </para>
 /// </remarks>
 public interface IDeadLetterInterceptor

--- a/src/Wolverine/Persistence/Durability/IDeadLetterInterceptor.cs
+++ b/src/Wolverine/Persistence/Durability/IDeadLetterInterceptor.cs
@@ -21,11 +21,9 @@ namespace Wolverine.Persistence.Durability;
 /// message) to control what is persisted.
 /// </para>
 /// <para>
-/// For encrypting or redacting the message <b>body</b> at rest, a custom <c>IMessageSerializer</c> is
-/// usually the better seam: it covers the wire and the durable inbox/outbox as well, not just dead
-/// letters, and avoids re-serialization here. This hook can still mutate the envelope body (edit
-/// <see cref="Envelope.Message"/> and set <see cref="Envelope.Data"/> to <c>null</c>) when a
-/// dead-letter-only transform is needed.
+/// The hook can also mutate the envelope body for dead-letter-only transforms: edit
+/// <see cref="Envelope.Message"/> and set <see cref="Envelope.Data"/> to <c>null</c> so the store
+/// re-serializes it.
 /// </para>
 /// <para>
 /// Not invoked for broker-native dead-lettering, where the original payload bytes are handled by the

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using ImTools;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using JasperFx;
 using JasperFx.MultiTenancy;
@@ -392,17 +393,34 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
         {
             foreach (var envelope in Envelope.Batch)
             {
-                await Storage.Inbox.MoveToDeadLetterStorageAsync(envelope, exception).ConfigureAwait(false);
+                var ex = await interceptDeadLetterAsync(envelope, exception).ConfigureAwait(false);
+                await Storage.Inbox.MoveToDeadLetterStorageAsync(envelope, ex).ConfigureAwait(false);
             }
         }
         else
         {
             // If persistable, persist
-            await Storage.Inbox.MoveToDeadLetterStorageAsync(Envelope, exception).ConfigureAwait(false);
+            var ex = await interceptDeadLetterAsync(Envelope, exception).ConfigureAwait(false);
+            await Storage.Inbox.MoveToDeadLetterStorageAsync(Envelope, ex).ConfigureAwait(false);
         }
 
         // If this is Inline
         await _channel.CompleteAsync(Envelope).ConfigureAwait(false);
+    }
+
+    // Give registered IDeadLetterInterceptor implementations a chance to mutate the envelope
+    // (e.g. redact/encrypt the body) and/or replace the exception that gets persisted, before a
+    // failed envelope is written to durable dead-letter storage. Interceptors run in registration
+    // order, each receiving the exception returned by the previous one. No-op when none are registered.
+    private async ValueTask<Exception?> interceptDeadLetterAsync(Envelope envelope, Exception? exception)
+    {
+        foreach (var interceptor in Runtime.Services.GetServices<IDeadLetterInterceptor>())
+        {
+            exception = await interceptor.BeforeStoreAsync(envelope, exception, Runtime.Cancellation)
+                .ConfigureAwait(false);
+        }
+
+        return exception;
     }
 
     public Task RetryExecutionNowAsync()


### PR DESCRIPTION
Add `IDeadLetterInterceptor`, a hook invoked before an envelope is written to durable dead-letter storage. Lets you scrub or replace the exception recorded with a dead letter (handlers sometimes put sensitive data in exception messages, which are stored outside the serializer) and optionally mutate the body. Registered via DI, runs in order chaining the returned exception, no-op when unused, durable path only.

`IDeadLetterExceptionInfo` (opt-in) lets a replacement exception keep the original `exception_type` while redacting the message, so type-based triage still works.