### PR TITLE
Postgresql queue: adopt shared BackgroundReceiveLoop + receive-loop health (#3236)

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueueListener.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueueListener.cs
@@ -12,7 +12,7 @@ using Wolverine.Transports;
 
 namespace Wolverine.Postgresql.Transport;
 
-internal class PostgresqlQueueListener : IListener
+internal class PostgresqlQueueListener : IListener, IReportReceiveLoopHealth
 {
     private readonly CancellationTokenSource _cancellation = new();
     private readonly PostgresqlQueue _queue;
@@ -20,7 +20,8 @@ internal class PostgresqlQueueListener : IListener
     private readonly NpgsqlDataSource _dataSource;
     private readonly string? _databaseName;
     private readonly ILogger<PostgresqlQueueListener> _logger;
-    private Task? _task;
+    // GH-3236: the main poll loop runs on the shared BackgroundReceiveLoop (heartbeat + fault/hung detection).
+    private BackgroundReceiveLoop? _loop;
     private readonly DurabilitySettings _settings;
     private Task? _scheduledTask;
     private readonly PostgresqlQueueSender _sender;
@@ -62,6 +63,10 @@ SELECT message.{DatabaseConstants.Body} from message;
 
     public IHandlerPipeline? Pipeline => _receiver.Pipeline;
 
+    // GH-3236: surface the poll loop's liveness (heartbeat + faulted/hung detection) for EndpointHealthSnapshot.
+    public ReceiveLoopStatus ReceiveLoopStatus => _loop?.ReceiveLoopStatus ?? ReceiveLoopStatus.NotStarted;
+    public DateTimeOffset? LastReceiveLoopActivityAt => _loop?.LastReceiveLoopActivityAt;
+
     public ValueTask CompleteAsync(Envelope envelope)
     {
         return ValueTask.CompletedTask;
@@ -75,7 +80,10 @@ SELECT message.{DatabaseConstants.Body} from message;
     public async ValueTask DisposeAsync()
     {
         await _cancellation.CancelAsync();
-        _task.SafeDispose();
+        if (_loop != null)
+        {
+            await _loop.DisposeAsync();
+        }
         _scheduledTask.SafeDispose();
     }
 
@@ -85,7 +93,10 @@ SELECT message.{DatabaseConstants.Body} from message;
     {
         await _cancellation.CancelAsync();
 
-        _task?.SafeDispose();
+        if (_loop != null)
+        {
+            await _loop.StopAsync(_settings.DrainTimeout);
+        }
         _scheduledTask?.SafeDispose();
     }
 
@@ -163,57 +174,28 @@ SELECT message.{DatabaseConstants.Body} from message;
         return count;
     }
 
-    private async Task listenForMessagesAsync()
+    // One poll-and-process iteration, driven by BackgroundReceiveLoop (which owns the loop task, the
+    // log -> backoff -> continue policy on error, the idle delay, the heartbeat, and teardown). Returns true when
+    // messages were processed (the busy-path delay below preserves the original pacing), false when idle (the loop
+    // applies its idle delay = _pollingInterval).
+    private async Task<bool> pollOnceAsync(CancellationToken token)
     {
-        var failedCount = 0;
+        var messages = _queue.Mode == EndpointMode.Durable
+            ? await TryPopDurablyAsync(_queue.MaximumMessagesToReceive, _settings, _logger, token)
+            : await TryPopAsync(_queue.MaximumMessagesToReceive, _logger, token);
 
-        while (!_cancellation.Token.IsCancellationRequested)
+        if (!messages.Any())
         {
-            try
-            {
-
-                var messages = _queue.Mode == EndpointMode.Durable
-                    ? await TryPopDurablyAsync(_queue.MaximumMessagesToReceive, _settings, _logger,
-                        _cancellation.Token)
-                    : await TryPopAsync(_queue.MaximumMessagesToReceive, _logger, _cancellation.Token);
-
-                failedCount = 0;
-
-                if (messages.Any())
-                {
-                    await _receiver.ReceivedAsync(this, messages.ToArray());
-
-                    if (messages.Count > _queue.MaximumMessagesToReceive)
-                    {
-                        await Task.Delay(250.Milliseconds());
-                    }
-                    else
-                    {
-                        await Task.Delay(_pollingInterval);
-                    }
-                }
-                else
-                {
-                    // Slow down if this is a periodically used queue
-                    await Task.Delay(_pollingInterval);
-                }
-            }
-            catch (Exception e)
-            {
-                if (e is TaskCanceledException && _cancellation.IsCancellationRequested)
-                {
-                    break;
-                }
-
-                failedCount++;
-                var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();
-
-                _logger.LogError(e, "Error while trying to retrieve messages from PostgreSQL Queue {Name}",
-                    _queueName);
-
-                await Task.Delay(pauseTime);
-            }
+            return false;
         }
+
+        await _receiver.ReceivedAsync(this, messages.ToArray());
+
+        // Preserve the original post-process pacing between polls.
+        await Task.Delay(
+            messages.Count > _queue.MaximumMessagesToReceive ? 250.Milliseconds() : _pollingInterval, token);
+
+        return true;
     }
 
     public async Task<IReadOnlyList<Envelope>> TryPopDurablyAsync(int count, DurabilitySettings settings,
@@ -330,7 +312,8 @@ SELECT message.{DatabaseConstants.Body} from message;
             await _queue.EnsureSchemaExists(_databaseName ?? string.Empty, _dataSource);
         }
         
-        _task = Task.Run(listenForMessagesAsync, _cancellation.Token);
+        _loop = new BackgroundReceiveLoop(Address, _logger, pollOnceAsync, _cancellation.Token, _pollingInterval);
+        _loop.Start();
         _scheduledTask = Task.Run(lookForScheduledMessagesAsync, _cancellation.Token);
     }
 }


### PR DESCRIPTION
Refs #3236 — follow-up to the foundation + SQS (#3242) and Redis (#3243). Third polling transport onto the shared loop.

## Change
The PostgreSQL queue transport's main poll loop now runs on the shared `BackgroundReceiveLoop` instead of a hand-rolled `while`/`try`/`catch`/`failedCount` backoff. The loop owns the task, the `log → backoff → continue` policy, the idle delay, the heartbeat, and safe teardown. `PostgresqlQueueListener` implements **`IReportReceiveLoopHealth`**, so a faulted/hung poll loop is visible on `EndpointHealthSnapshot`.

## Behavior preserved
- Durable (`TryPopDurablyAsync`) vs non-durable (`TryPopAsync`) read.
- The original **between-poll pacing**: the iteration keeps the post-process delay (250ms when over the max batch, else the polling interval) and the loop's idle delay is the polling interval — so both busy and idle paths pace exactly as before.
- The scheduled-message poller is left as-is (separate maintenance loop).

## Tests
All `PostgresqlTests/Transport` tests pass against PostgreSQL (basic functionality, compliance, end-to-end, durable inbox/outbox, external tables) — **95/95 on a clean re-run**; one transient `DatabaseOperationBatch` flake under the full concurrent run did not recur. Clean Release build on both TFMs.

SQS (#3242) and Redis (#3243) shipped; SqlServer queue and Kafka to follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)