### PR TITLE
docs: fix handler multi-tenancy + error-handling gaps (closes #3096, #3097)

### DIFF
--- a/docs/guide/handlers/error-handling.md
+++ b/docs/guide/handlers/error-handling.md
@@ -290,8 +290,6 @@ using var host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Runtime/Samples/error_handling.cs#L30-L44' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_globalerrorhandlingconfiguration' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-TODO -- link to chain policies, after that exists:)
-
 Lastly, you can use chain policies to add error handling policies to a selected subset of message handlers. First, here's
 a sample policy that applies an error handling policy based on `SqlException` errors for all message types from a certain namespace:
 
@@ -326,7 +324,26 @@ are transient versus failures that imply the message could never be processed.
 The attributes are limited to exception type, but the fluent interface has quite a few options to filter exception further with additional
 filters, inner exception tests, and compound filters:
 
-sample_filtering_by_exception_type
+<!-- snippet: sample_filtering_by_exception_type -->
+<a id='snippet-sample_filtering_by_exception_type'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.Policies
+            .OnException<SqlException>()
+            .Or<InvalidOperationException>(ex => ex.Message.Contains("Intermittent message of some kind"))
+            .OrInner<BadImageFormatException>()
+
+            // And apply the "continuation" action to take if the filters match
+            .Requeue();
+
+        // Use different actions for different exception types
+        opts.Policies.OnException<InvalidOperationException>().RetryTimes(3);
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Runtime/Samples/error_handling.cs#L49-L65' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_filtering_by_exception_type' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 
 ## Custom Actions

--- a/docs/guide/handlers/multi-tenancy.md
+++ b/docs/guide/handlers/multi-tenancy.md
@@ -76,12 +76,9 @@ but you don't want to inject the Wolverine `IMessageContext` or `Envelope` into 
 an easy way to just "push" the current tenant id into your handler methods. Maybe this is for ease of writing unit tests,
 or conditional logic, or some other reason.
 
-To that end, you can inject the `Wolverine.Persistence.TenantId` into any Wolverine message handler or HTTP endpoint method
-to get easy access to the tenant id:
-
-TODO/FIX: snippet: sample_TenantId
-
-There's really nothing to it other than just pulling that type in as a parameter argument to a message handler:
+To that end, you can inject the `JasperFx.MultiTenancy.TenantId` into any Wolverine message handler or HTTP endpoint method
+to get easy access to the tenant id. There's really nothing to it other than just pulling that type in as a parameter
+argument to a message handler:
 
 <!-- snippet: sample_injecting_tenant_id -->
 <a id='snippet-sample_injecting_tenant_id'></a>


### PR DESCRIPTION
Closes #3096 and #3097.

### multi-tenancy.md (#3096)
The `TODO/FIX: snippet: sample_TenantId` placeholder turned out to be **redundant** — the working `sample_injecting_tenant_id` snippet directly below it already demonstrates injecting `TenantId` into a handler. So rather than add a near-duplicate source region, this removes the placeholder. It also fixes a real bug in the surrounding prose: the type is **`JasperFx.MultiTenancy.TenantId`**, not `Wolverine.Persistence.TenantId` (verified against the host file's `using JasperFx.MultiTenancy;` and usage).

### error-handling.md (#3097)
- Removed the stale `TODO -- link to chain policies, after that exists:)` note — the chain-policies content (`sample_errorhandlingpolicy`) already follows immediately, so the TODO was obsolete.
- Wired the orphaned `sample_filtering_by_exception_type` (it was sitting as bare plain text). The source region already exists in `error_handling.cs:49-65`; added the snippet markers and ran mdsnippets so the compound/inner-exception filtering example renders.

No new source code — both snippets reference already-compiling regions. Found during the documentation review (#3089).

🤖 Generated with [Claude Code](https://claude.com/claude-code)