### PR TITLE
Configurable millisecond histogram buckets for execution/effective time (#3224)

### DIFF
--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -940,6 +940,28 @@ that scrapes many services can slice each series per service — `{source="my-se
 `sum by (source, ...)` works uniformly across all Wolverine metrics.
 :::
 
+### Histogram Buckets <Badge type="tip" text="6.14.1" />
+
+The `wolverine-execution-time` and `wolverine-effective-time` histograms record millisecond latencies, but the
+default OpenTelemetry histogram buckets are tuned for seconds — so quantile baselines computed from a
+time-series database (Prometheus / VictoriaMetrics) over those instruments are coarse. Wolverine therefore
+applies a millisecond-oriented set of explicit bucket boundaries (as instrument
+[advice](https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-advisory-parameters)) by default. You
+can override them, or opt back into the SDK defaults:
+
+```csharp
+builder.UseWolverine(opts =>
+{
+    // Supply your own ascending bucket boundaries, in milliseconds
+    opts.Metrics.HistogramBucketBoundaries = new double[] { 5, 25, 100, 500, 2000, 10000 };
+
+    // ...or fall back to the OpenTelemetry SDK / exporter defaults
+    opts.Metrics.HistogramBucketBoundaries = null;
+});
+```
+
+An explicit OpenTelemetry `View` for these instruments still overrides this advice when configured.
+
 As a sample set up for publishing metrics, here's a proof of concept built with Honeycomb as the metrics collector:
 
 ```csharp

--- a/src/Testing/CoreTests/Runtime/histogram_bucket_boundaries_3224.cs
+++ b/src/Testing/CoreTests/Runtime/histogram_bucket_boundaries_3224.cs
@@ -1,0 +1,90 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using Shouldly;
+using Wolverine;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Runtime;
+
+// GH-3224: configurable, millisecond-tuned histogram bucket boundaries for wolverine-execution-time and
+// wolverine-effective-time, applied via instrument advice.
+public class histogram_bucket_boundaries_3224
+{
+    [Fact]
+    public void default_boundaries_are_non_empty_and_ascending_milliseconds()
+    {
+        var boundaries = MetricsOptions.DefaultHistogramBucketBoundaries;
+        boundaries.ShouldNotBeEmpty();
+        boundaries.ShouldBe(boundaries.OrderBy(x => x).ToArray()); // strictly ascending order
+        boundaries[0].ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task histograms_use_the_configured_bucket_boundaries()
+    {
+        var serviceName = "buckets-" + Guid.NewGuid().ToString("N");
+
+        // Distinctive custom boundaries that won't match the OTel defaults.
+        var boundaries = new double[] { 7, 42, 99, 654 };
+
+        var exporter = new CapturingMetricExporter();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter("Wolverine:" + serviceName)
+            .AddReader(new BaseExportingMetricReader(exporter))
+            .Build();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = serviceName;
+                opts.Metrics.HistogramBucketBoundaries = boundaries;
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<MetricSuccessHandler>();
+            }).StartAsync();
+
+        // Drive a message so both histograms (execution-time + effective-time) record.
+        await host.TrackActivity().SendMessageAndWaitAsync(new MetricSuccess());
+
+        meterProvider!.ForceFlush(5000);
+
+        exporter.BoundsFor(MetricsConstants.ExecutionTime).ShouldBe(boundaries);
+        exporter.BoundsFor(MetricsConstants.EffectiveMessageTime).ShouldBe(boundaries);
+    }
+
+    private sealed class CapturingMetricExporter : BaseExporter<Metric>
+    {
+        private readonly ConcurrentDictionary<string, double[]> _bounds = new();
+
+        public double[] BoundsFor(string instrumentName) =>
+            _bounds.TryGetValue(instrumentName, out var b) ? b : Array.Empty<double>();
+
+        public override ExportResult Export(in Batch<Metric> batch)
+        {
+            foreach (var metric in batch)
+            {
+                if (metric.MetricType != MetricType.Histogram)
+                {
+                    continue;
+                }
+
+                foreach (ref readonly var point in metric.GetMetricPoints())
+                {
+                    var explicitBounds = new List<double>();
+                    foreach (var bucket in point.GetHistogramBuckets())
+                    {
+                        if (!double.IsPositiveInfinity(bucket.ExplicitBound))
+                        {
+                            explicitBounds.Add(bucket.ExplicitBound);
+                        }
+                    }
+
+                    _bounds[metric.Name] = explicitBounds.ToArray();
+                }
+            }
+
+            return ExportResult.Success;
+        }
+    }
+}

--- a/src/Testing/CoreTests/Runtime/metrics_source_tag.cs
+++ b/src/Testing/CoreTests/Runtime/metrics_source_tag.cs
@@ -114,8 +114,13 @@ public record MetricFail;
 
 public class MetricSuccessHandler
 {
-    public void Handle(MetricSuccess _)
+    public async Task Handle(MetricSuccess _)
     {
+        // Ensure a measurable, non-zero execution time so the wolverine-execution-time histogram actually
+        // records — ExecutionFinished only records when StopTiming() (truncated to whole milliseconds) is
+        // > 0. Without this the histogram has no data points on a fast machine, which made the source-tag
+        // and bucket-boundary tests flaky in CI.
+        await Task.Delay(5);
     }
 }
 

--- a/src/Wolverine/Runtime/WolverineRuntime.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.cs
@@ -106,10 +106,20 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IWolverineRunt
         Handlers.AddMessageHandler(typeof(Acknowledgement), new AcknowledgementHandler(Replies));
         Handlers.AddMessageHandler(typeof(FailureAcknowledgement), new FailureAcknowledgementHandler(Replies, LoggerFactory.CreateLogger<FailureAcknowledgementHandler>()));
 
+        // GH-3224: millisecond-tuned histogram bucket boundaries (advice). Null => OpenTelemetry SDK
+        // defaults. The execution-time histogram is long-typed, so the boundaries are cast to long.
+        var bucketBoundaries = options.Metrics.HistogramBucketBoundaries;
+        var executionTimeAdvice = bucketBoundaries == null
+            ? null
+            : new InstrumentAdvice<long> { HistogramBucketBoundaries = bucketBoundaries.Select(x => (long)x).ToArray() };
+        var effectiveTimeAdvice = bucketBoundaries == null
+            ? null
+            : new InstrumentAdvice<double> { HistogramBucketBoundaries = bucketBoundaries.ToArray() };
+
         _sentCounter = Meter.CreateCounter<int>(MetricsConstants.MessagesSent, MetricsConstants.Messages,
             "Number of messages sent");
         _executionCounter = Meter.CreateHistogram<long>(MetricsConstants.ExecutionTime, MetricsConstants.Milliseconds,
-            "Execution time in milliseconds");
+            "Execution time in milliseconds", tags: null, advice: executionTimeAdvice);
         _successCounter = Meter.CreateCounter<int>(MetricsConstants.MessagesSucceeded, MetricsConstants.Messages,
             "Number of messages successfully processed");
 
@@ -124,7 +134,8 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IWolverineRunt
 
         _effectiveTime = Meter.CreateHistogram<double>(MetricsConstants.EffectiveMessageTime,
             MetricsConstants.Milliseconds,
-            "Effective time between a message being sent and being completely handled in milliseconds");
+            "Effective time between a message being sent and being completely handled in milliseconds",
+            tags: null, advice: effectiveTimeAdvice);
 
         _invokers = new LightweightCache<Type, IMessageInvoker>(findInvoker);
 

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -132,6 +132,25 @@ public class MetricsOptions
     /// Wolverine will sample and publish metric data collection. Default is 5 seconds
     /// </summary>
     public TimeSpan SamplingPeriod { get; set; } = 5.Seconds();
+
+    /// <summary>
+    /// Default explicit histogram bucket boundaries (in milliseconds) applied to the
+    /// <c>wolverine-execution-time</c> and <c>wolverine-effective-time</c> histograms. The
+    /// OpenTelemetry SDK's default buckets are poor for millisecond-scale latencies; these are tuned for
+    /// message handling. See GH-3224.
+    /// </summary>
+    public static readonly IReadOnlyList<double> DefaultHistogramBucketBoundaries =
+        new double[] { 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000 };
+
+    /// <summary>
+    /// Explicit histogram bucket boundaries (in milliseconds) used as the instrument <em>advice</em> for
+    /// the <c>wolverine-execution-time</c> and <c>wolverine-effective-time</c> histograms, so quantile
+    /// baselines computed from a time-series database (Prometheus / VictoriaMetrics) are meaningful for
+    /// millisecond latencies. Defaults to <see cref="DefaultHistogramBucketBoundaries"/>. Set to
+    /// <c>null</c> to fall back to the OpenTelemetry SDK / exporter defaults, or supply your own ascending
+    /// boundaries. An OpenTelemetry <c>View</c> still overrides this advice when configured. See GH-3224.
+    /// </summary>
+    public IReadOnlyList<double>? HistogramBucketBoundaries { get; set; } = DefaultHistogramBucketBoundaries;
 }
 
 /// <summary>


### PR DESCRIPTION
Closes #3224. Follow-up split from #3221.

The default OpenTelemetry histogram buckets are tuned for seconds, so quantile baselines computed from a TSDB (Prometheus / VictoriaMetrics) over `wolverine-execution-time` / `wolverine-effective-time` — which record **millisecond** latencies — were coarse.

## Change
- `MetricsOptions.HistogramBucketBoundaries` (new) — defaults to a millisecond-oriented set: `1,2,5,10,25,50,100,250,500,1000,2500,5000,10000,30000,60000` ms. Set to `null` to fall back to the SDK/exporter defaults, or supply your own ascending boundaries.
- Applied as instrument **advice** (`InstrumentAdvice<T>.HistogramBucketBoundaries`) when the two histograms are created in `WolverineRuntime`; the `long`-typed execution-time histogram casts the boundaries to `long`. An OpenTelemetry `View` still overrides this advice when configured.

## Test
`histogram_bucket_boundaries_3224`: an end-to-end OpenTelemetry `MeterProvider` + a custom exporter reads back the exported histograms' explicit bucket bounds and asserts they match the configured boundaries for **both** instruments; plus a unit check that the default set is non-empty and ascending.

## Docs
`logging.md` gains a **Histogram Buckets** section.

Full `wolverine.slnx` Release build clean.