### PR TITLE
Expose gRPC endpoint → message-type mapping via IGrpcEndpointManifest (#3235)

### DIFF
--- a/src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj
+++ b/src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj
@@ -25,6 +25,7 @@
         <ProjectReference Include="..\Samples\PingPongWithGrpcStreaming\Ponger\Ponger.csproj"/>
         <ProjectReference Include="..\Samples\GreeterProtoFirstGrpc\Messages\Messages.csproj"/>
         <ProjectReference Include="..\Samples\GreeterProtoFirstGrpc\Server\Server.csproj"/>
+        <ProjectReference Include="..\Samples\GreeterCodeFirstGrpc\Messages\Messages.csproj"/>
         <ProjectReference Include="..\Samples\RacerWithGrpc\RacerContracts\RacerContracts.csproj"/>
         <ProjectReference Include="..\Samples\RacerWithGrpc\RacerServer\RacerServer.csproj"/>
     </ItemGroup>

--- a/src/Wolverine.Grpc.Tests/grpc_endpoint_manifest_3235.cs
+++ b/src/Wolverine.Grpc.Tests/grpc_endpoint_manifest_3235.cs
@@ -1,0 +1,77 @@
+using GreeterCodeFirstGrpc.Messages;
+using GreeterProtoFirstGrpc.Messages;
+using GreeterProtoFirstGrpc.Server;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests;
+
+// GH-3235: Wolverine.Grpc projects its discovered proto-first + code-first unary services into the core
+// IGrpcEndpointManifest abstraction so diagnostic consumers (CritterWatch) can read the endpoint -> message-type
+// mapping without referencing WolverineFx.Grpc.
+[Collection(GrpcSerialTestsCollection.Name)]
+public class grpc_endpoint_manifest_3235
+{
+    [Fact]
+    public async Task projects_proto_first_and_code_first_unary_endpoints()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Proto-first Greeter stub lives in the GreeterProtoFirstGrpc.Server assembly.
+                opts.ApplicationAssembly = typeof(GreeterGrpcService).Assembly;
+                // Pull in the code-first contract assembly so it is discovered too.
+                opts.Discovery.IncludeAssembly(typeof(IGreeterCodeFirstService).Assembly);
+            })
+            .ConfigureServices(services => services.AddWolverineGrpc())
+            .StartAsync();
+
+        var manifest = host.Services.GetRequiredService<IGrpcEndpointManifest>();
+
+        // Reading Endpoints self-triggers discovery (no MapWolverineGrpcServices required).
+        var endpoints = manifest.Endpoints;
+
+        endpoints.ShouldNotBeEmpty();
+
+        // v1 surfaces only the unary, bus-forwarding flavors.
+        endpoints.ShouldAllBe(e =>
+            e.Mode == GrpcServiceDiscoveryMode.ProtoFirst || e.Mode == GrpcServiceDiscoveryMode.CodeFirst);
+
+        // Proto-first: Greeter.SayHello forwards HelloRequest to the bus. ServiceName is the proto service's simple
+        // name (Wolverine's GrpcServiceChain.ProtoServiceName), not the package-qualified "greet.Greeter".
+        var sayHello = endpoints.Single(e =>
+            e.Mode == GrpcServiceDiscoveryMode.ProtoFirst && e.MethodName == "SayHello");
+        sayHello.ServiceName.ShouldBe("Greeter");
+        sayHello.RequestType.ShouldBe(typeof(HelloRequest));
+        sayHello.ResponseType.ShouldBe(typeof(HelloReply));
+        sayHello.HandlerType.ShouldBe(typeof(GreeterGrpcService));
+
+        // The other proto-first unary RPCs are present...
+        endpoints.ShouldContain(e =>
+            e.Mode == GrpcServiceDiscoveryMode.ProtoFirst && e.MethodName == "SayGoodbye");
+
+        // ...but the server-streaming RPC (StreamGreetings, in both the proto and the code-first contract) is excluded.
+        endpoints.ShouldNotContain(e => e.MethodName == "StreamGreetings");
+
+        // Code-first: IGreeterCodeFirstService.Greet forwards GreetRequest to the bus.
+        var greet = endpoints.Single(e =>
+            e.Mode == GrpcServiceDiscoveryMode.CodeFirst && e.MethodName == "Greet");
+        greet.RequestType.ShouldBe(typeof(GreetRequest));
+        greet.ResponseType.ShouldBe(typeof(GreetReply));
+        greet.ServiceName.ShouldBe("GreeterCodeFirstService");
+        greet.HandlerType.ShouldBe(typeof(IGreeterCodeFirstService));
+    }
+
+    [Fact]
+    public async Task manifest_is_not_registered_without_grpc()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine()
+            .StartAsync();
+
+        host.Services.GetService<IGrpcEndpointManifest>().ShouldBeNull();
+    }
+}

--- a/src/Wolverine.Grpc/GrpcEndpointManifest.cs
+++ b/src/Wolverine.Grpc/GrpcEndpointManifest.cs
@@ -1,0 +1,127 @@
+using System.Reflection;
+using System.ServiceModel;
+using Wolverine.Configuration;
+
+namespace Wolverine.Grpc;
+
+/// <summary>
+///     Projects <see cref="GrpcGraph"/>'s discovered proto-first and code-first service chains into the core
+///     <see cref="IGrpcEndpointManifest"/> abstraction. Only unary RPCs are included — those are the methods whose
+///     generated wrapper forwards the request to <c>IMessageBus.InvokeAsync</c>, so the request type is genuinely the
+///     published Wolverine message. Streaming methods, hand-written and direct-mapped services are excluded from v1.
+/// </summary>
+internal sealed class GrpcEndpointManifest : IGrpcEndpointManifest
+{
+    private readonly GrpcGraph _graph;
+    private readonly WolverineGrpcOptions _grpcOptions;
+    private readonly object _lock = new();
+    private volatile IReadOnlyList<GrpcEndpointDescriptor>? _endpoints;
+
+    public GrpcEndpointManifest(GrpcGraph graph, WolverineGrpcOptions grpcOptions)
+    {
+        _graph = graph ?? throw new ArgumentNullException(nameof(graph));
+        _grpcOptions = grpcOptions ?? throw new ArgumentNullException(nameof(grpcOptions));
+    }
+
+    public IReadOnlyList<GrpcEndpointDescriptor> Endpoints
+    {
+        get
+        {
+            if (_endpoints != null)
+            {
+                return _endpoints;
+            }
+
+            lock (_lock)
+            {
+                if (_endpoints != null)
+                {
+                    return _endpoints;
+                }
+
+                // Robust to startup ordering: if no chains have been built yet (e.g. MapWolverineGrpcServices
+                // hasn't run), discover now so the manifest is still populated.
+                if (_graph.Chains.Count == 0 && _graph.CodeFirstChains.Count == 0 &&
+                    _graph.HandWrittenChains.Count == 0)
+                {
+                    _graph.DiscoverServices(_grpcOptions);
+                }
+
+                _endpoints = build(_graph);
+                return _endpoints;
+            }
+        }
+    }
+
+    private static IReadOnlyList<GrpcEndpointDescriptor> build(GrpcGraph graph)
+    {
+        var descriptors = new List<GrpcEndpointDescriptor>();
+
+        // Proto-first: chain.UnaryMethods already excludes streaming RPCs.
+        foreach (var chain in graph.Chains)
+        {
+            foreach (var method in chain.UnaryMethods)
+            {
+                descriptors.Add(new GrpcEndpointDescriptor(
+                    chain.ProtoServiceName,
+                    method.Name,
+                    method.GetParameters()[0].ParameterType,
+                    unwrapResponse(method.ReturnType),
+                    chain.StubType,
+                    GrpcServiceDiscoveryMode.ProtoFirst));
+            }
+        }
+
+        // Code-first: only the unary methods are bus-invoked.
+        foreach (var chain in graph.CodeFirstChains)
+        {
+            var serviceName = serviceNameFor(chain.ServiceContractType);
+
+            foreach (var rpc in chain.SupportedMethods.Where(m => m.Kind == CodeFirstMethodKind.Unary))
+            {
+                descriptors.Add(new GrpcEndpointDescriptor(
+                    serviceName,
+                    rpc.Method.Name,
+                    rpc.Method.GetParameters()[0].ParameterType,
+                    unwrapResponse(rpc.Method.ReturnType),
+                    chain.ServiceContractType,
+                    GrpcServiceDiscoveryMode.CodeFirst));
+            }
+        }
+
+        return descriptors;
+    }
+
+    private static Type? unwrapResponse(Type returnType)
+    {
+        if (returnType.IsGenericType)
+        {
+            var definition = returnType.GetGenericTypeDefinition();
+            if (definition == typeof(Task<>) || definition == typeof(ValueTask<>))
+            {
+                return returnType.GetGenericArguments()[0];
+            }
+        }
+
+        return null;
+    }
+
+    // Best-effort wire service name for a code-first contract: the [ServiceContract] Name if set, otherwise the
+    // interface's simple name with a leading 'I' stripped.
+    private static string serviceNameFor(Type contractType)
+    {
+        var attribute = contractType.GetCustomAttribute<ServiceContractAttribute>();
+        if (attribute?.Name is { Length: > 0 } name)
+        {
+            return name;
+        }
+
+        var simple = contractType.Name;
+        if (simple.Length > 1 && simple[0] == 'I' && char.IsUpper(simple[1]))
+        {
+            simple = simple[1..];
+        }
+
+        return simple;
+    }
+}

--- a/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
@@ -71,6 +71,12 @@ public static class WolverineGrpcExtensions
             return new GrpcGraph(runtime.Options, container);
         });
 
+        // GH-3235: expose the discovered gRPC endpoint -> message-type mapping via the core IGrpcEndpointManifest
+        // abstraction so diagnostic consumers (CritterWatch) can read it without referencing WolverineFx.Grpc.
+        services.AddSingleton<IGrpcEndpointManifest>(sp =>
+            new GrpcEndpointManifest(sp.GetRequiredService<GrpcGraph>(),
+                sp.GetRequiredService<WolverineGrpcOptions>()));
+
         services.AddSingleton<WolverineGrpcExceptionInterceptor>();
         services.Configure<GrpcServiceOptions>(opts =>
         {

--- a/src/Wolverine/Configuration/GrpcEndpointManifest.cs
+++ b/src/Wolverine/Configuration/GrpcEndpointManifest.cs
@@ -1,0 +1,54 @@
+namespace Wolverine.Configuration;
+
+/// <summary>
+/// How a Wolverine gRPC service endpoint was discovered. v1 of the manifest only surfaces
+/// <see cref="ProtoFirst"/> and <see cref="CodeFirst"/> endpoints (the flavors whose generated wrapper forwards
+/// the request to the message bus); the remaining members exist for forward compatibility.
+/// </summary>
+public enum GrpcServiceDiscoveryMode
+{
+    /// <summary>Proto-first: an abstract stub inheriting a proto-generated service base.</summary>
+    ProtoFirst,
+
+    /// <summary>Code-first: a <c>[ServiceContract]</c> interface that Wolverine generates an implementation for.</summary>
+    CodeFirst,
+
+    /// <summary>Hand-written: a concrete service class wrapped by a generated delegation wrapper.</summary>
+    HandWritten,
+
+    /// <summary>Direct-mapped: a service mapped without a Wolverine-generated chain.</summary>
+    DirectMapped
+}
+
+/// <summary>
+/// A discovered unary gRPC endpoint and the Wolverine message type it forwards to the message bus. For proto-first
+/// and code-first services the generated wrapper forwards the request (the first parameter) to
+/// <c>IMessageBus.InvokeAsync</c>, so <see cref="RequestType"/> is the published Wolverine message.
+/// </summary>
+/// <param name="ServiceName">The service name — the proto service's simple name for proto-first, or the contract's
+/// service name for code-first (not necessarily package-qualified).</param>
+/// <param name="MethodName">The unary RPC method name.</param>
+/// <param name="RequestType">The request type — the Wolverine message forwarded to the bus.</param>
+/// <param name="ResponseType">The response type, or <c>null</c> for a method with no typed response.</param>
+/// <param name="HandlerType">The identity of the discovered service (stub or contract type).</param>
+/// <param name="Mode">How the service was discovered.</param>
+public sealed record GrpcEndpointDescriptor(
+    string ServiceName,
+    string MethodName,
+    Type RequestType,
+    Type? ResponseType,
+    Type HandlerType,
+    GrpcServiceDiscoveryMode Mode);
+
+/// <summary>
+/// Exposes Wolverine's discovered gRPC unary endpoint → message-type mapping so monitoring/diagnostic consumers
+/// (e.g. CritterWatch's <c>PublisherKind.GrpcEndpoint</c>) can read it without referencing <c>WolverineFx.Grpc</c>.
+/// Registered by <c>Wolverine.Grpc</c>; resolves to <c>null</c> (unregistered) when the application has no gRPC.
+/// </summary>
+public interface IGrpcEndpointManifest
+{
+    /// <summary>
+    /// The discovered unary gRPC endpoints. Empty when gRPC is enabled but no services were discovered.
+    /// </summary>
+    IReadOnlyList<GrpcEndpointDescriptor> Endpoints { get; }
+}


### PR DESCRIPTION
Closes #3235. Downstream: JasperFx/CritterWatch#499.

Exposes Wolverine's discovered **gRPC unary endpoint → message-type** mapping through a core-Wolverine abstraction so monitoring/diagnostic consumers (CritterWatch) can populate `PublisherKind.GrpcEndpoint` **without referencing `WolverineFx.Grpc`** (which transitively pulls `Grpc.AspNetCore` + `protobuf-net.Grpc`).

## Core abstraction (`Wolverine.Configuration`)
```csharp
public enum GrpcServiceDiscoveryMode { ProtoFirst, CodeFirst, HandWritten, DirectMapped }

public sealed record GrpcEndpointDescriptor(
    string ServiceName, string MethodName,
    Type RequestType, Type? ResponseType, Type HandlerType,
    GrpcServiceDiscoveryMode Mode);

public interface IGrpcEndpointManifest { IReadOnlyList<GrpcEndpointDescriptor> Endpoints { get; } }
```

## Implementation (`Wolverine.Grpc`)
`GrpcEndpointManifest` projects `GrpcGraph`'s chains into descriptors and is registered as an `IGrpcEndpointManifest` singleton by `AddWolverineGrpc`. It computes lazily and **self-triggers `GrpcGraph.DiscoverServices` if the graph is still empty**, so it's robust to startup ordering (doesn't require `MapWolverineGrpcServices` first).

## Design decisions (the issue's open questions)
- **Home/name:** `Wolverine.Configuration` (with the other diagnostic descriptor DTOs).
- **v1 scope:** **proto-first + code-first only** — the flavors whose generated wrapper forwards the request to `IMessageBus.InvokeAsync`, so `RequestType` is genuinely the published Wolverine message. Streaming RPCs are excluded; hand-written / direct-mapped (bus-forwarding not guaranteed) are deferred.
- **Type form:** raw `System.Type` (matches the issue's record sketch; CritterWatch wraps on its side).

Note: `ServiceName` is the proto service's **simple** name (Wolverine's existing `GrpcServiceChain.ProtoServiceName`), not package-qualified `greet.Greeter` — Wolverine doesn't currently track the proto `package`. Promoting that to fully-qualified would be a separate change to `ProtoServiceName` itself.

## Acceptance / tests
- `IGrpcEndpointManifest` resolves on a stock `AddWolverineGrpc` host; **`null` when no gRPC** (core has no registration).
- Projection verified for proto-first (request-type extraction, `HandlerType` = stub) and code-first (`Greet` → `GreetRequest`).
- **Streaming excluded** (the `StreamGreetings` RPCs in both the proto and the code-first contract are absent).
- Full `Wolverine.Grpc.Tests` suite (220) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)