### PR TITLE
Extract a shared DatabaseListener base for the DB interop poll loop

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlQueueListener.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/MassTransit/MassTransitPostgresqlQueueListener.cs
@@ -1,25 +1,20 @@
-using System.Collections.Concurrent;
-using JasperFx.Core;
 using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
 using Npgsql;
 using NpgsqlTypes;
 using Weasel.Core;
 using Weasel.Postgresql;
-using Wolverine.Configuration;
+using Wolverine.RDBMS.Transport;
 using Wolverine.Runtime;
 using Wolverine.Transports;
 
 namespace Wolverine.Postgresql.Transport.MassTransit;
 
-internal class MassTransitPostgresqlQueueListener : IListener
+internal class MassTransitPostgresqlQueueListener : DatabaseListener
 {
-    private readonly CancellationTokenSource _cancellation = new();
     private readonly MassTransitPostgresqlQueue _queue;
-    private readonly IReceiver _receiver;
     private readonly NpgsqlDataSource _dataSource;
-    private readonly ILogger _logger;
     private readonly MassTransitPostgresqlEnvelopeMapper _mapper;
-    private readonly TimeSpan _pollingInterval;
     private readonly TimeSpan _lockDuration;
     private readonly Guid _consumerId = Guid.NewGuid();
     private readonly string _fetchSql;
@@ -30,20 +25,16 @@ internal class MassTransitPostgresqlQueueListener : IListener
     // nack (unlock_message) using the (delivery id, lock id) pair MassTransit handed us.
     private readonly ConcurrentDictionary<Guid, (long DeliveryId, Guid LockId)> _leases = new();
 
-    private Task? _task;
-
     public MassTransitPostgresqlQueueListener(MassTransitPostgresqlQueue queue, IWolverineRuntime runtime,
         IReceiver receiver)
+        : base(queue.Uri, queue.Name, receiver,
+            runtime.LoggerFactory.CreateLogger<MassTransitPostgresqlQueueListener>(),
+            queue.PollingInterval ?? runtime.DurabilitySettings.ScheduledJobPollingTime)
     {
         _queue = queue;
-        _receiver = receiver;
         _dataSource = queue.Parent.Store.NpgsqlDataSource;
-        _logger = runtime.LoggerFactory.CreateLogger<MassTransitPostgresqlQueueListener>();
         _mapper = queue.BuildMapper(runtime);
-        _pollingInterval = queue.PollingInterval ?? runtime.DurabilitySettings.ScheduledJobPollingTime;
         _lockDuration = queue.LockDuration;
-
-        Address = queue.Uri;
 
         var schema = queue.Parent.SchemaName;
 
@@ -54,11 +45,9 @@ internal class MassTransitPostgresqlQueueListener : IListener
         _unlockSql = $"SELECT {schema}.unlock_message(:delivery_id, :lock_id, :delay, :headers)";
     }
 
-    public IHandlerPipeline? Pipeline => _receiver.Pipeline;
+    protected override int MaximumMessagesToReceive => _queue.MaximumMessagesToReceive;
 
-    public Uri Address { get; }
-
-    public async ValueTask CompleteAsync(Envelope envelope)
+    public override async ValueTask CompleteAsync(Envelope envelope)
     {
         if (!_leases.TryGetValue(envelope.Id, out var lease))
         {
@@ -80,7 +69,7 @@ internal class MassTransitPostgresqlQueueListener : IListener
         }
     }
 
-    public async ValueTask DeferAsync(Envelope envelope)
+    public override async ValueTask DeferAsync(Envelope envelope)
     {
         if (!_leases.TryGetValue(envelope.Id, out var lease))
         {
@@ -104,60 +93,7 @@ internal class MassTransitPostgresqlQueueListener : IListener
         }
     }
 
-    public ValueTask DisposeAsync()
-    {
-        return StopAsync();
-    }
-
-    public async ValueTask StopAsync()
-    {
-        await _cancellation.CancelAsync();
-        _task?.SafeDispose();
-    }
-
-    public Task StartAsync()
-    {
-        _task = Task.Run(listenForMessagesAsync, _cancellation.Token);
-        return Task.CompletedTask;
-    }
-
-    private async Task listenForMessagesAsync()
-    {
-        var failedCount = 0;
-
-        while (!_cancellation.Token.IsCancellationRequested)
-        {
-            try
-            {
-                var messages = await fetchAsync(_queue.MaximumMessagesToReceive, _cancellation.Token);
-                failedCount = 0;
-
-                if (messages.Count > 0)
-                {
-                    await _receiver.ReceivedAsync(this, messages.ToArray());
-                }
-                else
-                {
-                    await Task.Delay(_pollingInterval, _cancellation.Token);
-                }
-            }
-            catch (Exception e)
-            {
-                if (e is TaskCanceledException or OperationCanceledException && _cancellation.IsCancellationRequested)
-                {
-                    break;
-                }
-
-                failedCount++;
-                var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();
-                _logger.LogError(e, "Error while trying to receive messages from MassTransit PostgreSQL queue {Name}",
-                    _queue.Name);
-                await Task.Delay(pauseTime);
-            }
-        }
-    }
-
-    private async Task<IReadOnlyList<Envelope>> fetchAsync(int count, CancellationToken token)
+    protected override async Task<IReadOnlyList<Envelope>> TryPopAsync(int count, CancellationToken token)
     {
         // A fresh lock_id per fetch call; the consumer_id is stable for the listener lifetime.
         var lockId = Guid.NewGuid();

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueListener.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueListener.cs
@@ -1,37 +1,31 @@
-using JasperFx.Core;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using Weasel.Core;
 using Weasel.Postgresql;
+using Wolverine.RDBMS.Transport;
 using Wolverine.Runtime;
 using Wolverine.Transports;
 
 namespace Wolverine.Postgresql.Transport.NServiceBus;
 
-internal class NServiceBusPostgresqlQueueListener : IListener
+internal class NServiceBusPostgresqlQueueListener : DatabaseListener
 {
-    private readonly CancellationTokenSource _cancellation = new();
     private readonly NServiceBusPostgresqlQueue _queue;
-    private readonly IReceiver _receiver;
     private readonly NpgsqlDataSource _dataSource;
-    private readonly ILogger _logger;
     private readonly NServiceBusPostgresqlEnvelopeMapper _mapper;
     private readonly NServiceBusPostgresqlQueueSender _sender;
-    private readonly TimeSpan _pollingInterval;
     private readonly string _receiveSql;
-    private Task? _task;
 
-    public NServiceBusPostgresqlQueueListener(NServiceBusPostgresqlQueue queue, IWolverineRuntime runtime, IReceiver receiver)
+    public NServiceBusPostgresqlQueueListener(NServiceBusPostgresqlQueue queue, IWolverineRuntime runtime,
+        IReceiver receiver)
+        : base(queue.Uri, queue.Name, receiver,
+            runtime.LoggerFactory.CreateLogger<NServiceBusPostgresqlQueueListener>(),
+            queue.PollingInterval ?? runtime.DurabilitySettings.ScheduledJobPollingTime)
     {
         _queue = queue;
-        _receiver = receiver;
         _dataSource = queue.Parent.Store.NpgsqlDataSource;
-        _logger = runtime.LoggerFactory.CreateLogger<NServiceBusPostgresqlQueueListener>();
         _mapper = queue.BuildMapper(runtime);
         _sender = new NServiceBusPostgresqlQueueSender(queue, runtime);
-        _pollingInterval = queue.PollingInterval ?? runtime.DurabilitySettings.ScheduledJobPollingTime;
-
-        Address = queue.Uri;
 
         // Destructive competing-consumer pop honoring NServiceBus FIFO-by-Seq ordering. The
         // column identifiers are left unquoted: Weasel provisions the queue table with
@@ -48,76 +42,21 @@ WITH message AS (
 SELECT Id, Headers, Body FROM message;";
     }
 
-    public IHandlerPipeline? Pipeline => _receiver.Pipeline;
+    protected override int MaximumMessagesToReceive => _queue.MaximumMessagesToReceive;
 
-    public Uri Address { get; }
-
-    public ValueTask CompleteAsync(Envelope envelope)
+    public override ValueTask CompleteAsync(Envelope envelope)
     {
         // The row was already removed by the destructive pop.
         return ValueTask.CompletedTask;
     }
 
-    public async ValueTask DeferAsync(Envelope envelope)
+    public override async ValueTask DeferAsync(Envelope envelope)
     {
         // Re-expose the message by writing it back to the NServiceBus queue table.
         await _sender.SendAsync(envelope);
     }
 
-    public ValueTask DisposeAsync()
-    {
-        return StopAsync();
-    }
-
-    public async ValueTask StopAsync()
-    {
-        await _cancellation.CancelAsync();
-        _task?.SafeDispose();
-    }
-
-    public Task StartAsync()
-    {
-        _task = Task.Run(listenForMessagesAsync, _cancellation.Token);
-        return Task.CompletedTask;
-    }
-
-    private async Task listenForMessagesAsync()
-    {
-        var failedCount = 0;
-
-        while (!_cancellation.Token.IsCancellationRequested)
-        {
-            try
-            {
-                var messages = await tryPopAsync(_queue.MaximumMessagesToReceive, _cancellation.Token);
-                failedCount = 0;
-
-                if (messages.Count > 0)
-                {
-                    await _receiver.ReceivedAsync(this, messages.ToArray());
-                }
-                else
-                {
-                    await Task.Delay(_pollingInterval, _cancellation.Token);
-                }
-            }
-            catch (Exception e)
-            {
-                if (e is TaskCanceledException or OperationCanceledException && _cancellation.IsCancellationRequested)
-                {
-                    break;
-                }
-
-                failedCount++;
-                var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();
-                _logger.LogError(e, "Error while trying to receive messages from NServiceBus PostgreSQL queue {Name}",
-                    _queue.Name);
-                await Task.Delay(pauseTime);
-            }
-        }
-    }
-
-    private async Task<IReadOnlyList<Envelope>> tryPopAsync(int count, CancellationToken token)
+    protected override async Task<IReadOnlyList<Envelope>> TryPopAsync(int count, CancellationToken token)
     {
         await using var conn = await _dataSource.OpenConnectionAsync(token);
 

--- a/src/Persistence/Wolverine.RDBMS/Transport/DatabaseListener.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/DatabaseListener.cs
@@ -1,0 +1,103 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.RDBMS.Transport;
+
+/// <summary>
+/// Base class for the database-backed interop transport listeners (NServiceBus / MassTransit over
+/// SQL Server or PostgreSQL). Owns the common polling loop: a cancellable background task that
+/// repeatedly pops a batch of messages from a queue table/function, forwards them to the receiver,
+/// and backs off on idle or error. Subclasses supply only the dialect-specific batch pop
+/// (<see cref="TryPopAsync"/>) and the ack / nack behaviour (<see cref="CompleteAsync"/> /
+/// <see cref="DeferAsync"/>).
+/// </summary>
+public abstract class DatabaseListener : IListener
+{
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly IReceiver _receiver;
+    private readonly ILogger _logger;
+    private readonly TimeSpan _pollingInterval;
+    private readonly string _queueName;
+    private Task? _task;
+
+    protected DatabaseListener(Uri address, string queueName, IReceiver receiver, ILogger logger,
+        TimeSpan pollingInterval)
+    {
+        Address = address;
+        _queueName = queueName;
+        _receiver = receiver;
+        _logger = logger;
+        _pollingInterval = pollingInterval;
+    }
+
+    public Uri Address { get; }
+
+    public IHandlerPipeline? Pipeline => _receiver.Pipeline;
+
+    /// <summary>The cancellation token signalled when the listener is stopped.</summary>
+    protected CancellationToken Cancellation => _cancellation.Token;
+
+    /// <summary>The maximum number of messages to fetch in a single poll.</summary>
+    protected abstract int MaximumMessagesToReceive { get; }
+
+    /// <summary>Pop up to <paramref name="maximumMessages"/> messages from the database queue.</summary>
+    protected abstract Task<IReadOnlyList<Envelope>> TryPopAsync(int maximumMessages, CancellationToken token);
+
+    public abstract ValueTask CompleteAsync(Envelope envelope);
+
+    public abstract ValueTask DeferAsync(Envelope envelope);
+
+    public Task StartAsync()
+    {
+        _task = Task.Run(listenForMessagesAsync, _cancellation.Token);
+        return Task.CompletedTask;
+    }
+
+    public async ValueTask StopAsync()
+    {
+        await _cancellation.CancelAsync();
+        _task?.SafeDispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return StopAsync();
+    }
+
+    private async Task listenForMessagesAsync()
+    {
+        var failedCount = 0;
+
+        while (!_cancellation.Token.IsCancellationRequested)
+        {
+            try
+            {
+                var messages = await TryPopAsync(MaximumMessagesToReceive, _cancellation.Token);
+                failedCount = 0;
+
+                if (messages.Count > 0)
+                {
+                    await _receiver.ReceivedAsync(this, messages.ToArray());
+                }
+                else
+                {
+                    await Task.Delay(_pollingInterval, _cancellation.Token);
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is TaskCanceledException or OperationCanceledException && _cancellation.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                failedCount++;
+                var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();
+                _logger.LogError(e, "Error while trying to receive messages from database queue {Name}", _queueName);
+                await Task.Delay(pauseTime);
+            }
+        }
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueueListener.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueueListener.cs
@@ -1,37 +1,31 @@
-using JasperFx.Core;
-using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+using Microsoft.Data.SqlClient;
 using Weasel.Core;
 using Weasel.SqlServer;
+using Wolverine.RDBMS.Transport;
 using Wolverine.Runtime;
 using Wolverine.Transports;
 
 namespace Wolverine.SqlServer.Transport.NServiceBus;
 
-internal class NServiceBusSqlServerQueueListener : IListener
+internal class NServiceBusSqlServerQueueListener : DatabaseListener
 {
-    private readonly CancellationTokenSource _cancellation = new();
     private readonly NServiceBusSqlServerQueue _queue;
-    private readonly IReceiver _receiver;
     private readonly string _connectionString;
-    private readonly ILogger _logger;
     private readonly NServiceBusSqlServerEnvelopeMapper _mapper;
     private readonly NServiceBusSqlServerQueueSender _sender;
-    private readonly TimeSpan _pollingInterval;
     private readonly string _receiveSql;
-    private Task? _task;
 
-    public NServiceBusSqlServerQueueListener(NServiceBusSqlServerQueue queue, IWolverineRuntime runtime, IReceiver receiver)
+    public NServiceBusSqlServerQueueListener(NServiceBusSqlServerQueue queue, IWolverineRuntime runtime,
+        IReceiver receiver)
+        : base(queue.Uri, queue.Name, receiver,
+            runtime.LoggerFactory.CreateLogger<NServiceBusSqlServerQueueListener>(),
+            queue.PollingInterval ?? runtime.DurabilitySettings.ScheduledJobPollingTime)
     {
         _queue = queue;
-        _receiver = receiver;
         _connectionString = queue.Parent.Settings.ConnectionString!;
-        _logger = runtime.LoggerFactory.CreateLogger<NServiceBusSqlServerQueueListener>();
         _mapper = queue.BuildMapper(runtime);
         _sender = new NServiceBusSqlServerQueueSender(queue, runtime);
-        _pollingInterval = queue.PollingInterval ?? runtime.DurabilitySettings.ScheduledJobPollingTime;
-
-        Address = queue.Uri;
 
         // Destructive competing-consumer pop honoring NServiceBus FIFO-by-RowVersion ordering.
         _receiveSql = $@"
@@ -43,76 +37,21 @@ DELETE FROM message
 OUTPUT deleted.Id, deleted.Headers, deleted.Body;";
     }
 
-    public IHandlerPipeline? Pipeline => _receiver.Pipeline;
+    protected override int MaximumMessagesToReceive => _queue.MaximumMessagesToReceive;
 
-    public Uri Address { get; }
-
-    public ValueTask CompleteAsync(Envelope envelope)
+    public override ValueTask CompleteAsync(Envelope envelope)
     {
         // The row was already removed by the destructive pop.
         return ValueTask.CompletedTask;
     }
 
-    public async ValueTask DeferAsync(Envelope envelope)
+    public override async ValueTask DeferAsync(Envelope envelope)
     {
         // Re-expose the message by writing it back to the NServiceBus queue table.
         await _sender.SendAsync(envelope);
     }
 
-    public ValueTask DisposeAsync()
-    {
-        return StopAsync();
-    }
-
-    public async ValueTask StopAsync()
-    {
-        await _cancellation.CancelAsync();
-        _task?.SafeDispose();
-    }
-
-    public Task StartAsync()
-    {
-        _task = Task.Run(listenForMessagesAsync, _cancellation.Token);
-        return Task.CompletedTask;
-    }
-
-    private async Task listenForMessagesAsync()
-    {
-        var failedCount = 0;
-
-        while (!_cancellation.Token.IsCancellationRequested)
-        {
-            try
-            {
-                var messages = await tryPopAsync(_queue.MaximumMessagesToReceive, _cancellation.Token);
-                failedCount = 0;
-
-                if (messages.Count > 0)
-                {
-                    await _receiver.ReceivedAsync(this, messages.ToArray());
-                }
-                else
-                {
-                    await Task.Delay(_pollingInterval, _cancellation.Token);
-                }
-            }
-            catch (Exception e)
-            {
-                if (e is TaskCanceledException or OperationCanceledException && _cancellation.IsCancellationRequested)
-                {
-                    break;
-                }
-
-                failedCount++;
-                var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();
-                _logger.LogError(e, "Error while trying to receive messages from NServiceBus Sql Server queue {Name}",
-                    _queue.Name);
-                await Task.Delay(pauseTime);
-            }
-        }
-    }
-
-    private async Task<IReadOnlyList<Envelope>> tryPopAsync(int count, CancellationToken token)
+    protected override async Task<IReadOnlyList<Envelope>> TryPopAsync(int count, CancellationToken token)
     {
         await using var conn = new SqlConnection(_connectionString);
         await conn.OpenAsync(token);


### PR DESCRIPTION
## What

Extracts the common polling-listener loop shared by the three database interop transports into a single `DatabaseListener` base class in `Wolverine.RDBMS`.

## Why

The NServiceBus (SQL Server, PostgreSQL) and MassTransit (PostgreSQL) interop listeners had independently duplicated the same loop: a cancellable background task that pops a batch, forwards it to the receiver, and backs off on idle/error, plus the boilerplate `Address` / `Pipeline` / `StartAsync` / `StopAsync` / `DisposeAsync`.

`DatabaseListener` now owns all of that. Each transport listener supplies only what's actually dialect-specific:
- `TryPopAsync(max, token)` — the batch pop (NSB destructive `DELETE … OUTPUT` / `… RETURNING`; MassTransit `fetch_messages` lease).
- `CompleteAsync` / `DeferAsync` — ack/nack (NSB: no-op / requeue via the sender; MassTransit: `delete_message` / `unlock_message`).
- `MaximumMessagesToReceive`.

Net: ~80 lines of duplicated loop/lifecycle removed across the three listeners, one place to reason about the poll cadence and failure backoff.

## Validation

All three database interop suites pass against the real foreign hosts:
- NServiceBus + SQL Server — **4/4**
- NServiceBus + PostgreSQL — **4/4**
- MassTransit + PostgreSQL — **2/2**

`dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)