### PR TITLE
Fix two Amazon SQS interop bugs (MassTransit/NServiceBus)

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
@@ -244,7 +244,7 @@ internal class NServiceBusEnvelopeMapper : ISqsEnvelopeMapper
 
         if (sqs.Headers.TryGetValue("NServiceBus.ReplyToAddress", out var replyQueue))
         {
-            envelope.ReplyUri = new Uri($"sqs://queue/{replyQueue}");
+            envelope.ReplyUri = new Uri($"sqs://{replyQueue}");
         }
 
         if (sqs.Headers.TryGetValue("NServiceBus.ContentType", out var contentType))

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -214,7 +214,13 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue
     private AmazonSqsEnvelope buildEnvelope(Message message)
     {
         var envelope = new AmazonSqsEnvelope(message);
-        _mapper.ReadEnvelopeData(envelope, message.Body, message.MessageAttributes);
+
+        // SQS only returns MessageAttributes when they were explicitly requested, and
+        // brokers/SDKs may hand back a null collection when a message carries none (as is
+        // the case for MassTransit/NServiceBus messages that keep their metadata in the body).
+        // Guarantee a non-null dictionary so ISqsEnvelopeMapper implementations can read freely.
+        var attributes = message.MessageAttributes ?? new Dictionary<string, MessageAttributeValue>();
+        _mapper.ReadEnvelopeData(envelope, message.Body, attributes);
 
         return envelope;
     }


### PR DESCRIPTION
While validating Wolverine ⇄ MassTransit / NServiceBus interoperability over Amazon SQS, two bugs in `Wolverine.AmazonSqs` surfaced. Both are fixed here.

## 1. `NullReferenceException` on receive when a message has no SQS message attributes

`SqsListener.buildEnvelope` passed `Message.MessageAttributes` straight into `ISqsEnvelopeMapper.ReadEnvelopeData`. SQS returns a **null** attribute collection when a message carries none — which is exactly the case for MassTransit/NServiceBus messages that keep their metadata in the body. The `MassTransitMapper` and `NServiceBusEnvelopeMapper` then NRE'd on `attributes.TryGetValue(...)`.

Fix: guarantee a non-null dictionary at the call site, so every `ISqsEnvelopeMapper` (including user-supplied ones) can read freely.

## 2. NServiceBus interop reply URI produced an invalid SQS queue name

`NServiceBusEnvelopeMapper.ReadEnvelopeData` built the reply URI as `sqs://queue/{name}`, but the canonical SQS endpoint URI is `sqs://{name}` (see `AmazonSqsQueue` constructor). `AmazonSqsTransport.findEndpointByUri` resolves a queue name via `uri.OriginalString.Split("//")[1]`, so the stray `queue/` segment yielded a queue literally named `queue/{name}` and SQS rejected it:

> Can only include alphanumeric characters, hyphens, or underscores. 1 to 80 in length

Fix: emit `sqs://{name}` to match the canonical scheme.

## Validation

Verified against an external Wolverine⇄MassTransit/NServiceBus interop suite running on LocalStack: the MassTransit-over-SQS round-trip (both directions) now passes; previously both directions failed with the NRE above. The NServiceBus reply-URI fix removes the invalid-queue errors on that path as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)