### PR TITLE
Tag inbox/outbox/scheduled-count gauges dimensionally (source + database)

### DIFF
--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -917,6 +917,9 @@ will be added back to Wolverine in 4.0.
 | wolverine-dead-letter-queue  | Counter                                                                                                   | Number of messages moved to dead letter queues                                                                                                                                                                                                                                         |
 | wolverine-effective-time     | Histogram                                                                                                 | Effective time between a message being sent and being completely handled in milliseconds. Right now this works between Wolverine to Wolverine application sending and from NServiceBus applications sending to Wolverine applications through Wolverine’s NServiceBus interoperability. |
 | wolverine-execution-failure  | Counter                                                                                                   | Number of message execution failures. Tagged by exception type                                                                                                                                                                                                                         |
+| wolverine-inbox-count        | [Observable Gauge](https://opentelemetry.io/docs/specs/otel/metrics/api/#asynchronous-gauge)             | Current number of persisted incoming (inbox) messages. Tagged by `source` and `database`                                                                                                                                                                                                |
+| wolverine-outbox-count       | Observable Gauge                                                                                          | Current number of persisted outgoing (outbox) messages. Tagged by `source` and `database`                                                                                                                                                                                              |
+| wolverine-scheduled-count    | Observable Gauge                                                                                          | Current number of persisted scheduled messages. Tagged by `source` and `database`                                                                                                                                                                                                      |
 
 ### Standard Metrics Tags
 
@@ -1049,3 +1052,21 @@ public static async Task publish_operation(IMessageBus bus, string tenantId, str
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/MetricsSamples.cs#L29-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenant_id_tagging' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+### Queue Depth Gauge Tags <Badge type="tip" text="6.14.1" />
+
+The inbox / outbox / scheduled queue-depth gauges (`wolverine-inbox-count`, `wolverine-outbox-count`,
+`wolverine-scheduled-count`) are tagged so you can slice persisted message depth from a shared metrics backend:
+
+| Tag        | Description                                                                                          |
+|------------|------------------------------------------------------------------------------------------------------|
+| `source`   | The Wolverine `ServiceName` of the application emitting the metric                                    |
+| `database` | The database name backing the store. Only present when more than one message database is in play (e.g. multi-tenancy through separate databases) |
+
+::: tip
+Before **6.14.1**, the multi-database build emitted one gauge *per database* by appending the database name to the
+instrument **name** (`wolverine-inbox-count.<database>`). That made the depth impossible to group across databases
+in a TSDB. The database is now a `database` **tag** on the canonical `wolverine-inbox-count` instrument instead, so
+`sum by (database) (wolverine_inbox_count)` works as expected. Update any dashboards that referenced the old
+per-database instrument names.
+:::

--- a/src/Testing/CoreTests/Persistence/gauge_dimensional_tags_3225.cs
+++ b/src/Testing/CoreTests/Persistence/gauge_dimensional_tags_3225.cs
@@ -1,0 +1,111 @@
+using System.Diagnostics.Metrics;
+using CoreTests.Runtime;
+using Shouldly;
+using Wolverine;
+using Wolverine.Logging;
+using Wolverine.Persistence;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+// GH-3225: the wolverine-inbox-count / -outbox-count / -scheduled-count observable gauges must carry dimensional
+// tags (source = service name, and database where applicable) so queue depth can be sliced per service/database
+// from an external TSDB. Previously the multi-database path baked the database name into the instrument *name*
+// (e.g. "wolverine-inbox-count.<db>"), which a TSDB can't group cleanly; that is now a `database` tag instead.
+public class gauge_dimensional_tags_3225
+{
+    private const string TheServiceName = "depth-svc";
+
+    private List<(string Name, Dictionary<string, object?> Tags, int Value)> captureGauges(string? databaseName)
+    {
+        var runtime = new MockWolverineRuntime();
+        runtime.Options.ServiceName = TheServiceName;
+
+        var metrics = new PersistenceMetrics(runtime, runtime.Options.Durability, databaseName);
+        metrics.Counts = new PersistedCounts { Incoming = 5, Outgoing = 3, Scheduled = 2 };
+
+        var captured = new List<(string, Dictionary<string, object?>, int)>();
+
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                // Only this runtime's meter; reference equality keeps the capture isolated from any other test's meter.
+                if (ReferenceEquals(instrument.Meter, runtime.Meter))
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        listener.SetMeasurementEventCallback<int>((inst, measurement, tags, _) =>
+        {
+            // source/database are instrument-level tags (constant for the gauge's lifetime); OTel merges these into
+            // every exported point. The raw MeterListener callback only carries per-measurement tags, so read the
+            // instrument tags too.
+            var dict = new Dictionary<string, object?>();
+            if (inst.Tags != null)
+            {
+                foreach (var tag in inst.Tags)
+                {
+                    dict[tag.Key] = tag.Value;
+                }
+            }
+
+            foreach (var tag in tags)
+            {
+                dict[tag.Key] = tag.Value;
+            }
+
+            captured.Add((inst.Name, dict, measurement));
+        });
+
+        listener.Start();
+        listener.RecordObservableInstruments();
+
+        metrics.Dispose();
+
+        return captured;
+    }
+
+    [Fact]
+    public void single_database_gauges_carry_source_tag_and_no_database_tag()
+    {
+        var gauges = captureGauges(null);
+
+        // All three gauges use their canonical names (no per-database suffix) and report the live counts.
+        gauges.ShouldContain(g => g.Name == MetricsConstants.InboxCount && g.Value == 5);
+        gauges.ShouldContain(g => g.Name == MetricsConstants.OutboxCount && g.Value == 3);
+        gauges.ShouldContain(g => g.Name == MetricsConstants.ScheduledCount && g.Value == 2);
+
+        foreach (var gauge in gauges)
+        {
+            gauge.Tags.ContainsKey(MetricsConstants.SourceKey).ShouldBeTrue($"{gauge.Name} missing source");
+            gauge.Tags[MetricsConstants.SourceKey].ShouldBe(TheServiceName);
+
+            // No database known -> no database dimension.
+            gauge.Tags.ContainsKey(MetricsConstants.DatabaseKey).ShouldBeFalse($"{gauge.Name} should not carry a database tag");
+        }
+    }
+
+    [Fact]
+    public void multi_database_gauges_carry_source_and_database_tags_on_canonical_names()
+    {
+        const string theDatabase = "tenant_db";
+        var gauges = captureGauges(theDatabase);
+
+        // The database identity is now a tag, NOT an instrument-name suffix: the names stay canonical so a TSDB can
+        // group "wolverine-inbox-count" by the `database` dimension across every database.
+        gauges.Select(x => x.Name).ShouldBe(
+            new[] { MetricsConstants.InboxCount, MetricsConstants.OutboxCount, MetricsConstants.ScheduledCount },
+            ignoreOrder: true);
+
+        foreach (var gauge in gauges)
+        {
+            gauge.Name.ShouldNotContain(theDatabase); // never baked into the instrument name
+
+            gauge.Tags[MetricsConstants.SourceKey].ShouldBe(TheServiceName);
+            gauge.Tags[MetricsConstants.DatabaseKey].ShouldBe(theDatabase);
+        }
+    }
+}

--- a/src/Wolverine/MetricsConstants.cs
+++ b/src/Wolverine/MetricsConstants.cs
@@ -23,4 +23,5 @@ public class MetricsConstants
     public const string MessagesFailed = "wolverine-execution-failure";
     public const string ExceptionType = "exception.type";
     public const string SourceKey = "source";
+    public const string DatabaseKey = "database";
 }

--- a/src/Wolverine/Persistence/PersistenceMetrics.cs
+++ b/src/Wolverine/Persistence/PersistenceMetrics.cs
@@ -25,24 +25,25 @@ public class PersistenceMetrics : IDisposable
         _observer = runtime.Observer;
         var meter = runtime.Meter;
 
-        if (databaseName.IsEmpty())
+        // GH-3225: tag the queue-depth gauges dimensionally so an external TSDB can slice inbox/outbox/scheduled
+        // depth per service ("source") and per database. The database is a dimensional tag rather than a per-database
+        // instrument *name* suffix (the old behavior) so a single series can be grouped/filtered by database.
+        var tags = new List<KeyValuePair<string, object?>>
         {
-            _incoming = meter.CreateObservableGauge(MetricsConstants.InboxCount, () => Counts.Incoming,
-                MetricsConstants.Messages, "Inbox messages");
-            _outgoing = meter.CreateObservableGauge(MetricsConstants.OutboxCount, () => Counts.Outgoing,
-                MetricsConstants.Messages, "Outbox messages");
-            _scheduled = meter.CreateObservableGauge(MetricsConstants.ScheduledCount, () => Counts.Scheduled,
-                MetricsConstants.Messages, "Scheduled messages");
-        }
-        else
+            new(MetricsConstants.SourceKey, runtime.Options.ServiceName)
+        };
+
+        if (databaseName.IsNotEmpty())
         {
-            _incoming = meter.CreateObservableGauge( MetricsConstants.InboxCount + "." + databaseName, () => Counts.Incoming,
-                MetricsConstants.Messages, "Inbox messages for database " + databaseName);
-            _outgoing = meter.CreateObservableGauge(MetricsConstants.OutboxCount+ "." + databaseName, () => Counts.Outgoing,
-                MetricsConstants.Messages, "Outbox messages for database " + databaseName);
-            _scheduled = meter.CreateObservableGauge(MetricsConstants.ScheduledCount+ "." + databaseName, () => Counts.Scheduled,
-                MetricsConstants.Messages, "Scheduled messages for database " + databaseName);
+            tags.Add(new KeyValuePair<string, object?>(MetricsConstants.DatabaseKey, databaseName));
         }
+
+        _incoming = meter.CreateObservableGauge(MetricsConstants.InboxCount, () => Counts.Incoming,
+            MetricsConstants.Messages, "Inbox messages", tags);
+        _outgoing = meter.CreateObservableGauge(MetricsConstants.OutboxCount, () => Counts.Outgoing,
+            MetricsConstants.Messages, "Outbox messages", tags);
+        _scheduled = meter.CreateObservableGauge(MetricsConstants.ScheduledCount, () => Counts.Scheduled,
+            MetricsConstants.Messages, "Scheduled messages", tags);
     }
     
     public PersistedCounts Counts { get; set; } = new();


### PR DESCRIPTION
Closes #3225 (follow-up split from #3221).

## Problem
The `wolverine-inbox-count` / `-outbox-count` / `-scheduled-count` observable gauges (`PersistenceMetrics.cs`) carried **no dimensional tags**, so persisted queue depth couldn't be sliced per service/database from an external TSDB. The multi-database path also baked the database name into the instrument **name** (`wolverine-inbox-count.<db>`), which a TSDB can't group across databases.

## Change
- Tag all three gauges with:
  - **`source`** = the app's `ServiceName` (parity with the message instruments from #3221)
  - **`database`** = the backing database name, **only when** a database name is known (multi-database setups)
- The database is now a dimensional **tag** on the canonical instrument name, replacing the per-database instrument-name suffix — so `sum by (database) (wolverine_inbox_count)` works. (The issue explicitly asked to reconcile this.)
- Added `MetricsConstants.DatabaseKey = "database"`.
- Docs: added the gauges to the metrics table + a new "Queue Depth Gauge Tags" section in `logging.md`, including a migration note about the dropped per-database instrument names.

## Scope note
Per-**endpoint** slicing (mentioned in the issue title) is intentionally **out of scope**: `IMessageStoreAdmin.FetchCountsAsync()` returns store-aggregate counts, not per-endpoint breakdowns, so there's no endpoint dimension to attach without a larger change. `source` + `database` (+ tenant via separate-database tenancy) cover the requested slicing.

## Tests
`gauge_dimensional_tags_3225.cs` (CoreTests, no DB needed): drives the gauges via a `MeterListener` and asserts
- single-database: canonical instrument names + `source` tag, **no** `database` tag;
- multi-database: canonical names (no `.<db>` suffix) + both `source` and `database` tags with correct values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)