### PR TITLE
MassTransit PostgreSQL transport interop

### DIFF
--- a/docs/guide/durability/postgresql.md
+++ b/docs/guide/durability/postgresql.md
@@ -293,6 +293,44 @@ receive uses `FOR UPDATE SKIP LOCKED` ordered by the NServiceBus `seq` column. A
 See the [interop tutorial](/tutorials/interop) for the bigger picture and the
 [wolverine-interop](https://github.com/JasperFx/wolverine-interop) repository for a runnable, bidirectional sample.
 
+## MassTransit Interoperability <Badge type="tip" text="6.0" />
+
+Wolverine can also interoperate with a [MassTransit](https://masstransit.io) application that uses the
+[PostgreSQL SQL transport](https://masstransit.io/documentation/transports/sql). Unlike NServiceBus' documented
+table contract, MassTransit's SQL transport is a function-driven, two-table model
+(`transport.message` + `transport.message_delivery`) that MassTransit **owns and migrates itself**, so Wolverine
+interoperates by calling MassTransit's stored functions — `send_message` to publish, `fetch_messages` to lease, and
+`delete_message`/`unlock_message` to ack/nack — rather than reading and writing a table directly. MassTransit must be
+running (or have run) to migrate the `transport` schema; Wolverine never provisions it (beyond optionally calling
+`create_queue_v2` for a queue it listens to).
+
+```cs
+using Wolverine.Postgresql.Transport.MassTransit;
+
+builder.UseWolverine(opts =>
+{
+    // Wolverine's durable inbox/outbox lives in PostgreSQL
+    opts.PersistMessagesWithPostgresql(connectionString, "wolverine");
+
+    // Opt into the MassTransit PostgreSQL interop transport. autoProvision: true makes Wolverine
+    // call create_queue_v2 for its own listening queues.
+    opts.UseMassTransitPostgresqlInterop(autoProvision: true);
+
+    // Send Wolverine messages to a MassTransit queue
+    opts.PublishMessage<OrderPlaced>().ToMassTransitPostgresqlQueue("masstransit");
+
+    // Listen to the queue MassTransit sends to, and use it for replies
+    opts.ListenToMassTransitPostgresqlQueue("wolverine").UseForReplies();
+
+    opts.Policies.RegisterInteropMessageAssembly(typeof(IMyMessageContract).Assembly);
+});
+```
+
+Wolverine writes the bare message JSON into the `body` column and the envelope fields into the message columns,
+emitting the MassTransit `urn:message:{Namespace}:{TypeName}` message type. Incoming messages are leased through
+`fetch_messages` and acked/nacked with the `(message_delivery_id, lock_id)` pair MassTransit hands back. Message
+types are resolved against the assemblies you register with `RegisterInteropMessageAssembly`.
+
 ## Multi-Tenancy
 
 As of Wolverine 4.0, you have two ways to use multi-tenancy through separate databases per tenant with PostgreSQL:

--- a/docs/tutorials/interop.md
+++ b/docs/tutorials/interop.md
@@ -490,3 +490,43 @@ See the [SQL Server](/guide/durability/sqlserver.html#nservicebus-interoperabili
 [PostgreSQL](/guide/durability/postgresql.html#nservicebus-interoperability) transport guides for the full set of
 options, and the [wolverine-interop](https://github.com/JasperFx/wolverine-interop) repository for runnable,
 bidirectional samples with both frameworks hosted side by side.
+
+## Interop with MassTransit over Database Transports
+
+Wolverine can also interoperate with MassTransit over its
+[PostgreSQL SQL transport](https://masstransit.io/documentation/transports/sql). This is quite different from the
+NServiceBus database interop above: MassTransit's SQL transport is a function-driven, two-table model
+(`transport.message` + `transport.message_delivery`) that MassTransit owns and migrates itself. Rather than reading and
+writing a table, Wolverine calls MassTransit's stored functions — `send_message` to publish, `fetch_messages` to lease
+a batch, and `delete_message` / `unlock_message` to ack / nack.
+
+```cs
+using Wolverine.Postgresql.Transport.MassTransit;
+
+builder.UseWolverine(opts =>
+{
+    opts.PersistMessagesWithPostgresql(connectionString, "wolverine");
+
+    opts.UseMassTransitPostgresqlInterop(autoProvision: true);
+
+    opts.PublishMessage<OrderPlaced>().ToMassTransitPostgresqlQueue("masstransit");
+
+    opts.ListenToMassTransitPostgresqlQueue("wolverine").UseForReplies();
+
+    opts.Policies.RegisterInteropMessageAssembly(typeof(IMyMessageContract).Assembly);
+});
+```
+
+A few things to note:
+
+* MassTransit owns and migrates its `transport` schema, so it must be running (or have run) to create it. Wolverine
+  never provisions that schema — `autoProvision: true` only calls `create_queue_v2` for the queues Wolverine listens to.
+* Wolverine writes the **bare** message JSON to the `body` column plus the envelope fields as columns, and emits the
+  MassTransit `urn:message:{Namespace}:{TypeName}` message type. This is *not* the wrapped
+  `application/vnd.masstransit+json` envelope used by the broker transports above.
+* Receive is lease-based: each fetched message carries a `(message_delivery_id, lock_id)` pair that Wolverine uses to
+  ack (`delete_message`) on success or nack (`unlock_message`) on failure.
+
+See the [PostgreSQL transport guide](/guide/durability/postgresql.html#masstransit-interoperability) for the full set of
+options, and the [wolverine-interop](https://github.com/JasperFx/wolverine-interop) repository for a runnable,
+bidirectional sample.

--- a/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlConfiguration.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlConfiguration.cs
@@ -1,0 +1,80 @@
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+
+namespace Wolverine.Postgresql.Transport.MassTransit;
+
+public class MassTransitPostgresqlListenerConfiguration
+    : ListenerConfiguration<MassTransitPostgresqlListenerConfiguration, MassTransitPostgresqlQueue>
+{
+    public MassTransitPostgresqlListenerConfiguration(MassTransitPostgresqlQueue endpoint) : base(endpoint)
+    {
+    }
+
+    /// <summary>
+    ///     The maximum number of messages to receive in a single poll. Default is 20.
+    /// </summary>
+    public MassTransitPostgresqlListenerConfiguration MaximumMessagesToReceive(int maximum)
+    {
+        add(e => e.MaximumMessagesToReceive = maximum);
+        return this;
+    }
+
+    /// <summary>
+    ///     Configure how often to poll for new messages when the queue is idle.
+    /// </summary>
+    public MassTransitPostgresqlListenerConfiguration PollingInterval(TimeSpan interval)
+    {
+        add(e => e.PollingInterval = interval);
+        return this;
+    }
+
+    /// <summary>
+    ///     How long a fetched message is leased before MassTransit re-delivers it. Default 5 minutes.
+    /// </summary>
+    public MassTransitPostgresqlListenerConfiguration LockDuration(TimeSpan duration)
+    {
+        add(e => e.LockDuration = duration);
+        return this;
+    }
+
+    /// <summary>
+    ///     The bare MassTransit queue name that foreign endpoints should reply to.
+    ///     When not set, the Wolverine endpoint marked <c>UseForReplies()</c> is used.
+    /// </summary>
+    public MassTransitPostgresqlListenerConfiguration ReplyQueueName(string queueName)
+    {
+        add(e => e.InteropReplyQueueName = queueName);
+        return this;
+    }
+
+    /// <summary>
+    ///     Add circuit breaker exception handling to this listener.
+    /// </summary>
+    public MassTransitPostgresqlListenerConfiguration CircuitBreaker(Action<CircuitBreakerOptions>? configure = null)
+    {
+        add(e =>
+        {
+            e.CircuitBreakerOptions = new CircuitBreakerOptions();
+            configure?.Invoke(e.CircuitBreakerOptions);
+        });
+        return this;
+    }
+}
+
+public class MassTransitPostgresqlSubscriberConfiguration
+    : SubscriberConfiguration<MassTransitPostgresqlSubscriberConfiguration, MassTransitPostgresqlQueue>
+{
+    public MassTransitPostgresqlSubscriberConfiguration(MassTransitPostgresqlQueue endpoint) : base(endpoint)
+    {
+    }
+
+    /// <summary>
+    ///     The bare MassTransit queue name that the receiving endpoint should reply to.
+    ///     When not set, the Wolverine endpoint marked <c>UseForReplies()</c> is used.
+    /// </summary>
+    public MassTransitPostgresqlSubscriberConfiguration ReplyQueueName(string queueName)
+    {
+        add(e => e.InteropReplyQueueName = queueName);
+        return this;
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlEnvelopeMapper.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlEnvelopeMapper.cs
@@ -1,0 +1,330 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Wolverine.Util;
+using Endpoint = Wolverine.Configuration.Endpoint;
+
+namespace Wolverine.Postgresql.Transport.MassTransit;
+
+[JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSerializable(typeof(MassTransitPostgresqlHostInfo))]
+internal partial class MassTransitPostgresqlJsonContext : JsonSerializerContext;
+
+/// <summary>
+/// The MassTransit "host" object stored in the <c>host</c> jsonb column of a MassTransit
+/// message. Only the small set of fields MassTransit populates for a host descriptor.
+/// </summary>
+internal sealed class MassTransitPostgresqlHostInfo
+{
+    public string? MachineName { get; set; }
+    public string? ProcessName { get; set; }
+    public int ProcessId { get; set; }
+    public string? Assembly { get; set; }
+    public string? AssemblyVersion { get; set; }
+    public string? FrameworkVersion { get; set; }
+    public string? MassTransitVersion { get; set; }
+    public string? OperatingSystemVersion { get; set; }
+}
+
+/// <summary>
+/// Translates between Wolverine <see cref="Envelope"/>s and the MassTransit PostgreSQL transport
+/// message model. MassTransit stores the BARE message contract JSON in the <c>body</c> column
+/// (content type <c>application/json</c>) with the envelope metadata in dedicated columns, and
+/// keys handler dispatch off a <c>urn:message:{Namespace}:{TypeName}</c> message type.
+/// </summary>
+internal class MassTransitPostgresqlEnvelopeMapper
+{
+    private const string JsonContentType = "application/json";
+
+    private readonly Endpoint _endpoint;
+    private readonly MassTransitPostgresqlTransport _transport;
+    private readonly Func<string?> _replyQueueName;
+
+    public MassTransitPostgresqlEnvelopeMapper(MassTransitPostgresqlQueue queue, Func<string?> replyQueueName)
+    {
+        _endpoint = queue;
+        _transport = queue.Parent;
+        _replyQueueName = replyQueueName;
+    }
+
+    /// <summary>
+    /// Build the parameter values passed to <c>transport.send_message</c> for an outgoing envelope.
+    /// </summary>
+    public OutgoingMessage MapOutgoing(MassTransitPostgresqlQueue destination, Envelope envelope)
+    {
+        var serializer = envelope.Serializer ?? _endpoint.DefaultSerializer
+            ?? throw new InvalidOperationException("No serializer is configured for this endpoint");
+
+        var bodyBytes = envelope.Data ?? serializer.WriteMessage(envelope.Message!);
+        var body = Encoding.UTF8.GetString(bodyBytes);
+
+        var messageType = envelope.Message?.GetType();
+        var messageTypeUrn = messageType != null
+            ? BuildMessageTypeUrn(messageType)
+            : envelope.MessageType;
+
+        var headers = new Dictionary<string, string>();
+        foreach (var pair in envelope.Headers)
+        {
+            if (pair.Value != null)
+            {
+                headers[pair.Key] = pair.Value;
+            }
+        }
+
+        var headersJson = JsonSerializer.Serialize(headers,
+            MassTransitPostgresqlJsonContext.Default.DictionaryStringString);
+
+        var hostJson = JsonSerializer.Serialize(BuildHostInfo(),
+            MassTransitPostgresqlJsonContext.Default.MassTransitPostgresqlHostInfo);
+
+        var destinationAddress = BuildDbUri(destination.Name);
+
+        string? responseAddress = null;
+        var replyName = _replyQueueName();
+        if (replyName.IsNotEmpty())
+        {
+            responseAddress = BuildDbUri(replyName!);
+        }
+
+        return new OutgoingMessage
+        {
+            EntityName = destination.Name,
+            Body = body,
+            ContentType = JsonContentType,
+            MessageType = messageTypeUrn,
+            MessageId = envelope.Id,
+            CorrelationId = parseGuid(envelope.CorrelationId),
+            ConversationId = envelope.ConversationId == Guid.Empty ? null : envelope.ConversationId,
+            SourceAddress = responseAddress,
+            DestinationAddress = destinationAddress,
+            ResponseAddress = responseAddress,
+            Headers = headersJson,
+            Host = hostJson
+        };
+    }
+
+    /// <summary>
+    /// Hydrate an <see cref="Envelope"/> from a <c>transport.fetch_messages</c> result row.
+    /// </summary>
+    public Envelope MapIncoming(FetchedRow row)
+    {
+        var envelope = new Envelope
+        {
+            Data = row.Body.IsNotEmpty() ? Encoding.UTF8.GetBytes(row.Body!) : [],
+            ContentType = JsonContentType
+        };
+
+        envelope.Id = row.MessageId ?? Guid.NewGuid();
+
+        if (row.ConversationId.HasValue)
+        {
+            envelope.ConversationId = row.ConversationId.Value;
+        }
+
+        if (row.CorrelationId.HasValue)
+        {
+            envelope.CorrelationId = row.CorrelationId.Value.ToString();
+        }
+
+        if (row.MessageType.IsNotEmpty())
+        {
+            envelope.MessageType = ResolveMessageType(row.MessageType!);
+        }
+
+        // Mirror MassTransitJsonSerializer: reply to the response address, else the source address.
+        var replyAddress = row.ResponseAddress.IsNotEmpty() ? row.ResponseAddress : row.SourceAddress;
+        if (replyAddress.IsNotEmpty())
+        {
+            var translated = TranslateDbUriToWolverine(replyAddress!);
+            if (translated != null)
+            {
+                envelope.ReplyUri = translated;
+            }
+        }
+
+        if (row.SentTime.HasValue)
+        {
+            envelope.SentAt = new DateTimeOffset(row.SentTime.Value.ToUniversalTime(), TimeSpan.Zero);
+        }
+
+        if (row.Headers.IsNotEmpty())
+        {
+            var headers = JsonSerializer.Deserialize(row.Headers!,
+                MassTransitPostgresqlJsonContext.Default.DictionaryStringString);
+            if (headers != null)
+            {
+                foreach (var pair in headers)
+                {
+                    envelope.Headers[pair.Key] = pair.Value;
+                }
+            }
+        }
+
+        envelope.Serializer = _endpoint.TryFindSerializer(JsonContentType) ?? _endpoint.DefaultSerializer;
+
+        return envelope;
+    }
+
+    /// <summary>
+    /// MassTransit keys dispatch off <c>urn:message:{Namespace}:{TypeName}</c>; mirror the
+    /// existing <c>MassTransitEnvelope</c> shape (NameInCode for generic-aware naming).
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification =
+            "Reflecting over a live message instance's runtime type to build the MassTransit urn; the type is present at runtime.")]
+    internal static string BuildMessageTypeUrn(Type messageType)
+    {
+        return $"urn:message:{messageType.Namespace}:{messageType.NameInCode()}";
+    }
+
+    /// <summary>
+    /// Resolve a MassTransit <c>urn:message:Ns:Type</c> back to a Wolverine message type name.
+    /// The last ':'-separated segment is the type name; the remainder (joined by '.') is the
+    /// namespace. If the resulting type can be loaded use <see cref="TypeExtensions.ToMessageTypeName"/>,
+    /// otherwise fall back to the bare type name.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2057",
+        Justification =
+            "The message type name comes from a foreign MassTransit endpoint at runtime; a failed resolution falls back to the full type name which Wolverine binds via RegisterInteropMessageAssembly.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification =
+            "Resolving an interop message type by name across loaded assemblies; the assembly is registered via RegisterInteropMessageAssembly and a miss falls back to the full type name.")]
+    internal static string ResolveMessageType(string messageType)
+    {
+        // MassTransit may carry multiple type entries separated by ';' (concrete + interfaces).
+        var first = messageType.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault() ?? messageType;
+
+        const string prefix = "urn:message:";
+        var bare = first.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? first[prefix.Length..]
+            : first;
+
+        var lastColon = bare.LastIndexOf(':');
+        if (lastColon <= 0 || lastColon == bare.Length - 1)
+        {
+            return bare;
+        }
+
+        var typeName = bare[(lastColon + 1)..];
+        var ns = bare[..lastColon].Replace(':', '.');
+        var fullName = $"{ns}.{typeName}";
+
+        // The urn carries no assembly, so Type.GetType(fullName) usually fails; search the loaded
+        // assemblies (the interop message assembly is registered via RegisterInteropMessageAssembly).
+        var type = Type.GetType(fullName);
+        if (type == null)
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                type = assembly.GetType(fullName);
+                if (type != null) break;
+            }
+        }
+
+        // Fall back to the full "Namespace.TypeName" (NOT the bare type name) so it matches the
+        // Wolverine message-type-name the handler is registered under.
+        return type != null ? type.ToMessageTypeName() : fullName;
+    }
+
+    /// <summary>
+    /// Build a MassTransit <c>db://{host}:{port}/{queue}</c> address.
+    /// </summary>
+    internal string BuildDbUri(string queueName)
+    {
+        return $"db://{_transport.MassTransitHost}/{queueName}";
+    }
+
+    /// <summary>
+    /// Translate a MassTransit <c>db://...</c> response address to this transport's
+    /// <c>masstransit-postgresql://{queue}</c> reply URI by taking the last path segment.
+    /// </summary>
+    internal static Uri? TranslateDbUriToWolverine(string dbUri)
+    {
+        if (Uri.TryCreate(dbUri, UriKind.Absolute, out var uri))
+        {
+            var lastSegment = uri.Segments.LastOrDefault()?.Trim('/');
+            if (lastSegment.IsNotEmpty())
+            {
+                return MassTransitPostgresqlQueue.ToUri(lastSegment!);
+            }
+        }
+        else
+        {
+            // Best-effort: take the substring after the last '/'.
+            var slash = dbUri.LastIndexOf('/');
+            if (slash >= 0 && slash < dbUri.Length - 1)
+            {
+                return MassTransitPostgresqlQueue.ToUri(dbUri[(slash + 1)..]);
+            }
+        }
+
+        return null;
+    }
+
+    private static MassTransitPostgresqlHostInfo BuildHostInfo()
+    {
+        var instance = Wolverine.Runtime.Interop.MassTransit.BusHostInfo.Instance;
+        return new MassTransitPostgresqlHostInfo
+        {
+            MachineName = instance.MachineName,
+            ProcessName = instance.ProcessName,
+            ProcessId = instance.ProcessId,
+            Assembly = instance.Assembly,
+            AssemblyVersion = instance.AssemblyVersion,
+            FrameworkVersion = instance.FrameworkVersion,
+            MassTransitVersion = instance.MassTransitVersion,
+            OperatingSystemVersion = instance.OperatingSystemVersion
+        };
+    }
+
+    private static Guid? parseGuid(string? value)
+    {
+        return value.IsNotEmpty() && Guid.TryParse(value, out var guid) ? guid : null;
+    }
+
+    /// <summary>
+    /// Carries the values bound into the <c>transport.send_message</c> call for an outgoing
+    /// message. Nullable Guid/string values are sent as typed NULLs by the sender.
+    /// </summary>
+    internal sealed class OutgoingMessage
+    {
+        public string EntityName { get; init; } = string.Empty;
+        public string Body { get; init; } = string.Empty;
+        public string ContentType { get; init; } = JsonContentType;
+        public string? MessageType { get; init; }
+        public Guid MessageId { get; init; }
+        public Guid? CorrelationId { get; init; }
+        public Guid? ConversationId { get; init; }
+        public string? SourceAddress { get; init; }
+        public string? DestinationAddress { get; init; }
+        public string? ResponseAddress { get; init; }
+        public string Headers { get; init; } = "{}";
+        public string Host { get; init; } = "{}";
+    }
+
+    /// <summary>
+    /// One row read back from <c>transport.fetch_messages</c>, including the lease coordinates
+    /// (<see cref="MessageDeliveryId"/> / <see cref="LockId"/>) needed for ack/nack.
+    /// </summary>
+    internal sealed class FetchedRow
+    {
+        public long MessageDeliveryId { get; init; }
+        public Guid LockId { get; init; }
+        public string? ContentType { get; init; }
+        public string? MessageType { get; init; }
+        public string? Body { get; init; }
+        public Guid? MessageId { get; init; }
+        public Guid? CorrelationId { get; init; }
+        public Guid? ConversationId { get; init; }
+        public string? SourceAddress { get; init; }
+        public string? DestinationAddress { get; init; }
+        public string? ResponseAddress { get; init; }
+        public DateTime? SentTime { get; init; }
+        public string? Headers { get; init; }
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlQueue.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlQueue.cs
@@ -1,0 +1,245 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Interop.MassTransit;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.Postgresql.Transport.MassTransit;
+
+public class MassTransitPostgresqlQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoint
+{
+    internal static Uri ToUri(string name)
+    {
+        var uriString = $"{MassTransitPostgresqlTransport.ProtocolName}://{name}";
+        return Uri.TryCreate(uriString, UriKind.Absolute, out var uri)
+            ? uri
+            : new Uri($"{MassTransitPostgresqlTransport.ProtocolName}://queue/{Uri.EscapeDataString(name)}");
+    }
+
+    private MassTransitPostgresqlEnvelopeMapper? _mapper;
+    private MassTransitPostgresqlQueueSender? _sender;
+
+    public MassTransitPostgresqlQueue(string name, MassTransitPostgresqlTransport parent,
+        EndpointRole role = EndpointRole.Application) : base(ToUri(name), role)
+    {
+        Parent = parent;
+        Name = name;
+        EndpointName = name;
+        BrokerRole = "queue";
+
+        // Interop endpoints exchange the foreign wire format; run buffered like the broker
+        // interop transports do.
+        Mode = EndpointMode.BufferedInMemory;
+    }
+
+    public string Name { get; }
+
+    internal MassTransitPostgresqlTransport Parent { get; }
+
+    /// <summary>
+    /// The bare MassTransit queue name that foreign endpoints should reply to. When null the
+    /// configured Wolverine reply endpoint name is used.
+    /// </summary>
+    public string? InteropReplyQueueName { get; set; }
+
+    /// <summary>
+    ///     The maximum number of messages to receive in a single poll. Default is 20.
+    /// </summary>
+    public int MaximumMessagesToReceive { get; set; } = 20;
+
+    /// <summary>
+    ///     How often to poll for new messages when the queue is idle. If null, falls back to
+    ///     DurabilitySettings.ScheduledJobPollingTime (default 5s).
+    /// </summary>
+    public TimeSpan? PollingInterval { get; set; }
+
+    /// <summary>
+    ///     How long a fetched message is leased before MassTransit considers it abandoned and
+    ///     re-delivers it. Default is 5 minutes.
+    /// </summary>
+    public TimeSpan LockDuration { get; set; } = 5.Minutes();
+
+    protected override bool supportsMode(EndpointMode mode)
+    {
+        return mode == EndpointMode.BufferedInMemory || mode == EndpointMode.Inline;
+    }
+
+    internal MassTransitPostgresqlEnvelopeMapper BuildMapper(IWolverineRuntime runtime)
+    {
+        if (_mapper != null) return _mapper;
+
+        DefaultSerializer ??= runtime.Options.DefaultSerializer;
+
+        var replyName = new Lazy<string?>(() =>
+        {
+            if (InteropReplyQueueName.IsNotEmpty()) return InteropReplyQueueName;
+            return Parent.ReplyEndpoint()?.EndpointName;
+        });
+
+        _mapper = new MassTransitPostgresqlEnvelopeMapper(this, () => replyName.Value);
+        return _mapper;
+    }
+
+    public override async ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+    {
+        if (Parent.AutoProvision)
+        {
+            await SetupAsync(runtime.LoggerFactory.CreateLogger<MassTransitPostgresqlQueue>());
+        }
+
+        var listener = new MassTransitPostgresqlQueueListener(this, runtime, receiver);
+        await listener.StartAsync();
+        return listener;
+    }
+
+    protected override ISender CreateSender(IWolverineRuntime runtime)
+    {
+        return _sender ??= new MassTransitPostgresqlQueueSender(this, runtime);
+    }
+
+    public override async ValueTask InitializeAsync(ILogger logger)
+    {
+        if (Parent.AutoProvision)
+        {
+            await SetupAsync(logger);
+        }
+
+        if (Parent.AutoPurgeAllQueues)
+        {
+            await PurgeAsync(logger);
+        }
+    }
+
+    // IBrokerQueue.CheckAsync -- does the MassTransit queue exist (type=1 is a regular queue).
+    public async ValueTask<bool> CheckAsync()
+    {
+        await using var conn = await Parent.Store.NpgsqlDataSource.OpenConnectionAsync();
+        try
+        {
+            return await queueExistsAsync(conn);
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    public async ValueTask SetupAsync(ILogger logger)
+    {
+        await using var conn = await Parent.Store.NpgsqlDataSource.OpenConnectionAsync();
+        try
+        {
+            await using var cmd = conn
+                .CreateCommand($"SELECT {Parent.SchemaName}.create_queue_v2(:name)")
+                .With("name", Name);
+            await cmd.ExecuteScalarAsync();
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    public async ValueTask TeardownAsync(ILogger logger)
+    {
+        // MassTransit owns the schema and its queue lifecycle; the minimal teardown is a purge.
+        await PurgeAsync(logger);
+    }
+
+    public async ValueTask PurgeAsync(ILogger logger)
+    {
+        await using var conn = await Parent.Store.NpgsqlDataSource.OpenConnectionAsync();
+        try
+        {
+            if (!await queueExistsAsync(conn)) return;
+
+            await using var cmd = conn
+                .CreateCommand($"SELECT {Parent.SchemaName}.purge_queue(:name)")
+                .With("name", Name);
+            await cmd.ExecuteScalarAsync();
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    public async ValueTask<Dictionary<string, string>> GetAttributesAsync()
+    {
+        var count = await CountAsync();
+        return new Dictionary<string, string> { { "MassTransit Queue", Name }, { "Count", count.ToString() } };
+    }
+
+    public async Task<long> CountAsync()
+    {
+        await using var conn = await Parent.Store.NpgsqlDataSource.OpenConnectionAsync();
+        try
+        {
+            if (!await queueExistsAsync(conn)) return 0;
+
+            await using var cmd = conn.CreateCommand(
+                    $"SELECT count(*) FROM {Parent.SchemaName}.message_delivery md JOIN {Parent.SchemaName}.queue q ON q.id = md.queue_id WHERE q.name = :name AND q.type = 1")
+                .With("name", Name);
+            return (long)(await cmd.ExecuteScalarAsync())!;
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    /// <summary>
+    /// Lightweight existence probe used to guard runtime DML and the sender ping.
+    /// </summary>
+    internal async Task<bool> ExistsAsync()
+    {
+        await using var conn = await Parent.Store.NpgsqlDataSource.OpenConnectionAsync();
+        try
+        {
+            return await queueExistsAsync(conn);
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    private async Task<bool> queueExistsAsync(NpgsqlConnection conn)
+    {
+        await using var cmd = conn
+            .CreateCommand($"SELECT EXISTS(SELECT 1 FROM {Parent.SchemaName}.queue WHERE name = :name AND type = 1)")
+            .With("name", Name);
+        return (bool)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    public Uri? MassTransitUri()
+    {
+        return $"db://{Parent.MassTransitHost}/{Name}".ToUri();
+    }
+
+    public Uri? MassTransitReplyUri()
+    {
+        if (InteropReplyQueueName.IsNotEmpty())
+        {
+            return $"db://{Parent.MassTransitHost}/{InteropReplyQueueName}".ToUri();
+        }
+
+        if (Parent.ReplyEndpoint() is MassTransitPostgresqlQueue replyQueue)
+        {
+            return replyQueue.MassTransitUri();
+        }
+
+        return null;
+    }
+
+    public Uri? TranslateMassTransitToWolverineUri(Uri uri)
+    {
+        var lastSegment = uri.Segments.LastOrDefault()?.Trim('/');
+        return lastSegment.IsNotEmpty() ? ToUri(lastSegment!) : null;
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlQueueListener.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlQueueListener.cs
@@ -1,0 +1,248 @@
+using System.Collections.Concurrent;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.Postgresql.Transport.MassTransit;
+
+internal class MassTransitPostgresqlQueueListener : IListener
+{
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly MassTransitPostgresqlQueue _queue;
+    private readonly IReceiver _receiver;
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly ILogger _logger;
+    private readonly MassTransitPostgresqlEnvelopeMapper _mapper;
+    private readonly TimeSpan _pollingInterval;
+    private readonly TimeSpan _lockDuration;
+    private readonly Guid _consumerId = Guid.NewGuid();
+    private readonly string _fetchSql;
+    private readonly string _deleteSql;
+    private readonly string _unlockSql;
+
+    // The lease coordinates per delivered envelope, so we can ack (delete_message) or
+    // nack (unlock_message) using the (delivery id, lock id) pair MassTransit handed us.
+    private readonly ConcurrentDictionary<Guid, (long DeliveryId, Guid LockId)> _leases = new();
+
+    private Task? _task;
+
+    public MassTransitPostgresqlQueueListener(MassTransitPostgresqlQueue queue, IWolverineRuntime runtime,
+        IReceiver receiver)
+    {
+        _queue = queue;
+        _receiver = receiver;
+        _dataSource = queue.Parent.Store.NpgsqlDataSource;
+        _logger = runtime.LoggerFactory.CreateLogger<MassTransitPostgresqlQueueListener>();
+        _mapper = queue.BuildMapper(runtime);
+        _pollingInterval = queue.PollingInterval ?? runtime.DurabilitySettings.ScheduledJobPollingTime;
+        _lockDuration = queue.LockDuration;
+
+        Address = queue.Uri;
+
+        var schema = queue.Parent.SchemaName;
+
+        _fetchSql =
+            $@"SELECT message_delivery_id, lock_id, content_type, message_type, body, message_id, correlation_id, conversation_id, source_address, destination_address, response_address, sent_time, headers FROM {schema}.fetch_messages(:queue, :consumer_id, :lock_id, :lock_duration, :count)";
+
+        _deleteSql = $"SELECT {schema}.delete_message(:delivery_id, :lock_id)";
+        _unlockSql = $"SELECT {schema}.unlock_message(:delivery_id, :lock_id, :delay, :headers)";
+    }
+
+    public IHandlerPipeline? Pipeline => _receiver.Pipeline;
+
+    public Uri Address { get; }
+
+    public async ValueTask CompleteAsync(Envelope envelope)
+    {
+        if (!_leases.TryGetValue(envelope.Id, out var lease))
+        {
+            return;
+        }
+
+        await using var conn = await _dataSource.OpenConnectionAsync();
+        try
+        {
+            await using var cmd = conn.CreateCommand(_deleteSql);
+            cmd.Parameters.Add(new NpgsqlParameter("delivery_id", NpgsqlDbType.Bigint) { Value = lease.DeliveryId });
+            cmd.Parameters.Add(new NpgsqlParameter("lock_id", NpgsqlDbType.Uuid) { Value = lease.LockId });
+            await cmd.ExecuteScalarAsync();
+        }
+        finally
+        {
+            await conn.CloseAsync();
+            _leases.TryRemove(envelope.Id, out _);
+        }
+    }
+
+    public async ValueTask DeferAsync(Envelope envelope)
+    {
+        if (!_leases.TryGetValue(envelope.Id, out var lease))
+        {
+            return;
+        }
+
+        await using var conn = await _dataSource.OpenConnectionAsync();
+        try
+        {
+            await using var cmd = conn.CreateCommand(_unlockSql);
+            cmd.Parameters.Add(new NpgsqlParameter("delivery_id", NpgsqlDbType.Bigint) { Value = lease.DeliveryId });
+            cmd.Parameters.Add(new NpgsqlParameter("lock_id", NpgsqlDbType.Uuid) { Value = lease.LockId });
+            cmd.Parameters.Add(new NpgsqlParameter("delay", NpgsqlDbType.Interval) { Value = TimeSpan.Zero });
+            cmd.Parameters.Add(new NpgsqlParameter("headers", NpgsqlDbType.Jsonb) { Value = DBNull.Value });
+            await cmd.ExecuteScalarAsync();
+        }
+        finally
+        {
+            await conn.CloseAsync();
+            _leases.TryRemove(envelope.Id, out _);
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return StopAsync();
+    }
+
+    public async ValueTask StopAsync()
+    {
+        await _cancellation.CancelAsync();
+        _task?.SafeDispose();
+    }
+
+    public Task StartAsync()
+    {
+        _task = Task.Run(listenForMessagesAsync, _cancellation.Token);
+        return Task.CompletedTask;
+    }
+
+    private async Task listenForMessagesAsync()
+    {
+        var failedCount = 0;
+
+        while (!_cancellation.Token.IsCancellationRequested)
+        {
+            try
+            {
+                var messages = await fetchAsync(_queue.MaximumMessagesToReceive, _cancellation.Token);
+                failedCount = 0;
+
+                if (messages.Count > 0)
+                {
+                    await _receiver.ReceivedAsync(this, messages.ToArray());
+                }
+                else
+                {
+                    await Task.Delay(_pollingInterval, _cancellation.Token);
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is TaskCanceledException or OperationCanceledException && _cancellation.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                failedCount++;
+                var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();
+                _logger.LogError(e, "Error while trying to receive messages from MassTransit PostgreSQL queue {Name}",
+                    _queue.Name);
+                await Task.Delay(pauseTime);
+            }
+        }
+    }
+
+    private async Task<IReadOnlyList<Envelope>> fetchAsync(int count, CancellationToken token)
+    {
+        // A fresh lock_id per fetch call; the consumer_id is stable for the listener lifetime.
+        var lockId = Guid.NewGuid();
+
+        await using var conn = await _dataSource.OpenConnectionAsync(token);
+        try
+        {
+            await using var cmd = conn.CreateCommand(_fetchSql);
+            cmd.Parameters.Add(new NpgsqlParameter("queue", NpgsqlDbType.Text) { Value = _queue.Name });
+            cmd.Parameters.Add(new NpgsqlParameter("consumer_id", NpgsqlDbType.Uuid) { Value = _consumerId });
+            cmd.Parameters.Add(new NpgsqlParameter("lock_id", NpgsqlDbType.Uuid) { Value = lockId });
+            cmd.Parameters.Add(new NpgsqlParameter("lock_duration", NpgsqlDbType.Interval) { Value = _lockDuration });
+            cmd.Parameters.Add(new NpgsqlParameter("count", NpgsqlDbType.Integer) { Value = count });
+
+            var envelopes = new List<Envelope>();
+
+            await using var reader = await cmd.ExecuteReaderAsync(token);
+            while (await reader.ReadAsync(token))
+            {
+                var row = await readRowAsync(reader, token);
+                var envelope = _mapper.MapIncoming(row);
+
+                // Stash the lease so CompleteAsync / DeferAsync can ack/nack this delivery.
+                _leases[envelope.Id] = (row.MessageDeliveryId, row.LockId);
+                envelopes.Add(envelope);
+            }
+
+            return envelopes;
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    private static async Task<MassTransitPostgresqlEnvelopeMapper.FetchedRow> readRowAsync(NpgsqlDataReader reader,
+        CancellationToken token)
+    {
+        return new MassTransitPostgresqlEnvelopeMapper.FetchedRow
+        {
+            MessageDeliveryId = await reader.GetFieldValueAsync<long>(0, token),
+            LockId = await reader.GetFieldValueAsync<Guid>(1, token),
+            ContentType = await readNullableStringAsync(reader, 2, token),
+            MessageType = await readNullableStringAsync(reader, 3, token),
+            Body = await readJsonbAsync(reader, 4, token),
+            MessageId = await readNullableGuidAsync(reader, 5, token),
+            CorrelationId = await readNullableGuidAsync(reader, 6, token),
+            ConversationId = await readNullableGuidAsync(reader, 7, token),
+            SourceAddress = await readNullableStringAsync(reader, 8, token),
+            DestinationAddress = await readNullableStringAsync(reader, 9, token),
+            ResponseAddress = await readNullableStringAsync(reader, 10, token),
+            SentTime = await readNullableDateTimeAsync(reader, 11, token),
+            Headers = await readJsonbAsync(reader, 12, token)
+        };
+    }
+
+    private static async Task<string?> readNullableStringAsync(NpgsqlDataReader reader, int ordinal,
+        CancellationToken token)
+    {
+        return await reader.IsDBNullAsync(ordinal, token)
+            ? null
+            : await reader.GetFieldValueAsync<string>(ordinal, token);
+    }
+
+    // jsonb columns come back as the JSON text representation.
+    private static async Task<string?> readJsonbAsync(NpgsqlDataReader reader, int ordinal, CancellationToken token)
+    {
+        return await reader.IsDBNullAsync(ordinal, token)
+            ? null
+            : await reader.GetFieldValueAsync<string>(ordinal, token);
+    }
+
+    private static async Task<Guid?> readNullableGuidAsync(NpgsqlDataReader reader, int ordinal,
+        CancellationToken token)
+    {
+        return await reader.IsDBNullAsync(ordinal, token)
+            ? null
+            : await reader.GetFieldValueAsync<Guid>(ordinal, token);
+    }
+
+    private static async Task<DateTime?> readNullableDateTimeAsync(NpgsqlDataReader reader, int ordinal,
+        CancellationToken token)
+    {
+        return await reader.IsDBNullAsync(ordinal, token)
+            ? null
+            : await reader.GetFieldValueAsync<DateTime>(ordinal, token);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlQueueSender.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlQueueSender.cs
@@ -1,0 +1,101 @@
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Wolverine.Runtime;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.Postgresql.Transport.MassTransit;
+
+internal class MassTransitPostgresqlQueueSender : ISender
+{
+    private readonly MassTransitPostgresqlQueue _queue;
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly MassTransitPostgresqlEnvelopeMapper _mapper;
+    private readonly string _sendSql;
+
+    public MassTransitPostgresqlQueueSender(MassTransitPostgresqlQueue queue, IWolverineRuntime runtime)
+    {
+        _queue = queue;
+        _dataSource = queue.Parent.Store.NpgsqlDataSource;
+        _mapper = queue.BuildMapper(runtime);
+        Destination = queue.Uri;
+
+        // Call MassTransit's transport.send_message with NAMED args, supplying only the
+        // parameters we populate so the function's own defaults cover the rest.
+        _sendSql =
+            $@"SELECT {queue.Parent.SchemaName}.send_message(
+    entity_name => :entity_name,
+    priority => :priority,
+    body => :body,
+    content_type => :content_type,
+    message_type => :message_type,
+    message_id => :message_id,
+    correlation_id => :correlation_id,
+    conversation_id => :conversation_id,
+    source_address => :source_address,
+    destination_address => :destination_address,
+    response_address => :response_address,
+    sent_time => :sent_time,
+    headers => :headers,
+    host => :host)";
+    }
+
+    // MassTransit delayed delivery uses a scheduling token + delay interval; not supported in v1.
+    public bool SupportsNativeScheduledSend => false;
+
+    public Uri Destination { get; }
+
+    public async Task<bool> PingAsync()
+    {
+        try
+        {
+            return await _queue.ExistsAsync();
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    public async ValueTask SendAsync(Envelope envelope)
+    {
+        var message = _mapper.MapOutgoing(_queue, envelope);
+
+        await using var conn = await _dataSource.OpenConnectionAsync();
+        try
+        {
+            await using var cmd = conn.CreateCommand(_sendSql);
+
+            cmd.Parameters.Add(new NpgsqlParameter("entity_name", NpgsqlDbType.Text) { Value = message.EntityName });
+            // MassTransit's message_delivery.priority is NOT NULL; the function doesn't default it,
+            // so pass MassTransit's normal default (100).
+            cmd.Parameters.Add(new NpgsqlParameter("priority", NpgsqlDbType.Integer) { Value = 100 });
+            cmd.Parameters.Add(new NpgsqlParameter("body", NpgsqlDbType.Jsonb) { Value = message.Body });
+            cmd.Parameters.Add(new NpgsqlParameter("content_type", NpgsqlDbType.Text) { Value = message.ContentType });
+            cmd.Parameters.Add(new NpgsqlParameter("message_type", NpgsqlDbType.Text)
+                { Value = (object?)message.MessageType ?? DBNull.Value });
+            cmd.Parameters.Add(new NpgsqlParameter("message_id", NpgsqlDbType.Uuid) { Value = message.MessageId });
+            cmd.Parameters.Add(new NpgsqlParameter("correlation_id", NpgsqlDbType.Uuid)
+                { Value = (object?)message.CorrelationId ?? DBNull.Value });
+            cmd.Parameters.Add(new NpgsqlParameter("conversation_id", NpgsqlDbType.Uuid)
+                { Value = (object?)message.ConversationId ?? DBNull.Value });
+            cmd.Parameters.Add(new NpgsqlParameter("source_address", NpgsqlDbType.Text)
+                { Value = (object?)message.SourceAddress ?? DBNull.Value });
+            cmd.Parameters.Add(new NpgsqlParameter("destination_address", NpgsqlDbType.Text)
+                { Value = (object?)message.DestinationAddress ?? DBNull.Value });
+            cmd.Parameters.Add(new NpgsqlParameter("response_address", NpgsqlDbType.Text)
+                { Value = (object?)message.ResponseAddress ?? DBNull.Value });
+            cmd.Parameters.Add(new NpgsqlParameter("sent_time", NpgsqlDbType.TimestampTz)
+                { Value = envelope.SentAt.UtcDateTime });
+            cmd.Parameters.Add(new NpgsqlParameter("headers", NpgsqlDbType.Jsonb) { Value = message.Headers });
+            cmd.Parameters.Add(new NpgsqlParameter("host", NpgsqlDbType.Jsonb) { Value = message.Host });
+
+            await cmd.ExecuteScalarAsync();
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlTransport.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlTransport.cs
@@ -1,0 +1,139 @@
+using JasperFx.Core;
+using Npgsql;
+using Spectre.Console;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using MultiTenantedMessageStore = Wolverine.Persistence.Durability.MultiTenantedMessageStore;
+
+namespace Wolverine.Postgresql.Transport.MassTransit;
+
+/// <summary>
+/// A Wolverine transport that interoperates with MassTransit's PostgreSQL SQL transport by
+/// calling MassTransit's own stored functions (<c>transport.send_message</c>,
+/// <c>transport.fetch_messages</c>, etc.) rather than writing the queue tables directly.
+/// MassTransit owns, provisions, and migrates its <c>transport</c> schema; Wolverine only
+/// invokes the documented functions. Requires Wolverine itself to be using PostgreSQL backed
+/// message persistence (for the durable inbox/outbox).
+/// </summary>
+public class MassTransitPostgresqlTransport : BrokerTransport<MassTransitPostgresqlQueue>
+{
+    public const string ProtocolName = "masstransit-postgresql";
+
+    private string _massTransitHost = "localhost:5432";
+
+    public MassTransitPostgresqlTransport() : base(ProtocolName, "MassTransit PostgreSQL Interop", [ProtocolName])
+    {
+        Queues = new LightweightCache<string, MassTransitPostgresqlQueue>(name => new MassTransitPostgresqlQueue(name, this));
+
+        // MassTransit owns its own schema; do not provision it by default.
+        AutoProvision = false;
+    }
+
+    public LightweightCache<string, MassTransitPostgresqlQueue> Queues { get; }
+
+    /// <summary>
+    /// Schema name for the MassTransit transport functions and tables. Defaults to "transport",
+    /// matching the MassTransit PostgreSQL transport default.
+    /// </summary>
+    public string SchemaName { get; set; } = "transport";
+
+    public override Uri ResourceUri => new("masstransit-postgresql-transport://");
+
+    /// <summary>
+    /// The MassTransit "host" identity ("{host}:{port}") used to build the MassTransit
+    /// <c>db://</c> addresses for source/destination/response URIs. Derived from the Npgsql
+    /// connection string during <see cref="ConnectAsync"/>.
+    /// </summary>
+    internal string MassTransitHost => _massTransitHost;
+
+    protected override IEnumerable<MassTransitPostgresqlQueue> endpoints()
+    {
+        return Queues;
+    }
+
+    protected override IEnumerable<Endpoint> explicitEndpoints()
+    {
+        return Queues;
+    }
+
+    // MassTransit queue names are matched verbatim against the foreign endpoint name.
+    public override string SanitizeIdentifier(string identifier)
+    {
+        return identifier;
+    }
+
+    protected override MassTransitPostgresqlQueue findEndpointByUri(Uri uri)
+    {
+        return Queues[uri.Host];
+    }
+
+    public override async ValueTask ConnectAsync(IWolverineRuntime runtime)
+    {
+        if (runtime.Storage is PostgresqlMessageStore store)
+        {
+            Store = store;
+        }
+        else if (runtime.Storage is MultiTenantedMessageStore mt && mt.Main is PostgresqlMessageStore s)
+        {
+            Store = s;
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                "The MassTransit PostgreSQL interop transport can only be used if Wolverine's message persistence is also PostgreSQL backed");
+        }
+
+        _massTransitHost = ResolveMassTransitHost(Store.Settings.ConnectionString!);
+
+        // de facto environment test
+        await using var conn = await Store.NpgsqlDataSource.OpenConnectionAsync();
+        await conn.CloseAsync();
+    }
+
+    internal PostgresqlMessageStore Store { get; set; } = null!;
+
+    /// <summary>
+    /// Resolve the PostgreSQL connection string used for the MassTransit transport. Works
+    /// before <see cref="ConnectAsync"/> has run by falling back to the PostgreSQL message
+    /// store registered for Wolverine's own persistence.
+    /// </summary>
+    internal string ResolveConnectionString(IWolverineRuntime runtime)
+    {
+        if (Store is not null)
+        {
+            return Store.Settings.ConnectionString!;
+        }
+
+        if (runtime.Storage is PostgresqlMessageStore store)
+        {
+            return store.Settings.ConnectionString!;
+        }
+
+        if (runtime.Storage is MultiTenantedMessageStore mt && mt.Main is PostgresqlMessageStore s)
+        {
+            return s.Settings.ConnectionString!;
+        }
+
+        throw new InvalidOperationException(
+            "The MassTransit PostgreSQL interop transport requires PostgreSQL backed message persistence");
+    }
+
+    /// <summary>
+    /// Build the MassTransit "host:port" identity from the Npgsql connection string. MassTransit
+    /// uses this to build its <c>db://{host}:{port}/{queue}</c> source/destination addresses.
+    /// </summary>
+    internal static string ResolveMassTransitHost(string connectionString)
+    {
+        var builder = new NpgsqlConnectionStringBuilder(connectionString);
+        var host = builder.Host.IsNotEmpty() ? builder.Host! : "localhost";
+        var port = builder.Port == 0 ? 5432 : builder.Port;
+        return $"{host}:{port}";
+    }
+
+    public override IEnumerable<PropertyColumn> DiagnosticColumns()
+    {
+        yield return new PropertyColumn("MassTransit Queue");
+        yield return new PropertyColumn("Count", Justify.Right);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlTransportExtensions.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlTransportExtensions.cs
@@ -1,0 +1,87 @@
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Wolverine.Configuration;
+
+namespace Wolverine.Postgresql.Transport.MassTransit;
+
+public static class MassTransitPostgresqlTransportExtensions
+{
+    /// <summary>
+    /// Find or add the MassTransit PostgreSQL interop transport for this application.
+    /// Requires Wolverine to also be using PostgreSQL backed message persistence.
+    /// </summary>
+    internal static MassTransitPostgresqlTransport MassTransitPostgresqlTransport(this WolverineOptions options,
+        string? schema = null)
+    {
+        var transport = options.Transports.OfType<MassTransitPostgresqlTransport>().FirstOrDefault();
+        if (transport == null)
+        {
+            transport = new MassTransitPostgresqlTransport();
+            options.Transports.Add(transport);
+
+            // NOTE: unlike the NServiceBus interop transport, MassTransit owns and migrates its
+            // own "transport" schema, so we deliberately do NOT register an IDatabase here.
+        }
+
+        if (schema.IsNotEmpty())
+        {
+            transport.SchemaName = schema!;
+        }
+
+        return transport;
+    }
+
+    /// <summary>
+    /// Opt into the MassTransit PostgreSQL interop transport and configure transport-wide
+    /// settings. Calling this is optional; <see cref="ListenToMassTransitPostgresqlQueue"/> and
+    /// <see cref="ToMassTransitPostgresqlQueue"/> will register the transport on demand.
+    /// </summary>
+    /// <param name="schema">Schema that owns the MassTransit transport functions; defaults to "transport"</param>
+    /// <param name="autoProvision">
+    /// When true, Wolverine will create the MassTransit queue (via <c>create_queue_v2</c>) if it
+    /// does not already exist. Defaults to false because MassTransit normally provisions its own.
+    /// </param>
+    public static WolverineOptions UseMassTransitPostgresqlInterop(this WolverineOptions options,
+        string? schema = null, bool autoProvision = false)
+    {
+        var transport = options.MassTransitPostgresqlTransport(schema);
+        transport.AutoProvision = autoProvision;
+        return options;
+    }
+
+    /// <summary>
+    /// Listen for messages published by a MassTransit endpoint to a PostgreSQL queue of the given
+    /// name. The queue is owned by MassTransit; Wolverine leases messages via its functions.
+    /// </summary>
+    /// <param name="queueName">The MassTransit queue name (matched verbatim)</param>
+    /// <param name="schema">Optional schema for the MassTransit transport; defaults to "transport"</param>
+    public static MassTransitPostgresqlListenerConfiguration ListenToMassTransitPostgresqlQueue(
+        this WolverineOptions options, string queueName, string? schema = null)
+    {
+        var transport = options.MassTransitPostgresqlTransport(schema);
+        var queue = transport.Queues[queueName];
+        queue.EndpointName = queueName;
+        queue.IsListener = true;
+
+        return new MassTransitPostgresqlListenerConfiguration(queue);
+    }
+
+    /// <summary>
+    /// Publish matching messages straight to a MassTransit-owned PostgreSQL queue using its
+    /// <c>transport.send_message</c> function, encoded in the MassTransit message model.
+    /// </summary>
+    /// <param name="queueName">The MassTransit queue name (matched verbatim)</param>
+    /// <param name="schema">Optional schema for the MassTransit transport; defaults to "transport"</param>
+    public static MassTransitPostgresqlSubscriberConfiguration ToMassTransitPostgresqlQueue(
+        this IPublishToExpression publishing, string queueName, string? schema = null)
+    {
+        var options = publishing.As<PublishingExpression>().Parent;
+        var transport = options.MassTransitPostgresqlTransport(schema);
+        var queue = transport.Queues[queueName];
+        queue.EndpointName = queueName;
+
+        publishing.To(queue.Uri);
+
+        return new MassTransitPostgresqlSubscriberConfiguration(queue);
+    }
+}


### PR DESCRIPTION
## What

Adds a database-backed Wolverine transport that interoperates **bidirectionally** with a [MassTransit](https://masstransit.io) application using the [PostgreSQL SQL transport](https://masstransit.io/documentation/transports/sql). Third permutation of the database-backed transport interop plan, after [#3198](https://github.com/JasperFx/wolverine/pull/3198) (NSB/SQL Server) and [#3201](https://github.com/JasperFx/wolverine/pull/3201) (NSB/PostgreSQL).

## How — different from NServiceBus

MassTransit's SQL transport is **not** a documented "write the table" contract. It's a function-driven, two-table model — `transport.message` (the bare contract JSON in `body` + envelope fields as columns) and `transport.message_delivery` (per-queue lease/retry rows) — that MassTransit **owns and migrates itself**. So `masstransit-postgresql` (in `Wolverine.Postgresql`) interoperates by **calling MassTransit's stored functions** rather than reading/writing a Weasel-modeled table (no `IDatabase`):

- **Send:** `transport.send_message` with the bare message body (jsonb) + the envelope columns and the `urn:message:{Namespace}:{TypeName}` message type, content type `application/json`. (Must supply `priority` and `sent_time` — the function defaults them to NULL but the underlying columns are NOT NULL.)
- **Receive (lease):** `transport.fetch_messages(queue, consumer_id, lock_id, lock_duration, count)`; ack via `delete_message`, nack via `unlock_message`, tracked per envelope by `(message_delivery_id, lock_id)`.
- **Provision (opt-in):** `create_queue_v2` for the queues Wolverine listens to.
- Resolves the `urn` back to a Wolverine message type across loaded assemblies (`RegisterInteropMessageAssembly`), reusing Wolverine's MassTransit `db://` URI conventions (`IMassTransitInteropEndpoint`). Reply address falls back from `response_address` to `source_address`.

## Tests

- Both directions green against a **real MassTransit 8.5.10 PostgreSQL host** in the [wolverine-interop](https://github.com/JasperFx/wolverine-interop) repo (`InteropTestsWithMassTransitAndPostgresql`) — `masstransit_sends_message_to_wolverine` and `wolverine_sends_message_to_masstransit_that_then_responds`, stable across repeated runs.
- `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors).

## Docs

- `docs/guide/durability/postgresql.md` — MassTransit interoperability section.
- `docs/tutorials/interop.md` — MassTransit over database transports section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)