### PR TITLE
Kafka: bounded one-shot replay (seek by offset/timestamp via Assign) (#3147)

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -390,6 +390,45 @@ A few things to know:
 - Reach for `TailFromLatest()` when you want **all** nodes to process each message; use a normal
   shared-group listener (the default) when you want each message processed **once** across the cluster.
 
+## Replaying a Topic <Badge type="tip" text="6.8" />
+
+When you need to **reprocess** a window of a topic's history — error recovery, rebuilding downstream
+state, replaying after a bug fix — Wolverine offers a **bounded, one-shot replay** that reads a range of a
+topic back through the **normal handler pipeline**. It uses a throwaway `Assign()`-based consumer with a
+unique group id and **never commits to the live consumer group**, so steady-state consumption is
+completely untouched.
+
+```csharp
+// Programmatic API on IHost
+await host.ReplayKafkaTopicAsync(new KafkaReplayRequest
+{
+    Topic = "orders",
+    FromTimestamp = DateTimeOffset.UtcNow.AddHours(-1),  // or FromOffset = 1500
+    // ToTimestamp / ToOffset optional — defaults to "now" (the current high-water mark)
+    // Partitions = [0, 1]                                // optional subset; defaults to all
+});
+```
+
+Start defaults to the beginning of each partition and end defaults to the current high-water mark, so
+omitting the bounds replays the whole topic as it stands. Timestamps are resolved to offsets per partition
+via Kafka's `OffsetsForTimes`.
+
+There is also a CLI verb wrapping the same API:
+
+```bash
+dotnet run -- kafka-replay orders --from-timestamp 2026-06-18T12:00:00Z
+dotnet run -- kafka-replay orders --from-offset 1500 --to-offset 2000 --partitions 0,1
+```
+
+::: warning Replayed messages are re-handled
+Each replayed record flows through your handlers again, exactly like live consumption. Handlers should be
+**idempotent** (the same expectation as any at-least-once reprocessing). If you use the durable inbox,
+replayed envelopes pass through the same inbox + de-duplication path.
+:::
+
+Replay reads forward to the end boundary and stops cleanly. It is a discrete operation — for *live* seek of
+a running listener, or a CritterWatch control-pane, see the follow-up issues.
+
 ## Publishing by Partition Key
 
 To publish messages with Kafka using a designated [partition key](https://developer.confluent.io/courses/apache-kafka/partitions/), use the

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/kafka_replay.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/kafka_replay.cs
@@ -1,0 +1,113 @@
+using System.Collections.Concurrent;
+using Confluent.Kafka;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+
+namespace Wolverine.Kafka.Tests;
+
+// GH-3147: bounded one-shot replay. Reuses HotTailMessage / NodeSink / HotTailHandler.
+public class kafka_replay
+{
+    private Task<IHost> hostAsync(string topic, string liveGroup) => WolverineHost.ForAsync(opts =>
+    {
+        opts.UseKafka(KafkaContainerFixture.ConnectionString).AutoProvision();
+        opts.PublishAllMessages().ToKafkaTopic(topic).SendInline();
+        opts.ListenToKafkaTopic(topic)
+            .ProcessInline()
+            .ConfigureConsumer(x =>
+            {
+                x.GroupId = liveGroup;
+                x.AutoOffsetReset = AutoOffsetReset.Earliest;
+            });
+        opts.Services.AddSingleton<NodeSink>();
+        opts.Discovery.DisableConventionalDiscovery().IncludeType<HotTailHandler>();
+    });
+
+    private static long QueryCommittedOffset(string groupId, string topic)
+    {
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = KafkaContainerFixture.ConnectionString,
+            GroupId = groupId
+        };
+        using var consumer = new ConsumerBuilder<string, byte[]>(config).Build();
+        var committed = consumer.Committed([new TopicPartition(topic, new Partition(0))], TimeSpan.FromSeconds(10));
+        return committed[0].Offset.Value;
+    }
+
+    [Fact]
+    public async Task replay_from_offset_reprocesses_the_window_without_touching_the_live_group()
+    {
+        var topic = Guid.NewGuid().ToString();
+        var liveGroup = Guid.NewGuid().ToString();
+
+        using var host = await hostAsync(topic, liveGroup);
+        var sink = host.Services.GetRequiredService<NodeSink>();
+
+        // Single partition (auto-provisioned default), so offsets 0..5 == m-0..m-5.
+        for (var i = 0; i < 6; i++)
+        {
+            await host.SendAsync(new HotTailMessage { Id = "m-" + i });
+        }
+
+        await waitForCountAsync(sink.Received, 6);
+        // Let the live group commit its progress through the topic.
+        await Task.Delay(2000);
+        var committedBefore = QueryCommittedOffset(liveGroup, topic);
+
+        // Now replay just the tail of the window through the pipeline again.
+        sink.Received.Clear();
+        var result = await host.ReplayKafkaTopicAsync(new KafkaReplayRequest { Topic = topic, FromOffset = 2 });
+
+        result.RecordsReplayed.ShouldBe(4);
+        await waitForCountAsync(sink.Received, 4);
+        sink.Received.OrderBy(x => x).ShouldBe(["m-2", "m-3", "m-4", "m-5"]);
+
+        // The live group's committed offset must be untouched by the replay (it used a throwaway group).
+        QueryCommittedOffset(liveGroup, topic).ShouldBe(committedBefore);
+    }
+
+    [Fact]
+    public async Task replay_from_timestamp_reprocesses_only_records_after_it()
+    {
+        var topic = Guid.NewGuid().ToString();
+        var liveGroup = Guid.NewGuid().ToString();
+
+        using var host = await hostAsync(topic, liveGroup);
+        var sink = host.Services.GetRequiredService<NodeSink>();
+
+        await host.SendAsync(new HotTailMessage { Id = "old-0" });
+        await host.SendAsync(new HotTailMessage { Id = "old-1" });
+        await waitForCountAsync(sink.Received, 2);
+
+        await Task.Delay(1500);
+        var boundary = DateTimeOffset.UtcNow;
+        await Task.Delay(1500);
+
+        await host.SendAsync(new HotTailMessage { Id = "new-0" });
+        await host.SendAsync(new HotTailMessage { Id = "new-1" });
+        await host.SendAsync(new HotTailMessage { Id = "new-2" });
+        await waitForCountAsync(sink.Received, 5);
+
+        sink.Received.Clear();
+        var result = await host.ReplayKafkaTopicAsync(new KafkaReplayRequest { Topic = topic, FromTimestamp = boundary });
+
+        result.RecordsReplayed.ShouldBe(3);
+        await waitForCountAsync(sink.Received, 3);
+        sink.Received.OrderBy(x => x).ShouldBe(["new-0", "new-1", "new-2"]);
+    }
+
+    private static async Task waitForCountAsync(ConcurrentBag<string> bag, int count, int timeoutMs = 30000)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            if (bag.Count >= count) return;
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Only received {bag.Count} of {count} expected messages within {timeoutMs}ms");
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/AssemblyAttributes.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/AssemblyAttributes.cs
@@ -1,0 +1,6 @@
+using JasperFx;
+
+// Marks Wolverine.Kafka as a JasperFx module assembly so its command-line verbs (e.g. the GH-3147
+// `kafka-replay` command) are discovered by the host's command runner. Wolverine.Kafka declares no
+// IWolverineExtension or message handlers, so extension/handler discovery over this assembly is a no-op.
+[assembly: JasperFxAssembly]

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaReplay.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaReplay.cs
@@ -1,0 +1,219 @@
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Util;
+
+namespace Wolverine.Kafka.Internals;
+
+/// <summary>
+/// Executes a bounded, one-shot Kafka replay (GH-3147): a separate <c>Assign()</c>-based consumer (with a
+/// unique throwaway group id and no commits) seeks to the requested start on each partition, reads
+/// forward to the end boundary, and feeds every record through the normal Wolverine handler pipeline. The
+/// live consumer group's committed offsets are never touched.
+/// </summary>
+internal sealed class KafkaReplay
+{
+    private static readonly TimeSpan _metadataTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan _pollTimeout = TimeSpan.FromSeconds(1);
+
+    private readonly KafkaTransport _transport;
+    private readonly IWolverineRuntime _runtime;
+    private readonly ILogger _logger;
+
+    public KafkaReplay(KafkaTransport transport, IWolverineRuntime runtime)
+    {
+        _transport = transport;
+        _runtime = runtime;
+        _logger = runtime.LoggerFactory.CreateLogger<KafkaReplay>();
+    }
+
+    public async Task<KafkaReplayResult> ExecuteAsync(KafkaReplayRequest request, CancellationToken token)
+    {
+        if (request.FromOffset.HasValue && request.FromTimestamp.HasValue)
+            throw new ArgumentException("Specify only one of FromOffset or FromTimestamp", nameof(request));
+        if (request.ToOffset.HasValue && request.ToTimestamp.HasValue)
+            throw new ArgumentException("Specify only one of ToOffset or ToTimestamp", nameof(request));
+
+        var topic = _transport.Topics[request.Topic];
+        var mapper = topic.EnsureEnvelopeMapper(_runtime);
+        var messageTypeName = topic.MessageType?.ToMessageTypeName();
+        var pipeline = _runtime.Pipeline;
+        var callback = new ReplayChannelCallback();
+
+        // Throwaway, Assign-only consumer: unique group, no commits, no offset store.
+        var config = new ConsumerConfig(_transport.ConsumerConfig)
+        {
+            GroupId = $"{_runtime.Options.ServiceName}-replay-{Guid.NewGuid():N}",
+            EnableAutoCommit = false,
+            EnableAutoOffsetStore = false
+        };
+
+        using var consumer = _transport.CreateConsumer(config);
+
+        var partitions = ResolvePartitions(request);
+        var plan = BuildPlan(consumer, request, partitions);
+
+        var toAssign = plan.Where(x => x.Start < x.End)
+            .Select(x => new TopicPartitionOffset(x.Partition, new Offset(x.Start))).ToList();
+
+        if (toAssign.Count == 0)
+        {
+            return new KafkaReplayResult { RecordsReplayed = 0, PartitionsReplayed = 0 };
+        }
+
+        consumer.Assign(toAssign);
+
+        var ends = plan.Where(x => x.Start < x.End).ToDictionary(x => x.Partition, x => x.End);
+        var remaining = new HashSet<TopicPartition>(ends.Keys);
+        long replayed = 0;
+
+        _logger.LogInformation("Starting Kafka replay of topic {Topic} across {Count} partition(s)",
+            request.Topic, remaining.Count);
+
+        try
+        {
+            while (remaining.Count > 0 && !token.IsCancellationRequested)
+            {
+                var result = consumer.Consume(_pollTimeout);
+                if (result?.Message == null)
+                {
+                    continue;
+                }
+
+                var tp = result.TopicPartition;
+                if (!remaining.Contains(tp))
+                {
+                    continue;
+                }
+
+                if (result.Offset.Value >= ends[tp])
+                {
+                    // Reached this partition's end boundary; stop pulling from it.
+                    remaining.Remove(tp);
+                    consumer.Pause([tp]);
+                    continue;
+                }
+
+                var envelope = mapper.CreateEnvelope(result.Topic, result.Message);
+                envelope.TopicName = result.Topic;
+                envelope.Offset = result.Offset.Value;
+                envelope.PartitionId = result.Partition.Value;
+                envelope.MessageType ??= messageTypeName;
+
+                await pipeline.InvokeAsync(envelope, callback);
+                replayed++;
+
+                if (result.Offset.Value + 1 >= ends[tp])
+                {
+                    remaining.Remove(tp);
+                    consumer.Pause([tp]);
+                }
+            }
+        }
+        finally
+        {
+            // Close without committing — the live group's offsets are untouched.
+            consumer.Close();
+        }
+
+        _logger.LogInformation("Finished Kafka replay of topic {Topic}: {Count} record(s) replayed",
+            request.Topic, replayed);
+
+        return new KafkaReplayResult { RecordsReplayed = replayed, PartitionsReplayed = ends.Count };
+    }
+
+    private List<TopicPartition> ResolvePartitions(KafkaReplayRequest request)
+    {
+        using var admin = _transport.CreateAdminClient();
+        var metadata = admin.GetMetadata(request.Topic, _metadataTimeout);
+        var topicMetadata = metadata.Topics.SingleOrDefault(x => x.Topic == request.Topic);
+        if (topicMetadata == null || topicMetadata.Error.IsError)
+        {
+            throw new InvalidOperationException(
+                $"Unable to read metadata for Kafka topic '{request.Topic}': {topicMetadata?.Error.Reason ?? "not found"}");
+        }
+
+        var ids = topicMetadata.Partitions.Select(x => x.PartitionId);
+        if (request.Partitions is { Length: > 0 })
+        {
+            var wanted = request.Partitions.ToHashSet();
+            ids = ids.Where(wanted.Contains);
+        }
+
+        return ids.Select(id => new TopicPartition(request.Topic, new Partition(id))).ToList();
+    }
+
+    private List<PartitionPlan> BuildPlan(IConsumer<string, byte[]> consumer, KafkaReplayRequest request,
+        List<TopicPartition> partitions)
+    {
+        var startTimes = request.FromTimestamp.HasValue
+            ? OffsetsForTimes(consumer, partitions, request.FromTimestamp.Value)
+            : null;
+        var endTimes = request.ToTimestamp.HasValue
+            ? OffsetsForTimes(consumer, partitions, request.ToTimestamp.Value)
+            : null;
+
+        var plan = new List<PartitionPlan>();
+        foreach (var tp in partitions)
+        {
+            var watermarks = consumer.QueryWatermarkOffsets(tp, _metadataTimeout);
+            var low = watermarks.Low.Value;
+            var high = watermarks.High.Value;
+
+            long start;
+            if (request.FromOffset.HasValue)
+            {
+                start = Math.Clamp(request.FromOffset.Value, low, high);
+            }
+            else if (startTimes != null)
+            {
+                var resolved = startTimes[tp];
+                start = resolved < 0 ? high : Math.Clamp(resolved, low, high);
+            }
+            else
+            {
+                start = low;
+            }
+
+            long end;
+            if (request.ToOffset.HasValue)
+            {
+                end = Math.Clamp(request.ToOffset.Value, low, high);
+            }
+            else if (endTimes != null)
+            {
+                var resolved = endTimes[tp];
+                end = resolved < 0 ? high : Math.Clamp(resolved, low, high);
+            }
+            else
+            {
+                end = high;
+            }
+
+            plan.Add(new PartitionPlan(tp, start, end));
+        }
+
+        return plan;
+    }
+
+    private static Dictionary<TopicPartition, long> OffsetsForTimes(IConsumer<string, byte[]> consumer,
+        List<TopicPartition> partitions, DateTimeOffset timestamp)
+    {
+        var request = partitions
+            .Select(tp => new TopicPartitionTimestamp(tp, new Timestamp(timestamp.UtcDateTime, TimestampType.CreateTime)))
+            .ToList();
+
+        var resolved = consumer.OffsetsForTimes(request, _metadataTimeout);
+        return resolved.ToDictionary(x => x.TopicPartition, x => x.Offset.Value);
+    }
+
+    private sealed record PartitionPlan(TopicPartition Partition, long Start, long End);
+
+    private sealed class ReplayChannelCallback : IChannelCallback
+    {
+        public IHandlerPipeline? Pipeline => null;
+        public ValueTask CompleteAsync(Envelope envelope) => ValueTask.CompletedTask;
+        public ValueTask DeferAsync(Envelope envelope) => ValueTask.CompletedTask;
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaReplayCommand.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaReplayCommand.cs
@@ -1,0 +1,71 @@
+using System.Globalization;
+using JasperFx;
+using JasperFx.CommandLine;
+using Spectre.Console;
+
+namespace Wolverine.Kafka.Internals;
+
+public class KafkaReplayInput : NetCoreInput
+{
+    [Description("The Kafka topic to replay")]
+    public string Topic { get; set; } = string.Empty;
+
+    [Description("Start the replay at this absolute offset on every partition")]
+    public long? FromOffsetFlag { get; set; }
+
+    [Description("Start at the first record at or after this ISO-8601 timestamp")]
+    public string? FromTimestampFlag { get; set; }
+
+    [Description("Stop the replay at this absolute offset (exclusive) on every partition")]
+    public long? ToOffsetFlag { get; set; }
+
+    [Description("Stop at the first record at or after this ISO-8601 timestamp")]
+    public string? ToTimestampFlag { get; set; }
+
+    [Description("Restrict to these partitions (comma-separated, e.g. 0,1,2)")]
+    public string? PartitionsFlag { get; set; }
+
+    [Description("Target a specific named Kafka broker (omit for the default)")]
+    public string? BrokerFlag { get; set; }
+}
+
+[Description("Replay a window of a Kafka topic's history back through the Wolverine handler pipeline", Name = "kafka-replay")]
+public class KafkaReplayCommand : JasperFxAsyncCommand<KafkaReplayInput>
+{
+    public KafkaReplayCommand()
+    {
+        Usage("Replay an entire topic from the beginning").Arguments(x => x.Topic);
+        Usage("Replay a window of a topic").Arguments(x => x.Topic);
+    }
+
+    public override async Task<bool> Execute(KafkaReplayInput input)
+    {
+        using var host = input.BuildHost();
+
+        var request = new KafkaReplayRequest
+        {
+            Topic = input.Topic,
+            FromOffset = input.FromOffsetFlag,
+            FromTimestamp = ParseTimestamp(input.FromTimestampFlag),
+            ToOffset = input.ToOffsetFlag,
+            ToTimestamp = ParseTimestamp(input.ToTimestampFlag),
+            Partitions = input.PartitionsFlag?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(int.Parse).ToArray()
+        };
+
+        AnsiConsole.MarkupLine($"Replaying Kafka topic [blue]{input.Topic}[/]...");
+        var result = await host.ReplayKafkaTopicAsync(request, input.BrokerFlag);
+
+        AnsiConsole.MarkupLine(
+            $"[green]Replayed {result.RecordsReplayed} record(s) across {result.PartitionsReplayed} partition(s).[/]");
+
+        return true;
+    }
+
+    private static DateTimeOffset? ParseTimestamp(string? value)
+    {
+        return value == null
+            ? null
+            : DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaReplayExtensions.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaReplayExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Hosting;
+using Wolverine.Kafka.Internals;
+using Wolverine.Tracking;
+
+namespace Wolverine.Kafka;
+
+public static class KafkaReplayExtensions
+{
+    /// <summary>
+    /// Run a bounded, one-shot replay of a Kafka topic's history back through the normal Wolverine
+    /// handler pipeline against the default Kafka broker (GH-3147). Uses a throwaway Assign()-based
+    /// consumer and never commits to the live consumer group, so steady-state consumption is untouched.
+    /// Replayed messages are re-handled, so handlers should be idempotent.
+    /// </summary>
+    public static Task<KafkaReplayResult> ReplayKafkaTopicAsync(this IHost host, KafkaReplayRequest request,
+        CancellationToken token = default)
+    {
+        return host.ReplayKafkaTopicAsync(request, null, token);
+    }
+
+    /// <summary>
+    /// Run a bounded, one-shot Kafka replay against a specific named broker. See
+    /// <see cref="ReplayKafkaTopicAsync(IHost, KafkaReplayRequest, CancellationToken)"/>.
+    /// </summary>
+    public static async Task<KafkaReplayResult> ReplayKafkaTopicAsync(this IHost host, KafkaReplayRequest request,
+        string? brokerName, CancellationToken token = default)
+    {
+        var runtime = host.GetRuntime();
+        var transport = brokerName == null
+            ? runtime.Options.Transports.GetOrCreate<KafkaTransport>()
+            : runtime.Options.Transports.GetOrCreate<KafkaTransport>(new BrokerName(brokerName));
+
+        return await new KafkaReplay(transport, runtime).ExecuteAsync(request, token);
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaReplayRequest.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaReplayRequest.cs
@@ -1,0 +1,42 @@
+namespace Wolverine.Kafka;
+
+/// <summary>
+/// Describes a bounded, one-shot replay of a Kafka topic's history back through the normal Wolverine
+/// handler pipeline (GH-3147). The replay uses a throwaway <c>Assign()</c>-based consumer and never
+/// commits to the live consumer group, so steady-state consumption is untouched.
+///
+/// Start defaults to the beginning of each partition (earliest), end defaults to the current high-water
+/// mark ("now"). Replayed messages are re-handled, so handlers should be idempotent.
+/// </summary>
+public class KafkaReplayRequest
+{
+    /// <summary>The topic to replay.</summary>
+    public required string Topic { get; init; }
+
+    /// <summary>Start the replay at this absolute offset on every partition. Mutually exclusive with <see cref="FromTimestamp"/>.</summary>
+    public long? FromOffset { get; init; }
+
+    /// <summary>Start the replay at the first record whose timestamp is at or after this instant (resolved per partition via OffsetsForTimes).</summary>
+    public DateTimeOffset? FromTimestamp { get; init; }
+
+    /// <summary>Stop the replay at this absolute offset (exclusive) on every partition. Mutually exclusive with <see cref="ToTimestamp"/>.</summary>
+    public long? ToOffset { get; init; }
+
+    /// <summary>Stop the replay at the first record whose timestamp is at or after this instant. Mutually exclusive with <see cref="ToOffset"/>.</summary>
+    public DateTimeOffset? ToTimestamp { get; init; }
+
+    /// <summary>Restrict the replay to these partitions. Null or empty replays all partitions.</summary>
+    public int[]? Partitions { get; init; }
+}
+
+/// <summary>
+/// Outcome of a <see cref="KafkaReplayRequest"/>.
+/// </summary>
+public class KafkaReplayResult
+{
+    /// <summary>Number of records fed back through the handler pipeline.</summary>
+    public long RecordsReplayed { get; init; }
+
+    /// <summary>Number of partitions that had records within the requested window.</summary>
+    public int PartitionsReplayed { get; init; }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -149,6 +149,15 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
         return ProducerConfig ?? Parent.ProducerConfig;
     }
 
+    /// <summary>
+    /// Ensure the envelope mapper has been built (e.g. for a one-shot replay of a topic that isn't a
+    /// configured live listener). See GH-3147.
+    /// </summary>
+    internal IKafkaEnvelopeMapper EnsureEnvelopeMapper(IWolverineRuntime runtime)
+    {
+        return EnvelopeMapper ??= BuildMapper(runtime);
+    }
+
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
     {
         EnvelopeMapper ??= BuildMapper(runtime);


### PR DESCRIPTION
Closes #3147 (child of #3134). Adds **on-demand Kafka replay** as a bounded, one-shot operation: reprocess a window of a topic's history through the **normal Wolverine handler pipeline**, starting from an offset or timestamp, **without disturbing the live consumer group's committed offsets**.

## Executor (`KafkaReplay`)
- Discovers partitions via admin metadata; resolves per-partition **start/end** from explicit offsets or timestamps (`OffsetsForTimes`), defaulting start = earliest and end = current high-water mark.
- Spins up a **throwaway `Assign()`-based consumer** (unique group id, `EnableAutoCommit=false`), seeks to the start, reads forward, and feeds every record through `runtime.Pipeline.InvokeAsync` — same envelope mapping/handlers as live consumption.
- Pauses each partition at its end boundary and terminates when all are done. **Never commits to the live group.**

## Trigger surface
```csharp
await host.ReplayKafkaTopicAsync(new KafkaReplayRequest
{
    Topic = "orders",
    FromTimestamp = DateTimeOffset.UtcNow.AddHours(-1),   // or FromOffset = 1500
    // To*/Partitions optional
});
```
```bash
dotnet run -- kafka-replay orders --from-timestamp 2026-06-18T12:00:00Z
dotnet run -- kafka-replay orders --from-offset 1500 --to-offset 2000 --partitions 0,1
```
Wolverine.Kafka gains a `[JasperFxAssembly]` marker so the `kafka-replay` verb is discovered (the assembly declares no `IWolverineExtension`/handlers, so extension/handler discovery over it is a no-op — mirrors Wolverine.Http, which already carries the marker + the `openapi` command).

## Acceptance criteria
- [x] Programmatic replay API: start by offset or timestamp, end by target, over selected partitions
- [x] Uses a separate `Assign()` consumer; **never** commits to the production group
- [x] Records flow through the normal handler pipeline; replay terminates at the end boundary
- [x] CLI verb wrapping the API
- [x] Tests: replay-from-timestamp and replay-from-offset reprocess the expected window; live group's committed offset unchanged afterward

## Tests (Kafka docker)
- `replay_from_offset_reprocesses_the_window_without_touching_the_live_group` — reprocesses exactly the requested window **and** asserts the live group's committed offset is unchanged (queried via `Committed()`).
- `replay_from_timestamp_reprocesses_only_records_after_it`.
- Existing config/e2e/startup tests still green with the assembly marker.

## Docs
"Replaying a Topic" section in `kafka.md` — API + CLI + idempotency warning; live-seek and the CritterWatch control pane noted as deferred follow-ups.

## Out of scope (deferred)
Live seek of a running group-subscribed listener; CritterWatch UI (separate follow-up).

`dotnet build wolverine.slnx -c Release`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)