### PR TITLE
Add GCP Pub/Sub CI coverage (#3191)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
           - CIOracle
           - CIPersistence
           - CIPolecat
+          - CIPubsub
           - CIPulsar
           - CIRabbitMQ
           - CIRavenDb

--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -53,6 +53,32 @@ partial class Build
             WaitForAzureServiceBusEmulatorToBeReady();
         if (services.Contains("kafka"))
             WaitForKafkaToBeReady();
+        if (services.Contains("gcp-pubsub"))
+            WaitForPubsubEmulatorToBeReady();
+    }
+
+    void WaitForPubsubEmulatorToBeReady()
+    {
+        var attempt = 0;
+        while (attempt < 30)
+        {
+            try
+            {
+                using var tcpClient = new System.Net.Sockets.TcpClient();
+                tcpClient.Connect("localhost", 8085);
+                Log.Information("GCP Pub/Sub emulator is up and ready!");
+                return;
+            }
+            catch (Exception)
+            {
+                // ignore connection errors
+            }
+
+            Thread.Sleep(2000);
+            attempt++;
+        }
+
+        Log.Warning("GCP Pub/Sub emulator did not become ready after 60 seconds");
     }
 
     void WaitForKafkaToBeReady()
@@ -367,6 +393,20 @@ partial class Build
 
             BuildTestProjects(tests);
             StartDockerServices("postgresql");
+
+            RunTestProject(tests);
+        });
+
+    Target CIPubsub => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            var tests = RootDirectory / "src" / "Transports" / "GCP" / "Wolverine.Pubsub.Tests" / "Wolverine.Pubsub.Tests.csproj";
+
+            BuildTestProjects(tests);
+            // Durable compliance fixtures persist through Marten/Postgres; the rest use the
+            // Pub/Sub emulator started via docker compose. See #3191.
+            StartDockerServices("gcp-pubsub", "postgresql");
 
             RunTestProject(tests);
         });

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/TestingExtensions.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/TestingExtensions.cs
@@ -6,7 +6,10 @@ public static class TestingExtensions
 {
     public static PubsubConfiguration UsePubsubTesting(this WolverineOptions options)
     {
-        Environment.SetEnvironmentVariable("PUBSUB_EMULATOR_HOST", "[::1]:8085");
+        // Use localhost (not the IPv6 literal [::1]) so this resolves to the IPv4 address that
+        // Docker publishes the emulator on. CI Linux runners publish the container port on IPv4
+        // only, where [::1]:8085 is unreachable. See #3191.
+        Environment.SetEnvironmentVariable("PUBSUB_EMULATOR_HOST", "localhost:8085");
         Environment.SetEnvironmentVariable("PUBSUB_PROJECT_ID", "wolverine");
 
         return options


### PR DESCRIPTION
Fixes #3191.

GCP Pub/Sub was the one transport with **no CI job** — no `CIPubsub` Nuke target and no entry in the consolidated `tests.yml` matrix — so `Wolverine.Pubsub.Tests` never ran in CI and regressions shipped undetected. This is exactly why the reply-subject collision uncovered in #3189 wasn't caught automatically for GCP.

## Changes

- **`build/CITargets.cs`** — new `CIPubsub` target (builds `Wolverine.Pubsub.Tests`, starts the `gcp-pubsub` emulator + `postgresql` for the durable-compliance fixtures, runs the suite) plus a `WaitForPubsubEmulatorToBeReady()` TCP readiness poll on `:8085`.
- **`.github/workflows/tests.yml`** — added `CIPubsub` to the matrix.
- **`TestingExtensions.cs`** — point `PUBSUB_EMULATOR_HOST` at `localhost:8085` instead of the IPv6 literal `[::1]:8085`; CI Linux runners publish the emulator container on IPv4 only, where `[::1]` is unreachable.

## Validation

Ran the exact target locally: `./build.sh CIPubsub --framework net9.0` → **142/142 `Wolverine.Pubsub.Tests` green** (build + emulator startup + readiness wait + full suite).

Note: this branch is off `main`, which does not have #3189's "Solo == node 1" change, so GCP gets unique node numbers and the reply tests pass. The GCP reply-collision fix itself rides in #3189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)