### PR TITLE
Only call DbContext.Update() for untracked entities in Storage.Update

### DIFF
--- a/src/Persistence/EfCoreTests/EfCoreStorageActionApplierTests.cs
+++ b/src/Persistence/EfCoreTests/EfCoreStorageActionApplierTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.EntityFrameworkCore.Codegen;
+using Wolverine.Persistence;
+
+namespace EfCoreTests;
+
+public class EfCoreStorageActionApplierTests
+{
+    private static TodoDbContext InMemoryContext() =>
+        new(new DbContextOptionsBuilder<TodoDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    [Fact]
+    public async Task update_of_tracked_entity_only_marks_changed_properties()
+    {
+        await using var context = InMemoryContext();
+
+        var todo = new Todo { Id = "1", Name = "original", IsComplete = false };
+        context.Attach(todo);
+        todo.Name = "changed";
+
+        await EfCoreStorageActionApplier.ApplyAction(context, Storage.Update(todo));
+
+        var entry = context.Entry(todo);
+        entry.State.ShouldBe(EntityState.Modified);
+        entry.Property(x => x.Name).IsModified.ShouldBeTrue();
+        entry.Property(x => x.IsComplete).IsModified.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task update_of_detached_entity_still_marks_all_properties_modified()
+    {
+        await using var context = InMemoryContext();
+
+        var todo = new Todo { Id = "1", Name = "original", IsComplete = false };
+
+        await EfCoreStorageActionApplier.ApplyAction(context, Storage.Update(todo));
+
+        var entry = context.Entry(todo);
+        entry.State.ShouldBe(EntityState.Modified);
+        entry.Property(x => x.Name).IsModified.ShouldBeTrue();
+        entry.Property(x => x.IsComplete).IsModified.ShouldBeTrue();
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EfCoreStorageActionApplier.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EfCoreStorageActionApplier.cs
@@ -21,9 +21,17 @@ public static class EfCoreStorageActionApplier
                 context.Update(action.Entity); // Not really correct, but let it go
                 break;
             case StorageAction.Update:
-                context.Update(action.Entity);
+                if (!IsTracked(context, action.Entity))
+                {
+                    context.Update(action.Entity);
+                }
                 break;
-                
+
         }
+    }
+
+    private static bool IsTracked<TEntity>(DbContext context, TEntity entity)
+    {
+        return context.ChangeTracker.Entries().Any(entry => ReferenceEquals(entry.Entity, entity));
     }
 }


### PR DESCRIPTION
When an HTTP endpoint or message handler returns Storage.Update(entity) and the entity is already tracked by the DbContext, Wolverine now leaves the change tracker to decide which columns changed instead of calling DbContext.Update(). This produces an UPDATE touching only the modified columns. Untracked (detached) entities are unchanged. They still go through DbContext.Update().