### PR TITLE
NServiceBus PostgreSQL transport interop

### DIFF
--- a/docs/guide/durability/postgresql.md
+++ b/docs/guide/durability/postgresql.md
@@ -249,6 +249,49 @@ Wolverine has an internal control queue (`dbcontrol`) used for internal operatio
 This queue is hardcoded to poll every second and should not be changed to ensure the stability of the application.
 :::
 
+## NServiceBus Interoperability <Badge type="tip" text="6.0" />
+
+Wolverine can exchange messages with an [NServiceBus](https://particular.net/nservicebus) endpoint that uses the
+[PostgreSQL transport](https://docs.particular.net/transports/sql/) by reading and writing the NServiceBus queue
+tables directly — the same database-backed interop available for [SQL Server](/guide/durability/sqlserver.html#nservicebus-interoperability).
+One table per queue with a JSON `Headers` column and a raw `Body` column; Wolverine's own durable inbox/outbox still
+lives in its PostgreSQL message store, only the *queue* tables belong to NServiceBus.
+
+Because NServiceBus normally owns and provisions its own tables, `AutoProvision` is **off by default** for these endpoints.
+
+```cs
+using Wolverine.Postgresql.Transport.NServiceBus;
+
+builder.UseWolverine(opts =>
+{
+    // Wolverine's durable inbox/outbox lives in PostgreSQL
+    opts.PersistMessagesWithPostgresql(connectionString, "wolverine");
+
+    // Opt into the NServiceBus PostgreSQL interop transport (autoProvision: true only if you
+    // want Wolverine to create the queue tables itself; NServiceBus usually owns them).
+    opts.UseNServiceBusPostgresqlInterop(autoProvision: false);
+
+    // Send Wolverine messages to the "nsb" NServiceBus endpoint table
+    opts.PublishMessage<OrderPlaced>().ToNServiceBusPostgresqlQueue("nsb");
+
+    // Listen for messages NServiceBus sends to Wolverine's own "wolverine" table,
+    // and use it as the reply address Wolverine stamps onto outgoing messages
+    opts.ListenToNServiceBusPostgresqlQueue("wolverine").UseForReplies();
+
+    // Let NServiceBus send interface-typed messages that Wolverine binds to concrete types
+    opts.Policies.RegisterInteropMessageAssembly(typeof(IMyMessageContract).Assembly);
+});
+```
+
+The queue tables are modeled and migrated through Weasel like every other Wolverine transport table, and the destructive
+receive uses `FOR UPDATE SKIP LOCKED` ordered by the NServiceBus `seq` column. A few PostgreSQL-specific notes:
+
+* NServiceBus uses lowercase column names; Wolverine's send/receive SQL matches them with unquoted identifiers.
+* NServiceBus addresses queues as the schema-qualified `"schema"."table"`; Wolverine maps the reply address back to the
+  bare queue name so request/reply works in both directions.
+
+See the [interop tutorial](/tutorials/interop) for the bigger picture and the
+[wolverine-interop](https://github.com/JasperFx/wolverine-interop) repository for a runnable, bidirectional sample.
 
 ## Multi-Tenancy
 

--- a/docs/tutorials/interop.md
+++ b/docs/tutorials/interop.md
@@ -447,10 +447,13 @@ With CloudEvents interoperability:
 ## Interop with NServiceBus over Database Transports
 
 Besides the broker transports above, Wolverine can interoperate with NServiceBus over its
-[SQL Server transport](https://docs.particular.net/transports/sql/) by reading and writing the NServiceBus queue
-tables directly. Rather than a custom envelope mapper layered onto a shared broker, this is a dedicated transport that
-speaks Particular's documented [native integration](https://docs.particular.net/transports/sql/native-integration)
-contract — one table per queue with a JSON `Headers` column and a raw `Body` column.
+[SQL Server **and** PostgreSQL transports](https://docs.particular.net/transports/sql/) by reading and writing the
+NServiceBus queue tables directly. Rather than a custom envelope mapper layered onto a shared broker, these are
+dedicated transports that speak Particular's documented
+[native integration](https://docs.particular.net/transports/sql/native-integration) contract — one table per queue
+with a JSON `Headers` column and a raw `Body` column. The SQL Server flavor is shown below; PostgreSQL is identical
+with `UseNServiceBusPostgresqlInterop()` / `ListenToNServiceBusPostgresqlQueue()` / `ToNServiceBusPostgresqlQueue()`
+from `Wolverine.Postgresql.Transport.NServiceBus`.
 
 ```cs
 using Wolverine.SqlServer.Transport.NServiceBus;
@@ -483,6 +486,7 @@ A few things to note about NServiceBus database interop:
   `RegisterInteropMessageAssembly`.
 * Request/reply works: Wolverine stamps `NServiceBus.ReplyToAddress` from the endpoint you mark `UseForReplies()`.
 
-See the [SQL Server transport guide](/guide/durability/sqlserver.html#nservicebus-interoperability) for the full set of
-options, and the [wolverine-interop](https://github.com/JasperFx/wolverine-interop) repository for a runnable,
-bidirectional sample with both frameworks hosted side by side.
+See the [SQL Server](/guide/durability/sqlserver.html#nservicebus-interoperability) and
+[PostgreSQL](/guide/durability/postgresql.html#nservicebus-interoperability) transport guides for the full set of
+options, and the [wolverine-interop](https://github.com/JasperFx/wolverine-interop) repository for runnable,
+bidirectional samples with both frameworks hosted side by side.

--- a/src/Persistence/PostgresqlTests/Transport/NServiceBus/nservicebus_postgresql_transport_smoke.cs
+++ b/src/Persistence/PostgresqlTests/Transport/NServiceBus/nservicebus_postgresql_transport_smoke.cs
@@ -1,0 +1,87 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.Postgresql.Transport.NServiceBus;
+using Wolverine.Tracking;
+
+namespace PostgresqlTests.Transport.NServiceBus;
+
+// Exercises the NServiceBus PostgreSQL interop transport end to end against a real
+// PostgreSQL without requiring an NServiceBus host: a publishing Wolverine app writes
+// rows into the NServiceBus-shaped queue table and a listening Wolverine app pops and
+// handles them. This validates the send INSERT, the destructive Seq-ordered pop, and the
+// envelope <-> (Headers + Body) mapping. True NServiceBus wire fidelity is covered
+// separately by the wolverine-interop suite.
+public class nservicebus_postgresql_transport_smoke : IAsyncLifetime
+{
+    private readonly string _queue = "nsb_interop_" + Guid.NewGuid().ToString("N");
+    private IHost _publisher = null!;
+    private IHost _receiver = null!;
+
+    public async Task InitializeAsync()
+    {
+        _publisher = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "nsbpublisher");
+                opts.UseNServiceBusPostgresqlInterop(autoProvision: true);
+
+                opts.PublishMessage<NsbInteropPing>().ToNServiceBusPostgresqlQueue(_queue);
+
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        _receiver = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "nsbreceiver");
+                opts.UseNServiceBusPostgresqlInterop(autoProvision: true);
+
+                opts.ListenToNServiceBusPostgresqlQueue(_queue);
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<NsbInteropPingHandler>();
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task round_trips_a_message_through_the_nservicebus_queue_table()
+    {
+        var id = Guid.NewGuid();
+
+        var tracked = await _publisher.TrackActivity()
+            .Timeout(30.Seconds())
+            .AlsoTrack(_receiver)
+            .WaitForMessageToBeReceivedAt<NsbInteropPing>(_receiver)
+            .SendMessageAndWaitAsync(new NsbInteropPing(id, "hello"));
+
+        var received = tracked.Received.SingleEnvelope<NsbInteropPing>();
+        received.Message.ShouldBeOfType<NsbInteropPing>().Id.ShouldBe(id);
+        received.Message.ShouldBeOfType<NsbInteropPing>().Name.ShouldBe("hello");
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _publisher.StopAsync();
+        _publisher.Dispose();
+        await _receiver.StopAsync();
+        _receiver.Dispose();
+    }
+}
+
+public record NsbInteropPing(Guid Id, string Name);
+
+public class NsbInteropPingHandler
+{
+    public static void Handle(NsbInteropPing message)
+    {
+        // handled; assertion is via tracking
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlConfiguration.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlConfiguration.cs
@@ -1,0 +1,71 @@
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+
+namespace Wolverine.Postgresql.Transport.NServiceBus;
+
+public class NServiceBusPostgresqlListenerConfiguration
+    : ListenerConfiguration<NServiceBusPostgresqlListenerConfiguration, NServiceBusPostgresqlQueue>
+{
+    public NServiceBusPostgresqlListenerConfiguration(NServiceBusPostgresqlQueue endpoint) : base(endpoint)
+    {
+    }
+
+    /// <summary>
+    ///     The maximum number of messages to receive in a single poll. Default is 20.
+    /// </summary>
+    public NServiceBusPostgresqlListenerConfiguration MaximumMessagesToReceive(int maximum)
+    {
+        add(e => e.MaximumMessagesToReceive = maximum);
+        return this;
+    }
+
+    /// <summary>
+    ///     Configure how often to poll for new messages when the queue is idle.
+    /// </summary>
+    public NServiceBusPostgresqlListenerConfiguration PollingInterval(TimeSpan interval)
+    {
+        add(e => e.PollingInterval = interval);
+        return this;
+    }
+
+    /// <summary>
+    ///     The bare NServiceBus queue/table name that foreign endpoints should reply to.
+    ///     When not set, the Wolverine endpoint marked <c>UseForReplies()</c> is used.
+    /// </summary>
+    public NServiceBusPostgresqlListenerConfiguration ReplyQueueName(string queueName)
+    {
+        add(e => e.InteropReplyQueueName = queueName);
+        return this;
+    }
+
+    /// <summary>
+    ///     Add circuit breaker exception handling to this listener.
+    /// </summary>
+    public NServiceBusPostgresqlListenerConfiguration CircuitBreaker(Action<CircuitBreakerOptions>? configure = null)
+    {
+        add(e =>
+        {
+            e.CircuitBreakerOptions = new CircuitBreakerOptions();
+            configure?.Invoke(e.CircuitBreakerOptions);
+        });
+        return this;
+    }
+}
+
+public class NServiceBusPostgresqlSubscriberConfiguration
+    : SubscriberConfiguration<NServiceBusPostgresqlSubscriberConfiguration, NServiceBusPostgresqlQueue>
+{
+    public NServiceBusPostgresqlSubscriberConfiguration(NServiceBusPostgresqlQueue endpoint) : base(endpoint)
+    {
+    }
+
+    /// <summary>
+    ///     The bare NServiceBus queue/table name that the receiving endpoint should reply to.
+    ///     When not set, the Wolverine endpoint marked <c>UseForReplies()</c> is used.
+    /// </summary>
+    public NServiceBusPostgresqlSubscriberConfiguration ReplyQueueName(string queueName)
+    {
+        add(e => e.InteropReplyQueueName = queueName);
+        return this;
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlEnvelopeMapper.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlEnvelopeMapper.cs
@@ -1,0 +1,233 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Wolverine.Util;
+using Endpoint = Wolverine.Configuration.Endpoint;
+
+namespace Wolverine.Postgresql.Transport.NServiceBus;
+
+[JsonSerializable(typeof(Dictionary<string, string>))]
+internal partial class NServiceBusPostgresqlJsonContext : JsonSerializerContext;
+
+/// <summary>
+/// Translates between Wolverine <see cref="Envelope"/>s and the NServiceBus SQL transport
+/// wire shape: a queue table row carrying a JSON <c>Headers</c> dictionary and a raw
+/// <c>Body</c> payload. This is the documented, Particular-sanctioned "native integration"
+/// contract for the PostgreSQL transport.
+/// </summary>
+/// <remarks>
+/// The mapping deliberately mirrors the existing broker interop mappers
+/// (<c>NServiceBusEnvelopeMapper</c> in Wolverine.AmazonSns / the RabbitMQ NServiceBus
+/// interop) so that the same header conventions hold across every NServiceBus interop
+/// transport. The body is left as raw bytes and run through Wolverine's normal serializer
+/// negotiation so the receiving handler deserializes it like any other message.
+/// </remarks>
+internal class NServiceBusPostgresqlEnvelopeMapper
+{
+    // The minimal NSB header set documented for native integration.
+    public const string MessageIdHeader = "NServiceBus.MessageId";
+    public const string ConversationIdHeader = "NServiceBus.ConversationId";
+    public const string CorrelationIdHeader = "NServiceBus.CorrelationId";
+    public const string ReplyToAddressHeader = "NServiceBus.ReplyToAddress";
+    public const string MessageIntentHeader = "NServiceBus.MessageIntent";
+    public const string ContentTypeHeader = "NServiceBus.ContentType";
+    public const string TimeSentHeader = "NServiceBus.TimeSent";
+    public const string EnclosedMessageTypesHeader = "NServiceBus.EnclosedMessageTypes";
+
+    // NServiceBus formats NServiceBus.TimeSent with this exact pattern.
+    private const string TimeSentFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
+
+    private readonly Endpoint _endpoint;
+    private readonly Func<string?> _replyAddress;
+
+    public NServiceBusPostgresqlEnvelopeMapper(Endpoint endpoint, Func<string?> replyAddress)
+    {
+        _endpoint = endpoint;
+        _replyAddress = replyAddress;
+    }
+
+    /// <summary>
+    /// Build the row values written to the NServiceBus queue table for an outgoing envelope.
+    /// </summary>
+    public OutgoingRow MapOutgoing(Envelope envelope)
+    {
+        var serializer = envelope.Serializer ?? _endpoint.DefaultSerializer
+            ?? throw new InvalidOperationException("No serializer is configured for this endpoint");
+
+        var body = envelope.Data ?? serializer.WriteMessage(envelope.Message!);
+        var contentType = envelope.ContentType ?? serializer.ContentType;
+
+        // Pass through any "extra" Wolverine headers so they survive a round trip.
+        var headers = new Dictionary<string, string>();
+        foreach (var pair in envelope.Headers)
+        {
+            if (pair.Value != null)
+            {
+                headers[pair.Key] = pair.Value;
+            }
+        }
+
+        headers[MessageIdHeader] = envelope.Id.ToString();
+        headers[ConversationIdHeader] = (envelope.ConversationId == Guid.Empty ? envelope.Id : envelope.ConversationId).ToString();
+        headers[MessageIntentHeader] = "Send";
+        headers[ContentTypeHeader] = contentType;
+        headers[TimeSentHeader] = envelope.SentAt.ToUniversalTime().ToString(TimeSentFormat, CultureInfo.InvariantCulture);
+
+        if (envelope.CorrelationId.IsNotEmpty())
+        {
+            headers[CorrelationIdHeader] = envelope.CorrelationId!;
+        }
+
+        var replyAddress = _replyAddress();
+        if (replyAddress.IsNotEmpty())
+        {
+            headers[ReplyToAddressHeader] = replyAddress!;
+        }
+
+        if (envelope.Message != null)
+        {
+            headers[EnclosedMessageTypesHeader] = toEnclosedMessageType(envelope.Message.GetType());
+        }
+        else if (envelope.MessageType.IsNotEmpty())
+        {
+            headers[EnclosedMessageTypesHeader] = envelope.MessageType!;
+        }
+
+        var json = JsonSerializer.Serialize(headers, NServiceBusPostgresqlJsonContext.Default.DictionaryStringString);
+
+        return new OutgoingRow(envelope.Id, json, body, envelope.DeliverBy);
+    }
+
+    /// <summary>
+    /// Hydrate an <see cref="Envelope"/> from a row read off the NServiceBus queue table.
+    /// </summary>
+    public Envelope MapIncoming(Guid id, string? headersJson, byte[] body)
+    {
+        // NServiceBus' JSON serializer prefixes the body with a UTF-8 BOM, which
+        // System.Text.Json rejects ('0xEF' is an invalid start of a value). Strip it so
+        // the configured serializer can read the payload.
+        var envelope = new Envelope { Data = stripUtf8Bom(body) };
+
+        var headers = headersJson.IsNotEmpty()
+            ? JsonSerializer.Deserialize(headersJson!, NServiceBusPostgresqlJsonContext.Default.DictionaryStringString) ?? new()
+            : new Dictionary<string, string>();
+
+        envelope.Id = readGuid(headers, MessageIdHeader) ?? id;
+        if (envelope.Id == Guid.Empty) envelope.Id = id;
+
+        var conversationId = readGuid(headers, ConversationIdHeader);
+        if (conversationId.HasValue) envelope.ConversationId = conversationId.Value;
+
+        if (headers.TryGetValue(CorrelationIdHeader, out var correlationId))
+        {
+            envelope.CorrelationId = correlationId;
+        }
+
+        if (headers.TryGetValue(ReplyToAddressHeader, out var replyTo) && replyTo.IsNotEmpty())
+        {
+            envelope.ReplyUri = NServiceBusPostgresqlQueue.ToUri(normalizeAddress(replyTo));
+        }
+
+        if (headers.TryGetValue(ContentTypeHeader, out var contentType) && contentType.IsNotEmpty())
+        {
+            envelope.ContentType = contentType;
+        }
+
+        if (headers.TryGetValue(TimeSentHeader, out var timeSent)
+            && DateTimeOffset.TryParse(timeSent, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var sentAt))
+        {
+            envelope.SentAt = sentAt;
+        }
+
+        if (headers.TryGetValue(EnclosedMessageTypesHeader, out var enclosed) && enclosed.IsNotEmpty())
+        {
+            envelope.MessageType = resolveMessageType(enclosed);
+        }
+
+        envelope.Serializer = _endpoint.TryFindSerializer(envelope.ContentType) ?? _endpoint.DefaultSerializer;
+
+        return envelope;
+    }
+
+    // The NServiceBus PostgreSQL transport addresses queues as the quoted, schema-qualified
+    // "schema"."table" (e.g. "public"."nsb"); the SQL Server transport uses table@schema@catalog.
+    // Either way we only want the bare queue/table name so it maps back to a Wolverine endpoint.
+    private static string normalizeAddress(string address)
+    {
+        // SQL Server form: take the part before the first '@'.
+        var at = address.IndexOf('@');
+        if (at >= 0)
+        {
+            address = address[..at];
+        }
+
+        // PostgreSQL form: drop quoting and take the last dotted segment ("public"."nsb" -> nsb).
+        address = address.Replace("\"", string.Empty);
+        var dot = address.LastIndexOf('.');
+        if (dot >= 0)
+        {
+            address = address[(dot + 1)..];
+        }
+
+        return address;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification =
+            "Reflecting over the interfaces of a live message instance's runtime type for NServiceBus interop; the type and its interfaces are present at runtime.")]
+    private static string toEnclosedMessageType(Type type)
+    {
+        // NServiceBus keys handler dispatch off NServiceBus.EnclosedMessageTypes, a
+        // ';'-separated, most-derived-first list of the message's type hierarchy. Emit the
+        // concrete type plus its implemented interfaces so that a Wolverine message defined
+        // in one assembly can still bind to an NServiceBus handler registered against a
+        // shared interface (e.g. IHandleMessages<ISomeInterface>) living in another.
+        var names = new List<string> { format(type) };
+        names.AddRange(type.GetInterfaces().Select(format));
+        return string.Join(";", names);
+
+        static string format(Type t) => $"{t.FullName}, {t.Assembly.GetName().Name}";
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2057",
+        Justification =
+            "The enclosed message type name comes from a foreign NServiceBus endpoint at runtime; a failed resolution falls back to the bare type name which Wolverine binds via RegisterInteropMessageAssembly.")]
+    private static string resolveMessageType(string enclosed)
+    {
+        // NServiceBus lists several types separated by ';' (concrete + interfaces),
+        // most-derived first. Use the first entry that resolves to a type loadable in this
+        // process; that is the one Wolverine can map to a handler (directly or via the
+        // RegisterInteropMessageAssembly interface->concrete binding).
+        var entries = enclosed.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (var entry in entries)
+        {
+            var type = Type.GetType(entry);
+            if (type != null)
+            {
+                return type.ToMessageTypeName();
+            }
+        }
+
+        // Fall back to the bare type name; Wolverine's interop assembly registration
+        // can still bind it to a concrete handler.
+        return entries.First().Split(',', StringSplitOptions.TrimEntries).First();
+    }
+
+    private static byte[] stripUtf8Bom(byte[] body)
+    {
+        return body.Length >= 3 && body[0] == 0xEF && body[1] == 0xBB && body[2] == 0xBF
+            ? body[3..]
+            : body;
+    }
+
+    private static Guid? readGuid(IReadOnlyDictionary<string, string> headers, string key)
+    {
+        return headers.TryGetValue(key, out var raw) && Guid.TryParse(raw, out var value) ? value : null;
+    }
+
+    internal readonly record struct OutgoingRow(Guid Id, string Headers, byte[] Body, DateTimeOffset? Expires);
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueue.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueue.cs
@@ -1,0 +1,232 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.Postgresql.Transport.NServiceBus;
+
+public class NServiceBusPostgresqlQueue : Endpoint, IBrokerQueue
+{
+    internal static Uri ToUri(string name)
+    {
+        var uriString = $"{NServiceBusPostgresqlTransport.ProtocolName}://{name}";
+        return Uri.TryCreate(uriString, UriKind.Absolute, out var uri)
+            ? uri
+            // Fall back to a path-based form when the queue/address contains characters that
+            // are not valid in a URI host (some foreign address formats do).
+            : new Uri($"{NServiceBusPostgresqlTransport.ProtocolName}://queue/{Uri.EscapeDataString(name)}");
+    }
+
+    private NServiceBusPostgresqlEnvelopeMapper? _mapper;
+    private NServiceBusPostgresqlQueueSender? _sender;
+    private readonly Lazy<NServiceBusQueueTable> _queueTable;
+
+    public NServiceBusPostgresqlQueue(string name, NServiceBusPostgresqlTransport parent,
+        EndpointRole role = EndpointRole.Application) : base(ToUri(name), role)
+    {
+        Parent = parent;
+        Name = name;
+        EndpointName = name;
+        BrokerRole = "queue";
+
+        // Interop endpoints exchange the foreign wire format; they cannot participate in
+        // Wolverine's durable inbox/outbox table layout, so run buffered like the broker
+        // interop transports do.
+        Mode = EndpointMode.BufferedInMemory;
+
+        // Lazy so the transport schema name is settled before the table identifier is built.
+        _queueTable = new Lazy<NServiceBusQueueTable>(
+            () => new NServiceBusQueueTable(new DbObjectName(Parent.SchemaName, Name)));
+    }
+
+    public string Name { get; }
+
+    internal NServiceBusPostgresqlTransport Parent { get; }
+
+    /// <summary>
+    /// The bare queue/table name that NServiceBus should reply to. Set by
+    /// <c>UseNServiceBusInterop(replyQueueName)</c>; when null the configured Wolverine
+    /// reply endpoint name is used.
+    /// </summary>
+    public string? InteropReplyQueueName { get; set; }
+
+    /// <summary>
+    ///     The maximum number of messages to receive in a single poll. Default is 20.
+    /// </summary>
+    public int MaximumMessagesToReceive { get; set; } = 20;
+
+    /// <summary>
+    ///     How often to poll for new messages when the queue is idle. If null, falls back to
+    ///     DurabilitySettings.ScheduledJobPollingTime (default 5s).
+    /// </summary>
+    public TimeSpan? PollingInterval { get; set; }
+
+    /// <summary>
+    /// The Weasel model of the NServiceBus queue table. Used for all schema management and as
+    /// the single source of truth for the table name in the send/receive DML.
+    /// </summary>
+    internal Table QueueTable => _queueTable.Value;
+
+    internal DbObjectName TableIdentifier => QueueTable.Identifier;
+
+    protected override bool supportsMode(EndpointMode mode)
+    {
+        return mode == EndpointMode.BufferedInMemory || mode == EndpointMode.Inline;
+    }
+
+    internal NServiceBusPostgresqlEnvelopeMapper BuildMapper(IWolverineRuntime runtime)
+    {
+        if (_mapper != null) return _mapper;
+
+        DefaultSerializer ??= runtime.Options.DefaultSerializer;
+
+        var replyName = new Lazy<string?>(() =>
+        {
+            if (InteropReplyQueueName.IsNotEmpty()) return InteropReplyQueueName;
+            return Parent.ReplyEndpoint()?.EndpointName;
+        });
+
+        _mapper = new NServiceBusPostgresqlEnvelopeMapper(this, () => replyName.Value);
+        return _mapper;
+    }
+
+    public override async ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+    {
+        if (Parent.AutoProvision)
+        {
+            await SetupAsync(runtime.LoggerFactory.CreateLogger<NServiceBusPostgresqlQueue>());
+        }
+
+        var listener = new NServiceBusPostgresqlQueueListener(this, runtime, receiver);
+        await listener.StartAsync();
+        return listener;
+    }
+
+    protected override ISender CreateSender(IWolverineRuntime runtime)
+    {
+        return _sender ??= new NServiceBusPostgresqlQueueSender(this, runtime);
+    }
+
+    public override async ValueTask InitializeAsync(ILogger logger)
+    {
+        if (Parent.AutoProvision)
+        {
+            await SetupAsync(logger);
+        }
+
+        if (Parent.AutoPurgeAllQueues)
+        {
+            await PurgeAsync(logger);
+        }
+    }
+
+    // IBrokerQueue.CheckAsync compares the live table against the Weasel model. Used by the
+    // resource model / db-assert; not on the message hot path.
+    public async ValueTask<bool> CheckAsync()
+    {
+        await using var conn = await Parent.Store.NpgsqlDataSource.OpenConnectionAsync();
+        try
+        {
+            var delta = await QueueTable.FindDeltaAsync(conn);
+            return !delta.HasChanges();
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    public async ValueTask SetupAsync(ILogger logger)
+    {
+        await using var conn = await Parent.Store.NpgsqlDataSource.OpenConnectionAsync();
+        try
+        {
+            await QueueTable.ApplyChangesAsync(conn);
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    public async ValueTask TeardownAsync(ILogger logger)
+    {
+        await using var conn = await Parent.Store.NpgsqlDataSource.OpenConnectionAsync();
+        try
+        {
+            await QueueTable.DropAsync(conn);
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    public async ValueTask PurgeAsync(ILogger logger)
+    {
+        await using var conn = await Parent.Store.NpgsqlDataSource.OpenConnectionAsync();
+        try
+        {
+            if (!await tableExistsAsync(conn)) return;
+
+            await using var cmd = conn.CreateCommand($"DELETE FROM {TableIdentifier}");
+            await cmd.ExecuteNonQueryAsync();
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    public async ValueTask<Dictionary<string, string>> GetAttributesAsync()
+    {
+        var count = await CountAsync();
+        return new Dictionary<string, string> { { "NServiceBus Queue", Name }, { "Count", count.ToString() } };
+    }
+
+    public async Task<long> CountAsync()
+    {
+        await using var conn = await Parent.Store.NpgsqlDataSource.OpenConnectionAsync();
+        try
+        {
+            if (!await tableExistsAsync(conn)) return 0;
+
+            await using var cmd = conn.CreateCommand($"SELECT COUNT(*) FROM {TableIdentifier}");
+            return (long)(await cmd.ExecuteScalarAsync())!;
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    /// <summary>
+    /// Lightweight existence probe (a read, not a schema change) used to guard runtime DML and
+    /// the sender ping. Schema creation/migration goes through <see cref="SetupAsync"/> / Weasel.
+    /// </summary>
+    internal async Task<bool> ExistsAsync()
+    {
+        await using var conn = await Parent.Store.NpgsqlDataSource.OpenConnectionAsync();
+        try
+        {
+            return await tableExistsAsync(conn);
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    private async Task<bool> tableExistsAsync(NpgsqlConnection conn)
+    {
+        await using var cmd = conn.CreateCommand("SELECT to_regclass(:name) IS NOT NULL")
+            .With("name", TableIdentifier.QualifiedName);
+        return (bool)(await cmd.ExecuteScalarAsync())!;
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueListener.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueListener.cs
@@ -1,0 +1,146 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.Postgresql.Transport.NServiceBus;
+
+internal class NServiceBusPostgresqlQueueListener : IListener
+{
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly NServiceBusPostgresqlQueue _queue;
+    private readonly IReceiver _receiver;
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly ILogger _logger;
+    private readonly NServiceBusPostgresqlEnvelopeMapper _mapper;
+    private readonly NServiceBusPostgresqlQueueSender _sender;
+    private readonly TimeSpan _pollingInterval;
+    private readonly string _receiveSql;
+    private Task? _task;
+
+    public NServiceBusPostgresqlQueueListener(NServiceBusPostgresqlQueue queue, IWolverineRuntime runtime, IReceiver receiver)
+    {
+        _queue = queue;
+        _receiver = receiver;
+        _dataSource = queue.Parent.Store.NpgsqlDataSource;
+        _logger = runtime.LoggerFactory.CreateLogger<NServiceBusPostgresqlQueueListener>();
+        _mapper = queue.BuildMapper(runtime);
+        _sender = new NServiceBusPostgresqlQueueSender(queue, runtime);
+        _pollingInterval = queue.PollingInterval ?? runtime.DurabilitySettings.ScheduledJobPollingTime;
+
+        Address = queue.Uri;
+
+        // Destructive competing-consumer pop honoring NServiceBus FIFO-by-Seq ordering. The
+        // column identifiers are left unquoted: Weasel provisions the queue table with
+        // case-folded (lowercase) column names, so unquoted references resolve correctly.
+        _receiveSql = $@"
+WITH message AS (
+    DELETE FROM {queue.TableIdentifier}
+    WHERE ctid IN (
+        SELECT ctid FROM {queue.TableIdentifier}
+        ORDER BY Seq
+        LIMIT :count
+        FOR UPDATE SKIP LOCKED)
+    RETURNING Id, Headers, Body)
+SELECT Id, Headers, Body FROM message;";
+    }
+
+    public IHandlerPipeline? Pipeline => _receiver.Pipeline;
+
+    public Uri Address { get; }
+
+    public ValueTask CompleteAsync(Envelope envelope)
+    {
+        // The row was already removed by the destructive pop.
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DeferAsync(Envelope envelope)
+    {
+        // Re-expose the message by writing it back to the NServiceBus queue table.
+        await _sender.SendAsync(envelope);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return StopAsync();
+    }
+
+    public async ValueTask StopAsync()
+    {
+        await _cancellation.CancelAsync();
+        _task?.SafeDispose();
+    }
+
+    public Task StartAsync()
+    {
+        _task = Task.Run(listenForMessagesAsync, _cancellation.Token);
+        return Task.CompletedTask;
+    }
+
+    private async Task listenForMessagesAsync()
+    {
+        var failedCount = 0;
+
+        while (!_cancellation.Token.IsCancellationRequested)
+        {
+            try
+            {
+                var messages = await tryPopAsync(_queue.MaximumMessagesToReceive, _cancellation.Token);
+                failedCount = 0;
+
+                if (messages.Count > 0)
+                {
+                    await _receiver.ReceivedAsync(this, messages.ToArray());
+                }
+                else
+                {
+                    await Task.Delay(_pollingInterval, _cancellation.Token);
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is TaskCanceledException or OperationCanceledException && _cancellation.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                failedCount++;
+                var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();
+                _logger.LogError(e, "Error while trying to receive messages from NServiceBus PostgreSQL queue {Name}",
+                    _queue.Name);
+                await Task.Delay(pauseTime);
+            }
+        }
+    }
+
+    private async Task<IReadOnlyList<Envelope>> tryPopAsync(int count, CancellationToken token)
+    {
+        await using var conn = await _dataSource.OpenConnectionAsync(token);
+
+        try
+        {
+            return await conn.CreateCommand(_receiveSql)
+                .With("count", count)
+                .FetchListAsync(async reader =>
+                {
+                    var id = await reader.GetFieldValueAsync<Guid>(0, token);
+                    var headers = await reader.IsDBNullAsync(1, token)
+                        ? null
+                        : await reader.GetFieldValueAsync<string>(1, token);
+                    var body = await reader.IsDBNullAsync(2, token)
+                        ? Array.Empty<byte>()
+                        : await reader.GetFieldValueAsync<byte[]>(2, token);
+
+                    return _mapper.MapIncoming(id, headers, body);
+                }, cancellation: token);
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueSender.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueSender.cs
@@ -1,0 +1,71 @@
+using System.Data;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Wolverine.Runtime;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.Postgresql.Transport.NServiceBus;
+
+internal class NServiceBusPostgresqlQueueSender : ISender
+{
+    private readonly NServiceBusPostgresqlQueue _queue;
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly NServiceBusPostgresqlEnvelopeMapper _mapper;
+    private readonly string _sendSql;
+
+    public NServiceBusPostgresqlQueueSender(NServiceBusPostgresqlQueue queue, IWolverineRuntime runtime)
+    {
+        _queue = queue;
+        _dataSource = queue.Parent.Store.NpgsqlDataSource;
+        _mapper = queue.BuildMapper(runtime);
+        Destination = queue.Uri;
+
+        // The documented NServiceBus PostgreSQL send statement. The column identifiers are left
+        // unquoted: Weasel provisions the queue table with case-folded (lowercase) column names,
+        // so unquoted references resolve correctly.
+        _sendSql =
+            $@"INSERT INTO {queue.TableIdentifier} (Id, Expires, Headers, Body) VALUES (:id, :expires, :headers, :body)";
+    }
+
+    // NServiceBus delayed delivery uses a separate timeout table + mover; not supported in v1.
+    public bool SupportsNativeScheduledSend => false;
+
+    public Uri Destination { get; }
+
+    public async Task<bool> PingAsync()
+    {
+        try
+        {
+            return await _queue.ExistsAsync();
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    public async ValueTask SendAsync(Envelope envelope)
+    {
+        var row = _mapper.MapOutgoing(envelope);
+
+        await using var conn = await _dataSource.OpenConnectionAsync();
+        try
+        {
+            var cmd = conn.CreateCommand(_sendSql)
+                .With("id", row.Id)
+                .With("headers", row.Headers)
+                .With("body", row.Body);
+
+            // The NServiceBus Expires column is a plain timestamp; bind it with an explicit
+            // type so a null is sent as a typed NULL rather than an untyped parameter.
+            cmd.With("expires", (object?)row.Expires?.UtcDateTime ?? DBNull.Value, DbType.DateTime);
+
+            await cmd.ExecuteNonQueryAsync();
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlTransport.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlTransport.cs
@@ -1,0 +1,114 @@
+using JasperFx.Core;
+using Spectre.Console;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using MultiTenantedMessageStore = Wolverine.Persistence.Durability.MultiTenantedMessageStore;
+
+namespace Wolverine.Postgresql.Transport.NServiceBus;
+
+/// <summary>
+/// A Wolverine transport that reads and writes the PostgreSQL queue tables owned by an
+/// NServiceBus endpoint, enabling bidirectional interop with NServiceBus over its
+/// documented PostgreSQL transport contract. Requires Wolverine itself to be using
+/// PostgreSQL backed message persistence (for the durable inbox/outbox); only the foreign
+/// queue tables belong to NServiceBus.
+/// </summary>
+public class NServiceBusPostgresqlTransport : BrokerTransport<NServiceBusPostgresqlQueue>
+{
+    public const string ProtocolName = "nservicebus-postgresql";
+
+    public NServiceBusPostgresqlTransport() : base(ProtocolName, "NServiceBus PostgreSQL Interop", [ProtocolName])
+    {
+        Queues = new LightweightCache<string, NServiceBusPostgresqlQueue>(name => new NServiceBusPostgresqlQueue(name, this));
+
+        // NServiceBus owns its own tables; do not provision them by default.
+        AutoProvision = false;
+    }
+
+    public LightweightCache<string, NServiceBusPostgresqlQueue> Queues { get; }
+
+    /// <summary>
+    /// Schema name for the NServiceBus queue tables. Defaults to "public", matching the
+    /// NServiceBus PostgreSQL transport default.
+    /// </summary>
+    public string SchemaName { get; set; } = "public";
+
+    public override Uri ResourceUri => new("nservicebus-postgresql-transport://");
+
+    protected override IEnumerable<NServiceBusPostgresqlQueue> endpoints()
+    {
+        return Queues;
+    }
+
+    protected override IEnumerable<Endpoint> explicitEndpoints()
+    {
+        return Queues;
+    }
+
+    // NServiceBus queue/table names are matched verbatim against the foreign endpoint name.
+    public override string SanitizeIdentifier(string identifier)
+    {
+        return identifier;
+    }
+
+    protected override NServiceBusPostgresqlQueue findEndpointByUri(Uri uri)
+    {
+        return Queues[uri.Host];
+    }
+
+    public override async ValueTask ConnectAsync(IWolverineRuntime runtime)
+    {
+        if (runtime.Storage is PostgresqlMessageStore store)
+        {
+            Store = store;
+        }
+        else if (runtime.Storage is MultiTenantedMessageStore mt && mt.Main is PostgresqlMessageStore s)
+        {
+            Store = s;
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                "The NServiceBus PostgreSQL interop transport can only be used if Wolverine's message persistence is also PostgreSQL backed");
+        }
+
+        // de facto environment test
+        await using var conn = await Store.NpgsqlDataSource.OpenConnectionAsync();
+        await conn.CloseAsync();
+    }
+
+    internal PostgresqlMessageStore Store { get; set; } = null!;
+
+    /// <summary>
+    /// Resolve the PostgreSQL connection string used for the NServiceBus queue tables. Works
+    /// before <see cref="ConnectAsync"/> has run (e.g. from the Weasel command line) by falling
+    /// back to the PostgreSQL message store registered for Wolverine's own persistence.
+    /// </summary>
+    internal string ResolveConnectionString(IWolverineRuntime runtime)
+    {
+        if (Store is not null)
+        {
+            return Store.Settings.ConnectionString!;
+        }
+
+        if (runtime.Storage is PostgresqlMessageStore store)
+        {
+            return store.Settings.ConnectionString!;
+        }
+
+        if (runtime.Storage is MultiTenantedMessageStore mt && mt.Main is PostgresqlMessageStore s)
+        {
+            return s.Settings.ConnectionString!;
+        }
+
+        throw new InvalidOperationException(
+            "The NServiceBus PostgreSQL interop transport requires PostgreSQL backed message persistence");
+    }
+
+    public override IEnumerable<PropertyColumn> DiagnosticColumns()
+    {
+        yield return new PropertyColumn("NServiceBus Queue");
+        yield return new PropertyColumn("Count", Justify.Right);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlTransportDatabase.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlTransportDatabase.cs
@@ -1,0 +1,93 @@
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using JasperFx.Descriptors;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Weasel.Postgresql;
+using Wolverine.RDBMS;
+using Wolverine.Runtime;
+
+namespace Wolverine.Postgresql.Transport.NServiceBus;
+
+/// <summary>
+/// Exposes the NServiceBus interop queue tables as a Weasel <see cref="IDatabase"/> so they
+/// participate in Wolverine's resource model and the Weasel command line tooling
+/// (db-apply / db-dump / db-assert).
+/// </summary>
+public class NServiceBusPostgresqlTransportDatabase : DatabaseBase<NpgsqlConnection>
+{
+    private readonly NServiceBusPostgresqlTransport _transport;
+    private readonly string _connectionString;
+
+    internal static NpgsqlConnection BuildConnection(IWolverineRuntime runtime)
+    {
+        var transport = runtime.Options.NServiceBusPostgresqlTransport();
+        return new NpgsqlConnection(transport.ResolveConnectionString(runtime));
+    }
+
+    public NServiceBusPostgresqlTransportDatabase(IWolverineRuntime runtime) : base(
+        new MigrationLogger(runtime.LoggerFactory.CreateLogger<NServiceBusPostgresqlTransportDatabase>()),
+        AutoCreate.CreateOrUpdate, new PostgresqlMigrator(), "NServiceBus PostgreSQL Interop",
+        () => BuildConnection(runtime))
+    {
+        _transport = runtime.Options.NServiceBusPostgresqlTransport();
+        _connectionString = _transport.ResolveConnectionString(runtime);
+
+        // ReSharper disable once VirtualMemberCallInConstructor
+        var descriptor = Describe();
+        Id = new DatabaseId(descriptor.ServerName, descriptor.DatabaseName);
+    }
+
+    public override DatabaseDescriptor Describe()
+    {
+        var builder = new NpgsqlConnectionStringBuilder(_connectionString);
+        var descriptor = new DatabaseDescriptor
+        {
+            Engine = "PostgreSQL",
+            ServerName = builder.Host ?? string.Empty,
+            DatabaseName = builder.Database ?? string.Empty,
+            Subject = GetType().FullNameInCode(),
+            SchemaOrNamespace = _transport.SchemaName
+        };
+
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.Host!));
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.Port));
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.Database!));
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.Username!));
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.ApplicationName!));
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.Pooling));
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.MinPoolSize));
+        descriptor.Properties.Add(OptionsValue.Read(builder, x => x.MaxPoolSize));
+
+        descriptor.Properties.RemoveAll(x => x.Name.ContainsIgnoreCase("password"));
+        descriptor.Properties.RemoveAll(x => x.Name.ContainsIgnoreCase("certificate"));
+
+        return descriptor;
+    }
+
+    public override IFeatureSchema[] BuildFeatureSchemas()
+    {
+        return _transport.Queues
+            .Select(queue => (IFeatureSchema)new NServiceBusPostgresqlQueueFeatureSchema(queue, Migrator))
+            .ToArray();
+    }
+}
+
+internal class NServiceBusPostgresqlQueueFeatureSchema : FeatureSchemaBase
+{
+    public NServiceBusPostgresqlQueue Queue { get; }
+
+    public NServiceBusPostgresqlQueueFeatureSchema(NServiceBusPostgresqlQueue queue, Migrator migrator)
+        : base($"NServiceBusPostgresqlQueue_{queue.Name}", migrator)
+    {
+        Queue = queue;
+    }
+
+    protected override IEnumerable<ISchemaObject> schemaObjects()
+    {
+        yield return Queue.QueueTable;
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlTransportExtensions.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlTransportExtensions.cs
@@ -1,0 +1,89 @@
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Weasel.Core.Migrations;
+using Wolverine.Configuration;
+
+namespace Wolverine.Postgresql.Transport.NServiceBus;
+
+public static class NServiceBusPostgresqlTransportExtensions
+{
+    /// <summary>
+    /// Find or add the NServiceBus PostgreSQL interop transport for this application.
+    /// Requires Wolverine to also be using PostgreSQL backed message persistence.
+    /// </summary>
+    internal static NServiceBusPostgresqlTransport NServiceBusPostgresqlTransport(this WolverineOptions options,
+        string? schema = null)
+    {
+        var transport = options.Transports.OfType<NServiceBusPostgresqlTransport>().FirstOrDefault();
+        if (transport == null)
+        {
+            transport = new NServiceBusPostgresqlTransport();
+            options.Transports.Add(transport);
+
+            // Expose the NServiceBus queue tables to the Weasel resource model / command line.
+            options.Services.AddTransient<IDatabase, NServiceBusPostgresqlTransportDatabase>();
+        }
+
+        if (schema.IsNotEmpty())
+        {
+            transport.SchemaName = schema!;
+        }
+
+        return transport;
+    }
+
+    /// <summary>
+    /// Opt into the NServiceBus PostgreSQL interop transport and configure transport-wide
+    /// settings. Calling this is optional; <see cref="ListenToNServiceBusPostgresqlQueue"/> and
+    /// <see cref="ToNServiceBusPostgresqlQueue"/> will register the transport on demand.
+    /// </summary>
+    /// <param name="schema">Schema that owns the NServiceBus queue tables; defaults to "public"</param>
+    /// <param name="autoProvision">
+    /// When true, Wolverine will create the NServiceBus queue tables if they do not already
+    /// exist. Defaults to false because NServiceBus normally owns and provisions its own tables.
+    /// </param>
+    public static WolverineOptions UseNServiceBusPostgresqlInterop(this WolverineOptions options,
+        string? schema = null, bool autoProvision = false)
+    {
+        var transport = options.NServiceBusPostgresqlTransport(schema);
+        transport.AutoProvision = autoProvision;
+        return options;
+    }
+
+    /// <summary>
+    /// Listen for messages published by an NServiceBus endpoint to a PostgreSQL queue table
+    /// of the given name. The table is owned by NServiceBus; Wolverine reads it directly.
+    /// </summary>
+    /// <param name="queueName">The NServiceBus queue/table name (matched verbatim)</param>
+    /// <param name="schema">Optional schema for the NServiceBus queue tables; defaults to "public"</param>
+    public static NServiceBusPostgresqlListenerConfiguration ListenToNServiceBusPostgresqlQueue(
+        this WolverineOptions options, string queueName, string? schema = null)
+    {
+        var transport = options.NServiceBusPostgresqlTransport(schema);
+        var queue = transport.Queues[queueName];
+        queue.EndpointName = queueName;
+        queue.IsListener = true;
+
+        return new NServiceBusPostgresqlListenerConfiguration(queue);
+    }
+
+    /// <summary>
+    /// Publish matching messages straight to an NServiceBus-owned PostgreSQL queue table
+    /// using the queue name, encoded in the NServiceBus SQL transport wire format.
+    /// </summary>
+    /// <param name="queueName">The NServiceBus queue/table name (matched verbatim)</param>
+    /// <param name="schema">Optional schema for the NServiceBus queue tables; defaults to "public"</param>
+    public static NServiceBusPostgresqlSubscriberConfiguration ToNServiceBusPostgresqlQueue(
+        this IPublishToExpression publishing, string queueName, string? schema = null)
+    {
+        var options = publishing.As<PublishingExpression>().Parent;
+        var transport = options.NServiceBusPostgresqlTransport(schema);
+        var queue = transport.Queues[queueName];
+        queue.EndpointName = queueName;
+
+        publishing.To(queue.Uri);
+
+        return new NServiceBusPostgresqlSubscriberConfiguration(queue);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusQueueTable.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusQueueTable.cs
@@ -1,0 +1,29 @@
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+
+namespace Wolverine.Postgresql.Transport.NServiceBus;
+
+/// <summary>
+/// Weasel model of an NServiceBus PostgreSQL transport queue table. Mirrors the layout the
+/// NServiceBus PostgreSQL transport creates, so that Wolverine's schema management — and the
+/// Weasel command line tooling — can create, diff, and drop these tables the same way it does
+/// its own messaging transport tables.
+/// </summary>
+internal class NServiceBusQueueTable : Table
+{
+    public NServiceBusQueueTable(DbObjectName identifier) : base(identifier)
+    {
+        AddColumn<Guid>("Id").AsPrimaryKey();
+        AddColumn("Expires", "timestamp");
+        AddColumn<string>("Headers").NotNull();
+        AddColumn("Body", "bytea");
+
+        // Seq is the auto-incrementing column NServiceBus orders on for FIFO receive. We model it
+        // only as a serial column: NServiceBus adds a UNIQUE *constraint* on seq, but Weasel can
+        // only express a unique *index*, and the two don't reconcile (Weasel would try to drop the
+        // constraint-backed index, which PostgreSQL refuses). Since the transport never needs to
+        // enforce seq uniqueness itself, leaving it off keeps schema diffs clean against the tables
+        // NServiceBus owns.
+        AddColumn<int>("Seq").AutoIncrement().NotNull();
+    }
+}


### PR DESCRIPTION
## What

Adds a database-backed Wolverine transport that interoperates **bidirectionally** with an [NServiceBus](https://particular.net/) endpoint using the [PostgreSQL transport](https://docs.particular.net/transports/sql/), by reading and writing the NServiceBus queue tables directly. This is the second permutation of the database-backed transport interop plan, following [#3198](https://github.com/JasperFx/wolverine/pull/3198) (NServiceBus + SQL Server).

## How

New `nservicebus-postgresql` transport in `Wolverine.Postgresql` (`src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/`), a faithful port of the SQL Server version:

- **Transport/Queue/Listener/Sender** over `NpgsqlDataSource`. Destructive `WITH … DELETE … WHERE ctid IN (… FOR UPDATE SKIP LOCKED) RETURNING` pop ordered by `seq`; `INSERT` send.
- **Envelope mapper** translating `Envelope` ⇄ (JSON `Headers` + raw `Body`) with the standard NServiceBus headers, the UTF-8 BOM strip, and the two-way `EnclosedMessageTypes` hierarchy mapping (concrete + interfaces) so interface-polymorphism interop works in both directions. AOT-safe (source-gen `JsonSerializerContext` + targeted suppressions).
- **Schema management entirely through Weasel** — `NServiceBusQueueTable` (`Weasel.Postgresql`) + a Weasel `IDatabase` (`DatabaseBase<NpgsqlConnection>` / `PostgresqlMigrator`), so the tables participate in the resource model and CLI.
- **Config:** `UseNServiceBusPostgresqlInterop(schema, autoProvision)`, `ListenToNServiceBusPostgresqlQueue(name)`, `ToNServiceBusPostgresqlQueue(name)`. `AutoProvision` off by default.

### Interop details discovered against a real NServiceBus host (NServiceBus 10 / `NServiceBus.Transport.PostgreSql` 9.1)
- NServiceBus uses **lowercase** column names — the DML matches via unquoted identifiers (which Postgres folds to lowercase, the same casing Weasel produces).
- NServiceBus adds a **unique constraint** on `seq` that Weasel can't reconcile with a unique index, so `seq` is modeled as a plain serial (the transport never needs to enforce its uniqueness).
- NServiceBus reply addresses are the quoted, schema-qualified `"schema"."table"`; the mapper extracts the bare queue name (so request/reply routes back) and `ToUri` is hardened against address forms that aren't valid URI hosts.

## Tests

- Framework smoke test (`nservicebus_postgresql_transport_smoke`): two Wolverine hosts round-trip through the NServiceBus-shaped table on real PostgreSQL.
- Full bidirectional fidelity (both directions, incl. interface polymorphism) against a **real NServiceBus.Transport.PostgreSql host** in the [wolverine-interop](https://github.com/JasperFx/wolverine-interop) repo — all 4 specs green.
- `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors).

## Docs

- `docs/guide/durability/postgresql.md` — NServiceBus interoperability section.
- `docs/tutorials/interop.md` — extended the database-transport NServiceBus section to cover PostgreSQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)