### PR TITLE
Managed distribution: per-tenant agents + database-affine assignment for sharded stores (#3280, marten#4806)

### DIFF
--- a/docs/guide/durability/marten/distribution.md
+++ b/docs/guide/durability/marten/distribution.md
@@ -59,6 +59,45 @@ Some other facts about this integration:
   new versions of a projection or subscription on some application nodes in order to do try ["blue/green deployment."](https://en.wikipedia.org/wiki/Blue%E2%80%93green_deployment)
 * This capability does depend on Wolverine's built-in [leadership election](https://en.wikipedia.org/wiki/Leader_election) -- which fortunately got a _lot_ better in Wolverine 3.0
 
+## Database-Affine Distribution for Sharded Stores <Badge type="tip" text="6.x" />
+
+By default Wolverine spreads subscription and projection agents *evenly* across the cluster (with blue/green
+capability matching). That is the right choice for a store-global event store or database-per-tenant multi-tenancy,
+where there is one agent per database anyway.
+
+It is *not* the right choice for a Marten store that combines [sharded multi-tenancy](https://martendb.io/configuration/multitenancy.html#sharded-multi-tenancy-with-database-pooling)
+with [per-tenant event partitioning](https://martendb.io/events/multitenancy.html#per-tenant-event-partitioning). There,
+many tenants are co-located in one shard database and each draws its own event sequence, so Wolverine fans agents out
+one-per-`(shard, tenant)` rather than one-per-database. With hundreds of tenants scattered across many shard databases,
+an even per-agent spread makes *every* node open a connection pool to *nearly every* shard database — so the pool count
+grows as `nodes × databases` and quickly exhausts a shared server's `max_connections`.
+
+To bound that, opt into **database-affine assignment** on the Marten side. Wolverine then keeps every agent for a given
+shard database together on a single node, so a node only opens pools to the databases it actually owns and the pool
+count scales with the number of shard databases, not `nodes × databases`:
+
+```cs
+services.AddMarten(opts =>
+{
+    // ... sharded tenancy + per-tenant event partitioning ...
+    opts.Events.UseTenantPartitionedEvents = true;
+
+    // Keep a shard database's per-tenant agents together on one node
+    opts.Events.UseDatabaseAffineAgentAssignment = true;
+
+    // The "mix": allow a single shard database's agents to fan out across up to N nodes
+    // for more parallelism (default 1 = strict affinity). Server-side connections for one
+    // database then stay bounded at roughly N × per-node pool size.
+    opts.Events.DatabaseAffineAgentFanout = 2;
+})
+.IntegrateWithWolverine();
+```
+
+Wolverine reads these off the store through `IEventStore.GroupAgentAssignmentsByDatabase` and
+`IEventStore.MaxNodesPerDatabaseForAgents`, so the behavior is entirely opt-in and store-driven — a store that does not
+set them keeps the default even distribution. The grouping key is the `[event store type]/[event store name]/[database]`
+prefix of the agent `Uri` (see below), so all of a shard database's per-tenant agents share one group.
+
 ## Uri Structure
 
 The `Uri` structure for event subscriptions or projections is:

--- a/docs/guide/durability/marten/distribution.md
+++ b/docs/guide/durability/marten/distribution.md
@@ -81,22 +81,27 @@ services.AddMarten(opts =>
 {
     // ... sharded tenancy + per-tenant event partitioning ...
     opts.Events.UseTenantPartitionedEvents = true;
-
-    // Keep a shard database's per-tenant agents together on one node
-    opts.Events.UseDatabaseAffineAgentAssignment = true;
-
-    // The "mix": allow a single shard database's agents to fan out across up to N nodes
-    // for more parallelism (default 1 = strict affinity). Server-side connections for one
-    // database then stay bounded at roughly N × per-node pool size.
-    opts.Events.DatabaseAffineAgentFanout = 2;
 })
-.IntegrateWithWolverine();
+.IntegrateWithWolverine(x =>
+{
+    x.UseWolverineManagedEventSubscriptionDistribution = true;
+
+    // Keep a shard database's per-tenant agents together on one node.
+    x.UseDatabaseAffineAgentAssignment = true;
+
+    // The "mix": allow a single shard database's agents to fan out across up to N nodes for more
+    // parallelism (default 1 = strict affinity). Server-side connections for one database then stay
+    // bounded at roughly N × per-node pool size.
+    x.DatabaseAffineAgentFanout = 2;
+});
 ```
 
-Wolverine reads these off the store through `IEventStore.GroupAgentAssignmentsByDatabase` and
-`IEventStore.MaxNodesPerDatabaseForAgents`, so the behavior is entirely opt-in and store-driven — a store that does not
-set them keeps the default even distribution. The grouping key is the `[event store type]/[event store name]/[database]`
-prefix of the agent `Uri` (see below), so all of a shard database's per-tenant agents share one group.
+These settings on `IntegrateWithWolverine` flow through to `StoreOptions.Events.UseDatabaseAffineAgentAssignment`
+and `DatabaseAffineAgentFanout` (you can also set them there directly). Wolverine reads them off the store through
+`IEventStore.GroupAgentAssignmentsByDatabase` and `IEventStore.MaxNodesPerDatabaseForAgents`, so the behavior is entirely
+opt-in and store-driven — a store that does not set them keeps the default even distribution. The grouping key is the
+`[event store type]/[event store name]/[database]` prefix of the agent `Uri` (see below), so all of a shard database's
+per-tenant agents share one group.
 
 ## Uri Structure
 

--- a/docs/guide/durability/marten/distribution.md
+++ b/docs/guide/durability/marten/distribution.md
@@ -88,18 +88,13 @@ services.AddMarten(opts =>
 
     // Keep a shard database's per-tenant agents together on one node.
     x.UseDatabaseAffineAgentAssignment = true;
-
-    // The "mix": allow a single shard database's agents to fan out across up to N nodes for more
-    // parallelism (default 1 = strict affinity). Server-side connections for one database then stay
-    // bounded at roughly N × per-node pool size.
-    x.DatabaseAffineAgentFanout = 2;
 });
 ```
 
-These settings on `IntegrateWithWolverine` flow through to `StoreOptions.Events.UseDatabaseAffineAgentAssignment`
-and `DatabaseAffineAgentFanout` (you can also set them there directly). Wolverine reads them off the store through
-`IEventStore.GroupAgentAssignmentsByDatabase` and `IEventStore.MaxNodesPerDatabaseForAgents`, so the behavior is entirely
-opt-in and store-driven — a store that does not set them keeps the default even distribution. The grouping key is the
+This setting on `IntegrateWithWolverine` flows through to `StoreOptions.Events.UseDatabaseAffineAgentAssignment`
+(you can also set it there directly). Wolverine reads it off the store through
+`IEventStore.GroupAgentAssignmentsByDatabase`, so the behavior is entirely opt-in and store-driven — a store that
+does not set it keeps the default even distribution. The grouping key is the
 `[event store type]/[event store name]/[database]` prefix of the agent `Uri` (see below), so all of a shard database's
 per-tenant agents share one group.
 

--- a/src/Persistence/MartenTests/Distribution/integrate_with_wolverine_affine_settings.cs
+++ b/src/Persistence/MartenTests/Distribution/integrate_with_wolverine_affine_settings.cs
@@ -1,0 +1,66 @@
+using IntegrationTests;
+using JasperFx.CodeGeneration;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Xunit;
+
+namespace MartenTests.Distribution;
+
+/// <summary>
+/// JasperFx/marten#4806: the database-affine agent-assignment settings can be configured on
+/// IntegrateWithWolverine (next to UseWolverineManagedEventSubscriptionDistribution), and they must flow
+/// through to the Marten event store — which is where Wolverine's distribution reads them via
+/// IEventStore.GroupAgentAssignmentsByDatabase / MaxNodesPerDatabaseForAgents. This guards the bridge
+/// (MartenOverrides resolving the MartenIntegration and applying the settings) against a DI-resolution
+/// regression that would silently leave the app on the default even distribution.
+/// </summary>
+public class integrate_with_wolverine_affine_settings
+{
+    private static async Task<IHost> StartHostAsync(Action<MartenIntegration> configure, string schema)
+    {
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(m =>
+                    {
+                        m.DisableNpgsqlLogging = true;
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = schema;
+                    })
+                    .IntegrateWithWolverine(configure);
+
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Auto;
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task affine_settings_flow_to_the_event_store()
+    {
+        using var host = await StartHostAsync(m =>
+        {
+            m.UseWolverineManagedEventSubscriptionDistribution = true;
+            m.UseDatabaseAffineAgentAssignment = true;
+            m.DatabaseAffineAgentFanout = 3;
+        }, "affine_on");
+
+        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+        store.Options.Events.UseDatabaseAffineAgentAssignment.ShouldBeTrue();
+        store.Options.Events.DatabaseAffineAgentFanout.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task defaults_are_unchanged_when_not_configured()
+    {
+        using var host = await StartHostAsync(
+            m => m.UseWolverineManagedEventSubscriptionDistribution = true, "affine_off");
+
+        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+        store.Options.Events.UseDatabaseAffineAgentAssignment.ShouldBeFalse();
+        store.Options.Events.DatabaseAffineAgentFanout.ShouldBe(1);
+    }
+}

--- a/src/Persistence/MartenTests/Distribution/integrate_with_wolverine_affine_settings.cs
+++ b/src/Persistence/MartenTests/Distribution/integrate_with_wolverine_affine_settings.cs
@@ -11,12 +11,12 @@ using Xunit;
 namespace MartenTests.Distribution;
 
 /// <summary>
-/// JasperFx/marten#4806: the database-affine agent-assignment settings can be configured on
-/// IntegrateWithWolverine (next to UseWolverineManagedEventSubscriptionDistribution), and they must flow
-/// through to the Marten event store — which is where Wolverine's distribution reads them via
-/// IEventStore.GroupAgentAssignmentsByDatabase / MaxNodesPerDatabaseForAgents. This guards the bridge
-/// (MartenOverrides resolving the MartenIntegration and applying the settings) against a DI-resolution
-/// regression that would silently leave the app on the default even distribution.
+/// JasperFx/marten#4806: the database-affine agent-assignment setting can be configured on
+/// IntegrateWithWolverine (next to UseWolverineManagedEventSubscriptionDistribution), and it must flow
+/// through to the Marten event store — which is where Wolverine's distribution reads it via
+/// IEventStore.GroupAgentAssignmentsByDatabase. This guards the bridge (MartenOverrides resolving the
+/// MartenIntegration and applying the setting) against a DI-resolution regression that would silently
+/// leave the app on the default even distribution.
 /// </summary>
 public class integrate_with_wolverine_affine_settings
 {
@@ -39,28 +39,25 @@ public class integrate_with_wolverine_affine_settings
     }
 
     [Fact]
-    public async Task affine_settings_flow_to_the_event_store()
+    public async Task affine_setting_flows_to_the_event_store()
     {
         using var host = await StartHostAsync(m =>
         {
             m.UseWolverineManagedEventSubscriptionDistribution = true;
             m.UseDatabaseAffineAgentAssignment = true;
-            m.DatabaseAffineAgentFanout = 3;
         }, "affine_on");
 
         var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
         store.Options.Events.UseDatabaseAffineAgentAssignment.ShouldBeTrue();
-        store.Options.Events.DatabaseAffineAgentFanout.ShouldBe(3);
     }
 
     [Fact]
-    public async Task defaults_are_unchanged_when_not_configured()
+    public async Task default_is_unchanged_when_not_configured()
     {
         using var host = await StartHostAsync(
             m => m.UseWolverineManagedEventSubscriptionDistribution = true, "affine_off");
 
         var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
         store.Options.Events.UseDatabaseAffineAgentAssignment.ShouldBeFalse();
-        store.Options.Events.DatabaseAffineAgentFanout.ShouldBe(1);
     }
 }

--- a/src/Persistence/MartenTests/Distribution/sharded_tenant_partitioned_distribution.cs
+++ b/src/Persistence/MartenTests/Distribution/sharded_tenant_partitioned_distribution.cs
@@ -1,0 +1,190 @@
+using IntegrationTests;
+using JasperFx.CodeGeneration;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Events;
+using MartenTests.Distribution.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MartenTests.Distribution;
+
+// Phase 3 of the per-tenant-partitioned-events matrix — the #3280 regression itself: under
+// MultiTenantedWithShardedDatabases + UseTenantPartitionedEvents, multiple tenants are CO-LOCATED in one
+// shard database, each drawing its own event sequence. A single store-global agent per (shard, database)
+// cannot track them (the lagging tenant's appends fall below the shared high-water mark and are skipped),
+// so managed distribution must fan out one agent per (shard, tenant) — asserted here end-to-end: two
+// ":all/<tenant>" agents for the co-located database, and both tenants' events actually projected.
+//
+// NOTE: this requires the companion JasperFx.Events (jasperfx#482) + Marten (marten#4799) changes — it
+// goes green in CI once those merge, per the PR's stated merge order.
+public class sharded_tenant_partitioned_distribution(ITestOutputHelper output) : PostgresqlContext, IAsyncLifetime
+{
+    private const string TenantA = "tenant-a";
+    private const string TenantB = "tenant-b";
+
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
+
+    // Unique names per run: managed partitions/databases from one run otherwise break the next run's
+    // resource-setup DDL reconciliation.
+    private readonly string theSuffix = Guid.NewGuid().ToString("N")[..8];
+    private string ShardDatabase => $"w3281_shard_{theSuffix}";
+    private string MasterSchema => $"csp_sharded_{theSuffix}";
+
+    public async Task InitializeAsync()
+    {
+        // Provision the physical shard database (the master/pool lives in the default test database
+        // under its own schema).
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            if (!await conn.DatabaseExists(ShardDatabase))
+            {
+                await new DatabaseSpecification().BuildDatabase(conn, ShardDatabase);
+            }
+        }
+
+        var shardConnectionString = new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString)
+        {
+            Database = ShardDatabase
+        }.ConnectionString;
+
+        void ConfigureShardedStore(StoreOptions m)
+        {
+            m.DisableNpgsqlLogging = true;
+            m.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = Servers.PostgresConnectionString;
+                x.SchemaName = MasterSchema;
+                x.PartitionSchemaName = MasterSchema + "_tenants";
+                x.AddDatabase("shard-1", shardConnectionString);
+            });
+
+            m.Events.StreamIdentity = StreamIdentity.AsString;
+            m.Events.TenancyStyle = TenancyStyle.Conjoined;
+            m.Events.AppendMode = EventAppendMode.Quick;
+            m.Events.UseTenantPartitionedEvents = true;
+            m.Events.UseIdentityMapForAggregates = false;
+
+            m.Schema.For<PartitionedCounter>().MultiTenanted();
+            m.Projections.Snapshot<PartitionedCounter>(SnapshotLifecycle.Async);
+        }
+
+        // Provision the two CO-LOCATED tenants BEFORE the Wolverine host starts, so the first agent
+        // enumeration already sees them and fans out per tenant. (Adding a database's FIRST tenants while
+        // the host runs leaves the store-global agent from the empty-database phase running alongside the
+        // new per-tenant agents until assignments reconcile — a transition edge outside this test's scope.)
+        await using (var provisioning = DocumentStore.For(ConfigureShardedStore))
+        {
+            // Apply the event schema (parent partitioned tables) to the shard database first, so the
+            // per-tenant LIST partitions + sequences created by the explicit assignment have a parent.
+            await provisioning.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+            await provisioning.Advanced.AddTenantToShardAsync(TenantA, "shard-1", default);
+            await provisioning.Advanced.AddTenantToShardAsync(TenantB, "shard-1", default);
+        }
+
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.HealthCheckPollingTime = 1.Seconds();
+                opts.Durability.CheckAssignmentPeriod = 1.Seconds();
+
+                opts.Services.AddMarten(ConfigureShardedStore)
+                    .IntegrateWithWolverine(m =>
+                    {
+                        m.UseWolverineManagedEventSubscriptionDistribution = true;
+                        // Sharded tenancy has no single "main" database, so Wolverine's message store needs
+                        // an explicit master (mirrors a real deployment pointing this at a references DB).
+                        m.MainDatabaseConnectionString = Servers.PostgresConnectionString;
+                    });
+
+                opts.Services.AddSingleton<ILoggerProvider>(new OutputLoggerProvider(output));
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Auto;
+            }).StartAsync();
+
+        theStore = theHost.Services.GetRequiredService<IDocumentStore>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        theHost.GetRuntime().Agents.DisableHealthChecks();
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task co_located_tenants_get_their_own_agents_and_both_project()
+    {
+        await theHost.WaitUntilAssumesLeadershipAsync(10.Seconds());
+
+        // One async projection over one shard database with two co-located tenants => one agent PER TENANT.
+        await theHost.WaitUntilAssignmentsChangeTo(w =>
+        {
+            w.AgentScheme = EventSubscriptionAgentFamily.SchemeName;
+            w.ExpectRunningAgents(theHost, 2);
+        }, 60.Seconds());
+
+        var uris = await GetAgentUrisAsync(theHost);
+        uris.Length.ShouldBe(2);
+        uris.ShouldContain(u => u.TrimEnd('/').EndsWith("/" + TenantA, StringComparison.OrdinalIgnoreCase));
+        uris.ShouldContain(u => u.TrimEnd('/').EndsWith("/" + TenantB, StringComparison.OrdinalIgnoreCase));
+
+        // Both tenants' events are projected — each tenant advances against its OWN high-water mark, so the
+        // second tenant's appends are not skipped below a shared mark (the #3280 failure mode).
+        var id = "pc-" + Guid.NewGuid().ToString("N");
+        await AppendAsync(TenantA, id, 5);
+        await AppendAsync(TenantB, id, 11); // same stream id, other tenant partition
+
+        (await WaitForProjectionAsync(TenantA, id, 60.Seconds()))!.Total.ShouldBe(5);
+        (await WaitForProjectionAsync(TenantB, id, 60.Seconds()))!.Total.ShouldBe(11);
+    }
+
+    private async Task AppendAsync(string tenant, string id, int amount)
+    {
+        await using var session = theStore.LightweightSession(tenant);
+        session.Events.StartStream<PartitionedCounter>(id, new CounterChanged(amount));
+        await session.SaveChangesAsync();
+    }
+
+    private async Task<PartitionedCounter?> WaitForProjectionAsync(string tenant, string id, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            await using var session = theStore.QuerySession(tenant);
+            var doc = await session.LoadAsync<PartitionedCounter>(id);
+            if (doc != null)
+            {
+                return doc;
+            }
+
+            await Task.Delay(250.Milliseconds());
+        }
+
+        return null;
+    }
+
+    private static async Task<string[]> GetAgentUrisAsync(IHost host)
+    {
+        var family = host.Services.GetServices<IAgentFamily>()
+            .OfType<EventSubscriptionAgentFamily>().Single();
+        var agents = await family.AllKnownAgentsAsync();
+        return [.. agents.Select(x => x.AbsoluteUri)];
+    }
+}

--- a/src/Persistence/Wolverine.Marten/MartenIntegration.cs
+++ b/src/Persistence/Wolverine.Marten/MartenIntegration.cs
@@ -58,16 +58,6 @@ public class MartenIntegration : IWolverineExtension, IEventForwarding
     /// </summary>
     public bool UseDatabaseAffineAgentAssignment { get; set; }
 
-    /// <summary>
-    /// When <see cref="UseDatabaseAffineAgentAssignment"/> is on, the maximum number of nodes a single shard
-    /// database's agents may fan out across (the "mix" between strict affinity and even spreading). 1 = strict
-    /// affinity (one node per database — fewest connections). A higher value lets a heavy database parallelize
-    /// across up to N least-loaded nodes, at the cost of that database being reachable from up to N nodes
-    /// (server-side connection ceiling per database ≈ N × per-node pool). Flows through to
-    /// <c>StoreOptions.Events.DatabaseAffineAgentFanout</c>. Default 1. See JasperFx/marten#4806.
-    /// </summary>
-    public int DatabaseAffineAgentFanout { get; set; } = 1;
-
     public void Configure(WolverineOptions options)
     {
         // Duplicate incoming messages
@@ -224,16 +214,15 @@ internal class MartenOverrides : IConfigureMarten
             }
         });
 
-        // Bridge the Wolverine-managed distribution's database-affine agent-assignment settings — configured
+        // Bridge the Wolverine-managed distribution's database-affine agent-assignment setting — configured
         // on IntegrateWithWolverine — onto the Marten event store, because Wolverine's distribution is what
-        // consumes them (via IEventStore.GroupAgentAssignmentsByDatabase / MaxNodesPerDatabaseForAgents).
-        // Only the main store (StoreType == null): this is a sharded per-tenant-store concern, not ancillary.
+        // consumes it (via IEventStore.GroupAgentAssignmentsByDatabase). Only the main store
+        // (StoreType == null): this is a sharded per-tenant-store concern, not ancillary.
         // See JasperFx/marten#4806.
         if (StoreType == null &&
-            services.GetService<MartenIntegration>() is { UseDatabaseAffineAgentAssignment: true } integration)
+            services.GetService<MartenIntegration>() is { UseDatabaseAffineAgentAssignment: true })
         {
             options.Events.UseDatabaseAffineAgentAssignment = true;
-            options.Events.DatabaseAffineAgentFanout = integration.DatabaseAffineAgentFanout;
         }
     }
 }

--- a/src/Persistence/Wolverine.Marten/MartenIntegration.cs
+++ b/src/Persistence/Wolverine.Marten/MartenIntegration.cs
@@ -40,11 +40,33 @@ public class MartenIntegration : IWolverineExtension, IEventForwarding
     public bool UseFastEventForwarding { get; set; }
     
     /// <summary>
-    /// Use this when using Wolverine to evenly distribute event projection and subscription 
-    /// work of Marten asynchronous projections. This replaces Marten's <c>AddAsyncDaemon(HotCold)</c> 
+    /// Use this when using Wolverine to evenly distribute event projection and subscription
+    /// work of Marten asynchronous projections. This replaces Marten's <c>AddAsyncDaemon(HotCold)</c>
     /// option and should not be used in combination with Marten's own load distribution.
     /// </summary>
     public bool UseWolverineManagedEventSubscriptionDistribution { get; set; }
+
+    /// <summary>
+    /// Opt-in (default false): when <see cref="UseWolverineManagedEventSubscriptionDistribution"/> is on and
+    /// the Marten store uses sharded databases with per-tenant event partitioning, assign each shard
+    /// database's per-(shard, tenant) agents with <b>database affinity</b> — all of a database's agents run
+    /// on one node — instead of spreading them evenly by count. This bounds each node to the shard databases
+    /// it owns, so connection pools scale with the number of shard databases rather than nodes × databases
+    /// (which otherwise exhausts a shared server's max_connections). Flows through to
+    /// <c>StoreOptions.Events.UseDatabaseAffineAgentAssignment</c>; only takes effect for a sharded,
+    /// per-tenant-partitioned store. See JasperFx/marten#4806.
+    /// </summary>
+    public bool UseDatabaseAffineAgentAssignment { get; set; }
+
+    /// <summary>
+    /// When <see cref="UseDatabaseAffineAgentAssignment"/> is on, the maximum number of nodes a single shard
+    /// database's agents may fan out across (the "mix" between strict affinity and even spreading). 1 = strict
+    /// affinity (one node per database — fewest connections). A higher value lets a heavy database parallelize
+    /// across up to N least-loaded nodes, at the cost of that database being reachable from up to N nodes
+    /// (server-side connection ceiling per database ≈ N × per-node pool). Flows through to
+    /// <c>StoreOptions.Events.DatabaseAffineAgentFanout</c>. Default 1. See JasperFx/marten#4806.
+    /// </summary>
+    public int DatabaseAffineAgentFanout { get; set; } = 1;
 
     public void Configure(WolverineOptions options)
     {
@@ -201,6 +223,18 @@ internal class MartenOverrides : IConfigureMarten
                     nameof(Saga.Version), typeof(int))!;
             }
         });
+
+        // Bridge the Wolverine-managed distribution's database-affine agent-assignment settings — configured
+        // on IntegrateWithWolverine — onto the Marten event store, because Wolverine's distribution is what
+        // consumes them (via IEventStore.GroupAgentAssignmentsByDatabase / MaxNodesPerDatabaseForAgents).
+        // Only the main store (StoreType == null): this is a sharded per-tenant-store concern, not ancillary.
+        // See JasperFx/marten#4806.
+        if (StoreType == null &&
+            services.GetService<MartenIntegration>() is { UseDatabaseAffineAgentAssignment: true } integration)
+        {
+            options.Events.UseDatabaseAffineAgentAssignment = true;
+            options.Events.DatabaseAffineAgentFanout = integration.DatabaseAffineAgentFanout;
+        }
     }
 }
 

--- a/src/Testing/CoreTests/Runtime/Agents/distribute_by_group_affinity.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/distribute_by_group_affinity.cs
@@ -64,38 +64,33 @@ public class distribute_by_group_affinity
     }
 
     [Fact]
-    public void bounded_fan_out_spreads_a_heavy_database_across_up_to_k_nodes()
+    public void a_heavy_database_stays_on_one_node_and_light_groups_balance_around_it()
     {
         var grid = new AssignmentGrid();
         grid.WithNode(1, Guid.NewGuid());
         grid.WithNode(2, Guid.NewGuid());
-        grid.WithNode(3, Guid.NewGuid());
 
-        // One heavy database with 6 tenants; bound = 2 → its agents span exactly 2 nodes (not 1, not 3).
-        var agents = Enumerable.Range(1, 6).Select(t => Agent("dbHeavy", "t" + t)).ToArray();
-        grid.WithAgents(agents);
+        // One heavy database (4 tenants) + two light ones (1 tenant each). Largest-first placement puts the
+        // heavy group on one node and both light groups on the other — totals stay as balanced as whole
+        // groups allow, and a database is never split across nodes.
+        var agents = new List<Uri>();
+        foreach (var tenant in new[] { "t1", "t2", "t3", "t4" })
+            agents.Add(Agent("dbHeavy", tenant));
+        agents.Add(Agent("dbLight1", "t1"));
+        agents.Add(Agent("dbLight2", "t1"));
 
-        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey, maxNodesPerGroup: 2);
+        grid.WithAgents(agents.ToArray());
 
-        var nodesUsed = agents.Select(a => grid.AgentFor(a).AssignedNode).Distinct().ToList();
-        nodesUsed.Count.ShouldBe(2, "a heavy database must fan out across up to the bound (2) nodes");
-        nodesUsed.ShouldAllBe(n => n != null);
-    }
+        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey);
 
-    [Fact]
-    public void a_group_smaller_than_the_bound_uses_fewer_nodes()
-    {
-        var grid = new AssignmentGrid();
-        grid.WithNode(1, Guid.NewGuid());
-        grid.WithNode(2, Guid.NewGuid());
-        grid.WithNode(3, Guid.NewGuid());
+        grid.AllAgents.ShouldAllBe(a => a.AssignedNode != null);
 
-        // A single-tenant database can only ever use one node, even with a higher bound.
-        grid.WithAgents(Agent("dbLight", "t1"));
+        var heavyNode = grid.AgentFor(Agent("dbHeavy", "t1")).AssignedNode;
+        new[] { "t2", "t3", "t4" }
+            .Select(t => grid.AgentFor(Agent("dbHeavy", t)).AssignedNode)
+            .ShouldAllBe(n => n == heavyNode);
 
-        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey, maxNodesPerGroup: 3);
-
-        grid.AgentFor(Agent("dbLight", "t1")).AssignedNode.ShouldNotBeNull();
-        grid.Nodes.Count(n => n.ForScheme("event-subscriptions").Any()).ShouldBe(1);
+        grid.AgentFor(Agent("dbLight1", "t1")).AssignedNode.ShouldNotBe(heavyNode);
+        grid.AgentFor(Agent("dbLight2", "t1")).AssignedNode.ShouldNotBe(heavyNode);
     }
 }

--- a/src/Testing/CoreTests/Runtime/Agents/distribute_by_group_affinity.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/distribute_by_group_affinity.cs
@@ -62,4 +62,40 @@ public class distribute_by_group_affinity
 
         node.ForScheme("event-subscriptions").Count().ShouldBe(3);
     }
+
+    [Fact]
+    public void bounded_fan_out_spreads_a_heavy_database_across_up_to_k_nodes()
+    {
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        grid.WithNode(3, Guid.NewGuid());
+
+        // One heavy database with 6 tenants; bound = 2 → its agents span exactly 2 nodes (not 1, not 3).
+        var agents = Enumerable.Range(1, 6).Select(t => Agent("dbHeavy", "t" + t)).ToArray();
+        grid.WithAgents(agents);
+
+        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey, maxNodesPerGroup: 2);
+
+        var nodesUsed = agents.Select(a => grid.AgentFor(a).AssignedNode).Distinct().ToList();
+        nodesUsed.Count.ShouldBe(2, "a heavy database must fan out across up to the bound (2) nodes");
+        nodesUsed.ShouldAllBe(n => n != null);
+    }
+
+    [Fact]
+    public void a_group_smaller_than_the_bound_uses_fewer_nodes()
+    {
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        grid.WithNode(3, Guid.NewGuid());
+
+        // A single-tenant database can only ever use one node, even with a higher bound.
+        grid.WithAgents(Agent("dbLight", "t1"));
+
+        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey, maxNodesPerGroup: 3);
+
+        grid.AgentFor(Agent("dbLight", "t1")).AssignedNode.ShouldNotBeNull();
+        grid.Nodes.Count(n => n.ForScheme("event-subscriptions").Any()).ShouldBe(1);
+    }
 }

--- a/src/Testing/CoreTests/Runtime/Agents/distribute_by_group_affinity.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/distribute_by_group_affinity.cs
@@ -1,0 +1,65 @@
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+// JasperFx/marten#4806: AssignmentGrid.DistributeByGroupAffinity keeps every agent of a group (e.g. one
+// shard database) on the same node, and spreads whole groups across nodes — so a node opens connection
+// pools only to the databases it owns, instead of every node touching every shard database.
+public class distribute_by_group_affinity
+{
+    // Group key = the database segment of an event-subscriptions agent URI:
+    // event-subscriptions://{type}/{name}/{databaseId}/{shard...}  ->  Segments[2].
+    private static string DatabaseKey(Uri uri) => uri.Segments[2].Trim('/');
+
+    private static Uri Agent(string db, string tenant) =>
+        new($"event-subscriptions://marten/main/{db}/Proj:All:{tenant}");
+
+    [Fact]
+    public void keeps_a_databases_agents_together_and_spreads_databases_across_nodes()
+    {
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+
+        // 4 shard databases, 3 tenants each = 12 per-tenant agents.
+        var agents = new List<Uri>();
+        foreach (var db in new[] { "db1", "db2", "db3", "db4" })
+        foreach (var tenant in new[] { "t1", "t2", "t3" })
+            agents.Add(Agent(db, tenant));
+
+        grid.WithAgents(agents.ToArray());
+
+        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey);
+
+        // Every tenant agent of a database lands on exactly one node (the database is never split).
+        foreach (var db in new[] { "db1", "db2", "db3", "db4" })
+        {
+            var nodes = new[] { "t1", "t2", "t3" }
+                .Select(t => grid.AgentFor(Agent(db, t)).AssignedNode)
+                .Distinct()
+                .ToList();
+
+            nodes.Count.ShouldBe(1, $"all agents of {db} must be on a single node");
+            nodes[0].ShouldNotBeNull();
+        }
+
+        // All agents are assigned, and the 4 databases are spread across both nodes (2 each).
+        grid.AllAgents.ShouldAllBe(a => a.AssignedNode != null);
+        var perNode = grid.Nodes.Select(n => n.ForScheme("event-subscriptions").Count()).OrderBy(x => x).ToList();
+        perNode.ShouldBe(new[] { 6, 6 });
+    }
+
+    [Fact]
+    public void single_node_takes_every_agent()
+    {
+        var grid = new AssignmentGrid();
+        var node = grid.WithNode(1, Guid.NewGuid());
+
+        grid.WithAgents(Agent("db1", "t1"), Agent("db1", "t2"), Agent("db2", "t1"));
+
+        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey);
+
+        node.ForScheme("event-subscriptions").Count().ShouldBe(3);
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Agents/event_store_agents_per_tenant_distribution.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/event_store_agents_per_tenant_distribution.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
+using JasperFx.Events.Projections;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// wolverine#3280: under sharded databases + per-tenant event partitioning multiple tenants are
+/// co-located in one shard database, each drawing its own event sequence, so a single store-global agent
+/// per (shard, database) cannot track them. When the store reports <see cref="IEventStore.DistributesAgentsPerTenant"/>,
+/// <see cref="EventStoreAgents.SupportedAgentsAsync"/> must fan out one agent per (shard, tenant); for any
+/// other store it must keep the single store-global agent.
+/// </summary>
+public class event_store_agents_per_tenant_distribution
+{
+    private static EventStoreUsage UsageWithOneAsyncShardOnADatabaseWith(params string[] tenantIds)
+    {
+        return new EventStoreUsage
+        {
+            Database = new DatabaseUsage
+            {
+                Databases =
+                {
+                    new DatabaseDescriptor
+                    {
+                        ServerName = "localhost",
+                        DatabaseName = "claims1",
+                        TenantIds = tenantIds.ToList()
+                    }
+                }
+            },
+            Subscriptions =
+            {
+                new SubscriptionDescriptor(SubscriptionType.SingleStreamProjection)
+                {
+                    Lifecycle = ProjectionLifecycle.Async,
+                    ShardNames = new[] { ShardName.Compose("provided-cares") }
+                }
+            }
+        };
+    }
+
+    private static EventStoreAgents AgentsFor(EventStoreUsage usage, bool distributesPerTenant)
+    {
+        var store = Substitute.For<IEventStore>();
+        store.Identity.Returns(new EventStoreIdentity("main", "marten"));
+        store.DistributesAgentsPerTenant.Returns(distributesPerTenant);
+        store.TryCreateUsage(Arg.Any<CancellationToken>()).Returns(Task.FromResult<EventStoreUsage?>(usage));
+        return new EventStoreAgents(store, Array.Empty<IObserver<ShardState>>());
+    }
+
+    [Fact]
+    public async Task fans_out_one_agent_per_tenant_when_the_store_distributes_per_tenant()
+    {
+        var agents = AgentsFor(UsageWithOneAsyncShardOnADatabaseWith("01059910", "08004464"), distributesPerTenant: true);
+
+        var uris = await agents.SupportedAgentsAsync(CancellationToken.None);
+
+        uris.Count.ShouldBe(2, "one async shard on a two-tenant database must yield one agent per tenant");
+        uris.ShouldContain(u => u.AbsolutePath.TrimEnd('/').EndsWith("/01059910", StringComparison.OrdinalIgnoreCase));
+        uris.ShouldContain(u => u.AbsolutePath.TrimEnd('/').EndsWith("/08004464", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task keeps_a_single_store_global_agent_when_the_store_does_not_distribute_per_tenant()
+    {
+        var agents = AgentsFor(UsageWithOneAsyncShardOnADatabaseWith("01059910", "08004464"), distributesPerTenant: false);
+
+        var uris = await agents.SupportedAgentsAsync(CancellationToken.None);
+
+        uris.Count.ShouldBe(1, "without per-tenant distribution a shard keeps its single store-global agent");
+        uris.ShouldNotContain(u => u.AbsolutePath.TrimEnd('/').EndsWith("/01059910", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task keeps_a_single_agent_when_the_database_has_no_tenants_yet()
+    {
+        var agents = AgentsFor(UsageWithOneAsyncShardOnADatabaseWith(), distributesPerTenant: true);
+
+        var uris = await agents.SupportedAgentsAsync(CancellationToken.None);
+
+        uris.Count.ShouldBe(1, "a per-tenant store with no tenants provisioned yet keeps one store-global agent");
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Agents/event_store_agents_per_tenant_distribution.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/event_store_agents_per_tenant_distribution.cs
@@ -91,4 +91,21 @@ public class event_store_agents_per_tenant_distribution
 
         uris.Count.ShouldBe(1, "a per-tenant store with no tenants provisioned yet keeps one store-global agent");
     }
+
+    [Fact]
+    public async Task dedupes_tenants_case_insensitively_and_skips_blank_ids()
+    {
+        // Tenant ids are matched case-insensitively elsewhere (TryResolveTenantDatabaseIdAsync), so the
+        // fan-out must not produce two agents for the same logical tenant in different casing, nor an
+        // invalid agent for a blank id that slipped into the usage descriptor.
+        var agents = AgentsFor(
+            UsageWithOneAsyncShardOnADatabaseWith("Clinic-A", "clinic-a", "clinic-b", "", "   "),
+            distributesPerTenant: true);
+
+        var uris = await agents.SupportedAgentsAsync(CancellationToken.None);
+
+        uris.Count.ShouldBe(2, "one agent per logical tenant: clinic-a (deduped across casing) and clinic-b");
+        uris.ShouldContain(u => u.AbsolutePath.TrimEnd('/').EndsWith("/clinic-a", StringComparison.OrdinalIgnoreCase));
+        uris.ShouldContain(u => u.AbsolutePath.TrimEnd('/').EndsWith("/clinic-b", StringComparison.OrdinalIgnoreCase));
+    }
 }

--- a/src/Testing/CoreTests/Runtime/Agents/event_subscription_family_affine_assignment.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/event_subscription_family_affine_assignment.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// JasperFx/marten#4806: when a sharded store opts into <see cref="IEventStore.GroupAgentAssignmentsByDatabase"/>,
+/// <see cref="EventSubscriptionAgentFamily.EvaluateAssignmentsAsync"/> must assign that store's per-(shard, tenant)
+/// agents with database affinity (a database's agents kept on one node, bounded by
+/// <see cref="IEventStore.MaxNodesPerDatabaseForAgents"/>) instead of the default even blue/green spread. These
+/// are fast unit tests: agents are registered directly on an <see cref="AssignmentGrid"/> and the store flags are
+/// stubbed, so no host or database is required.
+/// </summary>
+public class event_subscription_family_affine_assignment
+{
+    // Agent URI grammar is event-subscriptions://{type}/{name}/{databaseId}/{shard...} (see EventStoreAgents.UriFor).
+    private static Uri Agent(string db, string tenant) =>
+        new($"event-subscriptions://marten/main/{db}/Proj:All:{tenant}");
+
+    private static EventSubscriptionAgentFamily FamilyFor(bool affine, int maxNodesPerDatabase = 1)
+    {
+        var store = Substitute.For<IEventStore>();
+        store.Identity.Returns(new EventStoreIdentity("main", "marten"));
+        store.GroupAgentAssignmentsByDatabase.Returns(affine);
+        store.MaxNodesPerDatabaseForAgents.Returns(maxNodesPerDatabase);
+        return new EventSubscriptionAgentFamily(new[] { store }, Array.Empty<IObserver<JasperFx.Events.Projections.ShardState>>());
+    }
+
+    [Fact]
+    public async Task keeps_a_databases_agents_together_when_the_store_opts_into_affinity()
+    {
+        var family = FamilyFor(affine: true);
+
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        // One shard database with two tenants: even distribution would split it across the two nodes.
+        grid.WithAgents(Agent("dbShared", "t1"), Agent("dbShared", "t2"));
+
+        await family.EvaluateAssignmentsAsync(grid);
+
+        var nodes = new[] { "t1", "t2" }
+            .Select(t => grid.AgentFor(Agent("dbShared", t)).AssignedNode)
+            .Distinct()
+            .ToList();
+
+        nodes.Count.ShouldBe(1, "an affine store must keep a shard database's agents on a single node");
+        nodes[0].ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task spreads_a_databases_agents_evenly_when_the_store_does_not_opt_in()
+    {
+        var family = FamilyFor(affine: false);
+
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        grid.WithAgents(Agent("dbShared", "t1"), Agent("dbShared", "t2"));
+
+        await family.EvaluateAssignmentsAsync(grid);
+
+        var nodes = new[] { "t1", "t2" }
+            .Select(t => grid.AgentFor(Agent("dbShared", t)).AssignedNode)
+            .Distinct()
+            .ToList();
+
+        nodes.Count.ShouldBe(2, "without affinity even distribution splits a two-agent database across both nodes");
+    }
+
+    [Fact]
+    public async Task fans_a_heavy_database_out_across_the_stores_max_nodes_bound()
+    {
+        // The family must pass the store's MaxNodesPerDatabaseForAgents through to the grid so a heavy database
+        // parallelizes across up to that many nodes — not one (strict affinity) and not all three (even spread).
+        var family = FamilyFor(affine: true, maxNodesPerDatabase: 2);
+
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        grid.WithNode(3, Guid.NewGuid());
+        var agents = Enumerable.Range(1, 6).Select(t => Agent("dbHeavy", "t" + t)).ToArray();
+        grid.WithAgents(agents);
+
+        await family.EvaluateAssignmentsAsync(grid);
+
+        var nodesUsed = agents.Select(a => grid.AgentFor(a).AssignedNode).Distinct().ToList();
+        nodesUsed.Count.ShouldBe(2, "the family must honor the store's fan-out bound of 2");
+        nodesUsed.ShouldAllBe(n => n != null);
+    }
+
+    [Fact]
+    public void database_key_groups_a_databases_agents_and_separates_databases()
+    {
+        var t1 = EventSubscriptionAgentFamily.DatabaseKeyOf(Agent("claims1", "t1"));
+        var t2 = EventSubscriptionAgentFamily.DatabaseKeyOf(Agent("claims1", "t2"));
+        var other = EventSubscriptionAgentFamily.DatabaseKeyOf(Agent("claims2", "t1"));
+
+        t1.ShouldBe("marten/main/claims1");
+        t2.ShouldBe(t1, "two tenants on the same shard database must share a group key");
+        other.ShouldNotBe(t1, "a different shard database must be a different group");
+    }
+
+    [Fact]
+    public void database_key_falls_back_to_the_whole_uri_when_there_is_no_database_segment()
+    {
+        // Defensive: a URI without the {databaseId} segment (fewer than 3 path segments) can't be grouped by
+        // database, so each such agent is its own group rather than silently collapsing together.
+        var uri = new Uri("event-subscriptions://marten/main");
+        EventSubscriptionAgentFamily.DatabaseKeyOf(uri).ShouldBe(uri.AbsoluteUri);
+    }
+}
+
+/// <summary>
+/// <see cref="EventStoreAgents"/> surfaces the affine-assignment flags from its underlying
+/// <see cref="IEventStore"/> unchanged; the agent family reads them off the wrapper. See JasperFx/marten#4806.
+/// </summary>
+public class event_store_agents_affinity_passthrough
+{
+    private static EventStoreAgents AgentsFor(bool affine, int maxNodes)
+    {
+        var store = Substitute.For<IEventStore>();
+        store.Identity.Returns(new EventStoreIdentity("main", "marten"));
+        store.GroupAgentAssignmentsByDatabase.Returns(affine);
+        store.MaxNodesPerDatabaseForAgents.Returns(maxNodes);
+        return new EventStoreAgents(store, Array.Empty<IObserver<JasperFx.Events.Projections.ShardState>>());
+    }
+
+    [Fact]
+    public void surfaces_group_by_database_and_max_nodes_from_the_store()
+    {
+        var agents = AgentsFor(affine: true, maxNodes: 3);
+
+        agents.GroupAgentAssignmentsByDatabase.ShouldBeTrue();
+        agents.MaxNodesPerDatabaseForAgents.ShouldBe(3);
+    }
+
+    [Fact]
+    public void defaults_flow_through_for_a_non_affine_store()
+    {
+        var agents = AgentsFor(affine: false, maxNodes: 1);
+
+        agents.GroupAgentAssignmentsByDatabase.ShouldBeFalse();
+        agents.MaxNodesPerDatabaseForAgents.ShouldBe(1);
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Agents/event_subscription_family_affine_assignment.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/event_subscription_family_affine_assignment.cs
@@ -14,10 +14,9 @@ namespace CoreTests.Runtime.Agents;
 /// <summary>
 /// JasperFx/marten#4806: when a sharded store opts into <see cref="IEventStore.GroupAgentAssignmentsByDatabase"/>,
 /// <see cref="EventSubscriptionAgentFamily.EvaluateAssignmentsAsync"/> must assign that store's per-(shard, tenant)
-/// agents with database affinity (a database's agents kept on one node, bounded by
-/// <see cref="IEventStore.MaxNodesPerDatabaseForAgents"/>) instead of the default even blue/green spread. These
-/// are fast unit tests: agents are registered directly on an <see cref="AssignmentGrid"/> and the store flags are
-/// stubbed, so no host or database is required.
+/// agents with database affinity (a database's agents kept together on one node) instead of the default even
+/// blue/green spread. These are fast unit tests: agents are registered directly on an
+/// <see cref="AssignmentGrid"/> and the store flag is stubbed, so no host or database is required.
 /// </summary>
 public class event_subscription_family_affine_assignment
 {
@@ -25,12 +24,11 @@ public class event_subscription_family_affine_assignment
     private static Uri Agent(string db, string tenant) =>
         new($"event-subscriptions://marten/main/{db}/Proj:All:{tenant}");
 
-    private static EventSubscriptionAgentFamily FamilyFor(bool affine, int maxNodesPerDatabase = 1)
+    private static EventSubscriptionAgentFamily FamilyFor(bool affine)
     {
         var store = Substitute.For<IEventStore>();
         store.Identity.Returns(new EventStoreIdentity("main", "marten"));
         store.GroupAgentAssignmentsByDatabase.Returns(affine);
-        store.MaxNodesPerDatabaseForAgents.Returns(maxNodesPerDatabase);
         return new EventSubscriptionAgentFamily(new[] { store }, Array.Empty<IObserver<JasperFx.Events.Projections.ShardState>>());
     }
 
@@ -77,27 +75,6 @@ public class event_subscription_family_affine_assignment
     }
 
     [Fact]
-    public async Task fans_a_heavy_database_out_across_the_stores_max_nodes_bound()
-    {
-        // The family must pass the store's MaxNodesPerDatabaseForAgents through to the grid so a heavy database
-        // parallelizes across up to that many nodes — not one (strict affinity) and not all three (even spread).
-        var family = FamilyFor(affine: true, maxNodesPerDatabase: 2);
-
-        var grid = new AssignmentGrid();
-        grid.WithNode(1, Guid.NewGuid());
-        grid.WithNode(2, Guid.NewGuid());
-        grid.WithNode(3, Guid.NewGuid());
-        var agents = Enumerable.Range(1, 6).Select(t => Agent("dbHeavy", "t" + t)).ToArray();
-        grid.WithAgents(agents);
-
-        await family.EvaluateAssignmentsAsync(grid);
-
-        var nodesUsed = agents.Select(a => grid.AgentFor(a).AssignedNode).Distinct().ToList();
-        nodesUsed.Count.ShouldBe(2, "the family must honor the store's fan-out bound of 2");
-        nodesUsed.ShouldAllBe(n => n != null);
-    }
-
-    [Fact]
     public void database_key_groups_a_databases_agents_and_separates_databases()
     {
         var t1 = EventSubscriptionAgentFamily.DatabaseKeyOf(Agent("claims1", "t1"));
@@ -120,35 +97,28 @@ public class event_subscription_family_affine_assignment
 }
 
 /// <summary>
-/// <see cref="EventStoreAgents"/> surfaces the affine-assignment flags from its underlying
-/// <see cref="IEventStore"/> unchanged; the agent family reads them off the wrapper. See JasperFx/marten#4806.
+/// <see cref="EventStoreAgents"/> surfaces the affine-assignment flag from its underlying
+/// <see cref="IEventStore"/> unchanged; the agent family reads it off the wrapper. See JasperFx/marten#4806.
 /// </summary>
 public class event_store_agents_affinity_passthrough
 {
-    private static EventStoreAgents AgentsFor(bool affine, int maxNodes)
+    private static EventStoreAgents AgentsFor(bool affine)
     {
         var store = Substitute.For<IEventStore>();
         store.Identity.Returns(new EventStoreIdentity("main", "marten"));
         store.GroupAgentAssignmentsByDatabase.Returns(affine);
-        store.MaxNodesPerDatabaseForAgents.Returns(maxNodes);
         return new EventStoreAgents(store, Array.Empty<IObserver<JasperFx.Events.Projections.ShardState>>());
     }
 
     [Fact]
-    public void surfaces_group_by_database_and_max_nodes_from_the_store()
+    public void surfaces_group_by_database_from_the_store()
     {
-        var agents = AgentsFor(affine: true, maxNodes: 3);
-
-        agents.GroupAgentAssignmentsByDatabase.ShouldBeTrue();
-        agents.MaxNodesPerDatabaseForAgents.ShouldBe(3);
+        AgentsFor(affine: true).GroupAgentAssignmentsByDatabase.ShouldBeTrue();
     }
 
     [Fact]
-    public void defaults_flow_through_for_a_non_affine_store()
+    public void default_flows_through_for_a_non_affine_store()
     {
-        var agents = AgentsFor(affine: false, maxNodes: 1);
-
-        agents.GroupAgentAssignmentsByDatabase.ShouldBeFalse();
-        agents.MaxNodesPerDatabaseForAgents.ShouldBe(1);
+        AgentsFor(affine: false).GroupAgentAssignmentsByDatabase.ShouldBeFalse();
     }
 }

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
@@ -84,22 +84,21 @@ public partial class AssignmentGrid
     }
 
     /// <summary>
-    /// Distribute agents of a scheme across nodes with <b>group affinity</b>: every agent whose
-    /// <paramref name="groupKey"/> is equal is placed on the same node, and whole groups are spread
-    /// evenly across nodes. Intended for sharded event stores where each agent's group is its shard
-    /// database (JasperFx/marten#4806) — co-locating a database's agents on one node bounds that node
-    /// to the databases it owns, so connection pools scale with databases rather than nodes × databases.
+    /// Distribute agents of a scheme across nodes with <b>bounded group affinity</b>: agents that share a
+    /// <paramref name="groupKey"/> (e.g. a shard database) are kept together, but a group may fan out across
+    /// up to <paramref name="maxNodesPerGroup"/> nodes. This is the "mix" between strict affinity
+    /// (<c>maxNodesPerGroup == 1</c> — fewest connections, but a heavy group is serialized on one node's
+    /// pool) and even spreading: a higher bound lets a heavy group parallelize across several nodes while
+    /// still capping how many nodes reach that group's database, so its server-side connection ceiling stays
+    /// bounded at (bound × per-node pool). Intended for sharded event stores (JasperFx/marten#4806).
     ///
-    /// <para>Balanced by a greedy least-loaded fit: each database group (largest first) goes to the node
-    /// with the fewest agents so far, so nodes end up with roughly equal <em>total agent counts</em> — a
-    /// proxy for per-tenant work, since a database contributes one agent per resident tenant × projection —
-    /// rather than merely an equal number of databases. It balances by agent/tenant count, not by raw event
-    /// volume, so a database that is few-tenants-but-huge can still be heavier than its agent count implies.
-    /// Deterministic tie-breaks (prefer non-leaders, then node id) keep a steady grid from churning. This
-    /// prototype does not yet apply blue/green capability matching; use the standard
-    /// <see cref="DistributeEvenlyWithBlueGreenSemantics"/> when that is required.</para>
+    /// <para>Groups are placed largest-first onto their k = min(bound, group size, node count) least-loaded
+    /// nodes; each group's agents then greedily fill those nodes least-loaded-first, so total agent count
+    /// stays balanced and the result is deterministic (a steady grid does not churn). A group with fewer
+    /// agents than the bound naturally uses fewer nodes. This prototype does not apply blue/green capability
+    /// matching; use <see cref="DistributeEvenlyWithBlueGreenSemantics"/> when that is required.</para>
     /// </summary>
-    public void DistributeByGroupAffinity(string scheme, Func<Uri, string> groupKey)
+    public void DistributeByGroupAffinity(string scheme, Func<Uri, string> groupKey, int maxNodesPerGroup = 1)
     {
         if (_nodes.Count == 0)
         {
@@ -110,6 +109,11 @@ public partial class AssignmentGrid
         if (agents.Count == 0)
         {
             return;
+        }
+
+        if (maxNodesPerGroup < 1)
+        {
+            maxNodesPerGroup = 1;
         }
 
         var nodes = _nodes.OrderBy(x => x.IsLeader).ThenBy(x => x.AssignedId).ToList();
@@ -125,28 +129,39 @@ public partial class AssignmentGrid
             return;
         }
 
+        var load = nodes.ToDictionary(n => n, _ => 0);
+
         var groups = agents
             .GroupBy(a => groupKey(a.Uri))
             .OrderByDescending(g => g.Count())
             .ThenBy(g => g.Key, StringComparer.Ordinal)
             .ToList();
 
-        var agentCountByNode = nodes.ToDictionary(n => n, _ => 0);
         foreach (var group in groups)
         {
-            // Least-loaded node wins; prefer non-leaders and lower node ids on ties for a stable result.
-            var node = agentCountByNode
+            var members = group.ToList();
+            var k = Math.Min(Math.Min(maxNodesPerGroup, members.Count), nodes.Count);
+
+            // The k least-loaded nodes host this group; a group smaller than the bound uses fewer nodes.
+            var chosen = load
                 .OrderBy(kv => kv.Value)
                 .ThenBy(kv => kv.Key.IsLeader)
                 .ThenBy(kv => kv.Key.AssignedId)
-                .First().Key;
+                .Take(k)
+                .Select(kv => kv.Key)
+                .ToList();
 
-            foreach (var agent in group)
+            // Greedily fill the group's agents onto the chosen nodes, least-loaded first, to balance work.
+            foreach (var agent in members)
             {
+                var node = chosen
+                    .OrderBy(n => load[n])
+                    .ThenBy(n => n.IsLeader)
+                    .ThenBy(n => n.AssignedId)
+                    .First();
                 node.Assign(agent);
+                load[node]++;
             }
-
-            agentCountByNode[node] += group.Count();
         }
     }
 

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
@@ -84,21 +84,20 @@ public partial class AssignmentGrid
     }
 
     /// <summary>
-    /// Distribute agents of a scheme across nodes with <b>bounded group affinity</b>: agents that share a
-    /// <paramref name="groupKey"/> (e.g. a shard database) are kept together, but a group may fan out across
-    /// up to <paramref name="maxNodesPerGroup"/> nodes. This is the "mix" between strict affinity
-    /// (<c>maxNodesPerGroup == 1</c> — fewest connections, but a heavy group is serialized on one node's
-    /// pool) and even spreading: a higher bound lets a heavy group parallelize across several nodes while
-    /// still capping how many nodes reach that group's database, so its server-side connection ceiling stays
-    /// bounded at (bound × per-node pool). Intended for sharded event stores (JasperFx/marten#4806).
+    /// Distribute agents of a scheme across nodes with <b>group affinity</b>: all agents that share a
+    /// <paramref name="groupKey"/> (e.g. a shard database) are assigned to the same node. Intended for
+    /// sharded event stores whose per-(shard, tenant) agents each connect to their shard database: an even
+    /// per-agent spread makes every node open pools to (nearly) every database (pools grow as
+    /// nodes×databases and exhaust a shared server's max_connections), while grouping keeps each node
+    /// connected only to the databases it owns, so pools scale with the number of databases
+    /// (JasperFx/marten#4806).
     ///
-    /// <para>Groups are placed largest-first onto their k = min(bound, group size, node count) least-loaded
-    /// nodes; each group's agents then greedily fill those nodes least-loaded-first, so total agent count
-    /// stays balanced and the result is deterministic (a steady grid does not churn). A group with fewer
-    /// agents than the bound naturally uses fewer nodes. This prototype does not apply blue/green capability
-    /// matching; use <see cref="DistributeEvenlyWithBlueGreenSemantics"/> when that is required.</para>
+    /// <para>Groups are placed largest-first onto the least-loaded node (deterministic tie-breaks), so total
+    /// agent count stays balanced and a steady grid does not churn. This does not apply blue/green
+    /// capability matching; use <see cref="DistributeEvenlyWithBlueGreenSemantics"/> when that is
+    /// required.</para>
     /// </summary>
-    public void DistributeByGroupAffinity(string scheme, Func<Uri, string> groupKey, int maxNodesPerGroup = 1)
+    public void DistributeByGroupAffinity(string scheme, Func<Uri, string> groupKey)
     {
         if (_nodes.Count == 0)
         {
@@ -109,11 +108,6 @@ public partial class AssignmentGrid
         if (agents.Count == 0)
         {
             return;
-        }
-
-        if (maxNodesPerGroup < 1)
-        {
-            maxNodesPerGroup = 1;
         }
 
         var nodes = _nodes.OrderBy(x => x.IsLeader).ThenBy(x => x.AssignedId).ToList();
@@ -140,28 +134,20 @@ public partial class AssignmentGrid
         foreach (var group in groups)
         {
             var members = group.ToList();
-            var k = Math.Min(Math.Min(maxNodesPerGroup, members.Count), nodes.Count);
 
-            // The k least-loaded nodes host this group; a group smaller than the bound uses fewer nodes.
-            var chosen = load
+            // The least-loaded node hosts the whole group (tie-breaks: non-leader first, then node id).
+            var node = load
                 .OrderBy(kv => kv.Value)
                 .ThenBy(kv => kv.Key.IsLeader)
                 .ThenBy(kv => kv.Key.AssignedId)
-                .Take(k)
-                .Select(kv => kv.Key)
-                .ToList();
+                .First().Key;
 
-            // Greedily fill the group's agents onto the chosen nodes, least-loaded first, to balance work.
             foreach (var agent in members)
             {
-                var node = chosen
-                    .OrderBy(n => load[n])
-                    .ThenBy(n => n.IsLeader)
-                    .ThenBy(n => n.AssignedId)
-                    .First();
                 node.Assign(agent);
-                load[node]++;
             }
+
+            load[node] += members.Count;
         }
     }
 

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
@@ -83,6 +83,73 @@ public partial class AssignmentGrid
         }
     }
 
+    /// <summary>
+    /// Distribute agents of a scheme across nodes with <b>group affinity</b>: every agent whose
+    /// <paramref name="groupKey"/> is equal is placed on the same node, and whole groups are spread
+    /// evenly across nodes. Intended for sharded event stores where each agent's group is its shard
+    /// database (JasperFx/marten#4806) — co-locating a database's agents on one node bounds that node
+    /// to the databases it owns, so connection pools scale with databases rather than nodes × databases.
+    ///
+    /// <para>Balanced by a greedy least-loaded fit: each database group (largest first) goes to the node
+    /// with the fewest agents so far, so nodes end up with roughly equal <em>total agent counts</em> — a
+    /// proxy for per-tenant work, since a database contributes one agent per resident tenant × projection —
+    /// rather than merely an equal number of databases. It balances by agent/tenant count, not by raw event
+    /// volume, so a database that is few-tenants-but-huge can still be heavier than its agent count implies.
+    /// Deterministic tie-breaks (prefer non-leaders, then node id) keep a steady grid from churning. This
+    /// prototype does not yet apply blue/green capability matching; use the standard
+    /// <see cref="DistributeEvenlyWithBlueGreenSemantics"/> when that is required.</para>
+    /// </summary>
+    public void DistributeByGroupAffinity(string scheme, Func<Uri, string> groupKey)
+    {
+        if (_nodes.Count == 0)
+        {
+            throw new InvalidOperationException("There are no active nodes");
+        }
+
+        var agents = AvailableAgentsForScheme(scheme);
+        if (agents.Count == 0)
+        {
+            return;
+        }
+
+        var nodes = _nodes.OrderBy(x => x.IsLeader).ThenBy(x => x.AssignedId).ToList();
+
+        if (nodes.Count == 1)
+        {
+            var only = nodes[0];
+            foreach (var agent in agents)
+            {
+                only.Assign(agent);
+            }
+
+            return;
+        }
+
+        var groups = agents
+            .GroupBy(a => groupKey(a.Uri))
+            .OrderByDescending(g => g.Count())
+            .ThenBy(g => g.Key, StringComparer.Ordinal)
+            .ToList();
+
+        var agentCountByNode = nodes.ToDictionary(n => n, _ => 0);
+        foreach (var group in groups)
+        {
+            // Least-loaded node wins; prefer non-leaders and lower node ids on ties for a stable result.
+            var node = agentCountByNode
+                .OrderBy(kv => kv.Value)
+                .ThenBy(kv => kv.Key.IsLeader)
+                .ThenBy(kv => kv.Key.AssignedId)
+                .First().Key;
+
+            foreach (var agent in group)
+            {
+                node.Assign(agent);
+            }
+
+            agentCountByNode[node] += group.Count();
+        }
+    }
+
     public bool AllNodesHaveSameCapabilities(string scheme)
     {
         var gold = _nodes[0].OrderedCapabilitiesForScheme(scheme);

--- a/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
+++ b/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
@@ -38,12 +38,6 @@ public class EventStoreAgents : IAsyncDisposable
     /// </summary>
     public bool GroupAgentAssignmentsByDatabase => _store.GroupAgentAssignmentsByDatabase;
 
-    /// <summary>
-    /// Upper bound on how many nodes a single shard database's agents may fan out across under database-affine
-    /// assignment (the "mix"; 1 = strict affinity). Surfaces <see cref="IEventStore.MaxNodesPerDatabaseForAgents"/>.
-    /// </summary>
-    public int MaxNodesPerDatabaseForAgents => _store.MaxNodesPerDatabaseForAgents;
-
     public async ValueTask DisposeAsync()
     {
         foreach (var entry in _daemons.Enumerate())

--- a/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
+++ b/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
@@ -30,6 +30,14 @@ public class EventStoreAgents : IAsyncDisposable
     
     public EventStoreIdentity Identity { get; }
 
+    /// <summary>
+    /// When true (opt-in, sharded stores only), this store's per-(shard, tenant) agents should be assigned
+    /// with database affinity — all agents for a shard database on one node — so a node opens pools only to
+    /// the databases it owns. Surfaces <see cref="IEventStore.GroupAgentAssignmentsByDatabase"/>. See
+    /// JasperFx/marten#4806.
+    /// </summary>
+    public bool GroupAgentAssignmentsByDatabase => _store.GroupAgentAssignmentsByDatabase;
+
     public async ValueTask DisposeAsync()
     {
         foreach (var entry in _daemons.Enumerate())

--- a/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
+++ b/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
@@ -108,7 +108,12 @@ public class EventStoreAgents : IAsyncDisposable
         {
             if (_store.DistributesAgentsPerTenant && database.TenantIds.Count > 0)
             {
-                foreach (var tenantId in database.TenantIds.Distinct())
+                // Tenant ids are matched case-insensitively elsewhere in this class (see
+                // TryResolveTenantDatabaseIdAsync), so dedupe the fan-out the same way, and skip blank ids —
+                // a malformed usage descriptor must not yield duplicate or invalid per-tenant agent URIs.
+                foreach (var tenantId in database.TenantIds
+                             .Where(t => !string.IsNullOrWhiteSpace(t))
+                             .Distinct(StringComparer.OrdinalIgnoreCase))
                 {
                     var tenantShard = shardName.ForTenant(tenantId);
                     _shardNames = _shardNames.AddOrUpdate(tenantShard.RelativeUrl, tenantShard);

--- a/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
+++ b/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
@@ -38,6 +38,12 @@ public class EventStoreAgents : IAsyncDisposable
     /// </summary>
     public bool GroupAgentAssignmentsByDatabase => _store.GroupAgentAssignmentsByDatabase;
 
+    /// <summary>
+    /// Upper bound on how many nodes a single shard database's agents may fan out across under database-affine
+    /// assignment (the "mix"; 1 = strict affinity). Surfaces <see cref="IEventStore.MaxNodesPerDatabaseForAgents"/>.
+    /// </summary>
+    public int MaxNodesPerDatabaseForAgents => _store.MaxNodesPerDatabaseForAgents;
+
     public async ValueTask DisposeAsync()
     {
         foreach (var entry in _daemons.Enumerate())

--- a/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
+++ b/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
@@ -87,18 +87,43 @@ public class EventStoreAgents : IAsyncDisposable
         var usage = await _store.TryCreateUsage(cancellation);
         if (usage == null) return list;
 
+        var asyncShards = usage.Subscriptions
+            .Where(x => x.Lifecycle == ProjectionLifecycle.Async)
+            .SelectMany(x => x.ShardNames)
+            .ToArray();
+
+        // wolverine#3280: under sharded databases + per-tenant event partitioning, multiple tenants are
+        // co-located in one shard database and each draws its own event sequence, so a single store-global
+        // agent per (shard, database) cannot track them — fan out one agent per (shard, tenant) instead.
+        // For any other store (or a database with no tenants yet) keep the one store-global agent.
+        void addAgentsForShard(DatabaseDescriptor database, DatabaseId id, ShardName shardName)
+        {
+            if (_store.DistributesAgentsPerTenant && database.TenantIds.Count > 0)
+            {
+                foreach (var tenantId in database.TenantIds.Distinct())
+                {
+                    var tenantShard = shardName.ForTenant(tenantId);
+                    _shardNames = _shardNames.AddOrUpdate(tenantShard.RelativeUrl, tenantShard);
+                    list.Add(EventSubscriptionAgentFamily.UriFor(_store.Identity, id, tenantShard));
+                }
+            }
+            else
+            {
+                _shardNames = _shardNames.AddOrUpdate(shardName.RelativeUrl, shardName);
+                list.Add(EventSubscriptionAgentFamily.UriFor(_store.Identity, id, shardName));
+            }
+        }
+
         // Using this to keep from double dipping
         var databaseIds = new List<DatabaseId>();
         foreach (var database in usage.Database.Databases)
         {
             var id = new DatabaseId(database.ServerName, database.DatabaseName);
             databaseIds.Add(id);
-            
-            foreach (var shardName in usage.Subscriptions.Where(x => x.Lifecycle == ProjectionLifecycle.Async).SelectMany(x => x.ShardNames))
+
+            foreach (var shardName in asyncShards)
             {
-                _shardNames = _shardNames.AddOrUpdate(shardName.RelativeUrl, shardName);
-                var uri = EventSubscriptionAgentFamily.UriFor(_store.Identity, id, shardName);
-                list.Add(uri);
+                addAgentsForShard(database, id, shardName);
             }
         }
 
@@ -108,11 +133,9 @@ public class EventStoreAgents : IAsyncDisposable
             var id = new DatabaseId(database.ServerName, database.DatabaseName);
             if (!databaseIds.Contains(id))
             {
-                foreach (var shardName in usage.Subscriptions.Where(x => x.Lifecycle == ProjectionLifecycle.Async).SelectMany(x => x.ShardNames))
+                foreach (var shardName in asyncShards)
                 {
-                    _shardNames = _shardNames.AddOrUpdate(shardName.RelativeUrl, shardName);
-                    var uri = EventSubscriptionAgentFamily.UriFor(_store.Identity, id, shardName);
-                    list.Add(uri);
+                    addAgentsForShard(database, id, shardName);
                 }
             }
         }

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
@@ -160,9 +160,18 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
         // shard database's per-tenant agents together on one node so a node opens connection pools only to
         // the databases it owns (pools scale with databases, not nodes × databases, which otherwise
         // exhausts a shared server). Otherwise distribute evenly with blue/green semantics as before.
-        if (_stores.Enumerate().Any(e => e.Value.GroupAgentAssignmentsByDatabase))
+        var affineStores = _stores.Enumerate()
+            .Select(e => e.Value)
+            .Where(s => s.GroupAgentAssignmentsByDatabase)
+            .ToList();
+
+        if (affineStores.Count != 0)
         {
-            assignments.DistributeByGroupAffinity(SchemeName, DatabaseKeyOf);
+            // Bounded fan-out ("mix"): a shard database's agents may spread across up to this many nodes.
+            // One grid pass covers every store's agents (their per-store URI prefix keeps groups distinct),
+            // so use the largest bound any affine store asks for.
+            var maxNodesPerGroup = affineStores.Max(s => s.MaxNodesPerDatabaseForAgents);
+            assignments.DistributeByGroupAffinity(SchemeName, DatabaseKeyOf, maxNodesPerGroup);
         }
         else
         {

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
@@ -160,18 +160,13 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
         // shard database's per-tenant agents together on one node so a node opens connection pools only to
         // the databases it owns (pools scale with databases, not nodes × databases, which otherwise
         // exhausts a shared server). Otherwise distribute evenly with blue/green semantics as before.
-        var affineStores = _stores.Enumerate()
-            .Select(e => e.Value)
-            .Where(s => s.GroupAgentAssignmentsByDatabase)
-            .ToList();
+        var anyAffineStore = _stores.Enumerate()
+            .Any(e => e.Value.GroupAgentAssignmentsByDatabase);
 
-        if (affineStores.Count != 0)
+        if (anyAffineStore)
         {
-            // Bounded fan-out ("mix"): a shard database's agents may spread across up to this many nodes.
-            // One grid pass covers every store's agents (their per-store URI prefix keeps groups distinct),
-            // so use the largest bound any affine store asks for.
-            var maxNodesPerGroup = affineStores.Max(s => s.MaxNodesPerDatabaseForAgents);
-            assignments.DistributeByGroupAffinity(SchemeName, DatabaseKeyOf, maxNodesPerGroup);
+            // One grid pass covers every store's agents — their per-store URI prefix keeps groups distinct.
+            assignments.DistributeByGroupAffinity(SchemeName, DatabaseKeyOf);
         }
         else
         {

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
@@ -156,9 +156,29 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
 
     public ValueTask EvaluateAssignmentsAsync(AssignmentGrid assignments)
     {
-        assignments.DistributeEvenlyWithBlueGreenSemantics(SchemeName);
+        // JasperFx/marten#4806 (opt-in): when a sharded store asks for database-affine assignment, keep a
+        // shard database's per-tenant agents together on one node so a node opens connection pools only to
+        // the databases it owns (pools scale with databases, not nodes × databases, which otherwise
+        // exhausts a shared server). Otherwise distribute evenly with blue/green semantics as before.
+        if (_stores.Enumerate().Any(e => e.Value.GroupAgentAssignmentsByDatabase))
+        {
+            assignments.DistributeByGroupAffinity(SchemeName, DatabaseKeyOf);
+        }
+        else
+        {
+            assignments.DistributeEvenlyWithBlueGreenSemantics(SchemeName);
+        }
+
         return new ValueTask();
     }
+
+    // Agent URIs are event-subscriptions://{type}/{name}/{databaseId}/{shard...} (see UriFor); the
+    // (type, name, databaseId) prefix identifies the shard database an agent belongs to, so grouping on it
+    // co-locates every tenant/projection agent for one database on the same node.
+    internal static string DatabaseKeyOf(Uri uri)
+        => uri.Segments.Length >= 3
+            ? $"{uri.Host}/{uri.Segments[1].Trim('/')}/{uri.Segments[2].Trim('/')}"
+            : uri.AbsoluteUri;
 
     public async ValueTask DisposeAsync()
     {


### PR DESCRIPTION
Wolverine piece of #3280 and JasperFx/marten#4806. **Depends on JasperFx/jasperfx#482** and pairs with JasperFx/marten#4799.

### Per-tenant agents (#3280)
`EventStoreAgents.SupportedAgentsAsync` fans out one agent per (shard, tenant) when the store reports `DistributesAgentsPerTenant` — fixing sharded + tenant-partitioned stores where co-located tenants shared one high-water mark and a lagging tenant's events were skipped. Store-global and database-per-tenant stores keep one agent per (shard, database), unchanged.

### Database-affine assignment (marten#4806, opt-in)
With per-tenant agents across many shard databases, the default even spread makes every node open connection pools to (nearly) every database — pools grow as nodes × databases and exhaust a shared server's `max_connections` (observed in production-scale testing: Postgres 53300 at ~9% DB CPU — the ceiling was connections, not hardware). When a store reports `GroupAgentAssignmentsByDatabase`:

- New `AssignmentGrid.DistributeByGroupAffinity(scheme, groupKey)`: every agent sharing a group key (the `[store type]/[store name]/[database]` prefix of the agent Uri) is placed whole on the least-loaded node, largest group first, with deterministic tie-breaks — so a node only connects to the databases it owns and the connection budget scales with the topology (databases), not the deployment (replicas).
- `EventSubscriptionAgentFamily.EvaluateAssignmentsAsync` uses it when any registered store opts in; otherwise the existing `DistributeEvenlyWithBlueGreenSemantics` path is untouched. (The affine path does not apply blue/green capability matching — called out in code + docs.)
- Convenience: `IntegrateWithWolverine(m => m.UseDatabaseAffineAgentAssignment = true)` flows through to `StoreOptions.Events.UseDatabaseAffineAgentAssignment` for the main store.

### Tests & docs
Unit tests for the per-tenant fan-out, grid affinity (grouping, spreading, balancing around a heavy database), family branch selection, the Uri group key, and the IntegrateWithWolverine bridge; the distribution guide documents the opt-in.

**Merge order:** jasperfx#482 → Marten #4799 → this.