### PR TITLE
Pulsar: per-consumer / per-producer customization hooks (#3179)

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -133,6 +133,30 @@ For delayed / backoff redelivery (growing the delay between attempts), use the P
 retry-letter topics instead — DotPulsar's client does not expose negative-acknowledgment backoff
 or ack-timeout settings.
 
+## Customizing Consumers & Producers
+
+Beyond the global `IPulsarClientBuilder` passed to `UsePulsar(...)`, you can customize the
+individual DotPulsar consumer or producer per endpoint immediately before it is created — to set a
+consumer/producer name, compression, batching, receive-queue size, routing mode, priority level,
+and so on:
+
+```csharp
+opts.ListenToPulsarTopic("persistent://public/default/orders")
+    .ConfigureConsumer(consumer => consumer
+        .ConsumerName("orders-worker")
+        .PriorityLevel(1));
+
+opts.PublishMessage<OrderPlaced>()
+    .ToPulsarTopic("persistent://public/default/orders")
+    .ConfigureProducer(producer => producer
+        .ProducerName("orders-publisher")
+        .CompressionType(CompressionType.Lz4));
+```
+
+The callback receives the same `IConsumerBuilder` / `IProducerBuilder` Wolverine uses internally, so
+anything DotPulsar exposes is available. A listener also exposes `ConfigureProducer(...)` for the
+producer it uses on the requeue/redelivery path.
+
 ## Read Only Subscriptions <Badge type="tip" text="3.13" />
 
 As part of Wolverine's "Requeue" error handling action, the Pulsar transport tries to quietly create a matching sender

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/consumer_producer_hooks.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/consumer_producer_hooks.cs
@@ -1,0 +1,106 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.ComplianceTests;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+// GH-3179: per-consumer / per-producer customization hooks against DotPulsar's builders.
+public class consumer_producer_hooks
+{
+    [Fact]
+    public void configure_consumer_sets_the_hook()
+    {
+        var transport = new PulsarTransport();
+        var endpoint = transport[new Uri("pulsar://persistent/public/default/hooks")];
+        var config = new PulsarListenerConfiguration(endpoint);
+
+        config.ConfigureConsumer(_ => { });
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        endpoint.ConfigureConsumer.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void configure_producer_sets_the_hook()
+    {
+        var transport = new PulsarTransport();
+        var endpoint = transport[new Uri("pulsar://persistent/public/default/hooks2")];
+        var config = new PulsarSubscriberConfiguration(endpoint);
+
+        config.ConfigureProducer(_ => { });
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        endpoint.ConfigureProducer.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task per_endpoint_consumer_and_producer_hooks_are_invoked()
+    {
+        var topic = $"persistent://public/default/hooks-{Guid.NewGuid():N}";
+        var consumerConfigured = false;
+        var producerConfigured = false;
+
+        using var host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+
+            opts.PublishMessage<HookMessage>().ToPulsarTopic(topic).SendInline()
+                .ConfigureProducer(p =>
+                {
+                    producerConfigured = true;
+                    p.ProducerName("wolverine-test-producer-" + Guid.NewGuid().ToString("N"));
+                });
+
+            opts.ListenToPulsarTopic(topic)
+                .SubscriptionName("sub-" + Guid.NewGuid().ToString("N"))
+                .ConfigureConsumer(c =>
+                {
+                    consumerConfigured = true;
+                    c.ConsumerName("wolverine-test-consumer-" + Guid.NewGuid().ToString("N"));
+                });
+
+            opts.Services.AddSingleton<HookSink>();
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<HookHandler>();
+        });
+
+        await host.SendAsync(new HookMessage { Id = "h1" });
+
+        var sink = host.Services.GetRequiredService<HookSink>();
+        await waitForConditionAsync(() => sink.Received.Contains("h1"), 30000);
+
+        // Both customization callbacks ran while building the real consumer/producer, and the
+        // customized consumer/producer still deliver the message end to end.
+        consumerConfigured.ShouldBeTrue();
+        producerConfigured.ShouldBeTrue();
+    }
+
+    private static async Task waitForConditionAsync(Func<bool> condition, int timeoutMs)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            if (condition()) return;
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Condition not met within {timeoutMs}ms");
+    }
+}
+
+public class HookMessage
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class HookSink
+{
+    public ConcurrentBag<string> Received { get; } = new();
+}
+
+public class HookHandler
+{
+    public static void Handle(HookMessage message, HookSink sink) => sink.Received.Add(message.Id);
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -1,5 +1,7 @@
+using System.Buffers;
 using System.Text.RegularExpressions;
 using DotPulsar;
+using DotPulsar.Abstractions;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
@@ -81,6 +83,18 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
     ///     source topic. Delayed/backoff redelivery is handled by the retry-letter topics (#3182).
     /// </summary>
     public bool UseNativeRedelivery { get; internal set; }
+
+    /// <summary>
+    ///     Optional hook to customize the DotPulsar consumer for this listener (consumer name,
+    ///     receive-queue size, priority level, properties, etc.) immediately before it is created.
+    /// </summary>
+    internal Action<IConsumerBuilder<ReadOnlySequence<byte>>>? ConfigureConsumer { get; set; }
+
+    /// <summary>
+    ///     Optional hook to customize the DotPulsar producer for this endpoint (compression, batching,
+    ///     producer name, routing mode, etc.) immediately before it is created.
+    /// </summary>
+    internal Action<IProducerBuilder<ReadOnlySequence<byte>>>? ConfigureProducer { get; set; }
 
     /// <summary>
     ///     Use to override the dead letter topic for this endpoint

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -71,6 +71,8 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
             consumerBuilder = consumerBuilder.Topic(endpoint.PulsarTopic());
         }
 
+        endpoint.ConfigureConsumer?.Invoke(consumerBuilder);
+
         _consumer = consumerBuilder.Create();
 
         // Per-endpoint-override-wins resolution (endpoint override, else transport default).
@@ -146,12 +148,15 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
     {
         var topicRetry = getRetryLetterTopicUri(endpoint);
 
-        return transport.Client!.NewConsumer()
+        var retryBuilder = transport.Client!.NewConsumer()
             .SubscriptionName(endpoint.SubscriptionName)
             .SubscriptionType(endpoint.SubscriptionType)
             .InitialPosition(endpoint.SubscriptionInitialPosition)
-            .Topic(topicRetry!.ToString())
-            .Create();
+            .Topic(topicRetry!.ToString());
+
+        endpoint.ConfigureConsumer?.Invoke(retryBuilder);
+
+        return retryBuilder.Create();
     }
 
     private Uri? getRetryLetterTopicUri(PulsarEndpoint endpoint)

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarSender.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarSender.cs
@@ -19,7 +19,9 @@ public class PulsarSender : ISender, IAsyncDisposable
         var endpoint1 = endpoint;
         _cancellation = cancellation;
 
-        _producer = transport.Client!.NewProducer().Topic(endpoint1.PulsarTopic()).Create();
+        var producerBuilder = transport.Client!.NewProducer().Topic(endpoint1.PulsarTopic());
+        endpoint.ConfigureProducer?.Invoke(producerBuilder);
+        _producer = producerBuilder.Create();
 
         Destination = endpoint1.Uri;
         _mapper = endpoint.BuildMapper(runtime);

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Net;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -310,6 +311,31 @@ public class PulsarListenerConfiguration : InteroperableListenerConfiguration<Pu
     }
 
     /// <summary>
+    /// Customize the DotPulsar consumer for this listener (consumer name, receive-queue size,
+    /// priority level, read-compacted, properties, etc.) immediately before it is created. Runs
+    /// against the same <see cref="IConsumerBuilder{TMessage}"/> Wolverine uses internally.
+    /// </summary>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public PulsarListenerConfiguration ConfigureConsumer(Action<IConsumerBuilder<ReadOnlySequence<byte>>> configure)
+    {
+        add(e => { e.ConfigureConsumer = configure; });
+        return this;
+    }
+
+    /// <summary>
+    /// Customize the DotPulsar producer used by this listener for requeue/redelivery sends
+    /// immediately before it is created.
+    /// </summary>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public PulsarListenerConfiguration ConfigureProducer(Action<IProducerBuilder<ReadOnlySequence<byte>>> configure)
+    {
+        add(e => { e.ConfigureProducer = configure; });
+        return this;
+    }
+
+    /// <summary>
     /// Override the Pulsar subscription type to  <see cref="DotPulsar.SubscriptionType.Failover"/> for just this topic
     /// </summary>
     /// <param name="subscriptionType"></param>
@@ -581,5 +607,18 @@ public class PulsarSubscriberConfiguration : InteroperableSubscriberConfiguratio
 {
     public PulsarSubscriberConfiguration(PulsarEndpoint endpoint) : base(endpoint)
     {
+    }
+
+    /// <summary>
+    /// Customize the DotPulsar producer for this sending endpoint (compression, batching, producer
+    /// name, routing mode, etc.) immediately before it is created. Runs against the same
+    /// <see cref="IProducerBuilder{TMessage}"/> Wolverine uses internally.
+    /// </summary>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public PulsarSubscriberConfiguration ConfigureProducer(Action<IProducerBuilder<ReadOnlySequence<byte>>> configure)
+    {
+        add(e => { e.ConfigureProducer = configure; });
+        return this;
     }
 }


### PR DESCRIPTION
Part of the Pulsar re-evaluation epic #3176. Fixes #3179.

Adds per-endpoint `ConfigureConsumer` / `ConfigureProducer` hooks that run against DotPulsar's `IConsumerBuilder` / `IProducerBuilder` immediately before the consumer/producer is created. Previously only the global `IPulsarClientBuilder` (via `UsePulsar`) was exposed, so per-endpoint knobs (consumer/producer name, receive-queue size, priority, compression, batching, routing mode, …) weren't reachable. Analogue of Kafka's `ConfigureConsumer`/`ConfigureProducer`.

## Changes
- `PulsarEndpoint.ConfigureConsumer` / `ConfigureProducer` hooks.
- `PulsarListener` applies `ConfigureConsumer` to the main **and** retry consumers; `PulsarSender` applies `ConfigureProducer` (also covers the listener's internal requeue sender).
- `PulsarListenerConfiguration.ConfigureConsumer(...)` / `ConfigureProducer(...)` and `PulsarSubscriberConfiguration.ConfigureProducer(...)`.

## Tests
- Config unit tests (hooks stored on the endpoint).
- Integration test: both callbacks run while building the real consumer/producer (set a consumer/producer name) and the customized pair still delivers end-to-end.

## Docs
New "Customizing Consumers & Producers" section.

Unblocks #3180 (acknowledgment strategy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)