### PR TITLE
Optional [FromBody] in [AsParameters]: bind null + required:false (#3135)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/asparameters_binding.cs
+++ b/src/Http/Wolverine.Http.Tests/asparameters_binding.cs
@@ -224,4 +224,43 @@ public class asparameters_binding : IntegrationContext
             x.StatusCodeShouldBe(400);
         });
     }
+
+    // GH-3135 WS3: a nullable [FromBody] member is optional — a missing body binds null and the
+    // endpoint runs (200) instead of returning 400 ("input does not contain any JSON tokens").
+    [Fact]
+    public async Task nullable_from_body_missing_binds_null()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Post.Url("/api/3135/optional-body?Name=Jeremy");
+            x.StatusCodeShouldBe(200);
+        });
+
+        (await result.ReadAsTextAsync()).ShouldBe("no-body");
+    }
+
+    [Fact]
+    public async Task nullable_from_body_present_binds_value()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Post.Json(new WolverineWebApi.AddPassengerPayload("Bob"))
+                .ToUrl("/api/3135/optional-body")
+                .QueryString("Name", "Jeremy");
+            x.StatusCodeShouldBe(200);
+        });
+
+        (await result.ReadAsTextAsync()).ShouldBe("body:Bob");
+    }
+
+    // Regression guard: a NON-nullable [FromBody] member is still required — a missing body 400s.
+    [Fact]
+    public async Task non_nullable_from_body_missing_still_fails()
+    {
+        await Scenario(x =>
+        {
+            x.Post.Url($"/api/3135/journey/{Guid.NewGuid()}/passenger");
+            x.StatusCodeShouldBe(400);
+        });
+    }
 }

--- a/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
@@ -196,8 +196,11 @@ internal class AsParametersBindingFrame : SyncFrame
             _hasJsonBody = true;
             _jsonBodyCount++;
             chain.RequestType = memberType;
+            // A nullable [FromBody] member is an optional body: an empty request body binds null at
+            // runtime (instead of 400) and renders requestBody.required = false. See GH-3135.
+            chain.RequestBodyIsOptional = IsNullableMember(parameter);
             variable = chain.BuildJsonDeserializationVariable();
-            
+
             chain.IsFormData = false;
             return true;
         }
@@ -256,9 +259,13 @@ internal class AsParametersBindingFrame : SyncFrame
         if (propertyInfo.TryGetAttribute<FromBodyAttribute>(out var batt))
         {
             _hasJsonBody = true;
+            _jsonBodyCount++;
             chain.RequestType = memberType;
+            // A nullable [FromBody] member is an optional body: an empty request body binds null at
+            // runtime (instead of 400) and renders requestBody.required = false. See GH-3135.
+            chain.RequestBodyIsOptional = IsNullableMember(propertyInfo);
             variable = chain.BuildJsonDeserializationVariable();
-            
+
             chain.IsFormData = false;
             return true;
         }
@@ -295,5 +302,28 @@ internal class AsParametersBindingFrame : SyncFrame
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
         foreach (var parameter in _dependencies) yield return parameter;
+    }
+
+    // A member is nullable when it's a Nullable<T> value type or a reference type whose nullable
+    // annotation context marks it nullable. A fresh NullabilityInfoContext per call keeps this
+    // thread-safe across concurrent chain compilation.
+    private static bool IsNullableMember(ParameterInfo parameter)
+    {
+        if (parameter.ParameterType.IsValueType)
+        {
+            return parameter.ParameterType.IsNullable();
+        }
+
+        return new NullabilityInfoContext().Create(parameter).WriteState == NullabilityState.Nullable;
+    }
+
+    private static bool IsNullableMember(PropertyInfo property)
+    {
+        if (property.PropertyType.IsValueType)
+        {
+            return property.PropertyType.IsNullable();
+        }
+
+        return new NullabilityInfoContext().Create(property).WriteState == NullabilityState.Nullable;
     }
 }

--- a/src/Http/Wolverine.Http/CodeGen/JsonHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/JsonHandling.cs
@@ -31,11 +31,18 @@ internal class ReadJsonBody : AsyncFrame
 
     public Variable Variable { get; }
 
+    /// <summary>
+    /// When true the body is optional: an empty request body binds null and continues rather than
+    /// returning 400. Set for a nullable [FromBody] member inside an [AsParameters] type. See GH-3135.
+    /// </summary>
+    public bool Optional { get; init; }
+
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
         writer.WriteComment("Reading the request body via JSON deserialization");
+        var optionalArg = Optional ? ", true" : "";
         writer.Write(
-            $"var ({Variable.Usage}, jsonContinue) = await ReadJsonAsync<{Variable.VariableType.FullNameInCode()}>(httpContext);");
+            $"var ({Variable.Usage}, jsonContinue) = await ReadJsonAsync<{Variable.VariableType.FullNameInCode()}>(httpContext{optionalArg});");
         writer.Write(
             $"if (jsonContinue == {typeof(HandlerContinuation).FullNameInCode()}.{nameof(HandlerContinuation.Stop)}) return;");
 
@@ -49,8 +56,9 @@ internal class ReadJsonBody : AsyncFrame
         // ReadJsonAsync is an inherited *instance* method on HttpHandler (qualified with the member's
         // `this` self identifier, jasperfx#393) returning (body, continuation). F# has no early
         // `return`, so the abort guard renders the rest of the chain inside its `else` branch.
+        var optionalArg = Optional ? ", true" : "";
         writer.Write(
-            $"let! ({Variable.Usage}, jsonContinue) = this.{nameof(HttpHandler.ReadJsonAsync)}<{Variable.VariableType.FSharpName()}>(httpContext)");
+            $"let! ({Variable.Usage}, jsonContinue) = this.{nameof(HttpHandler.ReadJsonAsync)}<{Variable.VariableType.FSharpName()}>(httpContext{optionalArg})");
 
         var condition = $"jsonContinue = {typeof(HandlerContinuation).FSharpName()}.{nameof(HandlerContinuation.Stop)}";
         FSharpEmitHelpers.WriteAbortGuard(writer, method, condition, Next);
@@ -114,7 +122,7 @@ internal class JsonBodyParameterStrategy : IParameterStrategy
         {
             // It *could* be used twice, so let's watch out for this!
             chain.RequestBodyVariable ??= Usage == JsonUsage.SystemTextJson
-                ? new ReadJsonBody(chain.RequestType!).Variable
+                ? new ReadJsonBody(chain.RequestType!) { Optional = chain.RequestBodyIsOptional }.Variable
                 : RequireNewtonsoftCodeGen().CreateReadJsonBodyVariable(chain.RequestType!);
 
             variable = chain.RequestBodyVariable;

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -379,7 +379,8 @@ public partial class HttpChain
                 ModelMetadata = new EndpointModelMetadata(RequestType),
                 Source = BindingSource.Body,
                 Type = RequestType,
-                IsRequired = true
+                // A nullable [FromBody] member inside an [AsParameters] type is an optional body. See GH-3135.
+                IsRequired = !RequestBodyIsOptional
             };
 
             apiDescription.ParameterDescriptions.Add(parameterDescription);

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -63,6 +63,13 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
     internal Variable? RequestBodyVariable { get; set; }
 
+    /// <summary>
+    /// True when the request body is optional — i.e. a nullable [FromBody] member inside an
+    /// [AsParameters] type. Drives both the runtime read (an empty body binds null instead of 400)
+    /// and the generated OpenAPI (requestBody.required = false). See GH-3135.
+    /// </summary>
+    internal bool RequestBodyIsOptional { get; set; }
+
     private string? _fileName;
     private readonly List<string> _httpMethods = [];
 

--- a/src/Http/Wolverine.Http/HttpHandler.cs
+++ b/src/Http/Wolverine.Http/HttpHandler.cs
@@ -135,8 +135,16 @@ public abstract class HttpHandler
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public async ValueTask<(T?, HandlerContinuation)> ReadJsonAsync<T>(HttpContext context)
+    public async ValueTask<(T?, HandlerContinuation)> ReadJsonAsync<T>(HttpContext context, bool optional = false)
     {
+        // An optional body (a nullable [FromBody] member) with no content binds null and continues
+        // instead of failing content-type/JSON validation. Mirrors minimal-API optional-body
+        // semantics. See GH-3135.
+        if (optional && context.Request.ContentLength is null or 0)
+        {
+            return (default, HandlerContinuation.Continue);
+        }
+
         if (!isRequestJson(context))
         {
             context.Response.StatusCode = 415;

--- a/src/Http/WolverineWebApi/AsParametersOpenApiEndpoints.cs
+++ b/src/Http/WolverineWebApi/AsParametersOpenApiEndpoints.cs
@@ -22,9 +22,30 @@ public static class AsParametersSplitEndpoint
 {
     [WolverinePost("/api/3135/journey/{journeyId:guid}/passenger")]
     [ExpectParameter("journeyId", ParameterLocation.Path, Type = "string", Format = "uuid")]
-    [ExpectRequestBody("application/json", "passengerName", ForbiddenProperties = ["journeyId", "body"])]
+    // Non-nullable [FromBody] member -> required body.
+    [ExpectRequestBody("application/json", "passengerName", ForbiddenProperties = ["journeyId", "body"], Required = true)]
     public static string Post([AsParameters] AddPassengerCommand command)
         => $"{command.JourneyId}:{command.Body.PassengerName}";
+}
+
+// GH-3135 WS2/WS3: a nullable [FromBody] member is an OPTIONAL body — requestBody.required is false
+// and an empty request body binds null at runtime (200) instead of 400.
+public class OptionalBodyQuery
+{
+    [FromQuery]
+    public string? Name { get; set; }
+
+    [FromBody]
+    public AddPassengerPayload? Body { get; set; }
+}
+
+public static class OptionalBodyEndpoint
+{
+    [WolverinePost("/api/3135/optional-body")]
+    [ExpectParameter("Name", ParameterLocation.Query, Type = "string")]
+    [ExpectRequestBody("application/json", "passengerName", Required = false)]
+    public static string Post([AsParameters] OptionalBodyQuery query)
+        => query.Body is null ? "no-body" : $"body:{query.Body.PassengerName}";
 }
 
 // uniquelau's "Alternative" workaround (issue CASE A): a plain complex body whose property overlaps a

--- a/src/Http/WolverineWebApi/TestSupport/ExpectRequestBodyAttribute.cs
+++ b/src/Http/WolverineWebApi/TestSupport/ExpectRequestBodyAttribute.cs
@@ -20,6 +20,20 @@ public class ExpectRequestBodyAttribute : OpenApiExpectationAttribute
     /// <summary>Property names that must NOT be present on the body schema.</summary>
     public string[] ForbiddenProperties { get; set; } = [];
 
+    /// <summary>When set, asserts <c>requestBody.required</c> equals this value. Unset = don't assert.</summary>
+    public bool RequiredSet { get; private set; }
+    private bool _required;
+
+    public bool Required
+    {
+        get => _required;
+        set
+        {
+            _required = value;
+            RequiredSet = true;
+        }
+    }
+
     public ExpectRequestBodyAttribute(string contentType, params string[] properties)
     {
         ContentType = contentType;
@@ -31,6 +45,11 @@ public class ExpectRequestBodyAttribute : OpenApiExpectationAttribute
         op.RequestBody.ShouldNotBeNull("Expected a request body, but the operation has none");
         op.RequestBody.Content.Keys.ShouldContain(ContentType,
             $"Expected request body content type '{ContentType}'. Actual: {string.Join(", ", op.RequestBody.Content.Keys)}");
+
+        if (RequiredSet)
+        {
+            op.RequestBody.Required.ShouldBe(Required, $"requestBody.required for '{ContentType}'");
+        }
 
         var schema = OpenApiSchemaResolver.Resolve(op.RequestBody.Content[ContentType].Schema, openApi.GetOpenApiDocument());
         schema.ShouldNotBeNull($"Request body for '{ContentType}' has no schema");


### PR DESCRIPTION
Follow-up to #3141. Makes a **nullable `[FromBody]` member inside an `[AsParameters]` type** behave as an optional body — on both the runtime and the OpenAPI sides.

## WS3 — runtime: nullable `[FromBody]` binds `null` instead of 400
Previously, a missing/empty body on an endpoint with a nullable `[FromBody]` member returned **400** ("input does not contain any JSON tokens") because `JsonSerializer.DeserializeAsync` throws on an empty stream.

`ReadJsonAsync<T>` gains an `optional` parameter: when set and the request has no body (`ContentLength` null/0) it binds `null` and continues, mirroring minimal-API optional-body semantics. The flag is threaded from the binding via a new `chain.RequestBodyIsOptional` (set from the member's nullability via `NullabilityInfoContext`) → `ReadJsonBody.Optional` → the generated `ReadJsonAsync<T>(httpContext, true)` call (C# **and** F# emit). Non-nullable bodies are unchanged — a missing body still 400s.

## WS2 (body) — OpenAPI: `requestBody.required` reflects nullability
`fillRequestType` emitted `requestBody.required = true` unconditionally; it now uses `!RequestBodyIsOptional`, so a nullable `[FromBody]` renders `required: false`.

**Scoped to the body deliberately.** Query/header/form params stay `required: false` because Wolverine's runtime binds a missing value to `default` (no 400) — so `required: false` is the honest description of the contract there, unlike ASP.NET (which 400s and therefore marks them required). This was a deliberate scoping decision after confirming the runtime behavior in `IReadHttpFrame`.

## Bonus fix
Closes a gap in #3141's multiple-`[FromBody]` guard: the **property** overload of `tryCreateFrame` was missing the `_jsonBodyCount` increment, so two `[FromBody]` *properties* (vs constructor params) weren't caught. Now they are.

## Tests
- `ExpectRequestBody` gains a `Required` assertion (`requestBody.required`).
- Seed endpoint with a nullable `[FromBody]`: asserts `required:false` (OpenAPI) plus three runtime cases — missing body → 200 + null, present body → 200 + value, and a **non-nullable** body still → 400.
- The existing `...missing_body_should_fail` FluentValidation test still 400s — now via the `Body.NotNull()` validator (binds null first, then validation rejects), demonstrating the fix composes with validation.
- Full `Wolverine.Http.Tests` net9.0: **794 passed, 10 pre-existing skips, 0 failed**.
- `dotnet build wolverine.slnx -c Release`: clean.

## Remaining #3135 follow-ups (not in this PR)
- **WS5** product decision on stripping route-overlapping plain-body properties.
- The `[WriteAggregate]` + `[AsParameters]` runtime **500** (a Wolverine.Marten aggregate-id bug — should be filed separately; it's the original user-facing blocker).
- Enum parameter schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)