### PR TITLE
Rebuild a registered projection with no live agent (Inline/Live/undistributed) — GH-3163

### DIFF
--- a/src/Persistence/MartenTests/Distribution/inline_projection_rebuild.cs
+++ b/src/Persistence/MartenTests/Distribution/inline_projection_rebuild.cs
@@ -1,0 +1,121 @@
+using IntegrationTests;
+using JasperFx.Events.Projections;
+using Marten;
+using MartenTests.Distribution.TripDomain;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace MartenTests.Distribution;
+
+// GH-3163: rebuilding a projection that has NO live agent — an Inline or Live projection, or an async
+// projection not currently distributed — must still work. Wolverine resolves the registered projection
+// from the subscription set, spins up a transient rebuild agent for it on the handling node, runs the
+// rebuild to the high-water mark, then stops it. (An Inline projection has no agent URI at all, so the
+// usual "route the rebuild to the live agent" path can't reach it.)
+public class inline_projection_rebuild : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync("inline_rebuild");
+            await conn.CloseAsync();
+        }
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(m =>
+                    {
+                        m.DisableNpgsqlLogging = true;
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "inline_rebuild";
+
+                        // Registered as INLINE — runs in the event-capture transaction, so it has NO
+                        // continuous async agent and no distributed agent URI.
+                        m.Projections.Add<TripProjection>(ProjectionLifecycle.Inline);
+                    })
+                    .IntegrateWithWolverine(m => m.UseWolverineManagedEventSubscriptionDistribution = true);
+
+                opts.Discovery.DisableConventionalDiscovery();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _host.GetRuntime().Agents.DisableHealthChecks();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task rebuild_a_registered_inline_projection_that_has_no_live_agent()
+    {
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        var streamId = Guid.NewGuid();
+
+        // The Inline projection writes the Trip read model in the same transaction as the events.
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Trip>(streamId, new TripStarted { Day = 1 }, new TripEnded { Day = 2 });
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = store.QuerySession())
+        {
+            (await session.LoadAsync<Trip>(streamId)).ShouldNotBeNull("Inline projection should have created the Trip");
+        }
+
+        var family = _host.Services.GetServices<IAgentFamily>()
+            .OfType<EventSubscriptionAgentFamily>().Single();
+
+        // An Inline projection is not distributed as an agent — there is no agent URI to route a rebuild
+        // through. This is exactly the case the transient-rebuild path exists for.
+        (await family.FindAgentUriAsync("Trip:All", null)).ShouldBeNull(
+            "An Inline projection has no distributed agent, so it resolves no agent URI.");
+
+        // Wipe the read model — only a genuine rebuild re-applies the events to restore it.
+        await using (var session = store.LightweightSession())
+        {
+            session.DeleteWhere<Trip>(_ => true);
+            await session.SaveChangesAsync();
+        }
+        await using (var session = store.QuerySession())
+        {
+            (await session.Query<Trip>().CountAsync()).ShouldBe(0);
+        }
+
+        // Rebuild via the transient-agent path: Wolverine finds the registered Inline projection, spins a
+        // rebuild agent for it, replays to the high-water mark, then stops it.
+        var rebuilt = await family.TryRebuildRegisteredProjectionAsync("Trip:All", null, CancellationToken.None);
+        rebuilt.ShouldBeTrue("The registered Inline projection should be found and rebuilt.");
+
+        // PROOF the rebuild ran: the Trip read model is restored from the event stream.
+        await using (var session = store.QuerySession())
+        {
+            (await session.LoadAsync<Trip>(streamId)).ShouldNotBeNull(
+                "The transient rebuild should have restored the Inline projection's read model.");
+        }
+    }
+
+    [Fact]
+    public async Task returns_false_for_an_unregistered_projection()
+    {
+        var family = _host.Services.GetServices<IAgentFamily>()
+            .OfType<EventSubscriptionAgentFamily>().Single();
+
+        (await family.TryRebuildRegisteredProjectionAsync("DoesNotExist:All", null, CancellationToken.None))
+            .ShouldBeFalse("An unregistered shard identity must report no match so the caller can try other families.");
+    }
+}

--- a/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
+++ b/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
@@ -3,6 +3,7 @@ using JasperFx.Core;
 using JasperFx.Descriptors;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
 using JasperFx.Events.Projections;
 
 namespace Wolverine.Runtime.Agents;
@@ -146,8 +147,82 @@ public class EventStoreAgents : IAsyncDisposable
         }
 
         var daemon = await FindDaemonAsync(databaseId);
-        
+
         return new EventSubscriptionAgent(uri, shardName, daemon);
+    }
+
+    /// <summary>
+    /// Rebuild a REGISTERED projection addressed by its shard identity, regardless of lifecycle
+    /// (Inline / Live / Async) or whether it is currently distributed as a continuous agent. Unlike
+    /// <see cref="SupportedAgentsAsync" /> — which only surfaces <see cref="ProjectionLifecycle.Async" />
+    /// shards as distributable agents — this matches the shard across the full registered subscription set,
+    /// builds the projection daemon for the owning database, and runs the daemon's rebuild. The daemon
+    /// spins up a transient rebuild agent for that projection, replays to the high-water mark, then stops
+    /// it — exactly the "spin up an agent just for the rebuild, then shut it down" behavior an operator
+    /// wants when rebuilding a non-running (e.g. Inline) projection. Returns false when no registered shard
+    /// matches <paramref name="shardIdentity" />. See GH-3163.
+    /// </summary>
+    public async Task<bool> TryRebuildRegisteredProjectionAsync(string shardIdentity, string? tenantId,
+        CancellationToken cancellation)
+    {
+        if (!ShardName.TryParse(shardIdentity, out var baseName) || baseName is null)
+        {
+            return false;
+        }
+
+        var usage = await _store.TryCreateUsage(cancellation);
+        if (usage == null)
+        {
+            return false;
+        }
+
+        // Match across ALL lifecycles — an Inline/Live projection still carries its ShardNames on the
+        // descriptor (the descriptor populates them before the Async-only distribution filter), so a
+        // registered-but-not-distributed projection resolves here even though it has no agent URI.
+        var match = usage.Subscriptions
+            .SelectMany(sub => sub.ShardNames.Select(shard => (Subscription: sub, Shard: shard)))
+            .FirstOrDefault(x =>
+                string.Equals(x.Shard.Identity, baseName.Identity, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(x.Shard.RelativeUrl, baseName.RelativeUrl, StringComparison.OrdinalIgnoreCase));
+
+        if (match.Shard == null)
+        {
+            return false;
+        }
+
+        // Resolve the owning database: database-per-tenant resolves the tenant's database; otherwise the
+        // main/single database (single-database per-tenant rebuilds are scoped by the tenantId argument the
+        // daemon's rebuild overload understands, not by a separate database).
+        DatabaseId? databaseId = null;
+        if (!string.IsNullOrEmpty(tenantId))
+        {
+            databaseId = await TryResolveTenantDatabaseIdAsync(tenantId, cancellation);
+        }
+
+        databaseId ??= ResolveDefaultDatabaseId(usage);
+        if (databaseId == null)
+        {
+            return false;
+        }
+
+        var daemon = await FindDaemonAsync(databaseId);
+
+        // RebuildProjectionAsync builds a rebuild-mode agent for the projection, replays to the high-water
+        // mark, then stops it. The tenant overload scopes a per-tenant rebuild (and no-ops the tenant for a
+        // store-global projection).
+        await daemon.RebuildProjectionAsync(match.Subscription.Name, tenantId, cancellation);
+        return true;
+    }
+
+    private static DatabaseId? ResolveDefaultDatabaseId(EventStoreUsage usage)
+    {
+        if (usage.Database.MainDatabase != null)
+        {
+            return new DatabaseId(usage.Database.MainDatabase.ServerName, usage.Database.MainDatabase.DatabaseName);
+        }
+
+        var first = usage.Database.Databases.FirstOrDefault();
+        return first == null ? null : new DatabaseId(first.ServerName, first.DatabaseName);
     }
 
     public async Task StartAllAsync(CancellationToken cancellationToken)

--- a/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
+++ b/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
@@ -207,9 +207,13 @@ public class EventStoreAgents : IAsyncDisposable
 
         var daemon = await FindDaemonAsync(databaseId);
 
-        // RebuildProjectionAsync builds a rebuild-mode agent for the projection, replays to the high-water
-        // mark, then stops it. The tenant overload scopes a per-tenant rebuild (and no-ops the tenant for a
-        // store-global projection).
+        // Rebuild scope: today an event store can only rebuild an ENTIRE projection — every shard of the
+        // projection at once — so we rebuild by the projection name. The "All" shard key (the canonical
+        // identity, e.g. "Trip:All") denotes exactly that whole-projection rebuild. The ONE exception is
+        // per-tenant partitioning, where an individual shard IS a single tenant's partition: a non-null
+        // tenantId flows to the daemon's tenant overload to rebuild just that partition, leaving the other
+        // tenants untouched. For a store-global projection the tenant is a no-op. RebuildProjectionAsync
+        // builds a rebuild-mode agent, replays to the high-water mark, then stops it.
         await daemon.RebuildProjectionAsync(match.Subscription.Name, tenantId, cancellation);
         return true;
     }

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
@@ -82,6 +82,22 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
 
     private static bool MatchesShard(Uri agentUri, string relativeUrl)
         => agentUri.AbsolutePath.TrimEnd('/').EndsWith("/" + relativeUrl, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public async ValueTask<bool> TryRebuildRegisteredProjectionAsync(string shardIdentity, string? tenantId,
+        CancellationToken token = default)
+    {
+        foreach (var entry in _stores.Enumerate())
+        {
+            if (await entry.Value.TryRebuildRegisteredProjectionAsync(shardIdentity, tenantId, token)
+                    .ConfigureAwait(false))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
     
     public EventSubscriptionAgentFamily(IEnumerable<IEventStore> stores, IEnumerable<IObserver<ShardState>> observers)
     {

--- a/src/Wolverine/Runtime/Agents/IEventSubscriptionAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/IEventSubscriptionAgentFamily.cs
@@ -19,4 +19,19 @@ public interface IEventSubscriptionAgentFamily
     /// the first non-null hit.
     /// </summary>
     ValueTask<Uri?> FindAgentUriAsync(string shardIdentity, string? tenantId, CancellationToken token = default);
+
+    /// <summary>
+    /// Rebuild a REGISTERED projection addressed by its <paramref name="shardIdentity" /> (the JasperFx
+    /// <c>ShardName.Identity</c>, e.g. <c>"Trip:All"</c>) regardless of its lifecycle (Inline / Live /
+    /// Async) or whether it is currently distributed as a continuous agent. This is the path for rebuilding
+    /// a projection that has <em>no live agent</em> to route a rebuild through — an Inline or Live
+    /// projection, or an async projection not presently distributed to any node. Wolverine resolves the
+    /// projection from the registered subscription set, spins up a transient rebuild agent for it on the
+    /// handling node, replays to the high-water mark, then stops it. A non-null <paramref name="tenantId" />
+    /// scopes a per-tenant rebuild. Returns <c>true</c> when a registered projection matched and the rebuild
+    /// ran; <c>false</c> when no registered shard matches (so the caller can try the next family). See
+    /// GH-3163.
+    /// </summary>
+    ValueTask<bool> TryRebuildRegisteredProjectionAsync(string shardIdentity, string? tenantId,
+        CancellationToken token = default);
 }


### PR DESCRIPTION
## Problem

A projection that has **no live agent** cannot be rebuilt today. The only rebuild path resolves a live event-subscription agent URI (`IEventSubscriptionAgentFamily.FindAgentUriAsync`) and invokes `RebuildAsync` on the running agent. But:

- an **Inline** projection runs in the capture transaction and is never distributed as an agent (it resolves no URI at all),
- a **Live** projection has no persisted progression,
- and an **Async** projection not currently distributed to any node also has no live agent to route through.

So an operator (e.g. via CritterWatch) can't trigger a rebuild for any of these — `FindAgentUriAsync` returns null and the rebuild dead-ends. This builds on #3136 (event-subscription distribution lifted to core).

## Change

Adds `IEventSubscriptionAgentFamily.TryRebuildRegisteredProjectionAsync(shardIdentity, tenantId, token)`, implemented on `EventStoreAgents`:

- Matches the shard across the **full registered subscription set** — every lifecycle, not just the `Async` shards `SupportedAgentsAsync` surfaces as distributable agents. (Inline/Live projections still carry their `ShardNames` on the descriptor, so they resolve here.)
- Resolves the owning database (database-per-tenant resolves the tenant's DB; otherwise main/single).
- Builds the projection daemon and runs `RebuildProjectionAsync(name, tenantId, token)` — which **spins up a transient rebuild agent for the projection, replays to the high-water mark, then stops it**. That's exactly the "spin up an agent just for the rebuild, then shut it down" behavior an operator wants for a non-running projection.
- Returns `false` when no registered shard matches (so a caller can fall through to the next family).

No continuous agent is created or distributed — this is a one-shot rebuild on the handling node.

## Tests

`MartenTests/Distribution/inline_projection_rebuild.cs` (2/2):
- An **Inline** projection (which resolves **no** agent URI) is rebuilt via the new path and its read model is restored from the event stream.
- An unregistered shard identity returns `false`.

## Consumer

CritterWatch's `RebuildProjectionHandler` falls back to this path when `FindAgentUriAsync` returns null. Verified end-to-end against CritterWatch via a local nuget: full solution builds green and the async rebuild path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)