### PR TITLE
Fix Kafka ExtendConsumerConfiguration inheritance

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaTransportTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaTransportTests.cs
@@ -1,3 +1,4 @@
+using Confluent.Kafka;
 using Confluent.Kafka.Admin;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -136,23 +137,29 @@ public class KafkaListenerConfigurationTests
     }
 
     [Fact]
-    public void extend_consumer_configuration_creates_topic_consumer_configuration()
+    public void extend_consumer_configuration_preserves_parent_consumer_configuration()
     {
         var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.BootstrapServers = "localhost:9092";
+        topic.Parent.ConsumerConfig.ClientId = "global-client";
 
         var config = new KafkaListenerConfiguration(topic)
-            .ExtendConsumerConfiguration(consumer => consumer.GroupId = "topic");
+            .ExtendConsumerConfiguration(consumer => consumer.GroupId = "topic-group");
 
         ((IDelayedEndpointConfiguration)config).Apply();
 
         topic.ConsumerConfig.ShouldNotBeNull();
-        topic.ConsumerConfig.GroupId.ShouldBe("topic");
+        topic.ConsumerConfig.BootstrapServers.ShouldBe("localhost:9092");
+        topic.ConsumerConfig.ClientId.ShouldBe("global-client");
+        topic.ConsumerConfig.GroupId.ShouldBe("topic-group");
     }
 
     [Fact]
     public void extend_consumer_configuration_preserves_existing_topic_consumer_configuration()
     {
         var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.BootstrapServers = "localhost:9092";
+        topic.Parent.ConsumerConfig.ClientId = "global-client";
 
         var config = new KafkaListenerConfiguration(topic)
             .ConfigureConsumer(consumer => consumer.GroupId = "topic")
@@ -161,8 +168,33 @@ public class KafkaListenerConfigurationTests
         ((IDelayedEndpointConfiguration)config).Apply();
 
         topic.ConsumerConfig.ShouldNotBeNull();
+        topic.ConsumerConfig.BootstrapServers.ShouldBe("localhost:9092");
         topic.ConsumerConfig.GroupId.ShouldBe("topic");
         topic.ConsumerConfig.ClientId.ShouldBe("topic-client");
+    }
+
+    [Fact]
+    public void extend_consumer_configuration_applies_new_configuration_last()
+    {
+        var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.GroupId = "parent-group";
+
+        var config = new KafkaListenerConfiguration(topic)
+            .ConfigureConsumer(consumer => consumer.GroupId = "topic-group")
+            .ExtendConsumerConfiguration(consumer => consumer.GroupId = "extended-group");
+
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        topic.ConsumerConfig.ShouldNotBeNull();
+        topic.ConsumerConfig.GroupId.ShouldBe("extended-group");
+    }
+
+    [Fact]
+    public void extend_consumer_configuration_null_throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new KafkaListenerConfiguration(BuildTopic())
+                .ExtendConsumerConfiguration(null!));
     }
 }
 

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -352,13 +352,30 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
     /// </summary>
     /// <param name="configuration">An action that adds or updates consumer settings for this topic.</param>
     /// <returns>The current <see cref="KafkaListenerConfiguration"/> for fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException"></exception>
     public KafkaListenerConfiguration ExtendConsumerConfiguration(Action<ConsumerConfig> configuration)
     {
+        ArgumentNullException.ThrowIfNull(configuration);
+
         add(topic =>
         {
-            topic.ConsumerConfig ??= new ConsumerConfig();
-            configuration(topic.ConsumerConfig);
+            var values = topic.Parent.ConsumerConfig.
+                ToDictionary(x => x.Key, x => x.Value);
+
+            if (topic.ConsumerConfig != null)
+            {
+                foreach (var pair in topic.ConsumerConfig)
+                {
+                    values[pair.Key] = pair.Value;
+                }
+            }
+
+            var config = new ConsumerConfig(values);
+            configuration(config);
+
+            topic.ConsumerConfig = config;
         });
+
         return this;
     }
 }


### PR DESCRIPTION
## Summary

Fix `KafkaListenerConfiguration.ExtendConsumerConfiguration()` so it preserves parent/global Kafka consumer settings when applying topic-specific consumer changes.

Previously, In my previous PR #3034  `ExtendConsumerConfiguration()` created an empty topic-level `ConsumerConfig` when none existed. Because Kafka topics prefer `topic.ConsumerConfig` over `Parent.ConsumerConfig`, this caused global settings configured through `UseKafka(...).ConfigureClient(...)` or `ConfigureConsumers(...)` to be dropped when a listener only wanted to override a single setting like `GroupId`.

## Changes

- Update `ExtendConsumerConfiguration()` to build the topic config from:
  1. parent transport `ConsumerConfig`
  2. existing topic-level `ConsumerConfig`
  3. the new extension callback

- Add a null guard for the configuration callback.
- Strengthen Kafka listener configuration tests to verify:
  - parent/global consumer settings are preserved
  - existing topic-level settings are preserved
  - the extension callback applies last
  - null callback throws `ArgumentNullException`