### PR TITLE
Map Wolverine TenantId from incoming MassTransit messages (supersedes #3167)

### DIFF
--- a/docs/guide/messaging/transports/rabbitmq/interoperability.md
+++ b/docs/guide/messaging/transports/rabbitmq/interoperability.md
@@ -247,7 +247,7 @@ opts.ListenToRabbitQueue("orders")
     });
 ```
 
-The lambda receives the strongly-typed MassTransit envelope (`IMassTransitEnvelope<T>`), which exposes
+The lambda receives the strongly-typed MassTransit envelope (`MassTransitEnvelope<T>`), which exposes
 the deserialized `Message` alongside the MassTransit metadata. Each registration applies only to its own
 message type, and returning `null` or an empty string leaves the tenant id untouched. Tenant mapping
 affects only the inbound (deserialization) path, and works on any MassTransit-interop listener

--- a/docs/guide/messaging/transports/rabbitmq/interoperability.md
+++ b/docs/guide/messaging/transports/rabbitmq/interoperability.md
@@ -221,8 +221,34 @@ Wolverine = await Host.CreateDefaultBuilder().UseWolverine(opts =>
         // Tell Wolverine to make this endpoint interoperable with MassTransit
         .UseMassTransitInterop(mt =>
         {
-            // optionally customize the inner JSON serialization
+            // optionally customize the inner JSON serialization, or map the Wolverine
+            // tenant id from each incoming MassTransit message (see below)
         })
         .DefaultIncomingMessage<ResponseMessage>().UseForReplies();
 }).StartAsync();
 ```
+
+### Mapping the Tenant Id
+
+When consuming messages from MassTransit, you can derive Wolverine's tenant id for each incoming
+message from either the message body or the MassTransit envelope metadata (headers, addresses,
+correlation ids). Register one or more `MapTenantIdFrom<T>` mappers inside `UseMassTransitInterop`:
+
+```cs
+opts.ListenToRabbitQueue("orders")
+    .UseMassTransitInterop(mt =>
+    {
+        // Pull the tenant id straight off the strongly-typed message body
+        mt.MapTenantIdFrom<OrderPlaced>(env => env.Message?.TenantId);
+
+        // ...or from a MassTransit header carried on the envelope
+        mt.MapTenantIdFrom<OrderShipped>(env =>
+            env.Headers.TryGetValue("tenant-id", out var value) ? value?.ToString() : null);
+    });
+```
+
+The lambda receives the strongly-typed MassTransit envelope (`IMassTransitEnvelope<T>`), which exposes
+the deserialized `Message` alongside the MassTransit metadata. Each registration applies only to its own
+message type, and returning `null` or an empty string leaves the tenant id untouched. Tenant mapping
+affects only the inbound (deserialization) path, and works on any MassTransit-interop listener
+(Rabbit MQ, Azure Service Bus, Amazon SQS).

--- a/src/Testing/CoreTests/Runtime/Interop/MassTransitEnvelopeTests.cs
+++ b/src/Testing/CoreTests/Runtime/Interop/MassTransitEnvelopeTests.cs
@@ -7,12 +7,12 @@ public class MassTransitEnvelopeTests
 {
     private readonly Envelope theEnvelope = new();
     private readonly DateTimeOffset theExpirationTime = new(new DateTime(2022, 9, 13, 5, 5, 0));
-    private readonly MassTransitEnvelope theMassTransitEnvelope;
+    private readonly MassTransitEnvelope<object> theMassTransitEnvelope;
     private readonly DateTimeOffset theSentTime = new(new DateTime(2022, 9, 13, 5, 0, 0));
 
     public MassTransitEnvelopeTests()
     {
-        theMassTransitEnvelope = new MassTransitEnvelope
+        theMassTransitEnvelope = new MassTransitEnvelope<object>
         {
             MessageId = Guid.NewGuid().ToString(),
             CorrelationId = Guid.NewGuid().ToString(),
@@ -42,7 +42,7 @@ public class MassTransitEnvelopeTests
         envelope.Headers["color"] = "purple";
         envelope.Headers["number"] = "1";
 
-        var mtEnvelope = new MassTransitEnvelope(envelope);
+        var mtEnvelope = new MassTransitEnvelope<object>(envelope);
 
         mtEnvelope.MessageId.ShouldBe(envelope.Id.ToString());
         mtEnvelope.CorrelationId.ShouldBe(envelope.CorrelationId);

--- a/src/Testing/CoreTests/Runtime/Interop/MassTransitTenantMappingTests.cs
+++ b/src/Testing/CoreTests/Runtime/Interop/MassTransitTenantMappingTests.cs
@@ -1,0 +1,109 @@
+using NSubstitute;
+using Wolverine.Runtime.Interop.MassTransit;
+using Xunit;
+
+namespace CoreTests.Runtime.Interop;
+
+public class MassTransitTenantMappingTests
+{
+    private readonly IMassTransitInteropEndpoint theEndpoint = Substitute.For<IMassTransitInteropEndpoint>();
+
+    public MassTransitTenantMappingTests()
+    {
+        // The serializer round-trips a response address through the envelope; give the fake
+        // endpoint a valid reply Uri so the write path doesn't emit an empty address.
+        theEndpoint.MassTransitReplyUri().Returns(new Uri("rabbitmq://localhost/responses"));
+    }
+
+    // Round-trips a message through the MassTransit serializer: writes it in the
+    // MassTransit envelope format, then reads it back the way an incoming message would be
+    // deserialized. Returns the incoming Envelope so tests can assert on mapped metadata.
+    private Envelope readIncoming(MassTransitJsonSerializer serializer, object message)
+    {
+        var outgoing = new Envelope { Id = Guid.NewGuid(), Message = message };
+        var data = serializer.Write(outgoing);
+
+        var incoming = new Envelope { Data = data };
+        serializer.ReadFromData(message.GetType(), incoming);
+        return incoming;
+    }
+
+    [Fact]
+    public void maps_tenant_id_from_the_incoming_message_body()
+    {
+        var serializer = new MassTransitJsonSerializer(theEndpoint);
+        serializer.MapTenantIdFrom<TenantMessage>(env => env.Message?.TenantId);
+
+        var incoming = readIncoming(serializer, new TenantMessage("acme", "hello"));
+
+        incoming.TenantId.ShouldBe("acme");
+    }
+
+    [Fact]
+    public void maps_tenant_id_from_a_masstransit_header()
+    {
+        var serializer = new MassTransitJsonSerializer(theEndpoint);
+        serializer.MapTenantIdFrom<TenantMessage>(env =>
+            env.Headers.TryGetValue("tenant-id", out var value) ? value?.ToString() : null);
+
+        var outgoing = new Envelope { Id = Guid.NewGuid(), Message = new TenantMessage("ignored", "hello") };
+        outgoing.Headers["tenant-id"] = "globex";
+        var data = serializer.Write(outgoing);
+
+        var incoming = new Envelope { Data = data };
+        serializer.ReadFromData(typeof(TenantMessage), incoming);
+
+        incoming.TenantId.ShouldBe("globex");
+    }
+
+    [Fact]
+    public void leaves_tenant_id_untouched_for_an_unregistered_message_type()
+    {
+        var serializer = new MassTransitJsonSerializer(theEndpoint);
+        serializer.MapTenantIdFrom<TenantMessage>(env => env.Message?.TenantId);
+
+        var incoming = readIncoming(serializer, new OtherMessage("no tenant here"));
+
+        incoming.TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void does_not_overwrite_tenant_id_when_the_source_returns_empty()
+    {
+        var serializer = new MassTransitJsonSerializer(theEndpoint);
+        serializer.MapTenantIdFrom<TenantMessage>(_ => "");
+
+        var incoming = readIncoming(serializer, new TenantMessage("acme", "hello"));
+
+        incoming.TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void supports_multiple_registered_message_types()
+    {
+        var serializer = new MassTransitJsonSerializer(theEndpoint);
+        serializer
+            .MapTenantIdFrom<TenantMessage>(env => env.Message?.TenantId)
+            .MapTenantIdFrom<AnotherTenantMessage>(env => env.Message?.Org);
+
+        readIncoming(serializer, new TenantMessage("acme", "hello")).TenantId.ShouldBe("acme");
+        readIncoming(serializer, new AnotherTenantMessage("globex", "hi")).TenantId.ShouldBe("globex");
+    }
+
+    [Fact]
+    public void falls_through_the_whole_mapper_chain_for_an_unregistered_type()
+    {
+        var serializer = new MassTransitJsonSerializer(theEndpoint);
+        serializer
+            .MapTenantIdFrom<TenantMessage>(env => env.Message?.TenantId)
+            .MapTenantIdFrom<AnotherTenantMessage>(env => env.Message?.Org);
+
+        var incoming = readIncoming(serializer, new OtherMessage("matches nothing"));
+
+        incoming.TenantId.ShouldBeNull();
+    }
+}
+
+public record TenantMessage(string TenantId, string Body);
+public record AnotherTenantMessage(string Org, string Body);
+public record OtherMessage(string Body);

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/masstransit_mapper_tenant_mapping.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/masstransit_mapper_tenant_mapping.cs
@@ -1,0 +1,40 @@
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Runtime.Interop.MassTransit;
+using Xunit;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+public class masstransit_mapper_tenant_mapping
+{
+    // The SQS MassTransit mapper must apply the UseMassTransitInterop(configure) lambda to its
+    // serializer, otherwise MapTenantIdFrom (and any other serializer customization) silently
+    // no-ops on the Amazon SQS listener.
+    [Fact]
+    public void mapper_applies_the_configure_lambda_to_its_serializer()
+    {
+        var endpoint = new FakeMassTransitEndpoint();
+
+        var mapper = new MassTransitMapper(endpoint,
+            mt => mt.MapTenantIdFrom<SqsTenantMessage>(env => env.Message?.TenantId));
+
+        var serializer = mapper.Serializer;
+
+        var outgoing = new Envelope { Id = Guid.NewGuid(), Message = new SqsTenantMessage("acme", "hello") };
+        var data = serializer.Write(outgoing);
+
+        var incoming = new Envelope { Data = data };
+        serializer.ReadFromData(typeof(SqsTenantMessage), incoming);
+
+        incoming.TenantId.ShouldBe("acme");
+    }
+
+    private sealed class FakeMassTransitEndpoint : IMassTransitInteropEndpoint
+    {
+        public Uri? MassTransitUri() => null;
+        public Uri? MassTransitReplyUri() => new Uri("sqs://responses");
+        public Uri? TranslateMassTransitToWolverineUri(Uri uri) => null;
+    }
+
+    public record SqsTenantMessage(string TenantId, string Body);
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
@@ -156,7 +156,7 @@ public class AmazonSqsListenerConfiguration : ListenerConfiguration<AmazonSqsLis
 
     public AmazonSqsListenerConfiguration UseMassTransitInterop(Action<IMassTransitInterop>? configure = null)
     {
-        add(e => e.Mapper = new MassTransitMapper((Endpoint as IMassTransitInteropEndpoint)!));
+        add(e => e.Mapper = new MassTransitMapper((Endpoint as IMassTransitInteropEndpoint)!, configure));
         return this;
     }
     

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/MassTransitMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/MassTransitMapper.cs
@@ -12,10 +12,11 @@ internal class MassTransitMapper : ISqsEnvelopeMapper
     private readonly IMassTransitInteropEndpoint _endpoint;
     private MassTransitJsonSerializer _serializer;
 
-    public MassTransitMapper(IMassTransitInteropEndpoint endpoint)
+    public MassTransitMapper(IMassTransitInteropEndpoint endpoint, Action<IMassTransitInterop>? configure = null)
     {
         _endpoint = endpoint;
         _serializer = new MassTransitJsonSerializer(endpoint);
+        configure?.Invoke(_serializer);
     }
 
     public override string ToString() => "MassTransit Interop";

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/masstransit_interop_map_tenant_id.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/masstransit_interop_map_tenant_id.cs
@@ -1,0 +1,78 @@
+using System.Text;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Util;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+public class masstransit_interop_map_tenant_id
+{
+    // UseMassTransitInterop(configure) must thread the configure lambda all the way down to
+    // the MassTransit serializer so MapTenantIdFrom takes effect on the Rabbit MQ listener.
+    // Uses stubbed transports (no live broker) and drives the deserialization path directly.
+    [Fact]
+    public async Task map_tenant_id_from_is_applied_on_the_rabbitmq_listener()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.DisableConventionalDiscovery();
+                opts.IncludeType<TenantOrderPlacedHandler>();
+
+                // Bogus host name on purpose: stubbed transports must never connect.
+                opts.UseRabbitMq(x => x.HostName = Guid.NewGuid().ToString());
+                opts.ListenToRabbitQueue("orders")
+                    .UseMassTransitInterop(mt => mt.MapTenantIdFrom<TenantOrderPlaced>(env => env.Message?.Tenant));
+
+                opts.StubAllExternalTransports();
+            }).StartAsync();
+
+        var runtime = host.GetRuntime();
+
+        var endpoint = runtime.Endpoints.EndpointFor(new Uri("rabbitmq://queue/orders"))
+            .ShouldNotBeNull()
+            .ShouldBeAssignableTo<RabbitMqEndpoint>();
+
+        // Applies UseMassTransitInterop and wires the MassTransit serializer onto the endpoint
+        // (a live listener does this at startup; stubbed transports skip listener startup).
+        endpoint.BuildMapper(runtime);
+
+        // The wire payload a MassTransit producer sends: the real message lives under "message".
+        var json = $$"""
+        {
+            "messageId": "{{Guid.NewGuid()}}",
+            "messageType": ["urn:message:Orders:TenantOrderPlaced"],
+            "message": { "orderId": 92883, "tenant": "acme" }
+        }
+        """;
+
+        var incoming = new Envelope
+        {
+            Data = Encoding.UTF8.GetBytes(json),
+            ContentType = "application/vnd.masstransit+json",
+            MessageType = typeof(TenantOrderPlaced).ToMessageTypeName(),
+            Destination = endpoint.Uri
+        };
+
+        await runtime.Pipeline.TryDeserializeEnvelope(incoming);
+
+        incoming.Message.ShouldBeOfType<TenantOrderPlaced>().OrderId.ShouldBe(92883);
+        incoming.TenantId.ShouldBe("acme");
+    }
+
+    public record TenantOrderPlaced(int OrderId, string Tenant);
+
+    public class TenantOrderPlacedHandler
+    {
+        // Presence registers TenantOrderPlaced in the HandlerGraph so the pipeline can
+        // resolve its message type during deserialization.
+        public void Handle(TenantOrderPlaced order)
+        {
+        }
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEndpoint.MassTransit.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEndpoint.MassTransit.cs
@@ -54,6 +54,6 @@ public abstract partial class RabbitMqEndpoint : IMassTransitInteropEndpoint
 
     public void UseMassTransitInterop(Action<IMassTransitInterop>? configure = null)
     {
-        customizeMapping((m, _) => m.InteropWithMassTransit());
+        customizeMapping((m, _) => m.InteropWithMassTransit(configure));
     }
 }

--- a/src/Wolverine/Runtime/Interop/MassTransit/BusHostInfo.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/BusHostInfo.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Wolverine.Runtime.Interop.MassTransit;
 
 [Serializable]
-internal class BusHostInfo
+public class BusHostInfo
 {
     public static readonly BusHostInfo Instance = new();
 

--- a/src/Wolverine/Runtime/Interop/MassTransit/IMassTransitInterop.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/IMassTransitInterop.cs
@@ -10,6 +10,23 @@ public interface IMassTransitInterop
     /// <param name="configuration"></param>
     void UseSystemTextJsonForSerialization(Action<JsonSerializerOptions>? configuration = null);
 
+    /// <summary>
+    ///     Derive the Wolverine <see cref="Envelope.TenantId" /> for incoming MassTransit messages of
+    ///     type <typeparamref name="T" /> from the message itself or its MassTransit metadata. The
+    ///     supplied lambda receives the strongly-typed MassTransit envelope and returns the tenant id
+    ///     (or <c>null</c> / empty to leave the tenant id untouched). This only affects the inbound
+    ///     (deserialization) path. Registering multiple message types is supported — each registration
+    ///     applies only to its own <typeparamref name="T" />. Registering the same type more than once
+    ///     replaces the previous mapping for that type.
+    /// </summary>
+    /// <param name="tenantIdSource">
+    ///     Maps the incoming MassTransit envelope to a tenant id, e.g.
+    ///     <c>env =&gt; env.Message?.TenantId</c> or
+    ///     <c>env =&gt; env.Headers.TryGetValue("tenant-id", out var v) ? v?.ToString() : null</c>.
+    /// </param>
+    /// <typeparam name="T">The Wolverine message type to extract the tenant id from.</typeparam>
+    IMassTransitInterop MapTenantIdFrom<T>(Func<IMassTransitEnvelope<T>, string?> tenantIdSource) where T : class;
+
     // Newtonsoft.Json variant moved to WolverineFx.Newtonsoft as the
     // UseNewtonsoftForSerialization(this IMassTransitInterop, ...)
     // extension method. Install WolverineFx.Newtonsoft to opt in.

--- a/src/Wolverine/Runtime/Interop/MassTransit/IMassTransitInterop.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/IMassTransitInterop.cs
@@ -25,7 +25,7 @@ public interface IMassTransitInterop
     ///     <c>env =&gt; env.Headers.TryGetValue("tenant-id", out var v) ? v?.ToString() : null</c>.
     /// </param>
     /// <typeparam name="T">The Wolverine message type to extract the tenant id from.</typeparam>
-    IMassTransitInterop MapTenantIdFrom<T>(Func<IMassTransitEnvelope<T>, string?> tenantIdSource) where T : class;
+    IMassTransitInterop MapTenantIdFrom<T>(Func<MassTransitEnvelope<T>, string?> tenantIdSource) where T : class;
 
     // Newtonsoft.Json variant moved to WolverineFx.Newtonsoft as the
     // UseNewtonsoftForSerialization(this IMassTransitInterop, ...)

--- a/src/Wolverine/Runtime/Interop/MassTransit/MassTransitEnvelope.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/MassTransitEnvelope.cs
@@ -2,71 +2,28 @@ using JasperFx.Core.Reflection;
 
 namespace Wolverine.Runtime.Interop.MassTransit;
 
-internal interface IMassTransitEnvelope
-{
-    object? Body { get; }
-    string? ResponseAddress { get; set; }
-    string? SourceAddress { get; set; }
-    void TransferData(Envelope envelope);
-}
-
 /// <summary>
-///     Read-only, strongly-typed view over an incoming MassTransit "envelope" message. Exposed to
-///     user code through hooks such as <see cref="IMassTransitInterop.MapTenantIdFrom{T}" /> so that
-///     Wolverine metadata (e.g. the tenant id) can be derived either from the deserialized message
-///     body or from the surrounding MassTransit transport metadata (headers, addresses, ids).
+///     Strongly-typed view over a MassTransit "envelope" message. The non-generic base carries the
+///     MassTransit transport metadata (ids, addresses, headers); <see cref="MassTransitEnvelope{T}" />
+///     adds the deserialized message body. Exposed to user code through hooks such as
+///     <see cref="IMassTransitInterop.MapTenantIdFrom{T}" /> so that Wolverine metadata (e.g. the
+///     tenant id) can be derived from either the deserialized message body or the surrounding
+///     MassTransit transport metadata (headers, addresses, ids).
 /// </summary>
-/// <typeparam name="T">The Wolverine message type carried by the MassTransit envelope.</typeparam>
-public interface IMassTransitEnvelope<T> where T : class
+public abstract class MassTransitEnvelope
 {
-    /// <summary>The deserialized message body.</summary>
-    T? Message { get; }
-
-    string? MessageId { get; }
-    string? RequestId { get; }
-    string? CorrelationId { get; }
-    string? ConversationId { get; }
-    string? InitiatorId { get; }
-
-    string? SourceAddress { get; }
-    string? ResponseAddress { get; }
-    string? DestinationAddress { get; }
-    string? FaultAddress { get; }
-
-    string[]? MessageType { get; }
-
-    DateTime? SentTime { get; }
-    DateTime? ExpirationTime { get; }
-
-    /// <summary>The MassTransit message headers, as deserialized from the envelope.</summary>
-    IReadOnlyDictionary<string, object?> Headers { get; }
-}
-
-internal class MassTransitEnvelope<T> : IMassTransitEnvelope, IMassTransitEnvelope<T> where T : class
-{
-    public MassTransitEnvelope()
+    protected MassTransitEnvelope()
     {
     }
 
-    public MassTransitEnvelope(Envelope envelope)
+    protected MassTransitEnvelope(Envelope envelope)
     {
-        if (envelope.Message is T m)
-        {
-            Message = m;
-        }
-        else
-        {
-            throw new ArgumentOutOfRangeException(nameof(envelope.Message),
-                $"Message cannot be cast to {typeof(T).FullNameInCode()}");
-        }
-
         MessageId = envelope.Id.ToString();
         CorrelationId = envelope.CorrelationId;
         ConversationId = envelope.ConversationId.ToString();
         SentTime = DateTime.UtcNow;
-        Message = (T)envelope.Message!;
 
-        var messageType = envelope.Message.GetType();
+        var messageType = envelope.Message!.GetType();
         MessageType = [$"urn:message:{messageType.Namespace}:{messageType.NameInCode()}"];
 
         if (envelope.DeliverBy != null)
@@ -93,20 +50,18 @@ internal class MassTransitEnvelope<T> : IMassTransitEnvelope, IMassTransitEnvelo
     // ReSharper disable once UnusedAutoPropertyAccessor.Global
     public string[]? MessageType { get; set; }
 
-    public T? Message { get; set; }
-
     public DateTime? ExpirationTime { get; set; }
     public DateTime? SentTime { get; set; }
 
     public Dictionary<string, object?> Headers { get; set; } = new();
 
-    IReadOnlyDictionary<string, object?> IMassTransitEnvelope<T>.Headers => Headers;
-
-    // Wolverine doesn't care about this, so don't bother deserializing it
+    // Wolverine doesn't care about this on the inbound side, so don't bother deserializing it
     // ReSharper disable once UnusedMember.Global
     public BusHostInfo Host => BusHostInfo.Instance;
 
-    public object? Body => Message;
+    /// <summary>The deserialized message body.</summary>
+    public abstract object? Body { get; }
+
     public string? SourceAddress { get; set; }
     public string? ResponseAddress { get; set; }
 
@@ -138,8 +93,12 @@ internal class MassTransitEnvelope<T> : IMassTransitEnvelope, IMassTransitEnvelo
     }
 }
 
-[Serializable]
-internal class MassTransitEnvelope : MassTransitEnvelope<object>
+/// <summary>
+///     Strongly-typed MassTransit envelope view carrying the deserialized <typeparamref name="T" />
+///     message body alongside the MassTransit transport metadata.
+/// </summary>
+/// <typeparam name="T">The Wolverine message type carried by the MassTransit envelope.</typeparam>
+public class MassTransitEnvelope<T> : MassTransitEnvelope where T : class
 {
     public MassTransitEnvelope()
     {
@@ -147,5 +106,19 @@ internal class MassTransitEnvelope : MassTransitEnvelope<object>
 
     public MassTransitEnvelope(Envelope envelope) : base(envelope)
     {
+        if (envelope.Message is T m)
+        {
+            Message = m;
+        }
+        else
+        {
+            throw new ArgumentOutOfRangeException(nameof(envelope.Message),
+                $"Message cannot be cast to {typeof(T).FullNameInCode()}");
+        }
     }
+
+    /// <summary>The deserialized message body.</summary>
+    public T? Message { get; set; }
+
+    public override object? Body => Message;
 }

--- a/src/Wolverine/Runtime/Interop/MassTransit/MassTransitEnvelope.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/MassTransitEnvelope.cs
@@ -10,7 +10,39 @@ internal interface IMassTransitEnvelope
     void TransferData(Envelope envelope);
 }
 
-internal class MassTransitEnvelope<T> : IMassTransitEnvelope where T : class
+/// <summary>
+///     Read-only, strongly-typed view over an incoming MassTransit "envelope" message. Exposed to
+///     user code through hooks such as <see cref="IMassTransitInterop.MapTenantIdFrom{T}" /> so that
+///     Wolverine metadata (e.g. the tenant id) can be derived either from the deserialized message
+///     body or from the surrounding MassTransit transport metadata (headers, addresses, ids).
+/// </summary>
+/// <typeparam name="T">The Wolverine message type carried by the MassTransit envelope.</typeparam>
+public interface IMassTransitEnvelope<T> where T : class
+{
+    /// <summary>The deserialized message body.</summary>
+    T? Message { get; }
+
+    string? MessageId { get; }
+    string? RequestId { get; }
+    string? CorrelationId { get; }
+    string? ConversationId { get; }
+    string? InitiatorId { get; }
+
+    string? SourceAddress { get; }
+    string? ResponseAddress { get; }
+    string? DestinationAddress { get; }
+    string? FaultAddress { get; }
+
+    string[]? MessageType { get; }
+
+    DateTime? SentTime { get; }
+    DateTime? ExpirationTime { get; }
+
+    /// <summary>The MassTransit message headers, as deserialized from the envelope.</summary>
+    IReadOnlyDictionary<string, object?> Headers { get; }
+}
+
+internal class MassTransitEnvelope<T> : IMassTransitEnvelope, IMassTransitEnvelope<T> where T : class
 {
     public MassTransitEnvelope()
     {
@@ -67,6 +99,8 @@ internal class MassTransitEnvelope<T> : IMassTransitEnvelope where T : class
     public DateTime? SentTime { get; set; }
 
     public Dictionary<string, object?> Headers { get; set; } = new();
+
+    IReadOnlyDictionary<string, object?> IMassTransitEnvelope<T>.Headers => Headers;
 
     // Wolverine doesn't care about this, so don't bother deserializing it
     // ReSharper disable once UnusedMember.Global

--- a/src/Wolverine/Runtime/Interop/MassTransit/MassTransitJsonSerializer.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/MassTransitJsonSerializer.cs
@@ -17,7 +17,7 @@ public class MassTransitJsonSerializer : IMessageSerializer, IMassTransitInterop
 
     private ImHashMap<string, Uri?> _uriMap = ImHashMap<string, Uri?>.Empty;
 
-    private Func<IMassTransitEnvelope, string?>? _tenantIdSource;
+    private Func<MassTransitEnvelope, string?>? _tenantIdSource;
 
     public MassTransitJsonSerializer(IMassTransitInteropEndpoint endpoint)
     {
@@ -39,7 +39,7 @@ public class MassTransitJsonSerializer : IMessageSerializer, IMassTransitInterop
         _inner = new SystemTextJsonSerializer(options);
     }
 
-    public IMassTransitInterop MapTenantIdFrom<T>(Func<IMassTransitEnvelope<T>, string?> tenantIdSource)
+    public IMassTransitInterop MapTenantIdFrom<T>(Func<MassTransitEnvelope<T>, string?> tenantIdSource)
         where T : class
     {
         ArgumentNullException.ThrowIfNull(tenantIdSource);
@@ -48,7 +48,7 @@ public class MassTransitJsonSerializer : IMessageSerializer, IMassTransitInterop
         // contribute their own tenant id extraction. A mapper only fires for its own T.
         var previous = _tenantIdSource;
         _tenantIdSource = mtEnvelope =>
-            mtEnvelope is IMassTransitEnvelope<T> typed ? tenantIdSource(typed) : previous?.Invoke(mtEnvelope);
+            mtEnvelope is MassTransitEnvelope<T> typed ? tenantIdSource(typed) : previous?.Invoke(mtEnvelope);
 
         return this;
     }
@@ -74,7 +74,7 @@ public class MassTransitJsonSerializer : IMessageSerializer, IMassTransitInterop
 
     public byte[] Write(Envelope envelope)
     {
-        var message = new MassTransitEnvelope(envelope)
+        var message = new MassTransitEnvelope<object>(envelope)
         {
             DestinationAddress = _destination,
             ResponseAddress = _reply.Value
@@ -87,7 +87,7 @@ public class MassTransitJsonSerializer : IMessageSerializer, IMassTransitInterop
     {
         var wrappedType = typeof(MassTransitEnvelope<>).MakeGenericType(messageType);
 
-        var mtEnvelope = (IMassTransitEnvelope)_inner.ReadFromData(wrappedType, envelope);
+        var mtEnvelope = (MassTransitEnvelope)_inner.ReadFromData(wrappedType, envelope);
         mtEnvelope.TransferData(envelope);
         envelope.ReplyUri = mapResponseUri(mtEnvelope.ResponseAddress ?? mtEnvelope.SourceAddress);
 

--- a/src/Wolverine/Runtime/Interop/MassTransit/MassTransitJsonSerializer.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/MassTransitJsonSerializer.cs
@@ -17,6 +17,8 @@ public class MassTransitJsonSerializer : IMessageSerializer, IMassTransitInterop
 
     private ImHashMap<string, Uri?> _uriMap = ImHashMap<string, Uri?>.Empty;
 
+    private Func<IMassTransitEnvelope, string?>? _tenantIdSource;
+
     public MassTransitJsonSerializer(IMassTransitInteropEndpoint endpoint)
     {
         _endpoint = endpoint;
@@ -35,6 +37,20 @@ public class MassTransitJsonSerializer : IMessageSerializer, IMassTransitInterop
         configuration?.Invoke(options);
 
         _inner = new SystemTextJsonSerializer(options);
+    }
+
+    public IMassTransitInterop MapTenantIdFrom<T>(Func<IMassTransitEnvelope<T>, string?> tenantIdSource)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(tenantIdSource);
+
+        // Compose with any previously registered mapper so multiple message types can each
+        // contribute their own tenant id extraction. A mapper only fires for its own T.
+        var previous = _tenantIdSource;
+        _tenantIdSource = mtEnvelope =>
+            mtEnvelope is IMassTransitEnvelope<T> typed ? tenantIdSource(typed) : previous?.Invoke(mtEnvelope);
+
+        return this;
     }
 
     /// <summary>
@@ -74,6 +90,15 @@ public class MassTransitJsonSerializer : IMessageSerializer, IMassTransitInterop
         var mtEnvelope = (IMassTransitEnvelope)_inner.ReadFromData(wrappedType, envelope);
         mtEnvelope.TransferData(envelope);
         envelope.ReplyUri = mapResponseUri(mtEnvelope.ResponseAddress ?? mtEnvelope.SourceAddress);
+
+        if (_tenantIdSource != null)
+        {
+            var tenantId = _tenantIdSource(mtEnvelope);
+            if (tenantId.IsNotEmpty())
+            {
+                envelope.TenantId = tenantId;
+            }
+        }
 
         return mtEnvelope.Body!;
     }


### PR DESCRIPTION
Supersedes #3167 by @outofrange-consulting (Geoffrey MARC), whose original commits are retained here with authorship intact. This adds the requested feature and then reworks the public surface per maintainer review.

## Feature (from #3167)

`IMassTransitInterop.MapTenantIdFrom<T>(...)` lets you derive Wolverine's `Envelope.TenantId` for incoming MassTransit messages from either the deserialized message body or the surrounding MassTransit metadata (headers, addresses, ids). It affects only the inbound/deserialization path, supports multiple message types (each mapper fires only for its own `T`), and works on every MassTransit-interop listener (RabbitMQ, Azure Service Bus, Amazon SQS). The `UseMassTransitInterop(configure)` lambda is now threaded through to the serializer on the RabbitMQ and SQS listeners so the mapping actually takes effect.

## What changed vs #3167 (public API rework)

#3167 exposed a new **public interface** `IMassTransitEnvelope<T>` as the `MapTenantIdFrom` hook type. Per review, this instead exposes the **concrete `MassTransitEnvelope` type publicly** and removes the interface abstraction:

- `MassTransitEnvelope` is now a **public abstract base** (MassTransit transport metadata + `TransferData`); `MassTransitEnvelope<T>` is the **public generic subclass** adding the typed `Message`. (The non-generic type is now the base of the generic one — previously inverted — so it can serve as the non-generic handle the serializer needs.)
- Removed both the internal non-generic `IMassTransitEnvelope` and the `IMassTransitEnvelope<T>` interface that #3167 introduced.
- `MapTenantIdFrom<T>` now takes `Func<MassTransitEnvelope<T>, string?>`.
- `BusHostInfo` is made public so the public `MassTransitEnvelope.Host` property has consistent accessibility.

## Breaking-change assessment

- **`IMassTransitInterop.MapTenantIdFrom<T>`** is a new member on a **public** interface → technically a source/binary break for any external *implementer* of `IMassTransitInterop`. In practice the only implementer is the internal `MassTransitJsonSerializer` (it's a config seam, not a user-implemented interface), and `main` is on the 6.0 line where deliberate breaks are acceptable. Low real-world impact.
- Making `MassTransitEnvelope`/`MassTransitEnvelope<T>`/`BusHostInfo` public is **additive** (they were `internal`).
- `IMassTransitEnvelope<T>` only ever existed in the unmerged #3167, so removing it is **not** a break to any shipped API.

## Tests

All MassTransit interop tests pass locally: CoreTests (24, incl. the new `MassTransitTenantMappingTests` and the updated `MassTransitEnvelopeTests`), the RabbitMQ stubbed `masstransit_interop_map_tenant_id`, and the AWS SQS `masstransit_mapper_tenant_mapping`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)