### PR TITLE
Batch + decouple expired handled-inbox cleanup to stop blocking under load (#3116)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,15 @@ var bus = host.Services.GetRequiredService<IMessageBus>();
 var bus = host.MessageBus();
 ```
 
+### Database connection strings come from `Servers`
+
+Always obtain database connection strings from the `Servers` type (`src/Servers.cs`,
+e.g. `Servers.PostgresConnectionString`, `Servers.SqlServerConnectionString`). **Never
+hardcode a connection string literal in a test.** This keeps host/port/credentials
+centralized and CI-portable — e.g. Wolverine's own docker-compose Postgres runs on port
+**5433** (`docker compose up -d postgresql`), distinct from Marten's `5432`, and only
+`Servers` knows that.
+
 ## Configuration Organization
 
 WolverineOptions uses partial classes to organize concerns:

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
@@ -371,6 +371,9 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
         return new Weasel.Oracle.CommandBuilder();
     }
 
+    // Oracle falls back to an unbounded delete for expired handled envelope cleanup
+    public string? BatchedDeleteExpiredHandledEnvelopesSql(int batchSize) => null;
+
     public Task EnqueueAsync(IDatabaseOperation operation)
     {
         // For Oracle, we execute operations directly since we can't batch

--- a/src/Persistence/PostgresqlTests/PostgresqlMessageStoreTests.cs
+++ b/src/Persistence/PostgresqlTests/PostgresqlMessageStoreTests.cs
@@ -71,6 +71,35 @@ public class PostgresqlMessageStoreTests : MessageStoreCompliance
     }
 
     [Fact]
+    public async Task delete_expired_handled_envelopes_in_batches()
+    {
+        // Regression for #3116 -- batched ctid-based cleanup on the non-partitioned table
+        for (var i = 0; i < 5; i++)
+        {
+            var envelope = ObjectMother.Envelope();
+            await thePersistence.Inbox.StoreIncomingAsync(envelope);
+            await thePersistence.Inbox.MarkIncomingEnvelopeAsHandledAsync(envelope);
+        }
+
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.CreateCommand(
+                    $"update receiver.{DatabaseConstants.IncomingTable} set {DatabaseConstants.KeepUntil} = :cutoff where status = 'Handled'")
+                .With("cutoff", DateTimeOffset.UtcNow.Subtract(1.Hours()))
+                .ExecuteNonQueryAsync();
+            await conn.CloseAsync();
+        }
+
+        var command = new DeleteExpiredHandledEnvelopesCommand((IMessageDatabase)thePersistence,
+            new DurabilitySettings(), Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+        await theHost.InvokeAsync(command);
+
+        var counts = await thePersistence.Admin.FetchCountsAsync();
+        counts.Handled.ShouldBe(0);
+    }
+
+    [Fact]
     public async Task delete_old_log_node_records()
     {
         var nodeRecord1 = new NodeRecord()

--- a/src/Persistence/PostgresqlTests/compliance_using_table_partitioning.cs
+++ b/src/Persistence/PostgresqlTests/compliance_using_table_partitioning.cs
@@ -75,6 +75,37 @@ public class compliance_using_table_partitioning : MessageStoreCompliance
     }
 
     [Fact]
+    public async Task delete_expired_handled_envelopes_in_batches()
+    {
+        // Regression for #3116 -- the batched, ctid-based cleanup has to work against the
+        // partitioned _handled table without spilling across partitions.
+        for (var i = 0; i < 5; i++)
+        {
+            var envelope = ObjectMother.Envelope();
+            await thePersistence.Inbox.StoreIncomingAsync(envelope);
+            await thePersistence.Inbox.MarkIncomingEnvelopeAsHandledAsync(envelope);
+        }
+
+        // Force expiry by pushing keep_until into the past
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.CreateCommand(
+                    $"update receiver_partitioned.{DatabaseConstants.IncomingTable} set {DatabaseConstants.KeepUntil} = :cutoff where status = 'Handled'")
+                .With("cutoff", DateTimeOffset.UtcNow.Subtract(1.Hours()))
+                .ExecuteNonQueryAsync();
+            await conn.CloseAsync();
+        }
+
+        var command = new DeleteExpiredHandledEnvelopesCommand((IMessageDatabase)thePersistence,
+            new DurabilitySettings(), Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+        await theHost.InvokeAsync(command);
+
+        var counts = await thePersistence.Admin.FetchCountsAsync();
+        counts.Handled.ShouldBe(0);
+    }
+
+    [Fact]
     public async Task delete_old_log_node_records()
     {
         var nodeRecord1 = new NodeRecord()

--- a/src/Persistence/SqlServerTests/Persistence/SqlServerMessageStoreTests.cs
+++ b/src/Persistence/SqlServerTests/Persistence/SqlServerMessageStoreTests.cs
@@ -65,6 +65,35 @@ public class SqlServerMessageStoreTests : MessageStoreCompliance
     }
 
     [Fact]
+    public async Task delete_expired_handled_envelopes_in_batches()
+    {
+        // Regression for #3116 -- batched DELETE TOP cleanup on SQL Server
+        for (var i = 0; i < 5; i++)
+        {
+            var envelope = ObjectMother.Envelope();
+            await thePersistence.Inbox.StoreIncomingAsync(envelope);
+            await thePersistence.Inbox.MarkIncomingEnvelopeAsHandledAsync(envelope);
+        }
+
+        await using (var conn = new SqlConnection(Servers.SqlServerConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.CreateCommand(
+                    $"update receiver.{DatabaseConstants.IncomingTable} set {DatabaseConstants.KeepUntil} = @cutoff where status = 'Handled'")
+                .With("cutoff", DateTimeOffset.UtcNow.Subtract(1.Hours()))
+                .ExecuteNonQueryAsync();
+            await conn.CloseAsync();
+        }
+
+        var command = new DeleteExpiredHandledEnvelopesCommand((IMessageDatabase)thePersistence,
+            new DurabilitySettings(), NullLogger.Instance);
+        await theHost.InvokeAsync(command);
+
+        var counts = await thePersistence.Admin.FetchCountsAsync();
+        counts.Handled.ShouldBe(0);
+    }
+
+    [Fact]
     public async Task move_replayable_error_messages_to_incoming()
     {
         /*

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -150,6 +150,18 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>
         }
     }
 
+    public override string? BatchedDeleteExpiredHandledEnvelopesSql(int batchSize)
+    {
+        var table = $"{QuotedSchemaName}.{DatabaseConstants.IncomingTable}";
+
+        // Bound the delete via ctid so each statement holds locks for a short time. The status
+        // filter on both the inner select and the outer delete keeps partition pruning (and thus
+        // ctid uniqueness) scoped to the _handled partition when inbox partitioning is enabled.
+        return
+            $"delete from {table} where {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}' and ctid in " +
+            $"(select ctid from {table} where {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}' and {DatabaseConstants.KeepUntil} <= :now limit {batchSize});";
+    }
+
     public override ISchemaObject AddExternalMessageTable(ExternalMessageTable definition)
     {
         var table = new Table(definition.TableName);

--- a/src/Persistence/Wolverine.RDBMS/Durability/DeleteExpiredHandledEnvelopesCommand.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/DeleteExpiredHandledEnvelopesCommand.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Logging;
+using Weasel.Core;
+using Wolverine.RDBMS.Polling;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+
+namespace Wolverine.RDBMS.Durability;
+
+/// <summary>
+/// Background cleanup of expired, successfully handled incoming envelopes. Unlike the rest of the
+/// recovery loop, this runs on its own timer in a dedicated transaction and, for providers that
+/// support it, deletes in bounded batches so locks are held only briefly. This keeps the cleanup
+/// from blocking live inbox traffic and recovery work under heavy load (see issue #3116).
+/// </summary>
+internal class DeleteExpiredHandledEnvelopesCommand : IAgentCommand
+{
+    private readonly IMessageDatabase _database;
+    private readonly DurabilitySettings _settings;
+    private readonly ILogger _logger;
+
+    public DeleteExpiredHandledEnvelopesCommand(IMessageDatabase database, DurabilitySettings settings, ILogger logger)
+    {
+        _database = database;
+        _settings = settings;
+        _logger = logger;
+    }
+
+    public async Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var batchSize = _settings.HandledMessageCleanupBatchSize;
+        var sql = _database.BatchedDeleteExpiredHandledEnvelopesSql(batchSize);
+
+        if (string.IsNullOrEmpty(sql))
+        {
+            // This provider can't bound the delete; fall back to a single unbounded delete, but
+            // still on this dedicated timer and transaction, off the main recovery loop.
+            var incomingTable = new DbObjectName(_database.SchemaName, DatabaseConstants.IncomingTable);
+            var fallback = new DatabaseOperationBatch(_database,
+                [new DeleteExpiredEnvelopesOperation(incomingTable, now)]);
+            return await fallback.ExecuteAsync(runtime, cancellationToken);
+        }
+
+        var total = 0;
+        for (var i = 0; i < _settings.HandledMessageCleanupMaxBatchesPerCycle; i++)
+        {
+            if (cancellationToken.IsCancellationRequested) break;
+
+            await using var conn = await _database.DataSource.OpenConnectionAsync(cancellationToken);
+
+            int deleted;
+            try
+            {
+                deleted = await conn.CreateCommand(sql)
+                    .With("now", now)
+                    .ExecuteNonQueryAsync(cancellationToken);
+            }
+            finally
+            {
+                await conn.CloseAsync();
+            }
+
+            total += deleted;
+
+            // A short batch means we've drained everything that's currently expired
+            if (deleted < batchSize) break;
+        }
+
+        if (total > 0)
+        {
+            _logger.LogDebug("Deleted {Count} expired, handled incoming envelopes from database {Database}",
+                total, _database.Name);
+        }
+
+        return AgentCommands.Empty;
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
+++ b/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
@@ -29,6 +29,7 @@ internal class DurabilityAgent : IAgent
     private PersistenceMetrics _metrics = null!;
     private Timer? _recoveryTimer;
     private Timer? _scheduledJobTimer;
+    private Timer? _handledCleanupTimer;
 
     private readonly DurabilityHealthSignals _health;
     private DateTime _lastHealthCheck = DateTime.UtcNow;
@@ -122,6 +123,12 @@ internal class DurabilityAgent : IAgent
             }, _settings, 1.Minutes(), 1.Hours());
         }
 
+        _handledCleanupTimer = new Timer(_ =>
+        {
+            var command = new DeleteExpiredHandledEnvelopesCommand(_database, _settings, _logger);
+            _runningBlock.Post(command);
+        }, _settings, 5.Seconds(), _settings.HandledMessageCleanupPollingTime);
+
         if (AutoStartScheduledJobPolling)
         {
             StartScheduledJobPolling();
@@ -148,6 +155,11 @@ internal class DurabilityAgent : IAgent
         if (_expirationTimer != null)
         {
             await _expirationTimer.DisposeAsync();
+        }
+
+        if (_handledCleanupTimer != null)
+        {
+            await _handledCleanupTimer.DisposeAsync();
         }
 
         Status = AgentStatus.Stopped;
@@ -202,8 +214,9 @@ internal class DurabilityAgent : IAgent
         [
             new CheckRecoverableIncomingMessagesOperation(_database, _runtime.Endpoints, _settings, _logger),
             new CheckRecoverableOutgoingMessagesOperation(_database, _runtime, _logger),
-            new DeleteExpiredEnvelopesOperation(
-                incomingTable, now),
+            // Expired, handled inbox envelopes are cleaned up on a separate, slower timer
+            // (see _handledCleanupTimer / DeleteExpiredHandledEnvelopesCommand) so a large
+            // cleanup delete can't block recovery work in this shared transaction (issue #3116).
             new MoveReplayableErrorMessagesToIncomingOperation(_database)
         ];
 

--- a/src/Persistence/Wolverine.RDBMS/IMessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/IMessageDatabase.cs
@@ -71,6 +71,14 @@ public interface IMessageDatabase : IMessageStoreWithAgentSupport, ITenantDataba
 
     DbCommandBuilder ToCommandBuilder();
 
+    /// <summary>
+    /// Builds a provider-specific SQL statement that deletes at most <paramref name="batchSize"/>
+    /// expired, successfully handled incoming envelopes in a single statement. The SQL should
+    /// expose a single "now" parameter for the cutoff timestamp. Return null if this provider
+    /// cannot bound the delete, in which case the cleanup falls back to a single unbounded delete.
+    /// </summary>
+    string? BatchedDeleteExpiredHandledEnvelopesSql(int batchSize);
+
     Task EnqueueAsync(IDatabaseOperation operation);
     void WriteLoadScheduledEnvelopeSql(DbCommandBuilder builder, DateTimeOffset utcNow);
     Task PollForScheduledMessagesAsync(IWolverineRuntime runtime, ILogger runtimeLogger,

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
@@ -263,6 +263,13 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
 
     public abstract DbCommandBuilder ToCommandBuilder();
 
+    /// <summary>
+    /// Default implementation returns null, meaning "this provider cannot bound the
+    /// expired-handled-envelope delete". PostgreSQL and SQL Server override this to enable
+    /// batched cleanup. See <see cref="IMessageDatabase.BatchedDeleteExpiredHandledEnvelopesSql"/>.
+    /// </summary>
+    public virtual string? BatchedDeleteExpiredHandledEnvelopesSql(int batchSize) => null;
+
     public abstract Task<bool> ExistsAsync(Envelope envelope, CancellationToken cancellation);
 
     public async Task ReleaseIncomingAsync(int ownerId, Uri receivedAt)

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -146,6 +146,15 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>
         return false;
     }
 
+    public override string? BatchedDeleteExpiredHandledEnvelopesSql(int batchSize)
+    {
+        // DELETE TOP bounds each statement so locks are held only briefly, reducing contention
+        // with live inbox traffic under heavy load.
+        return
+            $"delete top ({batchSize}) from {SchemaName}.{DatabaseConstants.IncomingTable} " +
+            $"where {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}' and {DatabaseConstants.KeepUntil} <= @now;";
+    }
+
     protected override void writePagingAfter(DbCommandBuilder builder, int offset, int limit)
     {
         if (offset == 0) return;

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -138,6 +138,29 @@ public class DurabilitySettings : IDescribeMyself
     public TimeSpan KeepAfterMessageHandling { get; set; } = 5.Minutes();
 
     /// <summary>
+    ///     Polling interval for the background cleanup of expired, successfully handled incoming
+    ///     envelopes (the idempotency records). This cleanup runs on its own timer in a dedicated
+    ///     transaction, separate from the main recovery loop, so a slow cleanup cannot block inbox
+    ///     recovery work. Default is 1 minute.
+    /// </summary>
+    public TimeSpan HandledMessageCleanupPollingTime { get; set; } = 1.Minutes();
+
+    /// <summary>
+    ///     The maximum number of expired, handled incoming envelopes deleted in a single bounded
+    ///     DELETE statement for providers that support batching (currently PostgreSQL and SQL Server).
+    ///     Smaller batches hold locks for less time and reduce contention with live inbox traffic
+    ///     under heavy load. Default is 5000.
+    /// </summary>
+    public int HandledMessageCleanupBatchSize { get; set; } = 5000;
+
+    /// <summary>
+    ///     Safety cap on how many delete batches the handled-envelope cleanup runs in a single
+    ///     polling cycle before yielding. Any remaining expired rows are cleaned up on the next
+    ///     cycle. Default is 20.
+    /// </summary>
+    public int HandledMessageCleanupMaxBatchesPerCycle { get; set; } = 20;
+
+    /// <summary>
     ///     Governs the page size for how many persisted incoming or outgoing messages
     ///     will be loaded at one time for attempted retries or scheduled jobs
     /// </summary>


### PR DESCRIPTION
## Problem

Under heavy inbox load (large projection rebuild + high throughput), the scheduled cleanup of handled incoming envelopes stalls (~20s in the reporter's `EXPLAIN`) and blocks other inbox work. Per the analysis in #3116, the ~20s is spent **inside the Delete node** (lock-hold/contention), not the scan — so an index alone wouldn't fix it. Three design factors compound:

1. **Unbounded delete** — one statement removes the entire expired set, holding row locks until commit.
2. **Shared transaction** — `DeleteExpiredEnvelopesOperation` rode in the *same* `DatabaseOperationBatch` transaction as the recovery/move operations, so a slow delete stalls recovery work (and holds the snapshot open against autovacuum).
3. **Every 5 seconds** — it ran unconditionally on the main recovery timer.

## Phase 1 fix (this PR)

- **Dedicated timer + dedicated transaction.** The handled-envelope cleanup is removed from the shared 5s recovery batch (`DurabilityAgent.buildOperationBatch`) and runs on its own timer, mirroring the existing dead-letter expiration timer. A slow cleanup can no longer block recovery.
- **Bounded, short-transaction batches.** For providers that can bound a delete, cleanup loops bounded deletes, each in its own transaction, until drained or a per-cycle cap is hit:
  - **PostgreSQL**: `delete … where status='Handled' and ctid in (select ctid … limit N)`. The `status` guard on both sides keeps partition pruning — and thus `ctid` uniqueness — scoped to the `_handled` partition when inbox partitioning is enabled.
  - **SQL Server**: `DELETE TOP (N) …`.
  - Other providers (Oracle/MySQL/SQLite) fall back to the existing unbounded delete, but now on the dedicated timer/transaction.
- **New `DurabilitySettings` tunables:** `HandledMessageCleanupPollingTime` (default 1 min), `HandledMessageCleanupBatchSize` (default 5000), `HandledMessageCleanupMaxBatchesPerCycle` (default 20).

Provider seam: `IMessageDatabase.BatchedDeleteExpiredHandledEnvelopesSql(int batchSize)` — virtual default `null` on `MessageDatabase<T>` (meaning "no batching"), overridden by PostgreSQL and SQL Server.

> Scope note: Phases 2 (optional `keep_until` index) and 3 (time-range partitioning + `DROP PARTITION`) from the analysis are intentionally **not** included here.

## Tests

New end-to-end batched-cleanup tests (all green):
- **Partitioned PostgreSQL** (`compliance_using_table_partitioning`) — the reporter's exact config; exercises the ctid/partition-pruning path.
- **Non-partitioned PostgreSQL** (`PostgresqlMessageStoreTests`).
- **SQL Server** (`SqlServerMessageStoreTests`).

The full partitioning compliance suite (49 tests) remains green, confirming recovery/move behavior is unaffected by removing the delete from the shared batch.

Also documents the existing "always use the `Servers` type for connection strings in tests" convention in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)