### PR TITLE
Don't start an implicit EF Core transaction on ScheduleAsync for a Wolverine-mapped DbContext (closes #3121)

### DIFF
--- a/src/Persistence/EfCoreTests/end_to_end_efcore_persistence.cs
+++ b/src/Persistence/EfCoreTests/end_to_end_efcore_persistence.cs
@@ -194,6 +194,37 @@ public class end_to_end_efcore_persistence : IClassFixture<EFCorePersistenceCont
     }
 
     [Fact]
+    public async Task persisting_against_mapped_dbcontext_does_not_start_an_explicit_transaction()
+    {
+        await Host.ResetResourceState();
+
+        var envelope = new Envelope
+        {
+            Data = [1, 2, 3, 4],
+            OwnerId = 5,
+            Destination = TransportConstants.RepliesUri,
+            MessageType = "foo",
+            ContentType = EnvelopeConstants.JsonContentType,
+            Status = EnvelopeStatus.Scheduled,
+            ScheduledTime = DateTimeOffset.UtcNow.AddMinutes(1)
+        };
+
+        using var nested = Host.Services.CreateScope();
+        var messaging = nested.ServiceProvider.GetRequiredService<IDbContextOutbox<SampleMappedDbContext>>()
+            .ShouldBeOfType<DbContextOutbox<SampleMappedDbContext>>();
+
+        // Regression for #3121 -- scheduling/incoming persistence against a Wolverine-mapped
+        // DbContext must NOT begin an explicit EF Core transaction. SaveChanges provides its
+        // own implicit transaction, and the outgoing path already behaves this way.
+        await messaging.Transaction!.PersistIncomingAsync(envelope);
+        messaging.DbContext.Database.CurrentTransaction.ShouldBeNull();
+
+        // Symmetry check: the outgoing path likewise leaves the transaction alone
+        await messaging.Transaction!.PersistOutgoingAsync(envelope);
+        messaging.DbContext.Database.CurrentTransaction.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task persist_an_outgoing_envelope_raw()
     {
         await Host.ResetResourceState();

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs
@@ -100,10 +100,14 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
     {
         if (DbContext.IsWolverineEnabled())
         {
-            // For a Wolverine-mapped DbContext the envelope is just tracked and flushed inside
-            // SaveChangesAsync's own implicit transaction, so don't force an explicit transaction.
-            // This mirrors PersistOutgoingAsync and keeps ScheduleAsync from starting a transaction
-            // the caller never asked for (see #3121).
+            // For a Wolverine-mapped DbContext the envelope is just tracked and flushed by
+            // SaveChangesAsync, so don't force an explicit transaction here. We defer to whatever
+            // the ambient transaction mode established: in Eager middleware mode a transaction was
+            // already begun (EnrollDbContextInTransaction / StartDatabaseTransactionForDbContext) and
+            // the tracked entity enrolls into it at SaveChanges; in Lightweight/lazy mode there is no
+            // transaction and SaveChanges provides its own implicit one. This mirrors
+            // PersistOutgoingAsync and keeps ScheduleAsync from starting a transaction the caller
+            // never asked for (see #3121).
             DbContext.Add(new IncomingMessage(envelope));
         }
         else

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs
@@ -98,17 +98,23 @@ public class EfCoreEnvelopeTransaction : IEnvelopeTransaction
 
     public async Task PersistIncomingAsync(Envelope envelope)
     {
-        if (DbContext.Database.CurrentTransaction == null)
-        {
-            await DbContext.Database.BeginTransactionAsync();
-        }
-
         if (DbContext.IsWolverineEnabled())
         {
+            // For a Wolverine-mapped DbContext the envelope is just tracked and flushed inside
+            // SaveChangesAsync's own implicit transaction, so don't force an explicit transaction.
+            // This mirrors PersistOutgoingAsync and keeps ScheduleAsync from starting a transaction
+            // the caller never asked for (see #3121).
             DbContext.Add(new IncomingMessage(envelope));
         }
         else
         {
+            // The raw branch issues an ADO command that has to share the caller's transaction, so
+            // here we do need an explicit one when none is already in flight.
+            if (DbContext.Database.CurrentTransaction == null)
+            {
+                await DbContext.Database.BeginTransactionAsync();
+            }
+
             var conn = DbContext.Database.GetDbConnection();
             var tx = DbContext.Database.CurrentTransaction!.GetDbTransaction();
             var builder = _database.ToCommandBuilder();


### PR DESCRIPTION
## Problem

For a Wolverine-mapped `DbContext`, `IDbContextOutbox.ScheduleAsync` starts an explicit EF Core transaction the caller never asked for, while `PublishAsync` does not:

```csharp
outbox.Enroll(db);
await outbox.PublishAsync(new TestMsg());   // no implicit EF transaction
await outbox.ScheduleAsync(new TestMsg(), TimeSpan.FromMinutes(1));  // starts one ❌
```

## Root cause

`ScheduleAsync` produces an envelope with `EnvelopeStatus.Scheduled`, which `IEnvelopeTransaction.PersistAsync` routes to `PersistIncomingAsync` (`IEnvelopeTransaction.cs:33-34`). `EfCoreEnvelopeTransaction.PersistIncomingAsync` began an explicit transaction **unconditionally, before** checking `IsWolverineEnabled()`. But for a mapped DbContext the envelope is simply tracked via `DbContext.Add(new IncomingMessage(...))` and flushed inside `SaveChangesAsync`'s own implicit transaction — the explicit one is pure overhead.

This is an oversight from a prior refactor, not a deliberate tradeoff. Commit `5af99ae93` ("Outbox behavior alignment with EF Core transaction model") moved the unconditional `BeginTransactionAsync` out of **both** `PersistOutgoingAsync` overloads into their raw (non-mapped) branch — but left `PersistIncomingAsync` untouched. That's the entire asymmetry the reporter sees.

## Fix

Apply the same alignment to `PersistIncomingAsync`: only begin an explicit transaction in the **raw / non-`IsWolverineEnabled`** branch (where an ADO command must share the caller's transaction). The mapped branch just tracks the entity, exactly like `PersistOutgoingAsync`. One method; no API change.

The two other callers are unaffected:
- `TryMakeEagerIdempotencyCheckAsync` begins its own explicit transaction (`EfCoreEnvelopeTransaction.cs:140-143`).
- `CommitAsync`'s handled-idempotency insert already relied on a later `SaveChanges` to flush the tracked `Add`, not on this forced transaction.

## Tests

- New regression test `persisting_against_mapped_dbcontext_does_not_start_an_explicit_transaction` — asserts that persisting a scheduled/incoming **and** an outgoing envelope against a Wolverine-mapped DbContext leaves `Database.CurrentTransaction` null.
- The full `end_to_end_efcore_persistence` class + eager-idempotency tests (23 total) remain green, confirming the raw-mode persistence and idempotency paths are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)