### PR TITLE
Pulsar: transport-default DLQ/retry precedence + resolve DLQ-sender TODOs (#3186)

### DIFF
--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarEndpointTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarEndpointTests.cs
@@ -123,4 +123,64 @@ public class PulsarEndpointTests
         var uri = PulsarEndpoint.NativeTopicPath(true, "public", "default", "orders-DLQ");
         uri.ShouldBe(new Uri("persistent://public/default/orders-DLQ"));
     }
+
+    [Fact]
+    public void effective_dead_letter_topic_falls_back_to_transport_default()
+    {
+        var transport = new PulsarTransport
+        {
+            DeadLetterTopic = new DeadLetterTopic("transport-default-dlq", DeadLetterTopicMode.Native)
+        };
+
+        var endpoint = transport["pulsar://persistent/public/default/orders".ToUri()];
+
+        // No per-endpoint override -> transport-wide default is used.
+        endpoint.EffectiveDeadLetterTopic!.TopicName.ShouldBe("transport-default-dlq");
+    }
+
+    [Fact]
+    public void effective_dead_letter_topic_prefers_per_endpoint_override()
+    {
+        var transport = new PulsarTransport
+        {
+            DeadLetterTopic = new DeadLetterTopic("transport-default-dlq", DeadLetterTopicMode.Native)
+        };
+
+        var endpoint = transport["pulsar://persistent/public/default/orders".ToUri()];
+        endpoint.DeadLetterTopic = new DeadLetterTopic("endpoint-dlq", DeadLetterTopicMode.Native);
+
+        // Per-endpoint configuration always wins over the transport default.
+        endpoint.EffectiveDeadLetterTopic!.TopicName.ShouldBe("endpoint-dlq");
+    }
+
+    [Fact]
+    public void effective_retry_letter_topic_prefers_per_endpoint_override()
+    {
+        var transportDefault = new RetryLetterTopic([1.Seconds()]);
+        var endpointOverride = new RetryLetterTopic([2.Seconds()]);
+
+        var transport = new PulsarTransport { RetryLetterTopic = transportDefault };
+        var endpoint = transport["pulsar://persistent/public/default/orders".ToUri()];
+
+        endpoint.EffectiveRetryLetterTopic.ShouldBe(transportDefault);
+
+        endpoint.RetryLetterTopic = endpointOverride;
+        endpoint.EffectiveRetryLetterTopic.ShouldBe(endpointOverride);
+    }
+
+    [Theory]
+    [InlineData(DeadLetterTopicMode.Native)]
+    [InlineData(DeadLetterTopicMode.WolverineStorage)]
+    public void try_build_dead_letter_sender_is_always_false(DeadLetterTopicMode mode)
+    {
+        var transport = new PulsarTransport();
+        var endpoint = transport["pulsar://persistent/public/default/orders".ToUri()];
+        endpoint.DeadLetterTopic = new DeadLetterTopic(mode);
+
+        // Pulsar never uses an endpoint-level DLQ sender: native dead-lettering is owned by the
+        // listener (ISupportDeadLetterQueue, with reconsume metadata) and WolverineStorage by the
+        // durable store. Returning a sender here would hijack the native path. See #3186.
+        endpoint.TryBuildDeadLetterSender(null!, out var sender).ShouldBeFalse();
+        sender.ShouldBeNull();
+    }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarConfiguration.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarConfiguration.cs
@@ -1,0 +1,39 @@
+namespace Wolverine.Pulsar;
+
+/// <summary>
+/// Transport-wide configuration for the Pulsar integration, returned from
+/// <see cref="PulsarTransportExtensions.UsePulsar(Wolverine.WolverineOptions,System.Action{DotPulsar.Abstractions.IPulsarClientBuilder})"/>.
+/// Use it to set transport-level defaults that individual endpoints inherit unless they override them.
+/// </summary>
+public class PulsarConfiguration
+{
+    private readonly PulsarTransport _transport;
+
+    internal PulsarConfiguration(PulsarTransport transport)
+    {
+        _transport = transport;
+    }
+
+    /// <summary>
+    /// Set the transport-wide default dead letter topic applied to every Pulsar endpoint that does
+    /// not configure its own via <c>ListenToPulsarTopic(...).DeadLetterQueueing(...)</c>. Per-endpoint
+    /// configuration always wins (see <see cref="PulsarEndpoint.EffectiveDeadLetterTopic"/>). Mirrors
+    /// the Kafka transport-level dead letter default + per-endpoint override shape.
+    /// </summary>
+    public PulsarConfiguration DeadLetterQueueing(DeadLetterTopic deadLetterTopic)
+    {
+        _transport.DeadLetterTopic = deadLetterTopic ?? throw new ArgumentNullException(nameof(deadLetterTopic));
+        return this;
+    }
+
+    /// <summary>
+    /// Set the transport-wide default retry letter topic applied to every Pulsar endpoint that does
+    /// not configure its own. Per-endpoint configuration always wins (see
+    /// <see cref="PulsarEndpoint.EffectiveRetryLetterTopic"/>).
+    /// </summary>
+    public PulsarConfiguration RetryLetterQueueing(RetryLetterTopic retryLetterTopic)
+    {
+        _transport.RetryLetterTopic = retryLetterTopic ?? throw new ArgumentNullException(nameof(retryLetterTopic));
+        return this;
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -47,6 +47,29 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
     /// </summary>
     public RetryLetterTopic? RetryLetterTopic { get; set; }
 
+    /// <summary>
+    /// The dead letter topic actually in effect for this endpoint: the per-endpoint
+    /// <see cref="DeadLetterTopic"/> override if set, otherwise the transport-wide default
+    /// (<see cref="PulsarTransport.DeadLetterTopic"/>). Per-endpoint configuration always wins.
+    /// </summary>
+    internal DeadLetterTopic? EffectiveDeadLetterTopic => DeadLetterTopic ?? _parent.DeadLetterTopic;
+
+    /// <summary>
+    /// The retry letter topic actually in effect for this endpoint: the per-endpoint
+    /// <see cref="RetryLetterTopic"/> override if set, otherwise the transport-wide default
+    /// (<see cref="PulsarTransport.RetryLetterTopic"/>). Per-endpoint configuration always wins.
+    /// </summary>
+    internal RetryLetterTopic? EffectiveRetryLetterTopic => RetryLetterTopic ?? _parent.RetryLetterTopic;
+
+    /// <summary>
+    /// Native dead-lettering routes failed messages to a real Pulsar topic, so report that
+    /// (rather than the durable default) to monitoring when a native DLQ is in effect.
+    /// </summary>
+    public override DeadLetterStorageMode DeadLetterStorage =>
+        EffectiveDeadLetterTopic is { Mode: DeadLetterTopicMode.Native }
+            ? DeadLetterStorageMode.Native
+            : DeadLetterStorageMode.Durable;
+
     public bool IsPersistent => Persistence.Equals(Persistent);
 
     /// <summary>
@@ -112,13 +135,15 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
 
     public override bool TryBuildDeadLetterSender(IWolverineRuntime runtime, out ISender? deadLetterSender)
     {
+        // Resolves the former DLQ-sender stub TODO. Pulsar dead-lettering is intentionally NOT done
+        // through an endpoint-level sender:
+        //  - Native mode is handled by PulsarListener (ISupportDeadLetterQueue), which produces to the
+        //    {topic}-DLQ topic with the native reconsume metadata and retry-letter-topic chaining.
+        //  - WolverineStorage mode is handled by the durable dead letter store.
+        // Returning a sender here would make BufferedReceiver/DurableReceiver report
+        // NativeDeadLetterQueueEnabled, which MessageContext.tryGetDeadLetterQueue prefers over the
+        // listener — hijacking the richer native path and dropping the reconsume metadata. So we
+        // defer to the base (no native endpoint sender). See #3186.
         return base.TryBuildDeadLetterSender(runtime, out deadLetterSender);
-
-
-        // TODO: ?
-        //var queueName =  this.DeadLetterTopic?.TopicName ?? _parent.DeadLetterTopic.TopicName;
-        //var dlq = _parent[UriFor(queueName)];
-        //deadLetterSender = dlq.CreateSender(runtime);
-        //return true;
     }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -55,12 +55,11 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
             .Topic(endpoint.PulsarTopic())
             .Create();
 
-        NativeDeadLetterQueueEnabled = (transport.DeadLetterTopic is not null &&
-                                       transport.DeadLetterTopic.Mode != DeadLetterTopicMode.WolverineStorage) ||
-                                       (endpoint.DeadLetterTopic is not null && endpoint.DeadLetterTopic.Mode !=
-                                       DeadLetterTopicMode.WolverineStorage);
+        // Per-endpoint-override-wins resolution (endpoint override, else transport default).
+        NativeDeadLetterQueueEnabled = endpoint.EffectiveDeadLetterTopic is not null &&
+                                       endpoint.EffectiveDeadLetterTopic.Mode != DeadLetterTopicMode.WolverineStorage;
 
-        NativeRetryLetterQueueEnabled = endpoint.RetryLetterTopic is not null &&
+        NativeRetryLetterQueueEnabled = endpoint.EffectiveRetryLetterTopic is not null &&
                                         RetryLetterTopic.SupportedSubscriptionTypes.Contains(endpoint.SubscriptionType);
 
         trySetupNativeResiliency(endpoint, transport);
@@ -110,7 +109,7 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
             return;
         }
 
-        if (endpoint.RetryLetterTopic is not null)
+        if (endpoint.EffectiveRetryLetterTopic is not null)
         {
             _retryLetterQueueProducer = transport.Client!.NewProducer()
                 .Topic(getRetryLetterTopicUri(endpoint)!.ToString())
@@ -140,14 +139,14 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
     {
         return NativeRetryLetterQueueEnabled
             ? PulsarEndpoint.NativeTopicPath(endpoint.IsPersistent, endpoint.Tenant, endpoint.Namespace,
-                endpoint.RetryLetterTopic?.TopicName ?? $"{endpoint.TopicName}-RETRY")
+                endpoint.EffectiveRetryLetterTopic?.TopicName ?? $"{endpoint.TopicName}-RETRY")
             : null;
     }
 
     private Uri getDeadLetteredTopicUri(PulsarEndpoint endpoint)
     {
         return PulsarEndpoint.NativeTopicPath(endpoint.IsPersistent, endpoint.Tenant, endpoint.Namespace,
-            endpoint.DeadLetterTopic?.TopicName ?? $"{endpoint.TopicName}-DLQ");
+            endpoint.EffectiveDeadLetterTopic?.TopicName ?? $"{endpoint.TopicName}-DLQ");
     }
 
     public ValueTask CompleteAsync(Envelope envelope)

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransport.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransport.cs
@@ -28,8 +28,21 @@ public class PulsarTransport : TransportBase<PulsarEndpoint>, IAsyncDisposable
     public IPulsarClientBuilder Builder { get; }
 
     internal IPulsarClient? Client { get; private set; }
-    public DeadLetterTopic? DeadLetterTopic { get; internal set; } // TODO: should we even have a default or just per endpoint based?
-    public RetryLetterTopic? RetryLetterTopic { get; internal set; } // TODO: should we even have a default or just per endpoint based?
+    /// <summary>
+    /// Transport-wide default dead letter topic applied to every Pulsar endpoint that does not set
+    /// its own <see cref="PulsarEndpoint.DeadLetterTopic"/>. Resolution is per-endpoint-override-wins:
+    /// an endpoint reads its effective value through <see cref="PulsarEndpoint.EffectiveDeadLetterTopic"/>
+    /// (per-endpoint override, else this default). Mirrors the Kafka transport default + per-endpoint
+    /// override shape. Set via <c>UsePulsar(...).DeadLetterQueueing(...)</c>.
+    /// </summary>
+    public DeadLetterTopic? DeadLetterTopic { get; internal set; }
+
+    /// <summary>
+    /// Transport-wide default retry letter topic, resolved per-endpoint-override-wins through
+    /// <see cref="PulsarEndpoint.EffectiveRetryLetterTopic"/>. Set via
+    /// <c>UsePulsar(...).RetryLetterQueueing(...)</c>.
+    /// </summary>
+    public RetryLetterTopic? RetryLetterTopic { get; internal set; }
 
 
     //private IEnumerable<DeadLetterTopic> enabledDeadLetterTopics()

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -32,24 +32,23 @@ public static class PulsarTransportExtensions
     /// </summary>
     /// <param name="endpoints"></param>
     /// <param name="configure"></param>
-    public static void UsePulsar(this WolverineOptions endpoints, Action<IPulsarClientBuilder> configure)
+    public static PulsarConfiguration UsePulsar(this WolverineOptions endpoints, Action<IPulsarClientBuilder> configure)
     {
-        // doesn't apply the policy?!?:
-        //endpoints.Policies.Add<PulsarNativeResiliencyPolicy>();
-        //endpoints.Policies.Add(new PulsarNativeResiliencyPolicy());
-
         new PulsarNativeResiliencyPolicy().Apply(endpoints);
 
-        configure(endpoints.PulsarTransport().Builder);
+        var transport = endpoints.PulsarTransport();
+        configure(transport.Builder);
+
+        return new PulsarConfiguration(transport);
     }
 
     /// <summary>
     ///     Connect to a local, standalone Pulsar broker at the default port
     /// </summary>
     /// <param name="endpoints"></param>
-    public static void UsePulsar(this WolverineOptions endpoints)
+    public static PulsarConfiguration UsePulsar(this WolverineOptions endpoints)
     {
-        endpoints.UsePulsar(_ => { });
+        return endpoints.UsePulsar(_ => { });
     }
 
     /// <summary>


### PR DESCRIPTION
First PR of the Pulsar re-evaluation epic #3176. Fixes #3186.

Resolves the two loose-end TODOs in the Pulsar transport.

## Transport-vs-endpoint defaults (`PulsarTransport.cs:31` TODO)

The transport-level `DeadLetterTopic`/`RetryLetterTopic` are now real defaults that each endpoint inherits unless it sets its own, resolved **per-endpoint-override-wins** through the new `PulsarEndpoint.EffectiveDeadLetterTopic` / `EffectiveRetryLetterTopic` — mirroring the Kafka transport-default + per-endpoint override shape. `UsePulsar(...)` now returns a `PulsarConfiguration` exposing `DeadLetterQueueing(...)` / `RetryLetterQueueing(...)` to set the defaults. `PulsarListener` keys native DLQ/retry enablement **and** the resolved topic names off the effective values, so a transport default actually takes effect.

## DLQ sender (`PulsarEndpoint.cs:118` TODO) — resolved by decision

The stub looked like missing functionality, but native dead-lettering is **already** fully handled by `PulsarListener` (`ISupportDeadLetterQueue`), which produces to the `{topic}-DLQ` topic **with** the native reconsume metadata and retry-letter-topic chaining; `WolverineStorage` mode uses the durable store.

Implementing a competing endpoint-level `TryBuildDeadLetterSender` actively **regresses** this: `BufferedReceiver`/`DurableReceiver` then report `NativeDeadLetterQueueEnabled`, and `MessageContext.tryGetDeadLetterQueue` prefers the receiver (`_channel`) over the listener — hijacking the richer native path and dropping the reconsume metadata. This was caught by `PulsarNativeReliabilityTests` (differential: passes on `main`, failed with the naive sender impl). So `TryBuildDeadLetterSender` intentionally defers to the base, documented inline.

`DeadLetterStorage` now reports `Native` when a native DLQ is in effect (for monitoring).

## Tests

- New unit tests: effective-topic precedence (transport default vs per-endpoint override) for both DLQ and retry, and `TryBuildDeadLetterSender` is always false (native owned by the listener; WolverineStorage by the durable store).
- Native DLQ end-to-end + exception headers stays covered by the existing `PulsarNativeReliabilityTests`.

> Note: the `PulsarNativeReliabilityTests` retry-delay assertions are timing-flaky on a loaded/fresh broker (a different one intermittently fails per combined run; each passes in isolation). Not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)