### PR TITLE
Bump JasperFx + JasperFx.Events to 2.13.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,13 +33,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.13.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.13.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.0" />
+    <PackageVersion Include="JasperFx" Version="2.13.3" />
+    <PackageVersion Include="JasperFx.Events" Version="2.13.3" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.3" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.3" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.8.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />


### PR DESCRIPTION
Upgrade the JasperFx 2.13.x family from **2.13.0 → 2.13.3** (latest stable):
`JasperFx`, `JasperFx.Events`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator` — kept in lockstep. `JasperFx.RuntimeCompiler` is on its own 5.x line and is unchanged.

Patch bump:
- `dotnet restore wolverine.slnx` resolves cleanly — no version conflicts / NU warnings; `JasperFx.Events` resolves to `2.13.3`.
- Full `wolverine.slnx` builds clean in Release (0 warnings, 0 errors).

Isolated dependency-only change (just `Directory.Packages.props`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)