### PR TITLE
Index Seq on the NServiceBus PostgreSQL queue table

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusQueueTable.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusQueueTable.cs
@@ -1,4 +1,5 @@
 using Weasel.Core;
+using Weasel.Postgresql;
 using Weasel.Postgresql.Tables;
 
 namespace Wolverine.Postgresql.Transport.NServiceBus;
@@ -18,12 +19,18 @@ internal class NServiceBusQueueTable : Table
         AddColumn<string>("Headers").NotNull();
         AddColumn("Body", "bytea");
 
-        // Seq is the auto-incrementing column NServiceBus orders on for FIFO receive. We model it
-        // only as a serial column: NServiceBus adds a UNIQUE *constraint* on seq, but Weasel can
-        // only express a unique *index*, and the two don't reconcile (Weasel would try to drop the
-        // constraint-backed index, which PostgreSQL refuses). Since the transport never needs to
-        // enforce seq uniqueness itself, leaving it off keeps schema diffs clean against the tables
-        // NServiceBus owns.
         AddColumn<int>("Seq").AutoIncrement().NotNull();
+
+        // Seq is what the destructive receive orders by (FIFO), so a Wolverine-provisioned table
+        // needs an index on it or the ORDER BY degrades to a full sort once a backlog builds — a
+        // soak that let the table grow collapsed receiver throughput by ~60x without this. We use a
+        // *non-unique* index (NOT a unique one): NServiceBus puts a UNIQUE *constraint* on seq and
+        // Weasel can only express a unique *index*, so a unique index would make Weasel try to drop
+        // the constraint-backed index (which PostgreSQL refuses) when reconciling against an
+        // NServiceBus-owned table. The transport never needs to enforce seq uniqueness itself.
+        Indexes.Add(new IndexDefinition(PostgresqlIdentifier.Shorten($"idx_{identifier.Name}_seq"))
+        {
+            Columns = ["Seq"]
+        });
     }
 }


### PR DESCRIPTION
## What

Adds a **non-unique** index on `Seq` to the NServiceBus PostgreSQL interop queue table (`NServiceBusQueueTable`). Follow-up to [#3201](https://github.com/JasperFx/wolverine/pull/3201).

## Why

The destructive receive orders by `Seq` (`... ORDER BY Seq LIMIT :count FOR UPDATE SKIP LOCKED`). When Wolverine **provisions/owns** the queue table (e.g. its own listening queue), there was no index on `Seq`, so the `ORDER BY` degraded to a full sort as a backlog built up.

A soak that let the table grow made this concrete: with an un-indexed table, an unthrottled 5-minute run enqueued ~5.2M messages but the receiver only drained **~71k** as throughput collapsed. With this index the same run delivered **4.5M with zero loss** (receiver keeps pace) — a ~60× difference.

## Why non-unique

Earlier I had a *unique* index here and removed it: NServiceBus puts a UNIQUE **constraint** on `seq`, Weasel can only model a unique **index**, and the two don't reconcile — Weasel tries to `DROP` the constraint-backed index (which PostgreSQL refuses) when diffing against an NServiceBus-owned table, breaking startup. A **non-unique** index avoids that: it has a different name and uniqueness from `nsb_seq_key`, so Weasel just adds it and leaves NServiceBus's constraint alone. The transport never needs to enforce `seq` uniqueness itself.

## Validation

- NServiceBus/PostgreSQL interop suite still green — **4/4** against a real `NServiceBus.Transport.PostgreSql` host (provisioning against the NServiceBus-owned table is unaffected).
- Soak: un-indexed un­throttled 5-min ≈ 71k delivered → indexed ≈ 4.5M delivered, 0 failures, 0 loss.
- `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)