### PR TITLE
Add force-restart path for stuck listeners (#3232)

### DIFF
--- a/src/Testing/CoreTests/Transports/force_restart_default_3232.cs
+++ b/src/Testing/CoreTests/Transports/force_restart_default_3232.cs
@@ -1,0 +1,43 @@
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Transports;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests.Transports;
+
+// GH-3232: IListenerCircuit.RestartAsync has a default interface implementation that delegates to StartAsync, so
+// circuits without a real transport listener (in-memory local queues) get the gentle behavior for free. Only
+// ListeningAgent overrides it with the force teardown+rebuild (covered by RabbitMQ integration tests).
+public class force_restart_default_3232
+{
+    [Fact]
+    public async Task default_restart_delegates_to_start_async()
+    {
+        IListenerCircuit circuit = new FakeCircuit();
+
+        await circuit.RestartAsync();        // default param force: true
+        await circuit.RestartAsync(force: false);
+
+        ((FakeCircuit)circuit).StartCount.ShouldBe(2);
+    }
+
+    private class FakeCircuit : IListenerCircuit
+    {
+        public int StartCount;
+
+        public ListeningStatus Status => ListeningStatus.Stopped;
+        public Endpoint Endpoint => throw new NotSupportedException();
+        public int QueueCount => 0;
+        public ValueTask PauseAsync(TimeSpan pauseTime) => ValueTask.CompletedTask;
+        public ValueTask PauseWithDrainAsync(TimeSpan pauseTime) => ValueTask.CompletedTask;
+
+        public ValueTask StartAsync()
+        {
+            StartCount++;
+            return ValueTask.CompletedTask;
+        }
+
+        public Task EnqueueDirectlyAsync(IEnumerable<Envelope> envelopes) => Task.CompletedTask;
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/force_restart_listener_3232.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/force_restart_listener_3232.cs
@@ -1,0 +1,86 @@
+using JasperFx.Core;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+public record ForceRestartMessage(string Name);
+
+public class ForceRestartMessageHandler
+{
+    public void Handle(ForceRestartMessage message)
+    {
+        // no-op; only used to prove the rebuilt listener still consumes
+    }
+}
+
+// GH-3232: an operator/monitor must be able to force-recover a listener that reports Accepting but isn't actually
+// consuming (a stuck transport channel the framework can't self-heal) without a process bounce. Bare StartAsync()
+// is a no-op when Status == Accepting; RestartAsync(force: true) tears down and rebuilds regardless.
+[Trait("Category", "Flaky")]
+public class force_restart_listener_3232
+{
+    private static string nextQueue() => "force_restart_" + Guid.NewGuid().ToString("N");
+
+    [Fact]
+    public async Task force_restart_rebuilds_an_accepting_listener_and_it_still_consumes()
+    {
+        var queue = nextQueue();
+        using var host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UseRabbitMq().AutoProvision();
+            opts.ListenToRabbitQueue(queue);
+            opts.PublishMessage<ForceRestartMessage>().ToRabbitQueue(queue);
+        });
+
+        var runtime = host.GetRuntime();
+        var agent = (ListeningAgent)runtime.Endpoints.ActiveListeners()
+            .Single(a => a.Uri.Scheme == "rabbitmq" && a.Uri.ToString().Contains(queue));
+
+        agent.Status.ShouldBe(ListeningStatus.Accepting);
+        var before = agent.Listener;
+        before.ShouldNotBeNull();
+
+        // Gentle paths are a no-op while Accepting: the underlying IListener instance is unchanged.
+        await agent.StartAsync();
+        agent.Listener.ShouldBeSameAs(before);
+
+        await agent.RestartAsync(force: false);
+        agent.Listener.ShouldBeSameAs(before);
+
+        // Force restart tears down and rebuilds even though Status still reports Accepting.
+        await agent.RestartAsync(force: true);
+        agent.Status.ShouldBe(ListeningStatus.Accepting);
+        agent.Listener.ShouldNotBeNull();
+        agent.Listener.ShouldNotBeSameAs(before);
+
+        // And the rebuilt listener is genuinely live — a message sent after the restart is still handled.
+        await host.TrackActivity().Timeout(30.Seconds())
+            .SendMessageAndWaitAsync(new ForceRestartMessage("Hakeem Olajuwon"));
+    }
+
+    [Fact]
+    public async Task force_restart_recovers_a_stopped_listener()
+    {
+        var queue = nextQueue();
+        using var host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UseRabbitMq().AutoProvision();
+            opts.ListenToRabbitQueue(queue);
+        });
+
+        var runtime = host.GetRuntime();
+        var agent = (ListeningAgent)runtime.Endpoints.ActiveListeners()
+            .Single(a => a.Uri.Scheme == "rabbitmq" && a.Uri.ToString().Contains(queue));
+
+        await agent.StopAndDrainAsync();
+        agent.Status.ShouldBe(ListeningStatus.Stopped);
+
+        await agent.RestartAsync(force: true);
+        agent.Status.ShouldBe(ListeningStatus.Accepting);
+        agent.Listener.ShouldNotBeNull();
+    }
+}

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -26,6 +26,16 @@ public interface IListenerCircuit
     
     ValueTask StartAsync();
 
+    /// <summary>
+    /// Force the listener to stop and rebuild its underlying transport listener even if it currently reports
+    /// <see cref="ListeningStatus.Accepting"/>. This is the remediation primitive for recovering a "stuck"
+    /// listener — e.g. a dead transport channel that the framework could not self-heal but that still reports
+    /// Accepting — without bouncing the process. When <paramref name="force"/> is <c>false</c> this behaves like
+    /// <see cref="StartAsync"/> (a no-op when already Accepting). The default implementation is the gentle
+    /// <see cref="StartAsync"/>; circuits backed by a real transport listener override it to tear down and rebuild.
+    /// </summary>
+    ValueTask RestartAsync(bool force = true) => StartAsync();
+
     Task EnqueueDirectlyAsync(IEnumerable<Envelope> envelopes);
 }
 
@@ -300,6 +310,20 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
 
         _logger.LogInformation("Listener at {Uri} has been permanently latched", Uri);
         await _runtime.Observer.ListenerLatched(Endpoint);
+    }
+
+    public async ValueTask RestartAsync(bool force = true)
+    {
+        if (force)
+        {
+            // Tear the listener down even when Status still reports Accepting — the underlying transport channel
+            // may be dead while the orchestration status is stale (the #3171-class state, or anything the framework
+            // can't self-heal). StopAndDrainAsync sets Status to Stopped, so the StartAsync() below is no longer a
+            // no-op and fully rebuilds the listener.
+            await StopAndDrainAsync();
+        }
+
+        await StartAsync();
     }
 
     public async ValueTask StartAsync()


### PR DESCRIPTION
Closes #3232. Follow-on to the channel self-heal in #3171 — this is the **remediation** half (the observability half is #3231 / PR #3233, separate).

## Problem
`ListeningAgent.StartAsync()` early-returns when `Status == ListeningStatus.Accepting`, so a "Restart" affordance is a no-op on a listener that *reports* Accepting but isn't actually consuming (the #3171-class state before self-heal, or anything the framework can't self-heal). The only recovery today is Pause→Start (pause tears the channel down; the scheduled restarter rebuilds it) or a process bounce.

## Change
Adds **`IListenerCircuit.RestartAsync(bool force = true)`**:
- **Default interface implementation** delegates to `StartAsync()` — the gentle behavior. In-memory local queues (`BufferedLocalQueue` / `DurableLocalQueue`) have no transport channel to rebuild, so they inherit this for free with no changes.
- **`ListeningAgent` overrides it**: when `force` is `true` it `StopAndDrainAsync()` first (which sets `Status` to `Stopped`) and then `StartAsync()`, so the listener is torn down and rebuilt **even while it reports Accepting**. `force: false` behaves like `StartAsync()` (no-op when already Accepting).

This is the remediation primitive operators/automated monitors use to recover a stuck listener without restarting the process. Deliberate pauses are still respected — `StartAsync()` keeps its existing Balanced-mode agent-restriction guard.

## Tests
- `force_restart_listener_3232` (RabbitMQ integration, `[Flaky]`):
  - on an Accepting listener, `StartAsync()` and `RestartAsync(force: false)` are no-ops (same `IListener` instance), while `RestartAsync(force: true)` rebuilds it (new instance, still Accepting) **and** the rebuilt listener still consumes a freshly sent message;
  - `RestartAsync(force: true)` also recovers a `Stopped` listener back to Accepting.
- `force_restart_default_3232` (CoreTests, no broker): pins the default-interface-method contract — the default `RestartAsync` (both `force` values) delegates to `StartAsync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)