### PR TITLE
NullMessageStore never throws — no-op every member for storeless observers

### DIFF
--- a/src/Testing/CoreTests/Persistence/null_message_store_never_throws.cs
+++ b/src/Testing/CoreTests/Persistence/null_message_store_never_throws.cs
@@ -1,0 +1,77 @@
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+// A storeless host (Solo / NullMessageStore) is observed by diagnostics tooling such as CritterWatch,
+// which calls into the store (e.g. Nodes to persist NodeRecords). The null store must therefore never
+// throw — every member no-ops or returns non-null/empty. Previously several members threw
+// NotSupportedException / NotImplementedException, crashing the observer (the reported
+// "Error trying to persist node records" → NullMessageStore.get_Nodes()).
+public class null_message_store_never_throws
+{
+    private readonly NullMessageStore theStore = new();
+
+    [Fact]
+    public void nodes_is_a_usable_no_op_not_a_throw()
+    {
+        // The exact CritterWatch crash path: get Nodes, then log a node record.
+        var nodes = theStore.Nodes;
+        nodes.ShouldNotBeNull();
+
+        Should.NotThrow(async () =>
+        {
+            await nodes.LogRecordsAsync(new NodeRecord
+            {
+                NodeNumber = 1,
+                RecordType = NodeRecordType.NodeStarted,
+                ServiceName = "test"
+            });
+
+            (await nodes.LoadAllNodesAsync(CancellationToken.None)).ShouldBeEmpty();
+            (await nodes.FetchRecentRecordsAsync(10)).ShouldBeEmpty();
+            nodes.HasLeadershipLock().ShouldBeFalse();
+            (await nodes.TryAttainLeadershipLockAsync(CancellationToken.None)).ShouldBeFalse();
+        });
+    }
+
+    [Fact]
+    public void formerly_throwing_members_now_no_op_or_return_empty()
+    {
+        Should.NotThrow(async () =>
+        {
+            (await theStore.LoadOutgoingAsync(new Uri("local://one"))).ShouldBeEmpty();
+            (await theStore.LoadScheduledToExecuteAsync(DateTimeOffset.UtcNow)).ShouldBeEmpty();
+            (await theStore.LoadPageOfGloballyOwnedIncomingAsync(new Uri("local://one"), 10)).ShouldBeEmpty();
+
+            await theStore.ReassignOutgoingAsync(1, Array.Empty<Envelope>());
+            await theStore.ReassignIncomingAsync(1, Array.Empty<Envelope>());
+
+            (await theStore.DeadLetterEnvelopeByIdAsync(Guid.NewGuid())).ShouldBeNull();
+        });
+    }
+
+    [Fact]
+    public void start_scheduled_jobs_returns_a_non_null_agent()
+    {
+        // The no-op store has no durable scheduled-job agent, but must hand back a usable agent.
+        var agent = theStore.StartScheduledJobs(null!);
+        agent.ShouldNotBeNull();
+        agent.Uri.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void storing_a_scheduled_envelope_without_a_time_does_nothing_rather_than_throwing()
+    {
+        var scheduled = new Envelope { Status = EnvelopeStatus.Scheduled, ScheduledTime = null };
+
+        Should.NotThrow(async () =>
+        {
+            await theStore.StoreIncomingAsync(scheduled);
+            await theStore.RescheduleExistingEnvelopeForRetryAsync(scheduled);
+        });
+    }
+}

--- a/src/Wolverine/Persistence/Durability/NullMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/NullMessageStore.cs
@@ -75,14 +75,9 @@ public class NullMessageStore : IMessageStore, IMessageInbox, IMessageOutbox, IM
 
     public Task StoreIncomingAsync(Envelope envelope)
     {
-        if (envelope.Status == EnvelopeStatus.Scheduled)
+        // A no-op store never throws; just schedule in memory when we can and otherwise do nothing.
+        if (envelope.Status == EnvelopeStatus.Scheduled && envelope.ScheduledTime != null)
         {
-            if (envelope.ScheduledTime == null)
-            {
-                throw new ArgumentOutOfRangeException(
-                    $"The envelope {envelope} is marked as Scheduled, but does not have an ExecutionTime");
-            }
-
             ScheduledJobs?.Enqueue(envelope.ScheduledTime.Value, envelope);
         }
 
@@ -99,13 +94,10 @@ public class NullMessageStore : IMessageStore, IMessageInbox, IMessageOutbox, IM
 
     public Task RescheduleExistingEnvelopeForRetryAsync(Envelope envelope)
     {
-        if (!envelope.ScheduledTime.HasValue)
+        if (envelope.ScheduledTime.HasValue)
         {
-            throw new ArgumentOutOfRangeException(nameof(envelope),
-                $"Envelope does not have a value for {nameof(Envelope.ScheduledTime)}");
+            ScheduledJobs?.Enqueue(envelope.ScheduledTime.Value, envelope);
         }
-
-        ScheduledJobs?.Enqueue(envelope.ScheduledTime!.Value, envelope);
 
         return Task.CompletedTask;
     }
@@ -127,7 +119,7 @@ public class NullMessageStore : IMessageStore, IMessageInbox, IMessageOutbox, IM
 
     public Task<IReadOnlyList<Envelope>> LoadOutgoingAsync(Uri destination)
     {
-        throw new NotSupportedException();
+        return Task.FromResult((IReadOnlyList<Envelope>)Array.Empty<Envelope>());
     }
 
     public Task DiscardAndReassignOutgoingAsync(Envelope[] discards, Envelope[] reassigned, int nodeId)
@@ -144,7 +136,9 @@ public class NullMessageStore : IMessageStore, IMessageInbox, IMessageOutbox, IM
     public IMessageOutbox Outbox => this;
     public IDeadLetters DeadLetters => this;
     public IScheduledMessages ScheduledMessages => this;
-    public INodeAgentPersistence Nodes => throw new NotSupportedException();
+    // A no-op node persistence rather than throwing: observers / CritterWatch call this to record node
+    // lifecycle and must not blow up on a storeless (Solo / NullMessageStore) host.
+    public INodeAgentPersistence Nodes => NullNodeAgentPersistence.Instance;
 
     // No durable backing → no dynamic-listener registry. Solo-mode hosts that
     // *do* want dynamic listeners need a real message store.
@@ -172,7 +166,10 @@ public class NullMessageStore : IMessageStore, IMessageInbox, IMessageOutbox, IM
 
     public IAgent StartScheduledJobs(IWolverineRuntime wolverineRuntime)
     {
-        throw new NotSupportedException();
+        // In-memory scheduled jobs are wired separately (WolverineRuntime.startInMemoryScheduledJobs), so
+        // there is no durable scheduled-job agent to run here — return a no-op agent rather than throwing.
+        return new CompositeAgent(new Uri($"{PersistenceConstants.AgentScheme}://scheduledjobs/null"),
+            Array.Empty<IAgent>());
     }
 
     public Task<IReadOnlyList<Envelope>> AllIncomingAsync()
@@ -258,27 +255,27 @@ public class NullMessageStore : IMessageStore, IMessageInbox, IMessageOutbox, IM
 
     public Task<IReadOnlyList<Envelope>> LoadScheduledToExecuteAsync(DateTimeOffset utcNow)
     {
-        throw new NotSupportedException();
+        return Task.FromResult((IReadOnlyList<Envelope>)Array.Empty<Envelope>());
     }
 
     public Task ReassignOutgoingAsync(int ownerId, Envelope[] outgoing)
     {
-        throw new NotSupportedException();
+        return Task.CompletedTask;
     }
 
     public Task<IReadOnlyList<Envelope>> LoadPageOfGloballyOwnedIncomingAsync(Uri listenerAddress, int limit)
     {
-        throw new NotSupportedException();
+        return Task.FromResult((IReadOnlyList<Envelope>)Array.Empty<Envelope>());
     }
 
     public Task ReassignIncomingAsync(int ownerId, IReadOnlyList<Envelope> incoming)
     {
-        throw new NotSupportedException();
+        return Task.CompletedTask;
     }
 
     public Task<DeadLetterEnvelope?> DeadLetterEnvelopeByIdAsync(Guid id, string? tenantId = null)
     {
-        throw new NotImplementedException();
+        return Task.FromResult<DeadLetterEnvelope?>(null);
     }
 
     Task<ScheduledMessageResults> IScheduledMessages.QueryAsync(ScheduledMessageQuery query, CancellationToken token)
@@ -304,6 +301,8 @@ public class NullMessageStore : IMessageStore, IMessageInbox, IMessageOutbox, IM
 
 internal class NullNodeAgentPersistence : INodeAgentPersistence
 {
+    public static readonly NullNodeAgentPersistence Instance = new();
+
     public Task ClearAllAsync(CancellationToken cancellationToken)
     {
         return Task.CompletedTask;


### PR DESCRIPTION
A storeless host (Solo / `NullMessageStore`) is observed by diagnostics tooling such as **CritterWatch**, which calls into the store to record node lifecycle. `NullMessageStore.Nodes` threw `NotSupportedException`, crashing the observer:

```
Error trying to persist node records
System.NotSupportedException: Specified method is not supported.
   at Wolverine.Persistence.Durability.NullMessageStore.get_Nodes()
   at Wolverine.CritterWatch.CritterWatchObserver.persistRecord(NodeRecord nodeRecord)
```

A Nullo implementation should never throw — every member should no-op or return non-null/empty. This makes that true:

- **`Nodes`** now returns `NullNodeAgentPersistence.Instance` (the no-op implementation that already lived in this file) instead of throwing — fixes the reported crash.
- **`StartScheduledJobs`** returns a no-op `CompositeAgent` (in-memory scheduled jobs are wired separately in `WolverineRuntime.startInMemoryScheduledJobs`, so there's no durable agent to run here) instead of throwing.
- **`LoadOutgoingAsync` / `LoadScheduledToExecuteAsync` / `LoadPageOfGloballyOwnedIncomingAsync`** return empty lists; **`ReassignOutgoingAsync` / `ReassignIncomingAsync`** complete; **`DeadLetterEnvelopeByIdAsync`** returns null — all formerly threw `NotSupportedException` / `NotImplementedException`.
- **`StoreIncomingAsync` / `RescheduleExistingEnvelopeForRetryAsync`** now no-op a scheduled envelope with no `ScheduledTime` instead of throwing `ArgumentOutOfRangeException`.

After this, `grep 'throw new' NullMessageStore.cs` is empty.

## Test
`CoreTests/Persistence/null_message_store_never_throws` exercises the exact `Nodes → LogRecordsAsync(NodeRecord)` crash path plus every formerly-throwing member and asserts no throw + non-null/empty results. Full `wolverine.slnx` Release build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)