### PR TITLE
Bump all Weasel dependencies to 9.2.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -116,13 +116,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.1.5" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.1.5" />
-    <PackageVersion Include="Weasel.MySql" Version="9.1.5" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.1.5" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.1.5" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.1.5" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.1.5" />
+    <PackageVersion Include="Weasel.Core" Version="9.2.3" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.2.3" />
+    <PackageVersion Include="Weasel.MySql" Version="9.2.3" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.2.3" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.2.3" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.2.3" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.2.3" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />


### PR DESCRIPTION
Refreshes all seven Weasel packages from **9.1.5 → 9.2.3** via Central Package Management (`Directory.Packages.props`):

- `Weasel.Core`
- `Weasel.EntityFrameworkCore`
- `Weasel.MySql`
- `Weasel.Oracle`
- `Weasel.Postgresql`
- `Weasel.SqlServer`
- `Weasel.Sqlite`

`dotnet restore wolverine.slnx` is clean (no NU1605/downgrade conflict with the current Marten/JasperFx pins) and `dotnet build wolverine.slnx -c Release` succeeds with 0 errors locally.

Ships as part of 6.13.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)