### PR TITLE
Honor ResourceMigrationFailureMode for Wolverine's own startup transport init + store migration (closes #3130)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,13 +32,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.12.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.12.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.12.0" />
+    <PackageVersion Include="JasperFx" Version="2.13.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.13.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.12.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.8.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/src/Testing/CoreTests/Runtime/resource_migration_failure_mode_on_startup.cs
+++ b/src/Testing/CoreTests/Runtime/resource_migration_failure_mode_on_startup.cs
@@ -1,0 +1,58 @@
+using JasperFx;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Runtime;
+
+// Regression for #3130: ResourceMigrationFailureMode must govern Wolverine's OWN startup
+// infrastructure work (transport init / auto-provision and store migration), not just the
+// JasperFx resource-setup hosted service. A transport that fails to initialize should abort
+// startup under FailFast (the default) but be logged-and-skipped under ContinueOnFailures.
+public class resource_migration_failure_mode_on_startup
+{
+    [Fact]
+    public async Task fail_fast_is_the_default_and_aborts_startup()
+    {
+        await Should.ThrowAsync<Exception>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts => opts.Transports.Add(new ThrowingTransport()))
+                .StartAsync();
+        });
+    }
+
+    [Fact]
+    public async Task continue_on_failures_lets_the_application_start()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ResourceMigrationFailureMode = ResourceMigrationFailureMode.ContinueOnFailures;
+                opts.Transports.Add(new ThrowingTransport());
+            })
+            .StartAsync();
+
+        // If we got here, startup continued despite the transport's InitializeAsync throwing
+        host.Services.GetService(typeof(IWolverineRuntime)).ShouldNotBeNull();
+    }
+}
+
+internal class ThrowingTransport : TransportBase<Endpoint>
+{
+    public ThrowingTransport() : base("throwing", "Throwing Test Transport", ["throwing"])
+    {
+    }
+
+    public override ValueTask InitializeAsync(IWolverineRuntime runtime)
+        => throw new InvalidOperationException("Simulated transport initialization failure for #3130");
+
+    protected override IEnumerable<Endpoint> endpoints() => [];
+
+    protected override Endpoint findEndpointByUri(Uri uri)
+        => throw new NotSupportedException();
+}

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -244,7 +244,17 @@ public partial class WolverineRuntime
         
         if (Options.AutoBuildMessageStorageOnStartup != AutoCreate.None && Storage is not NullMessageStore)
         {
-            await _stores.Value.MigrateAsync();
+            try
+            {
+                await _stores.Value.MigrateAsync();
+            }
+            catch (Exception e) when (Options.ResourceMigrationFailureMode == ResourceMigrationFailureMode.ContinueOnFailures)
+            {
+                // e.g. a replica that lost the migration lock during a rolling deploy. Log and keep
+                // starting up rather than crash-looping. See GH-3130.
+                Logger.LogError(e,
+                    "Failed to migrate Wolverine message storage on startup. Continuing startup anyway because ResourceMigrationFailureMode is ContinueOnFailures.");
+            }
         }
 
         _hasMigratedStorage = true;
@@ -466,11 +476,24 @@ public partial class WolverineRuntime
             Options.Transports.RemoveLocal();
         }
 
+        var failedTransports = new List<ITransport>();
         foreach (var transport in Options.Transports)
         {
             if (!Options.ExternalTransportsAreStubbed)
             {
-                await transport.InitializeAsync(this).ConfigureAwait(false);
+                try
+                {
+                    await transport.InitializeAsync(this).ConfigureAwait(false);
+                }
+                catch (Exception e) when (Options.ResourceMigrationFailureMode == ResourceMigrationFailureMode.ContinueOnFailures)
+                {
+                    // e.g. a transient broker-provisioning failure during a rolling deploy. Log, skip this
+                    // transport's endpoint startup below, and keep the application starting. See GH-3130.
+                    failedTransports.Add(transport);
+                    Logger.LogError(e,
+                        "Failed to initialize Wolverine transport {Transport} on startup. Continuing startup anyway because ResourceMigrationFailureMode is ContinueOnFailures.",
+                        transport);
+                }
             }
             else
             {
@@ -480,6 +503,9 @@ public partial class WolverineRuntime
 
         foreach (var transport in Options.Transports)
         {
+            // A transport that failed to initialize under ContinueOnFailures has no usable endpoints
+            if (failedTransports.Contains(transport)) continue;
+
             var replyUri = transport.ReplyEndpoint()?.Uri;
 
             foreach (var endpoint in transport.Endpoints().Where(x => x.AutoStartSendingAgent()))

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -498,6 +498,25 @@ public sealed partial class WolverineOptions
         set => _autoBuildMessageStorageOnStartup = value;
     }
 
+    private ResourceMigrationFailureMode? _resourceMigrationFailureMode;
+
+    /// <summary>
+    ///     Controls what happens when Wolverine's own startup work — message store migration and
+    ///     messaging transport initialization / auto-provisioning — fails. Defaults (when not set here)
+    ///     to the active JasperFx profile's value, i.e. <see cref="ResourceMigrationFailureMode.FailFast"/>
+    ///     (abort startup). Set to <see cref="ResourceMigrationFailureMode.ContinueOnFailures"/> — typically
+    ///     only on the <c>Production</c> profile via <c>JasperFxOptions.Production.ResourceMigrationFailureMode</c> —
+    ///     so that, e.g., a replica that loses the migration lock during a rolling deploy logs the failure
+    ///     and continues starting up instead of crash-looping. Mirrors JasperFx's resource-setup hosted
+    ///     service for resources outside that service's reach (GH-3130). An explicit value set here wins
+    ///     over the profile.
+    /// </summary>
+    public ResourceMigrationFailureMode ResourceMigrationFailureMode
+    {
+        get => _resourceMigrationFailureMode ?? ResourceMigrationFailureMode.FailFast;
+        set => _resourceMigrationFailureMode = value;
+    }
+
     /// <summary>
     ///     Descriptive name of the running service. Used in Wolverine diagnostics and testing support
     /// </summary>
@@ -668,6 +687,11 @@ public sealed partial class WolverineOptions
         if (_autoBuildMessageStorageOnStartup == null)
         {
             _autoBuildMessageStorageOnStartup = jasperfx.ActiveProfile.ResourceAutoCreate;
+        }
+
+        if (_resourceMigrationFailureMode == null)
+        {
+            _resourceMigrationFailureMode = jasperfx.ActiveProfile.ResourceMigrationFailureMode;
         }
 
         // Propagate GeneratedCodeOutputPath from JasperFxOptions if not explicitly set


### PR DESCRIPTION
## Background

JasperFx [#456](https://github.com/JasperFx/jasperfx/pull/456) added `Profile.ResourceMigrationFailureMode` (`FailFast` default / `ContinueOnFailures`). JasperFx's `ResourceSetupHostService` honors it for resources gathered via `ISystemPart.FindResources()`.

## Problem

Wolverine does its own infrastructure work during `WolverineRuntime.StartAsync` that **bypasses** that service:

- durable message store migration — `_stores.Value.MigrateAsync()` (`WolverineRuntime.HostService.cs`), and
- per-transport `InitializeAsync` / auto-provision in `startMessagingTransportsAsync()`.

A failure in either (e.g. a replica losing the migration lock during a rolling deploy, or a transient broker-provisioning hiccup) threw out of `StartAsync` and crash-looped the replica **regardless** of `ResourceMigrationFailureMode`.

## Fix

Wire the active profile's `ResourceMigrationFailureMode` into both startup seams **centrally** — so all transports and message stores are covered without touching individual providers (as hoped in the issue):

- New `WolverineOptions.ResourceMigrationFailureMode`, read from `JasperFxOptions.ActiveProfile.ResourceMigrationFailureMode` in `ReadJasperFxOptions` (an explicit set wins over the profile), mirroring `AutoBuildMessageStorageOnStartup`.
- `tryMigrateStorage()`: on `ContinueOnFailures`, log and continue instead of throwing.
- `startMessagingTransportsAsync()`: catch a transport's `InitializeAsync` failure under `ContinueOnFailures`, log it, and **skip that transport's endpoint startup**. `FailFast` (the default) keeps today's abort-on-failure behavior.

The base-class approach works because both paths funnel through central code (`BrokerTransport<T>`/the init loop, and `MessageDatabase<T>` via `MessageStoreCollection.MigrateAsync()`).

## Package bump

JasperFx `2.12.0 → 2.13.0` (where the flag lives). Marten 9.8.0 / Weasel 9.1.5 / Polecat 4.5.0 are compatible; the **full `wolverine.slnx` Release build is clean (0 errors)**.

## Tests

`resource_migration_failure_mode_on_startup` (CoreTests): a throwing test transport proves `FailFast` aborts startup and `ContinueOnFailures` lets the application start — **no broker/container required** (deterministic injection).

## Follow-up / open question (from #3130)

Centralized listener startup (`Endpoints.StartListenersAsync()`) isn't yet made best-effort for a transport that failed to initialize; this PR skips the failed transport's *sender* startup. Hardening listener startup for a degraded transport is a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)