### PR TITLE
GH-3110: Redis transport supports caller-managed ConnectionMultiplexer / ConfigurationOptions

### DIFF
--- a/docs/guide/messaging/transports/redis.md
+++ b/docs/guide/messaging/transports/redis.md
@@ -81,9 +81,10 @@ using var host = await Host.CreateDefaultBuilder()
 
 ## Connection Options <Badge type="tip" text="6.9" />
 
-`UseRedisTransport()` accepts three different connection sources. The connection string overload above
-is the simplest, but you can also pass StackExchange.Redis [`ConfigurationOptions`](https://stackexchange.github.io/StackExchange.Redis/Configuration)
-or a fully caller-managed [`IConnectionMultiplexer`](https://stackexchange.github.io/StackExchange.Redis/Basics):
+`UseRedisTransport()` accepts four different connection sources. The connection string overload above
+is the simplest, but you can also pass StackExchange.Redis [`ConfigurationOptions`](https://stackexchange.github.io/StackExchange.Redis/Configuration),
+a fully caller-managed [`IConnectionMultiplexer`](https://stackexchange.github.io/StackExchange.Redis/Basics),
+or a factory that resolves one from your IoC container:
 
 ```csharp
 // 1. Connection string — Wolverine owns the ConnectionMultiplexer
@@ -98,10 +99,14 @@ opts.UseRedisTransport(configuration);
 // 3. A caller-managed IConnectionMultiplexer — you own its lifetime; Wolverine never disposes it
 IConnectionMultiplexer multiplexer = await ConnectionMultiplexer.ConnectAsync("localhost:6379");
 opts.UseRedisTransport(multiplexer);
+
+// 4. A factory resolved from the IoC container — share one multiplexer between Wolverine and
+//    the rest of your application. The container owns it; Wolverine never disposes it.
+opts.UseRedisTransport(sp => sp.GetRequiredService<IConnectionMultiplexer>());
 ```
 
-With options (2) and (3) Wolverine never has to recreate the connection from a static connection string,
-which is what makes token-based authentication possible.
+With options (2), (3), and (4) Wolverine never has to recreate the connection from a static connection
+string, which is what makes token-based authentication possible.
 
 ### Azure Managed Redis with Entra ID / Managed Identity
 
@@ -125,10 +130,10 @@ opts.UseRedisTransport(configuration);
 ```
 
 ::: tip
-When you pass an `IConnectionMultiplexer`, Wolverine uses it as-is and does **not** dispose it on shutdown —
-the multiplexer (and any token-refresh background work wired into it) is owned by your application. With the
-connection-string and `ConfigurationOptions` overloads Wolverine owns the multiplexer it builds and disposes
-it for you.
+When you pass an `IConnectionMultiplexer` (option 3) or a factory that resolves one (option 4), Wolverine uses
+it as-is and does **not** dispose it on shutdown — the multiplexer (and any token-refresh background work wired
+into it) is owned by your application / IoC container. With the connection-string and `ConfigurationOptions`
+overloads Wolverine owns the multiplexer it builds and disposes it for you.
 :::
 
 If you need to control the database id within Redis, you have these options:

--- a/docs/guide/messaging/transports/redis.md
+++ b/docs/guide/messaging/transports/redis.md
@@ -79,6 +79,58 @@ using var host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs#L19-L79' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_with_redis' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Connection Options <Badge type="tip" text="6.9" />
+
+`UseRedisTransport()` accepts three different connection sources. The connection string overload above
+is the simplest, but you can also pass StackExchange.Redis [`ConfigurationOptions`](https://stackexchange.github.io/StackExchange.Redis/Configuration)
+or a fully caller-managed [`IConnectionMultiplexer`](https://stackexchange.github.io/StackExchange.Redis/Basics):
+
+```csharp
+// 1. Connection string — Wolverine owns the ConnectionMultiplexer
+opts.UseRedisTransport("localhost:6379");
+
+// 2. ConfigurationOptions — Wolverine builds and owns the ConnectionMultiplexer,
+//    but you control every StackExchange.Redis setting
+var configuration = ConfigurationOptions.Parse("localhost:6379");
+configuration.ConnectRetry = 5;
+opts.UseRedisTransport(configuration);
+
+// 3. A caller-managed IConnectionMultiplexer — you own its lifetime; Wolverine never disposes it
+IConnectionMultiplexer multiplexer = await ConnectionMultiplexer.ConnectAsync("localhost:6379");
+opts.UseRedisTransport(multiplexer);
+```
+
+With options (2) and (3) Wolverine never has to recreate the connection from a static connection string,
+which is what makes token-based authentication possible.
+
+### Azure Managed Redis with Entra ID / Managed Identity
+
+Azure Managed Redis access tokens expire and must be refreshed. The
+[`Microsoft.Azure.StackExchangeRedis`](https://github.com/Azure/Microsoft.Azure.StackExchangeRedis) package
+handles that refresh by augmenting a `ConfigurationOptions` (or the multiplexer it builds). Because Wolverine
+can take that `ConfigurationOptions` (or the resulting `IConnectionMultiplexer`) directly, the connection
+re-authenticates in place and the application no longer has to restart when a token expires:
+
+```csharp
+// Requires the Microsoft.Azure.StackExchangeRedis package
+var configuration = await ConfigurationOptions
+    .Parse("your-cache.region.redis.azure.net:10000")
+    .ConfigureForAzureWithTokenCredentialAsync(new DefaultAzureCredential());
+
+opts.UseRedisTransport(configuration);
+
+// — or — build the multiplexer yourself and hand it to Wolverine:
+// var multiplexer = await ConnectionMultiplexer.ConnectAsync(configuration);
+// opts.UseRedisTransport(multiplexer);
+```
+
+::: tip
+When you pass an `IConnectionMultiplexer`, Wolverine uses it as-is and does **not** dispose it on shutdown —
+the multiplexer (and any token-refresh background work wired into it) is owned by your application. With the
+connection-string and `ConfigurationOptions` overloads Wolverine owns the multiplexer it builds and disposes
+it for you.
+:::
+
 If you need to control the database id within Redis, you have these options:
 
 <!-- snippet: sample_redis_database_configuration -->

--- a/src/Transports/Redis/Wolverine.Redis.Tests/redis_connection_source_configuration.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/redis_connection_source_configuration.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 using Shouldly;
 using StackExchange.Redis;
 using Wolverine.Redis.Internal;
+using Wolverine.Runtime;
 using Xunit;
 
 namespace Wolverine.Redis.Tests;
@@ -119,6 +120,80 @@ public class redis_connection_source_configuration
         // After the host that used it is disposed, the caller-managed multiplexer is still alive.
         mux.IsConnected.ShouldBeTrue();
         (await mux.GetDatabase().PingAsync()).ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void connection_summary_reports_a_caller_managed_multiplexer_factory()
+    {
+        var transport = new RedisTransport(_ => Substitute.For<IConnectionMultiplexer>());
+
+        transport.ConnectionSummary.ShouldBe("caller-managed IConnectionMultiplexer factory");
+    }
+
+    [Fact]
+    public async Task connection_factory_overload_round_trips_and_is_not_disposed_by_wolverine()
+    {
+        var streamKey = $"wolverine-tests-factory-mux-{Guid.NewGuid():N}";
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // The multiplexer is owned by the application here (not registered for disposal in the
+        // container), so if it is still alive after the host is gone, Wolverine did not dispose it.
+        await using var mux = await ConnectionMultiplexer.ConnectAsync(RedisContainerFixture.ConnectionString);
+
+        using (var host = await Host.CreateDefaultBuilder()
+                   .UseWolverine(opts =>
+                   {
+                       opts.UseRedisTransport(_ => mux).AutoProvision();
+
+                       opts.ListenToRedisStream(streamKey, "g1")
+                           .DefaultIncomingMessage<ByoMuxMessage>();
+
+                       opts.PublishAllMessages().ToRedisStream(streamKey);
+                       opts.Services.AddSingleton(tcs);
+                   })
+                   .StartAsync())
+        {
+            // The transport resolved its connection from the factory.
+            var transport = host.Services.GetRequiredService<IWolverineRuntime>()
+                .Options.Transports.GetOrCreate<RedisTransport>();
+            transport.GetConnection().ShouldBeSameAs(mux);
+
+            var bus = host.MessageBus();
+            await bus.EndpointFor(new Uri($"redis://stream/0/{streamKey}"))
+                .SendAsync(new ByoMuxMessage("123"));
+
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            completed.ShouldBe(tcs.Task);
+        }
+
+        mux.IsConnected.ShouldBeTrue();
+        (await mux.GetDatabase().PingAsync()).ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public async Task connection_factory_resolves_the_multiplexer_from_the_ioc_container()
+    {
+        var streamKey = $"wolverine-tests-factory-di-{Guid.NewGuid():N}";
+
+        await using var mux = await ConnectionMultiplexer.ConnectAsync(RedisContainerFixture.ConnectionString);
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton<IConnectionMultiplexer>(mux);
+
+                // Share the application's container-registered multiplexer with the transport.
+                opts.UseRedisTransport(sp => sp.GetRequiredService<IConnectionMultiplexer>())
+                    .AutoProvision();
+
+                opts.ListenToRedisStream(streamKey, "g1").DefaultIncomingMessage<ByoMuxMessage>();
+            })
+            .StartAsync();
+
+        var transport = host.Services.GetRequiredService<IWolverineRuntime>()
+            .Options.Transports.GetOrCreate<RedisTransport>();
+
+        transport.GetConnection().ShouldBeSameAs(mux);
     }
 
     public record ByoMuxMessage(string Id);

--- a/src/Transports/Redis/Wolverine.Redis.Tests/redis_connection_source_configuration.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/redis_connection_source_configuration.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using StackExchange.Redis;
+using Wolverine.Redis.Internal;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+// GH-3110: the Redis transport can be configured with caller-supplied ConfigurationOptions or a
+// caller-managed IConnectionMultiplexer (not only a connection string), so apps can plug in
+// StackExchange.Redis extensions such as Microsoft.Azure.StackExchangeRedis for Entra ID /
+// Managed Identity token refresh. Modeled on the Azure Service Bus transport's multiple
+// connection modes.
+public class redis_connection_source_configuration
+{
+    [Fact]
+    public void caller_managed_multiplexer_is_used_as_is_and_never_disposed()
+    {
+        var mux = Substitute.For<IConnectionMultiplexer>();
+        var transport = new RedisTransport(mux);
+
+        // The supplied multiplexer is the single shared connection.
+        transport.GetConnection().ShouldBeSameAs(mux);
+    }
+
+    [Fact]
+    public async Task disposing_the_transport_does_not_dispose_a_caller_managed_multiplexer()
+    {
+        var mux = Substitute.For<IConnectionMultiplexer>();
+        var transport = new RedisTransport(mux);
+
+        _ = transport.GetConnection();
+
+        await transport.DisposeAsync();
+
+        // The caller owns the multiplexer's lifetime — Wolverine must not close or dispose it.
+        await mux.DidNotReceive().CloseAsync(Arg.Any<bool>());
+        mux.DidNotReceive().Dispose();
+    }
+
+    [Fact]
+    public void connection_summary_reports_a_caller_managed_multiplexer_without_touching_it()
+    {
+        var mux = Substitute.For<IConnectionMultiplexer>();
+        var transport = new RedisTransport(mux);
+
+        transport.ConnectionSummary.ShouldBe("caller-managed IConnectionMultiplexer");
+    }
+
+    [Fact]
+    public void connection_summary_masks_the_password_for_a_connection_string()
+    {
+        var transport = new RedisTransport("localhost:6379,password=sup3rs3cret");
+
+        transport.ConnectionSummary.ShouldNotContain("sup3rs3cret");
+        transport.ConnectionSummary.ShouldContain("****");
+    }
+
+    [Fact]
+    public void connection_summary_masks_the_password_for_configuration_options()
+    {
+        var options = ConfigurationOptions.Parse("localhost:6379");
+        options.Password = "sup3rs3cret";
+
+        var transport = new RedisTransport(options);
+
+        transport.ConnectionSummary.ShouldNotContain("sup3rs3cret");
+        transport.ConnectionSummary.ShouldContain("****");
+    }
+
+    [Fact]
+    public async Task configuration_options_overload_builds_a_working_connection()
+    {
+        var options = ConfigurationOptions.Parse(RedisContainerFixture.ConnectionString);
+        var transport = new RedisTransport(options);
+
+        // Wolverine builds and owns the multiplexer from these options.
+        var pong = await transport.GetConnection().GetDatabase().PingAsync();
+        pong.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+
+        await transport.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task bootstrapping_with_a_caller_managed_multiplexer_round_trips_and_preserves_it()
+    {
+        var streamKey = $"wolverine-tests-byo-mux-{Guid.NewGuid():N}";
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // The application creates and owns the multiplexer (here a plain one; in production this is
+        // where Microsoft.Azure.StackExchangeRedis token refresh would be wired in).
+        await using var mux = await ConnectionMultiplexer.ConnectAsync(RedisContainerFixture.ConnectionString);
+
+        using (var host = await Host.CreateDefaultBuilder()
+                   .UseWolverine(opts =>
+                   {
+                       opts.UseRedisTransport(mux).AutoProvision();
+
+                       opts.ListenToRedisStream(streamKey, "g1")
+                           .DefaultIncomingMessage<ByoMuxMessage>();
+
+                       opts.PublishAllMessages().ToRedisStream(streamKey);
+                       opts.Services.AddSingleton(tcs);
+                   })
+                   .StartAsync())
+        {
+            var bus = host.MessageBus();
+            await bus.EndpointFor(new Uri($"redis://stream/0/{streamKey}"))
+                .SendAsync(new ByoMuxMessage("123"));
+
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            completed.ShouldBe(tcs.Task);
+        }
+
+        // After the host that used it is disposed, the caller-managed multiplexer is still alive.
+        mux.IsConnected.ShouldBeTrue();
+        (await mux.GetDatabase().PingAsync()).ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+    }
+
+    public record ByoMuxMessage(string Id);
+
+    public class ByoMuxHandler
+    {
+        private readonly TaskCompletionSource<bool> _tcs;
+        public ByoMuxHandler(TaskCompletionSource<bool> tcs) => _tcs = tcs;
+        public void Handle(ByoMuxMessage m) => _tcs.TrySetResult(true);
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
@@ -17,7 +17,15 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     
     private readonly LightweightCache<string, RedisStreamEndpoint> _streams;
     private readonly ConcurrentDictionary<string, IConnectionMultiplexer> _connections = new();
-    private readonly string _connectionString;
+    private readonly Lazy<IConnectionMultiplexer> _defaultConnection;
+
+    // Exactly one of these three connection sources is populated, used in precedence order:
+    // a caller-managed multiplexer, caller-supplied ConfigurationOptions, or a connection string.
+    // GH-3110 — the first two let callers wire up StackExchange.Redis extensions such as
+    // Microsoft.Azure.StackExchangeRedis for Entra ID / Managed Identity token refresh.
+    private readonly IConnectionMultiplexer? _externalConnection;
+    private readonly ConfigurationOptions? _configurationOptions;
+    private readonly string? _connectionString;
 
     /// <summary>
     /// Enable/disable creation of system endpoints like reply streams
@@ -46,11 +54,46 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
         // Default constructor for GetOrCreate<T>()
     }
     
+    /// <summary>
+    /// Connect to Redis with a StackExchange.Redis connection string. Wolverine owns the underlying
+    /// <see cref="ConnectionMultiplexer"/> and disposes it on shutdown.
+    /// </summary>
     public RedisTransport(string connectionString) : base(ProtocolName, "Redis Streams Transport", ["redis"])
     {
         _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
-        _streams = new LightweightCache<string, RedisStreamEndpoint>(
-            cacheKey => 
+        _streams = buildStreamCache();
+        _defaultConnection = new Lazy<IConnectionMultiplexer>(createDefaultConnection);
+    }
+
+    /// <summary>
+    /// Connect to Redis with a caller-supplied <see cref="ConfigurationOptions"/>. Wolverine owns the
+    /// <see cref="ConnectionMultiplexer"/> it builds from these options and disposes it on shutdown. Use
+    /// this to wire up StackExchange.Redis extensions (e.g. Microsoft.Azure.StackExchangeRedis for Entra
+    /// ID / Managed Identity token refresh) that augment <see cref="ConfigurationOptions"/>. GH-3110.
+    /// </summary>
+    public RedisTransport(ConfigurationOptions configurationOptions) : base(ProtocolName, "Redis Streams Transport", ["redis"])
+    {
+        _configurationOptions = configurationOptions ?? throw new ArgumentNullException(nameof(configurationOptions));
+        _streams = buildStreamCache();
+        _defaultConnection = new Lazy<IConnectionMultiplexer>(createDefaultConnection);
+    }
+
+    /// <summary>
+    /// Connect to Redis with a caller-managed <see cref="IConnectionMultiplexer"/>. Wolverine uses the
+    /// supplied multiplexer as-is and does NOT dispose it — the caller owns its lifetime (and any token
+    /// refresh / reconnect policy wired into it). GH-3110.
+    /// </summary>
+    public RedisTransport(IConnectionMultiplexer connection) : base(ProtocolName, "Redis Streams Transport", ["redis"])
+    {
+        _externalConnection = connection ?? throw new ArgumentNullException(nameof(connection));
+        _streams = buildStreamCache();
+        _defaultConnection = new Lazy<IConnectionMultiplexer>(createDefaultConnection);
+    }
+
+    private LightweightCache<string, RedisStreamEndpoint> buildStreamCache()
+    {
+        return new LightweightCache<string, RedisStreamEndpoint>(
+            cacheKey =>
             {
                 // Parse the cache key format: {databaseId}:{streamKey}
                 var parts = cacheKey.Split(':', 2);
@@ -66,13 +109,19 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
             });
     }
 
+    private IConnectionMultiplexer createDefaultConnection()
+    {
+        if (_externalConnection != null) return _externalConnection;
+        if (_configurationOptions != null) return ConnectionMultiplexer.Connect(_configurationOptions);
+        return ConnectionMultiplexer.Connect(_connectionString!);
+    }
+
     public override Uri ResourceUri
     {
         get
         {
-            // Parse connection string to build resource URI
-            var options = ConfigurationOptions.Parse(_connectionString);
-            var endpoint = options.EndPoints.FirstOrDefault();
+            // Derive the resource URI from whichever connection source is configured.
+            var endpoint = primaryEndPoint();
 
             if (endpoint == null)
             {
@@ -83,28 +132,46 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
         }
     }
 
+    private System.Net.EndPoint? primaryEndPoint()
+    {
+        if (_externalConnection != null) return _externalConnection.GetEndPoints().FirstOrDefault();
+        if (_configurationOptions != null) return _configurationOptions.EndPoints.FirstOrDefault();
+        return ConfigurationOptions.Parse(_connectionString!).EndPoints.FirstOrDefault();
+    }
+
     /// <summary>
-    /// The configured Redis connection string with the <c>password</c> value
-    /// masked. Safe to render in diagnostic output.
+    /// A diagnostic-safe summary of how this transport connects to Redis. The <c>password</c> in a
+    /// connection string or <see cref="ConfigurationOptions"/> is masked; a caller-managed multiplexer is
+    /// reported as such (Wolverine never sees its credentials). Safe to render in diagnostic output.
     /// </summary>
-    public string ConnectionSummary => SanitizeConnectionStringForLogging(_connectionString);
+    public string ConnectionSummary =>
+        _externalConnection != null ? "caller-managed IConnectionMultiplexer"
+        : _configurationOptions != null ? SanitizeConfigurationOptionsForLogging(_configurationOptions)
+        : SanitizeConnectionStringForLogging(_connectionString!);
 
     internal IDatabase GetDatabase(string? connectionString = null, int database = 0)
     {
         var connection = GetConnection(connectionString);
         return connection.GetDatabase(database);
     }
-    
+
     internal IConnectionMultiplexer GetConnection(string? connectionString = null)
     {
-        var connStr = connectionString ?? _connectionString;
-        return _connections.GetOrAdd(connStr, cs => ConnectionMultiplexer.Connect(cs));
+        // A caller-managed multiplexer is the single shared connection, regardless of any per-endpoint
+        // connection-string override.
+        if (_externalConnection != null) return _externalConnection;
+
+        if (connectionString != null)
+        {
+            return _connections.GetOrAdd(connectionString, cs => ConnectionMultiplexer.Connect(cs));
+        }
+
+        return _defaultConnection.Value;
     }
 
     public override async ValueTask ConnectAsync(IWolverineRuntime runtime)
     {
-        runtime.Logger.LogInformation("Connecting to Redis at {ConnectionString}", 
-            SanitizeConnectionStringForLogging(_connectionString));
+        runtime.Logger.LogInformation("Connecting to Redis at {ConnectionString}", ConnectionSummary);
         
         try
         {
@@ -226,7 +293,16 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     {
         try
         {
-            foreach (var connection in _connections.Values)
+            var owned = _connections.Values.ToList();
+
+            // Dispose the default connection only if Wolverine created it. A caller-managed
+            // IConnectionMultiplexer is owned by the caller and must never be disposed here. GH-3110.
+            if (_defaultConnection.IsValueCreated && !ReferenceEquals(_defaultConnection.Value, _externalConnection))
+            {
+                owned.Add(_defaultConnection.Value);
+            }
+
+            foreach (var connection in owned.Distinct())
             {
                 await connection.CloseAsync();
                 connection.Dispose();
@@ -277,6 +353,14 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
         var options = ConfigurationOptions.Parse(connectionString);
         options.Password = options.Password?.Length > 0 ? "****" : null;
         return options.ToString();
+    }
+
+    private static string SanitizeConfigurationOptionsForLogging(ConfigurationOptions options)
+    {
+        // Mask the password without mutating the caller's options instance.
+        var clone = options.Clone();
+        clone.Password = clone.Password?.Length > 0 ? "****" : null;
+        return clone.ToString();
     }
 
     protected override void tryBuildSystemEndpoints(IWolverineRuntime runtime)

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
@@ -19,11 +19,15 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     private readonly ConcurrentDictionary<string, IConnectionMultiplexer> _connections = new();
     private readonly Lazy<IConnectionMultiplexer> _defaultConnection;
 
-    // Exactly one of these three connection sources is populated, used in precedence order:
-    // a caller-managed multiplexer, caller-supplied ConfigurationOptions, or a connection string.
-    // GH-3110 — the first two let callers wire up StackExchange.Redis extensions such as
-    // Microsoft.Azure.StackExchangeRedis for Entra ID / Managed Identity token refresh.
+    // Exactly one of these four connection sources is populated, used in precedence order: a
+    // caller-managed multiplexer, a factory that resolves one from the IoC container, caller-supplied
+    // ConfigurationOptions, or a connection string. GH-3110 — the first three let callers wire up
+    // StackExchange.Redis extensions such as Microsoft.Azure.StackExchangeRedis for Entra ID /
+    // Managed Identity token refresh. Wolverine owns (and disposes) only the multiplexers it builds
+    // itself from ConfigurationOptions / a connection string.
     private readonly IConnectionMultiplexer? _externalConnection;
+    private readonly Func<IServiceProvider, IConnectionMultiplexer>? _connectionFactory;
+    private IServiceProvider? _services;
     private readonly ConfigurationOptions? _configurationOptions;
     private readonly string? _connectionString;
 
@@ -90,6 +94,20 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
         _defaultConnection = new Lazy<IConnectionMultiplexer>(createDefaultConnection);
     }
 
+    /// <summary>
+    /// Connect to Redis with an <see cref="IConnectionMultiplexer"/> resolved from the application's IoC
+    /// container at runtime. Use this to share a single multiplexer (e.g. one registered as a singleton,
+    /// possibly with Microsoft.Azure.StackExchangeRedis token refresh) between Wolverine and the rest of
+    /// the application. The resolved multiplexer is assumed to be owned by the container — Wolverine uses
+    /// it as-is and does NOT dispose it. GH-3110.
+    /// </summary>
+    public RedisTransport(Func<IServiceProvider, IConnectionMultiplexer> connectionFactory) : base(ProtocolName, "Redis Streams Transport", ["redis"])
+    {
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+        _streams = buildStreamCache();
+        _defaultConnection = new Lazy<IConnectionMultiplexer>(createDefaultConnection);
+    }
+
     private LightweightCache<string, RedisStreamEndpoint> buildStreamCache()
     {
         return new LightweightCache<string, RedisStreamEndpoint>(
@@ -112,9 +130,25 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     private IConnectionMultiplexer createDefaultConnection()
     {
         if (_externalConnection != null) return _externalConnection;
+
+        if (_connectionFactory != null)
+        {
+            var services = _services ?? throw new InvalidOperationException(
+                "The Redis transport's IConnectionMultiplexer factory cannot be resolved before the Wolverine host has started. " +
+                "This usually means a Redis connection was requested before ConnectAsync ran.");
+            return _connectionFactory(services);
+        }
+
         if (_configurationOptions != null) return ConnectionMultiplexer.Connect(_configurationOptions);
         return ConnectionMultiplexer.Connect(_connectionString!);
     }
+
+    /// <summary>
+    /// True when Wolverine built the default connection itself (from a connection string or
+    /// ConfigurationOptions) and is therefore responsible for disposing it. A caller-managed multiplexer
+    /// or one resolved from the IoC container is owned elsewhere and must not be disposed here.
+    /// </summary>
+    private bool OwnsDefaultConnection => _externalConnection == null && _connectionFactory == null;
 
     public override Uri ResourceUri
     {
@@ -135,6 +169,11 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     private System.Net.EndPoint? primaryEndPoint()
     {
         if (_externalConnection != null) return _externalConnection.GetEndPoints().FirstOrDefault();
+        if (_connectionFactory != null)
+        {
+            // Only known once the factory has resolved a multiplexer (after the host has started).
+            return _defaultConnection.IsValueCreated ? _defaultConnection.Value.GetEndPoints().FirstOrDefault() : null;
+        }
         if (_configurationOptions != null) return _configurationOptions.EndPoints.FirstOrDefault();
         return ConfigurationOptions.Parse(_connectionString!).EndPoints.FirstOrDefault();
     }
@@ -146,6 +185,7 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     /// </summary>
     public string ConnectionSummary =>
         _externalConnection != null ? "caller-managed IConnectionMultiplexer"
+        : _connectionFactory != null ? "caller-managed IConnectionMultiplexer factory"
         : _configurationOptions != null ? SanitizeConfigurationOptionsForLogging(_configurationOptions)
         : SanitizeConnectionStringForLogging(_connectionString!);
 
@@ -171,6 +211,10 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
 
     public override async ValueTask ConnectAsync(IWolverineRuntime runtime)
     {
+        // Capture the IoC container so a factory-based connection can be resolved. ConnectAsync runs
+        // before any endpoint forces a connection (BrokerTransport.startupAsync), so this is set in time.
+        _services ??= runtime.Services;
+
         runtime.Logger.LogInformation("Connecting to Redis at {ConnectionString}", ConnectionSummary);
         
         try
@@ -296,8 +340,9 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
             var owned = _connections.Values.ToList();
 
             // Dispose the default connection only if Wolverine created it. A caller-managed
-            // IConnectionMultiplexer is owned by the caller and must never be disposed here. GH-3110.
-            if (_defaultConnection.IsValueCreated && !ReferenceEquals(_defaultConnection.Value, _externalConnection))
+            // IConnectionMultiplexer, or one resolved from the IoC container via a factory, is owned
+            // elsewhere and must never be disposed here. GH-3110.
+            if (_defaultConnection.IsValueCreated && OwnsDefaultConnection)
             {
                 owned.Add(_defaultConnection.Value);
             }

--- a/src/Transports/Redis/Wolverine.Redis/WolverineOptionsExtensions.cs
+++ b/src/Transports/Redis/Wolverine.Redis/WolverineOptionsExtensions.cs
@@ -1,5 +1,6 @@
 using JasperFx.Core.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
 using Wolverine;
 using Wolverine.Configuration;
 using Wolverine.Redis.Internal;
@@ -37,9 +38,46 @@ public static class WolverineOptionsExtensions
     public static RedisTransportExpression UseRedisTransport(this WolverineOptions options, string connectionString)
     {
         var transport = new RedisTransport(connectionString);
-        
+
         options.Transports.Add(transport);
-        
+
+        return new RedisTransportExpression(transport, options);
+    }
+
+    /// <summary>
+    /// Adds the Redis Streams transport to Wolverine using caller-supplied StackExchange.Redis
+    /// <see cref="ConfigurationOptions"/> instead of a connection string. Wolverine builds and owns the
+    /// underlying <c>ConnectionMultiplexer</c>. Use this to wire up StackExchange.Redis extensions — for
+    /// example <a href="https://github.com/Azure/Microsoft.Azure.StackExchangeRedis">Microsoft.Azure.StackExchangeRedis</a>
+    /// for Azure Managed Redis with Entra ID / Managed Identity token refresh. GH-3110.
+    /// </summary>
+    /// <param name="options">Wolverine configuration options</param>
+    /// <param name="configurationOptions">Pre-configured StackExchange.Redis connection options</param>
+    /// <returns>RedisTransport for fluent configuration</returns>
+    public static RedisTransportExpression UseRedisTransport(this WolverineOptions options, ConfigurationOptions configurationOptions)
+    {
+        var transport = new RedisTransport(configurationOptions);
+
+        options.Transports.Add(transport);
+
+        return new RedisTransportExpression(transport, options);
+    }
+
+    /// <summary>
+    /// Adds the Redis Streams transport to Wolverine using a caller-managed
+    /// <see cref="IConnectionMultiplexer"/>. Wolverine uses the supplied multiplexer as-is and does NOT
+    /// dispose it — the caller owns its lifetime and any custom authentication, reconnect policy, or token
+    /// refresh wired into it (e.g. via Microsoft.Azure.StackExchangeRedis). GH-3110.
+    /// </summary>
+    /// <param name="options">Wolverine configuration options</param>
+    /// <param name="connectionMultiplexer">A connected, caller-managed multiplexer</param>
+    /// <returns>RedisTransport for fluent configuration</returns>
+    public static RedisTransportExpression UseRedisTransport(this WolverineOptions options, IConnectionMultiplexer connectionMultiplexer)
+    {
+        var transport = new RedisTransport(connectionMultiplexer);
+
+        options.Transports.Add(transport);
+
         return new RedisTransportExpression(transport, options);
     }
 

--- a/src/Transports/Redis/Wolverine.Redis/WolverineOptionsExtensions.cs
+++ b/src/Transports/Redis/Wolverine.Redis/WolverineOptionsExtensions.cs
@@ -82,6 +82,25 @@ public static class WolverineOptionsExtensions
     }
 
     /// <summary>
+    /// Adds the Redis Streams transport to Wolverine using an <see cref="IConnectionMultiplexer"/> resolved
+    /// from the application's IoC container at runtime. Use this to share one multiplexer (for example a
+    /// singleton registered with Microsoft.Azure.StackExchangeRedis token refresh) between Wolverine and the
+    /// rest of the application. The resolved multiplexer is assumed to be container-owned — Wolverine uses it
+    /// as-is and does NOT dispose it. GH-3110.
+    /// </summary>
+    /// <param name="options">Wolverine configuration options</param>
+    /// <param name="connectionFactory">Resolves the multiplexer from the built service provider</param>
+    /// <returns>RedisTransport for fluent configuration</returns>
+    public static RedisTransportExpression UseRedisTransport(this WolverineOptions options, Func<IServiceProvider, IConnectionMultiplexer> connectionFactory)
+    {
+        var transport = new RedisTransport(connectionFactory);
+
+        options.Transports.Add(transport);
+
+        return new RedisTransportExpression(transport, options);
+    }
+
+    /// <summary>
     /// Configure Wolverine to publish messages to the specified Redis stream (uses database 0)
     /// </summary>
     /// <param name="publishing">Publishing configuration</param>


### PR DESCRIPTION
Closes #3110.

## Problem
`Wolverine.Redis` could only be configured with a connection string, so it always created and owned the `ConnectionMultiplexer` internally. That blocks token-based auth — Azure Managed Redis with Entra ID / Managed Identity (via [Microsoft.Azure.StackExchangeRedis](https://github.com/Azure/Microsoft.Azure.StackExchangeRedis)) — because when an access token expires the app must be restarted; the underlying multiplexer can be neither replaced nor reconfigured.

## Approach (modeled on the Azure Service Bus transport)
ASB supports several construction modes (`UseAzureServiceBus(connectionString)`, `UseAzureServiceBus(namespace, TokenCredential)`, ...) by storing whichever inputs were supplied and building one client from them. This PR gives Redis the same shape — two new `UseRedisTransport` overloads matching the exact API requested in the issue:

```csharp
opts.UseRedisTransport(ConfigurationOptions options);       // Wolverine builds & owns the multiplexer
opts.UseRedisTransport(IConnectionMultiplexer multiplexer); // caller-managed; Wolverine never disposes it
```

`RedisTransport` now holds exactly one of three connection sources (caller-managed multiplexer > `ConfigurationOptions` > connection string) and resolves a single shared connection lazily from it. Key behaviors:

- A **caller-managed `IConnectionMultiplexer` is used as-is and is never disposed** on shutdown — the caller owns its lifetime and any token-refresh background work. The connection-string / `ConfigurationOptions` multiplexers are still owned and disposed by Wolverine.
- `ResourceUri`, `ConnectionSummary`, and connect-logging derive from whichever source is configured; passwords are masked (and a caller-managed multiplexer is reported as such, since Wolverine never sees its credentials).
- The existing connection-string overload and behavior are unchanged.

## Why this solves token refresh
With `ConfigurationOptions` or a caller-managed multiplexer, Wolverine never has to recreate the connection from a static connection string, so `Microsoft.Azure.StackExchangeRedis` can refresh the Entra token in place — no pod restart on expiry.

## Tests
`redis_connection_source_configuration` covers all three modes: caller-managed multiplexer reused and never closed/disposed, password masking for connection string + `ConfigurationOptions`, `ConfigurationOptions` building a working connection, and an **end-to-end round-trip with a caller-managed multiplexer that survives host disposal**. Existing pub/sub + diagnostics + non-default-database tests still pass.

## Docs
Adds a **Connection Options** section to the Redis transport guide, including the Azure Managed Redis / Entra ID example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)