### PR TITLE
Fix circuit breaker

### DIFF
--- a/.github/workflows/circuit-breaking.yml
+++ b/.github/workflows/circuit-breaking.yml
@@ -1,0 +1,35 @@
+name: circuit-breaking
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  config: Release
+  disable_test_parallelization: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run CircuitBreaking Tests
+        run: ./build.sh CICircuitBreaking --framework net9.0
+
+      - name: Stop containers
+        if: always()
+        run: docker compose down

--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -415,12 +415,23 @@ partial class Build
         .Executes(() =>
         {
             var rabbitTests = RootDirectory / "src" / "Transports" / "RabbitMQ" / "Wolverine.RabbitMQ.Tests" / "Wolverine.RabbitMQ.Tests.csproj";
-            var circuitTests = RootDirectory / "src" / "Transports" / "RabbitMQ" / "CircuitBreakingTests" / "CircuitBreakingTests.csproj";
 
-            BuildTestProjects(rabbitTests, circuitTests);
+            BuildTestProjects(rabbitTests);
             StartDockerServices("rabbitmq", "postgresql", "sqlserver");
 
-            RunTestProjects([rabbitTests, circuitTests]);
+            RunTestProject(rabbitTests);
+        });
+
+    Target CICircuitBreaking => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            var circuitTests = RootDirectory / "src" / "Transports" / "RabbitMQ" / "CircuitBreakingTests" / "CircuitBreakingTests.csproj";
+
+            BuildTestProjects(circuitTests);
+            StartDockerServices("rabbitmq", "postgresql");
+
+            RunTestProject(circuitTests);
         });
 
     /// <summary>

--- a/src/Testing/CoreTests/ErrorHandling/CircuitBreakerTests.cs
+++ b/src/Testing/CoreTests/ErrorHandling/CircuitBreakerTests.cs
@@ -34,14 +34,15 @@ public class CircuitBreakerTests
         }
     }
 
-    private ValueTask assertNoPause()
+    private async ValueTask assertNoPause()
     {
-        return theAgent.DidNotReceiveWithAnyArgs().PauseAsync(theOptions.PauseTime);
+        await theAgent.DidNotReceiveWithAnyArgs().PauseAsync(theOptions.PauseTime);
+        await theAgent.DidNotReceiveWithAnyArgs().PauseWithDrainAsync(theOptions.PauseTime);
     }
 
     private ValueTask assertThatTheListenerWasPaused()
     {
-        return theAgent.Received().PauseAsync(theOptions.PauseTime);
+        return theAgent.Received().PauseWithDrainAsync(theOptions.PauseTime);
     }
 
     internal ValueTask initialUpdateOfTotals(int failures, int total)

--- a/src/Transports/NATS/Wolverine.Nats.Tests/MultiTenancyTests.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/MultiTenancyTests.cs
@@ -1,11 +1,9 @@
+using IntegrationTests;
 using JasperFx.Core;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Shouldly;
 using Wolverine.Nats.Internal;
-using Wolverine.Nats.Tests.Helpers;
 using Wolverine.Tracking;
 using Wolverine.Transports.Sending;
 using Xunit;

--- a/src/Transports/NATS/Wolverine.Nats.Tests/NatsTransportIntegrationTests.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/NatsTransportIntegrationTests.cs
@@ -1,8 +1,8 @@
+using IntegrationTests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using JasperFx.Core;
 using Wolverine.Nats.Internal;
-using Wolverine.Nats.Tests.Helpers;
 using Wolverine.Runtime;
 using Wolverine.Tracking;
 using Xunit;

--- a/src/Transports/NATS/Wolverine.Nats.Tests/RequestReplyTests.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/RequestReplyTests.cs
@@ -1,7 +1,7 @@
+using IntegrationTests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NATS.Client.Core;
-using Wolverine.Nats.Tests.Helpers;
 using Wolverine.Runtime.Routing;
 using Wolverine.Tracking;
 using Xunit;

--- a/src/Transports/NATS/Wolverine.Nats.Tests/Wolverine.Nats.Tests.csproj
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/Wolverine.Nats.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
@@ -9,7 +9,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Shouldly" />
         <PackageReference Include="FluentAssertions" />
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -26,13 +26,12 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\Testing\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj" />
-        <ProjectReference Include="..\Wolverine.Nats\Wolverine.Nats.csproj"/>
+        <ProjectReference Include="..\Wolverine.Nats\Wolverine.Nats.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <Compile Include="..\..\..\Servers.cs">
-            <Link>Servers.cs</Link>
-        </Compile>
+        <Compile Include="..\..\..\Servers.cs" Link="Servers.cs"/>
+        <Compile Include="..\..\..\XunitLogger.cs" Link="XunitLogger.cs" />
     </ItemGroup>
 
 </Project>

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakerIntegrationContext.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakerIntegrationContext.cs
@@ -1,10 +1,12 @@
+using IntegrationTests;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using JasperFx.Resources;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using JasperFx.Resources;
 using Shouldly;
+using System.Collections.Concurrent;
 using Wolverine;
 using Wolverine.Logging;
 using Wolverine.Runtime;
@@ -13,74 +15,48 @@ using Xunit.Abstractions;
 
 namespace CircuitBreakingTests;
 
-[Collection("circuit_breaker")]
-[Trait("Category", "Flaky")]
-public abstract class CircuitBreakerIntegrationContext : IDisposable, IObserver<IWolverineEvent>
+//[Collection("circuit_breaker")]
+public abstract class CircuitBreakerIntegrationContext(ITestOutputHelper output)
+    : IAsyncLifetime
 {
-    private readonly IHost _host;
-    private readonly ITestOutputHelper _output;
-    private readonly Random _random = new();
+    private readonly List<Task> _tasks = [];
+    private IHost _host = null!;
+    private Recorder _recorder = null!;
+    private WolverineRuntime _runtime = null!;
+    private WolverineObserver _observer = null!;
+    private IDisposable _trackerSubscription = null!;
+    protected string _queueName = null!;
 
-    private readonly List<ListenerState> _recordedStates = new();
-    private readonly WolverineRuntime _runtime;
-    private readonly List<Task> _tasks = new();
-
-    public CircuitBreakerIntegrationContext(ITestOutputHelper output)
+    public async Task InitializeAsync()
     {
-        _output = output;
-        _host = Host.CreateDefaultBuilder()
-            .UseWolverine(configureListener).UseResourceSetupOnStartup(StartupAction.ResetState)
+        _queueName = $"{GetType().Name}_{DateTime.UtcNow:yyyyMMddHHmmss}";
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(configureListener)
+            .UseResourceSetupOnStartup(StartupAction.ResetState)
             .ConfigureServices(services =>
             {
-                services.AddSingleton(output);
-                services.AddSingleton(typeof(ILogger<>), typeof(OutputLogger<>));
+                services.AddLogging(x => x.AddXunitLogging(output));
+                services.AddSingleton<Recorder>();
+                services.AddSingleton<WolverineObserver>();
             })
-            .Start();
+            .StartAsync();
 
+        _recorder = _host.Services.GetRequiredService<Recorder>();
         _runtime = _host.Services.GetRequiredService<IWolverineRuntime>().As<WolverineRuntime>();
-        _runtime.Tracker.Subscribe(this);
+        _observer = _host.Services.GetRequiredService<WolverineObserver>();
+        _trackerSubscription = _runtime.Tracker.Subscribe(_observer);
     }
 
-    public void Dispose()
+    public async Task DisposeAsync()
     {
+        _trackerSubscription.Dispose();
+        await _host.TeardownResources();
+        await _host.StopAsync();
         _host.Dispose();
     }
 
-    void IObserver<IWolverineEvent>.OnCompleted()
-    {
-    }
-
-    void IObserver<IWolverineEvent>.OnError(Exception error)
-    {
-    }
-
-    void IObserver<IWolverineEvent>.OnNext(IWolverineEvent value)
-    {
-        if (value is ListenerState state)
-        {
-            _output.WriteLine($"Got status update {state.Status} with {Recorder.Received} processed");
-            _recordedStates.Add(state);
-        }
-    }
-
     protected abstract void configureListener(WolverineOptions opts);
-
-    protected void assertTheCircuitBreakerNeverTripped()
-    {
-        _recordedStates.Any(x => x.Status == ListeningStatus.Stopped).ShouldBeFalse();
-    }
-
-    protected void assertTheCircuitBreakerTripped()
-    {
-        _recordedStates.Any(x => x.Status == ListeningStatus.Stopped).ShouldBeTrue();
-    }
-
-    protected void assertTheCircuitBreakerWasReset()
-    {
-        assertTheCircuitBreakerTripped();
-
-        _recordedStates.Last().Status.ShouldBe(ListeningStatus.Accepting);
-    }
 
     protected SometimesFails[] buildHundredMessages(int failurePercent)
     {
@@ -92,7 +68,8 @@ public abstract class CircuitBreakerIntegrationContext : IDisposable, IObserver<
         {
             var shouldFail = i > 0 && i % everyOther == 0;
 
-            var message = new SometimesFails(i, shouldFail ? MessageResult.BadImage : MessageResult.Success,
+            var message = new SometimesFails(Guid.NewGuid(),
+                shouldFail ? MessageResult.BadImage : MessageResult.Success,
                 MessageResult.Success, MessageResult.Success);
 
             messages[i] = message;
@@ -104,12 +81,16 @@ public abstract class CircuitBreakerIntegrationContext : IDisposable, IObserver<
     protected void publishHundredMessagesNow(int failures)
     {
         var messages = buildHundredMessages(failures);
-        var publisher = new MessageBus(_runtime);
+        var publisher = _host.MessageBus();
         var task = Task.Run(async () =>
         {
-            foreach (var message in messages) await publisher.PublishAsync(message);
+            foreach (var message in messages)
+            {
+                await publisher.PublishAsync(message);
+                _recorder.TrackPublished(message.Id);
+            }
 
-            _output.WriteLine($"Finished publishing a batch with {failures}% failures");
+            output.WriteLine($"Finished publishing a batch with {failures}% failures");
         });
 
         _tasks.Add(task);
@@ -118,14 +99,19 @@ public abstract class CircuitBreakerIntegrationContext : IDisposable, IObserver<
     protected void delayPublishHundredMessages(TimeSpan delay, int failures)
     {
         var messages = buildHundredMessages(failures);
-        var publisher = new MessageBus(_runtime);
+        var publisher = _host.MessageBus();
         var task = Task.Run(async () =>
         {
             await Task.Delay(delay);
-            _output.WriteLine($"Starting to publish a batch with {failures}% failures");
-            foreach (var message in messages) await publisher.PublishAsync(message);
+            output.WriteLine($"Starting to publish a batch with {failures}% failures");
 
-            _output.WriteLine($"Finished publishing a batch with {failures}% failures");
+            foreach (var message in messages)
+            {
+                await publisher.PublishAsync(message);
+                _recorder.TrackPublished(message.Id);
+            }
+
+            output.WriteLine($"Finished publishing a batch with {failures}% failures");
         });
 
         _tasks.Add(task);
@@ -139,7 +125,7 @@ public abstract class CircuitBreakerIntegrationContext : IDisposable, IObserver<
     [Fact]
     public async Task everything_is_wonderful_even_though_there_are_some_failures_so_do_not_ever_trip()
     {
-        var messageWaiter = Recorder.WaitForMessagesToBeProcessed(_output, 1200, 2.Minutes());
+        var messageWaiter = _recorder.WaitForMessagesToBeProcessed(1200, 2.Minutes());
 
         publishHundredMessagesNow(5);
         publishHundredMessagesNow(5);
@@ -158,13 +144,13 @@ public abstract class CircuitBreakerIntegrationContext : IDisposable, IObserver<
 
         await messageWaiter;
 
-        assertTheCircuitBreakerNeverTripped();
+        _observer.AssertTheCircuitBreakerNeverTripped();
     }
 
     [Fact]
     public async Task the_circuit_breaker_should_trip_and_restart()
     {
-        var messageWaiter = Recorder.WaitForMessagesToBeProcessed(_output, 1200, 1.Minutes());
+        var messageWaiter = _recorder.WaitForMessagesToBeProcessed(1200, 2.Minutes());
 
         publishHundredMessagesNow(10);
         publishHundredMessagesNow(80);
@@ -172,10 +158,10 @@ public abstract class CircuitBreakerIntegrationContext : IDisposable, IObserver<
         publishHundredMessagesNow(25);
         publishHundredMessagesNow(25);
 
-        var _ = Task.Run(async () =>
+        _ = Task.Run(async () =>
         {
             await Task.Delay(10.Seconds());
-            Recorder.NeverFail = true;
+            _recorder.NeverFail = true;
         });
 
         delayPublishHundredMessages(5.Seconds(), 5);
@@ -190,8 +176,8 @@ public abstract class CircuitBreakerIntegrationContext : IDisposable, IObserver<
 
         await messageWaiter;
 
-        assertTheCircuitBreakerTripped();
-        assertTheCircuitBreakerWasReset();
+        _observer.AssertTheCircuitBreakerTripped();
+        _observer.AssertTheCircuitBreakerWasReset();
     }
 }
 
@@ -202,35 +188,42 @@ public enum MessageResult
     BadImage
 }
 
-public record SometimesFails(int Number, MessageResult First, MessageResult Second, MessageResult Third);
+public record SometimesFails(Guid Id, MessageResult First, MessageResult Second, MessageResult Third);
 
-public class OutputLogger<T> : ILogger<T>, IDisposable
+
+public class WolverineObserver(Recorder recorder, ILogger<WolverineObserver> logger)
+    : IObserver<IWolverineEvent>
 {
-    private readonly ITestOutputHelper _output;
+    private readonly ConcurrentQueue<ListenerState> _recordedStates = [];
 
-    public OutputLogger(ITestOutputHelper output)
+    public void OnCompleted() { }
+
+    public void OnError(Exception error) { }
+
+    void IObserver<IWolverineEvent>.OnNext(IWolverineEvent value)
     {
-        _output = output;
+        if (value is ListenerState state)
+        {
+            logger.LogDebug("CB status: {Status} (unique: {Count})",
+                state.Status, recorder.GetProcessedCount());
+            _recordedStates.Enqueue(state);
+        }
     }
 
-    public void Dispose()
+    public void AssertTheCircuitBreakerNeverTripped()
     {
+        _recordedStates.Any(x => x.Status == ListeningStatus.Stopped).ShouldBeFalse();
     }
 
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
-        Func<TState, Exception?, string> formatter)
+    public void AssertTheCircuitBreakerTripped()
     {
-        _output.WriteLine(formatter(state, exception));
+        _recordedStates.Any(x => x.Status == ListeningStatus.Stopped).ShouldBeTrue();
     }
 
-    public bool IsEnabled(LogLevel logLevel)
+    public void AssertTheCircuitBreakerWasReset()
     {
-        return true;
-        //return typeof(T).Name == "DurabilityAgent";
-    }
+        AssertTheCircuitBreakerTripped();
 
-    public IDisposable BeginScope<TState>(TState state) where TState : notnull
-    {
-        return this;
+        _recordedStates.Last().Status.ShouldBe(ListeningStatus.Accepting);
     }
 }

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakerIntegrationContext.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakerIntegrationContext.cs
@@ -4,26 +4,22 @@ using JasperFx.Core.Reflection;
 using JasperFx.Resources;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Shouldly;
-using System.Collections.Concurrent;
 using Wolverine;
-using Wolverine.Logging;
 using Wolverine.Runtime;
 using Wolverine.Transports;
 using Xunit.Abstractions;
 
 namespace CircuitBreakingTests;
 
-//[Collection("circuit_breaker")]
 public abstract class CircuitBreakerIntegrationContext(ITestOutputHelper output)
     : IAsyncLifetime
 {
     private readonly List<Task> _tasks = [];
     private IHost _host = null!;
-    private Recorder _recorder = null!;
+    private MessageRecorder _recorder = null!;
     private WolverineRuntime _runtime = null!;
-    private WolverineObserver _observer = null!;
+    private ListenerObserver _observer = null!;
     private IDisposable _trackerSubscription = null!;
     protected string _queueName = null!;
 
@@ -37,14 +33,14 @@ public abstract class CircuitBreakerIntegrationContext(ITestOutputHelper output)
             .ConfigureServices(services =>
             {
                 services.AddLogging(x => x.AddXunitLogging(output));
-                services.AddSingleton<Recorder>();
-                services.AddSingleton<WolverineObserver>();
+                services.AddSingleton<MessageRecorder>();
+                services.AddSingleton<ListenerObserver>();
             })
             .StartAsync();
 
-        _recorder = _host.Services.GetRequiredService<Recorder>();
+        _recorder = _host.Services.GetRequiredService<MessageRecorder>();
         _runtime = _host.Services.GetRequiredService<IWolverineRuntime>().As<WolverineRuntime>();
-        _observer = _host.Services.GetRequiredService<WolverineObserver>();
+        _observer = _host.Services.GetRequiredService<ListenerObserver>();
         _trackerSubscription = _runtime.Tracker.Subscribe(_observer);
     }
 
@@ -125,7 +121,7 @@ public abstract class CircuitBreakerIntegrationContext(ITestOutputHelper output)
     [Fact]
     public async Task everything_is_wonderful_even_though_there_are_some_failures_so_do_not_ever_trip()
     {
-        var messageWaiter = _recorder.WaitForMessagesToBeProcessed(1200, 2.Minutes());
+        var messageWaiter = _recorder.WaitForMessagesToBeProcessed(1200, 1.Minutes());
 
         publishHundredMessagesNow(5);
         publishHundredMessagesNow(5);
@@ -144,13 +140,13 @@ public abstract class CircuitBreakerIntegrationContext(ITestOutputHelper output)
 
         await messageWaiter;
 
-        _observer.AssertTheCircuitBreakerNeverTripped();
+        _observer.RecordedStates.ShouldNotContain(ListeningStatus.Stopped);
     }
 
     [Fact]
     public async Task the_circuit_breaker_should_trip_and_restart()
     {
-        var messageWaiter = _recorder.WaitForMessagesToBeProcessed(1200, 2.Minutes());
+        var messageWaiter = _recorder.WaitForMessagesToBeProcessed(1200, 1.Minutes());
 
         publishHundredMessagesNow(10);
         publishHundredMessagesNow(80);
@@ -176,8 +172,8 @@ public abstract class CircuitBreakerIntegrationContext(ITestOutputHelper output)
 
         await messageWaiter;
 
-        _observer.AssertTheCircuitBreakerTripped();
-        _observer.AssertTheCircuitBreakerWasReset();
+        _observer.RecordedStates.ShouldContain(ListeningStatus.Stopped);
+        _observer.RecordedStates.Last().ShouldBe(ListeningStatus.Accepting);
     }
 }
 
@@ -189,41 +185,3 @@ public enum MessageResult
 }
 
 public record SometimesFails(Guid Id, MessageResult First, MessageResult Second, MessageResult Third);
-
-
-public class WolverineObserver(Recorder recorder, ILogger<WolverineObserver> logger)
-    : IObserver<IWolverineEvent>
-{
-    private readonly ConcurrentQueue<ListenerState> _recordedStates = [];
-
-    public void OnCompleted() { }
-
-    public void OnError(Exception error) { }
-
-    void IObserver<IWolverineEvent>.OnNext(IWolverineEvent value)
-    {
-        if (value is ListenerState state)
-        {
-            logger.LogDebug("CB status: {Status} (unique: {Count})",
-                state.Status, recorder.GetProcessedCount());
-            _recordedStates.Enqueue(state);
-        }
-    }
-
-    public void AssertTheCircuitBreakerNeverTripped()
-    {
-        _recordedStates.Any(x => x.Status == ListeningStatus.Stopped).ShouldBeFalse();
-    }
-
-    public void AssertTheCircuitBreakerTripped()
-    {
-        _recordedStates.Any(x => x.Status == ListeningStatus.Stopped).ShouldBeTrue();
-    }
-
-    public void AssertTheCircuitBreakerWasReset()
-    {
-        AssertTheCircuitBreakerTripped();
-
-        _recordedStates.Last().Status.ShouldBe(ListeningStatus.Accepting);
-    }
-}

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakingTests.csproj
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakingTests.csproj
@@ -1,13 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Meziantou.Extensions.Logging.Xunit" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -19,18 +20,17 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\Persistence\Wolverine.Marten\Wolverine.Marten.csproj"/>
-        <ProjectReference Include="..\Wolverine.RabbitMQ\Wolverine.RabbitMQ.csproj"/>
+        <ProjectReference Include="..\..\..\Persistence\Wolverine.Marten\Wolverine.Marten.csproj" />
+        <ProjectReference Include="..\Wolverine.RabbitMQ\Wolverine.RabbitMQ.csproj" />
         <ProjectReference Include="..\..\..\Testing\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <Compile Include="..\..\..\Servers.cs">
-            <Link>Servers.cs</Link>
-        </Compile>
+        <Compile Include="..\..\..\Servers.cs" Link="Servers.cs" />
+        <Compile Include="..\..\..\XunitLogger.cs" Link="XunitLogger.cs" />
     </ItemGroup>
 
     <ItemGroup>
-        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 </Project>

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/ListenerObserver.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/ListenerObserver.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using Wolverine.Logging;
+using Wolverine.Transports;
+
+namespace CircuitBreakingTests;
+
+public class ListenerObserver(ILogger<ListenerObserver> logger)
+    : IObserver<IWolverineEvent>
+{
+    private readonly ConcurrentQueue<ListenerState> _recordedStates = [];
+
+    public void OnCompleted() { }
+
+    public void OnError(Exception error) { }
+
+    public void OnNext(IWolverineEvent value)
+    {
+        if (value is ListenerState state)
+        {
+            logger.LogDebug("CB status: {Status}", state.Status);
+            _recordedStates.Enqueue(state);
+        }
+    }
+
+    public ListeningStatus[] RecordedStates => [.. _recordedStates.Select(x => x.Status)];
+}

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/MessageRecorder.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/MessageRecorder.cs
@@ -3,16 +3,15 @@ using System.Collections.Concurrent;
 
 namespace CircuitBreakingTests;
 
-public class Recorder(ILogger<Recorder> logger)
+public class MessageRecorder(ILogger<MessageRecorder> logger) : IAsyncDisposable
 {
     private TaskCompletionSource<int> _completion = null!;
     private readonly ConcurrentDictionary<Guid, int> _processedIds = new();
     private readonly ConcurrentBag<Guid> _publishedIds = [];
     private int _expected;
+    private CancellationTokenSource? _timeoutCts;
 
     public bool NeverFail { get; set; }
-
-    public int GetProcessedCount() => _processedIds.Count;
 
     public void TrackPublished(Guid id)
     {
@@ -27,25 +26,19 @@ public class Recorder(ILogger<Recorder> logger)
         _completion = new TaskCompletionSource<int>();
         _expected = number;
 
-        var timeoutCts = new CancellationTokenSource(timeout);
-        timeoutCts.Token.Register(() =>
+        _timeoutCts = new CancellationTokenSource(timeout);
+        _timeoutCts.Token.Register(() =>
         {
             int uniqueCount = 0;
             int publishedCount = 0;
             var missing = new List<Guid>();
-            try
-            {
-                uniqueCount = _processedIds.Count;
-                publishedCount = _publishedIds.Count;
-                missing = [.. _publishedIds.Except(_processedIds.Keys)];
-                var sample = string.Join(", ", missing.Take(10).Select(x => x.ToString()[..8]));
-                logger.LogDebug("DIAG: Processed {uniqueCount}/{publishedCount} published messages", uniqueCount, publishedCount);
+            uniqueCount = _processedIds.Count;
+            publishedCount = _publishedIds.Count;
+            missing = [.. _publishedIds.Except(_processedIds.Keys)];
+            var sample = string.Join(", ", missing.Take(10));
+            logger.LogDebug("DIAG: Processed {uniqueCount}/{publishedCount} published messages", uniqueCount, publishedCount);
+            if (missing.Any())
                 logger.LogDebug("DIAG: {missingCount} never processed. Sample: {sample}", missing.Count, sample);
-            }
-            catch
-            {
-                // Test may have already completed — output helper may be disposed
-            }
 
             _completion.TrySetException(new TimeoutException(
                 $"Listener did not process the expected message count {number} in the time allowed. " +
@@ -56,17 +49,26 @@ public class Recorder(ILogger<Recorder> logger)
         return _completion.Task;
     }
 
-    public void Increment(Guid messageId, int attempt = 0)
+    public void Increment(Guid messageId)
     {
         _processedIds.AddOrUpdate(messageId, 1, (_, existing) => existing + 1);
-
+        var attempt = _processedIds[messageId];
         var uniqueCount = _processedIds.Count;
 
-        var shortId = messageId.ToString()[..8];
-        logger.LogDebug("msg#{shortId} completed (attempt {attempt}, unique: {uniqueCount})",
-            shortId, attempt, uniqueCount);
+        logger.LogDebug("msg#{Id} completed (attempt {attempt}, unique: {uniqueCount})",
+            messageId, attempt, uniqueCount);
 
         if (uniqueCount >= _expected)
             _completion.TrySetResult(uniqueCount);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_timeoutCts != null)
+        {
+            await _timeoutCts.CancelAsync();
+            _timeoutCts?.Dispose();
+            _timeoutCts = null;
+        }
     }
 }

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/back_pressure_tripping_off.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/back_pressure_tripping_off.cs
@@ -1,7 +1,8 @@
+using IntegrationTests;
 using JasperFx.Core;
+using JasperFx.Resources;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using JasperFx.Resources;
 using Shouldly;
 using Wolverine;
 using Wolverine.Logging;
@@ -12,48 +13,57 @@ using Xunit.Abstractions;
 
 namespace CircuitBreakingTests.RabbitMq;
 
-public class back_pressure_tripping_off
+public class back_pressure_tripping_off(ITestOutputHelper output) : IAsyncLifetime
 {
-    private readonly ITestOutputHelper _output;
+    private IHost _host = null!;
 
-    public back_pressure_tripping_off(ITestOutputHelper output)
+    public async Task InitializeAsync()
     {
-        _output = output;
-    }
-
-    [Fact]
-    public async Task back_pressure_trips_with_buffered_receiver()
-    {
-        using var host = await Host.CreateDefaultBuilder()
+        var queueName = $"{GetType().Name}_{DateTime.UtcNow:yyyyMMddHHmmss}";
+        _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.ListenToRabbitQueue("pressure").Named("incoming")
-
+                opts.ListenToRabbitQueue(queueName).Named("incoming")
                     // Setting it so that the endpoint should trip off with back
                     // pressure pretty easily
                     .BufferedInMemory(new BufferingLimits(100, 50));
+
+                opts.Services.AddLogging(x => x.AddXunitLogging(output));
+                opts.Services.AddSingleton<Recorder>();
             })
 
             // This builds any missing Rabbit MQ objects if they don't exist,
             // but purges existing queues so we start from a clean slate
             .UseResourceSetupOnStartup(StartupAction.ResetState)
             .StartAsync();
+    }
 
+    public async Task DisposeAsync()
+    {
+        await _host.TeardownResources();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task back_pressure_trips_with_buffered_receiver()
+    {
+        var recorder = _host.Services.GetRequiredService<Recorder>();
         // Make the tests run slow so they'll back up very easily
         SometimesSlowMessageHandler.RunSlow = true;
 
-        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
-        var statusRecorder = new StatusRecorder(_output);
+        var runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+        var statusRecorder = new StatusRecorder(output);
         runtime.Tracker.Subscribe(statusRecorder);
 
         var waitForTooBusy =
             runtime.Tracker.WaitForListenerStatusAsync("incoming", ListeningStatus.TooBusy, 1.Minutes());
 
-        var completion = Recorder.WaitForMessagesToBeProcessed(_output, 1000, 1.Minutes());
+        var completion = recorder.WaitForMessagesToBeProcessed(1000, 1.Minutes());
 
         var publishing = Task.Run(async () =>
         {
-            var publisher = host.MessageBus();
+            var publisher = _host.MessageBus();
 
             for (var i = 0; i < 1000; i++)
             {
@@ -74,15 +84,10 @@ public class back_pressure_tripping_off
         statusRecorder.StateChanges.ShouldContain(x => x.Status == ListeningStatus.TooBusy);
     }
 
-    public class StatusRecorder : IObserver<IWolverineEvent>
+    public class StatusRecorder(ITestOutputHelper output) : IObserver<IWolverineEvent>
     {
-        private readonly ITestOutputHelper _output;
-        public readonly List<ListenerState> StateChanges = new();
-
-        public StatusRecorder(ITestOutputHelper output)
-        {
-            _output = output;
-        }
+        private readonly ITestOutputHelper _output = output;
+        public readonly List<ListenerState> StateChanges = [];
 
         public void OnCompleted()
         {
@@ -98,7 +103,7 @@ public class back_pressure_tripping_off
         {
             if (value is ListenerState state)
             {
-                _output.WriteLine("Changed to " + state.Status);
+                _output.WriteLine($"Changed to {state.Status}");
                 StateChanges.Add(state);
             }
         }
@@ -114,13 +119,13 @@ public class SometimesSlowMessageHandler
 {
     public static bool RunSlow;
 
-    public static async Task Handle(SometimesSlowMessage message)
+    public static async Task Handle(SometimesSlowMessage message, Recorder recorder)
     {
         if (RunSlow)
         {
             await Task.Delay(2.Seconds());
         }
 
-        Recorder.Increment();
+        recorder.Increment(message.Id);
     }
 }

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/back_pressure_tripping_off.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/back_pressure_tripping_off.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Wolverine;
-using Wolverine.Logging;
 using Wolverine.RabbitMQ;
 using Wolverine.Runtime;
 using Wolverine.Transports;
@@ -16,10 +15,14 @@ namespace CircuitBreakingTests.RabbitMq;
 public class back_pressure_tripping_off(ITestOutputHelper output) : IAsyncLifetime
 {
     private IHost _host = null!;
+    private ListenerObserver _listenerObserver = null!;
+    private IWolverineRuntime _runtime = null!;
+    private IDisposable _trackSubscription = null!;
 
     public async Task InitializeAsync()
     {
         var queueName = $"{GetType().Name}_{DateTime.UtcNow:yyyyMMddHHmmss}";
+
         _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
@@ -29,17 +32,23 @@ public class back_pressure_tripping_off(ITestOutputHelper output) : IAsyncLifeti
                     .BufferedInMemory(new BufferingLimits(100, 50));
 
                 opts.Services.AddLogging(x => x.AddXunitLogging(output));
-                opts.Services.AddSingleton<Recorder>();
+                opts.Services.AddSingleton<ListenerObserver>();
+                opts.Services.AddSingleton<MessageRecorder>();
             })
 
             // This builds any missing Rabbit MQ objects if they don't exist,
             // but purges existing queues so we start from a clean slate
             .UseResourceSetupOnStartup(StartupAction.ResetState)
             .StartAsync();
+
+        _listenerObserver = _host.Services.GetRequiredService<ListenerObserver>();
+        _runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+        _trackSubscription = _runtime.Tracker.Subscribe(_listenerObserver);
     }
 
     public async Task DisposeAsync()
     {
+        _trackSubscription.Dispose();
         await _host.TeardownResources();
         await _host.StopAsync();
         _host.Dispose();
@@ -48,16 +57,12 @@ public class back_pressure_tripping_off(ITestOutputHelper output) : IAsyncLifeti
     [Fact]
     public async Task back_pressure_trips_with_buffered_receiver()
     {
-        var recorder = _host.Services.GetRequiredService<Recorder>();
+        var recorder = _host.Services.GetRequiredService<MessageRecorder>();
         // Make the tests run slow so they'll back up very easily
         SometimesSlowMessageHandler.RunSlow = true;
 
-        var runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
-        var statusRecorder = new StatusRecorder(output);
-        runtime.Tracker.Subscribe(statusRecorder);
-
-        var waitForTooBusy =
-            runtime.Tracker.WaitForListenerStatusAsync("incoming", ListeningStatus.TooBusy, 1.Minutes());
+        var waitForTooBusy = _runtime.Tracker.WaitForListenerStatusAsync(
+            "incoming", ListeningStatus.TooBusy, 1.Minutes());
 
         var completion = recorder.WaitForMessagesToBeProcessed(1000, 1.Minutes());
 
@@ -67,7 +72,10 @@ public class back_pressure_tripping_off(ITestOutputHelper output) : IAsyncLifeti
 
             for (var i = 0; i < 1000; i++)
             {
-                await publisher.EndpointFor("incoming").SendAsync( new SometimesSlowMessage());
+                var message = new SometimesSlowMessage();
+                await publisher.EndpointFor("incoming")
+                    .SendAsync(message);
+                recorder.TrackPublished(message.Id);
             }
         });
 
@@ -81,32 +89,7 @@ public class back_pressure_tripping_off(ITestOutputHelper output) : IAsyncLifeti
         // Got all the messages in the end
         await completion;
 
-        statusRecorder.StateChanges.ShouldContain(x => x.Status == ListeningStatus.TooBusy);
-    }
-
-    public class StatusRecorder(ITestOutputHelper output) : IObserver<IWolverineEvent>
-    {
-        private readonly ITestOutputHelper _output = output;
-        public readonly List<ListenerState> StateChanges = [];
-
-        public void OnCompleted()
-        {
-            // nothing
-        }
-
-        public void OnError(Exception error)
-        {
-            // nothing
-        }
-
-        public void OnNext(IWolverineEvent value)
-        {
-            if (value is ListenerState state)
-            {
-                _output.WriteLine($"Changed to {state.Status}");
-                StateChanges.Add(state);
-            }
-        }
+        _listenerObserver.RecordedStates.ShouldContain(ListeningStatus.TooBusy);
     }
 }
 
@@ -119,7 +102,7 @@ public class SometimesSlowMessageHandler
 {
     public static bool RunSlow;
 
-    public static async Task Handle(SometimesSlowMessage message, Recorder recorder)
+    public static async Task Handle(SometimesSlowMessage message, MessageRecorder recorder)
     {
         if (RunSlow)
         {

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/buffered_and_parallel.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/buffered_and_parallel.cs
@@ -6,20 +6,18 @@ using Xunit.Abstractions;
 
 namespace CircuitBreakingTests.RabbitMq;
 
-public class buffered_and_parallel : CircuitBreakerIntegrationContext
+public class buffered_and_parallel(ITestOutputHelper output)
+    : CircuitBreakerIntegrationContext(output)
 {
-    public buffered_and_parallel(ITestOutputHelper output) : base(output)
-    {
-    }
-
     protected override void configureListener(WolverineOptions opts)
     {
         // Requeue failed messages.
-        opts.Policies.OnException<BadImageFormatException>().Or<DivideByZeroException>()
+        opts.Policies.OnException<BadImageFormatException>()
+            .Or<DivideByZeroException>()
             .Requeue();
 
-        opts.PublishAllMessages().ToRabbitQueue("circuit4");
-        opts.ListenToRabbitQueue("circuit4").CircuitBreaker(cb =>
+        opts.PublishAllMessages().ToRabbitQueue(_queueName);
+        opts.ListenToRabbitQueue(_queueName).CircuitBreaker(cb =>
         {
             cb.MinimumThreshold = 250;
             cb.PauseTime = 10.Seconds();

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/buffered_not_parallelized.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/buffered_not_parallelized.cs
@@ -6,20 +6,18 @@ using Xunit.Abstractions;
 
 namespace CircuitBreakingTests.RabbitMq;
 
-public class buffered_not_parallelized : CircuitBreakerIntegrationContext
+public class buffered_not_parallelized(ITestOutputHelper output)
+    : CircuitBreakerIntegrationContext(output)
 {
-    public buffered_not_parallelized(ITestOutputHelper output) : base(output)
-    {
-    }
-
     protected override void configureListener(WolverineOptions opts)
     {
         // Requeue failed messages.
-        opts.Policies.OnException<BadImageFormatException>().Or<DivideByZeroException>()
+        opts.Policies.OnException<BadImageFormatException>()
+            .Or<DivideByZeroException>()
             .Requeue();
 
-        opts.PublishAllMessages().ToRabbitQueue("circuit2");
-        opts.ListenToRabbitQueue("circuit2").CircuitBreaker(cb =>
+        opts.PublishAllMessages().ToRabbitQueue(_queueName);
+        opts.ListenToRabbitQueue(_queueName).CircuitBreaker(cb =>
         {
             cb.MinimumThreshold = 250;
             cb.PauseTime = 10.Seconds();

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/durable_and_not_parallel.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/durable_and_not_parallel.cs
@@ -9,26 +9,24 @@ using Xunit.Abstractions;
 
 namespace CircuitBreakingTests.RabbitMq;
 
-public class durable_and_not_parallel : CircuitBreakerIntegrationContext
+public class durable_and_not_parallel(ITestOutputHelper output) 
+    : CircuitBreakerIntegrationContext(output)
 {
-    public durable_and_not_parallel(ITestOutputHelper output) : base(output)
-    {
-    }
-
     protected override void configureListener(WolverineOptions opts)
     {
         opts.Services.AddMarten(m =>
         {
             m.Connection(Servers.PostgresConnectionString);
-            m.DatabaseSchemaName = "circuit_breaker";
+            m.DatabaseSchemaName = _queueName;
         }).IntegrateWithWolverine();
 
         // Requeue failed messages.
-        opts.Policies.OnException<BadImageFormatException>().Or<DivideByZeroException>()
+        opts.Policies.OnException<BadImageFormatException>()
+            .Or<DivideByZeroException>()
             .Requeue();
 
-        opts.PublishAllMessages().ToRabbitQueue("circuit4");
-        opts.ListenToRabbitQueue("circuit4").CircuitBreaker(cb =>
+        opts.PublishAllMessages().ToRabbitQueue(_queueName);
+        opts.ListenToRabbitQueue(_queueName).CircuitBreaker(cb =>
         {
             cb.MinimumThreshold = 250;
             cb.PauseTime = 10.Seconds();

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/durable_and_parallel.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/durable_and_parallel.cs
@@ -9,26 +9,24 @@ using Xunit.Abstractions;
 
 namespace CircuitBreakingTests.RabbitMq;
 
-public class durable_and_parallel : CircuitBreakerIntegrationContext
+public class durable_and_parallel(ITestOutputHelper output)
+    : CircuitBreakerIntegrationContext(output)
 {
-    public durable_and_parallel(ITestOutputHelper output) : base(output)
-    {
-    }
-
     protected override void configureListener(WolverineOptions opts)
     {
         opts.Services.AddMarten(m =>
         {
             m.Connection(Servers.PostgresConnectionString);
-            m.DatabaseSchemaName = "circuit_breaker";
+            m.DatabaseSchemaName = _queueName;
         }).IntegrateWithWolverine();
 
         // Requeue failed messages.
-        opts.Policies.OnException<BadImageFormatException>().Or<DivideByZeroException>()
+        opts.Policies.OnException<BadImageFormatException>()
+            .Or<DivideByZeroException>()
             .Requeue();
 
-        opts.PublishAllMessages().ToRabbitQueue("circuit4");
-        opts.ListenToRabbitQueue("circuit4").CircuitBreaker(cb =>
+        opts.PublishAllMessages().ToRabbitQueue(_queueName);
+        opts.ListenToRabbitQueue(_queueName).CircuitBreaker(cb =>
         {
             cb.MinimumThreshold = 250;
             cb.PauseTime = 10.Seconds();

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/inline_and_parallel.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/inline_and_parallel.cs
@@ -6,20 +6,18 @@ using Xunit.Abstractions;
 
 namespace CircuitBreakingTests.RabbitMq;
 
-public class inline_and_parallel : CircuitBreakerIntegrationContext
+public class inline_and_parallel(ITestOutputHelper output)
+    : CircuitBreakerIntegrationContext(output)
 {
-    public inline_and_parallel(ITestOutputHelper output) : base(output)
-    {
-    }
-
     protected override void configureListener(WolverineOptions opts)
     {
         // Requeue failed messages.
-        opts.Policies.OnException<BadImageFormatException>().Or<DivideByZeroException>()
+        opts.Policies.OnException<BadImageFormatException>()
+            .Or<DivideByZeroException>()
             .Requeue();
 
-        opts.PublishAllMessages().ToRabbitQueue("circuit3");
-        opts.ListenToRabbitQueue("circuit3").CircuitBreaker(cb =>
+        opts.PublishAllMessages().ToRabbitQueue(_queueName);
+        opts.ListenToRabbitQueue(_queueName).CircuitBreaker(cb =>
         {
             cb.MinimumThreshold = 250;
             cb.PauseTime = 10.Seconds();

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/inline_not_parallelized.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/inline_not_parallelized.cs
@@ -6,20 +6,18 @@ using Xunit.Abstractions;
 
 namespace CircuitBreakingTests.RabbitMq;
 
-public class inline_not_parallelized : CircuitBreakerIntegrationContext
+public class inline_not_parallelized(ITestOutputHelper output)
+    : CircuitBreakerIntegrationContext(output)
 {
-    public inline_not_parallelized(ITestOutputHelper output) : base(output)
-    {
-    }
-
     protected override void configureListener(WolverineOptions opts)
     {
         // Requeue failed messages.
-        opts.Policies.OnException<BadImageFormatException>().Or<DivideByZeroException>()
+        opts.Policies.OnException<BadImageFormatException>()
+            .Or<DivideByZeroException>()
             .Requeue();
 
-        opts.PublishAllMessages().ToRabbitQueue("circuit1");
-        opts.ListenToRabbitQueue("circuit1").CircuitBreaker(cb =>
+        opts.PublishAllMessages().ToRabbitQueue(_queueName);
+        opts.ListenToRabbitQueue(_queueName).CircuitBreaker(cb =>
         {
             cb.MinimumThreshold = 250;
             cb.PauseTime = 10.Seconds();

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/Recorder.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/Recorder.cs
@@ -1,45 +1,72 @@
-using Xunit.Abstractions;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
 
 namespace CircuitBreakingTests;
 
-public static class Recorder
+public class Recorder(ILogger<Recorder> logger)
 {
-    public static int Received;
-    private static TaskCompletionSource<int> _completion = null!;
-    private static int _expected;
-    private static ITestOutputHelper _output = null!;
-    public static bool NeverFail { get; set; }
+    private TaskCompletionSource<int> _completion = null!;
+    private readonly ConcurrentDictionary<Guid, int> _processedIds = new();
+    private readonly ConcurrentBag<Guid> _publishedIds = [];
+    private int _expected;
 
-    public static Task WaitForMessagesToBeProcessed(ITestOutputHelper output, int number, TimeSpan timeout)
+    public bool NeverFail { get; set; }
+
+    public int GetProcessedCount() => _processedIds.Count;
+
+    public void TrackPublished(Guid id)
+    {
+        _publishedIds.Add(id);
+    }
+
+    public Task WaitForMessagesToBeProcessed(int number, TimeSpan timeout)
     {
         NeverFail = false;
-        _output = output;
-        Received = 0;
+        _processedIds.Clear();
+        _publishedIds.Clear();
         _completion = new TaskCompletionSource<int>();
         _expected = number;
 
-        var timeout1 = new CancellationTokenSource(timeout);
-        timeout1.Token.Register(() =>
+        var timeoutCts = new CancellationTokenSource(timeout);
+        timeoutCts.Token.Register(() =>
         {
+            int uniqueCount = 0;
+            int publishedCount = 0;
+            var missing = new List<Guid>();
+            try
+            {
+                uniqueCount = _processedIds.Count;
+                publishedCount = _publishedIds.Count;
+                missing = [.. _publishedIds.Except(_processedIds.Keys)];
+                var sample = string.Join(", ", missing.Take(10).Select(x => x.ToString()[..8]));
+                logger.LogDebug("DIAG: Processed {uniqueCount}/{publishedCount} published messages", uniqueCount, publishedCount);
+                logger.LogDebug("DIAG: {missingCount} never processed. Sample: {sample}", missing.Count, sample);
+            }
+            catch
+            {
+                // Test may have already completed — output helper may be disposed
+            }
+
             _completion.TrySetException(new TimeoutException(
-                $"Listener did not process the expected message count {number} in the time allowed. The actual was {Received}"));
+                $"Listener did not process the expected message count {number} in the time allowed. " +
+                $"Only {uniqueCount} unique messages received. " +
+                $"{missing.Count} of {publishedCount} published never made it."));
         });
 
         return _completion.Task;
     }
 
-    public static void Increment()
+    public void Increment(Guid messageId, int attempt = 0)
     {
-        Interlocked.Increment(ref Received);
+        _processedIds.AddOrUpdate(messageId, 1, (_, existing) => existing + 1);
 
-        if (Received % 50 == 0)
-        {
-            _output.WriteLine("Received " + Received);
-        }
+        var uniqueCount = _processedIds.Count;
 
-        if (Received >= _expected)
-        {
-            _completion.SetResult(Received);
-        }
+        var shortId = messageId.ToString()[..8];
+        logger.LogDebug("msg#{shortId} completed (attempt {attempt}, unique: {uniqueCount})",
+            shortId, attempt, uniqueCount);
+
+        if (uniqueCount >= _expected)
+            _completion.TrySetResult(uniqueCount);
     }
 }

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/SometimesFailsHandler.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/SometimesFailsHandler.cs
@@ -4,7 +4,7 @@ namespace CircuitBreakingTests;
 
 public class SometimesFailsHandler
 {
-    public void Handle(SometimesFails message, Envelope envelope, Recorder recorder)
+    public void Handle(SometimesFails message, Envelope envelope, MessageRecorder recorder)
     {
         var result = determineResult(message, envelope, recorder);
         switch (result)
@@ -14,12 +14,12 @@ public class SometimesFailsHandler
             case MessageResult.DivideByZero:
                 throw new DivideByZeroException();
             default:
-                recorder.Increment(message.Id, envelope.Attempts);
+                recorder.Increment(message.Id);
                 break;
         }
     }
 
-    private MessageResult determineResult(SometimesFails message, Envelope envelope, Recorder recorder)
+    private MessageResult determineResult(SometimesFails message, Envelope envelope, MessageRecorder recorder)
     {
         if (recorder.NeverFail)
             return MessageResult.Success;

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/SometimesFailsHandler.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/SometimesFailsHandler.cs
@@ -4,9 +4,9 @@ namespace CircuitBreakingTests;
 
 public class SometimesFailsHandler
 {
-    public void Handle(SometimesFails message, Envelope envelope)
+    public void Handle(SometimesFails message, Envelope envelope, Recorder recorder)
     {
-        var result = determineResult(message, envelope);
+        var result = determineResult(message, envelope, recorder);
         switch (result)
         {
             case MessageResult.BadImage:
@@ -14,17 +14,15 @@ public class SometimesFailsHandler
             case MessageResult.DivideByZero:
                 throw new DivideByZeroException();
             default:
-                Recorder.Increment();
+                recorder.Increment(message.Id, envelope.Attempts);
                 break;
         }
     }
 
-    private MessageResult determineResult(SometimesFails message, Envelope envelope)
+    private MessageResult determineResult(SometimesFails message, Envelope envelope, Recorder recorder)
     {
-        if (Recorder.NeverFail)
-        {
+        if (recorder.NeverFail)
             return MessageResult.Success;
-        }
 
         switch (envelope.Attempts)
         {

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/local_durable_queue.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/local_durable_queue.cs
@@ -10,30 +10,28 @@ using Xunit.Abstractions;
 
 namespace CircuitBreakingTests;
 
-public class local_durable_queue : CircuitBreakerIntegrationContext
+public class local_durable_queue(ITestOutputHelper output)
+    : CircuitBreakerIntegrationContext(output)
 {
-    public local_durable_queue(ITestOutputHelper output) : base(output)
-    {
-    }
-
     protected override void configureListener(WolverineOptions opts)
     {
-        opts.PublishAllMessages().ToLocalQueue("durable").UseDurableInbox(new BufferingLimits(5000, 1))
+        opts.PublishAllMessages()
+            .ToLocalQueue(_queueName)
+            .UseDurableInbox(new BufferingLimits(5000, 1))
             .CircuitBreaker(cb =>
             {
                 cb.MinimumThreshold = 250;
                 cb.PauseTime = 10.Seconds();
                 cb.TrackingPeriod = 1.Minutes();
                 cb.FailurePercentageThreshold = 20;
-            })
-            ;
+            });
 
         opts.Policies.OnAnyException().Requeue();
 
         opts.Services.AddMarten(opts =>
         {
             opts.Connection(Servers.PostgresConnectionString);
-            opts.DatabaseSchemaName = "circuit_breaker";
+            opts.DatabaseSchemaName = _queueName;
         }).IntegrateWithWolverine().ApplyAllDatabaseChangesOnStartup();
 
         opts.Services.AddResourceSetupOnStartup();

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/stopping_and_starting_listeners.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/stopping_and_starting_listeners.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using IntegrationTests;
 using JasperFx.Core;
 using Marten;
@@ -6,7 +5,6 @@ using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using JasperFx.Resources;
 using Shouldly;
-using Wolverine.ComplianceTests;
 using Wolverine.ComplianceTests.Compliance;
 using Wolverine;
 using Wolverine.ErrorHandling;
@@ -18,7 +16,7 @@ using Wolverine.Util;
 
 namespace CircuitBreakingTests;
 
-public class stopping_and_starting_listeners : IAsyncLifetime, IDisposable
+public class stopping_and_starting_listeners : IAsyncLifetime
 {
     private int _port1;
     private int _port2;
@@ -31,33 +29,35 @@ public class stopping_and_starting_listeners : IAsyncLifetime, IDisposable
         _port2 = PortFinder.GetAvailablePort();
         _port3 = PortFinder.GetAvailablePort();
 
-        theListener = await WolverineHost.ForAsync(opts =>
-        {
-            opts.Durability.Mode = DurabilityMode.Solo;
+        theListener = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
 
-            opts.Services.AddMarten(Servers.PostgresConnectionString)
-                .IntegrateWithWolverine();
+                opts.Services.AddMarten(Servers.PostgresConnectionString)
+                    .IntegrateWithWolverine();
 
-            opts.Services.AddResourceSetupOnStartup();
+                opts.Services.AddResourceSetupOnStartup();
 
-            opts.ListenAtPort(_port1).Named("one");
-            opts.ListenAtPort(_port2).Named("two");
-            opts.ListenAtPort(_port3).Named("three");
+                opts.ListenAtPort(_port1).Named("one");
+                opts.ListenAtPort(_port2).Named("two");
+                opts.ListenAtPort(_port3).Named("three");
 
-            opts.PublishMessage<Message1>().ToLocalQueue("one").UseDurableInbox().Named("local");
-            opts.PublishMessage<CanCauseErrorMessage>().ToLocalQueue("one").UseDurableInbox();
+                opts.PublishMessage<Message1>().ToLocalQueue("one").UseDurableInbox().Named("local");
+                opts.PublishMessage<CanCauseErrorMessage>().ToLocalQueue("one").UseDurableInbox();
 
-            opts.Policies.OnException<DivideByZeroException>()
-                .Requeue().AndPauseProcessing(5.Seconds());
-        });
+                opts.Policies.OnException<DivideByZeroException>()
+                    .Requeue().AndPauseProcessing(5.Seconds());
+            }).StartAsync();
     }
 
-    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
-
-    public void Dispose()
+    public async Task DisposeAsync() 
     {
-        theListener?.Dispose();
+        await theListener.TeardownResources();
+        await theListener.StopAsync();
+        theListener.Dispose();
     }
+   
 
     [Fact]
     public async Task pause_a_local_durable_queue()
@@ -128,19 +128,8 @@ public class stopping_and_starting_listeners : IAsyncLifetime, IDisposable
 
         agent.Status.ShouldBe(ListeningStatus.Stopped);
 
-        var stopwatch = new Stopwatch();
-        stopwatch.Start();
-
-        while (stopwatch.Elapsed < 10.Seconds())
-        {
-            if (agent.Status == ListeningStatus.Accepting)
-            {
-                stopwatch.Stop();
-                return;
-            }
-        }
-
-        agent.Status.ShouldBe(ListeningStatus.Accepting);
+        await theListener.GetRuntime().Tracker.WaitForListenerStatusAsync(
+            "one", ListeningStatus.Accepting, 30.Seconds());
     }
 
     [Fact]
@@ -153,34 +142,24 @@ public class stopping_and_starting_listeners : IAsyncLifetime, IDisposable
 
         agent.Status.ShouldBe(ListeningStatus.Stopped);
 
-        var stopwatch = new Stopwatch();
-        stopwatch.Start();
-
-        while (stopwatch.Elapsed < 10.Seconds())
-        {
-            if (agent.Status == ListeningStatus.Accepting)
-            {
-                stopwatch.Stop();
-                return;
-            }
-        }
-
-        agent.Status.ShouldBe(ListeningStatus.Accepting);
+        await theListener.GetRuntime().Tracker.WaitForListenerStatusAsync(
+            "one", ListeningStatus.Accepting, 30.Seconds());
     }
 
     [Fact]
     public async Task pause_listener_on_matching_error_condition()
     {
-        using var sender = await WolverineHost.ForAsync(opts =>
-        {
-            opts.Durability.Mode = DurabilityMode.Solo;
-            opts.PublishAllMessages().ToPort(_port1).Named("one");
-        });
+        using var sender = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.PublishAllMessages().ToPort(_port1).Named("one");
+            }).StartAsync();
 
         var runtime = theListener.GetRuntime();
 
-        var stopWaiter =
-            runtime.Tracker.WaitForListenerStatusAsync("one", ListeningStatus.Stopped, 1.Minutes());
+        var stopWaiter = runtime.Tracker.WaitForListenerStatusAsync(
+            "one", ListeningStatus.Stopped, 1.Minutes());
 
         await sender
             .TrackActivity()
@@ -193,20 +172,8 @@ public class stopping_and_starting_listeners : IAsyncLifetime, IDisposable
         var agent = runtime.Endpoints.FindListeningAgent("one")!;
         agent.Status.ShouldBe(ListeningStatus.Stopped);
 
-        // should restart
-        var stopwatch = new Stopwatch();
-        stopwatch.Start();
-
-        while (stopwatch.Elapsed < 10.Seconds())
-        {
-            if (agent.Status == ListeningStatus.Accepting)
-            {
-                stopwatch.Stop();
-                return;
-            }
-        }
-
-        agent.Status.ShouldBe(ListeningStatus.Accepting);
+        await runtime.Tracker.WaitForListenerStatusAsync(
+            "one", ListeningStatus.Accepting, 30.Seconds());
     }
 
     [Fact]
@@ -214,36 +181,24 @@ public class stopping_and_starting_listeners : IAsyncLifetime, IDisposable
     {
         var runtime = theListener.GetRuntime();
 
-        var stopWaiter =
-            runtime.Tracker.WaitForListenerStatusAsync("one", ListeningStatus.Stopped, 1.Minutes());
+        var stopWaiter = runtime.Tracker.WaitForListenerStatusAsync(
+            "local", ListeningStatus.Stopped, 1.Minutes());
 
-        await theListener
+        var session = await theListener
             .TrackActivity()
             .AlsoTrack(theListener)
             .DoNotAssertOnExceptionsDetected()
-            .SendMessageAndWaitAsync(new CanCauseErrorMessage{Throw = true});
+            .SendMessageAndWaitAsync(new CanCauseErrorMessage { Throw = true });
 
         await stopWaiter;
 
         var agent = (IListenerCircuit)runtime.Endpoints.AgentForLocalQueue("one");
         agent.Status.ShouldBe(ListeningStatus.TooBusy);
 
-        CanCauseErrorMessageHandler.Handled.ShouldBe(1);
+        session.Executed.MessagesOf<CanCauseErrorMessage>().Count().ShouldBe(1);
 
-        // should restart
-        var stopwatch = new Stopwatch();
-        stopwatch.Start();
-
-        while (stopwatch.Elapsed < 10.Seconds())
-        {
-            if (agent.Status == ListeningStatus.Accepting)
-            {
-                stopwatch.Stop();
-                return;
-            }
-        }
-
-        agent.Status.ShouldBe(ListeningStatus.Accepting);
+        await runtime.Tracker.WaitForListenerStatusAsync(
+            "local", ListeningStatus.Accepting, 30.Seconds());
     }
 }
 
@@ -254,16 +209,10 @@ public class CanCauseErrorMessage
 
 public static class CanCauseErrorMessageHandler
 {
-    public static int Handled = 0;
-
     public static void Handle(CanCauseErrorMessage message, Envelope envelope)
     {
-        Handled++;
-
         if (envelope.Attempts <= 1)
-        {
             throw new DivideByZeroException();
-        }
     }
 }
 
@@ -274,8 +223,6 @@ public class PausingMessageHandler
     public static void Handle(PausingMessage message, Envelope envelope)
     {
         if (envelope.Attempts <= 1)
-        {
             throw new DivideByZeroException("boom");
-        }
     }
 }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs
@@ -22,7 +22,8 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
 {
     private readonly RabbitMqTransport _transport;
     private readonly ILogger<RabbitMqTransport> _logger;
-    private readonly List<RabbitMqChannelAgent> _agents = new();
+    private readonly object _agentsLock = new();
+    private readonly List<RabbitMqChannelAgent> _agents = [];
     private IConnection? _connection;
 
     public ConnectionMonitor(RabbitMqTransport transport, ConnectionRole role)
@@ -34,17 +35,18 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
     
     public async Task ConnectAsync()
     {
-        _connection = await _transport.CreateConnectionAsync();
+        var connection = await _transport.CreateConnectionAsync();
+        _connection = connection;
         IsConnected = true;
         // Initial connection -- record the timestamp but don't bump the
         // reconnect counter (that's reserved for genuine recoveries).
         _transport.RecordInitialConnection();
 
-        _connection.ConnectionShutdownAsync += connectionOnConnectionShutdownAsync;
-        _connection.ConnectionUnblockedAsync += connectionOnConnectionUnblockedAsync;
-        _connection.ConnectionBlockedAsync += connectionOnConnectionBlockedAsync;
-        _connection.CallbackExceptionAsync += connectionOnCallbackExceptionAsync;
-        _connection.RecoverySucceededAsync += connectionOnRecoverySucceededAsync;
+        connection.ConnectionShutdownAsync += connectionOnConnectionShutdownAsync;
+        connection.ConnectionUnblockedAsync += connectionOnConnectionUnblockedAsync;
+        connection.ConnectionBlockedAsync += connectionOnConnectionBlockedAsync;
+        connection.CallbackExceptionAsync += connectionOnCallbackExceptionAsync;
+        connection.RecoverySucceededAsync += connectionOnRecoverySucceededAsync;
     }
 
     /// <summary>
@@ -54,14 +56,15 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
     /// <returns>A task that resolves to an <see cref="IChannel"/> instance for RabbitMQ communication.</returns>
     public Task<IChannel> CreateChannelAsync()
     {
-        if (_connection == null) throw new InvalidOperationException("The connection is not initialized");
+        var connection = _connection 
+            ?? throw new InvalidOperationException("The connection is not initialized");
 
         var wolverineOptions = new WolverineRabbitMqChannelOptions();
         _transport.ChannelCreationOptions?.Invoke(wolverineOptions);
 
         var options = new CreateChannelOptions(wolverineOptions.PublisherConfirmationsEnabled, wolverineOptions.PublisherConfirmationTrackingEnabled, consumerDispatchConcurrency: wolverineOptions.ConsumerDispatchConcurrency);
 
-        return _connection!.CreateChannelAsync(options);
+        return connection.CreateChannelAsync(options);
     }
 
     public ConnectionRole Role { get; }
@@ -79,23 +82,32 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
 
     public async ValueTask DisposeAsync()
     {
+        var connection = _connection;
+        if (connection is null)
+            return;
+        _connection = null;
+
         try
         {
-            if(_connection is not null)
-            {
-                await _connection.CloseAsync();
-            }
+            connection.ConnectionShutdownAsync -= connectionOnConnectionShutdownAsync;
+            connection.ConnectionUnblockedAsync -= connectionOnConnectionUnblockedAsync;
+            connection.ConnectionBlockedAsync -= connectionOnConnectionBlockedAsync;
+            connection.CallbackExceptionAsync -= connectionOnCallbackExceptionAsync;
+            connection.RecoverySucceededAsync -= connectionOnRecoverySucceededAsync;
+
+            await connection.CloseAsync();
         }
         catch (ObjectDisposedException)
         {
         }
 
-        _connection?.SafeDispose();
+        connection.SafeDispose();
     }
 
     public void Track(RabbitMqChannelAgent agent)
     {
-        _agents.Add(agent);
+        lock (_agentsLock)
+            _agents.Add(agent);
     }
 
     private async Task connectionOnRecoverySucceededAsync(object sender, AsyncEventArgs @event)
@@ -103,10 +115,12 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
         IsConnected = true;
         _transport.RecordReconnection();
 
-        foreach (var agent in _agents)
-        {
+        RabbitMqChannelAgent[] agentsSnaphot;
+        lock(_agentsLock)
+            agentsSnaphot = [.. _agents];
+
+        foreach (var agent in agentsSnaphot)
             await agent.ReconnectedAsync();
-        }
 
         _logger.LogInformation("RabbitMQ connection is recovered successfully");
     }
@@ -160,6 +174,7 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
 
     public void Remove(RabbitMqChannelAgent agent)
     {
-        _agents.Remove(agent);
+        lock (_agentsLock)
+            _agents.Remove(agent);
     }
 }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
@@ -10,7 +10,8 @@ namespace Wolverine.RabbitMQ.Internal;
 internal abstract class RabbitMqChannelAgent : IAsyncDisposable
 {
     private readonly ConnectionMonitor _monitor;
-    protected readonly SemaphoreSlim Locker = new(1, 1);
+    private readonly SemaphoreSlim Locker = new(1, 1);
+    private bool _disposed;
 
     protected RabbitMqChannelAgent(ConnectionMonitor monitor,
         ILogger logger)
@@ -29,9 +30,12 @@ internal abstract class RabbitMqChannelAgent : IAsyncDisposable
 
     public virtual async ValueTask DisposeAsync()
     {
+        if (_disposed)
+            return;
+        _disposed = true;
+
         _monitor.Remove(this);
         await teardownChannel();
-        Locker.Dispose();
     }
 
     internal async Task EnsureInitiated()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
@@ -41,20 +41,14 @@ internal abstract class RabbitMqChannelAgent : IAsyncDisposable
     internal async Task EnsureInitiated()
     {
         if (Channel is not null)
-        {
             return;
-        }
 
         await Locker.WaitAsync();
-        
-        if (Channel is not null)
-        {
-            Locker.Release();
-            return;
-        }
-
         try
         {
+            if (Channel is not null)
+                return;
+
             await startNewChannel();
             State = AgentState.Connected;
         }
@@ -72,47 +66,52 @@ internal abstract class RabbitMqChannelAgent : IAsyncDisposable
     {
         Channel = await _monitor.CreateChannelAsync();
 
-        Channel.CallbackExceptionAsync += (sender, args) =>
-        {
-            Logger.LogError(args.Exception, "Callback error in Rabbit Mq agent. Attempting to restart the channel");
-
-            // Try to restart the connection
-#pragma warning disable VSTHRD110
-            Task.Run(async () =>
-#pragma warning restore VSTHRD110
-            {
-                await Locker.WaitAsync();
-                try
-                {
-                    _monitor.Remove(this);
-                    try
-                    {
-                        await teardownChannel();
-                    }
-                    catch (Exception e)
-                    {
-                        Logger.LogError(e, "Error when trying to tear down a blocked channel");
-                    }
-
-                    Channel = null;
-                    await EnsureInitiated();
-                    Logger.LogInformation("Restarted the Rabbit MQ channel");
-                }
-                finally
-                {
-                    Locker.Release();
-                }
-            });
-            
-            return Task.CompletedTask;
-        };
-
-        Channel.ChannelShutdownAsync += ChannelOnModelShutdown;
+        Channel.CallbackExceptionAsync += HandleChannelExceptionAsync;
+        Channel.ChannelShutdownAsync += HandleChannelShutdownAsync;
 
         Logger.LogInformation("Opened a new channel for Wolverine endpoint {Endpoint}", this);
     }
 
-    private Task ChannelOnModelShutdown(object? sender, ShutdownEventArgs e)
+    private Task HandleChannelExceptionAsync(object? sender, CallbackExceptionEventArgs args)
+    {
+        Logger.LogError(args.Exception, "Callback error in Rabbit Mq agent. Attempting to restart the channel");
+
+        // Try to restart the connection
+#pragma warning disable VSTHRD110
+        Task.Run(async () =>
+#pragma warning restore VSTHRD110
+        {
+            await Locker.WaitAsync();
+            try
+            {
+                _monitor.Remove(this);
+                try
+                {
+                    await teardownChannel();
+                }
+                catch (Exception e)
+                {
+                    Logger.LogError(e, "Error when trying to tear down a blocked channel");
+                }
+
+                Channel = null;
+
+                // EnsureInitiated can be used here as Locker(SemaphoreSlim) is not re-entrant
+                await startNewChannel();
+                State = AgentState.Connected;
+
+                Logger.LogInformation("Restarted the Rabbit MQ channel");
+            }
+            finally
+            {
+                Locker.Release();
+            }
+        });
+
+        return Task.CompletedTask;
+    }
+
+    private Task HandleChannelShutdownAsync(object? sender, ShutdownEventArgs e)
     {
         State = AgentState.Disconnected;
 
@@ -137,7 +136,8 @@ internal abstract class RabbitMqChannelAgent : IAsyncDisposable
     {
         if (Channel != null)
         {
-            Channel.ChannelShutdownAsync -= ChannelOnModelShutdown;
+            Channel.ChannelShutdownAsync -= HandleChannelShutdownAsync;
+            Channel.CallbackExceptionAsync -= HandleChannelExceptionAsync;
             await Channel.CloseAsync();
             await Channel.AbortAsync();
             Channel.Dispose();

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -115,11 +115,9 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
         _consumer = null;
 
         await base.DisposeAsync();
-
-        if (_sender.IsValueCreated && _sender.Value is IAsyncDisposable ad)
-        {
-            await ad.DisposeAsync();
-        }
+        
+        // Don't dispose _sender.Value — it's a shared sender cached on
+        // RabbitMqQueue and reused across listener pause/restart cycles.
     }
 
     public async Task<bool> TryRequeueAsync(Envelope envelope)

--- a/src/Wolverine/ErrorHandling/CircuitBreaker.cs
+++ b/src/Wolverine/ErrorHandling/CircuitBreaker.cs
@@ -183,7 +183,7 @@ internal class CircuitBreaker : IAsyncDisposable, IMessageSuccessTracker
 
         if (failures > 0 && ShouldStopProcessing())
         {
-            await _circuit.PauseAsync(Options.PauseTime);
+            await _circuit.PauseWithDrainAsync(Options.PauseTime);
 
             if (_observer != null)
             {

--- a/src/Wolverine/ErrorHandling/CircuitBreaker.cs
+++ b/src/Wolverine/ErrorHandling/CircuitBreaker.cs
@@ -95,6 +95,7 @@ internal class CircuitBreaker : IAsyncDisposable, IMessageSuccessTracker
     private readonly Block<object[]> _processingBlock;
     private readonly double _ratio;
     private readonly IWolverineObserver? _observer;
+    private bool _disposed;
 
     public CircuitBreaker(CircuitBreakerOptions options, IListenerCircuit circuit, IWolverineObserver? observer = null)
     {
@@ -119,6 +120,9 @@ internal class CircuitBreaker : IAsyncDisposable, IMessageSuccessTracker
 
     public async ValueTask DisposeAsync()
     {
+        if (_disposed)
+            return;
+        _disposed = true;
         await _cancellation.CancelAsync();
         _processingBlock.Complete();
         await _batching.DisposeAsync();

--- a/src/Wolverine/Logging/WolverineTracker.cs
+++ b/src/Wolverine/Logging/WolverineTracker.cs
@@ -68,7 +68,7 @@ public class WolverineTracker : WatchedObservable<IWolverineEvent>, IObserver<IW
 
         var waiter =
             new ConditionalWaiter<IWolverineEvent, ListenerState>(
-                state => state.EndpointName == endpointName || state.Status == status, this, timeout);
+                state => state.EndpointName == endpointName && state.Status == status, this, timeout);
         Subscribe(waiter);
 
         return waiter.Completion;
@@ -83,7 +83,7 @@ public class WolverineTracker : WatchedObservable<IWolverineEvent>, IObserver<IW
         }
 
         var waiter =
-            new ConditionalWaiter<IWolverineEvent, ListenerState>(state => state.Uri == uri || state.Status == status,
+            new ConditionalWaiter<IWolverineEvent, ListenerState>(state => state.Uri == uri && state.Status == status,
                 this, timeout);
         Subscribe(waiter);
 

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -15,6 +15,15 @@ public interface IListenerCircuit
     Endpoint Endpoint { get; }
     int QueueCount { get; }
     ValueTask PauseAsync(TimeSpan pauseTime);
+    
+    /// <summary>
+    /// Pause the listener and fully drain any buffered messages before returning.
+    /// Unlike PauseAsync (which may skip the drain to avoid deadlocks when called from
+    /// within the handler pipeline), this method guarantees all queued messages are
+    /// processed before returning. Safe to call from background threads.
+    /// </summary>
+    ValueTask PauseWithDrainAsync(TimeSpan pauseTime);
+    
     ValueTask StartAsync();
 
     Task EnqueueDirectlyAsync(IEnumerable<Envelope> envelopes);
@@ -354,13 +363,25 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
 
     public async ValueTask PauseAsync(TimeSpan pauseTime)
     {
+        // Do NOT pre-latch the receiver here. PauseAsync may be called from within the
+        // handler pipeline (e.g. via RateLimitContinuation → PauseListenerContinuation).
+        // Pre-latching causes DrainAsync to wait for the ActionBlock to drain, which
+        // deadlocks because the current message's execute frame is still on the call stack.
+        await PauseCoreAsync(pauseTime, latchBeforeDrain: false);
+    }
+
+    public async ValueTask PauseWithDrainAsync(TimeSpan pauseTime)
+    {
+        // Safe to fully drain here: this method is called from background threads
+        // (circuit breaker), never from within the handler pipeline call stack.
+        await PauseCoreAsync(pauseTime, latchBeforeDrain: true);
+    }
+
+    private async ValueTask PauseCoreAsync(TimeSpan pauseTime, bool latchBeforeDrain)
+    {
         try
         {
-            // Do NOT pre-latch the receiver here. PauseAsync may be called from within the
-            // handler pipeline (e.g. via RateLimitContinuation → PauseListenerContinuation).
-            // Pre-latching causes DrainAsync to wait for the ActionBlock to drain, which
-            // deadlocks because the current message's execute frame is still on the call stack.
-            await StopAndDrainCoreAsync(latchBeforeDrain: false);
+            await StopAndDrainCoreAsync(latchBeforeDrain);
         }
         catch (Exception e)
         {

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -48,6 +48,7 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
     private IDisposable? _restarter;
     private int _lastObservedQueueCount;
     private DateTimeOffset _lastQueueCountChangeAt = DateTimeOffset.UtcNow;
+    private bool _disposed;
 
     public ListeningAgent(Endpoint endpoint, WolverineRuntime runtime)
     {
@@ -85,6 +86,10 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
 
     public async ValueTask DisposeAsync()
     {
+        if (_disposed)
+            return;
+        _disposed = true;
+
         _restarter?.SafeDispose();
         _backPressureAgent?.SafeDispose();
 
@@ -106,6 +111,10 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
 
     public void Dispose()
     {
+        if (_disposed)
+            return;
+        _disposed = true;
+
         _receiver?.Dispose();
         _circuitBreaker?.SafeDisposeSynchronously();
         _backPressureAgent?.SafeDispose();

--- a/src/Wolverine/Transports/Local/BufferedLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/BufferedLocalQueue.cs
@@ -29,6 +29,11 @@ internal class BufferedLocalQueue : BufferedReceiver, ISendingAgent, IListenerCi
         return ValueTask.CompletedTask;
     }
 
+    ValueTask IListenerCircuit.PauseWithDrainAsync(TimeSpan pauseTime)
+    {
+        return ValueTask.CompletedTask;
+    }
+
     ValueTask IListenerCircuit.StartAsync()
     {
         return ValueTask.CompletedTask;

--- a/src/Wolverine/Transports/Local/DurableLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/DurableLocalQueue.cs
@@ -159,9 +159,13 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
 
     async ValueTask IReceiver.DrainAsync()
     {
-        _receiver!.Latch();
+        var receiver = _receiver;
+
+        receiver?.Latch();
         await _storeAndEnqueue.DrainAsync();
-        await _receiver!.DrainAsync();
+
+        if (receiver != null)
+            await receiver.DrainAsync();
     }
 
     void ILocalReceiver.Enqueue(Envelope envelope)

--- a/src/Wolverine/Transports/Local/DurableLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/DurableLocalQueue.cs
@@ -248,9 +248,15 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
 
     private async Task storeAndEnqueueAsync(Envelope envelope)
     {
+        var isLatched = Latched;
+
         try
         {
-            envelope.OwnerId = _settings.AssignedNodeNumber;
+            // Use AnyNode when latched so the durability agent can recover the message.
+            envelope.OwnerId = isLatched
+                ? TransportConstants.AnyNode
+                : _settings.AssignedNodeNumber;
+
             assignAncillaryStoreIfNeeded(envelope);
             await _inbox.StoreIncomingAsync(envelope);
             envelope.WasPersistedInInbox = true;
@@ -261,7 +267,7 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
             return;
         }
 
-        if (Latched)
+        if (isLatched)
         {
             return;
         }

--- a/src/Wolverine/Transports/Local/DurableLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/DurableLocalQueue.cs
@@ -122,6 +122,15 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
         _restarter = new Restarter(this, pauseTime);
     }
 
+    public async ValueTask PauseWithDrainAsync(TimeSpan pauseTime)
+    {
+        // DurableLocalQueue.PauseAsync already fully drains. The behavioral split
+        // between PauseAsync and PauseWithDrainAsync is important for BufferedReceiver
+        // (which skips the drain in PauseAsync to avoid deadlocking when called from
+        // within the handler pipeline). For the durable local queue, both are identical.
+        await PauseAsync(pauseTime);
+    }
+
     public ValueTask StartAsync()
     {
         _receiver = new DurableReceiver(Endpoint, _runtime, Pipeline);

--- a/src/Wolverine/Transports/Tcp/SocketListener.cs
+++ b/src/Wolverine/Transports/Tcp/SocketListener.cs
@@ -18,6 +18,7 @@ public class SocketListener : IListener, IDisposable
     private CancellationTokenSource? _listenerCancellation;
     private Task? _receivingLoop;
     private Block<Socket>? _socketHandling;
+    private bool _disposed;
 
     public SocketListener(TcpEndpoint endpoint, IReceiver receiver, ILogger logger, IPAddress ipaddr, int port,
         CancellationToken cancellationToken)
@@ -36,6 +37,10 @@ public class SocketListener : IListener, IDisposable
 
     public void Dispose()
     {
+        if (_disposed)
+            return;
+        _disposed = true;
+
         _socketHandling?.Complete();
         _listener?.Stop();
         _listener?.Server.Dispose();
@@ -54,10 +59,15 @@ public class SocketListener : IListener, IDisposable
 
     public async ValueTask DisposeAsync()
     {
+        if (_disposed)
+            return;
+        _disposed = true;
+
         if (_listenerCancellation is not null)
         {
             await _listenerCancellation.CancelAsync();
             _listenerCancellation.Dispose();
+            _listenerCancellation = null;
         }
 
         _listener?.Stop();

--- a/src/XunitLogger.cs
+++ b/src/XunitLogger.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 
-namespace Wolverine.Nats.Tests.Helpers;
+namespace IntegrationTests;
 
 /// <summary>
 /// Logger provider that writes to xUnit test output


### PR DESCRIPTION
This PR fixes the issues in RabbitMQ circuit breaker and enables the corresponding tests skipped before.

### Fixed issues
* `PauseAsync` called by `CircuitBreaker` skipped draining buffered messages resulting in the lost in-flight messages on breaker trip. **Fix:** use separate `PauseAndDrainAsync` for `CircuitBreaker`.
* `RabbitMqChannelAgent` uses `SemaphoreSlim` (not reentrant) to guard channel initialization. The channel error handler called `EnsureInitiated()` and re-acquired the same semaphore - deadlock. **Fix:** embed channel creation into error handler.
* `ConnectionMonitor` uses thread unsafe `_agents` collection. **Fix:** Use lock for protection
* `ConnectionMonitor` and `RabbitMqChannelAgent` subscribed to client events but did not unsubscribe on disposal. **Fix:** unsubscribe correctly
* When latched persisted envelopes used `OwnerId = AssignedNodeNumber` making them unrecoverable by the durability agent. **Fix:**  Use `AnyNode` ownerId when latched.
* In `RabbitMqChannelAgent` disposed `SemaphoreSlim` can cause `ObjectDisposedException` on `WaitAsync`/`Release`. **Fix:** skip its disposal.
* `RabbitMqListener` disposes `_sender.Value` - a shared sender cached on `RabbitMqQueue` and reused across listener pause/restart cycles. **Fix:** skip its disposal.

Two last issues were introduced by me in https://github.com/JasperFx/wolverine/pull/2894.

### Supporting changes
- Double-dispose is prevented for `CircuitBreaker`, `ListeningAgent`, and `RabbitMqChannelAgent`.
- New `circuit-breaking` workflow and Nuke target to keep CI fast.  CircuitBreaking tests (unmarked as flaky) add ~4–6 minutes to RabbitMQ workflow, so they run independently.
- `XunitLogger` from NATS tests is extracted for reuse. 

### Note
The tests are still flaky (even though can succeed due to CI flaky retries). `buffered_not_parallelized` and `buffered_and_parallel` flake more frequently.