### PR TITLE
Fix RabbitMQ agent permanently latched Disconnected after a channel-only shutdown (#3171)

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_3171_channel_only_shutdown_recovery.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_3171_channel_only_shutdown_recovery.cs
@@ -1,0 +1,180 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using RabbitMQ.Client;
+using Shouldly;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests.Bugs;
+
+/// <summary>
+/// Regression coverage for #3171: a RabbitMQ channel can shut down while the
+/// underlying connection stays alive (a channel-only shutdown). Before the fix the
+/// agent latched into AgentState.Disconnected forever because EnsureInitiated()
+/// short-circuited on the stale, non-null channel and HandleChannelShutdownAsync
+/// never rebuilt. Senders threw "... is disconnected" on every send and listeners
+/// silently stopped consuming until a process restart.
+/// </summary>
+public class Bug_3171_channel_only_shutdown_recovery : IAsyncLifetime
+{
+    private readonly string _queueName = $"bug3171-{Guid.NewGuid():N}";
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "Bug3171";
+                opts.UseRabbitMq()
+                    .AutoProvision()
+                    .AutoPurgeOnStartup();
+
+                opts.PublishMessage<Bug3171Message>().ToRabbitQueue(_queueName);
+                opts.ListenToRabbitQueue(_queueName);
+
+                opts.LocalRoutingConventionDisabled = true;
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private RabbitMqSender FindSender()
+    {
+        var runtime = _host.GetRuntime();
+        var uri = new Uri($"rabbitmq://queue/{_queueName}");
+        var agent = runtime.Endpoints.GetOrBuildSendingAgent(uri);
+        var inner = agent switch
+        {
+            InlineSendingAgent i => i.Sender,
+            SendingAgent s => s.Sender,
+            _ => throw new InvalidOperationException($"Unexpected sending agent type {agent.GetType()}")
+        };
+
+        return inner.ShouldBeOfType<RabbitMqSender>();
+    }
+
+    private RabbitMqListener FindListener()
+    {
+        var runtime = _host.GetRuntime();
+        var agent = runtime.Endpoints.ActiveListeners()
+            .Single(x => x.Uri == new Uri($"rabbitmq://queue/{_queueName}"));
+        return ((ListeningAgent)agent).Listener.ShouldBeOfType<RabbitMqListener>();
+    }
+
+    private static async Task<bool> WaitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(100);
+        }
+
+        return condition();
+    }
+
+    // The single host both sends and receives over RabbitMQ; rather than rely on
+    // cross-transport tracking correlation, publish and poll the handler's record.
+    private async Task PublishAndExpectHandledAsync(string value)
+    {
+        await _host.MessageBus().PublishAsync(new Bug3171Message(value));
+
+        var handled = await WaitForAsync(() =>
+        {
+            lock (Bug3171MessageHandler.Received)
+            {
+                return Bug3171MessageHandler.Received.Contains(value);
+            }
+        }, 30.Seconds());
+
+        handled.ShouldBeTrue($"Expected the message '{value}' to be received and handled");
+    }
+
+    [Fact]
+    public async Task sender_recovers_after_a_channel_only_shutdown()
+    {
+        var sender = FindSender();
+        await sender.EnsureInitiated();
+        sender.State.ShouldBe(AgentState.Connected);
+        sender.Channel!.IsOpen.ShouldBeTrue();
+
+        // Close ONLY the channel; the connection underneath stays alive. This is the
+        // exact #3171 trigger: the channel goes away without a callback exception.
+        await sender.Channel!.CloseAsync(200, "channel-only shutdown", false, CancellationToken.None);
+
+        (await WaitForAsync(() => sender.State == AgentState.Disconnected, 5.Seconds())).ShouldBeTrue();
+
+        // The stale channel is retained (non-null but closed) — pre-fix this is what
+        // made EnsureInitiated() a permanent no-op.
+        sender.Channel.ShouldNotBeNull();
+        sender.Channel!.IsOpen.ShouldBeFalse();
+
+        // The fix: EnsureInitiated() treats a closed channel as unhealthy and rebuilds.
+        await sender.EnsureInitiated();
+
+        sender.State.ShouldBe(AgentState.Connected);
+        sender.Channel.ShouldNotBeNull();
+        sender.Channel!.IsOpen.ShouldBeTrue();
+
+        // And a real send now succeeds instead of throwing "... is disconnected".
+        await PublishAndExpectHandledAsync("after-sender-recovery");
+    }
+
+    [Fact]
+    public async Task listener_resumes_consuming_after_an_unexpected_channel_shutdown()
+    {
+        // Prove the pipe works before we break the channel.
+        await PublishAndExpectHandledAsync("before-break");
+
+        var listener = FindListener();
+        var originalChannel = listener.Channel!;
+        originalChannel.IsOpen.ShouldBeTrue();
+
+        // Force a broker-initiated (non-Application) channel shutdown without dropping the
+        // connection: a passive declare against a queue that does not exist returns 404
+        // NOT_FOUND, which makes the broker close the channel. This is the listener flavor
+        // of #3171 — the listener sits blocked and will not self-heal on its own.
+        try
+        {
+            await originalChannel.QueueDeclarePassiveAsync($"missing-{Guid.NewGuid():N}");
+        }
+        catch
+        {
+            // Expected — the passive declare fails and takes the channel down with it.
+        }
+
+        // The push-heal hook should rebuild the listener on a fresh, open channel.
+        var rebuilt = await WaitForAsync(
+            () => listener.Channel is { IsOpen: true } && !ReferenceEquals(listener.Channel, originalChannel),
+            30.Seconds());
+        rebuilt.ShouldBeTrue("The listener should have rebuilt its channel after an unexpected shutdown");
+        listener.State.ShouldBe(AgentState.Connected);
+
+        // The real proof: messages flow again without any process restart.
+        await PublishAndExpectHandledAsync("after-break");
+    }
+}
+
+public record Bug3171Message(string Value);
+
+public static class Bug3171MessageHandler
+{
+    public static readonly List<string> Received = new();
+
+    public static void Handle(Bug3171Message message)
+    {
+        lock (Received)
+        {
+            Received.Add(message.Value);
+        }
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
@@ -45,14 +45,38 @@ internal abstract class RabbitMqChannelAgent : IAsyncDisposable
 
     internal async Task EnsureInitiated()
     {
-        if (Channel is not null)
+        if (_disposed)
+            return;
+
+        // A non-null but closed channel is a dead channel. Treating "channel exists"
+        // as "channel healthy" would latch the agent permanently after a channel-only
+        // shutdown that didn't surface as a callback exception (see #3171), so we
+        // re-build whenever the channel is missing or no longer open.
+        if (Channel is { IsOpen: true })
             return;
 
         await Locker.WaitAsync();
         try
         {
-            if (Channel is not null)
+            if (_disposed)
                 return;
+
+            if (Channel is { IsOpen: true })
+                return;
+
+            // Drop a stale, closed channel before opening a fresh one. teardownChannel()
+            // unsubscribes the handlers and nulls Channel so startNewChannel() has a clean slate.
+            if (Channel is not null)
+            {
+                try
+                {
+                    await teardownChannel();
+                }
+                catch (Exception e)
+                {
+                    Logger.LogError(e, "Error tearing down a stale Rabbit MQ channel for {Endpoint}", this);
+                }
+            }
 
             await startNewChannel();
             State = AgentState.Connected;
@@ -127,8 +151,31 @@ internal abstract class RabbitMqChannelAgent : IAsyncDisposable
             Logger.LogError(e.Exception,
                 "Unexpected channel shutdown for Rabbit MQ. Wolverine will attempt to restart...");
         }
+        else
+        {
+            Logger.LogWarning(
+                "Unexpected channel shutdown for Rabbit MQ ({Endpoint}). Wolverine will attempt to restart...", this);
+        }
+
+        HandleUnexpectedChannelShutdown();
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// True when the underlying RabbitMQ connection is still alive. A channel-only shutdown
+    /// (see #3171) leaves this true; a full connection drop sets it false and is recovered
+    /// separately through <see cref="ConnectionMonitor"/>.
+    /// </summary>
+    protected bool ConnectionIsLive => _monitor.IsConnected;
+
+    /// <summary>
+    /// Hook for derived agents to eagerly recover from an unexpected channel-only shutdown.
+    /// Senders heal lazily on the next send through <see cref="EnsureInitiated"/>; listeners sit
+    /// blocked on the broker and won't self-pull, so they override this to re-declare/re-consume.
+    /// </summary>
+    protected virtual void HandleUnexpectedChannelShutdown()
+    {
     }
 
     internal virtual Task ReconnectedAsync()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -219,9 +219,54 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
         }
     }
 
+    /// <summary>
+    /// Eagerly rebuild the listener after an unexpected channel-only shutdown where the
+    /// connection is still alive (#3171). A listener sits blocked on the broker and never
+    /// calls EnsureInitiated again on its own, so unlike a sender it cannot heal lazily —
+    /// we re-declare and re-consume here. If the whole connection dropped, we let the
+    /// ConnectionMonitor recovery path own the rebuild to avoid a double restart.
+    /// </summary>
+    protected override void HandleUnexpectedChannelShutdown()
+    {
+        if (!ConnectionIsLive)
+        {
+            return;
+        }
+
+#pragma warning disable VSTHRD110
+        Task.Run(async () =>
+#pragma warning restore VSTHRD110
+        {
+            try
+            {
+                await ReconnectedAsync();
+                Logger.LogInformation(
+                    "Rebuilt the Rabbit MQ listener at {Uri} after an unexpected channel shutdown", Address);
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e,
+                    "Error trying to rebuild the Rabbit MQ listener at {Uri} after an unexpected channel shutdown",
+                    Address);
+            }
+        });
+    }
+
     internal override async Task ReconnectedAsync()
     {
-        await StopAsync();
+        try
+        {
+            await StopAsync();
+        }
+        catch (Exception e)
+        {
+            // The channel may already be dead, in which case cancelling the consumers throws.
+            // That's fine — we're about to tear it down and rebuild anyway.
+            Logger.LogDebug(e,
+                "Error cancelling consumers on a dead channel for {Uri} during reconnect; continuing with rebuild",
+                Address);
+        }
+
         await teardownChannel();
         await CreateAsync();
 


### PR DESCRIPTION
Fixes #3171.

## Problem

A RabbitMQ **channel** can shut down while the underlying **connection** stays alive — and without surfacing a callback exception (a *channel-only* shutdown). When that happens the agent latches into `AgentState.Disconnected` and never recovers until the process restarts:

- `RabbitMqSender.SendAsync` throws `InvalidOperationException: The RabbitMQ agent for ... is disconnected` on every send; the durable outbox retries forever.
- Listeners silently stop consuming.

Root cause (confirmed against `main`): the two channel-failure handlers were asymmetric.

- `HandleChannelExceptionAsync` (callback exception) tears down, nulls `Channel`, rebuilds, sets `Connected`. ✅
- `HandleChannelShutdownAsync` (channel shutdown) only set `State = Disconnected` and returned **without** nulling `Channel` or rebuilding.

`EnsureInitiated()` then short-circuited on the stale, non-null channel (`if (Channel is not null) return;`), so it never rebuilt. The only recovery paths both miss this case: callback-exception recovery needs an exception, and `ConnectionMonitor`/`ReconnectedAsync` needs the whole connection to drop.

## Fix

- **`EnsureInitiated()`** now treats a non-null-but-closed channel as dead: it rebuilds whenever `Channel` is missing or not `IsOpen`, tearing down the stale channel under the lock first. The under-lock `IsOpen` re-check avoids racing the existing callback-exception rebuild and double-restarts, and the `Application`-initiator close is left alone. This heals **senders** lazily on the next `SendAsync` — no fire-and-forget tasks.
- A new **`HandleUnexpectedChannelShutdown()`** hook is invoked from `HandleChannelShutdownAsync` for non-`Application` shutdowns. **Listeners** sit blocked on the broker and never call `EnsureInitiated()` again on their own, so `RabbitMqListener` overrides it to eagerly rebuild and re-consume via `ReconnectedAsync()`. It's guarded on `ConnectionIsLive` so a full connection drop is left to the `ConnectionMonitor` recovery path (no double restart).
- **`RabbitMqListener.ReconnectedAsync()`** is hardened to tolerate cancelling consumers on an already-dead channel before tearing down and rebuilding.

## Tests

`Bug_3171_channel_only_shutdown_recovery` covers both paths against a live broker:

- `sender_recovers_after_a_channel_only_shutdown` — closes only the channel, asserts the agent latches `Disconnected` with a stale closed channel, then recovers on `EnsureInitiated()` and a real send succeeds.
- `listener_resumes_consuming_after_an_unexpected_channel_shutdown` — forces a broker-initiated (non-`Application`) channel close and asserts the listener rebuilds on a fresh channel and resumes consuming end-to-end.

Both tests **fail without the fix** (the sender throws immediately; the listener times out at 30s, never recovering) and pass with it. The surrounding RabbitMQ lifecycle suite (`end_to_end`, `exclusive_listeners`, `rate_limiting_end_to_end`) passes; the only other failures observed were the pre-existing shared-broker flakes (`fan_out`/`direct_exchange`) which pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)