### PR TITLE
docs: fill messaging stubs (policies, SQS queues, intro, message delivery, ASB DLQ)

### DIFF
--- a/docs/guide/messaging/introduction.md
+++ b/docs/guide/messaging/introduction.md
@@ -64,11 +64,21 @@ builder.Host.UseWolverine(opts =>
 
 ## Listening Endpoint Configuration
 
+Once you've connected Wolverine to your external infrastructure, you'll want to configure listening endpoints so
+that Wolverine can receive and process incoming messages. Listening endpoints control which queues, topics, or
+subscriptions Wolverine reads from, how many messages are processed in parallel, and how received messages are
+buffered or made durable.
+
+See [Listener Configuration](/guide/messaging/listeners) for the full set of options, including parallelism,
+durability, and endpoint-level error handling.
 
 ## Sending Endpoint Configuration
 
+To publish messages out through external infrastructure, you'll configure sending endpoints and the routing
+rules that teach Wolverine where each message type should be sent.
 
-
-
+See [Subscriptions and Message Routing](/guide/messaging/subscriptions) for how to declare those rules, and
+[The Message Bus](/guide/messaging/message-bus) for the `IMessageBus` API you use to publish, send, and invoke
+messages from your application code.
 
 

--- a/docs/guide/messaging/message-bus.md
+++ b/docs/guide/messaging/message-bus.md
@@ -483,7 +483,30 @@ public static (Order, OrderTimeout) Start(StartOrder order, ILogger<Order> logge
 
 ## Customizing Message Delivery
 
-TODO -- more text here. NEW PAGE???
+When you publish or send a message you can optionally pass a `DeliveryOptions` object to override how — and
+when — that particular message is delivered. Every overload of `IMessageBus.PublishAsync()` and
+`IMessageBus.SendAsync()` accepts an optional `DeliveryOptions` argument, so you can tailor a single message
+without changing any endpoint-wide configuration.
+
+`DeliveryOptions` lets you control things like:
+
+* **Custom headers** — add arbitrary string metadata that travels with the message, either through the
+  `Headers` dictionary or the fluent `WithHeader(key, value)` method.
+* **Expiration** — `DeliverBy` (an absolute time) or the `DeliverWithin` convenience setter (a `TimeSpan` from
+  now) tell Wolverine to discard the message if it hasn't been delivered and processed in time. See
+  [Message Expiration](/guide/messaging/expiration).
+* **Scheduled delivery** — `ScheduledTime` (an absolute time) or `ScheduleDelay` (a `TimeSpan` from now) defer
+  processing until later.
+* **Request/response** — set `ResponseType` (or use the static `DeliveryOptions.RequireResponse<T>()` helper) to
+  ask the receiver to send a reply message of that type back to you.
+* **Tenancy and tracing** — override the `TenantId`, `CorrelationId`, or `CausationId` stamped onto the outgoing
+  envelope for just this message.
+* **Acknowledgements** — set `AckRequested` to request an acknowledgement from the receiver.
+* **Transport-specific routing** — `GroupId` (AMQP 1.0 group id / Azure Service Bus session id / Amazon SQS FIFO
+  `MessageGroupId`), `DeduplicationId` (Amazon SQS FIFO), and `PartitionKey` (Kafka) map onto the corresponding
+  native broker concepts.
+
+Here's an example exercising several of these options at once:
 
 <!-- snippet: sample_sendmessageswithdeliveryoptions -->
 <a id='snippet-sample_sendmessageswithdeliveryoptions'></a>

--- a/docs/guide/messaging/policies.md
+++ b/docs/guide/messaging/policies.md
@@ -1,1 +1,111 @@
 # Endpoint Policies
+
+An *endpoint policy* is a reusable rule that Wolverine applies to every messaging endpoint (listeners, senders,
+and local queues) as your application bootstraps. Rather than configuring each Rabbit MQ queue or Azure Service
+Bus subscription one at a time, you can write a single policy that's evaluated against *all* endpoints —
+including ones created by [conventional routing](/guide/messaging/subscriptions) that you never explicitly
+declared.
+
+Endpoint policies are how a lot of Wolverine's own behavior is implemented. For example, the Rabbit MQ
+`UseQuorumQueues()` helper is just an endpoint policy that flips every application-owned queue to a quorum queue.
+
+## Writing an Endpoint Policy
+
+Implement the `Wolverine.Configuration.IEndpointPolicy` interface. It has a single method that receives each
+`Endpoint` together with the live `IWolverineRuntime`:
+
+<!-- snippet: sample_custom_endpoint_policy -->
+<a id='snippet-sample_custom_endpoint_policy'></a>
+```cs
+// Force every application listening endpoint to process messages inline.
+// Wolverine's own internal/system endpoints are left alone.
+public class InlineListenersPolicy : IEndpointPolicy
+{
+    public void Apply(Endpoint endpoint, IWolverineRuntime runtime)
+    {
+        // Don't touch endpoints that Wolverine itself owns
+        if (endpoint.Role == EndpointRole.System) return;
+
+        if (endpoint.IsListener)
+        {
+            endpoint.Mode = EndpointMode.Inline;
+        }
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EndpointPolicySamples.cs#L8-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_custom_endpoint_policy' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+A few things worth knowing about the `Endpoint` you're handed:
+
+* `endpoint.Role` is either `EndpointRole.System` (something Wolverine created and owns internally) or
+  `EndpointRole.Application` (something you declared, or that conventional routing created on your behalf). It's
+  almost always correct to skip `System` endpoints in your policy.
+* `endpoint.Mode` controls the durability/buffering behavior and is one of `EndpointMode.Durable`,
+  `EndpointMode.BufferedInMemory`, or `EndpointMode.Inline`.
+* `endpoint.IsListener` tells you whether the endpoint is receiving messages.
+* `endpoint.Uri` is the unique address of the endpoint, which is handy for matching by transport scheme or queue
+  name.
+
+Your policy runs once per endpoint during bootstrapping, so it's the right place for cross-cutting configuration
+but *not* for per-message logic.
+
+## Registering a Policy
+
+Policies are registered through `opts.Policies` inside `UseWolverine()`. You can add a policy type that will be
+created by Wolverine, or add a pre-built instance:
+
+<!-- snippet: sample_register_endpoint_policy -->
+<a id='snippet-sample_register_endpoint_policy'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        // Register a custom IEndpointPolicy type
+        opts.Policies.Add<InlineListenersPolicy>();
+
+        // Or register a policy inline with LambdaEndpointPolicy<T>.
+        // The lambda only runs for endpoints assignable to T (here, every Endpoint)
+        opts.Policies.Add(new LambdaEndpointPolicy<Endpoint>((endpoint, runtime) =>
+        {
+            if (endpoint.Role == EndpointRole.System) return;
+            endpoint.Mode = EndpointMode.BufferedInMemory;
+        }));
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EndpointPolicySamples.cs#L32-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_register_endpoint_policy' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+When you only need to react to one kind of endpoint (say, just Rabbit MQ queues), the generic
+`LambdaEndpointPolicy<T>` is the most convenient option. The supplied lambda is only invoked for endpoints that
+are assignable to `T`. This is exactly how Wolverine's Rabbit MQ integration implements `UseQuorumQueues()`:
+
+```cs
+// From Wolverine's own Rabbit MQ integration
+Options.Policies.Add(new LambdaEndpointPolicy<RabbitMqQueue>((queue, _) =>
+{
+    if (queue.Role == EndpointRole.Application)
+    {
+        queue.QueueType = QueueType.quorum;
+    }
+}));
+```
+
+## Built-in Endpoint Policy Helpers
+
+You don't always need to write your own `IEndpointPolicy`. For the most common cases, `opts.Policies` already
+exposes convenience methods that build endpoint policies for you. Each one automatically skips Wolverine's
+internal `System` endpoints:
+
+* `opts.Policies.AllListeners(x => ...)` — apply a `ListenerConfiguration` action to every (non-local) listening
+  endpoint.
+* `opts.Policies.AllSenders(x => ...)` — apply an `ISubscriberConfiguration` action to every sending endpoint.
+* `opts.Policies.AllLocalQueues(x => ...)` — apply configuration to every local queue.
+
+For example:
+
+```cs
+opts.Policies.AllListeners(x => x.MaximumParallelMessages(5));
+```
+
+See [Configuring Listeners](/guide/messaging/listeners) for more on what's available through these helpers.

--- a/docs/guide/messaging/transports/azureservicebus/deadletterqueues.md
+++ b/docs/guide/messaging/transports/azureservicebus/deadletterqueues.md
@@ -8,21 +8,21 @@ For inline endpoints, Wolverine uses native [Azure Service Bus dead letter queue
 
 To configure an endpoint for inline processing:
 
-<!-- snippet-todo: sample_asb_inline_dlq -->
+<!-- snippet: sample_asb_inline_dlq -->
+<a id='snippet-sample_asb_inline_dlq'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.UseWolverine(opts =>
 {
-    // One way or another, you're probably pulling the Azure Service Bus
-    // connection string out of configuration
     var azureServiceBusConnectionString = builder
         .Configuration
-        .GetConnectionString("azure-service-bus");
+        .GetConnectionString("azure-service-bus")!;
 
-    // Connect to the broker
     opts.UseAzureServiceBus(azureServiceBusConnectionString).AutoProvision();
 
-    // Use inline processing with native Azure Service Bus DLQ
+    // Inline endpoints use Azure Service Bus's *native* dead letter
+    // subqueue of the source queue. There's no Wolverine inbox, so
+    // dead lettering is handled entirely by Azure Service Bus.
     opts.ListenToAzureServiceBusQueue("inline-queue")
         .ProcessInline();
 });
@@ -30,6 +30,8 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L528-L549' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asb_inline_dlq' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 ### Buffered Endpoints
 
@@ -37,18 +39,21 @@ For buffered endpoints, Wolverine sends failed messages to a designated dead let
 
 To customize the dead letter queue for buffered endpoints:
 
-<!-- snippet-todo: sample_asb_buffered_dlq -->
+<!-- snippet: sample_asb_buffered_dlq -->
+<a id='snippet-sample_asb_buffered_dlq'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.UseWolverine(opts =>
 {
     var azureServiceBusConnectionString = builder
         .Configuration
-        .GetConnectionString("azure-service-bus");
+        .GetConnectionString("azure-service-bus")!;
 
     opts.UseAzureServiceBus(azureServiceBusConnectionString).AutoProvision();
 
-    // Customize the dead letter queue name for buffered endpoint
+    // Buffered endpoints move failed messages to a Wolverine-managed
+    // dead letter queue. The default name is "wolverine-dead-letter-queue",
+    // but you can override it per endpoint.
     opts.ListenToAzureServiceBusQueue("buffered-queue")
         .BufferedInMemory()
         .ConfigureDeadLetterQueue("my-custom-dlq");
@@ -57,6 +62,8 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L554-L576' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asb_buffered_dlq' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 ### Durable Endpoints
 
@@ -64,18 +71,20 @@ Durable endpoints behave similarly to buffered endpoints, with dead lettering to
 
 To customize the dead letter queue for durable endpoints:
 
-<!-- snippet-todo: sample_asb_durable_dlq -->
+<!-- snippet: sample_asb_durable_dlq -->
+<a id='snippet-sample_asb_durable_dlq'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.UseWolverine(opts =>
 {
     var azureServiceBusConnectionString = builder
         .Configuration
-        .GetConnectionString("azure-service-bus");
+        .GetConnectionString("azure-service-bus")!;
 
     opts.UseAzureServiceBus(azureServiceBusConnectionString).AutoProvision();
 
-    // Customize the dead letter queue name for durable endpoint
+    // Durable endpoints behave like buffered endpoints for dead lettering,
+    // but add Wolverine's durable inbox persistence for reliability.
     opts.ListenToAzureServiceBusQueue("durable-queue")
         .UseDurableInbox()
         .ConfigureDeadLetterQueue("my-custom-dlq");
@@ -84,23 +93,27 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L581-L602' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asb_durable_dlq' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 ## Disabling Dead Letter Queues
 
 You can disable dead letter queuing for specific endpoints if needed:
 
-<!-- snippet-todo: sample_disable_asb_dlq -->
+<!-- snippet: sample_disable_asb_dlq -->
+<a id='snippet-sample_disable_asb_dlq'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.UseWolverine(opts =>
 {
     var azureServiceBusConnectionString = builder
         .Configuration
-        .GetConnectionString("azure-service-bus");
+        .GetConnectionString("azure-service-bus")!;
 
     opts.UseAzureServiceBus(azureServiceBusConnectionString).AutoProvision();
 
-    // Disable dead letter queuing for this endpoint
+    // Disable Wolverine-managed dead letter queueing for this endpoint.
+    // Failed messages fall back to Wolverine's regular error handling.
     opts.ListenToAzureServiceBusQueue("no-dlq")
         .DisableDeadLetterQueueing();
 });
@@ -108,3 +121,5 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L607-L627' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_asb_dlq' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->

--- a/docs/guide/messaging/transports/sqs/queues.md
+++ b/docs/guide/messaging/transports/sqs/queues.md
@@ -1,2 +1,154 @@
 # Configuring Queues
-~~~~
+
+Both listening and publishing endpoints in the Amazon SQS transport are backed by an `AmazonSqsQueue` endpoint.
+This page covers how Wolverine *creates* those queues and how to customize the queue attributes (visibility
+timeout, message retention, maximum message size, and so on). For receiving messages see
+[Listening](/guide/messaging/transports/sqs/listening) and for sending see
+[Publishing](/guide/messaging/transports/sqs/publishing).
+
+## Auto-Provisioning Queues
+
+By default Wolverine will *not* create any SQS queues for you. To let Wolverine create any missing queues at
+application startup, opt into auto-provisioning on the transport:
+
+```cs
+opts.UseAmazonSqsTransport()
+
+    // Let Wolverine create missing queues as necessary
+    .AutoProvision();
+```
+
+When `AutoProvision()` is enabled, every queue endpoint is created (if it does not already exist) using its
+`CreateQueueRequest` configuration. Without `AutoProvision()`, Wolverine assumes the queues already exist and
+simply resolves their queue URLs at runtime.
+
+::: tip
+Creating SQS queues requires IAM permissions that your application may not have in production. It's common to
+enable `AutoProvision()` only in development/test environments and to pre-create queues through your
+infrastructure-as-code tooling in production.
+:::
+
+You can also optionally purge all queues on startup with `AutoPurgeOnStartup()`, though be aware this can be
+slow:
+
+```cs
+opts.UseAmazonSqsTransport()
+    .AutoProvision()
+
+    // Optionally purge all queues on application startup.
+    // Beware that this is potentially slow
+    .AutoPurgeOnStartup();
+```
+
+## Configuring Queue Attributes
+
+Each `AmazonSqsQueue` endpoint exposes a `Configuration` property that is the actual
+[`CreateQueueRequest`](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/SQS/TCreateQueueRequest.html) used
+when Wolverine provisions the queue. You can set any SQS queue attribute directly on `Configuration.Attributes`.
+
+When configuring a listener, the second argument gives you direct access to the queue:
+
+<!-- snippet: sample_listen_to_sqs_queue -->
+<a id='snippet-sample_listen_to_sqs_queue'></a>
+```cs
+var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseAmazonSqsTransport()
+
+            // Let Wolverine create missing queues as necessary
+            .AutoProvision()
+
+            // Optionally purge all queues on application startup.
+            // Warning though, this is potentially slow
+            .AutoPurgeOnStartup();
+
+        opts.ListenToSqsQueue("incoming", queue =>
+            {
+                queue.Configuration.Attributes[QueueAttributeName.DelaySeconds]
+                    = "5";
+
+                queue.Configuration.Attributes[QueueAttributeName.MessageRetentionPeriod]
+                    = 4.Days().TotalSeconds.ToString();
+            })
+            // You can optimize the throughput by running multiple listeners
+            // in parallel
+            .ListenerCount(5);
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs#L147-L173' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_listen_to_sqs_queue' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+When configuring a subscription, use `ConfigureQueueCreation()` to reach the same `CreateQueueRequest`:
+
+<!-- snippet: sample_subscriber_rules_for_sqs -->
+<a id='snippet-sample_subscriber_rules_for_sqs'></a>
+```cs
+var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseAmazonSqsTransport();
+
+        opts.PublishMessage<Message1>()
+            .ToSqsQueue("outbound1")
+
+            // Increase the outgoing message throughput, but at the cost
+            // of strict ordering
+            .MessageBatchMaxDegreeOfParallelism(Environment.ProcessorCount);
+
+        opts.PublishMessage<Message2>()
+            .ToSqsQueue("outbound2").ConfigureQueueCreation(request =>
+            {
+                request.Attributes[QueueAttributeName.MaximumMessageSize] = "1024";
+            });
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs#L178-L199' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_subscriber_rules_for_sqs' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+`ConfigureQueueCreation(Action<CreateQueueRequest>)` is available on both the listener and the subscriber
+configuration, so you can customize the create request regardless of which side declares the queue.
+
+### Strongly-Typed Attribute Helpers
+
+For the most common attributes, Wolverine exposes extension methods on `AmazonSqsQueue` so you don't have to
+remember the attribute names or stringify values yourself:
+
+| Helper | SQS attribute |
+|---|---|
+| `MaximumMessageSize(int bytes)` | `MaximumMessageSize` |
+| `MessageRetentionPeriod(int seconds)` | `MessageRetentionPeriod` |
+| `ReceiveMessageWaitTimeSeconds(int seconds)` | `ReceiveMessageWaitTimeSeconds` |
+| `VisibilityTimeout(int seconds)` | `VisibilityTimeout` |
+
+```cs
+opts.ListenToSqsQueue("incoming", queue =>
+{
+    queue
+        // Maximum message size in bytes (default 256 KB)
+        .MaximumMessageSize(256 * 1024)
+
+        // How long SQS retains an unconsumed message, in seconds
+        .MessageRetentionPeriod((int)4.Days().TotalSeconds)
+
+        // The visibility timeout (in seconds) for messages pulled
+        // off of this queue
+        .VisibilityTimeout(120);
+});
+```
+
+Any attribute that does not have a dedicated helper can still be set through `Configuration.Attributes` using the
+`QueueAttributeName` constants from the AWS SDK, exactly as shown in the listener snippet above.
+
+## Relationship to Listening and Publishing
+
+The queue configuration described here is shared by both directions of communication:
+
+- [Listening](/guide/messaging/transports/sqs/listening) — receiving messages from a queue.
+- [Publishing](/guide/messaging/transports/sqs/publishing) — routing outgoing messages to a queue.
+- [FIFO Queues](/guide/messaging/transports/sqs/fifo-queues) — creating ordered, exactly-once queues by adding
+  the `FifoQueue` and `ContentBasedDeduplication` attributes.
+
+It does not matter whether a queue is first declared by a listener or by a subscription — Wolverine tracks a
+single `AmazonSqsQueue` per queue name, so its `CreateQueueRequest` configuration is applied once when the queue
+is provisioned.

--- a/src/Samples/DocumentationSamples/EndpointPolicySamples.cs
+++ b/src/Samples/DocumentationSamples/EndpointPolicySamples.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Hosting;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+
+namespace DocumentationSamples;
+
+#region sample_custom_endpoint_policy
+
+// Force every application listening endpoint to process messages inline.
+// Wolverine's own internal/system endpoints are left alone.
+public class InlineListenersPolicy : IEndpointPolicy
+{
+    public void Apply(Endpoint endpoint, IWolverineRuntime runtime)
+    {
+        // Don't touch endpoints that Wolverine itself owns
+        if (endpoint.Role == EndpointRole.System) return;
+
+        if (endpoint.IsListener)
+        {
+            endpoint.Mode = EndpointMode.Inline;
+        }
+    }
+}
+
+#endregion
+
+public static class EndpointPolicyRegistration
+{
+    public static async Task bootstrap()
+    {
+        #region sample_register_endpoint_policy
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Register a custom IEndpointPolicy type
+                opts.Policies.Add<InlineListenersPolicy>();
+
+                // Or register a policy inline with LambdaEndpointPolicy<T>.
+                // The lambda only runs for endpoints assignable to T (here, every Endpoint)
+                opts.Policies.Add(new LambdaEndpointPolicy<Endpoint>((endpoint, runtime) =>
+                {
+                    if (endpoint.Role == EndpointRole.System) return;
+                    endpoint.Mode = EndpointMode.BufferedInMemory;
+                }));
+            }).StartAsync();
+
+        #endregion
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs
@@ -522,6 +522,110 @@ opts.ListenToAzureServiceBusQueue("incoming")
         using var host = builder.Build();
         await host.StartAsync();
     }
+
+    public async Task configure_inline_dlq()
+    {
+        #region sample_asb_inline_dlq
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            var azureServiceBusConnectionString = builder
+                .Configuration
+                .GetConnectionString("azure-service-bus")!;
+
+            opts.UseAzureServiceBus(azureServiceBusConnectionString).AutoProvision();
+
+            // Inline endpoints use Azure Service Bus's *native* dead letter
+            // subqueue of the source queue. There's no Wolverine inbox, so
+            // dead lettering is handled entirely by Azure Service Bus.
+            opts.ListenToAzureServiceBusQueue("inline-queue")
+                .ProcessInline();
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        #endregion
+    }
+
+    public async Task configure_buffered_dlq()
+    {
+        #region sample_asb_buffered_dlq
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            var azureServiceBusConnectionString = builder
+                .Configuration
+                .GetConnectionString("azure-service-bus")!;
+
+            opts.UseAzureServiceBus(azureServiceBusConnectionString).AutoProvision();
+
+            // Buffered endpoints move failed messages to a Wolverine-managed
+            // dead letter queue. The default name is "wolverine-dead-letter-queue",
+            // but you can override it per endpoint.
+            opts.ListenToAzureServiceBusQueue("buffered-queue")
+                .BufferedInMemory()
+                .ConfigureDeadLetterQueue("my-custom-dlq");
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        #endregion
+    }
+
+    public async Task configure_durable_dlq()
+    {
+        #region sample_asb_durable_dlq
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            var azureServiceBusConnectionString = builder
+                .Configuration
+                .GetConnectionString("azure-service-bus")!;
+
+            opts.UseAzureServiceBus(azureServiceBusConnectionString).AutoProvision();
+
+            // Durable endpoints behave like buffered endpoints for dead lettering,
+            // but add Wolverine's durable inbox persistence for reliability.
+            opts.ListenToAzureServiceBusQueue("durable-queue")
+                .UseDurableInbox()
+                .ConfigureDeadLetterQueue("my-custom-dlq");
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        #endregion
+    }
+
+    public async Task disable_dlq()
+    {
+        #region sample_disable_asb_dlq
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            var azureServiceBusConnectionString = builder
+                .Configuration
+                .GetConnectionString("azure-service-bus")!;
+
+            opts.UseAzureServiceBus(azureServiceBusConnectionString).AutoProvision();
+
+            // Disable Wolverine-managed dead letter queueing for this endpoint.
+            // Failed messages fall back to Wolverine's regular error handling.
+            opts.ListenToAzureServiceBusQueue("no-dlq")
+                .DisableDeadLetterQueueing();
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        #endregion
+    }
 }
 
 public interface IInterfaceMessage;


### PR DESCRIPTION
Closes #3090, #3091, #3093, #3095, #3098. The messaging-area group of the documentation-review follow-ups (#3089).

| Page | Was | Now |
|---|---|---|
| `messaging/policies.md` | empty stub | Full `IEndpointPolicy` page — writing + registering policies, the `LambdaEndpointPolicy<T>` pattern (the real `UseQuorumQueues()` impl), and the `AllListeners/AllSenders/AllLocalQueues` helpers |
| `transports/sqs/queues.md` | empty stub + stray `~~~~` | AutoProvision, queue-attribute configuration via `Configuration.Attributes`/`ConfigureQueueCreation`, and the strongly-typed helpers |
| `messaging/introduction.md` | two empty headers | Listening/Sending Endpoint Configuration intros linking to the detailed pages |
| `messaging/message-bus.md` | `TODO -- more text here. NEW PAGE???` | Real `DeliveryOptions` prose under Customizing Message Delivery |
| `transports/azureservicebus/deadletterqueues.md` | 4 `snippet-todo` placeholders | 4 real source-backed snippets |

### Source changes (both projects build clean, net9.0)
- **New** `src/Samples/DocumentationSamples/EndpointPolicySamples.cs` — `sample_custom_endpoint_policy` + `sample_register_endpoint_policy` regions.
- `src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs` — 4 new regions (`sample_asb_inline_dlq`, `sample_asb_buffered_dlq`, `sample_asb_durable_dlq`, `sample_disable_asb_dlq`). The research confirmed inline vs buffered/durable are genuinely different DLQ mechanisms (native ASB subqueue vs Wolverine-managed queue), and all config method names (`ConfigureDeadLetterQueue`, `DisableDeadLetterQueueing`, `ProcessInline`/`BufferedInMemory`/`UseDurableInbox`) are real.

All snippets hydrated via mdsnippets. Prose wording is a draft open to your edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)