### PR TITLE
PS#5: Marten + Polecat EventStoreAgents call upstream daemon.SubscribeWithStoreUriStamp

### DIFF
--- a/src/Persistence/Wolverine.Marten/Distribution/EventStoreAgents.cs
+++ b/src/Persistence/Wolverine.Marten/Distribution/EventStoreAgents.cs
@@ -62,7 +62,14 @@ internal class EventStoreAgents : IAsyncDisposable
             foreach (var observer in _observers)
             {
                 // TODO -- do we need to care about un-subscribing?
-                daemon.Tracker.Subscribe(observer);
+                // JasperFx/ProductSupport#5 — wrap the observer so the owning
+                // store's URI rides through on every ShardState, then forward
+                // to the daemon's Tracker. The Tracker itself is shared across
+                // stores attached to the same database, so the stamping
+                // has to happen one level up where the store identity is
+                // known. Stamping lives in JasperFx.Events as a shared
+                // helper; Marten + Polecat call it the same way.
+                daemon.SubscribeWithStoreUriStamp(observer);
             }
             
             _daemons = _daemons.AddOrUpdate(databaseId, daemon);

--- a/src/Persistence/Wolverine.Polecat/Distribution/EventStoreAgents.cs
+++ b/src/Persistence/Wolverine.Polecat/Distribution/EventStoreAgents.cs
@@ -60,7 +60,9 @@ internal class EventStoreAgents : IAsyncDisposable
             daemon = await _store.BuildProjectionDaemonAsync(databaseId);
             foreach (var observer in _observers)
             {
-                daemon.Tracker.Subscribe(observer);
+                // JasperFx/ProductSupport#5 — defer to the upstream stamping
+                // extension so the same shape lands on both Marten and Polecat.
+                daemon.SubscribeWithStoreUriStamp(observer);
             }
 
             _daemons = _daemons.AddOrUpdate(databaseId, daemon);


### PR DESCRIPTION
Wolverine half of the JasperFx/ProductSupport#5 multi-store StoreUri fix. Pairs with the JasperFx PR that ships the `ShardState.StoreUri` property + `ProjectionDaemonExtensions.SubscribeWithStoreUriStamp` helper:

- JasperFx/jasperfx#440 — abstraction + extension helper + daemon-side stamping

## Problem

A singleton `IObserver<ShardState>` registered in DI (e.g. CritterWatch's shard observer) sees callbacks from every `EventStoreAgents`' daemon Tracker, but the bare `ShardState` carries no store identity — so multi-store hosts collapsed live shard updates into a single bucket on the consumer side. The `ShardStateTracker` itself can't fix that because Marten/Polecat databases that back multiple `IEventStore` registrations share a Tracker; the stamping has to happen one level up where the store identity is known.

## What this PR does

In `EventStoreAgents.FindDaemonAsync` on both the Marten and Polecat sides, route each subscribed observer through `daemon.SubscribeWithStoreUriStamp(observer)` instead of `daemon.Tracker.Subscribe(observer)`. The upstream JasperFx extension wraps the observer with a per-store `StoreUriStampingObserver` (bound to the daemon's `StoreUri`, which comes from `_store.Subject.ToString()`) and forwards to the Tracker.

The stamping abstraction lives in JasperFx.Events so every store integration uses the same shape — both Marten and Polecat use the identical one-line call.

```csharp
// Wolverine.Marten/Distribution/EventStoreAgents.cs
daemon = await _store.BuildProjectionDaemonAsync(databaseId);
foreach (var observer in _observers)
{
    daemon.SubscribeWithStoreUriStamp(observer);
}

// Wolverine.Polecat/Distribution/EventStoreAgents.cs — identical
```

## Diff

- Modified: `src/Persistence/Wolverine.Marten/Distribution/EventStoreAgents.cs` (~7 lines)
- Modified: `src/Persistence/Wolverine.Polecat/Distribution/EventStoreAgents.cs` (~5 lines)

No new classes, no new public API on the Wolverine side. The wrapping helper lives upstream where the rest of the JasperFx.Events abstraction is.

## Consumed by

- CritterWatch — `productsupport-fixes-4-10`: `CritterWatchShardObserver.OnNext` reads `ShardState.StoreUri` via reflection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
