### PR TITLE
Best-effort teardown ownership release + 'resources check' detects missing schema (closes #3123)

### DIFF
--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
@@ -181,6 +181,27 @@ public abstract partial class MessageDatabase<T>
         await conn.CloseAsync();
     }
 
+    public async Task AssertStorageExistsAsync(CancellationToken token)
+    {
+        await using var conn = await DataSource.OpenConnectionAsync(token);
+        try
+        {
+            // A reachable database is not enough — the schema/tables can be missing (e.g. never
+            // provisioned, or dropped). Reuse the same Weasel diff the migration path uses so that
+            // 'resources check' reports an un-provisioned schema as unhealthy.
+            var migration = await SchemaMigration.DetermineAsync(conn, token, Objects);
+            if (migration.Difference != SchemaPatchDifference.None)
+            {
+                throw new InvalidOperationException(
+                    $"The Wolverine message storage for database '{Name}' is missing or out of date (schema difference: {migration.Difference}). Run 'resources setup' or enable auto-provisioning.");
+            }
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
     private async Task migrateAsync(DbConnection conn)
     {
         var migration = await SchemaMigration.DetermineAsync(conn, _cancellation, Objects);

--- a/src/Testing/CoreTests/Persistence/release_all_ownership_is_best_effort.cs
+++ b/src/Testing/CoreTests/Persistence/release_all_ownership_is_best_effort.cs
@@ -1,0 +1,46 @@
+using CoreTests.Runtime;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Durability;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+// Regression for #3124's sibling teardown bug #3123: when teardown runs after a failed/partial
+// startup, an ancillary store whose schema was never created throws (e.g. PostgreSQL 42P01) from
+// ReleaseAllOwnershipAsync. That must not abort releasing the OTHER stores, nor surface as an
+// unhandled teardown exception that masks the original startup failure.
+public class release_all_ownership_is_best_effort
+{
+    private static IMessageStore StoreFor(string uri, MessageStoreRole role, IMessageStoreAdmin admin)
+    {
+        var store = Substitute.For<IMessageStore>();
+        store.Uri.Returns(new Uri(uri));
+        store.Role.Returns(role);
+        store.Admin.Returns(admin);
+        return store;
+    }
+
+    [Fact]
+    public async Task one_failing_store_does_not_stop_the_others_or_throw()
+    {
+        var failingAdmin = Substitute.For<IMessageStoreAdmin>();
+        failingAdmin.ReleaseAllOwnershipAsync(Arg.Any<int>())
+            .Returns(Task.FromException(new InvalidOperationException("42P01: relation does not exist")));
+
+        var healthyAdmin = Substitute.For<IMessageStoreAdmin>();
+        healthyAdmin.ReleaseAllOwnershipAsync(Arg.Any<int>()).Returns(Task.CompletedTask);
+
+        var failing = StoreFor("wolverinedb://fake/ancillary-without-schema", MessageStoreRole.Ancillary, failingAdmin);
+        var healthy = StoreFor("wolverinedb://fake/main", MessageStoreRole.Ancillary, healthyAdmin);
+
+        var collection = new MessageStoreCollection(new MockWolverineRuntime(), [failing, healthy], []);
+
+        // Must not throw even though one store's release fails
+        await Should.NotThrowAsync(() => collection.ReleaseAllOwnershipAsync(5));
+
+        // And the healthy store must still have had its ownership released
+        await healthyAdmin.Received().ReleaseAllOwnershipAsync(5);
+    }
+}

--- a/src/Wolverine/Persistence/Durability/IMessageStoreAdmin.cs
+++ b/src/Wolverine/Persistence/Durability/IMessageStoreAdmin.cs
@@ -60,6 +60,14 @@ public interface IMessageStoreAdmin
     public Task CheckConnectivityAsync(CancellationToken token);
 
     /// <summary>
+    ///     Verify that the durable envelope storage objects (schema/tables) actually exist and match the
+    ///     configured schema, throwing when they do not. Used by <c>resources check</c> so a missing or
+    ///     un-provisioned schema is reported as unhealthy rather than passing on connectivity alone.
+    ///     The default is a no-op for stores that don't support schema introspection.
+    /// </summary>
+    Task AssertStorageExistsAsync(CancellationToken token) => Task.CompletedTask;
+
+    /// <summary>
     ///     Apply any necessary database migrations to bring the underlying envelope
     ///     storage to the configured requirements of the Wolverine system
     /// </summary>

--- a/src/Wolverine/Persistence/Durability/MessageStoreResource.cs
+++ b/src/Wolverine/Persistence/Durability/MessageStoreResource.cs
@@ -18,9 +18,13 @@ internal class MessageStoreResource : IStatefulResource
     public Uri SubjectUri { get; }
     public Uri ResourceUri { get; }
 
-    public Task Check(CancellationToken token)
+    public async Task Check(CancellationToken token)
     {
-        return _persistence.Admin.CheckConnectivityAsync(token);
+        await _persistence.Admin.CheckConnectivityAsync(token);
+
+        // Connectivity alone isn't enough for "resources check" — verify the schema/tables actually
+        // exist so a missing or un-provisioned storage schema is reported as unhealthy.
+        await _persistence.Admin.AssertStorageExistsAsync(token);
     }
 
     public Task ClearState(CancellationToken token)

--- a/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
@@ -474,6 +474,11 @@ public partial class MultiTenantedMessageStore : IMessageStore, IMessageInbox, I
         return executeOnAllAsync(d => d.Admin.CheckConnectivityAsync(token));
     }
 
+    Task IMessageStoreAdmin.AssertStorageExistsAsync(CancellationToken token)
+    {
+        return executeOnAllAsync(d => d.Admin.AssertStorageExistsAsync(token));
+    }
+
     async Task IMessageStoreAdmin.MigrateAsync()
     {
         if (!_initialized)

--- a/src/Wolverine/Persistence/MessageStoreCollection.cs
+++ b/src/Wolverine/Persistence/MessageStoreCollection.cs
@@ -2,6 +2,7 @@ using ImTools;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
+using Microsoft.Extensions.Logging;
 using Wolverine.Persistence.Durability;
 using Wolverine.Persistence.Durability.DeadLetterManagement;
 using Wolverine.Runtime;
@@ -319,9 +320,25 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
 
     public async Task ReleaseAllOwnershipAsync(int nodeNumber)
     {
-        foreach (var store in  _services.Enumerate().Select(x => x.Value))
+        // Best-effort, per store. This runs during teardown — including after a FAILED or partial
+        // startup, where an ancillary store's schema (e.g. wolverine_incoming_envelopes) may never
+        // have been created and the release UPDATE throws (PostgreSQL 42P01, etc.). Releasing
+        // ownership is itself optional: any envelopes left as owner_id = nodeNumber are reclaimed by
+        // the durability agent's recovery polling on the next live node. So a single failing store
+        // must not abort releasing the others, nor surface as an unhandled teardown error that masks
+        // the real startup failure. See GH-3123.
+        foreach (var store in _services.Enumerate().Select(x => x.Value))
         {
-            await store.Admin.ReleaseAllOwnershipAsync(nodeNumber);
+            try
+            {
+                await store.Admin.ReleaseAllOwnershipAsync(nodeNumber);
+            }
+            catch (Exception e)
+            {
+                _runtime.Logger.LogDebug(e,
+                    "Error while releasing node ownership for message store {Store} during teardown. This is safe to ignore; ownership is reclaimed by recovery polling.",
+                    store.Name);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

When host startup aborts (e.g. a Marten schema-migration error), teardown threw an **uncaught** `Npgsql.PostgresException 42P01: relation "<schema>.wolverine_incoming_envelopes" does not exist` from `MessageStoreCollection.ReleaseAllOwnershipAsync`, masking the real startup failure. Ancillary stores are registered before schema migration, so after a failed/partial startup their tables may not exist; the per-store `UPDATE` had no guard, the loop had no per-iteration try/catch (so the first failure stranded the other stores too), and `StopAsync` doesn't catch `PostgresException`.

## Fix (two parts)

**1. Best-effort teardown ownership release.** `MessageStoreCollection.ReleaseAllOwnershipAsync` now wraps each store's release in a `try/catch` that logs at `Debug` and continues. Releasing ownership on teardown is optional — orphaned envelopes are reclaimed by the durability agent's recovery polling on the next live node — so a missing schema must neither strand the other stores nor surface as an unhandled teardown error.

**2. `resources check` now detects a missing/un-provisioned schema.** Making teardown stop throwing exposed that `MessageStoreResource.Check` (what `resources check` runs) only verified **connectivity** (`CheckConnectivityAsync` just opens/closes a connection). A reachable database with a dropped schema still passed — so the existing `check_negative` smoke test was getting its non-zero exit code *only from the teardown crash*, not from the check.

Added `IMessageStoreAdmin.AssertStorageExistsAsync` (default no-op, so non-RDBMS stores are unaffected), implemented for RDBMS stores by reusing the **same Weasel schema diff the migration path already uses** (`SchemaMigration.DetermineAsync`) and throwing when the schema is missing or out of date. `MessageStoreResource.Check` calls it after the connectivity check; `MultiTenantedMessageStore` forwards to every database. **No Weasel change required.** `IStatefulResource.Check` is only invoked by the `resources check` command (not normal startup), so there's no startup regression.

## Tests

- New unit test `release_all_ownership_is_best_effort` — a failing store neither aborts releasing the others nor throws.
- The existing `stateful_resource_smoke_tests.check_negative` now passes **because the check genuinely detects the missing schema** (exit 1), not because teardown crashed.
- Full `SqlServerTests` suite green (358 passed, 1 skipped); SqlServer + Postgres stateful-resource smoke tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)