### PR TITLE
Surface the gRPC manifest via a ServiceCapabilities descriptor source (GH-3267)

### DIFF
--- a/src/Wolverine.Grpc.Tests/grpc_capabilities_descriptor_source_3267.cs
+++ b/src/Wolverine.Grpc.Tests/grpc_capabilities_descriptor_source_3267.cs
@@ -1,0 +1,224 @@
+using GreeterCodeFirstGrpc.Messages;
+using GreeterProtoFirstGrpc.Messages;
+using GreeterProtoFirstGrpc.Server;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Grpc.Tests.GrpcBidiStreaming;
+using Wolverine.Grpc.Tests.GrpcBidiStreaming.Generated;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+using ProtoStreamGreetingsRequest = GreeterProtoFirstGrpc.Messages.StreamGreetingsRequest;
+using CodeFirstStreamGreetingsRequest = GreeterCodeFirstGrpc.Messages.StreamGreetingsRequest;
+
+namespace Wolverine.Grpc.Tests;
+
+// GH-3267: surface the gRPC endpoint manifest (GH-3266) along the ServiceCapabilities descriptor path so a monitoring
+// console (CritterWatch) can discover the gRPC services a Wolverine app exposes — parallel to how it discovers HTTP
+// chains and ASP.NET endpoints. Wolverine.Grpc registers an IGrpcEndpointDescriptorSource that projects the manifest
+// into serializable GrpcRpcDescriptors, and ServiceCapabilities.ReadFrom folds them into ServiceCapabilities.GrpcEndpoints.
+
+/// <summary>
+///     Builds a host discovering the proto-first <c>Greeter</c> sample (unary + server-streaming) and the code-first
+///     <c>IGreeterCodeFirstService</c> contract (unary + server-streaming), then captures both the raw descriptor
+///     source output and the full <see cref="ServiceCapabilities"/> snapshot once for the whole class.
+/// </summary>
+public sealed class GrpcCapabilitiesFixture : IAsyncLifetime
+{
+    private IHost? _host;
+
+    public IReadOnlyList<GrpcRpcDescriptor> SourceEndpoints { get; private set; } = [];
+    public ServiceCapabilities Capabilities { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ApplicationAssembly = typeof(GreeterGrpcService).Assembly;
+                opts.Discovery.IncludeAssembly(typeof(IGreeterCodeFirstService).Assembly);
+            })
+            .ConfigureServices(services => services.AddWolverineGrpc())
+            .StartAsync();
+
+        SourceEndpoints = _host.Services.GetRequiredService<IGrpcEndpointDescriptorSource>().Endpoints;
+        Capabilities = await ServiceCapabilities.ReadFrom(_host.GetRuntime(), null, CancellationToken.None);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_host is not null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+    }
+}
+
+[Collection(GrpcSerialTestsCollection.Name)]
+public class grpc_capabilities_descriptor_source_3267 : IClassFixture<GrpcCapabilitiesFixture>
+{
+    private readonly GrpcCapabilitiesFixture _fixture;
+
+    public grpc_capabilities_descriptor_source_3267(GrpcCapabilitiesFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private GrpcRpcDescriptor source(GrpcServiceDiscoveryMode mode, string method)
+        => _fixture.SourceEndpoints.Single(e => e.Mode == mode && e.MethodName == method);
+
+    [Fact]
+    public void source_is_registered_and_populated()
+    {
+        _fixture.SourceEndpoints.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void projects_proto_first_unary()
+    {
+        var e = source(GrpcServiceDiscoveryMode.ProtoFirst, "SayHello");
+        e.ServiceName.ShouldBe("Greeter");
+        e.MethodName.ShouldBe("SayHello");
+        e.StreamKind.ShouldBe(GrpcRpcStreamKind.Unary);
+        e.Mode.ShouldBe(GrpcServiceDiscoveryMode.ProtoFirst);
+        e.RequestType!.FullName.ShouldBe(typeof(HelloRequest).FullName);
+        e.ResponseType!.FullName.ShouldBe(typeof(HelloReply).FullName);
+        // Origin is the forwarding service identity — the proto-first stub whose generated wrapper dispatches to the bus.
+        e.Origin!.FullName.ShouldBe(typeof(GreeterGrpcService).FullName);
+        e.Subject.ShouldBe("GrpcEndpoint[Greeter/SayHello]");
+        e.Tags.ShouldContain("grpc");
+    }
+
+    [Fact]
+    public void projects_proto_first_server_streaming()
+    {
+        var e = source(GrpcServiceDiscoveryMode.ProtoFirst, "StreamGreetings");
+        e.StreamKind.ShouldBe(GrpcRpcStreamKind.ServerStreaming);
+        e.RequestType!.FullName.ShouldBe(typeof(ProtoStreamGreetingsRequest).FullName);
+        e.ResponseType!.FullName.ShouldBe(typeof(HelloReply).FullName);
+        e.Subject.ShouldBe("GrpcEndpoint[Greeter/StreamGreetings]");
+    }
+
+    [Fact]
+    public void projects_code_first_unary()
+    {
+        var e = source(GrpcServiceDiscoveryMode.CodeFirst, "Greet");
+        e.ServiceName.ShouldBe("GreeterCodeFirstService");
+        e.StreamKind.ShouldBe(GrpcRpcStreamKind.Unary);
+        e.Mode.ShouldBe(GrpcServiceDiscoveryMode.CodeFirst);
+        e.RequestType!.FullName.ShouldBe(typeof(GreetRequest).FullName);
+        e.ResponseType!.FullName.ShouldBe(typeof(GreetReply).FullName);
+        e.Origin!.FullName.ShouldBe(typeof(IGreeterCodeFirstService).FullName);
+    }
+
+    [Fact]
+    public void projects_code_first_server_streaming()
+    {
+        var e = source(GrpcServiceDiscoveryMode.CodeFirst, "StreamGreetings");
+        e.StreamKind.ShouldBe(GrpcRpcStreamKind.ServerStreaming);
+        e.RequestType!.FullName.ShouldBe(typeof(CodeFirstStreamGreetingsRequest).FullName);
+        e.ResponseType!.FullName.ShouldBe(typeof(GreetReply).FullName);
+        e.ServiceName.ShouldBe("GreeterCodeFirstService");
+    }
+
+    [Fact]
+    public void every_descriptor_carries_subject_request_origin_and_grpc_tag()
+    {
+        _fixture.SourceEndpoints.ShouldAllBe(e =>
+            e.Subject.StartsWith("GrpcEndpoint[")
+            && e.RequestType != null
+            && e.Origin != null
+            && e.Tags.Contains("grpc"));
+    }
+
+    // --- end-to-end through ServiceCapabilities.ReadFrom ------------------------------------------------------------
+
+    [Fact]
+    public void capabilities_grpc_endpoints_is_populated_from_the_source()
+    {
+        // The descriptor source is folded into ServiceCapabilities.GrpcEndpoints by ReadFrom.
+        _fixture.Capabilities.GrpcEndpoints.Count.ShouldBe(_fixture.SourceEndpoints.Count);
+        _fixture.Capabilities.GrpcEndpoints.ShouldContain(e =>
+            e.ServiceName == "Greeter" && e.MethodName == "SayHello");
+        _fixture.Capabilities.GrpcEndpoints.ShouldContain(e =>
+            e.ServiceName == "GreeterCodeFirstService" && e.MethodName == "Greet");
+    }
+
+    [Fact]
+    public void capabilities_grpc_endpoints_are_ordered_by_service_then_method()
+    {
+        var keys = _fixture.Capabilities.GrpcEndpoints
+            .Select(e => e.ServiceName + "::" + e.MethodName)
+            .ToArray();
+
+        keys.ShouldBe(keys.OrderBy(k => k, StringComparer.Ordinal).ToArray());
+    }
+}
+
+/// <summary>
+///     Covers the bidirectional-streaming origin (reusing the live <see cref="BidiStreamingFixture"/> host) and the
+///     no-gRPC case, both through the real <see cref="ServiceCapabilities.ReadFrom"/> path.
+/// </summary>
+public class grpc_capabilities_3267_bidi_and_absent
+{
+    public class with_bidi : IClassFixture<BidiStreamingFixture>
+    {
+        private readonly BidiStreamingFixture _fixture;
+
+        public with_bidi(BidiStreamingFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task capabilities_include_the_bidirectional_streaming_origin()
+        {
+            var runtime = _fixture.Services.GetRequiredService<IWolverineRuntime>();
+            var capabilities = await ServiceCapabilities.ReadFrom(runtime, null, CancellationToken.None);
+
+            var echo = capabilities.GrpcEndpoints.Single(e =>
+                e.ServiceName == "BidiEchoTest" && e.MethodName == "Echo");
+
+            echo.StreamKind.ShouldBe(GrpcRpcStreamKind.BidirectionalStreaming);
+            echo.Mode.ShouldBe(GrpcServiceDiscoveryMode.ProtoFirst);
+            // The published message is the per-item element type of the inbound request stream.
+            echo.RequestType!.FullName.ShouldBe(typeof(EchoRequest).FullName);
+            echo.ResponseType!.FullName.ShouldBe(typeof(EchoReply).FullName);
+            echo.Tags.ShouldContain("grpc");
+        }
+
+        [Fact]
+        public async Task capabilities_only_surface_bus_forwarding_modes()
+        {
+            // Even in an assembly packed with hand-written + direct-mapped services, GrpcEndpoints only reports the
+            // bus-forwarding proto-first/code-first origins (inherited from the manifest's exclusion rule).
+            var runtime = _fixture.Services.GetRequiredService<IWolverineRuntime>();
+            var capabilities = await ServiceCapabilities.ReadFrom(runtime, null, CancellationToken.None);
+
+            capabilities.GrpcEndpoints.ShouldNotBeEmpty();
+            capabilities.GrpcEndpoints.ShouldAllBe(e =>
+                e.Mode == GrpcServiceDiscoveryMode.ProtoFirst || e.Mode == GrpcServiceDiscoveryMode.CodeFirst);
+        }
+    }
+
+    [Collection(GrpcSerialTestsCollection.Name)]
+    public class without_grpc
+    {
+        [Fact]
+        public async Task no_grpc_means_empty_capabilities_and_no_registered_source()
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine()
+                .StartAsync();
+
+            host.Services.GetService<IGrpcEndpointDescriptorSource>().ShouldBeNull();
+
+            var capabilities = await ServiceCapabilities.ReadFrom(host.GetRuntime(), null, CancellationToken.None);
+            capabilities.GrpcEndpoints.ShouldBeEmpty();
+        }
+    }
+}

--- a/src/Wolverine.Grpc/GrpcEndpointDescriptorSource.cs
+++ b/src/Wolverine.Grpc/GrpcEndpointDescriptorSource.cs
@@ -1,0 +1,59 @@
+using JasperFx.Descriptors;
+using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
+
+namespace Wolverine.Grpc;
+
+/// <summary>
+///     Projects the runtime <see cref="IGrpcEndpointManifest"/> (discovered proto-first + code-first RPCs that
+///     forward a request to the message bus) into the serializable <see cref="GrpcRpcDescriptor"/> capability shape so
+///     <c>ServiceCapabilities.ReadFrom</c> can fold the gRPC surface into its snapshot for CritterWatch's gRPC
+///     Explorer. Mirrors <c>Wolverine.CritterWatch.Http</c>'s <c>AspNetEndpointDiscovery</c>. The manifest discovers
+///     services once and caches; this source projects on first read and caches the result.
+/// </summary>
+internal sealed class GrpcEndpointDescriptorSource : IGrpcEndpointDescriptorSource
+{
+    private readonly IGrpcEndpointManifest _manifest;
+    private readonly object _lock = new();
+    private volatile IReadOnlyList<GrpcRpcDescriptor>? _endpoints;
+
+    public GrpcEndpointDescriptorSource(IGrpcEndpointManifest manifest)
+    {
+        _manifest = manifest ?? throw new ArgumentNullException(nameof(manifest));
+    }
+
+    public IReadOnlyList<GrpcRpcDescriptor> Endpoints
+    {
+        get
+        {
+            if (_endpoints != null)
+            {
+                return _endpoints;
+            }
+
+            lock (_lock)
+            {
+                return _endpoints ??= _manifest.Endpoints.Select(toDescriptor).ToArray();
+            }
+        }
+    }
+
+    private static GrpcRpcDescriptor toDescriptor(GrpcEndpointDescriptor entry)
+    {
+        var descriptor = new GrpcRpcDescriptor
+        {
+            Subject = $"GrpcEndpoint[{entry.ServiceName}/{entry.MethodName}]",
+            ServiceName = entry.ServiceName,
+            MethodName = entry.MethodName,
+            StreamKind = entry.StreamKind,
+            Mode = entry.Mode,
+            RequestType = TypeDescriptor.For(entry.RequestType),
+            ResponseType = entry.ResponseType != null ? TypeDescriptor.For(entry.ResponseType) : null,
+            Origin = TypeDescriptor.For(entry.HandlerType)
+        };
+
+        descriptor.AddTag("grpc");
+
+        return descriptor;
+    }
+}

--- a/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
 using Wolverine.Runtime;
 
 namespace Wolverine.Grpc;
@@ -76,6 +77,11 @@ public static class WolverineGrpcExtensions
         services.AddSingleton<IGrpcEndpointManifest>(sp =>
             new GrpcEndpointManifest(sp.GetRequiredService<GrpcGraph>(),
                 sp.GetRequiredService<WolverineGrpcOptions>()));
+
+        // GH-3267: surface the manifest along the ServiceCapabilities descriptor path (ServiceCapabilities.GrpcEndpoints)
+        // so a monitoring console can discover the gRPC services this app exposes, parallel to AspNet/HTTP endpoints.
+        services.AddSingleton<IGrpcEndpointDescriptorSource>(sp =>
+            new GrpcEndpointDescriptorSource(sp.GetRequiredService<IGrpcEndpointManifest>()));
 
         services.AddSingleton<WolverineGrpcExceptionInterceptor>();
         services.Configure<GrpcServiceOptions>(opts =>

--- a/src/Wolverine/Configuration/Capabilities/GrpcRpcDescriptor.cs
+++ b/src/Wolverine/Configuration/Capabilities/GrpcRpcDescriptor.cs
@@ -1,0 +1,50 @@
+using JasperFx.Descriptors;
+
+namespace Wolverine.Configuration.Capabilities;
+
+/// <summary>
+/// Serializable, diagnostic snapshot of a single Wolverine gRPC RPC endpoint — one descriptor per RPC method whose
+/// generated wrapper forwards its request to the Wolverine message bus. Surfaced through
+/// <see cref="ServiceCapabilities.GrpcEndpoints"/> so a monitoring console (CritterWatch) can build a gRPC Explorer
+/// and tie each RPC to the Wolverine message it publishes — the same way <see cref="AspNetEndpointDescriptor"/> and
+/// <c>HttpChainDescriptor</c> surface the HTTP surface area.
+/// </summary>
+/// <remarks>
+/// Projected from <c>IGrpcEndpointManifest</c> (the runtime view inside <c>Wolverine.Grpc</c>) by an
+/// <see cref="IGrpcEndpointDescriptorSource"/>. Only proto-first and code-first services appear — hand-written and
+/// direct-mapped services delegate to the user's own implementation rather than forwarding to the bus, so they have
+/// no message-publishing origin to surface. Types are carried as <see cref="TypeDescriptor"/> so the descriptor stays
+/// JSON-serialisable across the capability boundary.
+/// </remarks>
+public class GrpcRpcDescriptor : OptionsDescription
+{
+    // Parameterless ctor for deserialization.
+    public GrpcRpcDescriptor()
+    {
+    }
+
+    /// <summary>The service name — the proto service's simple name (proto-first) or the contract's service name
+    /// (code-first); not necessarily package-qualified.</summary>
+    public string ServiceName { get; set; } = "";
+
+    /// <summary>The RPC method name.</summary>
+    public string MethodName { get; set; } = "";
+
+    /// <summary>The RPC cardinality (unary / server-streaming / bidirectional-streaming).</summary>
+    public GrpcRpcStreamKind StreamKind { get; set; }
+
+    /// <summary>How the service was discovered — <see cref="GrpcServiceDiscoveryMode.ProtoFirst"/> or
+    /// <see cref="GrpcServiceDiscoveryMode.CodeFirst"/>.</summary>
+    public GrpcServiceDiscoveryMode Mode { get; set; }
+
+    /// <summary>The request type — the Wolverine message this RPC forwards to the bus (the published origin). For
+    /// bidirectional RPCs this is the per-item element type of the inbound request stream.</summary>
+    public TypeDescriptor? RequestType { get; set; }
+
+    /// <summary>The response type, or <c>null</c> for a method with no typed response.</summary>
+    public TypeDescriptor? ResponseType { get; set; }
+
+    /// <summary>The forwarding origin — the discovered service identity (proto-first stub or code-first contract
+    /// interface) whose generated wrapper performs the bus dispatch.</summary>
+    public TypeDescriptor? Origin { get; set; }
+}

--- a/src/Wolverine/Configuration/Capabilities/IGrpcEndpointDescriptorSource.cs
+++ b/src/Wolverine/Configuration/Capabilities/IGrpcEndpointDescriptorSource.cs
@@ -1,0 +1,18 @@
+namespace Wolverine.Configuration.Capabilities;
+
+/// <summary>
+/// Implemented by <c>Wolverine.Grpc</c> to surface the application's discovered gRPC RPC endpoints — the proto-first
+/// and code-first RPCs whose generated wrapper forwards a request to the Wolverine message bus — as
+/// <see cref="GrpcRpcDescriptor"/> snapshots for a monitoring console (CritterWatch's gRPC Explorer).
+/// </summary>
+/// <remarks>
+/// Pure-Wolverine hosts with no gRPC integration won't register any source, so
+/// <see cref="ServiceCapabilities.GrpcEndpoints"/> stays empty. The descriptors are projected from
+/// <c>IGrpcEndpointManifest</c>, which discovers services once and caches the result; this interface just exposes the
+/// projected collection so <c>ServiceCapabilities.ReadFrom</c> can fold it into the snapshot without re-running
+/// discovery on every emit. Mirrors <see cref="IAspNetEndpointDescriptorSource"/>.
+/// </remarks>
+public interface IGrpcEndpointDescriptorSource
+{
+    IReadOnlyList<GrpcRpcDescriptor> Endpoints { get; }
+}

--- a/src/Wolverine/Configuration/Capabilities/ServiceCapabilities.cs
+++ b/src/Wolverine/Configuration/Capabilities/ServiceCapabilities.cs
@@ -122,6 +122,15 @@ public class ServiceCapabilities : OptionsDescription
     /// </summary>
     public List<AspNetEndpointDescriptor> AspNetEndpoints { get; set; } = [];
 
+    /// <summary>
+    /// Diagnostic snapshots of the application's Wolverine gRPC RPC endpoints — the proto-first and code-first RPCs
+    /// whose generated wrapper forwards a request to the message bus — populated by walking
+    /// <see cref="IGrpcEndpointDescriptorSource"/> services through DI. <c>Wolverine.Grpc</c> registers a single
+    /// source when gRPC integration is enabled. Empty when no gRPC integration is loaded (pure-Wolverine workers
+    /// incur no gRPC dependency). Mirrors <see cref="AspNetEndpoints"/>.
+    /// </summary>
+    public List<GrpcRpcDescriptor> GrpcEndpoints { get; set; } = [];
+
     public List<EndpointDescriptor> MessagingEndpoints { get; set; } = [];
 
     public DatabaseCardinality MessageStoreCardinality { get; set; } = DatabaseCardinality.None;
@@ -162,6 +171,8 @@ public class ServiceCapabilities : OptionsDescription
         await readHttpGraphs(runtime, token, capabilities);
 
         readAspNetEndpoints(runtime, capabilities);
+
+        readGrpcEndpoints(runtime, capabilities);
 
         readMessageTypes(runtime, capabilities);
 
@@ -218,6 +229,23 @@ public class ServiceCapabilities : OptionsDescription
         }
 
         capabilities.AspNetEndpoints.AddRange(list.OrderBy(x => x.Route + "::" + string.Join(",", x.HttpMethods)));
+    }
+
+    /// <summary>
+    /// Walk every <see cref="IGrpcEndpointDescriptorSource"/> in DI — registered by <c>Wolverine.Grpc</c> when gRPC
+    /// integration is enabled. Pure-Wolverine workers won't have any registered; the collection stays empty. Ordered
+    /// by service + method so the snapshot is stable across emits.
+    /// </summary>
+    private static void readGrpcEndpoints(IWolverineRuntime runtime, ServiceCapabilities capabilities)
+    {
+        var sources = runtime.Services.GetServices<IGrpcEndpointDescriptorSource>();
+        var list = new List<GrpcRpcDescriptor>();
+        foreach (var source in sources)
+        {
+            list.AddRange(source.Endpoints);
+        }
+
+        capabilities.GrpcEndpoints.AddRange(list.OrderBy(x => x.ServiceName + "::" + x.MethodName, StringComparer.Ordinal));
     }
 
     private static void readEndpoints(IWolverineRuntime runtime, ServiceCapabilities capabilities)


### PR DESCRIPTION
Closes #3267. Builds on #3266.

## Summary

The gRPC endpoint manifest (`IGrpcEndpointManifest`, #3266) lived only inside `Wolverine.Grpc` and never reached the `ServiceCapabilities` capability path. A monitoring console (CritterWatch) therefore had no way to **discover the gRPC services a Wolverine app exposes** — the way it already discovers HTTP chains (`IHttpGraphUsageSource`) and ASP.NET endpoints (`IAspNetEndpointDescriptorSource`) via `ServiceCapabilities.ReadFrom`.

This PR adds the parallel descriptor/source plumbing for gRPC:

- **`GrpcRpcDescriptor : OptionsDescription`** (Wolverine core, beside `ServiceCapabilities`) — one per RPC, carrying service name, method, RPC kind (`GrpcRpcStreamKind`), discovery mode, the published/request message type, response type, and the forwarding origin. Types are serializable `TypeDescriptor`s; `Subject` is `GrpcEndpoint[Service/Method]` and each is tagged `grpc`.
- **`IGrpcEndpointDescriptorSource`** — discovery source mirroring `IAspNetEndpointDescriptorSource`; registered in DI by `Wolverine.Grpc`, projecting the runtime `IGrpcEndpointManifest` into descriptors (lazy + cached).
- **`ServiceCapabilities.GrpcEndpoints`** + `readGrpcEndpoints` — folds every registered source into the snapshot, ordered by `service::method` (mirrors `AspNetEndpoints`).

### Design note — why Wolverine core, not JasperFx.Descriptors

The issue suggested putting the descriptor in `JasperFx.Descriptors` (mirroring `AspNetEndpointDescriptor`). But `ServiceCapabilities` is itself a **Wolverine-core** type and CritterWatch already references `WolverineFx`, so a core-resident descriptor is **equally consumable** — without a coordinated JasperFx release and a 2.16→2.18 pin bump. This keeps #3267 a single self-contained PR. Hand-written and direct-mapped services stay excluded (inherited from the manifest): they delegate to user code and have no message-publishing origin.

## Test coverage

`grpc_capabilities_descriptor_source_3267.cs` — across **every supported gRPC configuration**, through both the raw `IGrpcEndpointDescriptorSource` and the end-to-end `ServiceCapabilities.ReadFrom` path:

| Configuration | Asserted |
|---|---|
| proto-first unary (`SayHello`) | full mapping: service/method/kind/mode/request/response/origin/Subject/`grpc` tag |
| proto-first server-streaming (`StreamGreetings`) | kind + request DTO + stream-element response |
| proto-first **bidirectional** (`Echo`, via `BidiStreamingFixture`) | kind + per-item request element type |
| code-first unary (`Greet`) | full mapping incl. contract-interface origin |
| code-first server-streaming (`StreamGreetings`) | kind + `IAsyncEnumerable<T>` element response |
| invariants | every descriptor has Subject/RequestType/Origin/`grpc` tag; capabilities ordered by service::method; only bus-forwarding modes surface |
| no gRPC | `GrpcEndpoints` empty and no source registered |

Local: `Wolverine.Grpc.Tests` **247/247** + the CoreTests capability/`ReadFrom` acceptance suite **24/24** (net9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)