### PR TITLE
feat(efcore): add MainDbContext configuration to resolve multiple DbContext conflicts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -155,6 +155,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0-rc.2" />
   </ItemGroup>
   <!-- TFM-conditional EF Core ecosystem -->

--- a/src/Persistence/EfCoreTests/EfCoreTests.csproj
+++ b/src/Persistence/EfCoreTests/EfCoreTests.csproj
@@ -3,7 +3,8 @@
     <PropertyGroup>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <NoWarn>$(NoWarn);NU1608</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Persistence/EfCoreTests/transaction_middleware_mode_tests.cs
+++ b/src/Persistence/EfCoreTests/transaction_middleware_mode_tests.cs
@@ -283,6 +283,87 @@ public class transaction_middleware_mode_tests
             .Any(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
             .ShouldBeTrue();
     }
+
+    [Fact]
+    public async Task multiple_dbContexts_without_main_dbContext_should_throw_exception()
+    {
+        var builder = Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<ConflictAppDbContext>(x => x.UseInMemoryDatabase("app"));
+                opts.Services.AddDbContextWithWolverineIntegration<ConflictCommunDbContext>(x => x.UseInMemoryDatabase("commun"));
+
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<MultipleDbContextsHandler>();
+            });
+
+        var exception = await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            using var host = await builder.StartAsync();
+        });
+
+        exception.Message.ShouldContain("Cannot determine the DbContext type");
+        exception.Message.ShouldContain("multiple DbContext types detected: ConflictAppDbContext, ConflictCommunDbContext");
+    }
+
+    [Fact]
+    public async Task multiple_dbContexts_with_main_dbContext_via_fluent_api_should_resolve_conflict()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<ConflictAppDbContext>(x => x.UseInMemoryDatabase("app"));
+                opts.Services.AddDbContextWithWolverineIntegration<ConflictCommunDbContext>(x => x.UseInMemoryDatabase("commun"));
+
+                opts.UseEntityFrameworkCoreTransactions()
+                    .UseMainDbContext<ConflictAppDbContext>();
+                
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<MultipleDbContextsHandler>();
+            }).StartAsync();
+
+        var chain = host.GetRuntime().Handlers.ChainFor<MultipleDbContextsMessage>()!;
+        
+        chain.Middleware.OfType<EnrollDbContextInTransaction>()
+            .Any(x => x.DbContextType == typeof(ConflictAppDbContext))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task multiple_dbContexts_with_main_dbContext_via_options_should_resolve_conflict()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<ConflictAppDbContext>(x => x.UseInMemoryDatabase("app"));
+                opts.Services.AddDbContextWithWolverineIntegration<ConflictCommunDbContext>(x => x.UseInMemoryDatabase("commun"));
+
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.UseMainDbContext<ConflictAppDbContext>();
+                
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<MultipleDbContextsHandler>();
+            }).StartAsync();
+
+        var chain = host.GetRuntime().Handlers.ChainFor<MultipleDbContextsMessage>()!;
+        
+        chain.Middleware.OfType<EnrollDbContextInTransaction>()
+            .Any(x => x.DbContextType == typeof(ConflictAppDbContext))
+            .ShouldBeTrue();
+    }
 }
 
 public interface IRequiresEagerTransaction;
@@ -425,6 +506,25 @@ public class EagerStorageSideEffectHandler
     public static Insert<Item> Handle(EagerStorageSideEffectMessage message)
     {
         return Storage.Insert(new Item { Id = Guid.NewGuid(), Name = "test" });
+    }
+}
+
+public class ConflictAppDbContext : DbContext
+{
+    public ConflictAppDbContext(DbContextOptions<ConflictAppDbContext> options) : base(options) {}
+}
+
+public class ConflictCommunDbContext : DbContext
+{
+    public ConflictCommunDbContext(DbContextOptions<ConflictCommunDbContext> options) : base(options) {}
+}
+
+public record MultipleDbContextsMessage;
+
+public class MultipleDbContextsHandler
+{
+    public static void Handle(MultipleDbContextsMessage message, ConflictAppDbContext db1, ConflictCommunDbContext db2)
+    {
     }
 }
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -46,6 +46,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
     private ImHashMap<Type, Type> _abstractions = ImHashMap<Type, Type>.Empty;
 
     public TransactionMiddlewareMode DefaultMode { get; set; } = TransactionMiddlewareMode.Eager;
+    public Type? MainDbContextType { get; set; }
 
     public void RegisterAbstraction(Type abstractionType, Type dbContextType)
     {
@@ -496,6 +497,11 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 
         if (contextTypes.Length > 1)
         {
+            if (MainDbContextType != null && contextTypes.Contains(MainDbContextType))
+            {
+                return MainDbContextType;
+            }
+
             throw new InvalidOperationException(
                 $"Cannot determine the {nameof(DbContext)} type for {chain.Description}, multiple {nameof(DbContext)} types detected: {contextTypes.Select(x => x.Name).Join(", ")}");
         }

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EnrollDbContextInTransaction.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EnrollDbContextInTransaction.cs
@@ -26,6 +26,8 @@ internal class EnrollDbContextInTransaction : AsyncFrame, IFlushesMessages
         _envelopeTransaction = new Variable(typeof(EfCoreEnvelopeTransaction), this);
     }
 
+    public Type DbContextType => _dbContextType;
+
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
         writer.WriteLine("");

--- a/src/Persistence/Wolverine.EntityFrameworkCore/EFCoreTransactionConfiguration.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/EFCoreTransactionConfiguration.cs
@@ -26,4 +26,15 @@ public class EFCoreTransactionConfiguration
 
         return this;
     }
+
+    /// <summary>
+    /// Configures the default or main DbContext type to resolve conflicts when multiple DbContext types
+    /// are detected in a message handler chain.
+    /// </summary>
+    /// <typeparam name="TDbContext">The main DbContext type</typeparam>
+    public EFCoreTransactionConfiguration UseMainDbContext<TDbContext>() where TDbContext : Microsoft.EntityFrameworkCore.DbContext
+    {
+        _provider.MainDbContextType = typeof(TDbContext);
+        return this;
+    }
 }

--- a/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
@@ -463,4 +463,21 @@ public static class WolverineEntityCoreExtensions
         options.Services.AddSingleton<IDomainEventScraper>(scraper);
         return options;
     }
+
+    /// <summary>
+    /// Configures the default or main DbContext type to resolve conflicts when multiple DbContext types
+    /// are detected in a message handler chain.
+    /// </summary>
+    /// <typeparam name="TDbContext">The main DbContext type</typeparam>
+    public static WolverineOptions UseMainDbContext<TDbContext>(this WolverineOptions options) where TDbContext : DbContext
+    {
+        var providers = options.CodeGeneration.PersistenceProviders();
+        var efProvider = providers.OfType<EFCorePersistenceFrameProvider>().FirstOrDefault();
+        if (efProvider == null)
+        {
+            throw new InvalidOperationException($"Unable to find the {nameof(EFCorePersistenceFrameProvider)}. Please call {nameof(UseEntityFrameworkCoreTransactions)} first.");
+        }
+        efProvider.MainDbContextType = typeof(TDbContext);
+        return options;
+    }
 }


### PR DESCRIPTION
### Problem
When a message handler chain depends on multiple `DbContext` types (either directly or transitively via other services), Wolverine's EF Core transaction middleware throws a `System.InvalidOperationException` because it cannot determine which `DbContext` to enroll in the transaction and the Wolverine Outbox:

> `System.InvalidOperationException: Cannot determine the DbContext type for Message Handler for ..., multiple DbContext types detected: AppDbContext, CommunDbContext`

Currently, there is no simple way to resolve this conflict during Wolverine's EF Core configuration.

### Solution
This PR introduces a `UseMainDbContext<TDbContext>()` configuration option that lets you designate a default/main `DbContext` to use when multiple `DbContext` types are detected in a chain. 

If a main `DbContext` is configured, Wolverine will resolve to that type to enroll in transactions/outbox, bypassing the ambiguity exception. If no main `DbContext` is configured, it falls back to the original behavior of throwing the `InvalidOperationException`.

### Usage
You can configure the main `DbContext` in two ways:

1. **Via the fluent transactions configuration:**
   opts.UseEntityFrameworkCoreTransactions()
       .UseMainDbContext<AppDbContext>();
