### PR TITLE
feat: Add publish-side RabbitMQ dead-letter queue configuration

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Internals/RabbitMqQueueTests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Internals/RabbitMqQueueTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using RabbitMQ.Client;
 using Shouldly;
+using Wolverine.Configuration;
 using Wolverine.RabbitMQ.Internal;
 using Xunit;
 
@@ -37,7 +38,85 @@ public class RabbitMqQueueTests
         queue.Uri.ShouldBe(new Uri("random://queue/foo"));
 
     }
-    
+
+    [Fact]
+    public async Task publish_queue_dead_letter_queueing_sets_a_specific_dlq()
+    {
+        var options = new WolverineOptions();
+        options.UseRabbitMq()
+            .CustomizeDeadLetterQueueing(new DeadLetterQueue("default-dlx")
+            {
+                ExchangeName = "default-dlx-exchange"
+            });
+
+        var config = options.PublishMessage<PublishOverrideMessage>()
+            .ToRabbitQueue("publish-queue");
+
+        config.DeadLetterQueueing(new DeadLetterQueue("publish-dlx")
+        {
+            ExchangeName = "publish-dlx-exchange"
+        });
+
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var transport = options.RabbitMqTransport();
+        var queue = transport.Queues[transport.MaybeCorrectName("publish-queue")];
+
+        queue.DeadLetterQueue!.QueueName.ShouldBe("publish-dlx");
+        queue.DeadLetterQueue.ExchangeName.ShouldBe("publish-dlx-exchange");
+
+        var channel = Substitute.For<IChannel>();
+        channel.QueueDeclareAsync(default!, default, default, default, default!)
+            .ReturnsForAnyArgs(Task.FromResult(new QueueDeclareOk("publish-queue", 0, 0)));
+
+        await queue.DeclareAsync(channel, NullLogger.Instance);
+
+        await channel.Received().QueueDeclareAsync(
+            "publish-queue",
+            queue.IsDurable,
+            queue.IsExclusive,
+            queue.AutoDelete,
+            Arg.Is<IDictionary<string, object?>>(args =>
+                args.ContainsKey(RabbitMqTransport.DeadLetterQueueHeader) &&
+                Equals(args[RabbitMqTransport.DeadLetterQueueHeader], "publish-dlx-exchange")));
+    }
+
+    [Fact]
+    public async Task publish_queue_disable_dead_letter_queueing_clears_the_dlq()
+    {
+        var options = new WolverineOptions();
+        options.UseRabbitMq()
+            .CustomizeDeadLetterQueueing(new DeadLetterQueue("default-dlx")
+            {
+                ExchangeName = "default-dlx-exchange"
+            });
+
+        var config = options.PublishMessage<PublishOverrideMessage>()
+            .ToRabbitQueue("publish-queue");
+
+        config.DisableDeadLetterQueueing();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var transport = options.RabbitMqTransport();
+        var queue = transport.Queues[transport.MaybeCorrectName("publish-queue")];
+
+        queue.DeadLetterQueue.ShouldBeNull();
+
+        var channel = Substitute.For<IChannel>();
+        channel.QueueDeclareAsync(default!, default, default, default, default!)
+            .ReturnsForAnyArgs(Task.FromResult(new QueueDeclareOk("publish-queue", 0, 0)));
+
+        await queue.DeclareAsync(channel, NullLogger.Instance);
+
+        await channel.Received().QueueDeclareAsync(
+            "publish-queue",
+            queue.IsDurable,
+            queue.IsExclusive,
+            queue.AutoDelete,
+            Arg.Is<IDictionary<string, object?>>(args =>
+                !args.ContainsKey(RabbitMqTransport.DeadLetterQueueHeader)));
+    }
+
     [Fact]
     public void set_time_to_live()
     {
@@ -91,6 +170,8 @@ public class RabbitMqQueueTests
         await theChannel.DidNotReceiveWithAnyArgs().QueueDeclareAsync("foo", true, true, true, null);
         await theChannel.DidNotReceiveWithAnyArgs().QueuePurgeAsync("foo");
     }
+
+    public record PublishOverrideMessage;
 
     [Fact]
     public async Task initialize_with_no_auto_provision_but_auto_purge_on_endpoint_only()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_dead_letter_queue_mechanics.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_dead_letter_queue_mechanics.cs
@@ -6,6 +6,7 @@ using RabbitMQ.Client;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Shouldly;
+using Wolverine.RabbitMQ;
 using Wolverine.RabbitMQ.Internal;
 using Wolverine.Runtime;
 using Wolverine.Tracking;
@@ -75,6 +76,85 @@ public class native_dead_letter_queue_mechanics : IAsyncLifetime
         var queue = theTransport.Queues[QueueName];
 
         queue.Arguments[RabbitMqTransport.DeadLetterQueueHeader].ShouldBe(RabbitMqTransport.DeadLetterQueueName);
+    }
+
+    [Fact]
+    public async Task publish_side_queue_keeps_its_custom_dead_letter_exchange_during_auto_provision()
+    {
+        var queueName = QueueName + "-publish-override";
+        var defaultDeadLetterQueueName = "default-dlx";
+        var defaultDeadLetterExchangeName = "default-dlx-exchange";
+        var overrideDeadLetterExchangeName = "override-dlx-exchange";
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRabbitMq()
+                    .AutoProvision()
+                    .AutoPurgeOnStartup()
+                    .CustomizeDeadLetterQueueing(new DeadLetterQueue(defaultDeadLetterQueueName)
+                    {
+                        ExchangeName = defaultDeadLetterExchangeName
+                    });
+
+                opts.PublishMessage<PublishOverrideMessage>()
+                    .ToRabbitQueue(queueName)
+                    .DeadLetterQueueing(new DeadLetterQueue(queueName + "-dlq")
+                    {
+                        ExchangeName = overrideDeadLetterExchangeName
+                    });
+
+                opts.LocalRoutingConventionDisabled = true;
+            }).StartAsync();
+
+        theTransport = _host
+            .Services
+            .GetRequiredService<IWolverineRuntime>()
+            .Options
+            .Transports
+            .GetOrCreate<RabbitMqTransport>();
+
+        var queue = theTransport.Queues[queueName];
+
+        queue.DeadLetterQueue!.QueueName.ShouldBe(queueName + "-dlq");
+        queue.Arguments[RabbitMqTransport.DeadLetterQueueHeader].ShouldBe(overrideDeadLetterExchangeName);
+        queue.Arguments[RabbitMqTransport.DeadLetterQueueHeader].ShouldNotBe(defaultDeadLetterExchangeName);
+    }
+
+    [Fact]
+    public async Task publish_side_queue_can_disable_dead_letter_queueing_during_auto_provision()
+    {
+        var queueName = QueueName + "-publish-disabled";
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRabbitMq()
+                    .AutoProvision()
+                    .AutoPurgeOnStartup()
+                    .CustomizeDeadLetterQueueing(new DeadLetterQueue("default-dlx")
+                    {
+                        ExchangeName = "default-dlx-exchange"
+                    });
+
+                opts.PublishMessage<PublishOverrideMessage>()
+                    .ToRabbitQueue(queueName)
+                    .DisableDeadLetterQueueing();
+
+                opts.LocalRoutingConventionDisabled = true;
+            }).StartAsync();
+
+        theTransport = _host
+            .Services
+            .GetRequiredService<IWolverineRuntime>()
+            .Options
+            .Transports
+            .GetOrCreate<RabbitMqTransport>();
+
+        var queue = theTransport.Queues[queueName];
+
+        queue.DeadLetterQueue.ShouldBeNull();
+        queue.Arguments.ContainsKey(RabbitMqTransport.DeadLetterQueueHeader).ShouldBeFalse();
     }
 
     [Fact]
@@ -313,6 +393,8 @@ public class native_dead_letter_queue_mechanics : IAsyncLifetime
 }
 
 public record AlwaysErrors;
+
+public record PublishOverrideMessage;
 
 public static class AlwaysErrorsHandler
 {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqSubscriberConfiguration.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqSubscriberConfiguration.cs
@@ -31,6 +31,47 @@ public class
         add(e => e.UseNServiceBusInterop());
         return this;
     }
+
+    /// <summary>
+    /// Customize the dead letter queueing for this specific publish queue.
+    /// </summary>
+    /// <param name="dlq">The dead letter queue configuration to apply.</param>
+    /// <returns></returns>
+    public RabbitMqSubscriberConfiguration DeadLetterQueueing(DeadLetterQueue dlq)
+    {
+        add(e =>
+        {
+            if (e is not RabbitMqQueue queue)
+            {
+                throw new InvalidOperationException(
+                    "DeadLetterQueueing() is only supported for publish-to-queue endpoints.");
+            }
+
+            queue.DeadLetterQueue = dlq.Clone();
+        });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Remove dead letter queueing from this specific publish queue.
+    /// </summary>
+    /// <returns></returns>
+    public RabbitMqSubscriberConfiguration DisableDeadLetterQueueing()
+    {
+        add(e =>
+        {
+            if (e is not RabbitMqQueue queue)
+            {
+                throw new InvalidOperationException(
+                    "DisableDeadLetterQueueing() is only supported for publish-to-queue endpoints.");
+            }
+
+            queue.DeadLetterQueue = null;
+        });
+
+        return this;
+    }
 }
 
 public class RabbitMqExchangeConfiguration : InteroperableSubscriberConfiguration<RabbitMqExchangeConfiguration, RabbitMqExchange, IRabbitMqEnvelopeMapper, RabbitMqEnvelopeMapper>


### PR DESCRIPTION
**Summary**
- Adds DeadLetterQueueing(...) to options.PublishMessage<T>().ToRabbitQueue(...) so publish-side RabbitMQ queues can override their dead-letter queue the same way listeners can.
- Ensure queue declaration respects the configured DLQ when Wolverine auto-provisions RabbitMQ resources.
- Add focused regression coverage for publish-side DLQ configuration and auto-provision behavior.

**Validation**
- Ran the focused RabbitMQ test slice and it passed on both net9.0 and net10.0.