### PR TITLE
Reconcile competing 'Main' message stores via opt-in policy (#3226)

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/PostgresqlConfigurationExtensions.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlConfigurationExtensions.cs
@@ -103,9 +103,12 @@ public static class PostgresqlConfigurationExtensions
     public static PostgresqlPersistenceExpression UsePostgresqlPersistenceAndTransport(this WolverineOptions options,
         string connectionString,
         string? schema = null,
-        string? transportSchema = "wolverine_queues")
+        string? transportSchema = "wolverine_queues",
+        MessageStoreRole role = MessageStoreRole.Main)
     {
-        options.PersistMessagesWithPostgresql(connectionString, schema);
+        // GH-3226: forward the message-store role so apps that already have an event-store-backed Main
+        // (Marten / Polecat) can register this transport's persistence as Ancillary instead of a second Main.
+        options.PersistMessagesWithPostgresql(connectionString, schema, role);
 
         if (transportSchema != null)
         {

--- a/src/Persistence/Wolverine.SqlServer/SqlServerConfigurationExtensions.cs
+++ b/src/Persistence/Wolverine.SqlServer/SqlServerConfigurationExtensions.cs
@@ -83,9 +83,12 @@ public static class SqlServerConfigurationExtensions
     public static SqlServerPersistenceExpression UseSqlServerPersistenceAndTransport(this WolverineOptions options,
         string connectionString,
         string? schema = null,
-        string? transportSchema = null)
+        string? transportSchema = null,
+        MessageStoreRole role = MessageStoreRole.Main)
     {
-        options.PersistMessagesWithSqlServer(connectionString, schema);
+        // GH-3226: forward the message-store role so apps that already have an event-store-backed Main
+        // (Marten / Polecat) can register this transport's persistence as Ancillary instead of a second Main.
+        options.PersistMessagesWithSqlServer(connectionString, schema, role);
 
         options.Services.AddTransient<IDatabase, SqlServerTransportDatabase>();
 

--- a/src/Testing/CoreTests/Persistence/reconcile_competing_main_stores_3226.cs
+++ b/src/Testing/CoreTests/Persistence/reconcile_competing_main_stores_3226.cs
@@ -1,0 +1,72 @@
+using CoreTests.Runtime;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Durability;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+// GH-3226: when an event-store-backed Main (Marten/Polecat IntegrateWithWolverine) is combined with a
+// database-backed transport that also registers an implicit Main store, the app has two 'Main' stores.
+// An opt-in DurabilitySettings.ResolveMainStoreOnConflict callback can designate the Main and demote the
+// rest to Ancillary instead of Wolverine throwing.
+public class reconcile_competing_main_stores_3226
+{
+    private static IMessageStore MainStore(string uri)
+    {
+        var store = Substitute.For<IMessageStore>();
+        store.Uri.Returns(new Uri(uri));
+        store.Role.Returns(MessageStoreRole.Main);
+        // Mirror MessageDatabase.DemoteToAncillary, which flips the reported role.
+        store.When(x => x.DemoteToAncillary()).Do(_ => store.Role.Returns(MessageStoreRole.Ancillary));
+        return store;
+    }
+
+    [Fact]
+    public async Task throws_on_multiple_mains_when_no_resolver_is_configured()
+    {
+        var eventStore = MainStore("wolverinedb://eventstore/main");
+        var transport = MainStore("sqlserver://queue/control");
+
+        var collection = new MessageStoreCollection(new MockWolverineRuntime(), [eventStore, transport], []);
+
+        await Should.ThrowAsync<InvalidWolverineStorageConfigurationException>(
+            () => collection.InitializeAsync().AsTask());
+    }
+
+    [Fact]
+    public async Task resolver_keeps_the_chosen_main_and_demotes_the_others()
+    {
+        var eventStore = MainStore("wolverinedb://eventstore/main");
+        var transport = MainStore("sqlserver://queue/control");
+
+        var runtime = new MockWolverineRuntime();
+        runtime.Options.Durability.ResolveMainStoreOnConflict =
+            mains => mains.Single(x => x.Uri.Scheme == "wolverinedb");
+
+        var collection = new MessageStoreCollection(runtime, [eventStore, transport], []);
+
+        await Should.NotThrowAsync(() => collection.InitializeAsync().AsTask());
+
+        collection.Main.ShouldBeSameAs(eventStore);
+        transport.Role.ShouldBe(MessageStoreRole.Ancillary);
+        transport.Received().DemoteToAncillary();
+        eventStore.DidNotReceive().DemoteToAncillary();
+    }
+
+    [Fact]
+    public async Task resolver_returning_null_falls_back_to_the_strict_validation()
+    {
+        var eventStore = MainStore("wolverinedb://eventstore/main");
+        var transport = MainStore("sqlserver://queue/control");
+
+        var runtime = new MockWolverineRuntime();
+        runtime.Options.Durability.ResolveMainStoreOnConflict = _ => null;
+
+        var collection = new MessageStoreCollection(runtime, [eventStore, transport], []);
+
+        await Should.ThrowAsync<InvalidWolverineStorageConfigurationException>(
+            () => collection.InitializeAsync().AsTask());
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -87,6 +87,19 @@ public class DurabilitySettings : IDescribeMyself
     public DurabilityMode Mode { get; set; } = DurabilityMode.Balanced;
 
     /// <summary>
+    /// Opt-in reconciliation for when more than one registered message store claims the <c>Main</c> role
+    /// (GH-3226) — e.g. an event-store-backed main store (Marten / Polecat <c>IntegrateWithWolverine()</c>)
+    /// combined with a database-backed transport (the SQL Server / PostgreSQL queues) that also registers an
+    /// implicit <c>Main</c> store. The callback receives every <c>Main</c>-tagged store and returns the one to
+    /// keep as <c>Main</c>; the others are demoted to <c>Ancillary</c> instead of Wolverine throwing
+    /// "There must be exactly one message store tagged as the 'main' store". When left null (the default) the
+    /// strict single-Main validation is enforced. Return null from the callback to also fall back to the
+    /// strict validation.
+    /// </summary>
+    public Func<IReadOnlyList<Wolverine.Persistence.Durability.IMessageStore>,
+        Wolverine.Persistence.Durability.IMessageStore?>? ResolveMainStoreOnConflict { get; set; }
+
+    /// <summary>
     /// Direct Wolverine on how it judges message identity. "Classic" default is IdOnly. Switch to IdAndDestination
     /// for Modular Monolith usage where you may be receiving the same message and processing separately in different
     /// external transport listening endpoints

--- a/src/Wolverine/Persistence/MessageStoreCollection.cs
+++ b/src/Wolverine/Persistence/MessageStoreCollection.cs
@@ -118,6 +118,23 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
         var mains = _services.Enumerate().Select(x => x.Value)
             .Where(x => x.Role == MessageStoreRole.Main).ToArray();
 
+        // GH-3226: opt-in reconciliation for >1 Main store (e.g. an event-store-integrated main plus a
+        // database-backed transport that also claims Main). The policy designates the store to keep as
+        // Main and we demote the rest to Ancillary, rather than throwing.
+        if (mains.Length > 1 && _runtime.Options.Durability.ResolveMainStoreOnConflict is { } resolveMain)
+        {
+            var chosen = resolveMain(mains);
+            if (chosen != null && mains.Contains(chosen))
+            {
+                foreach (var demoted in mains.Where(x => !ReferenceEquals(x, chosen)))
+                {
+                    demoted.DemoteToAncillary();
+                }
+
+                mains = [chosen];
+            }
+        }
+
         if (mains.Length > 1)
         {
             throw new InvalidWolverineStorageConfigurationException(


### PR DESCRIPTION
Closes #3226.

When an app combines an **event-store-backed main store** (Marten/Polecat `IntegrateWithWolverine()`) with a **database-backed transport** (the SQL Server / PostgreSQL queues used as a control/messaging channel), the transport's implicit persistence also claims `MessageStoreRole.Main`, so the app has two `Main` stores and fails startup with `InvalidWolverineStorageConfigurationException`.

Two parts, smallest-first (as the issue requested):

## 1. Forward `role:` through the combined transport methods
`UseSqlServerPersistenceAndTransport` / `UsePostgresqlPersistenceAndTransport` gain a `MessageStoreRole role = MessageStoreRole.Main` parameter, forwarded to the inner `PersistMessagesWith…` call (the `role` overload already existed but wasn't passed through). This is the documented **manual** escape hatch — register the transport store as `Ancillary` explicitly.

## 2. Opt-in reconciliation seam
`DurabilitySettings.ResolveMainStoreOnConflict` — a `Func<IReadOnlyList<IMessageStore>, IMessageStore?>`. When set and more than one store claims `Main`, `MessageStoreCollection.InitializeAsync` invokes it **before** the strict `>1 Main` validation: the returned store stays `Main` and the rest are demoted to `Ancillary` (via `DemoteToAncillary()`) instead of throwing. Returning `null` falls back to the strict validation. CritterWatch consumes this to declare its event-store store as `Main` and auto-demote the DB-transport store with no user ceremony.

## Test
`reconcile_competing_main_stores_3226` (broker-free, NSubstitute):
- throws `InvalidWolverineStorageConfigurationException` with two `Main` stores and no resolver;
- with a resolver, keeps the chosen store as `Main` and demotes the other;
- a resolver returning `null` falls back to the strict throw.

Full `wolverine.slnx` Release build clean.

Downstream: JasperFx/CritterWatch#531 (DB-backed control queues).