### PR TITLE
Honor shared JasperFx.IdentityAttribute in Polecat aggregate id resolution (closes #3117)

### DIFF
--- a/docs/guide/durability/polecat/event-sourcing.md
+++ b/docs/guide/durability/polecat/event-sourcing.md
@@ -272,6 +272,15 @@ public class MarkItemReady
 }
 ```
 
+::: tip
+The Polecat integration recognizes both its own `Wolverine.Polecat.IdentityAttribute` and the
+shared `JasperFx.IdentityAttribute` used elsewhere in the Critter Stack (and by the
+[Marten integration](../marten/event-sourcing)). If you maintain a single, store-agnostic
+command/aggregate source that is compiled against both Marten and Polecat, decorate the identity
+member with the shared `JasperFx.IdentityAttribute` (i.e. `using JasperFx;`) and it will be honored
+by both stores — no per-store attribute alias is required.
+:::
+
 ## Forwarding Events
 
 See [Event Forwarding](./event-forwarding) for more information.

--- a/src/Persistence/PolecatTests/AggregateHandlerWorkflow/AggregateHandlerAttributeTests.cs
+++ b/src/Persistence/PolecatTests/AggregateHandlerWorkflow/AggregateHandlerAttributeTests.cs
@@ -89,6 +89,15 @@ public class AggregateHandlerAttributeTests
     }
 
     [Fact]
+    public void determine_aggregate_id_with_shared_jasperfx_identity_attribute()
+    {
+        // Regression for #3117 -- Polecat should honor the shared JasperFx.IdentityAttribute
+        // used across the rest of the Critter Stack (and Marten), not just its own [Identity].
+        AggregateHandling.DetermineAggregateIdMember(typeof(PcInvoice), typeof(RejectPcInvoiceShared))
+            .Name.ShouldBe(nameof(RejectPcInvoiceShared.Something));
+    }
+
+    [Fact]
     public void determine_aggregate_id_with_identity_attribute_bypass()
     {
         AggregateHandling.DetermineAggregateIdMember(typeof(PcInvoice), typeof(PcAggregateIdConventionBypassingCommand))
@@ -154,6 +163,10 @@ public record CreatePcInvoice(Guid Id);
 public record PcInvoiceCreated;
 
 public record RejectPcInvoice([property: Identity] Guid Something);
+
+// Uses the shared JasperFx.IdentityAttribute (fully qualified to bypass the
+// file-level alias pinning [Identity] to Wolverine.Polecat.IdentityAttribute).
+public record RejectPcInvoiceShared([property: JasperFx.Identity] Guid Something);
 
 public class PcInvoiceHandler
 {

--- a/src/Persistence/Wolverine.Polecat/AggregateHandling.cs
+++ b/src/Persistence/Wolverine.Polecat/AggregateHandling.cs
@@ -185,7 +185,12 @@ internal record AggregateHandling(IDataRequirement Requirement)
     internal static MemberInfo DetermineAggregateIdMember(Type aggregateType, Type commandType)
     {
         var conventionalMemberName = $"{aggregateType.Name}Id";
-        var member = commandType.GetMembers().FirstOrDefault(x => x.HasAttribute<IdentityAttribute>())
+
+        // Honor both the Polecat-specific [Identity] and the shared JasperFx.IdentityAttribute
+        // used across the rest of the Critter Stack (and Marten) so a single store-agnostic
+        // command/aggregate source can codegen against both stores.
+        var member = commandType.GetMembers().FirstOrDefault(x =>
+                         x.HasAttribute<IdentityAttribute>() || x.HasAttribute<JasperFx.IdentityAttribute>())
                      ?? commandType.GetMembers().FirstOrDefault(x =>
                          x.Name.EqualsIgnoreCase(conventionalMemberName) || x.Name.EqualsIgnoreCase("Id"));
 
@@ -197,7 +202,7 @@ internal record AggregateHandling(IDataRequirement Requirement)
         if (member == null)
         {
             throw new InvalidOperationException(
-                $"Unable to determine the aggregate id for aggregate type {aggregateType.FullNameInCode()} on command type {commandType.FullNameInCode()}. Either make a property or field named '{conventionalMemberName}', or decorate a member with the {typeof(IdentityAttribute).FullNameInCode()} attribute");
+                $"Unable to determine the aggregate id for aggregate type {aggregateType.FullNameInCode()} on command type {commandType.FullNameInCode()}. Either make a property or field named '{conventionalMemberName}', or decorate a member with the {typeof(IdentityAttribute).FullNameInCode()} or {typeof(JasperFx.IdentityAttribute).FullNameInCode()} attribute");
         }
 
         return member;


### PR DESCRIPTION
## Problem

`Wolverine.Polecat`'s aggregate-handler codegen only recognized its own `Wolverine.Polecat.IdentityAttribute` when resolving which command member is the aggregate stream id. Because the bare `IdentityAttribute` reference in `AggregateHandling.cs` resolves to the Polecat-local type (the file lives in the `Wolverine.Polecat` namespace), the shared `JasperFx.IdentityAttribute` used across the rest of the Critter Stack — and honored by `Wolverine.Marten` — was ignored.

This broke store-agnostic command/aggregate models meant to compile and codegen against both Marten and Polecat from a single shared source, throwing:

```
System.InvalidOperationException: Unable to determine the aggregate id for aggregate type ServiceSummary
on command type UpdateLabelName. ...
```

The identical model codegens fine under Marten, whose resolver picks up `JasperFx.IdentityAttribute` (Marten has no namespace-local `IdentityAttribute`, so `using JasperFx;` wins).

## Fix

`AggregateHandling.DetermineAggregateIdMember` now recognizes **both** `Wolverine.Polecat.IdentityAttribute` and the shared `JasperFx.IdentityAttribute`, matching Marten's behavior. A single shared `[Identity]` source now codegens against both stores without the per-project `global using IdentityAttribute = Wolverine.Polecat.IdentityAttribute;` alias workaround. The "unable to determine" error message also names both attributes.

## Tests

Added `determine_aggregate_id_with_shared_jasperfx_identity_attribute` to `PolecatTests.AggregateHandlerWorkflow.AggregateHandlerAttributeTests`, using a command record decorated with the fully-qualified `[property: JasperFx.Identity]` attribute. All 15 tests in the suite pass.

Closes #3117

🤖 Generated with [Claude Code](https://claude.com/claude-code)