### PR TITLE
Fix HTTP codegen infinite loop for [AsParameters] + [ReadAggregate]/[WriteAggregate]

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Marten/using_read_aggregate_attribute.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/using_read_aggregate_attribute.cs
@@ -62,4 +62,21 @@ public class using_read_aggregate_attribute(AppFixture fixture) : IntegrationCon
         var result = await Host.GetAsJson<Order>("/orders/latest/from-query?id=" + id);
         result!.Items.Keys.ShouldContain("Socks");
     }
+
+    [Fact]
+    public async Task happy_path_reading_aggregate_with_id_from_asparameters_route()
+    {
+        var id = Guid.NewGuid();
+
+        // Creating a new order
+        await Scenario(x =>
+        {
+            x.Post.Json(new StartOrderWithId(id, ["Socks", "Shoes", "Shirt"])).ToUrl("/orders/create4");
+        });
+
+        // The route id flows through an [AsParameters] object while [ReadAggregate] resolves the
+        // aggregate from that same id (previously this combination looped forever in codegen)
+        var result = await Host.GetAsJson<Order>("/orders/latest/asparameters/" + id);
+        result!.Items.Keys.ShouldContain("Socks");
+    }
 }

--- a/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
@@ -35,7 +35,9 @@ internal class AsParamatersAttributeUsage : IParameterStrategy
             chain.RequestType = parameter.ParameterType;
             chain.AsParametersType = parameter.ParameterType;
             chain.IsFormData = true;
-            variable = new AsParametersBindingFrame(parameter.ParameterType, chain, container).Variable;
+            var bindingFrame = new AsParametersBindingFrame(parameter.ParameterType, chain, container);
+            chain.AsParametersVariable = bindingFrame.Variable;
+            variable = bindingFrame.Variable;
             return true;
         }
 

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -207,6 +207,27 @@ public partial class HttpChain
 
     public override bool TryFindVariable(string valueName, ValueSource source, Type valueType, out Variable variable)
     {
+        // When the endpoint binds a parameter object via [AsParameters], a value that lives on that
+        // object must be read off it rather than via the route/query read frames that
+        // AsParametersBindingFrame owns and generates inline. Resolving to one of those owned frames
+        // (e.g. Marten's [ReadAggregate]/[WriteAggregate] aggregate-id resolution, which searches with
+        // ValueSource.Anything) makes the frame get pulled into the method's frame chain a second time,
+        // producing a cyclic Next reference and a StackOverflow during code generation. Scoped to
+        // ValueSource.Anything so specific-source bindings are unaffected.
+        if (source == ValueSource.Anything && AsParametersVariable != null && AsParametersType != null)
+        {
+            var asParameterMember = (MemberInfo?)AsParametersType.GetProperties()
+                    .FirstOrDefault(x => x.Name.EqualsIgnoreCase(valueName) && x.PropertyType == valueType && x.CanRead)
+                ?? AsParametersType.GetFields()
+                    .FirstOrDefault(x => x.Name.EqualsIgnoreCase(valueName) && x.FieldType == valueType);
+
+            if (asParameterMember != null)
+            {
+                variable = new MemberAccessVariable(AsParametersVariable, asParameterMember);
+                return true;
+            }
+        }
+
         if ((source == ValueSource.RouteValue || source == ValueSource.Anything) && FindRouteVariable(valueType, valueName, out variable!))
         {
             return true;

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -863,6 +863,17 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
     /// FluentValidation to also validate the AsParameters type itself.
     /// </summary>
     public Type? AsParametersType { get; internal set; }
+
+    /// <summary>
+    /// The codegen variable for the object bound from an <c>[AsParameters]</c> parameter, if any.
+    /// Other middleware that searches for a value with <see cref="ValueSource.Anything"/> (notably the
+    /// Marten <c>[ReadAggregate]</c>/<c>[WriteAggregate]</c> aggregate-id resolution) reads members off
+    /// this object rather than re-using the route/query read frames that <c>AsParametersBindingFrame</c>
+    /// owns and generates inline — sharing those owned frames produces a cyclic Next reference and a
+    /// StackOverflow during code generation.
+    /// </summary>
+    public Variable? AsParametersVariable { get; internal set; }
+
     public ServiceProviderSource ServiceProviderSource { get; set; } = ServiceProviderSource.IsolatedAndScoped;
 
     internal Variable BuildJsonDeserializationVariable()

--- a/src/Http/WolverineWebApi/Marten/Orders.cs
+++ b/src/Http/WolverineWebApi/Marten/Orders.cs
@@ -328,7 +328,15 @@ public static class MarkItemEndpoint
     
     [WolverineGet("/orders/latest/from-query")]
     public static Order GetLatestFromQuery([FromQuery] Guid id, [ReadAggregate] Order order) => order;
+
+    // Repro for the [AsParameters] + [ReadAggregate] + route-id combination (codegen infinite loop)
+    [WolverineGet("/orders/latest/asparameters/{id}")]
+    public static Order GetLatestViaAsParameters(
+        [Microsoft.AspNetCore.Http.AsParameters] GetLatestOrderQuery query,
+        [ReadAggregate] Order order) => order;
 }
+
+public record GetLatestOrderQuery([FromRoute] Guid Id);
 
 #region sample_write_aggregate_from_method
 public record ConfirmOrderFromMethod;


### PR DESCRIPTION
## Problem

A hybrid message-handler / HTTP endpoint that uses Marten with `[ReadAggregate]` (or `[WriteAggregate]`), brings the aggregate identifier through a **route argument**, **and** binds the request with `[AsParameters]` sends HTTP code generation into an **infinite loop** (StackOverflow), so the app can't boot.

Reproduction (the reported shape):

```csharp
public record GetJourney([FromRoute] Guid JourneyId);

public static class GetJourneyHandler
{
    [WolverineGet("/api/example-event-sourcing/journey/{journeyId:guid}")]
    public static JourneyResponse Handle([AsParameters] GetJourney query, [ReadAggregate] Journey journey)
        => JourneyResponse.From(journey);
}
```

## Root cause (all in code generation)

The cyclic `Next` chain that overflows the stack:

```
AsParametersBindingFrame.GenerateCode
 → TagHttpHandlerFrame → OpenMartenSessionFrame → CreateMessageContextWithMaybeTenantFrame
 → ReadHttpFrame.GenerateCode
 → AsParametersBindingFrame.GenerateCode   ← cycles forever
```

`AsParametersBindingFrame` **owns** the route-read `ReadHttpFrame` for the id and generates it inline (as a constructor argument of the bound `query` object). The `[ReadAggregate]`/`[WriteAggregate]` identity resolution searches with `ValueSource.Anything`, and `HttpChain.TryFindVariable` returned that **same owned route `Variable`**. The aggregate-loader frame therefore depended on it, so `MethodFrameArranger` pulled the owned `ReadHttpFrame` into the method chain and gave it a `Next` — and generating it inline re-entered the whole chain, forever.

(This only happens with `[AsParameters]`: a plain route param or `[FromQuery]` id binds to a standalone frame that nothing re-embeds, so there's no cycle — which is why the existing `/orders/latest/{id}` and `…/from-query` endpoints work.)

## Fix

When an endpoint binds an `[AsParameters]` object, a `ValueSource.Anything` lookup for a value that lives on that object now resolves to a **member access on the bound object** (`query.Id`) instead of the route/query read frame that `AsParametersBindingFrame` owns and generates inline. The aggregate loader then depends on the `[AsParameters]` object (a normal standalone frame in the chain) rather than on the inline-generated read frame — no cyclic `Next`.

- New `HttpChain.AsParametersVariable`, set by the `[AsParameters]` strategy.
- `HttpChain.TryFindVariable` short-circuits to `new MemberAccessVariable(AsParametersVariable, member)` for matching members, **scoped to `ValueSource.Anything`** so specific-source (`RouteValue`/`FromQuery`/`Header`) bindings are untouched.

Generated code is now straightforward and correct:

```csharp
var getLatestOrderQuery = new GetLatestOrderQuery(Id);
var order = await documentSession.Events.FetchLatest<Order>(getLatestOrderQuery.Id, httpContext.RequestAborted);
```

## Tests

- New end-to-end test `happy_path_reading_aggregate_with_id_from_asparameters_route` exercising the route-id-through-`[AsParameters]` + `[ReadAggregate]` combination (would hang on regression), plus the sample endpoint in `WolverineWebApi`.
- **Entire `Wolverine.Http.Tests` suite run locally: 779 passed, 10 skipped, 0 failed** — no regressions in the regression-prone HTTP codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)