### PR TITLE
Handle tests with Theory attribute in flaky retries

### DIFF
--- a/build/TestAllPersistence.cs
+++ b/build/TestAllPersistence.cs
@@ -22,86 +22,6 @@ partial class Build
         });
 
     /// <summary>
-    /// Discovers test classes from a compiled test project by running <c>dotnet test --list-tests</c>.
-    /// Returns the set of fully-qualified class names that contain at least one test.
-    /// This discovers inherited tests (e.g. TransportCompliance<>) that source-level regex misses.
-    /// </summary>
-    static string[] DiscoverTestClassesFromAssembly(string projectPath, string configuration, string frameworkOverride = null)
-    {
-        var args = $"test \"{projectPath}\" --no-build --list-tests --configuration {configuration}";
-        if (!string.IsNullOrEmpty(frameworkOverride))
-            args += $" --framework {frameworkOverride}";
-
-        var process = ProcessTasks.StartProcess("dotnet", args, logOutput: false, logInvocation: false);
-        process.AssertWaitForExit();
-
-        var classes = new HashSet<string>();
-        // Test lines are indented (start with whitespace):
-        //   Namespace.ClassName.MethodName                          ([Fact])
-        //   Namespace.ClassName.MethodName(param: value)            ([Theory] + [InlineData])
-        // Header lines (e.g. "Test run for ...", "The following...") are not indented.
-        // Class name = everything before the last dot BEFORE the first '('.
-        // Truncating at '(' first avoids dots in parameter values (e.g. "http://example").
-        foreach (var raw in process.Output.Select(line => line.Text))
-        {
-            if (raw.Length == 0 || !char.IsWhiteSpace(raw[0])) continue;  // skip header lines
-            var text = raw.Trim();
-
-            // Strip parameters before splitting: "method(param: val)" -> "method"
-            var paren = text.IndexOf('(');
-            var stripped = paren >= 0 ? text[..paren] : text;
-
-            var lastDot = stripped.LastIndexOf('.');
-            if (lastDot > 0)
-                classes.Add(stripped[..lastDot]);
-        }
-
-        return [.. classes];
-    }
-
-    /// <summary>
-    /// Discovers individual test methods from a compiled test project by running
-    /// <c>dotnet test --list-tests</c>. Returns tuples of (fully-qualified class name, method name).
-    /// This discovers inherited tests (e.g. TransportCompliance<>) that source-level regex misses.
-    /// Handles both [Fact] (simple method names) and [Theory] + [InlineData] (names with parameters).
-    /// </summary>
-    static List<(string ClassName, string MethodName)> DiscoverTestMethodsFromAssembly(string projectPath, string configuration, string frameworkOverride = null)
-    {
-        var args = $"test \"{projectPath}\" --no-build --list-tests --configuration {configuration}";
-        if (!string.IsNullOrEmpty(frameworkOverride))
-            args += $" --framework {frameworkOverride}";
-
-        var process = ProcessTasks.StartProcess("dotnet", args, logOutput: false, logInvocation: false);
-        process.AssertWaitForExit();
-
-        var results = new List<(string, string)>();
-        // Test lines are indented (start with whitespace):
-        //   Namespace.ClassName.MethodName                    ([Fact])
-        //   Namespace.ClassName.MethodName(param: value)      ([Theory] + [InlineData])
-        // Header lines (e.g. "Test run for ...", "The following...") are not indented.
-        // First strip parameters to avoid dots in param values (e.g. "http://example").
-        foreach (var raw in process.Output.Select(line => line.Text))
-        {
-            if (raw.Length == 0 || !char.IsWhiteSpace(raw[0])) continue;
-            var text = raw.Trim();
-
-            // Strip parameters: "method(param: val)" -> "method"
-            var paren = text.IndexOf('(');
-            var stripped = paren >= 0 ? text[..paren] : text;
-
-            var lastDot = stripped.LastIndexOf('.');
-            if (lastDot <= 0) continue;
-
-            var className = stripped[..lastDot];
-            var methodName = stripped[(lastDot + 1)..];
-
-            results.Add((className, methodName));
-        }
-
-        return results;
-    }
-
-    /// <summary>
     /// Runs a single dotnet test invocation with retry logic.
     /// Returns Passed, Flaky (passed on retry), or Failed.
     /// </summary>
@@ -211,10 +131,15 @@ partial class Build
 
     /// <summary>
     /// Escapes special characters in a test filter value for dotnet test --filter.
-    /// Replaces '&amp;' and '|' which are filter operators.
+    /// Also strips everything after the first '(' since theory parameters are not
+    /// needed for substring matching (FullyQualifiedName~ is a prefix/substring match).
     /// </summary>
     static string EscapeFilterValue(string value)
     {
+        var paren = value.IndexOf('(');
+        if (paren >= 0)
+            value = value[..paren];
+
         return value
             .Replace("&", "%26")
             .Replace("|", "%7C")


### PR DESCRIPTION
This PR is a continuation of  [PR 3073 ](https://github.com/JasperFx/wolverine/pull/3073) with corrected flaky retry for the tests with Theory attribute

Test name extracted from trx includes parameters from Theory attribute. The fix is to skip such parameters so the filter used to retry a test is correct. 

BEFORE
```
[WRN] CIEfCore: === EfCoreTests: Second round. Retrying 31 test(s) ===
  [ERR] CIEfCore: MSBUILD : error MSB4177: Invalid property. The name "outbox_flush_handler_codegen_eager)" contains an invalid character ")".
  [WRN] CIEfCore:   EfCoreTests/EfCoreTests.Bugs.Bug_efcore_outbox_flush_before_commit.handler_chain_does_not_flush_outgoing_messages_before_efcore_commit(mode: Eager, schema: "outbox_flush_handler_codegen_eager") failed on attempt 1/2, will retry: Process 'dotnet' exited with code 1.
     > /usr/share/dotnet/dotnet test /home/runner/work/wolverine/wolverine/src/Persistence/EfCoreTests/EfCoreTests.csproj --configuration Release --no-build --no-restore --framework net9.0 --filter "FullyQualifiedName~EfCoreTests.Bugs.Bug_efcore_outbox_flush_before_commit.handler_chain_does_not_flush_outgoing_messages_before_efcore_commit(mode: Eager, schema: \"outbox_flush_handler_codegen_eager\")" --logger trx;LogFilePrefix=EfCoreTests-1.trx
     @ /home/runner/work/wolverine/wolverine
  Standard output:
     MSBUILD : error MSB4177: Invalid property. The name "outbox_flush_handler_codegen_eager)" contains an invalid character ")".
```

AFTER
```
  19:18:53 [WRN] === EfCoreTests: Second round. Retrying 30 test(s) ===
  ...
  19:19:39 [INF] > /usr/share/dotnet/dotnet test /home/runner/work/wolverine/wolverine/src/Persistence/EfCoreTests/EfCoreTests.csproj --configuration Release --no-build --no-restore --framework net9.0 --filter FullyQualifiedName~EfCoreTests.Bugs.Bug_efcore_outbox_flush_before_commit.handler_chain_does_not_flush_outgoing_messages_before_efcore_commit --logger trx;LogFilePrefix=EfCoreTests-1.trx
  19:19:39 [DBG] Test run for /home/runner/work/wolverine/wolverine/src/Persistence/EfCoreTests/bin/Release/net9.0/EfCoreTests.dll (.NETCoreApp,Version=v9.0)
  19:19:40 [DBG] A total of 1 test files matched the specified pattern.
  19:19:46 [DBG] Results File: /home/runner/work/wolverine/wolverine/src/Persistence/EfCoreTests/TestResults/EfCoreTests-1.trx_net9.0_20260611191946.trx
  19:19:46 [DBG] 
  19:19:46 [DBG] Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 5 s - EfCoreTests.dll (net9.0)
```
