### PR TITLE
GCP Pub/Sub: emphasize per-connect credential recreation + rolling credentials docs/tests

### DIFF
--- a/docs/guide/messaging/transports/gcp-pubsub/customisation.md
+++ b/docs/guide/messaging/transports/gcp-pubsub/customisation.md
@@ -106,7 +106,102 @@ var host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pubsub_use_credential_async' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-The factory is invoked once per client builder during startup. If you need to share a single fetch across all three builders, close over a cached `Task<GoogleCredential>` in your factory lambda.
+The factory is **not** a one-time, startup-only hook. It runs again every time Wolverine constructs one of the underlying client builders:
+
+- the publisher and subscriber **API** client builders are rebuilt whenever the transport (re)connects;
+- the streaming **subscriber** client is rebuilt on *every listener (re)connect* — including each automatic restart after a transient fault such as `DEADLINE_EXCEEDED`.
+
+This per-connect re-invocation is deliberate, and it is the foundation for [rolling credentials](#rolling-credentials) below.
+
+::: tip
+Because the factory can fire frequently — once per listener reconnect, not just once at startup — keep it cheap. If you only need a single fetch shared across all three builders, close over a cached `Task<GoogleCredential>` (or use the caching pattern shown under [Rolling credentials](#rolling-credentials)) so you don't hit your secret store on every reconnect.
+:::
+
+## Rolling credentials
+
+A `GoogleCredential` built from Application Default Credentials or a Workload Identity Federation config file refreshes its own *access tokens* internally, so for those you do **not** need to do anything special.
+
+Rolling credentials matter when the credential **material itself** rotates and cannot self-refresh — most commonly when you mint short-lived access tokens yourself via `GoogleCredential.FromAccessToken(...)`, or when the underlying credential config is periodically rotated by an external system. A static `FromAccessToken` credential is frozen at the moment it is created and will eventually expire.
+
+Because Wolverine re-invokes the credential factory on every listener (re)connect, you can hand out a freshly-minted credential over time and have running listeners adopt it automatically — no host restart required. Wrap your token source in a small holder that caches the current credential and refreshes it as it nears expiry:
+
+<!-- snippet: sample_pubsub_use_credential_rolling -->
+<a id='snippet-sample_pubsub_use_credential_rolling'></a>
+```cs
+// A holder that vends a short-lived GoogleCredential and refreshes it as it nears expiry.
+// Short-lived access tokens minted via GoogleCredential.FromAccessToken cannot refresh
+// themselves, so something has to hand out a new one over time.
+var credentials = new RollingCredentialSource();
+
+var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UsePubsub("your-project-id")
+
+            // The async factory is invoked again on every listener (re)connect, so each
+            // reconnect picks up the freshest credential without restarting the host.
+            .UseCredential(() => credentials.GetAsync());
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pubsub_use_credential_rolling' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The `RollingCredentialSource` below caches the current credential, refreshes it once when it nears expiry (with other concurrent connects awaiting the same refresh), and reuses it on the fast path so a steady stream of reconnects doesn't hammer your secret store:
+
+<!-- snippet: sample_pubsub_rolling_credential_source -->
+<a id='snippet-sample_pubsub_rolling_credential_source'></a>
+```cs
+// A thread-safe source of short-lived credentials. The cached credential is reused until it
+// nears expiry, then refreshed once (other callers wait on the same refresh). Because Wolverine
+// rebuilds the streaming subscriber client on every listener (re)connect — for example after a
+// DEADLINE_EXCEEDED restart — GetAsync runs again each time and the listener transparently
+// adopts the latest credential.
+public class RollingCredentialSource
+{
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private readonly TimeSpan _refreshMargin = TimeSpan.FromMinutes(5);
+    private GoogleCredential? _current;
+    private DateTimeOffset _expiresAt = DateTimeOffset.MinValue;
+
+    public async ValueTask<GoogleCredential> GetAsync()
+    {
+        // Fast path: the cached credential is still comfortably valid
+        if (_current is not null && DateTimeOffset.UtcNow < _expiresAt - _refreshMargin)
+        {
+            return _current;
+        }
+
+        await _lock.WaitAsync();
+        try
+        {
+            // Double-check inside the lock in case another connect already refreshed it
+            if (_current is null || DateTimeOffset.UtcNow >= _expiresAt - _refreshMargin)
+            {
+                var (token, lifetime) = await FetchAccessTokenAsync();
+                _current = GoogleCredential.FromAccessToken(token);
+                _expiresAt = DateTimeOffset.UtcNow + lifetime;
+            }
+        }
+        finally
+        {
+            _lock.Release();
+        }
+
+        return _current;
+    }
+
+    // Replace with a real call to your token-vending source — e.g. Azure Key Vault, AWS Secrets
+    // Manager, GCP STS, or an internal token broker. Return the access token and how long it lives.
+    private Task<(string token, TimeSpan lifetime)> FetchAccessTokenAsync()
+        => throw new NotImplementedException();
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pubsub_rolling_credential_source' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: warning
+The credential is captured by the streaming subscriber client *at the point of each connect*. An already-running listener will not swap credentials mid-flight — it adopts the refreshed credential on its **next** (re)connect. Size your `_refreshMargin` so a fresh credential is always handed out comfortably before the old one expires.
+:::
 
 ## Customising the API Client Builders
 

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs
@@ -343,6 +343,27 @@ public class DocumentationSamples
         #endregion
     }
 
+    public async Task use_credential_rolling()
+    {
+        #region sample_pubsub_use_credential_rolling
+        // A holder that vends a short-lived GoogleCredential and refreshes it as it nears expiry.
+        // Short-lived access tokens minted via GoogleCredential.FromAccessToken cannot refresh
+        // themselves, so something has to hand out a new one over time.
+        var credentials = new RollingCredentialSource();
+
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UsePubsub("your-project-id")
+
+                    // The async factory is invoked again on every listener (re)connect, so each
+                    // reconnect picks up the freshest credential without restarting the host.
+                    .UseCredential(() => credentials.GetAsync());
+            }).StartAsync();
+
+        #endregion
+    }
+
     public async Task customize_mappers()
     {
         #region sample_configuring_custom_envelope_mapper_for_pubsub
@@ -399,6 +420,54 @@ public class CustomPubsubMapper : EnvelopeMapper<PubsubMessage, PubsubMessage>, 
 
         return false;
     }
+}
+
+#endregion
+
+#region sample_pubsub_rolling_credential_source
+// A thread-safe source of short-lived credentials. The cached credential is reused until it
+// nears expiry, then refreshed once (other callers wait on the same refresh). Because Wolverine
+// rebuilds the streaming subscriber client on every listener (re)connect — for example after a
+// DEADLINE_EXCEEDED restart — GetAsync runs again each time and the listener transparently
+// adopts the latest credential.
+public class RollingCredentialSource
+{
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private readonly TimeSpan _refreshMargin = TimeSpan.FromMinutes(5);
+    private GoogleCredential? _current;
+    private DateTimeOffset _expiresAt = DateTimeOffset.MinValue;
+
+    public async ValueTask<GoogleCredential> GetAsync()
+    {
+        // Fast path: the cached credential is still comfortably valid
+        if (_current is not null && DateTimeOffset.UtcNow < _expiresAt - _refreshMargin)
+        {
+            return _current;
+        }
+
+        await _lock.WaitAsync();
+        try
+        {
+            // Double-check inside the lock in case another connect already refreshed it
+            if (_current is null || DateTimeOffset.UtcNow >= _expiresAt - _refreshMargin)
+            {
+                var (token, lifetime) = await FetchAccessTokenAsync();
+                _current = GoogleCredential.FromAccessToken(token);
+                _expiresAt = DateTimeOffset.UtcNow + lifetime;
+            }
+        }
+        finally
+        {
+            _lock.Release();
+        }
+
+        return _current;
+    }
+
+    // Replace with a real call to your token-vending source — e.g. Azure Key Vault, AWS Secrets
+    // Manager, GCP STS, or an internal token broker. Return the access token and how long it lives.
+    private Task<(string token, TimeSpan lifetime)> FetchAccessTokenAsync()
+        => throw new NotImplementedException();
 }
 
 #endregion

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/PubsubConfigurationTests.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/PubsubConfigurationTests.cs
@@ -161,6 +161,138 @@ public class PubsubConfigurationTests
         observed.ShouldBe(credential);
     }
 
+    [Fact]
+    public async Task multiple_configure_subscriber_api_client_calls_compose_in_order()
+    {
+        var transport = new PubsubTransport("test");
+        var config = new PubsubConfiguration(transport, new WolverineOptions());
+        var order = new List<int>();
+
+        config.ConfigureSubscriberApiClient(_ => order.Add(1));
+        config.ConfigureSubscriberApiClient(_ => order.Add(2));
+
+        await transport.ConfigureSubscriberApiBuilder!(new SubscriberServiceApiClientBuilder());
+        order.ShouldBe([1, 2]);
+    }
+
+    [Fact]
+    public async Task async_configure_subscriber_api_client_callback_is_awaited()
+    {
+        var transport = new PubsubTransport("test");
+        var config = new PubsubConfiguration(transport, new WolverineOptions());
+        var called = false;
+
+        config.ConfigureSubscriberApiClient(async _ =>
+        {
+            await Task.Yield();
+            called = true;
+        });
+
+        await transport.ConfigureSubscriberApiBuilder!(new SubscriberServiceApiClientBuilder());
+        called.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task async_configure_subscriber_client_callback_is_awaited()
+    {
+        var transport = new PubsubTransport("test");
+        var config = new PubsubConfiguration(transport, new WolverineOptions());
+        var called = false;
+
+        config.ConfigureSubscriberClient(async _ =>
+        {
+            await Task.Yield();
+            called = true;
+        });
+
+        await transport.ConfigureSubscriberClientBuilder!(new SubscriberClientBuilder());
+        called.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task async_use_credential_factory_sets_credential_on_subscriber_api_builder()
+    {
+        var transport = new PubsubTransport("test");
+        var config = new PubsubConfiguration(transport, new WolverineOptions());
+        var credential = GoogleCredential.FromAccessToken("test-token");
+        GoogleCredential? observed = null;
+
+        config.UseCredential(async () =>
+        {
+            await Task.Yield();
+            return credential;
+        });
+        config.ConfigureSubscriberApiClient(b => observed = b.GoogleCredential);
+
+        await transport.ConfigureSubscriberApiBuilder!(new SubscriberServiceApiClientBuilder());
+        observed.ShouldBe(credential);
+    }
+
+    [Fact]
+    public async Task async_use_credential_factory_sets_credential_on_subscriber_client_builder()
+    {
+        var transport = new PubsubTransport("test");
+        var config = new PubsubConfiguration(transport, new WolverineOptions());
+        var credential = GoogleCredential.FromAccessToken("test-token");
+        GoogleCredential? observed = null;
+
+        config.UseCredential(async () =>
+        {
+            await Task.Yield();
+            return credential;
+        });
+        config.ConfigureSubscriberClient(b => observed = b.GoogleCredential);
+
+        await transport.ConfigureSubscriberClientBuilder!(new SubscriberClientBuilder());
+        observed.ShouldBe(credential);
+    }
+
+    [Fact]
+    public async Task subscriber_client_credential_factory_is_invoked_on_each_connect()
+    {
+        // Each listener (re)connect rebuilds the streaming SubscriberClient and re-applies the
+        // configure callback, so an async credential factory runs again every time. This is what
+        // lets rolling/rotated credentials be picked up without restarting the application.
+        var transport = new PubsubTransport("test");
+        var config = new PubsubConfiguration(transport, new WolverineOptions());
+        var invocations = 0;
+
+        config.UseCredential(async () =>
+        {
+            await Task.Yield();
+            invocations++;
+            return GoogleCredential.FromAccessToken($"token-{invocations}");
+        });
+
+        // Simulate two listener connects (e.g. an initial start plus a reconnect after DEADLINE_EXCEEDED)
+        await transport.ConfigureSubscriberClientBuilder!(new SubscriberClientBuilder());
+        await transport.ConfigureSubscriberClientBuilder!(new SubscriberClientBuilder());
+
+        invocations.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task subscriber_client_receives_a_fresh_credential_on_each_connect()
+    {
+        var transport = new PubsubTransport("test");
+        var config = new PubsubConfiguration(transport, new WolverineOptions());
+        var counter = 0;
+
+        config.UseCredential(async () =>
+        {
+            await Task.Yield();
+            return GoogleCredential.FromAccessToken($"token-{++counter}");
+        });
+
+        var first = new SubscriberClientBuilder();
+        var second = new SubscriberClientBuilder();
+        await transport.ConfigureSubscriberClientBuilder!(first);
+        await transport.ConfigureSubscriberClientBuilder!(second);
+
+        // A reconnect must not reuse the credential captured on the previous connect
+        first.GoogleCredential.ShouldNotBeSameAs(second.GoogleCredential);
+    }
+
     // Requires the emulator running via `docker compose up -d gcp-pubsub`
     [Fact]
     public async Task configure_callbacks_are_applied_to_live_builders()


### PR DESCRIPTION
Follow-up to #3172 (merged). **Documentation and test-only** — no production code changes.

## Background

#3172 added `UseCredential` / `Configure*` hooks to the GCP Pub/Sub transport. During review two things stood out:

1. The async credential factory is **not** a startup-only hook — the streaming `SubscriberClient` is rebuilt on *every listener (re)connect* (`listenForMessagesAsync` retry loop, e.g. after `DEADLINE_EXCEEDED`), so the factory runs again each time. The original docs said "invoked once per client builder during startup," which undersells this.
2. That per-connect re-invocation is exactly what enables **rolling credentials** (rotated/short-lived tokens), but there was no worked example.
3. The unit tests covered the three `Configure*` hooks asymmetrically.

## Docs

- Rewrote the "Async credential factory" note to spell out that the factory re-runs on every transport/listener (re)connect, with a cost caveat (keep it cheap; cache).
- New **Rolling credentials** section explaining when it matters (self-refreshing ADC/WIF vs. static `FromAccessToken` / externally-rotated material), with two compiling snippets:
  - `sample_pubsub_use_credential_rolling`
  - `sample_pubsub_rolling_credential_source` — a thread-safe `RollingCredentialSource` (cached credential + refresh margin + double-checked locking).

## Tests

Added 7 tests to `PubsubConfigurationTests` (all emulator-free, the existing live-emulator integration test is unchanged):

- Symmetry across all three hooks: `multiple_configure_subscriber_api_client_calls_compose_in_order`, `async_configure_subscriber_api_client_callback_is_awaited`, `async_configure_subscriber_client_callback_is_awaited`, `async_use_credential_factory_sets_credential_on_subscriber_api_builder`, `async_use_credential_factory_sets_credential_on_subscriber_client_builder`.
- Rolling semantics: `subscriber_client_credential_factory_is_invoked_on_each_connect`, `subscriber_client_receives_a_fresh_credential_on_each_connect`.
- Fixed the missing trailing newline in the test file.

## Verification

Ran the full GCP Pub/Sub suite locally against the emulator (`docker compose up -d gcp-pubsub`):

```
Passed! - Failed: 0, Passed: 160, Skipped: 0, Total: 160 (net9.0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)