### PR TITLE
fix(#3248): PostgresqlTransport.ConfigureAsync binds same-engine Ancillary store

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
@@ -68,10 +68,21 @@ public class PostgresqlTransport : BrokerTransport<PostgresqlQueue>, ITransportC
             }
         }
 
+        // #3248 — the Main envelope store is a different engine (e.g. a host that persists to SQL Server
+        // but wires a PostgreSQL queue transport). Bind to the same-engine store registered as Ancillary
+        // (found in `stores` above) instead of throwing — the transport's queue tables only need a
+        // PostgreSQL database, not the Main store. Same fallback as ConnectAsync.
+        if (Store == null && stores.Count == 1)
+        {
+            Store = stores[0];
+        }
+
         if (Store == null)
         {
             throw new InvalidOperationException(
-                $"The PostgreSQL transport is configured for usage, but the envelope storage is incompatible: {runtime.Storage}");
+                "The PostgreSQL transport requires exactly one PostgreSQL-backed message store (the Main store, " +
+                "or a single Ancillary store registered with role: MessageStoreRole.Ancillary), but the envelope " +
+                $"storage is incompatible: {runtime.Storage}");
         }
     }
 


### PR DESCRIPTION
Follow-up to #3249. `ConfigureAsync` has a second store-resolution that only inspected `runtime.Storage` (Main) and threw 'envelope storage is incompatible' when Main was a different engine — so cross-engine still failed there after the ConnectAsync fix. It already fetches all same-engine stores; fall back to the single Ancillary one, matching ConnectAsync.

Caught while verifying CritterWatch #531 cross-engine against a local pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)