### PR TITLE
[AsParameters] OpenAPI route-type fidelity + multiple-body guard (#3135)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/IntegrationContext.cs
+++ b/src/Http/Wolverine.Http.Tests/IntegrationContext.cs
@@ -143,17 +143,32 @@ public abstract class IntegrationContext : IAsyncLifetime, IOpenApiSource
 
     public (OpenApiPathItem, OpenApiOperation) FindOpenApiDocument(OperationType httpMethod, string path)
     {
-        var swagger = Host.Services.GetRequiredService<ISwaggerProvider>();
-        var document = swagger.GetSwagger("default");
+        var document = GetOpenApiDocument();
 
-        if (document.Paths.TryGetValue(path, out var item))
+        if (!document.Paths.TryGetValue(path, out var item))
         {
-            if (item.Operations.TryGetValue(httpMethod, out var operation))
-            {
-                return (item, operation);
-            }
+            // Generated document path keys drop inline route constraints (e.g. {id:guid} -> {id}),
+            // while the harness looks up by the raw route pattern. Fall back to a constraint-stripped
+            // comparison so constrained routes resolve. See GH-3135.
+            var normalized = StripRouteConstraints(path);
+            item = document.Paths
+                .FirstOrDefault(kv => StripRouteConstraints(kv.Key) == normalized).Value;
+        }
+
+        if (item != null && item.Operations.TryGetValue(httpMethod, out var operation))
+        {
+            return (item, operation);
         }
 
         throw new Exception($"Unable to find {httpMethod} {path}");
+    }
+
+    private static string StripRouteConstraints(string path)
+        => System.Text.RegularExpressions.Regex.Replace(path, "\\{([^:}?*]+)[^}]*\\}", "{$1}");
+
+    public OpenApiDocument GetOpenApiDocument()
+    {
+        var swagger = Host.Services.GetRequiredService<ISwaggerProvider>();
+        return swagger.GetSwagger("default");
     }
 }

--- a/src/Http/Wolverine.Http.Tests/asparameters_multiple_body_guard.cs
+++ b/src/Http/Wolverine.Http.Tests/asparameters_multiple_body_guard.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+using Wolverine.Attributes;
+
+namespace Wolverine.Http.Tests;
+
+// GH-3135 WS4: an [AsParameters] type that declares more than one [FromBody] member must fail fast
+// with a clear message rather than silently reusing the first member's deserialization variable.
+// These endpoint types live in the test assembly so the application host never discovers them
+// (which would break the shared fixture at startup).
+public class asparameters_multiple_body_guard
+{
+    [Fact]
+    public void throws_when_more_than_one_from_body_member()
+    {
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            HttpChain.ChainFor<TwoBodyEndpoint>(x => x.Post(null!)));
+
+        ex.Message.ShouldContain("more than one [FromBody]");
+    }
+
+    [Fact]
+    public void single_from_body_member_is_allowed()
+    {
+        // Sanity: the guard does not trip on the legitimate single-body case.
+        Should.NotThrow(() => HttpChain.ChainFor<SingleBodyEndpoint>(x => x.Post(null!)));
+    }
+}
+
+public record FirstBody(string Name);
+
+public record SecondBody(int Age);
+
+public record TwoBodyCommand([FromBody] FirstBody First, [FromBody] SecondBody Second);
+
+public class TwoBodyEndpoint
+{
+    // [WolverineIgnore] keeps the host from discovering this intentionally-invalid endpoint at
+    // startup (which would throw the guard and break every test-assembly-scoped host). ChainFor
+    // builds it directly, bypassing discovery, so the guard is still exercised under test.
+    [WolverineIgnore]
+    [WolverinePost("/3135/two-body")]
+    public string Post([AsParameters] TwoBodyCommand command) => "nope";
+}
+
+public record SingleBodyCommand([FromBody] FirstBody Body, [FromQuery] string? Name);
+
+public class SingleBodyEndpoint
+{
+    [WolverineIgnore]
+    [WolverinePost("/3135/single-body")]
+    public string Post([AsParameters] SingleBodyCommand command) => "ok";
+}

--- a/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
@@ -90,6 +90,7 @@ internal class AsParametersBindingFrame : SyncFrame
     
     private bool _hasForms = false;
     private bool _hasJsonBody = false;
+    private int _jsonBodyCount = 0;
 
     public AsParametersBindingFrame([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] Type queryType, HttpChain chain, IServiceContainer container)
     {
@@ -135,6 +136,16 @@ internal class AsParametersBindingFrame : SyncFrame
         {
             throw new InvalidOperationException(
                 $"{queryType.FullNameInCode()} cannot be decorated with [AsParameters] because it uses both [FromForm] and [FromBody] binding. You can only use one or the other option");
+        }
+
+        // The request body is read once (chain.RequestBodyVariable is single-shot), so a second
+        // [FromBody] member would silently reuse the first member's deserialization variable and
+        // produce a wrong-typed assignment. Fail fast with a clear message, mirroring the
+        // FromForm+FromBody guard above. ASP.NET likewise rejects more than one body. See GH-3135.
+        if (_jsonBodyCount > 1)
+        {
+            throw new InvalidOperationException(
+                $"{queryType.FullNameInCode()} cannot be decorated with [AsParameters] because it has more than one [FromBody] member. Only a single request body is supported");
         }
     }
     
@@ -183,6 +194,7 @@ internal class AsParametersBindingFrame : SyncFrame
         if (parameter.TryGetAttribute<FromBodyAttribute>(out var batt))
         {
             _hasJsonBody = true;
+            _jsonBodyCount++;
             chain.RequestType = memberType;
             variable = chain.BuildJsonDeserializationVariable();
             

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -447,9 +447,17 @@ public partial class HttpChain
 
     private ApiParameterDescription buildParameterDescription(RoutePatternParameterPart routeParameter)
     {
-        var variable = _routeVariables.FirstOrDefault(x => x.Usage == routeParameter.Name);
+        // Match the bound route variable case-insensitively: route tokens are conventionally
+        // lower-cased (e.g. {journeyId}) while the bound member/argument is PascalCased
+        // (JourneyId). A case-sensitive match here silently misses and falls back to string,
+        // losing the real type (e.g. Guid/int) on the generated OpenAPI parameter. See GH-3135.
+        var variable = _routeVariables.FirstOrDefault(x => x.Usage.EqualsIgnoreCase(routeParameter.Name));
 
-        var parameterType = variable?.VariableType ?? typeof(string);
+        // When no typed argument is bound to the route value (e.g. a plain complex-body endpoint
+        // whose body property overlaps a route token, or an aggregate-id route), fall back to the
+        // route constraint (`{id:guid}`, `{n:int}`, ...) so the parameter still gets its real
+        // type/format instead of defaulting to string. Both OpenAPI stacks schematize from .Type.
+        var parameterType = variable?.VariableType ?? TypeFromRouteConstraint(routeParameter) ?? typeof(string);
         var parameter = new ApiParameterDescription
         {
             Name = routeParameter.Name,
@@ -465,6 +473,49 @@ public partial class HttpChain
             }
         };
         return parameter;
+    }
+
+    // Maps an inline route constraint to the CLR type ASP.NET's own route binding would use, so the
+    // generated OpenAPI parameter carries the right schema type/format (e.g. {id:guid} -> uuid,
+    // {n:int} -> integer). Returns null for `string`/unconstrained or constraints that don't imply a
+    // type (length/regex/min/max/etc.), letting the caller default to string. See GH-3135.
+    private static Type? TypeFromRouteConstraint(RoutePatternParameterPart routeParameter)
+    {
+        foreach (var policy in routeParameter.ParameterPolicies)
+        {
+            var content = policy.Content;
+            if (content.IsEmpty())
+            {
+                continue;
+            }
+
+            // Constraints can be parameterized (e.g. "length(5)", "regex(...)"); only the leading
+            // constraint name carries the type signal.
+            var parenIndex = content.IndexOf('(');
+            var name = parenIndex > 0 ? content[..parenIndex] : content;
+
+            switch (name.ToLowerInvariant())
+            {
+                case "int":
+                    return typeof(int);
+                case "long":
+                    return typeof(long);
+                case "bool":
+                    return typeof(bool);
+                case "datetime":
+                    return typeof(DateTime);
+                case "decimal":
+                    return typeof(decimal);
+                case "double":
+                    return typeof(double);
+                case "float":
+                    return typeof(float);
+                case "guid":
+                    return typeof(Guid);
+            }
+        }
+
+        return null;
     }
 }
 

--- a/src/Http/WolverineWebApi/AsParametersOpenApiEndpoints.cs
+++ b/src/Http/WolverineWebApi/AsParametersOpenApiEndpoints.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.OpenApi.Models;
+using Wolverine.Http;
+using WolverineWebApi.TestSupport;
+
+namespace WolverineWebApi;
+
+// GH-3135 OpenAPI-shape coverage for [AsParameters] and overlapping route/body parameters.
+// These endpoints are deliberately free of database/Marten dependencies so they participate in the
+// Swashbuckle-driven open_api_generation harness. The new Expect* attributes assert parameter
+// type/format and request-body shape (presence AND absence of properties).
+
+public record AddPassengerPayload(string PassengerName);
+
+// uniquelau's preferred shape (issue CASE B): [AsParameters] splitting a typed [FromRoute] id from a
+// [FromBody] payload. The route id must keep its real type/format (uuid) and the body must be just
+// the payload member type — the container and the route-bound id must NOT appear in the body.
+public record AddPassengerCommand([FromRoute] Guid JourneyId, [FromBody] AddPassengerPayload Body);
+
+public static class AsParametersSplitEndpoint
+{
+    [WolverinePost("/api/3135/journey/{journeyId:guid}/passenger")]
+    [ExpectParameter("journeyId", ParameterLocation.Path, Type = "string", Format = "uuid")]
+    [ExpectRequestBody("application/json", "passengerName", ForbiddenProperties = ["journeyId", "body"])]
+    public static string Post([AsParameters] AddPassengerCommand command)
+        => $"{command.JourneyId}:{command.Body.PassengerName}";
+}
+
+// uniquelau's "Alternative" workaround (issue CASE A): a plain complex body whose property overlaps a
+// route token. The duplication (journeyId in path AND body) is intentional ASP.NET-parity behavior
+// and is locked in here; the win from GH-3135 is that the path param now carries format: uuid.
+public record AddPassengerFlatCommand(Guid JourneyId, string PassengerName);
+
+public static class PlainBodyRouteOverlapEndpoint
+{
+    [WolverinePost("/api/3135/flat/journey/{journeyId:guid}/passenger")]
+    [ExpectParameter("journeyId", ParameterLocation.Path, Type = "string", Format = "uuid")]
+    [ExpectRequestBody("application/json", "journeyId", "passengerName")]
+    public static string Post(AddPassengerFlatCommand command)
+        => $"{command.JourneyId}:{command.PassengerName}";
+}
+
+// Isolates the case-insensitive route-variable match (GH-3135): the member is PascalCase `Number`
+// while the route token is lowercase `number`, and the route is UNCONSTRAINED — so only a
+// case-insensitive match keeps the parameter typed as integer rather than falling back to string.
+public record RouteIntQuery([FromRoute] int Number, [FromQuery] string? Name);
+
+public static class AsParametersRouteIntEndpoint
+{
+    [WolverinePost("/api/3135/route-int/{number}")]
+    [ExpectParameter("number", ParameterLocation.Path, Type = "integer")]
+    [ExpectParameter("Name", ParameterLocation.Query, Type = "string")]
+    [ExpectNoRequestBody]
+    public static string Post([AsParameters] RouteIntQuery query)
+        => $"{query.Number}:{query.Name}";
+}
+
+// Exercises the route-constraint -> schema type/format fallback (GH-3135) when no typed argument is
+// bound to the route value at all (plain string handler argument, constrained route tokens).
+public static class RouteConstraintTypingEndpoint
+{
+    [WolverineGet("/api/3135/constraints/{id:guid}/{count:int}")]
+    [ExpectParameter("id", ParameterLocation.Path, Type = "string", Format = "uuid")]
+    [ExpectParameter("count", ParameterLocation.Path, Type = "integer")]
+    [ExpectNoRequestBody]
+    public static string Get(Guid id, int count) => $"{id}:{count}";
+}

--- a/src/Http/WolverineWebApi/TestSupport/ExpectNoRequestBodyAttribute.cs
+++ b/src/Http/WolverineWebApi/TestSupport/ExpectNoRequestBodyAttribute.cs
@@ -1,0 +1,20 @@
+using Microsoft.OpenApi.Models;
+using Shouldly;
+
+namespace WolverineWebApi.TestSupport;
+
+/// <summary>
+/// Asserts the generated OpenAPI operation has no request body (e.g. a pure query/route GET, or an
+/// [AsParameters] endpoint whose members are all query/header/route bound). See GH-3135.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public class ExpectNoRequestBodyAttribute : OpenApiExpectationAttribute
+{
+    public override void Validate(OpenApiPathItem item, OpenApiOperation op, IOpenApiSource openApi)
+    {
+        var hasContent = op.RequestBody?.Content?.Count > 0;
+        hasContent.ShouldBeFalse(
+            "Expected no request body, but found content types: " +
+            (op.RequestBody?.Content == null ? "<none>" : string.Join(", ", op.RequestBody.Content.Keys)));
+    }
+}

--- a/src/Http/WolverineWebApi/TestSupport/ExpectParameterAttribute.cs
+++ b/src/Http/WolverineWebApi/TestSupport/ExpectParameterAttribute.cs
@@ -1,0 +1,49 @@
+using Microsoft.OpenApi.Models;
+using Shouldly;
+
+namespace WolverineWebApi.TestSupport;
+
+/// <summary>
+/// Asserts that the generated OpenAPI operation exposes a single request parameter with the given
+/// name and location, and (optionally) the expected schema <c>type</c>/<c>format</c>. Drives the
+/// GH-3135 coverage of route/query/header parameter fidelity (e.g. {id:guid} -> uuid).
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public class ExpectParameterAttribute : OpenApiExpectationAttribute
+{
+    public string Name { get; }
+    public ParameterLocation In { get; }
+
+    /// <summary>Expected schema <c>type</c> (e.g. "string", "integer", "boolean"). Null = don't assert.</summary>
+    public string? Type { get; set; }
+
+    /// <summary>Expected schema <c>format</c> (e.g. "uuid", "int32", "date-time"). Null = don't assert.</summary>
+    public string? Format { get; set; }
+
+    public ExpectParameterAttribute(string name, ParameterLocation @in)
+    {
+        Name = name;
+        In = @in;
+    }
+
+    public override void Validate(OpenApiPathItem item, OpenApiOperation op, IOpenApiSource openApi)
+    {
+        var parameter = op.Parameters?.FirstOrDefault(x => x.Name == Name && x.In == In);
+        parameter.ShouldNotBeNull($"Expected a parameter '{Name}' in '{In}'. Actual parameters: " +
+                                  (op.Parameters == null
+                                      ? "<none>"
+                                      : string.Join(", ", op.Parameters.Select(p => $"{p.Name}({p.In})"))));
+
+        if (Type != null)
+        {
+            parameter.Schema.ShouldNotBeNull($"Parameter '{Name}' has no schema");
+            parameter.Schema.Type.ShouldBe(Type, $"Parameter '{Name}' schema type");
+        }
+
+        if (Format != null)
+        {
+            parameter.Schema.ShouldNotBeNull($"Parameter '{Name}' has no schema");
+            parameter.Schema.Format.ShouldBe(Format, $"Parameter '{Name}' schema format");
+        }
+    }
+}

--- a/src/Http/WolverineWebApi/TestSupport/ExpectRequestBodyAttribute.cs
+++ b/src/Http/WolverineWebApi/TestSupport/ExpectRequestBodyAttribute.cs
@@ -1,0 +1,52 @@
+using Microsoft.OpenApi.Models;
+using Shouldly;
+
+namespace WolverineWebApi.TestSupport;
+
+/// <summary>
+/// Asserts the request-body shape of the generated OpenAPI operation: the content type, the
+/// properties that must be present, and (via <see cref="ForbiddenProperties"/>) properties that must
+/// be absent — e.g. proving an [AsParameters] container type is decomposed rather than dumped whole
+/// into the body, or that a route-bound property is not duplicated in the body. See GH-3135.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public class ExpectRequestBodyAttribute : OpenApiExpectationAttribute
+{
+    public string ContentType { get; }
+
+    /// <summary>Property names that must be present on the (ref-resolved) body schema.</summary>
+    public string[] Properties { get; }
+
+    /// <summary>Property names that must NOT be present on the body schema.</summary>
+    public string[] ForbiddenProperties { get; set; } = [];
+
+    public ExpectRequestBodyAttribute(string contentType, params string[] properties)
+    {
+        ContentType = contentType;
+        Properties = properties;
+    }
+
+    public override void Validate(OpenApiPathItem item, OpenApiOperation op, IOpenApiSource openApi)
+    {
+        op.RequestBody.ShouldNotBeNull("Expected a request body, but the operation has none");
+        op.RequestBody.Content.Keys.ShouldContain(ContentType,
+            $"Expected request body content type '{ContentType}'. Actual: {string.Join(", ", op.RequestBody.Content.Keys)}");
+
+        var schema = OpenApiSchemaResolver.Resolve(op.RequestBody.Content[ContentType].Schema, openApi.GetOpenApiDocument());
+        schema.ShouldNotBeNull($"Request body for '{ContentType}' has no schema");
+
+        var propertyNames = OpenApiSchemaResolver.PropertyNames(schema, openApi.GetOpenApiDocument());
+
+        foreach (var property in Properties)
+        {
+            propertyNames.ShouldContain(property,
+                $"Expected body property '{property}'. Actual: {string.Join(", ", propertyNames)}");
+        }
+
+        foreach (var forbidden in ForbiddenProperties)
+        {
+            propertyNames.ShouldNotContain(forbidden,
+                $"Body should NOT contain property '{forbidden}'");
+        }
+    }
+}

--- a/src/Http/WolverineWebApi/TestSupport/IOpenApiSource.cs
+++ b/src/Http/WolverineWebApi/TestSupport/IOpenApiSource.cs
@@ -5,4 +5,10 @@ namespace WolverineWebApi.TestSupport;
 public interface IOpenApiSource
 {
     (OpenApiPathItem, OpenApiOperation) FindOpenApiDocument(OperationType httpMethod, string path);
+
+    /// <summary>
+    /// The full generated OpenAPI document, used by request-body expectations to resolve
+    /// <c>$ref</c> schemas against <see cref="OpenApiDocument.Components"/>.
+    /// </summary>
+    OpenApiDocument GetOpenApiDocument();
 }

--- a/src/Http/WolverineWebApi/TestSupport/OpenApiSchemaResolver.cs
+++ b/src/Http/WolverineWebApi/TestSupport/OpenApiSchemaResolver.cs
@@ -1,0 +1,55 @@
+using Microsoft.OpenApi.Models;
+
+namespace WolverineWebApi.TestSupport;
+
+/// <summary>
+/// Helpers for navigating a generated OpenAPI document's schemas — resolving <c>$ref</c> indirection
+/// against <see cref="OpenApiDocument.Components"/> and flattening composed (<c>allOf</c>) schemas — so
+/// request-body expectations can assert against effective property sets. See GH-3135.
+/// </summary>
+public static class OpenApiSchemaResolver
+{
+    /// <summary>
+    /// Resolve a schema that may be a bare <c>$ref</c> into its concrete component schema.
+    /// </summary>
+    public static OpenApiSchema? Resolve(OpenApiSchema? schema, OpenApiDocument document)
+    {
+        if (schema?.Reference?.Id is string id &&
+            document.Components?.Schemas?.TryGetValue(id, out var resolved) == true)
+        {
+            return resolved;
+        }
+
+        return schema;
+    }
+
+    /// <summary>
+    /// The effective set of property names declared by a schema, following a top-level <c>$ref</c>
+    /// and flattening one level of <c>allOf</c> composition (which Swashbuckle uses for form bodies).
+    /// </summary>
+    public static IReadOnlyList<string> PropertyNames(OpenApiSchema? schema, OpenApiDocument document)
+    {
+        var resolved = Resolve(schema, document);
+        if (resolved == null)
+        {
+            return [];
+        }
+
+        var names = new List<string>();
+
+        if (resolved.Properties != null)
+        {
+            names.AddRange(resolved.Properties.Keys);
+        }
+
+        if (resolved.AllOf != null)
+        {
+            foreach (var part in resolved.AllOf)
+            {
+                names.AddRange(PropertyNames(part, document));
+            }
+        }
+
+        return names;
+    }
+}


### PR DESCRIPTION
First, highest-leverage slice of #3135 (the order I proposed on the issue: "B1 + the dual-stack test harness first, then iterate").

## What this fixes

### WS1 — route parameter type/format from route constraints
`buildParameterDescription` matched the bound route variable **case-sensitively** (`x.Usage == routeParameter.Name`). Route tokens are conventionally lowercase (`{journeyId}`) while the bound member/argument is PascalCase (`JourneyId`), so the match silently missed and the parameter fell back to `type: string` — losing the real type (`Guid`/`int`/...). Now matched case-insensitively.

When **no** typed argument is bound to a route value (plain complex-body endpoints whose property overlaps a route token, aggregate-id routes), the parameter type now derives from the inline route **constraint** (`{id:guid}` → `uuid`, `{n:int}` → `integer`, ...) instead of defaulting to string. Both OpenAPI stacks schematize from `.Type`, so Swashbuckle **and** the built-in generator both benefit. This covers uniquelau's CASE A and CASE B path params.

### WS4 — guard multiple `[FromBody]` members
The request body is read once (`chain.RequestBodyVariable` is single-shot), so a second `[FromBody]` member silently reused the first member's deserialization variable. Now throws a clear startup error, mirroring the existing `[FromForm]`+`[FromBody]` guard. ASP.NET likewise rejects more than one body.

## Test harness (the coverage gap that let this go unnoticed)
There was **zero** OpenAPI coverage of request parameter/body *shape* for `[AsParameters]`. Added:
- `ExpectParameter(name, in, type, format)`, `ExpectRequestBody(contentType, props… + ForbiddenProperties)`, `ExpectNoRequestBody`, and `OpenApiSchemaResolver` (`$ref`/`allOf` resolution), driven through the existing Swashbuckle `open_api_generation` harness.
- Seed endpoints: CASE A (plain body, route overlap), CASE B (`[AsParameters]` `[FromRoute]`+`[FromBody]` split), a **bare** route-token case that isolates the case-insensitive match, and a constrained-route case. **Verified load-bearing** — all three regress to string/integer mismatches when WS1 is reverted.
- `FindOpenApiDocument` now tolerates constraint-stripped path keys (`{id:guid}`→`{id}`).
- A standalone unit test for the multiple-`[FromBody]` guard (the throwing endpoints are `[WolverineIgnore]`'d so host discovery skips them; `ChainFor` still exercises the guard).

## Verification
- `Wolverine.Http.Tests` on net9.0: **790 passed, 10 skipped (pre-existing), 0 failed**.
- `dotnet build wolverine.slnx -c Release`: clean.

## Deferred to follow-ups (noted on the issue)
- **WS2** required/nullability fidelity (needs member-level `NullabilityInfoContext` threaded into the param variables; Swashbuckle vs built-in legitimately diverge here).
- **WS3** nullable `[FromBody]` optional at runtime (changes shared `ReadJsonAsync` behavior).
- **WS5** product decision on stripping route-overlapping plain-body properties.
- Out of scope: the `[WriteAggregate]`+`[AsParameters]` runtime **500** (a Wolverine.Marten aggregate-id bug, file separately) and enum parameter schema.

Closes part of #3135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)