### PR TITLE
Pulsar: multi-topic & regex/pattern subscriptions (#3181)

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -87,6 +87,33 @@ resumes from its committed cursor on every restart regardless of this setting, a
 messages that are still retained on the topic. The default is `SubscriptionInitialPosition.Latest`, matching
 DotPulsar's own default.
 
+## Multi-Topic & Pattern Subscriptions
+
+A single Pulsar listener can consume from more than one topic, or from every topic matching a
+regular expression — the Pulsar analogue of Kafka topic groups. This reduces the number of
+consumers you need and lets a listener automatically pick up new topics that match a pattern.
+
+```csharp
+// One listener over several explicit topics
+opts.ListenToPulsarTopic("persistent://public/default/orders")
+    .Topics(
+        "persistent://public/default/orders-priority",
+        "persistent://public/default/orders-bulk");
+
+// One listener over every topic matching a regex pattern
+opts.ListenToPulsarTopic("persistent://public/default/events-all")
+    .TopicsPattern(new Regex("persistent://public/default/events-.*"));
+
+// Pattern, restricted to non-persistent topics (default is persistent only)
+opts.ListenToPulsarTopic("non-persistent://public/default/telemetry-all")
+    .TopicsPattern(new Regex("non-persistent://public/default/telemetry-.*"),
+        RegexSubscriptionMode.NonPersistent);
+```
+
+When a pattern is configured it takes precedence, and the topic the listener was created with is
+used only as the Wolverine endpoint identity. Pattern subscriptions match topics that exist at
+subscription time and pick up newly created matching topics as Pulsar discovers them.
+
 ## Read Only Subscriptions <Badge type="tip" text="3.13" />
 
 As part of Wolverine's "Requeue" error handling action, the Pulsar transport tries to quietly create a matching sender

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/multi_topic_and_pattern.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/multi_topic_and_pattern.cs
@@ -1,0 +1,171 @@
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+using DotPulsar;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.ComplianceTests;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+// GH-3181: multi-topic & regex/pattern subscriptions — one Pulsar consumer over many topics
+// (analogue of Kafka topic groups) and over a regex pattern.
+public class multi_topic_and_pattern
+{
+    private static PulsarEndpoint applyListener(string primary, Action<PulsarListenerConfiguration> configure)
+    {
+        var transport = new PulsarTransport();
+        var endpoint = transport[PulsarEndpointUri.Topic(primary)];
+        var config = new PulsarListenerConfiguration(endpoint);
+        configure(config);
+        ((IDelayedEndpointConfiguration)config).Apply();
+        return endpoint;
+    }
+
+    // ---- config unit tests (no broker) ----
+
+    [Fact]
+    public void topics_adds_additional_topics_and_dedupes_primary()
+    {
+        var endpoint = applyListener("persistent://public/default/one",
+            c => c.Topics("persistent://public/default/two", "persistent://public/default/three",
+                "persistent://public/default/one"));
+
+        endpoint.AllTopicPaths().ShouldBe([
+            "persistent://public/default/one",
+            "persistent://public/default/two",
+            "persistent://public/default/three"
+        ]);
+    }
+
+    [Fact]
+    public void topics_pattern_sets_pattern_and_mode()
+    {
+        var pattern = new Regex("persistent://public/default/orders-.*");
+        var endpoint = applyListener("persistent://public/default/orders-all",
+            c => c.TopicsPattern(pattern, RegexSubscriptionMode.All));
+
+        endpoint.TopicsPattern.ShouldBe(pattern);
+        endpoint.RegexSubscriptionMode.ShouldBe(RegexSubscriptionMode.All);
+    }
+
+    [Fact]
+    public void topics_validates_malformed_paths_eagerly()
+    {
+        Should.Throw<Exception>(() => applyListener("persistent://public/default/one",
+            c => c.Topics("not-a-valid-topic")));
+    }
+
+    // ---- end-to-end (Pulsar docker) ----
+
+    [Fact]
+    public async Task single_listener_consumes_multiple_explicit_topics()
+    {
+        var prefix = "mt-" + Guid.NewGuid().ToString("N");
+        var topic1 = $"persistent://public/default/{prefix}-1";
+        var topic2 = $"persistent://public/default/{prefix}-2";
+
+        using var publisher = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.PublishMessage<MultiTopicMessage>().ToPulsarTopic(topic1).SendInline();
+            opts.PublishMessage<OtherTopicMessage>().ToPulsarTopic(topic2).SendInline();
+        });
+
+        await publisher.SendAsync(new MultiTopicMessage { Id = "from-1" });
+        await publisher.SendAsync(new OtherTopicMessage { Id = "from-2" });
+
+        using var consumer = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.ListenToPulsarTopic(topic1)
+                .SubscriptionName("sub-" + Guid.NewGuid().ToString("N"))
+                .Topics(topic2)
+                .ProcessInline()
+                .BeginAtEarliest();
+            opts.Services.AddSingleton<MultiTopicSink>();
+            opts.Discovery.DisableConventionalDiscovery()
+                .IncludeType<MultiTopicHandler>()
+                .IncludeType<OtherTopicHandler>();
+        });
+
+        var sink = consumer.Services.GetRequiredService<MultiTopicSink>();
+        await waitForCountAsync(sink.Received, 2);
+        sink.Received.OrderBy(x => x).ShouldBe(["from-1", "from-2"]);
+    }
+
+    [Fact]
+    public async Task single_listener_consumes_a_regex_pattern()
+    {
+        var prefix = "ptn" + Guid.NewGuid().ToString("N");
+        var topicA = $"persistent://public/default/{prefix}-a";
+        var topicB = $"persistent://public/default/{prefix}-b";
+
+        using var publisher = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.PublishMessage<MultiTopicMessage>().ToPulsarTopic(topicA).SendInline();
+            opts.PublishMessage<OtherTopicMessage>().ToPulsarTopic(topicB).SendInline();
+        });
+
+        // Create the topics (and their backlog) before the pattern subscription matches them.
+        await publisher.SendAsync(new MultiTopicMessage { Id = "ptn-a" });
+        await publisher.SendAsync(new OtherTopicMessage { Id = "ptn-b" });
+
+        using var consumer = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.ListenToPulsarTopic($"persistent://public/default/{prefix}-a")
+                .SubscriptionName("sub-" + Guid.NewGuid().ToString("N"))
+                .TopicsPattern(new Regex($"persistent://public/default/{prefix}-.*"))
+                .ProcessInline()
+                .BeginAtEarliest();
+            opts.Services.AddSingleton<MultiTopicSink>();
+            opts.Discovery.DisableConventionalDiscovery()
+                .IncludeType<MultiTopicHandler>()
+                .IncludeType<OtherTopicHandler>();
+        });
+
+        var sink = consumer.Services.GetRequiredService<MultiTopicSink>();
+        await waitForCountAsync(sink.Received, 2, 45000);
+        sink.Received.OrderBy(x => x).ShouldBe(["ptn-a", "ptn-b"]);
+    }
+
+    private static async Task waitForCountAsync(ConcurrentBag<string> bag, int count, int timeoutMs = 30000)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            if (bag.Count >= count) return;
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Only received {bag.Count} of {count} expected messages within {timeoutMs}ms");
+    }
+}
+
+public class MultiTopicMessage
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class OtherTopicMessage
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class MultiTopicSink
+{
+    public ConcurrentBag<string> Received { get; } = new();
+}
+
+public class MultiTopicHandler
+{
+    public static void Handle(MultiTopicMessage message, MultiTopicSink sink) => sink.Received.Add(message.Id);
+}
+
+public class OtherTopicHandler
+{
+    public static void Handle(OtherTopicMessage message, MultiTopicSink sink) => sink.Received.Add(message.Id);
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using DotPulsar;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
@@ -43,6 +44,31 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
     /// </summary>
     public SubscriptionInitialPosition SubscriptionInitialPosition { get; internal set; } =
         SubscriptionInitialPosition.Latest;
+
+    /// <summary>
+    ///     Additional native Pulsar topic paths (e.g. <c>persistent://public/default/other</c>) that a
+    ///     single listener consumes alongside its primary topic. Pulsar supports one consumer over many
+    ///     topics; analogue of Kafka topic groups. Empty by default (single-topic listener).
+    /// </summary>
+    internal List<string> AdditionalTopics { get; } = new();
+
+    /// <summary>
+    ///     When set, the listener subscribes to every topic matching this regex pattern instead of an
+    ///     explicit topic (or topic list). Pulsar pattern subscription.
+    /// </summary>
+    internal Regex? TopicsPattern { get; set; }
+
+    /// <summary>
+    ///     Which topics a <see cref="TopicsPattern"/> subscription matches (persistent, non-persistent,
+    ///     or all). Defaults to persistent-only.
+    /// </summary>
+    internal RegexSubscriptionMode RegexSubscriptionMode { get; set; } = RegexSubscriptionMode.Persistent;
+
+    /// <summary>
+    ///     The full set of native topic paths this listener subscribes to explicitly: the primary topic
+    ///     plus any <see cref="AdditionalTopics"/>. Not used when <see cref="TopicsPattern"/> is set.
+    /// </summary>
+    internal IReadOnlyList<string> AllTopicPaths() => [PulsarTopic(), .. AdditionalTopics];
 
     public bool EnableRequeue { get; internal set; } = true;
     public bool UnsubscribeOnClose { get; internal set; } = true;

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -49,12 +49,29 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
 
         var combined = CancellationTokenSource.CreateLinkedTokenSource(_cancellation, _localCancellation.Token);
 
-        _consumer = transport.Client!.NewConsumer()
+        var consumerBuilder = transport.Client!.NewConsumer()
             .SubscriptionName(endpoint.SubscriptionName)
             .SubscriptionType(endpoint.SubscriptionType)
-            .InitialPosition(endpoint.SubscriptionInitialPosition)
-            .Topic(endpoint.PulsarTopic())
-            .Create();
+            .InitialPosition(endpoint.SubscriptionInitialPosition);
+
+        if (endpoint.TopicsPattern is not null)
+        {
+            // Pattern subscription: consume every topic matching the regex.
+            consumerBuilder = consumerBuilder
+                .TopicsPattern(endpoint.TopicsPattern)
+                .RegexSubscriptionMode(endpoint.RegexSubscriptionMode);
+        }
+        else if (endpoint.AdditionalTopics.Count > 0)
+        {
+            // Multi-topic subscription: one consumer over the primary + additional topics.
+            consumerBuilder = consumerBuilder.Topics(endpoint.AllTopicPaths());
+        }
+        else
+        {
+            consumerBuilder = consumerBuilder.Topic(endpoint.PulsarTopic());
+        }
+
+        _consumer = consumerBuilder.Create();
 
         // Per-endpoint-override-wins resolution (endpoint override, else transport default).
         NativeDeadLetterQueueEnabled = endpoint.EffectiveDeadLetterTopic is not null &&

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using DotPulsar;
 using DotPulsar.Abstractions;
 using JasperFx.Core.Reflection;
@@ -243,6 +244,54 @@ public class PulsarListenerConfiguration : InteroperableListenerConfiguration<Pu
     public PulsarListenerConfiguration BeginAtLatest()
     {
         add(e => { e.SubscriptionInitialPosition = DotPulsar.SubscriptionInitialPosition.Latest; });
+        return this;
+    }
+
+    /// <summary>
+    /// Have this single listener consume from one or more additional Pulsar topics alongside the
+    /// primary topic it was created with. Pulsar supports a single consumer over multiple topics;
+    /// this is the analogue of Kafka topic groups. Each value is a full native topic path, e.g.
+    /// <c>persistent://public/default/other</c>.
+    /// </summary>
+    /// <param name="additionalTopicPaths"></param>
+    /// <returns></returns>
+    public PulsarListenerConfiguration Topics(params string[] additionalTopicPaths)
+    {
+        // Validate eagerly so a malformed topic path fails at configuration time with a clear error.
+        foreach (var path in additionalTopicPaths)
+        {
+            _ = PulsarEndpointUri.Topic(path);
+        }
+
+        add(e =>
+        {
+            foreach (var path in additionalTopicPaths)
+            {
+                if (path != e.PulsarTopic() && !e.AdditionalTopics.Contains(path))
+                {
+                    e.AdditionalTopics.Add(path);
+                }
+            }
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Subscribe this listener to every topic matching <paramref name="pattern"/> (Pulsar pattern
+    /// subscription) rather than an explicit topic or topic list. The topic the listener was created
+    /// with is used only as the Wolverine endpoint identity.
+    /// </summary>
+    /// <param name="pattern">Regex matched against native topic paths within the namespace.</param>
+    /// <param name="mode">Which topics the pattern matches (persistent / non-persistent / all).</param>
+    /// <returns></returns>
+    public PulsarListenerConfiguration TopicsPattern(Regex pattern,
+        RegexSubscriptionMode mode = RegexSubscriptionMode.Persistent)
+    {
+        add(e =>
+        {
+            e.TopicsPattern = pattern;
+            e.RegexSubscriptionMode = mode;
+        });
         return this;
     }
 


### PR DESCRIPTION
Part of the Pulsar re-evaluation epic #3176. Fixes #3181.

A single Pulsar listener can now consume from multiple explicit topics, or from every topic matching a regex pattern — the Pulsar analogue of Kafka topic groups.

## Changes
- `PulsarEndpoint`: `AdditionalTopics` (+ `AllTopicPaths()`), `TopicsPattern`, `RegexSubscriptionMode`.
- `PulsarListener` builds the consumer with `.Topics(...)` (explicit list), `.TopicsPattern(...).RegexSubscriptionMode(...)` (pattern), or `.Topic(...)` (single-topic default).
- `PulsarListenerConfiguration`: `Topics(params string[])` and `TopicsPattern(Regex, RegexSubscriptionMode = Persistent)`. When a pattern is set it takes precedence; the primary topic is then only the Wolverine endpoint identity.

## Tests
- Config unit tests (additional topics dedupe the primary; pattern + mode set; malformed paths rejected eagerly).
- Integration: an explicit two-topic listener receives from both; a regex pattern listener receives from all matching topics.

## Docs
New "Multi-Topic & Pattern Subscriptions" section in the Pulsar guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)