### PR TITLE
fix(#3248): bind to the first same-engine store when several exist

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
@@ -69,10 +69,12 @@ public class PostgresqlTransport : BrokerTransport<PostgresqlQueue>, ITransportC
         }
 
         // #3248 — the Main envelope store is a different engine (e.g. a host that persists to SQL Server
-        // but wires a PostgreSQL queue transport). Bind to the same-engine store registered as Ancillary
-        // (found in `stores` above) instead of throwing — the transport's queue tables only need a
-        // PostgreSQL database, not the Main store. Same fallback as ConnectAsync.
-        if (Store == null && stores.Count == 1)
+        // but wires a PostgreSQL queue transport). Bind to a same-engine store registered as Ancillary
+        // instead of throwing — the transport's queue tables only need a PostgreSQL database, not the Main
+        // store, and the loop above already provisioned them in every same-engine store. A host can carry
+        // several same-engine stores (e.g. a primary + ancillary document store on the same server); they
+        // are co-located in practice, so the first is a safe binding. Same fallback as ConnectAsync.
+        if (Store == null && stores.Count > 0)
         {
             Store = stores[0];
         }
@@ -80,8 +82,8 @@ public class PostgresqlTransport : BrokerTransport<PostgresqlQueue>, ITransportC
         if (Store == null)
         {
             throw new InvalidOperationException(
-                "The PostgreSQL transport requires exactly one PostgreSQL-backed message store (the Main store, " +
-                "or a single Ancillary store registered with role: MessageStoreRole.Ancillary), but the envelope " +
+                "The PostgreSQL transport requires at least one PostgreSQL-backed message store (the Main store, " +
+                "or an Ancillary store registered with role: MessageStoreRole.Ancillary), but the envelope " +
                 $"storage is incompatible: {runtime.Storage}");
         }
     }
@@ -122,16 +124,15 @@ public class PostgresqlTransport : BrokerTransport<PostgresqlQueue>, ITransportC
             // PostgreSQL database, not the Main store, so bind to a same-engine store registered as
             // Ancillary (see MessageStoreRole.Ancillary / role: passthrough) instead of throwing.
             var postgresStores = await runtime.Stores.FindAllAsync<PostgresqlMessageStore>();
-            if (postgresStores.Count == 1)
+            if (postgresStores.Count > 0)
             {
                 Store = postgresStores[0];
             }
             else
             {
                 throw new ArgumentOutOfRangeException(
-                    "The PostgreSQL transport requires exactly one PostgreSQL-backed message store (the Main store, " +
-                    "or a single Ancillary store registered with role: MessageStoreRole.Ancillary), but found " +
-                    postgresStores.Count + ".");
+                    "The PostgreSQL transport requires at least one PostgreSQL-backed message store (the Main " +
+                    "store, or an Ancillary store registered with role: MessageStoreRole.Ancillary), but found none.");
             }
         }
 

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
@@ -92,16 +92,17 @@ public class SqlServerTransport : BrokerTransport<SqlServerQueue>
             // a SQL Server database, not the Main store, so bind to a same-engine store registered as
             // Ancillary (see MessageStoreRole.Ancillary / role: passthrough) instead of throwing.
             var sqlServerStores = await runtime.Stores.FindAllAsync<SqlServerMessageStore>();
-            if (sqlServerStores.Count == 1)
+            if (sqlServerStores.Count > 0)
             {
+                // A host can carry several same-engine stores (e.g. a primary + ancillary store on the
+                // same server); they are co-located in practice, so the first is a safe binding.
                 Storage = sqlServerStores[0];
             }
             else
             {
                 throw new InvalidOperationException(
-                    "The Sql Server Transport requires exactly one Sql Server-backed message store (the Main store, " +
-                    "or a single Ancillary store registered with role: MessageStoreRole.Ancillary), but found " +
-                    sqlServerStores.Count + ".");
+                    "The Sql Server Transport requires at least one Sql Server-backed message store (the Main " +
+                    "store, or an Ancillary store registered with role: MessageStoreRole.Ancillary), but found none.");
             }
         }
 


### PR DESCRIPTION
Follow-up to #3250. The Ancillary-store fallback required exactly one same-engine store, but a host can carry several (CritterWatch integrates a primary durability store plus an ancillary document store on the same PostgreSQL server). The transport already provisions its queue tables into every same-engine store, so bind to the first rather than throwing. Verifying CritterWatch #531 cross-engine against a local pack.