### PR TITLE
Sanitized, credential-free broker connection summary on BrokerDescription (GH-3269)

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/broker_connection_summary_3269.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/broker_connection_summary_3269.cs
@@ -1,0 +1,40 @@
+using Amazon;
+using Shouldly;
+using Wolverine.AmazonSns.Internal;
+using Wolverine.Configuration.Capabilities;
+using Xunit;
+
+namespace Wolverine.AmazonSns.Tests;
+
+// GH-3269: the SNS summary is the region (or an explicit ServiceURL such as LocalStack).
+public class broker_connection_summary_3269
+{
+    [Fact]
+    public void describe_endpoint_reports_the_region()
+    {
+        var transport = new AmazonSnsTransport();
+        transport.SnsConfig.RegionEndpoint = RegionEndpoint.USEast1;
+
+        transport.DescribeEndpoint().ShouldBe("us-east-1");
+    }
+
+    [Fact]
+    public void describe_endpoint_prefers_an_explicit_service_url()
+    {
+        var transport = new AmazonSnsTransport();
+        transport.SnsConfig.ServiceURL = "http://localhost:4566";
+
+        // The AWS SDK may normalize the URL (e.g. a trailing slash); DescribeEndpoint reports it verbatim.
+        transport.DescribeEndpoint().ShouldBe(transport.SnsConfig.ServiceURL);
+        transport.DescribeEndpoint()!.ShouldContain("localhost:4566");
+    }
+
+    [Fact]
+    public void broker_description_endpoint_is_populated()
+    {
+        var transport = new AmazonSnsTransport();
+        transport.SnsConfig.RegionEndpoint = RegionEndpoint.EUWest2;
+
+        new BrokerDescription(transport).Endpoint.ShouldBe("eu-west-2");
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTransport.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTransport.cs
@@ -68,6 +68,24 @@ public class AmazonSnsTransport : BrokerTransport<AmazonSnsTopic>
     internal IAmazonSimpleNotificationService? SnsClient { get; private set; }
     internal IAmazonSQS? SqsClient { get; private set; }
 
+    public override string? DescribeEndpoint()
+    {
+        // An explicit ServiceURL (e.g. LocalStack) is a plain endpoint URL; AWS credentials are supplied separately.
+        if (SnsConfig.ServiceURL.IsNotEmpty()) return SnsConfig.ServiceURL;
+
+        try
+        {
+            var region = SnsConfig.RegionEndpoint?.SystemName;
+            if (region.IsNotEmpty()) return region;
+        }
+        catch (Exception)
+        {
+            // RegionEndpoint resolution can probe ambient configuration; ignore.
+        }
+
+        return null;
+    }
+
     public int LocalStackPort { get; set; }
 
     public bool UseLocalStackInDevelopment { get; set; }

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/broker_connection_summary_3269.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/broker_connection_summary_3269.cs
@@ -1,0 +1,41 @@
+using Amazon;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Configuration.Capabilities;
+using Xunit;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+// GH-3269: the SQS summary is the region (or an explicit ServiceURL such as LocalStack). AWS credentials are supplied
+// separately (CredentialSource), never as a string on the transport.
+public class broker_connection_summary_3269
+{
+    [Fact]
+    public void describe_endpoint_reports_the_region()
+    {
+        var transport = new AmazonSqsTransport();
+        transport.Config.RegionEndpoint = RegionEndpoint.USEast1;
+
+        transport.DescribeEndpoint().ShouldBe("us-east-1");
+    }
+
+    [Fact]
+    public void describe_endpoint_prefers_an_explicit_service_url()
+    {
+        var transport = new AmazonSqsTransport();
+        transport.Config.ServiceURL = "http://localhost:4566";
+
+        // The AWS SDK may normalize the URL (e.g. a trailing slash); DescribeEndpoint reports it verbatim.
+        transport.DescribeEndpoint().ShouldBe(transport.Config.ServiceURL);
+        transport.DescribeEndpoint()!.ShouldContain("localhost:4566");
+    }
+
+    [Fact]
+    public void broker_description_endpoint_is_populated()
+    {
+        var transport = new AmazonSqsTransport();
+        transport.Config.RegionEndpoint = RegionEndpoint.EUWest2;
+
+        new BrokerDescription(transport).Endpoint.ShouldBe("eu-west-2");
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
@@ -71,6 +71,24 @@ public class AmazonSqsTransport : BrokerTransport<AmazonSqsQueue>
         Client = client;
     }
 
+    public override string? DescribeEndpoint()
+    {
+        // An explicit ServiceURL (e.g. LocalStack) is a plain endpoint URL; AWS credentials are supplied separately.
+        if (Config.ServiceURL.IsNotEmpty()) return Config.ServiceURL;
+
+        try
+        {
+            var region = Config.RegionEndpoint?.SystemName;
+            if (region.IsNotEmpty()) return region;
+        }
+        catch (Exception)
+        {
+            // RegionEndpoint resolution can probe ambient configuration; ignore.
+        }
+
+        return null;
+    }
+
     [DescribeAsConfigurationState]
     public Func<IWolverineRuntime, AWSCredentials>? CredentialSource { get; set; }
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/broker_connection_summary_3269.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/broker_connection_summary_3269.cs
@@ -1,0 +1,78 @@
+using JasperFx.Descriptors;
+using Shouldly;
+using Wolverine.AzureServiceBus;
+using Wolverine.Configuration.Capabilities;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+// GH-3269: the Azure Service Bus summary is the namespace FQDN, never the SharedAccessKey.
+public class broker_connection_summary_3269
+{
+    private const string Secret = "aSharedAccessKeySecretValue123=";
+
+    [Fact]
+    public void describe_endpoint_uses_the_fully_qualified_namespace()
+    {
+        var transport = new AzureServiceBusTransport { FullyQualifiedNamespace = "myns.servicebus.windows.net" };
+        transport.DescribeEndpoint().ShouldBe("myns.servicebus.windows.net");
+    }
+
+    [Fact]
+    public void describe_endpoint_extracts_namespace_from_connection_string()
+    {
+        var transport = new AzureServiceBusTransport
+        {
+            ConnectionString =
+                $"Endpoint=sb://myns.servicebus.windows.net/;SharedAccessKeyName=root;SharedAccessKey={Secret}"
+        };
+
+        transport.DescribeEndpoint().ShouldBe("myns.servicebus.windows.net");
+    }
+
+    [Fact]
+    public void shared_access_key_never_leaks_into_the_description()
+    {
+        var transport = new AzureServiceBusTransport
+        {
+            ConnectionString =
+                $"Endpoint=sb://myns.servicebus.windows.net/;SharedAccessKeyName=root;SharedAccessKey={Secret}"
+        };
+
+        var description = new BrokerDescription(transport);
+
+        description.Endpoint.ShouldBe("myns.servicebus.windows.net");
+        BrokerSecretScanner.AssertNoSecret(description, Secret);
+    }
+}
+
+internal static class BrokerSecretScanner
+{
+    public static void AssertNoSecret(BrokerDescription description, string secret)
+    {
+        (description.Endpoint ?? "").ShouldNotContain(secret);
+        foreach (var text in AllText(description))
+        {
+            text.ShouldNotContain(secret);
+        }
+    }
+
+    private static IEnumerable<string> AllText(OptionsDescription description)
+    {
+        if (description.Subject != null) yield return description.Subject;
+        foreach (var p in description.Properties)
+        {
+            if (p.Name != null) yield return p.Name;
+            if (p.Value != null) yield return p.Value;
+        }
+
+        foreach (var child in description.Children.Values)
+        foreach (var text in AllText(child))
+            yield return text;
+
+        foreach (var set in description.Sets.Values)
+        foreach (var row in set.Rows)
+        foreach (var text in AllText(row))
+            yield return text;
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
@@ -259,6 +259,16 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
         }
     }
 
+    public override string? DescribeEndpoint()
+    {
+        if (!string.IsNullOrEmpty(FullyQualifiedNamespace)) return FullyQualifiedNamespace;
+
+        // The Endpoint host inside the connection string is the namespace FQDN; only the SharedAccessKey is secret.
+        if (!string.IsNullOrEmpty(ConnectionString)) return HostName;
+
+        return null;
+    }
+
     protected override IEnumerable<Endpoint> explicitEndpoints()
     {
         foreach (var queue in Queues) yield return queue;

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/broker_connection_summary_3269.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/broker_connection_summary_3269.cs
@@ -1,0 +1,32 @@
+using Google.Api.Gax;
+using Shouldly;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Pubsub;
+using Xunit;
+
+namespace Wolverine.Pubsub.Tests;
+
+// GH-3269: the GCP Pub/Sub summary is the project id (with an emulator marker when applicable).
+public class broker_connection_summary_3269
+{
+    [Fact]
+    public void describe_endpoint_reports_the_project_id()
+    {
+        var transport = new PubsubTransport("my-project");
+        transport.DescribeEndpoint().ShouldBe("project: my-project");
+    }
+
+    [Fact]
+    public void describe_endpoint_marks_the_emulator()
+    {
+        var transport = new PubsubTransport("my-project") { EmulatorDetection = EmulatorDetection.EmulatorOnly };
+        transport.DescribeEndpoint().ShouldBe("project: my-project (emulator)");
+    }
+
+    [Fact]
+    public void broker_description_endpoint_is_populated()
+    {
+        var transport = new PubsubTransport("my-project");
+        new BrokerDescription(transport).Endpoint.ShouldBe("project: my-project");
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub/PubsubTransport.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/PubsubTransport.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Google.Api.Gax;
 using Google.Cloud.PubSub.V1;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Transports;
@@ -37,6 +38,7 @@ public class PubsubTransport : BrokerTransport<PubsubEndpoint>, IAsyncDisposable
     ///     Multiple calls compose in order. Use the async signature when credential construction requires I/O
     ///     (e.g. fetching a token from Azure Key Vault or Azure IMDS).
     /// </summary>
+    [IgnoreDescription]
     public Func<PublisherServiceApiClientBuilder, ValueTask>? ConfigurePublisherApiBuilder { get; set; }
 
     /// <summary>
@@ -44,6 +46,7 @@ public class PubsubTransport : BrokerTransport<PubsubEndpoint>, IAsyncDisposable
     ///     Applied after <see cref="EmulatorDetection" /> is set, so it may override any transport-level defaults.
     ///     Multiple calls compose in order. Use the async signature when credential construction requires I/O.
     /// </summary>
+    [IgnoreDescription]
     public Func<SubscriberServiceApiClientBuilder, ValueTask>? ConfigureSubscriberApiBuilder { get; set; }
 
     /// <summary>
@@ -51,6 +54,7 @@ public class PubsubTransport : BrokerTransport<PubsubEndpoint>, IAsyncDisposable
     ///     Applied after <see cref="EmulatorDetection" /> is set, so it may override any transport-level defaults.
     ///     Multiple calls compose in order. Use the async signature when credential construction requires I/O.
     /// </summary>
+    [IgnoreDescription]
     public Func<SubscriberClientBuilder, ValueTask>? ConfigureSubscriberClientBuilder { get; set; }
 
     public PubsubTransport() : base(ProtocolName, "Google Cloud Platform Pub/Sub", ["gcp", ProtocolName])
@@ -65,6 +69,14 @@ public class PubsubTransport : BrokerTransport<PubsubEndpoint>, IAsyncDisposable
     }
 
     public override Uri ResourceUri => new Uri("pubsub://" + ProjectId);
+
+    public override string? DescribeEndpoint()
+    {
+        if (string.IsNullOrWhiteSpace(ProjectId)) return null;
+        return EmulatorDetection == EmulatorDetection.None
+            ? $"project: {ProjectId}"
+            : $"project: {ProjectId} (emulator)";
+    }
 
     public ValueTask DisposeAsync()
     {

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/broker_connection_summary_3269.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/broker_connection_summary_3269.cs
@@ -1,0 +1,83 @@
+using JasperFx.Descriptors;
+using Shouldly;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Kafka.Internals;
+using Xunit;
+
+namespace Wolverine.Kafka.Tests;
+
+// GH-3269: BrokerDescription must carry a sanitized, credential-free connection summary per transport. For Kafka the
+// summary is the bootstrap servers, and the SASL credentials on the Confluent configs must NEVER leak into the
+// diagnostic tree.
+public class broker_connection_summary_3269
+{
+    private const string Secret = "S3CR3T_SASL_PASSWORD";
+
+    [Fact]
+    public void describe_endpoint_reports_bootstrap_servers()
+    {
+        var transport = new KafkaTransport();
+        transport.ProducerConfig.BootstrapServers = "broker1:9092,broker2:9092";
+
+        transport.DescribeEndpoint().ShouldBe("broker1:9092,broker2:9092");
+    }
+
+    [Fact]
+    public void broker_description_endpoint_is_populated()
+    {
+        var transport = new KafkaTransport();
+        transport.ConsumerConfig.BootstrapServers = "kafka.internal:9092";
+
+        new BrokerDescription(transport).Endpoint.ShouldBe("kafka.internal:9092");
+    }
+
+    [Fact]
+    public void sasl_credentials_never_leak_into_the_description()
+    {
+        var transport = new KafkaTransport();
+        transport.ProducerConfig.BootstrapServers = "broker:9092";
+        transport.ProducerConfig.SaslUsername = "admin";
+        transport.ProducerConfig.SaslPassword = Secret;
+        transport.ConsumerConfig.SaslPassword = Secret;
+        transport.AdminClientConfig.SaslPassword = Secret;
+
+        var description = new BrokerDescription(transport);
+
+        // The sanitized target is present, the secret is not — anywhere in the reflected diagnostic tree.
+        description.Endpoint.ShouldBe("broker:9092");
+        BrokerSecretScanner.AssertNoSecret(description, Secret);
+    }
+}
+
+// Shared, project-local helper: recursively scan an OptionsDescription (Properties, Children, Sets) plus the typed
+// BrokerDescription fields for a forbidden secret substring.
+internal static class BrokerSecretScanner
+{
+    public static void AssertNoSecret(BrokerDescription description, string secret)
+    {
+        (description.Endpoint ?? "").ShouldNotContain(secret);
+        foreach (var text in AllText(description))
+        {
+            text.ShouldNotContain(secret);
+        }
+    }
+
+    private static IEnumerable<string> AllText(OptionsDescription description)
+    {
+        if (description.Subject != null) yield return description.Subject;
+        foreach (var p in description.Properties)
+        {
+            if (p.Name != null) yield return p.Name;
+            if (p.Value != null) yield return p.Value;
+        }
+
+        foreach (var child in description.Children.Values)
+        foreach (var text in AllText(child))
+            yield return text;
+
+        foreach (var set in description.Sets.Values)
+        foreach (var row in set.Rows)
+        foreach (var text in AllText(row))
+            yield return text;
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -30,24 +30,37 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
 
     internal List<KafkaTopicGroup> TopicGroups { get; } = new();
 
-    [ChildDescription]
+    // GH-3269: Confluent's ProducerConfig/ConsumerConfig/AdminClientConfig (ClientConfig) expose SaslUsername,
+    // SaslPassword, SslKeyPassword, SslKeystorePassword, … as public properties. Reflecting them into the diagnostic
+    // tree (the old [ChildDescription]) leaks those secrets to monitoring consumers, so they are suppressed.
+    // The sanitized bootstrap-servers target is surfaced via DescribeEndpoint() instead.
+    [IgnoreDescription]
     public ProducerConfig ProducerConfig { get; } = new();
     [IgnoreDescription]
     public Action<ProducerBuilder<string, byte[]>> ConfigureProducerBuilders { get; internal set; } = _ => {};
 
-    [ChildDescription]
+    [IgnoreDescription]
     public ConsumerConfig ConsumerConfig { get; } = new();
     [IgnoreDescription]
     public Action<ConsumerBuilder<string, byte[]>> ConfigureConsumerBuilders { get; internal set; } = _ => {};
 
-    [ChildDescription]
+    [IgnoreDescription]
     public AdminClientConfig AdminClientConfig { get; } = new();
     [IgnoreDescription]
     public Action<AdminClientBuilder> ConfigureAdminClientBuilders { get; internal set; } = _ => {};
 
+    public override string? DescribeEndpoint()
+    {
+        // BootstrapServers is a CSV of host:port (e.g. "broker1:9092, broker2:9092"); it carries no credentials.
+        var bootstrap = ProducerConfig.BootstrapServers
+                        ?? ConsumerConfig.BootstrapServers
+                        ?? AdminClientConfig.BootstrapServers;
+        return string.IsNullOrWhiteSpace(bootstrap) ? null : bootstrap;
+    }
+
     public KafkaTransport() : this("kafka")
     {
-        
+
     }
 
     public KafkaTransport(string protocol) : base(protocol, "Kafka Topics", ["kafka"])

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/broker_connection_summary_3269.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/broker_connection_summary_3269.cs
@@ -1,0 +1,68 @@
+using JasperFx.Descriptors;
+using MQTTnet.Client;
+using Shouldly;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.MQTT.Internals;
+using Xunit;
+
+namespace Wolverine.MQTT.Tests;
+
+// GH-3269: the MQTT summary is the broker host:port, never the username/password in the client options.
+public class broker_connection_summary_3269
+{
+    private const string Secret = "S3CR3T_MQTT_PWD";
+
+    [Fact]
+    public void describe_endpoint_reports_tcp_host_and_port()
+    {
+        var transport = new MqttTransport();
+        transport.Options.ClientOptions.ChannelOptions = new MqttClientTcpOptions { Server = "mqtt.host", Port = 8883 };
+
+        transport.DescribeEndpoint().ShouldBe("mqtt.host:8883");
+    }
+
+    [Fact]
+    public void credentials_never_leak_into_the_description()
+    {
+        var transport = new MqttTransport();
+        transport.Options.ClientOptions.ChannelOptions = new MqttClientTcpOptions { Server = "mqtt.host", Port = 1883 };
+        transport.Options.ClientOptions.Credentials =
+            new MqttClientCredentials("user", System.Text.Encoding.UTF8.GetBytes(Secret));
+
+        var description = new BrokerDescription(transport);
+
+        description.Endpoint.ShouldBe("mqtt.host:1883");
+        BrokerSecretScanner.AssertNoSecret(description, Secret);
+    }
+}
+
+internal static class BrokerSecretScanner
+{
+    public static void AssertNoSecret(BrokerDescription description, string secret)
+    {
+        (description.Endpoint ?? "").ShouldNotContain(secret);
+        foreach (var text in AllText(description))
+        {
+            text.ShouldNotContain(secret);
+        }
+    }
+
+    private static IEnumerable<string> AllText(OptionsDescription description)
+    {
+        if (description.Subject != null) yield return description.Subject;
+        foreach (var p in description.Properties)
+        {
+            if (p.Name != null) yield return p.Name;
+            if (p.Value != null) yield return p.Value;
+        }
+
+        foreach (var child in description.Children.Values)
+        foreach (var text in AllText(child))
+            yield return text;
+
+        foreach (var set in description.Sets.Values)
+        foreach (var row in set.Rows)
+        foreach (var text in AllText(row))
+            yield return text;
+    }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTransport.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTransport.cs
@@ -187,9 +187,27 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
     internal IManagedMqttClient Client { get; set; } = null!;
     internal MqttJwtAuthenticationOptions? JwtAuthenticationOptions { get; set; }
 
-    [ChildDescription]
+    // GH-3269: ManagedMqttClientOptions.ClientOptions carries Credentials (username/password) and other secrets.
+    // Reflecting it into the diagnostic tree would leak them, so it is suppressed; the sanitized host:port target is
+    // surfaced via DescribeEndpoint() instead.
+    [IgnoreDescription]
     public ManagedMqttClientOptions Options { get; set; } = new ManagedMqttClientOptions
         { ClientOptions = new MqttClientOptions() };
+
+    public override string? DescribeEndpoint()
+    {
+        switch (Options.ClientOptions?.ChannelOptions)
+        {
+            case MqttClientTcpOptions tcp:
+                var port = tcp.Port ?? 1883;
+                return $"{tcp.Server}:{port}";
+            case MqttClientWebSocketOptions ws:
+                // The websocket URI is the endpoint; credentials ride on Credentials, not the URI.
+                return ws.Uri;
+            default:
+                return null;
+        }
+    }
 
     public override Endpoint ReplyEndpoint()
     {

--- a/src/Transports/NATS/Wolverine.Nats.Tests/broker_connection_summary_3269.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/broker_connection_summary_3269.cs
@@ -1,0 +1,78 @@
+using JasperFx.Descriptors;
+using Shouldly;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Nats.Internal;
+using Xunit;
+
+namespace Wolverine.Nats.Tests;
+
+// GH-3269: the NATS broker summary must be host:port with NO credentials, even though the connection string can embed
+// userinfo (nats://user:pass@host) and the configuration carries Username/Password/Token.
+public class broker_connection_summary_3269
+{
+    private const string Secret = "S3CR3T_NATS_PASSWORD";
+
+    [Fact]
+    public void describe_endpoint_strips_embedded_userinfo()
+    {
+        var transport = new NatsTransport();
+        transport.Configuration.ConnectionString = $"nats://user:{Secret}@nats.host:4222";
+
+        transport.DescribeEndpoint().ShouldBe("nats.host:4222");
+    }
+
+    [Fact]
+    public void describe_endpoint_handles_a_server_list()
+    {
+        var transport = new NatsTransport();
+        transport.Configuration.ConnectionString = "nats://one:4222, nats://two:4222";
+
+        transport.DescribeEndpoint().ShouldBe("one:4222, two:4222");
+    }
+
+    [Fact]
+    public void credentials_never_leak_into_the_description()
+    {
+        var transport = new NatsTransport();
+        transport.Configuration.ConnectionString = $"nats://user:{Secret}@nats.host:4222";
+        transport.Configuration.Username = "user";
+        transport.Configuration.Password = Secret;
+        transport.Configuration.Token = Secret;
+
+        var description = new BrokerDescription(transport);
+
+        description.Endpoint.ShouldBe("nats.host:4222");
+        BrokerSecretScanner.AssertNoSecret(description, Secret);
+    }
+}
+
+internal static class BrokerSecretScanner
+{
+    public static void AssertNoSecret(BrokerDescription description, string secret)
+    {
+        (description.Endpoint ?? "").ShouldNotContain(secret);
+        foreach (var text in AllText(description))
+        {
+            text.ShouldNotContain(secret);
+        }
+    }
+
+    private static IEnumerable<string> AllText(OptionsDescription description)
+    {
+        if (description.Subject != null) yield return description.Subject;
+        foreach (var p in description.Properties)
+        {
+            if (p.Name != null) yield return p.Name;
+            if (p.Value != null) yield return p.Value;
+        }
+
+        foreach (var child in description.Children.Values)
+        foreach (var text in AllText(child))
+            yield return text;
+
+        foreach (var set in description.Sets.Values)
+        foreach (var row in set.Rows)
+        foreach (var text in AllText(row))
+            yield return text;
+    }
+}

--- a/src/Transports/NATS/Wolverine.Nats/Configuration/NatsTransportConfiguration.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Configuration/NatsTransportConfiguration.cs
@@ -1,3 +1,4 @@
+using JasperFx.Descriptors;
 using NATS.Client.Core;
 using NATS.Client.JetStream;
 using NATS.Client.JetStream.Models;
@@ -6,18 +7,30 @@ namespace Wolverine.Nats.Configuration;
 
 public class NatsTransportConfiguration
 {
+    // GH-3269: the raw connection string may embed userinfo (nats://user:pass@host), and the auth properties below are
+    // secrets. They are suppressed from the reflected diagnostic tree; the sanitized host:port target is surfaced via
+    // NatsTransport.DescribeEndpoint() instead.
+    [IgnoreDescription]
     public string ConnectionString { get; set; } = "nats://localhost:4222";
     public string? ClientName { get; set; }
     public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds(10);
     public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
+    [IgnoreDescription]
     public string? Username { get; set; }
+    [IgnoreDescription]
     public string? Password { get; set; }
+    [IgnoreDescription]
     public string? Token { get; set; }
+    [IgnoreDescription]
     public string? Jwt { get; set; }
+    [IgnoreDescription]
     public string? NKeySeed { get; set; }
+    [IgnoreDescription]
     public string? CredentialsFile { get; set; }
+    [IgnoreDescription]
     public string? NKeyFile { get; set; }
+    [IgnoreDescription]
     public Func<Uri, CancellationToken, ValueTask<NatsAuthCred>>? AuthCallback { get; set; }
 
     public bool EnableTls { get; set; }

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsTransport.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsTransport.cs
@@ -43,6 +43,9 @@ public class NatsTransport : BrokerTransport<NatsEndpoint>, IAsyncDisposable
         };
     }
 
+    // GH-3269: built straight from the connection string, which may embed userinfo (nats://user:pass@host). Suppressed
+    // from the reflected diagnostic tree so credentials never leak; the sanitized target is on DescribeEndpoint().
+    [IgnoreDescription]
     public override Uri ResourceUri =>
         Configuration.ConnectionString != null
             ? new Uri(Configuration.ConnectionString)
@@ -50,12 +53,43 @@ public class NatsTransport : BrokerTransport<NatsEndpoint>, IAsyncDisposable
 
     public string ResponseSubject { get; private set; } = "wolverine.response";
 
+    public override string? DescribeEndpoint()
+    {
+        var cs = Configuration.ConnectionString;
+        if (string.IsNullOrWhiteSpace(cs)) return null;
+
+        // The connection string may be a comma-separated server list and may embed userinfo (nats://user:pass@host);
+        // report host:port only so no credentials are surfaced.
+        var servers = cs
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(safeHostPort)
+            .Where(x => x != null);
+
+        var summary = string.Join(", ", servers);
+        return string.IsNullOrEmpty(summary) ? null : summary;
+    }
+
+    private static string? safeHostPort(string server)
+    {
+        if (Uri.TryCreate(server, UriKind.Absolute, out var uri))
+        {
+            var port = uri.Port > 0 ? uri.Port : 4222;
+            return $"{uri.Host}:{port}";
+        }
+
+        return null;
+    }
+
     [ChildDescription]
     public NatsTransportConfiguration Configuration { get; } = new();
 
+    // Live runtime objects (not configuration) that throw before the transport connects — never part of the
+    // diagnostic description.
+    [IgnoreDescription]
     public NatsConnection Connection =>
         _connection ?? throw new InvalidOperationException("NATS connection not initialized");
 
+    [IgnoreDescription]
     public INatsJSContext JetStreamContext =>
         _jetStreamContext
         ?? throw new InvalidOperationException("JetStream context not initialized");

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/broker_connection_summary_3269.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/broker_connection_summary_3269.cs
@@ -1,0 +1,77 @@
+using JasperFx.Descriptors;
+using Shouldly;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.RabbitMQ.Internal;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+// GH-3269: the RabbitMQ broker summary is host:port (vhost: …) built from the connection factory, never the password.
+public class broker_connection_summary_3269
+{
+    private const string Secret = "S3CR3T_RABBIT_PWD";
+
+    [Fact]
+    public void describe_endpoint_reports_host_port_and_vhost()
+    {
+        var transport = new RabbitMqTransport();
+        transport.ConfigureFactory(f =>
+        {
+            f.HostName = "rabbit.host";
+            f.Port = 5672;
+            f.VirtualHost = "/prod";
+            f.UserName = "guest";
+            f.Password = Secret;
+        });
+
+        transport.DescribeEndpoint().ShouldBe("rabbit.host:5672 (vhost: /prod)");
+    }
+
+    [Fact]
+    public void password_never_leaks_into_the_description()
+    {
+        var transport = new RabbitMqTransport();
+        transport.ConfigureFactory(f =>
+        {
+            f.HostName = "rabbit.host";
+            f.Port = 5672;
+            f.Password = Secret;
+        });
+
+        var description = new BrokerDescription(transport);
+
+        description.Endpoint.ShouldBe("rabbit.host:5672 (vhost: /)");
+        BrokerSecretScanner.AssertNoSecret(description, Secret);
+    }
+}
+
+internal static class BrokerSecretScanner
+{
+    public static void AssertNoSecret(BrokerDescription description, string secret)
+    {
+        (description.Endpoint ?? "").ShouldNotContain(secret);
+        foreach (var text in AllText(description))
+        {
+            text.ShouldNotContain(secret);
+        }
+    }
+
+    private static IEnumerable<string> AllText(OptionsDescription description)
+    {
+        if (description.Subject != null) yield return description.Subject;
+        foreach (var p in description.Properties)
+        {
+            if (p.Name != null) yield return p.Name;
+            if (p.Value != null) yield return p.Value;
+        }
+
+        foreach (var child in description.Children.Values)
+        foreach (var text in AllText(child))
+            yield return text;
+
+        foreach (var set in description.Sets.Values)
+        foreach (var row in set.Rows)
+        foreach (var text in AllText(row))
+            yield return text;
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
@@ -118,6 +118,21 @@ public partial class RabbitMqTransport : BrokerTransport<RabbitMqEndpoint>, IAsy
             ? null
             : new RabbitMqConnectionDescription(ConnectionFactory, AmqpTcpEndpoints.ToList());
 
+    public override string? DescribeEndpoint()
+    {
+        var factory = ConnectionFactory;
+        if (factory == null)
+        {
+            // Explicit endpoint list configured without a single resolved factory host.
+            return AmqpTcpEndpoints.Count > 0
+                ? string.Join(", ", AmqpTcpEndpoints.Select(e => $"{e.HostName}:{e.Port}"))
+                : null;
+        }
+
+        var vhost = string.IsNullOrEmpty(factory.VirtualHost) ? "/" : factory.VirtualHost;
+        return $"{factory.HostName}:{factory.Port} (vhost: {vhost})";
+    }
+
     internal void ConfigureFactory(Action<ConnectionFactory> configure)
     {
         var factory = new ConnectionFactory

--- a/src/Transports/Redis/Wolverine.Redis.Tests/broker_connection_summary_3269.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/broker_connection_summary_3269.cs
@@ -1,0 +1,62 @@
+using JasperFx.Descriptors;
+using Shouldly;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Redis.Internal;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+// GH-3269: the Redis summary is host:port, never the password from the connection string.
+public class broker_connection_summary_3269
+{
+    private const string Secret = "S3CR3T_REDIS_PWD";
+
+    [Fact]
+    public void describe_endpoint_reports_host_and_port()
+    {
+        var transport = new RedisTransport($"redis.host:6379,password={Secret}");
+        transport.DescribeEndpoint().ShouldBe("redis.host:6379");
+    }
+
+    [Fact]
+    public void password_never_leaks_into_the_description()
+    {
+        var transport = new RedisTransport($"redis.host:6379,password={Secret}");
+
+        var description = new BrokerDescription(transport);
+
+        description.Endpoint.ShouldBe("redis.host:6379");
+        BrokerSecretScanner.AssertNoSecret(description, Secret);
+    }
+}
+
+internal static class BrokerSecretScanner
+{
+    public static void AssertNoSecret(BrokerDescription description, string secret)
+    {
+        (description.Endpoint ?? "").ShouldNotContain(secret);
+        foreach (var text in AllText(description))
+        {
+            text.ShouldNotContain(secret);
+        }
+    }
+
+    private static IEnumerable<string> AllText(OptionsDescription description)
+    {
+        if (description.Subject != null) yield return description.Subject;
+        foreach (var p in description.Properties)
+        {
+            if (p.Name != null) yield return p.Name;
+            if (p.Value != null) yield return p.Value;
+        }
+
+        foreach (var child in description.Children.Values)
+        foreach (var text in AllText(child))
+            yield return text;
+
+        foreach (var set in description.Sets.Values)
+        foreach (var row in set.Rows)
+        foreach (var text in AllText(row))
+            yield return text;
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
@@ -189,6 +189,19 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
         : _configurationOptions != null ? SanitizeConfigurationOptionsForLogging(_configurationOptions)
         : SanitizeConnectionStringForLogging(_connectionString!);
 
+    public override string? DescribeEndpoint()
+    {
+        // Prefer a clean host:port; primaryEndPoint() never exposes credentials. Fall back to the already-sanitized
+        // ConnectionSummary for caller-managed multiplexers or a factory not yet resolved.
+        return primaryEndPoint() switch
+        {
+            System.Net.DnsEndPoint dns => $"{dns.Host}:{dns.Port}",
+            System.Net.IPEndPoint ip => $"{ip.Address}:{ip.Port}",
+            { } endpoint => endpoint.ToString(),
+            _ => ConnectionSummary
+        };
+    }
+
     internal IDatabase GetDatabase(string? connectionString = null, int database = 0)
     {
         var connection = GetConnection(connectionString);

--- a/src/Wolverine/Configuration/Capabilities/BrokerDescription.cs
+++ b/src/Wolverine/Configuration/Capabilities/BrokerDescription.cs
@@ -18,9 +18,18 @@ public class BrokerDescription : OptionsDescription
         Name = subject.Name;
 
         ReplyUri = subject.ReplyEndpoint()?.Uri;
+        Endpoint = subject.DescribeEndpoint();
     }
 
     public string ProtocolName { get; set; } = null!;
     public string Name { get; set; } = null!;
     public Uri? ReplyUri { get; set; }
+
+    /// <summary>
+    /// A sanitized, credential-free summary of what this broker is pointing to (host + port, virtual host, namespace,
+    /// region, bootstrap servers, …) for monitoring consoles. Null when the transport reports no connection target.
+    /// Built from parsed connection components only — never contains usernames, passwords, SAS keys, or connection
+    /// strings. See <see cref="ITransport.DescribeEndpoint"/>.
+    /// </summary>
+    public string? Endpoint { get; set; }
 }

--- a/src/Wolverine/Transports/ITransport.cs
+++ b/src/Wolverine/Transports/ITransport.cs
@@ -41,6 +41,15 @@ public interface ITransport
     /// </summary>
     string Describe() => $"{Name} broker (scheme '{Protocol}')";
 
+    /// <summary>
+    /// A sanitized, credential-free, human-readable summary of what this broker is pointing to — the connection
+    /// target (host + port, virtual host, namespace, region, bootstrap servers, …) for diagnostic consumers such as
+    /// CritterWatch's messaging topology. MUST be built from parsed connection components, NEVER from a raw connection
+    /// string: no usernames, passwords, SAS keys, or secrets of any kind. Returns null when the transport has no
+    /// meaningful connection target (e.g. the in-memory/local transport) or it cannot be determined safely.
+    /// </summary>
+    string? DescribeEndpoint() => null;
+
     Endpoint? ReplyEndpoint();
 
     Endpoint GetOrCreateEndpoint(Uri uri);

--- a/src/Wolverine/Transports/TransportBase.cs
+++ b/src/Wolverine/Transports/TransportBase.cs
@@ -23,6 +23,13 @@ public abstract class TransportBase<TEndpoint> : ITransport, ITagged where TEndp
         return true;
     }
 
+    /// <summary>
+    /// A sanitized, credential-free summary of this broker's connection target. The default returns null;
+    /// concrete broker transports override to report host/port/namespace/region built from parsed connection
+    /// components only — never a raw connection string or any secret. See <see cref="ITransport.DescribeEndpoint"/>.
+    /// </summary>
+    public virtual string? DescribeEndpoint() => null;
+
     public string Name { get; }
 
     public string Protocol { get; }


### PR DESCRIPTION
Closes #3269.

## Summary

`BrokerDescription` previously captured only `ProtocolName`, `Name`, and `ReplyUri`. A monitoring console (CritterWatch's messaging topology) wants a human-readable **"what is this broker pointing to"** summary — but only the transport knows its connection target.

This adds:
- **`ITransport.DescribeEndpoint()`** — default interface member returning `null`; `public virtual` on `TransportBase`, overridden per transport.
- **`BrokerDescription.Endpoint`** — captures it.

The summary is built from **parsed connection components only** — host/port/vhost/namespace/region/bootstrap-servers — **never** from a raw connection string.

| Transport | Summary |
|---|---|
| RabbitMQ | `host:port (vhost: …)` |
| Azure Service Bus | namespace FQDN |
| Amazon SQS / SNS | region (or explicit ServiceURL, e.g. LocalStack) |
| Kafka | bootstrap servers |
| NATS | `host:port` (server list ok), embedded userinfo stripped |
| Redis | `host:port` from the primary endpoint |
| MQTT | broker `host:port` (or websocket URI) |
| GCP Pub/Sub | `project: <id>` (+ emulator marker) |
| Pulsar | `null` — DotPulsar's builder doesn't expose the service URL |

## Hard requirement — no credentials, ever (+ security audit)

`BrokerDescription : OptionsDescription` reflects the transport's public properties, so any credential-bearing public property is a leak. Audited each transport and closed the gaps:

- **Kafka** — `ProducerConfig`/`ConsumerConfig`/`AdminClientConfig` were `[ChildDescription]`, and Confluent's `ClientConfig` exposes `SaslUsername`/`SaslPassword`/`SslKeyPassword` as public **string** properties → **real plaintext leak**. Now `[IgnoreDescription]`; bootstrap servers surface via `Endpoint`.
- **NATS** — `NatsTransportConfiguration.ConnectionString` (may embed `user:pass@`) + `Username`/`Password`/`Token`/`Jwt`/`NKeySeed`/`CredentialsFile`/`AuthCallback` now `[IgnoreDescription]`; also suppressed `ResourceUri` (built from the connection string) and the throwing live `Connection`/`JetStreamContext` getters.
- **MQTT** — `ManagedMqttClientOptions` (carries `Credentials`) now `[IgnoreDescription]`.
- **GCP** — the three builder-callback properties now `[IgnoreDescription]`.
- RabbitMQ / Azure / Pulsar / Redis credential properties were already suppressed (verified).

## Tests

Per-transport unit tests (9 transports, 24 methods) asserting the summary is correct **and** that a sentinel secret never appears anywhere in the reflected `BrokerDescription` tree (`Properties` / `Children` / `Sets`). The scan caught two real issues during development (Kafka SASL leak; a NATS getter that threw during reflection). Existing CoreTests capability/broker suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)