### PR TITLE
GH-3053: Upgraded dictionary.packages.props dotnet 8 support ranges

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618;VSTHRD200</NoWarn>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.39.3</Version>
+        <Version>5.39.5</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -119,16 +119,16 @@
   <!-- TFM-conditional Microsoft.Extensions.* for Wolverine core (version ranges for NuGet compatibility) -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="[8.0.0,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="[8.0.0,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[8.0.2,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="[8.0.1,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[8.0.8,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="[8.0.8,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.1,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.1,10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="[8.0.23,10.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1,11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="[8.0.0,11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="[8.0.0,11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[8.0.2,11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="[8.0.1,11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[8.0.8,11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="[8.0.8,11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.1,11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.1,11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="[8.0.23,11.0.0)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />


### PR DESCRIPTION
I had build with the wrong dotnet tooling (dotnet 10) which resulted in a successful build. This fixes now the dotnet 8 compability. This is a follow up for #3053.