### PR TITLE
fix(#3258): leader-pinned Pub/Sub listeners use one shared subscription

### DIFF
--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/PubsubEndpointTests.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/PubsubEndpointTests.cs
@@ -61,6 +61,44 @@ public class PubsubEndpointTests
     }
 
     [Fact]
+    public async Task competing_consumer_listener_gets_per_node_subscription()
+    {
+        var transport = createTransport();
+        transport.AssignedNodeNumber = 5;
+
+        var endpoint = new PubsubEndpoint("foo", transport)
+        {
+            IsListener = true,
+            ListenerScope = ListenerScope.CompetingConsumers
+        };
+
+        await endpoint.SetupAsync(NullLogger.Instance);
+
+        // Competing consumers should each read from their own per-node subscription
+        endpoint.Server.Subscription.Name.SubscriptionId.ShouldBe("foo.5");
+    }
+
+    [Fact]
+    public async Task leader_pinned_listener_uses_a_single_shared_subscription()
+    {
+        var transport = createTransport();
+        transport.AssignedNodeNumber = 5;
+
+        var endpoint = new PubsubEndpoint("foo", transport)
+        {
+            IsListener = true,
+            ListenerScope = ListenerScope.PinnedToLeader
+        };
+
+        await endpoint.SetupAsync(NullLogger.Instance);
+
+        // A leader-pinned listener must NOT get a per-node subscription name, otherwise every
+        // node creates its own subscription and Pub/Sub fans a copy of every message to each,
+        // breaking the single-consumer (leader-only) guarantee.
+        endpoint.Server.Subscription.Name.SubscriptionId.ShouldBe("foo");
+    }
+
+    [Fact]
     public async Task initialize_with_auto_provision()
     {
         var transport = createTransport();

--- a/src/Transports/GCP/Wolverine.Pubsub/PubsubEndpoint.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/PubsubEndpoint.cs
@@ -130,7 +130,12 @@ public class PubsubEndpoint : Endpoint<IPubsubEnvelopeMapper, PubsubEnvelopeMapp
 
         try
         {
-            if (!IsDeadLetter)
+            // Only competing-consumer listeners get a per-node subscription so that each node
+            // load balances a distinct copy of the stream. A leader-pinned (or otherwise
+            // single-node) listener must read from one shared, cluster-stable subscription;
+            // otherwise every node creates its own subscription and Pub/Sub fans a copy of every
+            // message to each, breaking the single-consumer (leader-only) guarantee.
+            if (!IsDeadLetter && ListenerScope == ListenerScope.CompetingConsumers)
             {
                 Server.Subscription.Name =
                     Server.Subscription.Name.WithAssignedNodeNumber(_transport.AssignedNodeNumber);


### PR DESCRIPTION
Fixes #3258

## Problem

GCP Pub/Sub listeners pinned to the leader via `ListenOnlyAtLeader()` still got a **per-node subscription**. `PubsubEndpoint.SetupAsync` appended the assigned node number to the subscription name for *every* listener (`Server.Subscription.Name.WithAssignedNodeNumber(...)`), so every node in a cluster created its own subscription on the topic. Pub/Sub fans a copy of every message to each subscription, so:

- the "only the leader consumes" guarantee was broken — every node received the message, and
- across a leader election the new leader's subscription may not exist yet / the old one strands undelivered messages.

This was the lone gap blocking running CritterWatch's control channel over Pub/Sub (the same `ListenOnlyAtLeader()` + per-endpoint serializer pattern that already works on RabbitMQ / Azure Service Bus / Amazon SQS).

## Fix

Only append the per-node suffix when `ListenerScope == CompetingConsumers`, where a distinct per-node subscription is the desired load-balancing behavior. `PinnedToLeader` (and any single-node `Exclusive`) listeners now read from **one shared, cluster-stable subscription** — which `LeaderPinnedListenerAgent` already gates at the listener-agent level.

## Tests

Added two tests in `PubsubEndpointTests` (mock-based, no emulator needed):

- `competing_consumer_listener_gets_per_node_subscription` — confirms competing consumers still get `foo.5`
- `leader_pinned_listener_uses_a_single_shared_subscription` — the regression test; fails on `main` (`foo.5`) and passes with the fix (`foo`)

All 8 `PubsubEndpointTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)