### PR TITLE
Kafka: opt-in intra-partition concurrency by key (#3140)

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -349,6 +349,32 @@ group must not mix eager and cooperative members. Do a two-step deploy: first ro
 deploy that drops the eager strategy.
 :::
 
+### By-Key Concurrency Within a Partition <Badge type="tip" text="6.8" />
+
+This is the **second** concurrency lever, not the first.
+
+1. **First, scale out natively** — add partitions and run more nodes in the same consumer group (above).
+   Kafka routes same-key messages to the same partition, so ordering is free up to the partition count.
+   Reaching for in-partition concurrency *before* adding partitions is usually a smell.
+2. **Then**, when you have a hot partition or can't add more partitions, process **different keys
+   concurrently within a single partition** while keeping strict ordering per key:
+
+```csharp
+opts.ListenToKafkaTopic("orders")
+    .ProcessConcurrentlyByKey(PartitionSlots.Five);
+```
+
+Within each partition assigned to this node, messages are sharded across the configured number of slots by
+their **Kafka message key** — same key → same slot (strictly ordered), different keys → different slots
+(concurrent). To group by a business field instead of the raw Kafka key, configure
+[message partitioning rules](/guide/messaging/partitioning).
+
+This runs in **durable** mode: the Kafka offset is committed as each message is persisted to the inbox in
+consumption order, and the inbox processing is then sharded by key. That **decouples offset commit from
+out-of-order completion** — if key A (offset 5) is still running when key B (offset 6) finishes, the inbox
+owns both, so a crash or rebalance can't lose A. Pairs naturally with cooperative-sticky (above), which
+keeps a rebalance from disrupting unaffected partitions.
+
 ### Cold Start vs. Live Tail <Badge type="tip" text="6.8" />
 
 `auto.offset.reset` controls where a consumer **starts** when its group has **no committed offset** for a

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/kafka_by_key_concurrency.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/kafka_by_key_concurrency.cs
@@ -1,0 +1,133 @@
+using System.Collections.Concurrent;
+using Confluent.Kafka;
+using IntegrationTests;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Postgresql;
+
+namespace Wolverine.Kafka.Tests;
+
+// GH-3140: intra-partition concurrency by key. Same-key messages stay ordered (one slot); different
+// keys run concurrently. Durable mode (Postgres inbox) is the reliability boundary.
+public class kafka_by_key_concurrency : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private string _topic = null!;
+
+    public async Task InitializeAsync()
+    {
+        ByKeyState.Reset();
+        _topic = $"bykey-{Guid.NewGuid():N}";
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka(KafkaContainerFixture.ConnectionString)
+                    .AutoProvision()
+                    .ConfigureConsumers(c => c.AutoOffsetReset = AutoOffsetReset.Earliest);
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "kafka_bykey");
+
+                opts.PublishAllMessages().ToKafkaTopic(_topic).SendInline();
+                opts.ListenToKafkaTopic(_topic).ProcessConcurrentlyByKey(PartitionSlots.Five);
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<ByKeyHandler>();
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task same_key_ordered_different_keys_concurrent()
+    {
+        var keys = new[] { "A", "B", "C" };
+
+        // Interleave so the consumer sees A0,B0,C0,A1,B1,C1,... — same-key order must be preserved.
+        for (var seq = 0; seq < 3; seq++)
+        {
+            foreach (var key in keys)
+            {
+                await _host.SendAsync(new ByKeyMessage(key, seq), new DeliveryOptions { PartitionKey = key });
+            }
+        }
+
+        await waitForTotalAsync(9);
+
+        // Each key handled in publish order on its own slot.
+        foreach (var key in keys)
+        {
+            ByKeyState.Order[key].ShouldBe([0, 1, 2]);
+        }
+
+        // Different keys ran concurrently across slots.
+        ByKeyState.MaxInFlight.ShouldBeGreaterThanOrEqualTo(2);
+
+        // Exactly-once: every (key, seq) handled once (durable inbox dedup + correct offset handling).
+        ByKeyState.Order.Values.Sum(x => x.Count).ShouldBe(9);
+    }
+
+    private static async Task waitForTotalAsync(int count, int timeoutMs = 60000)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            if (ByKeyState.Order.Values.Sum(x => x.Count) >= count) return;
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Only handled {ByKeyState.Order.Values.Sum(x => x.Count)} of {count}");
+    }
+}
+
+public record ByKeyMessage(string Key, int Seq);
+
+public static class ByKeyState
+{
+    public static int InFlight;
+    public static int MaxInFlight;
+    public static readonly ConcurrentDictionary<string, List<int>> Order = new();
+
+    public static void Reset()
+    {
+        InFlight = 0;
+        MaxInFlight = 0;
+        Order.Clear();
+    }
+
+    public static void RecordMax(int current)
+    {
+        int prev;
+        do
+        {
+            prev = MaxInFlight;
+            if (current <= prev) return;
+        } while (Interlocked.CompareExchange(ref MaxInFlight, current, prev) != prev);
+    }
+}
+
+public class ByKeyHandler
+{
+    public static async Task Handle(ByKeyMessage message)
+    {
+        var current = Interlocked.Increment(ref ByKeyState.InFlight);
+        ByKeyState.RecordMax(current);
+
+        var list = ByKeyState.Order.GetOrAdd(message.Key, _ => new List<int>());
+        lock (list)
+        {
+            list.Add(message.Seq);
+        }
+
+        // Hold the slot long enough that concurrent keys overlap.
+        await Task.Delay(250);
+
+        Interlocked.Decrement(ref ByKeyState.InFlight);
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -54,8 +54,15 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
                         envelope.PartitionId = result.Partition.Value;
                         envelope.MessageType ??= _messageTypeName;
 
-                        if (topic.StampConsumerGroupIdOnEnvelope)
+                        if (topic.GroupByMessageKey)
+                        {
+                            // GH-3140: shard by-key processing on the Kafka message key.
+                            envelope.GroupId = message.Key;
+                        }
+                        else if (topic.StampConsumerGroupIdOnEnvelope)
+                        {
                             envelope.GroupId = config.GroupId;
+                        }
 
                         await receiver.ReceivedAsync(this, envelope);
                     }

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
@@ -52,8 +52,15 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
                         envelope.Offset = result.Offset.Value;
                         envelope.PartitionId = result.Partition.Value;
 
-                        if (endpoint.StampConsumerGroupIdOnEnvelope)
+                        if (endpoint.GroupByMessageKey)
+                        {
+                            // GH-3140: shard by-key processing on the Kafka message key.
+                            envelope.GroupId = message.Key;
+                        }
+                        else if (endpoint.StampConsumerGroupIdOnEnvelope)
+                        {
                             envelope.GroupId = config.GroupId;
+                        }
 
                         await receiver.ReceivedAsync(this, envelope);
                     }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -162,6 +162,37 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
     }
 
     /// <summary>
+    /// Opt into intra-partition concurrency by key (GH-3140): within each Kafka partition assigned to
+    /// this node, messages with <em>different</em> keys are processed concurrently across
+    /// <paramref name="numberOfSlots"/> slots while messages sharing the <em>same</em> key stay strictly
+    /// ordered. This is the *second* concurrency lever — prefer scaling out (more partitions + nodes,
+    /// see <see cref="UseCooperativeStickyAssignment"/>) first; reach for this for hot partitions or a
+    /// capped partition count.
+    ///
+    /// Runs in durable mode: the Kafka offset is committed as each message is persisted to the inbox (in
+    /// consumption order), and the inbox processing is sharded by key — so offset commit is decoupled
+    /// from out-of-order completion and a crash/rebalance can't lose in-flight work. The grouping key is
+    /// the Kafka message key by default; supply a custom grouping via
+    /// <c>opts.Policies.PartitionMessagesByGroupId(...)</c> / message partitioning rules instead.
+    /// </summary>
+    public KafkaListenerConfiguration ProcessConcurrentlyByKey(PartitionSlots numberOfSlots)
+    {
+        add(topic =>
+        {
+            topic.GroupShardingSlotNumber = numberOfSlots;
+            topic.GroupByMessageKey = true;
+            // The grouping key must be the Kafka *message* key, not the consumer group, or every message
+            // would hash to the same slot.
+            topic.StampConsumerGroupIdOnEnvelope = false;
+        });
+
+        // The inbox is the reliability boundary for by-key concurrency (offset commit decoupled from
+        // processing-completion order). See GH-3140.
+        UseDurableInbox();
+        return this;
+    }
+
+    /// <summary>
     /// Set this listener's consumer isolation level to <c>read_committed</c>, so records from aborted
     /// Kafka transactions are skipped when reading transactionally-written topics. Default is
     /// <c>read_uncommitted</c>. See GH-3149.

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -89,6 +89,13 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     internal bool IsHotTail { get; set; }
 
     /// <summary>
+    /// True when intra-partition by-key concurrency is enabled (GH-3140): the incoming Kafka message key
+    /// is stamped as the envelope's grouping key so same-key messages process sequentially and different
+    /// keys process concurrently across the sharded execution slots. Inherited by <see cref="KafkaTopicGroup"/>.
+    /// </summary>
+    internal bool GroupByMessageKey { get; set; }
+
+    /// <summary>
     /// Enable native dead letter queue support for this endpoint.
     /// When enabled, failed messages will be produced to the Kafka DLQ topic
     /// instead of being moved to database-backed dead letter storage.


### PR DESCRIPTION
Closes #3140 (child of #3134). Within each Kafka partition assigned to this node, process **different keys concurrently** while keeping **strict ordering per key** — the *second* concurrency lever after native scale-out (#3139).

## Reuses existing machinery (no bespoke worker pool)
The key realization: an endpoint with `GroupShardingSlotNumber` set **already** routes processing through `ShardedExecutionBlock` in the `DurableReceiver`, which:
1. persists each envelope to the **inbox** in consumption order,
2. commits the Kafka offset on persist (the specific offset, from #3150),
3. then **shards the inbox processing by group key**.

That decouples offset commit from out-of-order completion, and the inbox is the reliability boundary — a crash/rebalance can't lose in-flight work. This is exactly the issue's "commit on inbox-persist in consumption order, then shard by key" design, already implemented generically.

## Kafka-specific pieces
```csharp
opts.ListenToKafkaTopic("orders").ProcessConcurrentlyByKey(PartitionSlots.Five);
```
- `ProcessConcurrentlyByKey(PartitionSlots)` — sets the slot count, forces the durable inbox, and groups by the **Kafka message key** (disabling consumer-group-id stamping so the key isn't clobbered).
- Both listeners stamp the incoming Kafka message key as the envelope grouping key (`GroupId`) when enabled; a custom business grouping can be supplied via the existing `MessagePartitioningRules`.

## Acceptance criteria
- [x] `ProcessConcurrentlyByKey(PartitionSlots)`, durable mode
- [x] Default ordering key = Kafka message key; optional custom grouping via `MessagePartitioningRules`
- [x] Offset committed on inbox-persist in consumption order; concurrent by-key processing from the inbox
- [x] Reuses `ShardedExecutionBlock` / partitioned-local machinery (no bespoke worker pool)
- [x] Test: same-key in order on one slot; different keys concurrent; exactly-once
- [x] Docs frame it as the second lever after native scale-out

## Test (Postgres durable inbox + Kafka)
`same_key_ordered_different_keys_concurrent` — interleaved keyed messages: each key handled in publish order on its own slot; different keys overlap (`MaxInFlight >= 2`); every message handled exactly once. **Load-bearing** (failed with a non-grouping key, passes with proper grouping) and stable across repeated runs.

## Docs
"By-Key Concurrency Within a Partition" subsection — second-lever framing + the durable/offset-decoupling rationale.

## Out of scope (deferred)
Buffered-mode by-key concurrency (needs the offset-watermark gate for the buffered path).

`dotnet build wolverine.slnx -c Release`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)