### PR TITLE
NServiceBus SQL Server interop: multi-tenancy + inline docs samples

### DIFF
--- a/docs/guide/durability/postgresql.md
+++ b/docs/guide/durability/postgresql.md
@@ -279,7 +279,7 @@ builder.UseWolverine(opts =>
     opts.ListenToNServiceBusPostgresqlQueue("wolverine").UseForReplies();
 
     // Let NServiceBus send interface-typed messages that Wolverine binds to concrete types
-    opts.Policies.RegisterInteropMessageAssembly(typeof(IMyMessageContract).Assembly);
+    opts.Policies.RegisterInteropMessageAssembly(typeof(IOrderContract).Assembly);
 });
 ```
 
@@ -290,8 +290,15 @@ receive uses `FOR UPDATE SKIP LOCKED` ordered by the NServiceBus `seq` column. A
 * NServiceBus addresses queues as the schema-qualified `"schema"."table"`; Wolverine maps the reply address back to the
   bare queue name so request/reply works in both directions.
 
-See the [interop tutorial](/tutorials/interop) for the bigger picture and the
-[wolverine-interop](https://github.com/JasperFx/wolverine-interop) repository for a runnable, bidirectional sample.
+Tenant propagation works exactly as it does for SQL Server: NServiceBus carries the tenant id in a message
+header, and Wolverine maps it to and from `Envelope.TenantId` when you add `MapTenantIdToHeader` /
+`MapTenantIdFromHeader` to the endpoints. See the
+[SQL Server multi-tenancy section](/guide/durability/sqlserver.html#multi-tenancy) for the full explanation and sample.
+
+The [SQL Server NServiceBus interoperability guide](/guide/durability/sqlserver.html#nservicebus-interoperability)
+shows the complete bidirectional setup inline — the shared message contracts, the NServiceBus host configuration, and
+a handler — all of which applies here apart from swapping the `*SqlServer*` configuration calls for the `*Postgresql*`
+ones shown above. See the [interop tutorial](/tutorials/interop) for the bigger picture.
 
 ## MassTransit Interoperability <Badge type="tip" text="6.0" />
 
@@ -322,7 +329,7 @@ builder.UseWolverine(opts =>
     // Listen to the queue MassTransit sends to, and use it for replies
     opts.ListenToMassTransitPostgresqlQueue("wolverine").UseForReplies();
 
-    opts.Policies.RegisterInteropMessageAssembly(typeof(IMyMessageContract).Assembly);
+    opts.Policies.RegisterInteropMessageAssembly(typeof(IOrderContract).Assembly);
 });
 ```
 

--- a/docs/guide/durability/sqlserver.md
+++ b/docs/guide/durability/sqlserver.md
@@ -204,7 +204,32 @@ The transport reuses Wolverine's own SQL Server message store for the durable in
 belong to NServiceBus. Because NServiceBus normally owns and provisions its own tables, `AutoProvision` is **off by
 default** for these endpoints.
 
+Start with the message contracts shared by both applications. In a real system these usually live in a
+small contracts assembly referenced by both the Wolverine and NServiceBus hosts:
+
 ```cs
+// Shared between the Wolverine and NServiceBus applications.
+public interface IOrderContract
+{
+    Guid Id { get; set; }
+}
+
+public class OrderPlaced : IOrderContract
+{
+    public Guid Id { get; set; }
+}
+
+public class OrderConfirmed
+{
+    public Guid Id { get; set; }
+}
+```
+
+Configure the Wolverine application to read and write the NServiceBus queue tables:
+
+```cs
+using Wolverine;
+using Wolverine.SqlServer;
 using Wolverine.SqlServer.Transport.NServiceBus;
 
 builder.UseWolverine(opts =>
@@ -224,8 +249,40 @@ builder.UseWolverine(opts =>
     opts.ListenToNServiceBusSqlServerQueue("wolverine").UseForReplies();
 
     // Let NServiceBus send interface-typed messages that Wolverine binds to concrete types
-    opts.Policies.RegisterInteropMessageAssembly(typeof(IMyMessageContract).Assembly);
+    opts.Policies.RegisterInteropMessageAssembly(typeof(IOrderContract).Assembly);
 });
+```
+
+The NServiceBus application is configured normally with its own SQL Server transport pointed at the same
+database. NServiceBus owns and provisions the queue tables; Wolverine just reads and writes them:
+
+```cs
+using NServiceBus;
+
+var endpointConfiguration = new EndpointConfiguration("nsb");
+endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();
+
+var transport = new SqlServerTransport(connectionString)
+{
+    TransportTransactionMode = TransportTransactionMode.SendsAtomicWithReceive
+};
+endpointConfiguration.UseTransport(transport);
+
+// NServiceBus creates its queue tables on startup
+endpointConfiguration.EnableInstallers();
+```
+
+An NServiceBus handler receives the Wolverine-produced message like any other NServiceBus message and can
+reply straight back to Wolverine's listening table:
+
+```cs
+public class OrderPlacedHandler : IHandleMessages<OrderPlaced>
+{
+    public Task Handle(OrderPlaced message, IMessageHandlerContext context)
+    {
+        return context.Reply(new OrderConfirmed { Id = message.Id });
+    }
+}
 ```
 
 Wolverine translates between its `Envelope` and the NServiceBus wire format with the standard NServiceBus headers
@@ -239,9 +296,43 @@ The `Body` written by NServiceBus' JSON serializer begins with a UTF-8 byte orde
 receive so the payload deserializes cleanly with either the default `System.Text.Json` or a Newtonsoft serializer.
 :::
 
-A full, runnable bidirectional example (both frameworks hosted side by side) lives in the
-[wolverine-interop](https://github.com/JasperFx/wolverine-interop) repository. See the
-[interop tutorial](/tutorials/interop) for the bigger picture.
+### Multi-Tenancy
+
+NServiceBus implements multi-tenancy as a *persistence* concern rather than a transport one: the SQL Server
+transport queue tables live in a single shared database, and the tenant identity travels as a user-defined
+**message header** (the Particular [SQL persistence multi-tenancy sample](https://docs.particular.net/persistence/sql/multi-tenant)
+uses `tenant_id`). A receiving NServiceBus endpoint reads that header in its `MultiTenantConnectionBuilder`
+to open the correct tenant database.
+
+Wolverine maps that header to and from its own `Envelope.TenantId` so the two systems stay tenant-aware across
+the boundary. Opt in per endpoint with `MapTenantIdToHeader` on the sending side and `MapTenantIdFromHeader`
+on the listening side, passing the header name your NServiceBus endpoint is configured with (defaults to
+`tenant_id`):
+
+```cs
+builder.UseWolverine(opts =>
+{
+    opts.PersistMessagesWithSqlServer(connectionString, "wolverine");
+    opts.UseNServiceBusSqlServerInterop();
+
+    // Stamp Wolverine's Envelope.TenantId onto the NServiceBus "tenant_id" header
+    opts.PublishMessage<OrderPlaced>().ToNServiceBusSqlServerQueue("nsb")
+        .MapTenantIdToHeader();
+
+    // Surface the NServiceBus "tenant_id" header back as Envelope.TenantId
+    opts.ListenToNServiceBusSqlServerQueue("wolverine")
+        .MapTenantIdFromHeader()
+        .UseForReplies();
+});
+```
+
+Now when Wolverine sends with a tenant id (for example `bus.PublishAsync(message, new DeliveryOptions { TenantId = "tenant-green" })`),
+the NServiceBus endpoint receives the `tenant_id` header and resolves the matching tenant database; and any
+message NServiceBus sends with that header arrives at Wolverine with `Envelope.TenantId` already populated.
+The default (non-)tenant is never written as a header, so single-tenant traffic is unaffected.
+
+A full, runnable bidirectional example (both frameworks hosted side by side, including the multi-tenant case)
+is maintained in Wolverine's interop test suite. See the [interop tutorial](/tutorials/interop) for the bigger picture.
 
 ## Lightweight Saga Usage <Badge type="tip" text="3.0" />
 

--- a/docs/tutorials/interop.md
+++ b/docs/tutorials/interop.md
@@ -472,7 +472,7 @@ builder.UseWolverine(opts =>
     opts.ListenToNServiceBusSqlServerQueue("wolverine").UseForReplies();
 
     // Bind NServiceBus interface-typed messages to Wolverine's concrete types
-    opts.Policies.RegisterInteropMessageAssembly(typeof(IMyMessageContract).Assembly);
+    opts.Policies.RegisterInteropMessageAssembly(typeof(IOrderContract).Assembly);
 });
 ```
 
@@ -488,8 +488,7 @@ A few things to note about NServiceBus database interop:
 
 See the [SQL Server](/guide/durability/sqlserver.html#nservicebus-interoperability) and
 [PostgreSQL](/guide/durability/postgresql.html#nservicebus-interoperability) transport guides for the full set of
-options, and the [wolverine-interop](https://github.com/JasperFx/wolverine-interop) repository for runnable,
-bidirectional samples with both frameworks hosted side by side.
+options, including complete inline samples of both frameworks hosted side by side and the multi-tenant case.
 
 ## Interop with MassTransit over Database Transports
 
@@ -513,7 +512,7 @@ builder.UseWolverine(opts =>
 
     opts.ListenToMassTransitPostgresqlQueue("wolverine").UseForReplies();
 
-    opts.Policies.RegisterInteropMessageAssembly(typeof(IMyMessageContract).Assembly);
+    opts.Policies.RegisterInteropMessageAssembly(typeof(IOrderContract).Assembly);
 });
 ```
 
@@ -528,5 +527,5 @@ A few things to note:
   ack (`delete_message`) on success or nack (`unlock_message`) on failure.
 
 See the [PostgreSQL transport guide](/guide/durability/postgresql.html#masstransit-interoperability) for the full set of
-options, and the [wolverine-interop](https://github.com/JasperFx/wolverine-interop) repository for a runnable,
-bidirectional sample.
+options. The Wolverine-side configuration shown above is the complete setup; MassTransit owns and migrates its own
+`transport` schema.

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerConfiguration.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerConfiguration.cs
@@ -39,6 +39,20 @@ public class NServiceBusSqlServerListenerConfiguration
     }
 
     /// <summary>
+    ///     Map an NServiceBus tenant header on incoming messages to Wolverine's
+    ///     <c>Envelope.TenantId</c> (and stamp it on replies). NServiceBus multi-tenancy carries
+    ///     the tenant id in a user-defined header that the receiving endpoint's
+    ///     <c>MultiTenantConnectionBuilder</c> resolves to a tenant database; the Particular
+    ///     SQL-persistence sample uses <c>tenant_id</c>. Pass the header name your NServiceBus
+    ///     endpoint is configured with.
+    /// </summary>
+    public NServiceBusSqlServerListenerConfiguration MapTenantIdFromHeader(string headerName = "tenant_id")
+    {
+        add(e => e.TenantHeader = headerName);
+        return this;
+    }
+
+    /// <summary>
     ///     Add circuit breaker exception handling to this listener.
     /// </summary>
     public NServiceBusSqlServerListenerConfiguration CircuitBreaker(Action<CircuitBreakerOptions>? configure = null)
@@ -66,6 +80,19 @@ public class NServiceBusSqlServerSubscriberConfiguration
     public NServiceBusSqlServerSubscriberConfiguration ReplyQueueName(string queueName)
     {
         add(e => e.InteropReplyQueueName = queueName);
+        return this;
+    }
+
+    /// <summary>
+    ///     Stamp Wolverine's <c>Envelope.TenantId</c> onto an NServiceBus tenant header for
+    ///     messages published to this NServiceBus endpoint, so a multi-tenant NServiceBus endpoint
+    ///     resolves the correct tenant database via its <c>MultiTenantConnectionBuilder</c>. The
+    ///     Particular SQL-persistence sample uses <c>tenant_id</c>; pass the header name your
+    ///     NServiceBus endpoint expects.
+    /// </summary>
+    public NServiceBusSqlServerSubscriberConfiguration MapTenantIdToHeader(string headerName = "tenant_id")
+    {
+        add(e => e.TenantHeader = headerName);
         return this;
     }
 }

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerEnvelopeMapper.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerEnvelopeMapper.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using JasperFx;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Wolverine.Util;
@@ -42,11 +43,13 @@ internal class NServiceBusSqlServerEnvelopeMapper
 
     private readonly Endpoint _endpoint;
     private readonly Func<string?> _replyAddress;
+    private readonly string? _tenantHeader;
 
-    public NServiceBusSqlServerEnvelopeMapper(Endpoint endpoint, Func<string?> replyAddress)
+    public NServiceBusSqlServerEnvelopeMapper(Endpoint endpoint, Func<string?> replyAddress, string? tenantHeader = null)
     {
         _endpoint = endpoint;
         _replyAddress = replyAddress;
+        _tenantHeader = tenantHeader;
     }
 
     /// <summary>
@@ -94,6 +97,15 @@ internal class NServiceBusSqlServerEnvelopeMapper
         else if (envelope.MessageType.IsNotEmpty())
         {
             headers[EnclosedMessageTypesHeader] = envelope.MessageType!;
+        }
+
+        // NServiceBus multi-tenancy: carry Wolverine's tenant id in the NServiceBus tenant header
+        // so the receiving endpoint's SQL persistence resolves the right tenant database. Skip the
+        // default (non-)tenant so single-tenant traffic stays byte-for-byte unchanged.
+        if (_tenantHeader.IsNotEmpty() && envelope.TenantId.IsNotEmpty() &&
+            envelope.TenantId != StorageConstants.DefaultTenantId)
+        {
+            headers[_tenantHeader!] = envelope.TenantId!;
         }
 
         var json = JsonSerializer.Serialize(headers, NServiceBusSqlJsonContext.Default.DictionaryStringString);
@@ -145,6 +157,14 @@ internal class NServiceBusSqlServerEnvelopeMapper
         if (headers.TryGetValue(EnclosedMessageTypesHeader, out var enclosed) && enclosed.IsNotEmpty())
         {
             envelope.MessageType = resolveMessageType(enclosed);
+        }
+
+        // NServiceBus multi-tenancy: surface the tenant id NServiceBus stamped on the message as
+        // Wolverine's Envelope.TenantId so the rest of the Wolverine pipeline is tenant-aware.
+        if (_tenantHeader.IsNotEmpty() && headers.TryGetValue(_tenantHeader!, out var tenantId) &&
+            tenantId.IsNotEmpty())
+        {
+            envelope.TenantId = tenantId;
         }
 
         envelope.Serializer = _endpoint.TryFindSerializer(envelope.ContentType) ?? _endpoint.DefaultSerializer;

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueue.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerQueue.cs
@@ -52,6 +52,15 @@ public class NServiceBusSqlServerQueue : Endpoint, IBrokerQueue
     public string? InteropReplyQueueName { get; set; }
 
     /// <summary>
+    /// When set, Wolverine maps its <see cref="Envelope.TenantId"/> to and from this NServiceBus
+    /// message header on this queue. NServiceBus multi-tenancy is a persistence concern: the tenant
+    /// id rides as a user-defined header (the Particular SQL-persistence sample uses
+    /// <c>tenant_id</c>) and the receiving endpoint's <c>MultiTenantConnectionBuilder</c> uses it to
+    /// open the tenant's database. Null (the default) disables tenant mapping.
+    /// </summary>
+    public string? TenantHeader { get; set; }
+
+    /// <summary>
     ///     The maximum number of messages to receive in a single poll. Default is 20.
     /// </summary>
     public int MaximumMessagesToReceive { get; set; } = 20;
@@ -87,7 +96,7 @@ public class NServiceBusSqlServerQueue : Endpoint, IBrokerQueue
             return Parent.ReplyEndpoint()?.EndpointName;
         });
 
-        _mapper = new NServiceBusSqlServerEnvelopeMapper(this, () => replyName.Value);
+        _mapper = new NServiceBusSqlServerEnvelopeMapper(this, () => replyName.Value, TenantHeader);
         return _mapper;
     }
 


### PR DESCRIPTION
Follow-up to #3198 (NServiceBus ⇄ Wolverine over the SQL Server queue transport).

## Multi-tenancy

NServiceBus implements multi-tenancy as a **persistence** concern, not a transport one: the SQL Server transport queue tables live in a single shared database, and the tenant id rides as a user-defined message header (the Particular [SQL persistence multi-tenancy sample](https://docs.particular.net/persistence/sql/multi-tenant) uses `tenant_id`). The receiving endpoint's `MultiTenantConnectionBuilder` reads that header to open the tenant database.

This PR makes the NServiceBus SQL Server interop transport tenant-aware by mapping that header to and from Wolverine's `Envelope.TenantId`:

- `NServiceBusSqlServerQueue.TenantHeader` flows into the envelope mapper.
- Outgoing: `Envelope.TenantId` is stamped onto the configured header (the default tenant is skipped, so single-tenant traffic is byte-for-byte unchanged).
- Incoming: the header is surfaced back as `Envelope.TenantId`.
- Fluent opt-in: `MapTenantIdToHeader(header = "tenant_id")` on the subscriber and `MapTenantIdFromHeader(header = "tenant_id")` on the listener.

## Docs

The SQL Server and PostgreSQL durability guides and the interop tutorial linked to the **private** `wolverine-interop` repository for the "full, runnable" sample. Those samples are now **inlined**: the shared message contracts, the Wolverine configuration, the NServiceBus host configuration, and a handler — plus a new multi-tenancy section showing the `MapTenantIdToHeader` / `MapTenantIdFromHeader` opt-in.

## Validation

Both tenant directions verified against a real `NServiceBus.Transport.SqlServer` host on real SQL Server (full NServiceBus⇄Wolverine SQL Server interop suite, 6/6 green incl. the two new tenant tests):
- `wolverine_propagates_tenant_id_to_nservicebus_as_tenant_header`
- `nservicebus_tenant_header_maps_to_wolverine_envelope_tenant_id`

Release build of `Wolverine.SqlServer` is clean (0 warnings; the mapper is AOT-enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)