### PR TITLE
Receive-loop health + shared BackgroundReceiveLoop, adopted in SQS (#3236, phase 1)

### DIFF
--- a/src/Testing/CoreTests/Configuration/receive_loop_health_default_3236.cs
+++ b/src/Testing/CoreTests/Configuration/receive_loop_health_default_3236.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Wolverine.Transports.Tcp;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+// GH-3236: listeners that don't run a managed BackgroundReceiveLoop (TCP accept loop, in-memory local queues) must
+// report ReceiveLoopStatus.Unknown with no heartbeat rather than a misleading status.
+public class receive_loop_health_default_3236
+{
+    [Fact]
+    public async Task non_loop_listeners_report_unknown()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ListenAtPort(PortFinder.GetAvailablePort());
+            }).StartAsync();
+
+        var snapshots = host.GetRuntime().Endpoints.CollectEndpointHealth();
+        snapshots.ShouldNotBeEmpty();
+
+        foreach (var snapshot in snapshots)
+        {
+            snapshot.ReceiveLoopStatus.ShouldBe(ReceiveLoopStatus.Unknown, $"{snapshot.Direction} {snapshot.Uri}");
+            snapshot.LastReceiveLoopActivityAt.ShouldBeNull();
+        }
+    }
+}

--- a/src/Testing/CoreTests/Transports/background_receive_loop_3236.cs
+++ b/src/Testing/CoreTests/Transports/background_receive_loop_3236.cs
@@ -1,0 +1,125 @@
+using System.Diagnostics;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Transports;
+
+// GH-3236: BackgroundReceiveLoop standardizes polling-listener loops (managed task, catch->backoff->continue,
+// idle delay, heartbeat, fault detection, safe teardown) and reports loop health for EndpointHealthSnapshot.
+public class background_receive_loop_3236
+{
+    private static BackgroundReceiveLoop loop(Func<CancellationToken, Task<bool>> body, TimeSpan? idle = null)
+        => new(new Uri("test://loop"), NullLogger.Instance, body, CancellationToken.None, idle ?? 20.Milliseconds());
+
+    [Fact]
+    public void status_is_not_started_before_start()
+    {
+        var theLoop = loop(_ => Task.FromResult(true));
+        theLoop.ReceiveLoopStatus.ShouldBe(ReceiveLoopStatus.NotStarted);
+        theLoop.LastReceiveLoopActivityAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task running_and_heartbeat_advances_while_iterating()
+    {
+        var count = 0;
+        // Idle iterations (return false) so the loop paces itself with the idle delay rather than hot-spinning.
+        var theLoop = loop(_ =>
+        {
+            Interlocked.Increment(ref count);
+            return Task.FromResult(false);
+        });
+
+        theLoop.Start();
+        theLoop.ReceiveLoopStatus.ShouldBe(ReceiveLoopStatus.Running);
+
+        await waitUntil(() => count > 2);
+        var first = theLoop.LastReceiveLoopActivityAt;
+        first.ShouldNotBeNull();
+
+        await waitUntil(() => count > 6);
+        theLoop.LastReceiveLoopActivityAt!.Value.ShouldBeGreaterThanOrEqualTo(first.Value);
+
+        await theLoop.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task exceptions_increment_consecutive_failures_keep_running_then_recover()
+    {
+        var fail = true;
+        var theLoop = loop(_ =>
+        {
+            if (Volatile.Read(ref fail))
+            {
+                throw new InvalidOperationException("boom");
+            }
+
+            return Task.FromResult(false);
+        }, idle: 10.Milliseconds());
+
+        theLoop.Start();
+        await waitUntil(() => theLoop.ConsecutiveFailures >= 2);
+
+        // The loop keeps running through failures (it does not silently die).
+        theLoop.ReceiveLoopStatus.ShouldBe(ReceiveLoopStatus.Running);
+
+        Volatile.Write(ref fail, false);
+        await waitUntil(() => theLoop.ConsecutiveFailures == 0);
+
+        await theLoop.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task a_hung_iteration_freezes_the_heartbeat()
+    {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var theLoop = loop(async token =>
+        {
+            entered.TrySetResult();
+            // Hang until the loop is cancelled (DisposeAsync below). Token-aware so teardown is clean.
+            await Task.Delay(Timeout.Infinite, token);
+            return true;
+        });
+
+        theLoop.Start();
+        await entered.Task.WaitAsync(5.Seconds()); // heartbeat was bumped before the iteration call
+        var frozen = theLoop.LastReceiveLoopActivityAt;
+        frozen.ShouldNotBeNull();
+
+        // While the iteration is hung, the heartbeat stops advancing — this is exactly the "Accepting but not
+        // consuming" signal an external monitor reads.
+        await Task.Delay(100);
+        theLoop.LastReceiveLoopActivityAt.ShouldBe(frozen);
+
+        // Cancellation unblocks the hung Task.Delay; the loop observes the OCE and stops cleanly.
+        await theLoop.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task stop_async_cancels_and_marks_stopped()
+    {
+        var theLoop = loop(_ => Task.FromResult(false));
+        theLoop.Start();
+        await Task.Delay(30);
+
+        await theLoop.StopAsync(2.Seconds());
+
+        theLoop.ReceiveLoopStatus.ShouldBe(ReceiveLoopStatus.Stopped);
+        await theLoop.DisposeAsync();
+    }
+
+    private static async Task waitUntil(Func<bool> condition, int timeoutMs = 5000)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (!condition() && stopwatch.ElapsedMilliseconds < timeoutMs)
+        {
+            await Task.Delay(10);
+        }
+
+        condition().ShouldBeTrue();
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -7,15 +7,14 @@ using Wolverine.Transports;
 
 namespace Wolverine.AmazonSqs.Internal;
 
-internal class SqsListener : IListener, ISupportDeadLetterQueue
+internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveLoopHealth
 {
-    private readonly CancellationTokenSource _cancellation = new();
     private readonly RetryBlock<Envelope>? _deadLetterBlock;
     private readonly AmazonSqsQueue? _deadLetterQueue;
     private readonly AmazonSqsQueue _queue;
     private readonly IReceiver _receiver;
     private readonly RetryBlock<AmazonSqsEnvelope> _requeueBlock;
-    private readonly Task _task;
+    private readonly BackgroundReceiveLoop _loop;
     private readonly AmazonSqsTransport _transport;
     private readonly ISqsEnvelopeMapper _mapper;
     private readonly TimeSpan _drainTimeout;
@@ -45,8 +44,6 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue
             _deadLetterQueue = _transport.Queues[_queue.DeadLetterQueueName];
         }
 
-        var failedCount = 0;
-
         _requeueBlock = new RetryBlock<AmazonSqsEnvelope>(async (env, _) =>
         {
             if (!env.WasDeleted)
@@ -61,84 +58,68 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue
             new RetryBlock<Envelope>(async (e, _) => { await _deadLetterQueue!.SendMessageAsync(e, logger); }, logger,
                 runtime.Cancellation);
 
-        _receiver = receiver;
-
-        _task = Task.Run(async () =>
-        {
-            while (!_cancellation.Token.IsCancellationRequested)
-            {
-                try
-                {
-                    var request = new ReceiveMessageRequest(_queue.QueueUrl);
-
-                    _queue.ConfigureRequest(request);
-
-                    var results = await _transport.Client.ReceiveMessageAsync(request, _cancellation.Token);
-
-                    failedCount = 0;
-
-                    if (results.Messages != null && results.Messages.Any())
-                    {
-                        var envelopes = new List<Envelope>(results.Messages.Count);
-                        foreach (var message in results.Messages)
-                        {
-                            try
-                            {
-                                var envelope = buildEnvelope(message);
-
-                                envelopes.Add(envelope);
-                            }
-                            catch (Exception e)
-                            {
-                                if (_deadLetterQueue != null)
-                                {
-                                    try
-                                    {
-                                        await _transport.Client.SendMessageAsync(new SendMessageRequest(
-                                            _deadLetterQueue.QueueUrl,
-                                            message.Body));
-                                    }
-                                    catch (Exception exception)
-                                    {
-                                        logger.LogError(exception,
-                                            "Error while trying to directly send a dead letter message {Id} from {Uri}",
-                                            message.MessageId, _queue.Uri);
-                                    }
-                                }
-
-                                logger.LogError(e, "Error while reading message {Id} from {Uri}", message.MessageId,
-                                    _queue.Uri);
-                            }
-                        }
-
-                        // ReSharper disable once CoVariantArrayConversion
-                        if (envelopes.Any())
-                        {
-                            await receiver.ReceivedAsync(this, envelopes.ToArray());
-                        }
-                    }
-                    else
-                    {
-                        // Slow down if this is a periodically used queue
-                        await Task.Delay(250.Milliseconds());
-                    }
-                }
-                catch (TaskCanceledException)
-                {
-                    // do nothing here, it's all good
-                }
-                catch (Exception e)
-                {
-                    failedCount++;
-                    var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();
-
-                    logger.LogError(e, "Error while trying to retrieve messages from SQS Queue {Uri}",
-                        queue.Uri);
-                    await Task.Delay(pauseTime);
-                }
-            }
-        }, _cancellation.Token);
+        // GH-3236: the receive loop is now a shared BackgroundReceiveLoop — it owns the task, the
+        // catch -> log -> exponential-backoff -> continue policy, the idle delay when a poll returns nothing, the
+        // heartbeat, and safe teardown. The listener just provides one poll-and-process iteration and reports the
+        // loop's health through IReportReceiveLoopHealth.
+        _loop = new BackgroundReceiveLoop(_queue.Uri, logger, pollOnceAsync, runtime.Cancellation);
+        _loop.Start();
     }
+
+    private async Task<bool> pollOnceAsync(CancellationToken token)
+    {
+        var request = new ReceiveMessageRequest(_queue.QueueUrl);
+        _queue.ConfigureRequest(request);
+
+        var results = await _transport.Client!.ReceiveMessageAsync(request, token);
+
+        if (results.Messages == null || !results.Messages.Any())
+        {
+            // No work — the loop applies its idle delay before polling again.
+            return false;
+        }
+
+        var envelopes = new List<Envelope>(results.Messages.Count);
+        foreach (var message in results.Messages)
+        {
+            try
+            {
+                envelopes.Add(buildEnvelope(message));
+            }
+            catch (Exception e)
+            {
+                if (_deadLetterQueue != null)
+                {
+                    try
+                    {
+                        await _transport.Client.SendMessageAsync(new SendMessageRequest(
+                            _deadLetterQueue.QueueUrl,
+                            message.Body));
+                    }
+                    catch (Exception exception)
+                    {
+                        _logger.LogError(exception,
+                            "Error while trying to directly send a dead letter message {Id} from {Uri}",
+                            message.MessageId, _queue.Uri);
+                    }
+                }
+
+                _logger.LogError(e, "Error while reading message {Id} from {Uri}", message.MessageId, _queue.Uri);
+            }
+        }
+
+        // ReSharper disable once CoVariantArrayConversion
+        if (envelopes.Any())
+        {
+            await _receiver.ReceivedAsync(this, envelopes.ToArray());
+        }
+
+        return true;
+    }
+
+    public ReceiveLoopStatus ReceiveLoopStatus => _loop.ReceiveLoopStatus;
+
+    public DateTimeOffset? LastReceiveLoopActivityAt => _loop.LastReceiveLoopActivityAt;
 
     public ValueTask CompleteAsync(Envelope envelope)
     {
@@ -162,34 +143,16 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue
 
     public async ValueTask DisposeAsync()
     {
-        if (!_cancellation.IsCancellationRequested)
-        {
-            await _cancellation.CancelAsync();
-        }
-
-        _cancellation.Dispose();
+        await _loop.DisposeAsync();
         _requeueBlock.Dispose();
         _deadLetterBlock?.Dispose();
-        _task.SafeDispose();
     }
 
     public Uri Address => _queue.Uri;
 
     public async ValueTask StopAsync()
     {
-        await _cancellation.CancelAsync();
-
-        try
-        {
-            await _task.WaitAsync(_drainTimeout);
-        }
-        catch (Exception e)
-        {
-            if (e is not TaskCanceledException)
-            {
-                _logger.LogDebug(e, "Error waiting for SQS polling task to complete during shutdown for {Uri}", _queue.Uri);
-            }
-        }
+        await _loop.StopAsync(_drainTimeout);
     }
 
     public async Task<bool> TryRequeueAsync(Envelope envelope)

--- a/src/Wolverine/Configuration/EndpointCollection.cs
+++ b/src/Wolverine/Configuration/EndpointCollection.cs
@@ -135,6 +135,7 @@ public class EndpointCollection : IEndpointCollection
 
         foreach (var listener in _listeners.Values)
         {
+            var loopHealth = receiveLoopHealthOf(listener);
             snapshots.Add(new EndpointHealthSnapshot(
                 Uri: listener.Uri,
                 EndpointName: listener.Endpoint.EndpointName,
@@ -145,7 +146,9 @@ public class EndpointCollection : IEndpointCollection
                 LastMessageSentAt: null,
                 SenderLatched: false,
                 BufferLimit: listener.Endpoint.BufferingLimits?.Maximum,
-                ConnectionState: connectionStateOf(listener)));
+                ConnectionState: connectionStateOf(listener),
+                ReceiveLoopStatus: loopHealth?.ReceiveLoopStatus ?? ReceiveLoopStatus.Unknown,
+                LastReceiveLoopActivityAt: loopHealth?.LastReceiveLoopActivityAt));
         }
 
         foreach (var sender in _senders.Enumerate().Select(x => x.Value))
@@ -164,6 +167,23 @@ public class EndpointCollection : IEndpointCollection
         }
 
         return snapshots;
+    }
+
+    // Resolve the background receive-loop health for a listener. The agent itself may report it, otherwise reach
+    // through to the IListener it owns. Listeners with no managed loop (push transports, local queues) report null.
+    private static IReportReceiveLoopHealth? receiveLoopHealthOf(IListeningAgent agent)
+    {
+        if (agent is IReportReceiveLoopHealth reporter)
+        {
+            return reporter;
+        }
+
+        if (agent is ListeningAgent { Listener: IReportReceiveLoopHealth listenerReporter })
+        {
+            return listenerReporter;
+        }
+
+        return null;
     }
 
     // Resolve the underlying transport channel/connection state for a listener. The agent itself may report it

--- a/src/Wolverine/Configuration/EndpointHealthSnapshot.cs
+++ b/src/Wolverine/Configuration/EndpointHealthSnapshot.cs
@@ -16,7 +16,9 @@ public record EndpointHealthSnapshot(
     bool SenderLatched,
     int? BufferLimit,
     long? BrokerQueueDepth = null,
-    TransportConnectionState ConnectionState = TransportConnectionState.Unknown);
+    TransportConnectionState ConnectionState = TransportConnectionState.Unknown,
+    ReceiveLoopStatus ReceiveLoopStatus = ReceiveLoopStatus.Unknown,
+    DateTimeOffset? LastReceiveLoopActivityAt = null);
 
 public enum EndpointDirection
 {

--- a/src/Wolverine/Transports/BackgroundReceiveLoop.cs
+++ b/src/Wolverine/Transports/BackgroundReceiveLoop.cs
@@ -1,0 +1,184 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.Transports;
+
+/// <summary>
+///     A shared, managed background receive loop for polling-style listeners (SQS, Kafka, Redis, the database queue
+///     transports, …). It owns the loop <see cref="Task"/> and standardizes the behavior every hand-rolled listener
+///     loop used to re-implement (divergently): cancellation, per-iteration try/catch → log → exponential backoff →
+///     continue, an idle delay when an iteration finds no work, a heartbeat timestamp, fault detection, and safe
+///     async teardown. The heartbeat + fault state are surfaced through <see cref="IReportReceiveLoopHealth"/> so an
+///     external monitor can see a loop that has faulted or hung — the gap that connection state alone can't (GH-3236).
+/// </summary>
+public sealed class BackgroundReceiveLoop : IAsyncDisposable, IReportReceiveLoopHealth
+{
+    // One iteration of the loop. Returns true when it did work (received/processed messages), false when idle —
+    // an idle iteration is followed by IdleDelay so a quiet queue isn't hot-polled.
+    private readonly Func<CancellationToken, Task<bool>> _iteration;
+    private readonly TimeSpan _idleDelay;
+    private readonly ILogger _logger;
+    private readonly Uri _uri;
+    private readonly CancellationTokenSource _cancellation;
+
+    private Task? _task;
+    private volatile int _consecutiveFailures;
+    private long _lastActivityTicks;
+    private volatile ReceiveLoopStatus _status = ReceiveLoopStatus.NotStarted;
+
+    public BackgroundReceiveLoop(Uri uri, ILogger logger, Func<CancellationToken, Task<bool>> iteration,
+        CancellationToken parentToken, TimeSpan? idleDelay = null)
+    {
+        _uri = uri ?? throw new ArgumentNullException(nameof(uri));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _iteration = iteration ?? throw new ArgumentNullException(nameof(iteration));
+        _idleDelay = idleDelay ?? 250.Milliseconds();
+        _cancellation = CancellationTokenSource.CreateLinkedTokenSource(parentToken);
+    }
+
+    /// <summary>The linked cancellation token that ends the loop. Use it for the iteration's own awaits.</summary>
+    public CancellationToken Token => _cancellation.Token;
+
+    public int ConsecutiveFailures => _consecutiveFailures;
+
+    public ReceiveLoopStatus ReceiveLoopStatus => _status;
+
+    public DateTimeOffset? LastReceiveLoopActivityAt
+    {
+        get
+        {
+            var ticks = Interlocked.Read(ref _lastActivityTicks);
+            return ticks == 0 ? null : new DateTimeOffset(ticks, TimeSpan.Zero);
+        }
+    }
+
+    /// <summary>Start iterating on a background task. Idempotent — a second call is a no-op.</summary>
+    public void Start()
+    {
+        if (_task != null)
+        {
+            return;
+        }
+
+        _status = ReceiveLoopStatus.Running;
+        _task = Task.Run(runAsync, _cancellation.Token);
+    }
+
+    private async Task runAsync()
+    {
+        try
+        {
+            while (!_cancellation.IsCancellationRequested)
+            {
+                // Heartbeat: bump before each iteration so a hung iteration shows a stale timestamp.
+                Interlocked.Exchange(ref _lastActivityTicks, DateTimeOffset.UtcNow.Ticks);
+
+                try
+                {
+                    var didWork = await _iteration(_cancellation.Token).ConfigureAwait(false);
+                    _consecutiveFailures = 0;
+
+                    if (!didWork)
+                    {
+                        await Task.Delay(_idleDelay, _cancellation.Token).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception e)
+                {
+                    var failures = Interlocked.Increment(ref _consecutiveFailures);
+                    _logger.LogError(e,
+                        "Error in the receive loop for {Uri} (consecutive failures: {Count}); backing off and retrying",
+                        _uri, failures);
+
+                    try
+                    {
+                        await Task.Delay(backoffFor(failures), _cancellation.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            _status = ReceiveLoopStatus.Stopped;
+        }
+        catch (OperationCanceledException)
+        {
+            _status = ReceiveLoopStatus.Stopped;
+        }
+        catch (Exception e)
+        {
+            // The loop scaffolding itself fell over — this is the silent-death case GH-3236 exists to surface.
+            _status = ReceiveLoopStatus.Faulted;
+            _logger.LogError(e, "The receive loop for {Uri} terminated unexpectedly and is no longer consuming", _uri);
+        }
+    }
+
+    // Mirrors the historical SQS backoff curve: a gentle ramp, capped at one second.
+    private static TimeSpan backoffFor(int failures)
+        => failures > 5 ? 1.Seconds() : (failures * 100).Milliseconds();
+
+    /// <summary>
+    /// Cancel the loop and await its completion, up to <paramref name="timeout"/>. Safe to call from background
+    /// threads / shutdown; swallows the expected cancellation.
+    /// </summary>
+    public async Task StopAsync(TimeSpan timeout)
+    {
+        if (!_cancellation.IsCancellationRequested)
+        {
+            await _cancellation.CancelAsync().ConfigureAwait(false);
+        }
+
+        if (_task == null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _task.WaitAsync(timeout).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogDebug("Receive loop for {Uri} did not drain within {Timeout} during shutdown", _uri, timeout);
+        }
+        catch (OperationCanceledException)
+        {
+            // expected
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!_cancellation.IsCancellationRequested)
+        {
+            await _cancellation.CancelAsync().ConfigureAwait(false);
+        }
+
+        if (_task != null)
+        {
+            try
+            {
+                // We own _task (created in Start) — awaiting it here is safe.
+#pragma warning disable VSTHRD003
+                await _task.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+            }
+            catch (OperationCanceledException)
+            {
+                // expected on shutdown
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e, "Error awaiting the receive loop for {Uri} during disposal", _uri);
+            }
+        }
+
+        _cancellation.Dispose();
+    }
+}

--- a/src/Wolverine/Transports/ReceiveLoopHealth.cs
+++ b/src/Wolverine/Transports/ReceiveLoopHealth.cs
@@ -1,0 +1,55 @@
+namespace Wolverine.Transports;
+
+/// <summary>
+/// The health of a listener's background receive/poll loop. Surfaced on
+/// <see cref="Wolverine.Configuration.EndpointHealthSnapshot"/> so external monitors can detect a listener whose
+/// receive loop has faulted or hung while its orchestration <c>ListeningStatus</c> still reports <c>Accepting</c> —
+/// a failure mode that connection state alone (GH-3231) cannot see.
+/// </summary>
+public enum ReceiveLoopStatus
+{
+    /// <summary>
+    /// The listener has no managed receive loop, or does not report loop health. This is the default.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// The receive loop has been created but has not started iterating yet.
+    /// </summary>
+    NotStarted,
+
+    /// <summary>
+    /// The receive loop is running and iterating.
+    /// </summary>
+    Running,
+
+    /// <summary>
+    /// The receive loop has stopped cleanly (e.g. the listener was paused/stopped).
+    /// </summary>
+    Stopped,
+
+    /// <summary>
+    /// The receive loop terminated on an unexpected exception and is no longer consuming. The listener is silently
+    /// dead even though its <c>ListeningStatus</c> may still read <c>Accepting</c>.
+    /// </summary>
+    Faulted
+}
+
+/// <summary>
+/// Optional capability implemented by an <see cref="IListener"/> (or the loop it owns) that runs a long-lived
+/// background receive/poll loop and can report that loop's liveness. Listeners with no such loop simply do not
+/// implement this and report <see cref="ReceiveLoopStatus.Unknown"/>.
+/// </summary>
+public interface IReportReceiveLoopHealth
+{
+    /// <summary>
+    /// The current status of the background receive loop.
+    /// </summary>
+    ReceiveLoopStatus ReceiveLoopStatus { get; }
+
+    /// <summary>
+    /// Approximate timestamp of the last receive-loop iteration (a heartbeat the loop bumps each pass). A value that
+    /// stops advancing while the listener reports <c>Accepting</c> indicates a hung loop. Null when never started.
+    /// </summary>
+    DateTimeOffset? LastReceiveLoopActivityAt { get; }
+}


### PR DESCRIPTION
Refs #3236. **Phase 1**: the foundation + first adopter. Follow-on to #3231 (connection state) and #3232 (force-restart) — this addresses the *second* silent-death mode those can't see: a listener's background receive/poll loop can **fault or hang** while the connection is fine and `ListeningStatus` still reads `Accepting`.

## Core
- **`BackgroundReceiveLoop`** — a shared, managed receive loop for polling-style listeners. It owns the loop `Task` and standardizes what every listener used to hand-roll divergently: cancellation, per-iteration `try/catch → log → exponential backoff → continue`, an idle delay when a poll finds no work, a **heartbeat** timestamp, fault detection, and safe async teardown.
- **`IReportReceiveLoopHealth` + `ReceiveLoopStatus`** (`Unknown`/`NotStarted`/`Running`/`Stopped`/`Faulted`). A loop that **hangs** freezes its heartbeat (`LastReceiveLoopActivityAt` stops advancing); a loop that **dies** reports `Faulted` — both visible to an external monitor.
- **`EndpointHealthSnapshot`** gains `ReceiveLoopStatus` + `LastReceiveLoopActivityAt`; `CollectEndpointHealth` resolves them from the listener, mirroring the #3231 `ConnectionState` seam. Listeners with no managed loop report `Unknown` / `null`.

## First adopter — SQS
`SqsListener` now drives its poll loop through `BackgroundReceiveLoop` and reports loop health. The hand-rolled `while`/`try`/`catch`/`backoff` and the `failedCount` bookkeeping are gone — the listener provides one poll-and-process iteration.

## Tests
- `background_receive_loop_3236` (CoreTests, no broker): heartbeat advances while iterating; **a hung iteration freezes the heartbeat**; exceptions back off + keep running + recover; clean stop → `Stopped`.
- `receive_loop_health_default_3236`: non-loop listeners (TCP) report `Unknown` / `null`.
- SQS validated against LocalStack: `send_and_receive` (5), Inline/Buffered/Prefixed compliance (70), and **Durable compliance (23, with Postgres)** — all green.

## Follow-up (intentionally not in this PR)
Migrating the remaining polling listeners — **Kafka, Redis, Postgresql/SqlServer queues** — onto `BackgroundReceiveLoop` is the next phase. Each has nuances (Kafka commit-on-cancel, Redis status checks, the DB inbox-recovery restarter) that deserve their own focused, separately-validated change rather than being bundled here. Optional future work noted in #3236: auto-trigger `RestartAsync(force:true)` (#3232) on a detected `Faulted`/hung loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)