### PR TITLE
fix(runtime): resolve endpoint-scoped serializer on replay/retry path

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/masstransit_interop_serializer_on_retry.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/masstransit_interop_serializer_on_retry.cs
@@ -1,0 +1,97 @@
+using System.Text;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Util;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+public class masstransit_interop_serializer_on_retry
+{
+    // Reproduces the MassTransit interop "double path" bug: UseMassTransitInterop
+    // registers its serializer only on the listener endpoint. At first receipt the
+    // envelope carries that serializer, but on a replay (scheduled retry, durable
+    // recovery) the runtime-only Serializer reference is gone. The deserialization
+    // path then has to re-resolve the serializer, and resolving from the global
+    // content-type registry (which never saw "application/vnd.masstransit+json")
+    // falls back to the default JSON serializer. That deserializes the *un-unwrapped*
+    // MassTransit envelope root, so every field on the real message comes back as a
+    // default value (here, OrderId 0).
+    [Fact]
+    public async Task replayed_masstransit_envelope_is_unwrapped_on_the_retry_path()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.DisableConventionalDiscovery();
+                opts.IncludeType<OrderPlacedHandler>();
+
+                // Bogus host name on purpose: stubbed transports must never connect.
+                opts.UseRabbitMq(x => x.HostName = Guid.NewGuid().ToString());
+                opts.ListenToRabbitQueue("orders").UseMassTransitInterop();
+
+                opts.StubAllExternalTransports();
+            }).StartAsync();
+
+        var runtime = host.GetRuntime();
+
+        var endpoint = runtime.Endpoints.EndpointFor(new Uri("rabbitmq://queue/orders"))
+            .ShouldNotBeNull()
+            .ShouldBeAssignableTo<RabbitMqEndpoint>();
+
+        // Building the envelope mapper is what applies UseMassTransitInterop and wires
+        // the MassTransit serializer onto the endpoint. A live listener does this at
+        // startup; StubAllExternalTransports() skips listener startup, so trigger it
+        // here to reach the same post-startup endpoint state.
+        endpoint.BuildMapper(runtime);
+
+        // The wire payload a MassTransit producer actually sends: the real message
+        // lives under "message", not at the root.
+        var json = $$"""
+        {
+            "messageId": "{{Guid.NewGuid()}}",
+            "messageType": ["urn:message:Orders:OrderPlaced"],
+            "message": { "orderId": 92883 }
+        }
+        """;
+
+        // Rebuild the envelope the way durable storage hands it back on a retry:
+        // ContentType + Destination + Data are persisted, but Serializer is not.
+        var replayed = new Envelope
+        {
+            Data = Encoding.UTF8.GetBytes(json),
+            ContentType = "application/vnd.masstransit+json",
+            MessageType = typeof(OrderPlaced).ToMessageTypeName(),
+            Destination = endpoint.Uri
+        };
+
+        // The replay precondition: no Serializer is attached, so resolution must go
+        // through serializerFor(envelope) — the code path under test.
+        replayed.Serializer.ShouldBeNull();
+
+        var continuation = await runtime.Pipeline.TryDeserializeEnvelope(replayed);
+
+        // A clean deserialization yields NullContinuation. Asserting it here surfaces a
+        // deserialization failure (MoveToErrorQueue) directly instead of as a confusing
+        // null Message on the next assertion.
+        continuation.ShouldBeOfType<NullContinuation>();
+
+        replayed.Message.ShouldBeOfType<OrderPlaced>()
+            .OrderId.ShouldBe(92883);
+    }
+
+    public record OrderPlaced(int OrderId);
+
+    public class OrderPlacedHandler
+    {
+        // Presence registers OrderPlaced in the HandlerGraph so the pipeline can
+        // resolve its message type during deserialization.
+        public void Handle(OrderPlaced order)
+        {
+        }
+    }
+}

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -34,7 +34,7 @@ public class HandlerPipeline : IHandlerPipeline
 
         _executors = new LightweightCache<Type, IExecutor>(executorFactory.BuildFor);
     }
-    
+
     internal HandlerPipeline(WolverineRuntime runtime, IExecutorFactory executorFactory, Endpoint endpoint)
     {
         _graph = runtime.Handlers;
@@ -133,7 +133,7 @@ public class HandlerPipeline : IHandlerPipeline
                 return new MoveToErrorQueue(new EncryptionPolicyViolationException(envelope));
             }
 
-            var serializer = envelope.Serializer ?? _runtime.Options.DetermineSerializer(envelope);
+            var serializer = envelope.Serializer ?? serializerFor(envelope);
             serializer.UnwrapEnvelopeIfNecessary(envelope);
 
             if (envelope.Data == null)
@@ -190,6 +190,39 @@ public class HandlerPipeline : IHandlerPipeline
         }
     }
 
+    // Resolve the serializer for an envelope whose runtime-only Serializer reference
+    // is no longer set. This happens on replay paths (scheduled retry, durable
+    // recovery) where the envelope is rehydrated from storage: ContentType and
+    // Destination survive, but Serializer does not. Resolve from the originating
+    // endpoint first so endpoint-scoped serializers are honored on replay exactly
+    // as they are at first receipt. This matters most for the MassTransit and
+    // NServiceBus interop serializers wired by UseMassTransitInterop() /
+    // UseNServiceBusInterop(): they register only on the listener endpoint, never in
+    // the global content-type registry. Without this, DetermineSerializer falls back
+    // to the default JSON serializer, which deserializes the un-unwrapped interop
+    // envelope root and yields an all-default message. Mirrors DeadLetterEnvelope.TryReadData.
+    private IMessageSerializer serializerFor(Envelope envelope)
+    {
+        if (envelope.ContentType.IsNotEmpty())
+        {
+            // _endpoint is set on per-listener pipelines and is the most reliable
+            // source; fall back to the persisted Destination for the global pipeline.
+            var endpoint = _endpoint ?? endpointFor(envelope.Destination);
+            var serializer = endpoint?.TryFindSerializer(envelope.ContentType);
+            if (serializer != null)
+            {
+                return serializer;
+            }
+        }
+
+        return _runtime.Options.DetermineSerializer(envelope);
+    }
+
+    private Endpoint? endpointFor(Uri? destination)
+    {
+        return destination == null ? null : _runtime.Endpoints.EndpointFor(destination);
+    }
+
     private bool RequiresEncryption(Envelope envelope)
     {
         var options = _runtime.Options;
@@ -216,7 +249,7 @@ public class HandlerPipeline : IHandlerPipeline
         if (envelope.Message == null)
         {
             var deserializationResult = await TryDeserializeEnvelope(envelope).ConfigureAwait(false);
-            if(deserializationResult is not NullContinuation)
+            if (deserializationResult is not NullContinuation)
             {
                 activity?.SetStatus(ActivityStatusCode.Error, "Serialization Failure");
                 return deserializationResult;


### PR DESCRIPTION
## Problem

When consuming MassTransit-produced messages through `UseMassTransitInterop()`, the **first delivery** deserializes correctly, but any **retry / replay** (scheduled retry, durable recovery) deserializes into an all-default message — every field `0`/`null` (e.g. `OrderId` comes back `0`, leading to spurious `NotFound`-style failures).

## Root cause — the interop serializer is endpoint-scoped, the retry path resolves globally

MassTransit (and NServiceBus) interop wraps the real message inside an envelope and serializes it under a `message` property with content type `application/vnd.masstransit+json`. The unwrapping is done by `MassTransitJsonSerializer`, which `UseMassTransitInterop()` registers **only on the listener endpoint** (`EnvelopeMapper.InteropWithMassTransit` → `_endpoint.DefaultSerializer = serializer`) — never in the global content-type registry.

Two deserialization paths then disagree:

| Path | Serializer resolution | Unwraps `message`? |
|---|---|---|
| First receipt | `envelope.Serializer`, set by `EnvelopeMapper.MapIncomingToEnvelope` from the **endpoint** | ✅ |
| Replay / retry | `envelope.Serializer` is `null` (runtime-only, not persisted) → falls back to `WolverineOptions.DetermineSerializer`, which only checks the **global** registry | ❌ |

On replay, `HandlerPipeline.TryDeserializeEnvelope` did:

```csharp
var serializer = envelope.Serializer ?? _runtime.Options.DetermineSerializer(envelope);
```

The global registry has no entry for `application/vnd.masstransit+json`, so it falls back to the default System.Text.Json serializer, which deserializes the **un-unwrapped MassTransit envelope root** (`messageId`, `messageType`, `host`, …) into the target type — leaving every real field at its default value.

## Fix

Resolve the serializer from the **originating endpoint first**, then fall back to the global registry — exactly mirroring the existing `DeadLetterEnvelope.TryReadData` precedent (and restoring parity with first-receipt resolution in `EnvelopeMapper.MapIncomingToEnvelope`):

```csharp
var serializer = envelope.Serializer ?? serializerFor(envelope);
```

`serializerFor` uses the per-listener pipeline's `_endpoint` when available, otherwise `EndpointFor(envelope.Destination)` (the persisted `Destination` set by `Envelope.MarkReceived`), and only then falls back to `DetermineSerializer`.

This fixes the issue for **any** endpoint-scoped serializer on the replay path — MassTransit interop, NServiceBus interop, and custom per-endpoint serializers — with no change to the global registry and no cross-endpoint content-type collisions.

## Why endpoint-first (vs. registering the interop serializer globally)

- The interop serializer is intentionally endpoint-scoped (`EnvelopeMapper.InteropWithMassTransit`); promoting it to the global registry would risk content-type collisions across multiple interop endpoints (last writer wins its `TranslateMassTransitToWolverineUri`).
- `Endpoint.TryFindSerializer` already falls back to the global registry, so "endpoint-first, then global" is the established read-path convention in the codebase.

## Tests

`masstransit_interop_serializer_on_retry` (broker-free, `StubAllExternalTransports`): forges a real MassTransit wire payload (message nested under `message`), rebuilds the envelope the way durable storage hands it back on a retry (`ContentType` + `Destination` + `Data`, no `Serializer`), runs it through `HandlerPipeline.TryDeserializeEnvelope`, and asserts the message is unwrapped (`OrderId == 92883`). Confirmed **RED before** the fix (`OrderId` was `0`) and **GREEN after**, on `net9.0` and `net10.0`.

No regression in the existing serialization / pipeline / interop / error-handling / scheduling suites in `CoreTests`.
