### PR TITLE
Fix AmazonSqs/AmazonSns Transport.ResourceUri throwing ArgumentNullException when only RegionEndpoint is set (closes #3115)

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/AmazonSnsTransportTests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/AmazonSnsTransportTests.cs
@@ -1,10 +1,40 @@
- using Shouldly;
+ using Amazon;
+using Shouldly;
 using Wolverine.AmazonSns.Internal;
 
 namespace Wolverine.AmazonSns.Tests;
 
 public class AmazonSnsTransportTests
 {
+    [Fact]
+    public void resource_uri_uses_explicit_service_url_when_set()
+    {
+        var transport = new AmazonSnsTransport();
+        transport.SnsConfig.ServiceURL = "http://localhost:4566";
+
+        transport.ResourceUri.ShouldBe(new Uri("http://localhost:4566"));
+    }
+
+    [Fact]
+    public void resource_uri_falls_back_to_region_when_service_url_not_set()
+    {
+        // Reproduces #3115 -- setting only RegionEndpoint used to throw
+        // ArgumentNullException from new Uri(SnsConfig.ServiceURL)
+        var transport = new AmazonSnsTransport();
+        transport.SnsConfig.RegionEndpoint = RegionEndpoint.USWest2;
+
+        transport.ResourceUri.ShouldBe(new Uri("https://sns.us-west-2.amazonaws.com"));
+    }
+
+    [Fact]
+    public void resource_uri_does_not_throw_when_neither_service_url_nor_region_set()
+    {
+        var transport = new AmazonSnsTransport();
+
+        // Should not throw an ArgumentNullException
+        Should.NotThrow(() => transport.ResourceUri);
+    }
+
     [Theory]
     [InlineData("good.fifo", "good.fifo")]
     [InlineData("good", "good")]

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTransport.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTransport.cs
@@ -28,7 +28,35 @@ public class AmazonSnsTransport : BrokerTransport<AmazonSnsTopic>
         SqsClient = sqsClient;
     }
 
-    public override Uri ResourceUri => new(SnsConfig.ServiceURL);
+    public override Uri ResourceUri
+    {
+        get
+        {
+            // An explicitly set ServiceURL (e.g. LocalStack) wins
+            if (SnsConfig.ServiceURL.IsNotEmpty())
+            {
+                return new Uri(SnsConfig.ServiceURL);
+            }
+
+            // Otherwise fall back to the configured region so that this purely
+            // diagnostic Uri doesn't throw when only RegionEndpoint was set
+            try
+            {
+                var region = SnsConfig.RegionEndpoint?.SystemName;
+                if (region.IsNotEmpty())
+                {
+                    return new Uri($"https://sns.{region}.amazonaws.com");
+                }
+            }
+            catch (Exception)
+            {
+                // RegionEndpoint resolution can probe ambient configuration; ignore and
+                // use the generic fallback below
+            }
+
+            return new Uri("sns://amazon");
+        }
+    }
 
     [DescribeAsConfigurationState]
     public Func<IWolverineRuntime, AWSCredentials>? CredentialSource { get; set; }

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/AmazonSqsTransportTests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/AmazonSqsTransportTests.cs
@@ -1,3 +1,4 @@
+using Amazon;
 using Shouldly;
 using Wolverine.AmazonSqs.Internal;
 
@@ -5,6 +6,35 @@ namespace Wolverine.AmazonSqs.Tests;
 
 public class AmazonSqsTransportTests
 {
+    [Fact]
+    public void resource_uri_uses_explicit_service_url_when_set()
+    {
+        var transport = new AmazonSqsTransport();
+        transport.Config.ServiceURL = "http://localhost:4566";
+
+        transport.ResourceUri.ShouldBe(new Uri("http://localhost:4566"));
+    }
+
+    [Fact]
+    public void resource_uri_falls_back_to_region_when_service_url_not_set()
+    {
+        // Reproduces #3115 -- setting only RegionEndpoint used to throw
+        // ArgumentNullException from new Uri(Config.ServiceURL)
+        var transport = new AmazonSqsTransport();
+        transport.Config.RegionEndpoint = RegionEndpoint.USWest2;
+
+        transport.ResourceUri.ShouldBe(new Uri("https://sqs.us-west-2.amazonaws.com"));
+    }
+
+    [Fact]
+    public void resource_uri_does_not_throw_when_neither_service_url_nor_region_set()
+    {
+        var transport = new AmazonSqsTransport();
+
+        // Should not throw an ArgumentNullException
+        Should.NotThrow(() => transport.ResourceUri);
+    }
+
     [Theory]
     [InlineData("good.fifo", "good.fifo")]
     [InlineData("good", "good")]

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
@@ -36,7 +36,35 @@ public class AmazonSqsTransport : BrokerTransport<AmazonSqsQueue>
 
     }
 
-    public override Uri ResourceUri => new Uri(Config.ServiceURL);
+    public override Uri ResourceUri
+    {
+        get
+        {
+            // An explicitly set ServiceURL (e.g. LocalStack) wins
+            if (Config.ServiceURL.IsNotEmpty())
+            {
+                return new Uri(Config.ServiceURL);
+            }
+
+            // Otherwise fall back to the configured region so that this purely
+            // diagnostic Uri doesn't throw when only RegionEndpoint was set
+            try
+            {
+                var region = Config.RegionEndpoint?.SystemName;
+                if (region.IsNotEmpty())
+                {
+                    return new Uri($"https://sqs.{region}.amazonaws.com");
+                }
+            }
+            catch (Exception)
+            {
+                // RegionEndpoint resolution can probe ambient configuration; ignore and
+                // use the generic fallback below
+            }
+
+            return new Uri("sqs://amazon");
+        }
+    }
 
     internal AmazonSqsTransport(IAmazonSQS client) : this()
     {


### PR DESCRIPTION
## Problem

`AmazonSqsTransport.ResourceUri` was implemented as:

```csharp
public override Uri ResourceUri => new Uri(Config.ServiceURL);
```

When the SQS transport is configured with a `RegionEndpoint` (the normal AWS path) rather than an explicit `ServiceURL` (used for LocalStack), `Config.ServiceURL` is `null`, so `new Uri(null)` throws `ArgumentNullException`. `ResourceUri` is documented on `IBrokerTransport` as *purely diagnostic*, so it should never throw.

The sibling `AmazonSnsTransport.ResourceUri` had the identical `new Uri(SnsConfig.ServiceURL)` shape and the same defect.

Closes #3115.

## Fix

Both `AmazonSqsTransport.ResourceUri` and `AmazonSnsTransport.ResourceUri` now:

1. Prefer an explicit `ServiceURL` when set (preserves existing LocalStack behavior).
2. Fall back to a region-derived endpoint (`https://sqs.{region}.amazonaws.com` / `https://sns.{region}.amazonaws.com`) when only `RegionEndpoint` is configured.
3. Use a generic `sqs://amazon` / `sns://amazon` placeholder when neither is configured.

Region resolution is wrapped in a guard since the AWS SDK's `RegionEndpoint` getter can probe ambient configuration — that path can't throw out of a diagnostic property either.

## Tests

Added three broker-free tests to each of `AmazonSqsTransportTests` and `AmazonSnsTransportTests`:
- `resource_uri_uses_explicit_service_url_when_set`
- `resource_uri_falls_back_to_region_when_service_url_not_set` (the #3115 regression)
- `resource_uri_does_not_throw_when_neither_service_url_nor_region_set`

All tests in both suites pass (SQS: 10, SNS: 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)