### PR TITLE
Kafka: commit-strategy overhaul with CommitMode (#3150)

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -221,15 +221,45 @@ at the cost of potential message loss during an ungraceful shutdown.
 
 ### Offset Commit Behavior in the Listener
 
-Regardless of endpoint mode, the `KafkaListener` calls `_consumer.Commit()` in these situations:
+The `KafkaListener` advances the consumer offset (commits the *specific* `TopicPartitionOffset` of the
+message, never the consumer's global position) in these situations:
 
-- **On successful processing** -- `CompleteAsync()` explicitly commits the consumer offset after a message
-  finishes processing. In durable mode this is the *only* path that advances the offset.
+- **On successful processing** -- `CompleteAsync()` stores/commits the message's offset after it finishes
+  processing. In durable mode this is the path that advances the offset.
 - **On poison pill messages** -- If an incoming Kafka message cannot be deserialized into a Wolverine envelope
-  at all (a true poison pill), the listener commits the offset to skip past the bad message and avoid blocking
-  the consumer.
+  at all (a true poison pill), the listener advances past that message's offset to skip the bad message and
+  avoid blocking the consumer.
 - **On dead letter queue routing** -- When a message exhausts all retries and is moved to the native dead letter
-  queue topic, the offset is committed after the DLQ produce succeeds.
+  queue topic, its offset is advanced after the DLQ produce succeeds.
+
+### Commit Strategy <Badge type="tip" text="6.8" />
+
+How and when those offsets are flushed to the broker is controlled by `CommitMode`. The default,
+`StoreThenAutoFlush`, is the idiomatic high-throughput Kafka model: each processed offset is *stored*
+locally (`EnableAutoOffsetStore = false` + `StoreOffset`) and Kafka's background committer flushes them on
+`AutoCommitIntervalMs`. There is **no** synchronous broker round trip per message.
+
+```csharp
+opts.ListenToKafkaTopic("orders")
+    // The default — non-blocking, at-least-once, idiomatic high throughput
+    .CommitOffsets(CommitMode.StoreThenAutoFlush);
+
+opts.ListenToKafkaTopic("strict")
+    // Synchronously commit each message as it completes (strict at-least-once, lowest throughput)
+    .CommitOffsets(CommitMode.PerMessage);
+
+opts.ListenToKafkaTopic("bulk")
+    // Wolverine commits the contiguous offset watermark every N messages...
+    .CommitOffsetsAfterCount(500);
+
+opts.ListenToKafkaTopic("bulk2")
+    // ...or every elapsed interval. Neither commits ahead of the lowest in-flight offset.
+    .CommitOffsetsAfterInterval(TimeSpan.FromSeconds(2));
+```
+
+If you explicitly set `EnableAutoCommit = true` via `ConfigureConsumer`, Wolverine suppresses its own manual
+commits and leaves offset management entirely to the Kafka client. Pending/stored offsets are flushed on a
+graceful shutdown so progress is not lost.
 
 ### Recommended Configuration by Use Case
 

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/commit_strategy_end_to_end.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/commit_strategy_end_to_end.cs
@@ -1,0 +1,109 @@
+using System.Collections.Concurrent;
+using Confluent.Kafka;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+
+namespace Wolverine.Kafka.Tests;
+
+// GH-3150: end-to-end proof that the default StoreThenAutoFlush commit strategy actually commits the
+// processed offsets — a second consumer in the same group resumes past them rather than reprocessing.
+public class commit_strategy_end_to_end
+{
+    private readonly BrokerName brokerName = new("commit3150");
+
+    private Task<IHost> publisherAsync(string topicName) => WolverineHost.ForAsync(opts =>
+    {
+        opts.AddNamedKafkaBroker(brokerName, KafkaContainerFixture.ConnectionString).AutoProvision();
+        opts.PublishAllMessages().ToKafkaTopicOnNamedBroker(brokerName, topicName).SendInline();
+    });
+
+    private Task<IHost> receiverAsync(string topicName, string groupId) => WolverineHost.ForAsync(opts =>
+    {
+        opts.AddNamedKafkaBroker(brokerName, KafkaContainerFixture.ConnectionString).AutoProvision();
+        opts.ListenToKafkaTopicOnNamedBroker(brokerName, topicName)
+            .ProcessInline()
+            // Default CommitMode (StoreThenAutoFlush) — not overridden.
+            .ConfigureConsumer(x =>
+            {
+                x.GroupId = groupId;
+                x.AutoOffsetReset = AutoOffsetReset.Earliest;
+            });
+
+        opts.Discovery.DisableConventionalDiscovery().IncludeType<CommitResumeHandler>();
+    });
+
+    [Fact]
+    public async Task second_consumer_in_same_group_resumes_past_committed_offsets()
+    {
+        var topic = Guid.NewGuid().ToString();
+        var groupId = Guid.NewGuid().ToString();
+
+        using var publisher = await publisherAsync(topic);
+
+        // --- Phase 1: first consumer processes the initial batch, then shuts down gracefully ---
+        var firstBatch = new ConcurrentBag<string>();
+        CommitResumeState.Sink = firstBatch;
+
+        var first = await receiverAsync(topic, groupId);
+        for (var i = 0; i < 5; i++)
+        {
+            await publisher.SendAsync(new CommitResumeMessage { Id = "first-" + i });
+        }
+
+        await waitForCountAsync(firstBatch, 5);
+
+        // Graceful shutdown flushes/commits the stored offsets (StoreThenAutoFlush + clean Close).
+        await first.StopAsync();
+        first.Dispose();
+
+        // --- Phase 2: a fresh consumer in the SAME group should only see the new messages ---
+        var secondBatch = new ConcurrentBag<string>();
+        CommitResumeState.Sink = secondBatch;
+
+        using var second = await receiverAsync(topic, groupId);
+        for (var i = 0; i < 3; i++)
+        {
+            await publisher.SendAsync(new CommitResumeMessage { Id = "second-" + i });
+        }
+
+        await waitForCountAsync(secondBatch, 3);
+
+        // Give any (incorrect) redelivery of the first batch a chance to show up before asserting.
+        await Task.Delay(1000);
+
+        secondBatch.ShouldNotContain(x => x.StartsWith("first-"),
+            "The second consumer reprocessed already-committed messages — offsets were not committed/flushed");
+        secondBatch.Count(x => x.StartsWith("second-")).ShouldBe(3);
+    }
+
+    private static async Task waitForCountAsync(ConcurrentBag<string> bag, int count, int timeoutMs = 30000)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            if (bag.Count >= count) return;
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Only received {bag.Count} of {count} expected messages within {timeoutMs}ms");
+    }
+}
+
+public class CommitResumeMessage
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public static class CommitResumeState
+{
+    public static ConcurrentBag<string>? Sink;
+}
+
+public class CommitResumeHandler
+{
+    public static void Handle(CommitResumeMessage message)
+    {
+        CommitResumeState.Sink?.Add(message.Id);
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/configure_consumers_and_publishers.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/configure_consumers_and_publishers.cs
@@ -150,14 +150,17 @@ public class configure_consumers_and_publishers : IAsyncLifetime
     }
 
     [Fact]
-    public void durable_mode_disables_auto_commit_but_not_auto_offset_store()
+    public void default_commit_mode_wires_store_then_auto_flush()
     {
+        // GH-3150: the default CommitMode is StoreThenAutoFlush, which relies on Kafka's background
+        // committer flushing manually-stored offsets — so EnableAutoCommit is on and offset storage
+        // is manual. (Replaces the previous blanket EnableAutoCommit=false for durable listeners.)
         var blue = _host.GetRuntime().Endpoints.ActiveListeners()
             .Single(x => x.Uri.ToString().Contains("blue")).ShouldBeOfType<ListeningAgent>()
             .Listener.ShouldBeOfType<KafkaListener>();
 
-        blue.Config.EnableAutoCommit.ShouldBe(false);
-        blue.Config.EnableAutoOffsetStore.ShouldBeNull();
+        blue.Config.EnableAutoCommit.ShouldBe(true);
+        blue.Config.EnableAutoOffsetStore.ShouldBe(false);
     }
 
 }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/kafka_offset_committer.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/kafka_offset_committer.cs
@@ -1,0 +1,171 @@
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Kafka;
+using Wolverine.Kafka.Internals;
+
+namespace Wolverine.Kafka.Tests;
+
+// GH-3150: unit coverage for the commit-strategy resolution, specific-offset commits, the contiguous
+// watermark, and shutdown flush — all without a broker (mocked IConsumer).
+public class kafka_offset_committer
+{
+    private readonly IConsumer<string, byte[]> theConsumer = Substitute.For<IConsumer<string, byte[]>>();
+
+    private KafkaOffsetCommitter committerFor(CommitMode mode, ConsumerConfig? config = null, int batchCount = 100,
+        TimeSpan? interval = null)
+    {
+        config ??= new ConsumerConfig();
+        KafkaOffsetCommitter.ApplyTo(config, mode);
+        return new KafkaOffsetCommitter(theConsumer, config, mode, batchCount,
+            interval ?? TimeSpan.FromSeconds(5), NullLogger.Instance);
+    }
+
+    [Fact]
+    public void apply_to_store_then_auto_flush_sets_autocommit_and_disables_offset_store()
+    {
+        var config = new ConsumerConfig();
+        KafkaOffsetCommitter.ApplyTo(config, CommitMode.StoreThenAutoFlush);
+
+        config.EnableAutoCommit.ShouldBe(true);
+        config.EnableAutoOffsetStore.ShouldBe(false);
+    }
+
+    [Fact]
+    public void apply_to_per_message_disables_autocommit()
+    {
+        var config = new ConsumerConfig();
+        KafkaOffsetCommitter.ApplyTo(config, CommitMode.PerMessage);
+        config.EnableAutoCommit.ShouldBe(false);
+    }
+
+    [Fact]
+    public void apply_to_respects_explicit_user_autocommit()
+    {
+        var config = new ConsumerConfig { EnableAutoCommit = true };
+        KafkaOffsetCommitter.ApplyTo(config, CommitMode.PerMessage);
+        // user's choice is untouched
+        config.EnableAutoCommit.ShouldBe(true);
+    }
+
+    [Fact]
+    public void resolve_strategy_matrix()
+    {
+        KafkaOffsetCommitter.ResolveStrategy(new ConsumerConfig { EnableAutoCommit = true },
+            CommitMode.StoreThenAutoFlush).ShouldBe(KafkaOffsetCommitter.Strategy.Automatic);
+
+        KafkaOffsetCommitter.ResolveStrategy(new ConsumerConfig { EnableAutoCommit = true, EnableAutoOffsetStore = false },
+            CommitMode.StoreThenAutoFlush).ShouldBe(KafkaOffsetCommitter.Strategy.Store);
+
+        KafkaOffsetCommitter.ResolveStrategy(new ConsumerConfig { EnableAutoCommit = false },
+            CommitMode.PerMessage).ShouldBe(KafkaOffsetCommitter.Strategy.PerMessage);
+
+        KafkaOffsetCommitter.ResolveStrategy(new ConsumerConfig { EnableAutoCommit = false },
+            CommitMode.BatchCount).ShouldBe(KafkaOffsetCommitter.Strategy.Batch);
+    }
+
+    [Fact]
+    public void store_mode_stores_specific_offset_plus_one_and_never_commits()
+    {
+        var committer = committerFor(CommitMode.StoreThenAutoFlush);
+
+        committer.Complete("topic-a", 2, 41);
+
+        // Kafka convention: committed/stored offset is last-processed + 1
+        theConsumer.Received(1).StoreOffset(
+            Arg.Is<TopicPartitionOffset>(t => t.Topic == "topic-a" && t.Partition.Value == 2 && t.Offset.Value == 42));
+        theConsumer.DidNotReceive().Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>());
+    }
+
+    [Fact]
+    public void per_message_commits_specific_offset_plus_one()
+    {
+        var committer = committerFor(CommitMode.PerMessage);
+
+        committer.Complete("topic-a", 0, 9);
+
+        theConsumer.Received(1).Commit(Arg.Is<IEnumerable<TopicPartitionOffset>>(list =>
+            list.Single().Topic == "topic-a" && list.Single().Partition.Value == 0 && list.Single().Offset.Value == 10));
+    }
+
+    [Fact]
+    public void automatic_mode_neither_stores_nor_commits()
+    {
+        var committer = committerFor(CommitMode.StoreThenAutoFlush, new ConsumerConfig { EnableAutoCommit = true });
+        committer.ResolvedStrategy.ShouldBe(KafkaOffsetCommitter.Strategy.Automatic);
+
+        committer.Complete("topic-a", 0, 5);
+
+        theConsumer.DidNotReceive().StoreOffset(Arg.Any<TopicPartitionOffset>());
+        theConsumer.DidNotReceive().Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>());
+    }
+
+    [Fact]
+    public void batch_count_commits_watermark_after_threshold()
+    {
+        var committer = committerFor(CommitMode.BatchCount, batchCount: 3);
+
+        committer.Complete("t", 0, 100);
+        committer.Complete("t", 0, 101);
+        theConsumer.DidNotReceive().Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>());
+
+        committer.Complete("t", 0, 102); // hits batch size 3
+
+        theConsumer.Received(1).Commit(Arg.Is<IEnumerable<TopicPartitionOffset>>(list =>
+            list.Single().Offset.Value == 103)); // watermark = last contiguous (102) + 1
+    }
+
+    [Fact]
+    public void batch_count_never_commits_ahead_of_a_gap()
+    {
+        var committer = committerFor(CommitMode.BatchCount, batchCount: 3);
+
+        // Out-of-order completion: 100, 102, 103 — 101 is still in flight.
+        committer.Complete("t", 0, 100);
+        committer.Complete("t", 0, 102);
+        committer.Complete("t", 0, 103); // threshold reached, but 101 is missing
+
+        // Watermark may only advance to 100+1 = 101 (everything below the gap), never past it.
+        theConsumer.Received(1).Commit(Arg.Is<IEnumerable<TopicPartitionOffset>>(list =>
+            list.Single().Offset.Value == 101));
+
+        theConsumer.ClearReceivedCalls();
+
+        // Now 101 completes -> the gap fills and the watermark jumps to 103+1 = 104 on flush.
+        committer.Complete("t", 0, 101);
+        committer.Flush();
+
+        theConsumer.Received(1).Commit(Arg.Is<IEnumerable<TopicPartitionOffset>>(list =>
+            list.Single().Offset.Value == 104));
+    }
+
+    [Fact]
+    public void flush_commits_pending_batch_watermark()
+    {
+        var committer = committerFor(CommitMode.BatchCount, batchCount: 1000);
+
+        committer.Complete("t", 1, 7);
+        committer.Complete("t", 1, 8);
+        theConsumer.DidNotReceive().Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>());
+
+        committer.Flush();
+
+        theConsumer.Received(1).Commit(Arg.Is<IEnumerable<TopicPartitionOffset>>(list =>
+            list.Single().Topic == "t" && list.Single().Partition.Value == 1 && list.Single().Offset.Value == 9));
+    }
+
+    [Fact]
+    public void watermark_handles_independent_partitions()
+    {
+        var committer = committerFor(CommitMode.BatchCount, batchCount: 1000);
+
+        committer.Complete("t", 0, 50);
+        committer.Complete("t", 1, 200);
+        committer.Flush();
+
+        theConsumer.Received(1).Commit(Arg.Is<IEnumerable<TopicPartitionOffset>>(list =>
+            list.Any(x => x.Partition.Value == 0 && x.Offset.Value == 51) &&
+            list.Any(x => x.Partition.Value == 1 && x.Offset.Value == 201)));
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/CommitMode.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/CommitMode.cs
@@ -1,0 +1,34 @@
+namespace Wolverine.Kafka;
+
+/// <summary>
+/// Controls how a Kafka listener commits consumer offsets back to the broker. See GH-3150.
+/// </summary>
+public enum CommitMode
+{
+    /// <summary>
+    /// Synchronously commit each message's own offset as it finishes processing. Strict
+    /// at-least-once with minimal reprocessing on restart, but the slowest option — every message
+    /// pays for a synchronous broker round trip.
+    /// </summary>
+    PerMessage,
+
+    /// <summary>
+    /// (Default) Store each successfully processed offset locally (<c>EnableAutoOffsetStore=false</c> +
+    /// <c>StoreOffset</c>) and let Kafka's background auto-committer flush them on
+    /// <c>AutoCommitIntervalMs</c>. Non-blocking, at-least-once, and the idiomatic high-throughput
+    /// Kafka model.
+    /// </summary>
+    StoreThenAutoFlush,
+
+    /// <summary>
+    /// Wolverine commits the contiguous offset watermark after every N successfully processed
+    /// messages. Never commits ahead of the lowest in-flight offset.
+    /// </summary>
+    BatchCount,
+
+    /// <summary>
+    /// Wolverine commits the contiguous offset watermark once at least the configured interval has
+    /// elapsed since the previous commit. Never commits ahead of the lowest in-flight offset.
+    /// </summary>
+    BatchInterval
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -17,6 +17,7 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
     private readonly IReceiver _receiver;
     private readonly string? _messageTypeName;
     private readonly ILogger _logger;
+    private readonly KafkaOffsetCommitter _committer;
     public KafkaListener(KafkaTopic topic, ConsumerConfig config,
         IConsumer<string, byte[]> consumer, IReceiver receiver,
         ILogger<KafkaListener> logger)
@@ -31,6 +32,8 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
 
         Config = config;
         _receiver = receiver;
+        _committer = new KafkaOffsetCommitter(consumer, config, topic.CommitMode, topic.CommitBatchCount,
+            topic.CommitBatchInterval, logger);
 
         _runner = Task.Run(async () =>
         {
@@ -39,12 +42,14 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
             {
                 while (!_cancellation.IsCancellationRequested)
                 {
+                    ConsumeResult<string, byte[]>? result = null;
                     try
                     {
-                        var result = _consumer.Consume(_cancellation.Token);
+                        result = _consumer.Consume(_cancellation.Token);
                         var message = result.Message;
 
                         var envelope = mapper!.CreateEnvelope(result.Topic, message);
+                        envelope.TopicName = result.Topic;
                         envelope.Offset = result.Offset.Value;
                         envelope.PartitionId = result.Partition.Value;
                         envelope.MessageType ??= _messageTypeName;
@@ -60,14 +65,11 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
                     }
                     catch (Exception e)
                     {
-                        // Might be a poison pill message, try to get out of here
-                        try
+                        // Might be a poison pill message, advance past its specific offset so we don't
+                        // get stuck re-consuming it (only possible when the consume itself succeeded).
+                        if (result != null)
                         {
-                            _consumer.Commit();
-                        }
-                        // ReSharper disable once EmptyGeneralCatchClause
-                        catch (Exception)
-                        {
+                            _committer.Complete(result.Topic, result.Partition.Value, result.Offset.Value);
                         }
 
                         logger.LogError(e, "Error trying to map Kafka message to a Wolverine envelope");
@@ -78,10 +80,9 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
             {
                 // Shutting down
             }
-            finally
-            {
-                _consumer.Close();
-            }
+            // The consumer is intentionally NOT closed here. StopAsync/Dispose flush pending offsets
+            // first and then close the consumer, so a batch-mode commit isn't issued against an
+            // already-closed consumer. See GH-3150.
         }, _cancellation.Token);
     }
 
@@ -91,14 +92,11 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
 
     public ValueTask CompleteAsync(Envelope envelope)
     {
-        try
+        if (envelope.TopicName != null && envelope.PartitionId.HasValue)
         {
-            _consumer.Commit();
+            _committer.Complete(envelope.TopicName, envelope.PartitionId.Value, envelope.Offset);
         }
-        catch (Exception)
-        {
 
-        }
         return ValueTask.CompletedTask;
     }
 
@@ -124,6 +122,18 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
 #pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
         await _runner;
 #pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+
+        // The consume loop has exited, so single-threaded access to the consumer is guaranteed: flush
+        // pending/stored offsets first (GH-3150), then close cleanly.
+        _committer.Flush();
+        try
+        {
+            _consumer.Close();
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "Error closing Kafka consumer on shutdown");
+        }
     }
 
     public bool NativeDeadLetterQueueEnabled => _endpoint.NativeDeadLetterQueueEnabled;
@@ -151,15 +161,10 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
                 "Moved envelope {EnvelopeId} to dead letter queue topic {DlqTopic}. Exception: {ExceptionType}: {ExceptionMessage}",
                 envelope.Id, dlqTopicName, exception.GetType().Name, exception.Message);
 
-            try
+            // Advance past the failed message's specific offset now that it's safely in the DLQ.
+            if (envelope.TopicName != null && envelope.PartitionId.HasValue)
             {
-                _consumer.Commit();
-            }
-            catch (Exception commitEx)
-            {
-                _logger.LogWarning(commitEx,
-                    "Error committing offset after moving envelope {EnvelopeId} to dead letter queue",
-                    envelope.Id);
+                _committer.Complete(envelope.TopicName, envelope.PartitionId.Value, envelope.Offset);
             }
         }
         catch (Exception ex)
@@ -178,6 +183,7 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
         _runner.Wait();
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+        _committer.Flush();
         _consumer.SafeDispose();
         _runner.Dispose();
     }

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaOffsetCommitter.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaOffsetCommitter.cs
@@ -1,0 +1,315 @@
+using System.Diagnostics;
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.Kafka.Internals;
+
+/// <summary>
+/// Encapsulates the offset-commit strategy for a single Kafka consumer (GH-3150). Shared by the
+/// single-topic and grouped listeners. Commits the *specific* TopicPartitionOffset of each completed
+/// message (never the consumer's global position), batches with a contiguous per-partition watermark
+/// so it never commits ahead of the lowest in-flight offset, and respects the user's
+/// EnableAutoCommit/EnableAutoOffsetStore configuration.
+/// </summary>
+internal sealed class KafkaOffsetCommitter
+{
+    internal enum Strategy
+    {
+        /// User opted into Kafka's own auto-commit; Wolverine issues no offset calls.
+        Automatic,
+
+        /// Store each completed offset; Kafka's background committer flushes it.
+        Store,
+
+        /// Synchronously commit each completed offset.
+        PerMessage,
+
+        /// Commit the contiguous watermark after N messages / T elapsed.
+        Batch
+    }
+
+    private readonly IConsumer<string, byte[]> _consumer;
+    private readonly ILogger _logger;
+    private readonly CommitMode _mode;
+    private readonly int _batchCount;
+    private readonly TimeSpan _batchInterval;
+    private readonly Strategy _strategy;
+
+    private readonly object _lock = new();
+    private readonly Dictionary<TopicPartition, OffsetWatermark> _watermarks = new();
+    private int _sinceLastCommit;
+    private long _lastCommitTimestamp;
+
+    public KafkaOffsetCommitter(IConsumer<string, byte[]> consumer, ConsumerConfig config, CommitMode mode,
+        int batchCount, TimeSpan batchInterval, ILogger logger)
+    {
+        _consumer = consumer;
+        _logger = logger;
+        _mode = mode;
+        _batchCount = batchCount < 1 ? 1 : batchCount;
+        _batchInterval = batchInterval;
+        _strategy = ResolveStrategy(config, mode);
+        _lastCommitTimestamp = Stopwatch.GetTimestamp();
+    }
+
+    internal Strategy ResolvedStrategy => _strategy;
+
+    /// <summary>
+    /// Determine the effective commit behavior by reconciling the requested <see cref="CommitMode"/>
+    /// with the consumer configuration. An explicit <c>EnableAutoCommit=true</c> always suppresses
+    /// Wolverine's manual commits (GH-3150 acceptance #1).
+    /// </summary>
+    internal static Strategy ResolveStrategy(ConsumerConfig config, CommitMode mode)
+    {
+        if (config.EnableAutoCommit == true)
+        {
+            // The user (or StoreThenAutoFlush wiring) turned on Kafka's background committer. If offset
+            // storage is manual we still store each completed offset; otherwise stay fully hands-off.
+            return config.EnableAutoOffsetStore == false ? Strategy.Store : Strategy.Automatic;
+        }
+
+        return mode switch
+        {
+            CommitMode.PerMessage => Strategy.PerMessage,
+            CommitMode.BatchCount => Strategy.Batch,
+            CommitMode.BatchInterval => Strategy.Batch,
+            // StoreThenAutoFlush requires EnableAutoCommit=true to flush; if that wasn't wired the
+            // stored offsets would never flush, so fall back to per-message commits rather than silently
+            // never committing.
+            _ => Strategy.PerMessage
+        };
+    }
+
+    /// <summary>
+    /// Mutate <paramref name="config"/> so the Kafka client is wired for the requested mode. Called
+    /// once at listener-build time. Leaves an explicit user EnableAutoCommit choice untouched.
+    /// </summary>
+    internal static void ApplyTo(ConsumerConfig config, CommitMode mode)
+    {
+        if (config.EnableAutoCommit == true)
+        {
+            return; // respect the user's explicit auto-commit choice
+        }
+
+        switch (mode)
+        {
+            case CommitMode.StoreThenAutoFlush:
+                config.EnableAutoCommit = true;
+                config.EnableAutoOffsetStore = false;
+                break;
+
+            case CommitMode.PerMessage:
+            case CommitMode.BatchCount:
+            case CommitMode.BatchInterval:
+                config.EnableAutoCommit = false;
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Record successful processing of a message at the given coordinates and commit/store as the
+    /// strategy dictates. The committed offset is always <paramref name="offset"/> + 1 (the next
+    /// offset to resume from), per Kafka convention.
+    /// </summary>
+    public void Complete(string topic, int partition, long offset)
+    {
+        if (_strategy == Strategy.Automatic)
+        {
+            return;
+        }
+
+        var tp = new TopicPartition(topic, new Partition(partition));
+
+        if (_strategy == Strategy.PerMessage)
+        {
+            CommitOffsets([new TopicPartitionOffset(tp, new Offset(offset + 1))]);
+            return;
+        }
+
+        if (_strategy == Strategy.Store)
+        {
+            StoreOffsets([new TopicPartitionOffset(tp, new Offset(offset + 1))]);
+            return;
+        }
+
+        // Strategy.Batch — advance the per-partition contiguous watermark and commit on threshold.
+        List<TopicPartitionOffset>? toCommit = null;
+        lock (_lock)
+        {
+            if (!_watermarks.TryGetValue(tp, out var watermark))
+            {
+                watermark = new OffsetWatermark();
+                _watermarks[tp] = watermark;
+            }
+
+            watermark.Register(offset);
+            _sinceLastCommit++;
+
+            if (ShouldCommitBatch())
+            {
+                toCommit = PendingWatermarkOffsets();
+                _sinceLastCommit = 0;
+                _lastCommitTimestamp = Stopwatch.GetTimestamp();
+            }
+        }
+
+        if (toCommit is { Count: > 0 })
+        {
+            CommitOffsets(toCommit);
+        }
+    }
+
+    private bool ShouldCommitBatch()
+    {
+        if (_mode == CommitMode.BatchCount)
+        {
+            return _sinceLastCommit >= _batchCount;
+        }
+
+        // BatchInterval: commit once at least the interval has elapsed since the last commit. (Any
+        // residual is flushed on shutdown, so an idle partition never strands progress permanently.)
+        var elapsed = Stopwatch.GetElapsedTime(_lastCommitTimestamp);
+        return elapsed >= _batchInterval;
+    }
+
+    private List<TopicPartitionOffset> PendingWatermarkOffsets()
+    {
+        var list = new List<TopicPartitionOffset>();
+        foreach (var (tp, watermark) in _watermarks)
+        {
+            if (watermark.TryTakeCommittable(out var nextOffset))
+            {
+                list.Add(new TopicPartitionOffset(tp, new Offset(nextOffset)));
+            }
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// Flush any pending offsets. Called on graceful shutdown so a clean stop doesn't lose progress
+    /// (GH-3150 acceptance #4).
+    /// </summary>
+    public void Flush()
+    {
+        switch (_strategy)
+        {
+            case Strategy.Batch:
+                List<TopicPartitionOffset> pending;
+                lock (_lock)
+                {
+                    pending = PendingWatermarkOffsets();
+                    _sinceLastCommit = 0;
+                }
+
+                if (pending.Count > 0)
+                {
+                    CommitOffsets(pending);
+                }
+
+                break;
+
+            case Strategy.Store:
+                // Force the stored offsets to be committed synchronously rather than waiting for the
+                // next background flush (Close() also does this, but be explicit and resilient).
+                try
+                {
+                    _consumer.Commit();
+                }
+                catch (KafkaException e) when (e.Error.Code == ErrorCode.Local_NoOffset)
+                {
+                    // Nothing stored yet — nothing to flush.
+                }
+                catch (Exception e)
+                {
+                    _logger.LogDebug(e, "Error flushing stored Kafka offsets on shutdown");
+                }
+
+                break;
+        }
+    }
+
+    private void CommitOffsets(List<TopicPartitionOffset> offsets)
+    {
+        try
+        {
+            _consumer.Commit(offsets);
+        }
+        catch (KafkaException e) when (e.Error.Code == ErrorCode.Local_NoOffset)
+        {
+            // No offsets to commit.
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "Error committing Kafka offsets {Offsets}", offsets);
+        }
+    }
+
+    private void StoreOffsets(List<TopicPartitionOffset> offsets)
+    {
+        try
+        {
+            foreach (var tpo in offsets)
+            {
+                _consumer.StoreOffset(tpo);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "Error storing Kafka offsets {Offsets}", offsets);
+        }
+    }
+
+    /// <summary>
+    /// Tracks the highest contiguous (gap-free) completed offset for a single partition so a batch
+    /// commit never moves the committed position past an offset whose predecessors are still in
+    /// flight. Offsets within a Kafka partition are contiguous, so a simple "advance while the next
+    /// offset is present" loop yields the correct watermark even under out-of-order completion.
+    /// </summary>
+    internal sealed class OffsetWatermark
+    {
+        private long _contiguous = -1; // highest contiguous completed offset, or -1 before seeding
+        private bool _seeded;
+        private bool _dirty;
+        private readonly SortedSet<long> _ahead = new();
+
+        public void Register(long offset)
+        {
+            if (!_seeded)
+            {
+                _contiguous = offset - 1;
+                _seeded = true;
+            }
+
+            if (offset <= _contiguous)
+            {
+                return; // already covered
+            }
+
+            _ahead.Add(offset);
+
+            while (_ahead.Remove(_contiguous + 1))
+            {
+                _contiguous++;
+                _dirty = true;
+            }
+        }
+
+        /// <summary>
+        /// If new contiguous progress has been made since the last take, return the offset to commit
+        /// (contiguous + 1, i.e. the next offset to resume from) and reset the dirty flag.
+        /// </summary>
+        public bool TryTakeCommittable(out long nextOffset)
+        {
+            if (_dirty)
+            {
+                nextOffset = _contiguous + 1;
+                _dirty = false;
+                return true;
+            }
+
+            nextOffset = default;
+            return false;
+        }
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
@@ -16,6 +16,7 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
     private readonly Task _runner;
     private readonly IReceiver _receiver;
     private readonly ILogger _logger;
+    private readonly KafkaOffsetCommitter _committer;
 
     public KafkaTopicGroupListener(KafkaTopicGroup endpoint, ConsumerConfig config,
         IConsumer<string, byte[]> consumer, IReceiver receiver,
@@ -29,6 +30,8 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
 
         Config = config;
         _receiver = receiver;
+        _committer = new KafkaOffsetCommitter(consumer, config, endpoint.CommitMode, endpoint.CommitBatchCount,
+            endpoint.CommitBatchInterval, logger);
 
         _runner = Task.Run(async () =>
         {
@@ -38,12 +41,14 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
             {
                 while (!_cancellation.IsCancellationRequested)
                 {
+                    ConsumeResult<string, byte[]>? result = null;
                     try
                     {
-                        var result = _consumer.Consume(_cancellation.Token);
+                        result = _consumer.Consume(_cancellation.Token);
                         var message = result.Message;
 
                         var envelope = mapper!.CreateEnvelope(result.Topic, message);
+                        envelope.TopicName = result.Topic;
                         envelope.Offset = result.Offset.Value;
                         envelope.PartitionId = result.Partition.Value;
 
@@ -58,14 +63,11 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
                     }
                     catch (Exception e)
                     {
-                        // Might be a poison pill message, try to get out of here
-                        try
+                        // Might be a poison pill message, advance past its specific offset so we don't
+                        // get stuck re-consuming it (only possible when the consume itself succeeded).
+                        if (result != null)
                         {
-                            _consumer.Commit();
-                        }
-                        // ReSharper disable once EmptyGeneralCatchClause
-                        catch (Exception)
-                        {
+                            _committer.Complete(result.Topic, result.Partition.Value, result.Offset.Value);
                         }
 
                         logger.LogError(e, "Error trying to map Kafka message to a Wolverine envelope");
@@ -76,10 +78,9 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
             {
                 // Shutting down
             }
-            finally
-            {
-                _consumer.Close();
-            }
+            // The consumer is intentionally NOT closed here. StopAsync/Dispose flush pending offsets
+            // first and then close the consumer, so a batch-mode commit isn't issued against an
+            // already-closed consumer. See GH-3150.
         }, _cancellation.Token);
     }
 
@@ -89,13 +90,11 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
 
     public ValueTask CompleteAsync(Envelope envelope)
     {
-        try
+        if (envelope.TopicName != null && envelope.PartitionId.HasValue)
         {
-            _consumer.Commit();
+            _committer.Complete(envelope.TopicName, envelope.PartitionId.Value, envelope.Offset);
         }
-        catch (Exception)
-        {
-        }
+
         return ValueTask.CompletedTask;
     }
 
@@ -120,6 +119,18 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
 #pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
         await _runner;
 #pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+
+        // The consume loop has exited, so single-threaded access to the consumer is guaranteed: flush
+        // pending/stored offsets first (GH-3150), then close cleanly.
+        _committer.Flush();
+        try
+        {
+            _consumer.Close();
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "Error closing Kafka consumer on shutdown");
+        }
     }
 
     public bool NativeDeadLetterQueueEnabled => _endpoint.NativeDeadLetterQueueEnabled;
@@ -147,15 +158,10 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
                 "Moved envelope {EnvelopeId} to dead letter queue topic {DlqTopic}. Exception: {ExceptionType}: {ExceptionMessage}",
                 envelope.Id, dlqTopicName, exception.GetType().Name, exception.Message);
 
-            try
+            // Advance past the failed message's specific offset now that it's safely in the DLQ.
+            if (envelope.TopicName != null && envelope.PartitionId.HasValue)
             {
-                _consumer.Commit();
-            }
-            catch (Exception commitEx)
-            {
-                _logger.LogWarning(commitEx,
-                    "Error committing offset after moving envelope {EnvelopeId} to dead letter queue",
-                    envelope.Id);
+                _committer.Complete(envelope.TopicName, envelope.PartitionId.Value, envelope.Offset);
             }
         }
         catch (Exception ex)
@@ -174,6 +180,7 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
         _runner.Wait();
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+        _committer.Flush();
         _consumer.SafeDispose();
         _runner.Dispose();
     }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -33,6 +33,44 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
         add(topic => configure(topic.Specification));
         return this;
     }
+
+    /// <summary>
+    /// Choose how this listener commits consumer offsets back to Kafka. Defaults to
+    /// <see cref="CommitMode.StoreThenAutoFlush"/> (non-blocking, idiomatic high throughput). See GH-3150.
+    /// </summary>
+    public KafkaListenerConfiguration CommitOffsets(CommitMode mode)
+    {
+        add(topic => topic.CommitMode = mode);
+        return this;
+    }
+
+    /// <summary>
+    /// Have Wolverine commit the contiguous offset watermark after every <paramref name="count"/>
+    /// successfully processed messages. Never commits ahead of the lowest in-flight offset.
+    /// </summary>
+    public KafkaListenerConfiguration CommitOffsetsAfterCount(int count)
+    {
+        add(topic =>
+        {
+            topic.CommitMode = CommitMode.BatchCount;
+            topic.CommitBatchCount = count;
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Have Wolverine commit the contiguous offset watermark once at least <paramref name="interval"/>
+    /// has elapsed since the previous commit. Never commits ahead of the lowest in-flight offset.
+    /// </summary>
+    public KafkaListenerConfiguration CommitOffsetsAfterInterval(TimeSpan interval)
+    {
+        add(topic =>
+        {
+            topic.CommitMode = CommitMode.BatchInterval;
+            topic.CommitBatchInterval = interval;
+        });
+        return this;
+    }
     
     /// <summary>
     /// Configures circuit breaker behavior for this Kafka listener.

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -57,6 +57,25 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     public ProducerConfig? ProducerConfig { get; internal set; }
 
     /// <summary>
+    /// How this listener commits consumer offsets back to Kafka. Defaults to
+    /// <see cref="Kafka.CommitMode.StoreThenAutoFlush"/> — the non-blocking, idiomatic high-throughput
+    /// model. See GH-3150. Inherited by <see cref="KafkaTopicGroup"/>.
+    /// </summary>
+    public CommitMode CommitMode { get; set; } = CommitMode.StoreThenAutoFlush;
+
+    /// <summary>
+    /// Number of completed messages between commits when <see cref="CommitMode"/> is
+    /// <see cref="Kafka.CommitMode.BatchCount"/>. Default 100.
+    /// </summary>
+    public int CommitBatchCount { get; set; } = 100;
+
+    /// <summary>
+    /// Minimum elapsed time between commits when <see cref="CommitMode"/> is
+    /// <see cref="Kafka.CommitMode.BatchInterval"/>. Default 5 seconds.
+    /// </summary>
+    public TimeSpan CommitBatchInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
     /// Enable native dead letter queue support for this endpoint.
     /// When enabled, failed messages will be produced to the Kafka DLQ topic
     /// instead of being moved to database-backed dead letter storage.
@@ -123,10 +142,10 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
 
         var config = GetEffectiveConsumerConfig();
 
-        if (Mode == EndpointMode.Durable)
-        {
-            config.EnableAutoCommit = false;
-        }
+        // Wire the Kafka client for the configured commit strategy (GH-3150). Replaces the previous
+        // blanket EnableAutoCommit=false for Durable mode — the default StoreThenAutoFlush mode relies
+        // on Kafka's background committer flushing manually stored offsets.
+        KafkaOffsetCommitter.ApplyTo(config, CommitMode);
 
         var listener = new KafkaListener(this, config,
             Parent.CreateConsumer(config), receiver, runtime.LoggerFactory.CreateLogger<KafkaListener>());

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
@@ -43,10 +43,8 @@ public class KafkaTopicGroup : KafkaTopic, IBrokerEndpoint
 
         var config = GetEffectiveConsumerConfig();
 
-        if (Mode == EndpointMode.Durable)
-        {
-            config.EnableAutoCommit = false;
-        }
+        // Wire the Kafka client for the configured commit strategy (GH-3150).
+        KafkaOffsetCommitter.ApplyTo(config, CommitMode);
 
         var listener = new KafkaTopicGroupListener(this, config,
             Parent.CreateConsumer(config), receiver, runtime.LoggerFactory.CreateLogger<KafkaTopicGroupListener>());


### PR DESCRIPTION
Closes #3150 (the foundational first step of the #3134 Kafka re-evaluation). Fixes the ~20x throughput bottleneck originally reported in #3134 and a latent global-vs-specific offset bug.

## Problem
`KafkaListener.CompleteAsync` called argument-less `_consumer.Commit()` on **every** message — a synchronous broker round trip per message, committing the consumer's *global* position rather than the message's own offset.

## What changed

### `CommitMode` (new, on the Kafka listener)
- **`StoreThenAutoFlush` (default)** — `EnableAutoOffsetStore=false` + `StoreOffset` per completed message; Kafka's background committer flushes on `AutoCommitIntervalMs`. Non-blocking, at-least-once, idiomatic high throughput. **No synchronous commit per message.**
- **`PerMessage`** — synchronous commit of each message's own offset (strict at-least-once).
- **`BatchCount` / `BatchInterval`** — Wolverine commits the **contiguous offset watermark** after N messages / T elapsed, and **never commits ahead of the lowest in-flight offset** (builds the watermark gate #3140's buffered path needs).

### Correctness — specific-offset commit
`CompleteAsync` (plus the poison-pill and DLQ paths) now commits/stores the message's **specific `TopicPartitionOffset` (offset+1)**, not the global position. The envelope is stamped with its `TopicName` so the grouped (multi-topic) listener commits the right per-topic offset. This is required before any concurrency work.

### Respect `EnableAutoCommit`
If the user turns on Kafka auto-commit via `ConfigureConsumer`, Wolverine issues no manual commits (stores offsets only under `StoreThenAutoFlush`, otherwise hands off entirely). Replaces the previous blanket `EnableAutoCommit=false` for durable listeners.

### Graceful-shutdown flush
The consumer is no longer closed inside the consume loop's `finally`; `StopAsync`/`Dispose` **flush pending/stored offsets first, then close** — so a batch-mode commit is never issued against an already-closed consumer.

A shared `KafkaOffsetCommitter` drives both the single-topic and grouped listeners. Fluent config: `CommitOffsets(mode)`, `CommitOffsetsAfterCount(n)`, `CommitOffsetsAfterInterval(t)`.

## Acceptance criteria
- [x] Manual commits suppressed when `EnableAutoCommit = true`
- [x] `CommitMode` with `PerMessage` / `StoreThenAutoFlush` (default) / `BatchCount` / `BatchInterval`
- [x] `CompleteAsync` commits/stores the specific `TopicPartitionOffset`, not the global position
- [x] Batch modes never commit ahead of the lowest in-flight offset (contiguous watermark)
- [x] Offsets flushed on graceful shutdown
- [x] Tests: throughput model issues no per-message synchronous commit; offsets advance; resume-from-last-flushed; specific-offset under simulated out-of-order completion

## Tests
- **`kafka_offset_committer`** (no broker, mocked `IConsumer`): strategy resolution incl. `EnableAutoCommit` suppression, specific `offset+1`, store-vs-commit per mode, contiguous watermark never commits past a gap, flush, independent partitions.
- **`commit_strategy_end_to_end`** (Kafka docker): a second consumer in the same group **resumes past the committed offsets** rather than reprocessing (load-bearing — without commits, Earliest + same group would reprocess).
- Updated the durable-mode config test to assert the new `StoreThenAutoFlush` wiring.
- Full Kafka suite green **except** the pre-existing, CI-excluded (`Category!=Flaky`) `batch_processing_with_kafka` — **verified it fails identically on clean `main`**, so it's unrelated to this change.
- `dotnet build wolverine.slnx -c Release`: clean.

## Docs
New "Commit Strategy" section in `kafka.md`.

## Out of scope (per #3150)
Intra-partition concurrency by key (#3140) — consumes the watermark gate built here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)