### PR TITLE
Honor [FromKeyedServices] on handler constructor params (closes #3081)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,13 +32,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.8.2" />
-    <PackageVersion Include="JasperFx.Events" Version="2.8.2" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.8.2" />
+    <PackageVersion Include="JasperFx" Version="2.9.10" />
+    <PackageVersion Include="JasperFx.Events" Version="2.9.10" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.10" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.8.2" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.10" />
     <PackageVersion Include="Marten" Version="9.6.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.2.1" />
@@ -46,7 +46,7 @@
     <PackageVersion Include="Marten.AspNetCore" Version="9.6.0" />
     <PackageVersion Include="Marten.Newtonsoft" Version="9.6.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
-    <PackageVersion Include="MessagePack" Version="3.1.3" />
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.14" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.2.9" />

--- a/src/Testing/CoreTests/Acceptance/keyed_services_on_handler_constructor.cs
+++ b/src/Testing/CoreTests/Acceptance/keyed_services_on_handler_constructor.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine;
+using Wolverine.Attributes;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+// GH-3081: keyed services injected through a handler's CONSTRUCTOR were resolved by type only,
+// dropping the [FromKeyedServices] key — so two keyed parameters of the same service type both
+// resolved to the default (last) registration. Fixed in JasperFx 2.9.10: ConstructorFrame now
+// resolves constructor parameters via the attribute-aware FindVariable(ParameterInfo) overload.
+//
+// Companion to using_with_keyed_services, which covers keyed services on Handle METHOD parameters
+// (that path always worked because MethodCall already used the attribute-aware overload).
+public class keyed_services_on_handler_constructor
+{
+    [Fact]
+    public async Task each_keyed_constructor_parameter_resolves_to_its_own_registration()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<KeyedCtorHandler>();
+
+                opts.Services.AddKeyedScoped<IKeyedRepo, FirstRepo>("Test");
+                opts.Services.AddKeyedScoped<IKeyedRepo, SecondRepo>("Test2");
+            }).StartAsync();
+
+        KeyedCtorRecording.Seen.Clear();
+
+        await host.InvokeAsync(new KeyedCtorCommand());
+
+        // first ctor param -> "Test" -> FirstRepo; second -> "Test2" -> SecondRepo.
+        // Before the fix both parameters resolved to the last registration (SecondRepo).
+        KeyedCtorRecording.Seen.ShouldBe(["First", "Second"]);
+    }
+}
+
+public interface IKeyedRepo
+{
+    string Name { get; }
+}
+
+public class FirstRepo : IKeyedRepo
+{
+    public string Name => "First";
+}
+
+public class SecondRepo : IKeyedRepo
+{
+    public string Name => "Second";
+}
+
+public static class KeyedCtorRecording
+{
+    public static readonly List<string> Seen = new();
+}
+
+public record KeyedCtorCommand;
+
+[WolverineIgnore]
+public class KeyedCtorHandler(
+    [FromKeyedServices("Test")] IKeyedRepo first,
+    [FromKeyedServices("Test2")] IKeyedRepo second)
+{
+    public void Handle(KeyedCtorCommand command)
+    {
+        KeyedCtorRecording.Seen.Add(first.Name);
+        KeyedCtorRecording.Seen.Add(second.Name);
+    }
+}


### PR DESCRIPTION
Follow-up to [JasperFx/jasperfx#445](https://github.com/JasperFx/jasperfx/pull/445), which fixed the root cause of #3081. This bumps Wolverine to the published fix and adds an end-to-end regression test.

## Background

#3081: a handler with `[FromKeyedServices("…")]` on its **constructor** parameters generated code that ignored the key — each keyed parameter was resolved by type only and fell through to the default (last) registration. With two keyed params of the same service type, both bound to the same instance (the reporter's `new TestRepo2()` for both).

Root cause was in JasperFx's `ConstructorFrame.FindVariables`, which resolved constructor parameters via the type-only `FindVariable(Type)` overload instead of the attribute-aware `FindVariable(ParameterInfo)` overload that `MethodCall` already used. That asymmetry is exactly why keyed services on a `Handle(...)` **method** parameter already worked but the same attribute on the handler **constructor** did not. Fixed in **JasperFx 2.9.10**.

Lamar's keyed resolution was already correct (verified directly in the Lamar repo — both at runtime and in its own generated build plan); the bug was container-agnostic, in the shared codegen layer.

## Changes

- **JasperFx 2.8.2 → 2.9.10** (`JasperFx`, `JasperFx.Events`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator`; `JasperFx.RuntimeCompiler` stays on its 5.x line).
- **`keyed_services_on_handler_constructor`** — a handler whose constructor takes two `[FromKeyedServices]` params of the same service type (`"Test"` → `FirstRepo`, `"Test2"` → `SecondRepo`); asserts each resolves to its own registration. Companion to the existing `using_with_keyed_services` (method-parameter case).
- **MessagePack 3.1.3 → 3.1.7** — clears the freshly-published NU1903 advisory that otherwise fails the build under `TreatWarningsAsErrors` (affects `main` too; bundled here to keep this PR's CI green).

## Verification

- New test passes; existing `using_with_keyed_services` (4) still pass; 267 CoreTests green.
- `wolverine.slnx -c Release` builds clean — 0 warnings, 0 errors.

## Note on Lamar

I did not add a Lamar-specific variant: Wolverine's test suite has no Lamar dependency, the bug reproduces identically on the default container (same `ConstructorFrame` codegen path), and Lamar's keyed correctness is covered in the Lamar repo. Happy to wire up a Lamar test if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)