### PR TITLE
fix(#3252): PersistAgentRestrictionsAsync no-ops on empty restriction list

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/PostgresqlNodePersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlNodePersistence.cs
@@ -113,6 +113,11 @@ internal class PostgresqlNodePersistence : DatabaseConstants, INodeAgentPersiste
     public async Task PersistAgentRestrictionsAsync(IReadOnlyList<AgentRestriction> restrictions,
         CancellationToken cancellationToken)
     {
+        // No changes to persist. Compiling/executing an empty BatchBuilder yields a single command with
+        // an empty CommandText, which throws "CommandText property has not been initialized" — so no-op
+        // instead. The empty case happens on an idempotent restriction apply (no delta). See wolverine#3252.
+        if (restrictions.Count == 0) return;
+
         var builder = new BatchBuilder();
         foreach (var restriction in restrictions)
         {

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerNodePersistence.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerNodePersistence.cs
@@ -126,6 +126,11 @@ internal class SqlServerNodePersistence : DatabaseConstants, INodeAgentPersisten
     public async Task PersistAgentRestrictionsAsync(IReadOnlyList<AgentRestriction> restrictions,
         CancellationToken cancellationToken)
     {
+        // No changes to persist. Compiling/executing an empty BatchBuilder yields a single command with
+        // an empty CommandText, which throws "CommandText property has not been initialized" — so no-op
+        // instead. The empty case happens on an idempotent restriction apply (no delta). See wolverine#3252.
+        if (restrictions.Count == 0) return;
+
         var builder = new BatchBuilder();
         foreach (var restriction in restrictions)
         {


### PR DESCRIPTION
Fixes #3252.

`PostgresqlNodePersistence.PersistAgentRestrictionsAsync` (and its `SqlServerNodePersistence` twin) throws `System.InvalidOperationException: CommandText property has not been initialized` when called with an **empty** restriction list.

### Why it happens

`WolverineRuntime.ApplyRestrictionsAsync` persists `assignments.FindChanges()` — the *delta*. An idempotent restriction apply (e.g. re-pausing an already-paused agent, common when durability/restriction state is shared across runs) yields an empty delta. With an empty list the build loop never runs, and `Weasel.Postgresql.BatchBuilder.Compile()` falls into its `BatchCommands.Count == 0` branch, emitting a single command whose `CommandText` is the empty `_builder` — so `ExecuteNonQueryAsync` throws.

### Impact

Surfaces as a "silent no-op" for operator actions built on agent restrictions: the handler throws and the message dead-letters, so e.g. a projection pause never takes effect. Unless the caller tracks the handler's host (`TrackActivity().AlsoTrack(...).IncludeExternalTransports()`), the exception is invisible. This was the root cause behind a downstream CritterWatch "projection pause no-ops in the fleet" investigation.

### Fix

Guard the empty case in both `PersistAgentRestrictionsAsync` implementations — persisting zero changes is a no-op:

```csharp
if (restrictions.Count == 0) return;
```

Verified against a CritterWatch in-process integration test that pauses a real projection agent: before, the pause dead-letters with the `CommandText` exception; after, it applies cleanly.
