### PR TITLE
Allow multiple flushes from EF Core DbContextOutbox

### DIFF
--- a/docs/guide/durability/efcore/outbox-and-inbox.md
+++ b/docs/guide/durability/efcore/outbox-and-inbox.md
@@ -103,6 +103,51 @@ public async Task Post(
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/EFCoreSample/ItemService/CreateItemController.cs#L12-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_dbcontext_outbox_1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### Multiple Flushes in Batching Loops
+
+`IDbContextOutbox<T>` and `IDbContextOutbox` use the same `MessageContext` mechanics as Wolverine's
+handler pipeline. By default, `MultiFlushMode` is `OnlyOnce`. That default prevents accidental duplicate
+outgoing messages when Wolverine's generated handler pipeline reaches the flush step more than once for
+the same incoming message.
+
+If you are using the EF Core outbox directly from application code and intentionally call
+`SaveChangesAndFlushMessagesAsync()` more than once on the same scoped outbox instance, opt into multiple
+flushes for those calls:
+
+```cs
+public async Task SendInBatches(
+    IDbContextOutbox<ItemsDbContext> outbox,
+    IReadOnlyList<CreateItemCommand> commands,
+    CancellationToken cancellation)
+{
+    foreach (var chunk in commands.Chunk(500))
+    {
+        foreach (var command in chunk)
+        {
+            var item = new Item { Name = command.Name };
+            outbox.DbContext.Items.Add(item);
+
+            await outbox.PublishAsync(new ItemCreated { Id = item.Id });
+        }
+
+        await outbox.SaveChangesAndFlushMessagesAsync(MultiFlushMode.AllowMultiples, cancellation);
+    }
+}
+```
+
+Without the explicit `AllowMultiples` setting, the first batch would flush normally, but later calls to
+`SaveChangesAndFlushMessagesAsync()` in the same scoped outbox instance would be ignored by the default
+`OnlyOnce` guard. For example, sending 2,000 messages in four batches of 500 would send the first 500,
+then skip the next three flushes. With `AllowMultiples`, each batch flush is honored.
+
+Passing the mode to `SaveChangesAndFlushMessagesAsync()` applies it only to that call and then restores the
+outbox's previous mode, so the setting does not leak into other code using the same scoped outbox instance.
+
+This setting only controls whether repeated EF Core outbox flushes are honored. It does not force a broker
+transport such as Kafka to send one native producer batch of 500 messages. For Kafka, Wolverine's non-inline
+sending path can group outgoing envelopes through its batching sender, but the Kafka sender still produces
+the envelopes individually within that Wolverine batch.
+
 Or use the `IDbContextOutbox` as shown below, but in this case you will need to explicitly call `Enroll()` on
 the `IDbContextOutbox` to connect the outbox sending to the `DbContext`:
 

--- a/src/Persistence/EfCoreTests/end_to_end_efcore_persistence.cs
+++ b/src/Persistence/EfCoreTests/end_to_end_efcore_persistence.cs
@@ -371,6 +371,92 @@ public class end_to_end_efcore_persistence : IClassFixture<EFCorePersistenceCont
     }
 
     [Fact]
+    public async Task DbContextOutbox_generic_can_opt_into_multiple_save_changes_and_flush_calls_in_one_scope()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+
+        var waiter1 = OutboxedMessageHandler.WaitForNextMessage();
+
+        using (var nested = Host.Services.CreateScope())
+        {
+            var outbox = nested.ServiceProvider.GetRequiredService<IDbContextOutbox<ItemsDbContext>>();
+            var context = outbox.ShouldBeOfType<DbContextOutbox<ItemsDbContext>>();
+
+            context.MultiFlushMode.ShouldBe(MultiFlushMode.OnlyOnce);
+
+            outbox.DbContext.Items.Add(new Item { Id = id1, Name = "First" });
+            await outbox.SendAsync(new OutboxedMessage { Id = id1 });
+            await outbox.SaveChangesAndFlushMessagesAsync(MultiFlushMode.AllowMultiples);
+            context.MultiFlushMode.ShouldBe(MultiFlushMode.OnlyOnce);
+
+            var message1 = await waiter1;
+            message1.Id.ShouldBe(id1);
+
+            var waiter2 = OutboxedMessageHandler.WaitForNextMessage();
+
+            outbox.DbContext.Items.Add(new Item { Id = id2, Name = "Second" });
+            await outbox.SendAsync(new OutboxedMessage { Id = id2 });
+            await outbox.SaveChangesAndFlushMessagesAsync(MultiFlushMode.AllowMultiples);
+            context.MultiFlushMode.ShouldBe(MultiFlushMode.OnlyOnce);
+
+            var message2 = await waiter2;
+            message2.Id.ShouldBe(id2);
+        }
+
+        using (var nested = Host.Services.CreateScope())
+        {
+            var context = nested.ServiceProvider.GetRequiredService<ItemsDbContext>();
+            (await context.Items.FindAsync(id1)).ShouldNotBeNull();
+            (await context.Items.FindAsync(id2)).ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task DbContextOutbox_non_generic_can_opt_into_multiple_save_changes_and_flush_calls_in_one_scope()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+
+        var waiter1 = OutboxedMessageHandler.WaitForNextMessage();
+
+        using (var nested = Host.Services.CreateScope())
+        {
+            var context = nested.ServiceProvider.GetRequiredService<ItemsDbContext>();
+            var outbox = nested.ServiceProvider.GetRequiredService<IDbContextOutbox>();
+            var messageContext = outbox.ShouldBeOfType<DbContextOutbox>();
+
+            outbox.Enroll(context);
+            messageContext.MultiFlushMode.ShouldBe(MultiFlushMode.OnlyOnce);
+
+            context.Items.Add(new Item { Id = id1, Name = "First" });
+            await outbox.SendAsync(new OutboxedMessage { Id = id1 });
+            await outbox.SaveChangesAndFlushMessagesAsync(MultiFlushMode.AllowMultiples);
+            messageContext.MultiFlushMode.ShouldBe(MultiFlushMode.OnlyOnce);
+
+            var message1 = await waiter1;
+            message1.Id.ShouldBe(id1);
+
+            var waiter2 = OutboxedMessageHandler.WaitForNextMessage();
+
+            context.Items.Add(new Item { Id = id2, Name = "Second" });
+            await outbox.SendAsync(new OutboxedMessage { Id = id2 });
+            await outbox.SaveChangesAndFlushMessagesAsync(MultiFlushMode.AllowMultiples);
+            messageContext.MultiFlushMode.ShouldBe(MultiFlushMode.OnlyOnce);
+
+            var message2 = await waiter2;
+            message2.Id.ShouldBe(id2);
+        }
+
+        using (var nested = Host.Services.CreateScope())
+        {
+            var context = nested.ServiceProvider.GetRequiredService<ItemsDbContext>();
+            (await context.Items.FindAsync(id1)).ShouldNotBeNull();
+            (await context.Items.FindAsync(id2)).ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
     public async Task use_generic_outbox_mapped()
     {
         var id = Guid.NewGuid();

--- a/src/Persistence/Wolverine.EntityFrameworkCore/DbContextOutbox.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/DbContextOutbox.cs
@@ -33,6 +33,21 @@ public class DbContextOutbox<T> : MessageContext, IDbContextOutbox<T> where T : 
 
         await FlushOutgoingMessagesAsync();
     }
+
+    public async Task SaveChangesAndFlushMessagesAsync(MultiFlushMode multiFlushMode, CancellationToken token = default)
+    {
+        var previous = MultiFlushMode;
+        MultiFlushMode = multiFlushMode;
+
+        try
+        {
+            await SaveChangesAndFlushMessagesAsync(token).ConfigureAwait(false);
+        }
+        finally
+        {
+            MultiFlushMode = previous;
+        }
+    }
 }
 
 public class DbContextOutbox : MessageContext, IDbContextOutbox
@@ -73,5 +88,20 @@ public class DbContextOutbox : MessageContext, IDbContextOutbox
         }
 
         await FlushOutgoingMessagesAsync();
+    }
+
+    public async Task SaveChangesAndFlushMessagesAsync(MultiFlushMode multiFlushMode, CancellationToken token = default)
+    {
+        var previous = MultiFlushMode;
+        MultiFlushMode = multiFlushMode;
+
+        try
+        {
+            await SaveChangesAndFlushMessagesAsync(token).ConfigureAwait(false);
+        }
+        finally
+        {
+            MultiFlushMode = previous;
+        }
     }
 }

--- a/src/Persistence/Wolverine.EntityFrameworkCore/IDbContextOutbox.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/IDbContextOutbox.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Wolverine.Runtime;
 
 namespace Wolverine.EntityFrameworkCore;
 
@@ -20,6 +21,15 @@ public interface IDbContextOutbox<T> : IMessageBus where T : DbContext
     /// <param name="token"></param>
     /// <returns></returns>
     Task SaveChangesAndFlushMessagesAsync(CancellationToken token = default);
+
+    /// <summary>
+    ///     Saves outstanding changes in the DbContext and flushes outbox messages to the
+    ///     sending agents with an explicit multi-flush mode for just this call
+    /// </summary>
+    /// <param name="multiFlushMode"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    Task SaveChangesAndFlushMessagesAsync(MultiFlushMode multiFlushMode, CancellationToken token = default);
 
     /// <summary>
     ///     Calling this
@@ -54,6 +64,15 @@ public interface IDbContextOutbox : IMessageBus
     /// <param name="token"></param>
     /// <returns></returns>
     Task SaveChangesAndFlushMessagesAsync(CancellationToken token = default);
+
+    /// <summary>
+    ///     Saves outstanding changes in the DbContext and flushes outbox messages to the
+    ///     sending agents with an explicit multi-flush mode for just this call
+    /// </summary>
+    /// <param name="multiFlushMode"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    Task SaveChangesAndFlushMessagesAsync(MultiFlushMode multiFlushMode, CancellationToken token = default);
 
     /// <summary>
     ///     Calling this


### PR DESCRIPTION
Adds a per-call `MultiFlushMode` option to the EF Core outbox save/flush API:

```csharp
await outbox.SaveChangesAndFlushMessagesAsync(
    MultiFlushMode.AllowMultiples,
    cancellationToken);
```

The default behavior is unchanged. `MessageContext.MultiFlushMode` still defaults to `OnlyOnce`.

## Use Cases

### Chunked publishing from Minimal APIs or MVC controllers

A common pattern is to publish a large number of messages in chunks so each chunk is committed and flushed separately:

```csharp
app.MapPost("/send-bulk", async (
    IDbContextOutbox<AppDbContext> outbox,
    IReadOnlyList<CreateInvoiceCommand> commands,
    CancellationToken cancellationToken) =>
{
    foreach (var chunk in commands.Chunk(500))
    {
        foreach (var command in chunk)
        {
            await outbox.PublishAsync(command);
        }

        await outbox.SaveChangesAndFlushMessagesAsync(
            MultiFlushMode.AllowMultiples,
            cancellationToken);
    }
});
```

Without `AllowMultiples`, only the first flush is honored on the scoped outbox instance.

For example, with 2,000 messages split into 4 chunks of 500:

- chunk 1: 500 messages flushed
- chunk 2: flush skipped
- chunk 3: flush skipped
- chunk 4: flush skipped

Result: only the first 500 messages are flushed.

### Import jobs that save progress per batch

Background import jobs often process records in batches and commit progress after each batch:

```csharp
public async Task ImportAsync(
    IDbContextOutbox<AppDbContext> outbox,
    IReadOnlyList<CustomerRow> rows,
    CancellationToken cancellationToken)
{
    foreach (var batch in rows.Chunk(100))
    {
        foreach (var row in batch)
        {
            var customer = Customer.From(row);

            outbox.DbContext.Customers.Add(customer);

            await outbox.PublishAsync(new CustomerImported
            {
                CustomerId = customer.Id
            });
        }

        await outbox.SaveChangesAndFlushMessagesAsync(
            MultiFlushMode.AllowMultiples,
            cancellationToken);
    }
}
```

Each batch saves EF Core changes and flushes the messages produced by that batch.
