### PR TITLE
Fix Polecat projection agents not starting under managed distribution (#3168)

### DIFF
--- a/src/Persistence/PolecatTests/Distribution/polecat_managed_distribution_starts_agents_3168.cs
+++ b/src/Persistence/PolecatTests/Distribution/polecat_managed_distribution_starts_agents_3168.cs
@@ -1,0 +1,78 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using PolecatTests.Distribution.TripDomain;
+using Shouldly;
+using Wolverine;
+using Wolverine.Polecat;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+
+namespace PolecatTests.Distribution;
+
+// Regression for GH-3168: under UseWolverineManagedEventSubscriptionDistribution a Polecat host must not
+// only SURFACE the async projection shards as agent URIs (polecat_managed_event_subscription_distribution)
+// but actually START them on the node. Previously every start threw "Unknown event projection or
+// subscription": the agent URI carries the store Type ("SqlServer") in its authority, which System.Uri
+// lowercases, while the EventSubscriptionAgentFamily store map was keyed by the original-cased
+// Identity.ToString() ("Polecat:SqlServer") — so the reverse lookup missed and no agent ran (node N: []).
+// Marten dodged it only because its Type is already lowercase ("marten").
+public class polecat_managed_distribution_starts_agents_3168 : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Speed up the leader-election + assignment loops (mirrors the Marten harness).
+                opts.Durability.HealthCheckPollingTime = 1.Seconds();
+                opts.Durability.CheckAssignmentPeriod = 1.Seconds();
+
+                opts.Services.AddPolecat(m =>
+                    {
+                        m.ConnectionString = Servers.SqlServerConnectionString;
+                        m.DatabaseSchemaName = "polecat_3168";
+
+                        m.Projections.Add<TripProjection>(ProjectionLifecycle.Async);
+                        m.Projections.Add<DayProjection>(ProjectionLifecycle.Async);
+                        m.Projections.Add<DistanceProjection>(ProjectionLifecycle.Async);
+                    })
+                    .IntegrateWithWolverine(o => o.UseWolverineManagedEventSubscriptionDistribution = true)
+                    .ApplyAllDatabaseChangesOnStartup();
+
+                opts.Discovery.DisableConventionalDiscovery();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _host.GetRuntime().Agents.DisableHealthChecks();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task the_three_async_projection_agents_actually_run_on_one_node()
+    {
+        await _host.WaitUntilAssumesLeadershipAsync(5.Seconds());
+
+        // All three async projection shards must actually be running on the single node (GH-3168).
+        await _host.WaitUntilAssignmentsChangeTo(w =>
+        {
+            w.AgentScheme = EventSubscriptionAgentFamily.SchemeName;
+            w.ExpectRunningAgents(_host, 3);
+        }, 30.Seconds());
+
+        var running = _host.RunningAgents()
+            .Where(x => x.Scheme == EventSubscriptionAgentFamily.SchemeName)
+            .ToArray();
+
+        running.Length.ShouldBe(3);
+    }
+}

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
@@ -19,6 +19,12 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
         return new Uri($"{SchemeName}://{storeIdentity.Type}/{storeIdentity.Name}/{databaseId}/{name.RelativeUrl}");
     }
 
+    // The store Type rides in the agent URI's authority (host), and System.Uri lowercases the authority
+    // while EventStoreIdentity.ToString() preserves the original casing. Normalize both the stored key
+    // and the reverse lookup to one casing so a store whose Identity.Type has uppercase letters (e.g.
+    // Polecat's "SqlServer") still round-trips from URI back to its EventStoreAgents. See GH-3168.
+    private static string StoreKey(string identity) => identity.ToLowerInvariant();
+
     /// <summary>
     /// Resolve the agent <see cref="Uri" /> for a projection/subscription shard identified by its
     /// <paramref name="shardIdentity" /> (the JasperFx <c>ShardName.Identity</c>, e.g. <c>"Trip:All"</c>)
@@ -105,7 +111,7 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
 
         foreach (var store in stores)
         {
-            _stores = _stores.AddOrUpdate(store.Identity.ToString(), new EventStoreAgents(store, _observers));
+            _stores = _stores.AddOrUpdate(StoreKey(store.Identity.ToString()), new EventStoreAgents(store, _observers));
         }
     }
 
@@ -123,7 +129,7 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
         // segments[2] database id
         // other segments get you the relative path
         
-        var storeIdentity = $"{uri.Segments[1].Trim('/')}:{uri.Host}";
+        var storeIdentity = StoreKey($"{uri.Segments[1].Trim('/')}:{uri.Host}");
         if (_stores.TryFind(storeIdentity, out var store))
         {
             var databaseId = DatabaseId.Parse(uri.Segments[2].Trim('/'));
@@ -164,7 +170,7 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
 
     internal EventStoreAgents FindStore(EventStoreIdentity identity)
     {
-        if (_stores.TryFind(identity.ToString(), out var store))
+        if (_stores.TryFind(StoreKey(identity.ToString()), out var store))
         {
             return store;
         }


### PR DESCRIPTION
Closes #3168.

## Root cause

Under `UseWolverineManagedEventSubscriptionDistribution`, a Polecat-backed store's async projection agents **surfaced** (`AllKnownAgentsAsync` returned them) but never **started** — even single-node — with the node reporting no running agents (`node N: []`). Every start threw:

```
AgentStartingException: Failed trying to start agent
  event-subscriptions://sqlserver/Polecat/localhost,1434.master/trip/all
  ---> System.ArgumentOutOfRangeException: Unknown event projection or subscription
```

`EventSubscriptionAgentFamily` keyed its store map by `EventStoreIdentity.ToString()` (`"{Name}:{Type}"`, original casing → `"Polecat:SqlServer"`), but `BuildAgentAsync` rebuilt the lookup key from the agent URI: `$"{uri.Segments[1]}:{uri.Host}"`. The store `Type` rides in the URI **authority**, which `System.Uri` **lowercases** → `"Polecat:sqlserver"` → lookup miss → throw.

Marten was unaffected purely because its `Identity.Type` is already lowercase (`"marten"`); it's a latent bug for **any** provider with an uppercase `Type`.

## Fix

Normalize the store key to one casing (matching `System.Uri`'s authority normalization) at all three sites — the `_stores` keying, the `BuildAgentAsync` reverse lookup, and `FindStore` — via a small documented `StoreKey` helper in core `EventSubscriptionAgentFamily`.

## Tests

- New Polecat regression test `polecat_managed_distribution_starts_agents_3168` asserts the three async projection agents **actually run** on one node (mirrors Marten's `everything_is_started_up_on_one_node`). Fails before the fix (30s timeout, `node N: []`), passes after (~5s).
- Existing Polecat surfacing tests + Marten single/multi-node distribution tests still green — confirms no regression and no double-start (the `WolverineProjectionCoordinator` path is unchanged and identical to Marten's).
- `dotnet build wolverine.slnx -c Release` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)