### PR TITLE
Tag every metrics instrument with source (service name) (#3221)

### DIFF
--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -918,6 +918,28 @@ will be added back to Wolverine in 4.0.
 | wolverine-effective-time     | Histogram                                                                                                 | Effective time between a message being sent and being completely handled in milliseconds. Right now this works between Wolverine to Wolverine application sending and from NServiceBus applications sending to Wolverine applications through Wolverine’s NServiceBus interoperability. |
 | wolverine-execution-failure  | Counter                                                                                                   | Number of message execution failures. Tagged by exception type                                                                                                                                                                                                                         |
 
+### Standard Metrics Tags
+
+Every Wolverine metric instrument above is tagged with these dimensions so you can slice the series in your
+observability tooling:
+
+| Tag                   | Description                                                                            |
+|-----------------------|----------------------------------------------------------------------------------------|
+| `message.type`        | The message type name                                                                  |
+| `message.destination` | The endpoint URI the message was sent to / received at (when known)                    |
+| `tenant.id`           | The tenant id (when the message is tenant-scoped)                                       |
+| `source`              | The Wolverine `ServiceName` of the application emitting the metric                      |
+
+The `wolverine-execution-failure` instrument additionally carries an `exception.type` tag. You can attach your
+own per-message tags with [`Envelope.SetMetricsTag`](#additional-metrics-tags).
+
+::: tip The `source` tag <Badge type="tip" text="6.14.1" />
+Before 6.14.1 the `source` (service-name) tag was only present on `wolverine-messages-sent` and
+`wolverine-messages-received`. As of **6.14.1** it is added to **every** instrument, so a shared metrics backend
+that scrapes many services can slice each series per service — `{source="my-service"}` /
+`sum by (source, ...)` works uniformly across all Wolverine metrics.
+:::
+
 As a sample set up for publishing metrics, here's a proof of concept built with Honeycomb as the metrics collector:
 
 ```csharp

--- a/src/Testing/CoreTests/Runtime/metrics_source_tag.cs
+++ b/src/Testing/CoreTests/Runtime/metrics_source_tag.cs
@@ -1,0 +1,125 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.ErrorHandling;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Runtime;
+
+// GH-3221: the `source` (service name) tag must be present on EVERY Wolverine metric instrument, not just
+// wolverine-messages-sent / -received, so a shared metrics backend can slice each series per service.
+public class metrics_source_tag : IAsyncLifetime
+{
+    private const string TheServiceName = "metrics-source-test";
+
+    private IHost _host = null!;
+    private MeterListener _listener = null!;
+
+    // instrument name -> list of tag dictionaries captured for each recorded measurement
+    private readonly ConcurrentDictionary<string, ConcurrentBag<Dictionary<string, object?>>> _measurements = new();
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = TheServiceName;
+
+                // A matching exception is moved to the error queue on the first failure, which drives the
+                // execution-failure + dead-letter-queue instruments.
+                opts.OnException<InvalidOperationException>().MoveToErrorQueue();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<MetricSuccessHandler>()
+                    .IncludeType<MetricFailHandler>();
+            }).StartAsync();
+
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == "Wolverine:" + TheServiceName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        _listener.SetMeasurementEventCallback<int>((inst, _, tags, _) => Record(inst, tags));
+        _listener.SetMeasurementEventCallback<long>((inst, _, tags, _) => Record(inst, tags));
+        _listener.SetMeasurementEventCallback<double>((inst, _, tags, _) => Record(inst, tags));
+        _listener.Start();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _listener.Dispose();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private void Record(Instrument instrument, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    {
+        var dict = new Dictionary<string, object?>();
+        foreach (var tag in tags)
+        {
+            dict[tag.Key] = tag.Value;
+        }
+
+        _measurements.GetOrAdd(instrument.Name, _ => new ConcurrentBag<Dictionary<string, object?>>()).Add(dict);
+    }
+
+    [Fact]
+    public async Task every_instrument_carries_the_source_tag()
+    {
+        // Success path -> execution-time, messages-succeeded, effective-time.
+        await _host.TrackActivity().SendMessageAndWaitAsync(new MetricSuccess());
+
+        // Failure path -> execution-failure, dead-letter-queue (+ effective-time).
+        await _host.TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(new MetricFail());
+
+        // The instruments this issue is specifically about must all have recorded.
+        foreach (var name in new[]
+                 {
+                     MetricsConstants.ExecutionTime,
+                     MetricsConstants.MessagesSucceeded,
+                     MetricsConstants.EffectiveMessageTime,
+                     MetricsConstants.MessagesFailed,
+                     MetricsConstants.DeadLetterQueue
+                 })
+        {
+            _measurements.ContainsKey(name).ShouldBeTrue($"instrument {name} did not record");
+        }
+
+        // Invariant: NO Wolverine instrument records a measurement without the source tag.
+        foreach (var (name, records) in _measurements)
+        {
+            foreach (var tags in records)
+            {
+                tags.ContainsKey(MetricsConstants.SourceKey).ShouldBeTrue($"instrument {name} missing source");
+                tags[MetricsConstants.SourceKey].ShouldBe(TheServiceName, $"instrument {name} wrong source");
+            }
+        }
+    }
+}
+
+public record MetricSuccess;
+
+public record MetricFail;
+
+public class MetricSuccessHandler
+{
+    public void Handle(MetricSuccess _)
+    {
+    }
+}
+
+public class MetricFailHandler
+{
+    public void Handle(MetricFail _) => throw new InvalidOperationException("boom");
+}

--- a/src/Wolverine/Runtime/WolverineRuntime.Tracking.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Tracking.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
@@ -59,11 +60,22 @@ public sealed partial class WolverineRuntime : IMessageTracker
 
     internal TrackedSession? ActiveSession { get; set; }
 
-    public void Sent(Envelope envelope)
+    /// <summary>
+    /// Build the metric tag set for an envelope: the standard tags (message.type + message.destination +
+    /// tenant.id + any custom SetMetricsTag values) plus the <c>source</c> service-name tag. The
+    /// <c>source</c> tag is added to *every* instrument (GH-3221) so a shared metrics backend that scrapes
+    /// many services can slice each series per service.
+    /// </summary>
+    private TagList metricTags(Envelope envelope)
     {
         var tags = envelope.ToMetricsHeaders();
         tags.Add(MetricsConstants.SourceKey, _serviceName);
-        _sentCounter.Add(1, tags);
+        return tags;
+    }
+
+    public void Sent(Envelope envelope)
+    {
+        _sentCounter.Add(1, metricTags(envelope));
 
         if (Options.Metrics.Mode != WolverineMetricsMode.SystemDiagnosticsMeter
             && envelope.MessageType.IsNotEmpty()
@@ -89,9 +101,7 @@ public sealed partial class WolverineRuntime : IMessageTracker
 
         if (isExternal)
         {
-            var tags = envelope.ToMetricsHeaders();
-            tags.Add(MetricsConstants.SourceKey, _serviceName);
-            _receivedCounter.Add(1, tags);
+            _receivedCounter.Add(1, metricTags(envelope));
         }
 
         if (isExternal && Options.Metrics.Mode != WolverineMetricsMode.SystemDiagnosticsMeter
@@ -119,7 +129,7 @@ public sealed partial class WolverineRuntime : IMessageTracker
         var time = envelope.StopTiming();
         if (time > 0)
         {
-            _executionCounter.Record(time, envelope.ToMetricsHeaders());
+            _executionCounter.Record(time, metricTags(envelope));
         }
 
         ActiveSession?.Record(MessageEventType.ExecutionFinished, envelope, _serviceName, _uniqueNodeId);
@@ -128,7 +138,7 @@ public sealed partial class WolverineRuntime : IMessageTracker
     public void ExecutionFinished(Envelope envelope, Exception exception)
     {
         ExecutionFinished(envelope);
-        var tags = envelope.ToMetricsHeaders();
+        var tags = metricTags(envelope);
         tags.Add(MetricsConstants.ExceptionType, exception.GetType().Name);
         _failureCounter.Add(1, tags);
     }
@@ -136,7 +146,7 @@ public sealed partial class WolverineRuntime : IMessageTracker
     public void MessageSucceeded(Envelope envelope)
     {
         var time = DateTimeOffset.UtcNow.Subtract(envelope.SentAt.ToUniversalTime()).TotalMilliseconds;
-        var tags = envelope.ToMetricsHeaders();
+        var tags = metricTags(envelope);
         _effectiveTime.Record(time, tags);
 
         _successCounter.Add(1, tags);
@@ -157,7 +167,7 @@ public sealed partial class WolverineRuntime : IMessageTracker
     public void MessageFailed(Envelope envelope, Exception ex)
     {
         var time = DateTimeOffset.UtcNow.Subtract(envelope.SentAt.ToUniversalTime()).TotalMilliseconds;
-        var tags = envelope.ToMetricsHeaders();
+        var tags = metricTags(envelope);
         _effectiveTime.Record(time, tags);
 
         _deadLetterQueueCounter.Add(1, tags);


### PR DESCRIPTION
Closes #3221.

Only `wolverine-messages-sent` / `-received` carried the `source` (service-name) tag. A shared metrics backend (Prometheus / VictoriaMetrics) that scrapes many services can't reliably slice the other instruments per service, since the meter name (`Wolverine:{ServiceName}`) isn't exposed as a label the consumer controls.

## Change
Centralize tag-building into one helper and use it at every record site:

```csharp
private TagList metricTags(Envelope envelope)
{
    var tags = envelope.ToMetricsHeaders();   // message.type + destination + tenant + custom
    tags.Add(MetricsConstants.SourceKey, _serviceName);
    return tags;
}
```

`wolverine-execution-time`, `wolverine-execution-failure` (+ `exception.type`), `wolverine-messages-succeeded`, `wolverine-dead-letter-queue`, and `wolverine-effective-time` now carry `source`; `sent`/`received` refactor onto the same helper (no behavior change). **No hot-path branch and no extra allocation** — `TagList` is a stack struct, and `metricTags` just adds one tag to the existing build.

Per our discussion this is **unconditional** (no `EnableAdvancedTracking` light/heavy gating for now — we can revisit that separately if cardinality becomes a concern). The two secondary nice-to-haves in the issue (configurable histogram buckets; dimensional tags on the inbox/outbox/scheduled-count gauges) are left as follow-ups.

## Test
`CoreTests/Runtime/metrics_source_tag` drives a real host with a `MeterListener` and asserts the five instruments all record **and** that **no** Wolverine instrument records a measurement without `source` == `ServiceName`.

## Docs
`logging.md` gains a **Standard Metrics Tags** section (`message.type` / `message.destination` / `tenant.id` / `source`), noting `source` is on every instrument as of **6.14.1**.

Full `wolverine.slnx` Release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)