### PR TITLE
Kafka: cooperative-sticky rebalancing + static membership (#3139)

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -298,6 +298,57 @@ opts.ListenToKafkaTopic("events")
 You can always override any consumer setting per-topic using `ConfigureConsumer()`. Note that this
 **completely replaces** the parent-level consumer configuration -- it is not combinatorial.
 
+## Scaling Out / Concurrency <Badge type="tip" text="6.8" />
+
+The Kafka-native way to scale out message processing is to **run more nodes in the same consumer group**.
+Kafka's own group coordinator assigns the topic's partitions across the live consumers in the group and
+guarantees that only one consumer processes a given partition at a time, so you get safe, ordered,
+horizontally-scaled processing for free. This is the recommended approach for Kafka — reach for it before
+in-process parallelism.
+
+The ceiling is the **partition count**: a topic with _N_ partitions can be processed by at most _N_ nodes
+concurrently (extra nodes sit idle as hot standbys). Size your partition count for your target throughput
+and node count.
+
+Two consumer settings make that native assignment stable and production-grade. Both are **opt-in** —
+Wolverine does not change the defaults, because silently switching an existing group's assignment strategy
+breaks live rolling upgrades.
+
+```csharp
+opts.UseKafka(connectionString)
+    // Incremental rebalancing: a rebalance keeps each consumer's unaffected partitions instead of a
+    // stop-the-world revoke-everything cycle.
+    .UseCooperativeStickyAssignment()
+
+    // Static membership: rolling restarts/deploys of the same node don't trigger partition churn.
+    // The group.instance.id defaults to POD_NAME, then HOSTNAME, then the machine name.
+    .UseStaticMembership();
+```
+
+Both are also available per-listener on `ListenToKafkaTopic(...)` (`UseCooperativeStickyAssignment()` /
+`UseStaticMembership(...)`).
+
+::: warning group.instance.id must be unique per node and stable across restarts
+Static membership only works when each node uses a **distinct** `group.instance.id` that **stays the same**
+across restarts of that node. Two nodes sharing one id makes Kafka treat them as a single member and fence
+one out — silently losing messages. The default resolution (`POD_NAME` → `HOSTNAME` → machine name) matches
+the k8s `StatefulSet` idiom; supply your own when those aren't suitable:
+
+```csharp
+.UseStaticMembership(() => Environment.GetEnvironmentVariable("MY_INSTANCE"))
+```
+
+Wolverine logs the resolved `group.instance.id` at startup so you can verify per-node uniqueness, and warns
+if no stable value could be resolved. Avoid a single hard-coded literal applied to every node.
+:::
+
+::: tip Rolling-upgrade path onto cooperative-sticky
+Don't flip an existing, running group straight from the default (eager) assignor to cooperative-sticky — a
+group must not mix eager and cooperative members. Do a two-step deploy: first roll out a build that lists
+**both** strategies (`[CooperativeSticky, Range]`) so every member supports cooperative, then a second
+deploy that drops the eager strategy.
+:::
+
 ## Publishing by Partition Key
 
 To publish messages with Kafka using a designated [partition key](https://developer.confluent.io/courses/apache-kafka/partitions/), use the

--- a/docs/tutorials/concurrency.md
+++ b/docs/tutorials/concurrency.md
@@ -140,3 +140,8 @@ More likely though, to both protect against concurrent access against resources 
 * [Session Identifier and FIFO queue support for Azure Service Bus](/guide/messaging/transports/azureservicebus/session-identifiers)
 * Wolverine's [Partitioned Sequential Messaging](/guide/messaging/partitioning) feature introduced in Wolverine 5.0 that was designed specifically to alleviate problems with concurrency within
   Wolverine systems.
+
+If you are on **Kafka**, the idiomatic way to scale out concurrency is to run more nodes in the same
+consumer group and let Kafka assign partitions across them (one consumer per partition at a time), rather
+than reaching for in-process parallelism. See [Kafka — Scaling Out / Concurrency](/guide/messaging/transports/kafka#scaling-out-concurrency)
+for the recommended cooperative-sticky + static-membership configuration.

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/cooperative_sticky_and_static_membership.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/cooperative_sticky_and_static_membership.cs
@@ -1,0 +1,148 @@
+using Confluent.Kafka;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Kafka.Internals;
+
+namespace Wolverine.Kafka.Tests;
+
+// GH-3139: cooperative-sticky assignment + static membership config surface. No broker required —
+// these assert the resolved ConsumerConfig and the instance-id resolution precedence.
+public class cooperative_sticky_and_static_membership
+{
+    private static KafkaTopic apply(Action<KafkaListenerConfiguration> configure)
+    {
+        var transport = new KafkaTransport();
+        var topic = transport.Topics["orders"];
+        var config = new KafkaListenerConfiguration(topic);
+        configure(config);
+        ((IDelayedEndpointConfiguration)config).Apply();
+        return topic;
+    }
+
+    // ---- transport scope ----
+
+    [Fact]
+    public void transport_cooperative_sticky_sets_assignment_strategy()
+    {
+        var transport = new KafkaTransport();
+        new KafkaTransportExpression(transport, new WolverineOptions()).UseCooperativeStickyAssignment();
+
+        transport.ConsumerConfig.PartitionAssignmentStrategy.ShouldBe(PartitionAssignmentStrategy.CooperativeSticky);
+    }
+
+    [Fact]
+    public void transport_static_membership_with_explicit_id()
+    {
+        var transport = new KafkaTransport();
+        new KafkaTransportExpression(transport, new WolverineOptions()).UseStaticMembership("node-7");
+
+        transport.ConsumerConfig.GroupInstanceId.ShouldBe("node-7");
+        transport.StaticMembershipRequested.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void transport_static_membership_defaults_to_env()
+    {
+        var prior = Environment.GetEnvironmentVariable("POD_NAME");
+        Environment.SetEnvironmentVariable("POD_NAME", "pod-abc");
+        try
+        {
+            var transport = new KafkaTransport();
+            new KafkaTransportExpression(transport, new WolverineOptions()).UseStaticMembership();
+
+            transport.ConsumerConfig.GroupInstanceId.ShouldBe("pod-abc");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("POD_NAME", prior);
+        }
+    }
+
+    // ---- listener scope ----
+
+    [Fact]
+    public void listener_cooperative_sticky_sets_assignment_strategy()
+    {
+        var topic = apply(c => c.UseCooperativeStickyAssignment());
+        topic.ConsumerConfig.ShouldNotBeNull();
+        topic.ConsumerConfig!.PartitionAssignmentStrategy.ShouldBe(PartitionAssignmentStrategy.CooperativeSticky);
+    }
+
+    [Fact]
+    public void listener_static_membership_with_explicit_id()
+    {
+        var topic = apply(c => c.UseStaticMembership("node-9"));
+        topic.ConsumerConfig!.GroupInstanceId.ShouldBe("node-9");
+        topic.StaticMembershipRequested.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void listener_static_membership_with_source_func()
+    {
+        var topic = apply(c => c.UseStaticMembership(() => "from-func"));
+        topic.ConsumerConfig!.GroupInstanceId.ShouldBe("from-func");
+    }
+
+    [Fact]
+    public void listener_combines_with_configure_consumer_when_ordered_after()
+    {
+        var topic = apply(c => c
+            .ConfigureConsumer(x => x.GroupId = "grp")
+            .UseCooperativeStickyAssignment()
+            .UseStaticMembership("node-1"));
+
+        topic.ConsumerConfig!.GroupId.ShouldBe("grp");
+        topic.ConsumerConfig.PartitionAssignmentStrategy.ShouldBe(PartitionAssignmentStrategy.CooperativeSticky);
+        topic.ConsumerConfig.GroupInstanceId.ShouldBe("node-1");
+    }
+
+    // ---- resolution precedence ----
+
+    [Fact]
+    public void resolve_prefers_explicit_source_over_env()
+    {
+        var prior = Environment.GetEnvironmentVariable("POD_NAME");
+        Environment.SetEnvironmentVariable("POD_NAME", "pod-x");
+        try
+        {
+            KafkaStaticMembership.Resolve(() => "explicit").ShouldBe("explicit");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("POD_NAME", prior);
+        }
+    }
+
+    [Fact]
+    public void resolve_blank_source_falls_through_to_env()
+    {
+        var prior = Environment.GetEnvironmentVariable("POD_NAME");
+        Environment.SetEnvironmentVariable("POD_NAME", "pod-y");
+        try
+        {
+            KafkaStaticMembership.Resolve(() => "   ").ShouldBe("pod-y");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("POD_NAME", prior);
+        }
+    }
+
+    [Fact]
+    public void resolve_falls_back_to_machine_name_when_no_env()
+    {
+        var priorPod = Environment.GetEnvironmentVariable("POD_NAME");
+        var priorHost = Environment.GetEnvironmentVariable("HOSTNAME");
+        Environment.SetEnvironmentVariable("POD_NAME", null);
+        Environment.SetEnvironmentVariable("HOSTNAME", null);
+        try
+        {
+            KafkaStaticMembership.Resolve(null).ShouldBe(Environment.MachineName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("POD_NAME", priorPod);
+            Environment.SetEnvironmentVariable("HOSTNAME", priorHost);
+        }
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaStaticMembership.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaStaticMembership.cs
@@ -1,0 +1,23 @@
+namespace Wolverine.Kafka.Internals;
+
+/// <summary>
+/// Resolves a Kafka <c>group.instance.id</c> for static group membership (GH-3139). The id must be
+/// unique per node and stable across restarts of the same logical node, so it is sourced from an
+/// explicit value or — by default — the environment conventions used by k8s StatefulSets.
+/// </summary>
+internal static class KafkaStaticMembership
+{
+    /// <summary>
+    /// Resolution order: an explicitly supplied value, then <c>POD_NAME</c>, then <c>HOSTNAME</c>,
+    /// then the machine name. Returns null only if every source is blank.
+    /// </summary>
+    public static string? Resolve(Func<string?>? source)
+    {
+        return Clean(source?.Invoke())
+               ?? Clean(Environment.GetEnvironmentVariable("POD_NAME"))
+               ?? Clean(Environment.GetEnvironmentVariable("HOSTNAME"))
+               ?? Clean(Environment.MachineName);
+    }
+
+    private static string? Clean(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -2,6 +2,7 @@ using Confluent.Kafka;
 using JasperFx.Core;
 using JasperFx.Descriptors;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Routing;
@@ -61,6 +62,12 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
     public string DeadLetterQueueTopicName { get; set; } = DeadLetterQueueConstants.DefaultQueueName;
 
     public KafkaUsage Usage { get; set; } = KafkaUsage.ProduceAndConsume;
+
+    /// <summary>
+    /// True when static group membership was requested at the transport level (GH-3139). Used to emit a
+    /// startup diagnostic about the resolved group.instance.id.
+    /// </summary>
+    internal bool StaticMembershipRequested { get; set; }
 
     public override Uri ResourceUri
     {
@@ -132,7 +139,41 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
             dlqTopic.Compile(runtime);
         }
 
+        warnOnStaticMembership(runtime);
+
         return ValueTask.CompletedTask;
+    }
+
+    // GH-3139: surface the resolved group.instance.id so operators can verify per-node uniqueness, and
+    // warn loudly if static membership was requested but no stable id could be resolved.
+    private void warnOnStaticMembership(IWolverineRuntime runtime)
+    {
+        var logger = runtime.LoggerFactory.CreateLogger<KafkaTransport>();
+
+        void Check(bool requested, string? instanceId, string scope)
+        {
+            if (!requested) return;
+
+            if (string.IsNullOrWhiteSpace(instanceId))
+            {
+                logger.LogWarning(
+                    "Kafka static membership was requested ({Scope}) but no stable group.instance.id could be resolved (checked the supplied source, POD_NAME, HOSTNAME, and machine name). Static membership will not take effect and rolling restarts may trigger partition rebalancing. Provide an explicit per-node id via UseStaticMembership(...).",
+                    scope);
+            }
+            else
+            {
+                logger.LogInformation(
+                    "Kafka static membership enabled ({Scope}) with group.instance.id '{InstanceId}'. Ensure this value is unique per node and stable across restarts of the same node.",
+                    scope, instanceId);
+            }
+        }
+
+        Check(StaticMembershipRequested, ConsumerConfig.GroupInstanceId, "transport");
+
+        foreach (var topic in Topics.Where(x => x.StaticMembershipRequested))
+        {
+            Check(true, topic.GetEffectiveConsumerConfig().GroupInstanceId, $"topic '{topic.TopicName}'");
+        }
     }
 
     public WolverineTransportHealthCheck BuildHealthCheck(IWolverineRuntime runtime)

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -71,7 +71,49 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
         });
         return this;
     }
-    
+
+    /// <summary>
+    /// Opt this listener's consumer into cooperative-sticky rebalancing
+    /// (<c>partition.assignment.strategy = CooperativeSticky</c>) so a rebalance keeps unaffected
+    /// partitions instead of revoking everything. Opt-in. See GH-3139. Call after
+    /// <see cref="ConfigureConsumer"/> if you also use that (it replaces the whole consumer config).
+    /// </summary>
+    public KafkaListenerConfiguration UseCooperativeStickyAssignment()
+    {
+        add(topic =>
+        {
+            topic.ConsumerConfig ??= new ConsumerConfig();
+            topic.ConsumerConfig.PartitionAssignmentStrategy = PartitionAssignmentStrategy.CooperativeSticky;
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Enable Kafka static group membership (<c>group.instance.id</c>) for this listener so rolling
+    /// restarts of the same node don't churn partitions. The id is resolved from
+    /// <paramref name="instanceId"/> if supplied, otherwise from <c>POD_NAME</c>, then <c>HOSTNAME</c>,
+    /// then the machine name. Must be unique per node and stable across restarts. See GH-3139.
+    /// </summary>
+    public KafkaListenerConfiguration UseStaticMembership(Func<string?>? instanceId = null)
+    {
+        add(topic =>
+        {
+            topic.ConsumerConfig ??= new ConsumerConfig();
+            topic.ConsumerConfig.GroupInstanceId = KafkaStaticMembership.Resolve(instanceId);
+            topic.StaticMembershipRequested = true;
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Enable Kafka static group membership with an explicit <c>group.instance.id</c>. Discouraged unless
+    /// the value is guaranteed unique per node. See GH-3139.
+    /// </summary>
+    public KafkaListenerConfiguration UseStaticMembership(string instanceId)
+    {
+        return UseStaticMembership(() => instanceId);
+    }
+
     /// <summary>
     /// Configures circuit breaker behavior for this Kafka listener.
     /// </summary>

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -76,6 +76,12 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     public TimeSpan CommitBatchInterval { get; set; } = TimeSpan.FromSeconds(5);
 
     /// <summary>
+    /// True when static group membership was requested for this specific listener (GH-3139).
+    /// Inherited by <see cref="KafkaTopicGroup"/>.
+    /// </summary>
+    internal bool StaticMembershipRequested { get; set; }
+
+    /// <summary>
     /// Enable native dead letter queue support for this endpoint.
     /// When enabled, failed messages will be produced to the Kafka DLQ topic
     /// instead of being moved to database-backed dead letter storage.

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
@@ -74,6 +74,43 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     }
 
     /// <summary>
+    /// Opt every Kafka consumer on this node into cooperative-sticky rebalancing
+    /// (<c>partition.assignment.strategy = CooperativeSticky</c>) so a rebalance keeps each consumer's
+    /// unaffected partitions instead of a stop-the-world revoke-everything rebalance. Opt-in: do not
+    /// switch an existing group between eager and cooperative assignors during a live rolling upgrade.
+    /// See GH-3139 and the Kafka "Scaling out" docs.
+    /// </summary>
+    public KafkaTransportExpression UseCooperativeStickyAssignment()
+    {
+        _transport.ConsumerConfig.PartitionAssignmentStrategy = PartitionAssignmentStrategy.CooperativeSticky;
+        return this;
+    }
+
+    /// <summary>
+    /// Enable Kafka static group membership (<c>group.instance.id</c>) so rolling restarts/deploys of the
+    /// same node don't trigger partition churn. The id is resolved from <paramref name="instanceId"/> if
+    /// supplied, otherwise from <c>POD_NAME</c>, then <c>HOSTNAME</c>, then the machine name. The id MUST
+    /// be unique per node and stable across restarts of that node — Wolverine logs the resolved value at
+    /// startup so you can verify. See GH-3139.
+    /// </summary>
+    public KafkaTransportExpression UseStaticMembership(Func<string?>? instanceId = null)
+    {
+        _transport.StaticMembershipRequested = true;
+        _transport.ConsumerConfig.GroupInstanceId = KafkaStaticMembership.Resolve(instanceId);
+        return this;
+    }
+
+    /// <summary>
+    /// Enable Kafka static group membership with an explicit <c>group.instance.id</c>. Discouraged unless
+    /// the caller guarantees the value is unique per node (a single literal applied to every node makes
+    /// Kafka fence all but one out and silently lose messages). See GH-3139.
+    /// </summary>
+    public KafkaTransportExpression UseStaticMembership(string instanceId)
+    {
+        return UseStaticMembership(() => instanceId);
+    }
+
+    /// <summary>
     /// Create newly used Kafka topics on endpoint activation if the topic is missing
     /// </summary>
     /// <param name="configure"></param>


### PR DESCRIPTION
Closes #3139 (child of #3134). Makes Kafka's **native** partition→consumer assignment the recommended way to scale concurrency in Wolverine, with first-class config for the two stability knobs. Both are **opt-in** — defaults unchanged, so a live rolling upgrade isn't broken by silently switching assignment strategies.

## Fluent API (transport + per-listener)
```csharp
opts.UseKafka(connectionString)
    .UseCooperativeStickyAssignment()   // incremental rebalancing
    .UseStaticMembership();             // group.instance.id, defaults to POD_NAME -> HOSTNAME -> machine name

opts.ListenToKafkaTopic("orders")
    .UseCooperativeStickyAssignment()
    .UseStaticMembership("node-7");
```

## Static membership instance-id sourcing (the real work)
`group.instance.id` must be **unique per node** and **stable across restarts of that node**. Resolved via `KafkaStaticMembership.Resolve` from an explicit value/func, else `POD_NAME` → `HOSTNAME` → machine name (the k8s StatefulSet idiom). Wolverine **logs the resolved id at startup** (`ConnectAsync`) so operators can verify per-node uniqueness, and **warns** if no stable id could be resolved. Wolverine's own node number is deliberately *not* used (it's per-process and would defeat the purpose).

Relies on Kafka's own group coordinator for one-consumer-per-partition; no Wolverine-agent-owned partition model (deferred).

## Acceptance criteria
- [x] `UseCooperativeStickyAssignment()` + `UseStaticMembership(...)` at transport + listener scope
- [x] Default `group.instance.id` resolution from env with documented precedence; per-node uniqueness preserved
- [x] Startup warning when a stable instance id cannot be resolved (+ info log of the resolved value)
- [x] Defaults unchanged (opt-in); rolling-upgrade path documented
- [x] Kafka docs gain a Concurrency section; concurrency tutorial references the Kafka option
- [x] Tests assert the resolved `ConsumerConfig` carries the expected `PartitionAssignmentStrategy` / `GroupInstanceId`

## Tests (no broker)
`cooperative_sticky_and_static_membership` — assignment strategy + `group.instance.id` resolved at transport and listener scope; resolution precedence (explicit > POD_NAME > HOSTNAME > machine name); blank source falls through; combines with `ConfigureConsumer` when ordered after it. Existing config/e2e tests still green.

## Docs
- New **"Scaling Out / Concurrency"** section in `kafka.md` — cooperative-sticky + static membership config, the `group.instance.id` uniqueness footgun, and the **two-step rolling-upgrade path** onto cooperative-sticky.
- Kafka callout woven into the general **concurrency tutorial**.

`dotnet build wolverine.slnx -c Release`: clean.

## Out of scope
Wolverine-agent-owned partition assignment (manual `Assign()` + `IAgentFamily`) — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)