### PR TITLE
SqlServer queue: adopt shared BackgroundReceiveLoop + receive-loop health (#3236)

### DIFF
--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueueListener.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueueListener.cs
@@ -11,7 +11,7 @@ using Wolverine.Transports;
 
 namespace Wolverine.SqlServer.Transport;
 
-internal class SqlServerQueueListener : IListener
+internal class SqlServerQueueListener : IListener, IReportReceiveLoopHealth
 {
     private readonly CancellationTokenSource _cancellation = new();
     private readonly SqlServerQueue _queue;
@@ -19,7 +19,8 @@ internal class SqlServerQueueListener : IListener
     private readonly string _connectionString;
     private readonly string? _databaseName;
     private readonly ILogger<SqlServerQueueListener> _logger;
-    private Task? _task;
+    // GH-3236: the main poll loop runs on the shared BackgroundReceiveLoop (heartbeat + fault/hung detection).
+    private BackgroundReceiveLoop? _loop;
     private readonly DurabilitySettings _settings;
     private Task? _scheduledTask;
     private readonly SqlServerQueueSender _sender;
@@ -103,6 +104,10 @@ select count(*) from #temp_move_{queue.Name}
 
     public IHandlerPipeline? Pipeline => _receiver.Pipeline;
 
+    // GH-3236: surface the poll loop's liveness (heartbeat + faulted/hung detection) for EndpointHealthSnapshot.
+    public ReceiveLoopStatus ReceiveLoopStatus => _loop?.ReceiveLoopStatus ?? ReceiveLoopStatus.NotStarted;
+    public DateTimeOffset? LastReceiveLoopActivityAt => _loop?.LastReceiveLoopActivityAt;
+
     public ValueTask CompleteAsync(Envelope envelope)
     {
         return ValueTask.CompletedTask;
@@ -113,9 +118,14 @@ select count(*) from #temp_move_{queue.Name}
         await _sender.SendAsync(envelope, _cancellation.Token);
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        return StopAsync();
+        await _cancellation.CancelAsync();
+        if (_loop != null)
+        {
+            await _loop.DisposeAsync();
+        }
+        _scheduledTask?.SafeDispose();
     }
 
     public Uri Address { get; }
@@ -123,7 +133,10 @@ select count(*) from #temp_move_{queue.Name}
     public async ValueTask StopAsync()
     {
         await _cancellation.CancelAsync();
-        _task?.SafeDispose();
+        if (_loop != null)
+        {
+            await _loop.StopAsync(_settings.DrainTimeout);
+        }
         _scheduledTask?.SafeDispose();
     }
 
@@ -134,7 +147,8 @@ select count(*) from #temp_move_{queue.Name}
             await _queue.EnsureSchemaExists(_databaseName ?? string.Empty, _connectionString);
         }
 
-        _task = Task.Run(listenForMessagesAsync, _cancellation.Token);
+        _loop = new BackgroundReceiveLoop(Address, _logger, pollOnceAsync, _cancellation.Token, _pollingInterval);
+        _loop.Start();
         _scheduledTask = Task.Run(lookForScheduledMessagesAsync, _cancellation.Token);
     }
 
@@ -204,47 +218,23 @@ select count(*) from #temp_move_{queue.Name}
         await conn.CloseAsync();
     }
 
-    private async Task listenForMessagesAsync()
+    // One poll-and-process iteration, driven by BackgroundReceiveLoop (which owns the loop task, the
+    // log -> backoff -> continue policy on error, the idle delay = _pollingInterval, the heartbeat, and teardown).
+    // Returns true when messages were processed (loop continues immediately), false when idle (loop applies its
+    // idle delay) — exactly the previous "process, else wait the polling interval" pacing.
+    private async Task<bool> pollOnceAsync(CancellationToken token)
     {
-        var failedCount = 0;
+        var messages = _queue.Mode == EndpointMode.Durable
+            ? await TryPopDurablyAsync(_queue.MaximumMessagesToReceive, _settings, _logger, token)
+            : await TryPopAsync(_queue.MaximumMessagesToReceive, _logger, token);
 
-        while (!_cancellation.Token.IsCancellationRequested)
+        if (!messages.Any())
         {
-            try
-            {
-                var messages = _queue.Mode == EndpointMode.Durable
-                    ? await TryPopDurablyAsync(_queue.MaximumMessagesToReceive, _settings, _logger,
-                        _cancellation.Token)
-                    : await TryPopAsync(_queue.MaximumMessagesToReceive, _logger, _cancellation.Token);
-
-                failedCount = 0;
-
-                if (messages.Any())
-                {
-                    await _receiver.ReceivedAsync(this, messages.ToArray());
-                }
-                else
-                {
-                    // Slow down if this is a periodically used queue
-                    await Task.Delay(_pollingInterval);
-                }
-            }
-            catch (Exception e)
-            {
-                if (e is TaskCanceledException && _cancellation.IsCancellationRequested)
-                {
-                    break;
-                }
-
-                failedCount++;
-                var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();
-
-                _logger.LogError(e, "Error while trying to retrieve messages from Sql Server Queue {Name}",
-                    _queue.Name);
-
-                await Task.Delay(pauseTime);
-            }
+            return false;
         }
+
+        await _receiver.ReceivedAsync(this, messages.ToArray());
+        return true;
     }
 
     public async Task<IReadOnlyList<Envelope>> TryPopAsync(int count, ILogger logger,


### PR DESCRIPTION
Refs #3236 — follow-up to SQS (#3242), Redis (#3243), Postgresql (#3244). Fourth polling transport onto the shared loop.

## Change
The SQL Server queue transport's main poll loop now runs on the shared `BackgroundReceiveLoop` instead of a hand-rolled `while`/`try`/`catch`/`failedCount` backoff. The loop owns the task, the `log → backoff → continue` policy, the idle delay (= the polling interval), the heartbeat, and safe teardown. `SqlServerQueueListener` implements **`IReportReceiveLoopHealth`**.

This is the cleanest fit of the DB queue transports: the old loop had **no** post-process delay ("process, else wait the polling interval"), which maps exactly to `didWork → no idle delay` / `idle → idle delay`. `DisposeAsync`/`StopAsync` are split so the loop is disposed on dispose and drained on stop. The scheduled-message poller is left as-is.

## Tests
Buffered (**23**) and Durable (**22**) queue-transport compliance suites pass against SQL Server **in isolation**. Clean Release build on both TFMs.

> Note: running all ~80 `SqlServerTests.Transport` tests in one process still trips the **pre-existing** SQL Server under-load connection-drop flake (`SniNetworkStream.ReadAsync` failures) — unrelated to this change; the same tests pass when batched.

SQS/Redis/Postgresql shipped; **Kafka** is the last one, coming as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)