### PR TITLE
Allow multiple flushes from EF Core DbContextOutbox

### DIFF
--- a/src/Persistence/EfCoreTests/end_to_end_efcore_persistence.cs
+++ b/src/Persistence/EfCoreTests/end_to_end_efcore_persistence.cs
@@ -371,6 +371,85 @@ public class end_to_end_efcore_persistence : IClassFixture<EFCorePersistenceCont
     }
 
     [Fact]
+    public async Task DbContextOutbox_generic_allows_multiple_save_changes_and_flush_calls_in_one_scope()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+
+        var waiter1 = OutboxedMessageHandler.WaitForNextMessage();
+
+        using (var nested = Host.Services.CreateScope())
+        {
+            var outbox = nested.ServiceProvider.GetRequiredService<IDbContextOutbox<ItemsDbContext>>();
+            outbox.As<MessageContext>().MultiFlushMode.ShouldBe(MultiFlushMode.AllowMultiples);
+
+            outbox.DbContext.Items.Add(new Item { Id = id1, Name = "First" });
+            await outbox.SendAsync(new OutboxedMessage { Id = id1 });
+            await outbox.SaveChangesAndFlushMessagesAsync();
+
+            var message1 = await waiter1;
+            message1.Id.ShouldBe(id1);
+
+            var waiter2 = OutboxedMessageHandler.WaitForNextMessage();
+
+            outbox.DbContext.Items.Add(new Item { Id = id2, Name = "Second" });
+            await outbox.SendAsync(new OutboxedMessage { Id = id2 });
+            await outbox.SaveChangesAndFlushMessagesAsync();
+
+            var message2 = await waiter2;
+            message2.Id.ShouldBe(id2);
+        }
+
+        using (var nested = Host.Services.CreateScope())
+        {
+            var context = nested.ServiceProvider.GetRequiredService<ItemsDbContext>();
+            (await context.Items.FindAsync(id1)).ShouldNotBeNull();
+            (await context.Items.FindAsync(id2)).ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task DbContextOutbox_non_generic_allows_multiple_save_changes_and_flush_calls_in_one_scope()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+
+        var waiter1 = OutboxedMessageHandler.WaitForNextMessage();
+
+        using (var nested = Host.Services.CreateScope())
+        {
+            var context = nested.ServiceProvider.GetRequiredService<ItemsDbContext>();
+            var outbox = nested.ServiceProvider.GetRequiredService<IDbContextOutbox>();
+
+            outbox.Enroll(context);
+            outbox.As<MessageContext>().MultiFlushMode.ShouldBe(MultiFlushMode.AllowMultiples);
+
+            context.Items.Add(new Item { Id = id1, Name = "First" });
+            await outbox.SendAsync(new OutboxedMessage { Id = id1 });
+            await outbox.SaveChangesAndFlushMessagesAsync();
+
+            var message1 = await waiter1;
+            message1.Id.ShouldBe(id1);
+
+            var waiter2 = OutboxedMessageHandler.WaitForNextMessage();
+
+            context.Items.Add(new Item { Id = id2, Name = "Second" });
+            await outbox.SendAsync(new OutboxedMessage { Id = id2 });
+            await outbox.SaveChangesAndFlushMessagesAsync();
+
+            var message2 = await waiter2;
+            message2.Id.ShouldBe(id2);
+        }
+
+        using (var nested = Host.Services.CreateScope())
+        {
+            var context = nested.ServiceProvider.GetRequiredService<ItemsDbContext>();
+            (await context.Items.FindAsync(id1)).ShouldNotBeNull();
+            (await context.Items.FindAsync(id2)).ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
     public async Task use_generic_outbox_mapped()
     {
         var id = Guid.NewGuid();

--- a/src/Persistence/Wolverine.EntityFrameworkCore/DbContextOutbox.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/DbContextOutbox.cs
@@ -12,6 +12,7 @@ public class DbContextOutbox<T> : MessageContext, IDbContextOutbox<T> where T : 
     {
         _scrapers = scrapers.ToArray();
         DbContext = dbContext;
+        MultiFlushMode = MultiFlushMode.AllowMultiples;
 
         Transaction = new EfCoreEnvelopeTransaction(dbContext, this);
     }
@@ -42,6 +43,7 @@ public class DbContextOutbox : MessageContext, IDbContextOutbox
     public DbContextOutbox(IWolverineRuntime runtime, IEnumerable<IDomainEventScraper> scrapers) : base(runtime)
     {
         _scrapers = scrapers.ToArray();
+        MultiFlushMode = MultiFlushMode.AllowMultiples;
     }
 
     public void Enroll(DbContext dbContext)


### PR DESCRIPTION
This PR makes EF Core `DbContextOutbox` opt into `MultiFlushMode.AllowMultiples`.

Both generic and non-generic outbox implementations now allow more than one `FlushOutgoingMessagesAsync()` call within the same scoped outbox instance:

```csharp
MultiFlushMode = MultiFlushMode.AllowMultiples;
```

This matches the behavior already used by Marten/Polecat outbox integrations.

## Why this is needed

`MessageContext` defaults to `MultiFlushMode.OnlyOnce`. That default is correct for the normal Wolverine handler pipeline because the same message context can be flushed by more than one pipeline step, and duplicate flushes must not send duplicate cascading messages.

However, EF Core `DbContextOutbox` is also used as a standalone scoped outbox, for example in HTTP/API code that saves and flushes messages in batches.

A valid batching scenario looks like this:

```csharp
const int batchSize = 500;

foreach (var batch in messages.Chunk(batchSize))
{
    foreach (var message in batch)
    {
        await outbox.SendAsync(message);
    }

    await outbox.SaveChangesAndFlushMessagesAsync();
}
```

If `messages` contains 2,000 items, this loop runs 4 batches:

```text
Batch 1: 500 messages
Batch 2: 500 messages
Batch 3: 500 messages
Batch 4: 500 messages
```

Before this PR, only the first batch was flushed.

The first call to `SaveChangesAndFlushMessagesAsync()` eventually calls:

```csharp
await FlushOutgoingMessagesAsync();
```

That first flush succeeds and sets:

```csharp
_hasFlushed = true;
```

On the second batch, `FlushOutgoingMessagesAsync()` hits this guard:

```csharp
if (_hasFlushed)
{
    switch (MultiFlushMode)
    {
        case MultiFlushMode.OnlyOnce:
            return;
    }
}
```

Because EF Core `DbContextOutbox` previously used the default `OnlyOnce` mode, batches 2, 3, and 4 were silently ignored.

So the actual behavior was:

```text
Expected:
Batch 1: 500 sent
Batch 2: 500 sent
Batch 3: 500 sent
Batch 4: 500 sent
Total:   2,000 sent

Actual before fix:
Batch 1: 500 sent
Batch 2: 0 sent
Batch 3: 0 sent
Batch 4: 0 sent
Total:   500 sent
```

## Why the fix is scoped to DbContextOutbox

This PR does not change the global `MessageContext` default.

`OnlyOnce` is still the correct default for Wolverine’s generated handler/executor pipeline, where multiple automatic flush calls may happen for the same incoming message.

The problem is specific to EF Core `DbContextOutbox` being used as a standalone outbox where multiple explicit calls to `SaveChangesAndFlushMessagesAsync()` in one scope are valid and expected.

After this PR:

```text
Batch 1: 500 sent
Batch 2: 500 sent
Batch 3: 500 sent
Batch 4: 500 sent
Total:   2,000 sent
```
