### PR TITLE
Pulsar: JSON schema support with broker-side registration (#3183)

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -328,6 +328,44 @@ using var host = await Host.CreateDefaultBuilder()
 
 This creates Pulsar topics named `orders1` through `orders4` with companion local queues `global-orders1` through `global-orders4`. Messages are routed to the correct shard based on their group id, and Wolverine handles the coordination between nodes automatically.
 
+## Schema Support <Badge type="tip" text="6.8" />
+
+Schema is one of Pulsar's defining features: the broker stores a schema per topic and enforces schema
+**compatibility / evolution** rules when producers and consumers connect. Wolverine can register a **JSON
+schema** for a topic so you get that broker-side registration and compatibility checking, while Wolverine
+continues to own the message body (its normal `System.Text.Json` serialization):
+
+```csharp
+// Producing endpoint
+opts.PublishMessage<OrderPlaced>()
+    .ToPulsarTopic("persistent://public/default/orders")
+    .UseJsonSchema<OrderPlaced>();
+
+// Listening endpoint — register a compatible schema
+opts.ListenToPulsarTopic("persistent://public/default/orders")
+    .UseJsonSchema<OrderPlaced>();
+```
+
+`UseJsonSchema<T>()` generates the Avro-format JSON schema Pulsar uses for `SchemaType.Json` from the CLR
+type's public properties and registers it with the broker when the producer/consumer connects. The schema
+covers the common POCO shapes (primitives, strings, enums and `Guid`/`DateTime` as strings, nullable value
+types as `["null", T]` unions, arrays, and nested records) and falls back to `string` for anything it
+can't map, so registration never fails on an exotic property.
+
+::: info The body stays Wolverine-serialized
+The schema is a **pass-through** over the bytes Wolverine already serializes — it declares the schema the
+broker stores and checks for compatibility, but does not change how the body is encoded. Existing
+raw-bytes and CloudEvents endpoints are unaffected (no schema is registered unless you opt in).
+:::
+
+For full control — a custom schema definition, a different `SchemaType`, or your own codec — supply an
+`ISchema<ReadOnlySequence<byte>>` directly:
+
+```csharp
+opts.ListenToPulsarTopic("persistent://public/default/orders")
+    .UsePulsarSchema(myCustomSchema);
+```
+
 ## Interoperability
 
 ::: tip

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/pulsar_json_schema.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/pulsar_json_schema.cs
@@ -1,0 +1,144 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Pulsar.Schemas;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+// GH-3183: Pulsar schema support. A JSON schema is registered with the broker for the topic while
+// Wolverine keeps owning the message body bytes (pass-through schema).
+public class pulsar_json_schema
+{
+    // ---- generator unit tests (no broker) ----
+
+    [Fact]
+    public void generates_an_avro_record_schema_for_a_poco()
+    {
+        var json = AvroSchemaGenerator.Generate(typeof(SchemaOrder));
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        root.GetProperty("type").GetString().ShouldBe("record");
+        root.GetProperty("name").GetString().ShouldBe("SchemaOrder");
+
+        var fields = root.GetProperty("fields").EnumerateArray()
+            .ToDictionary(f => f.GetProperty("name").GetString()!, f => f.GetProperty("type"));
+
+        fields.ContainsKey("Id").ShouldBeTrue();
+        fields["Id"].GetString().ShouldBe("string");          // Guid -> string
+        fields["Amount"].GetString().ShouldBe("double");
+        fields["Quantity"].GetString().ShouldBe("int");
+        fields["Note"].GetString().ShouldBe("string");        // reference type -> string
+        // Nullable<T> value type -> ["null", T]
+        fields["Priority"].ValueKind.ShouldBe(JsonValueKind.Array);
+    }
+
+    [Fact]
+    public void for_json_marks_the_schema_info_as_json()
+    {
+        var schema = PulsarSchema.ForJson(typeof(SchemaOrder));
+        schema.SchemaInfo.Type.ShouldBe(DotPulsar.SchemaType.Json);
+        schema.SchemaInfo.Name.ShouldBe("SchemaOrder");
+    }
+
+    // ---- end-to-end (Pulsar docker) ----
+
+    [Fact]
+    public async Task round_trips_under_a_json_schema_and_registers_it_with_the_broker()
+    {
+        var shortName = $"schema-json-{Guid.NewGuid():N}";
+        var topic = $"persistent://public/default/{shortName}";
+
+        using var listener = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.ListenToPulsarTopic(topic)
+                .SubscriptionName("sub-" + Guid.NewGuid().ToString("N"))
+                .UseJsonSchema<SchemaOrder>()
+                .ProcessInline()
+                .BeginAtEarliest();
+            opts.Services.AddSingleton<SchemaSink>();
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<SchemaOrderHandler>();
+        });
+
+        using var publisher = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.PublishAllMessages().ToPulsarTopic(topic).UseJsonSchema<SchemaOrder>().SendInline();
+        });
+
+        var order = new SchemaOrder { Id = Guid.NewGuid(), Amount = 42.5, Quantity = 3, Note = "rush" };
+        await publisher.SendAsync(order);
+
+        var sink = listener.Services.GetRequiredService<SchemaSink>();
+        var received = await waitForOneAsync(sink.Received);
+        received.Id.ShouldBe(order.Id);
+        received.Amount.ShouldBe(order.Amount);
+        received.Quantity.ShouldBe(order.Quantity);
+        received.Note.ShouldBe(order.Note);
+
+        // The broker must have registered a JSON schema for the topic.
+        var registered = await getRegisteredSchemaAsync(shortName);
+        registered.ShouldNotBeNull("No schema was registered with the broker for the topic");
+        registered.Value.GetProperty("type").GetString().ShouldBe("JSON");
+    }
+
+    private static async Task<SchemaOrder> waitForOneAsync(ConcurrentBag<SchemaOrder> bag, int timeoutMs = 30000)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            if (bag.TryPeek(out var order)) return order;
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException("No message received within the timeout");
+    }
+
+    private static async Task<JsonElement?> getRegisteredSchemaAsync(string topicShortName)
+    {
+        using var http = new HttpClient();
+        var url = $"{PulsarContainerFixture.HttpServiceUrl}/admin/v2/schemas/public/default/{topicShortName}/schema";
+
+        var cutoff = DateTimeOffset.UtcNow.AddSeconds(15);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            var response = await http.GetAsync(url);
+            if (response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync();
+                return JsonDocument.Parse(body).RootElement.Clone();
+            }
+
+            await Task.Delay(250);
+        }
+
+        return null;
+    }
+}
+
+public class SchemaOrder
+{
+    public Guid Id { get; set; }
+    public double Amount { get; set; }
+    public int Quantity { get; set; }
+    public string? Note { get; set; }
+    public int? Priority { get; set; }
+}
+
+public class SchemaSink
+{
+    public ConcurrentBag<SchemaOrder> Received { get; } = new();
+}
+
+public class SchemaOrderHandler
+{
+    public static void Handle(SchemaOrder order, SchemaSink sink)
+    {
+        sink.Received.Add(order);
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -124,6 +124,15 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
     internal Action<IProducerBuilder<ReadOnlySequence<byte>>>? ConfigureProducer { get; set; }
 
     /// <summary>
+    ///     Optional Pulsar schema for this endpoint (GH-3183). When set, the producer and consumer are
+    ///     created with this schema so the broker registers it for the topic (schema registration,
+    ///     compatibility checks, evolution). The schema is a pass-through over the bytes Wolverine already
+    ///     serializes, so the rest of the byte-oriented pipeline (mapper, CloudEvents, headers) is
+    ///     unchanged. Null (the default) uses DotPulsar's raw <c>ByteSequence</c> schema (no registration).
+    /// </summary>
+    internal ISchema<ReadOnlySequence<byte>>? Schema { get; set; }
+
+    /// <summary>
     ///     Use to override the dead letter topic for this endpoint
     /// </summary>
     public DeadLetterTopic? DeadLetterTopic { get; set; }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -59,7 +59,13 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
 
         var combined = CancellationTokenSource.CreateLinkedTokenSource(_cancellation, _localCancellation.Token);
 
-        var consumerBuilder = transport.Client!.NewConsumer()
+        // GH-3183: when an endpoint schema is configured, create the consumer with it so the broker
+        // registers/enforces the schema for the topic. The schema is a pass-through over Wolverine's
+        // bytes, so the builder is still IConsumerBuilder<ReadOnlySequence<byte>> and the receive path is
+        // unchanged.
+        var consumerBuilder = (endpoint.Schema != null
+                ? transport.Client!.NewConsumer(endpoint.Schema)
+                : transport.Client!.NewConsumer())
             .SubscriptionName(endpoint.SubscriptionName)
             .SubscriptionType(endpoint.SubscriptionType)
             .InitialPosition(endpoint.SubscriptionInitialPosition);

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarSender.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarSender.cs
@@ -19,7 +19,13 @@ public class PulsarSender : ISender, IAsyncDisposable
         var endpoint1 = endpoint;
         _cancellation = cancellation;
 
-        var producerBuilder = transport.Client!.NewProducer().Topic(endpoint1.PulsarTopic());
+        // GH-3183: when an endpoint schema is configured, create the producer with it so the broker
+        // registers the schema for the topic. The schema is a pass-through over Wolverine's bytes, so the
+        // builder is still IProducerBuilder<ReadOnlySequence<byte>> and the send path is unchanged.
+        var producerBuilder = (endpoint.Schema != null
+                ? transport.Client!.NewProducer(endpoint.Schema)
+                : transport.Client!.NewProducer())
+            .Topic(endpoint1.PulsarTopic());
         endpoint.ConfigureProducer?.Invoke(producerBuilder);
         _producer = producerBuilder.Create();
 

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -9,6 +9,7 @@ using Wolverine.Configuration;
 using Wolverine.ErrorHandling;
 using Wolverine.Pulsar.ErrorHandling;
 using Wolverine.Pulsar.Internal;
+using Wolverine.Pulsar.Schemas;
 using Wolverine.Runtime.Partitioning;
 
 namespace Wolverine.Pulsar;
@@ -327,6 +328,29 @@ public class PulsarListenerConfiguration : InteroperableListenerConfiguration<Pu
     public PulsarListenerConfiguration UseNativeRedelivery()
     {
         add(e => { e.UseNativeRedelivery = true; });
+        return this;
+    }
+
+    /// <summary>
+    /// Register a Pulsar JSON schema for <typeparamref name="T"/> on this listener (GH-3183). The broker
+    /// registers the topic's JSON schema (enabling schema compatibility checks + evolution); the message
+    /// body remains Wolverine's normal JSON serialization. The producing endpoint must register a
+    /// compatible schema.
+    /// </summary>
+    public PulsarListenerConfiguration UseJsonSchema<T>()
+    {
+        add(e => e.Schema = PulsarSchema.ForJson(typeof(T)));
+        return this;
+    }
+
+    /// <summary>
+    /// Register a custom Pulsar schema on this listener (GH-3183). The schema's <c>SchemaInfo</c> is what
+    /// the broker stores for the topic; <c>Encode</c>/<c>Decode</c> operate over the bytes Wolverine
+    /// serializes, so use a pass-through schema unless you are also replacing Wolverine's body serializer.
+    /// </summary>
+    public PulsarListenerConfiguration UsePulsarSchema(ISchema<ReadOnlySequence<byte>> schema)
+    {
+        add(e => e.Schema = schema);
         return this;
     }
 
@@ -684,6 +708,27 @@ public class PulsarSubscriberConfiguration : InteroperableSubscriberConfiguratio
     public PulsarSubscriberConfiguration ConfigureProducer(Action<IProducerBuilder<ReadOnlySequence<byte>>> configure)
     {
         add(e => { e.ConfigureProducer = configure; });
+        return this;
+    }
+
+    /// <summary>
+    /// Register a Pulsar JSON schema for <typeparamref name="T"/> on this sending endpoint (GH-3183). The
+    /// broker registers the topic's JSON schema; the message body remains Wolverine's normal JSON
+    /// serialization. The consuming endpoint must register a compatible schema.
+    /// </summary>
+    public PulsarSubscriberConfiguration UseJsonSchema<T>()
+    {
+        add(e => e.Schema = PulsarSchema.ForJson(typeof(T)));
+        return this;
+    }
+
+    /// <summary>
+    /// Register a custom Pulsar schema on this sending endpoint (GH-3183). See
+    /// <see cref="PulsarListenerConfiguration.UsePulsarSchema"/>.
+    /// </summary>
+    public PulsarSubscriberConfiguration UsePulsarSchema(ISchema<ReadOnlySequence<byte>> schema)
+    {
+        add(e => e.Schema = schema);
         return this;
     }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/Schemas/AvroSchemaGenerator.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/Schemas/AvroSchemaGenerator.cs
@@ -1,0 +1,147 @@
+using System.Collections;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+
+namespace Wolverine.Pulsar.Schemas;
+
+/// <summary>
+/// Generates an Avro-format JSON schema string from a CLR type. Pulsar represents both its
+/// <c>SchemaType.Json</c> and <c>SchemaType.Avro</c> definitions as an Avro schema, so this is what gets
+/// registered with the broker for a JSON-schema'd topic (GH-3183). The generator covers the common POCO
+/// shapes — primitives, strings, enums, <c>Guid</c>/<c>DateTime</c>(-ish) as strings, nullable value
+/// types as <c>["null", T]</c> unions, arrays, and nested records — and falls back to <c>string</c> for
+/// anything it can't map so registration never fails on an exotic property.
+/// </summary>
+internal static class AvroSchemaGenerator
+{
+    public static string Generate(Type type)
+    {
+        var node = BuildRecord(type, new HashSet<Type>());
+        return JsonSerializer.Serialize(node);
+    }
+
+    private static object BuildRecord(Type type, HashSet<Type> seen)
+    {
+        // Guard against recursive types: a record that (transitively) contains itself degrades to string.
+        if (!seen.Add(type))
+        {
+            return "string";
+        }
+
+        var fields = new List<Dictionary<string, object>>();
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                     .Where(p => p.CanRead && p.GetIndexParameters().Length == 0))
+        {
+            fields.Add(new Dictionary<string, object>
+            {
+                ["name"] = property.Name,
+                ["type"] = MapType(property.PropertyType, seen)
+            });
+        }
+
+        seen.Remove(type);
+
+        return new Dictionary<string, object>
+        {
+            ["type"] = "record",
+            ["name"] = SanitizeName(type.Name),
+            ["namespace"] = type.Namespace ?? "wolverine",
+            ["fields"] = fields
+        };
+    }
+
+    private static object MapType(Type type, HashSet<Type> seen)
+    {
+        var underlying = Nullable.GetUnderlyingType(type);
+        if (underlying != null)
+        {
+            // Nullable value type -> ["null", T]
+            return new object[] { "null", MapType(underlying, seen) };
+        }
+
+        if (type == typeof(string))
+        {
+            return "string";
+        }
+
+        if (type == typeof(bool))
+        {
+            return "boolean";
+        }
+
+        if (type == typeof(byte) || type == typeof(sbyte) || type == typeof(short) || type == typeof(ushort)
+            || type == typeof(int) || type == typeof(uint) || type == typeof(char))
+        {
+            return "int";
+        }
+
+        if (type == typeof(long) || type == typeof(ulong))
+        {
+            return "long";
+        }
+
+        if (type == typeof(float))
+        {
+            return "float";
+        }
+
+        if (type == typeof(double) || type == typeof(decimal))
+        {
+            return "double";
+        }
+
+        if (type == typeof(byte[]))
+        {
+            return "bytes";
+        }
+
+        // Guid / DateTime / DateTimeOffset / TimeSpan / enums and anything else scalar -> string.
+        if (type.IsEnum || type == typeof(Guid) || type == typeof(DateTime) || type == typeof(DateTimeOffset)
+            || type == typeof(TimeSpan) || type == typeof(Uri))
+        {
+            return "string";
+        }
+
+        if (type != typeof(string) && typeof(IEnumerable).IsAssignableFrom(type))
+        {
+            var element = ElementType(type);
+            return new Dictionary<string, object>
+            {
+                ["type"] = "array",
+                ["items"] = element == null ? "string" : MapType(element, seen)
+            };
+        }
+
+        if (type.IsClass || (type.IsValueType && !type.IsPrimitive))
+        {
+            return BuildRecord(type, seen);
+        }
+
+        return "string";
+    }
+
+    private static Type? ElementType(Type type)
+    {
+        if (type.IsArray)
+        {
+            return type.GetElementType();
+        }
+
+        var enumerable = type.GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+        return enumerable?.GetGenericArguments()[0];
+    }
+
+    private static string SanitizeName(string name)
+    {
+        // Avro names must be alphanumeric/underscore; strip generic-arity backticks etc.
+        var builder = new StringBuilder(name.Length);
+        foreach (var c in name)
+        {
+            builder.Append(char.IsLetterOrDigit(c) || c == '_' ? c : '_');
+        }
+
+        return builder.Length == 0 ? "Record" : builder.ToString();
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/Schemas/PulsarSchema.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/Schemas/PulsarSchema.cs
@@ -1,0 +1,49 @@
+using System.Buffers;
+using DotPulsar;
+using DotPulsar.Abstractions;
+
+namespace Wolverine.Pulsar.Schemas;
+
+/// <summary>
+/// A Pulsar schema that registers schema metadata with the broker (so the topic gets broker-side schema
+/// registration, compatibility checks, and evolution) while leaving the message body bytes owned by
+/// Wolverine's own serialization (GH-3183). <see cref="Encode"/> / <see cref="Decode"/> are pass-through:
+/// the body is whatever Wolverine already serialized (e.g. JSON via <c>System.Text.Json</c>), and the
+/// <see cref="SchemaInfo"/> declares the schema type + definition the broker stores for the topic.
+///
+/// This keeps the entire existing byte-oriented sender/listener/<see cref="PulsarEnvelopeMapper"/> and
+/// CloudEvents pipeline intact — the only change is that the producer/consumer are created with this
+/// schema so the broker registers it.
+/// </summary>
+internal sealed class PulsarSchema : ISchema<ReadOnlySequence<byte>>
+{
+    public PulsarSchema(SchemaInfo schemaInfo)
+    {
+        SchemaInfo = schemaInfo;
+    }
+
+    public SchemaInfo SchemaInfo { get; }
+
+    public ReadOnlySequence<byte> Decode(ReadOnlySequence<byte> bytes, byte[]? schemaVersion = null)
+    {
+        return bytes;
+    }
+
+    public ReadOnlySequence<byte> Encode(ReadOnlySequence<byte> message)
+    {
+        return message;
+    }
+
+    /// <summary>
+    /// Build a JSON-schema-typed Pulsar schema for the CLR message type <paramref name="messageType"/>.
+    /// The schema definition is the Avro-format JSON schema Pulsar uses for <see cref="SchemaType.Json"/>,
+    /// generated from the type's public properties. The body bytes remain Wolverine's JSON serialization.
+    /// </summary>
+    public static PulsarSchema ForJson(Type messageType)
+    {
+        var definition = AvroSchemaGenerator.Generate(messageType);
+        var info = new SchemaInfo(messageType.Name, System.Text.Encoding.UTF8.GetBytes(definition),
+            SchemaType.Json, new Dictionary<string, string>());
+        return new PulsarSchema(info);
+    }
+}


### PR DESCRIPTION
Part of the **Re-Evaluate Pulsar Integration** epic #3176. Addresses #3183 (the headline differentiator) — the **JSON-first** slice of the revised scope.

The Pulsar transport previously sent/received **raw bytes only**, with no schema registered on the broker — the single biggest divergence from idiomatic Pulsar. This adds **JSON schema support** so a topic gets broker-side schema registration and Pulsar's schema **compatibility / evolution** checks, while Wolverine keeps owning the message body (its normal `System.Text.Json` serialization).

```csharp
opts.PublishMessage<OrderPlaced>().ToPulsarTopic(topic).UseJsonSchema<OrderPlaced>();
opts.ListenToPulsarTopic(topic).UseJsonSchema<OrderPlaced>();
```

## Design — pass-through schema, zero pipeline rewrite
- `PulsarSchema : ISchema<ReadOnlySequence<byte>>` is a **pass-through** over Wolverine's bytes whose `SchemaInfo` declares the schema the broker stores. Because it stays typed as `ReadOnlySequence<byte>`, the entire existing sender/listener/`PulsarEnvelopeMapper` and CloudEvents pipeline is **unchanged** — the producer/consumer are simply created with the schema (`NewProducer(schema)` / `NewConsumer(schema)`) so the broker registers it.
- `AvroSchemaGenerator` builds the Avro-format JSON schema Pulsar uses for `SchemaType.Json` from a CLR type's public properties (primitives, strings, enums/`Guid`/`DateTime` as strings, nullable value types as `["null", T]` unions, arrays, nested records), falling back to `string` for anything unmappable so registration never fails on an exotic property.
- DSL: `UseJsonSchema<T>()` and `UsePulsarSchema(ISchema<…>)` on both listener and subscriber configs.

## Scope notes
- `AUTO_CONSUME` is **dropped** (not available in DotPulsar 5.1.2, per the [API verification](https://github.com/JasperFx/wolverine/issues/3183#issuecomment-4769487074)).
- **No regression:** no schema is registered unless you opt in, so raw-bytes and CloudEvents endpoints are unaffected.
- The `UsePulsarSchema(ISchema<ReadOnlySequence<byte>>)` seam accepts a custom schema for advanced cases (custom definition / `SchemaType` / codec). Built-in typed **Avro** (`Schema.AvroISpecificRecord<T>()`, which is `ISchema<T>` and needs the typed producer/consumer path) is a natural follow-up on top of this seam.

## Acceptance criteria
- ✅ A typed message produced and consumed under a JSON schema with **broker-side schema registration**, proven by integration test (verified via the Pulsar admin REST `…/schemas/…/schema` endpoint returning `type: JSON`).
- ✅ Existing raw-bytes / CloudEvents paths remain working (opt-in only).

## Tests / build
- `pulsar_json_schema`: JSON round-trip + broker registration (integration) and Avro-format schema generator (unit) — green against a Testcontainers broker.
- Full `wolverine.slnx` builds clean in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)