### PR TITLE
Register IEventStore for Polecat stores so they're discoverable (#3219)

### DIFF
--- a/src/Persistence/PolecatTests/AncillaryStores/bootstrapping_ancillary_polecat_stores_with_wolverine.cs
+++ b/src/Persistence/PolecatTests/AncillaryStores/bootstrapping_ancillary_polecat_stores_with_wolverine.cs
@@ -1,5 +1,6 @@
 using IntegrationTests;
 using JasperFx;
+using JasperFx.Events;
 using JasperFx.Resources;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -74,6 +75,25 @@ public class bootstrapping_ancillary_polecat_stores_with_wolverine : IAsyncLifet
     {
         theHost.Services.GetRequiredService<OutboxedSessionFactory<IPlayerStore>>()
             .ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void resolves_both_the_primary_and_ancillary_event_stores()
+    {
+        // GH-3219: ancillary Polecat stores must surface via GetServices<IEventStore>() the same way the
+        // primary does (and the same way core Marten registers both) — otherwise the ancillary store is
+        // invisible to the read-only capabilities / CritterWatch projection-explorer surface that
+        // discovers stores this way. Asserted by reference because both stores are present as distinct
+        // IEventStore instances (Polecat currently reports the same Identity string for both, which is a
+        // separate concern from discovery).
+        var stores = theHost.Services.GetServices<IEventStore>().ToArray();
+
+        var primary = (IEventStore)theHost.Services.GetRequiredService<IDocumentStore>();
+        var ancillary = (IEventStore)theHost.Services.GetRequiredService<IPlayerStore>();
+
+        primary.ShouldNotBeSameAs(ancillary);
+        stores.ShouldContain(primary);
+        stores.ShouldContain(ancillary);
     }
 
     [Fact]

--- a/src/Persistence/Wolverine.Polecat/AncillaryWolverineOptionsPolecatExtensions.cs
+++ b/src/Persistence/Wolverine.Polecat/AncillaryWolverineOptionsPolecatExtensions.cs
@@ -1,6 +1,7 @@
 using JasperFx;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using JasperFx.Events;
 using JasperFx.Events.Subscriptions;
 using Polecat;
 using Microsoft.Extensions.DependencyInjection;
@@ -58,6 +59,13 @@ public static class AncillaryWolverineOptionsPolecatExtensions
         configure?.Invoke(integration);
 
         expression.Services.AddSingleton<IConfigurePolecat<T>, PolecatOverrides<T>>();
+
+        // GH-3219: bridge the store-agnostic JasperFx.Events.IEventStore for the ancillary store type T,
+        // mirroring the primary store (WolverineOptionsPolecatExtensions) and core Marten's ancillary
+        // registration. Without it the ancillary Polecat store is invisible to anything that discovers
+        // stores via GetServices<IEventStore>() — the EventSubscriptionAgentFamily (so ancillary async
+        // projections never distribute) and downstream tooling like CritterWatch's projection explorer.
+        expression.Services.AddSingleton<IEventStore>(s => (IEventStore)s.GetRequiredService<T>());
 
         expression.Services.AddSingleton<AncillaryMessageStore>(s =>
         {

--- a/src/Persistence/Wolverine.Polecat/WolverineOptionsPolecatExtensions.cs
+++ b/src/Persistence/Wolverine.Polecat/WolverineOptionsPolecatExtensions.cs
@@ -106,15 +106,17 @@ public static class WolverineOptionsPolecatExtensions
                 s.GetRequiredService<IWolverineRuntime>(),
                 (IMessageDatabase)s.GetRequiredService<IMessageStore>()));
 
+        // GH-3133 / GH-3219, Gap 2: Polecat's AddPolecat registers IDocumentStore but not the
+        // store-agnostic JasperFx.Events.IEventStore (the Polecat DocumentStore implements
+        // IEventStore<IDocumentSession, IQuerySession>). Bridge it UNCONDITIONALLY so the store is
+        // discoverable via GetServices<IEventStore>() regardless of whether managed distribution is
+        // enabled — the EventSubscriptionAgentFamily resolves stores this way (when managed distribution
+        // is on) AND so does the read-only capabilities / CritterWatch projection-explorer surface
+        // (always). Marten registers IEventStore unconditionally in its own AddMarten.
+        expression.Services.AddSingleton<IEventStore>(s => (IEventStore)s.GetRequiredService<IDocumentStore>());
+
         if (integration.UseWolverineManagedEventSubscriptionDistribution)
         {
-            // GH-3133, Gap 2: Polecat's AddPolecat registers IDocumentStore but not the store-agnostic
-            // JasperFx.Events.IEventStore that EventSubscriptionAgentFamily(IEnumerable<IEventStore>)
-            // resolves — without it the family sees no stores and no projection shards distribute.
-            // Marten registers IEventStore in its own AddMarten; bridge it here for Polecat. The
-            // Polecat DocumentStore implements IEventStore<IDocumentSession, IQuerySession>.
-            expression.Services.AddSingleton<IEventStore>(s => (IEventStore)s.GetRequiredService<IDocumentStore>());
-
             expression.Services.AddSingleton<WolverineProjectionCoordinator>();
             expression.Services.AddSingleton<EventSubscriptionAgentFamily>();
             expression.Services.AddSingleton<IAgentFamily>(s => s.GetRequiredService<EventSubscriptionAgentFamily>());


### PR DESCRIPTION
Closes #3219.

`Wolverine.Polecat`'s **ancillary** store integration (`AddPolecatStore<T>().IntegrateWithWolverine()`) never registered the store-agnostic `JasperFx.Events.IEventStore` for the marker type `T`, so ancillary Polecat stores were invisible to anything that discovers stores via `GetServices<IEventStore>()` — the read-only capabilities / CritterWatch projection-explorer surface (`ServiceCapabilities.readEventStores`) and the `EventSubscriptionAgentFamily`. Core Marten registers `IEventStore` for **both** primary and ancillary stores, so this was a Marten/Polecat parity gap.

## Fix
- **Ancillary:** bridge `IEventStore` from `T` in `AncillaryWolverineOptionsPolecatExtensions.IntegrateWithWolverine<T>` — mirrors core Marten's `AddMartenStore<T>` (the exact fix proposed in the issue).
- **Primary:** the existing bridge was gated behind `UseWolverineManagedEventSubscriptionDistribution`, so a *primary* Polecat store was **also** undiscoverable when managed distribution was off. Since CritterWatch monitors apps regardless of that flag, I moved the primary bridge **out of the gate** so it registers unconditionally. This only affects **discovery** — the `EventSubscriptionAgentFamily` and the rest of managed distribution stay gated, so there's no distribution behavior change; the diagnostics/capabilities surface now simply reports the store(s).

## Test
`bootstrapping_ancillary_polecat_stores_with_wolverine` (primary + ancillary Polecat host) now asserts `GetServices<IEventStore>()` resolves **both** the primary and the ancillary store (by reference). Full `wolverine.slnx` Release build is clean.

## Out-of-scope finding (flagged for follow-up)
While testing I found the two Polecat stores report the **same `IEventStore.Identity` string**. That's a separate concern from discovery — it would matter for *managed distribution* of ancillary projections, because `EventSubscriptionAgentFamily._stores` is keyed by identity and would collide. Marten gives ancillary stores distinct identities. Worth a follow-up issue (likely a Polecat-side identity change); not addressed here since #3219 is about discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)