### PR TITLE
Adopt document-diagnostics stack: JasperFx 2.14.2 + Marten 9.11.0-alpha.1 + Polecat 4.6.0-alpha.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,12 +41,12 @@
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
     <PackageVersion Include="JasperFx.SourceGenerator" Version="2.14.2" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
-    <PackageVersion Include="Marten" Version="9.11.0-alpha.1" />
+    <PackageVersion Include="Marten" Version="9.11.0-alpha.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="4.6.0-alpha.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.11.0-alpha.1" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.11.0-alpha.1" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.11.0-alpha.2" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.11.0-alpha.2" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,20 +33,20 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.13.3" />
-    <PackageVersion Include="JasperFx.Events" Version="2.13.3" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.3" />
+    <PackageVersion Include="JasperFx" Version="2.14.2" />
+    <PackageVersion Include="JasperFx.Events" Version="2.14.2" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.14.2" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.3" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.14.2" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
-    <PackageVersion Include="Marten" Version="9.8.0" />
+    <PackageVersion Include="Marten" Version="9.11.0-alpha.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="4.5.0" />
+    <PackageVersion Include="Polecat" Version="4.6.0-alpha.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.8.0" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.8.0" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.11.0-alpha.1" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.11.0-alpha.1" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />

--- a/src/Persistence/PolecatTests/PolecatTests.csproj
+++ b/src/Persistence/PolecatTests/PolecatTests.csproj
@@ -37,4 +37,17 @@
         </Compile>
     </ItemGroup>
 
+  <!-- JasperFx.Events.SourceGenerator is bundled inside the Polecat nupkg (analyzers/dotnet/cs/)
+       AND referenced explicitly above. When both copies are the identical version they load as two
+       analyzer instances, each emitting every projection's .Evolver dispatcher into this assembly,
+       so the compile fails with CS0433 ("type exists in both PolecatTests and PolecatTests"). The
+       generator dedupes within a single instance but cannot coordinate across two instances. Drop
+       the Polecat-bundled copy and keep the explicit one — the kept copy is the same store-agnostic
+       generator and still emits dispatchers for every projection in the compilation. -->
+  <Target Name="DropDuplicateBundledEventSourceGenerator" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Filename)' == 'JasperFx.Events.SourceGenerator' and $([System.String]::Copy('%(Identity)').Replace('\', '/').Contains('/polecat/'))" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Bumps the JasperFx/Marten/Polecat stack to pick up the document-diagnostics surface (`IDocumentStoreDiagnostics` + enriched `DocumentMappingDescriptor`) and the three projection-codegen fixes that landed in JasperFx 2.14.x:

- **JasperFx** 2.13.3 → **2.14.2** — document diagnostics (jasperfx#469) + #4185 DI-activated projection evolver, #297 multi-identity dispatcher, and derived/custom-named projection evolver inheritance.
- **Marten** 9.8.0 → **9.11.0-alpha.1** (+ Marten.AspNetCore, Marten.Newtonsoft).
- **Polecat** 4.5.0 → **4.6.0-alpha.1**.

Wolverine.Marten / Wolverine.Polecat / Wolverine.Http.Polecat all build clean against the published stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)