### PR TITLE
fix(#3256): ApplyRestrictions tolerates non-grid paused-agent URIs (paused listeners)

### DIFF
--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.cs
@@ -255,8 +255,17 @@ public partial class AssignmentGrid
 
         foreach (var agentUri in restrictions.FindPausedAgentUris())
         {
-            var agent = AgentFor(agentUri);
-            if (agent == null) continue;
+            // A paused-agent restriction can legitimately reference a URI that is NOT a distributable
+            // grid agent — e.g. a receiving-endpoint listener paused application-wide (CritterWatch #533).
+            // Such a URI honors its pause directly in ListeningAgent.StartAsync() via FindPausedAgentUris(),
+            // not through the assignment grid, so it simply has no Agent here. AgentFor(uri) does a dictionary
+            // indexer lookup that THROWS KeyNotFoundException for a missing key (the `agent == null` guard
+            // below was dead code), which poisoned every subsequent EvaluateAssignmentsAsync cycle once such
+            // a restriction was persisted. Skip URIs that aren't grid agents instead.
+            if (!_agents.TryGetValue(agentUri, out var agent))
+            {
+                continue;
+            }
 
             agent.IsPaused = true;
             if (agent.AssignedNode != null)


### PR DESCRIPTION
Fixes #3256.

`AssignmentGrid.ApplyRestrictions` called `AgentFor(uri)` (a throwing dictionary indexer) for every paused-agent restriction URI. A paused-agent restriction can legitimately reference a URI that is **not** a distributable grid agent — e.g. a receiving-endpoint listener paused application-wide (CritterWatch #533), which honors its pause in `ListeningAgent.StartAsync()` via `FindPausedAgentUris()`, not through the grid. For such a URI `AgentFor` threw `KeyNotFoundException` (the `agent == null` guard below it was dead code), and since the restriction is persisted **before** `EvaluateAssignmentsAsync` runs, every later assignment cycle then threw — breaking node/agent assignment until the restriction was cleared.

Fix: use `TryGetValue` and skip URIs that aren't grid agents (the behavior the existing guard intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
