### PR TITLE
Cover keyed constructor injection under Lamar too (#3081)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
     <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.10" />
+    <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.6.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.2.1" />

--- a/src/Testing/CoreTests/Acceptance/keyed_services_on_handler_constructor.cs
+++ b/src/Testing/CoreTests/Acceptance/keyed_services_on_handler_constructor.cs
@@ -1,3 +1,4 @@
+using Lamar.Microsoft.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Wolverine;
@@ -13,12 +14,27 @@ namespace CoreTests.Acceptance;
 //
 // Companion to using_with_keyed_services, which covers keyed services on Handle METHOD parameters
 // (that path always worked because MethodCall already used the attribute-aware overload).
+//
+// Covered against both the default container and Lamar (the issue was reported on Lamar). The fix
+// is in the shared codegen layer, so both containers must resolve the keyed constructor parameters
+// correctly.
 public class keyed_services_on_handler_constructor
 {
     [Fact]
-    public async Task each_keyed_constructor_parameter_resolves_to_its_own_registration()
+    public Task each_keyed_constructor_parameter_resolves_to_its_own_registration()
     {
-        using var host = await Host.CreateDefaultBuilder()
+        return assertKeyedConstructorInjectionResolvesByKey(Host.CreateDefaultBuilder());
+    }
+
+    [Fact]
+    public Task each_keyed_constructor_parameter_resolves_to_its_own_registration_on_lamar()
+    {
+        return assertKeyedConstructorInjectionResolvesByKey(Host.CreateDefaultBuilder().UseLamar());
+    }
+
+    private static async Task assertKeyedConstructorInjectionResolvesByKey(IHostBuilder builder)
+    {
+        using var host = await builder
             .UseWolverine(opts =>
             {
                 opts.Discovery.DisableConventionalDiscovery().IncludeType<KeyedCtorHandler>();

--- a/src/Testing/CoreTests/CoreTests.csproj
+++ b/src/Testing/CoreTests/CoreTests.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentResults" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
         <PackageReference Include="Microsoft.FeatureManagement"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="OpenTelemetry.Exporter.Console"/>


### PR DESCRIPTION
Follow-up to #3086 (which closed #3081). That PR added a keyed-constructor-injection regression test against the default container. Since #3081 was reported on **Lamar**, this adds an explicit Lamar variant so the scenario is covered on both containers.

The JasperFx 2.9.10 fix is in the shared codegen layer (`ConstructorFrame`), so it's container-agnostic — but having a Lamar test guards the Lamar `ServiceVariableSource` keyed-resolution path explicitly.

## Changes

- Add `Lamar.Microsoft.DependencyInjection` 16.0.0 to `CoreTests`. Its transitive JasperFx unifies up to Wolverine's 2.9.10 — no version conflict / no downgrade.
- `keyed_services_on_handler_constructor` now runs the same scenario (two `[FromKeyedServices]` constructor params of the same service type, `"Test"` → `FirstRepo`, `"Test2"` → `SecondRepo`) against **both** the default container and `Host.CreateDefaultBuilder().UseLamar()`, via one shared helper.

## Verification

- Both tests pass (default container + Lamar).
- Full CoreTests Acceptance suite (218) green — adding the Lamar package doesn't disturb other tests (Lamar only activates via `UseLamar()`).
- `wolverine.slnx -c Release` builds clean — 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)