### PR TITLE
Pulsar: producer deduplication (#3185)

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -412,6 +412,37 @@ opts.ListenToPulsarTopic("persistent://public/default/orders")
     .UsePulsarSchema(myCustomSchema);
 ```
 
+## Producer Deduplication <Badge type="tip" text="6.8" />
+
+Pulsar can deduplicate messages **at the broker** using a per-producer sequence id, so a message that is
+sent more than once — most commonly an outbox **resend** of the same envelope after a transient failure —
+is stored only once. Opt in on a sending endpoint with `EnableDeduplication()`:
+
+```csharp
+opts.PublishMessage<OrderPlaced>()
+    .ToPulsarTopic("persistent://public/default/orders")
+    .EnableDeduplication();
+```
+
+Wolverine creates the producer with a **stable producer name** and stamps a monotonic sequence id per
+message, reusing the same sequence id when the *same envelope* is sent again so the broker discards the
+duplicate. A brand-new message always gets a new id and is delivered normally.
+
+You must also enable deduplication on the broker side (it is off by default), e.g.:
+
+```bash
+pulsar-admin namespaces set-deduplication public/default --enable
+# or per topic:
+pulsar-admin topics set-deduplication-status persistent://public/default/orders --enable
+```
+
+::: warning Producer→broker only — not end-to-end exactly-once
+This suppresses duplicates on the **produce** side; it is not a transactional read-process-write
+exactly-once engine (a deliberate non-goal for the transport — and Pulsar transactions are not exposed by
+the DotPulsar client). Deduplication keys on `(producer name, sequence id)`, so pass a fixed
+`EnableDeduplication("my-producer")` name if you need it to hold across process restarts.
+:::
+
 ## Interoperability
 
 ::: tip

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/pulsar_producer_dedup.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/pulsar_producer_dedup.cs
@@ -1,0 +1,138 @@
+using System.Buffers;
+using System.Text;
+using DotPulsar;
+using DotPulsar.Abstractions;
+using DotPulsar.Extensions;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+// GH-3185: producer deduplication. The same envelope re-sent (e.g. an outbox resend) carries the same
+// sequence id, so the broker discards the duplicate; a distinct envelope is delivered.
+[Collection("pulsar")]
+public class pulsar_producer_dedup
+{
+    // ---- config unit test (no broker) ----
+
+    [Fact]
+    public void enable_deduplication_sets_the_flag_and_name()
+    {
+        var transport = new PulsarTransport();
+        var endpoint = transport.EndpointFor("persistent://public/default/dedup-config");
+        var config = new PulsarSubscriberConfiguration(endpoint);
+
+        config.EnableDeduplication("orders-producer");
+        ((Wolverine.Configuration.IDelayedEndpointConfiguration)config).Apply();
+
+        endpoint.DeduplicationEnabled.ShouldBeTrue();
+        endpoint.ProducerName.ShouldBe("orders-producer");
+    }
+
+    // ---- end-to-end (Pulsar docker) ----
+
+    [Fact]
+    public async Task resending_the_same_envelope_is_deduplicated_by_the_broker()
+    {
+        var shortName = $"dedup-{Guid.NewGuid():N}";
+        var topic = $"persistent://public/default/{shortName}";
+
+        using var host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+        });
+
+        var runtime = host.GetRuntime();
+        var transport = runtime.Options.Transports.GetOrCreate<PulsarTransport>();
+        var endpoint = transport.EndpointFor(topic);
+        endpoint.DeduplicationEnabled = true;
+        endpoint.ProducerName = "dedup-test-producer";
+
+        // Enable broker-side deduplication on the namespace before producing.
+        await enableNamespaceDeduplicationAsync();
+
+        await using var sender = new PulsarSender(runtime, endpoint, transport, CancellationToken.None);
+
+        var first = BuildEnvelope("a");
+        await sender.SendAsync(first);
+        await sender.SendAsync(first);   // exact resend of the same envelope -> deduplicated
+
+        var second = BuildEnvelope("b");  // distinct envelope -> delivered
+        await sender.SendAsync(second);
+
+        // Only two distinct messages should have actually landed on the topic.
+        var delivered = await countMessagesAsync(transport, topic, expected: 2);
+        delivered.ShouldBe(2);
+    }
+
+    private static Envelope BuildEnvelope(string id)
+    {
+        return new Envelope(new DedupMessage { Id = id })
+        {
+            Data = Encoding.UTF8.GetBytes($"{{\"Id\":\"{id}\"}}"),
+            MessageType = "dedup-message",
+            ContentType = "application/json"
+        };
+    }
+
+    private static async Task enableNamespaceDeduplicationAsync()
+    {
+        using var http = new HttpClient();
+        var url = $"{PulsarContainerFixture.HttpServiceUrl}/admin/v2/namespaces/public/default/deduplication";
+        using var content = new StringContent("true", Encoding.UTF8, "application/json");
+        var response = await http.PostAsync(url, content);
+        response.EnsureSuccessStatusCode();
+        // Give the broker a moment to apply the policy before producing.
+        await Task.Delay(1.Seconds());
+    }
+
+    private static async Task<int> countMessagesAsync(PulsarTransport transport, string topic, int expected)
+    {
+        await using var consumer = transport.Client!.NewConsumer()
+            .SubscriptionName("count-" + Guid.NewGuid().ToString("N"))
+            .SubscriptionType(SubscriptionType.Exclusive)
+            .InitialPosition(SubscriptionInitialPosition.Earliest)
+            .Topic(topic)
+            .Create();
+
+        var count = 0;
+        // Keep trying until an overall deadline so we tolerate cold-start connect latency; only stop early
+        // once we've seen at least the expected count and then hit an idle gap (so we'd also catch an
+        // over-count if dedup failed to suppress anything).
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(25);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            using var cts = new CancellationTokenSource(3.Seconds());
+            IMessage<ReadOnlySequence<byte>> message;
+            try
+            {
+                message = await consumer.Receive(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Idle window with nothing delivered. If we've already got everything expected, we're
+                // done; otherwise keep waiting for slow delivery.
+                if (count >= expected)
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            count++;
+            await consumer.Acknowledge(message, CancellationToken.None);
+        }
+
+        return count;
+    }
+}
+
+public class DedupMessage
+{
+    public string Id { get; set; } = string.Empty;
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -133,6 +133,22 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
     internal ISchema<ReadOnlySequence<byte>>? Schema { get; set; }
 
     /// <summary>
+    ///     When true, this sending endpoint opts into Pulsar producer deduplication (GH-3185): the
+    ///     producer is created with a stable <see cref="ProducerName"/> and stamps a monotonic per-message
+    ///     sequence id, so the broker discards duplicate sends of the same message (e.g. outbox resends).
+    ///     This is producer→broker dedup only, not end-to-end exactly-once, and requires broker
+    ///     deduplication to be enabled on the namespace/topic. Set via <c>EnableDeduplication()</c>.
+    /// </summary>
+    internal bool DeduplicationEnabled { get; set; }
+
+    /// <summary>
+    ///     Stable Pulsar producer name used for deduplication. The broker tracks the last sequence id per
+    ///     producer name, so this must be stable across producer sessions for dedup to span restarts. When
+    ///     null, the sender derives one from the service name and topic.
+    /// </summary>
+    internal string? ProducerName { get; set; }
+
+    /// <summary>
     ///     Use to override the dead letter topic for this endpoint
     /// </summary>
     public DeadLetterTopic? DeadLetterTopic { get; set; }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarSender.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarSender.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Collections.Concurrent;
 using DotPulsar;
 using DotPulsar.Abstractions;
 using DotPulsar.Extensions;
@@ -13,6 +14,12 @@ public class PulsarSender : ISender, IAsyncDisposable
     private readonly IPulsarEnvelopeMapper _mapper;
     private readonly IProducer<ReadOnlySequence<byte>> _producer;
 
+    // GH-3185: producer deduplication state.
+    private const int SequenceCacheLimit = 100_000;
+    private readonly bool _deduplicationEnabled;
+    private readonly ConcurrentDictionary<Guid, ulong>? _sequenceIds;
+    private long _sequence;
+
     public PulsarSender(IWolverineRuntime runtime, PulsarEndpoint endpoint, PulsarTransport transport,
         CancellationToken cancellation)
     {
@@ -26,6 +33,22 @@ public class PulsarSender : ISender, IAsyncDisposable
                 ? transport.Client!.NewProducer(endpoint.Schema)
                 : transport.Client!.NewProducer())
             .Topic(endpoint1.PulsarTopic());
+
+        if (endpoint.DeduplicationEnabled)
+        {
+            _deduplicationEnabled = true;
+
+            // A stable producer name is required: the broker tracks the last sequence id per producer
+            // name, so dedup only works if the name is stable across producer sessions.
+            producerBuilder.ProducerName(endpoint.ProducerName ?? $"{runtime.Options.ServiceName}-{endpoint1.TopicName}");
+
+            // Seed the sequence from the clock so a fresh producer session never reuses an id from a prior
+            // one (DotPulsar 5.1.2 exposes no broker LastSequenceId to resume from). Ticks dwarfs any
+            // realistic per-session message count, so post-restart ids stay strictly above prior ones.
+            _sequence = DateTimeOffset.UtcNow.Ticks;
+            _sequenceIds = new ConcurrentDictionary<Guid, ulong>();
+        }
+
         endpoint.ConfigureProducer?.Invoke(producerBuilder);
         _producer = producerBuilder.Create();
 
@@ -61,6 +84,18 @@ public class PulsarSender : ISender, IAsyncDisposable
         var message = new MessageMetadata();
 
         _mapper.MapEnvelopeToOutgoing(envelope, message);
+
+        if (_deduplicationEnabled && _sequenceIds != null)
+        {
+            // Reuse the same sequence id for repeat sends of the same envelope (e.g. outbox resends) so
+            // the broker discards the duplicate; a brand-new envelope gets the next monotonic id.
+            if (_sequenceIds.Count > SequenceCacheLimit)
+            {
+                _sequenceIds.Clear();
+            }
+
+            message.SequenceId = _sequenceIds.GetOrAdd(envelope.Id, _ => (ulong)Interlocked.Increment(ref _sequence));
+        }
 
         await _producer.Send(message, new ReadOnlySequence<byte>(envelope.Data!), _cancellation);
     }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -731,4 +731,31 @@ public class PulsarSubscriberConfiguration : InteroperableSubscriberConfiguratio
         add(e => e.Schema = schema);
         return this;
     }
+
+    /// <summary>
+    /// Enable Pulsar producer deduplication for this sending endpoint (GH-3185). The producer is created
+    /// with a stable producer name and stamps a monotonic per-message sequence id, so the broker discards
+    /// duplicate sends of the same message (for example outbox resends of the same envelope).
+    ///
+    /// This is **producer→broker** deduplication only, not end-to-end exactly-once, and it requires broker
+    /// deduplication to be enabled on the namespace/topic (e.g. <c>pulsar-admin namespaces
+    /// set-deduplication public/default --enable</c>).
+    /// </summary>
+    /// <param name="producerName">
+    /// Optional stable producer name. The broker tracks the last sequence id per producer name, so a fixed
+    /// name lets dedup span producer restarts. When omitted, a name is derived from the service name and
+    /// topic.
+    /// </param>
+    public PulsarSubscriberConfiguration EnableDeduplication(string? producerName = null)
+    {
+        add(e =>
+        {
+            e.DeduplicationEnabled = true;
+            if (producerName != null)
+            {
+                e.ProducerName = producerName;
+            }
+        });
+        return this;
+    }
 }


### PR DESCRIPTION
Closes #3185. **Final issue of the Re-Evaluate Pulsar Integration epic — also closes #3176.**

(Rebased replacement for #3211, which became conflicting after the JSON-schema PR #3210 merged; identical content, conflicts with #3210 resolved so schema + dedup coexist.)

Opt-in **producer→broker deduplication** on a sending endpoint:

```csharp
opts.PublishMessage<OrderPlaced>()
    .ToPulsarTopic("persistent://public/default/orders")
    .EnableDeduplication();   // optional stable producer name: EnableDeduplication("orders-producer")
```

## How it works
- The producer is created with a **stable producer name** and stamps a **monotonic per-message sequence id** (Pulsar dedups on `producer-name + sequence-id`).
- The sequence id is cached by `Envelope.Id`, so a **repeat send of the same envelope** (e.g. an outbox resend after a transient failure) reuses its id and the broker discards the duplicate, while a brand-new envelope always gets the next id and is delivered.
- The counter is seeded from the clock so a fresh producer session never reuses ids from a prior one (DotPulsar 5.1.2 exposes no broker `LastSequenceId` to resume from).

## Scope
- **Producer→broker** dedup only, **not** end-to-end exactly-once; requires broker deduplication enabled on the namespace/topic.
- **Transactions deferred:** DotPulsar 5.1.2 exposes no public transactions API (only exception types) — matches the epic's declared non-goal.

## Acceptance criteria
- ✅ Producer dedup is selectable and proven to suppress duplicate sends — integration test (`resending_the_same_envelope_is_deduplicated_by_the_broker`: resent envelope dropped, distinct one delivered → 2 messages from 3 sends) against a real broker.

## Tests / build
- `pulsar_producer_dedup`: integration + config unit test — green against a Testcontainers broker.
- Full `wolverine.slnx` builds clean in Release (with #3210's schema work merged in).

---

**10th and final** child of epic #3176. With this merged the epic is complete: #3186, #3178, #3181, #3177, #3179, #3180, #3184, #3182, #3183, #3185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)