### PR TITLE
Fix #3053 dotnet8 azure function durable task

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618;VSTHRD200</NoWarn>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.39.1</Version>
+        <Version>5.39.4</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -119,7 +119,7 @@
   <!-- TFM-conditional Microsoft.Extensions.* for Wolverine core (version ranges for NuGet compatibility) -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1,10.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1,11.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="[8.0.0,10.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="[8.0.0,10.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[8.0.2,10.0.0)" />


### PR DESCRIPTION
Fix for Azure Functions Durable Task package for dotnet 8 support. Extended the accepted range of Microsoft.Extensions.Memory.Caching package from >= 8.0.1 && < 10.0.0  to >= 8.0.1 && < 11.0.0.