### PR TITLE
Pulsar: acknowledgment-strategy choice (individual / cumulative / batched) (#3180)

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -157,6 +157,32 @@ The callback receives the same `IConsumerBuilder` / `IProducerBuilder` Wolverine
 anything DotPulsar exposes is available. A listener also exposes `ConfigureProducer(...)` for the
 producer it uses on the requeue/redelivery path.
 
+## Acknowledgment Strategy
+
+By default the listener acknowledges each message individually as it completes. On high-volume
+subscriptions you can reduce broker chatter by acknowledging cumulatively or in batches:
+
+```csharp
+// Individual (default)
+opts.ListenToPulsarTopic("persistent://public/default/orders")
+    .AcknowledgeIndividually();
+
+// Cumulative — one ack confirms everything up to a point. Exclusive/Failover only.
+opts.ListenToPulsarTopic("persistent://public/default/orders")
+    .AcknowledgeCumulative();
+
+// Batched — individual acks flushed by count or interval
+opts.ListenToPulsarTopic("persistent://public/default/orders")
+    .AcknowledgeInBatches(batchSize: 100, interval: TimeSpan.FromSeconds(1));
+```
+
+**Cumulative ack is only valid for Exclusive / Failover subscriptions** — configuring it on a
+Shared / Key_Shared subscription throws a clear error at startup. Because Wolverine's buffered
+listener can complete messages out of order, cumulative ack only ever advances to the highest
+**contiguous-completed** message: it will never acknowledge a message that is still being processed,
+so no in-flight work is lost. Batched ack has no such ordering constraint and is safe for any
+subscription type.
+
 ## Read Only Subscriptions <Badge type="tip" text="3.13" />
 
 As part of Wolverine's "Requeue" error handling action, the Pulsar transport tries to quietly create a matching sender

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/acknowledgment_strategy.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/acknowledgment_strategy.cs
@@ -1,0 +1,208 @@
+using System.Buffers;
+using System.Collections.Concurrent;
+using DotPulsar;
+using DotPulsar.Abstractions;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.ComplianceTests;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+// GH-3180: acknowledgment-strategy choice (individual / cumulative / batched).
+public class acknowledgment_strategy
+{
+    private static MessageId Id(ulong entryId) => new(0UL, entryId, -1, -1, "");
+
+    private static (IConsumer<ReadOnlySequence<byte>> consumer, List<MessageId> cumulative,
+        List<List<MessageId>> batches, List<MessageId> individual) fakeConsumer()
+    {
+        var consumer = Substitute.For<IConsumer<ReadOnlySequence<byte>>>();
+        var cumulative = new List<MessageId>();
+        var batches = new List<List<MessageId>>();
+        var individual = new List<MessageId>();
+
+        consumer.AcknowledgeCumulative(Arg.Any<MessageId>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.CompletedTask);
+        consumer.When(c => c.AcknowledgeCumulative(Arg.Any<MessageId>(), Arg.Any<CancellationToken>()))
+            .Do(ci => cumulative.Add(ci.Arg<MessageId>()));
+
+        consumer.Acknowledge(Arg.Any<IEnumerable<MessageId>>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.CompletedTask);
+        consumer.When(c => c.Acknowledge(Arg.Any<IEnumerable<MessageId>>(), Arg.Any<CancellationToken>()))
+            .Do(ci => batches.Add(ci.Arg<IEnumerable<MessageId>>().ToList()));
+
+        consumer.Acknowledge(Arg.Any<MessageId>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.CompletedTask);
+        consumer.When(c => c.Acknowledge(Arg.Any<MessageId>(), Arg.Any<CancellationToken>()))
+            .Do(ci => individual.Add(ci.Arg<MessageId>()));
+
+        return (consumer, cumulative, batches, individual);
+    }
+
+    // ---- config unit tests ----
+
+    [Fact]
+    public void config_sets_each_strategy()
+    {
+        PulsarEndpoint apply(Action<PulsarListenerConfiguration> configure)
+        {
+            var endpoint = new PulsarTransport()[new Uri("pulsar://persistent/public/default/ack")];
+            var config = new PulsarListenerConfiguration(endpoint);
+            configure(config);
+            ((IDelayedEndpointConfiguration)config).Apply();
+            return endpoint;
+        }
+
+        apply(c => { }).AckStrategy.ShouldBe(PulsarAckStrategy.Individual);
+        apply(c => c.AcknowledgeCumulative()).AckStrategy.ShouldBe(PulsarAckStrategy.Cumulative);
+
+        var batched = apply(c => c.AcknowledgeInBatches(50, 2.Seconds()));
+        batched.AckStrategy.ShouldBe(PulsarAckStrategy.Batched);
+        batched.AckBatchSize.ShouldBe(50);
+        batched.AckBatchInterval.ShouldBe(2.Seconds());
+    }
+
+    // ---- handler logic (deterministic, no broker) ----
+
+    [Fact]
+    public async Task individual_acks_each_message()
+    {
+        var (consumer, _, _, individual) = fakeConsumer();
+        var handler = new PulsarAckHandler(consumer, PulsarAckStrategy.Individual, 100, TimeSpan.Zero, default);
+
+        await handler.CompleteAsync(Id(1));
+        await handler.CompleteAsync(Id(2));
+
+        individual.Select(x => x.EntryId).ShouldBe([1UL, 2UL]);
+    }
+
+    [Fact]
+    public async Task batched_flushes_by_count()
+    {
+        var (consumer, _, batches, _) = fakeConsumer();
+        var handler = new PulsarAckHandler(consumer, PulsarAckStrategy.Batched, 3, TimeSpan.Zero, default);
+
+        await handler.CompleteAsync(Id(1));
+        await handler.CompleteAsync(Id(2));
+        batches.ShouldBeEmpty();
+
+        await handler.CompleteAsync(Id(3));
+        batches.ShouldHaveSingleItem();
+        batches[0].Select(x => x.EntryId).ShouldBe([1UL, 2UL, 3UL]);
+    }
+
+    [Fact]
+    public async Task cumulative_never_acks_past_an_in_flight_message()
+    {
+        var (consumer, cumulative, _, _) = fakeConsumer();
+        var handler = new PulsarAckHandler(consumer, PulsarAckStrategy.Cumulative, 100, TimeSpan.Zero, default);
+
+        var m1 = Id(1);
+        var m2 = Id(2);
+        var m3 = Id(3);
+        handler.Track(m1);
+        handler.Track(m2);
+        handler.Track(m3);
+
+        // Out-of-order completion: 2 and 3 finish while 1 is still in flight. Cumulative ack must NOT
+        // advance, because doing so would confirm the still-in-flight message 1.
+        await handler.CompleteAsync(m2);
+        cumulative.ShouldBeEmpty();
+        await handler.CompleteAsync(m3);
+        cumulative.ShouldBeEmpty();
+
+        // Now the earliest in-flight message completes: the contiguous prefix is 1,2,3, so a single
+        // cumulative ack advances straight to 3.
+        await handler.CompleteAsync(m1);
+        cumulative.ShouldHaveSingleItem();
+        cumulative[0].EntryId.ShouldBe(3UL);
+    }
+
+    [Fact]
+    public async Task cumulative_advances_in_order()
+    {
+        var (consumer, cumulative, _, _) = fakeConsumer();
+        var handler = new PulsarAckHandler(consumer, PulsarAckStrategy.Cumulative, 100, TimeSpan.Zero, default);
+
+        var m1 = Id(1);
+        var m2 = Id(2);
+        handler.Track(m1);
+        handler.Track(m2);
+
+        await handler.CompleteAsync(m1);
+        await handler.CompleteAsync(m2);
+
+        cumulative.Select(x => x.EntryId).ShouldBe([1UL, 2UL]);
+    }
+
+    // ---- startup validation ----
+
+    [Fact]
+    public async Task cumulative_on_a_shared_subscription_is_rejected_at_startup()
+    {
+        var ex = await Should.ThrowAsync<Exception>(async () =>
+        {
+            using var _ = await WolverineHost.ForAsync(opts =>
+            {
+                opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+                opts.ListenToPulsarTopic($"persistent://public/default/ackshared-{Guid.NewGuid():N}")
+                    .SubscriptionType(SubscriptionType.Shared)
+                    .AcknowledgeCumulative();
+            });
+        });
+
+        ex.ToString().ShouldContain("Cumulative");
+    }
+
+    // ---- end-to-end ----
+
+    [Fact]
+    public async Task batched_acknowledgment_delivers_all_messages()
+    {
+        var topic = $"persistent://public/default/ackbatch-{Guid.NewGuid():N}";
+
+        using var host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.PublishMessage<AckMessage>().ToPulsarTopic(topic).SendInline();
+            opts.ListenToPulsarTopic(topic)
+                .SubscriptionName("sub-" + Guid.NewGuid().ToString("N"))
+                .AcknowledgeInBatches(3, 500.Milliseconds());
+            opts.Services.AddSingleton<AckSink>();
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<AckHandler>();
+        });
+
+        for (var i = 0; i < 5; i++)
+        {
+            await host.SendAsync(new AckMessage { Id = "m-" + i });
+        }
+
+        var sink = host.Services.GetRequiredService<AckSink>();
+        var cutoff = DateTimeOffset.UtcNow.AddSeconds(30);
+        while (DateTimeOffset.UtcNow < cutoff && sink.Received.Count < 5)
+        {
+            await Task.Delay(100);
+        }
+
+        sink.Received.OrderBy(x => x).ShouldBe(["m-0", "m-1", "m-2", "m-3", "m-4"]);
+    }
+}
+
+public class AckMessage
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class AckSink
+{
+    public ConcurrentBag<string> Received { get; } = new();
+}
+
+public class AckHandler
+{
+    public static void Handle(AckMessage message, AckSink sink) => sink.Received.Add(message.Id);
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarAckHandler.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarAckHandler.cs
@@ -1,0 +1,220 @@
+using System.Buffers;
+using DotPulsar;
+using DotPulsar.Abstractions;
+using DotPulsar.Extensions;
+
+namespace Wolverine.Pulsar;
+
+/// <summary>
+/// Encapsulates how a Pulsar consumer acknowledges completed messages for a given
+/// <see cref="PulsarAckStrategy"/>. See #3180.
+///
+/// The cumulative strategy is the only one with an ordering hazard: under the buffered listener,
+/// messages complete out of order, and a naive cumulative ack of a later message would confirm the
+/// earlier, still-in-flight ones (silent message loss). This handler tracks in-flight message ids and
+/// only ever advances the cumulative ack to the highest <em>contiguous</em> completed message — i.e.
+/// the largest completed id with no smaller id still in flight — so it never acks past in-flight work.
+/// </summary>
+internal sealed class PulsarAckHandler : IAsyncDisposable
+{
+    internal static readonly IComparer<MessageId> Comparer = new MessageIdComparer();
+
+    private readonly IConsumer<ReadOnlySequence<byte>> _consumer;
+    private readonly PulsarAckStrategy _strategy;
+    private readonly int _batchSize;
+    private readonly CancellationToken _cancellation;
+    private readonly object _lock = new();
+
+    // Batched
+    private readonly List<MessageId> _pendingBatch = new();
+    private readonly Timer? _batchTimer;
+
+    // Cumulative
+    private readonly SortedSet<MessageId> _inFlight = new(Comparer);
+    private readonly SortedSet<MessageId> _completed = new(Comparer);
+
+    public PulsarAckHandler(IConsumer<ReadOnlySequence<byte>> consumer, PulsarAckStrategy strategy, int batchSize,
+        TimeSpan batchInterval, CancellationToken cancellation)
+    {
+        _consumer = consumer;
+        _strategy = strategy;
+        _batchSize = batchSize < 1 ? 1 : batchSize;
+        _cancellation = cancellation;
+
+        if (_strategy == PulsarAckStrategy.Batched && batchInterval > TimeSpan.Zero)
+        {
+            _batchTimer = new Timer(_ => _ = flushBatchOnTimerAsync(), null, batchInterval, batchInterval);
+        }
+    }
+
+    /// <summary>
+    /// Record a message as received/in-flight. Only the cumulative strategy needs this so it can
+    /// compute the contiguous-completed watermark.
+    /// </summary>
+    public void Track(MessageId messageId)
+    {
+        if (_strategy != PulsarAckStrategy.Cumulative)
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            _inFlight.Add(messageId);
+        }
+    }
+
+    public async ValueTask CompleteAsync(MessageId messageId)
+    {
+        switch (_strategy)
+        {
+            case PulsarAckStrategy.Individual:
+                await _consumer.Acknowledge(messageId, _cancellation);
+                break;
+
+            case PulsarAckStrategy.Batched:
+                List<MessageId>? toFlush = null;
+                lock (_lock)
+                {
+                    _pendingBatch.Add(messageId);
+                    if (_pendingBatch.Count >= _batchSize)
+                    {
+                        toFlush = [.. _pendingBatch];
+                        _pendingBatch.Clear();
+                    }
+                }
+
+                if (toFlush != null)
+                {
+                    await _consumer.Acknowledge(toFlush, _cancellation);
+                }
+
+                break;
+
+            case PulsarAckStrategy.Cumulative:
+                MessageId? watermark;
+                lock (_lock)
+                {
+                    _inFlight.Remove(messageId);
+                    _completed.Add(messageId);
+                    watermark = takeCumulativeWatermark();
+                }
+
+                if (watermark is not null)
+                {
+                    await _consumer.AcknowledgeCumulative(watermark, _cancellation);
+                }
+
+                break;
+        }
+    }
+
+    /// <summary>
+    /// The highest completed id that is strictly below the smallest still-in-flight id (or the highest
+    /// completed id if nothing is in flight). Completed ids up to the watermark are removed from
+    /// tracking because the single cumulative ack covers them all. Caller must hold <see cref="_lock"/>.
+    /// </summary>
+    private MessageId? takeCumulativeWatermark()
+    {
+        MessageId? floor = null;
+        if (_inFlight.Count > 0)
+        {
+            floor = _inFlight.Min;
+        }
+
+        MessageId? watermark = null;
+        foreach (var completed in _completed)
+        {
+            if (floor is not null && Comparer.Compare(completed, floor) >= 0)
+            {
+                break;
+            }
+
+            watermark = completed;
+        }
+
+        if (watermark is not null)
+        {
+            _completed.RemoveWhere(x => Comparer.Compare(x, watermark) <= 0);
+        }
+
+        return watermark;
+    }
+
+    private async Task flushBatchOnTimerAsync()
+    {
+        try
+        {
+            List<MessageId>? toFlush = null;
+            lock (_lock)
+            {
+                if (_pendingBatch.Count > 0)
+                {
+                    toFlush = [.. _pendingBatch];
+                    _pendingBatch.Clear();
+                }
+            }
+
+            if (toFlush != null)
+            {
+                await _consumer.Acknowledge(toFlush, _cancellation);
+            }
+        }
+        catch
+        {
+            // Best-effort periodic flush; the next flush (or disposal) will retry remaining acks.
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_batchTimer != null)
+        {
+            await _batchTimer.DisposeAsync();
+        }
+
+        // Flush any remaining batched acks on shutdown.
+        if (_strategy == PulsarAckStrategy.Batched)
+        {
+            List<MessageId>? toFlush = null;
+            lock (_lock)
+            {
+                if (_pendingBatch.Count > 0)
+                {
+                    toFlush = [.. _pendingBatch];
+                    _pendingBatch.Clear();
+                }
+            }
+
+            if (toFlush != null)
+            {
+                try
+                {
+                    await _consumer.Acknowledge(toFlush, _cancellation);
+                }
+                catch
+                {
+                    // Shutting down — unacked messages will simply be redelivered.
+                }
+            }
+        }
+    }
+
+    private sealed class MessageIdComparer : IComparer<MessageId>
+    {
+        public int Compare(MessageId? x, MessageId? y)
+        {
+            if (ReferenceEquals(x, y)) return 0;
+            if (x is null) return -1;
+            if (y is null) return 1;
+
+            var c = x.LedgerId.CompareTo(y.LedgerId);
+            if (c != 0) return c;
+            c = x.EntryId.CompareTo(y.EntryId);
+            if (c != 0) return c;
+            c = x.Partition.CompareTo(y.Partition);
+            if (c != 0) return c;
+            return x.BatchIndex.CompareTo(y.BatchIndex);
+        }
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarAckStrategy.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarAckStrategy.cs
@@ -1,0 +1,28 @@
+namespace Wolverine.Pulsar;
+
+/// <summary>
+/// How a Pulsar listener acknowledges successfully processed messages. The Pulsar analogue of the
+/// Kafka transport's commit-mode choice (#3150).
+/// </summary>
+public enum PulsarAckStrategy
+{
+    /// <summary>
+    /// Acknowledge each message individually as soon as it completes (default, current behavior).
+    /// </summary>
+    Individual,
+
+    /// <summary>
+    /// Acknowledge cumulatively — a single ack confirms every message up to and including a point in
+    /// the subscription. Reduces broker chatter on high-volume ordered subscriptions. Only valid for
+    /// Exclusive / Failover subscriptions. Wolverine only advances the cumulative ack to the highest
+    /// contiguous-completed message, so a cumulative ack never confirms a still-in-flight message.
+    /// </summary>
+    Cumulative,
+
+    /// <summary>
+    /// Acknowledge messages individually but in batches, flushed when a batch size is reached or a
+    /// time interval elapses. Reduces broker chatter without the ordering constraints of cumulative
+    /// ack; safe for every subscription type.
+    /// </summary>
+    Batched
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -85,6 +85,25 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
     public bool UseNativeRedelivery { get; internal set; }
 
     /// <summary>
+    ///     How this listener acknowledges completed messages: individually (default), cumulatively, or
+    ///     batched. See <see cref="PulsarAckStrategy"/>.
+    /// </summary>
+    public PulsarAckStrategy AckStrategy { get; internal set; } = PulsarAckStrategy.Individual;
+
+    /// <summary>
+    ///     For <see cref="PulsarAckStrategy.Batched"/>: flush the pending acknowledgments once this many
+    ///     messages have completed. Default 100.
+    /// </summary>
+    public int AckBatchSize { get; internal set; } = 100;
+
+    /// <summary>
+    ///     For <see cref="PulsarAckStrategy.Batched"/>: also flush pending acknowledgments at least this
+    ///     often, even if the batch size has not been reached. Default 1 second; set to
+    ///     <see cref="TimeSpan.Zero"/> to flush only by count.
+    /// </summary>
+    public TimeSpan AckBatchInterval { get; internal set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
     ///     Optional hook to customize the DotPulsar consumer for this listener (consumer name,
     ///     receive-queue size, priority level, properties, etc.) immediately before it is created.
     /// </summary>

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -21,6 +21,7 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
     private readonly IReceiver _receiver;
     private readonly Task? _receivingRetryLoop;
     private readonly PulsarEndpoint _endpoint;
+    private readonly PulsarAckHandler _ackHandler;
     private IProducer<ReadOnlySequence<byte>>? _retryLetterQueueProducer;
     private IProducer<ReadOnlySequence<byte>>? _dlqProducer;
 
@@ -31,6 +32,15 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
         _endpoint = endpoint;
         _receiver = receiver ?? throw new ArgumentNullException(nameof(receiver));
         _cancellation = cancellation;
+
+        if (endpoint.AckStrategy == PulsarAckStrategy.Cumulative &&
+            endpoint.SubscriptionType is SubscriptionType.Shared or SubscriptionType.KeyShared)
+        {
+            throw new InvalidOperationException(
+                $"Cumulative acknowledgment is only valid for Exclusive or Failover subscriptions, not " +
+                $"{endpoint.SubscriptionType}, on Pulsar topic {endpoint.PulsarTopic()}. Use Individual or " +
+                "Batched acknowledgment for shared subscriptions.");
+        }
 
         Address = endpoint.Uri;
 
@@ -75,6 +85,9 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
 
         _consumer = consumerBuilder.Create();
 
+        _ackHandler = new PulsarAckHandler(_consumer, endpoint.AckStrategy, endpoint.AckBatchSize,
+            endpoint.AckBatchInterval, _cancellation);
+
         // Per-endpoint-override-wins resolution (endpoint override, else transport default).
         NativeDeadLetterQueueEnabled = endpoint.EffectiveDeadLetterTopic is not null &&
                                        endpoint.EffectiveDeadLetterTopic.Mode != DeadLetterTopicMode.WolverineStorage;
@@ -88,6 +101,9 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
         {
             await foreach (var message in _consumer.Messages(combined.Token))
             {
+                // Record receipt so the ack handler can compute the cumulative-ack watermark safely.
+                _ackHandler.Track(FixMessageId(message.MessageId, _consumer.Topic));
+
                 var envelope = new PulsarEnvelope(message)
                 {
                     Data = message.Data.ToArray(),
@@ -177,11 +193,17 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
     {
         if (envelope is PulsarEnvelope e)
         {
-            // Acknowledge on the appropriate consumer based on where the message came from
-            var consumer = e.IsFromRetryConsumer && _retryConsumer != null ? _retryConsumer : _consumer;
-            if (consumer != null)
+            // Retry-consumer messages always acknowledge individually; the configurable ack strategy
+            // (#3180) applies to the primary consumer.
+            if (e.IsFromRetryConsumer && _retryConsumer != null)
             {
-                return consumer.Acknowledge(FixMessageId(e.MessageData.MessageId, consumer.Topic), _cancellation);
+                return _retryConsumer.Acknowledge(FixMessageId(e.MessageData.MessageId, _retryConsumer.Topic),
+                    _cancellation);
+            }
+
+            if (_consumer != null)
+            {
+                return _ackHandler.CompleteAsync(FixMessageId(e.MessageData.MessageId, _consumer.Topic));
             }
         }
 
@@ -219,6 +241,9 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
     {
         await _localCancellation.CancelAsync();
         _localCancellation.Dispose();
+
+        // Flush any pending batched acks before the consumer is torn down.
+        await _ackHandler.DisposeAsync();
 
         if (_consumer != null)
         {

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -336,6 +336,51 @@ public class PulsarListenerConfiguration : InteroperableListenerConfiguration<Pu
     }
 
     /// <summary>
+    /// Acknowledge each message individually as it completes (the default).
+    /// </summary>
+    /// <returns></returns>
+    public PulsarListenerConfiguration AcknowledgeIndividually()
+    {
+        add(e => { e.AckStrategy = PulsarAckStrategy.Individual; });
+        return this;
+    }
+
+    /// <summary>
+    /// Acknowledge cumulatively — one ack confirms every message up to a point in the subscription,
+    /// reducing broker chatter on high-volume ordered subscriptions. Only valid for Exclusive /
+    /// Failover subscriptions (a clear error is thrown at startup otherwise). Wolverine only advances
+    /// the cumulative ack to the highest contiguous-completed message, so it never acks a message
+    /// that is still being processed.
+    /// </summary>
+    /// <returns></returns>
+    public PulsarListenerConfiguration AcknowledgeCumulative()
+    {
+        add(e => { e.AckStrategy = PulsarAckStrategy.Cumulative; });
+        return this;
+    }
+
+    /// <summary>
+    /// Acknowledge messages individually but in batches, flushed when <paramref name="batchSize"/>
+    /// messages have completed or every <paramref name="interval"/> (whichever comes first). Reduces
+    /// broker chatter without the ordering constraints of cumulative ack; safe for every subscription
+    /// type.
+    /// </summary>
+    /// <param name="batchSize">Flush after this many completed messages. Default 100.</param>
+    /// <param name="interval">Also flush at least this often. Default 1 second; pass
+    /// <see cref="TimeSpan.Zero"/> to flush only by count.</param>
+    /// <returns></returns>
+    public PulsarListenerConfiguration AcknowledgeInBatches(int batchSize = 100, TimeSpan? interval = null)
+    {
+        add(e =>
+        {
+            e.AckStrategy = PulsarAckStrategy.Batched;
+            e.AckBatchSize = batchSize;
+            e.AckBatchInterval = interval ?? TimeSpan.FromSeconds(1);
+        });
+        return this;
+    }
+
+    /// <summary>
     /// Override the Pulsar subscription type to  <see cref="DotPulsar.SubscriptionType.Failover"/> for just this topic
     /// </summary>
     /// <param name="subscriptionType"></param>


### PR DESCRIPTION
Part of the Pulsar re-evaluation epic #3176. Fixes #3180. Builds on #3179.

The Pulsar analogue of the Kafka `CommitMode` overhaul (#3150). Adds a per-listener acknowledgment strategy.

## Strategies
- **Individual** (default) — ack each message as it completes (unchanged).
- **Cumulative** — one ack confirms everything up to a point in the subscription. **Exclusive/Failover only** (a clear error is thrown at startup for Shared/Key_Shared).
- **Batched** — individual acks flushed by count or interval; no ordering constraint, safe for any subscription type.

## Cumulative ordering safety (the correctness-sensitive bit)
Wolverine's buffered listener completes messages out of order. A naive cumulative ack of a later message would confirm earlier, still-in-flight ones — silent message loss. `PulsarAckHandler` tracks in-flight ids and the completed set, and only ever advances the cumulative ack to the **highest contiguous-completed** message, so it **never acks past in-flight work**. This is proven deterministically by a unit test (complete 2 and 3 while 1 is in flight → no ack; complete 1 → single cumulative ack jumps to 3).

## Changes
- New `PulsarAckStrategy` enum + `PulsarAckHandler` (encapsulates all three modes, watermark logic, batch flush + shutdown flush).
- `PulsarListener` tracks receipts and routes `CompleteAsync` through the handler (retry-consumer messages always ack individually); startup validation for cumulative-on-Shared.
- `PulsarListenerConfiguration.AcknowledgeIndividually() / AcknowledgeCumulative() / AcknowledgeInBatches(size, interval)`.

## Tests
Deterministic handler unit tests (individual; batched-by-count; cumulative **out-of-order watermark** + in-order), startup rejection of cumulative-on-Shared, and an end-to-end batched delivery test. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)