### PR TITLE
Fix EF Core durable outbox ignoring overridden message storage

### DIFF
--- a/src/Persistence/EfCoreTests/Bugs/Bug_DurableLocalQueue_ancillary_store_routing.cs
+++ b/src/Persistence/EfCoreTests/Bugs/Bug_DurableLocalQueue_ancillary_store_routing.cs
@@ -69,6 +69,12 @@ public class MainLocalQueueDbContext(DbContextOptions<MainLocalQueueDbContext> o
     }
 }
 
+/// <summary>
+/// Raw DbContext without Wolverine's envelope mappings. This forces
+/// EfCoreEnvelopeTransaction to use raw SQL against the active message database.
+/// </summary>
+public class RawAncillaryOutboxDbContext(DbContextOptions<RawAncillaryOutboxDbContext> options) : DbContext(options);
+
 public class AncillaryLocalQueueDoc
 {
     public Guid Id { get; set; }
@@ -124,16 +130,19 @@ public static class MainLocalQueueMessageHandler
 [Collection("postgresql")]
 public class Bug_DurableLocalQueue_ancillary_store_routing : IAsyncLifetime
 {
+    private NpgsqlDataSource _dataSource = null!;
     private IHost _host = null!;
 
     public async Task InitializeAsync()
     {
+        _dataSource = NpgsqlDataSource.Create(Servers.PostgresConnectionString);
+
         // Clean up schemas from previous runs
         await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
         await conn.OpenAsync();
         await using (var cmd = conn.CreateCommand())
         {
-            cmd.CommandText = "DROP SCHEMA IF EXISTS dlq_main CASCADE; DROP SCHEMA IF EXISTS dlq_ancillary CASCADE;";
+            cmd.CommandText = "DROP SCHEMA IF EXISTS dlq_main CASCADE; DROP SCHEMA IF EXISTS dlq_ancillary CASCADE; DROP SCHEMA IF EXISTS raw_outbox_ancillary CASCADE;";
             await cmd.ExecuteNonQueryAsync();
         }
         await conn.CloseAsync();
@@ -145,18 +154,26 @@ public class Bug_DurableLocalQueue_ancillary_store_routing : IAsyncLifetime
 
                 // Main EF Core DbContext + message store
                 opts.Services.AddDbContextWithWolverineIntegration<MainLocalQueueDbContext>(
-                    x => x.UseNpgsql(Servers.PostgresConnectionString));
+                    x => x.UseNpgsql(_dataSource));
 
-                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "dlq_main");
+                opts.PersistMessagesWithPostgresql(_dataSource, "dlq_main");
 
                 // Ancillary EF Core DbContext + message store (same server, different schema)
                 opts.Services.AddDbContextWithWolverineIntegration<AncillaryLocalQueueDbContext>(
-                    x => x.UseNpgsql(Servers.PostgresConnectionString));
+                    x => x.UseNpgsql(_dataSource));
 
                 opts.PersistMessagesWithPostgresql(
-                        Servers.PostgresConnectionString, "dlq_ancillary",
+                        _dataSource, "dlq_ancillary",
                         MessageStoreRole.Ancillary)
                     .Enroll<AncillaryLocalQueueDbContext>();
+
+                opts.Services.AddDbContext<RawAncillaryOutboxDbContext>(
+                    x => x.UseNpgsql(_dataSource));
+
+                opts.PersistMessagesWithPostgresql(
+                        _dataSource, "raw_outbox_ancillary",
+                        MessageStoreRole.Ancillary)
+                    .Enroll<RawAncillaryOutboxDbContext>();
 
                 opts.UseEntityFrameworkCoreTransactions();
                 opts.Policies.AutoApplyTransactions();
@@ -201,6 +218,7 @@ public class Bug_DurableLocalQueue_ancillary_store_routing : IAsyncLifetime
     {
         await _host.StopAsync();
         _host.Dispose();
+        await _dataSource.DisposeAsync();
         NpgsqlConnection.ClearAllPools();
     }
 
@@ -267,5 +285,39 @@ public class Bug_DurableLocalQueue_ancillary_store_routing : IAsyncLifetime
         var doc = await db.Docs.FindAsync(message.Id);
         doc.ShouldNotBeNull();
         doc.Name.ShouldBe("test-entity");
+    }
+
+    [Fact]
+    public async Task dbcontext_outbox_should_persist_outgoing_to_overridden_ancillary_store()
+    {
+        var runtime = _host.GetRuntime();
+        var ancillaryStore = runtime.Stores.FindAncillaryStore(typeof(RawAncillaryOutboxDbContext));
+        var envelope = new Envelope
+        {
+            Id = Guid.NewGuid(),
+            Status = EnvelopeStatus.Outgoing,
+            OwnerId = 5,
+            Data = [1, 2, 3],
+            MessageType = "raw-ancillary-outbox",
+            ContentType = EnvelopeConstants.JsonContentType,
+            Destination = new Uri("rabbitmq://queue/raw-ancillary")
+        };
+
+        using (var scope = _host.Services.CreateScope())
+        {
+            var outbox = scope.ServiceProvider.GetRequiredService<IDbContextOutbox<RawAncillaryOutboxDbContext>>()
+                .ShouldBeOfType<DbContextOutbox<RawAncillaryOutboxDbContext>>();
+
+            outbox.OverrideStorage(ancillaryStore);
+
+            await outbox.Transaction!.PersistOutgoingAsync(envelope);
+            await outbox.SaveChangesAndFlushMessagesAsync();
+        }
+
+        var mainOutgoing = await runtime.Storage.Admin.AllOutgoingAsync();
+        mainOutgoing.Any(x => x.Id == envelope.Id).ShouldBeFalse();
+
+        var ancillaryOutgoing = await ancillaryStore.Admin.AllOutgoingAsync();
+        ancillaryOutgoing.Single(x => x.Id == envelope.Id).MessageType.ShouldBe("raw-ancillary-outbox");
     }
 }

--- a/src/Persistence/EfCoreTests/Bugs/Bug_DurableLocalQueue_ancillary_store_routing.cs
+++ b/src/Persistence/EfCoreTests/Bugs/Bug_DurableLocalQueue_ancillary_store_routing.cs
@@ -69,12 +69,6 @@ public class MainLocalQueueDbContext(DbContextOptions<MainLocalQueueDbContext> o
     }
 }
 
-/// <summary>
-/// Raw DbContext without Wolverine's envelope mappings. This forces
-/// EfCoreEnvelopeTransaction to use raw SQL against the active message database.
-/// </summary>
-public class RawAncillaryOutboxDbContext(DbContextOptions<RawAncillaryOutboxDbContext> options) : DbContext(options);
-
 public class AncillaryLocalQueueDoc
 {
     public Guid Id { get; set; }
@@ -130,19 +124,16 @@ public static class MainLocalQueueMessageHandler
 [Collection("postgresql")]
 public class Bug_DurableLocalQueue_ancillary_store_routing : IAsyncLifetime
 {
-    private NpgsqlDataSource _dataSource = null!;
     private IHost _host = null!;
 
     public async Task InitializeAsync()
     {
-        _dataSource = NpgsqlDataSource.Create(Servers.PostgresConnectionString);
-
         // Clean up schemas from previous runs
         await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
         await conn.OpenAsync();
         await using (var cmd = conn.CreateCommand())
         {
-            cmd.CommandText = "DROP SCHEMA IF EXISTS dlq_main CASCADE; DROP SCHEMA IF EXISTS dlq_ancillary CASCADE; DROP SCHEMA IF EXISTS raw_outbox_ancillary CASCADE;";
+            cmd.CommandText = "DROP SCHEMA IF EXISTS dlq_main CASCADE; DROP SCHEMA IF EXISTS dlq_ancillary CASCADE;";
             await cmd.ExecuteNonQueryAsync();
         }
         await conn.CloseAsync();
@@ -154,26 +145,18 @@ public class Bug_DurableLocalQueue_ancillary_store_routing : IAsyncLifetime
 
                 // Main EF Core DbContext + message store
                 opts.Services.AddDbContextWithWolverineIntegration<MainLocalQueueDbContext>(
-                    x => x.UseNpgsql(_dataSource));
+                    x => x.UseNpgsql(Servers.PostgresConnectionString));
 
-                opts.PersistMessagesWithPostgresql(_dataSource, "dlq_main");
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "dlq_main");
 
                 // Ancillary EF Core DbContext + message store (same server, different schema)
                 opts.Services.AddDbContextWithWolverineIntegration<AncillaryLocalQueueDbContext>(
-                    x => x.UseNpgsql(_dataSource));
+                    x => x.UseNpgsql(Servers.PostgresConnectionString));
 
                 opts.PersistMessagesWithPostgresql(
-                        _dataSource, "dlq_ancillary",
+                        Servers.PostgresConnectionString, "dlq_ancillary",
                         MessageStoreRole.Ancillary)
                     .Enroll<AncillaryLocalQueueDbContext>();
-
-                opts.Services.AddDbContext<RawAncillaryOutboxDbContext>(
-                    x => x.UseNpgsql(_dataSource));
-
-                opts.PersistMessagesWithPostgresql(
-                        _dataSource, "raw_outbox_ancillary",
-                        MessageStoreRole.Ancillary)
-                    .Enroll<RawAncillaryOutboxDbContext>();
 
                 opts.UseEntityFrameworkCoreTransactions();
                 opts.Policies.AutoApplyTransactions();
@@ -218,7 +201,6 @@ public class Bug_DurableLocalQueue_ancillary_store_routing : IAsyncLifetime
     {
         await _host.StopAsync();
         _host.Dispose();
-        await _dataSource.DisposeAsync();
         NpgsqlConnection.ClearAllPools();
     }
 
@@ -285,39 +267,5 @@ public class Bug_DurableLocalQueue_ancillary_store_routing : IAsyncLifetime
         var doc = await db.Docs.FindAsync(message.Id);
         doc.ShouldNotBeNull();
         doc.Name.ShouldBe("test-entity");
-    }
-
-    [Fact]
-    public async Task dbcontext_outbox_should_persist_outgoing_to_overridden_ancillary_store()
-    {
-        var runtime = _host.GetRuntime();
-        var ancillaryStore = runtime.Stores.FindAncillaryStore(typeof(RawAncillaryOutboxDbContext));
-        var envelope = new Envelope
-        {
-            Id = Guid.NewGuid(),
-            Status = EnvelopeStatus.Outgoing,
-            OwnerId = 5,
-            Data = [1, 2, 3],
-            MessageType = "raw-ancillary-outbox",
-            ContentType = EnvelopeConstants.JsonContentType,
-            Destination = new Uri("rabbitmq://queue/raw-ancillary")
-        };
-
-        using (var scope = _host.Services.CreateScope())
-        {
-            var outbox = scope.ServiceProvider.GetRequiredService<IDbContextOutbox<RawAncillaryOutboxDbContext>>()
-                .ShouldBeOfType<DbContextOutbox<RawAncillaryOutboxDbContext>>();
-
-            outbox.OverrideStorage(ancillaryStore);
-
-            await outbox.Transaction!.PersistOutgoingAsync(envelope);
-            await outbox.SaveChangesAndFlushMessagesAsync();
-        }
-
-        var mainOutgoing = await runtime.Storage.Admin.AllOutgoingAsync();
-        mainOutgoing.Any(x => x.Id == envelope.Id).ShouldBeFalse();
-
-        var ancillaryOutgoing = await ancillaryStore.Admin.AllOutgoingAsync();
-        ancillaryOutgoing.Single(x => x.Id == envelope.Id).MessageType.ShouldBe("raw-ancillary-outbox");
     }
 }

--- a/src/Persistence/EfCoreTests/Bugs/Bug_EfCore_outbox_override_storage.cs
+++ b/src/Persistence/EfCoreTests/Bugs/Bug_EfCore_outbox_override_storage.cs
@@ -1,0 +1,95 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Wolverine;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.Runtime;
+
+namespace EfCoreTests.Bugs;
+
+public class OverrideStorageOutboxDbContext(DbContextOptions<OverrideStorageOutboxDbContext> options) : DbContext(options);
+
+[Collection("postgresql")]
+public class Bug_EfCore_outbox_override_storage : IAsyncLifetime
+{
+    private NpgsqlDataSource _dataSource = null!;
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _dataSource = NpgsqlDataSource.Create(Servers.PostgresConnectionString);
+
+        await using var conn = await _dataSource.OpenConnectionAsync();
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText =
+                "DROP SCHEMA IF EXISTS ef_override_main CASCADE; DROP SCHEMA IF EXISTS ef_override_ancillary CASCADE;";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContext<OverrideStorageOutboxDbContext>(
+                    x => x.UseNpgsql(_dataSource));
+
+                opts.PersistMessagesWithPostgresql(_dataSource, "ef_override_main");
+                opts.PersistMessagesWithPostgresql(_dataSource, "ef_override_ancillary", MessageStoreRole.Ancillary)
+                    .Enroll<OverrideStorageOutboxDbContext>();
+
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+        await _dataSource.DisposeAsync();
+        NpgsqlConnection.ClearAllPools();
+    }
+
+    [Fact]
+    public async Task dbcontext_outbox_should_persist_outgoing_to_overridden_ancillary_store()
+    {
+        var runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+        var ancillaryStore = runtime.Stores.FindAncillaryStore(typeof(OverrideStorageOutboxDbContext));
+        var envelope = new Envelope
+        {
+            Id = Guid.NewGuid(),
+            Status = EnvelopeStatus.Outgoing,
+            OwnerId = 5,
+            Data = [1, 2, 3],
+            MessageType = "ef-core-override-storage",
+            ContentType = EnvelopeConstants.JsonContentType,
+            Destination = new Uri("rabbitmq://queue/ef-core-override-storage")
+        };
+
+        using (var scope = _host.Services.CreateScope())
+        {
+            var outbox = scope.ServiceProvider.GetRequiredService<IDbContextOutbox<OverrideStorageOutboxDbContext>>()
+                .ShouldBeOfType<DbContextOutbox<OverrideStorageOutboxDbContext>>();
+
+            outbox.OverrideStorage(ancillaryStore);
+
+            await outbox.Transaction!.PersistOutgoingAsync(envelope);
+            await outbox.SaveChangesAndFlushMessagesAsync();
+        }
+
+        var mainOutgoing = await runtime.Storage.Admin.AllOutgoingAsync();
+        mainOutgoing.ShouldNotContain(x => x.Id == envelope.Id);
+
+        var ancillaryOutgoing = await ancillaryStore.Admin.AllOutgoingAsync();
+        ancillaryOutgoing.Single(x => x.Id == envelope.Id).MessageType.ShouldBe("ef-core-override-storage");
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs
@@ -47,6 +47,17 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
 
     public DbContext DbContext { get; }
 
+    private IMessageDatabase ResolveCurrentDatabase()
+    {
+        if (_messaging.TryFindMessageDatabase(out var database) && database != null &&
+            database.DataSource == _database.DataSource)
+        {
+            return database;
+        }
+
+        return _database;
+    }
+
     public async Task PersistOutgoingAsync(Envelope envelope)
     {
         if (DbContext.IsWolverineEnabled())
@@ -61,7 +72,8 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
             }
             var conn = DbContext.Database.GetDbConnection();
             var tx = DbContext.Database.CurrentTransaction!.GetDbTransaction();
-            var cmd = DatabasePersistence.BuildOutgoingStorageCommand(envelope, envelope.OwnerId, _database);
+            var database = ResolveCurrentDatabase();
+            var cmd = DatabasePersistence.BuildOutgoingStorageCommand(envelope, envelope.OwnerId, database);
             cmd.Transaction = tx;
             cmd.Connection = conn;
 
@@ -88,7 +100,8 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
             }
             var conn = DbContext.Database.GetDbConnection();
             var tx = DbContext.Database.CurrentTransaction!.GetDbTransaction();
-            var cmd = DatabasePersistence.BuildOutgoingStorageCommand(envelopes, envelopes[0].OwnerId, _database);
+            var database = ResolveCurrentDatabase();
+            var cmd = DatabasePersistence.BuildOutgoingStorageCommand(envelopes, envelopes[0].OwnerId, database);
             cmd.Transaction = tx;
             cmd.Connection = conn;
 
@@ -111,8 +124,9 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
         {
             var conn = DbContext.Database.GetDbConnection();
             var tx = DbContext.Database.CurrentTransaction!.GetDbTransaction();
-            var builder = _database.ToCommandBuilder();
-            DatabasePersistence.BuildIncomingStorageCommand(_database, builder, envelope);
+            var database = ResolveCurrentDatabase();
+            var builder = database.ToCommandBuilder();
+            DatabasePersistence.BuildIncomingStorageCommand(database, builder, envelope);
 
 
             await using var command = builder.Compile();
@@ -184,10 +198,11 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
             // Are we marking an existing envelope as persisted?
             if (_messaging.Envelope.WasPersistedInInbox)
             {
+                var database = ResolveCurrentDatabase();
                 var keepUntil =
                     DateTimeOffset.UtcNow.Add(_messaging.Runtime.Options.Durability.KeepAfterMessageHandling);
                 await using var cmd = conn.CreateCommand(
-                        $"update {_database.SchemaName}.{DatabaseConstants.IncomingTable} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keep where id = @id")
+                        $"update {database.SchemaName}.{DatabaseConstants.IncomingTable} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keep where id = @id")
                     .With("id", _messaging.Envelope.Id)
                     .With("keep", keepUntil);
                 cmd.Transaction = tx;


### PR DESCRIPTION
Fixes `EfCoreEnvelopeTransaction` so `IDbContextOutbox<T>` respects `MessageContext.OverrideStorage()` when persisting outgoing/incoming envelopes through the raw EF Core outbox path.

Previously, `EfCoreEnvelopeTransaction` captured the `IMessageDatabase` once in its constructor. If code later called `OverrideStorage(ancillaryStore)`, the message context changed, but the transaction kept writing SQL against the original main store schema.

## Why

This matters for cases where a high-volume workflow needs its own ancillary outbox table while still using EF Core transactional outbox semantics.

Example:

```csharp
var outbox = scope.ServiceProvider
    .GetRequiredService<IDbContextOutbox<AppDbContext>>();

var context = (MessageContext)outbox;

context.OverrideStorage(ancillaryStore);

await context.PublishAsync(new BulkRecordApproved(recordId));
await outbox.SaveChangesAndFlushMessagesAsync();
```

Expected:

```text
bulk_outbox.wolverine_outgoing_envelopes
```

Actual before this fix:

```text
wolverine.wolverine_outgoing_envelopes
```

That meant bulk operations could flood the main outbox table and delay unrelated outgoing messages.

## Fix

`EfCoreEnvelopeTransaction` now resolves the active `IMessageDatabase` at persistence time instead of always using the constructor-captured database.

It only switches to the override database when the override store shares the same `DbDataSource` as the original database. That keeps the SQL schema switch safe for same-physical-database ancillary stores, while avoiding accidentally generating SQL for one database and executing it on another `DbContext` connection.

Affected paths:

- `PersistOutgoingAsync(Envelope)`
- `PersistOutgoingAsync(Envelope[])`
- `PersistIncomingAsync(Envelope)`
- `CommitAsync`