### PR TITLE
Wolverine.Polecat: inherit DatabaseSchemaName for durability storage (#3175)

### DIFF
--- a/src/Persistence/Wolverine.Polecat/WolverineOptionsPolecatExtensions.cs
+++ b/src/Persistence/Wolverine.Polecat/WolverineOptionsPolecatExtensions.cs
@@ -72,8 +72,13 @@ public static class WolverineOptionsPolecatExtensions
             var runtime = s.GetRequiredService<IWolverineRuntime>();
             var logger = s.GetRequiredService<ILogger<SqlServerMessageStore>>();
 
+            // Mirror Wolverine.Marten: when no message-storage schema is configured, inherit the
+            // Polecat store's DatabaseSchemaName so distinct-schema Polecat services are isolated by
+            // default (separate durability tables: dead letters, nodes/assignments, …) instead of
+            // all sharing the "wolverine" schema. See GH-3175.
             var schemaName = integration.MessageStorageSchemaName ??
                              runtime.Options.Durability.MessageStorageSchemaName ??
+                             store.Options.DatabaseSchemaName ??
                              "wolverine";
 
             return BuildSqlServerMessageStore(schemaName, store, runtime, logger);


### PR DESCRIPTION
## What

`Wolverine.Polecat`'s `IntegrateWithWolverine()` now defaults the message-durability storage schema to the **Polecat store's `DatabaseSchemaName`** when no `MessageStorageSchemaName` is configured, mirroring `Wolverine.Marten`.

## Why

Marten resolves the message-store schema as:
```csharp
integration.MessageStorageSchemaName
  ?? runtime.Options.Durability.MessageStorageSchemaName
  ?? store.Options.DatabaseSchemaName   // <-- inherit the document schema
  ?? "public";
```
Polecat skipped the `store.Options.DatabaseSchemaName` step and fell straight back to `"wolverine"`. So two Polecat services with **distinct document schemas** (e.g. `polecat_trips` / `polecat_repair_shop`) silently landed in the **same** durability schema and shared their durability tables — dead letters, node/assignment state, agent-restriction state. (Found via CritterWatch #504.)

This aligns Polecat with Marten: distinct-schema Polecat services are isolated by default; an explicit `MessageStorageSchemaName` still wins.

## Note on `TransportSchemaName`

The issue also mentions `TransportSchemaName`, but Polecat's `IntegrateWithWolverine` doesn't currently configure a SQL Server **queue transport** (unlike Marten's PostgreSQL transport), so that property is presently vestigial — there's nothing reading it. Only the message-store schema needed the fix. If/when a Polecat queue transport is added, it should inherit `DatabaseSchemaName` the same way.

Closes #3175

🤖 Generated with [Claude Code](https://claude.com/claude-code)