### PR TITLE
perf(postgresql-transport): index dequeue path + robust idempotency

### DIFF
--- a/docs/guide/durability/postgresql.md
+++ b/docs/guide/durability/postgresql.md
@@ -244,6 +244,19 @@ opts.ListenToPostgresqlQueue("inbound").PollingInterval(2.Seconds());
 
 When not set, the queue falls back to the global `DurabilitySettings.ScheduledJobPollingTime`.
 
+### Dequeue Performance <Badge type="tip" text="6.16" />
+
+The PostgreSQL queue tables carry a btree index on the dequeue ordering column so that the
+`ORDER BY ... LIMIT n FOR UPDATE SKIP LOCKED` pull each poll performs is an ordered index scan rather
+than a scan + sort of the whole table. This is applied automatically — no configuration is required.
+
+Unlike the [Sql Server transport's `OptimizeQueueThroughput()`](./sqlserver.html#optimizing-queue-throughput),
+there is no clustered-storage opt-in for PostgreSQL: PostgreSQL tables are heaps (there is no clustered
+index to align with the dequeue order), so the index above already captures essentially all of the
+available benefit. For very high-churn queues the main operational lever is PostgreSQL autovacuum —
+busy queue tables accumulate dead tuples from the constant insert/delete cycle, so ensure autovacuum
+is keeping up (and consider per-table autovacuum tuning) rather than reaching for a storage-layout change.
+
 ::: info Control queue
 Wolverine has an internal control queue (`dbcontrol`) used for internal operations.
 This queue is hardcoded to poll every second and should not be changed to ensure the stability of the application.

--- a/src/Persistence/PostgresqlTests/Transport/transport_perf_benchmark.cs
+++ b/src/Persistence/PostgresqlTests/Transport/transport_perf_benchmark.cs
@@ -1,0 +1,160 @@
+using System.Diagnostics;
+using IntegrationTests;
+using Npgsql;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PostgresqlTests.Transport;
+
+// Manual benchmark for the PostgreSQL queue transport schema decision. Not part of CI.
+// Postgres tables are heaps (no clustered index), so unlike SQL Server the win here is expected to
+// come almost entirely from indexing the dequeue ordering column, not from any physical clustering.
+// Compares three designs head-to-head with raw DDL:
+//   A) baseline: PRIMARY KEY on a uuid id, no index on the ordering column   (current)
+//   B) + btree index on timestamp                                           (index-only)
+//   C) + bigint identity "seq" with a btree index, dequeue by seq           (monotonic ordering)
+// Run:
+//   BENCH_PG="Host=localhost;Port=5433;Database=postgres;Username=postgres;password=postgres" \
+//     dotnet test --filter "FullyQualifiedName~transport_perf_benchmark"
+[Trait("Category", "Benchmark")]
+public class transport_perf_benchmark
+{
+    private readonly ITestOutputHelper _output;
+    public transport_perf_benchmark(ITestOutputHelper output) => _output = output;
+
+    private static string ConnString =>
+        Environment.GetEnvironmentVariable("BENCH_PG") ?? Servers.PostgresConnectionString;
+
+    private const int BodySize = 250;
+    private const int InsertCount = 3000;
+    private const int DrainBatch = 50;
+    private const int Backlog = 30000;
+    private const int BacklogPops = 30;
+
+    private record Variant(string Name, string Table, string CreateDdl, string OrderBy);
+
+    private static Variant[] Variants() =>
+    [
+        new("A baseline (uuid PK, no index)", "bench_a", @"
+CREATE TABLE bench_a (
+    id uuid NOT NULL PRIMARY KEY,
+    body bytea NOT NULL,
+    message_type varchar NOT NULL,
+    keep_until timestamptz NULL,
+    ""timestamp"" timestamptz NOT NULL DEFAULT (now() at time zone 'utc'));", "\"timestamp\""),
+
+        new("B uuid PK + timestamp index", "bench_b", @"
+CREATE TABLE bench_b (
+    id uuid NOT NULL PRIMARY KEY,
+    body bytea NOT NULL,
+    message_type varchar NOT NULL,
+    keep_until timestamptz NULL,
+    ""timestamp"" timestamptz NOT NULL DEFAULT (now() at time zone 'utc'));
+CREATE INDEX idx_bench_b_timestamp ON bench_b (""timestamp"");", "\"timestamp\""),
+
+        new("C uuid PK + bigint identity seq + seq index", "bench_c", @"
+CREATE TABLE bench_c (
+    id uuid NOT NULL PRIMARY KEY,
+    seq bigint GENERATED ALWAYS AS IDENTITY,
+    body bytea NOT NULL,
+    message_type varchar NOT NULL,
+    keep_until timestamptz NULL,
+    ""timestamp"" timestamptz NOT NULL DEFAULT (now() at time zone 'utc'));
+CREATE INDEX idx_bench_c_seq ON bench_c (seq);", "seq")
+    ];
+
+    [Fact(Skip = "Manual benchmark; run explicitly with BENCH_PG set")]
+    public async Task run()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(ConnString);
+        await using var conn = await dataSource.OpenConnectionAsync();
+
+        foreach (var v in Variants())
+        {
+            await exec(conn, $"DROP TABLE IF EXISTS {v.Table};");
+            await exec(conn, v.CreateDdl);
+
+            // B1: insert throughput (single connection, mirrors per-message INSERT)
+            var insertSql = $"insert into {v.Table} (id, body, message_type) values (@id, @body, 'bench')";
+            var body = new byte[BodySize];
+            var sw = Stopwatch.StartNew();
+            for (var i = 0; i < InsertCount; i++)
+            {
+                await using var cmd = conn.CreateCommand(insertSql);
+                cmd.Parameters.AddWithValue("id", Guid.NewGuid());
+                cmd.Parameters.AddWithValue("body", body);
+                await cmd.ExecuteNonQueryAsync();
+            }
+            sw.Stop();
+            var insertRate = InsertCount / sw.Elapsed.TotalSeconds;
+
+            // B2: ordered drain throughput
+            sw.Restart();
+            long drained = 0;
+            while (true)
+            {
+                var n = await pop(conn, v, DrainBatch);
+                if (n == 0) break;
+                drained += n;
+            }
+            sw.Stop();
+            var drainRate = drained / sw.Elapsed.TotalSeconds;
+
+            // B3: deep-backlog single-pop latency
+            await bulkInsert(conn, v, Backlog);
+            var times = new List<double>();
+            for (var i = 0; i < BacklogPops; i++)
+            {
+                var t = Stopwatch.StartNew();
+                await pop(conn, v, DrainBatch);
+                t.Stop();
+                times.Add(t.Elapsed.TotalMilliseconds);
+            }
+            times.Sort();
+
+            await exec(conn, $"DROP TABLE {v.Table};");
+
+            _output.WriteLine(
+                $"{v.Name}\n" +
+                $"   B1 insert: {insertRate:F0} msg/s\n" +
+                $"   B2 drain : {drainRate:F0} msg/s\n" +
+                $"   B3 deep-pop (batch {DrainBatch} over {Backlog}): median {times[times.Count / 2]:F1} ms, " +
+                $"p95 {times[(int)(times.Count * 0.95)]:F1} ms, max {times[^1]:F1} ms\n");
+        }
+    }
+
+    private static async Task exec(NpgsqlConnection conn, string sql)
+    {
+        await using var cmd = conn.CreateCommand(sql);
+        cmd.CommandTimeout = 120;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<long> pop(NpgsqlConnection conn, Variant v, int batch)
+    {
+        var sql = $@"
+WITH message AS (
+    DELETE FROM {v.Table}
+    WHERE ctid IN (SELECT ctid FROM {v.Table} ORDER BY {v.OrderBy} LIMIT {batch} FOR UPDATE SKIP LOCKED)
+    RETURNING body)
+SELECT body FROM message;";
+        await using var cmd = conn.CreateCommand(sql);
+        cmd.CommandTimeout = 120;
+        var rows = 0L;
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync()) rows++;
+        return rows;
+    }
+
+    private static async Task bulkInsert(NpgsqlConnection conn, Variant v, int count)
+    {
+        var sql = $@"
+INSERT INTO {v.Table} (id, body, message_type)
+SELECT gen_random_uuid(), decode(repeat('78', {BodySize}), 'hex'), 'bench'
+FROM generate_series(1, {count});";
+        await using var cmd = conn.CreateCommand(sql);
+        cmd.CommandTimeout = 120;
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueueSender.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueueSender.cs
@@ -158,8 +158,9 @@ DO UPDATE SET {DatabaseConstants.Body} = :body, {DatabaseConstants.MessageType} 
         }
         catch (NpgsqlException e)
         {
-            // Making this idempotent, but optimistically
-            if (e.Message.ContainsIgnoreCase("duplicate key value")) return;
+            // Idempotent on a duplicate send. Match on the SQLSTATE unique-violation code (23505)
+            // rather than the localized message text.
+            if (e is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation }) return;
             throw;
         }
         finally
@@ -186,7 +187,7 @@ DO UPDATE SET {DatabaseConstants.Body} = :body, {DatabaseConstants.MessageType} 
         }
         catch (NpgsqlException e)
         {
-            if (e.Message.ContainsIgnoreCase("duplicate key value"))
+            if (e is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
             {
                 await conn.CreateCommand(
                         $"delete from {_quotedStorageSchemaName}.{DatabaseConstants.OutgoingTable} where id = @id")
@@ -226,7 +227,7 @@ DO UPDATE SET {DatabaseConstants.Body} = :body, {DatabaseConstants.MessageType} 
                 catch (NpgsqlException e)
                 {
                     // Making this idempotent, but optimistically
-                    if (e.Message.ContainsIgnoreCase("duplicate key value")) return;
+                    if (e is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation }) return;
                     throw;
                 }
             }

--- a/src/Persistence/Wolverine.Postgresql/Transport/QueueTable.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/QueueTable.cs
@@ -1,4 +1,5 @@
 using Weasel.Core;
+using Weasel.Postgresql;
 using Weasel.Postgresql.Tables;
 using Wolverine.RDBMS;
 
@@ -14,5 +15,15 @@ internal class QueueTable : Table
         AddColumn<string>(DatabaseConstants.MessageType).NotNull();
         AddColumn<DateTimeOffset>(DatabaseConstants.KeepUntil);
         AddColumn<DateTimeOffset>("timestamp").DefaultValueByExpression("((now() at time zone 'utc'))");
+
+        // The dequeue path orders by timestamp (TOP/LIMIT n ... ORDER BY timestamp) on every poll.
+        // Without this index the ordered LIMIT has to scan + sort the whole queue table; a btree on
+        // timestamp turns it into an ordered index scan. See GH perf review. The index name is run
+        // through Shorten() to stay under PostgreSQL's 63-char NAMEDATALEN limit (see GH-2942).
+        var indexName = PostgresqlIdentifier.Shorten($"idx_{tableName}_timestamp");
+        Indexes.Add(new IndexDefinition(indexName)
+        {
+            Columns = ["timestamp"]
+        });
     }
 }


### PR DESCRIPTION
## Summary

The Postgres counterpart to #3277. The PostgreSQL queue transport's dequeue (`ORDER BY timestamp LIMIT n FOR UPDATE SKIP LOCKED`) had no supporting index, so each poll scanned and sorted the queue table.

## Changes
- **Index the queue table `timestamp` column** so the ordered `LIMIT` dequeue is an index scan. No SQL changes (ordering stays on `timestamp`); the index name goes through `PostgresqlIdentifier.Shorten` for NAMEDATALEN (GH-2942).
- **Robust idempotency**: replaced locale-fragile `e.Message.Contains("duplicate key value")` with the SQLSTATE unique-violation code (`PostgresException.SqlState == 23505`).
- **Docs**: new "Dequeue Performance" note in the PostgreSQL guide.

## Why no `OptimizeQueueThroughput()` here
SQL Server got an opt-in clustered-storage layout (#3277) that gave a ~350× drain improvement. **That does not translate to Postgres**: PG tables are heaps with no clustered index, so the physical-clustering win doesn't exist. Benchmarked A/B/C to confirm before deciding:

| Variant | drain | deep-pop median (30k backlog) | p95 |
|---|---|---|---|
| baseline (uuid PK, no index) | 69,634/s | 3.1 ms | 3.9 ms |
| **+ `timestamp` index** (this PR) | 98,401/s | **0.8 ms** | 1.0 ms |
| + `bigint` identity `seq` (rejected) | 97,308/s | 0.6 ms | 0.8 ms |

The `seq` redesign is marginal, so adding the knob would mean a table migration for ~no gain and misleading cross-DB parity. The doc instead points at autovacuum tuning as the real operational lever for high-churn PG queues.

## Follow-up (not in this PR)
Batched outbox→queue send, matching the SQL Server transport plan.

## Validation
- ✅ Full `wolverine.slnx` Release build clean.
- ✅ **24 PG transport tests pass locally against PostgreSQL 17** (the Postgres dev environment is reliable, so unlike #3277 the integration suite — including schema provisioning with the new index and idempotent double-send — was validated locally).
- A manual A/B/C benchmark is included (skipped in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)