### PR TITLE
fix(rdbms): DLQ admin readers tolerate a NULL received_at (DLQ explorer shows 0 despite dead letters)

### DIFF
--- a/src/Persistence/PostgresqlTests/Bugs/Bug_GH3166_dlq_null_received_at.cs
+++ b/src/Persistence/PostgresqlTests/Bugs/Bug_GH3166_dlq_null_received_at.cs
@@ -1,0 +1,79 @@
+using IntegrationTests;
+using JasperFx.Core;
+using Marten;
+using Npgsql;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Marten;
+using Wolverine.Persistence.Durability;
+using Wolverine.Persistence.Durability.DeadLetterManagement;
+using Wolverine.Runtime;
+using Wolverine.Transports.Tcp;
+using Xunit;
+
+namespace PostgresqlTests.Bugs;
+
+// GH-3166: a dead letter is written with received_at = envelope.Destination?.ToString(), so received_at is
+// NULL for any envelope that dead-lettered without a Destination (e.g. a locally-published message that
+// failed before routing). The DLQ admin readers (SummarizeAllAsync + ReadDeadLetterAsync) read received_at
+// as a non-null string, so a SINGLE destination-less dead letter threw on the DBNull and aborted the whole
+// read — the DLQ explorer reported "No dead letter queue entries found" / "No messages loaded" for the
+// entire store even though count(*) (the durability monitor's path) reported hundreds. (CritterWatch ProductSupport#21)
+[Collection("marten")]
+public class Bug_GH3166_dlq_null_received_at : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private IMessageStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                MartenServiceCollectionExtensions.AddMarten(opts.Services, x =>
+                {
+                    x.Connection(Servers.PostgresConnectionString);
+                    x.DatabaseSchemaName = "dlq_nullrecv";
+                }).IntegrateWithWolverine();
+
+                opts.ListenAtPort(2356).UseDurableInbox();
+            }).StartAsync();
+
+        var marten = _host.Services.GetRequiredService<IDocumentStore>();
+        await marten.Advanced.Clean.CompletelyRemoveAllAsync();
+
+        _store = _host.Services.GetRequiredService<IWolverineRuntime>().Storage;
+    }
+
+    public async Task DisposeAsync() => await _host.StopAsync();
+
+    [Fact]
+    public async Task summarize_and_query_tolerate_a_null_received_at()
+    {
+        // Write a dead letter normally (valid Destination → valid body), then null out received_at directly
+        // to reproduce the destination-less row that the write path persists as received_at = NULL.
+        var envelope = ObjectMother.Envelope();
+        envelope.Status = EnvelopeStatus.Incoming;
+        await _store.Inbox.StoreIncomingAsync(new[] { envelope });
+        await _store.Inbox.MoveToDeadLetterStorageAsync(envelope, new DivideByZeroException("kaboom"));
+
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "update dlq_nullrecv.wolverine_dead_letters set received_at = null";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // Both of these threw on the DBNull received_at before the fix.
+        var summary = await _store.DeadLetters.SummarizeAllAsync("svc", TimeRange.AllTime(), CancellationToken.None);
+        summary.Sum(x => x.Count).ShouldBe(1);
+
+        var results = await _store.DeadLetters.QueryAsync(
+            new DeadLetterEnvelopeQuery(TimeRange.AllTime()), CancellationToken.None);
+        results.Envelopes.Count.ShouldBe(1);
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/DatabasePersistence.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabasePersistence.cs
@@ -122,7 +122,12 @@ public static class DatabasePersistence
         var executionTime = await reader.IsDBNullAsync(1, cancellation).ConfigureAwait(false) ? null : await reader.GetFieldValueAsync<DateTimeOffset?>(1, cancellation);
         var envelope = EnvelopeSerializer.Deserialize(await reader.GetFieldValueAsync<byte[]>(2, cancellation));
         var messageType = await reader.GetFieldValueAsync<string>(3, cancellation);
-        var receivedAt = await reader.GetFieldValueAsync<string>(4, cancellation);
+        // GH-3166: received_at is written as envelope.Destination?.ToString() (DatabasePersistence's dead
+        // letter insert), so it is NULL for any envelope that dead-lettered without a destination (e.g. a
+        // locally-published message that failed before routing). Guard the read the same way `source` is —
+        // an unguarded GetFieldValueAsync<string> throws on DBNull, which previously poisoned the whole
+        // DLQ "Query Messages" fetch and surfaced as "No messages loaded".
+        var receivedAt = await reader.IsDBNullAsync(4, cancellation) ? string.Empty : await reader.GetFieldValueAsync<string>(4, cancellation);
         var source = await reader.IsDBNullAsync(5, cancellation) ? string.Empty : await reader.GetFieldValueAsync<string>(5, cancellation);
         var exceptionType = await reader.GetFieldValueAsync<string>(6, cancellation);
         var exceptionMessage = await reader.GetFieldValueAsync<string>(7, cancellation);

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.DeadLetterAdminService.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.DeadLetterAdminService.cs
@@ -10,6 +10,9 @@ namespace Wolverine.RDBMS;
 
 public abstract partial class MessageDatabase<T>
 {
+    // GH-3166: sentinel "received at" for dead letters whose envelope had no Destination (received_at is NULL).
+    internal static readonly Uri UnknownReceivedAtUri = new("unknown://none");
+
     public async Task<IReadOnlyList<DeadLetterQueueCount>> SummarizeAllAsync(string serviceName, TimeRange range,
         CancellationToken token)
     {
@@ -44,7 +47,15 @@ public abstract partial class MessageDatabase<T>
 
             while (await reader.ReadAsync(token))
             {
-                var uri = new Uri(await reader.GetFieldValueAsync<string>(0, token));
+                // GH-3166: received_at is envelope.Destination?.ToString() and is NULL for any envelope
+                // that dead-lettered without a destination. An unguarded new Uri(GetFieldValueAsync<string>)
+                // threw on DBNull and aborted the ENTIRE summarize — so a single destination-less dead
+                // letter made the DLQ explorer report "No dead letter queue entries found" for the whole
+                // store, even though count(*) (the durability monitor's path) reported hundreds. Group the
+                // destination-less rows under a clear sentinel instead of throwing.
+                var uri = await reader.IsDBNullAsync(0, token)
+                    ? UnknownReceivedAtUri
+                    : new Uri(await reader.GetFieldValueAsync<string>(0, token));
                 var messageType = await reader.GetFieldValueAsync<string>(1, token);
                 var exceptionType = await reader.GetFieldValueAsync<string>(2, token);
                 var count = await reader.GetFieldValueAsync<int>(3, token);


### PR DESCRIPTION
## Problem

A dead letter is persisted with `received_at = envelope.Destination?.ToString()` (`DatabasePersistence.ConfigureDeadLetterCommands`), so `received_at` is **NULL** for any envelope that dead-lettered without a `Destination` — e.g. a locally-published message that failed before routing.

But the DLQ admin readers read `received_at` as a **non-null string**:
- `SummarizeAllAsync`: `new Uri(await reader.GetFieldValueAsync<string>(0, token))`
- `ReadDeadLetterAsync` (used by `QueryAsync`): `await reader.GetFieldValueAsync<string>(4, cancellation)`

`GetFieldValueAsync<string>` throws on `DBNull`, so a **single** destination-less dead letter aborts the entire read. The DLQ explorer then reports *"No dead letter queue entries found"* / *"No messages loaded"* for the whole store — even though `count(*)` (the durability monitor's path, which never touches `received_at`) reports the real count.

Reported via CritterWatch ProductSupport #21: the Durability monitor showed **254** dead letters for a store while the `/dlq` explorer showed **0**, with no client-side error (the throw is swallowed server-side). DB ground truth confirmed hundreds of rows.

Note the adjacent `source` column (and `execution_time`) are already null-guarded in `ReadDeadLetterAsync` — `received_at` was the one that wasn't.

## Fix

Read-side null-guards (so existing NULL rows are handled, not just future writes):
- `ReadDeadLetterAsync`: `received_at` → `string.Empty` when DBNull (mirrors `source`).
- `SummarizeAllAsync`: group destination-less rows under a clear `unknown://none` sentinel `Uri` instead of `new Uri(null)`.

## Test

`PostgresqlTests/Bugs/Bug_GH3166_dlq_null_received_at.cs` — writes a dead letter, forces `received_at = NULL`, and asserts both `SummarizeAllAsync` and `QueryAsync` return it without throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)