### PR TITLE
fix(#3248): DB transport binds a same-engine Ancillary store when Main is a different engine

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
@@ -106,8 +106,22 @@ public class PostgresqlTransport : BrokerTransport<PostgresqlQueue>, ITransportC
         }
         else
         {
-            throw new ArgumentOutOfRangeException(
-                "The PostgreSQL transport can only be used if PostgreSQL is the backing message store");
+            // #3248 — the Main envelope store is a different engine (e.g. a host that persists to SQL
+            // Server but wires a PostgreSQL queue transport). The transport's queue tables only need a
+            // PostgreSQL database, not the Main store, so bind to a same-engine store registered as
+            // Ancillary (see MessageStoreRole.Ancillary / role: passthrough) instead of throwing.
+            var postgresStores = await runtime.Stores.FindAllAsync<PostgresqlMessageStore>();
+            if (postgresStores.Count == 1)
+            {
+                Store = postgresStores[0];
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(
+                    "The PostgreSQL transport requires exactly one PostgreSQL-backed message store (the Main store, " +
+                    "or a single Ancillary store registered with role: MessageStoreRole.Ancillary), but found " +
+                    postgresStores.Count + ".");
+            }
         }
 
         // This is de facto a little environment test

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
@@ -87,8 +87,22 @@ public class SqlServerTransport : BrokerTransport<SqlServerQueue>
         }
         else
         {
-            throw new InvalidOperationException(
-                "The Sql Server Transport can only be used if the message persistence is also Sql Server backed");
+            // #3248 — the Main envelope store is a different engine (e.g. a host that persists to
+            // PostgreSQL but wires a SQL Server queue transport). The transport's queue tables only need
+            // a SQL Server database, not the Main store, so bind to a same-engine store registered as
+            // Ancillary (see MessageStoreRole.Ancillary / role: passthrough) instead of throwing.
+            var sqlServerStores = await runtime.Stores.FindAllAsync<SqlServerMessageStore>();
+            if (sqlServerStores.Count == 1)
+            {
+                Storage = sqlServerStores[0];
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    "The Sql Server Transport requires exactly one Sql Server-backed message store (the Main store, " +
+                    "or a single Ancillary store registered with role: MessageStoreRole.Ancillary), but found " +
+                    sqlServerStores.Count + ".");
+            }
         }
 
         Settings = Storage.Settings;


### PR DESCRIPTION
Closes #3248.

The SQL Server and PostgreSQL queue transports resolved the store for their queue tables from `runtime.Storage` (the Main store) only, throwing when Main was a different engine. This blocked **cross-engine** setups — e.g. a PostgreSQL Main + a SQL Server queue transport — even when a same-engine store existed as an `Ancillary` (which the `role:` passthrough now registers).

`ConnectAsync` now falls back to a same-engine store among all stores (`runtime.Stores.FindAllAsync<TStore>()`, already used elsewhere in the Postgres transport) when Main isn't the transport's engine, binding to the single same-engine Ancillary store. Same-engine behavior is unchanged; a genuine misconfiguration (no same-engine store) still throws.

Enables CritterWatch (JasperFx/CritterWatch#531) cross-engine DB-queue control channels; CritterWatch will verify via a local pack (flipping its skipped `db_queue_control_channel_cross_engine` repro to passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)