### PR TITLE
Pin the NServiceBus SQL Server interop transport to a dedicated database under multi-tenanted storage

### DIFF
--- a/docs/guide/durability/sqlserver.md
+++ b/docs/guide/durability/sqlserver.md
@@ -334,6 +334,41 @@ The default (non-)tenant is never written as a header, so single-tenant traffic 
 A full, runnable bidirectional example (both frameworks hosted side by side, including the multi-tenant case)
 is maintained in Wolverine's interop test suite. See the [interop tutorial](/tutorials/interop) for the bigger picture.
 
+#### Dedicated interop database under multi-tenanted storage <Badge type="tip" text="6.16" />
+
+The NServiceBus header-based tenancy above is about NServiceBus' *own* persistence. A different situation arises
+when **Wolverine's** message storage is multi-tenanted with [a separate database per tenant](#multi-tenancy): there,
+the NServiceBus interop queue tables still live on the **one shared database** NServiceBus reads from — they must
+*not* be replicated into each tenant database.
+
+By default the interop transport binds to Wolverine's `Main` SQL Server message store. To pin it instead to a single,
+dedicated database that is fully decoupled from the tenanted storage, pass an explicit `connectionString` to
+`UseNServiceBusSqlServerInterop`:
+
+```cs
+builder.UseWolverine(opts =>
+{
+    // Wolverine's message storage is multi-tenanted: a database per tenant
+    opts.PersistMessagesWithSqlServer(mainConnectionString)
+        .UseMasterTableTenancy(tenants =>
+        {
+            tenants.Register("tenant_one", tenantOneConnectionString);
+            tenants.Register("tenant_two", tenantTwoConnectionString);
+        });
+
+    // ...but the NServiceBus interop queues live on ONE shared database. Pin the transport to it
+    // so Wolverine never tries to create the queue tables per tenant database.
+    opts.UseNServiceBusSqlServerInterop(autoProvision: true, connectionString: nsbSharedConnectionString);
+
+    opts.PublishMessage<OrderPlaced>().ToNServiceBusSqlServerQueue("nsb");
+});
+```
+
+With the explicit connection string set, the interop queue tables are created, sent to, and listened on against
+that one database only — regardless of which tenant a message is sent under. (This is independent of the per-message
+`tenant_id` header mapping above, which you can still apply if the receiving NServiceBus endpoint is itself
+tenant-partitioned.)
+
 ## Lightweight Saga Usage <Badge type="tip" text="3.0" />
 
 See the details on [Lightweight Saga Storage](/guide/durability/sagas.html#lightweight-saga-storage) for more information.

--- a/src/Persistence/SqlServerTests/Transport/NServiceBus/nsb_dedicated_database_multitenancy.cs
+++ b/src/Persistence/SqlServerTests/Transport/NServiceBus/nsb_dedicated_database_multitenancy.cs
@@ -1,0 +1,178 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Weasel.Core;
+using Wolverine;
+using Wolverine.SqlServer;
+using Wolverine.SqlServer.Transport.NServiceBus;
+using Xunit;
+
+namespace SqlServerTests.Transport.NServiceBus;
+
+// GH: the NServiceBus SQL Server interop transport can be pinned to one dedicated database via
+// UseNServiceBusSqlServerInterop(connectionString: ...), decoupled from Wolverine's multi-tenanted
+// (database-per-tenant) message storage. The transport must own its queue tables on that single
+// database ONLY — never replicated across tenant databases (mirrors simonfox/wolverine.spike).
+public class nsb_dedicated_database_multitenancy : IAsyncLifetime
+{
+    private string _mainCs = null!;
+    private string _t1Cs = null!;
+    private string _t2Cs = null!;
+    private string _dedicatedCs = null!;
+    private IHost _host = null!;
+    private readonly string _queue = "dedicated_nsb_" + Guid.NewGuid().ToString("N")[..8];
+
+    public async Task InitializeAsync()
+    {
+        _mainCs = await NsbMtDb.CreateDb("nsb_ded_main");
+        _t1Cs = await NsbMtDb.CreateDb("nsb_ded_t1");
+        _t2Cs = await NsbMtDb.CreateDb("nsb_ded_t2");
+        _dedicatedCs = await NsbMtDb.CreateDb("nsb_ded_shared");
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Native transport + persistence on the main database.
+                opts.UseSqlServerPersistenceAndTransport(_mainCs);
+
+                // Multi-tenanted storage: a database per tenant.
+                opts.PersistMessagesWithSqlServer(_mainCs)
+                    .UseMasterTableTenancy(t =>
+                    {
+                        t.Register("tenant_one", _t1Cs);
+                        t.Register("tenant_two", _t2Cs);
+                    });
+
+                // NServiceBus interop pinned to one dedicated shared database, NOT the tenanted storage.
+                opts.UseNServiceBusSqlServerInterop(autoProvision: true, connectionString: _dedicatedCs);
+
+                opts.PublishMessage<ReproPing>().ToNServiceBusSqlServerQueue(_queue);
+
+                opts.Services.AddResourceSetupOnStartup();
+                opts.Discovery.DisableConventionalDiscovery();
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task queue_table_is_provisioned_only_in_the_dedicated_database()
+    {
+        (await NsbMtDb.TableExists(_dedicatedCs, _queue)).ShouldBeTrue("queue table must exist in the dedicated NSB database");
+
+        (await NsbMtDb.TableExists(_mainCs, _queue)).ShouldBeFalse("queue table must NOT be in the storage main database");
+        (await NsbMtDb.TableExists(_t1Cs, _queue)).ShouldBeFalse("queue table must NOT be in tenant_one's database");
+        (await NsbMtDb.TableExists(_t2Cs, _queue)).ShouldBeFalse("queue table must NOT be in tenant_two's database");
+    }
+
+    [Fact]
+    public async Task sending_under_a_tenant_writes_to_the_dedicated_database_only()
+    {
+        await _host.MessageBus().PublishAsync(new ReproPing(Guid.NewGuid()),
+            new DeliveryOptions { TenantId = "tenant_one" });
+
+        // Buffered interop send — poll briefly for the row to land in the dedicated database.
+        long dedicated = 0;
+        for (var i = 0; i < 40 && dedicated == 0; i++)
+        {
+            dedicated = await RowCount(_dedicatedCs, _queue);
+            if (dedicated == 0) await Task.Delay(100);
+        }
+
+        dedicated.ShouldBe(1);
+
+        // And nowhere else — the tenant's own database never receives an interop queue table.
+        (await NsbMtDb.TableExists(_t1Cs, _queue)).ShouldBeFalse();
+        (await NsbMtDb.TableExists(_mainCs, _queue)).ShouldBeFalse();
+    }
+
+    private static async Task<long> RowCount(string cs, string table)
+    {
+        if (!await NsbMtDb.TableExists(cs, table)) return 0;
+        await using var conn = new SqlConnection(cs);
+        await conn.OpenAsync();
+        var cmd = conn.CreateCommand($"SELECT COUNT(*) FROM [dbo].[{table}]");
+        return (int)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+}
+
+// Locks in the DEFAULT behavior (no explicit connection string): under database-per-tenant storage the NServiceBus
+// interop transport binds to the Main store only and is NEVER replicated into tenant databases.
+public class nsb_default_database_multitenancy : IAsyncLifetime
+{
+    private string _mainCs = null!;
+    private string _t1Cs = null!;
+    private IHost _host = null!;
+    private readonly string _queue = "default_nsb_" + Guid.NewGuid().ToString("N")[..8];
+
+    public async Task InitializeAsync()
+    {
+        _mainCs = await NsbMtDb.CreateDb("nsb_def_main");
+        _t1Cs = await NsbMtDb.CreateDb("nsb_def_t1");
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseSqlServerPersistenceAndTransport(_mainCs);
+                opts.PersistMessagesWithSqlServer(_mainCs)
+                    .UseMasterTableTenancy(t => t.Register("tenant_one", _t1Cs));
+
+                // No explicit connection string — falls back to the Main store.
+                opts.UseNServiceBusSqlServerInterop(autoProvision: true);
+                opts.PublishMessage<ReproPing>().ToNServiceBusSqlServerQueue(_queue);
+
+                opts.Services.AddResourceSetupOnStartup();
+                opts.Discovery.DisableConventionalDiscovery();
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task binds_to_main_store_not_tenant_databases()
+    {
+        (await NsbMtDb.TableExists(_mainCs, _queue)).ShouldBeTrue("default binding is the Main message store");
+        (await NsbMtDb.TableExists(_t1Cs, _queue)).ShouldBeFalse("must NOT be replicated into a tenant database");
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+}
+
+public record ReproPing(Guid Id);
+
+internal static class NsbMtDb
+{
+    public static async Task<bool> TableExists(string cs, string table)
+    {
+        await using var conn = new SqlConnection(cs);
+        await conn.OpenAsync();
+        var cmd = conn.CreateCommand("SELECT CASE WHEN OBJECT_ID(@n, N'U') IS NULL THEN 0 ELSE 1 END")
+            .With("n", $"[dbo].[{table}]");
+        return (int)(await cmd.ExecuteScalarAsync())! == 1;
+    }
+
+    public static async Task<string> CreateDb(string name)
+    {
+        var builder = new SqlConnectionStringBuilder(Servers.SqlServerConnectionString);
+        await using (var conn = new SqlConnection(builder.ConnectionString))
+        {
+            await conn.OpenAsync();
+            var exists = await conn.CreateCommand($"SELECT DB_ID('{name}')").ExecuteScalarAsync();
+            if (exists == null || exists == DBNull.Value)
+            {
+                await conn.CreateCommand($"CREATE DATABASE [{name}]").ExecuteNonQueryAsync();
+            }
+        }
+
+        builder.InitialCatalog = name;
+        return builder.ConnectionString;
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransport.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransport.cs
@@ -37,6 +37,15 @@ public class NServiceBusSqlServerTransport : BrokerTransport<NServiceBusSqlServe
     /// </summary>
     public string SchemaName { get; set; } = "dbo";
 
+    /// <summary>
+    /// Optional explicit connection string for the single database that owns the NServiceBus interop queue tables.
+    /// When set, the transport binds to this one database and is fully decoupled from Wolverine's message storage —
+    /// use this when storage is multi-tenanted (a database per tenant) but the NServiceBus queues live on one shared
+    /// database that must NOT be replicated per tenant. When null (the default), the transport falls back to
+    /// Wolverine's SQL Server message store (the <c>Main</c> store under multi-tenancy).
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
     public override Uri ResourceUri => new("nservicebus-sqlserver-transport://");
 
     protected override IEnumerable<NServiceBusSqlServerQueue> endpoints()
@@ -62,21 +71,29 @@ public class NServiceBusSqlServerTransport : BrokerTransport<NServiceBusSqlServe
 
     public override async ValueTask ConnectAsync(IWolverineRuntime runtime)
     {
-        if (runtime.Storage is SqlServerMessageStore store)
+        if (ConnectionString.IsNotEmpty())
+        {
+            // Explicit single database for the NServiceBus interop queues, decoupled from Wolverine's
+            // (possibly multi-tenanted) message storage. No requirement that storage itself be SQL Server backed:
+            // the interop queues are buffered and never touch Wolverine's durable inbox/outbox tables.
+            Settings = new DatabaseSettings { ConnectionString = ConnectionString, SchemaName = SchemaName };
+        }
+        else if (runtime.Storage is SqlServerMessageStore store)
         {
             Storage = store;
+            Settings = Storage.Settings;
         }
         else if (runtime.Storage is MultiTenantedMessageStore mt && mt.Main is SqlServerMessageStore s)
         {
             Storage = s;
+            Settings = Storage.Settings;
         }
         else
         {
             throw new InvalidOperationException(
-                "The NServiceBus Sql Server interop transport can only be used if Wolverine's message persistence is also Sql Server backed");
+                "The NServiceBus Sql Server interop transport requires either an explicit connection string " +
+                "(UseNServiceBusSqlServerInterop(connectionString: ...)) or Wolverine's message persistence to be Sql Server backed");
         }
-
-        Settings = Storage.Settings;
 
         // de facto environment test
         await using var conn = new SqlConnection(Settings.ConnectionString);
@@ -95,6 +112,13 @@ public class NServiceBusSqlServerTransport : BrokerTransport<NServiceBusSqlServe
     /// </summary>
     internal string ResolveConnectionString(IWolverineRuntime runtime)
     {
+        // An explicit connection string pins the interop queues to one database regardless of storage tenancy,
+        // and is resolvable before ConnectAsync has run (e.g. from the Weasel command line).
+        if (ConnectionString.IsNotEmpty())
+        {
+            return ConnectionString!;
+        }
+
         if (Settings is not null)
         {
             return Settings.ConnectionString!;

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransportExtensions.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerTransportExtensions.cs
@@ -13,7 +13,7 @@ public static class NServiceBusSqlServerTransportExtensions
     /// Requires Wolverine to also be using SQL Server backed message persistence.
     /// </summary>
     internal static NServiceBusSqlServerTransport NServiceBusSqlServerTransport(this WolverineOptions options,
-        string? schema = null)
+        string? schema = null, string? connectionString = null)
     {
         var transport = options.Transports.OfType<NServiceBusSqlServerTransport>().FirstOrDefault();
         if (transport == null)
@@ -30,6 +30,11 @@ public static class NServiceBusSqlServerTransportExtensions
             transport.SchemaName = schema!;
         }
 
+        if (connectionString.IsNotEmpty())
+        {
+            transport.ConnectionString = connectionString;
+        }
+
         return transport;
     }
 
@@ -43,10 +48,17 @@ public static class NServiceBusSqlServerTransportExtensions
     /// When true, Wolverine will create the NServiceBus queue tables if they do not already
     /// exist. Defaults to false because NServiceBus normally owns and provisions its own tables.
     /// </param>
+    /// <param name="connectionString">
+    /// Optional explicit connection string for the single database that owns the NServiceBus interop queue tables.
+    /// Set this when Wolverine's message storage is multi-tenanted (a database per tenant) but the NServiceBus queues
+    /// live on one shared database: the transport binds to this one database only and never creates a queue per tenant
+    /// database. When null (the default), the transport uses Wolverine's SQL Server message store (the <c>Main</c>
+    /// store under multi-tenancy).
+    /// </param>
     public static WolverineOptions UseNServiceBusSqlServerInterop(this WolverineOptions options,
-        string? schema = null, bool autoProvision = false)
+        string? schema = null, bool autoProvision = false, string? connectionString = null)
     {
-        var transport = options.NServiceBusSqlServerTransport(schema);
+        var transport = options.NServiceBusSqlServerTransport(schema, connectionString);
         transport.AutoProvision = autoProvision;
         return options;
     }


### PR DESCRIPTION
## Scenario

From the [wolverine.spike](https://github.com/simonfox/wolverine.spike) sample: Wolverine's SQL Server **message storage** is multi-tenanted with a database per tenant (`UseMasterTableTenancy`), while the **NServiceBus-compliant SQL Server interop** queues live on one shared database NServiceBus reads from — and must **not** be replicated into each tenant database.

## What I found (reproduced vs. real SQL Server)

The interop transport already only ever provisioned/sent/listened against a **single** database (`Storage.Main`) — it never iterated tenant databases (unlike the native SQL Server transport, whose `SqlServerQueue` deliberately fans out over `Parent.Databases.ActiveDatabases()`). So the reported "creates a queue per database" symptom does not occur on `main`.

The real gap: that single database was **hardcoded** to `Storage.Main`, with no way to point the interop transport at a dedicated shared database decoupled from the tenanted storage.

## Change — opt-in dedicated database

```csharp
opts.PersistMessagesWithSqlServer(main)
    .UseMasterTableTenancy(t => { t.Register("tenant_one", t1); t.Register("tenant_two", t2); });

// Pin the interop queues to ONE shared database, independent of tenant storage
opts.UseNServiceBusSqlServerInterop(autoProvision: true, connectionString: nsbSharedDb);
```

- `NServiceBusSqlServerTransport.ConnectionString` (optional explicit DB).
- `ConnectAsync` builds `Settings` from the explicit string when set, and **no longer requires SQL-Server-backed storage** in that case — the interop queues are buffered and never touch Wolverine's durable inbox/outbox.
- `ResolveConnectionString` prefers the explicit string, so it resolves before `ConnectAsync` (Weasel CLI / resource model) and the `IDatabase` resource also targets the dedicated DB.
- **Non-breaking:** `connectionString` is a trailing optional parameter; when omitted, behavior is unchanged (binds to the `Main` store).

## Tests (vs. real SQL Server)

- **Dedicated opt-in:** queue table provisioned **only** in the dedicated DB (asserted absent from main + both tenant DBs); a send under `tenant_one` lands a row in the dedicated DB only.
- **Default (no opt-in) under multi-tenancy:** binds to `Main` only, never replicated into a tenant database.
- Existing NSB smoke test still green — 4/4 NSB transport tests pass locally (net9.0).

Plus a docs subsection in `docs/guide/durability/sqlserver.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)