### PR TITLE
Pulsar: Reader interface — bounded replay + non-durable hot-tail (#3184)

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -87,6 +87,62 @@ resumes from its committed cursor on every restart regardless of this setting, a
 messages that are still retained on the topic. The default is `SubscriptionInitialPosition.Latest`, matching
 DotPulsar's own default.
 
+### Hot-tail / broadcast consume <Badge type="tip" text="6.8" />
+
+Sometimes you want **every node** to see **every message** as it arrives — live dashboards, cache
+invalidation, fan-out-to-all-instances — rather than the competing-consumer model where each message goes to
+exactly one node on a shared subscription. Use `TailFromLatest()`:
+
+```csharp
+opts.ListenToPulsarTopic("persistent://public/default/live-events").TailFromLatest();
+```
+
+Each process consumes through its own **ephemeral, non-durable [Reader](https://pulsar.apache.org/docs/concepts-clients/#reader-interface)**
+cursor starting at the tail, so every node receives all messages, never replays old data, and commits no
+subscription cursor. This is the idiomatic Pulsar pattern for broadcast — the analogue of the Kafka
+transport's `TailFromLatest()`.
+
+A few things to know:
+
+- Because the reader starts at the tail, only messages published **after** a node has attached its reader are
+  delivered — there is no backlog replay.
+- The reader cursor is throwaway and unacknowledged, so dead-letter / retry-letter queueing, native
+  redelivery, and acknowledgment strategies do not apply to a hot-tail listener.
+- Reach for `TailFromLatest()` when you want **all** nodes to process each message; use a normal `Shared` /
+  `KeyShared` subscription when you want each message processed **once** across the cluster.
+
+## Replaying a Topic <Badge type="tip" text="6.8" />
+
+When you need to **reprocess** a window of a topic's history — error recovery, rebuilding downstream state,
+replaying after a bug fix — Wolverine offers a **bounded, one-shot replay** that reads a range of a topic back
+through the **normal handler pipeline**. It uses a throwaway, non-durable Pulsar `Reader` cursor and **never
+touches any live durable subscription**, so steady-state consumption is completely untouched.
+
+```csharp
+// Programmatic API on IHost
+await host.ReplayPulsarTopicAsync(new PulsarReplayRequest
+{
+    Topic = "persistent://public/default/orders",
+    FromTimestamp = DateTimeOffset.UtcNow.AddHours(-1),  // or FromMessageId = someMessageId
+    // ToTimestamp / ToMessageId optional — defaults to "now" (the topic's last message at start)
+});
+```
+
+Start defaults to the earliest retained message and end defaults to the topic's last message at the moment the
+replay begins, so omitting the bounds replays the whole topic as it stands and never tails live traffic
+published after the replay started. Both `From`/`To` accept either a publish-time `DateTimeOffset` or a Pulsar
+`MessageId` (the two are mutually exclusive on each end).
+
+::: warning Replayed messages are re-handled
+Each replayed message flows through your handlers again, exactly like live consumption. Handlers should be
+**idempotent** (the same expectation as any at-least-once reprocessing). If you use the durable inbox, replayed
+envelopes pass through the same inbox + de-duplication path.
+:::
+
+Replay reads forward to the end boundary and stops cleanly. It is a discrete operation that runs on its own
+non-durable reader cursor, so it can safely run on a node that is also listening to the same topic on a durable
+subscription.
+
 ## Multi-Topic & Pattern Subscriptions
 
 A single Pulsar listener can consume from more than one topic, or from every topic matching a

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/pulsar_hot_tail.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/pulsar_hot_tail.cs
@@ -1,0 +1,114 @@
+using System.Collections.Concurrent;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.ComplianceTests;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+// GH-3184: ephemeral hot-tail / broadcast consume built on a non-durable Reader at the tail.
+public class pulsar_hot_tail
+{
+    private static PulsarEndpoint applyListener(Action<PulsarListenerConfiguration> configure)
+    {
+        var transport = new PulsarTransport();
+        var endpoint = new PulsarEndpoint("pulsar://persistent/public/default/events".ToUri(), transport);
+        var config = new PulsarListenerConfiguration(endpoint);
+        configure(config);
+        ((IDelayedEndpointConfiguration)config).Apply();
+        return endpoint;
+    }
+
+    // ---- config unit test (no broker) ----
+
+    [Fact]
+    public void tail_from_latest_marks_hot_tail_and_latest()
+    {
+        var endpoint = applyListener(c => c.TailFromLatest());
+        endpoint.IsHotTail.ShouldBeTrue();
+        endpoint.SubscriptionInitialPosition.ShouldBe(DotPulsar.SubscriptionInitialPosition.Latest);
+    }
+
+    // ---- end-to-end (Pulsar docker) ----
+
+    private static Task<IHost> publisherAsync(string topic) => WolverineHost.ForAsync(opts =>
+    {
+        opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+        opts.PublishAllMessages().ToPulsarTopic(topic).SendInline();
+    });
+
+    private static Task<IHost> hotTailNodeAsync(string topic) => WolverineHost.ForAsync(opts =>
+    {
+        opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+        opts.ListenToPulsarTopic(topic).ProcessInline().TailFromLatest();
+        opts.Services.AddSingleton<HotTailSink>();
+        opts.Discovery.DisableConventionalDiscovery().IncludeType<HotTailHandler>();
+    });
+
+    [Fact]
+    public async Task hot_tail_delivers_all_tail_messages_to_every_node_and_never_replays_history()
+    {
+        var topic = $"persistent://public/default/hottail-{Guid.NewGuid():N}";
+
+        using var publisher = await publisherAsync(topic);
+
+        // Published BEFORE any hot-tail reader exists -> must NOT be delivered (no history replay).
+        for (var i = 0; i < 3; i++)
+        {
+            await publisher.SendAsync(new HotTailMessage { Id = "pre-" + i });
+        }
+
+        using var nodeA = await hotTailNodeAsync(topic);
+        using var nodeB = await hotTailNodeAsync(topic);
+
+        // Latest means only messages published AFTER the readers attach are seen — give them a moment.
+        await Task.Delay(3.Seconds());
+
+        for (var i = 0; i < 5; i++)
+        {
+            await publisher.SendAsync(new HotTailMessage { Id = "m-" + i });
+        }
+
+        var sinkA = nodeA.Services.GetRequiredService<HotTailSink>();
+        var sinkB = nodeB.Services.GetRequiredService<HotTailSink>();
+        await waitForCountAsync(sinkA.Received, 5);
+        await waitForCountAsync(sinkB.Received, 5);
+
+        // Both nodes received all five tail messages and none of the pre-subscription history.
+        sinkA.Received.OrderBy(x => x).ShouldBe(["m-0", "m-1", "m-2", "m-3", "m-4"]);
+        sinkB.Received.OrderBy(x => x).ShouldBe(["m-0", "m-1", "m-2", "m-3", "m-4"]);
+    }
+
+    private static async Task waitForCountAsync(ConcurrentBag<string> bag, int count, int timeoutMs = 30000)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            if (bag.Count >= count) return;
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Only received {bag.Count} of {count} expected messages within {timeoutMs}ms");
+    }
+}
+
+public class HotTailMessage
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class HotTailSink
+{
+    public ConcurrentBag<string> Received { get; } = new();
+}
+
+public class HotTailHandler
+{
+    public static void Handle(HotTailMessage message, HotTailSink sink)
+    {
+        sink.Received.Add(message.Id);
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/pulsar_replay.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/pulsar_replay.cs
@@ -1,0 +1,153 @@
+using System.Collections.Concurrent;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+// GH-3184: bounded one-shot replay via a non-durable Reader cursor that never touches the live
+// durable subscription.
+public class pulsar_replay
+{
+    private static Task<IHost> publisherAsync(string topic) => WolverineHost.ForAsync(opts =>
+    {
+        opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+        opts.PublishAllMessages().ToPulsarTopic(topic).SendInline();
+    });
+
+    // A host that runs the replay through the normal handler pipeline but does NOT listen to the topic,
+    // so its sink only ever sees replayed messages (never the live stream).
+    private static Task<IHost> replayerAsync() => WolverineHost.ForAsync(opts =>
+    {
+        opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+        opts.Services.AddSingleton<ReplaySink>();
+        opts.Discovery.DisableConventionalDiscovery().IncludeType<ReplayHandler>();
+    });
+
+    private static Task<IHost> liveListenerAsync(string topic, string subscription) => WolverineHost.ForAsync(opts =>
+    {
+        opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+        opts.ListenToPulsarTopic(topic)
+            .SubscriptionName(subscription)
+            .ProcessInline()
+            .BeginAtEarliest();
+        opts.Services.AddSingleton<ReplaySink>();
+        opts.Discovery.DisableConventionalDiscovery().IncludeType<ReplayHandler>();
+    });
+
+    [Fact]
+    public async Task replay_reprocesses_the_whole_topic_without_touching_the_live_subscription()
+    {
+        var topic = $"persistent://public/default/replay-all-{Guid.NewGuid():N}";
+        var subscription = "sub-" + Guid.NewGuid().ToString("N");
+
+        using var publisher = await publisherAsync(topic);
+        using var live = await liveListenerAsync(topic, subscription);
+        var liveSink = live.Services.GetRequiredService<ReplaySink>();
+
+        for (var i = 0; i < 6; i++)
+        {
+            await publisher.SendAsync(new ReplayMessage { Id = "m-" + i });
+        }
+
+        await waitForCountAsync(liveSink.Received, 6);
+
+        // Replay the entire topic on a separate host that is NOT listening, so its sink only sees the
+        // replayed messages.
+        using var replayer = await replayerAsync();
+        var replaySink = replayer.Services.GetRequiredService<ReplaySink>();
+
+        var result = await replayer.ReplayPulsarTopicAsync(new PulsarReplayRequest { Topic = topic });
+
+        result.MessagesReplayed.ShouldBe(6);
+        await waitForCountAsync(replaySink.Received, 6);
+        replaySink.Received.OrderBy(x => x).ShouldBe(["m-0", "m-1", "m-2", "m-3", "m-4", "m-5"]);
+
+        // The live durable subscription must be untouched: it already saw all six and stays at the tail.
+        // Publishing one more delivers exactly that one message (no reset-to-earliest, no duplicates).
+        await publisher.SendAsync(new ReplayMessage { Id = "m-6" });
+        await waitForCountAsync(liveSink.Received, 7);
+
+        liveSink.Received.OrderBy(x => x)
+            .ShouldBe(["m-0", "m-1", "m-2", "m-3", "m-4", "m-5", "m-6"]);
+    }
+
+    [Fact]
+    public async Task replay_from_timestamp_reprocesses_only_messages_after_it()
+    {
+        var topic = $"persistent://public/default/replay-ts-{Guid.NewGuid():N}";
+
+        using var publisher = await publisherAsync(topic);
+
+        await publisher.SendAsync(new ReplayMessage { Id = "old-0" });
+        await publisher.SendAsync(new ReplayMessage { Id = "old-1" });
+
+        await Task.Delay(1500);
+        var boundary = DateTimeOffset.UtcNow;
+        await Task.Delay(1500);
+
+        await publisher.SendAsync(new ReplayMessage { Id = "new-0" });
+        await publisher.SendAsync(new ReplayMessage { Id = "new-1" });
+        await publisher.SendAsync(new ReplayMessage { Id = "new-2" });
+
+        using var replayer = await replayerAsync();
+        var replaySink = replayer.Services.GetRequiredService<ReplaySink>();
+
+        var result = await replayer.ReplayPulsarTopicAsync(new PulsarReplayRequest
+        {
+            Topic = topic,
+            FromTimestamp = boundary
+        });
+
+        result.MessagesReplayed.ShouldBe(3);
+        await waitForCountAsync(replaySink.Received, 3);
+        replaySink.Received.OrderBy(x => x).ShouldBe(["new-0", "new-1", "new-2"]);
+    }
+
+    [Fact]
+    public async Task replay_of_empty_topic_returns_zero()
+    {
+        var topic = $"persistent://public/default/replay-empty-{Guid.NewGuid():N}";
+
+        // Touch the topic so it exists but has no messages.
+        using var publisher = await publisherAsync(topic);
+
+        using var replayer = await replayerAsync();
+        var result = await replayer.ReplayPulsarTopicAsync(new PulsarReplayRequest { Topic = topic });
+
+        result.MessagesReplayed.ShouldBe(0);
+    }
+
+    private static async Task waitForCountAsync(ConcurrentBag<string> bag, int count, int timeoutMs = 30000)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            if (bag.Count >= count) return;
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Only received {bag.Count} of {count} expected messages within {timeoutMs}ms");
+    }
+}
+
+public class ReplayMessage
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class ReplaySink
+{
+    public ConcurrentBag<string> Received { get; } = new();
+}
+
+public class ReplayHandler
+{
+    public static void Handle(ReplayMessage message, ReplaySink sink)
+    {
+        sink.Received.Add(message.Id);
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/Internal/PulsarReplay.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/Internal/PulsarReplay.cs
@@ -1,0 +1,179 @@
+using System.Buffers;
+using DotPulsar;
+using DotPulsar.Abstractions;
+using DotPulsar.Extensions;
+using Microsoft.Extensions.Logging;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.Pulsar.Internal;
+
+/// <summary>
+/// Executes a bounded, one-shot Pulsar replay (GH-3184): a throwaway, non-durable <c>Reader</c> cursor
+/// reads forward from the start bound and feeds every message in the requested window through the normal
+/// Wolverine handler pipeline. The Reader owns its own auto-generated, non-durable subscription, so the
+/// live durable subscription's cursor is never touched.
+/// </summary>
+internal sealed class PulsarReplay
+{
+    private readonly PulsarTransport _transport;
+    private readonly IWolverineRuntime _runtime;
+    private readonly ILogger _logger;
+
+    public PulsarReplay(PulsarTransport transport, IWolverineRuntime runtime)
+    {
+        _transport = transport;
+        _runtime = runtime;
+        _logger = runtime.LoggerFactory.CreateLogger<PulsarReplay>();
+    }
+
+    public async Task<PulsarReplayResult> ExecuteAsync(PulsarReplayRequest request, CancellationToken token)
+    {
+        if (request.FromMessageId is not null && request.FromTimestamp.HasValue)
+            throw new ArgumentException("Specify only one of FromMessageId or FromTimestamp", nameof(request));
+        if (request.ToMessageId is not null && request.ToTimestamp.HasValue)
+            throw new ArgumentException("Specify only one of ToMessageId or ToTimestamp", nameof(request));
+
+        var endpoint = _transport.EndpointFor(request.Topic);
+        var destination = endpoint.Uri;
+        var topic = endpoint.PulsarTopic();
+        var mapper = endpoint.BuildMapper(_runtime);
+        var pipeline = _runtime.Pipeline;
+        var callback = new ReplayChannelCallback();
+
+        // Reader at Earliest with its own non-durable, auto-named cursor: never touches the live
+        // durable subscription. We filter the requested window in code rather than seeking so the
+        // From/To bounds are inclusive and unambiguous.
+        var reader = _transport.Client!.NewReader()
+            .Topic(topic)
+            .StartMessageId(MessageId.Earliest)
+            .Create();
+
+        try
+        {
+            // Snapshot the topic's current end per partition so the replay stops at "now" and never
+            // tails traffic published after it began. An empty topic yields only sentinel ids.
+            var endByPartition = (await reader.GetLastMessageIds(token))
+                .Where(x => !IsSentinel(x))
+                .ToDictionary(x => x.Partition, x => x);
+
+            if (endByPartition.Count == 0)
+            {
+                _logger.LogInformation("Pulsar replay of topic {Topic}: topic is empty, nothing to replay", topic);
+                return new PulsarReplayResult { MessagesReplayed = 0 };
+            }
+
+            var remaining = new HashSet<int>(endByPartition.Keys);
+            long replayed = 0;
+
+            _logger.LogInformation("Starting Pulsar replay of topic {Topic} across {Count} partition(s)",
+                topic, remaining.Count);
+
+            await foreach (var message in reader.Messages(token))
+            {
+                var id = message.MessageId;
+                if (remaining.Contains(id.Partition))
+                {
+                    var atEnd = id.CompareTo(endByPartition[id.Partition]) >= 0;
+
+                    if (ShouldReplay(request, message, id, out var pastEnd))
+                    {
+                        var envelope = new PulsarEnvelope(message) { Data = message.Data.ToArray() };
+                        mapper.MapIncomingToEnvelope(envelope, message);
+
+                        // The replay bypasses a real listener (and so the IListener-driven
+                        // Envelope.MarkReceived), so stamp the Destination the pipeline expects for an
+                        // incoming envelope — the listener address for this endpoint.
+                        envelope.Destination = destination;
+
+                        await pipeline.InvokeAsync(envelope, callback);
+                        replayed++;
+                    }
+
+                    if (atEnd || pastEnd)
+                    {
+                        // This partition has reached its snapshot end (or run past the requested upper
+                        // bound); stop pulling from it.
+                        remaining.Remove(id.Partition);
+                    }
+                }
+
+                // Break the instant every partition is done — within this iteration, *before* calling
+                // the reader's MoveNextAsync again. DotPulsar's Messages() async-enumerable has no poll
+                // timeout, so a top-of-loop check would block forever waiting for a message past the
+                // snapshot end that never arrives.
+                if (remaining.Count == 0)
+                {
+                    break;
+                }
+            }
+
+            _logger.LogInformation("Finished Pulsar replay of topic {Topic}: {Count} message(s) replayed",
+                topic, replayed);
+
+            return new PulsarReplayResult { MessagesReplayed = replayed };
+        }
+        finally
+        {
+            await reader.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Apply the request's start/end window to a single message. Sets <paramref name="pastUpperBound"/>
+    /// when the message is beyond the requested upper bound so the caller can stop reading the partition.
+    /// </summary>
+    private static bool ShouldReplay(PulsarReplayRequest request, IMessage<ReadOnlySequence<byte>> message,
+        MessageId id, out bool pastUpperBound)
+    {
+        pastUpperBound = false;
+
+        // Upper bound (inclusive): once exceeded, this partition is done.
+        if (request.ToMessageId is not null && id.CompareTo(request.ToMessageId) > 0)
+        {
+            pastUpperBound = true;
+            return false;
+        }
+
+        if (request.ToTimestamp.HasValue && PublishTime(message) > request.ToTimestamp.Value)
+        {
+            pastUpperBound = true;
+            return false;
+        }
+
+        // Lower bound (inclusive): skip anything before the requested start.
+        if (request.FromMessageId is not null && id.CompareTo(request.FromMessageId) < 0)
+        {
+            return false;
+        }
+
+        if (request.FromTimestamp.HasValue && PublishTime(message) < request.FromTimestamp.Value)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static DateTimeOffset PublishTime(IMessage<ReadOnlySequence<byte>> message)
+    {
+        return DateTimeOffset.FromUnixTimeMilliseconds((long)message.PublishTime);
+    }
+
+    /// <summary>
+    /// True for the <see cref="MessageId.Earliest"/> / <see cref="MessageId.Latest"/> sentinels and the
+    /// "no messages yet" id Pulsar returns for an empty topic — all of which carry <c>ulong.MaxValue</c>
+    /// ledger/entry components rather than a real position.
+    /// </summary>
+    private static bool IsSentinel(MessageId id)
+    {
+        return id is null || id.LedgerId == ulong.MaxValue || id.EntryId == ulong.MaxValue;
+    }
+
+    private sealed class ReplayChannelCallback : IChannelCallback
+    {
+        public IHandlerPipeline? Pipeline => null;
+        public ValueTask CompleteAsync(Envelope envelope) => ValueTask.CompletedTask;
+        public ValueTask DeferAsync(Envelope envelope) => ValueTask.CompletedTask;
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -76,6 +76,14 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
     public bool UnsubscribeOnClose { get; internal set; } = true;
 
     /// <summary>
+    ///     When true, this listener consumes via an ephemeral, non-durable Pulsar <c>Reader</c> starting
+    ///     at the tail (<see cref="DotPulsar.MessageId.Latest"/>) instead of a durable subscription, so
+    ///     every node receives all messages published after it joins and never replays history (GH-3184).
+    ///     Set via <c>TailFromLatest()</c>.
+    /// </summary>
+    internal bool IsHotTail { get; set; }
+
+    /// <summary>
     ///     When true, a requeue/defer of a single message uses Pulsar's native per-message
     ///     redelivery (<c>RedeliverUnacknowledgedMessages([messageId])</c>) — the message is left
     ///     unacknowledged and Pulsar redelivers that one message, preserving its redelivery count —
@@ -202,6 +210,13 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
 
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
     {
+        // Hot-tail (GH-3184): a non-durable Reader at the tail rather than a durable subscription.
+        if (IsHotTail)
+        {
+            var readerListener = new PulsarReaderListener(runtime, this, receiver, _parent, runtime.Cancellation);
+            return ValueTask.FromResult<IListener>(readerListener);
+        }
+
         var listener = new PulsarListener(runtime, this, receiver, _parent, runtime.Cancellation);
         return ValueTask.FromResult<IListener>(listener);
     }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarReaderListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarReaderListener.cs
@@ -1,0 +1,86 @@
+using System.Buffers;
+using DotPulsar;
+using DotPulsar.Abstractions;
+using DotPulsar.Extensions;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.Pulsar;
+
+/// <summary>
+/// Ephemeral "hot-tail" / broadcast listener (GH-3184) built on a non-durable Pulsar <c>Reader</c>
+/// starting at <see cref="MessageId.Latest"/>. Each process gets its own throwaway, auto-named reader
+/// cursor, so every node receives all messages published after it joins and never replays history — the
+/// idiomatic Pulsar pattern for live dashboards and fan-out-to-all. No subscription cursor is committed,
+/// so there is nothing to acknowledge: <see cref="CompleteAsync"/> / <see cref="DeferAsync"/> are no-ops.
+/// </summary>
+internal class PulsarReaderListener : IListener
+{
+    private readonly CancellationTokenSource _localCancellation;
+    private readonly IReader<ReadOnlySequence<byte>> _reader;
+    private readonly Task _receivingLoop;
+
+    public PulsarReaderListener(IWolverineRuntime runtime, PulsarEndpoint endpoint, IReceiver receiver,
+        PulsarTransport transport, CancellationToken cancellation)
+    {
+        if (receiver == null)
+        {
+            throw new ArgumentNullException(nameof(receiver));
+        }
+
+        Address = endpoint.Uri;
+
+        var mapper = endpoint.BuildMapper(runtime);
+
+        _localCancellation = new CancellationTokenSource();
+        var combined = CancellationTokenSource.CreateLinkedTokenSource(cancellation, _localCancellation.Token);
+
+        var readerBuilder = transport.Client!.NewReader()
+            .Topic(endpoint.PulsarTopic())
+            .StartMessageId(MessageId.Latest);
+
+        _reader = readerBuilder.Create();
+
+        _receivingLoop = Task.Run(async () =>
+        {
+            await foreach (var message in _reader.Messages(combined.Token))
+            {
+                var envelope = new PulsarEnvelope(message)
+                {
+                    Data = message.Data.ToArray()
+                };
+
+                mapper.MapIncomingToEnvelope(envelope, message);
+
+                await receiver.ReceivedAsync(this, envelope);
+            }
+        }, combined.Token);
+
+        Pipeline = receiver.Pipeline;
+    }
+
+    public Uri Address { get; }
+
+    public IHandlerPipeline? Pipeline { get; }
+
+    // A Reader cursor is non-durable and unacknowledged: there is nothing to complete or defer.
+    public ValueTask CompleteAsync(Envelope envelope) => ValueTask.CompletedTask;
+
+    public ValueTask DeferAsync(Envelope envelope) => ValueTask.CompletedTask;
+
+    public ValueTask StopAsync()
+    {
+        // Nothing to unsubscribe — the reader cursor is throwaway. Tear-down happens in DisposeAsync.
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _localCancellation.CancelAsync();
+        _localCancellation.Dispose();
+
+        await _reader.DisposeAsync();
+
+        _receivingLoop.Dispose();
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarReplayExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarReplayExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Hosting;
+using Wolverine.Pulsar.Internal;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+
+namespace Wolverine.Pulsar;
+
+public static class PulsarReplayExtensions
+{
+    /// <summary>
+    /// Run a bounded, one-shot replay of a Pulsar topic's history back through the normal Wolverine
+    /// handler pipeline (GH-3184). Uses a throwaway, non-durable <c>Reader</c> cursor and never touches
+    /// any live durable subscription, so steady-state consumption is undisturbed. Replayed messages are
+    /// re-handled, so handlers should be idempotent.
+    /// </summary>
+    /// <param name="host">A running Wolverine host configured with the Pulsar transport.</param>
+    /// <param name="request">The bounded window to replay.</param>
+    /// <param name="token"></param>
+    public static async Task<PulsarReplayResult> ReplayPulsarTopicAsync(this IHost host, PulsarReplayRequest request,
+        CancellationToken token = default)
+    {
+        var runtime = host.GetRuntime();
+        var transport = runtime.Options.Transports.GetOrCreate<PulsarTransport>();
+
+        return await new PulsarReplay(transport, runtime).ExecuteAsync(request, token);
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarReplayRequest.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarReplayRequest.cs
@@ -1,0 +1,54 @@
+using DotPulsar;
+
+namespace Wolverine.Pulsar;
+
+/// <summary>
+/// Describes a bounded, one-shot replay of a Pulsar topic's history back through the normal Wolverine
+/// handler pipeline (GH-3184). The replay uses a throwaway, non-durable <c>Reader</c> cursor and never
+/// touches any live durable subscription, so steady-state consumption is undisturbed.
+///
+/// Start defaults to the earliest retained message in the topic, end defaults to the topic's last
+/// message at the moment the replay begins ("now") so the replay never tails live traffic. Replayed
+/// messages are re-handled, so handlers should be idempotent.
+/// </summary>
+public class PulsarReplayRequest
+{
+    /// <summary>
+    /// The native Pulsar topic path to replay, e.g. <c>persistent://public/default/orders</c>.
+    /// </summary>
+    public required string Topic { get; init; }
+
+    /// <summary>
+    /// Start the replay at this <see cref="MessageId"/> (inclusive). Mutually exclusive with
+    /// <see cref="FromTimestamp"/>. When neither is set the replay starts at the earliest retained message.
+    /// </summary>
+    public MessageId? FromMessageId { get; init; }
+
+    /// <summary>
+    /// Start the replay at the first message whose publish time is at or after this instant. Mutually
+    /// exclusive with <see cref="FromMessageId"/>.
+    /// </summary>
+    public DateTimeOffset? FromTimestamp { get; init; }
+
+    /// <summary>
+    /// Stop the replay at this <see cref="MessageId"/> (inclusive). Mutually exclusive with
+    /// <see cref="ToTimestamp"/>. When neither is set the replay stops at the topic's last message as of
+    /// the moment the replay began.
+    /// </summary>
+    public MessageId? ToMessageId { get; init; }
+
+    /// <summary>
+    /// Stop the replay at the last message whose publish time is at or before this instant. Mutually
+    /// exclusive with <see cref="ToMessageId"/>.
+    /// </summary>
+    public DateTimeOffset? ToTimestamp { get; init; }
+}
+
+/// <summary>
+/// Outcome of a <see cref="PulsarReplayRequest"/>.
+/// </summary>
+public class PulsarReplayResult
+{
+    /// <summary>Number of messages fed back through the handler pipeline.</summary>
+    public long MessagesReplayed { get; init; }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -249,6 +249,26 @@ public class PulsarListenerConfiguration : InteroperableListenerConfiguration<Pu
     }
 
     /// <summary>
+    /// Ephemeral "hot-tail" / broadcast consume (GH-3184): this listener uses a non-durable Pulsar
+    /// <c>Reader</c> cursor starting at the tail (<see cref="DotPulsar.MessageId.Latest"/>) instead of a
+    /// durable subscription, so every node receives all messages published after it joins and never
+    /// replays history — the idiomatic Pulsar pattern for live dashboards and fan-out-to-all. The reader
+    /// cursor is throwaway and unacknowledged, so dead-letter / retry-letter queueing, native redelivery,
+    /// and acknowledgment strategies do not apply. Pulsar analogue of the Kafka transport's
+    /// <c>TailFromLatest()</c>.
+    /// </summary>
+    /// <returns></returns>
+    public PulsarListenerConfiguration TailFromLatest()
+    {
+        add(e =>
+        {
+            e.IsHotTail = true;
+            e.SubscriptionInitialPosition = DotPulsar.SubscriptionInitialPosition.Latest;
+        });
+        return this;
+    }
+
+    /// <summary>
     /// Have this single listener consume from one or more additional Pulsar topics alongside the
     /// primary topic it was created with. Pulsar supports a single consumer over multiple topics;
     /// this is the analogue of Kafka topic groups. Each value is a full native topic path, e.g.


### PR DESCRIPTION
Closes #3184. Part of the **Re-Evaluate Pulsar Integration** epic #3176.

Adds two `Reader`-based consumption capabilities to the Pulsar transport — the combined analogue of Kafka #3146 (`TailFromLatest`) + #3147 (`ReplayKafkaTopicAsync`).

## Bounded replay — `ReplayPulsarTopicAsync`

```csharp
await host.ReplayPulsarTopicAsync(new PulsarReplayRequest
{
    Topic = "persistent://public/default/orders",
    FromTimestamp = DateTimeOffset.UtcNow.AddHours(-1),  // or FromMessageId
    // ToTimestamp / ToMessageId optional — defaults to the topic's last message at start
});
```

A bounded, one-shot replay that reads a window of a topic's history back through the **normal handler pipeline** using a throwaway, **non-durable `Reader` cursor**. It snapshots the topic's per-partition end at start (so it never tails live traffic published after the replay began) and **never touches any live durable subscription**. Start/end bounds accept either a `MessageId` or a publish-time `DateTimeOffset` (mutually exclusive per end). Handlers should be idempotent.

## Hot-tail / broadcast — `TailFromLatest()`

```csharp
opts.ListenToPulsarTopic("persistent://public/default/live-events").TailFromLatest();
```

An ephemeral hot-tail / broadcast listener built on a non-durable `Reader` at `MessageId.Latest`. Every node gets its own throwaway cursor, so **all nodes receive every message** published after they join, with no history replay and nothing acknowledged — the idiomatic Pulsar broadcast pattern (live dashboards, cache invalidation, fan-out-to-all).

## Implementation notes

- DotPulsar's `Reader.Messages()` async-enumerable has **no poll timeout** (unlike Kafka's `Consume(timeout)`), so the replay loop breaks the instant every partition reaches its snapshot end rather than re-entering a blocking `MoveNextAsync`.
- Replay bypasses a real `IListener`, so it stamps `Envelope.Destination` (the listener address) that `Envelope.MarkReceived` would normally set.

## Acceptance criteria

- ✅ A bounded replay over a known window delivers exactly those messages and leaves the live durable subscription's cursor untouched (integration test).
- ✅ A hot-tail listener on two nodes both receive all tail messages with no replay of history (integration test).

## Tests / docs

- `pulsar_replay`: whole-topic replay + live-subscription-untouched, from-timestamp window, empty-topic guard — **3/3 green** against a Testcontainers broker.
- `pulsar_hot_tail`: config unit test + two-node broadcast with no history replay — **2/2 green**.
- `pulsar.md`: new Hot-tail and Replay sections.
- Full `wolverine.slnx` builds clean in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)