### PR TITLE
Set EndpointName on RabbitMqRouting so sending endpoints are named in health snapshots (GH-3270)

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/routing_endpoint_name_and_status_3270.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/routing_endpoint_name_and_status_3270.cs
@@ -1,0 +1,51 @@
+using Shouldly;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+// GH-3270: RabbitMQ sending endpoints (exchange + routing key) were under-populated in the endpoint-health snapshot —
+// blank Name and "Unknown" status. RabbitMqRouting now sets a recognizable EndpointName, and RabbitMQ senders report
+// a broker-connection-aware status via IReportConnectionState (so consumers see Connected/Disconnected, not Unknown).
+public class routing_endpoint_name_and_status_3270
+{
+    [Fact]
+    public void named_exchange_routing_combines_exchange_and_routing_key()
+    {
+        var transport = new RabbitMqTransport();
+        var routing = transport.Exchanges["orders"].Routings["high-priority"];
+
+        routing.EndpointName.ShouldBe("orders/high-priority");
+    }
+
+    [Fact]
+    public void default_exchange_routing_uses_the_routing_key_as_the_name()
+    {
+        // The default exchange routes by routing key, which is the target queue name — so that name alone is the
+        // most recognizable identity (rather than "default/<key>").
+        var transport = new RabbitMqTransport();
+        var routing = transport.Exchanges[TransportConstants.Default].Routings["target-queue"];
+
+        routing.EndpointName.ShouldBe("target-queue");
+    }
+
+    [Fact]
+    public void routing_endpoint_name_is_not_the_synthetic_uri()
+    {
+        var transport = new RabbitMqTransport();
+        var routing = transport.Exchanges["orders"].Routings["high"];
+
+        routing.EndpointName.ShouldNotContain("routing/");
+        routing.EndpointName.ShouldNotBe(routing.Uri.ToString());
+    }
+
+    [Fact]
+    public void rabbitmq_senders_report_a_broker_connection_aware_status()
+    {
+        // RabbitMqSender derives from RabbitMqChannelAgent, which implements IReportConnectionState — so the
+        // endpoint-health snapshot resolves Connected/Disconnected for senders rather than Unknown.
+        typeof(IReportConnectionState).IsAssignableFrom(typeof(RabbitMqSender)).ShouldBeTrue();
+        typeof(IReportConnectionState).IsAssignableFrom(typeof(RabbitMqChannelAgent)).ShouldBeTrue();
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqRouting.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqRouting.cs
@@ -22,6 +22,13 @@ public class RabbitMqRouting : RabbitMqEndpoint
 
         ExchangeName = _exchange.ExchangeName;
         BrokerRole = "exchange";
+
+        // GH-3270: give the sending endpoint a recognizable EndpointName so it doesn't fall through to the synthetic
+        // Uri (blank/"unknown" in the endpoint-health snapshot). The default exchange routes by routing key — which is
+        // the target queue name — so use the key alone; a named exchange combines its name with the routing key.
+        EndpointName = string.IsNullOrEmpty(_exchange.DeclaredName)
+            ? routingKey
+            : $"{_exchange.DeclaredName}/{routingKey}";
     }
 
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)


### PR DESCRIPTION
Closes #3270.

## Name fix (the bug)

RabbitMQ exchange + routing-key sending endpoints (`RabbitMqRouting`) set `ExchangeName` and `BrokerRole` but **never `EndpointName`**, so they fell through to the base default (the synthetic `rabbitmq://exchange/{name}/routing/{key}` Uri). In `EndpointCollection.CollectEndpointHealth()` that surfaces as a blank / `"unknown"` Name (and makes per-endpoint sent metrics impossible to join to a recognizable endpoint).

`RabbitMqRouting` now sets a recognizable `EndpointName`:
- named exchange → `"{exchange}/{routingKey}"` (e.g. `orders/high-priority`)
- default exchange → just the routing key (the default exchange routes by key, which is the target queue name)

## Status (already satisfied on main)

The issue also asked for a broker-connection-aware sender status instead of `Unknown`. That's already in place: `RabbitMqChannelAgent` (the base of `RabbitMqSender`) implements `IReportConnectionState`, and `EndpointCollection.connectionStateOf(ISendingAgent)` reaches through the sending agent to the sender — so the snapshot's `ConnectionState` reports `Connected`/`Disconnected`. Added a regression test asserting that contract.

(Note: `AgentState` has only `Connected`/`Disconnected` today, so `Reconnecting` is not yet reported — a possible small follow-up.)

## Tests

Broker-free unit tests (4): named-exchange and default-exchange routing names, the name is not the synthetic Uri, and RabbitMQ senders implement `IReportConnectionState`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)