### PR TITLE
Pulsar: tiered retry-letter error policy MoveToPulsarRetryTopic (#3182)

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -189,6 +189,52 @@ For delayed / backoff redelivery (growing the delay between attempts), use the P
 retry-letter topics instead — DotPulsar's client does not expose negative-acknowledgment backoff
 or ack-timeout settings.
 
+## Tiered Retry-Letter Policy <Badge type="tip" text="6.8" />
+
+`RetryLetterQueueing(...)` configures Pulsar's native retry-letter topic per endpoint. For a
+first-class, discoverable **error policy** — the Pulsar analogue of the Kafka transport's
+`MoveToKafkaRetryTopic` — use `MoveToPulsarRetryTopic(...)`:
+
+```csharp
+opts.ListenToPulsarTopic("persistent://public/default/orders")
+    .SubscriptionType(SubscriptionType.Shared);
+
+// On failure: redeliver after 5s, then 30s, then 2m, then dead-letter.
+opts.OnException<TransientException>()
+    .MoveToPulsarRetryTopic(5.Seconds(), 30.Seconds(), 2.Minutes());
+```
+
+Each `TimeSpan` is one retry tier. On the first failure the message is routed to the retry-letter
+topic and redelivered after the first delay; on the next failure after the second delay; and so on.
+After the last tier is exhausted the message lands in the dead-letter topic. The delays are wired
+onto every Pulsar listener at startup (provisioning the retry-letter producer/consumer and the DLQ),
+so you don't also need an explicit `RetryLetterQueueing(...)` call.
+
+::: warning Requires a Shared or Key_Shared subscription
+Pulsar message delaying only works on `Shared` / `KeyShared` subscriptions. Applying
+`MoveToPulsarRetryTopic` to an `Exclusive` / `Failover` listener emits a startup warning and the
+policy falls back to an inline retry. The policy is also Pulsar-only: a failure arriving over any
+other transport falls back to an inline retry (and a startup warning is emitted when non-Pulsar
+listeners are present).
+:::
+
+### By-key concurrency with Key_Shared
+
+Pulsar's `Key_Shared` subscription is the idiomatic, **zero-extra-code** path for intra-partition
+concurrency by key — the free Pulsar analogue of the Kafka transport's sticky by-key processing. With
+a `Key_Shared` subscription, Pulsar distributes messages across the connected consumers (nodes) by
+message key, so messages that share a key are always delivered to the **same** consumer in order,
+while different keys are processed concurrently across the cluster:
+
+```csharp
+opts.ListenToPulsarTopic("persistent://public/default/orders")
+    .SubscriptionType(SubscriptionType.KeyShared);
+```
+
+Set the key on the way out via the ordinary Wolverine `GroupId` / partition-key conventions (the
+producer stamps it as the Pulsar message key). This pairs naturally with `MoveToPulsarRetryTopic`,
+which also requires `Shared` / `Key_Shared`.
+
 ## Customizing Consumers & Producers
 
 Beyond the global `IPulsarClientBuilder` passed to `UsePulsar(...)`, you can customize the

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/pulsar_retry_topic_dsl.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/pulsar_retry_topic_dsl.cs
@@ -1,0 +1,131 @@
+using System.Collections.Concurrent;
+using DotPulsar;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.ErrorHandling;
+using Wolverine.Tracking;
+using Wolverine.Transports.Tcp;
+using Wolverine.Util;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+// GH-3182: first-class, discoverable retry-letter error policy (MoveToPulsarRetryTopic) — the Pulsar
+// analogue of MoveToKafkaRetryTopic. Routes a failed message through tiered retry-letter delays then to
+// the dead-letter topic, and warns at startup when applied alongside non-Pulsar listeners.
+[Collection("pulsar")]
+public class pulsar_retry_topic_dsl
+{
+    [Fact]
+    public async Task permanent_failure_walks_the_tiers_then_dead_letters()
+    {
+        var topicPath = $"persistent://public/default/retry-dsl-{Guid.NewGuid():N}";
+
+        using var host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.PublishMessage<RetryDslMessage>().ToPulsarTopic(topicPath);
+
+            opts.ListenToPulsarTopic(topicPath)
+                .SubscriptionType(SubscriptionType.Shared)
+                .ProcessInline();
+
+            // The retry-letter policy under test: two tiers, then the dead-letter topic.
+            opts.OnException<RetryDslFailure>().MoveToPulsarRetryTopic(2.Seconds(), 3.Seconds());
+
+            opts.Services.AddSingleton<RetryDslSink>();
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<RetryDslHandler>();
+        });
+
+        var session = await host.TrackActivity(60.Seconds())
+            .DoNotAssertOnExceptionsDetected()
+            .IncludeExternalTransports()
+            .WaitForCondition(new WaitForDeadLetteredMessage<RetryDslMessage>())
+            .SendMessageAndWaitAsync(new RetryDslMessage());
+
+        // Tried on the source + both retry tiers (initial + 2 tiers = 3 deliveries), then dead-lettered.
+        session.Received.MessagesOf<RetryDslMessage>().Count().ShouldBe(3);
+        session.MovedToErrorQueue.MessagesOf<RetryDslMessage>().Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task non_pulsar_listener_emits_a_startup_warning()
+    {
+        var topicPath = $"persistent://public/default/retry-dsl-warn-{Guid.NewGuid():N}";
+        var capture = new CapturingLoggerProvider();
+
+        using var host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+
+            opts.ListenToPulsarTopic(topicPath)
+                .SubscriptionType(SubscriptionType.Shared)
+                .ProcessInline();
+
+            // A non-Pulsar listener present alongside the policy -> should warn at startup.
+            opts.ListenAtPort(PortFinder.GetAvailablePort());
+
+            opts.OnException<RetryDslFailure>().MoveToPulsarRetryTopic(2.Seconds(), 3.Seconds());
+
+            opts.Services.AddSingleton<ILoggerProvider>(capture);
+            opts.Discovery.DisableConventionalDiscovery();
+        });
+
+        capture.Warnings.ShouldContain(w =>
+            w.Contains("MoveToPulsarRetryTopic") && w.Contains("non-Pulsar"));
+    }
+}
+
+public class RetryDslMessage;
+
+public class RetryDslFailure : Exception
+{
+    public RetryDslFailure() : base("simulated retry-dsl failure")
+    {
+    }
+}
+
+public class RetryDslSink
+{
+    public ConcurrentBag<DateTimeOffset> Deliveries { get; } = new();
+}
+
+public class RetryDslHandler
+{
+    public void Handle(RetryDslMessage message, RetryDslSink sink)
+    {
+        sink.Deliveries.Add(DateTimeOffset.UtcNow);
+        throw new RetryDslFailure();
+    }
+}
+
+public sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    public ConcurrentBag<string> Warnings { get; } = new();
+
+    public ILogger CreateLogger(string categoryName) => new CapturingLogger(Warnings);
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class CapturingLogger(ConcurrentBag<string> warnings) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel >= LogLevel.Warning)
+            {
+                warnings.Add(formatter(state, exception));
+            }
+        }
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/ErrorHandling/MoveToPulsarRetryTopicContinuation.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/ErrorHandling/MoveToPulsarRetryTopicContinuation.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics;
+using Wolverine.ErrorHandling;
+using Wolverine.Runtime;
+
+namespace Wolverine.Pulsar.ErrorHandling;
+
+/// <summary>
+/// Discoverable error-policy continuation for Pulsar's native tiered retry-letter topics (GH-3182), the
+/// Pulsar analogue of <c>MoveToKafkaRetryTopic</c>. On failure it routes the message through the
+/// retry-letter topic with the configured per-tier delays (each tier reprocessed by the retry consumer
+/// after its delay elapses), and after the last tier is exhausted it moves the message to the dead-letter
+/// topic.
+///
+/// The configured delays are wired onto the matching Pulsar listener endpoints at startup
+/// (<see cref="PulsarTransport"/>), which spins up the retry-letter producer + consumer and the DLQ; the
+/// runtime routing itself is performed by Pulsar's native resiliency pipeline. This continuation only ever
+/// acts on Pulsar listeners — a failure arriving over any other transport falls back to a normal inline
+/// retry, so the Pulsar retry-letter routing can never be applied cross-transport.
+/// </summary>
+internal sealed class MoveToPulsarRetryTopicContinuation : UserDefinedContinuation
+{
+    private readonly TimeSpan[] _delays;
+    private readonly Exception? _exception;
+
+    public MoveToPulsarRetryTopicContinuation(TimeSpan[] delays) : this(delays, null)
+    {
+    }
+
+    private MoveToPulsarRetryTopicContinuation(TimeSpan[] delays, Exception? exception)
+        : base($"Move to Pulsar retry topic ({delays.Length} tiers)")
+    {
+        _delays = delays;
+        _exception = exception;
+    }
+
+    public TimeSpan[] Delays => _delays;
+
+    public override IContinuation Build(Exception ex, Envelope envelope)
+    {
+        if (envelope.Listener is PulsarListener)
+        {
+            return new MoveToPulsarRetryTopicContinuation(_delays, ex);
+        }
+
+        // Anything arriving over another transport degrades to a normal inline retry — never
+        // cross-transport.
+        return RetryInlineContinuation.Instance;
+    }
+
+    public override async ValueTask ExecuteAsync(IEnvelopeLifecycle lifecycle, IWolverineRuntime runtime,
+        DateTimeOffset now, Activity? activity)
+    {
+        var envelope = lifecycle.Envelope!;
+        var exception = _exception ?? envelope.Failure ?? new Exception("Unknown failure");
+
+        if (envelope.Listener is not PulsarListener listener)
+        {
+            await RetryInlineContinuation.Instance.ExecuteAsync(lifecycle, runtime, now, activity);
+            return;
+        }
+
+        // Tiers remaining -> schedule into the retry-letter topic at this attempt's delay. The native
+        // retry consumer reprocesses the message once the delay elapses, incrementing the attempt count.
+        if (listener.NativeRetryLetterQueueEnabled && listener.RetryLetterTopic is { } retry &&
+            retry.Retry.Count >= envelope.Attempts)
+        {
+            await new ScheduledRetryContinuation(retry.Retry[envelope.Attempts - 1])
+                .ExecuteAsync(lifecycle, runtime, now, activity);
+            return;
+        }
+
+        // Tiers exhausted -> native dead-letter topic.
+        if (listener.NativeDeadLetterQueueEnabled)
+        {
+            await new MoveToErrorQueue(exception).ExecuteAsync(lifecycle, runtime, now, activity);
+            return;
+        }
+
+        // No native retry-letter or dead-letter topic is in effect (e.g. an unsupported subscription
+        // type); degrade to an inline retry rather than silently dropping the failure.
+        await RetryInlineContinuation.Instance.ExecuteAsync(lifecycle, runtime, now, activity);
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarRetryExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarRetryExtensions.cs
@@ -1,0 +1,31 @@
+using Wolverine.ErrorHandling;
+using Wolverine.Pulsar.ErrorHandling;
+
+namespace Wolverine.Pulsar;
+
+public static class PulsarRetryExtensions
+{
+    /// <summary>
+    /// Route a failed Pulsar message through Pulsar's native tiered retry-letter topic with the supplied
+    /// per-tier delays, then to the dead-letter topic once every tier is exhausted (GH-3182). The Pulsar
+    /// analogue of <c>MoveToKafkaRetryTopic</c>, exposed as a first-class, discoverable error policy.
+    ///
+    /// Each delay is one retry tier: on the first failure the message is redelivered after
+    /// <c>delays[0]</c>, on the second after <c>delays[1]</c>, and so on; after the last tier it lands in
+    /// the dead-letter topic. The delays are applied to every Pulsar listener endpoint at startup, which
+    /// provisions the retry-letter producer + consumer and the DLQ.
+    ///
+    /// Pulsar message delaying only works on <see cref="DotPulsar.SubscriptionType.Shared"/> /
+    /// <see cref="DotPulsar.SubscriptionType.KeyShared"/> subscriptions; a startup warning is emitted for
+    /// any Pulsar listener using another subscription type (where this degrades to an inline retry).
+    /// </summary>
+    public static IAdditionalActions MoveToPulsarRetryTopic(this PolicyExpression expression, params TimeSpan[] delays)
+    {
+        if (delays == null || delays.Length == 0)
+        {
+            throw new ArgumentException("At least one retry delay tier is required", nameof(delays));
+        }
+
+        return expression.ContinueWith(new MoveToPulsarRetryTopicContinuation(delays));
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransport.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransport.cs
@@ -2,6 +2,7 @@ using DotPulsar;
 using DotPulsar.Abstractions;
 using JasperFx.Core;
 using JasperFx.Descriptors;
+using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Transports;
@@ -100,7 +101,55 @@ public class PulsarTransport : TransportBase<PulsarEndpoint>, IAsyncDisposable
     public override ValueTask InitializeAsync(IWolverineRuntime runtime)
     {
         Client = Builder.Build();
+        configureRetryTopics(runtime);
         return ValueTask.CompletedTask;
+    }
+
+    // GH-3182: discover the MoveToPulsarRetryTopic error policy in the global failure rules and wire its
+    // per-tier delays onto every Pulsar listener endpoint (provisioning the native retry-letter
+    // producer/consumer + DLQ), plus startup validation warnings for non-Pulsar listeners (where the
+    // policy degrades to an inline retry) and for unsupported subscription types (where Pulsar message
+    // delaying does not work).
+    private void configureRetryTopics(IWolverineRuntime runtime)
+    {
+        var continuation = runtime.Options.HandlerGraph.Failures
+            .Select(rule => rule.InfiniteSource)
+            .OfType<ErrorHandling.MoveToPulsarRetryTopicContinuation>()
+            .FirstOrDefault();
+
+        if (continuation == null)
+        {
+            return;
+        }
+
+        var logger = runtime.LoggerFactory.CreateLogger<PulsarTransport>();
+
+        var hasNonPulsarListener = runtime.Options.Transports
+            .Where(t => t is not PulsarTransport)
+            .SelectMany(t => t.Endpoints())
+            .Any(e => e.IsListener);
+        if (hasNonPulsarListener)
+        {
+            logger.LogWarning(
+                "MoveToPulsarRetryTopic is configured but non-Pulsar listeners are present. The Pulsar retry-letter topics only apply to messages received over Pulsar; failures on other transports will fall back to an inline retry.");
+        }
+
+        var delays = continuation.Delays.ToList();
+
+        foreach (var endpoint in endpoints().Where(e => e.IsListener))
+        {
+            // Respect an explicit RetryLetterQueueing(...) / DeadLetterQueueing(...) on the endpoint;
+            // otherwise provision the native pipeline from the policy's delays.
+            endpoint.RetryLetterTopic ??= new RetryLetterTopic(delays);
+            endpoint.DeadLetterTopic ??= DeadLetterTopic.DefaultNative;
+
+            if (!RetryLetterTopic.SupportedSubscriptionTypes.Contains(endpoint.SubscriptionType))
+            {
+                logger.LogWarning(
+                    "MoveToPulsarRetryTopic requires a Shared or KeyShared subscription, but listener {Topic} uses {SubscriptionType}; the tiered retry-letter delays will not apply and failures will fall back to an inline retry.",
+                    endpoint.PulsarTopic(), endpoint.SubscriptionType);
+            }
+        }
     }
 
     public WolverineTransportHealthCheck BuildHealthCheck(IWolverineRuntime runtime)


### PR DESCRIPTION
Closes #3182. Part of the **Re-Evaluate Pulsar Integration** epic #3176.

Adds a first-class, discoverable retry-letter **error policy** — the Pulsar analogue of `MoveToKafkaRetryTopic`:

```csharp
opts.ListenToPulsarTopic("persistent://public/default/orders")
    .SubscriptionType(SubscriptionType.Shared);

opts.OnException<TransientException>()
    .MoveToPulsarRetryTopic(5.Seconds(), 30.Seconds(), 2.Minutes());
```

Each `TimeSpan` is one retry tier: on failure the message is routed through Pulsar's native retry-letter topic with that delay, reprocessed by the retry consumer once it elapses, and after the last tier is exhausted it lands in the dead-letter topic.

## How it works
- `MoveToPulsarRetryTopicContinuation` (a `UserDefinedContinuation`, not an opaque `CustomAction`) **self-guards to `PulsarListener`** — a failure arriving over any other transport falls back to a normal inline retry, never cross-transport — and is discoverable in diagnostics.
- `PulsarTransport` discovers the policy at startup and wires its per-tier delays onto every Pulsar listener (provisioning the retry-letter producer/consumer + DLQ), so an explicit `RetryLetterQueueing(...)` is not also required.
- **Startup validation warnings** when (a) non-Pulsar listeners are present (policy degrades to inline retry there), or (b) a Pulsar listener uses a subscription type other than `Shared`/`Key_Shared` (Pulsar message delaying does not work there).

## Acceptance criteria
- ✅ The DSL routes a failed message through tiered retry-letter delays then to DLQ — integration test (`permanent_failure_walks_the_tiers_then_dead_letters`: 3 deliveries → 1 dead-lettered).
- ✅ Applying it to a non-Pulsar listener emits a startup warning — integration test (`non_pulsar_listener_emits_a_startup_warning`).
- ✅ Docs section added for `Key_Shared` by-key concurrency (the free Pulsar analogue of Kafka #3140).

## Tests / build
- `pulsar_retry_topic_dsl`: 2/2 green against a Testcontainers broker.
- Full `wolverine.slnx` builds clean in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)