### PR TITLE
GH-3109: enable Polecat ancillary stores + generic [Storage] attribute

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.8.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="4.4.5" />
+    <PackageVersion Include="Polecat" Version="4.5.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageVersion Include="Marten.AspNetCore" Version="9.8.0" />
     <PackageVersion Include="Marten.Newtonsoft" Version="9.8.0" />

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -333,6 +333,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                                 {text: 'Subscription/Projection Distribution', link: '/guide/durability/polecat/distribution'},
                                 {text: 'Sagas', link: '/guide/durability/polecat/sagas'},
                                 {text: 'Multi-Tenancy and Polecat', link: '/guide/durability/polecat/multi-tenancy'},
+                                {text: 'Ancillary Polecat Stores', link: '/guide/durability/polecat/ancillary-stores'},
                             ]},
                         {text: 'Sql Server Integration', link: '/guide/durability/sqlserver'},
                         {text: 'PostgreSQL Integration', link: '/guide/durability/postgresql'},

--- a/docs/guide/durability/marten/ancillary-stores.md
+++ b/docs/guide/durability/marten/ancillary-stores.md
@@ -127,6 +127,29 @@ At this point the "Critter Stack" team is voting to make the attribute an explic
 any kind of conventional application of what handlers/messages/HTTP routes are covered by what Marten document store
 :::
 
+## Provider-agnostic `[Storage]` attribute <Badge type="tip" text="6.9" />
+
+If you'd rather not couple your handler code to Marten specifically, you can use the provider-agnostic
+`[Storage(store type)]` attribute from the `Wolverine.Persistence` namespace in place of `[MartenStore]`. Wolverine
+resolves the owning integration (Marten, [Polecat](/guide/durability/polecat/ancillary-stores), ...) from the store
+marker type, so the same attribute works whether that store is backed by Marten or Polecat:
+
+```cs
+using Wolverine.Persistence;
+
+[Storage(typeof(IPlayerStore))]
+public static class PlayerMessageHandler
+{
+    public static IMartenOp Handle(PlayerMessage message)
+    {
+        return MartenOps.Store(new Player { Id = message.Id });
+    }
+}
+```
+
+To route a whole assembly of handlers to one ancillary store from an `IChainPolicy` without per-handler attributes,
+call `chain.UseMartenStore(storeType)` (or the provider-agnostic `chain.UseAncillaryStorage(storeType, container)`).
+
 So what's possible so far?
 
 * The transactional inbox support is available in all configured Marten stores

--- a/docs/guide/durability/polecat/ancillary-stores.md
+++ b/docs/guide/durability/polecat/ancillary-stores.md
@@ -1,0 +1,156 @@
+# "Separate" or Ancillary Polecat Stores
+
+Just like the [ancillary Marten stores](/guide/durability/marten/ancillary-stores) feature, Wolverine can integrate
+with secondary ("ancillary" in Wolverine parlance) Polecat document stores for [modular monolith
+architectures](https://jeremydmiller.com/2024/04/01/thoughts-on-modular-monoliths/). Each module can use its own
+logical Polecat `IDocumentStore` -- even when everything ultimately lives in the same SQL Server database -- while
+still getting Wolverine's:
+
+* Transaction middleware support, including the transactional outbox
+* Scheduled message support
+* The Polecat side effect model (`IPolecatOp`)
+* Inline-projection side effects relayed through the Wolverine outbox
+* Automatic setup of the necessary envelope storage tables in each database or schema
+
+## Registering the stores
+
+A secondary store is identified by a marker interface that inherits from Polecat's `IDocumentStore`:
+
+```cs
+public interface IPlayerStore : IDocumentStore;
+
+public interface IThingStore : IDocumentStore;
+```
+
+Register each ancillary store with `AddPolecatStore<T>()` and opt into Wolverine with `IntegrateWithWolverine()`,
+exactly as you would for the primary store:
+
+```cs
+theHost = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        // IMPORTANT FOR MODULAR MONOLITH USAGE: share one envelope storage schema
+        // across all modules for more efficient use of resources.
+        opts.Durability.MessageStorageSchemaName = "wolverine";
+        opts.Policies.AutoApplyTransactions();
+
+        // Primary Polecat store
+        opts.Services.AddPolecat(m =>
+            {
+                m.ConnectionString = connectionString;
+                m.DatabaseSchemaName = "main";
+            })
+            .UseLightweightSessions()
+            .IntegrateWithWolverine();
+
+        // Ancillary Polecat store on the same SQL Server, different document schema
+        opts.Services.AddPolecatStore<IPlayerStore>(m =>
+            {
+                m.Connection(connectionString);
+                m.DatabaseSchemaName = "players";
+            })
+            .IntegrateWithWolverine();
+
+        opts.Services.AddResourceSetupOnStartup();
+    }).StartAsync();
+```
+
+As with Marten, setting `opts.Durability.MessageStorageSchemaName` lets Wolverine share one transactional inbox/outbox
+across every Polecat store that targets the same physical database.
+
+## Routing a handler to an ancillary store
+
+Tag the handler class (or an individual handler method) with `[PolecatStore(store type)]` so its session is opened from
+that store rather than the primary `IDocumentStore`:
+
+```cs
+// This uses a Polecat session from the IPlayerStore ancillary store
+// rather than the main IDocumentStore.
+[PolecatStore(typeof(IPlayerStore))]
+public static class PlayerMessageHandler
+{
+    public static void Handle(PlayerMessage message, IDocumentSession session)
+    {
+        session.Store(new Player { Id = message.Id });
+    }
+}
+```
+
+## Provider-agnostic `[Storage]` attribute <Badge type="tip" text="6.9" />
+
+If you don't want your handler code to be coupled to a specific persistence tool, use the provider-agnostic
+`[Storage(store type)]` attribute from the `Wolverine.Persistence` namespace instead of `[PolecatStore]` (or
+`[MartenStore]`). Wolverine resolves the owning integration -- Polecat, Marten, ... -- from the store marker type, so
+the very same attribute works regardless of which Critter Stack tool backs that store:
+
+```cs
+using Wolverine.Persistence;
+
+[Storage(typeof(IPlayerStore))]
+public static class PlayerMessageHandler
+{
+    public static void Handle(PlayerMessage message, IDocumentSession session)
+    {
+        session.Store(new Player { Id = message.Id });
+    }
+}
+```
+
+This is handy when a set of handlers is shared across a Marten flavor and a Polecat/SQL-Server flavor of an
+application -- one attribute, both stores. If you want to route an entire assembly of handlers to one ancillary store
+without per-handler attributes, call `chain.UsePolecatStore(storeType)` (or the provider-agnostic
+`chain.UseAncillaryStorage(storeType, container)`) from an `IChainPolicy`.
+
+## Multi-tenancy through separate databases
+
+Polecat multi-tenancy is *database per tenant*. An ancillary store can be multi-tenanted, and Wolverine will build a
+`MultiTenantedMessageStore` for it:
+
+```cs
+opts.Services.AddPolecatStore<IThingStore>(m =>
+    {
+        // Polecat still needs a base connection string (the default-tenant / master database)
+        m.ConnectionString = masterConnectionString;
+        m.MultiTenantedDatabases(tenancy =>
+        {
+            tenancy.AddTenant("tenant1", tenant1ConnectionString);
+            tenancy.AddTenant("tenant2", tenant2ConnectionString);
+        });
+        m.DatabaseSchemaName = "things";
+    })
+    .IntegrateWithWolverine(x => x.MainConnectionString = masterConnectionString);
+```
+
+::: info
+Unlike Marten, Polecat does not support "conjoined" tenant-partitioned events
+(`UseTenantPartitionedEvents`). Multi-tenant ancillary Polecat stores use a separate database per tenant.
+:::
+
+## Inline-projection side effects
+
+A projection registered against an ancillary store can publish Wolverine messages from a `RaiseSideEffects` override,
+and those messages relay through the Wolverine outbox after the projection batch commits. Opt in per store with
+`Events.EnableSideEffectsOnInlineProjections`:
+
+```cs
+opts.Services.AddPolecatStore<ISideEffectStore>(m =>
+    {
+        m.Connection(connectionString);
+        m.DatabaseSchemaName = "se_ancillary";
+        m.Events.EnableSideEffectsOnInlineProjections = true;
+        m.Projections.Add(new CounterSideEffectProjection(), ProjectionLifecycle.Inline);
+    })
+    .IntegrateWithWolverine();
+```
+
+::: tip
+As with the ancillary Marten stores, the `IDocumentSession` objects created for ancillary Polecat stores are
+"lightweight" sessions without identity-map mechanics for better performance.
+:::
+
+## What's not (yet) supported
+
+* It is not possible to use more than one ancillary store in the same handler with the middleware
+* Conjoined / tenant-partitioned events (Polecat multi-tenancy is database-per-tenant)
+* The SQL Server messaging transport will not span the ancillary databases, but still works when the ancillary store
+  targets the same database as the primary store

--- a/src/Persistence/MartenTests/AncillaryStores/storage_attribute_routes_to_marten_store.cs
+++ b/src/Persistence/MartenTests/AncillaryStores/storage_attribute_routes_to_marten_store.cs
@@ -1,0 +1,79 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Persistence;
+using Wolverine.Tracking;
+
+namespace MartenTests.AncillaryStores;
+
+// GH-3109: the provider-agnostic [Storage(typeof(IMyStore))] attribute must route a handler to a Marten
+// ancillary store exactly like [MartenStore], by resolving the Marten IAncillaryStoreFrameProvider from
+// the store marker type. The Marten half of the same coverage the Polecat tests give.
+public class storage_attribute_routes_to_marten_store : IAsyncLifetime
+{
+    private IHost theHost = null!;
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.MessageStorageSchemaName = "wolverine";
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Services.AddMarten(Servers.PostgresConnectionString).IntegrateWithWolverine();
+
+                opts.Services.AddMartenStore<IStorageAttrStore>(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "storage_attr_players";
+                    })
+                    .IntegrateWithWolverine();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(StorageAttrPlayerHandler));
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task storage_attribute_opens_and_commits_through_the_marten_ancillary_store()
+    {
+        var message = new StorageAttrPlayerMessage(Guid.NewGuid().ToString());
+        await theHost.InvokeMessageAndWaitAsync(message);
+
+        var store = theHost.DocumentStore<IStorageAttrStore>();
+        await using var session = store.QuerySession();
+        (await session.LoadAsync<StorageAttrPlayer>(message.Id)).ShouldNotBeNull();
+    }
+}
+
+public interface IStorageAttrStore : IDocumentStore;
+
+public class StorageAttrPlayer
+{
+    public string Id { get; set; } = null!;
+}
+
+public record StorageAttrPlayerMessage(string Id);
+
+// The provider-agnostic [Storage] attribute routes this handler to the Marten ancillary store.
+[Storage(typeof(IStorageAttrStore))]
+public static class StorageAttrPlayerHandler
+{
+    public static IMartenOp Handle(StorageAttrPlayerMessage message)
+    {
+        return MartenOps.Store(new StorageAttrPlayer { Id = message.Id });
+    }
+}

--- a/src/Persistence/PolecatTests/AncillaryStores/AncillaryPolecatModel.cs
+++ b/src/Persistence/PolecatTests/AncillaryStores/AncillaryPolecatModel.cs
@@ -1,0 +1,18 @@
+using Polecat;
+
+namespace PolecatTests.AncillaryStores;
+
+// Marker interfaces for ancillary Polecat stores, mirroring MartenTests.AncillaryStores.
+public interface IPlayerStore : IDocumentStore;
+
+public interface IThingStore : IDocumentStore;
+
+public class Player
+{
+    public string Id { get; set; } = null!;
+}
+
+public class Thing
+{
+    public string Id { get; set; } = null!;
+}

--- a/src/Persistence/PolecatTests/AncillaryStores/ancillary_store_subject_uri_uniqueness.cs
+++ b/src/Persistence/PolecatTests/AncillaryStores/ancillary_store_subject_uri_uniqueness.cs
@@ -1,0 +1,87 @@
+using IntegrationTests;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Polecat;
+using Wolverine.SqlServer.Persistence;
+using Wolverine.Tracking;
+
+namespace PolecatTests.AncillaryStores;
+
+// GH-3109 (Polecat mirror of MartenTests' ancillary_store_subject_uri_uniqueness): when multiple
+// Polecat stores live in the same host, each store's Wolverine message-store identity must be unique
+// so JasperFx generates separate schema migrations / durability agents per store. On SQL Server the
+// per-store identity is the agent Uri (engine/server/database/envelope-schema) rather than the
+// SubjectUri (which the RDBMS store only specializes for the Main role).
+public class ancillary_store_subject_uri_uniqueness : IAsyncLifetime
+{
+    private IHost theHost = null!;
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                // Primary Polecat store.
+                opts.Services.AddPolecat(m =>
+                    {
+                        m.ConnectionString = Servers.SqlServerConnectionString;
+                        m.DatabaseSchemaName = "uri_main";
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                // Ancillary store 1 — same database, different envelope schema.
+                opts.Services.AddPolecatStore<IPlayerStore>(m =>
+                    {
+                        m.Connection(Servers.SqlServerConnectionString);
+                        m.DatabaseSchemaName = "uri_players";
+                    })
+                    .IntegrateWithWolverine(x => x.SchemaName = "uri_players_wolverine");
+
+                // Ancillary store 2 — same database, different envelope schema.
+                opts.Services.AddPolecatStore<IThingStore>(m =>
+                    {
+                        m.Connection(Servers.SqlServerConnectionString);
+                        m.DatabaseSchemaName = "uri_things";
+                    })
+                    .IntegrateWithWolverine(x => x.SchemaName = "uri_things_wolverine");
+
+                opts.Discovery.DisableConventionalDiscovery();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public void every_store_should_have_a_unique_identity_uri()
+    {
+        var runtime = theHost.GetRuntime();
+
+        var primaryUri = runtime.Stores.Main.As<SqlServerMessageStore>().Uri;
+
+        var ancillaries = theHost.Services.GetServices<AncillaryMessageStore>().ToList();
+
+        var playerUri = ancillaries.Single(x => x.MarkerType == typeof(IPlayerStore))
+            .Inner.As<SqlServerMessageStore>().Uri;
+
+        var thingUri = ancillaries.Single(x => x.MarkerType == typeof(IThingStore))
+            .Inner.As<SqlServerMessageStore>().Uri;
+
+        // All three must be distinct so JasperFx generates separate migration scripts / durability
+        // agents per store.
+        playerUri.ShouldNotBe(primaryUri);
+        thingUri.ShouldNotBe(primaryUri);
+        thingUri.ShouldNotBe(playerUri);
+    }
+}

--- a/src/Persistence/PolecatTests/AncillaryStores/ancillary_stores_use_different_databases.cs
+++ b/src/Persistence/PolecatTests/AncillaryStores/ancillary_stores_use_different_databases.cs
@@ -1,0 +1,152 @@
+using IntegrationTests;
+using JasperFx.Core.Reflection;
+using JasperFx.Resources;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Polecat;
+using Wolverine.Polecat.Publishing;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+
+namespace PolecatTests.AncillaryStores;
+
+// GH-3109 (Polecat mirror of MartenTests' ancillary_stores_use_different_databases): ancillary Polecat
+// stores can live on separate SQL Server databases, and a multi-tenanted ancillary store (database per
+// tenant) produces a MultiTenantedMessageStore. Mirrors the Marten coverage adapted to Polecat's
+// separate-database multi-tenancy (Polecat has no UseTenantPartitionedEvents — see notes.md).
+public class ancillary_stores_use_different_databases : IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private string playersConnectionString = null!;
+    private string tenant1ConnectionString = null!;
+    private string tenant2ConnectionString = null!;
+    private IAgentFamily theStores = null!;
+
+    public async Task InitializeAsync()
+    {
+        await using (var conn = new SqlConnection(Servers.SqlServerConnectionString))
+        {
+            await conn.OpenAsync();
+            playersConnectionString = await CreateDatabaseIfNotExists(conn, "polecat_players_db");
+            tenant1ConnectionString = await CreateDatabaseIfNotExists(conn, "polecat_things_t1");
+            tenant2ConnectionString = await CreateDatabaseIfNotExists(conn, "polecat_things_t2");
+        }
+
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.MessageStorageSchemaName = "wolverine";
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Services.AddPolecat(m =>
+                    {
+                        m.ConnectionString = Servers.SqlServerConnectionString;
+                        m.DatabaseSchemaName = "diffdb_main";
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                // Single-database ancillary store on its own SQL Server database.
+                opts.Services.AddPolecatStore<IPlayerStore>(m =>
+                    {
+                        m.Connection(playersConnectionString);
+                        m.DatabaseSchemaName = "players";
+                    })
+                    .IntegrateWithWolverine();
+
+                // Multi-tenanted ancillary store: database per tenant.
+                opts.Services.AddPolecatStore<IThingStore>(m =>
+                    {
+                        // Polecat still needs a base connection string (the default-tenant / master
+                        // database) even when separate per-tenant databases are configured.
+                        m.ConnectionString = Servers.SqlServerConnectionString;
+                        m.MultiTenantedDatabases(tenancy =>
+                        {
+                            tenancy.AddTenant("tenant1", tenant1ConnectionString);
+                            tenancy.AddTenant("tenant2", tenant2ConnectionString);
+                        });
+                        m.DatabaseSchemaName = "things";
+                    })
+                    .IntegrateWithWolverine(x => x.MainConnectionString = Servers.SqlServerConnectionString);
+
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        theStores = theHost.GetRuntime().Stores;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private static async Task<string> CreateDatabaseIfNotExists(SqlConnection conn, string databaseName)
+    {
+        var builder = new SqlConnectionStringBuilder(Servers.SqlServerConnectionString);
+
+        await using (var check = conn.CreateCommand())
+        {
+            check.CommandText = "SELECT DB_ID(@name)";
+            check.Parameters.AddWithValue("@name", databaseName);
+            var exists = await check.ExecuteScalarAsync();
+            if (exists is null || exists == DBNull.Value)
+            {
+                await using var create = conn.CreateCommand();
+                create.CommandText = $"CREATE DATABASE [{databaseName}]";
+                await create.ExecuteNonQueryAsync();
+            }
+        }
+
+        builder.InitialCatalog = databaseName;
+        return builder.ConnectionString;
+    }
+
+    [Fact]
+    public void registers_the_single_tenant_ancillary_store_on_its_own_database()
+    {
+        var ancillaries = theHost.Services.GetServices<AncillaryMessageStore>().ToList();
+        var player = ancillaries.Single(x => x.MarkerType == typeof(IPlayerStore));
+        player.Inner.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void registers_the_multi_tenanted_ancillary_store()
+    {
+        var ancillaries = theHost.Services.GetServices<AncillaryMessageStore>().ToList();
+        ancillaries.Single(x => x.MarkerType == typeof(IThingStore))
+            .Inner
+            .ShouldBeOfType<MultiTenantedMessageStore>();
+    }
+
+    [Fact]
+    public async Task open_session_for_player_store_targets_its_own_database()
+    {
+        var factory = theHost.Services.GetRequiredService<OutboxedSessionFactory<IPlayerStore>>();
+        var context = new MessageContext(theHost.GetRuntime());
+
+        await using var session = factory.OpenSession(context);
+
+        // OpenSession overrides the context's storage to the ancillary store; its agent Uri must
+        // reference the players database rather than the primary.
+        context.Storage.Uri.ToString().ShouldContain("polecat_players_db");
+    }
+
+    [Fact]
+    public async Task durability_agents_exist_for_every_ancillary_database()
+    {
+        var uris = (await theStores.AllKnownAgentsAsync()).Select(x => x.ToString()).ToArray();
+
+        uris.ShouldContain(x => x.Contains("polecat_players_db"));
+        uris.ShouldContain(x => x.Contains("polecat_things_t1"));
+        uris.ShouldContain(x => x.Contains("polecat_things_t2"));
+    }
+}

--- a/src/Persistence/PolecatTests/AncillaryStores/bootstrapping_ancillary_polecat_stores_with_wolverine.cs
+++ b/src/Persistence/PolecatTests/AncillaryStores/bootstrapping_ancillary_polecat_stores_with_wolverine.cs
@@ -1,0 +1,108 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Polecat;
+using Wolverine.Polecat.Publishing;
+using Wolverine.Tracking;
+
+namespace PolecatTests.AncillaryStores;
+
+// GH-3109: Polecat mirror of bootstrapping_ancillary_marten_stores_with_wolverine. Brings up a primary
+// (SQL-Server-backed) Polecat store integrated with Wolverine plus an ancillary Polecat store
+// (AddPolecatStore<IPlayerStore>().IntegrateWithWolverine()), and verifies the ancillary integration is
+// fully wired: AncillaryMessageStore + OutboxedSessionFactory<T> registered, envelope schema built, and a
+// [PolecatStore]-routed handler opens/commits through the ancillary store end to end.
+public class bootstrapping_ancillary_polecat_stores_with_wolverine : IAsyncLifetime
+{
+    private IHost theHost = null!;
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // IMPORTANT FOR MODULAR MONOLITH USAGE: share one envelope storage schema across modules.
+                opts.Durability.MessageStorageSchemaName = "wolverine";
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+
+                // Primary Polecat store + Wolverine integration (SQL Server backed).
+                opts.Services.AddPolecat(m =>
+                    {
+                        m.ConnectionString = Servers.SqlServerConnectionString;
+                        m.DatabaseSchemaName = "anc_main";
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                // Ancillary Polecat store on the same SQL Server, different document schema.
+                opts.Services.AddPolecatStore<IPlayerStore>(m =>
+                    {
+                        m.Connection(Servers.SqlServerConnectionString);
+                        m.DatabaseSchemaName = "players";
+                    })
+                    .IntegrateWithWolverine();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(PlayerMessageHandler));
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public void registers_the_ancillary_store()
+    {
+        theHost.Services.GetRequiredService<IPlayerStore>().ShouldNotBeNull();
+
+        var ancillaries = theHost.Services.GetServices<AncillaryMessageStore>();
+        ancillaries.Any(x => x.MarkerType == typeof(IPlayerStore)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void registers_the_outbox_factory_for_the_store()
+    {
+        theHost.Services.GetRequiredService<OutboxedSessionFactory<IPlayerStore>>()
+            .ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task try_to_use_the_session_transactional_middleware_end_to_end()
+    {
+        var message = new PlayerMessage(Guid.NewGuid().ToString());
+        await theHost.InvokeMessageAndWaitAsync(message);
+
+        // The [PolecatStore]-routed handler must have stored the Player in the ANCILLARY store.
+        var store = theHost.Services.GetRequiredService<IPlayerStore>();
+        await using var session = store.QuerySession();
+        var player = await session.LoadAsync<Player>(message.Id);
+
+        player.ShouldNotBeNull();
+    }
+}
+
+public record PlayerMessage(string Id);
+
+#region sample_polecat_store_handler
+// This will use a Polecat session from the IPlayerStore ancillary store rather than the
+// main IDocumentStore.
+[PolecatStore(typeof(IPlayerStore))]
+public static class PlayerMessageHandler
+{
+    public static void Handle(PlayerMessage message, IDocumentSession session)
+    {
+        session.Store(new Player { Id = message.Id });
+    }
+}
+
+#endregion

--- a/src/Persistence/PolecatTests/AncillaryStores/inline_projection_side_effects_on_ancillary_polecat_store.cs
+++ b/src/Persistence/PolecatTests/AncillaryStores/inline_projection_side_effects_on_ancillary_polecat_store.cs
@@ -1,0 +1,126 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Polecat.Projections;
+using Shouldly;
+using Wolverine;
+using Wolverine.Polecat;
+using Wolverine.Tracking;
+
+namespace PolecatTests.AncillaryStores;
+
+// GH-3109 acceptance criterion: inline-projection side effects (RaiseSideEffects → PublishMessage) on
+// an ANCILLARY Polecat store must relay through the Wolverine outbox. The ancillary store's
+// PolecatToWolverineOutbox bridge (wired by PolecatOverrides<T>) is what makes this work — without it
+// the published message would hit Polecat's NulloMessageOutbox and be dropped.
+public class inline_projection_side_effects_on_ancillary_polecat_store : IAsyncLifetime
+{
+    private IHost theHost = null!;
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.MessageStorageSchemaName = "wolverine";
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Services.AddPolecat(m =>
+                    {
+                        m.ConnectionString = Servers.SqlServerConnectionString;
+                        m.DatabaseSchemaName = "se_main";
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                // Ancillary store with an INLINE projection that publishes a Wolverine message from
+                // RaiseSideEffects. EnableSideEffectsOnInlineProjections is the per-store opt-in.
+                opts.Services.AddPolecatStore<ISideEffectStore>(m =>
+                    {
+                        m.Connection(Servers.SqlServerConnectionString);
+                        m.DatabaseSchemaName = "se_ancillary";
+                        m.Events.EnableSideEffectsOnInlineProjections = true;
+                        m.Projections.Add(new CounterSideEffectProjection(), ProjectionLifecycle.Inline);
+                    })
+                    .IntegrateWithWolverine();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(CounterIncrementedHandler));
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task inline_projection_side_effect_relays_through_the_wolverine_outbox()
+    {
+        CounterIncrementedHandler.Seen.Clear();
+        var streamId = Guid.NewGuid();
+
+        var tracked = await theHost
+            .TrackActivity()
+            .Timeout(30.Seconds())
+            .ExecuteAndWaitAsync((Func<IMessageContext, Task>)(async _ =>
+            {
+                using var scope = theHost.Services.CreateScope();
+                var store = scope.ServiceProvider.GetRequiredService<ISideEffectStore>();
+                await using var session = store.LightweightSession();
+                session.Events.StartStream<Counter>(streamId, new IncrementCounter());
+                await session.SaveChangesAsync();
+            }));
+
+        tracked.Executed.MessagesOf<CounterIncremented>()
+            .ShouldContain(m => m.StreamId == streamId);
+    }
+}
+
+public interface ISideEffectStore : IDocumentStore;
+
+public record IncrementCounter;
+
+public record CounterIncremented(Guid StreamId, int Count);
+
+public class Counter
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+
+    public void Apply(IncrementCounter _) => Count++;
+}
+
+public class CounterSideEffectProjection : SingleStreamProjection<Counter, Guid>
+{
+    public static Counter Create(IncrementCounter _, IEvent metadata) =>
+        new() { Id = metadata.StreamId, Count = 1 };
+
+    public override ValueTask RaiseSideEffects(IDocumentSession session, IEventSlice<Counter> slice)
+    {
+        if (slice.Snapshot is not null)
+        {
+            slice.PublishMessage(new CounterIncremented(slice.Snapshot.Id, slice.Snapshot.Count));
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}
+
+public static class CounterIncrementedHandler
+{
+    public static readonly List<Guid> Seen = new();
+
+    public static void Handle(CounterIncremented message)
+    {
+        lock (Seen) Seen.Add(message.StreamId);
+    }
+}

--- a/src/Persistence/PolecatTests/AncillaryStores/notes.md
+++ b/src/Persistence/PolecatTests/AncillaryStores/notes.md
@@ -1,0 +1,34 @@
+# Polecat ancillary-store tests (GH-3109)
+
+Polecat mirror of `MartenTests/AncillaryStores`. Polecat is SQL-Server-backed, so these use
+`Servers.SqlServerConnectionString` and create real SQL Server databases for the separate-database
+scenarios.
+
+## Coverage map vs the Marten battery
+
+| Marten test | Polecat mirror |
+|---|---|
+| `bootstrapping_ancillary_marten_stores_with_wolverine` | `bootstrapping_ancillary_polecat_stores_with_wolverine` (registration + `OutboxedSessionFactory<T>` + end-to-end `[PolecatStore]` middleware) |
+| `ancillary_stores_use_different_databases` | `ancillary_stores_use_different_databases` (separate SQL Server databases + multi-tenanted store → `MultiTenantedMessageStore` + durability agents) |
+| `ancillary_store_subject_uri_uniqueness` | `ancillary_store_subject_uri_uniqueness` (asserts the per-store agent `Uri`, see note below) |
+| `multi_stream_projection_with_side_effects_on_ancillary_store` | `inline_projection_side_effects_on_ancillary_polecat_store` (inline projection `RaiseSideEffects` → `PublishMessage` relayed through the Wolverine outbox) |
+| `tenant_partitioned_ancillary_store` | *(not mirrored — see below)* |
+| *(generic attribute — new in GH-3109)* | `storage_attribute_routes_to_polecat_store` (`[Storage(typeof(T))]` parity with `[PolecatStore]`) |
+
+## Polecat-specific differences
+
+* **No `UseTenantPartitionedEvents`.** Polecat multi-tenancy is *separate database per tenant*, not
+  Marten's Conjoined + partitioned-events model. So Marten's `tenant_partitioned_ancillary_store`
+  (which relies on `Events.UseTenantPartitionedEvents` + `AddMartenManagedTenantsAsync`) has no
+  verbatim Polecat equivalent. The multi-tenant ancillary coverage instead lives in
+  `ancillary_stores_use_different_databases` (database-per-tenant → `MultiTenantedMessageStore`).
+
+* **`SubjectUri` vs `Uri`.** The RDBMS message store only specializes `SubjectUri` for the `Main`
+  role, so SQL-Server ancillary stores share `wolverine://messages`. The per-store identity that
+  must be unique on SQL Server is the agent `Uri` (`engine/server/database/envelope-schema`), which
+  is what `ancillary_store_subject_uri_uniqueness` asserts.
+
+* **Inline (not async-daemon) side effects.** Polecat relays projection side effects through
+  `StoreOptions.Events.MessageOutbox`. The Wolverine integration wires the ancillary store's outbox
+  to `PolecatToWolverineOutbox` (via `PolecatOverrides<T>`), and the per-store opt-in is
+  `Events.EnableSideEffectsOnInlineProjections`.

--- a/src/Persistence/PolecatTests/AncillaryStores/storage_attribute_routes_to_polecat_store.cs
+++ b/src/Persistence/PolecatTests/AncillaryStores/storage_attribute_routes_to_polecat_store.cs
@@ -1,0 +1,82 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence;
+using Wolverine.Polecat;
+using Wolverine.Tracking;
+
+namespace PolecatTests.AncillaryStores;
+
+// GH-3109: the provider-agnostic [Storage(typeof(IMyStore))] attribute must route a handler to a
+// Polecat ancillary store exactly like [PolecatStore], by resolving the Polecat
+// IAncillaryStoreFrameProvider from the store marker type.
+public class storage_attribute_routes_to_polecat_store : IAsyncLifetime
+{
+    private IHost theHost = null!;
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.MessageStorageSchemaName = "wolverine";
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Services.AddPolecat(m =>
+                    {
+                        m.ConnectionString = Servers.SqlServerConnectionString;
+                        m.DatabaseSchemaName = "storage_attr_main";
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                opts.Services.AddPolecatStore<IPlayerStore>(m =>
+                    {
+                        m.Connection(Servers.SqlServerConnectionString);
+                        m.DatabaseSchemaName = "storage_attr_players";
+                    })
+                    .IntegrateWithWolverine();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(StoragePlayerHandler));
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task storage_attribute_opens_and_commits_through_the_polecat_ancillary_store()
+    {
+        var message = new StoragePlayerMessage(Guid.NewGuid().ToString());
+        await theHost.InvokeMessageAndWaitAsync(message);
+
+        var store = theHost.Services.GetRequiredService<IPlayerStore>();
+        await using var session = store.QuerySession();
+        (await session.LoadAsync<Player>(message.Id)).ShouldNotBeNull();
+    }
+}
+
+public record StoragePlayerMessage(string Id);
+
+#region sample_generic_storage_attribute_handler
+// The provider-agnostic [Storage] attribute — works for Polecat, Marten, ... — routes this handler to
+// the IPlayerStore ancillary store.
+[Storage(typeof(IPlayerStore))]
+public static class StoragePlayerHandler
+{
+    public static void Handle(StoragePlayerMessage message, IDocumentSession session)
+    {
+        session.Store(new Player { Id = message.Id });
+    }
+}
+
+#endregion

--- a/src/Persistence/Wolverine.Marten/MartenAncillaryStoreFrameProvider.cs
+++ b/src/Persistence/Wolverine.Marten/MartenAncillaryStoreFrameProvider.cs
@@ -1,0 +1,18 @@
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.Core.Reflection;
+using Marten;
+using Wolverine.Marten.Codegen;
+using Wolverine.Persistence;
+
+namespace Wolverine.Marten;
+
+/// <summary>
+/// Teaches the generic <see cref="StorageAttribute"/> (<c>[Storage(typeof(IMyStore))]</c>) how to
+/// route a handler to a Marten ancillary store. Registered when Marten is integrated with Wolverine.
+/// </summary>
+internal class MartenAncillaryStoreFrameProvider : IAncillaryStoreFrameProvider
+{
+    public bool Matches(Type storeType) => storeType.CanBeCastTo<IDocumentStore>();
+
+    public Frame BuildOutboxFactoryFrame(Type storeType) => new AncillaryOutboxFactoryFrame(storeType);
+}

--- a/src/Persistence/Wolverine.Marten/MartenStoreAttribute.cs
+++ b/src/Persistence/Wolverine.Marten/MartenStoreAttribute.cs
@@ -2,7 +2,6 @@ using JasperFx;
 using JasperFx.CodeGeneration;
 using Wolverine.Attributes;
 using Wolverine.Configuration;
-using Wolverine.Marten.Codegen;
 using Wolverine.Runtime;
 
 namespace Wolverine.Marten;
@@ -19,7 +18,6 @@ public class MartenStoreAttribute : ModifyChainAttribute
 
     public override void Modify(IChain chain, GenerationRules rules, IServiceContainer container)
     {
-        chain.AncillaryStoreType = StoreType;
-        chain.Middleware.Insert(0, new AncillaryOutboxFactoryFrame(StoreType));
+        chain.UseMartenStore(StoreType);
     }
 }

--- a/src/Persistence/Wolverine.Marten/MartenStoreChainExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/MartenStoreChainExtensions.cs
@@ -1,0 +1,22 @@
+using Wolverine.Configuration;
+using Wolverine.Marten.Codegen;
+
+namespace Wolverine.Marten;
+
+public static class MartenStoreChainExtensions
+{
+    /// <summary>
+    /// Route a chain to a Marten ancillary (secondary) document store. Sets
+    /// <see cref="IChain.AncillaryStoreType"/> and inserts the Marten outbox-factory frame at the front
+    /// of the chain's middleware so the handler opens and commits through that store's
+    /// outbox-enrolled session. Callable directly from an <see cref="IChainPolicy"/> so a whole
+    /// assembly of handlers can be routed to one ancillary store without per-handler attributes.
+    /// </summary>
+    /// <param name="chain">The handler or HTTP chain</param>
+    /// <param name="storeType">The Marten store marker type (e.g. <c>IMyStore : IDocumentStore</c>)</param>
+    public static void UseMartenStore(this IChain chain, Type storeType)
+    {
+        chain.AncillaryStoreType = storeType;
+        chain.Middleware.Insert(0, new AncillaryOutboxFactoryFrame(storeType));
+    }
+}

--- a/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
@@ -9,6 +9,7 @@ using Marten;
 using Marten.Events.Daemon.Coordination;
 using Marten.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using Weasel.Core;
@@ -153,6 +154,14 @@ public static class WolverineOptionsMartenExtensions
         expression.Services.AddSingleton<IConfigureMarten, MartenOverrides>();
 
         expression.Services.AddSingleton<OutboxedSessionFactory>();
+
+        // GH-3109: lets the provider-agnostic [Storage(typeof(IMyStore))] attribute route a handler to
+        // a Marten ancillary store by resolving this provider from the store marker type. Registered
+        // here (not in MartenIntegration.Configure) so the singleton is present in the codegen-time
+        // container that StorageAttribute.Modify queries. TryAddEnumerable keeps it to one instance
+        // even when multiple Marten stores integrate.
+        expression.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<Wolverine.Persistence.IAncillaryStoreFrameProvider, MartenAncillaryStoreFrameProvider>());
 
         // CritterWatch / saga-explorer diagnostic surface — Marten owns
         // every saga whose state class is a Marten document, so register

--- a/src/Persistence/Wolverine.Polecat/AncillaryWolverineOptionsPolecatExtensions.cs
+++ b/src/Persistence/Wolverine.Polecat/AncillaryWolverineOptionsPolecatExtensions.cs
@@ -1,6 +1,3 @@
-// NOTE: This file requires Polecat 1.1+ (AddPolecatStore<T>, IConfigurePolecat<T>, PolecatStoreExpression<T>)
-// Uncomment #if POLECAT_1_1 / #endif when ready, or remove the guards after upgrading the Polecat NuGet
-#if POLECAT_1_1
 using JasperFx;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
@@ -317,7 +314,14 @@ internal class PolecatOverrides<T> : IConfigurePolecat<T> where T : IDocumentSto
     public void Configure(IServiceProvider services, StoreOptions options)
     {
         // Polecat's DocumentMapping automatically detects IRevisioned types
-        // and enables numeric revisions
+        // and enables numeric revisions.
+
+        // GH-3109: replace this ancillary store's default NulloMessageOutbox with the Wolverine
+        // bridge so a projection author who calls slice.PublishMessage(...) from a RaiseSideEffects
+        // override on THIS store has the message delivered through the Wolverine outbox after the
+        // projection batch commits — parity with the primary store (PolecatOverrides above) and the
+        // Marten ancillary side. Without this the ancillary store silently drops projection-published
+        // messages.
+        options.Events.MessageOutbox = new PolecatToWolverineOutbox(services);
     }
 }
-#endif

--- a/src/Persistence/Wolverine.Polecat/Codegen/AncillaryOutboxFactoryFrame.cs
+++ b/src/Persistence/Wolverine.Polecat/Codegen/AncillaryOutboxFactoryFrame.cs
@@ -1,6 +1,3 @@
-// NOTE: This file requires Polecat 1.1+ (OutboxedSessionFactory<T>)
-// Uncomment #if POLECAT_1_1 / #endif when ready, or remove the guards after upgrading the Polecat NuGet
-#if POLECAT_1_1
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
@@ -14,7 +11,7 @@ internal class AncillaryOutboxFactoryFrame : SyncFrame
 {
     private readonly Type _storeType;
     private readonly Type _factoryType;
-    private Variable _outerFactory;
+    private Variable _outerFactory = null!;
 
     public AncillaryOutboxFactoryFrame(Type storeType)
     {
@@ -48,4 +45,3 @@ internal class AncillaryOutboxFactoryFrame : SyncFrame
         Next?.GenerateCode(method, writer);
     }
 }
-#endif

--- a/src/Persistence/Wolverine.Polecat/PolecatAncillaryStoreFrameProvider.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatAncillaryStoreFrameProvider.cs
@@ -1,0 +1,18 @@
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.Core.Reflection;
+using Polecat;
+using Wolverine.Persistence;
+using Wolverine.Polecat.Codegen;
+
+namespace Wolverine.Polecat;
+
+/// <summary>
+/// Teaches the generic <see cref="StorageAttribute"/> (<c>[Storage(typeof(IMyStore))]</c>) how to
+/// route a handler to a Polecat ancillary store. Registered when Polecat is integrated with Wolverine.
+/// </summary>
+internal class PolecatAncillaryStoreFrameProvider : IAncillaryStoreFrameProvider
+{
+    public bool Matches(Type storeType) => storeType.CanBeCastTo<IDocumentStore>();
+
+    public Frame BuildOutboxFactoryFrame(Type storeType) => new AncillaryOutboxFactoryFrame(storeType);
+}

--- a/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
@@ -9,6 +9,7 @@ using Wolverine.Middleware;
 using Wolverine.Polecat.Codegen;
 using Wolverine.Polecat.Persistence.Sagas;
 using Wolverine.Polecat.Publishing;
+using Wolverine.Persistence;
 using Wolverine.Persistence.Sagas;
 using Wolverine.RDBMS;
 using Wolverine.Runtime;
@@ -67,6 +68,12 @@ public class PolecatIntegration : IWolverineExtension, IEventForwarding
         // SQL Server transport will be configured when the message store is built
 
         options.Policies.Add<PolecatOpPolicy>();
+
+        // GH-3109: pre-populate chain.AncillaryStoreType for [PolecatStore]-attributed handlers so the
+        // message-type-to-ancillary-store map built later in WolverineRuntime.HostService sees it.
+        // Mirrors Marten's MartenStoreEagerPolicy; see PolecatStoreEagerPolicy for the Phase-A vs
+        // Phase-B ordering trap this addresses.
+        options.Policies.Add<PolecatStoreEagerPolicy>();
 
         options.CodeGeneration.AddContinuationStrategy<Wolverine.Polecat.Requirements.PolecatDataRequirementContinuationStrategy>();
 

--- a/src/Persistence/Wolverine.Polecat/PolecatMessageDatabaseSource.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatMessageDatabaseSource.cs
@@ -1,6 +1,3 @@
-// NOTE: This file requires Polecat 1.1+ (public ITenancy, ConnectionFactory, PolecatDatabase.ConnectionString)
-// Uncomment #if POLECAT_1_1 / #endif when ready, or remove the guards after upgrading the Polecat NuGet
-#if POLECAT_1_1
 using ImTools;
 using JasperFx;
 using JasperFx.Core.Reflection;
@@ -183,4 +180,3 @@ internal class PolecatMessageDatabaseSource : ITenantedMessageSource
         return store;
     }
 }
-#endif

--- a/src/Persistence/Wolverine.Polecat/PolecatStoreAttribute.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatStoreAttribute.cs
@@ -1,0 +1,30 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using Wolverine.Attributes;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+
+namespace Wolverine.Polecat;
+
+/// <summary>
+/// Route a handler (or every handler on a class) to an ancillary (secondary) Polecat document store.
+/// The Polecat mirror of <c>[MartenStore]</c>; the handler opens and commits its work through the
+/// targeted store's outbox-enrolled session, and inline-projection side effects relayed by that store
+/// flow through the Wolverine outbox. Use <c>[Storage(typeof(IMyStore))]</c> instead when you want a
+/// single provider-agnostic attribute.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class PolecatStoreAttribute : ModifyChainAttribute
+{
+    public Type StoreType { get; }
+
+    public PolecatStoreAttribute(Type storeType)
+    {
+        StoreType = storeType;
+    }
+
+    public override void Modify(IChain chain, GenerationRules rules, IServiceContainer container)
+    {
+        chain.UsePolecatStore(StoreType);
+    }
+}

--- a/src/Persistence/Wolverine.Polecat/PolecatStoreChainExtensions.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatStoreChainExtensions.cs
@@ -1,0 +1,22 @@
+using Wolverine.Configuration;
+using Wolverine.Polecat.Codegen;
+
+namespace Wolverine.Polecat;
+
+public static class PolecatStoreChainExtensions
+{
+    /// <summary>
+    /// Route a chain to a Polecat ancillary (secondary) document store. Sets
+    /// <see cref="IChain.AncillaryStoreType"/> and inserts the Polecat outbox-factory frame at the front
+    /// of the chain's middleware so the handler opens and commits through that store's
+    /// outbox-enrolled session. Callable directly from an <see cref="IChainPolicy"/> so a whole
+    /// assembly of handlers can be routed to one ancillary store without per-handler attributes.
+    /// </summary>
+    /// <param name="chain">The handler or HTTP chain</param>
+    /// <param name="storeType">The Polecat store marker type (e.g. <c>IMyStore : IDocumentStore</c>)</param>
+    public static void UsePolecatStore(this IChain chain, Type storeType)
+    {
+        chain.AncillaryStoreType = storeType;
+        chain.Middleware.Insert(0, new AncillaryOutboxFactoryFrame(storeType));
+    }
+}

--- a/src/Persistence/Wolverine.Polecat/PolecatStoreEagerPolicy.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatStoreEagerPolicy.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.Polecat;
+
+/// <summary>
+/// Phase-A counterpart to <see cref="PolecatStoreAttribute"/>. Pre-populates
+/// <see cref="IChain.AncillaryStoreType"/> on every handler chain decorated with
+/// <see cref="PolecatStoreAttribute"/> so the message-type-to-ancillary-store map that
+/// WolverineRuntime.HostService builds eagerly during startup sees the targeting. This is the Polecat
+/// mirror of Marten's <c>MartenStoreEagerPolicy</c> — see that type for the Phase-A vs Phase-B ordering
+/// trap (GH-2944) this addresses. The Phase-B <see cref="PolecatStoreAttribute.Modify"/> still runs later
+/// and re-assigns the same value (idempotent) plus inserts the Polecat outbox-factory frame.
+///
+/// <para>
+/// Walks the per-endpoint sticky child chains (<see cref="HandlerChain.ByEndpoint"/>) too so
+/// <c>MultipleHandlerBehavior.Separated</c> keeps working — matching the <c>AllChains()</c> iteration the
+/// HostService loop uses (refs GH-2576).
+/// </para>
+/// </summary>
+internal class PolecatStoreEagerPolicy : IHandlerPolicy
+{
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        foreach (var chain in chains)
+        {
+            applyTo(chain);
+
+            foreach (var byEndpoint in chain.ByEndpoint)
+            {
+                applyTo(byEndpoint);
+            }
+        }
+    }
+
+    private static void applyTo(HandlerChain chain)
+    {
+        if (chain.AncillaryStoreType != null) return;
+
+        foreach (var call in chain.Handlers)
+        {
+            var att = call.Method.GetCustomAttribute<PolecatStoreAttribute>(inherit: true)
+                      ?? call.HandlerType.GetCustomAttribute<PolecatStoreAttribute>(inherit: true);
+
+            if (att != null)
+            {
+                chain.AncillaryStoreType = att.StoreType;
+                return;
+            }
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Polecat/Publishing/OutboxedSessionFactoryGeneric.cs
+++ b/src/Persistence/Wolverine.Polecat/Publishing/OutboxedSessionFactoryGeneric.cs
@@ -1,6 +1,3 @@
-// NOTE: This file requires Polecat 1.1+ (AddPolecatStore<T>)
-// Uncomment #if POLECAT_1_1 / #endif when ready, or remove the guards after upgrading the Polecat NuGet
-#if POLECAT_1_1
 using JasperFx.Core.Reflection;
 using Polecat;
 using Wolverine.Persistence.Durability;
@@ -40,4 +37,3 @@ internal class DefaultSessionFactory : ISessionFactory
         return _store.QuerySession();
     }
 }
-#endif

--- a/src/Persistence/Wolverine.Polecat/WolverineOptionsPolecatExtensions.cs
+++ b/src/Persistence/Wolverine.Polecat/WolverineOptionsPolecatExtensions.cs
@@ -6,6 +6,7 @@ using JasperFx.Events.Projections;
 using JasperFx.Events.Subscriptions;
 using Polecat;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Wolverine.Polecat.Distribution;
 using Wolverine.Polecat.Publishing;
@@ -81,6 +82,14 @@ public static class WolverineOptionsPolecatExtensions
         expression.Services.AddSingleton<IConfigurePolecat, PolecatOverrides>();
 
         expression.Services.AddSingleton<OutboxedSessionFactory>();
+
+        // GH-3109: lets the provider-agnostic [Storage(typeof(IMyStore))] attribute route a handler to
+        // a Polecat ancillary store by resolving this provider from the store marker type. Registered
+        // here (not in PolecatIntegration.Configure) so the singleton is present in the codegen-time
+        // container that StorageAttribute.Modify queries. TryAddEnumerable keeps it to one instance
+        // even when multiple Polecat stores integrate.
+        expression.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<Wolverine.Persistence.IAncillaryStoreFrameProvider, PolecatAncillaryStoreFrameProvider>());
 
         // CritterWatch / saga-explorer diagnostic surface — Polecat
         // builds a SqlServerMessageStore underneath, so the lightweight

--- a/src/Wolverine/Persistence/IAncillaryStoreFrameProvider.cs
+++ b/src/Wolverine/Persistence/IAncillaryStoreFrameProvider.cs
@@ -1,0 +1,29 @@
+using JasperFx.CodeGeneration.Frames;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Implemented by a Wolverine persistence integration (Marten, Polecat, EF Core, ...) to teach the
+/// generic <see cref="StorageAttribute"/> how to route a handler chain to an ancillary
+/// (secondary) store owned by that integration. Each integration registers exactly one of these in
+/// the IoC container when its <c>IntegrateWithWolverine()</c> is called, so a single
+/// <c>[Storage(typeof(IMyStore))]</c> attribute can resolve the right provider purely from the
+/// store marker type.
+/// </summary>
+public interface IAncillaryStoreFrameProvider
+{
+    /// <summary>
+    /// Does this provider own the supplied ancillary store marker type? For example, the Marten
+    /// integration returns <c>true</c> when <paramref name="storeType"/> is castable to Marten's
+    /// <c>IDocumentStore</c>, and the Polecat integration for Polecat's <c>IDocumentStore</c>.
+    /// </summary>
+    bool Matches(Type storeType);
+
+    /// <summary>
+    /// Build the codegen <see cref="Frame"/> that resolves the ancillary store's
+    /// outbox-enrolled session factory and exposes it (as the non-generic factory variable) for the
+    /// downstream session-opening frame. Inserted at the front of the chain's middleware so the
+    /// handler opens and commits through that store rather than the primary store.
+    /// </summary>
+    Frame BuildOutboxFactoryFrame(Type storeType);
+}

--- a/src/Wolverine/Persistence/StorageAttribute.cs
+++ b/src/Wolverine/Persistence/StorageAttribute.cs
@@ -1,0 +1,66 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Wolverine.Attributes;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Route a handler (or every handler on a class) to an ancillary (secondary) store, regardless of
+/// which Wolverine persistence integration owns that store. This is the provider-agnostic sibling of
+/// <c>[MartenStore]</c> and <c>[PolecatStore]</c> — apply <c>[Storage(typeof(IMyStore))]</c> once and
+/// Wolverine resolves the owning integration (Marten, Polecat, EF Core, ...) from the store marker
+/// type via the registered <see cref="IAncillaryStoreFrameProvider"/> instances.
+/// </summary>
+/// <remarks>
+/// The handler will open and commit its work through the targeted store's outbox-enrolled session,
+/// and inline-projection side effects relayed by that store flow through the Wolverine outbox — the
+/// same behavior as the provider-specific attributes.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class StorageAttribute : ModifyChainAttribute
+{
+    public Type StoreType { get; }
+
+    public StorageAttribute(Type storeType)
+    {
+        StoreType = storeType;
+    }
+
+    public override void Modify(IChain chain, GenerationRules rules, IServiceContainer container)
+    {
+        chain.UseAncillaryStorage(StoreType, container);
+    }
+}
+
+public static class AncillaryStorageChainExtensions
+{
+    /// <summary>
+    /// Route a chain to the ancillary (secondary) store identified by <paramref name="storeType"/>.
+    /// Sets <see cref="IChain.AncillaryStoreType"/> and inserts the owning integration's
+    /// outbox-factory frame at the front of the chain's middleware. Resolves the owning integration
+    /// from the registered <see cref="IAncillaryStoreFrameProvider"/> instances, so it works for any
+    /// persistence provider that has been integrated with Wolverine. Callable directly from an
+    /// <see cref="IChainPolicy"/> so a whole assembly of handlers can be routed without per-handler
+    /// markup.
+    /// </summary>
+    public static void UseAncillaryStorage(this IChain chain, Type storeType, IServiceContainer container)
+    {
+        chain.AncillaryStoreType = storeType;
+
+        var provider = container.GetAllInstances<IAncillaryStoreFrameProvider>()
+            .FirstOrDefault(x => x.Matches(storeType));
+
+        if (provider == null)
+        {
+            throw new InvalidOperationException(
+                $"No registered Wolverine persistence integration owns the ancillary store type '{storeType.FullNameInCode()}'. " +
+                "Be sure you have called IntegrateWithWolverine() on that store (e.g. via AddMartenStore<T>() or AddPolecatStore<T>()).");
+        }
+
+        chain.Middleware.Insert(0, provider.BuildOutboxFactoryFrame(storeType));
+    }
+}

--- a/src/Wolverine/Persistence/StorageAttributeEagerPolicy.cs
+++ b/src/Wolverine/Persistence/StorageAttributeEagerPolicy.cs
@@ -1,0 +1,64 @@
+using System.Reflection;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Phase-A counterpart to <see cref="StorageAttribute"/>. Pre-populates
+/// <see cref="IChain.AncillaryStoreType"/> on every handler chain decorated with
+/// <c>[Storage(typeof(...))]</c> so the message-type-to-ancillary-store map that
+/// WolverineRuntime.HostService builds eagerly during startup sees the targeting.
+///
+/// <para>
+/// <see cref="StorageAttribute"/> is a <see cref="Wolverine.Attributes.ModifyChainAttribute"/>, whose
+/// <c>Modify()</c> runs lazily at first-codegen time. The HostService ancillary-store mapping loop
+/// (<c>Handlers.AllChains().Where(c =&gt; c.AncillaryStoreType != null)</c>) runs eagerly, long before
+/// any chain is compiled, so without this policy that loop would see a null
+/// <see cref="IChain.AncillaryStoreType"/> and external interop messages would land in the main store's
+/// inbox instead of the ancillary store's. This mirrors the per-provider eager policies (Marten's
+/// <c>MartenStoreEagerPolicy</c>); the Phase-B <c>StorageAttribute.Modify</c> still runs later and
+/// re-assigns the same value (idempotent) plus inserts the provider's outbox-factory frame.
+/// </para>
+///
+/// <para>
+/// Walks the per-endpoint sticky child chains (<see cref="HandlerChain.ByEndpoint"/>) too, so
+/// <c>MultipleHandlerBehavior.Separated</c> keeps working — matching the <c>AllChains()</c> iteration
+/// that the HostService loop uses (refs GH-2576/GH-2944).
+/// </para>
+/// </summary>
+internal class StorageAttributeEagerPolicy : IHandlerPolicy
+{
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        foreach (var chain in chains)
+        {
+            applyTo(chain);
+
+            foreach (var byEndpoint in chain.ByEndpoint)
+            {
+                applyTo(byEndpoint);
+            }
+        }
+    }
+
+    private static void applyTo(HandlerChain chain)
+    {
+        if (chain.AncillaryStoreType != null) return;
+
+        foreach (var call in chain.Handlers)
+        {
+            var att = call.Method.GetCustomAttribute<StorageAttribute>(inherit: true)
+                      ?? call.HandlerType.GetCustomAttribute<StorageAttribute>(inherit: true);
+
+            if (att != null)
+            {
+                chain.AncillaryStoreType = att.StoreType;
+                return;
+            }
+        }
+    }
+}

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -243,6 +243,11 @@ public sealed partial class WolverineOptions
         Policies.Add<ResponsePolicy>();
         Policies.Add<OutgoingMessagesPolicy>();
 
+        // Phase-A pre-population of IChain.AncillaryStoreType for [Storage]-attributed handlers so the
+        // ancillary-store inbox routing map sees them eagerly at startup. Mirrors the per-provider
+        // eager policies (e.g. Marten's MartenStoreEagerPolicy). See StorageAttributeEagerPolicy.
+        Policies.Add<StorageAttributeEagerPolicy>();
+
         this.OnException<DuplicateIncomingEnvelopeException>().Discard();
 
         MessagePartitioning = new MessagePartitioningRules(this);


### PR DESCRIPTION
Closes #3109.

Enables the dormant Polecat ancillary-store integration (dead code behind an undefined `#if POLECAT_1_1`) and adds a provider-agnostic `[Storage(Type)]` attribute so a single attribute can route a handler to a Marten **or** Polecat ancillary store (EF Core later).

## Core (`Wolverine.Persistence`)
- `IAncillaryStoreFrameProvider` — a seam each persistence integration registers so `[Storage(typeof(IStore))]` can resolve the owning provider purely from the store marker type.
- `StorageAttribute` + `chain.UseAncillaryStorage(type, container)`.
- `StorageAttributeEagerPolicy` — Phase-A pre-population of `chain.AncillaryStoreType` (mirrors the per-provider eager policies; GH-2944 ordering).

## Marten
- `MartenAncillaryStoreFrameProvider` + `chain.UseMartenStore(type)`. `[MartenStore]` now routes through the shared extension (behavior unchanged; all existing ancillary tests still pass).

## Polecat
- Removed the `#if POLECAT_1_1` guards from the four ancillary files.
- `[PolecatStore]`, `PolecatStoreEagerPolicy`, `PolecatAncillaryStoreFrameProvider`, `chain.UsePolecatStore(type)`.
- The ancillary `PolecatOverrides<T>` now wires `PolecatToWolverineOutbox` so inline-projection side effects on an ancillary store relay through the Wolverine outbox (it was a no-op, so they were silently dropped).

Frame providers are registered in the primary `IntegrateWithWolverine` extension method (not `*Integration.Configure`) so the singleton is visible to the codegen-time `IServiceContainer` that `StorageAttribute.Modify` queries.

## Dependency
Requires **Polecat 4.5.0** (JasperFx/polecat#194). `AddPolecatStore<T>` hard-cast a bare `DocumentStore` to the marker interface in every prior version, so it threw `InvalidCastException` on resolution — the whole ancillary path could never have worked at runtime. `Directory.Packages.props` is bumped to 4.5.0.

## Tests & docs
- Full Polecat ancillary battery: bootstrap + end-to-end `[PolecatStore]` middleware, separate SQL Server databases + multi-tenant (`MultiTenantedMessageStore`), identity-URI uniqueness, inline-projection side effects relayed through the outbox, and `[Storage]` routing — 10 tests.
- Marten `[Storage]` mirror.
- New Polecat ancillary-stores doc + `[Storage]` sections on the Marten doc + sidebar.
- Full `wolverine.slnx` Release build is clean (0/0) against published Polecat 4.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)