### PR TITLE
Kafka: adopt shared BackgroundReceiveLoop + receive-loop health (#3236)

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -8,16 +8,20 @@ using Wolverine.Util;
 
 namespace Wolverine.Kafka.Internals;
 
-public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
+public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue, IReportReceiveLoopHealth
 {
     private readonly KafkaTopic _endpoint;
     private readonly IConsumer<string, byte[]> _consumer;
     private CancellationTokenSource _cancellation = new();
-    private readonly Task _runner;
+    // GH-3236: the consume loop now runs on the shared BackgroundReceiveLoop (backoff on Consume errors instead of
+    // the previous hot-loop, plus a heartbeat + fault detection). Offset flush + consumer close still happen in
+    // StopAsync/Dispose AFTER the loop has fully exited, so consumer access stays single-threaded (GH-3150).
+    private readonly BackgroundReceiveLoop _loop;
     private readonly IReceiver _receiver;
     private readonly string? _messageTypeName;
     private readonly ILogger _logger;
     private readonly KafkaOffsetCommitter _committer;
+
     public KafkaListener(KafkaTopic topic, ConsumerConfig config,
         IConsumer<string, byte[]> consumer, IReceiver receiver,
         ILogger<KafkaListener> logger)
@@ -26,7 +30,6 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
         _logger = logger;
         Address = topic.Uri;
         _consumer = consumer;
-        var mapper = topic.EnvelopeMapper;
 
         _messageTypeName = topic.MessageType?.ToMessageTypeName();
 
@@ -35,84 +38,79 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
         _committer = new KafkaOffsetCommitter(consumer, config, topic.CommitMode, topic.CommitBatchCount,
             topic.CommitBatchInterval, logger);
 
-        _runner = Task.Run(async () =>
+        _consumer.Subscribe(topic.TopicName);
+        _loop = new BackgroundReceiveLoop(Address, logger, consumeOnceAsync, _cancellation.Token);
+        _loop.Start();
+    }
+
+    // One consume-and-process iteration. _consumer.Consume blocks until a record (or throws). An
+    // OperationCanceledException ends the loop; any other Consume error flows to BackgroundReceiveLoop's
+    // log -> backoff -> continue (previously this hot-looped on every error). A processing error AFTER a
+    // successful consume is a poison pill — advance past its offset and continue, exactly as before.
+    private async Task<bool> consumeOnceAsync(CancellationToken token)
+    {
+        var result = _consumer.Consume(token);
+
+        try
         {
-            _consumer.Subscribe(topic.TopicName);
-            try
+            var message = result.Message;
+
+            // Seed the offset watermark in consume (in-order) order so out-of-order handler completion can never
+            // commit past this still-in-flight offset (GH-3161).
+            _committer.Track(result.Topic, result.Partition.Value, result.Offset.Value);
+
+            // Non-blocking retry-tier topic (GH-3148): wait out the fixed delay relative to when the record was
+            // produced before reprocessing. Records in a tier are time-ordered, so the head record gates the rest.
+            if (_endpoint.RetryTierDelay is { } retryDelay)
             {
-                while (!_cancellation.IsCancellationRequested)
+                var due = message.Timestamp.UtcDateTime + retryDelay;
+                var wait = due - DateTime.UtcNow;
+                if (wait > TimeSpan.Zero)
                 {
-                    ConsumeResult<string, byte[]>? result = null;
-                    try
-                    {
-                        result = _consumer.Consume(_cancellation.Token);
-                        var message = result.Message;
-
-                        // Seed the offset watermark in consume (in-order) order so out-of-order handler
-                        // completion can never commit past this still-in-flight offset (GH-3161).
-                        _committer.Track(result.Topic, result.Partition.Value, result.Offset.Value);
-
-                        // Non-blocking retry-tier topic (GH-3148): wait out the fixed delay relative to
-                        // when the record was produced before reprocessing. Records in a tier are
-                        // time-ordered, so the head record gates the rest.
-                        if (topic.RetryTierDelay is { } retryDelay)
-                        {
-                            var due = message.Timestamp.UtcDateTime + retryDelay;
-                            var wait = due - DateTime.UtcNow;
-                            if (wait > TimeSpan.Zero)
-                            {
-                                await Task.Delay(wait, _cancellation.Token);
-                            }
-                        }
-
-                        var envelope = mapper!.CreateEnvelope(result.Topic, message);
-                        envelope.TopicName = result.Topic;
-                        envelope.Offset = result.Offset.Value;
-                        envelope.PartitionId = result.Partition.Value;
-                        envelope.MessageType ??= _messageTypeName;
-
-                        if (topic.GroupByMessageKey)
-                        {
-                            // GH-3140: shard by-key processing on the Kafka message key.
-                            envelope.GroupId = message.Key;
-                        }
-                        else if (topic.StampConsumerGroupIdOnEnvelope)
-                        {
-                            envelope.GroupId = config.GroupId;
-                        }
-
-                        await receiver.ReceivedAsync(this, envelope);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // we're done here!
-                    }
-                    catch (Exception e)
-                    {
-                        // Might be a poison pill message, advance past its specific offset so we don't
-                        // get stuck re-consuming it (only possible when the consume itself succeeded).
-                        if (result != null)
-                        {
-                            _committer.Complete(result.Topic, result.Partition.Value, result.Offset.Value);
-                        }
-
-                        logger.LogError(e, "Error trying to map Kafka message to a Wolverine envelope");
-                    }
+                    await Task.Delay(wait, token);
                 }
             }
-            catch (OperationCanceledException)
+
+            var envelope = _endpoint.EnvelopeMapper!.CreateEnvelope(result.Topic, message);
+            envelope.TopicName = result.Topic;
+            envelope.Offset = result.Offset.Value;
+            envelope.PartitionId = result.Partition.Value;
+            envelope.MessageType ??= _messageTypeName;
+
+            if (_endpoint.GroupByMessageKey)
             {
-                // Shutting down
+                // GH-3140: shard by-key processing on the Kafka message key.
+                envelope.GroupId = message.Key;
             }
-            // The consumer is intentionally NOT closed here. StopAsync/Dispose flush pending offsets
-            // first and then close the consumer, so a batch-mode commit isn't issued against an
-            // already-closed consumer. See GH-3150.
-        }, _cancellation.Token);
+            else if (_endpoint.StampConsumerGroupIdOnEnvelope)
+            {
+                envelope.GroupId = Config.GroupId;
+            }
+
+            await _receiver.ReceivedAsync(this, envelope);
+        }
+        catch (OperationCanceledException)
+        {
+            // shutting down mid-process — let the loop stop
+            throw;
+        }
+        catch (Exception e)
+        {
+            // Might be a poison pill message; advance past its specific offset so we don't get stuck re-consuming it.
+            _committer.Complete(result.Topic, result.Partition.Value, result.Offset.Value);
+            _logger.LogError(e, "Error trying to map Kafka message to a Wolverine envelope");
+        }
+
+        return true;
     }
 
     public ConsumerConfig Config { get; }
 
     public IHandlerPipeline? Pipeline => _receiver.Pipeline;
+
+    // GH-3236: surface the consume loop's liveness (heartbeat + faulted/hung detection) for EndpointHealthSnapshot.
+    public ReceiveLoopStatus ReceiveLoopStatus => _loop.ReceiveLoopStatus;
+    public DateTimeOffset? LastReceiveLoopActivityAt => _loop.LastReceiveLoopActivityAt;
 
     public ValueTask CompleteAsync(Envelope envelope)
     {
@@ -133,9 +131,9 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
     public async ValueTask DisposeAsync()
     {
         await StopAsync();
+        await _loop.DisposeAsync();
         _cancellation.Dispose();
         _consumer.SafeDispose();
-        _runner.Dispose();
     }
 
     public Uri Address { get; }
@@ -143,12 +141,10 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
     public async ValueTask StopAsync()
     {
         await _cancellation.CancelAsync();
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
-        await _runner;
-#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+        // Await the loop fully (Infinite) so the consume loop has exited and consumer access is single-threaded
+        // before we flush offsets and close (GH-3150) — matching the previous "await _runner" semantics.
+        await _loop.StopAsync(Timeout.InfiniteTimeSpan);
 
-        // The consume loop has exited, so single-threaded access to the consumer is guaranteed: flush
-        // pending/stored offsets first (GH-3150), then close cleanly.
         _committer.Flush();
         try
         {
@@ -203,12 +199,11 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue
     public void Dispose()
     {
         _cancellation.Cancel();
-        _cancellation.Dispose();
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-        _runner.Wait();
+        _loop.StopAsync(Timeout.InfiniteTimeSpan).GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         _committer.Flush();
+        _cancellation.Dispose();
         _consumer.SafeDispose();
-        _runner.Dispose();
     }
 }

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
@@ -8,12 +8,15 @@ using Wolverine.Util;
 
 namespace Wolverine.Kafka.Internals;
 
-public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLetterQueue
+public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLetterQueue, IReportReceiveLoopHealth
 {
     private readonly KafkaTopicGroup _endpoint;
     private readonly IConsumer<string, byte[]> _consumer;
     private CancellationTokenSource _cancellation = new();
-    private readonly Task _runner;
+    // GH-3236: the consume loop now runs on the shared BackgroundReceiveLoop (backoff on Consume errors + heartbeat
+    // + fault detection). Offset flush + consumer close still happen in StopAsync/Dispose after the loop has fully
+    // exited, so consumer access stays single-threaded (GH-3150).
+    private readonly BackgroundReceiveLoop _loop;
     private readonly IReceiver _receiver;
     private readonly ILogger _logger;
     private readonly KafkaOffsetCommitter _committer;
@@ -26,78 +29,72 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
         _logger = logger;
         Address = endpoint.Uri;
         _consumer = consumer;
-        var mapper = endpoint.EnvelopeMapper;
 
         Config = config;
         _receiver = receiver;
         _committer = new KafkaOffsetCommitter(consumer, config, endpoint.CommitMode, endpoint.CommitBatchCount,
             endpoint.CommitBatchInterval, logger);
 
-        _runner = Task.Run(async () =>
+        // Subscribe to all topics at once — single consumer, multiple topics.
+        _consumer.Subscribe(endpoint.TopicNames);
+        _loop = new BackgroundReceiveLoop(Address, logger, consumeOnceAsync, _cancellation.Token);
+        _loop.Start();
+    }
+
+    // One consume-and-process iteration (see KafkaListener for the rationale). _consumer.Consume blocks until a
+    // record; an OperationCanceledException ends the loop, any other Consume error flows to BackgroundReceiveLoop's
+    // log -> backoff -> continue; a processing error after a successful consume is a poison pill (advance + continue).
+    private async Task<bool> consumeOnceAsync(CancellationToken token)
+    {
+        var result = _consumer.Consume(token);
+
+        try
         {
-            // Subscribe to all topics at once — single consumer, multiple topics
-            _consumer.Subscribe(endpoint.TopicNames);
-            try
+            var message = result.Message;
+
+            // Seed the offset watermark in consume (in-order) order so out-of-order handler completion can never
+            // commit past this still-in-flight offset (GH-3161).
+            _committer.Track(result.Topic, result.Partition.Value, result.Offset.Value);
+
+            var envelope = _endpoint.EnvelopeMapper!.CreateEnvelope(result.Topic, message);
+            envelope.TopicName = result.Topic;
+            envelope.Offset = result.Offset.Value;
+            envelope.PartitionId = result.Partition.Value;
+
+            if (_endpoint.GroupByMessageKey)
             {
-                while (!_cancellation.IsCancellationRequested)
-                {
-                    ConsumeResult<string, byte[]>? result = null;
-                    try
-                    {
-                        result = _consumer.Consume(_cancellation.Token);
-                        var message = result.Message;
-
-                        // Seed the offset watermark in consume (in-order) order so out-of-order handler
-                        // completion can never commit past this still-in-flight offset (GH-3161).
-                        _committer.Track(result.Topic, result.Partition.Value, result.Offset.Value);
-
-                        var envelope = mapper!.CreateEnvelope(result.Topic, message);
-                        envelope.TopicName = result.Topic;
-                        envelope.Offset = result.Offset.Value;
-                        envelope.PartitionId = result.Partition.Value;
-
-                        if (endpoint.GroupByMessageKey)
-                        {
-                            // GH-3140: shard by-key processing on the Kafka message key.
-                            envelope.GroupId = message.Key;
-                        }
-                        else if (endpoint.StampConsumerGroupIdOnEnvelope)
-                        {
-                            envelope.GroupId = config.GroupId;
-                        }
-
-                        await receiver.ReceivedAsync(this, envelope);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // we're done here!
-                    }
-                    catch (Exception e)
-                    {
-                        // Might be a poison pill message, advance past its specific offset so we don't
-                        // get stuck re-consuming it (only possible when the consume itself succeeded).
-                        if (result != null)
-                        {
-                            _committer.Complete(result.Topic, result.Partition.Value, result.Offset.Value);
-                        }
-
-                        logger.LogError(e, "Error trying to map Kafka message to a Wolverine envelope");
-                    }
-                }
+                // GH-3140: shard by-key processing on the Kafka message key.
+                envelope.GroupId = message.Key;
             }
-            catch (OperationCanceledException)
+            else if (_endpoint.StampConsumerGroupIdOnEnvelope)
             {
-                // Shutting down
+                envelope.GroupId = Config.GroupId;
             }
-            // The consumer is intentionally NOT closed here. StopAsync/Dispose flush pending offsets
-            // first and then close the consumer, so a batch-mode commit isn't issued against an
-            // already-closed consumer. See GH-3150.
-        }, _cancellation.Token);
+
+            await _receiver.ReceivedAsync(this, envelope);
+        }
+        catch (OperationCanceledException)
+        {
+            // shutting down mid-process — let the loop stop
+            throw;
+        }
+        catch (Exception e)
+        {
+            // Might be a poison pill message; advance past its specific offset so we don't get stuck re-consuming it.
+            _committer.Complete(result.Topic, result.Partition.Value, result.Offset.Value);
+            _logger.LogError(e, "Error trying to map Kafka message to a Wolverine envelope");
+        }
+
+        return true;
     }
 
     public ConsumerConfig Config { get; }
 
     public IHandlerPipeline? Pipeline => _receiver.Pipeline;
+
+    // GH-3236: surface the consume loop's liveness (heartbeat + faulted/hung detection) for EndpointHealthSnapshot.
+    public ReceiveLoopStatus ReceiveLoopStatus => _loop.ReceiveLoopStatus;
+    public DateTimeOffset? LastReceiveLoopActivityAt => _loop.LastReceiveLoopActivityAt;
 
     public ValueTask CompleteAsync(Envelope envelope)
     {
@@ -117,9 +114,9 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
     public async ValueTask DisposeAsync()
     {
         await StopAsync();
+        await _loop.DisposeAsync();
         _cancellation.Dispose();
         _consumer.SafeDispose();
-        _runner.Dispose();
     }
 
     public Uri Address { get; }
@@ -127,12 +124,10 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
     public async ValueTask StopAsync()
     {
         await _cancellation.CancelAsync();
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
-        await _runner;
-#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+        // Await the loop fully (Infinite) so the consume loop has exited and consumer access is single-threaded
+        // before we flush offsets and close (GH-3150).
+        await _loop.StopAsync(Timeout.InfiniteTimeSpan);
 
-        // The consume loop has exited, so single-threaded access to the consumer is guaranteed: flush
-        // pending/stored offsets first (GH-3150), then close cleanly.
         _committer.Flush();
         try
         {
@@ -187,12 +182,11 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
     public void Dispose()
     {
         _cancellation.Cancel();
-        _cancellation.Dispose();
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-        _runner.Wait();
+        _loop.StopAsync(Timeout.InfiniteTimeSpan).GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         _committer.Flush();
+        _cancellation.Dispose();
         _consumer.SafeDispose();
-        _runner.Dispose();
     }
 }


### PR DESCRIPTION
Refs #3236 — the **final** polling transport, after SQS (#3242), Redis (#3243), Postgresql (#3244), SqlServer (#3245).

## Change
Both Kafka consume loops — `KafkaListener` and `KafkaTopicGroupListener` — now run on the shared `BackgroundReceiveLoop` instead of a hand-rolled `Task.Run`/`while`. Both implement **`IReportReceiveLoopHealth`**.

**Why Kafka benefits:** previously a `Consume()` error was caught per-iteration and the loop continued with **no delay** — a hot-spin on a persistent broker error. Now `Consume()` errors flow to the loop's `log → exponential-backoff → continue`, and the loop adds the heartbeat + faulted/hung detection.

## Semantics preserved exactly
- Per-record offset watermark `Track` (#3161) and the poison-pill `Complete`-and-continue on a processing error after a successful consume.
- Retry-tier delay (#3148) on `KafkaListener`.
- **#3150 ordering**: `StopAsync` cancels and awaits the loop **fully** (`Timeout.InfiniteTimeSpan`) *before* flushing offsets and closing the consumer, so consumer access stays single-threaded. The synchronous `Dispose()` does the same via a sync wait.

## Tests
commit-strategy (offset modes), compliance, broadcast, and DLQ-landing tests pass against the Kafka container. One failure — `DeadLetterQueueTests.dead_letter_message_has_exception_headers` — **reproduces on unmodified `main`** (1-min tracking timeout) and is unrelated to this change.

This completes migrating the polling transports onto `BackgroundReceiveLoop` (#3236).

🤖 Generated with [Claude Code](https://claude.com/claude-code)