### PR TITLE
Log handler execution duration on the "Finished processing" message (closes #3063)

### DIFF
--- a/src/Testing/CoreTests/Acceptance/execution_finished_logs_duration_3063.cs
+++ b/src/Testing/CoreTests/Acceptance/execution_finished_logs_duration_3063.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Wolverine;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+// GH-3063: the "Finished processing" execution log emitted from Executor.ExecuteAsync (the
+// transport-received path) now carries the handler's execution duration in milliseconds, both in
+// the formatted message ("...executed in {Duration} ms") and as a structured "Duration" property
+// so it can be filtered in structured logs to find slow handlers.
+public class execution_finished_logs_duration_3063
+{
+    [Fact]
+    public async Task finished_processing_log_includes_a_nonzero_duration()
+    {
+        var logger = new StructuredCapturingLogger();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton<ILoggerFactory>(new SingleLoggerFactory(logger));
+            })
+            .StartAsync();
+
+        // Route through the worker (Executor.ExecuteAsync), not the inline invoke path
+        await host.SendMessageAndWaitAsync(new DurationTestMessage("hello"));
+
+        var entry = logger.Entries.FirstOrDefault(e =>
+            e.Message.Contains("Finished processing") && e.Message.Contains(nameof(DurationTestMessage)));
+
+        entry.ShouldNotBeNull();
+
+        // Formatted message reads "...executed in {Duration} ms"
+        entry.Message.ShouldContain("executed in");
+        entry.Message.ShouldContain(" ms");
+
+        // The structured "Duration" property is present and non-zero
+        var duration = entry.State.Single(pair => pair.Key == "Duration").Value;
+        Convert.ToInt64(duration).ShouldBeGreaterThan(0);
+    }
+}
+
+public record DurationTestMessage(string Text);
+
+public static class DurationTestMessageHandler
+{
+    public static async Task Handle(DurationTestMessage message)
+    {
+        // Sleep long enough that the elapsed-ms timer rounds to a positive integer
+        await Task.Delay(25);
+    }
+}
+
+/// <summary>
+/// Captures each log entry's formatted message together with its structured state so tests can
+/// assert on individual log properties, not just the rendered string.
+/// </summary>
+internal class StructuredCapturingLogger : ILogger
+{
+    public record Entry(LogLevel Level, string Message,
+        IReadOnlyList<KeyValuePair<string, object?>> State, Exception? Exception);
+
+    public List<Entry> Entries { get; } = new();
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        var pairs = state as IReadOnlyList<KeyValuePair<string, object?>>
+                    ?? Array.Empty<KeyValuePair<string, object?>>();
+
+        lock (Entries)
+        {
+            Entries.Add(new Entry(logLevel, formatter(state, exception), pairs.ToList(), exception));
+        }
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+}

--- a/src/Wolverine/Runtime/Handlers/Executor.cs
+++ b/src/Wolverine/Runtime/Handlers/Executor.cs
@@ -44,7 +44,7 @@ internal class Executor : IExecutor
     public const int ExecutionFinishedEventId = 103;
 
     private readonly ObjectPool<MessageContext> _contextPool;
-    private readonly Action<ILogger, string, string, Guid, Exception?> _executionFinished;
+    private readonly Action<ILogger, string, string, Guid, long, Exception?> _executionFinished;
     private readonly Action<ILogger, string, string, Guid, Exception?> _executionStarted;
     private readonly ILogger _logger;
 
@@ -87,8 +87,8 @@ internal class Executor : IExecutor
         _executionStarted = LoggerMessage.Define<string, string, Guid>(handler.ProcessingLogLevel, ExecutionStartedEventId,
             "{CorrelationId}: Started processing {Name}#{Id}");
 
-        _executionFinished = LoggerMessage.Define<string, string, Guid>(handler.ProcessingLogLevel, ExecutionFinishedEventId,
-            "{CorrelationId}: Finished processing {Name}#{Id}");
+        _executionFinished = LoggerMessage.Define<string, string, Guid, long>(handler.ProcessingLogLevel, ExecutionFinishedEventId,
+            "{CorrelationId}: Finished processing {Name}#{Id}, executed in {Duration} ms");
     }
 
     public IMessageHandler Handler { get; }
@@ -259,7 +259,10 @@ internal class Executor : IExecutor
         }
         finally
         {
-            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
+            // StopTiming() has already been called via _tracker.ExecutionFinished in the
+            // try/catch above, so envelope.ExecutionTime is populated by this point. GH-3063.
+            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id,
+                envelope.ExecutionTime, null);
         }
     }
 

--- a/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
+++ b/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
@@ -31,7 +31,7 @@ internal class TracingExecutor : IExecutor
     private readonly string _messageTypeName;
 
     private readonly Action<ILogger, string, string, Guid, Exception?> _executionStarted;
-    private readonly Action<ILogger, string, string, Guid, Exception?> _executionFinished;
+    private readonly Action<ILogger, string, string, Guid, long, Exception?> _executionFinished;
     private readonly Action<ILogger, string, Guid, string, Exception?> _messageSucceeded;
     private readonly Action<ILogger, string, Guid, string, Exception> _messageFailed;
 
@@ -65,9 +65,9 @@ internal class TracingExecutor : IExecutor
             ExecutionStartedEventId,
             "{CorrelationId}: Started processing {Name}#{Id}");
 
-        _executionFinished = LoggerMessage.Define<string, string, Guid>(handler.ProcessingLogLevel,
+        _executionFinished = LoggerMessage.Define<string, string, Guid, long>(handler.ProcessingLogLevel,
             ExecutionFinishedEventId,
-            "{CorrelationId}: Finished processing {Name}#{Id}");
+            "{CorrelationId}: Finished processing {Name}#{Id}, executed in {Duration} ms");
     }
 
     public IMessageHandler Handler { get; }
@@ -108,7 +108,8 @@ internal class TracingExecutor : IExecutor
         finally
         {
             _contextPool.Return(context);
-            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
+            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id,
+                envelope.ExecutionTime, null);
             activity?.Stop();
         }
     }
@@ -195,7 +196,8 @@ internal class TracingExecutor : IExecutor
         }
         finally
         {
-            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
+            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id,
+                envelope.ExecutionTime, null);
         }
     }
 
@@ -276,7 +278,8 @@ internal class TracingExecutor : IExecutor
             _messageFailed(_logger, _messageTypeName, envelope.Id,
                 envelope.Destination?.ToString() ?? "local", e);
             _contextPool.Return(context);
-            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
+            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id,
+                envelope.ExecutionTime, null);
             throw;
         }
 
@@ -287,7 +290,8 @@ internal class TracingExecutor : IExecutor
             _messageSucceeded(_logger, _messageTypeName, envelope.Id,
                 envelope.Destination?.ToString() ?? "local", null);
             _contextPool.Return(context);
-            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
+            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id,
+                envelope.ExecutionTime, null);
             yield break;
         }
 
@@ -326,7 +330,8 @@ internal class TracingExecutor : IExecutor
         finally
         {
             _contextPool.Return(context);
-            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id, null);
+            _executionFinished(_logger, envelope.CorrelationId!, _messageTypeName, envelope.Id,
+                envelope.ExecutionTime, null);
         }
     }
 }


### PR DESCRIPTION
Closes #3063. Adds the handler's execution time to the execution-finished log so it's possible to pinpoint slow handlers in production logs (and filter for them in structured logging).

## Change

The `_executionFinished` log message now reads:

```
{CorrelationId}: Finished processing {Name}#{Id}, executed in {Duration} ms
```

`{Duration}` is also a **structured property** (`Duration`), so you can filter for all handlers over some threshold across a time window — which was the actual ask in the issue (metrics are too coarse-grained; per-operation log math can't separate transport time from handler time).

The value comes from `Envelope.ExecutionTime`, which is set by `Envelope.StopTiming()` inside `IMessageTracker.ExecutionFinished(...)`. Both executors log `_executionFinished` *after* that tracker call (in the `finally` / post-tracking paths), so the timing is always populated at the log site.

Applied to:
- `Executor.ExecuteAsync` — the transport-received path
- every `_executionFinished` call site in `TracingExecutor` (the `InvokeTracing.Full` path), including the inline-invoke and streaming branches, so the message is consistent wherever "Finished processing" is emitted

## Test

`execution_finished_logs_duration_3063` routes a deliberately-slow message (`Task.Delay(25)`) through the worker via `SendMessageAndWaitAsync` so it exercises `Executor.ExecuteAsync` (not the inline-invoke path), then asserts both that the rendered message contains `executed in … ms` and that the structured `Duration` property is present and `> 0`.

All 6 related CoreTests pass (the new test + the 5 existing `invoke_tracing_mode` tests). `wolverine.slnx -c Release` builds clean (0 warnings, 0 errors).

## Note on log level

`_executionFinished` is emitted at `HandlerChain.ProcessingLogLevel`, which defaults to `Debug` — so the duration rides the existing "Finished processing" line rather than the Information-level "Successfully processed" line the issue author mentioned. This keeps the change to a single, already-existing log statement; if we'd rather surface the duration at Information level, that's a follow-up decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)