### PR TITLE
Kafka: first-class AutoOffsetReset (cold start) + ephemeral hot-tail (#3146)

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -349,6 +349,47 @@ group must not mix eager and cooperative members. Do a two-step deploy: first ro
 deploy that drops the eager strategy.
 :::
 
+### Cold Start vs. Live Tail <Badge type="tip" text="6.8" />
+
+`auto.offset.reset` controls where a consumer **starts** when its group has **no committed offset** for a
+partition — i.e. a cold start. Once the group has committed an offset, it resumes from there and this
+setting is ignored. It is *not* a replay switch.
+
+```csharp
+opts.ListenToKafkaTopic("orders").BeginAtEarliest();   // cold start from the beginning of the topic
+opts.ListenToKafkaTopic("orders").BeginAtLatest();     // cold start from the tail (skip the backlog)
+```
+
+Both are also available as a transport-wide default (`opts.UseKafka(...).BeginAtEarliest()`).
+
+::: warning This only affects the *first* read of a partition by a group
+If the consumer group already has a committed offset, `BeginAtEarliest()`/`BeginAtLatest()` do nothing —
+the group resumes from its committed position. To genuinely re-read old data you need a new group id or an
+explicit seek/replay (a separate, bounded operation).
+:::
+
+#### Hot-tail / broadcast consume
+
+Sometimes you want **every node** to see **every message** as it arrives — live dashboards, cache
+invalidation, fan-out-to-all-instances — rather than the competing-consumer model where each message goes
+to exactly one node in the group. Use `TailFromLatest()`:
+
+```csharp
+opts.ListenToKafkaTopic("live-events").TailFromLatest();
+```
+
+Each process joins a **unique, ephemeral consumer group** and starts at the tail, so every node receives all
+messages, never replays old data, and commits nothing. This is the idiomatic Kafka pattern for broadcast.
+
+A few things to know:
+
+- Because it starts at the tail, only messages published **after** a node has joined and been assigned its
+  partitions are delivered — there is no backlog replay.
+- Each process creates a transient consumer-group entry on the broker; Kafka expires these automatically via
+  `offsets.retention.minutes`. Harmless, but worth knowing for cluster operators.
+- Reach for `TailFromLatest()` when you want **all** nodes to process each message; use a normal
+  shared-group listener (the default) when you want each message processed **once** across the cluster.
+
 ## Publishing by Partition Key
 
 To publish messages with Kafka using a designated [partition key](https://developer.confluent.io/courses/apache-kafka/partitions/), use the

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/cold_start_and_hot_tail.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/cold_start_and_hot_tail.cs
@@ -1,0 +1,191 @@
+using System.Collections.Concurrent;
+using Confluent.Kafka;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.ComplianceTests;
+using Wolverine.Kafka.Internals;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+
+namespace Wolverine.Kafka.Tests;
+
+// GH-3146: cold-start AutoOffsetReset + ephemeral hot-tail/broadcast consume.
+public class cold_start_and_hot_tail
+{
+    private readonly BrokerName brokerName = new("coldhot3146");
+
+    private static KafkaTopic applyListener(Action<KafkaListenerConfiguration> configure)
+    {
+        var transport = new KafkaTransport();
+        var topic = transport.Topics["events"];
+        var config = new KafkaListenerConfiguration(topic);
+        configure(config);
+        ((IDelayedEndpointConfiguration)config).Apply();
+        return topic;
+    }
+
+    // ---- config unit tests (no broker) ----
+
+    [Fact]
+    public void listener_begin_at_earliest()
+    {
+        var topic = applyListener(c => c.BeginAtEarliest());
+        topic.ConsumerConfig!.AutoOffsetReset.ShouldBe(AutoOffsetReset.Earliest);
+    }
+
+    [Fact]
+    public void listener_begin_at_latest()
+    {
+        var topic = applyListener(c => c.BeginAtLatest());
+        topic.ConsumerConfig!.AutoOffsetReset.ShouldBe(AutoOffsetReset.Latest);
+    }
+
+    [Fact]
+    public void tail_from_latest_marks_hot_tail_and_latest()
+    {
+        var topic = applyListener(c => c.TailFromLatest());
+        topic.IsHotTail.ShouldBeTrue();
+        topic.ConsumerConfig!.AutoOffsetReset.ShouldBe(AutoOffsetReset.Latest);
+    }
+
+    [Fact]
+    public void transport_begin_at_earliest_and_latest()
+    {
+        var transport = new KafkaTransport();
+        var expr = new KafkaTransportExpression(transport, new WolverineOptions());
+
+        expr.BeginAtEarliest();
+        transport.ConsumerConfig.AutoOffsetReset.ShouldBe(AutoOffsetReset.Earliest);
+
+        expr.BeginAtLatest();
+        transport.ConsumerConfig.AutoOffsetReset.ShouldBe(AutoOffsetReset.Latest);
+    }
+
+    // ---- end-to-end (Kafka docker) ----
+
+    private Task<IHost> publisherAsync(string topic) => WolverineHost.ForAsync(opts =>
+    {
+        opts.AddNamedKafkaBroker(brokerName, KafkaContainerFixture.ConnectionString).AutoProvision();
+        opts.PublishAllMessages().ToKafkaTopicOnNamedBroker(brokerName, topic).SendInline();
+    });
+
+    private Task<IHost> hotTailNodeAsync(string topic) => WolverineHost.ForAsync(opts =>
+    {
+        opts.AddNamedKafkaBroker(brokerName, KafkaContainerFixture.ConnectionString).AutoProvision();
+        opts.ListenToKafkaTopicOnNamedBroker(brokerName, topic).ProcessInline().TailFromLatest();
+        opts.Services.AddSingleton<NodeSink>();
+        opts.Discovery.DisableConventionalDiscovery().IncludeType<HotTailHandler>();
+    });
+
+    [Fact]
+    public async Task hot_tail_delivers_all_messages_to_every_node()
+    {
+        var topic = Guid.NewGuid().ToString();
+
+        using var publisher = await publisherAsync(topic);
+        using var nodeA = await hotTailNodeAsync(topic);
+        using var nodeB = await hotTailNodeAsync(topic);
+
+        // Each node should have joined a unique, ephemeral hot-tail group with no commits.
+        string? GroupIdFor(IHost node)
+        {
+            var listener = node.GetRuntime().Endpoints.ActiveListeners()
+                .Single(x => x.Uri.ToString().Contains(topic)).ShouldBeOfType<ListeningAgent>()
+                .Listener.ShouldBeOfType<KafkaListener>();
+            listener.Config.GroupId.ShouldNotBeNull();
+            listener.Config.GroupId.ShouldContain("hot-tail");
+            listener.Config.EnableAutoCommit.ShouldBe(true);
+            return listener.Config.GroupId;
+        }
+
+        var groupA = GroupIdFor(nodeA);
+        var groupB = GroupIdFor(nodeB);
+        groupA.ShouldNotBe(groupB);
+
+        // Latest means only messages published AFTER the consumers join are seen — give them a moment
+        // to be assigned their partitions before publishing.
+        await Task.Delay(3000);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await publisher.SendAsync(new HotTailMessage { Id = "m-" + i });
+        }
+
+        var sinkA = nodeA.Services.GetRequiredService<NodeSink>();
+        var sinkB = nodeB.Services.GetRequiredService<NodeSink>();
+        await waitForCountAsync(sinkA.Received, 5);
+        await waitForCountAsync(sinkB.Received, 5);
+
+        // Both nodes (each its own group) received all five messages.
+        sinkA.Received.OrderBy(x => x).ShouldBe(["m-0", "m-1", "m-2", "m-3", "m-4"]);
+        sinkB.Received.OrderBy(x => x).ShouldBe(["m-0", "m-1", "m-2", "m-3", "m-4"]);
+    }
+
+    [Fact]
+    public async Task cold_start_at_earliest_replays_from_the_beginning()
+    {
+        var topic = Guid.NewGuid().ToString();
+        var groupId = Guid.NewGuid().ToString();
+
+        using var publisher = await publisherAsync(topic);
+
+        // Publish BEFORE any consumer exists for this group.
+        for (var i = 0; i < 4; i++)
+        {
+            await publisher.SendAsync(new HotTailMessage { Id = "pre-" + i });
+        }
+
+        // A fresh group starting at earliest should replay everything already on the topic.
+        using var consumer = await WolverineHost.ForAsync(opts =>
+        {
+            opts.AddNamedKafkaBroker(brokerName, KafkaContainerFixture.ConnectionString).AutoProvision();
+            opts.ListenToKafkaTopicOnNamedBroker(brokerName, topic)
+                .ProcessInline()
+                .BeginAtEarliest()
+                .ConfigureConsumer(x =>
+                {
+                    x.GroupId = groupId;
+                    x.AutoOffsetReset = AutoOffsetReset.Earliest;
+                });
+            opts.Services.AddSingleton<NodeSink>();
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<HotTailHandler>();
+        });
+
+        var sink = consumer.Services.GetRequiredService<NodeSink>();
+        await waitForCountAsync(sink.Received, 4);
+        sink.Received.OrderBy(x => x).ShouldBe(["pre-0", "pre-1", "pre-2", "pre-3"]);
+    }
+
+    private static async Task waitForCountAsync(ConcurrentBag<string> bag, int count, int timeoutMs = 30000)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            if (bag.Count >= count) return;
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Only received {bag.Count} of {count} expected messages within {timeoutMs}ms");
+    }
+}
+
+public class HotTailMessage
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class NodeSink
+{
+    public ConcurrentBag<string> Received { get; } = new();
+}
+
+public class HotTailHandler
+{
+    public static void Handle(HotTailMessage message, NodeSink sink)
+    {
+        sink.Received.Add(message.Id);
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -115,6 +115,53 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
     }
 
     /// <summary>
+    /// On a cold start (no committed offset for the group), begin reading from the *earliest* available
+    /// offset (<c>auto.offset.reset = earliest</c>). Once the group has committed, it resumes from the
+    /// committed position and this is ignored. See GH-3146.
+    /// </summary>
+    public KafkaListenerConfiguration BeginAtEarliest()
+    {
+        add(topic =>
+        {
+            topic.ConsumerConfig ??= new ConsumerConfig();
+            topic.ConsumerConfig.AutoOffsetReset = AutoOffsetReset.Earliest;
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// On a cold start (no committed offset for the group), begin reading from the *latest* offset (the
+    /// tail). Only applies when the group has no committed offset for a partition. See GH-3146.
+    /// </summary>
+    public KafkaListenerConfiguration BeginAtLatest()
+    {
+        add(topic =>
+        {
+            topic.ConsumerConfig ??= new ConsumerConfig();
+            topic.ConsumerConfig.AutoOffsetReset = AutoOffsetReset.Latest;
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Ephemeral "hot-tail" / broadcast consume (GH-3146): this listener joins a *unique per-process*
+    /// consumer group and starts at the tail (<c>AutoOffsetReset.Latest</c>), so every node receives all
+    /// messages and never replays — the idiomatic Kafka pattern for live dashboards and fan-out-to-all.
+    /// No offsets are committed. Note: each process creates a transient consumer-group entry on the broker
+    /// (Kafka expires these via <c>offsets.retention.minutes</c>).
+    /// </summary>
+    public KafkaListenerConfiguration TailFromLatest()
+    {
+        add(topic =>
+        {
+            topic.IsHotTail = true;
+            topic.ConsumerConfig ??= new ConsumerConfig();
+            topic.ConsumerConfig.AutoOffsetReset = AutoOffsetReset.Latest;
+        });
+        return this;
+    }
+
+    /// <summary>
     /// Configures circuit breaker behavior for this Kafka listener.
     /// </summary>
     /// <param name="configure">

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -82,6 +82,13 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     internal bool StaticMembershipRequested { get; set; }
 
     /// <summary>
+    /// True for an ephemeral "hot-tail" listener (GH-3146): a unique per-process consumer group +
+    /// AutoOffsetReset.Latest so every node tails live and receives all messages, never committing or
+    /// replaying. Inherited by <see cref="KafkaTopicGroup"/>.
+    /// </summary>
+    internal bool IsHotTail { get; set; }
+
+    /// <summary>
     /// Enable native dead letter queue support for this endpoint.
     /// When enabled, failed messages will be produced to the Kafka DLQ topic
     /// instead of being moved to database-backed dead letter storage.
@@ -148,6 +155,8 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
 
         var config = GetEffectiveConsumerConfig();
 
+        ApplyHotTailConfig(config, runtime);
+
         // Wire the Kafka client for the configured commit strategy (GH-3150). Replaces the previous
         // blanket EnableAutoCommit=false for Durable mode — the default StoreThenAutoFlush mode relies
         // on Kafka's background committer flushing manually stored offsets.
@@ -156,6 +165,22 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
         var listener = new KafkaListener(this, config,
             Parent.CreateConsumer(config), receiver, runtime.LoggerFactory.CreateLogger<KafkaListener>());
         return ValueTask.FromResult((IListener)listener);
+    }
+
+    /// <summary>
+    /// For an ephemeral hot-tail listener (GH-3146), assign a unique per-process consumer group so every
+    /// node receives all messages and never replays, and disable Wolverine-managed commits (the
+    /// position is throwaway). Setting EnableAutoCommit=true makes the commit strategy hands-off.
+    /// </summary>
+    private protected void ApplyHotTailConfig(ConsumerConfig config, IWolverineRuntime runtime)
+    {
+        if (!IsHotTail)
+        {
+            return;
+        }
+
+        config.GroupId = $"{runtime.Options.ServiceName}-hot-tail-{Guid.NewGuid():N}";
+        config.EnableAutoCommit = true;
     }
 
     protected override ISender CreateSender(IWolverineRuntime runtime)

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
@@ -43,6 +43,8 @@ public class KafkaTopicGroup : KafkaTopic, IBrokerEndpoint
 
         var config = GetEffectiveConsumerConfig();
 
+        ApplyHotTailConfig(config, runtime);
+
         // Wire the Kafka client for the configured commit strategy (GH-3150).
         KafkaOffsetCommitter.ApplyTo(config, CommitMode);
 

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
@@ -111,6 +111,28 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     }
 
     /// <summary>
+    /// Default consumers on this node to begin from the *earliest* available offset on a cold start
+    /// (<c>auto.offset.reset = earliest</c>). This only applies the first time a consumer group reads a
+    /// partition — once the group has a committed offset, it resumes there and this is ignored. See GH-3146.
+    /// </summary>
+    public KafkaTransportExpression BeginAtEarliest()
+    {
+        _transport.ConsumerConfig.AutoOffsetReset = AutoOffsetReset.Earliest;
+        return this;
+    }
+
+    /// <summary>
+    /// Default consumers on this node to begin from the *latest* offset (the tail) on a cold start
+    /// (<c>auto.offset.reset = latest</c>). Only applies when the group has no committed offset for a
+    /// partition. See GH-3146.
+    /// </summary>
+    public KafkaTransportExpression BeginAtLatest()
+    {
+        _transport.ConsumerConfig.AutoOffsetReset = AutoOffsetReset.Latest;
+        return this;
+    }
+
+    /// <summary>
     /// Create newly used Kafka topics on endpoint activation if the topic is missing
     /// </summary>
     /// <param name="configure"></param>


### PR DESCRIPTION
Closes #3146 (child of #3134). Makes Kafka **cold-start vs. live-tail** consumption first-class and ergonomic.

## Cold start
```csharp
opts.ListenToKafkaTopic("orders").BeginAtEarliest();   // cold start from the beginning
opts.ListenToKafkaTopic("orders").BeginAtLatest();     // cold start from the tail
```
`BeginAtEarliest()`/`BeginAtLatest()` at transport + listener scope, mapping to `ConsumerConfig.AutoOffsetReset`. The docs make the key semantic explicit: this **only applies when the group has no committed offset** for a partition — it's a cold-start control, not a replay switch.

## Hot-tail / broadcast (Kafka-local)
```csharp
opts.ListenToKafkaTopic("live-events").TailFromLatest();
```
Each process joins a **unique, ephemeral consumer group** (`{ServiceName}-hot-tail-{guid}`) and starts at the tail, so **every node receives all messages**, never replays, and commits nothing (`EnableAutoCommit=true` ⇒ the commit strategy is hands-off). The idiomatic Kafka pattern for live dashboards / fan-out-to-all-instances (vs. competing-consumer). Applied at `BuildListenerAsync` for both the single-topic and grouped listeners.

No Wolverine-agent-owned partition model (deferred); on-demand replay/seek is its own issue.

## Acceptance criteria
- [x] `BeginAtEarliest()` / `BeginAtLatest()` at listener + transport scope → `AutoOffsetReset`
- [x] `TailFromLatest()` ephemeral unique-group + latest; verified N nodes each receive all messages
- [x] Hot-tail mode issues no commits
- [x] Docs subsection on cold-start vs. live-tail + committed-offset semantics
- [x] Tests: cold start replays from beginning on a fresh group; hot-tail delivers only post-subscribe messages to every node

## Tests
- **Config** (no broker): `BeginAtEarliest/Latest` set `AutoOffsetReset` at both scopes; `TailFromLatest` marks hot-tail + Latest.
- **e2e** (Kafka docker): `hot_tail_delivers_all_messages_to_every_node` (two nodes, each its own unique `hot-tail` group with `EnableAutoCommit` on, both receive all 5); `cold_start_at_earliest_replays_from_the_beginning` (fresh group replays the pre-existing backlog).

## Docs
"Cold Start vs. Live Tail" subsection added to the Kafka **Scaling Out** section (from #3139): `BeginAtEarliest/Latest`, the committed-offset gotcha, `TailFromLatest` broadcast vs. competing-consumer, and the ephemeral-group ops note.

`dotnet build wolverine.slnx -c Release`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)