### PR TITLE
fix(sqlserver): node capabilities delimiter must be newline, not comma (Polecat managed distribution startup crash)

### DIFF
--- a/src/Persistence/SqlServerTests/Agents/node_capability_with_comma_round_trips.cs
+++ b/src/Persistence/SqlServerTests/Agents/node_capability_with_comma_round_trips.cs
@@ -1,0 +1,74 @@
+using IntegrationTests;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Weasel.SqlServer;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Sagas;
+using Wolverine.Runtime.Agents;
+using Wolverine.SqlServer.Persistence;
+using Xunit;
+
+namespace SqlServerTests.Agents;
+
+// GH-3165: SQL Server has no array column type, so node capabilities are serialized to a single delimited
+// string. The delimiter was a comma — but an event-subscription agent capability URI can legitimately
+// contain a comma: the URI embeds a DatabaseId, and a SQL Server DatabaseId server name is "host,port"
+// (e.g. "localhost,1434"). Comma-splitting on read then shredded one URI into invalid fragments and threw,
+// which broke node startup under Polecat managed event-subscription distribution. This pins the round-trip.
+public class node_capability_with_comma_round_trips : IAsyncLifetime
+{
+    private SqlServerMessageStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        await using (var conn = new SqlConnection(Servers.SqlServerConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync("node_caps");
+        }
+
+        var settings = new DatabaseSettings
+        {
+            ConnectionString = Servers.SqlServerConnectionString,
+            SchemaName = "node_caps",
+            Role = MessageStoreRole.Main
+        };
+
+        _store = new SqlServerMessageStore(settings, new DurabilitySettings(),
+            NullLogger<SqlServerMessageStore>.Instance, Array.Empty<SagaTableDefinition>());
+
+        await _store.Admin.MigrateAsync();
+    }
+
+    public async Task DisposeAsync() => await _store.DisposeAsync();
+
+    [Fact]
+    public async Task persists_and_reads_a_capability_uri_that_contains_a_comma()
+    {
+        // The exact shape that broke Polecat managed distribution on SQL Server: the DatabaseId server
+        // segment carries the "host,port" form, so the agent URI contains a comma.
+        var commaUri = new Uri("event-subscriptions://polecat/main/localhost,1434.master/trip/all");
+        var plainUri = new Uri("event-subscriptions://polecat/main/localhost,1434.master/day/all");
+
+        var node = new WolverineNode
+        {
+            NodeId = Guid.NewGuid(),
+            ControlUri = new Uri("tcp://localhost:5000"),
+            Description = "comma-caps-test",
+            Version = new Version(1, 0, 0)
+        };
+        node.Capabilities.Add(commaUri);
+        node.Capabilities.Add(plainUri);
+
+        await _store.Nodes.PersistAsync(node, CancellationToken.None);
+
+        var loaded = (await _store.Nodes.LoadAllNodesAsync(CancellationToken.None)).Single();
+
+        loaded.Capabilities.ShouldContain(commaUri);
+        loaded.Capabilities.ShouldContain(plainUri);
+        loaded.Capabilities.Count.ShouldBe(2);
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerNodePersistence.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerNodePersistence.cs
@@ -58,7 +58,14 @@ internal class SqlServerNodePersistence : DatabaseConstants, INodeAgentPersisten
 
     private async Task<object> persistNode(SqlConnection conn, WolverineNode node, CancellationToken cancellationToken)
     {
-        var strings = node.Capabilities.Select(x => x.ToString()).Join(",");
+        // GH-3165: join capabilities with a newline, NOT a comma. SQL Server has no array column type
+        // (unlike Postgres, which stores capabilities as text[]), so we serialize to a single delimited
+        // string. A comma is unsafe because an agent capability URI can legitimately contain a comma —
+        // an event-subscription agent URI embeds the DatabaseId, and a SQL Server DatabaseId's server name
+        // is "host,port" (e.g. "localhost,1434"). Comma-splitting then shredded one URI into invalid
+        // fragments and threw on read. A newline can never appear in a Uri.ToString() (it would be
+        // percent-encoded), so it is a safe delimiter.
+        var strings = node.Capabilities.Select(x => x.ToString()).Join("\n");
 
         await using var cmd = conn.CreateCommand($"insert into {_nodeTable} (id, uri, capabilities, description, version) OUTPUT Inserted.node_number values (@id, @uri, @capabilities, @description, @version) ")
             .With("id", node.NodeId)
@@ -278,7 +285,12 @@ internal class SqlServerNodePersistence : DatabaseConstants, INodeAgentPersisten
         var capabilities = await reader.GetFieldValueAsync<string>(7);
         if (capabilities.IsNotEmpty())
         {
-            node.Capabilities.AddRange(capabilities.Split(',').Select(x => new Uri(x)));
+            // GH-3165: split on newline (see persistNode) — a comma can appear inside an agent URI, so it
+            // is not a safe delimiter. Tolerate legacy comma-joined rows that carried no comma-bearing URI
+            // by also treating a lone comma-free string as a single entry (newline-split yields one element).
+            node.Capabilities.AddRange(capabilities
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => new Uri(x)));
         }
 
         return node;


### PR DESCRIPTION
## Problem

`SqlServerNodePersistence` serializes a node's capability URIs to the `capabilities` column as a **comma-joined** string and splits on `,` when reading back (SQL Server has no array column type, unlike Postgres which uses `text[]`).

But an **event-subscription agent capability URI can contain a comma**: the URI embeds a `DatabaseId`, and a SQL Server `DatabaseId`'s server name is `host,port` — e.g. `event-subscriptions://polecat/main/localhost,1434.master/trip/all`. On read, `capabilities.Split(',')` shreds that single URI into invalid fragments and `new Uri(fragment)` throws `UriFormatException` in `readNodeAsync`, which fails node startup via `LoadNodeAgentStateAsync`.

This was **latent** until #3136 lifted event-subscription distribution to core and enabled **Polecat managed distribution on SQL Server** — the first time these comma-bearing agent URIs get written into node capabilities. It currently crashes every node at startup in that configuration.

## Fix

Join/split capabilities on `'\n'` instead of `','`. A newline can never appear in a `Uri.ToString()` (it is percent-encoded), so it is a safe delimiter. Node records are transient (re-registered on startup), so there is no migration concern.

## Tests

`SqlServerTests/Agents/node_capability_with_comma_round_trips.cs` — persists a node with a comma-bearing capability URI and asserts it round-trips intact through `PersistAsync` / `LoadAllNodesAsync`.

Also verified end-to-end: with this fix, CritterWatch's Polecat projection-coordination suite (SQL Server) now boots past the startup crash. Found while validating that #3136 closes the Polecat managed-distribution work for 6.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)