### PR TITLE
docs(kafka): polish ExternallyOwned() section (follow-up to #3062)

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -663,7 +663,7 @@ Use individual `ListenToKafkaTopic()` calls when:
 - Topics need different processing modes (inline vs buffered vs durable)
 - You want independent scaling or error handling per topic
 
-## Externally-Owned Topics
+## Externally-Owned Topics <Badge type="tip" text="6.7" />
 
 Some topics on the Kafka cluster may be owned by an external system where your service only has consume or produce ACLs — not `CreateTopics` or `DeleteTopics`. With `AutoProvision()` enabled, Wolverine attempts to create every declared topic at startup, which fails with `Authorization failed` on topics you don't own. Likewise, `dotnet run -- resources teardown` would attempt to delete those topics.
 
@@ -688,6 +688,12 @@ opts.ListenToKafkaTopic("our-orders");
 ```
 
 The flag is per-endpoint, so externally-owned and owned topics can coexist in the same `AutoProvision()` configuration. It applies symmetrically to both `SetupAsync` (startup, `resources setup`) and `TeardownAsync` (`resources teardown`).
+
+`ExternallyOwned()` and the [Topic Creation Options](#topic-creation-options) above are the two ends of a single spectrum: use `Specification()` / `TopicCreation()` to customize how Wolverine creates topics you *do* own, and `ExternallyOwned()` to bow out entirely for topics you don't. They compose freely — you can mix all three on listeners in the same host.
+
+::: tip
+`dotnet run -- resources check` is **not** skipped for externally-owned topics. The check sends a small "ping" probe to verify each topic is reachable, which requires `Produce` access on that topic (or `KafkaUsage.ConsumeOnly` at the transport level, which skips the probe entirely). If your externally-owned topics are consume-only at the topic level but the transport publishes to other topics, prefer running `resources check` against a limited configuration, or skip it for those topics.
+:::
 
 ## Disabling all Sending
 


### PR DESCRIPTION
Follow-up to the docs added in #3062, touching only `docs/guide/messaging/transports/kafka.md` (+7, -1).

## What this PR adds

Three focused improvements to the new \"Externally-Owned Topics\" section:

1. **Version `<Badge>` on the heading** — every other section added to this file (5.16, 5.17, 5.18, 5.22, 5.27, 6.0, …) carries one; the new section was missing it. Set to **6.7** as the likely next-minor release that will include #3062; **happy to retarget to whatever you'd actually like to ship this under** — one-word edit.

2. **Cross-reference to the [Topic Creation Options](https://wolverinefx.io/guide/messaging/transports/kafka.html#topic-creation-options) section** just above. `Specification()` / `TopicCreation()` (for topics you do own) and `ExternallyOwned()` (for topics you don't) are the two ends of the same spectrum — the section above already documents the owned side, so a one-sentence pointer ties them together.

3. **`::: tip` callout about `resources check`** — `KafkaTopic.CheckAsync` is **not** skipped for externally-owned topics. It sends a small \"ping\" `Produce` probe to verify reachability, which has observable consequences (requires `Produce` access on every checked topic; can land a probe message on a topic you don't fully own). The transport-level `KafkaUsage.ConsumeOnly` is the only existing escape hatch. Worth a sentence so users running `resources check` aren't surprised.

Whether `CheckAsync` *should* skip `IsExternallyOwned` topics is a separate question — I'd be happy to file that as a small follow-up issue if you'd like. Not changing the behaviour in this PR.

## Why no mdsnippets conversion

`kafka.md` consistently uses inline code blocks rather than mdsnippets (the convention in `sagas.md`, `command-line.md`, `validation.md`, etc.). Converting just this one section would create an inconsistency within the file; converting the whole file is its own (much larger) project. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)