### PR TITLE
Add PublishAllAsync for publishing message sequences

### DIFF
--- a/src/Persistence/EfCoreTests/DomainEvents/configuration_of_domain_events_scrapers.cs
+++ b/src/Persistence/EfCoreTests/DomainEvents/configuration_of_domain_events_scrapers.cs
@@ -103,6 +103,26 @@ public class configuration_of_domain_events_scrapers : IAsyncDisposable
 
         tracked.MessageSucceeded.SingleMessage<Event1>().Color.ShouldBe("orange");
     }
+
+    [Fact]
+    public async Task publish_all_domain_events_using_dbcontextoutbox()
+    {
+        await startHostAsync(_ => { });
+
+        await using var scope = theHost.Services.CreateAsyncScope();
+        var outbox = scope.ServiceProvider.GetRequiredService<IDbContextOutbox<CleanDbContext>>();
+        IDomainEvent[] events = [new Event1("red"), new Event2("green"), new Event3("blue")];
+
+        var tracked = await theHost.ExecuteAndWaitAsync(async _ =>
+        {
+            await outbox.PublishAllAsync(events);
+            await outbox.SaveChangesAndFlushMessagesAsync();
+        });
+
+        tracked.MessageSucceeded.SingleMessage<Event1>().Color.ShouldBe("red");
+        tracked.MessageSucceeded.SingleMessage<Event2>().Color.ShouldBe("green");
+        tracked.MessageSucceeded.SingleMessage<Event3>().Color.ShouldBe("blue");
+    }
     
         
     [Fact]

--- a/src/Testing/CoreTests/TestMessageContextTests.cs
+++ b/src/Testing/CoreTests/TestMessageContextTests.cs
@@ -74,6 +74,56 @@ public class TestMessageContextTests
     }
 
     [Fact]
+    public async Task publish_all_typed_messages_in_order()
+    {
+        var messages = new List<Message1> { new(), new(), new() };
+
+        await theContext.PublishAllAsync(messages);
+
+        theSpy.Published.Select(x => x.ShouldBeOfType<Envelope>().Message).ShouldBe(messages);
+    }
+
+    [Fact]
+    public async Task publish_all_heterogeneous_messages_in_order()
+    {
+        object[] messages = [new Message1(), new Message2(), new Message3()];
+
+        await theContext.PublishAllAsync(messages);
+
+        theSpy.Published.Select(x => x.ShouldBeOfType<Envelope>().Message).ShouldBe(messages);
+    }
+
+    [Fact]
+    public async Task publish_all_with_no_messages_is_a_no_op()
+    {
+        await theContext.PublishAllAsync(Array.Empty<Message1>());
+
+        theSpy.Published.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task publish_all_rejects_a_null_sequence()
+    {
+        IEnumerable<Message1> messages = null!;
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await theContext.PublishAllAsync(messages));
+
+        theSpy.Published.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task publish_all_stops_and_propagates_an_enumeration_failure()
+    {
+        var first = new Message1();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await theContext.PublishAllAsync(messagesThatFailAfter(first)));
+
+        theSpy.Published.Single().ShouldBeOfType<Envelope>().Message.ShouldBeSameAs(first);
+    }
+
+    [Fact]
     public async Task send_to_endpoint()
     {
         var message1 = new Message1();
@@ -531,6 +581,12 @@ public class TestMessageContextTests
             .InvokeAsync<NumberResponse>(new NumberRequest(5, 6));
 
         #endregion
+    }
+
+    private static IEnumerable<Message1> messagesThatFailAfter(Message1 first)
+    {
+        yield return first;
+        throw new InvalidOperationException("Expected test failure");
     }
 }
 

--- a/src/Wolverine/IMessageBus.cs
+++ b/src/Wolverine/IMessageBus.cs
@@ -3,6 +3,23 @@ namespace Wolverine;
 public static class MessageBusExtensions
 {
     /// <summary>
+    ///     Publish a sequence of messages to all known subscribers in the order in which
+    ///     the messages are enumerated. Messages without known subscribers are ignored.
+    /// </summary>
+    /// <param name="bus"></param>
+    /// <param name="messages"></param>
+    /// <typeparam name="T"></typeparam>
+    public static async ValueTask PublishAllAsync<T>(this IMessageBus bus, IEnumerable<T> messages)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+
+        foreach (var message in messages)
+        {
+            await bus.PublishAsync(message).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
     ///     Schedule the publishing or execution of a message until a later time
     /// </summary>
     /// <param name="message"></param>


### PR DESCRIPTION
## Adds `PublishAllAsync<T>(IEnumerable<T>)` for publishing a sequence of messages through `IMessageBus`.

Applications often collect several domain events that need to be published through an outbox. Currently, every caller has to write the same loop:

```csharp
foreach (var domainEvent in events)
{
    await outbox.PublishAsync(domainEvent);
}
```

With this change, the sequence can be published directly:

```csharp
await outbox.PublishAllAsync(events);
```

## Examples

### EF Core outbox

Before:

```csharp
IReadOnlyList<OrderEvent> events = order.DequeueEvents();

foreach (var domainEvent in events)
{
    await outbox.PublishAsync(domainEvent);
}

await outbox.SaveChangesAndFlushMessagesAsync();
```

After:

```csharp
IReadOnlyList<OrderEvent> events = order.DequeueEvents();

await outbox.PublishAllAsync(events);
await outbox.SaveChangesAndFlushMessagesAsync();
```

### Regular message bus

```csharp
var notifications = new[]
{
    new OrderCreated(orderId),
    new CustomerNotified(customerId)
};

await bus.PublishAllAsync(notifications);
```

## Why `PublishAllAsync`?

Adding an overload such as:

```csharp
PublishAsync<T>(IEnumerable<T> messages)
```

would be ambiguous with the existing:

```csharp
PublishAsync<T>(T message)
```

A collection can itself be a valid Wolverine message. Depending on its static type, the compiler could select the existing overload and publish the entire collection as one message.