### PR TITLE
Fix flaky multi-node event-subscription agent distribution (#3216)

### DIFF
--- a/src/Persistence/PolecatTests/Distribution/polecat_multinode_agent_build_3216.cs
+++ b/src/Persistence/PolecatTests/Distribution/polecat_multinode_agent_build_3216.cs
@@ -1,0 +1,105 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using PolecatTests.Distribution.TripDomain;
+using Shouldly;
+using Wolverine;
+using Wolverine.Polecat;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+
+namespace PolecatTests.Distribution;
+
+// Regression for GH-3216: the residual multi-node flakiness after #3133/#3168. The leader evaluates
+// assignments — calling SupportedAgentsAsync, which is what populated EventStoreAgents._shardNames — and
+// then tells *another* node to start the agent. That assigned node builds the agent on its OWN family
+// instance, whose _shardNames was never populated, so BuildAgentAsync used to throw "Unable to find a
+// shard with path ..." and the agent silently failed to start (non-deterministically, depending on which
+// node won the assignment / survived a failover). Polecat exposed this more than Marten purely because
+// its SQL Server descriptor/daemon timing widened the window.
+//
+// This reproduces the cross-node ordering deterministically with a second, cold family instance over the
+// same store, with no flaky 3-node cluster timing.
+public class polecat_multinode_agent_build_3216 : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddPolecat(m =>
+                    {
+                        m.ConnectionString = Servers.SqlServerConnectionString;
+                        m.DatabaseSchemaName = "polecat_3216";
+
+                        m.Projections.Add<TripProjection>(ProjectionLifecycle.Async);
+                        m.Projections.Add<DayProjection>(ProjectionLifecycle.Async);
+                        m.Projections.Add<DistanceProjection>(ProjectionLifecycle.Async);
+                    })
+                    .IntegrateWithWolverine(o => o.UseWolverineManagedEventSubscriptionDistribution = true)
+                    .ApplyAllDatabaseChangesOnStartup();
+
+                opts.Discovery.DisableConventionalDiscovery();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _host.GetRuntime().Agents.DisableHealthChecks();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task assigned_node_can_build_agent_without_having_enumerated_its_own_shards_first()
+    {
+        // The "leader" enumerates the known agents (this is the only thing that populated _shardNames).
+        var leaderFamily = _host.Services.GetRequiredService<EventSubscriptionAgentFamily>();
+        var uris = await leaderFamily.AllKnownAgentsAsync();
+        uris.ShouldNotBeEmpty();
+        var assignedUri = uris[0];
+
+        // Simulate the *assigned* node: a brand-new family over the same store whose shard cache has never
+        // been populated (it never ran SupportedAgentsAsync / AllKnownAgentsAsync).
+        var store = _host.Services.GetRequiredService<IEventStore>();
+        var coldFamily =
+            new EventSubscriptionAgentFamily([store], Array.Empty<IObserver<ShardState>>());
+
+        // Pre-3216 this threw ArgumentOutOfRangeException("Unable to find a shard with path ...").
+        var agent = await coldFamily.BuildAgentAsync(assignedUri, _host.GetRuntime());
+
+        agent.ShouldNotBeNull();
+        agent.Uri.ShouldBe(assignedUri);
+
+        await coldFamily.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task every_known_agent_is_buildable_from_a_cold_family()
+    {
+        var leaderFamily = _host.Services.GetRequiredService<EventSubscriptionAgentFamily>();
+        var uris = await leaderFamily.AllKnownAgentsAsync();
+        uris.Count.ShouldBe(3); // Trip, Day, Distance async projections
+
+        var store = _host.Services.GetRequiredService<IEventStore>();
+
+        foreach (var uri in uris)
+        {
+            // A fresh cold family per URI — the strongest version of "this node never enumerated".
+            var coldFamily =
+                new EventSubscriptionAgentFamily([store], Array.Empty<IObserver<ShardState>>());
+
+            var agent = await coldFamily.BuildAgentAsync(uri, _host.GetRuntime());
+            agent.Uri.ShouldBe(uri);
+
+            await coldFamily.DisposeAsync();
+        }
+    }
+}

--- a/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
+++ b/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
@@ -14,7 +14,12 @@ public class EventStoreAgents : IAsyncDisposable
     private readonly IObserver<ShardState>[] _observers;
     private readonly SemaphoreSlim _daemonLock = new(1);
     private ImHashMap<DatabaseId, IProjectionDaemon> _daemons = ImHashMap<DatabaseId, IProjectionDaemon>.Empty;
-    private readonly List<ShardName> _shardNames = new();
+
+    // Keyed by ShardName.RelativeUrl. Populated as a side effect of SupportedAgentsAsync, but also resolved
+    // on demand by BuildAgentAsync (a node assigned an agent may never have enumerated its own shards). An
+    // ImHashMap so the enumeration writes and the BuildAgentAsync reads are lock-free across threads. See
+    // GH-3216.
+    private ImHashMap<string, ShardName> _shardNames = ImHashMap<string, ShardName>.Empty;
     
     public EventStoreAgents(IEventStore store, IObserver<ShardState>[] observers)
     {
@@ -91,7 +96,7 @@ public class EventStoreAgents : IAsyncDisposable
             
             foreach (var shardName in usage.Subscriptions.Where(x => x.Lifecycle == ProjectionLifecycle.Async).SelectMany(x => x.ShardNames))
             {
-                _shardNames.Fill(shardName);
+                _shardNames = _shardNames.AddOrUpdate(shardName.RelativeUrl, shardName);
                 var uri = EventSubscriptionAgentFamily.UriFor(_store.Identity, id, shardName);
                 list.Add(uri);
             }
@@ -105,7 +110,7 @@ public class EventStoreAgents : IAsyncDisposable
             {
                 foreach (var shardName in usage.Subscriptions.Where(x => x.Lifecycle == ProjectionLifecycle.Async).SelectMany(x => x.ShardNames))
                 {
-                    _shardNames.Fill(shardName);
+                    _shardNames = _shardNames.AddOrUpdate(shardName.RelativeUrl, shardName);
                     var uri = EventSubscriptionAgentFamily.UriFor(_store.Identity, id, shardName);
                     list.Add(uri);
                 }
@@ -140,7 +145,7 @@ public class EventStoreAgents : IAsyncDisposable
 
     public async Task<EventSubscriptionAgent> BuildAgentAsync(Uri uri, DatabaseId databaseId, string shardPath)
     {
-        var shardName = _shardNames.FirstOrDefault(x => x.RelativeUrl == shardPath);
+        var shardName = await ResolveShardNameAsync(shardPath, CancellationToken.None);
         if (shardName == null)
         {
             throw new ArgumentOutOfRangeException(nameof(shardPath), $"Unable to find a shard with path '{shardPath}'");
@@ -149,6 +154,26 @@ public class EventStoreAgents : IAsyncDisposable
         var daemon = await FindDaemonAsync(databaseId);
 
         return new EventSubscriptionAgent(uri, shardName, daemon);
+    }
+
+    /// <summary>
+    /// Resolve a shard by its <c>RelativeUrl</c>. The cache is populated lazily as a side effect of
+    /// <see cref="SupportedAgentsAsync" />, which only runs on the node that evaluates assignments (the
+    /// leader). A node that is *assigned* an agent may never have enumerated its own shards yet, so on a
+    /// cache miss enumerate the store's registered subscriptions directly before giving up — otherwise
+    /// agent start fails non-deterministically on followers / after failover. See GH-3216.
+    /// </summary>
+    private async ValueTask<ShardName?> ResolveShardNameAsync(string shardPath, CancellationToken cancellation)
+    {
+        if (_shardNames.TryFind(shardPath, out var shardName))
+        {
+            return shardName;
+        }
+
+        // Populate the cache from the store usage (the same source SupportedAgentsAsync reads), then retry.
+        await SupportedAgentsAsync(cancellation);
+
+        return _shardNames.TryFind(shardPath, out shardName) ? shardName : null;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3216. Residual after #3133 / #3168.

Under `DurabilityMode.Balanced` with multiple nodes, Wolverine-managed event-subscription agents distributed **non-deterministically** — the agent intermittently failed to start on the node it was assigned to, or failed to redistribute after a pause/restart/failover. Polecat exposed it far more than Marten purely because its SQL Server descriptor/daemon timing widens the race window; **the code path is shared, so this fixes both** (and removes a latent Marten hazard).

## Root cause — Wolverine core, not upstream

`EventStoreAgents.BuildAgentAsync` resolved the shard from a private `_shardNames` cache that is only populated as a **side effect** of `SupportedAgentsAsync`. But `SupportedAgentsAsync` runs on the node that **evaluates assignments** (the leader, via `NodeAgentController.EvaluateAssignmentsAsync` → `AllKnownAgentsAsync`); the node that is **assigned** an agent then calls `BuildAgentAsync` on its *own* family instance, whose cache may never have been populated. So the lookup missed and threw `"Unable to find a shard with path ..."`, silently failing the start. Whether the assignee had run an enumeration cycle first was a race — hence the run-to-run flakiness and the post-failover failures.

> No upstream (Polecat / JasperFx.Events) change is needed — Polecat's `TryCreateUsage()` already returns the right data (the leader's enumeration succeeds with it); the bug was Wolverine consuming it through a fragile ordering side-effect.

## Fix

- **`BuildAgentAsync` is now self-sufficient**: on a cache miss it enumerates the store's registered subscriptions (the same source `SupportedAgentsAsync` reads) and retries, so an assignee node can always build its agent regardless of whether it enumerated first.
- **`_shardNames` is now an `ImHashMap<string, ShardName>`** (keyed by `RelativeUrl`) instead of a bare `List<ShardName>`, so the enumeration writes and the `BuildAgentAsync` reads are lock-free across threads (heartbeat/evaluate-assignments thread vs the agent-start command thread).

The diff is small and additive — the populated-cache fast path (what Marten normally hits) is unchanged; only the previously-throwing miss path is now self-healing.

## Verification

- New regression test `PolecatTests/Distribution/polecat_multinode_agent_build_3216`: a **cold** second family instance over the same store (simulating the assigned node that never enumerated) must still build the agent. **Confirmed it fails pre-fix with the exact production error** (`ArgumentOutOfRangeException : Unable to find a shard with path 'trip/all'`) and **passes after**.
- Existing Polecat #3168 / #3133 distribution tests: green.
- Marten multi-host distribution tests (`basic_agent_mechanics_single_tenant`, incl. `spread_out_over_multiple_hosts`): green — no regression to the shared path.
- Full `wolverine.slnx` builds clean in Release.

Downstream: this should let CritterWatch un-skip the five `cluster_*` Polecat scenarios in JasperFx/CritterWatch#483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)