### PR TITLE
RabbitMQ post-#3132 cleanup: typo fix + intentional-non-disposal comment

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs
@@ -115,11 +115,11 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
         IsConnected = true;
         _transport.RecordReconnection();
 
-        RabbitMqChannelAgent[] agentsSnaphot;
+        RabbitMqChannelAgent[] agentsSnapshot;
         lock(_agentsLock)
-            agentsSnaphot = [.. _agents];
+            agentsSnapshot = [.. _agents];
 
-        foreach (var agent in agentsSnaphot)
+        foreach (var agent in agentsSnapshot)
             await agent.ReconnectedAsync();
 
         _logger.LogInformation("RabbitMQ connection is recovered successfully");

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
@@ -36,6 +36,11 @@ internal abstract class RabbitMqChannelAgent : IAsyncDisposable
 
         _monitor.Remove(this);
         await teardownChannel();
+
+        // Intentionally NOT calling Locker.Dispose() — rapid pause/restart cycles
+        // can have an in-flight WaitAsync/Release race with disposal, which would
+        // throw ObjectDisposedException. The kernel handle is reclaimed by the
+        // SemaphoreSlim finalizer. See #3132.
     }
 
     internal async Task EnsureInitiated()


### PR DESCRIPTION
Two micro-fixes from the [code review](https://github.com/JasperFx/wolverine/pull/3132#issuecomment) of [#3132](https://github.com/JasperFx/wolverine/pull/3132). Bundled because both touch the same RabbitMQ internals.

## Changes

### 1. `agentsSnaphot` → `agentsSnapshot` (×3)

[`ConnectionMonitor.connectionOnRecoverySucceededAsync`](src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs) — typo of an internal local.

### 2. Document the intentional `Locker.Dispose()` omission

[`RabbitMqChannelAgent.DisposeAsync`](src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs) — #3132 removed the `Locker.Dispose()` call to avoid `ObjectDisposedException` on rapid pause/restart races (in-flight `WaitAsync`/`Release` after disposal). Adding a comment so the next "missing-Dispose" PR doesn't undo it.

## Diff footprint

`git diff -w` shows **8 insertions / 3 deletions** across two files. The raw diff is noisier because saving the files also stripped trailing whitespace that #3132 introduced on lines I didn't touch — `.editorconfig`/save-hook behavior, not intentional.

## Why now

[Code review of #3132](https://github.com/JasperFx/wolverine/pull/3132) flagged these as low-priority follow-ups; bundling them while the context is fresh.

## Test plan

- [x] `dotnet build src/Transports/RabbitMQ/Wolverine.RabbitMQ/Wolverine.RabbitMQ.csproj -c Release` — clean, 0 warnings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)