### PR TITLE
Tier 1: IReportConnectionState for NATS, MQTT, Pulsar, Redis (#3231)

### DIFF
--- a/src/Testing/Wolverine.ComplianceTests/ConnectionStateTestHelpers.cs
+++ b/src/Testing/Wolverine.ComplianceTests/ConnectionStateTestHelpers.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Configuration;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+
+namespace Wolverine.ComplianceTests;
+
+public static class ConnectionStateTestHelpers
+{
+    /// <summary>
+    /// Poll the endpoint health snapshots until the listening endpoint with the given URI scheme reports the
+    /// expected <see cref="TransportConnectionState"/>, or the timeout elapses. Returns the last observed state.
+    /// Brokers connect asynchronously at startup (and Pulsar's consumer transitions Disconnected -> Active), so a
+    /// poll is more robust than a single read.
+    /// </summary>
+    public static async Task<TransportConnectionState> WaitForListenerConnectionStateAsync(
+        IHost host, string scheme, TransportConnectionState expected, int timeoutMilliseconds = 15000)
+    {
+        var runtime = host.GetRuntime();
+        var stopwatch = Stopwatch.StartNew();
+        var last = TransportConnectionState.Unknown;
+
+        while (stopwatch.ElapsedMilliseconds < timeoutMilliseconds)
+        {
+            var snapshot = runtime.Endpoints.CollectEndpointHealth()
+                .FirstOrDefault(s => s.Direction == EndpointDirection.Listening && s.Uri.Scheme == scheme);
+
+            if (snapshot != null)
+            {
+                last = snapshot.ConnectionState;
+                if (last == expected)
+                {
+                    return last;
+                }
+            }
+
+            await Task.Delay(100);
+        }
+
+        return last;
+    }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/connection_state_3231.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/connection_state_3231.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Transports;
+using Wolverine.Util;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Wolverine.MQTT.Tests;
+
+// GH-3231: MqttListener implements IReportConnectionState off the managed MQTT client's IsConnected, so a healthy
+// listener surfaces Connected on EndpointHealthSnapshot.
+[Collection("acceptance")]
+public class connection_state_3231 : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private IHost _host = null!;
+    private LocalMqttBroker _broker = null!;
+
+    public connection_state_3231(ITestOutputHelper output) => _output = output;
+
+    public async Task InitializeAsync()
+    {
+        var port = PortFinder.GetAvailablePort();
+        _broker = new LocalMqttBroker(port) { Logger = new XUnitLogger(_output, "MQTT") };
+        await _broker.StartAsync();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseMqttWithLocalBroker(port);
+                opts.ListenToMqttTopic("connstate");
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+        await _broker.StopAsync();
+    }
+
+    [Fact]
+    public async Task healthy_mqtt_listener_reports_connected()
+    {
+        var state = await ConnectionStateTestHelpers.WaitForListenerConnectionStateAsync(
+            _host, "mqtt", TransportConnectionState.Connected);
+
+        state.ShouldBe(TransportConnectionState.Connected);
+    }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttListener.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttListener.cs
@@ -8,7 +8,7 @@ using Wolverine.Transports;
 
 namespace Wolverine.MQTT.Internals;
 
-internal class MqttListener : IListener
+internal class MqttListener : IListener, IReportConnectionState
 {
     private readonly MqttTransport _broker;
     private readonly CancellationTokenSource _cancellation = new();
@@ -18,6 +18,10 @@ internal class MqttListener : IListener
     private readonly IReceiver _receiver;
     private readonly MqttTopic _topic;
 
+    // GH-3231: surface the managed MQTT client's connection state so external monitors can detect a listener whose
+    // broker connection has dropped (and not resubscribed) while it still reports Accepting.
+    public TransportConnectionState ConnectionState =>
+        _broker.Client.IsConnected ? TransportConnectionState.Connected : TransportConnectionState.Disconnected;
 
     public MqttListener(MqttTransport broker, ILogger logger, MqttTopic topic, IReceiver receiver)
     {

--- a/src/Transports/NATS/Wolverine.Nats.Tests/connection_state_3231.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/connection_state_3231.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.Nats.Tests;
+
+// GH-3231: NatsListener implements IReportConnectionState off the NATS connection's ConnectionState, so a healthy
+// listener surfaces Connected on EndpointHealthSnapshot.
+public class connection_state_3231 : IClassFixture<NatsContainerFixture>
+{
+    private readonly NatsContainerFixture _fixture;
+
+    public connection_state_3231(NatsContainerFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task healthy_nats_listener_reports_connected()
+    {
+        var subject = $"connstate.{Guid.NewGuid():N}";
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseNats(_fixture.ConnectionString);
+                opts.ListenToNatsSubject(subject);
+            }).StartAsync();
+
+        var state = await ConnectionStateTestHelpers.WaitForListenerConnectionStateAsync(
+            host, "nats", TransportConnectionState.Connected);
+
+        state.ShouldBe(TransportConnectionState.Connected);
+    }
+}

--- a/src/Transports/NATS/Wolverine.Nats/Internal/CoreNatsSubscriber.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/CoreNatsSubscriber.cs
@@ -31,6 +31,8 @@ internal class CoreNatsSubscriber : INatsSubscriber
 
     public bool SupportsNativeDeadLetterQueue => false;
 
+    public TransportConnectionState ConnectionState => _connection.ConnectionState.ToTransportConnectionState();
+
     public async Task StartAsync(
         IListener listener,
         IReceiver receiver,

--- a/src/Transports/NATS/Wolverine.Nats/Internal/INatsSubscriber.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/INatsSubscriber.cs
@@ -9,6 +9,11 @@ internal interface INatsSubscriber : IAsyncDisposable
 {
     Task StartAsync(IListener listener, IReceiver receiver, CancellationToken cancellation);
     bool SupportsNativeDeadLetterQueue { get; }
+
+    /// <summary>
+    /// The current connection state of the underlying NATS connection, mapped onto Wolverine's transport-agnostic enum.
+    /// </summary>
+    TransportConnectionState ConnectionState { get; }
     
     /// <summary>
     /// Republish a message to the subject for requeue support in Core NATS

--- a/src/Transports/NATS/Wolverine.Nats/Internal/JetStreamSubscriber.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/JetStreamSubscriber.cs
@@ -36,6 +36,8 @@ internal class JetStreamSubscriber : INatsSubscriber
 
     public bool SupportsNativeDeadLetterQueue => _endpoint.DeadLetterQueueEnabled;
 
+    public TransportConnectionState ConnectionState => _connection.ConnectionState.ToTransportConnectionState();
+
     public async Task StartAsync(
         IListener listener,
         IReceiver receiver,

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsConnectionStateExtensions.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsConnectionStateExtensions.cs
@@ -1,0 +1,18 @@
+using NATS.Client.Core;
+using Wolverine.Transports;
+
+namespace Wolverine.Nats.Internal;
+
+internal static class NatsConnectionStateExtensions
+{
+    // GH-3231: map the NATS.Net client's native connection state onto Wolverine's transport-agnostic enum so the
+    // listener's connection health flows to EndpointHealthSnapshot.
+    public static TransportConnectionState ToTransportConnectionState(this NatsConnectionState state) => state switch
+    {
+        NatsConnectionState.Open => TransportConnectionState.Connected,
+        NatsConnectionState.Connecting => TransportConnectionState.Reconnecting,
+        NatsConnectionState.Reconnecting => TransportConnectionState.Reconnecting,
+        NatsConnectionState.Closed => TransportConnectionState.Disconnected,
+        _ => TransportConnectionState.Unknown
+    };
+}

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsListener.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsListener.cs
@@ -7,7 +7,7 @@ using Wolverine.Transports.Sending;
 
 namespace Wolverine.Nats.Internal;
 
-public class NatsListener : IListener, ISupportDeadLetterQueue
+public class NatsListener : IListener, ISupportDeadLetterQueue, IReportConnectionState
 {
     private readonly NatsEndpoint _endpoint;
     private readonly IWolverineRuntime _runtime;
@@ -20,6 +20,10 @@ public class NatsListener : IListener, ISupportDeadLetterQueue
     private readonly ISender _deadLetterSender;
 
     public IHandlerPipeline? Pipeline { get; private set; }
+
+    // GH-3231: surface the NATS connection state (via the subscriber that owns the connection) so external monitors
+    // can detect a listener whose connection has dropped while it still reports Accepting.
+    public TransportConnectionState ConnectionState => _subscriber.ConnectionState;
 
     internal NatsListener(
         NatsEndpoint endpoint,

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/connection_state_3231.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/connection_state_3231.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+// GH-3231: PulsarListener tracks the DotPulsar consumer state in the background and implements IReportConnectionState,
+// so a healthy listener surfaces Connected on EndpointHealthSnapshot once its consumer becomes Active.
+[Collection("pulsar")]
+public class connection_state_3231
+{
+    [Fact]
+    public async Task healthy_pulsar_listener_reports_connected()
+    {
+        var topic = $"persistent://public/default/connstate-{Guid.NewGuid():N}";
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+                opts.ListenToPulsarTopic(topic);
+            }).StartAsync();
+
+        var state = await ConnectionStateTestHelpers.WaitForListenerConnectionStateAsync(
+            host, "pulsar", TransportConnectionState.Connected);
+
+        state.ShouldBe(TransportConnectionState.Connected);
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarConnectionStateExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarConnectionStateExtensions.cs
@@ -1,0 +1,28 @@
+using DotPulsar;
+using Wolverine.Transports;
+
+namespace Wolverine.Pulsar;
+
+internal static class PulsarConnectionStateExtensions
+{
+    // GH-3231: map DotPulsar's consumer/reader state onto Wolverine's transport-agnostic enum so a Pulsar listener's
+    // connection health flows to EndpointHealthSnapshot. Anything other than an actively-usable state is reported as
+    // Disconnected so an external monitor can see a listener that has silently stopped consuming (e.g. a Fenced or
+    // Faulted consumer) even while its ListeningStatus still reads Accepting.
+    public static TransportConnectionState ToTransportConnectionState(this ConsumerState state) => state switch
+    {
+        ConsumerState.Active => TransportConnectionState.Connected,
+        ConsumerState.Inactive => TransportConnectionState.Connected,         // Failover standby — connected, just not the active consumer
+        ConsumerState.ReachedEndOfTopic => TransportConnectionState.Connected,
+        ConsumerState.Disconnected => TransportConnectionState.Disconnected,
+        _ => TransportConnectionState.Disconnected                            // Closed, Fenced, Faulted, Unsubscribed
+    };
+
+    public static TransportConnectionState ToTransportConnectionState(this ReaderState state) => state switch
+    {
+        ReaderState.Connected => TransportConnectionState.Connected,
+        ReaderState.ReachedEndOfTopic => TransportConnectionState.Connected,
+        ReaderState.Disconnected => TransportConnectionState.Disconnected,
+        _ => TransportConnectionState.Disconnected                            // Closed, Faulted
+    };
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -8,7 +8,7 @@ using Wolverine.Transports;
 
 namespace Wolverine.Pulsar;
 
-internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNativeScheduling
+internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNativeScheduling, IReportConnectionState
 {
     private readonly CancellationToken _cancellation;
     private readonly IConsumer<ReadOnlySequence<byte>>? _consumer;
@@ -25,6 +25,12 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
     private readonly Schemas.IPulsarMessageCodec? _codec;
     private IProducer<ReadOnlySequence<byte>>? _retryLetterQueueProducer;
     private IProducer<ReadOnlySequence<byte>>? _dlqProducer;
+
+    // GH-3231: DotPulsar exposes consumer state only via change-notifications, so a background monitor tracks the
+    // latest state here. Volatile because it is written by the monitor task and read by external health probes.
+    private volatile TransportConnectionState _connectionState = TransportConnectionState.Disconnected;
+
+    public TransportConnectionState ConnectionState => _connectionState;
 
     public PulsarListener(IWolverineRuntime runtime, PulsarEndpoint endpoint, IReceiver receiver,
         PulsarTransport transport,
@@ -70,7 +76,10 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
                 : transport.Client!.NewConsumer())
             .SubscriptionName(endpoint.SubscriptionName)
             .SubscriptionType(endpoint.SubscriptionType)
-            .InitialPosition(endpoint.SubscriptionInitialPosition);
+            .InitialPosition(endpoint.SubscriptionInitialPosition)
+            // GH-3231: track the consumer's connection state so health probes can read it (see ConnectionState). A
+            // user-supplied StateChangedHandler via ConfigureConsumer below would override this.
+            .StateChangedHandler(changed => _connectionState = changed.ConsumerState.ToTransportConnectionState());
 
         if (endpoint.TopicsPattern is not null)
         {

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarReaderListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarReaderListener.cs
@@ -14,11 +14,17 @@ namespace Wolverine.Pulsar;
 /// idiomatic Pulsar pattern for live dashboards and fan-out-to-all. No subscription cursor is committed,
 /// so there is nothing to acknowledge: <see cref="CompleteAsync"/> / <see cref="DeferAsync"/> are no-ops.
 /// </summary>
-internal class PulsarReaderListener : IListener
+internal class PulsarReaderListener : IListener, IReportConnectionState
 {
     private readonly CancellationTokenSource _localCancellation;
     private readonly IReader<ReadOnlySequence<byte>> _reader;
     private readonly Task _receivingLoop;
+
+    // GH-3231: updated by the reader's StateChangedHandler (registered on the builder below). Volatile because it is
+    // written from DotPulsar's state-change callback and read by external health probes.
+    private volatile TransportConnectionState _connectionState = TransportConnectionState.Disconnected;
+
+    public TransportConnectionState ConnectionState => _connectionState;
 
     public PulsarReaderListener(IWolverineRuntime runtime, PulsarEndpoint endpoint, IReceiver receiver,
         PulsarTransport transport, CancellationToken cancellation)
@@ -37,7 +43,9 @@ internal class PulsarReaderListener : IListener
 
         var readerBuilder = transport.Client!.NewReader()
             .Topic(endpoint.PulsarTopic())
-            .StartMessageId(MessageId.Latest);
+            .StartMessageId(MessageId.Latest)
+            // GH-3231: track the reader's connection state so health probes can read it (see ConnectionState).
+            .StateChangedHandler(changed => _connectionState = changed.ReaderState.ToTransportConnectionState());
 
         _reader = readerBuilder.Create();
 

--- a/src/Transports/Redis/Wolverine.Redis.Tests/connection_state_3231.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/connection_state_3231.cs
@@ -1,0 +1,31 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+// GH-3231: RedisStreamListener implements IReportConnectionState off the StackExchange.Redis multiplexer's
+// IsConnected, so a healthy listener surfaces Connected on EndpointHealthSnapshot.
+public class connection_state_3231
+{
+    [Fact]
+    public async Task healthy_redis_listener_reports_connected()
+    {
+        var streamKey = $"connstate-{Guid.NewGuid():N}";
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRedisTransport(RedisContainerFixture.ConnectionString).AutoProvision();
+                opts.ListenToRedisStream(streamKey, "g1").BlockTimeout(100.Milliseconds());
+            }).StartAsync();
+
+        var state = await ConnectionStateTestHelpers.WaitForListenerConnectionStateAsync(
+            host, "redis", TransportConnectionState.Connected);
+
+        state.ShouldBe(TransportConnectionState.Connected);
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
@@ -10,7 +10,7 @@ using Wolverine.Transports;
 
 namespace Wolverine.Redis.Internal;
 
-public class RedisStreamListener : IListener, ISupportDeadLetterQueue
+public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportConnectionState
 {
     private readonly RedisTransport _transport;
     private readonly RedisStreamEndpoint _endpoint;
@@ -44,6 +44,14 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue
     public Uri Address { get; }
     public ListeningStatus Status => _status;
     public IHandlerPipeline? Pipeline => _receiver.Pipeline;
+
+    // GH-3231: surface the StackExchange.Redis multiplexer connection state. The XREADGROUP poll loop runs over a
+    // long-lived, auto-reconnecting multiplexer, so this lets external monitors see a listener whose multiplexer is
+    // down even though ListeningStatus still reports Accepting.
+    public TransportConnectionState ConnectionState =>
+        _transport.GetDatabase(database: _endpoint.DatabaseId).Multiplexer.IsConnected
+            ? TransportConnectionState.Connected
+            : TransportConnectionState.Disconnected;
 
     internal bool DeleteOnAck => _transport.DeleteStreamEntryOnAck;
     


### PR DESCRIPTION
Follow-on to #3231 (which added the `IReportConnectionState` capability + `EndpointHealthSnapshot.ConnectionState` and wired RabbitMQ). This implements the **Tier 1** transports from the cross-transport analysis — the ones that hold a long-lived connection whose liveness is **queryable**, so they can honestly surface `Connected`/`Disconnected` for external monitors (CritterWatch).

## What's implemented
| Transport | Source of truth |
|---|---|
| **NATS** | `NatsConnection.ConnectionState` (Open→Connected, Connecting/Reconnecting→Reconnecting, Closed→Disconnected), exposed via the subscriber that owns the connection |
| **MQTT** | `IManagedMqttClient.IsConnected` |
| **Redis** | `IConnectionMultiplexer.IsConnected` (the XREADGROUP poll loop runs over an auto-reconnecting multiplexer) |
| **Pulsar** | DotPulsar consumer/reader state, captured via the builder's `StateChangedHandler`; `Active`/`Inactive`/`ReachedEndOfTopic`→Connected, everything else (incl. `Fenced`, `Faulted`)→Disconnected |

For NATS, MQTT, Redis the native state property is already consumed by that transport's own broker health check, so this just relocates a proven signal to the per-listener snapshot. For Pulsar, DotPulsar exposes state only via change-notifications, so the listener registers a `StateChangedHandler` on the consumer/reader builder and records the latest state (no background task, no cast).

## Out of scope (tracked separately)
- **Tier 2** — Azure Service Bus, GCP Pub/Sub, Kafka (SDKs hide connection state): #3237.
- **Tier 3** — SQS, DB queues, TCP, SignalR server hub, Local stay `Unknown` (no queryable connection).
- **Dead receive-loop** detection + shared polling abstraction: #3236.

## Tests
Each transport gets a `connection_state_3231` integration test asserting a healthy listener reports `Connected` (polled via a shared `ConnectionStateTestHelpers` added to `Wolverine.ComplianceTests`). All four pass locally (MQTT in-process broker; NATS/Redis/Pulsar via their Testcontainers fixtures).

Refs #3231

🤖 Generated with [Claude Code](https://claude.com/claude-code)