### PR TITLE
Generalize EnableDeadLetterQueueRecovery to SQS and Azure Service Bus (#3103)

### DIFF
--- a/docs/guide/messaging/transports/azureservicebus/deadletterqueues.md
+++ b/docs/guide/messaging/transports/azureservicebus/deadletterqueues.md
@@ -123,3 +123,58 @@ await host.StartAsync();
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L607-L627' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_asb_dlq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Recovering Native Dead Letters to Durable Storage <Badge type="tip" text="6.9" />
+
+Azure Service Bus dead letters land in one of two places depending on the endpoint mode: buffered and
+durable endpoints move failures to a Wolverine-managed dead letter **queue** (default
+`wolverine-dead-letter-queue`), while inline endpoints — and Azure Service Bus itself, on TTL or
+max-delivery — use the native
+[`$DeadLetterQueue` sub-queue](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues)
+of the source entity. Either way, those messages are only visible through Azure tooling. Tools that
+manage Wolverine's *durable* dead letters (for example [CritterWatch](https://github.com/JasperFx/CritterWatch))
+can't see or replay them.
+
+`EnableDeadLetterQueueRecovery()` starts a background listener that drains **both** kinds of source —
+the Wolverine-managed dead letter queue(s) and the native `$DeadLetterQueue` sub-queue of every
+listening queue and subscription — copying each message into Wolverine's durable dead letter storage
+(the `wolverine_dead_letters` table), where it becomes queryable and replayable through
+`IDeadLetters`:
+
+```csharp
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        // Durable message storage is required — the recovered dead letters
+        // are written to the wolverine_dead_letters table.
+        opts.PersistMessagesWithPostgresql(connectionString);
+
+        opts.UseAzureServiceBus(connectionString)
+            .AutoProvision()
+            // Drain the native $DeadLetterQueue sub-queue of every listening
+            // queue and subscription into Wolverine's durable storage.
+            .EnableDeadLetterQueueRecovery();
+
+        opts.ListenToAzureServiceBusQueue("orders");
+    }).StartAsync();
+```
+
+With no arguments, every managed dead letter queue and every listening queue/subscription's native
+sub-queue is drained. Pass explicit names (a managed dead letter queue name, a listening queue name,
+or a subscription endpoint name) to restrict recovery to a subset:
+
+```csharp
+opts.UseAzureServiceBus(connectionString)
+    .EnableDeadLetterQueueRecovery("orders", "shipments");
+```
+
+The original exception type and message are preserved: from the stamped failure metadata for messages
+in the managed dead letter queue, or from the native `DeadLetterReason`/`DeadLetterErrorDescription`
+for messages in a native sub-queue. A message is only completed off its source *after* it has been
+safely written to durable storage, so a transient database outage never loses a dead letter.
+
+::: tip
+This is the Azure Service Bus equivalent of the
+[RabbitMQ dead letter recovery](../rabbitmq/deadletterqueues.html) feature, and uses the same
+`EnableDeadLetterQueueRecovery()` syntax across every native-dead-letter transport.
+:::

--- a/docs/guide/messaging/transports/rabbitmq/deadletterqueues.md
+++ b/docs/guide/messaging/transports/rabbitmq/deadletterqueues.md
@@ -126,6 +126,53 @@ using var host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Samples.cs#L469-L489' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_rabbit_mq_dead_letter_queue' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Recovering Native Dead Letters to Durable Storage <Badge type="tip" text="6.9" />
+
+With native dead lettering, failed messages land in a RabbitMQ dead letter queue and are only visible
+through RabbitMQ tooling. Tools that manage Wolverine's *durable* dead letters (for example
+[CritterWatch](https://github.com/JasperFx/CritterWatch)) can't see or replay them.
+
+`EnableDeadLetterQueueRecovery()` starts a background listener that consumes the native dead letter
+queue(s) and copies each message into Wolverine's durable dead letter storage (the
+`wolverine_dead_letters` table), where it becomes queryable and replayable through `IDeadLetters`:
+
+```csharp
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        // Durable message storage is required — the recovered dead letters
+        // are written to the wolverine_dead_letters table.
+        opts.PersistMessagesWithPostgresql(connectionString);
+
+        opts.UseRabbitMq()
+            .AutoProvision()
+            // Consume the native dead letter queue and copy the messages into
+            // Wolverine's durable dead letter storage.
+            .EnableDeadLetterQueueRecovery();
+
+        opts.ListenToRabbitQueue("orders");
+    }).StartAsync();
+```
+
+With no arguments, the default `wolverine-dead-letter-queue` is consumed. Pass explicit queue names
+to recover from custom-named dead letter queues:
+
+```csharp
+opts.UseRabbitMq()
+    .EnableDeadLetterQueueRecovery("orders-errors", "shipments-errors");
+```
+
+The original exception type and message are reconstructed from the RabbitMQ `x-death` metadata (and
+from the [enhanced dead lettering](#enhanced-dead-lettering-with-exception-metadata) headers when
+those are present).
+
+::: tip
+The same `EnableDeadLetterQueueRecovery()` syntax is available on the
+[Amazon SQS](../sqs/deadletterqueues.html) and
+[Azure Service Bus](../azureservicebus/deadletterqueues.html) transports, so "bridge my native dead
+letters into durable storage" is a one-call decision on every native-dead-letter transport.
+:::
+
 
 
 

--- a/docs/guide/messaging/transports/sqs/deadletterqueues.md
+++ b/docs/guide/messaging/transports/sqs/deadletterqueues.md
@@ -85,5 +85,57 @@ using var host = await Host.CreateDefaultBuilder()
 
 This would force Wolverine to use any persistent envelope storage for dead letter queueing.
 
+## Recovering Native Dead Letters to Durable Storage <Badge type="tip" text="6.9" />
+
+By default an Amazon SQS dead letter queue is just another SQS queue — its messages are only visible
+through the AWS console or SDK, and tools that manage Wolverine's *durable* dead letters (for example
+[CritterWatch](https://github.com/JasperFx/CritterWatch)) can't see or replay them.
+
+`EnableDeadLetterQueueRecovery()` starts a background listener that drains the native SQS dead letter
+queue(s) and copies each message into Wolverine's durable dead letter storage (the
+`wolverine_dead_letters` table), where it becomes queryable and replayable through `IDeadLetters`:
+
+```csharp
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        // Durable message storage is required — the recovered dead letters
+        // are written to the wolverine_dead_letters table.
+        opts.PersistMessagesWithPostgresql(connectionString);
+
+        opts.UseAmazonSqsTransport()
+            .AutoProvision()
+            // Drain every dead letter queue used by a listener and copy the
+            // messages into Wolverine's durable dead letter storage.
+            .EnableDeadLetterQueueRecovery();
+
+        opts.ListenToSqsQueue("orders");
+    }).StartAsync();
+```
+
+With no arguments, every distinct dead letter queue used by a listening SQS queue is drained. Pass
+explicit names when the dead letter queues you want to recover from aren't directly attached to a
+Wolverine listener — for example, queues fed by an SQS [native redrive policy](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
+that you manage yourself:
+
+```csharp
+opts.UseAmazonSqsTransport()
+    .EnableDeadLetterQueueRecovery("orders-dlq", "payments-dlq");
+```
+
+The names are sanitized with the same `SanitizeSqsName` normalization used everywhere else, so dots
+become hyphens consistently.
+
+Each recovered message is reconstructed back into a Wolverine `Envelope`. When Wolverine itself moved
+the message to the dead letter queue, the original exception type and message are preserved (stamped
+on the envelope when it failed). A message is only deleted from the SQS dead letter queue *after* it
+has been safely written to durable storage, so a transient database outage never loses a dead letter.
+
+::: tip
+This is the SQS equivalent of the [RabbitMQ dead letter recovery](../rabbitmq/deadletterqueues.html)
+feature, and uses the same `EnableDeadLetterQueueRecovery()` syntax across every native-dead-letter
+transport.
+:::
+
 
 

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/dead_letter_queue_recovery.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/dead_letter_queue_recovery.cs
@@ -1,0 +1,106 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Marten;
+using Wolverine.Persistence.Durability;
+using Wolverine.Persistence.Durability.DeadLetterManagement;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+/// <summary>
+/// End-to-end coverage for the SQS <c>EnableDeadLetterQueueRecovery()</c> bridge added for #3103:
+/// a failing message is moved to the native SQS dead letter queue, the background recovery listener
+/// drains it, and the dead letter ends up queryable in Wolverine's durable storage.
+/// </summary>
+public class dead_letter_queue_recovery : IAsyncLifetime
+{
+    private readonly string _queueName = $"dlq-recovery-{Guid.NewGuid():N}";
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "SqsDlqRecoveryTest";
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.UseAmazonSqsTransportLocally()
+                    .AutoProvision()
+                    .AutoPurgeOnStartup()
+                    .EnableDeadLetterQueueRecovery();
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "sqs_dlq_recovery";
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine();
+
+                opts.ListenToSqsQueue(_queueName);
+                opts.PublishMessage<SqsRecoveryTestMessage>().ToSqsQueue(_queueName);
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+            }).StartAsync();
+
+        await _host.ResetResourceState();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_host != null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task recovers_native_dlq_message_to_durable_storage()
+    {
+        await _host
+            .TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .Timeout(30.Seconds())
+            .PublishMessageAndWaitAsync(new SqsRecoveryTestMessage("test-recovery"));
+
+        var messageStore = _host.Services.GetRequiredService<IMessageStore>();
+        var query = new DeadLetterEnvelopeQuery { PageSize = 100 };
+
+        DeadLetterEnvelopeResults? results = null;
+        var deadline = DateTimeOffset.UtcNow.Add(30.Seconds());
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            results = await messageStore.DeadLetters.QueryAsync(query, CancellationToken.None);
+            if (results.Envelopes.Any()) break;
+            await Task.Delay(500);
+        }
+
+        results.ShouldNotBeNull();
+        results.Envelopes.ShouldNotBeEmpty(
+            "The SQS dead letter recovery listener should have recovered the failed message into durable storage");
+
+        var envelope = results.Envelopes.First();
+        envelope.MessageType.ShouldNotBeNullOrEmpty();
+    }
+}
+
+public record SqsRecoveryTestMessage(string Value);
+
+public static class SqsRecoveryTestMessageHandler
+{
+    public static void Handle(SqsRecoveryTestMessage message)
+    {
+        throw new DivideByZeroException($"SQS recovery test failure: {message.Value}");
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/dead_letter_queue_recovery_registration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/dead_letter_queue_recovery_registration.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Xunit;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+/// <summary>
+/// Infrastructure-free coverage of the <c>EnableDeadLetterQueueRecovery()</c> registration wiring
+/// (#3103): the settings holder and the background recovery listener should be registered exactly
+/// once, and explicit queue names should be sanitized and accumulated.
+/// </summary>
+public class dead_letter_queue_recovery_registration
+{
+    private static (AmazonSqsDeadLetterQueueRecoverySettings settings, int hostedServiceCount) Build(
+        Action<AmazonSqsTransportConfiguration> configure)
+    {
+        var options = new WolverineOptions();
+        var transport = options.Transports.GetOrCreate<AmazonSqsTransport>();
+        var configuration = new AmazonSqsTransportConfiguration(transport, options);
+
+        configure(configuration);
+
+        var settings = options.Services
+            .Where(x => x.ServiceType == typeof(AmazonSqsDeadLetterQueueRecoverySettings))
+            .Select(x => x.ImplementationInstance)
+            .OfType<AmazonSqsDeadLetterQueueRecoverySettings>()
+            .Single();
+
+        var hostedServiceCount = options.Services
+            .Count(x => x.ServiceType == typeof(IHostedService)
+                        && x.ImplementationType == typeof(SqsDeadLetterQueueListener));
+
+        return (settings, hostedServiceCount);
+    }
+
+    [Fact]
+    public void no_arg_overload_registers_listener_with_no_explicit_queue_names()
+    {
+        var (settings, hostedServiceCount) = Build(c => c.EnableDeadLetterQueueRecovery());
+
+        settings.QueueNames.ShouldBeEmpty();
+        hostedServiceCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void params_overload_sanitizes_and_records_queue_names()
+    {
+        var (settings, _) = Build(c => c.EnableDeadLetterQueueRecovery("acme.payments.dlq", "orders-dlq"));
+
+        // Periods are normalized to hyphens just like every other SQS name.
+        settings.QueueNames.ShouldBe(["acme-payments-dlq", "orders-dlq"]);
+    }
+
+    [Fact]
+    public void repeated_calls_register_the_listener_only_once()
+    {
+        var (settings, hostedServiceCount) = Build(c =>
+        {
+            c.EnableDeadLetterQueueRecovery("first-dlq");
+            c.EnableDeadLetterQueueRecovery("second-dlq");
+            c.EnableDeadLetterQueueRecovery();
+        });
+
+        hostedServiceCount.ShouldBe(1);
+        settings.QueueNames.ShouldBe(["first-dlq", "second-dlq"]);
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransportConfiguration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransportConfiguration.cs
@@ -1,4 +1,5 @@
 using Amazon.Runtime;
+using Microsoft.Extensions.DependencyInjection;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Transports;
@@ -145,6 +146,66 @@ public class AmazonSqsTransportConfiguration : BrokerExpression<AmazonSqsTranspo
         Transport.DefaultDeadLetterQueueName =
             AmazonSqsTransport.SanitizeSqsName(deadLetterQueueName);
         return this;
+    }
+
+    /// <summary>
+    /// Enable a background listener that drains the native Amazon SQS dead letter queue(s) and
+    /// recovers the messages into Wolverine's durable dead letter storage (the
+    /// <c>wolverine_dead_letters</c> table), making natively dead-lettered messages queryable and
+    /// replayable through <c>IDeadLetters</c> and tools like CritterWatch. This is the SQS analogue
+    /// of RabbitMQ's <c>EnableDeadLetterQueueRecovery()</c>.
+    ///
+    /// With no arguments, every distinct dead letter queue used by a listening SQS queue is drained.
+    /// Requires Wolverine's durable message storage (a database) to be configured.
+    /// </summary>
+    /// <returns></returns>
+    public AmazonSqsTransportConfiguration EnableDeadLetterQueueRecovery()
+    {
+        ensureRecoveryServicesRegistered();
+        return this;
+    }
+
+    /// <summary>
+    /// Enable a background listener that drains the named Amazon SQS dead letter queue(s) and
+    /// recovers the messages into Wolverine's durable dead letter storage. Use this overload when
+    /// the dead letter queues you want to recover from are not directly attached to a Wolverine
+    /// listener (for example, queues fed by an SQS native redrive policy you manage yourself).
+    /// </summary>
+    /// <param name="deadLetterQueueNames">The names of the SQS dead letter queues to drain.</param>
+    /// <returns></returns>
+    public AmazonSqsTransportConfiguration EnableDeadLetterQueueRecovery(params string[] deadLetterQueueNames)
+    {
+        var settings = ensureRecoveryServicesRegistered();
+        foreach (var name in deadLetterQueueNames)
+        {
+            var sanitized = AmazonSqsTransport.SanitizeSqsName(name);
+            if (!settings.QueueNames.Contains(sanitized))
+            {
+                settings.QueueNames.Add(sanitized);
+            }
+        }
+
+        return this;
+    }
+
+    private AmazonSqsDeadLetterQueueRecoverySettings ensureRecoveryServicesRegistered()
+    {
+        var existing = Options.Services
+            .Where(s => s.ServiceType == typeof(AmazonSqsDeadLetterQueueRecoverySettings))
+            .Select(s => s.ImplementationInstance)
+            .OfType<AmazonSqsDeadLetterQueueRecoverySettings>()
+            .FirstOrDefault();
+
+        if (existing != null)
+        {
+            return existing;
+        }
+
+        var settings = new AmazonSqsDeadLetterQueueRecoverySettings();
+        Options.Services.AddSingleton(settings);
+        Options.Services.AddSingleton(Transport);
+        Options.Services.AddHostedService<SqsDeadLetterQueueListener>();
+        return settings;
     }
 
     /// <summary>

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsDeadLetterQueueListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsDeadLetterQueueListener.cs
@@ -1,0 +1,229 @@
+using Amazon.SQS.Model;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.AmazonSqs.Internal;
+
+/// <summary>
+/// Configuration holder for Amazon SQS dead letter queue recovery. Registered as a singleton
+/// so the listener can discover which dead letter queues to drain. When no queue names are
+/// supplied, the listener recovers from every distinct dead-letter queue used by a listening
+/// SQS queue.
+/// </summary>
+public class AmazonSqsDeadLetterQueueRecoverySettings
+{
+    public List<string> QueueNames { get; } = new();
+}
+
+/// <summary>
+/// Background service that drains one or more Amazon SQS dead letter queues and recovers the
+/// messages into Wolverine's durable dead letter storage (the <c>wolverine_dead_letters</c> table).
+/// This bridges SQS's native dead-lettering with Wolverine's database-backed dead letter management,
+/// so natively dead-lettered messages become queryable and replayable through <see cref="Wolverine.Persistence.Durability.IDeadLetters"/>
+/// and tools like CritterWatch. This mirrors the RabbitMQ <c>EnableDeadLetterQueueRecovery()</c> feature.
+/// </summary>
+public class SqsDeadLetterQueueListener : BackgroundService
+{
+    private readonly AmazonSqsTransport _transport;
+    private readonly IWolverineRuntime _runtime;
+    private readonly AmazonSqsDeadLetterQueueRecoverySettings _settings;
+    private readonly ILogger<SqsDeadLetterQueueListener> _logger;
+
+    public SqsDeadLetterQueueListener(AmazonSqsTransport transport, IWolverineRuntime runtime,
+        AmazonSqsDeadLetterQueueRecoverySettings settings, ILogger<SqsDeadLetterQueueListener> logger)
+    {
+        _transport = transport;
+        _runtime = runtime;
+        _settings = settings;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            // The transport's SQS client is created when Wolverine connects the transport during
+            // startup. Wait for it rather than building a second client so we share configuration,
+            // credentials, and (for LocalStack) the service URL.
+            await waitForClientAsync(stoppingToken);
+
+            var queueNames = resolveQueueNames();
+            if (queueNames.Count == 0)
+            {
+                _logger.LogInformation(
+                    "Amazon SQS dead letter queue recovery was enabled, but no dead letter queues could be resolved. No recovery listeners were started.");
+                return;
+            }
+
+            var tasks = queueNames.Select(name => drainQueueLoopAsync(name, stoppingToken)).ToArray();
+            await Task.WhenAll(tasks);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normal shutdown
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Amazon SQS dead letter queue recovery listener failed");
+        }
+    }
+
+    private async Task waitForClientAsync(CancellationToken token)
+    {
+        while (_transport.Client == null)
+        {
+            token.ThrowIfCancellationRequested();
+            await Task.Delay(250.Milliseconds(), token);
+        }
+    }
+
+    private List<string> resolveQueueNames()
+    {
+        if (_settings.QueueNames.Count > 0)
+        {
+            return _settings.QueueNames.Distinct().ToList();
+        }
+
+        return _transport.Queues
+            .Where(x => x.IsListener)
+            .Select(x => x.DeadLetterQueueName)
+            .Where(x => x.IsNotEmpty())
+            .Distinct()
+            .Select(x => x!)
+            .ToList();
+    }
+
+    private async Task drainQueueLoopAsync(string queueName, CancellationToken stoppingToken)
+    {
+        var queue = _transport.Queues[queueName];
+        var failedCount = 0;
+
+        _logger.LogInformation(
+            "Started Amazon SQS dead letter queue recovery listener on queue '{QueueName}'. Messages will be recovered to durable storage.",
+            queueName);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (queue.QueueUrl.IsEmpty())
+                {
+                    await queue.InitializeAsync(_logger);
+                }
+
+                var request = new ReceiveMessageRequest(queue.QueueUrl)
+                {
+                    MaxNumberOfMessages = 10,
+                    WaitTimeSeconds = 5,
+                    VisibilityTimeout = 60,
+                    MessageAttributeNames = ["All"]
+                };
+
+                var results = await _transport.Client!.ReceiveMessageAsync(request, stoppingToken);
+
+                failedCount = 0;
+
+                if (results.Messages == null || results.Messages.Count == 0)
+                {
+                    await Task.Delay(250.Milliseconds(), stoppingToken);
+                    continue;
+                }
+
+                foreach (var message in results.Messages)
+                {
+                    await recoverMessageAsync(queue, message, stoppingToken);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception e)
+            {
+                failedCount++;
+                var pause = failedCount > 5 ? 5.Seconds() : (failedCount * 200).Milliseconds();
+                _logger.LogError(e,
+                    "Error while recovering dead letters from Amazon SQS queue '{QueueName}'", queueName);
+                await Task.Delay(pause, stoppingToken);
+            }
+        }
+    }
+
+    private async Task recoverMessageAsync(AmazonSqsQueue queue, Message message, CancellationToken token)
+    {
+        try
+        {
+            var envelope = new Envelope();
+            string exceptionType;
+            string exceptionMessage;
+
+            try
+            {
+                var mapper = queue.BuildMapper(_runtime);
+                mapper.ReadEnvelopeData(envelope, message.Body, message.MessageAttributes ?? new Dictionary<string, MessageAttributeValue>());
+
+                // Wolverine stamps these onto the envelope headers when it moves a failed message to
+                // the dead letter queue (see DeadLetterQueueConstants.StampFailureMetadata).
+                exceptionType = headerOrDefault(envelope, DeadLetterQueueConstants.ExceptionTypeHeader, "Unknown");
+                exceptionMessage = headerOrDefault(envelope, DeadLetterQueueConstants.ExceptionMessageHeader,
+                    "Recovered from Amazon SQS dead letter queue");
+            }
+            catch (Exception readError)
+            {
+                // The dead letter body wasn't a Wolverine envelope (for example, a message moved by a
+                // native SQS redrive policy from a non-Wolverine producer). Preserve it with a minimal
+                // envelope so it is still visible and not silently lost.
+                _logger.LogWarning(readError,
+                    "Could not reconstruct a Wolverine envelope from SQS dead letter message {MessageId} on '{QueueName}'. Persisting a minimal envelope.",
+                    message.MessageId, queue.QueueName);
+
+                envelope = new Envelope
+                {
+                    Data = System.Text.Encoding.UTF8.GetBytes(message.Body ?? string.Empty),
+                    ContentType = EnvelopeConstants.JsonContentType,
+                    MessageType = "unknown"
+                };
+                exceptionType = "Unknown";
+                exceptionMessage = "Recovered from Amazon SQS dead letter queue (non-Wolverine message)";
+            }
+
+            if (envelope.Id == Guid.Empty)
+            {
+                envelope.Id = Guid.NewGuid();
+            }
+
+            envelope.Destination ??= queue.Uri;
+            envelope.Source ??= queue.Uri.ToString();
+            if (envelope.SentAt == default)
+            {
+                envelope.SentAt = DateTimeOffset.UtcNow;
+            }
+
+            var exception = new DeadLetterRecoveredException(exceptionType, exceptionMessage);
+            await _runtime.Storage.Inbox.MoveToDeadLetterStorageAsync(envelope, exception);
+
+            // Only delete once the dead letter has been safely persisted.
+            await _transport.Client!.DeleteMessageAsync(queue.QueueUrl, message.ReceiptHandle, token);
+
+            _logger.LogInformation(
+                "Recovered dead letter {MessageId} (type={MessageType}) from Amazon SQS queue '{QueueName}' to durable storage.",
+                envelope.Id, envelope.MessageType ?? "unknown", queue.QueueName);
+        }
+        catch (Exception e)
+        {
+            // Leave the message on the queue (its visibility timeout returns it) so a transient
+            // storage failure doesn't lose the dead letter.
+            _logger.LogError(e,
+                "Failed to recover SQS dead letter message {MessageId} from '{QueueName}'", message.MessageId,
+                queue.QueueName);
+        }
+    }
+
+    private static string headerOrDefault(Envelope envelope, string key, string fallback)
+    {
+        return envelope.Headers.TryGetValue(key, out var value) && value.IsNotEmpty() ? value! : fallback;
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/dead_letter_queue_recovery.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/dead_letter_queue_recovery.cs
@@ -1,0 +1,111 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Marten;
+using Wolverine.Persistence.Durability;
+using Wolverine.Persistence.Durability.DeadLetterManagement;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+/// <summary>
+/// End-to-end coverage for the Azure Service Bus <c>EnableDeadLetterQueueRecovery()</c> bridge added
+/// for #3103. A failing handler makes Wolverine natively dead-letter the message to the queue's
+/// <c>$DeadLetterQueue</c> sub-queue (with <c>DeadLetterReason</c>/<c>DeadLetterErrorDescription</c>
+/// set). The background recovery listener drains the sub-queue and the dead letter ends up queryable
+/// in Wolverine's durable storage.
+/// </summary>
+[Trait("Category", "Flaky")]
+public class dead_letter_queue_recovery : IAsyncLifetime
+{
+    private readonly string _queueName = $"dlqrecovery{Guid.NewGuid():N}";
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "AsbDlqRecoveryTest";
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.UseAzureServiceBusTesting()
+                    .AutoProvision()
+                    .AutoPurgeOnStartup()
+                    .EnableDeadLetterQueueRecovery();
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "asb_dlq_recovery";
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine();
+
+                opts.ListenToAzureServiceBusQueue(_queueName);
+                opts.PublishMessage<AsbRecoveryTestMessage>().ToAzureServiceBusQueue(_queueName);
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+            }).StartAsync();
+
+        await _host.ResetResourceState();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_host != null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task recovers_native_dlq_message_to_durable_storage()
+    {
+        await _host
+            .TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .Timeout(30.Seconds())
+            .PublishMessageAndWaitAsync(new AsbRecoveryTestMessage("test-recovery"));
+
+        var messageStore = _host.Services.GetRequiredService<IMessageStore>();
+        var query = new DeadLetterEnvelopeQuery { PageSize = 100 };
+
+        DeadLetterEnvelopeResults? results = null;
+        var deadline = DateTimeOffset.UtcNow.Add(30.Seconds());
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            results = await messageStore.DeadLetters.QueryAsync(query, CancellationToken.None);
+            if (results.Envelopes.Any()) break;
+            await Task.Delay(500);
+        }
+
+        results.ShouldNotBeNull();
+        results.Envelopes.ShouldNotBeEmpty(
+            "The Azure Service Bus dead letter recovery listener should have recovered the natively dead-lettered message into durable storage");
+
+        var envelope = results.Envelopes.First();
+        envelope.MessageType.ShouldNotBeNullOrEmpty();
+
+        // The native DeadLetterReason (the exception type) should be preserved as the dead letter's
+        // exception type rather than the DeadLetterRecoveredException wrapper.
+        envelope.ExceptionType.ShouldNotBeNullOrEmpty();
+    }
+}
+
+public record AsbRecoveryTestMessage(string Value);
+
+public static class AsbRecoveryTestMessageHandler
+{
+    public static void Handle(AsbRecoveryTestMessage message)
+    {
+        throw new DivideByZeroException($"ASB recovery test failure: {message.Value}");
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/dead_letter_queue_recovery_registration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/dead_letter_queue_recovery_registration.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+/// <summary>
+/// Infrastructure-free coverage of the Azure Service Bus <c>EnableDeadLetterQueueRecovery()</c>
+/// registration wiring (#3103): the settings holder and the background recovery listener should be
+/// registered exactly once, and explicit queue/subscription names should be accumulated.
+/// </summary>
+public class dead_letter_queue_recovery_registration
+{
+    private static (AzureServiceBusDeadLetterQueueRecoverySettings settings, int hostedServiceCount) Build(
+        Action<AzureServiceBusConfiguration> configure)
+    {
+        var options = new WolverineOptions();
+        var transport = options.Transports.GetOrCreate<AzureServiceBusTransport>();
+        var configuration = new AzureServiceBusConfiguration(transport, options);
+
+        configure(configuration);
+
+        var settings = options.Services
+            .Where(x => x.ServiceType == typeof(AzureServiceBusDeadLetterQueueRecoverySettings))
+            .Select(x => x.ImplementationInstance)
+            .OfType<AzureServiceBusDeadLetterQueueRecoverySettings>()
+            .Single();
+
+        var hostedServiceCount = options.Services
+            .Count(x => x.ServiceType == typeof(IHostedService)
+                        && x.ImplementationType == typeof(AzureServiceBusDeadLetterQueueListener));
+
+        return (settings, hostedServiceCount);
+    }
+
+    [Fact]
+    public void no_arg_overload_registers_listener_with_no_explicit_names()
+    {
+        var (settings, hostedServiceCount) = Build(c => c.EnableDeadLetterQueueRecovery());
+
+        settings.EndpointNames.ShouldBeEmpty();
+        hostedServiceCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void params_overload_records_endpoint_names()
+    {
+        var (settings, _) = Build(c => c.EnableDeadLetterQueueRecovery("orders", "shipments"));
+
+        settings.EndpointNames.ShouldBe(["orders", "shipments"]);
+    }
+
+    [Fact]
+    public void repeated_calls_register_the_listener_only_once()
+    {
+        var (settings, hostedServiceCount) = Build(c =>
+        {
+            c.EnableDeadLetterQueueRecovery("orders");
+            c.EnableDeadLetterQueueRecovery("shipments");
+            c.EnableDeadLetterQueueRecovery();
+        });
+
+        hostedServiceCount.ShouldBe(1);
+        settings.EndpointNames.ShouldBe(["orders", "shipments"]);
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusConfiguration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusConfiguration.cs
@@ -1,5 +1,6 @@
 using Azure.Messaging.ServiceBus.Administration;
 using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
 using Wolverine.AzureServiceBus.Internal;
 using Wolverine.Configuration;
 using Wolverine.Transports;
@@ -163,6 +164,68 @@ public class AzureServiceBusConfiguration : BrokerExpression<AzureServiceBusTran
         Options.RouteWith(routing);
 
         return this;
+    }
+
+    /// <summary>
+    /// Enable a background listener that drains the native Azure Service Bus dead letter sub-queues
+    /// (<c>$DeadLetterQueue</c>) of every listening queue and subscription, recovering the messages
+    /// into Wolverine's durable dead letter storage (the <c>wolverine_dead_letters</c> table). This
+    /// makes natively dead-lettered messages queryable and replayable through <c>IDeadLetters</c>
+    /// and tools like CritterWatch. It is the Azure Service Bus analogue of RabbitMQ's
+    /// <c>EnableDeadLetterQueueRecovery()</c>, and reads the native
+    /// <c>DeadLetterReason</c>/<c>DeadLetterErrorDescription</c> as the recorded failure metadata.
+    ///
+    /// Requires Wolverine's durable message storage (a database) to be configured.
+    /// </summary>
+    /// <returns></returns>
+    public AzureServiceBusConfiguration EnableDeadLetterQueueRecovery()
+    {
+        ensureRecoveryServicesRegistered();
+        return this;
+    }
+
+    /// <summary>
+    /// Enable a background listener that drains the native Azure Service Bus dead letter sub-queues
+    /// of only the named queues (or subscription endpoint names), recovering the messages into
+    /// Wolverine's durable dead letter storage.
+    /// </summary>
+    /// <param name="queueOrSubscriptionNames">
+    /// The queue names — or subscription endpoint names — whose native dead letter sub-queues should
+    /// be drained.
+    /// </param>
+    /// <returns></returns>
+    public AzureServiceBusConfiguration EnableDeadLetterQueueRecovery(params string[] queueOrSubscriptionNames)
+    {
+        var settings = ensureRecoveryServicesRegistered();
+        foreach (var name in queueOrSubscriptionNames)
+        {
+            if (!settings.EndpointNames.Contains(name))
+            {
+                settings.EndpointNames.Add(name);
+            }
+        }
+
+        return this;
+    }
+
+    private AzureServiceBusDeadLetterQueueRecoverySettings ensureRecoveryServicesRegistered()
+    {
+        var existing = Options.Services
+            .Where(s => s.ServiceType == typeof(AzureServiceBusDeadLetterQueueRecoverySettings))
+            .Select(s => s.ImplementationInstance)
+            .OfType<AzureServiceBusDeadLetterQueueRecoverySettings>()
+            .FirstOrDefault();
+
+        if (existing != null)
+        {
+            return existing;
+        }
+
+        var settings = new AzureServiceBusDeadLetterQueueRecoverySettings();
+        Options.Services.AddSingleton(settings);
+        Options.Services.AddSingleton(Transport);
+        Options.Services.AddHostedService<AzureServiceBusDeadLetterQueueListener>();
+        return settings;
     }
 
     /// <summary>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusDeadLetterQueueListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusDeadLetterQueueListener.cs
@@ -1,0 +1,295 @@
+using Azure.Messaging.ServiceBus;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.AzureServiceBus.Internal;
+
+/// <summary>
+/// Configuration holder for Azure Service Bus dead letter queue recovery. Registered as a singleton
+/// so the listener can discover which dead letter sources to drain. When no names are supplied, the
+/// listener recovers from both the Wolverine-managed dead letter queue(s) and the native
+/// <c>$DeadLetterQueue</c> sub-queue of every listening queue and subscription.
+/// </summary>
+public class AzureServiceBusDeadLetterQueueRecoverySettings
+{
+    /// <summary>
+    /// Optional set of names to restrict recovery to. A name may be a Wolverine-managed dead letter
+    /// queue name, a listening queue name, or a subscription endpoint name. When empty, every
+    /// managed dead letter queue and every listening queue/subscription's native dead letter
+    /// sub-queue is drained.
+    /// </summary>
+    public List<string> EndpointNames { get; } = new();
+}
+
+/// <summary>
+/// Background service that recovers Azure Service Bus dead letters into Wolverine's durable dead
+/// letter storage (the <c>wolverine_dead_letters</c> table), so natively dead-lettered messages
+/// become queryable and replayable through <see cref="Wolverine.Persistence.Durability.IDeadLetters"/>
+/// and tools like CritterWatch. It drains two kinds of source:
+/// <list type="bullet">
+///   <item>The Wolverine-managed dead letter queue(s) (default <c>wolverine-dead-letter-queue</c>),
+///   where buffered and durable endpoints move failed messages with the exception metadata stamped
+///   onto the message.</item>
+///   <item>The native <c>$DeadLetterQueue</c> sub-queue of each listening queue and subscription,
+///   where inline endpoints and Azure Service Bus itself (TTL / max-delivery) dead-letter messages,
+///   reading the native <c>DeadLetterReason</c>/<c>DeadLetterErrorDescription</c>.</item>
+/// </list>
+/// This mirrors the RabbitMQ <c>EnableDeadLetterQueueRecovery()</c> feature.
+/// </summary>
+public class AzureServiceBusDeadLetterQueueListener : BackgroundService
+{
+    private readonly AzureServiceBusTransport _transport;
+    private readonly IWolverineRuntime _runtime;
+    private readonly AzureServiceBusDeadLetterQueueRecoverySettings _settings;
+    private readonly ILogger<AzureServiceBusDeadLetterQueueListener> _logger;
+
+    public AzureServiceBusDeadLetterQueueListener(AzureServiceBusTransport transport, IWolverineRuntime runtime,
+        AzureServiceBusDeadLetterQueueRecoverySettings settings,
+        ILogger<AzureServiceBusDeadLetterQueueListener> logger)
+    {
+        _transport = transport;
+        _runtime = runtime;
+        _settings = settings;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Describes one dead letter source to drain. A managed source is a normal Wolverine dead letter
+    /// queue (full envelope, exception metadata in application properties); a sub-queue source is a
+    /// native <c>$DeadLetterQueue</c> (exception metadata in DeadLetterReason/DeadLetterErrorDescription).
+    /// </summary>
+    private sealed record DrainSource(string Name, bool IsSubQueue, AzureServiceBusEndpoint? Endpoint,
+        Func<ServiceBusReceiver> CreateReceiver);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            var sources = resolveSources();
+            if (sources.Count == 0)
+            {
+                _logger.LogInformation(
+                    "Azure Service Bus dead letter queue recovery was enabled, but no dead letter sources were found. No recovery listeners were started.");
+                return;
+            }
+
+            var tasks = sources.Select(source => drainLoopAsync(source, stoppingToken)).ToArray();
+            await Task.WhenAll(tasks);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normal shutdown
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Azure Service Bus dead letter queue recovery listener failed");
+        }
+    }
+
+    private List<DrainSource> resolveSources()
+    {
+        var listeningQueues = _transport.Queues.Where(x => x.IsListener).ToArray();
+        var listeningSubscriptions = _transport.Subscriptions.Where(x => x.IsListener).ToArray();
+
+        var sources = new List<DrainSource>();
+
+        // Wolverine-managed dead letter queues — where buffered/durable endpoints move failures.
+        var managedDlqNames = listeningQueues
+            .Select(x => x.DeadLetterQueueName)
+            .Where(x => x.IsNotEmpty())
+            .Distinct()
+            .Select(x => x!);
+
+        foreach (var name in managedDlqNames)
+        {
+            var dlqName = name;
+            // Resolve the managed dead letter queue as a real endpoint so the recovered envelope gets
+            // a non-null Destination/Uri and that queue's own envelope mapper.
+            var dlqEndpoint = _transport.Queues[dlqName];
+            sources.Add(new DrainSource(dlqName, false, dlqEndpoint,
+                () => _transport.BusClient.CreateReceiver(dlqName)));
+        }
+
+        // Native $DeadLetterQueue sub-queues — inline endpoints and ASB-native dead letters.
+        foreach (var queue in listeningQueues)
+        {
+            var queueName = queue.QueueName;
+            sources.Add(new DrainSource(queueName, true, queue,
+                () => _transport.BusClient.CreateReceiver(queueName,
+                    new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter })));
+        }
+
+        foreach (var subscription in listeningSubscriptions)
+        {
+            var sub = subscription;
+            sources.Add(new DrainSource(sub.SubscriptionName, true, sub,
+                () => _transport.BusClient.CreateReceiver(sub.Topic.TopicName, sub.SubscriptionName,
+                    new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter })));
+        }
+
+        if (_settings.EndpointNames.Count > 0)
+        {
+            var allowed = _settings.EndpointNames.Select(x => _transport.SanitizeIdentifier(x)).ToHashSet();
+            sources = sources.Where(x => allowed.Contains(_transport.SanitizeIdentifier(x.Name))).ToList();
+        }
+
+        return sources;
+    }
+
+    private async Task drainLoopAsync(DrainSource source, CancellationToken stoppingToken)
+    {
+        var failedCount = 0;
+        ServiceBusReceiver? receiver = null;
+
+        // The managed dead letter queue holds full Wolverine envelopes; use a real endpoint's mapper
+        // when we have one, otherwise fall back to the default mapper.
+        var mapper = (source.Endpoint ?? _transport.Queues.FirstOrDefault(x => x.IsListener))?.BuildMapper(_runtime);
+
+        _logger.LogInformation(
+            "Started Azure Service Bus dead letter recovery listener on '{Source}' ({Kind}). Messages will be recovered to durable storage.",
+            source.Name, source.IsSubQueue ? "native sub-queue" : "managed queue");
+
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    receiver ??= source.CreateReceiver();
+
+                    var messages = await receiver.ReceiveMessagesAsync(20, 5.Seconds(), stoppingToken);
+
+                    failedCount = 0;
+
+                    if (messages == null || messages.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    foreach (var message in messages)
+                    {
+                        await recoverMessageAsync(source, mapper, receiver, message, stoppingToken);
+                    }
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception e)
+                {
+                    failedCount++;
+                    var pause = failedCount > 5 ? 5.Seconds() : (failedCount * 200).Milliseconds();
+                    _logger.LogError(e,
+                        "Error while recovering dead letters from Azure Service Bus source '{Source}'", source.Name);
+
+                    // Rebuild the receiver on the next pass in case the connection went bad
+                    if (receiver != null)
+                    {
+                        await receiver.DisposeAsync();
+                        receiver = null;
+                    }
+
+                    await Task.Delay(pause, stoppingToken);
+                }
+            }
+        }
+        finally
+        {
+            if (receiver != null)
+            {
+                await receiver.DisposeAsync();
+            }
+        }
+    }
+
+    private async Task recoverMessageAsync(DrainSource source, IAzureServiceBusEnvelopeMapper? mapper,
+        ServiceBusReceiver receiver, ServiceBusReceivedMessage message, CancellationToken token)
+    {
+        try
+        {
+            var envelope = new Envelope();
+
+            try
+            {
+                if (mapper != null)
+                {
+                    mapper.MapIncomingToEnvelope(envelope, message);
+                }
+                else
+                {
+                    envelope.Data = message.Body.ToArray();
+                    envelope.ContentType = message.ContentType ?? EnvelopeConstants.JsonContentType;
+                    envelope.MessageType = message.Subject;
+                }
+            }
+            catch (Exception readError)
+            {
+                _logger.LogWarning(readError,
+                    "Could not reconstruct a Wolverine envelope from Azure Service Bus dead letter message {MessageId} on '{Source}'. Persisting a minimal envelope.",
+                    message.MessageId, source.Name);
+
+                envelope = new Envelope
+                {
+                    Data = message.Body.ToArray(),
+                    ContentType = message.ContentType ?? EnvelopeConstants.JsonContentType,
+                    MessageType = message.Subject ?? "unknown"
+                };
+            }
+
+            if (envelope.Id == Guid.Empty)
+            {
+                envelope.Id = Guid.NewGuid();
+            }
+
+            envelope.Destination ??= source.Endpoint?.Uri;
+            envelope.Source ??= source.Endpoint?.Uri.ToString() ?? source.Name;
+            if (envelope.SentAt == default)
+            {
+                envelope.SentAt = DateTimeOffset.UtcNow;
+            }
+
+            var (exceptionType, exceptionMessage) = resolveExceptionInfo(envelope, message);
+            var exception = new DeadLetterRecoveredException(exceptionType, exceptionMessage);
+            await _runtime.Storage.Inbox.MoveToDeadLetterStorageAsync(envelope, exception);
+
+            // Only settle the dead letter once it is safely persisted.
+            await receiver.CompleteMessageAsync(message, token);
+
+            _logger.LogInformation(
+                "Recovered dead letter {MessageId} (type={MessageType}) from Azure Service Bus '{Source}' to durable storage. Reason: {Reason}",
+                envelope.Id, envelope.MessageType ?? "unknown", source.Name, exceptionType);
+        }
+        catch (Exception e)
+        {
+            // Leave the message in place (its lock expires and it returns) so a transient storage
+            // failure doesn't lose the dead letter.
+            _logger.LogError(e,
+                "Failed to recover Azure Service Bus dead letter message {MessageId} from '{Source}'",
+                message.MessageId, source.Name);
+        }
+    }
+
+    private static (string exceptionType, string exceptionMessage) resolveExceptionInfo(Envelope envelope,
+        ServiceBusReceivedMessage message)
+    {
+        // Wolverine stamps these onto the message (and thus the envelope headers) when it moves a
+        // failed message to its managed dead letter queue.
+        var type = headerOrNull(envelope, DeadLetterQueueConstants.ExceptionTypeHeader)
+                   ?? (message.DeadLetterReason.IsNotEmpty() ? message.DeadLetterReason : null)
+                   ?? "Unknown";
+
+        var description = headerOrNull(envelope, DeadLetterQueueConstants.ExceptionMessageHeader)
+                          ?? (message.DeadLetterErrorDescription.IsNotEmpty() ? message.DeadLetterErrorDescription : null)
+                          ?? "Recovered from Azure Service Bus dead letter queue";
+
+        return (type!, description!);
+    }
+
+    private static string? headerOrNull(Envelope envelope, string key)
+    {
+        return envelope.Headers.TryGetValue(key, out var value) && value.IsNotEmpty() ? value : null;
+    }
+}

--- a/src/Wolverine/Transports/DeadLetterRecoveredException.cs
+++ b/src/Wolverine/Transports/DeadLetterRecoveredException.cs
@@ -1,0 +1,30 @@
+using Wolverine.Persistence.Durability;
+
+namespace Wolverine.Transports;
+
+/// <summary>
+/// Synthetic exception used when a natively dead-lettered broker message is recovered into
+/// Wolverine's durable dead-letter storage. It carries the original exception type name and
+/// message reconstructed from the transport's native dead-letter metadata (RabbitMQ <c>x-death</c>,
+/// SQS failure headers, Azure Service Bus <c>DeadLetterReason</c>/<c>DeadLetterErrorDescription</c>),
+/// and implements <see cref="IDeadLetterExceptionInfo"/> so the durable store records the original
+/// exception type rather than this wrapper. That keeps dead letters triageable by type in tools
+/// like CritterWatch.
+/// </summary>
+public class DeadLetterRecoveredException : Exception, IDeadLetterExceptionInfo
+{
+    public DeadLetterRecoveredException(string? originalExceptionType, string message) : base(message)
+    {
+        ExceptionType = string.IsNullOrWhiteSpace(originalExceptionType) ? "Unknown" : originalExceptionType!;
+    }
+
+    /// <summary>
+    /// The original exception type name, as reconstructed from the transport's native dead-letter
+    /// metadata. Persisted to durable storage in place of this wrapper's runtime type.
+    /// </summary>
+    public string ExceptionType { get; }
+
+    public string ExceptionMessage => Message;
+
+    public override string ToString() => $"{ExceptionType}: {Message}";
+}


### PR DESCRIPTION
Closes #3103.

## Summary
RabbitMQ already has a first-class native-DLQ → durable-storage bridge via `EnableDeadLetterQueueRecovery()`. This generalizes that feature — with the **same syntax** — to **Amazon SQS** and **Azure Service Bus**, so natively dead-lettered messages land in `wolverine_dead_letters` and become queryable/replayable through `IDeadLetters` and tools like CritterWatch, instead of being invisible in a broker DLQ.

```csharp
opts.UseAmazonSqsTransport().EnableDeadLetterQueueRecovery();          // SQS
opts.UseAzureServiceBus(cnx).EnableDeadLetterQueueRecovery();          // Azure Service Bus
// optional explicit names:
opts.UseAmazonSqsTransport().EnableDeadLetterQueueRecovery("orders-dlq");
```

## What it does
- **`SqsDeadLetterQueueListener`** — background service that drains the SQS dead letter queue(s) used by listeners (or explicit names) and writes each message into durable storage via `MoveToDeadLetterStorageAsync`. Original exception type/message come from the stamped failure headers.
- **`AzureServiceBusDeadLetterQueueListener`** — drains **both** the Wolverine-managed dead letter queue (where buffered/durable endpoints move failures) **and** the native `$DeadLetterQueue` sub-queues of every listening queue/subscription (inline endpoints + ASB-native TTL/max-delivery). Exception metadata comes from stamped headers or the native `DeadLetterReason`/`DeadLetterErrorDescription`.
- **`Wolverine.Transports.DeadLetterRecoveredException`** (core, shared) implements `IDeadLetterExceptionInfo` so the **original** exception type is recorded in durable storage rather than the recovery wrapper.
- Messages are only deleted/completed off the broker **after** being safely persisted, so a transient storage outage never loses a dead letter.

> Implementation note: I verified empirically that Wolverine's buffered/durable Azure Service Bus endpoints route failures to the managed `wolverine-dead-letter-queue` **queue** (not the native sub-queue, which is only inline + ASB-native). The ASB listener therefore drains both kinds of source, which is why the no-arg overload "just works" across endpoint modes.

## Documentation
New **"Recovering Native Dead Letters to Durable Storage"** sections on the SQS, Azure Service Bus, and (previously undocumented) RabbitMQ dead-letter-queue pages, cross-linked so the consistent syntax is discoverable from each transport.

## Tests
- Per-transport **registration tests** (no infrastructure) — settings holder + hosted service registered exactly once; name handling.
- End-to-end **recovery integration tests** — failing handler → broker DLQ → recovery listener → durable storage → queryable. Verified locally against **LocalStack + Postgres** (SQS) and the **Azure Service Bus emulator + Postgres** (ASB).

## Verification
- Full `wolverine.slnx` **Release build clean (0 warnings / 0 errors)**.
- All 8 new tests green; SQS and ASB recovery validated end-to-end against real infrastructure.

## Pairs with
#3104 (per-endpoint dead-letter-destination contract) — filed/implemented separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)