### PR TITLE
fix: BeginAtEarliest/BeginAtLatest drops GroupId from transport-level ConsumerConfig

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaTransportTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaTransportTests.cs
@@ -196,6 +196,56 @@ public class KafkaListenerConfigurationTests
             new KafkaListenerConfiguration(BuildTopic())
                 .ExtendConsumerConfiguration(null!));
     }
+
+    [Fact]
+    public void begin_at_earliest_inherits_group_id_from_parent_transport()
+    {
+        var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.GroupId = "my-group";
+        topic.Parent.ConsumerConfig.BootstrapServers = "localhost:9092";
+
+        var config = new KafkaListenerConfiguration(topic)
+            .BeginAtEarliest();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var effective = topic.GetEffectiveConsumerConfig();
+        effective.GroupId.ShouldBe("my-group");
+        effective.AutoOffsetReset.ShouldBe(AutoOffsetReset.Earliest);
+        effective.BootstrapServers.ShouldBe("localhost:9092");
+    }
+
+    [Fact]
+    public void begin_at_latest_inherits_group_id_from_parent_transport()
+    {
+        var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.GroupId = "my-group";
+        topic.Parent.ConsumerConfig.BootstrapServers = "localhost:9092";
+
+        var config = new KafkaListenerConfiguration(topic)
+            .BeginAtLatest();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var effective = topic.GetEffectiveConsumerConfig();
+        effective.GroupId.ShouldBe("my-group");
+        effective.AutoOffsetReset.ShouldBe(AutoOffsetReset.Latest);
+        effective.BootstrapServers.ShouldBe("localhost:9092");
+    }
+
+    [Fact]
+    public void begin_at_earliest_does_not_override_explicitly_set_group_id()
+    {
+        var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.GroupId = "parent-group";
+
+        var config = new KafkaListenerConfiguration(topic)
+            .ConfigureConsumer(c => c.GroupId = "topic-group")
+            .BeginAtEarliest();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var effective = topic.GetEffectiveConsumerConfig();
+        effective.GroupId.ShouldBe("topic-group");
+        effective.AutoOffsetReset.ShouldBe(AutoOffsetReset.Earliest);
+    }
 }
 
 public class UseKafkaUsingNamedConnectionTests

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -147,6 +147,11 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
             ConsumerConfig.BootstrapServers = Parent.ConsumerConfig.BootstrapServers;
         }
 
+        if (ConsumerConfig != null && string.IsNullOrEmpty(ConsumerConfig.GroupId))
+        {
+            ConsumerConfig.GroupId = Parent.ConsumerConfig.GroupId;
+        }
+
         return ConsumerConfig ?? Parent.ConsumerConfig;
     }
 


### PR DESCRIPTION
## Bug

`KafkaListenerConfiguration.BeginAtEarliest()` / `BeginAtLatest()` call:

```csharp
topic.ConsumerConfig ??= new ConsumerConfig();
topic.ConsumerConfig.AutoOffsetReset = AutoOffsetReset.Earliest;
```

This creates a fresh per-topic `ConsumerConfig` with **only** `AutoOffsetReset` set.
`KafkaTopic.GetEffectiveConsumerConfig()` then returns this sparse config — it already
copied `BootstrapServers` from the parent, but not `GroupId`. Confluent.Kafka requires
`group.id` and throws at startup:

```
System.ArgumentException: 'group.id' configuration parameter is required and was not specified.
```

This is a breaking change introduced with the `BeginAtEarliest()` / `BeginAtLatest()`
methods added in 6.13.x (GH-3146).

## Root cause

`GetEffectiveConsumerConfig()` in `KafkaTopic.cs`:

```csharp
internal ConsumerConfig GetEffectiveConsumerConfig()
{
    if (ConsumerConfig != null && string.IsNullOrEmpty(ConsumerConfig.BootstrapServers))
    {
        ConsumerConfig.BootstrapServers = Parent.ConsumerConfig.BootstrapServers;
    }
    // GroupId was never propagated — the returned config has no group.id
    return ConsumerConfig ?? Parent.ConsumerConfig;
}
```

## Fix

Add `GroupId` inheritance immediately after `BootstrapServers`, using the same pattern:

```csharp
if (ConsumerConfig != null && string.IsNullOrEmpty(ConsumerConfig.GroupId))
{
    ConsumerConfig.GroupId = Parent.ConsumerConfig.GroupId;
}
```

## Tests

Three new unit tests in `KafkaListenerConfigurationTests`:

- `begin_at_earliest_inherits_group_id_from_parent_transport` — verifies GroupId + AutoOffsetReset.Earliest + BootstrapServers are all present after `.BeginAtEarliest()`
- `begin_at_latest_inherits_group_id_from_parent_transport` — same for `.BeginAtLatest()`
- `begin_at_earliest_does_not_override_explicitly_set_group_id` — verifies a per-topic GroupId set via `ConfigureConsumer` is not overwritten

## Workaround (for users who cannot wait for a fix release)

Use `ExtendConsumerConfiguration` instead of `BeginAtEarliest()`:

```csharp
opts.ListenToKafkaTopic("my-topic")
    .ExtendConsumerConfiguration(c => c.AutoOffsetReset = AutoOffsetReset.Earliest);
```
