### PR TITLE
Resolve per-tenant agent URI under database-per-tenant in FindAgentUriAsync (closes #3128)

### DIFF
--- a/src/Persistence/MartenTests/Distribution/find_agent_uri_per_tenant_database.cs
+++ b/src/Persistence/MartenTests/Distribution/find_agent_uri_per_tenant_database.cs
@@ -1,0 +1,52 @@
+using JasperFx.Core;
+using JasperFx.Events.Projections;
+using Marten;
+using MartenTests.Distribution.Support;
+using MartenTests.Distribution.TripDomain;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten.Distribution;
+using Wolverine.Runtime.Agents;
+using Xunit.Abstractions;
+
+namespace MartenTests.Distribution;
+
+// Regression for #3128: under database-per-tenant (sharded databases) FindAgentUriAsync must resolve
+// a registered shard's agent URI for a specific tenant by mapping tenantId -> its database.
+public class find_agent_uri_per_tenant_database(ITestOutputHelper output) : MultiTenantContext(output)
+{
+    protected override void SetupProjections(StoreOptions storeOptions)
+    {
+        storeOptions.Projections.Add<TripProjection>(ProjectionLifecycle.Async);
+        storeOptions.Projections.Add<DayProjection>(ProjectionLifecycle.Async);
+        storeOptions.Projections.Add<DistanceProjection>(ProjectionLifecycle.Async);
+    }
+
+    [Fact]
+    public async Task resolves_per_tenant_agent_uri()
+    {
+        string[] tenants = ["tenant1", "tenant2"];
+        await AddTenantsAsync(tenants);
+
+        // Wait until the tenant databases are picked up by the distribution (3 projections x 2 tenants)
+        await theOriginalHost.WaitUntilAssignmentsChangeTo(w =>
+        {
+            w.AgentScheme = EventSubscriptionAgentFamily.SchemeName;
+            w.ExpectRunningAgents(theOriginalHost, 6);
+        }, 60.Seconds());
+
+        var family = theOriginalHost.Services.GetServices<IAgentFamily>()
+            .OfType<EventSubscriptionAgentFamily>().Single();
+
+        (await family.FindAgentUriAsync("Trip:All", "tenant1"))!.AbsoluteUri
+            .ShouldBe("event-subscriptions://marten/main/localhost.tenant1/trip/all");
+
+        (await family.FindAgentUriAsync("Day:All", "tenant2"))!.AbsoluteUri
+            .ShouldBe("event-subscriptions://marten/main/localhost.tenant2/day/all");
+
+        // An unknown tenant still resolves to nothing
+        (await family.FindAgentUriAsync("Trip:All", "tenant-nope")).ShouldBeNull();
+    }
+}

--- a/src/Persistence/Wolverine.Marten/Distribution/EventStoreAgents.cs
+++ b/src/Persistence/Wolverine.Marten/Distribution/EventStoreAgents.cs
@@ -114,6 +114,29 @@ internal class EventStoreAgents : IAsyncDisposable
         return list;
     }
 
+    /// <summary>
+    /// Resolve the <see cref="DatabaseId" /> backing <paramref name="tenantId" /> under database-per-tenant
+    /// multi-tenancy, using the store-agnostic tenant→database mapping carried on the usage descriptor.
+    /// Returns null when the tenant isn't found (e.g. single-database tenancy, or an unknown tenant). See GH-3128.
+    /// </summary>
+    public async ValueTask<DatabaseId?> TryResolveTenantDatabaseIdAsync(string tenantId, CancellationToken cancellation)
+    {
+        var usage = await _store.TryCreateUsage(cancellation);
+        if (usage?.Database == null)
+        {
+            return null;
+        }
+
+        var candidates = usage.Database.Databases.ToList();
+        if (usage.Database.MainDatabase != null)
+        {
+            candidates.Add(usage.Database.MainDatabase);
+        }
+
+        var match = candidates.FirstOrDefault(db => db.TenantIds.Contains(tenantId, StringComparer.OrdinalIgnoreCase));
+        return match == null ? null : new DatabaseId(match.ServerName, match.DatabaseName);
+    }
+
     public async Task<EventSubscriptionAgent> BuildAgentAsync(Uri uri, DatabaseId databaseId, string shardPath)
     {
         var shardName = _shardNames.FirstOrDefault(x => x.RelativeUrl == shardPath);

--- a/src/Persistence/Wolverine.Marten/Distribution/EventSubscriptionAgentFamily.cs
+++ b/src/Persistence/Wolverine.Marten/Distribution/EventSubscriptionAgentFamily.cs
@@ -32,10 +32,10 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
     /// lives here, not in the consumer. Returns <c>null</c> when no matching registered shard is
     /// found.</para>
     ///
-    /// <para>Handles store-global shards and single-database per-tenant partitioning (where the tenant
-    /// is part of the shard's <c>RelativeUrl</c>). Database-per-tenant resolution (tenant in the
-    /// database segment) is matched only for the store-global case here; a per-tenant lookup in that
-    /// model needs a tenant→database resolution and is handled separately.</para>
+    /// <para>Handles store-global shards, single-database per-tenant partitioning (where the tenant is
+    /// part of the shard's <c>RelativeUrl</c>), and database-per-tenant (sharded databases) — for the
+    /// latter, a non-null <paramref name="tenantId" /> is resolved to its <c>DatabaseId</c> via the
+    /// store's tenant→database mapping and matched by the database segment of the agent URI (GH-3128).</para>
     /// </summary>
     public async ValueTask<Uri?> FindAgentUriAsync(string shardIdentity, string? tenantId,
         CancellationToken token = default)
@@ -54,7 +54,31 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
 
         // Single-database per-tenant partitioning: the tenant rides in the shard RelativeUrl.
         var perTenant = ShardName.Compose(baseName.Name, baseName.ShardKey, tenantId);
-        return known.FirstOrDefault(u => MatchesShard(u, perTenant.RelativeUrl));
+        var partitioned = known.FirstOrDefault(u => MatchesShard(u, perTenant.RelativeUrl));
+        if (partitioned != null)
+        {
+            return partitioned;
+        }
+
+        // Database-per-tenant (sharded databases): the shard RelativeUrl is identical across tenant
+        // databases, so resolve the tenant's database and match the base-shard agent URI in it. See GH-3128.
+        foreach (var entry in _stores.Enumerate())
+        {
+            var agents = entry.Value;
+            var databaseId = await agents.TryResolveTenantDatabaseIdAsync(tenantId, token).ConfigureAwait(false);
+            if (databaseId == null)
+            {
+                continue;
+            }
+
+            var candidate = UriFor(agents.Identity, databaseId, baseName);
+            if (known.Contains(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
     }
 
     private static bool MatchesShard(Uri agentUri, string relativeUrl)


### PR DESCRIPTION
## Problem

`IEventSubscriptionAgentFamily.FindAgentUriAsync(shardIdentity, tenantId, ct)` resolves registered shards regardless of run state (delivered in #3126), but a non-null `tenantId` was only handled for **single-database** per-tenant partitioning (tenant in the shard `RelativeUrl`). Under **database-per-tenant** (sharded databases, e.g. `MultiTenantedWithShardedDatabases`) it returned null, so CritterWatch couldn't pause/restart/rebuild a projection for a specific tenant. Follow-up to #3124.

## Why it returned null

Agent URIs are `event-subscriptions://{type}/{name}/{databaseId}/{shard.RelativeUrl}`. Under database-per-tenant each tenant has its **own `{databaseId}`** while the shard `RelativeUrl` is identical across tenant databases (`.../localhost.tenant1/trip/all`, `.../localhost.tenant2/trip/all`, …). The old per-tenant path only matched a tenant-in-`RelativeUrl` shape, which never matches in this model.

## Fix

Resolve the tenant to its database and match the base-shard agent URI in that database — using the **store-agnostic `tenant → database` mapping already carried on the usage descriptor** (`DatabaseDescriptor.TenantIds`), so **no Marten/JasperFx change is required**:

- `EventStoreAgents.TryResolveTenantDatabaseIdAsync(tenantId, ct)` looks up the `DatabaseId` whose descriptor lists `tenantId` (via `IEventStore.TryCreateUsage()`).
- `FindAgentUriAsync` adds a database-per-tenant branch (after the existing single-database-partitioning attempt): resolve `tenantId → DatabaseId` per store, reconstruct the expected URI with `UriFor(...)`, and return it if it's among the supported agents.

The existing behavior is untouched: store-global (`null` tenant) and single-database per-tenant partitioning resolve exactly as before; the new branch only runs when those don't match.

## Tests

- New `find_agent_uri_per_tenant_database` (master-table multi-database tenancy): `FindAgentUriAsync("Trip:All", "tenant1")` → `.../localhost.tenant1/trip/all`, `("Day:All", "tenant2")` → `.../localhost.tenant2/day/all`, and an unknown tenant → null.
- #3124's `find_agent_uri_for_registered_projection` (non-tenant + unregistered) still passes — 3/3 FindAgentUri tests green, confirming no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)