### PR TITLE
Route message types to ancillary durable stores

### DIFF
--- a/docs/guide/durability/index.md
+++ b/docs/guide/durability/index.md
@@ -142,6 +142,44 @@ using var host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DocumentationSamples.cs#L52-L61' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_make_all_subscribers_be_durable' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### Routing Message Types to Ancillary Stores <Badge type="tip" text="6.0" />
+
+If one or more message types create a much higher volume of durable outgoing messages than the rest of your
+application, you can isolate those messages into a separate ancillary message store. This gives the selected message
+types their own `wolverine_outgoing_envelopes` table and durability agents instead of making every outgoing message
+compete for the main outbox table.
+
+First register the main message store, then register an ancillary store and enroll it with a marker type. Finally,
+route the high-volume message types to that marker type:
+
+```cs
+public interface BulkOutboxStore;
+
+builder.Host.UseWolverine(opts =>
+{
+    opts.PersistMessagesWithPostgresql(connectionString, "wolverine");
+
+    opts.PersistMessagesWithPostgresql(
+            connectionString,
+            "bulk_outbox",
+            role: MessageStoreRole.Ancillary)
+        .Enroll<BulkOutboxStore>();
+
+    opts.Policies.RouteMessagesToAncillaryStore<BulkOutboxStore>(
+        typeof(BulkEvent),
+        typeof(AnotherHighVolumeMessage));
+});
+```
+
+The policy affects both sides of durable persistence:
+
+* Handler chains for the matching message types are assigned to the ancillary store for durable inbox persistence.
+* Outgoing envelopes for the matching message types are stamped with the ancillary store before durable outbox persistence.
+
+This works with normal Wolverine publishing APIs, including `IMessageBus`, `IMessageContext`, and transactional outbox
+services like `IDbContextOutbox<T>`, so handlers and application services do not need to manually call
+`MessageContext.OverrideStorage()`.
+
 ### Bumping out Stale Inbox/Outbox Messages <Badge type="tip" text="5.2" />
 
 ::: warning

--- a/src/Testing/CoreTests/Configuration/ancillary_store_routing_policy_specs.cs
+++ b/src/Testing/CoreTests/Configuration/ancillary_store_routing_policy_specs.cs
@@ -1,0 +1,60 @@
+using CoreTests.Runtime;
+using JasperFx.CodeGeneration;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+public class ancillary_store_routing_policy_specs
+{
+    [Fact]
+    public void route_messages_to_ancillary_store_marks_matching_handler_chains()
+    {
+        var options = new WolverineOptions();
+        options.Policies.RouteMessagesToAncillaryStore<BulkStoreMarker>(typeof(BulkEvent));
+
+        var matching = new HandlerChain(typeof(BulkEvent), new HandlerGraph());
+        var other = new HandlerChain(typeof(RegularEvent), new HandlerGraph());
+
+        foreach (var policy in options.Policies.OfType<IHandlerPolicy>())
+        {
+            policy.Apply([matching, other], new GenerationRules("Testing"), null!);
+        }
+
+        matching.AncillaryStoreType.ShouldBe(typeof(BulkStoreMarker));
+        other.AncillaryStoreType.ShouldBeNull();
+    }
+
+    [Fact]
+    public void route_messages_to_ancillary_store_stamps_matching_outgoing_envelopes()
+    {
+        var ancillaryStore = new NullMessageStore();
+        var runtime = new MockWolverineRuntime([new AncillaryMessageStore(typeof(BulkStoreMarker), ancillaryStore)]);
+        var context = new MessageContext(runtime);
+        var options = new WolverineOptions();
+        options.Policies.RouteMessagesToAncillaryStore<BulkStoreMarker>(typeof(BulkEvent));
+
+        var matching = new Envelope(new BulkEvent());
+        var other = new Envelope(new RegularEvent());
+
+        foreach (var rule in options.MetadataRules)
+        {
+            rule.ApplyCorrelation(context, matching);
+            rule.ApplyCorrelation(context, other);
+        }
+
+        matching.Store.ShouldBeSameAs(ancillaryStore);
+        other.Store.ShouldBeNull();
+    }
+}
+
+public record BulkEvent;
+
+public record RegularEvent;
+
+public interface BulkStoreMarker;

--- a/src/Testing/CoreTests/Runtime/MockWolverineRuntime.cs
+++ b/src/Testing/CoreTests/Runtime/MockWolverineRuntime.cs
@@ -49,13 +49,20 @@ public class NullAgentFamily : IAgentFamily
 
 public class MockWolverineRuntime : IWolverineRuntime, IObserver<IWolverineEvent>
 {
+    private readonly MessageStoreCollection _stores;
+
     public List<IWolverineEvent> ReceivedEvents { get; } = new();
 
-    public MockWolverineRuntime()
+    public MockWolverineRuntime() : this([])
+    {
+    }
+
+    public MockWolverineRuntime(IEnumerable<AncillaryMessageStore> ancillaryStores)
     {
         Tracker.Subscribe(this);
         MetricsAccumulator = new MetricsAccumulator(this);
         Options.ServiceName = "Mock";
+        _stores = new MessageStoreCollection(this, [], ancillaryStores);
     }
 
     public MetricsAccumulator MetricsAccumulator { get; }
@@ -122,7 +129,7 @@ public class MockWolverineRuntime : IWolverineRuntime, IObserver<IWolverineEvent
     public ILogger Logger { get; } = Substitute.For<ILogger>();
 
 
-    public MessageStoreCollection Stores => new MessageStoreCollection(this, [], []);
+    public MessageStoreCollection Stores => _stores;
 
     public ISagaStoreDiagnostics SagaStorage { get; } = Substitute.For<ISagaStoreDiagnostics>();
 

--- a/src/Wolverine/IPolicies.cs
+++ b/src/Wolverine/IPolicies.cs
@@ -149,6 +149,15 @@ public interface IPolicies : IEnumerable<IWolverinePolicy>, IWithFailurePolicies
     MessageTypePolicies<T> ForMessagesOfType<T>();
 
     /// <summary>
+    /// Route the supplied message types to the ancillary message store enrolled
+    /// with marker type <typeparamref name="TStore"/> for both durable inbox
+    /// persistence and durable outbox persistence.
+    /// </summary>
+    /// <param name="messageTypes">The message types to route to the ancillary store</param>
+    /// <typeparam name="TStore">The ancillary store marker type used with Enroll&lt;TStore&gt;()</typeparam>
+    void RouteMessagesToAncillaryStore<TStore>(params Type[] messageTypes);
+
+    /// <summary>
     /// Override the log level for Wolverine's built in logging for messages
     /// being completed successfully. This is Information by default
     /// </summary>

--- a/src/Wolverine/Persistence/AncillaryStoreRoutingPolicy.cs
+++ b/src/Wolverine/Persistence/AncillaryStoreRoutingPolicy.cs
@@ -1,0 +1,81 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+using Wolverine.Util;
+
+namespace Wolverine.Persistence;
+
+internal sealed class AncillaryStoreRoutingPolicy : IHandlerPolicy, IEnvelopeRule
+{
+    private readonly Type _storeMarkerType;
+    private readonly Type[] _messageTypes;
+    private readonly HashSet<string> _messageTypeNames;
+
+    public AncillaryStoreRoutingPolicy(Type storeMarkerType, Type[] messageTypes)
+    {
+        _storeMarkerType = storeMarkerType ?? throw new ArgumentNullException(nameof(storeMarkerType));
+
+        if (messageTypes == null || messageTypes.Length == 0)
+        {
+            throw new ArgumentException("At least one message type is required", nameof(messageTypes));
+        }
+
+        _messageTypes = messageTypes.Distinct().ToArray();
+        if (_messageTypes.Any(x => x is null))
+        {
+            throw new ArgumentException("Message types cannot contain null values", nameof(messageTypes));
+        }
+
+        _messageTypeNames = _messageTypes.Select(x => x.ToMessageTypeName()).ToHashSet();
+    }
+
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        foreach (var chain in chains)
+        {
+            applyTo(chain);
+
+            foreach (var byEndpoint in chain.ByEndpoint)
+            {
+                applyTo(byEndpoint);
+            }
+        }
+    }
+
+    private void applyTo(HandlerChain chain)
+    {
+        if (_messageTypes.Contains(chain.MessageType))
+        {
+            chain.AncillaryStoreType = _storeMarkerType;
+        }
+    }
+
+    public void Modify(Envelope envelope)
+    {
+        // This rule needs the current runtime to resolve the enrolled ancillary
+        // store, so the work happens in ApplyCorrelation().
+    }
+
+    public void ApplyCorrelation(IMessageContext originator, Envelope outgoing)
+    {
+        if (outgoing.MessageType == null || !_messageTypeNames.Contains(outgoing.MessageType))
+        {
+            return;
+        }
+
+        if (originator is MessageBus bus)
+        {
+            outgoing.Store = bus.Runtime.Stores.FindAncillaryStore(_storeMarkerType);
+        }
+    }
+
+    public override string ToString()
+    {
+        return
+            $"Route messages {nameof(_messageTypes)}: {_messageTypes.Select(x => x.FullNameInCode()).Join(", ")} to ancillary store {_storeMarkerType.FullNameInCode()}";
+    }
+}

--- a/src/Wolverine/WolverineOptions.Policies.cs
+++ b/src/Wolverine/WolverineOptions.Policies.cs
@@ -259,6 +259,18 @@ public sealed partial class WolverineOptions : IPolicies
         return new MessageTypePolicies<T>(this);
     }
 
+    void IPolicies.RouteMessagesToAncillaryStore<TStore>(Type[] messageTypes)
+    {
+        if (messageTypes == null || messageTypes.Length == 0)
+        {
+            throw new ArgumentException("At least one message type is required", nameof(messageTypes));
+        }
+
+        var policy = new AncillaryStoreRoutingPolicy(typeof(TStore), messageTypes);
+        RegisteredPolicies.Insert(0, policy);
+        MetadataRules.Add(policy);
+    }
+
     /// <summary>
     /// Logger level for Wolverine to use to log the successful processing of a message. The
     /// default is Information


### PR DESCRIPTION

## Why

Wolverine already supports ancillary message stores through provider registrations like:

```csharp
opts.PersistMessagesWithPostgresql(
        connectionString,
        "bulk_outbox",
        role: MessageStoreRole.Ancillary)
    .Enroll<BulkOutboxStore>();
```

But routing specific message types to those stores was not first-class. Users had to combine several lower-level mechanisms:

- set `chain.AncillaryStoreType` through a custom `IHandlerPolicy`
- manually call `MessageContext.OverrideStorage()` before publishing
- cast outbox abstractions like `IDbContextOutbox<T>` back to `MessageContext`
- duplicate that logic across handlers or wrapper services

That works, but it is fragile and easy to miss in high-volume publishing paths.

This PR adds a single policy API for routing selected message types to an enrolled ancillary store for both durable inbox and durable outbox persistence.

## Example

```csharp
public interface BulkOutboxStore;

builder.Host.UseWolverine(opts =>
{
    opts.PersistMessagesWithPostgresql(connectionString, "wolverine");

    opts.PersistMessagesWithPostgresql(
            connectionString,
            "bulk_outbox",
            role: MessageStoreRole.Ancillary)
        .Enroll<BulkOutboxStore>();

    opts.Policies.RouteMessagesToAncillaryStore<BulkOutboxStore>(
        typeof(BulkEvent),
        typeof(AnotherHighVolumeMessage));
});
```

## What this does

For matching message types, the policy:

- sets `HandlerChain.AncillaryStoreType` so durable inbox persistence targets the enrolled ancillary store
- stamps outgoing envelopes with the ancillary message store before durable outbox persistence
- works with normal publishing APIs, including `IMessageBus`, `IMessageContext`, and `IDbContextOutbox<T>`
- removes the need for user code to manually call `OverrideStorage()`