### PR TITLE
Fix [AsParameters]+[FromBody]+[WriteAggregate] codegen 500 (#3143)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Marten/write_aggregate_with_asparameters.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/write_aggregate_with_asparameters.cs
@@ -1,0 +1,38 @@
+using Alba;
+using Marten;
+using Shouldly;
+using WolverineWebApi.Marten;
+
+namespace Wolverine.Http.Tests.Marten;
+
+// GH-3135: the route id flows through an [AsParameters] object while [WriteAggregate]
+// IEventStream<Order> resolves the stream from that same id. uniquelau reported this combination
+// returns a runtime 500 (the bare [AsParameters] FromRoute+FromBody binding works in isolation).
+public class write_aggregate_with_asparameters(AppFixture fixture) : IntegrationContext(fixture)
+{
+    [Fact]
+    public async Task write_aggregate_with_id_from_asparameters_route()
+    {
+        var id = Guid.NewGuid();
+
+        await Scenario(x =>
+        {
+            x.Post.Json(new StartOrderWithId(id, ["Socks", "Shoes", "Shirt"])).ToUrl("/orders/create4");
+        });
+
+        var result = await Scenario(x =>
+        {
+            x.Post.Json(new ShipOrderPayload("FedEx")).ToUrl($"/orders/asparameters/{id}/ship");
+            x.StatusCodeShouldBe(200);
+        });
+
+        var response = await result.ReadAsJsonAsync<OrderShipmentResponse>();
+        response.OrderId.ShouldBe(id);
+        response.Carrier.ShouldBe("FedEx");
+
+        // The OrderShipped event was appended to the resolved stream
+        using var session = Store.LightweightSession();
+        var order = await session.Events.AggregateStreamAsync<Order>(id);
+        order!.IsShipped().ShouldBeTrue();
+    }
+}

--- a/src/Http/Wolverine.Http/HttpChain.Codegen.cs
+++ b/src/Http/Wolverine.Http/HttpChain.Codegen.cs
@@ -135,7 +135,18 @@ public partial class HttpChain
         
         if (AuditedMembers.Count != 0)
         {
-            Middleware.Insert(0, new AuditToActivityFrame(this));
+            // When the endpoint binds via [AsParameters], an audited member (e.g. an inferred aggregate
+            // id) lives on the container type, not on InputType() — which a [FromBody] member may have
+            // overwritten to the body type. Resolve the audit variable from the container in that case
+            // so the member access is valid and the codegen doesn't fail to resolve a body-typed
+            // variable that has no standalone binding. See GH-3135.
+            Type? auditInputType = null;
+            if (AsParametersType != null && AuditedMembers.All(x => x.Member.DeclaringType == AsParametersType))
+            {
+                auditInputType = AsParametersType;
+            }
+
+            Middleware.Insert(0, new AuditToActivityFrame(this, auditInputType));
         }
 
         var index = 0;

--- a/src/Http/WolverineWebApi/Marten/Orders.cs
+++ b/src/Http/WolverineWebApi/Marten/Orders.cs
@@ -338,6 +338,29 @@ public static class MarkItemEndpoint
 
 public record GetLatestOrderQuery([FromRoute] Guid Id);
 
+// GH-3135 repro: an [AsParameters] object carries the conventional aggregate-id route value
+// ({orderId}) AND a [FromBody] payload, while [WriteAggregate] IEventStream<Order> resolves the
+// stream from that same id. Mirrors uniquelau's
+//   (Response, IEventStream<Journey>) Handle([AsParameters] cmd, [WriteAggregate] IEventStream<Journey>)
+// where cmd = ([FromRoute] Guid JourneyId, [FromBody] Payload) — the shape that reportedly 500s.
+public record ShipOrderPayload(string Carrier);
+
+public record ShipOrderViaAsParameters([FromRoute] Guid OrderId, [FromBody] ShipOrderPayload Body);
+
+public record OrderShipmentResponse(Guid OrderId, string Carrier);
+
+public static class WriteAggregateViaAsParametersEndpoint
+{
+    [WolverinePost("/orders/asparameters/{orderId}/ship")]
+    public static OrderShipmentResponse Post(
+        [Microsoft.AspNetCore.Http.AsParameters] ShipOrderViaAsParameters command,
+        [WriteAggregate] IEventStream<Order> stream)
+    {
+        stream.AppendOne(new OrderShipped());
+        return new OrderShipmentResponse(command.OrderId, command.Body.Carrier);
+    }
+}
+
 #region sample_write_aggregate_from_method
 public record ConfirmOrderFromMethod;
 

--- a/src/Persistence/Polecat/PolecatIncidentService.Tests/PolecatIncidentService.Tests.csproj
+++ b/src/Persistence/Polecat/PolecatIncidentService.Tests/PolecatIncidentService.Tests.csproj
@@ -23,5 +23,9 @@
 
     <ItemGroup>
       <ProjectReference Include="..\PolecatIncidentService\PolecatIncidentService.csproj" />
+      <!-- Registers the Roslyn runtime compiler so the Wolverine host can run in TypeLoadMode.Dynamic
+           under test (core WolverineFx no longer ships it; GH-2876). Matches every other Dynamic-mode
+           test project in the repo. -->
+      <ProjectReference Include="..\..\..\Wolverine.RuntimeCompilation\Wolverine.RuntimeCompilation.csproj" />
     </ItemGroup>
 </Project>

--- a/src/Persistence/Polecat/PolecatIncidentService.Tests/when_categorising_via_asparameters.cs
+++ b/src/Persistence/Polecat/PolecatIncidentService.Tests/when_categorising_via_asparameters.cs
@@ -1,0 +1,49 @@
+using Alba;
+using Polecat;
+using Shouldly;
+using Wolverine.Http;
+using Xunit;
+
+namespace PolecatIncidentService.Tests;
+
+// GH-3135: the route id flows through an [AsParameters] object (with a [FromBody] payload) while
+// [WriteAggregate] IEventStream<Incident> resolves the stream from that same id. This shares the
+// Wolverine.Http core codegen path that 500'd under Marten, so it verifies the fix on Polecat too.
+public class when_categorising_via_asparameters : IntegrationContext
+{
+    public when_categorising_via_asparameters(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task can_categorise_with_id_from_asparameters_route()
+    {
+        var contact = new Contact(ContactChannel.Email);
+        var logCommand = new LogIncident(Guid.NewGuid(), contact, "Network down", Guid.NewGuid());
+
+        var initial = await Scenario(x =>
+        {
+            x.Post.Json(logCommand).ToUrl("/api/incidents");
+            x.StatusCodeShouldBe(201);
+        });
+
+        var incidentId = initial.ReadAsJson<CreationResponse<Guid>>().Value;
+
+        var payload = new CategoriseIncidentPayload(IncidentCategory.Network, Guid.NewGuid());
+
+        var result = await Scenario(x =>
+        {
+            x.Post.Json(payload).ToUrl($"/api/incidents/asparameters/{incidentId}/category");
+            x.StatusCodeShouldBe(200);
+        });
+
+        var response = result.ReadAsJson<IncidentCategorisedResponse>();
+        response.IncidentId.ShouldBe(incidentId);
+        response.Category.ShouldBe(IncidentCategory.Network);
+
+        await using var session = Store.LightweightSession();
+        var incident = await session.Events.FetchLatest<Incident>(incidentId);
+        incident.ShouldNotBeNull();
+        incident!.Category.ShouldBe(IncidentCategory.Network);
+    }
+}

--- a/src/Persistence/Polecat/PolecatIncidentService/CategoriseViaAsParameters.cs
+++ b/src/Persistence/Polecat/PolecatIncidentService/CategoriseViaAsParameters.cs
@@ -1,0 +1,30 @@
+using JasperFx.Events;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine.Http;
+using Wolverine.Polecat;
+
+namespace PolecatIncidentService;
+
+// GH-3135 repro for the Polecat integration: an [AsParameters] object carries the conventional
+// aggregate-id route value ({incidentId}) AND a [FromBody] payload, while [WriteAggregate]
+// IEventStream<Incident> resolves the stream from that same id. This mirrors the Marten repro and
+// shares the same Wolverine.Http core codegen path (AuditToActivityFrame over the inferred
+// aggregate-id identity member).
+public record CategoriseIncidentPayload(IncidentCategory Category, Guid CategorisedBy);
+
+public record CategoriseViaAsParameters([FromRoute] Guid IncidentId, [FromBody] CategoriseIncidentPayload Body);
+
+public record IncidentCategorisedResponse(Guid IncidentId, IncidentCategory Category);
+
+public static class CategoriseViaAsParametersEndpoint
+{
+    [WolverinePost("/api/incidents/asparameters/{incidentId}/category")]
+    public static IncidentCategorisedResponse Post(
+        [AsParameters] CategoriseViaAsParameters command,
+        [WriteAggregate] IEventStream<Incident> stream)
+    {
+        stream.AppendOne(new IncidentCategorised(command.IncidentId, command.Body.Category, command.Body.CategorisedBy));
+        return new IncidentCategorisedResponse(command.IncidentId, command.Body.Category);
+    }
+}

--- a/src/Persistence/Polecat/PolecatIncidentService/PolecatIncidentService.csproj
+++ b/src/Persistence/Polecat/PolecatIncidentService/PolecatIncidentService.csproj
@@ -10,6 +10,10 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
         <PackageReference Include="JasperFx" />
+        <!-- Polecat (unlike Marten) does not bundle the event source generator, so projects that
+             define self-aggregating event types need it explicitly to emit the compile-time
+             Apply/Create dispatchers. Matches PolecatTests. -->
+        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Wolverine/Logging/AuditToActivityFrame.cs
+++ b/src/Wolverine/Logging/AuditToActivityFrame.cs
@@ -13,9 +13,19 @@ public class AuditToActivityFrame : SyncFrame
     private readonly List<AuditedMember> _members;
     private Variable? _input;
 
-    public AuditToActivityFrame(IChain chain)
+    public AuditToActivityFrame(IChain chain) : this(chain, null)
     {
-        _inputType = chain.InputType()!;
+    }
+
+    /// <param name="inputType">
+    /// The type of the variable the audited members are read from. Defaults to <see cref="IChain.InputType"/>,
+    /// but callers can override it when the audited members live on a different bound variable than the
+    /// chain's request body — e.g. an [AsParameters] container whose [FromBody] member has overwritten
+    /// the request type. See GH-3135.
+    /// </param>
+    public AuditToActivityFrame(IChain chain, Type? inputType)
+    {
+        _inputType = inputType ?? chain.InputType()!;
         _members = chain.AuditedMembers;
     }
 


### PR DESCRIPTION
Fixes #3143 — uniquelau's original runtime **500** from #3135, now root-caused and fixed on **both Marten and Polecat**.

## The bug
An endpoint combining an `[AsParameters]` command (carrying the aggregate-id route value **and** a `[FromBody]` member) with `[WriteAggregate]`/`[Aggregate]` failed at endpoint build:

```
UnResolvableVariableException: unable to resolve a variable of type <Payload>
  at MethodFrameArranger.FindVariable
  at Wolverine.Logging.AuditToActivityFrame.FindVariables
```

## Root cause
1. The `[FromBody]` branch of `AsParametersBindingFrame` overwrites `chain.RequestType` with the **body member type**, so `HttpChain.InputType()` returns the body type, not the `[AsParameters]` container.
2. `WriteAggregateAttribute.TryInferMessageIdentity` infers the aggregate-id member (which lives on the **container**); `HttpChain.Codegen` audits it → inserts an `AuditToActivityFrame`.
3. `AuditToActivityFrame.FindVariables` resolved a variable of `InputType()` (= the body type), which only exists as `command.Body` — not a standalone variable → codegen fails.

The bare `[AsParameters]` binding works in isolation (200); the crash only appears with `[WriteAggregate]`/`[Aggregate]`, because that's what triggers the inferred-identity audit frame. Route-only `[AsParameters]` (no `[FromBody]`) also works — the `[FromBody]` `RequestType` overwrite is what diverges `InputType()`.

## Fix
`AuditToActivityFrame` gains an optional explicit input type. `HttpChain.Codegen` passes the `[AsParameters]` container type when the audited members are declared on it, so the audit reads the container variable (`command.<Id>`) instead of a body-typed variable with no binding. **Backward compatible** — message handlers and sagas use the param-less ctor and are unaffected.

## Verified on both integrations
Shared Wolverine.Http core path → reproduces identically on Marten and Polecat. **Confirmed load-bearing on both**: reverting the fix reproduces the identical `UnResolvableVariableException` (for the `[FromBody]` member type) on each.

- **Marten**: `Wolverine.Http.Tests` → `Marten/write_aggregate_with_asparameters` (uniquelau's exact shape: `[AsParameters]([FromRoute] id + [FromBody] payload)` + `[WriteAggregate] IEventStream<Order>`).
- **Polecat**: `PolecatIncidentService.Tests` → `when_categorising_via_asparameters` (same shape against `IEventStream<Incident>`).

## Incidental infra repair (PolecatIncidentService)
To run the Polecat HTTP test at all, this also fixes two pre-existing setup gaps that prevented the sample app's host from starting under test locally:
- The **test project** was missing the `Wolverine.RuntimeCompilation` reference (the Dynamic-mode Roslyn compiler core no longer ships, GH-2876) — every other Dynamic-mode test project has it.
- The **service project** was missing the `JasperFx.Events.SourceGenerator` analyzer (Polecat, unlike Marten, doesn't bundle it), so the `Incident` projection had no generated Apply/Create dispatcher.

All 9 incident-service tests now pass locally.

## Verification
- Marten HTTP aggregate + AsParameters + OpenAPI: 55 passed.
- Polecat incident-service: 9 passed.
- Full `Wolverine.Http.Tests` net9.0: 793 passed, 10 pre-existing skips; 2 unrelated failures are a local macOS port-5000 (AirPlay) conflict in `Bug_using_host_stop`, not this change.
- `dotnet build wolverine.slnx -c Release`: clean.

## Remaining #3135 follow-ups (not in this PR)
- WS5: plain-body route-overlap stripping (product decision).
- Enum parameter schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)