### PR TITLE
Kafka: idempotent producer + read_committed isolation + EOS docs (#3149)

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -429,6 +429,68 @@ replayed envelopes pass through the same inbox + de-duplication path.
 Replay reads forward to the end boundary and stops cleanly. It is a discrete operation — for *live* seek of
 a running listener, or a CritterWatch control-pane, see the follow-up issues.
 
+## Idempotency & Exactly-Once with Kafka <Badge type="tip" text="6.8" />
+
+Kafka delivery is **at-least-once** by default: a consumer can see a message more than once (after a
+rebalance, a crash before the offset is committed, or a [replay](#replaying-a-topic)). There are two very
+different ways to get "exactly-once-ish" behavior, and for most Wolverine users the first one is the answer.
+
+### Recommended for database-backed apps: Wolverine's durable inbox/outbox
+
+If your handlers touch a database, use Wolverine's [durable inbox/outbox](/guide/durability/). The incoming
+message and its side effects commit in **one database transaction** (inbox), and outgoing messages commit in
+the **same transaction** as your business state (outbox) before being forwarded. The inbox **de-duplicates**
+redelivered messages, so your handlers are safe under at-least-once delivery:
+
+```csharp
+opts.ListenToKafkaTopic("orders").UseDurableInbox();
+```
+
+This gives you effectively-once processing that **spans your database and Kafka** — something Kafka
+transactions alone cannot do, because they can't enlist an external database. This is how most Wolverine
+applications should get exactly-once-style guarantees; you do **not** need Kafka transactions for it.
+
+### Idempotent producer
+
+Opt into the idempotent producer so producer-side retries can't write duplicates to the broker:
+
+```csharp
+opts.UseKafka(connectionString).UseIdempotentProducer();       // node-wide
+opts.PublishMessage<T>().ToKafkaTopic("t").UseIdempotentProducer();  // per topic
+```
+
+This sets `enable.idempotence = true` (which implies `acks=all` and bounded in-flight requests). It is
+**producer→broker** de-duplication only — it does not make consume-process-produce atomic, and it has a
+slight throughput cost. Opt-in; the default is unchanged.
+
+### `read_committed` isolation
+
+When you consume a topic that is written by Kafka transactions, set the consumer to skip records from
+aborted transactions:
+
+```csharp
+opts.UseKafka(connectionString).UseReadCommitted();             // node-wide
+opts.ListenToKafkaTopic("orders").UseReadCommitted();           // per listener
+```
+
+The default is `read_uncommitted`.
+
+### Handler idempotency
+
+Because delivery is at-least-once, **design your handlers to tolerate redelivery** — especially if you
+don't use the durable inbox, and always when using [retry topics](#) or [replay](#replaying-a-topic). Make
+writes idempotent (upserts keyed by a business id, conditional updates, dedupe tables), so reprocessing the
+same message is harmless.
+
+### Non-goal: a transactional read-process-write EOS engine
+
+Wolverine does **not** implement a Kafka transactional read-process-write engine (`transactional.id` +
+`Begin/Commit/AbortTransaction` + `SendOffsetsToTransaction` to make consume→transform→produce→commit-offset
+atomic inside Kafka). That mode bypasses both the durable inbox and Wolverine's commit strategy, and only
+adds value for **DB-free Kafka→Kafka** pipelines — which are better served by Kafka Streams. Wolverine stays
+in the message-bus + database-outbox lane; if you need pure in-Kafka transactional exactly-once, reach for
+Kafka Streams.
+
 ## Publishing by Partition Key
 
 To publish messages with Kafka using a designated [partition key](https://developer.confluent.io/courses/apache-kafka/partitions/), use the

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/kafka_eos_building_blocks.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/kafka_eos_building_blocks.cs
@@ -1,0 +1,61 @@
+using Confluent.Kafka;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Kafka.Internals;
+
+namespace Wolverine.Kafka.Tests;
+
+// GH-3149: opt-in exactly-once building blocks — idempotent producer + read_committed isolation.
+public class kafka_eos_building_blocks
+{
+    [Fact]
+    public void transport_idempotent_producer()
+    {
+        var transport = new KafkaTransport();
+        new KafkaTransportExpression(transport, new WolverineOptions()).UseIdempotentProducer();
+
+        transport.ProducerConfig.EnableIdempotence.ShouldBe(true);
+    }
+
+    [Fact]
+    public void transport_read_committed()
+    {
+        var transport = new KafkaTransport();
+        new KafkaTransportExpression(transport, new WolverineOptions()).UseReadCommitted();
+
+        transport.ConsumerConfig.IsolationLevel.ShouldBe(IsolationLevel.ReadCommitted);
+    }
+
+    [Fact]
+    public void listener_read_committed()
+    {
+        var transport = new KafkaTransport();
+        var topic = transport.Topics["events"];
+        var config = new KafkaListenerConfiguration(topic);
+        config.UseReadCommitted();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        topic.ConsumerConfig!.IsolationLevel.ShouldBe(IsolationLevel.ReadCommitted);
+    }
+
+    [Fact]
+    public void subscriber_idempotent_producer()
+    {
+        var transport = new KafkaTransport();
+        var topic = transport.Topics["events"];
+        var config = new KafkaSubscriberConfiguration(topic);
+        config.UseIdempotentProducer();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        topic.ProducerConfig!.EnableIdempotence.ShouldBe(true);
+    }
+
+    [Fact]
+    public void defaults_are_unchanged()
+    {
+        // Opt-in: a vanilla transport touches neither setting.
+        var transport = new KafkaTransport();
+        transport.ProducerConfig.EnableIdempotence.ShouldBeNull();
+        transport.ConsumerConfig.IsolationLevel.ShouldBeNull();
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -162,6 +162,21 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
     }
 
     /// <summary>
+    /// Set this listener's consumer isolation level to <c>read_committed</c>, so records from aborted
+    /// Kafka transactions are skipped when reading transactionally-written topics. Default is
+    /// <c>read_uncommitted</c>. See GH-3149.
+    /// </summary>
+    public KafkaListenerConfiguration UseReadCommitted()
+    {
+        add(topic =>
+        {
+            topic.ConsumerConfig ??= new ConsumerConfig();
+            topic.ConsumerConfig.IsolationLevel = IsolationLevel.ReadCommitted;
+        });
+        return this;
+    }
+
+    /// <summary>
     /// Configures circuit breaker behavior for this Kafka listener.
     /// </summary>
     /// <param name="configure">

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaSubscriberConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaSubscriberConfiguration.cs
@@ -78,6 +78,22 @@ public class KafkaSubscriberConfiguration : InteroperableSubscriberConfiguration
     }
 
     /// <summary>
+    /// Opt this topic's producer into the idempotent producer (<c>enable.idempotence = true</c>, which
+    /// implies <c>acks=all</c> and bounded in-flight requests) so producer-side retries can't write
+    /// duplicates to the broker. Opt-in; producer→broker de-duplication only (not transactional
+    /// exactly-once). See GH-3149. Call after <see cref="ConfigureProducer"/> if you also use that.
+    /// </summary>
+    public KafkaSubscriberConfiguration UseIdempotentProducer()
+    {
+        add(topic =>
+        {
+            topic.ProducerConfig ??= new ProducerConfig();
+            topic.ProducerConfig.EnableIdempotence = true;
+        });
+        return this;
+    }
+
+    /// <summary>
     /// Marks this topic as owned by an external system. Wolverine
     /// will not attempt to create it during startup or delete it during resource
     /// teardown, even when AutoProvision is enabled on the parent transport.

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
@@ -133,6 +133,29 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     }
 
     /// <summary>
+    /// Opt every Kafka producer on this node into the idempotent producer
+    /// (<c>enable.idempotence = true</c>, which implies <c>acks=all</c> and bounded in-flight requests),
+    /// so producer-side retries can't write duplicates to the broker. Opt-in; slight throughput cost.
+    /// This is producer→broker de-duplication only — it is not transactional exactly-once. See GH-3149.
+    /// </summary>
+    public KafkaTransportExpression UseIdempotentProducer()
+    {
+        _transport.ProducerConfig.EnableIdempotence = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Set the consumer isolation level for every consumer on this node to <c>read_committed</c>, so
+    /// records from aborted Kafka transactions are skipped when reading transactionally-written topics.
+    /// Default is <c>read_uncommitted</c>. See GH-3149.
+    /// </summary>
+    public KafkaTransportExpression UseReadCommitted()
+    {
+        _transport.ConsumerConfig.IsolationLevel = IsolationLevel.ReadCommitted;
+        return this;
+    }
+
+    /// <summary>
     /// Create newly used Kafka topics on endpoint activation if the topic is missing
     /// </summary>
     /// <param name="configure"></param>


### PR DESCRIPTION
Closes #3149 (child of #3134). Ships the **cheap, opt-in exactly-once building blocks** for Kafka and — the centerpiece — documents Wolverine's idempotency/exactly-once story so users reach for the right tool. The transactional read-process-write EOS engine remains an **explicit non-goal**.

## Config (all opt-in; defaults unchanged)
```csharp
opts.UseKafka(cs).UseIdempotentProducer();              // enable.idempotence (implies acks=all + bounded in-flight)
opts.PublishMessage<T>().ToKafkaTopic("t").UseIdempotentProducer();

opts.UseKafka(cs).UseReadCommitted();                   // IsolationLevel = ReadCommitted
opts.ListenToKafkaTopic("orders").UseReadCommitted();
```
- `UseIdempotentProducer()` (transport + per-subscriber) → producer→broker de-duplication only (not transactional EOS), slight throughput cost.
- `UseReadCommitted()` (transport + per-listener) → skip records from aborted Kafka transactions. Default stays `read_uncommitted`.

## Docs (the centerpiece)
New **"Idempotency & Exactly-Once with Kafka"** section that leads with the **durable inbox/outbox** as the recommended path for DB-backed apps (effectively-once across DB + Kafka — which Kafka transactions can't span), then the idempotent producer, `read_committed`, the handler-idempotency (at-least-once) reality, and a clear **non-goal callout** pointing DB-free Kafka→Kafka EOS users at Kafka Streams.

## Acceptance criteria
- [x] `UseIdempotentProducer()` opt-in, sets `enable.idempotence`; documented throughput trade-off
- [x] First-class `IsolationLevel` config for consumers (`UseReadCommitted()`)
- [x] Docs section covering inbox/outbox (recommended), idempotent producer, read_committed, handler idempotency, and the transactional-EOS non-goal
- [x] Tests asserting resolved `ProducerConfig.EnableIdempotence` / `ConsumerConfig.IsolationLevel`

## Tests (no broker)
`kafka_eos_building_blocks` — resolved config at transport/listener/subscriber scope; defaults remain unset.

`dotnet build wolverine.slnx -c Release`: clean.

## Out of scope
Transactional read-process-write EOS engine — **non-goal** (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)