### PR TITLE
Durable HTTP transport never deletes the outgoing envelope (#3173)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Transport/HttpSenderTests.cs
+++ b/src/Http/Wolverine.Http.Tests/Transport/HttpSenderTests.cs
@@ -179,6 +179,39 @@ public class HttpSenderTests
         await mockClient.Received(1).SendBatchAsync(
             Arg.Is("https://batch.com/api"),
             Arg.Is<OutgoingMessageBatch>(b => b.Messages.Count == 2));
+
+        // #3173: a successful send must acknowledge the batch so the durable sending agent deletes
+        // the outgoing envelopes from the outbox; otherwise the messages redeliver forever.
+        await callback.Received(1).MarkSuccessfulAsync(batch);
+    }
+
+    [Fact]
+    public async Task batched_sender_protocol_marks_failure_when_client_throws()
+    {
+        var endpoint = new HttpEndpoint(new Uri("https://batch.com/api"), EndpointRole.Application)
+        {
+            OutboundUri = "https://batch.com/api"
+        };
+
+        var services = new ServiceCollection();
+        var mockClient = Substitute.For<IWolverineHttpTransportClient>();
+        var failure = new HttpRequestException("boom");
+        mockClient.SendBatchAsync(Arg.Any<string>(), Arg.Any<OutgoingMessageBatch>())
+            .Returns(Task.FromException(failure));
+        services.AddSingleton(mockClient);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var protocol = new HttpSenderProtocol(endpoint, serviceProvider);
+
+        var batch = new OutgoingMessageBatch(endpoint.Uri,
+            new[] { new Envelope { Id = Guid.NewGuid(), Data = new byte[] { 1 } } });
+        var callback = Substitute.For<ISenderCallback>();
+
+        await protocol.SendBatchAsync(callback, batch);
+
+        // A failed send must be reported as a failure (requeue), never acknowledged as success.
+        await callback.Received(1).MarkProcessingFailureAsync(batch, failure);
+        await callback.DidNotReceive().MarkSuccessfulAsync(batch);
     }
 
     [Fact]

--- a/src/Http/Wolverine.Http/Transport/HttpSenderProtocol.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpSenderProtocol.cs
@@ -20,6 +20,20 @@ internal class HttpSenderProtocol : ISenderProtocol
         using var scope = _services.CreateScope();
         var client = scope.ServiceProvider.GetRequiredService<IWolverineHttpTransportClient>() ??
                      throw new InvalidOperationException("IWolverineHttpTransportClient is not registered in the service container");
-        await client.SendBatchAsync(_endpoint.OutboundUri, batch);
+
+        try
+        {
+            await client.SendBatchAsync(_endpoint.OutboundUri, batch);
+        }
+        catch (Exception e)
+        {
+            // Signal failure so the durable sending agent requeues rather than dropping the batch.
+            await callback.MarkProcessingFailureAsync(batch, e);
+            return;
+        }
+
+        // Acknowledge success so the durable sending agent deletes the outgoing envelopes from the
+        // outbox. Without this the durable HTTP transport redelivers the same messages forever (#3173).
+        await callback.MarkSuccessfulAsync(batch);
     }
 }

--- a/src/Http/Wolverine.Http/Transport/WolverineHttpTransportClient.cs
+++ b/src/Http/Wolverine.Http/Transport/WolverineHttpTransportClient.cs
@@ -13,15 +13,19 @@ public class WolverineHttpTransportClient(IHttpClientFactory clientFactory) : IW
         var client = clientFactory.CreateClient(uri);
         var content = new ByteArrayContent(EnvelopeSerializer.Serialize(batch.Messages));
         content.Headers.ContentType = new MediaTypeHeaderValue(HttpTransport.EnvelopeBatchContentType);
-        await client.PostAsync(client.BaseAddress, content);
+        var response = await client.PostAsync(client.BaseAddress, content);
+        // Throw on a non-success status so the durable sender treats it as a failure and requeues,
+        // rather than acknowledging success and deleting the outgoing envelope (#3173).
+        response.EnsureSuccessStatusCode();
     }
-    
+
     public async Task SendAsync(string uri, Envelope envelope, JsonSerializerOptions? options = null)
     {
         var client = clientFactory.CreateClient(uri);
         var content = new ByteArrayContent(EnvelopeSerializer.Serialize(envelope));
         content.Headers.ContentType = new MediaTypeHeaderValue(HttpTransport.EnvelopeContentType);
-        await client.PostAsync(client.BaseAddress, content);
+        var response = await client.PostAsync(client.BaseAddress, content);
+        response.EnsureSuccessStatusCode();
     }
 
     public async Task<InlineHttpReply> InvokeAsync(string uri, Envelope envelope, JsonSerializerOptions? options = null)
@@ -42,9 +46,12 @@ public class WolverineHttpTransportClientCloudEvents(IHttpClientFactory clientFa
         var client = clientFactory.CreateClient(uri);
         var content = new ByteArrayContent(EnvelopeSerializer.Serialize(batch.Messages));
         content.Headers.ContentType = new MediaTypeHeaderValue(HttpTransport.EnvelopeBatchContentType);
-        await client.PostAsync(client.BaseAddress, content);
+        var response = await client.PostAsync(client.BaseAddress, content);
+        // Throw on a non-success status so the durable sender treats it as a failure and requeues
+        // rather than deleting the outgoing envelope (#3173).
+        response.EnsureSuccessStatusCode();
     }
-    
+
     public async Task SendAsync(string uri, Envelope envelope, JsonSerializerOptions? options = null)
     {
         var client = clientFactory.CreateClient(uri);


### PR DESCRIPTION
## What

Fixes the durable HTTP transport redelivering successfully-processed messages forever (the `Outgoing` outbox count never drops).

## Root cause

`HttpSenderProtocol.SendBatchAsync` posted the batch but **never invoked the `ISenderCallback`**:

```csharp
await client.SendBatchAsync(_endpoint.OutboundUri, batch);
// no callback.MarkSuccessfulAsync(batch)  ← here
```

Every other transport's `ISenderProtocol` (Redis, Kafka, …) calls `callback.MarkSuccessfulAsync(batch)` on success / `callback.MarkProcessingFailureAsync(batch, ex)` on failure. That callback is what drives `DurableSendingAgent.MarkSuccessfulAsync` → `DeleteOutgoingAsync`, removing the outbox row. Without it, the outgoing envelope is never deleted and the durable sending agent re-sends it indefinitely.

## Fix

- `HttpSenderProtocol.SendBatchAsync` now `MarkSuccessfulAsync` on success and `MarkProcessingFailureAsync` on exception.
- `WolverineHttpTransportClient.SendBatchAsync` (and the CloudEvents client) now `EnsureSuccessStatusCode()`, so a non-2xx response throws → is treated as a failure (requeue) rather than silently acknowledged and deleted.
- Regression tests in `HttpSenderTests`: a successful batch acks (`MarkSuccessfulAsync`), a throwing client reports failure (`MarkProcessingFailureAsync`) and never acks.

Closes #3173

🤖 Generated with [Claude Code](https://claude.com/claude-code)