### PR TITLE
NServiceBus SQL Server transport interop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,18 @@ Valid handler method names: `Handle`, `HandleAsync`, `Consume`, `ConsumeAsync` (
 
 Handlers are discovered by scanning assemblies. Use attributes like `[WolverineHandler]`, `[WolverineMessage]`, `[WolverineIgnore]` to control discovery.
 
+## Naming conventions
+
+Member casing is driven by **accessibility**, not by member kind:
+
+- **`internal` and `public` members** (methods, properties, events, constants) use **PascalCase**.
+- **`private` and `protected` members** (methods, properties) use **camelCase** — e.g. `buildSenderIfMissing()`,
+  `writeOutgoingHeader()`, `tableExistsAsync()`. This includes `private static` helper methods.
+- Private/protected **fields** keep the conventional leading underscore + camelCase (`_sender`, `_queueTable`).
+
+When in doubt, match the surrounding file. Examples: `EnvelopeMapper` (`buildIncoming`/`buildOutgoing` private vs
+`MapProperty`/`ReceivesMessage` public), `SqlServerQueue` (`buildSenderIfMissing` private vs `SendAsync` public).
+
 ## Performance conventions
 
 ### Use `ImHashMap` for hot-path dictionary lookups

--- a/docs/guide/durability/sqlserver.md
+++ b/docs/guide/durability/sqlserver.md
@@ -192,6 +192,57 @@ _listener = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/SqlServerTests/Transport/with_multiple_hosts.cs#L21-L56' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sql_server_as_queue_between_two_apps' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## NServiceBus Interoperability <Badge type="tip" text="6.0" />
+
+Wolverine can exchange messages with an [NServiceBus](https://particular.net/nservicebus) endpoint that uses the
+[SQL Server transport](https://docs.particular.net/transports/sql/) by reading and writing the NServiceBus queue
+tables directly. This is Particular's documented
+[native integration](https://docs.particular.net/transports/sql/native-integration) contract: one table per queue,
+a JSON `Headers` column, and a raw `Body` column.
+
+The transport reuses Wolverine's own SQL Server message store for the durable inbox/outbox; only the *queue* tables
+belong to NServiceBus. Because NServiceBus normally owns and provisions its own tables, `AutoProvision` is **off by
+default** for these endpoints.
+
+```cs
+using Wolverine.SqlServer.Transport.NServiceBus;
+
+builder.UseWolverine(opts =>
+{
+    // Wolverine's durable inbox/outbox lives in SQL Server
+    opts.PersistMessagesWithSqlServer(connectionString, "wolverine");
+
+    // Opt into the NServiceBus SQL Server interop transport. Pass autoProvision: true only
+    // if you want Wolverine to create the queue tables itself (NServiceBus usually owns them).
+    opts.UseNServiceBusSqlServerInterop(autoProvision: false);
+
+    // Send Wolverine messages to the "nsb" NServiceBus endpoint table
+    opts.PublishMessage<OrderPlaced>().ToNServiceBusSqlServerQueue("nsb");
+
+    // Listen for messages NServiceBus sends to Wolverine's own "wolverine" table,
+    // and use it as the reply address Wolverine stamps onto outgoing messages
+    opts.ListenToNServiceBusSqlServerQueue("wolverine").UseForReplies();
+
+    // Let NServiceBus send interface-typed messages that Wolverine binds to concrete types
+    opts.Policies.RegisterInteropMessageAssembly(typeof(IMyMessageContract).Assembly);
+});
+```
+
+Wolverine translates between its `Envelope` and the NServiceBus wire format with the standard NServiceBus headers
+(`NServiceBus.EnclosedMessageTypes`, `MessageId`, `ConversationId`, `CorrelationId`, `ReplyToAddress`, `ContentType`,
+and `TimeSent`). Message-type identity is mapped two ways: outgoing messages carry their concrete type plus their
+implemented interfaces so an NServiceBus handler registered against a shared interface still binds, and incoming
+`EnclosedMessageTypes` are resolved against the assemblies you register with `RegisterInteropMessageAssembly`.
+
+::: tip
+The `Body` written by NServiceBus' JSON serializer begins with a UTF-8 byte order mark. Wolverine strips it on
+receive so the payload deserializes cleanly with either the default `System.Text.Json` or a Newtonsoft serializer.
+:::
+
+A full, runnable bidirectional example (both frameworks hosted side by side) lives in the
+[wolverine-interop](https://github.com/JasperFx/wolverine-interop) repository. See the
+[interop tutorial](/tutorials/interop) for the bigger picture.
+
 ## Lightweight Saga Usage <Badge type="tip" text="3.0" />
 
 See the details on [Lightweight Saga Storage](/guide/durability/sagas.html#lightweight-saga-storage) for more information.

--- a/docs/tutorials/interop.md
+++ b/docs/tutorials/interop.md
@@ -443,3 +443,46 @@ With CloudEvents interoperability:
 * Wolverine is again depending on [message type aliases](/guide/messages.html#message-type-name-or-alias) to "know" what message type the CloudEvents envelopes are referring to, and you might very well
   have to explicitly register message type aliases to bridge the gap between CloudEvents and your Wolverine application.
 
+
+## Interop with NServiceBus over Database Transports
+
+Besides the broker transports above, Wolverine can interoperate with NServiceBus over its
+[SQL Server transport](https://docs.particular.net/transports/sql/) by reading and writing the NServiceBus queue
+tables directly. Rather than a custom envelope mapper layered onto a shared broker, this is a dedicated transport that
+speaks Particular's documented [native integration](https://docs.particular.net/transports/sql/native-integration)
+contract — one table per queue with a JSON `Headers` column and a raw `Body` column.
+
+```cs
+using Wolverine.SqlServer.Transport.NServiceBus;
+
+builder.UseWolverine(opts =>
+{
+    // Wolverine's own durable inbox/outbox still lives in SQL Server
+    opts.PersistMessagesWithSqlServer(connectionString, "wolverine");
+
+    opts.UseNServiceBusSqlServerInterop();
+
+    // Publish to an NServiceBus endpoint's queue table
+    opts.PublishMessage<OrderPlaced>().ToNServiceBusSqlServerQueue("nsb");
+
+    // Listen to Wolverine's own queue table and use it for replies
+    opts.ListenToNServiceBusSqlServerQueue("wolverine").UseForReplies();
+
+    // Bind NServiceBus interface-typed messages to Wolverine's concrete types
+    opts.Policies.RegisterInteropMessageAssembly(typeof(IMyMessageContract).Assembly);
+});
+```
+
+A few things to note about NServiceBus database interop:
+
+* NServiceBus normally owns and provisions its own queue tables, so `AutoProvision` is **off by default** for these
+  endpoints. Pass `UseNServiceBusSqlServerInterop(autoProvision: true)` only when you want Wolverine to create them.
+* Message-type identity is mapped two ways. Outgoing messages carry the `NServiceBus.EnclosedMessageTypes` hierarchy
+  (concrete type *plus* implemented interfaces) so an NServiceBus handler registered against a shared interface still
+  binds. Incoming `EnclosedMessageTypes` are resolved against the assemblies you register with
+  `RegisterInteropMessageAssembly`.
+* Request/reply works: Wolverine stamps `NServiceBus.ReplyToAddress` from the endpoint you mark `UseForReplies()`.
+
+See the [SQL Server transport guide](/guide/durability/sqlserver.html#nservicebus-interoperability) for the full set of
+options, and the [wolverine-interop](https://github.com/JasperFx/wolverine-interop) repository for a runnable,
+bidirectional sample with both frameworks hosted side by side.

--- a/src/Persistence/SqlServerTests/Transport/NServiceBus/nservicebus_sql_server_transport_smoke.cs
+++ b/src/Persistence/SqlServerTests/Transport/NServiceBus/nservicebus_sql_server_transport_smoke.cs
@@ -1,0 +1,87 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.SqlServer;
+using Wolverine.SqlServer.Transport.NServiceBus;
+using Wolverine.Tracking;
+
+namespace SqlServerTests.Transport.NServiceBus;
+
+// Exercises the NServiceBus SQL Server interop transport end to end against a real
+// SQL Server without requiring an NServiceBus host: a publishing Wolverine app writes
+// rows into the NServiceBus-shaped queue table and a listening Wolverine app pops and
+// handles them. This validates the send INSERT, the destructive RowVersion-ordered pop,
+// and the envelope <-> (Headers + Body) mapping. True NServiceBus wire fidelity is
+// covered separately by the wolverine-interop suite.
+public class nservicebus_sql_server_transport_smoke : IAsyncLifetime
+{
+    private readonly string _queue = "nsb_interop_" + Guid.NewGuid().ToString("N");
+    private IHost _publisher = null!;
+    private IHost _receiver = null!;
+
+    public async Task InitializeAsync()
+    {
+        _publisher = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseSqlServerPersistenceAndTransport(Servers.SqlServerConnectionString, "nsbpublisher");
+                opts.UseNServiceBusSqlServerInterop(autoProvision: true);
+
+                opts.PublishMessage<NsbInteropPing>().ToNServiceBusSqlServerQueue(_queue);
+
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        _receiver = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseSqlServerPersistenceAndTransport(Servers.SqlServerConnectionString, "nsbreceiver");
+                opts.UseNServiceBusSqlServerInterop(autoProvision: true);
+
+                opts.ListenToNServiceBusSqlServerQueue(_queue);
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<NsbInteropPingHandler>();
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task round_trips_a_message_through_the_nservicebus_queue_table()
+    {
+        var id = Guid.NewGuid();
+
+        var tracked = await _publisher.TrackActivity()
+            .Timeout(30.Seconds())
+            .AlsoTrack(_receiver)
+            .WaitForMessageToBeReceivedAt<NsbInteropPing>(_receiver)
+            .SendMessageAndWaitAsync(new NsbInteropPing(id, "hello"));
+
+        var received = tracked.Received.SingleEnvelope<NsbInteropPing>();
+        received.Message.ShouldBeOfType<NsbInteropPing>().Id.ShouldBe(id);
+        received.Message.ShouldBeOfType<NsbInteropPing>().Name.ShouldBe("hello");
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _publisher.StopAsync();
+        _publisher.Dispose();
+        await _receiver.StopAsync();
+        _receiver.Dispose();
+    }
+}
+
+public record NsbInteropPing(Guid Id, string Name);
+
+public class NsbInteropPingHandler
+{
+    public static void Handle(NsbInteropPing message)
+    {
+        // handled; assertion is via tracking
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusQueueTable.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusQueueTable.cs
@@ -1,0 +1,40 @@
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+
+namespace Wolverine.SqlServer.Transport.NServiceBus;
+
+/// <summary>
+/// Weasel model of an NServiceBus SQL Server transport queue table. Mirrors the layout the
+/// NServiceBus SQL Server transport creates (including the legacy
+/// CorrelationId/ReplyToAddress/Recoverable columns the transport still probes), so that
+/// Wolverine's schema management — and the Weasel command line tooling — can create, diff,
+/// and drop these tables the same way it does its own messaging transport tables.
+/// </summary>
+internal class NServiceBusQueueTable : Table
+{
+    public NServiceBusQueueTable(DbObjectName identifier) : base(identifier)
+    {
+        AddColumn<Guid>("Id").NotNull();
+        AddColumn("CorrelationId", "varchar(255)");
+        AddColumn("ReplyToAddress", "varchar(255)");
+        AddColumn<bool>("Recoverable").NotNull();
+        AddColumn("Expires", "datetime");
+        AddColumn("Headers", "nvarchar(max)").NotNull();
+        AddColumn("Body", "varbinary(max)");
+        AddColumn<long>("RowVersion").AutoNumber().NotNull();
+
+        // NServiceBus clusters on RowVersion for FIFO receive ordering and keeps a filtered
+        // index on Expires for the expiry sweep.
+        Indexes.Add(new IndexDefinition("Index_RowVersion")
+        {
+            Columns = ["RowVersion"],
+            IsClustered = true
+        });
+
+        Indexes.Add(new IndexDefinition("Index_Expires")
+        {
+            Columns = ["Expires"],
+            Predicate = "Expires IS NOT NULL"
+        });
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerConfiguration.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerConfiguration.cs
@@ -1,0 +1,71 @@
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+
+namespace Wolverine.SqlServer.Transport.NServiceBus;
+
+public class NServiceBusSqlServerListenerConfiguration
+    : ListenerConfiguration<NServiceBusSqlServerListenerConfiguration, NServiceBusSqlServerQueue>
+{
+    public NServiceBusSqlServerListenerConfiguration(NServiceBusSqlServerQueue endpoint) : base(endpoint)
+    {
+    }
+
+    /// <summary>
+    ///     The maximum number of messages to receive in a single poll. Default is 20.
+    /// </summary>
+    public NServiceBusSqlServerListenerConfiguration MaximumMessagesToReceive(int maximum)
+    {
+        add(e => e.MaximumMessagesToReceive = maximum);
+        return this;
+    }
+
+    /// <summary>
+    ///     Configure how often to poll for new messages when the queue is idle.
+    /// </summary>
+    public NServiceBusSqlServerListenerConfiguration PollingInterval(TimeSpan interval)
+    {
+        add(e => e.PollingInterval = interval);
+        return this;
+    }
+
+    /// <summary>
+    ///     The bare NServiceBus queue/table name that foreign endpoints should reply to.
+    ///     When not set, the Wolverine endpoint marked <c>UseForReplies()</c> is used.
+    /// </summary>
+    public NServiceBusSqlServerListenerConfiguration ReplyQueueName(string queueName)
+    {
+        add(e => e.InteropReplyQueueName = queueName);
+        return this;
+    }
+
+    /// <summary>
+    ///     Add circuit breaker exception handling to this listener.
+    /// </summary>
+    public NServiceBusSqlServerListenerConfiguration CircuitBreaker(Action<CircuitBreakerOptions>? configure = null)
+    {
+        add(e =>
+        {
+            e.CircuitBreakerOptions = new CircuitBreakerOptions();
+            configure?.Invoke(e.CircuitBreakerOptions);
+        });
+        return this;
+    }
+}
+
+public class NServiceBusSqlServerSubscriberConfiguration
+    : SubscriberConfiguration<NServiceBusSqlServerSubscriberConfiguration, NServiceBusSqlServerQueue>
+{
+    public NServiceBusSqlServerSubscriberConfiguration(NServiceBusSqlServerQueue endpoint) : base(endpoint)
+    {
+    }
+
+    /// <summary>
+    ///     The bare NServiceBus queue/table name that the receiving endpoint should reply to.
+    ///     When not set, the Wolverine endpoint marked <c>UseForReplies()</c> is used.
+    /// </summary>
+    public NServiceBusSqlServerSubscriberConfiguration ReplyQueueName(string queueName)
+    {
+        add(e => e.InteropReplyQueueName = queueName);
+        return this;
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerEnvelopeMapper.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerEnvelopeMapper.cs
@@ -1,0 +1,192 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Wolverine.Util;
+using Endpoint = Wolverine.Configuration.Endpoint;
+
+namespace Wolverine.SqlServer.Transport.NServiceBus;
+
+[JsonSerializable(typeof(Dictionary<string, string>))]
+internal partial class NServiceBusSqlJsonContext : JsonSerializerContext;
+
+/// <summary>
+/// Translates between Wolverine <see cref="Envelope"/>s and the NServiceBus SQL transport
+/// wire shape: a queue table row carrying a JSON <c>Headers</c> dictionary and a raw
+/// <c>Body</c> payload. This is the documented, Particular-sanctioned "native integration"
+/// contract for the SQL Server transport.
+/// </summary>
+/// <remarks>
+/// The mapping deliberately mirrors the existing broker interop mappers
+/// (<c>NServiceBusEnvelopeMapper</c> in Wolverine.AmazonSns / the RabbitMQ NServiceBus
+/// interop) so that the same header conventions hold across every NServiceBus interop
+/// transport. The body is left as raw bytes and run through Wolverine's normal serializer
+/// negotiation so the receiving handler deserializes it like any other message.
+/// </remarks>
+internal class NServiceBusSqlServerEnvelopeMapper
+{
+    // The minimal NSB header set documented for native integration.
+    public const string MessageIdHeader = "NServiceBus.MessageId";
+    public const string ConversationIdHeader = "NServiceBus.ConversationId";
+    public const string CorrelationIdHeader = "NServiceBus.CorrelationId";
+    public const string ReplyToAddressHeader = "NServiceBus.ReplyToAddress";
+    public const string MessageIntentHeader = "NServiceBus.MessageIntent";
+    public const string ContentTypeHeader = "NServiceBus.ContentType";
+    public const string TimeSentHeader = "NServiceBus.TimeSent";
+    public const string EnclosedMessageTypesHeader = "NServiceBus.EnclosedMessageTypes";
+
+    // NServiceBus formats NServiceBus.TimeSent with this exact pattern.
+    private const string TimeSentFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
+
+    private readonly Endpoint _endpoint;
+    private readonly Func<string?> _replyAddress;
+
+    public NServiceBusSqlServerEnvelopeMapper(Endpoint endpoint, Func<string?> replyAddress)
+    {
+        _endpoint = endpoint;
+        _replyAddress = replyAddress;
+    }
+
+    /// <summary>
+    /// Build the row values written to the NServiceBus queue table for an outgoing envelope.
+    /// </summary>
+    public OutgoingRow MapOutgoing(Envelope envelope)
+    {
+        var serializer = envelope.Serializer ?? _endpoint.DefaultSerializer
+            ?? throw new InvalidOperationException("No serializer is configured for this endpoint");
+
+        var body = envelope.Data ?? serializer.WriteMessage(envelope.Message!);
+        var contentType = envelope.ContentType ?? serializer.ContentType;
+
+        // Pass through any "extra" Wolverine headers so they survive a round trip.
+        var headers = new Dictionary<string, string>();
+        foreach (var pair in envelope.Headers)
+        {
+            if (pair.Value != null)
+            {
+                headers[pair.Key] = pair.Value;
+            }
+        }
+
+        headers[MessageIdHeader] = envelope.Id.ToString();
+        headers[ConversationIdHeader] = (envelope.ConversationId == Guid.Empty ? envelope.Id : envelope.ConversationId).ToString();
+        headers[MessageIntentHeader] = "Send";
+        headers[ContentTypeHeader] = contentType;
+        headers[TimeSentHeader] = envelope.SentAt.ToUniversalTime().ToString(TimeSentFormat, CultureInfo.InvariantCulture);
+
+        if (envelope.CorrelationId.IsNotEmpty())
+        {
+            headers[CorrelationIdHeader] = envelope.CorrelationId!;
+        }
+
+        var replyAddress = _replyAddress();
+        if (replyAddress.IsNotEmpty())
+        {
+            headers[ReplyToAddressHeader] = replyAddress!;
+        }
+
+        if (envelope.Message != null)
+        {
+            headers[EnclosedMessageTypesHeader] = ToEnclosedMessageType(envelope.Message.GetType());
+        }
+        else if (envelope.MessageType.IsNotEmpty())
+        {
+            headers[EnclosedMessageTypesHeader] = envelope.MessageType!;
+        }
+
+        var json = JsonSerializer.Serialize(headers, NServiceBusSqlJsonContext.Default.DictionaryStringString);
+
+        return new OutgoingRow(envelope.Id, json, body, envelope.DeliverBy);
+    }
+
+    /// <summary>
+    /// Hydrate an <see cref="Envelope"/> from a row read off the NServiceBus queue table.
+    /// </summary>
+    public Envelope MapIncoming(Guid id, string? headersJson, byte[] body)
+    {
+        var envelope = new Envelope { Data = body };
+
+        var headers = headersJson.IsNotEmpty()
+            ? JsonSerializer.Deserialize(headersJson!, NServiceBusSqlJsonContext.Default.DictionaryStringString) ?? new()
+            : new Dictionary<string, string>();
+
+        envelope.Id = ReadGuid(headers, MessageIdHeader) ?? id;
+        if (envelope.Id == Guid.Empty) envelope.Id = id;
+
+        var conversationId = ReadGuid(headers, ConversationIdHeader);
+        if (conversationId.HasValue) envelope.ConversationId = conversationId.Value;
+
+        if (headers.TryGetValue(CorrelationIdHeader, out var correlationId))
+        {
+            envelope.CorrelationId = correlationId;
+        }
+
+        if (headers.TryGetValue(ReplyToAddressHeader, out var replyTo) && replyTo.IsNotEmpty())
+        {
+            envelope.ReplyUri = NServiceBusSqlServerQueue.ToUri(NormalizeAddress(replyTo));
+        }
+
+        if (headers.TryGetValue(ContentTypeHeader, out var contentType) && contentType.IsNotEmpty())
+        {
+            envelope.ContentType = contentType;
+        }
+
+        if (headers.TryGetValue(TimeSentHeader, out var timeSent)
+            && DateTimeOffset.TryParse(timeSent, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var sentAt))
+        {
+            envelope.SentAt = sentAt;
+        }
+
+        if (headers.TryGetValue(EnclosedMessageTypesHeader, out var enclosed) && enclosed.IsNotEmpty())
+        {
+            envelope.MessageType = ResolveMessageType(enclosed);
+        }
+
+        envelope.Serializer = _endpoint.TryFindSerializer(envelope.ContentType) ?? _endpoint.DefaultSerializer;
+
+        return envelope;
+    }
+
+    // NServiceBus addresses take the form "table@schema@catalog"; we only care about the table/queue name.
+    private static string NormalizeAddress(string address)
+    {
+        var at = address.IndexOf('@');
+        return at >= 0 ? address[..at] : address;
+    }
+
+    private static string ToEnclosedMessageType(Type type)
+    {
+        // NServiceBus resolves enclosed message types via Type.GetType; emit a
+        // "FullName, AssemblyName" form so the foreign endpoint can bind the handler.
+        return $"{type.FullName}, {type.Assembly.GetName().Name}";
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2057",
+        Justification =
+            "The enclosed message type name comes from a foreign NServiceBus endpoint at runtime; a failed resolution falls back to the bare type name which Wolverine binds via RegisterInteropMessageAssembly.")]
+    private static string ResolveMessageType(string enclosed)
+    {
+        // NServiceBus may list several types separated by ';' (concrete + interfaces).
+        // The first entry is the most-derived concrete type.
+        var first = enclosed.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).First();
+
+        var type = Type.GetType(first);
+        if (type != null)
+        {
+            return type.ToMessageTypeName();
+        }
+
+        // Fall back to the bare type name; Wolverine's interop assembly registration
+        // (RegisterInteropMessageAssembly) can still bind it to a concrete handler.
+        return first.Split(',', StringSplitOptions.TrimEntries).First();
+    }
+
+    private static Guid? ReadGuid(IReadOnlyDictionary<string, string> headers, string key)
+    {
+        return headers.TryGetValue(key, out var raw) && Guid.TryParse(raw, out var value) ? value : null;
+    }
+
+    internal readonly record struct OutgoingRow(Guid Id, string Headers, byte[] Body, DateTimeOffset? Expires);
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerEnvelopeMapper.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerEnvelopeMapper.cs
@@ -159,11 +159,21 @@ internal class NServiceBusSqlServerEnvelopeMapper
         return at >= 0 ? address[..at] : address;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification =
+            "Reflecting over the interfaces of a live message instance's runtime type for NServiceBus interop; the type and its interfaces are present at runtime.")]
     private static string ToEnclosedMessageType(Type type)
     {
-        // NServiceBus resolves enclosed message types via Type.GetType; emit a
-        // "FullName, AssemblyName" form so the foreign endpoint can bind the handler.
-        return $"{type.FullName}, {type.Assembly.GetName().Name}";
+        // NServiceBus keys handler dispatch off NServiceBus.EnclosedMessageTypes, a
+        // ';'-separated, most-derived-first list of the message's type hierarchy. Emit the
+        // concrete type plus its implemented interfaces so that a Wolverine message defined
+        // in one assembly can still bind to an NServiceBus handler registered against a
+        // shared interface (e.g. IHandleMessages<ISomeInterface>) living in another.
+        var names = new List<string> { Format(type) };
+        names.AddRange(type.GetInterfaces().Select(Format));
+        return string.Join(";", names);
+
+        static string Format(Type t) => $"{t.FullName}, {t.Assembly.GetName().Name}";
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2057",
@@ -171,19 +181,24 @@ internal class NServiceBusSqlServerEnvelopeMapper
             "The enclosed message type name comes from a foreign NServiceBus endpoint at runtime; a failed resolution falls back to the bare type name which Wolverine binds via RegisterInteropMessageAssembly.")]
     private static string ResolveMessageType(string enclosed)
     {
-        // NServiceBus may list several types separated by ';' (concrete + interfaces).
-        // The first entry is the most-derived concrete type.
-        var first = enclosed.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).First();
+        // NServiceBus lists several types separated by ';' (concrete + interfaces),
+        // most-derived first. Use the first entry that resolves to a type loadable in this
+        // process; that is the one Wolverine can map to a handler (directly or via the
+        // RegisterInteropMessageAssembly interface->concrete binding).
+        var entries = enclosed.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-        var type = Type.GetType(first);
-        if (type != null)
+        foreach (var entry in entries)
         {
-            return type.ToMessageTypeName();
+            var type = Type.GetType(entry);
+            if (type != null)
+            {
+                return type.ToMessageTypeName();
+            }
         }
 
         // Fall back to the bare type name; Wolverine's interop assembly registration
-        // (RegisterInteropMessageAssembly) can still bind it to a concrete handler.
-        return first.Split(',', StringSplitOptions.TrimEntries).First();
+        // can still bind it to a concrete handler.
+        return entries.First().Split(',', StringSplitOptions.TrimEntries).First();
     }
 
     private static byte[] StripUtf8Bom(byte[] body)

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerEnvelopeMapper.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerEnvelopeMapper.cs
@@ -106,7 +106,10 @@ internal class NServiceBusSqlServerEnvelopeMapper
     /// </summary>
     public Envelope MapIncoming(Guid id, string? headersJson, byte[] body)
     {
-        var envelope = new Envelope { Data = body };
+        // NServiceBus' JSON serializer prefixes the body with a UTF-8 BOM, which
+        // System.Text.Json rejects ('0xEF' is an invalid start of a value). Strip it so
+        // the configured serializer can read the payload.
+        var envelope = new Envelope { Data = StripUtf8Bom(body) };
 
         var headers = headersJson.IsNotEmpty()
             ? JsonSerializer.Deserialize(headersJson!, NServiceBusSqlJsonContext.Default.DictionaryStringString) ?? new()
@@ -181,6 +184,13 @@ internal class NServiceBusSqlServerEnvelopeMapper
         // Fall back to the bare type name; Wolverine's interop assembly registration
         // (RegisterInteropMessageAssembly) can still bind it to a concrete handler.
         return first.Split(',', StringSplitOptions.TrimEntries).First();
+    }
+
+    private static byte[] StripUtf8Bom(byte[] body)
+    {
+        return body.Length >= 3 && body[0] == 0xEF && body[1] == 0xBB && body[2] == 0xBF
+            ? body[3..]
+            : body;
     }
 
     private static Guid? ReadGuid(IReadOnlyDictionary<string, string> headers, string key)

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerEnvelopeMapper.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerEnvelopeMapper.cs
@@ -89,7 +89,7 @@ internal class NServiceBusSqlServerEnvelopeMapper
 
         if (envelope.Message != null)
         {
-            headers[EnclosedMessageTypesHeader] = ToEnclosedMessageType(envelope.Message.GetType());
+            headers[EnclosedMessageTypesHeader] = toEnclosedMessageType(envelope.Message.GetType());
         }
         else if (envelope.MessageType.IsNotEmpty())
         {
@@ -109,16 +109,16 @@ internal class NServiceBusSqlServerEnvelopeMapper
         // NServiceBus' JSON serializer prefixes the body with a UTF-8 BOM, which
         // System.Text.Json rejects ('0xEF' is an invalid start of a value). Strip it so
         // the configured serializer can read the payload.
-        var envelope = new Envelope { Data = StripUtf8Bom(body) };
+        var envelope = new Envelope { Data = stripUtf8Bom(body) };
 
         var headers = headersJson.IsNotEmpty()
             ? JsonSerializer.Deserialize(headersJson!, NServiceBusSqlJsonContext.Default.DictionaryStringString) ?? new()
             : new Dictionary<string, string>();
 
-        envelope.Id = ReadGuid(headers, MessageIdHeader) ?? id;
+        envelope.Id = readGuid(headers, MessageIdHeader) ?? id;
         if (envelope.Id == Guid.Empty) envelope.Id = id;
 
-        var conversationId = ReadGuid(headers, ConversationIdHeader);
+        var conversationId = readGuid(headers, ConversationIdHeader);
         if (conversationId.HasValue) envelope.ConversationId = conversationId.Value;
 
         if (headers.TryGetValue(CorrelationIdHeader, out var correlationId))
@@ -128,7 +128,7 @@ internal class NServiceBusSqlServerEnvelopeMapper
 
         if (headers.TryGetValue(ReplyToAddressHeader, out var replyTo) && replyTo.IsNotEmpty())
         {
-            envelope.ReplyUri = NServiceBusSqlServerQueue.ToUri(NormalizeAddress(replyTo));
+            envelope.ReplyUri = NServiceBusSqlServerQueue.ToUri(normalizeAddress(replyTo));
         }
 
         if (headers.TryGetValue(ContentTypeHeader, out var contentType) && contentType.IsNotEmpty())
@@ -144,7 +144,7 @@ internal class NServiceBusSqlServerEnvelopeMapper
 
         if (headers.TryGetValue(EnclosedMessageTypesHeader, out var enclosed) && enclosed.IsNotEmpty())
         {
-            envelope.MessageType = ResolveMessageType(enclosed);
+            envelope.MessageType = resolveMessageType(enclosed);
         }
 
         envelope.Serializer = _endpoint.TryFindSerializer(envelope.ContentType) ?? _endpoint.DefaultSerializer;
@@ -153,7 +153,7 @@ internal class NServiceBusSqlServerEnvelopeMapper
     }
 
     // NServiceBus addresses take the form "table@schema@catalog"; we only care about the table/queue name.
-    private static string NormalizeAddress(string address)
+    private static string normalizeAddress(string address)
     {
         var at = address.IndexOf('@');
         return at >= 0 ? address[..at] : address;
@@ -162,24 +162,24 @@ internal class NServiceBusSqlServerEnvelopeMapper
     [UnconditionalSuppressMessage("Trimming", "IL2070",
         Justification =
             "Reflecting over the interfaces of a live message instance's runtime type for NServiceBus interop; the type and its interfaces are present at runtime.")]
-    private static string ToEnclosedMessageType(Type type)
+    private static string toEnclosedMessageType(Type type)
     {
         // NServiceBus keys handler dispatch off NServiceBus.EnclosedMessageTypes, a
         // ';'-separated, most-derived-first list of the message's type hierarchy. Emit the
         // concrete type plus its implemented interfaces so that a Wolverine message defined
         // in one assembly can still bind to an NServiceBus handler registered against a
         // shared interface (e.g. IHandleMessages<ISomeInterface>) living in another.
-        var names = new List<string> { Format(type) };
-        names.AddRange(type.GetInterfaces().Select(Format));
+        var names = new List<string> { format(type) };
+        names.AddRange(type.GetInterfaces().Select(format));
         return string.Join(";", names);
 
-        static string Format(Type t) => $"{t.FullName}, {t.Assembly.GetName().Name}";
+        static string format(Type t) => $"{t.FullName}, {t.Assembly.GetName().Name}";
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2057",
         Justification =
             "The enclosed message type name comes from a foreign NServiceBus endpoint at runtime; a failed resolution falls back to the bare type name which Wolverine binds via RegisterInteropMessageAssembly.")]
-    private static string ResolveMessageType(string enclosed)
+    private static string resolveMessageType(string enclosed)
     {
         // NServiceBus lists several types separated by ';' (concrete + interfaces),
         // most-derived first. Use the first entry that resolves to a type loadable in this
@@ -201,14 +201,14 @@ internal class NServiceBusSqlServerEnvelopeMapper
         return entries.First().Split(',', StringSplitOptions.TrimEntries).First();
     }
 
-    private static byte[] StripUtf8Bom(byte[] body)
+    private static byte[] stripUtf8Bom(byte[] body)
     {
         return body.Length >= 3 && body[0] == 0xEF && body[1] == 0xBB && body[2] == 0xBF
             ? body[3..]
             : body;
     }
 
-    private static Guid? ReadGuid(IReadOnlyDictionary<string, string> headers, string key)
+    private static Guid? readGuid(IReadOnlyDictionary<string, string> headers, string key)
     {
         return headers.TryGetValue(key, out var raw) && Guid.TryParse(raw, out var value) ? value : null;
     }

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueue.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueue.cs
@@ -216,8 +216,8 @@ BEGIN
         Body varbinary(max),
         RowVersion bigint IDENTITY(1,1) NOT NULL
     );
-    CREATE NONCLUSTERED INDEX [Index_RowVersion] ON {TableIdentifier} (RowVersion);
-    CREATE CLUSTERED INDEX [Index_Expires] ON {TableIdentifier} (Expires) WHERE Expires IS NOT NULL;
+    CREATE CLUSTERED INDEX [Index_RowVersion] ON {TableIdentifier} (RowVersion);
+    CREATE NONCLUSTERED INDEX [Index_Expires] ON {TableIdentifier} (Expires) WHERE Expires IS NOT NULL;
 END";
     }
 }

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueue.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueue.cs
@@ -1,7 +1,9 @@
 using JasperFx.Core;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+using Weasel.Core;
 using Weasel.SqlServer;
+using Weasel.SqlServer.Tables;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Transports;
@@ -18,6 +20,7 @@ public class NServiceBusSqlServerQueue : Endpoint, IBrokerQueue
 
     private NServiceBusSqlServerEnvelopeMapper? _mapper;
     private NServiceBusSqlServerQueueSender? _sender;
+    private readonly Lazy<NServiceBusQueueTable> _queueTable;
 
     public NServiceBusSqlServerQueue(string name, NServiceBusSqlServerTransport parent,
         EndpointRole role = EndpointRole.Application) : base(ToUri(name), role)
@@ -31,6 +34,10 @@ public class NServiceBusSqlServerQueue : Endpoint, IBrokerQueue
         // Wolverine's durable inbox/outbox table layout, so run buffered like the broker
         // interop transports do.
         Mode = EndpointMode.BufferedInMemory;
+
+        // Lazy so the transport schema name is settled before the table identifier is built.
+        _queueTable = new Lazy<NServiceBusQueueTable>(
+            () => new NServiceBusQueueTable(new DbObjectName(Parent.SchemaName, Name)));
     }
 
     public string Name { get; }
@@ -55,7 +62,13 @@ public class NServiceBusSqlServerQueue : Endpoint, IBrokerQueue
     /// </summary>
     public TimeSpan? PollingInterval { get; set; }
 
-    internal string TableIdentifier => $"[{Parent.SchemaName}].[{Name}]";
+    /// <summary>
+    /// The Weasel model of the NServiceBus queue table. Used for all schema management and as
+    /// the single source of truth for the table name in the send/receive DML.
+    /// </summary>
+    internal Table QueueTable => _queueTable.Value;
+
+    internal DbObjectName TableIdentifier => QueueTable.Identifier;
 
     protected override bool supportsMode(EndpointMode mode)
     {
@@ -108,16 +121,16 @@ public class NServiceBusSqlServerQueue : Endpoint, IBrokerQueue
         }
     }
 
+    // IBrokerQueue.CheckAsync compares the live table against the Weasel model. Used by the
+    // resource model / db-assert; not on the message hot path.
     public async ValueTask<bool> CheckAsync()
     {
         await using var conn = new SqlConnection(Parent.Settings.ConnectionString);
         await conn.OpenAsync();
         try
         {
-            await using var cmd = conn.CreateCommand(
-                $"SELECT CASE WHEN OBJECT_ID(N'{Parent.SchemaName}.{Name}', N'U') IS NULL THEN 0 ELSE 1 END");
-            var exists = (int)(await cmd.ExecuteScalarAsync())!;
-            return exists == 1;
+            var delta = await QueueTable.FindDeltaAsync(conn);
+            return !delta.HasChanges();
         }
         finally
         {
@@ -131,12 +144,7 @@ public class NServiceBusSqlServerQueue : Endpoint, IBrokerQueue
         await conn.OpenAsync();
         try
         {
-            await using var schemaCmd = conn.CreateCommand(
-                $"IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{Parent.SchemaName}') EXEC('CREATE SCHEMA [{Parent.SchemaName}]')");
-            await schemaCmd.ExecuteNonQueryAsync();
-
-            await using var cmd = conn.CreateCommand(CreateTableSql());
-            await cmd.ExecuteNonQueryAsync();
+            await QueueTable.ApplyChangesAsync(conn);
         }
         finally
         {
@@ -150,8 +158,7 @@ public class NServiceBusSqlServerQueue : Endpoint, IBrokerQueue
         await conn.OpenAsync();
         try
         {
-            await using var cmd = conn.CreateCommand($"DROP TABLE IF EXISTS {TableIdentifier}");
-            await cmd.ExecuteNonQueryAsync();
+            await QueueTable.Drop(conn);
         }
         finally
         {
@@ -161,12 +168,12 @@ public class NServiceBusSqlServerQueue : Endpoint, IBrokerQueue
 
     public async ValueTask PurgeAsync(ILogger logger)
     {
-        if (!await CheckAsync()) return;
-
         await using var conn = new SqlConnection(Parent.Settings.ConnectionString);
         await conn.OpenAsync();
         try
         {
+            if (!await tableExistsAsync(conn)) return;
+
             await using var cmd = conn.CreateCommand($"DELETE FROM {TableIdentifier}");
             await cmd.ExecuteNonQueryAsync();
         }
@@ -184,12 +191,12 @@ public class NServiceBusSqlServerQueue : Endpoint, IBrokerQueue
 
     public async Task<long> CountAsync()
     {
-        if (!await CheckAsync()) return 0;
-
         await using var conn = new SqlConnection(Parent.Settings.ConnectionString);
         await conn.OpenAsync();
         try
         {
+            if (!await tableExistsAsync(conn)) return 0;
+
             await using var cmd = conn.CreateCommand($"SELECT COUNT(*) FROM {TableIdentifier}");
             return (int)(await cmd.ExecuteScalarAsync())!;
         }
@@ -199,25 +206,28 @@ public class NServiceBusSqlServerQueue : Endpoint, IBrokerQueue
         }
     }
 
-    // Matches the NServiceBus SQL Server transport queue table layout, including the
-    // legacy CorrelationId/ReplyToAddress/Recoverable columns the transport still probes.
-    private string CreateTableSql()
+    /// <summary>
+    /// Lightweight existence probe (a read, not a schema change) used to guard runtime DML and
+    /// the sender ping. Schema creation/migration goes through <see cref="SetupAsync"/> / Weasel.
+    /// </summary>
+    internal async Task<bool> ExistsAsync()
     {
-        return $@"
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{Parent.SchemaName}.{Name}') AND type = 'U')
-BEGIN
-    CREATE TABLE {TableIdentifier} (
-        Id uniqueidentifier NOT NULL,
-        CorrelationId varchar(255),
-        ReplyToAddress varchar(255),
-        Recoverable bit NOT NULL,
-        Expires datetime,
-        Headers nvarchar(max) NOT NULL,
-        Body varbinary(max),
-        RowVersion bigint IDENTITY(1,1) NOT NULL
-    );
-    CREATE CLUSTERED INDEX [Index_RowVersion] ON {TableIdentifier} (RowVersion);
-    CREATE NONCLUSTERED INDEX [Index_Expires] ON {TableIdentifier} (Expires) WHERE Expires IS NOT NULL;
-END";
+        await using var conn = new SqlConnection(Parent.Settings.ConnectionString);
+        await conn.OpenAsync();
+        try
+        {
+            return await tableExistsAsync(conn);
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    private async Task<bool> tableExistsAsync(SqlConnection conn)
+    {
+        await using var cmd = conn.CreateCommand("SELECT CASE WHEN OBJECT_ID(@name, N'U') IS NULL THEN 0 ELSE 1 END")
+            .With("name", TableIdentifier.QualifiedName);
+        return (int)(await cmd.ExecuteScalarAsync())! == 1;
     }
 }

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueue.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueue.cs
@@ -1,0 +1,223 @@
+using JasperFx.Core;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Weasel.SqlServer;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.SqlServer.Transport.NServiceBus;
+
+public class NServiceBusSqlServerQueue : Endpoint, IBrokerQueue
+{
+    internal static Uri ToUri(string name)
+    {
+        return new Uri($"{NServiceBusSqlServerTransport.ProtocolName}://{name}");
+    }
+
+    private NServiceBusSqlServerEnvelopeMapper? _mapper;
+    private NServiceBusSqlServerQueueSender? _sender;
+
+    public NServiceBusSqlServerQueue(string name, NServiceBusSqlServerTransport parent,
+        EndpointRole role = EndpointRole.Application) : base(ToUri(name), role)
+    {
+        Parent = parent;
+        Name = name;
+        EndpointName = name;
+        BrokerRole = "queue";
+
+        // Interop endpoints exchange the foreign wire format; they cannot participate in
+        // Wolverine's durable inbox/outbox table layout, so run buffered like the broker
+        // interop transports do.
+        Mode = EndpointMode.BufferedInMemory;
+    }
+
+    public string Name { get; }
+
+    internal NServiceBusSqlServerTransport Parent { get; }
+
+    /// <summary>
+    /// The bare queue/table name that NServiceBus should reply to. Set by
+    /// <c>UseNServiceBusInterop(replyQueueName)</c>; when null the configured Wolverine
+    /// reply endpoint name is used.
+    /// </summary>
+    public string? InteropReplyQueueName { get; set; }
+
+    /// <summary>
+    ///     The maximum number of messages to receive in a single poll. Default is 20.
+    /// </summary>
+    public int MaximumMessagesToReceive { get; set; } = 20;
+
+    /// <summary>
+    ///     How often to poll for new messages when the queue is idle. If null, falls back to
+    ///     DurabilitySettings.ScheduledJobPollingTime (default 5s).
+    /// </summary>
+    public TimeSpan? PollingInterval { get; set; }
+
+    internal string TableIdentifier => $"[{Parent.SchemaName}].[{Name}]";
+
+    protected override bool supportsMode(EndpointMode mode)
+    {
+        return mode == EndpointMode.BufferedInMemory || mode == EndpointMode.Inline;
+    }
+
+    internal NServiceBusSqlServerEnvelopeMapper BuildMapper(IWolverineRuntime runtime)
+    {
+        if (_mapper != null) return _mapper;
+
+        DefaultSerializer ??= runtime.Options.DefaultSerializer;
+
+        var replyName = new Lazy<string?>(() =>
+        {
+            if (InteropReplyQueueName.IsNotEmpty()) return InteropReplyQueueName;
+            return Parent.ReplyEndpoint()?.EndpointName;
+        });
+
+        _mapper = new NServiceBusSqlServerEnvelopeMapper(this, () => replyName.Value);
+        return _mapper;
+    }
+
+    public override async ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+    {
+        if (Parent.AutoProvision)
+        {
+            await SetupAsync(runtime.LoggerFactory.CreateLogger<NServiceBusSqlServerQueue>());
+        }
+
+        var listener = new NServiceBusSqlServerQueueListener(this, runtime, receiver);
+        await listener.StartAsync();
+        return listener;
+    }
+
+    protected override ISender CreateSender(IWolverineRuntime runtime)
+    {
+        return _sender ??= new NServiceBusSqlServerQueueSender(this, runtime);
+    }
+
+    public override async ValueTask InitializeAsync(ILogger logger)
+    {
+        if (Parent.AutoProvision)
+        {
+            await SetupAsync(logger);
+        }
+
+        if (Parent.AutoPurgeAllQueues)
+        {
+            await PurgeAsync(logger);
+        }
+    }
+
+    public async ValueTask<bool> CheckAsync()
+    {
+        await using var conn = new SqlConnection(Parent.Settings.ConnectionString);
+        await conn.OpenAsync();
+        try
+        {
+            await using var cmd = conn.CreateCommand(
+                $"SELECT CASE WHEN OBJECT_ID(N'{Parent.SchemaName}.{Name}', N'U') IS NULL THEN 0 ELSE 1 END");
+            var exists = (int)(await cmd.ExecuteScalarAsync())!;
+            return exists == 1;
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    public async ValueTask SetupAsync(ILogger logger)
+    {
+        await using var conn = new SqlConnection(Parent.Settings.ConnectionString);
+        await conn.OpenAsync();
+        try
+        {
+            await using var schemaCmd = conn.CreateCommand(
+                $"IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{Parent.SchemaName}') EXEC('CREATE SCHEMA [{Parent.SchemaName}]')");
+            await schemaCmd.ExecuteNonQueryAsync();
+
+            await using var cmd = conn.CreateCommand(CreateTableSql());
+            await cmd.ExecuteNonQueryAsync();
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    public async ValueTask TeardownAsync(ILogger logger)
+    {
+        await using var conn = new SqlConnection(Parent.Settings.ConnectionString);
+        await conn.OpenAsync();
+        try
+        {
+            await using var cmd = conn.CreateCommand($"DROP TABLE IF EXISTS {TableIdentifier}");
+            await cmd.ExecuteNonQueryAsync();
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    public async ValueTask PurgeAsync(ILogger logger)
+    {
+        if (!await CheckAsync()) return;
+
+        await using var conn = new SqlConnection(Parent.Settings.ConnectionString);
+        await conn.OpenAsync();
+        try
+        {
+            await using var cmd = conn.CreateCommand($"DELETE FROM {TableIdentifier}");
+            await cmd.ExecuteNonQueryAsync();
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    public async ValueTask<Dictionary<string, string>> GetAttributesAsync()
+    {
+        var count = await CountAsync();
+        return new Dictionary<string, string> { { "NServiceBus Queue", Name }, { "Count", count.ToString() } };
+    }
+
+    public async Task<long> CountAsync()
+    {
+        if (!await CheckAsync()) return 0;
+
+        await using var conn = new SqlConnection(Parent.Settings.ConnectionString);
+        await conn.OpenAsync();
+        try
+        {
+            await using var cmd = conn.CreateCommand($"SELECT COUNT(*) FROM {TableIdentifier}");
+            return (int)(await cmd.ExecuteScalarAsync())!;
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    // Matches the NServiceBus SQL Server transport queue table layout, including the
+    // legacy CorrelationId/ReplyToAddress/Recoverable columns the transport still probes.
+    private string CreateTableSql()
+    {
+        return $@"
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{Parent.SchemaName}.{Name}') AND type = 'U')
+BEGIN
+    CREATE TABLE {TableIdentifier} (
+        Id uniqueidentifier NOT NULL,
+        CorrelationId varchar(255),
+        ReplyToAddress varchar(255),
+        Recoverable bit NOT NULL,
+        Expires datetime,
+        Headers nvarchar(max) NOT NULL,
+        Body varbinary(max),
+        RowVersion bigint IDENTITY(1,1) NOT NULL
+    );
+    CREATE NONCLUSTERED INDEX [Index_RowVersion] ON {TableIdentifier} (RowVersion);
+    CREATE CLUSTERED INDEX [Index_Expires] ON {TableIdentifier} (Expires) WHERE Expires IS NOT NULL;
+END";
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueueListener.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueueListener.cs
@@ -84,7 +84,7 @@ OUTPUT deleted.Id, deleted.Headers, deleted.Body;";
         {
             try
             {
-                var messages = await TryPopAsync(_queue.MaximumMessagesToReceive, _cancellation.Token);
+                var messages = await tryPopAsync(_queue.MaximumMessagesToReceive, _cancellation.Token);
                 failedCount = 0;
 
                 if (messages.Count > 0)
@@ -112,7 +112,7 @@ OUTPUT deleted.Id, deleted.Headers, deleted.Body;";
         }
     }
 
-    private async Task<IReadOnlyList<Envelope>> TryPopAsync(int count, CancellationToken token)
+    private async Task<IReadOnlyList<Envelope>> tryPopAsync(int count, CancellationToken token)
     {
         await using var conn = new SqlConnection(_connectionString);
         await conn.OpenAsync(token);

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueueListener.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueueListener.cs
@@ -1,0 +1,142 @@
+using JasperFx.Core;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Weasel.Core;
+using Weasel.SqlServer;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.SqlServer.Transport.NServiceBus;
+
+internal class NServiceBusSqlServerQueueListener : IListener
+{
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly NServiceBusSqlServerQueue _queue;
+    private readonly IReceiver _receiver;
+    private readonly string _connectionString;
+    private readonly ILogger _logger;
+    private readonly NServiceBusSqlServerEnvelopeMapper _mapper;
+    private readonly NServiceBusSqlServerQueueSender _sender;
+    private readonly TimeSpan _pollingInterval;
+    private readonly string _receiveSql;
+    private Task? _task;
+
+    public NServiceBusSqlServerQueueListener(NServiceBusSqlServerQueue queue, IWolverineRuntime runtime, IReceiver receiver)
+    {
+        _queue = queue;
+        _receiver = receiver;
+        _connectionString = queue.Parent.Settings.ConnectionString!;
+        _logger = runtime.LoggerFactory.CreateLogger<NServiceBusSqlServerQueueListener>();
+        _mapper = queue.BuildMapper(runtime);
+        _sender = new NServiceBusSqlServerQueueSender(queue, runtime);
+        _pollingInterval = queue.PollingInterval ?? runtime.DurabilitySettings.ScheduledJobPollingTime;
+
+        Address = queue.Uri;
+
+        // Destructive competing-consumer pop honoring NServiceBus FIFO-by-RowVersion ordering.
+        _receiveSql = $@"
+WITH message AS (
+    SELECT TOP(@count) Id, Headers, Body
+    FROM {queue.TableIdentifier} WITH (UPDLOCK, READPAST, ROWLOCK)
+    ORDER BY RowVersion)
+DELETE FROM message
+OUTPUT deleted.Id, deleted.Headers, deleted.Body;";
+    }
+
+    public IHandlerPipeline? Pipeline => _receiver.Pipeline;
+
+    public Uri Address { get; }
+
+    public ValueTask CompleteAsync(Envelope envelope)
+    {
+        // The row was already removed by the destructive pop.
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DeferAsync(Envelope envelope)
+    {
+        // Re-expose the message by writing it back to the NServiceBus queue table.
+        await _sender.SendAsync(envelope);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return StopAsync();
+    }
+
+    public async ValueTask StopAsync()
+    {
+        await _cancellation.CancelAsync();
+        _task?.SafeDispose();
+    }
+
+    public Task StartAsync()
+    {
+        _task = Task.Run(listenForMessagesAsync, _cancellation.Token);
+        return Task.CompletedTask;
+    }
+
+    private async Task listenForMessagesAsync()
+    {
+        var failedCount = 0;
+
+        while (!_cancellation.Token.IsCancellationRequested)
+        {
+            try
+            {
+                var messages = await TryPopAsync(_queue.MaximumMessagesToReceive, _cancellation.Token);
+                failedCount = 0;
+
+                if (messages.Count > 0)
+                {
+                    await _receiver.ReceivedAsync(this, messages.ToArray());
+                }
+                else
+                {
+                    await Task.Delay(_pollingInterval, _cancellation.Token);
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is TaskCanceledException or OperationCanceledException && _cancellation.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                failedCount++;
+                var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();
+                _logger.LogError(e, "Error while trying to receive messages from NServiceBus Sql Server queue {Name}",
+                    _queue.Name);
+                await Task.Delay(pauseTime);
+            }
+        }
+    }
+
+    private async Task<IReadOnlyList<Envelope>> TryPopAsync(int count, CancellationToken token)
+    {
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(token);
+
+        try
+        {
+            return await conn.CreateCommand(_receiveSql)
+                .With("count", count)
+                .FetchListAsync(async reader =>
+                {
+                    var id = await reader.GetFieldValueAsync<Guid>(0, token);
+                    var headers = await reader.IsDBNullAsync(1, token)
+                        ? null
+                        : await reader.GetFieldValueAsync<string>(1, token);
+                    var body = await reader.IsDBNullAsync(2, token)
+                        ? Array.Empty<byte>()
+                        : await reader.GetFieldValueAsync<byte[]>(2, token);
+
+                    return _mapper.MapIncoming(id, headers, body);
+                }, cancellation: token);
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueueSender.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueueSender.cs
@@ -34,7 +34,7 @@ internal class NServiceBusSqlServerQueueSender : ISender
     {
         try
         {
-            return await _queue.CheckAsync();
+            return await _queue.ExistsAsync();
         }
         catch (Exception)
         {

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueueSender.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueueSender.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.Data.SqlClient;
 using Weasel.SqlServer;
 using Wolverine.Runtime;
@@ -49,12 +50,19 @@ internal class NServiceBusSqlServerQueueSender : ISender
         await conn.OpenAsync();
         try
         {
-            await conn.CreateCommand(_sendSql)
+            var cmd = conn.CreateCommand(_sendSql)
                 .With("Id", row.Id)
-                .With("Expires", (object?)row.Expires?.UtcDateTime ?? DBNull.Value)
                 .With("Headers", row.Headers)
-                .With("Body", row.Body)
-                .ExecuteNonQueryAsync();
+                .With("Body", row.Body);
+
+            // The NServiceBus Expires column is a plain datetime; bind it with an explicit
+            // type so a null doesn't get inferred as sql_variant (which datetime rejects).
+            cmd.Parameters.Add(new SqlParameter("Expires", SqlDbType.DateTime)
+            {
+                Value = (object?)row.Expires?.UtcDateTime ?? DBNull.Value
+            });
+
+            await cmd.ExecuteNonQueryAsync();
         }
         finally
         {

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueueSender.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueueSender.cs
@@ -1,0 +1,64 @@
+using Microsoft.Data.SqlClient;
+using Weasel.SqlServer;
+using Wolverine.Runtime;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.SqlServer.Transport.NServiceBus;
+
+internal class NServiceBusSqlServerQueueSender : ISender
+{
+    private readonly NServiceBusSqlServerQueue _queue;
+    private readonly string _connectionString;
+    private readonly NServiceBusSqlServerEnvelopeMapper _mapper;
+    private readonly string _sendSql;
+
+    public NServiceBusSqlServerQueueSender(NServiceBusSqlServerQueue queue, IWolverineRuntime runtime)
+    {
+        _queue = queue;
+        _connectionString = queue.Parent.Settings.ConnectionString!;
+        _mapper = queue.BuildMapper(runtime);
+        Destination = queue.Uri;
+
+        // The documented NServiceBus SQL Server send statement.
+        _sendSql =
+            $@"INSERT INTO {queue.TableIdentifier} (Id, Recoverable, Expires, Headers, Body) VALUES (@Id, 1, @Expires, @Headers, @Body)";
+    }
+
+    // NServiceBus delayed delivery uses a separate timeout table + mover; not supported in v1.
+    public bool SupportsNativeScheduledSend => false;
+
+    public Uri Destination { get; }
+
+    public async Task<bool> PingAsync()
+    {
+        try
+        {
+            return await _queue.CheckAsync();
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    public async ValueTask SendAsync(Envelope envelope)
+    {
+        var row = _mapper.MapOutgoing(envelope);
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync();
+        try
+        {
+            await conn.CreateCommand(_sendSql)
+                .With("Id", row.Id)
+                .With("Expires", (object?)row.Expires?.UtcDateTime ?? DBNull.Value)
+                .With("Headers", row.Headers)
+                .With("Body", row.Body)
+                .ExecuteNonQueryAsync();
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransport.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransport.cs
@@ -1,0 +1,96 @@
+using JasperFx.Core;
+using Microsoft.Data.SqlClient;
+using Spectre.Console;
+using Wolverine.Configuration;
+using Wolverine.RDBMS;
+using Wolverine.Runtime;
+using Wolverine.SqlServer.Persistence;
+using Wolverine.Transports;
+using MultiTenantedMessageStore = Wolverine.Persistence.Durability.MultiTenantedMessageStore;
+
+namespace Wolverine.SqlServer.Transport.NServiceBus;
+
+/// <summary>
+/// A Wolverine transport that reads and writes the SQL Server queue tables owned by an
+/// NServiceBus endpoint, enabling bidirectional interop with NServiceBus over its
+/// documented SQL Server transport contract. Requires Wolverine itself to be using
+/// SQL Server backed message persistence (for the durable inbox/outbox); only the foreign
+/// queue tables belong to NServiceBus.
+/// </summary>
+public class NServiceBusSqlServerTransport : BrokerTransport<NServiceBusSqlServerQueue>
+{
+    public const string ProtocolName = "nservicebus-sqlserver";
+
+    public NServiceBusSqlServerTransport() : base(ProtocolName, "NServiceBus Sql Server Interop", [ProtocolName])
+    {
+        Queues = new LightweightCache<string, NServiceBusSqlServerQueue>(name => new NServiceBusSqlServerQueue(name, this));
+
+        // NServiceBus owns its own tables; do not provision them by default.
+        AutoProvision = false;
+    }
+
+    public LightweightCache<string, NServiceBusSqlServerQueue> Queues { get; }
+
+    /// <summary>
+    /// Schema name for the NServiceBus queue tables. Defaults to "dbo", matching the
+    /// NServiceBus SQL Server transport default.
+    /// </summary>
+    public string SchemaName { get; set; } = "dbo";
+
+    public override Uri ResourceUri => new("nservicebus-sqlserver-transport://");
+
+    protected override IEnumerable<NServiceBusSqlServerQueue> endpoints()
+    {
+        return Queues;
+    }
+
+    protected override IEnumerable<Endpoint> explicitEndpoints()
+    {
+        return Queues;
+    }
+
+    // NServiceBus queue/table names are matched verbatim against the foreign endpoint name.
+    public override string SanitizeIdentifier(string identifier)
+    {
+        return identifier;
+    }
+
+    protected override NServiceBusSqlServerQueue findEndpointByUri(Uri uri)
+    {
+        return Queues[uri.Host];
+    }
+
+    public override async ValueTask ConnectAsync(IWolverineRuntime runtime)
+    {
+        if (runtime.Storage is SqlServerMessageStore store)
+        {
+            Storage = store;
+        }
+        else if (runtime.Storage is MultiTenantedMessageStore mt && mt.Main is SqlServerMessageStore s)
+        {
+            Storage = s;
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                "The NServiceBus Sql Server interop transport can only be used if Wolverine's message persistence is also Sql Server backed");
+        }
+
+        Settings = Storage.Settings;
+
+        // de facto environment test
+        await using var conn = new SqlConnection(Settings.ConnectionString);
+        await conn.OpenAsync();
+        await conn.CloseAsync();
+    }
+
+    internal DatabaseSettings Settings { get; set; } = null!;
+
+    internal SqlServerMessageStore Storage { get; set; } = null!;
+
+    public override IEnumerable<PropertyColumn> DiagnosticColumns()
+    {
+        yield return new PropertyColumn("NServiceBus Queue");
+        yield return new PropertyColumn("Count", Justify.Right);
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransport.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransport.cs
@@ -88,6 +88,32 @@ public class NServiceBusSqlServerTransport : BrokerTransport<NServiceBusSqlServe
 
     internal SqlServerMessageStore Storage { get; set; } = null!;
 
+    /// <summary>
+    /// Resolve the SQL Server connection string used for the NServiceBus queue tables. Works
+    /// before <see cref="ConnectAsync"/> has run (e.g. from the Weasel command line) by falling
+    /// back to the SQL Server message store registered for Wolverine's own persistence.
+    /// </summary>
+    internal string ResolveConnectionString(IWolverineRuntime runtime)
+    {
+        if (Settings is not null)
+        {
+            return Settings.ConnectionString!;
+        }
+
+        if (runtime.Storage is SqlServerMessageStore store)
+        {
+            return store.Settings.ConnectionString!;
+        }
+
+        if (runtime.Storage is MultiTenantedMessageStore mt && mt.Main is SqlServerMessageStore s)
+        {
+            return s.Settings.ConnectionString!;
+        }
+
+        throw new InvalidOperationException(
+            "The NServiceBus Sql Server interop transport requires Sql Server backed message persistence");
+    }
+
     public override IEnumerable<PropertyColumn> DiagnosticColumns()
     {
         yield return new PropertyColumn("NServiceBus Queue");

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransportDatabase.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransportDatabase.cs
@@ -1,0 +1,91 @@
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using JasperFx.Descriptors;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Weasel.SqlServer;
+using Wolverine.RDBMS;
+using Wolverine.Runtime;
+
+namespace Wolverine.SqlServer.Transport.NServiceBus;
+
+/// <summary>
+/// Exposes the NServiceBus interop queue tables as a Weasel <see cref="IDatabase"/> so they
+/// participate in Wolverine's resource model and the Weasel command line tooling
+/// (db-apply / db-dump / db-assert). Modeled on <see cref="SqlServerTransportDatabase"/>.
+/// </summary>
+public class NServiceBusSqlServerTransportDatabase : DatabaseBase<SqlConnection>
+{
+    private readonly NServiceBusSqlServerTransport _transport;
+    private readonly string _connectionString;
+
+    internal static SqlConnection BuildConnection(IWolverineRuntime runtime)
+    {
+        var transport = runtime.Options.NServiceBusSqlServerTransport();
+        return new SqlConnection(transport.ResolveConnectionString(runtime));
+    }
+
+    public NServiceBusSqlServerTransportDatabase(IWolverineRuntime runtime) : base(
+        new MigrationLogger(runtime.LoggerFactory.CreateLogger<NServiceBusSqlServerTransportDatabase>()),
+        AutoCreate.CreateOrUpdate, new SqlServerMigrator(), "NServiceBus Sql Server Interop",
+        () => BuildConnection(runtime))
+    {
+        _transport = runtime.Options.NServiceBusSqlServerTransport();
+        _connectionString = _transport.ResolveConnectionString(runtime);
+
+        // ReSharper disable once VirtualMemberCallInConstructor
+        var descriptor = Describe();
+        Id = new DatabaseId(descriptor.ServerName, descriptor.DatabaseName);
+    }
+
+    public override DatabaseDescriptor Describe()
+    {
+        var builder = new SqlConnectionStringBuilder(_connectionString);
+        var descriptor = new DatabaseDescriptor
+        {
+            Engine = "SqlServer",
+            ServerName = builder.DataSource ?? string.Empty,
+            DatabaseName = builder.InitialCatalog ?? string.Empty,
+            Subject = GetType().FullNameInCode(),
+            SchemaOrNamespace = _transport.SchemaName
+        };
+
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.ApplicationName));
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.Pooling));
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.MinPoolSize));
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.MaxPoolSize));
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.CommandTimeout));
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.TrustServerCertificate));
+
+        descriptor.Properties.RemoveAll(x => x.Name.ContainsIgnoreCase("password"));
+        descriptor.Properties.RemoveAll(x => x.Name.ContainsIgnoreCase("certificate"));
+
+        return descriptor;
+    }
+
+    public override IFeatureSchema[] BuildFeatureSchemas()
+    {
+        return _transport.Queues
+            .Select(queue => (IFeatureSchema)new NServiceBusSqlServerQueueFeatureSchema(queue, Migrator))
+            .ToArray();
+    }
+}
+
+internal class NServiceBusSqlServerQueueFeatureSchema : FeatureSchemaBase
+{
+    public NServiceBusSqlServerQueue Queue { get; }
+
+    public NServiceBusSqlServerQueueFeatureSchema(NServiceBusSqlServerQueue queue, Migrator migrator)
+        : base($"NServiceBusSqlServerQueue_{queue.Name}", migrator)
+    {
+        Queue = queue;
+    }
+
+    protected override IEnumerable<ISchemaObject> schemaObjects()
+    {
+        yield return Queue.QueueTable;
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransportExtensions.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransportExtensions.cs
@@ -1,0 +1,66 @@
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Wolverine.Configuration;
+
+namespace Wolverine.SqlServer.Transport.NServiceBus;
+
+public static class NServiceBusSqlServerTransportExtensions
+{
+    /// <summary>
+    /// Find or add the NServiceBus SQL Server interop transport for this application.
+    /// Requires Wolverine to also be using SQL Server backed message persistence.
+    /// </summary>
+    internal static NServiceBusSqlServerTransport NServiceBusSqlServerTransport(this WolverineOptions options,
+        string? schema = null)
+    {
+        var transport = options.Transports.OfType<NServiceBusSqlServerTransport>().FirstOrDefault();
+        if (transport == null)
+        {
+            transport = new NServiceBusSqlServerTransport();
+            options.Transports.Add(transport);
+        }
+
+        if (schema.IsNotEmpty())
+        {
+            transport.SchemaName = schema!;
+        }
+
+        return transport;
+    }
+
+    /// <summary>
+    /// Listen for messages published by an NServiceBus endpoint to a SQL Server queue table
+    /// of the given name. The table is owned by NServiceBus; Wolverine reads it directly.
+    /// </summary>
+    /// <param name="queueName">The NServiceBus queue/table name (matched verbatim)</param>
+    /// <param name="schema">Optional schema for the NServiceBus queue tables; defaults to "dbo"</param>
+    public static NServiceBusSqlServerListenerConfiguration ListenToNServiceBusSqlServerQueue(
+        this WolverineOptions options, string queueName, string? schema = null)
+    {
+        var transport = options.NServiceBusSqlServerTransport(schema);
+        var queue = transport.Queues[queueName];
+        queue.EndpointName = queueName;
+        queue.IsListener = true;
+
+        return new NServiceBusSqlServerListenerConfiguration(queue);
+    }
+
+    /// <summary>
+    /// Publish matching messages straight to an NServiceBus-owned SQL Server queue table
+    /// using the queue name, encoded in the NServiceBus SQL transport wire format.
+    /// </summary>
+    /// <param name="queueName">The NServiceBus queue/table name (matched verbatim)</param>
+    /// <param name="schema">Optional schema for the NServiceBus queue tables; defaults to "dbo"</param>
+    public static NServiceBusSqlServerSubscriberConfiguration ToNServiceBusSqlServerQueue(
+        this IPublishToExpression publishing, string queueName, string? schema = null)
+    {
+        var options = publishing.As<PublishingExpression>().Parent;
+        var transport = options.NServiceBusSqlServerTransport(schema);
+        var queue = transport.Queues[queueName];
+        queue.EndpointName = queueName;
+
+        publishing.To(queue.Uri);
+
+        return new NServiceBusSqlServerSubscriberConfiguration(queue);
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransportExtensions.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransportExtensions.cs
@@ -29,6 +29,24 @@ public static class NServiceBusSqlServerTransportExtensions
     }
 
     /// <summary>
+    /// Opt into the NServiceBus SQL Server interop transport and configure transport-wide
+    /// settings. Calling this is optional; <see cref="ListenToNServiceBusSqlServerQueue"/> and
+    /// <see cref="ToNServiceBusSqlServerQueue"/> will register the transport on demand.
+    /// </summary>
+    /// <param name="schema">Schema that owns the NServiceBus queue tables; defaults to "dbo"</param>
+    /// <param name="autoProvision">
+    /// When true, Wolverine will create the NServiceBus queue tables if they do not already
+    /// exist. Defaults to false because NServiceBus normally owns and provisions its own tables.
+    /// </param>
+    public static WolverineOptions UseNServiceBusSqlServerInterop(this WolverineOptions options,
+        string? schema = null, bool autoProvision = false)
+    {
+        var transport = options.NServiceBusSqlServerTransport(schema);
+        transport.AutoProvision = autoProvision;
+        return options;
+    }
+
+    /// <summary>
     /// Listen for messages published by an NServiceBus endpoint to a SQL Server queue table
     /// of the given name. The table is owned by NServiceBus; Wolverine reads it directly.
     /// </summary>

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransportExtensions.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransportExtensions.cs
@@ -1,5 +1,7 @@
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Weasel.Core.Migrations;
 using Wolverine.Configuration;
 
 namespace Wolverine.SqlServer.Transport.NServiceBus;
@@ -18,6 +20,9 @@ public static class NServiceBusSqlServerTransportExtensions
         {
             transport = new NServiceBusSqlServerTransport();
             options.Transports.Add(transport);
+
+            // Expose the NServiceBus queue tables to the Weasel resource model / command line.
+            options.Services.AddTransient<IDatabase, NServiceBusSqlServerTransportDatabase>();
         }
 
         if (schema.IsNotEmpty())


### PR DESCRIPTION
## What

Adds a database-backed Wolverine transport that interoperates **bidirectionally** with an [NServiceBus](https://particular.net/) endpoint using the [SQL Server transport](https://docs.particular.net/transports/sql/), by reading and writing the NServiceBus queue tables directly. This is the first permutation of the database-backed transport interop plan (Wolverine ⇄ NServiceBus/MassTransit over SQL Server/PostgreSQL).

Approach: a dedicated transport (not an envelope mapper layered on an existing broker) because the native SQL queue stores the whole envelope as one opaque blob, which is incompatible with NServiceBus's documented table shape, wire format, and receive protocol.

## How

New `nservicebus-sqlserver` transport in `Wolverine.SqlServer` (`src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/`):

- **Transport/Queue/Listener/Sender** reusing the existing SQL queue scaffolding pattern. Destructive `WITH (UPDLOCK, READPAST, ROWLOCK) … DELETE … OUTPUT` pop ordered by `RowVersion`; documented `INSERT` send. Buffered mode; Wolverine's own SQL Server message store still backs the durable inbox/outbox — only the *queue* tables belong to NServiceBus.
- **Envelope mapper** translating `Envelope` ⇄ (JSON `Headers` + raw `Body`) with the standard NServiceBus headers (`EnclosedMessageTypes`, `MessageId`, `ConversationId`, `CorrelationId`, `ReplyToAddress`, `ContentType`, `TimeSent`). Two-way message-type identity: outgoing carries the concrete type **plus implemented interfaces** so an NServiceBus handler registered against a shared interface binds; incoming `EnclosedMessageTypes` resolved against `RegisterInteropMessageAssembly`. AOT-safe (source-gen `JsonSerializerContext` + targeted suppressions).
- **Config:** `UseNServiceBusSqlServerInterop(schema, autoProvision)`, `ListenToNServiceBusSqlServerQueue(name)`, `ToNServiceBusSqlServerQueue(name)`. `AutoProvision` is **off by default** since NServiceBus owns its tables; optional raw `CREATE TABLE` matches the NServiceBus layout.
- NServiceBus' JSON body carries a UTF-8 BOM that `System.Text.Json` rejects; the mapper strips it on receive.

## Tests

- Framework smoke test (`nservicebus_sql_server_transport_smoke`): two Wolverine hosts round-trip a message through the NServiceBus-shaped queue table on real SQL Server.
- Full bidirectional fidelity (both directions, incl. interface polymorphism) is covered against a **real NServiceBus.Transport.SqlServer host** in the [wolverine-interop](https://github.com/JasperFx/wolverine-interop) repo (`InteropTestsWithNServiceBusAndSqlServer`) — all 4 specs green.
- `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors).

## Docs

- `docs/guide/durability/sqlserver.md` — NServiceBus interoperability section.
- `docs/tutorials/interop.md` — database-transport NServiceBus interop section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)