### PR TITLE
Surface every bus-forwarding RPC kind in the gRPC endpoint manifest (GH-3265)

### DIFF
--- a/src/Wolverine.Grpc.Tests/grpc_endpoint_manifest_3235.cs
+++ b/src/Wolverine.Grpc.Tests/grpc_endpoint_manifest_3235.cs
@@ -36,7 +36,8 @@ public class grpc_endpoint_manifest_3235
 
         endpoints.ShouldNotBeEmpty();
 
-        // v1 surfaces only the unary, bus-forwarding flavors.
+        // The manifest surfaces only the proto-first + code-first bus-forwarding flavors (hand-written and
+        // direct-mapped are excluded by design).
         endpoints.ShouldAllBe(e =>
             e.Mode == GrpcServiceDiscoveryMode.ProtoFirst || e.Mode == GrpcServiceDiscoveryMode.CodeFirst);
 
@@ -48,13 +49,18 @@ public class grpc_endpoint_manifest_3235
         sayHello.RequestType.ShouldBe(typeof(HelloRequest));
         sayHello.ResponseType.ShouldBe(typeof(HelloReply));
         sayHello.HandlerType.ShouldBe(typeof(GreeterGrpcService));
+        sayHello.StreamKind.ShouldBe(GrpcRpcStreamKind.Unary);
 
         // The other proto-first unary RPCs are present...
         endpoints.ShouldContain(e =>
             e.Mode == GrpcServiceDiscoveryMode.ProtoFirst && e.MethodName == "SayGoodbye");
 
-        // ...but the server-streaming RPC (StreamGreetings, in both the proto and the code-first contract) is excluded.
-        endpoints.ShouldNotContain(e => e.MethodName == "StreamGreetings");
+        // ...and the server-streaming RPC (StreamGreetings) is now surfaced too (GH-3265): it forwards its request to
+        // the bus via StreamAsync, so it is a genuine message-publishing origin. There is a proto-first one (response
+        // HelloReply) and a code-first one (response GreetReply).
+        endpoints.ShouldContain(e =>
+            e.Mode == GrpcServiceDiscoveryMode.ProtoFirst && e.MethodName == "StreamGreetings"
+            && e.StreamKind == GrpcRpcStreamKind.ServerStreaming);
 
         // Code-first: IGreeterCodeFirstService.Greet forwards GreetRequest to the bus.
         var greet = endpoints.Single(e =>
@@ -63,6 +69,7 @@ public class grpc_endpoint_manifest_3235
         greet.ResponseType.ShouldBe(typeof(GreetReply));
         greet.ServiceName.ShouldBe("GreeterCodeFirstService");
         greet.HandlerType.ShouldBe(typeof(IGreeterCodeFirstService));
+        greet.StreamKind.ShouldBe(GrpcRpcStreamKind.Unary);
     }
 
     [Fact]

--- a/src/Wolverine.Grpc.Tests/grpc_endpoint_manifest_3265.cs
+++ b/src/Wolverine.Grpc.Tests/grpc_endpoint_manifest_3265.cs
@@ -1,0 +1,273 @@
+using GreeterCodeFirstGrpc.Messages;
+using GreeterProtoFirstGrpc.Messages;
+using GreeterProtoFirstGrpc.Server;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Grpc.Tests.GrpcBidiStreaming;
+using Wolverine.Grpc.Tests.GrpcBidiStreaming.Generated;
+using Wolverine.Grpc.Tests.HandWrittenChain;
+using Xunit;
+using ProtoStreamGreetingsRequest = GreeterProtoFirstGrpc.Messages.StreamGreetingsRequest;
+using CodeFirstStreamGreetingsRequest = GreeterCodeFirstGrpc.Messages.StreamGreetingsRequest;
+
+namespace Wolverine.Grpc.Tests;
+
+// GH-3265: comprehensive coverage of IGrpcEndpointManifest across every gRPC endpoint configuration Wolverine
+// supports, so CritterWatch can populate PublisherKind.GrpcEndpoint for each message-publishing origin.
+//
+// The manifest surfaces every RPC kind whose Wolverine-generated wrapper forwards the request to the message bus:
+//   * proto-first  — unary (InvokeAsync), server-streaming (StreamAsync), bidirectional-streaming (StreamAsync)
+//   * code-first   — unary (InvokeAsync), server-streaming (StreamAsync)
+// and deliberately EXCLUDES the two discovery modes Wolverine does not forward to the bus:
+//   * hand-written — the generated wrapper delegates to the user's own service class
+//   * direct-mapped — mapped with no Wolverine chain at all
+// For those two there is no reliable message-publishing origin, so they must never appear in the manifest.
+
+/// <summary>
+///     Shared host discovering the proto-first <c>Greeter</c> sample (unary + server-streaming) and the code-first
+///     <c>IGreeterCodeFirstService</c> contract (unary + server-streaming). Built once for the whole class so the
+///     per-fact assertions stay fast and isolated from the other gRPC services living in the test assembly.
+/// </summary>
+public sealed class GreeterManifestFixture : IAsyncLifetime
+{
+    private IHost? _host;
+
+    public IReadOnlyList<GrpcEndpointDescriptor> Endpoints { get; private set; } = [];
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Proto-first Greeter stub lives in the GreeterProtoFirstGrpc.Server assembly.
+                opts.ApplicationAssembly = typeof(GreeterGrpcService).Assembly;
+                // Pull in the code-first contract assembly so it is discovered too.
+                opts.Discovery.IncludeAssembly(typeof(IGreeterCodeFirstService).Assembly);
+            })
+            .ConfigureServices(services => services.AddWolverineGrpc())
+            .StartAsync();
+
+        // Reading Endpoints self-triggers discovery (no MapWolverineGrpcServices required).
+        Endpoints = _host.Services.GetRequiredService<IGrpcEndpointManifest>().Endpoints;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_host is not null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+    }
+}
+
+[Collection(GrpcSerialTestsCollection.Name)]
+public class grpc_endpoint_manifest_3265 : IClassFixture<GreeterManifestFixture>
+{
+    private readonly IReadOnlyList<GrpcEndpointDescriptor> _endpoints;
+
+    public grpc_endpoint_manifest_3265(GreeterManifestFixture fixture)
+    {
+        _endpoints = fixture.Endpoints;
+    }
+
+    private GrpcEndpointDescriptor protoFirst(string methodName)
+        => _endpoints.Single(e => e.Mode == GrpcServiceDiscoveryMode.ProtoFirst && e.MethodName == methodName);
+
+    private GrpcEndpointDescriptor codeFirst(string methodName)
+        => _endpoints.Single(e => e.Mode == GrpcServiceDiscoveryMode.CodeFirst && e.MethodName == methodName);
+
+    [Fact]
+    public void manifest_is_populated()
+    {
+        _endpoints.ShouldNotBeEmpty();
+    }
+
+    // --- proto-first: unary ----------------------------------------------------------------------------------------
+
+    [Fact]
+    public void proto_first_unary_say_hello()
+    {
+        var e = protoFirst("SayHello");
+        e.StreamKind.ShouldBe(GrpcRpcStreamKind.Unary);
+        e.ServiceName.ShouldBe("Greeter");
+        e.RequestType.ShouldBe(typeof(HelloRequest));
+        e.ResponseType.ShouldBe(typeof(HelloReply));
+        e.HandlerType.ShouldBe(typeof(GreeterGrpcService));
+    }
+
+    [Fact]
+    public void proto_first_unary_say_goodbye()
+    {
+        var e = protoFirst("SayGoodbye");
+        e.StreamKind.ShouldBe(GrpcRpcStreamKind.Unary);
+        e.ServiceName.ShouldBe("Greeter");
+        e.RequestType.ShouldBe(typeof(GoodbyeRequest));
+        e.ResponseType.ShouldBe(typeof(GoodbyeReply));
+        e.HandlerType.ShouldBe(typeof(GreeterGrpcService));
+    }
+
+    [Fact]
+    public void proto_first_unary_fault()
+    {
+        // The Fault RPC is unary too — it forwards FaultRequest to the bus like any other unary method.
+        var e = protoFirst("Fault");
+        e.StreamKind.ShouldBe(GrpcRpcStreamKind.Unary);
+        e.RequestType.ShouldBe(typeof(FaultRequest));
+        e.ResponseType.ShouldBe(typeof(FaultReply));
+    }
+
+    // --- proto-first: server-streaming -----------------------------------------------------------------------------
+
+    [Fact]
+    public void proto_first_server_streaming_stream_greetings()
+    {
+        var e = protoFirst("StreamGreetings");
+        e.StreamKind.ShouldBe(GrpcRpcStreamKind.ServerStreaming);
+        e.ServiceName.ShouldBe("Greeter");
+        // The request is the single request DTO forwarded to StreamAsync.
+        e.RequestType.ShouldBe(typeof(ProtoStreamGreetingsRequest));
+        // The response is the element type of the outbound IServerStreamWriter<HelloReply>, NOT the writer itself.
+        e.ResponseType.ShouldBe(typeof(HelloReply));
+        e.HandlerType.ShouldBe(typeof(GreeterGrpcService));
+    }
+
+    // --- code-first: unary -----------------------------------------------------------------------------------------
+
+    [Fact]
+    public void code_first_unary_greet()
+    {
+        var e = codeFirst("Greet");
+        e.StreamKind.ShouldBe(GrpcRpcStreamKind.Unary);
+        e.ServiceName.ShouldBe("GreeterCodeFirstService");
+        e.RequestType.ShouldBe(typeof(GreetRequest));
+        e.ResponseType.ShouldBe(typeof(GreetReply));
+        e.HandlerType.ShouldBe(typeof(IGreeterCodeFirstService));
+    }
+
+    // --- code-first: server-streaming ------------------------------------------------------------------------------
+
+    [Fact]
+    public void code_first_server_streaming_stream_greetings()
+    {
+        var e = codeFirst("StreamGreetings");
+        e.StreamKind.ShouldBe(GrpcRpcStreamKind.ServerStreaming);
+        e.ServiceName.ShouldBe("GreeterCodeFirstService");
+        e.RequestType.ShouldBe(typeof(CodeFirstStreamGreetingsRequest));
+        // Code-first server-streaming returns IAsyncEnumerable<GreetReply>; the response is its element type.
+        e.ResponseType.ShouldBe(typeof(GreetReply));
+        e.HandlerType.ShouldBe(typeof(IGreeterCodeFirstService));
+    }
+
+    // --- invariants across the whole manifest ----------------------------------------------------------------------
+
+    [Fact]
+    public void every_descriptor_is_a_bus_forwarding_mode()
+    {
+        _endpoints.ShouldAllBe(e =>
+            e.Mode == GrpcServiceDiscoveryMode.ProtoFirst || e.Mode == GrpcServiceDiscoveryMode.CodeFirst);
+    }
+
+    [Fact]
+    public void every_descriptor_has_a_request_message()
+    {
+        // RequestType is the published Wolverine message — it must always be present.
+        _endpoints.ShouldAllBe(e => e.RequestType != null);
+    }
+
+    [Fact]
+    public void every_descriptor_has_service_and_method_names()
+    {
+        _endpoints.ShouldAllBe(e => !string.IsNullOrWhiteSpace(e.ServiceName) && !string.IsNullOrWhiteSpace(e.MethodName));
+    }
+
+    [Fact]
+    public void greeter_host_has_no_bidirectional_streaming()
+    {
+        // The Greeter contracts declare no bidi RPC, so none should be surfaced here (bidi is covered separately).
+        _endpoints.ShouldNotContain(e => e.StreamKind == GrpcRpcStreamKind.BidirectionalStreaming);
+    }
+
+    [Fact]
+    public void stream_greetings_is_surfaced_once_per_discovery_mode()
+    {
+        // Both the proto-first and code-first contracts declare a StreamGreetings RPC; each is its own origin.
+        var streamGreetings = _endpoints.Where(e => e.MethodName == "StreamGreetings").ToArray();
+        streamGreetings.Length.ShouldBe(2);
+        streamGreetings.ShouldAllBe(e => e.StreamKind == GrpcRpcStreamKind.ServerStreaming);
+        streamGreetings.Select(e => e.Mode).OrderBy(m => m)
+            .ShouldBe([GrpcServiceDiscoveryMode.ProtoFirst, GrpcServiceDiscoveryMode.CodeFirst]);
+    }
+}
+
+/// <summary>
+///     Covers the two configurations that share the test assembly host: the proto-first bidirectional-streaming
+///     wrapper (surfaced) and the hand-written / direct-mapped services (excluded). Reuses the live
+///     <see cref="BidiStreamingFixture"/> host, which discovers the entire test assembly — a realistic
+///     "many gRPC configurations in one application" surface.
+/// </summary>
+public class grpc_endpoint_manifest_3265_bidi_and_exclusions : IClassFixture<BidiStreamingFixture>
+{
+    private readonly BidiStreamingFixture _fixture;
+
+    public grpc_endpoint_manifest_3265_bidi_and_exclusions(BidiStreamingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private IReadOnlyList<GrpcEndpointDescriptor> Endpoints
+        => _fixture.Services.GetRequiredService<IGrpcEndpointManifest>().Endpoints;
+
+    [Fact]
+    public void proto_first_bidirectional_streaming_echo_is_surfaced()
+    {
+        var echo = Endpoints.Single(e =>
+            e.Mode == GrpcServiceDiscoveryMode.ProtoFirst
+            && e.ServiceName == "BidiEchoTest"
+            && e.MethodName == "Echo");
+
+        echo.StreamKind.ShouldBe(GrpcRpcStreamKind.BidirectionalStreaming);
+        // The published message is the per-item element type of the inbound request stream — EchoRequest — NOT the
+        // IAsyncStreamReader<EchoRequest> wrapper. This guards the bidi request-type unwrap.
+        echo.RequestType.ShouldBe(typeof(EchoRequest));
+        // The response is the element type of the outbound IServerStreamWriter<EchoReply>.
+        echo.ResponseType.ShouldBe(typeof(EchoReply));
+        echo.HandlerType.ShouldBe(typeof(BidiEchoStub));
+    }
+
+    [Fact]
+    public void hand_written_services_are_discovered_but_excluded_from_the_manifest()
+    {
+        var graph = _fixture.Services.GetRequiredService<GrpcGraph>();
+
+        // Sanity: the hand-written service IS discovered as a hand-written chain (so the exclusion below is a
+        // deliberate manifest decision, not merely the absence of discovery).
+        graph.HandWrittenChains.ShouldContain(c => c.ServiceClassType == typeof(HandWrittenTestGrpcService));
+
+        // ...yet none of its methods (Echo / EchoStream / EchoBidi) leak into the message-origin manifest, because
+        // Wolverine delegates them to the user's own implementation rather than forwarding to the bus.
+        Endpoints.ShouldNotContain(e => e.HandlerType == typeof(HandWrittenTestGrpcService));
+        Endpoints.ShouldNotContain(e => e.HandlerType == typeof(IHandWrittenTestService));
+    }
+
+    [Fact]
+    public void manifest_never_surfaces_hand_written_or_direct_mapped_modes()
+    {
+        // Even in an application packed with every discovery flavor, the manifest only ever reports the two
+        // bus-forwarding modes. Hand-written and direct-mapped have no message-publishing origin.
+        Endpoints.ShouldAllBe(e =>
+            e.Mode == GrpcServiceDiscoveryMode.ProtoFirst || e.Mode == GrpcServiceDiscoveryMode.CodeFirst);
+    }
+
+    [Fact]
+    public void every_surfaced_endpoint_carries_a_request_message_and_known_stream_kind()
+    {
+        Endpoints.ShouldAllBe(e =>
+            e.RequestType != null
+            && (e.StreamKind == GrpcRpcStreamKind.Unary
+                || e.StreamKind == GrpcRpcStreamKind.ServerStreaming
+                || e.StreamKind == GrpcRpcStreamKind.BidirectionalStreaming));
+    }
+}

--- a/src/Wolverine.Grpc/GrpcEndpointManifest.cs
+++ b/src/Wolverine.Grpc/GrpcEndpointManifest.cs
@@ -6,9 +6,11 @@ namespace Wolverine.Grpc;
 
 /// <summary>
 ///     Projects <see cref="GrpcGraph"/>'s discovered proto-first and code-first service chains into the core
-///     <see cref="IGrpcEndpointManifest"/> abstraction. Only unary RPCs are included — those are the methods whose
-///     generated wrapper forwards the request to <c>IMessageBus.InvokeAsync</c>, so the request type is genuinely the
-///     published Wolverine message. Streaming methods, hand-written and direct-mapped services are excluded from v1.
+///     <see cref="IGrpcEndpointManifest"/> abstraction. Every RPC whose generated wrapper forwards the request to the
+///     message bus is included — unary (via <c>IMessageBus.InvokeAsync</c>) plus server- and bidirectional-streaming
+///     (via <c>IMessageBus.StreamAsync</c>) — so the request type is genuinely the published Wolverine message
+///     (GH-3265). Hand-written and direct-mapped services are excluded: Wolverine delegates those to the user's own
+///     implementation rather than forwarding to the bus, so there is no reliable message-publishing origin to surface.
 /// </summary>
 internal sealed class GrpcEndpointManifest : IGrpcEndpointManifest
 {
@@ -57,54 +59,93 @@ internal sealed class GrpcEndpointManifest : IGrpcEndpointManifest
     {
         var descriptors = new List<GrpcEndpointDescriptor>();
 
-        // Proto-first: chain.UnaryMethods already excludes streaming RPCs.
+        // Proto-first: every RPC kind Wolverine forwards to the bus. The chain pre-classifies its methods into
+        // unary / server-streaming / bidirectional-streaming lists (client-streaming is rejected at construction,
+        // so it never reaches here).
         foreach (var chain in graph.Chains)
         {
+            // Unary: Task<TResponse> Name(TRequest, ServerCallContext) → InvokeAsync(request).
             foreach (var method in chain.UnaryMethods)
             {
+                var p = method.GetParameters();
                 descriptors.Add(new GrpcEndpointDescriptor(
                     chain.ProtoServiceName,
                     method.Name,
-                    method.GetParameters()[0].ParameterType,
-                    unwrapResponse(method.ReturnType),
+                    p[0].ParameterType,
+                    genericArgument(method.ReturnType),
                     chain.StubType,
-                    GrpcServiceDiscoveryMode.ProtoFirst));
+                    GrpcServiceDiscoveryMode.ProtoFirst,
+                    GrpcRpcStreamKind.Unary));
+            }
+
+            // Server-streaming: Task Name(TRequest, IServerStreamWriter<TResponse>, ServerCallContext) → StreamAsync(request).
+            foreach (var method in chain.ServerStreamingMethods)
+            {
+                var p = method.GetParameters();
+                descriptors.Add(new GrpcEndpointDescriptor(
+                    chain.ProtoServiceName,
+                    method.Name,
+                    p[0].ParameterType,
+                    genericArgument(p[1].ParameterType),
+                    chain.StubType,
+                    GrpcServiceDiscoveryMode.ProtoFirst,
+                    GrpcRpcStreamKind.ServerStreaming));
+            }
+
+            // Bidirectional: Task Name(IAsyncStreamReader<TRequest>, IServerStreamWriter<TResponse>, ServerCallContext).
+            // Each inbound item is forwarded individually via StreamAsync, so the published message is the per-item
+            // element type of the request stream — not the IAsyncStreamReader wrapper.
+            foreach (var method in chain.BidirectionalStreamingMethods)
+            {
+                var p = method.GetParameters();
+                var requestType = genericArgument(p[0].ParameterType);
+                if (requestType == null) continue; // defensive: a bidi reader always has an element type
+
+                descriptors.Add(new GrpcEndpointDescriptor(
+                    chain.ProtoServiceName,
+                    method.Name,
+                    requestType,
+                    genericArgument(p[1].ParameterType),
+                    chain.StubType,
+                    GrpcServiceDiscoveryMode.ProtoFirst,
+                    GrpcRpcStreamKind.BidirectionalStreaming));
             }
         }
 
-        // Code-first: only the unary methods are bus-invoked.
+        // Code-first: unary and server-streaming are bus-forwarded (no bidi shape in the code-first model).
         foreach (var chain in graph.CodeFirstChains)
         {
             var serviceName = serviceNameFor(chain.ServiceContractType);
 
-            foreach (var rpc in chain.SupportedMethods.Where(m => m.Kind == CodeFirstMethodKind.Unary))
+            foreach (var rpc in chain.SupportedMethods)
             {
+                // Unary returns Task<TResponse>; server-streaming returns IAsyncEnumerable<TResponse>. Either way the
+                // response type is the single generic argument of the return type, and the request is the first param.
+                var streamKind = rpc.Kind == CodeFirstMethodKind.ServerStreaming
+                    ? GrpcRpcStreamKind.ServerStreaming
+                    : GrpcRpcStreamKind.Unary;
+
                 descriptors.Add(new GrpcEndpointDescriptor(
                     serviceName,
                     rpc.Method.Name,
                     rpc.Method.GetParameters()[0].ParameterType,
-                    unwrapResponse(rpc.Method.ReturnType),
+                    genericArgument(rpc.Method.ReturnType),
                     chain.ServiceContractType,
-                    GrpcServiceDiscoveryMode.CodeFirst));
+                    GrpcServiceDiscoveryMode.CodeFirst,
+                    streamKind));
             }
         }
 
         return descriptors;
     }
 
-    private static Type? unwrapResponse(Type returnType)
-    {
-        if (returnType.IsGenericType)
-        {
-            var definition = returnType.GetGenericTypeDefinition();
-            if (definition == typeof(Task<>) || definition == typeof(ValueTask<>))
-            {
-                return returnType.GetGenericArguments()[0];
-            }
-        }
-
-        return null;
-    }
+    /// <summary>
+    ///     The single generic type argument of <paramref name="type"/> — used to unwrap <c>Task&lt;T&gt;</c>,
+    ///     <c>IAsyncEnumerable&lt;T&gt;</c>, <c>IServerStreamWriter&lt;T&gt;</c>, and <c>IAsyncStreamReader&lt;T&gt;</c>
+    ///     to their payload type. Returns <c>null</c> for a non-generic type (e.g. a bare <c>Task</c>).
+    /// </summary>
+    private static Type? genericArgument(Type type)
+        => type.IsGenericType ? type.GetGenericArguments()[0] : null;
 
     // Best-effort wire service name for a code-first contract: the [ServiceContract] Name if set, otherwise the
     // interface's simple name with a leading 'I' stripped.

--- a/src/Wolverine/Configuration/GrpcEndpointManifest.cs
+++ b/src/Wolverine/Configuration/GrpcEndpointManifest.cs
@@ -21,24 +21,51 @@ public enum GrpcServiceDiscoveryMode
 }
 
 /// <summary>
-/// A discovered unary gRPC endpoint and the Wolverine message type it forwards to the message bus. For proto-first
-/// and code-first services the generated wrapper forwards the request (the first parameter) to
-/// <c>IMessageBus.InvokeAsync</c>, so <see cref="RequestType"/> is the published Wolverine message.
+/// The RPC cardinality of a discovered gRPC endpoint — the dimension CritterWatch needs to render the right
+/// chain-detail affordance for a gRPC origin. Only the kinds whose generated wrapper forwards the request to the
+/// Wolverine message bus are represented; client-streaming has no Wolverine forwarding path and never appears.
+/// </summary>
+public enum GrpcRpcStreamKind
+{
+    /// <summary>Unary RPC — a single request forwarded via <c>IMessageBus.InvokeAsync</c>.</summary>
+    Unary,
+
+    /// <summary>Server-streaming RPC — a single request forwarded via <c>IMessageBus.StreamAsync</c>.</summary>
+    ServerStreaming,
+
+    /// <summary>
+    /// Bidirectional-streaming RPC — each inbound request-stream item is forwarded via <c>IMessageBus.StreamAsync</c>.
+    /// Only proto-first services reach this shape today.
+    /// </summary>
+    BidirectionalStreaming
+}
+
+/// <summary>
+/// A discovered gRPC endpoint and the Wolverine message type it forwards to the message bus. For proto-first and
+/// code-first services the generated wrapper forwards the request to the bus, so <see cref="RequestType"/> is the
+/// published Wolverine message. Unary RPCs forward via <c>IMessageBus.InvokeAsync</c>; server- and
+/// bidirectional-streaming RPCs forward via <c>IMessageBus.StreamAsync</c>. Hand-written and direct-mapped services
+/// are excluded — Wolverine does not own their dispatch, so there is no reliable message-publishing origin to surface.
 /// </summary>
 /// <param name="ServiceName">The service name — the proto service's simple name for proto-first, or the contract's
 /// service name for code-first (not necessarily package-qualified).</param>
-/// <param name="MethodName">The unary RPC method name.</param>
-/// <param name="RequestType">The request type — the Wolverine message forwarded to the bus.</param>
-/// <param name="ResponseType">The response type, or <c>null</c> for a method with no typed response.</param>
+/// <param name="MethodName">The RPC method name.</param>
+/// <param name="RequestType">The request type — the Wolverine message forwarded to the bus. For unary and
+/// server-streaming RPCs this is the request parameter; for bidirectional-streaming it is the per-item element type of
+/// the inbound request stream (each item is forwarded individually).</param>
+/// <param name="ResponseType">The response type — unwrapped from <c>Task&lt;T&gt;</c> for unary RPCs, or the element
+/// type of the outbound response stream for streaming RPCs; <c>null</c> for a method with no typed response.</param>
 /// <param name="HandlerType">The identity of the discovered service (stub or contract type).</param>
 /// <param name="Mode">How the service was discovered.</param>
+/// <param name="StreamKind">The RPC cardinality (unary, server-streaming, or bidirectional-streaming).</param>
 public sealed record GrpcEndpointDescriptor(
     string ServiceName,
     string MethodName,
     Type RequestType,
     Type? ResponseType,
     Type HandlerType,
-    GrpcServiceDiscoveryMode Mode);
+    GrpcServiceDiscoveryMode Mode,
+    GrpcRpcStreamKind StreamKind);
 
 /// <summary>
 /// Exposes Wolverine's discovered gRPC unary endpoint → message-type mapping so monitoring/diagnostic consumers
@@ -48,7 +75,9 @@ public sealed record GrpcEndpointDescriptor(
 public interface IGrpcEndpointManifest
 {
     /// <summary>
-    /// The discovered unary gRPC endpoints. Empty when gRPC is enabled but no services were discovered.
+    /// The discovered gRPC endpoints whose generated wrapper forwards the request to the message bus — unary,
+    /// server-streaming, and bidirectional-streaming RPCs across proto-first and code-first services. Empty when
+    /// gRPC is enabled but no such services were discovered.
     /// </summary>
     IReadOnlyList<GrpcEndpointDescriptor> Endpoints { get; }
 }


### PR DESCRIPTION
Closes #3265.

## Summary

`IGrpcEndpointManifest` (#3235) exposed Wolverine's discovered gRPC endpoint → message-type mapping so CritterWatch can populate `PublisherKind.GrpcEndpoint`, but it surfaced **only unary** proto-first/code-first endpoints. Server-streaming and bidirectional-streaming RPCs also forward their request to the message bus (via `IMessageBus.StreamAsync`), so they are equally valid message-publishing origins — they were invisible.

This PR completes #3265:

- **Surfaces every RPC kind Wolverine forwards to the bus** — proto-first unary + server-streaming + bidirectional-streaming, and code-first unary + server-streaming.
- Adds a **`GrpcRpcStreamKind`** discriminator (`Unary` / `ServerStreaming` / `BidirectionalStreaming`) to `GrpcEndpointDescriptor` so consumers can render the right cardinality on a chain-detail page.
- For **bidirectional** RPCs, the published message is the **per-item element type** of the inbound request stream (unwrapped from `IAsyncStreamReader<T>`), not the reader wrapper — each item is forwarded individually via `StreamAsync`.

### The "or decide it's N/A" half

Hand-written and direct-mapped services remain **excluded by design**: Wolverine delegates those to the user's own service implementation rather than forwarding to the bus, so there is no reliable message-publishing origin to surface. The decision is now encoded in code, docs, and tests rather than left implicit.

## Test coverage

Comprehensive coverage across **every supported gRPC configuration** (`grpc_endpoint_manifest_3265.cs`):

| Configuration | Kind | Asserted |
|---|---|---|
| proto-first | Unary (`SayHello`, `SayGoodbye`, `Fault`) | service/method/request/response/handler/kind |
| proto-first | ServerStreaming (`StreamGreetings`) | request DTO + response = stream element type |
| proto-first | BidirectionalStreaming (`Echo`) | request = stream **element** type, not the reader |
| code-first | Unary (`Greet`) | full descriptor |
| code-first | ServerStreaming (`StreamGreetings`) | request + `IAsyncEnumerable<T>` element response |
| hand-written | — | discovered as a chain but **excluded** from the manifest |
| direct-mapped | — | manifest never reports the mode |

Plus manifest-wide invariants (every descriptor carries a request message, a known stream kind, and a bus-forwarding discovery mode). The pre-existing #3235 test was updated where it previously asserted streaming was excluded.

`Wolverine.Grpc.Tests` — **236/236 passing** locally (net9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)