### PR TITLE
Pulsar: native per-message redelivery (#3177)

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -114,6 +114,25 @@ When a pattern is configured it takes precedence, and the topic the listener was
 used only as the Wolverine endpoint identity. Pattern subscriptions match topics that exist at
 subscription time and pick up newly created matching topics as Pulsar discovers them.
 
+## Per-Message Redelivery
+
+By default, when a message fails and is requeued, the Pulsar listener acknowledges it and
+re-publishes a fresh copy to the source topic. You can instead opt into Pulsar's native
+per-message redelivery, where the message is left **unacknowledged** and Pulsar redelivers just
+that one message (preserving its redelivery count) rather than creating a duplicate:
+
+```csharp
+opts.ListenToPulsarTopic("persistent://public/default/orders")
+    .UseNativeRedelivery();
+
+// Combine with a retry policy that requeues on failure:
+opts.Policies.OnException<TransientException>().Requeue(3);
+```
+
+For delayed / backoff redelivery (growing the delay between attempts), use the Pulsar
+retry-letter topics instead — DotPulsar's client does not expose negative-acknowledgment backoff
+or ack-timeout settings.
+
 ## Read Only Subscriptions <Badge type="tip" text="3.13" />
 
 As part of Wolverine's "Requeue" error handling action, the Pulsar transport tries to quietly create a matching sender

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/per_message_redelivery.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/per_message_redelivery.cs
@@ -1,0 +1,96 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.ComplianceTests;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+// GH-3177: per-message redelivery via RedeliverUnacknowledgedMessages([messageId]) instead of
+// redeliver-all / ack+resend. (DotPulsar 5.1.2 has no nack; delayed/backoff redelivery is #3182.)
+public class per_message_redelivery
+{
+    [Fact]
+    public void use_native_redelivery_sets_the_flag()
+    {
+        var transport = new PulsarTransport();
+        var endpoint = transport[new Uri("pulsar://persistent/public/default/redeliver")];
+        var config = new PulsarListenerConfiguration(endpoint);
+
+        endpoint.UseNativeRedelivery.ShouldBeFalse();
+
+        config.UseNativeRedelivery();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        endpoint.UseNativeRedelivery.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task native_redelivery_redelivers_a_failed_message_until_it_succeeds()
+    {
+        var topic = $"persistent://public/default/redeliver-{Guid.NewGuid():N}";
+
+        using var host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.PublishMessage<RedeliveryMessage>().ToPulsarTopic(topic).SendInline();
+            // With UseNativeRedelivery, a failure with no retry-letter/DLQ configured leaves the
+            // message unacknowledged and asks Pulsar to redeliver just it.
+            opts.ListenToPulsarTopic(topic)
+                .SubscriptionName("sub-" + Guid.NewGuid().ToString("N"))
+                .UseNativeRedelivery();
+
+            opts.Services.AddSingleton<RedeliverySink>();
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<RedeliveryHandler>();
+        });
+
+        await host.SendAsync(new RedeliveryMessage { Id = "m1" });
+
+        var sink = host.Services.GetRequiredService<RedeliverySink>();
+        await waitForConditionAsync(() => sink.Succeeded.Contains("m1"), 30000);
+
+        // First physical delivery threw; Pulsar redelivered the same message and the retry succeeded.
+        sink.Deliveries.TryGetValue("m1", out var deliveries).ShouldBeTrue();
+        deliveries.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    private static async Task waitForConditionAsync(Func<bool> condition, int timeoutMs)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            if (condition()) return;
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Condition not met within {timeoutMs}ms");
+    }
+}
+
+public class RedeliveryMessage
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class RedeliverySink
+{
+    public ConcurrentDictionary<string, int> Deliveries { get; } = new();
+    public ConcurrentBag<string> Succeeded { get; } = new();
+}
+
+public class RedeliveryHandler
+{
+    public static void Handle(RedeliveryMessage message, RedeliverySink sink)
+    {
+        var count = sink.Deliveries.AddOrUpdate(message.Id, 1, (_, c) => c + 1);
+
+        // Fail the very first physical delivery so Pulsar has to redeliver it.
+        if (count == 1)
+        {
+            throw new InvalidOperationException("Simulated failure on first delivery");
+        }
+
+        sink.Succeeded.Add(message.Id);
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/ErrorHandling/PulsarNativeResiliencyContinuation.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/ErrorHandling/PulsarNativeResiliencyContinuation.cs
@@ -34,6 +34,15 @@ public class PulsarNativeResiliencyContinuation : IContinuation
                 await new MoveToErrorQueue(_exception)
                     .ExecuteAsync(lifecycle, runtime, now, activity);
                 //await listener.MoveToErrorsAsync(envelope, _exception);
+                return;
+            }
+
+            // No native retry-letter or dead-letter topic configured. If the endpoint opted into
+            // native per-message redelivery (#3177), leave the message unacknowledged and ask Pulsar
+            // to redeliver just it; otherwise keep the historical no-op behavior.
+            if (listener.UsesNativeRedelivery)
+            {
+                await listener.DeferAsync(envelope);
             }
 
             return;

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -74,6 +74,15 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
     public bool UnsubscribeOnClose { get; internal set; } = true;
 
     /// <summary>
+    ///     When true, a requeue/defer of a single message uses Pulsar's native per-message
+    ///     redelivery (<c>RedeliverUnacknowledgedMessages([messageId])</c>) — the message is left
+    ///     unacknowledged and Pulsar redelivers that one message, preserving its redelivery count —
+    ///     instead of the default behavior of acknowledging and re-publishing a fresh copy to the
+    ///     source topic. Delayed/backoff redelivery is handled by the retry-letter topics (#3182).
+    /// </summary>
+    public bool UseNativeRedelivery { get; internal set; }
+
+    /// <summary>
     ///     Use to override the dead letter topic for this endpoint
     /// </summary>
     public DeadLetterTopic? DeadLetterTopic { get; set; }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -187,7 +187,22 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
 
     public async ValueTask DeferAsync(Envelope envelope)
     {
-        if (_enableRequeue && _sender is not null && envelope is PulsarEnvelope e)
+        if (envelope is not PulsarEnvelope e)
+        {
+            return;
+        }
+
+        if (_endpoint.UseNativeRedelivery)
+        {
+            var consumer = e.IsFromRetryConsumer && _retryConsumer != null ? _retryConsumer : _consumer;
+            // Native per-message redelivery: leave the message unacknowledged and ask Pulsar to
+            // redeliver just this one message (preserves its redelivery count) — #3177.
+            await consumer!.RedeliverUnacknowledgedMessages(
+                [FixMessageId(e.MessageData.MessageId, consumer.Topic)], _cancellation);
+            return;
+        }
+
+        if (_enableRequeue && _sender is not null)
         {
             var consumer = e.IsFromRetryConsumer && _retryConsumer != null ? _retryConsumer : _consumer;
             await consumer!.Acknowledge(FixMessageId(e.MessageData.MessageId, consumer.Topic), _cancellation);
@@ -262,16 +277,34 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
             throw new InvalidOperationException("Requeue is not enabled for this endpoint");
         }
 
-        if (_sender is not null && envelope is PulsarEnvelope)
+        if (envelope is PulsarEnvelope e)
         {
-            await _sender.SendAsync(envelope);
-            return true;
+            if (_endpoint.UseNativeRedelivery)
+            {
+                var consumer = e.IsFromRetryConsumer && _retryConsumer != null ? _retryConsumer : _consumer;
+                await consumer!.RedeliverUnacknowledgedMessages(
+                    [FixMessageId(e.MessageData.MessageId, consumer.Topic)], _cancellation);
+                return true;
+            }
+
+            if (_sender is not null)
+            {
+                await _sender.SendAsync(envelope);
+                return true;
+            }
         }
 
         return false;
     }
 
     public bool NativeDeadLetterQueueEnabled { get; }
+
+    /// <summary>
+    /// Whether this listener should use Pulsar's native per-message redelivery for failed messages
+    /// when no retry-letter / dead-letter topic is configured. See #3177.
+    /// </summary>
+    internal bool UsesNativeRedelivery => _endpoint.UseNativeRedelivery;
+
     public RetryLetterTopic? RetryLetterTopic => _endpoint.RetryLetterTopic;
 
     public async Task MoveToErrorsAsync(Envelope envelope, Exception exception)

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -296,6 +296,20 @@ public class PulsarListenerConfiguration : InteroperableListenerConfiguration<Pu
     }
 
     /// <summary>
+    /// Requeue/defer a failed message using Pulsar's native per-message redelivery
+    /// (<c>RedeliverUnacknowledgedMessages</c>) instead of acknowledging it and re-publishing a
+    /// fresh copy to the source topic. The original message is left unacknowledged and Pulsar
+    /// redelivers just that one message, preserving its redelivery count. For delayed/backoff
+    /// redelivery use the retry-letter topics instead.
+    /// </summary>
+    /// <returns></returns>
+    public PulsarListenerConfiguration UseNativeRedelivery()
+    {
+        add(e => { e.UseNativeRedelivery = true; });
+        return this;
+    }
+
+    /// <summary>
     /// Override the Pulsar subscription type to  <see cref="DotPulsar.SubscriptionType.Failover"/> for just this topic
     /// </summary>
     /// <param name="subscriptionType"></param>


### PR DESCRIPTION
Part of the Pulsar re-evaluation epic #3176. Fixes #3177 (reduced scope — DotPulsar 5.1.2 has no negative-acknowledgment; delayed/backoff redelivery stays with the retry-letter topics, #3182).

Adds opt-in **native per-message redelivery**: instead of acknowledging a failed message and re-publishing a fresh copy to the source topic, the message is left **unacknowledged** and Pulsar is asked to redeliver just that one message via `RedeliverUnacknowledgedMessages([messageId])`, preserving its redelivery count.

## Changes
- `PulsarEndpoint.UseNativeRedelivery` + `PulsarListenerConfiguration.UseNativeRedelivery()`.
- `PulsarListener.DeferAsync` / `TryRequeueAsync` issue `RedeliverUnacknowledgedMessages([id])` when enabled.
- **Key fix:** the Pulsar native-resiliency continuation (an `AlwaysMatches` failure rule installed by `UsePulsar`, which preempts the generic `Requeue` continuation) previously **no-op'd** a failure when no retry-letter/dead-letter topic was configured — leaving the message hanging. It now performs native per-message redelivery in that case when `UseNativeRedelivery` is set. Existing retry-letter / DLQ / opt-out behavior is unchanged.

## Tests
- Config unit test (flag wiring).
- Integration test: a handler that throws on its first delivery is redelivered by Pulsar and succeeds on the retry.

## Docs
New "Per-Message Redelivery" section, noting that bounded/backoff redelivery uses the retry-letter topics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)