### PR TITLE
Make TrackedSession bookkeeping thread-safe

### DIFF
--- a/src/Testing/CoreTests/Tracking/envelope_history_thread_safety.cs
+++ b/src/Testing/CoreTests/Tracking/envelope_history_thread_safety.cs
@@ -1,0 +1,50 @@
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Tracking;
+
+public class envelope_history_thread_safety
+{
+    [Fact]
+    public async Task recording_from_concurrent_listeners_is_thread_safe()
+    {
+        // Reproduces a race seen with TrackActivity().IncludeExternalTransports() against a real
+        // broker: multiple transport listener threads record into the same EnvelopeHistory, which
+        // was backed by an unsynchronized List<T>. Concurrent Add + LINQ iteration threw
+        // intermittent NullReferenceExceptions from RecordCrossApplication, failing whatever
+        // tracked session happened to be active.
+        var history = new EnvelopeHistory(Guid.NewGuid());
+
+        const int writers = 8;
+        const int recordsPerWriter = 10_000;
+
+        var tasks = Enumerable.Range(0, writers).Select(_ => Task.Run(() =>
+        {
+            var nodeId = Guid.NewGuid();
+            for (var i = 0; i < recordsPerWriter; i++)
+            {
+                var eventType = (i % 4) switch
+                {
+                    0 => MessageEventType.Sent,
+                    1 => MessageEventType.Received,
+                    2 => MessageEventType.ExecutionStarted,
+                    _ => MessageEventType.ExecutionFinished
+                };
+
+                history.RecordCrossApplication(new EnvelopeRecord(eventType, ObjectMother.Envelope(), i, null)
+                {
+                    UniqueNodeId = nodeId
+                });
+
+                // Interleave the read paths TrackedSession uses while writes are in flight
+                history.IsComplete();
+            }
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        history.Records.Count().ShouldBe(writers * recordsPerWriter);
+    }
+}

--- a/src/Wolverine/Tracking/EnvelopeHistory.cs
+++ b/src/Wolverine/Tracking/EnvelopeHistory.cs
@@ -5,6 +5,10 @@ namespace Wolverine.Tracking;
 
 internal class EnvelopeHistory
 {
+    // Records arrive concurrently from parallel transport listener threads (e.g. multiple
+    // Rabbit MQ queues) when external transports are tracked, so every access to _records
+    // has to be synchronized
+    private readonly object _lock = new();
     private readonly List<EnvelopeRecord> _records = new();
 
     public EnvelopeHistory(Guid envelopeId)
@@ -18,12 +22,24 @@ internal class EnvelopeHistory
     {
         get
         {
-            return _records
-                .FirstOrDefault(x => x.Envelope!.Message != null)?.Envelope!.Message;
+            lock (_lock)
+            {
+                return _records
+                    .FirstOrDefault(x => x.Envelope!.Message != null)?.Envelope!.Message;
+            }
         }
     }
 
-    public IEnumerable<EnvelopeRecord> Records => _records;
+    public IEnumerable<EnvelopeRecord> Records
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _records.ToArray();
+            }
+        }
+    }
 
     private EnvelopeRecord? lastOf(MessageEventType eventType)
     {
@@ -51,141 +67,149 @@ internal class EnvelopeHistory
     // ReSharper disable once CyclomaticComplexity
     public void RecordLocally(EnvelopeRecord record)
     {
-        switch (record.MessageEventType)
+        lock (_lock)
         {
-            case MessageEventType.Sent:
-                // Not tracking anything outgoing
-                // when it's testing locally
-                if (record.Envelope!.Destination?.Scheme != TransportConstants.Local ||
-                    record.Envelope.MessageType == TransportConstants.ScheduledEnvelope)
-                {
+            switch (record.MessageEventType)
+            {
+                case MessageEventType.Sent:
+                    // Not tracking anything outgoing
+                    // when it's testing locally
+                    if (record.Envelope!.Destination?.Scheme != TransportConstants.Local ||
+                        record.Envelope.MessageType == TransportConstants.ScheduledEnvelope)
+                    {
+                        record.IsComplete = true;
+                        record.WasScheduled = true;
+                    }
+
+                    if (record.Envelope.Status == EnvelopeStatus.Scheduled)
+                    {
+                        record.WasScheduled = true;
+                        record.IsComplete = true;
+                    }
+
+                    break;
+
+                case MessageEventType.Received:
+                    if (record.Envelope!.Destination?.Scheme == TransportConstants.Local)
+                    {
+                        markLastCompleted(MessageEventType.Sent);
+                    }
+
+                    break;
+
+                case MessageEventType.ExecutionStarted:
+                    // Nothing special here
+                    break;
+
+
+                case MessageEventType.ExecutionFinished:
+                    markLastCompleted(MessageEventType.ExecutionStarted);
                     record.IsComplete = true;
-                    record.WasScheduled = true;
-                }
+                    break;
 
-                if (record.Envelope.Status == EnvelopeStatus.Scheduled)
-                {
-                    record.WasScheduled = true;
+                case MessageEventType.NoHandlers:
+                case MessageEventType.NoRoutes:
+                case MessageEventType.MessageFailed:
+                case MessageEventType.MessageSucceeded:
+                case MessageEventType.Discarded:
+                case MessageEventType.MovedToErrorQueue:
+                    // The message is complete
+                    foreach (var envelopeRecord in _records) envelopeRecord.IsComplete = true;
+
                     record.IsComplete = true;
-                }
 
-                break;
+                    break;
 
-            case MessageEventType.Received:
-                if (record.Envelope!.Destination?.Scheme == TransportConstants.Local)
-                {
-                    markLastCompleted(MessageEventType.Sent);
-                }
+                case MessageEventType.Requeued:
+                    // Do nothing, just informative
+                    break;
 
-                break;
+                case MessageEventType.AutoFaultPublished:
+                    // Informational marker derived from the outgoing Sent envelope; never blocks completion.
+                    record.IsComplete = true;
+                    break;
 
-            case MessageEventType.ExecutionStarted:
-                // Nothing special here
-                break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(record.MessageEventType), record.MessageEventType,
+                        null);
+            }
 
-
-            case MessageEventType.ExecutionFinished:
-                markLastCompleted(MessageEventType.ExecutionStarted);
-                record.IsComplete = true;
-                break;
-
-            case MessageEventType.NoHandlers:
-            case MessageEventType.NoRoutes:
-            case MessageEventType.MessageFailed:
-            case MessageEventType.MessageSucceeded:
-            case MessageEventType.Discarded:
-            case MessageEventType.MovedToErrorQueue:
-                // The message is complete
-                foreach (var envelopeRecord in _records) envelopeRecord.IsComplete = true;
-
-                record.IsComplete = true;
-
-                break;
-
-            case MessageEventType.Requeued:
-                // Do nothing, just informative
-                break;
-
-            case MessageEventType.AutoFaultPublished:
-                // Informational marker derived from the outgoing Sent envelope; never blocks completion.
-                record.IsComplete = true;
-                break;
-
-            default:
-                throw new ArgumentOutOfRangeException(nameof(record.MessageEventType), record.MessageEventType, null);
+            _records.Add(record);
         }
-
-        _records.Add(record);
     }
 
     public void RecordCrossApplication(EnvelopeRecord record)
     {
-        switch (record.MessageEventType)
+        lock (_lock)
         {
-            case MessageEventType.Sent:
-                if (record.Envelope!.Status == EnvelopeStatus.Scheduled)
-                {
-                    record.WasScheduled = true;
+            switch (record.MessageEventType)
+            {
+                case MessageEventType.Sent:
+                    if (record.Envelope!.Status == EnvelopeStatus.Scheduled)
+                    {
+                        record.WasScheduled = true;
+                        record.IsComplete = true;
+
+                        record.TryUseInnerFromScheduledEnvelope();
+                    }
+
+                    // This can be out of order with Rabbit MQ *somehow*, so:
+                    var received = _records.LastOrDefault(x => x.MessageEventType == MessageEventType.Received);
+                    if (received != null)
+                    {
+                        record.IsComplete = true;
+                    }
+
+                    break;
+
+                case MessageEventType.ExecutionStarted:
+                    break;
+
+                case MessageEventType.Received:
+                    markLastCompleted(MessageEventType.Sent);
+                    break;
+
+
+                case MessageEventType.ExecutionFinished:
+                    markLastCompleted(MessageEventType.ExecutionStarted, record.UniqueNodeId);
+                    record.IsComplete = true;
+                    break;
+
+                case MessageEventType.MovedToErrorQueue:
+                case MessageEventType.MessageFailed:
+                case MessageEventType.Discarded:
+                case MessageEventType.MessageSucceeded:
+                    // The message is complete
+                    for (var i = 0; i < _records.Count; i++)
+                    {
+                        if (_records[i].UniqueNodeId == record.UniqueNodeId)
+                            _records[i].IsComplete = true;
+                    }
+
                     record.IsComplete = true;
 
-                    record.TryUseInnerFromScheduledEnvelope();
-                }
+                    break;
 
-                // This can be out of order with Rabbit MQ *somehow*, so:
-                var received = _records.LastOrDefault(x => x.MessageEventType == MessageEventType.Received);
-                if (received != null)
-                {
+                case MessageEventType.NoHandlers:
+                case MessageEventType.NoRoutes:
                     record.IsComplete = true;
-                }
+                    break;
 
-                break;
+                case MessageEventType.Requeued:
+                    break;
 
-            case MessageEventType.ExecutionStarted:
-                break;
+                case MessageEventType.AutoFaultPublished:
+                    // Informational marker derived from the outgoing Sent envelope; never blocks completion.
+                    record.IsComplete = true;
+                    break;
 
-            case MessageEventType.Received:
-                markLastCompleted(MessageEventType.Sent);
-                break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(record.MessageEventType), record.MessageEventType,
+                        null);
+            }
 
-
-            case MessageEventType.ExecutionFinished:
-                markLastCompleted(MessageEventType.ExecutionStarted, record.UniqueNodeId);
-                record.IsComplete = true;
-                break;
-
-            case MessageEventType.MovedToErrorQueue:
-            case MessageEventType.MessageFailed:
-            case MessageEventType.Discarded:
-            case MessageEventType.MessageSucceeded:
-                // The message is complete
-                for (var i = 0; i < _records.Count; i++)
-                {
-                    if (_records[i].UniqueNodeId == record.UniqueNodeId)
-                        _records[i].IsComplete = true;
-                }
-
-                record.IsComplete = true;
-
-                break;
-
-            case MessageEventType.NoHandlers:
-            case MessageEventType.NoRoutes:
-                record.IsComplete = true;
-                break;
-
-            case MessageEventType.Requeued:
-                break;
-
-            case MessageEventType.AutoFaultPublished:
-                // Informational marker derived from the outgoing Sent envelope; never blocks completion.
-                record.IsComplete = true;
-                break;
-
-            default:
-                throw new ArgumentOutOfRangeException(nameof(record.MessageEventType), record.MessageEventType, null);
+            _records.Add(record);
         }
-
-        _records.Add(record);
     }
 
     private void markLastCompleted(MessageEventType eventType, Guid uniqueNodeId)
@@ -199,28 +223,37 @@ internal class EnvelopeHistory
 
     public bool IsComplete()
     {
-        for (var i = 0; i < _records.Count; i++)
+        lock (_lock)
         {
-            if (!_records[i].IsComplete) return false;
-        }
+            for (var i = 0; i < _records.Count; i++)
+            {
+                if (!_records[i].IsComplete) return false;
+            }
 
-        return true;
+            return true;
+        }
     }
 
     public bool Has(MessageEventType eventType)
     {
-        for (var i = 0; i < _records.Count; i++)
+        lock (_lock)
         {
-            if (_records[i].MessageEventType == eventType) return true;
-        }
+            for (var i = 0; i < _records.Count; i++)
+            {
+                if (_records[i].MessageEventType == eventType) return true;
+            }
 
-        return false;
+            return false;
+        }
     }
 
     public object? MessageFor(MessageEventType eventType)
     {
-        return _records.Where(x => x.MessageEventType == eventType)
-            .LastOrDefault(x => x.Envelope!.Message != null)?.Envelope!.Message;
+        lock (_lock)
+        {
+            return _records.Where(x => x.MessageEventType == eventType)
+                .LastOrDefault(x => x.Envelope!.Message != null)?.Envelope!.Message;
+        }
     }
 
     public override string ToString()

--- a/src/Wolverine/Tracking/TrackedSession.cs
+++ b/src/Wolverine/Tracking/TrackedSession.cs
@@ -17,6 +17,9 @@ internal partial class TrackedSession : ITrackedSession
     private readonly IList<ITrackedCondition> _conditions = new List<ITrackedCondition>();
 
     private Cache<Guid, EnvelopeHistory> _envelopes = new(id => new EnvelopeHistory(id));
+
+    // _statuses and _exceptions are appended from concurrent transport listener threads,
+    // so all access is synchronized by locking on the collection instance itself
     private readonly List<EnvelopeRecord> _statuses = new();
 
     private readonly IList<Exception> _exceptions = new List<Exception>();
@@ -143,14 +146,14 @@ internal partial class TrackedSession : ITrackedSession
 
     public EnvelopeRecord[] AllRecordsInOrder()
     {
-        return _envelopes.SelectMany(x => x.Records).Concat(_statuses).OrderBy(x => x.SessionTime).ToArray();
+        return _envelopes.SelectMany(x => x.Records).Concat(statusesSnapshot()).OrderBy(x => x.SessionTime).ToArray();
     }
 
     public EnvelopeRecord[] AllRecordsInOrder(MessageEventType eventType)
     {
         return _envelopes
             .SelectMany(x => x.Records)
-            .Concat(_statuses)
+            .Concat(statusesSnapshot())
             .Where(x => x.MessageEventType == eventType)
             .OrderBy(x => x.SessionTime)
             .ToArray();
@@ -159,8 +162,24 @@ internal partial class TrackedSession : ITrackedSession
     public IReadOnlyList<Exception> AllExceptions()
     {
         return _envelopes.SelectMany(x => x.Records)
-            .Select(x => x.Exception).Where(x => x != null).Concat(_exceptions)
+            .Select(x => x.Exception).Where(x => x != null).Concat(exceptionsSnapshot())
             .Distinct().ToList()!;
+    }
+
+    private EnvelopeRecord[] statusesSnapshot()
+    {
+        lock (_statuses)
+        {
+            return _statuses.ToArray();
+        }
+    }
+
+    private Exception[] exceptionsSnapshot()
+    {
+        lock (_exceptions)
+        {
+            return _exceptions.ToArray();
+        }
     }
 
     public void AssertCondition(string message, Func<bool> condition)
@@ -280,9 +299,10 @@ internal partial class TrackedSession : ITrackedSession
     
     public void AssertNoExceptionsWereThrown()
     {
-        if (_exceptions.Count > 0)
+        var exceptions = exceptionsSnapshot();
+        if (exceptions.Length > 0)
         {
-            throw new AggregateException(_exceptions);
+            throw new AggregateException(exceptions);
         }
     }
 
@@ -345,11 +365,12 @@ internal partial class TrackedSession : ITrackedSession
             foreach (var condition in _conditions) writer.WriteLine($"{condition} ({condition.IsCompleted()})");
         }
 
-        if (_exceptions.Any())
+        var exceptions = exceptionsSnapshot();
+        if (exceptions.Any())
         {
             writer.WriteLine();
             writer.WriteLine("Exceptions detected: ");
-            foreach (var exception in _exceptions)
+            foreach (var exception in exceptions)
             {
                 writer.WriteLine(exception.ToString());
                 writer.WriteLine();
@@ -484,7 +505,10 @@ internal partial class TrackedSession : ITrackedSession
 
         if (ex != null)
         {
-            _exceptions.Add(ex);
+            lock (_exceptions)
+            {
+                _exceptions.Add(ex);
+            }
         }
 
         // Auto-fault detection: if this is a Sent event for an envelope that the failure
@@ -539,7 +563,10 @@ internal partial class TrackedSession : ITrackedSession
     public void LogException(Exception exception, string? serviceName)
     {
         Debug.WriteLine($"Exception Occurred in {serviceName}: {exception}");
-        _exceptions.Add(exception);
+        lock (_exceptions)
+        {
+            _exceptions.Add(exception);
+        }
     }
 
     public void AddCondition(ITrackedCondition condition)
@@ -552,7 +579,7 @@ internal partial class TrackedSession : ITrackedSession
     {
         var conditions = $"Conditions:\n{_conditions.Select(x => x.ToString())!.Join("\n")}";
         var activity = $"Activity:\n{AllRecordsInOrder().Select(x => x.ToString()).Join("\n")}";
-        var exceptions = $"Exceptions:\n{_exceptions.Select(x => x.ToString()).Join("\n")}";
+        var exceptions = $"Exceptions:\n{exceptionsSnapshot().Select(x => x.ToString()).Join("\n")}";
 
         return $"{conditions}\n\n{activity}\\{exceptions}";
     }
@@ -565,7 +592,10 @@ internal partial class TrackedSession : ITrackedSession
     public void LogStatus(string message)
     {
         var record = new EnvelopeRecord(MessageEventType.Status, null, _stopwatch.ElapsedMilliseconds, null);
-        _statuses.Add(record);
+        lock (_statuses)
+        {
+            _statuses.Add(record);
+        }
     }
 }
 


### PR DESCRIPTION
## What & why

When tracked sessions run with `IncludeExternalTransports()`, envelope records arrive concurrently from parallel transport listener threads (in our case ~90 Rabbit MQ queues on one host). `EnvelopeHistory` backed its records with an unsynchronized `List<T>`, so concurrent `Add` + LINQ iteration intermittently threw a `NullReferenceException` from inside the tracking bookkeeping itself, surfacing through `AssertNoExceptionsWereThrown()` and failing whatever test happened to have an active session (~1 in 4 runs of a ~50-test integration suite for us):

```
System.AggregateException : One or more errors occurred. (Object reference not set to an instance of an object.)
---- System.NullReferenceException
   at System.Linq.Enumerable.TryGetLast[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at Wolverine.Tracking.EnvelopeHistory.RecordCrossApplication(EnvelopeRecord record)
   at Wolverine.Runtime.WolverineRuntime.Received(Envelope envelope)
   at Wolverine.Runtime.HandlerPipeline.TryDeserializeEnvelope(Envelope envelope)
   ...
```

`TrackedSession`'s `_statuses` and `_exceptions` lists have the same unguarded add/enumerate pattern (`Record(...)` / `LogException(...)` append from listener threads while `AllRecordsInOrder()` / `AssertNoExceptionsWereThrown()` enumerate).

## The fix

- `EnvelopeHistory`: all members that touch `_records` now synchronize on a private lock; the `Records` property returns a snapshot array instead of the live list.
- `TrackedSession`: `_statuses` and `_exceptions` are appended under a lock on the collection instance, and all read sites go through snapshot helpers.

This is test-support code on cold paths, so the locking has no practical overhead.

## Testing

- New regression test `envelope_history_thread_safety` hammers `RecordCrossApplication` + the read paths from 8 threads. Against the previous implementation it fails deterministically (in under 150 ms) with the exact `NullReferenceException` from the report above; with this change it passes.
- All 43 existing `CoreTests.Tracking` tests pass on net9.0 and net10.0.

Fixes #3069
