### PR TITLE
Allow [Transactional] to select the DbContext for multi-DbContext han…

### DIFF
--- a/docs/guide/durability/efcore/transactional-middleware.md
+++ b/docs/guide/durability/efcore/transactional-middleware.md
@@ -384,3 +384,103 @@ opts.UseEntityFrameworkCoreTransactions()
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests/dbContext_abstraction_scenarios.cs#L62-L83' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_register_mixed_dbcontexts' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Selecting the Transactional DbContext <Badge type="tip" text="6.17" />
+
+A handler chain can only have **one** transactional `DbContext` — the one Wolverine enrolls in the
+transaction and uses for the outbox. But a handler is often legitimately given more than one
+`DbContext`-shaped dependency: one it writes through, plus one it only *reads* from — a shared
+read-only lookup database, or another module's context in a modular monolith.
+
+When a chain depends on more than one `DbContext`-shaped service, Wolverine resolves which one is
+transactional in this order:
+
+1. A `[Transactional(typeof(TDbContext))]` attribute on the handler (most specific).
+2. A registration-side selection made with `WithTransactionalDbContext<T>()`.
+3. **Automatic**: the single [Wolverine-enabled](#automatic-selection) candidate, if there is exactly one.
+
+If none of these resolves to a single context, Wolverine fails fast at startup and names the
+candidates.
+
+### Automatic selection
+
+Only a `DbContext` that mapped Wolverine's envelope storage (via `MapWolverineEnvelopeStorage`,
+which `AddDbContextWithWolverineIntegration<T>()` sets up) can own the transaction and outbox. A
+plain `AddDbContext<T>()` read-only lookup context therefore is **never** a transactional candidate.
+When exactly one of a handler's `DbContext` dependencies is Wolverine-enabled, Wolverine selects it
+automatically — no attribute, no configuration, and the read context is simply an ordinary injected
+dependency:
+
+```cs
+builder.Host.UseWolverine(opts =>
+{
+    // The write side — enrolled in the transaction + outbox.
+    opts.Services.AddDbContextWithWolverineIntegration<LedgerDbContext>(x =>
+        x.UseNpgsql(connectionString));
+
+    // A shared read-only lookup context: a plain AddDbContext<>, never enrolled.
+    opts.Services.AddDbContext<RatesDbContext>(x => x.UseNpgsql(connectionString));
+
+    opts.PersistMessagesWithPostgresql(connectionString, "wolverine");
+    opts.UseEntityFrameworkCoreTransactions();
+    opts.Policies.AutoApplyTransactions();
+});
+
+public class PostLedgerEntryHandler
+{
+    // No [Transactional] attribute and no need to name a DbContext: LedgerDbContext is the only
+    // Wolverine-enabled dependency, so it is selected automatically. RatesDbContext is read-only.
+    public static void Handle(PostLedgerEntry cmd, LedgerDbContext ledger, RatesDbContext rates)
+    {
+        ledger.Entries.Add(new LedgerEntry { Id = cmd.Id, Memo = cmd.Memo });
+    }
+}
+```
+
+### Explicit selection at registration
+
+When **both** contexts are Wolverine-enabled — for example two modules that each own an outbox —
+nothing can be inferred automatically. Rather than putting a `[Transactional(typeof(...))]` attribute
+on the handler (which a Clean Architecture application layer should not carry), select the write
+context in the composition root with `WithTransactionalDbContext<T>()`. The handler stays free of any
+`DbContext` reference and any Wolverine attribute:
+
+```cs
+opts.Services.AddDbContextWithWolverineIntegration<SalesDbContext>(x => x.UseNpgsql(connectionString));
+opts.Services.AddDbContextWithWolverineIntegration<AuditDbContext>(x => x.UseNpgsql(connectionString));
+
+opts.PersistMessagesWithPostgresql(connectionString, "wolverine");
+
+opts.UseEntityFrameworkCoreTransactions()
+    // SalesDbContext is the transactional one wherever it is a handler dependency.
+    .WithTransactionalDbContext<SalesDbContext>();
+
+opts.Policies.AutoApplyTransactions();
+```
+
+The type argument can be a concrete `DbContext` **or** an abstraction registered with
+`WithDbContextAbstraction<TAbstraction, TDbContext>()`, so an Application-layer handler can depend on,
+and the composition root can select, an abstraction — never the concrete EF Core type:
+
+```cs
+opts.UseEntityFrameworkCoreTransactions()
+    .WithDbContextAbstraction<ISalesStore, SalesDbContext>()
+    .WithTransactionalDbContext<ISalesStore>();
+```
+
+### Modular monolith
+
+In a modular monolith each module typically owns its own write `DbContext`, while a handler may read
+from another module's context. Give each module's registration its own selection scoped to that
+module's handler assembly, so a handler enrolls only its module's context even when it reads from
+another's:
+
+```cs
+opts.UseEntityFrameworkCoreTransactions()
+    .WithTransactionalDbContext<SalesDbContext>(typeof(SalesModuleHandler).Assembly)
+    .WithTransactionalDbContext<AuditDbContext>(typeof(AuditModuleHandler).Assembly);
+```
+
+For finer control, an overload accepts a predicate over the handler chain
+(`Func<IChain, bool>`). A selection that matches a chain but names a `DbContext` the chain does not
+depend on — and two selections that conflict on the same chain — both fail fast at startup.

--- a/src/Persistence/EfCoreTests/transactional_dbcontext_registration_selection_tests.cs
+++ b/src/Persistence/EfCoreTests/transactional_dbcontext_registration_selection_tests.cs
@@ -1,0 +1,546 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.CodeGeneration.Frames;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore.Codegen;
+using Wolverine.Postgresql;
+using Wolverine.Tracking;
+
+// Sub-namespace so this file's fixtures don't collide with the identically-shaped ones in
+// transactional_dbcontext_selection_tests.cs (which cover the [Transactional]-attribute path).
+namespace EfCoreTests.RegistrationSelection;
+
+// Companion to transactional_dbcontext_selection_tests.cs. That file proves the *handler-side*
+// disambiguation: [Transactional(typeof(TDbContext))]. This file proves the *registration-side*
+// story required by Clean Architecture / modular monoliths, where the application-layer handler
+// must carry no DbContext reference AND no [Transactional] attribute at all:
+//
+//   * Layer A (this test): when a chain has more than one DbContext-shaped dependency but only ONE
+//     of them is Wolverine-enabled (mapped Wolverine envelope storage / registered via
+//     AddDbContextWithWolverineIntegration), Wolverine auto-selects that one. A plain read-only
+//     lookup DbContext registered with vanilla AddDbContext<> can never own the outbox, so it is
+//     not a transactional candidate. Zero configuration, zero handler references.
+public class transactional_dbcontext_registration_selection_tests
+{
+    [Fact]
+    public async Task auto_selects_the_only_wolverine_enabled_dbcontext_when_the_other_is_a_plain_read_context()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync("ledger_reg_schema");
+            await conn.CreateCommand(
+                    """
+                    CREATE SCHEMA "ledger_reg_schema";
+                    CREATE TABLE ledger_reg_schema.entries (
+                        "Id" uuid PRIMARY KEY,
+                        "Memo" text NOT NULL
+                    );
+                    """)
+                .ExecuteNonQueryAsync();
+        }
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                // The write side: enrolled in the transaction + outbox.
+                opts.Services.AddDbContextWithWolverineIntegration<LedgerDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                // The read side: a plain AddDbContext<> lookup context with NO Wolverine envelope
+                // storage of its own. It is DbContext-shaped (so Wolverine sees it as a candidate)
+                // but can never be the transactional/outbox owner.
+                opts.Services.AddDbContext<RatesDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_ledger_reg");
+
+                opts.UseEntityFrameworkCoreTransactions();
+
+                // Note: NO [Transactional] attribute on the handler, NO explicit selection here.
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<PostLedgerEntryHandler>();
+            }).StartAsync();
+
+        // Force lazy chain compilation the same way transaction_middleware_mode_tests.cs does.
+        host.GetRuntime().Handlers.HandlerFor<PostLedgerEntry>();
+        var chain = host.GetRuntime().Handlers.ChainFor<PostLedgerEntry>();
+        chain.ShouldNotBeNull();
+
+        // Only the Wolverine-enabled LedgerDbContext should be enrolled.
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ToArray().Length.ShouldBe(1);
+
+        var saveChanges = chain.Postprocessors.OfType<MethodCall>()
+            .Single(x => x.Method.Name == nameof(DbContext.SaveChangesAsync));
+        saveChanges.HandlerType.ShouldBe(typeof(LedgerDbContext));
+
+        var entryId = Guid.NewGuid();
+        await host.InvokeMessageAndWaitAsync(new PostLedgerEntry(entryId, "opening balance"));
+
+        await using var scope = host.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<LedgerDbContext>();
+        (await db.Entries.AnyAsync(e => e.Id == entryId)).ShouldBeTrue();
+    }
+
+    // --- Layer B: explicit registration-side selection --------------------------------------------
+    // When BOTH DbContexts are Wolverine-enabled (e.g. two modules that each own an outbox), the
+    // automatic rule can't disambiguate. The composition root selects the write context with
+    // WithTransactionalDbContext<T>() - the handler still carries no DbContext reference.
+
+    [Fact]
+    public async Task explicit_registration_selection_by_concrete_type_disambiguates_two_enabled_contexts()
+    {
+        await createSalesAndAuditSchemasAsync();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<SalesDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+                opts.Services.AddDbContextWithWolverineIntegration<AuditDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_sales_reg");
+
+                opts.UseEntityFrameworkCoreTransactions()
+                    .WithTransactionalDbContext<SalesDbContext>();
+
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<RecordSaleHandler>();
+            }).StartAsync();
+
+        host.GetRuntime().Handlers.HandlerFor<RecordSale>();
+        var chain = host.GetRuntime().Handlers.ChainFor<RecordSale>();
+        chain.ShouldNotBeNull();
+
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ToArray().Length.ShouldBe(1);
+        chain.Postprocessors.OfType<MethodCall>()
+            .Single(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
+            .HandlerType.ShouldBe(typeof(SalesDbContext));
+
+        var saleId = Guid.NewGuid();
+        await host.InvokeMessageAndWaitAsync(new RecordSale(saleId, "widget"));
+
+        await using var scope = host.Services.CreateAsyncScope();
+        (await scope.ServiceProvider.GetRequiredService<SalesDbContext>()
+            .Sales.AnyAsync(s => s.Id == saleId)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task explicit_registration_selection_can_be_a_registered_abstraction()
+    {
+        await createSalesAndAuditSchemasAsync();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<SalesDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+                opts.Services.AddScoped<ISalesStore>(sp => sp.GetRequiredService<SalesDbContext>());
+                opts.Services.AddDbContextWithWolverineIntegration<AuditDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_sales_reg");
+
+                // The application layer only knows ISalesStore; the concrete DbContext never leaks.
+                opts.UseEntityFrameworkCoreTransactions()
+                    .WithDbContextAbstraction<ISalesStore, SalesDbContext>()
+                    .WithTransactionalDbContext<ISalesStore>();
+
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<RecordSaleViaStoreHandler>();
+            }).StartAsync();
+
+        host.GetRuntime().Handlers.HandlerFor<RecordSaleViaStore>();
+        var chain = host.GetRuntime().Handlers.ChainFor<RecordSaleViaStore>();
+        chain.ShouldNotBeNull();
+
+        chain.Postprocessors.OfType<MethodCall>()
+            .Single(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
+            .HandlerType.ShouldBe(typeof(SalesDbContext));
+
+        var saleId = Guid.NewGuid();
+        await host.InvokeMessageAndWaitAsync(new RecordSaleViaStore(saleId, "gizmo"));
+
+        await using var scope = host.Services.CreateAsyncScope();
+        (await scope.ServiceProvider.GetRequiredService<SalesDbContext>()
+            .Sales.AnyAsync(s => s.Id == saleId)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task registration_selection_scoped_per_handler_supports_modular_monolith()
+    {
+        await createSalesAndAuditSchemasAsync();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<SalesDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+                opts.Services.AddDbContextWithWolverineIntegration<AuditDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_sales_reg");
+
+                // Each "module" declares its own write context for its own handlers. Both handlers
+                // depend on both contexts, but each writes only through its module's context.
+                opts.UseEntityFrameworkCoreTransactions()
+                    .WithTransactionalDbContext<SalesDbContext>(
+                        chain => chain.HandlerCalls().Any(c => c.HandlerType == typeof(SalesModuleHandler)))
+                    .WithTransactionalDbContext<AuditDbContext>(
+                        chain => chain.HandlerCalls().Any(c => c.HandlerType == typeof(AuditModuleHandler)));
+
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<SalesModuleHandler>()
+                    .IncludeType<AuditModuleHandler>();
+            }).StartAsync();
+
+        host.GetRuntime().Handlers.HandlerFor<SalesModuleOp>();
+        host.GetRuntime().Handlers.HandlerFor<AuditModuleOp>();
+
+        var salesChain = host.GetRuntime().Handlers.ChainFor<SalesModuleOp>();
+        salesChain.ShouldNotBeNull();
+        salesChain.Postprocessors.OfType<MethodCall>()
+            .Single(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
+            .HandlerType.ShouldBe(typeof(SalesDbContext));
+
+        var auditChain = host.GetRuntime().Handlers.ChainFor<AuditModuleOp>();
+        auditChain.ShouldNotBeNull();
+        auditChain.Postprocessors.OfType<MethodCall>()
+            .Single(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
+            .HandlerType.ShouldBe(typeof(AuditDbContext));
+
+        var salesId = Guid.NewGuid();
+        var auditId = Guid.NewGuid();
+        await host.InvokeMessageAndWaitAsync(new SalesModuleOp(salesId));
+        await host.InvokeMessageAndWaitAsync(new AuditModuleOp(auditId));
+
+        await using var scope = host.Services.CreateAsyncScope();
+        (await scope.ServiceProvider.GetRequiredService<SalesDbContext>()
+            .Sales.AnyAsync(s => s.Id == salesId)).ShouldBeTrue();
+        (await scope.ServiceProvider.GetRequiredService<AuditDbContext>()
+            .AuditRecords.AnyAsync(a => a.Id == auditId)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task registration_selection_that_is_not_a_dependency_throws_clear_error()
+    {
+        await createSalesAndAuditSchemasAsync();
+
+        async Task startBadHost()
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Durability.Mode = DurabilityMode.Solo;
+
+                    opts.Services.AddDbContextWithWolverineIntegration<SalesDbContext>(x =>
+                        x.UseNpgsql(Servers.PostgresConnectionString));
+                    opts.Services.AddDbContext<RatesDbContext>(x =>
+                        x.UseNpgsql(Servers.PostgresConnectionString));
+
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_sales_reg");
+
+                    // Selects AuditDbContext, which this handler does not depend on at all.
+                    opts.UseEntityFrameworkCoreTransactions()
+                        .WithTransactionalDbContext<AuditDbContext>(
+                            chain => chain.HandlerCalls().Any(c => c.HandlerType == typeof(SalesOnlyHandler)));
+
+                    opts.Policies.AutoApplyTransactions();
+
+                    opts.Discovery.DisableConventionalDiscovery()
+                        .IncludeType<SalesOnlyHandler>();
+                }).StartAsync();
+
+            host.GetRuntime().Handlers.HandlerFor<SalesOnlyOp>();
+        }
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(startBadHost);
+        ex.Message.ShouldContain("is not one of this chain's dependencies");
+    }
+
+    [Fact]
+    public async Task handler_transactional_attribute_overrides_registration_selection()
+    {
+        await createSalesAndAuditSchemasAsync();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<SalesDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+                opts.Services.AddDbContextWithWolverineIntegration<AuditDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_sales_reg");
+
+                // Registration selects Sales globally, but the handler's [Transactional(typeof(Audit))]
+                // must win - the per-handler attribute is the most specific signal.
+                opts.UseEntityFrameworkCoreTransactions()
+                    .WithTransactionalDbContext<SalesDbContext>();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<AttributeWinsHandler>();
+            }).StartAsync();
+
+        host.GetRuntime().Handlers.HandlerFor<PrecedenceOp>();
+        var chain = host.GetRuntime().Handlers.ChainFor<PrecedenceOp>();
+        chain.ShouldNotBeNull();
+        chain.Postprocessors.OfType<MethodCall>()
+            .Single(x => x.Method.Name == nameof(DbContext.SaveChangesAsync))
+            .HandlerType.ShouldBe(typeof(AuditDbContext));
+    }
+
+    [Fact]
+    public async Task registration_selection_naming_a_non_dependency_on_a_single_context_handler_throws()
+    {
+        await createSalesAndAuditSchemasAsync();
+
+        async Task startBadHost()
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Durability.Mode = DurabilityMode.Solo;
+
+                    opts.Services.AddDbContextWithWolverineIntegration<SalesDbContext>(x =>
+                        x.UseNpgsql(Servers.PostgresConnectionString));
+
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_sales_reg");
+
+                    // The handler depends only on SalesDbContext, yet this selection (scoped to it)
+                    // names AuditDbContext. A mis-scoped selection must fail even when the chain is
+                    // otherwise unambiguous, exactly like a mismatched [Transactional(typeof(...))].
+                    opts.UseEntityFrameworkCoreTransactions()
+                        .WithTransactionalDbContext<AuditDbContext>(
+                            chain => chain.HandlerCalls().Any(c => c.HandlerType == typeof(SingleContextHandler)));
+
+                    opts.Policies.AutoApplyTransactions();
+
+                    opts.Discovery.DisableConventionalDiscovery()
+                        .IncludeType<SingleContextHandler>();
+                }).StartAsync();
+
+            host.GetRuntime().Handlers.HandlerFor<SingleContextOp>();
+        }
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(startBadHost);
+        ex.Message.ShouldContain("is not one of this chain's dependencies");
+    }
+
+    private static async Task createSalesAndAuditSchemasAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync("sales_reg_schema");
+        await conn.DropSchemaAsync("audit_reg_schema");
+        await conn.CreateCommand(
+                """
+                CREATE SCHEMA "sales_reg_schema";
+                CREATE TABLE sales_reg_schema.sales (
+                    "Id" uuid PRIMARY KEY,
+                    "Product" text NOT NULL
+                );
+                CREATE SCHEMA "audit_reg_schema";
+                CREATE TABLE audit_reg_schema.audits (
+                    "Id" uuid PRIMARY KEY,
+                    "Note" text NOT NULL
+                );
+                """)
+            .ExecuteNonQueryAsync();
+    }
+}
+
+// === Entities + DbContexts ====================================================================
+
+public class LedgerEntry
+{
+    public Guid Id { get; set; }
+    public string Memo { get; set; } = string.Empty;
+}
+
+public class Rate
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+// Write side — Wolverine-enabled (maps envelope storage).
+public class LedgerDbContext(DbContextOptions<LedgerDbContext> options) : DbContext(options)
+{
+    public DbSet<LedgerEntry> Entries => Set<LedgerEntry>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("ledger_reg_schema");
+        modelBuilder.MapWolverineEnvelopeStorage("ledger_reg_schema");
+        modelBuilder.Entity<LedgerEntry>().ToTable("entries");
+    }
+}
+
+// Read side — intentionally NOT Wolverine-enabled: no MapWolverineEnvelopeStorage call.
+public class RatesDbContext(DbContextOptions<RatesDbContext> options) : DbContext(options)
+{
+    public DbSet<Rate> Rates => Set<Rate>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("rates_reg_schema");
+        modelBuilder.Entity<Rate>().ToTable("rates");
+    }
+}
+
+// === Messages + handlers ======================================================================
+
+public record PostLedgerEntry(Guid Id, string Memo);
+
+public class PostLedgerEntryHandler
+{
+    // No [Transactional] attribute, no DbContext-type reference anywhere in application code.
+    public static void Handle(PostLedgerEntry cmd, LedgerDbContext ledger, RatesDbContext rates)
+    {
+        ledger.Entries.Add(new LedgerEntry { Id = cmd.Id, Memo = cmd.Memo });
+    }
+}
+
+// === Layer B fixtures: two Wolverine-enabled contexts + an abstraction ========================
+
+public class Sale
+{
+    public Guid Id { get; set; }
+    public string Product { get; set; } = string.Empty;
+}
+
+public class AuditRecord
+{
+    public Guid Id { get; set; }
+    public string Note { get; set; } = string.Empty;
+}
+
+// Application-layer abstraction over the sales write store - the only thing a Clean Architecture
+// handler is allowed to depend on.
+public interface ISalesStore
+{
+    DbSet<Sale> Sales { get; }
+}
+
+public class SalesDbContext(DbContextOptions<SalesDbContext> options) : DbContext(options), ISalesStore
+{
+    public DbSet<Sale> Sales => Set<Sale>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("sales_reg_schema");
+        modelBuilder.MapWolverineEnvelopeStorage("sales_reg_schema");
+        modelBuilder.Entity<Sale>().ToTable("sales");
+    }
+}
+
+public class AuditDbContext(DbContextOptions<AuditDbContext> options) : DbContext(options)
+{
+    public DbSet<AuditRecord> AuditRecords => Set<AuditRecord>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("audit_reg_schema");
+        modelBuilder.MapWolverineEnvelopeStorage("audit_reg_schema");
+        modelBuilder.Entity<AuditRecord>().ToTable("audits");
+    }
+}
+
+public record RecordSale(Guid Id, string Product);
+
+public class RecordSaleHandler
+{
+    public static void Handle(RecordSale cmd, SalesDbContext sales, AuditDbContext audit)
+    {
+        sales.Sales.Add(new Sale { Id = cmd.Id, Product = cmd.Product });
+    }
+}
+
+public record RecordSaleViaStore(Guid Id, string Product);
+
+public class RecordSaleViaStoreHandler
+{
+    public static void Handle(RecordSaleViaStore cmd, ISalesStore sales, AuditDbContext audit)
+    {
+        sales.Sales.Add(new Sale { Id = cmd.Id, Product = cmd.Product });
+    }
+}
+
+public record SalesModuleOp(Guid Id);
+
+public class SalesModuleHandler
+{
+    public static void Handle(SalesModuleOp cmd, SalesDbContext sales, AuditDbContext audit)
+    {
+        sales.Sales.Add(new Sale { Id = cmd.Id, Product = "module-sale" });
+    }
+}
+
+public record AuditModuleOp(Guid Id);
+
+public class AuditModuleHandler
+{
+    public static void Handle(AuditModuleOp cmd, SalesDbContext sales, AuditDbContext audit)
+    {
+        audit.AuditRecords.Add(new AuditRecord { Id = cmd.Id, Note = "module-audit" });
+    }
+}
+
+public record SalesOnlyOp(Guid Id);
+
+public class SalesOnlyHandler
+{
+    public static void Handle(SalesOnlyOp cmd, SalesDbContext sales, RatesDbContext rates)
+    {
+        sales.Sales.Add(new Sale { Id = cmd.Id, Product = "sales-only" });
+    }
+}
+
+public record PrecedenceOp(Guid Id);
+
+public class AttributeWinsHandler
+{
+    [Transactional(typeof(AuditDbContext))]
+    public static void Handle(PrecedenceOp cmd, SalesDbContext sales, AuditDbContext audit)
+    {
+        audit.AuditRecords.Add(new AuditRecord { Id = cmd.Id, Note = "attr-wins" });
+    }
+}
+
+public record SingleContextOp(Guid Id);
+
+public class SingleContextHandler
+{
+    public static void Handle(SingleContextOp cmd, SalesDbContext sales)
+    {
+        sales.Sales.Add(new Sale { Id = cmd.Id, Product = "single" });
+    }
+}

--- a/src/Persistence/EfCoreTests/transactional_dbcontext_selection_tests.cs
+++ b/src/Persistence/EfCoreTests/transactional_dbcontext_selection_tests.cs
@@ -1,0 +1,267 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.CodeGeneration.Frames;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore.Codegen;
+using Wolverine.Postgresql;
+using Wolverine.Tracking;
+
+namespace EfCoreTests;
+
+// Reproduces the scenario from the "per-handler transactional DbContext" architecture review:
+// a single handler depends on two different DbContext types - one that owns the write/aggregate
+// and must be enrolled in the transaction + outbox, and one that is only used for read-only
+// lookups and must never be wrapped in a transaction. Today `EFCorePersistenceFrameProvider.
+// DetermineDbContextType(IChain, ...)` throws `InvalidOperationException` the moment it sees more
+// than one DbContext-shaped dependency (EFCorePersistenceFrameProvider.cs:497-501) - it has no way
+// to know which one is "the" transactional context for this chain. `[Transactional(typeof(TDbContext))]`
+// disambiguates that per-chain.
+public class transactional_dbcontext_selection_tests
+{
+    [Fact]
+    public async Task explicit_dbcontext_type_disambiguates_and_only_enrolls_that_context()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync("widget_selection_schema");
+            await conn.CreateCommand(
+                    """
+                    CREATE SCHEMA "widget_selection_schema";
+                    CREATE TABLE widget_selection_schema.widgets (
+                        "Id" uuid PRIMARY KEY,
+                        "Name" text NOT NULL
+                    );
+                    """)
+                .ExecuteNonQueryAsync();
+        }
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<WidgetDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                // A second, unrelated DbContext used only for read-only lookups. It must never
+                // participate in the transaction/outbox even though it's also DbContext-shaped.
+                opts.Services.AddDbContext<LookupDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_widget_sel");
+
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<CreateWidgetHandler>();
+            }).StartAsync();
+
+        // [Transactional]-attributed chains apply their attribute lazily on first compile, so force
+        // it the same way transaction_middleware_mode_tests.cs does before inspecting Middleware.
+        host.GetRuntime().Handlers.HandlerFor<CreateWidget>();
+        var chain = host.GetRuntime().Handlers.ChainFor<CreateWidget>();
+        chain.ShouldNotBeNull();
+
+        // Only the tagged DbContext should be enrolled in the transaction.
+        var enrollFrames = chain.Middleware.OfType<EnrollDbContextInTransaction>().ToArray();
+        enrollFrames.Length.ShouldBe(1);
+
+        var saveChanges = chain.Postprocessors.OfType<JasperFx.CodeGeneration.Frames.MethodCall>()
+            .Single(x => x.Method.Name == nameof(DbContext.SaveChangesAsync));
+        saveChanges.HandlerType.ShouldBe(typeof(WidgetDbContext));
+
+        var widgetId = Guid.NewGuid();
+        await host.InvokeMessageAndWaitAsync(new CreateWidget(widgetId, "gizmo"));
+
+        await using var scope = host.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<WidgetDbContext>();
+        (await db.Widgets.AnyAsync(w => w.Id == widgetId)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task explicit_dbcontext_type_that_is_not_a_dependency_throws_clear_error()
+    {
+        async Task startBadHost()
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Durability.Mode = DurabilityMode.Solo;
+
+                    opts.Services.AddDbContextWithWolverineIntegration<WidgetDbContext>(x =>
+                        x.UseNpgsql(Servers.PostgresConnectionString));
+
+                    opts.Services.AddDbContext<LookupDbContext>(x =>
+                        x.UseNpgsql(Servers.PostgresConnectionString));
+
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_widget_sel_err");
+
+                    opts.UseEntityFrameworkCoreTransactions();
+                    opts.Policies.AutoApplyTransactions();
+
+                    opts.Discovery.DisableConventionalDiscovery()
+                        .IncludeType<CreateWidgetWithBadTagHandler>();
+                }).StartAsync();
+
+            // [Transactional] is applied lazily on first compile - force it.
+            host.GetRuntime().Handlers.HandlerFor<CreateWidgetWithBadTag>();
+        }
+
+        // The attribute references LookupDbContext, but this handler doesn't depend on it - only
+        // on WidgetDbContext. That mismatch must fail loudly and name the offending type, rather
+        // than silently falling back to some default DbContext.
+        var ex = await Should.ThrowAsync<InvalidOperationException>(startBadHost);
+        ex.Message.ShouldContain("is not one of this chain's dependencies");
+    }
+
+    // Clean Architecture handlers can't reference the concrete DbContext type at all (it lives in
+    // Infrastructure). They depend on a repository abstraction registered via
+    // `WithDbContextAbstraction<TAbstraction, TDbContext>()` instead, so [Transactional] must accept
+    // that abstraction type and resolve it to the concrete DbContext internally.
+    [Fact]
+    public async Task explicit_dbcontext_type_can_be_a_registered_abstraction()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync("gadget_selection_schema");
+            await conn.CreateCommand(
+                    """
+                    CREATE SCHEMA "gadget_selection_schema";
+                    CREATE TABLE gadget_selection_schema.gadgets (
+                        "Id" uuid PRIMARY KEY,
+                        "Name" text NOT NULL
+                    );
+                    """)
+                .ExecuteNonQueryAsync();
+        }
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<GadgetDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+                opts.Services.AddScoped<IGadgetRepository>(sp => sp.GetRequiredService<GadgetDbContext>());
+
+                opts.Services.AddDbContext<LookupDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_gadget_sel");
+
+                opts.UseEntityFrameworkCoreTransactions()
+                    .WithDbContextAbstraction<IGadgetRepository, GadgetDbContext>();
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<CreateGadgetHandler>();
+            }).StartAsync();
+
+        host.GetRuntime().Handlers.HandlerFor<CreateGadget>();
+        var chain = host.GetRuntime().Handlers.ChainFor<CreateGadget>();
+        chain.ShouldNotBeNull();
+
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ToArray().Length.ShouldBe(1);
+
+        var saveChanges = chain.Postprocessors.OfType<JasperFx.CodeGeneration.Frames.MethodCall>()
+            .Single(x => x.Method.Name == nameof(DbContext.SaveChangesAsync));
+        saveChanges.HandlerType.ShouldBe(typeof(GadgetDbContext));
+
+        var gadgetId = Guid.NewGuid();
+        await host.InvokeMessageAndWaitAsync(new CreateGadget(gadgetId, "sprocket"));
+
+        await using var scope = host.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<GadgetDbContext>();
+        (await db.Gadgets.AnyAsync(g => g.Id == gadgetId)).ShouldBeTrue();
+    }
+}
+
+public class Widget
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class WidgetDbContext(DbContextOptions<WidgetDbContext> options) : DbContext(options)
+{
+    public DbSet<Widget> Widgets => Set<Widget>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("widget_selection_schema");
+        modelBuilder.MapWolverineEnvelopeStorage("widget_selection_schema");
+        modelBuilder.Entity<Widget>().ToTable("widgets");
+    }
+}
+
+// Deliberately has no entities mapped that overlap with WidgetDbContext - it exists purely to
+// prove a second, unrelated DbContext dependency doesn't have to participate in the transaction.
+public class LookupDbContext(DbContextOptions<LookupDbContext> options) : DbContext(options);
+
+public record CreateWidget(Guid Id, string Name);
+
+public class CreateWidgetHandler
+{
+    [Transactional(typeof(WidgetDbContext))]
+    public static void Handle(CreateWidget cmd, WidgetDbContext widgets, LookupDbContext lookup)
+    {
+        widgets.Widgets.Add(new Widget { Id = cmd.Id, Name = cmd.Name });
+    }
+}
+
+public record CreateWidgetWithBadTag(Guid Id);
+
+public class CreateWidgetWithBadTagHandler
+{
+    [Transactional(typeof(LookupDbContext))]
+    public static void Handle(CreateWidgetWithBadTag cmd, WidgetDbContext widgets)
+    {
+        widgets.Widgets.Add(new Widget { Id = cmd.Id, Name = "n/a" });
+    }
+}
+
+public class GadgetEntity
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+// The Application-layer-facing abstraction - the only thing the handler is allowed to depend on.
+public interface IGadgetRepository
+{
+    DbSet<GadgetEntity> Gadgets { get; }
+}
+
+public class GadgetDbContext(DbContextOptions<GadgetDbContext> options) : DbContext(options), IGadgetRepository
+{
+    public DbSet<GadgetEntity> Gadgets => Set<GadgetEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("gadget_selection_schema");
+        modelBuilder.MapWolverineEnvelopeStorage("gadget_selection_schema");
+        modelBuilder.Entity<GadgetEntity>().ToTable("gadgets");
+    }
+}
+
+public record CreateGadget(Guid Id, string Name);
+
+public class CreateGadgetHandler
+{
+    [Transactional(typeof(IGadgetRepository))]
+    public static void Handle(CreateGadget cmd, IGadgetRepository gadgets, LookupDbContext lookup)
+    {
+        gadgets.Gadgets.Add(new GadgetEntity { Id = cmd.Id, Name = cmd.Name });
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -45,6 +45,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
     public const string TransactionalDbContextTypeKey = "TransactionalDbContextType";
     private ImHashMap<Type, Type?> _dbContextTypes = ImHashMap<Type, Type?>.Empty;
     private ImHashMap<Type, Type> _abstractions = ImHashMap<Type, Type>.Empty;
+    private ImHashMap<Type, bool> _wolverineEnabled = ImHashMap<Type, bool>.Empty;
 
     public TransactionMiddlewareMode DefaultMode { get; set; } = TransactionMiddlewareMode.Eager;
 
@@ -52,6 +53,23 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
     {
         _abstractions = _abstractions.AddOrUpdate(abstractionType, dbContextType);
     }
+
+    /// <summary>
+    /// Registration-side transactional DbContext selection (WithTransactionalDbContext&lt;T&gt;).
+    /// Lets the composition root pick which DbContext-shaped dependency of a chain is the transactional
+    /// one, so Clean Architecture / modular-monolith handlers never need a [Transactional] attribute or
+    /// a DbContext reference. <paramref name="selectionType"/> may be a concrete DbContext or a registered
+    /// DbContext abstraction. A null <paramref name="predicate"/> applies wherever that context is a
+    /// candidate dependency; a predicate scopes it (e.g. to a module's handler assembly).
+    /// </summary>
+    public void RegisterTransactionalSelection(Type selectionType, Func<IChain, bool>? predicate)
+    {
+        _transactionalSelections.Add(new TransactionalSelection(selectionType, predicate));
+    }
+
+    private readonly List<TransactionalSelection> _transactionalSelections = new();
+
+    private sealed record TransactionalSelection(Type SelectionType, Func<IChain, bool>? Predicate);
 
     public bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService)
     {
@@ -316,6 +334,96 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
         return container.HasRegistrationFor(typeof(IDbContextBuilder<>).MakeGenericType(dbContextType));
     }
 
+    /// <summary>
+    /// Resolves the transactional DbContext for this chain from any registration-side selections
+    /// (WithTransactionalDbContext). Returns null when none apply. A selection may name a concrete
+    /// DbContext or a registered abstraction; a selection that matches a chain but names a type the
+    /// chain does not depend on fails loudly, as do two conflicting selections on the same chain.
+    /// </summary>
+    private Type? resolveRegistrationSelection(IChain chain, Type[] contextTypes)
+    {
+        Type? selected = null;
+
+        foreach (var selection in _transactionalSelections)
+        {
+            var resolved = _abstractions.TryFind(selection.SelectionType, out var concrete)
+                ? concrete
+                : selection.SelectionType;
+
+            // A null predicate means "applies wherever this context is a candidate dependency".
+            var applies = selection.Predicate?.Invoke(chain) ?? contextTypes.Contains(resolved);
+            if (!applies)
+            {
+                continue;
+            }
+
+            if (!contextTypes.Contains(resolved))
+            {
+                throw new InvalidOperationException(
+                    $"The registration-side transactional DbContext selection {selection.SelectionType.FullNameInCode()} for {chain.Description} is not one of this chain's dependencies (directly or via a registered DbContext abstraction). Detected {nameof(DbContext)} types: {contextTypes.Select(x => x.Name).Join(", ")}");
+            }
+
+            if (selected != null && selected != resolved)
+            {
+                throw new InvalidOperationException(
+                    $"Conflicting registration-side transactional DbContext selections for {chain.Description}: both {selected.Name} and {resolved.Name} apply. Scope each WithTransactionalDbContext<T>(...) call so at most one matches a given handler.");
+            }
+
+            selected = resolved;
+        }
+
+        return selected;
+    }
+
+    /// <summary>
+    /// Is this DbContext "Wolverine-enabled" - i.e. did it map Wolverine envelope storage
+    /// (via <c>MapWolverineEnvelopeStorage</c>, typically through
+    /// <c>AddDbContextWithWolverineIntegration</c>)? Only Wolverine-enabled contexts can own the
+    /// transaction + outbox, so this is the signal used to disambiguate a chain that depends on more
+    /// than one DbContext-shaped service without any handler-side selection. Result cached per type.
+    /// </summary>
+    private bool isWolverineEnabled(Type dbContextType, IServiceContainer container)
+    {
+        if (_wolverineEnabled.TryFind(dbContextType, out var enabled))
+        {
+            return enabled;
+        }
+
+        enabled = determineWolverineEnabled(dbContextType, container);
+        _wolverineEnabled = _wolverineEnabled.AddOrUpdate(dbContextType, enabled);
+        return enabled;
+    }
+
+    private bool determineWolverineEnabled(Type dbContextType, IServiceContainer container)
+    {
+        try
+        {
+            using var nested = container.Services.CreateScope();
+
+            // Multi-tenant DbContexts aren't resolved directly - they're produced by an
+            // IDbContextBuilder<T>. Build the "main" instance to inspect its model.
+            var builderType = typeof(IDbContextBuilder<>).MakeGenericType(dbContextType);
+            if (container.HasRegistrationFor(builderType))
+            {
+                var builder = (IDbContextBuilder)nested.ServiceProvider.GetRequiredService(builderType);
+                return builder.BuildForMain().IsWolverineEnabled();
+            }
+
+            return nested.ServiceProvider.GetService(dbContextType) is DbContext dbContext
+                   && dbContext.IsWolverineEnabled();
+        }
+        catch (Exception e)
+        {
+            // Mirror TryDetermineDbContextType: a candidate whose model can't be built is simply not
+            // treated as the Wolverine-enabled one; we fall through to the explicit-selection error.
+            var logger = container.Services.GetService<ILogger<EFCorePersistenceFrameProvider>>();
+            logger?.LogError(e,
+                "Error determining whether DbContext type {DbContextType} is Wolverine-enabled",
+                dbContextType.FullNameInCode());
+            return false;
+        }
+    }
+
     public void ApplyTransactionSupport(IChain chain, IServiceContainer container, Type entityType)
     {
         // GH-3039: For saga chains, defer to the saga's own transaction-support application at codegen
@@ -513,10 +621,31 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
                 $"Cannot determine the {nameof(DbContext)} type for {chain.Description}");
         }
 
+        // Explicit registration-side selection (WithTransactionalDbContext). This is the Clean
+        // Architecture / modular-monolith path: the composition root chooses, the handler stays free
+        // of any DbContext reference. Consulted for every chain with at least one DbContext dependency
+        // so a mis-scoped selection is validated the same way the [Transactional] tag is above. Ranks
+        // below the per-handler [Transactional] tag and above automatic resolution.
+        var selected = resolveRegistrationSelection(chain, contextTypes);
+        if (selected != null)
+        {
+            return selected;
+        }
+
         if (contextTypes.Length > 1)
         {
+            // Automatic disambiguation: a DbContext that never mapped Wolverine envelope storage
+            // (e.g. a plain AddDbContext<> read-only lookup, or another module's context used here
+            // only for reads) can't own the transaction + outbox. If exactly one candidate is
+            // Wolverine-enabled, it is unambiguously the transactional one - no config required.
+            var enabled = contextTypes.Where(x => isWolverineEnabled(x, container)).ToArray();
+            if (enabled.Length == 1)
+            {
+                return enabled[0];
+            }
+
             throw new InvalidOperationException(
-                $"Cannot determine the {nameof(DbContext)} type for {chain.Description}, multiple {nameof(DbContext)} types detected: {contextTypes.Select(x => x.Name).Join(", ")}. Use [Transactional(typeof(YourDbContext))] to select which one is transactional for this handler.");
+                $"Cannot determine the {nameof(DbContext)} type for {chain.Description}, multiple {nameof(DbContext)} types detected: {contextTypes.Select(x => x.Name).Join(", ")}. Select which one is transactional with [Transactional(typeof(YourDbContext))] on the handler, or at registration via UseEntityFrameworkCoreTransactions().WithTransactionalDbContext<YourDbContext>().");
         }
 
         return contextTypes.Single();

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -42,6 +42,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 {
     public const string UsingEfCoreTransaction = "uses_efcore_transaction";
     public const string TransactionModeKey = "TransactionMiddlewareMode";
+    public const string TransactionalDbContextTypeKey = "TransactionalDbContextType";
     private ImHashMap<Type, Type?> _dbContextTypes = ImHashMap<Type, Type?>.Empty;
     private ImHashMap<Type, Type> _abstractions = ImHashMap<Type, Type>.Empty;
 
@@ -478,6 +479,24 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 
         var contextTypes = FindDbContextTypes().ToArray();
 
+        if (chain.Tags.TryGetValue(TransactionalDbContextTypeKey, out var taggedTypeObj) && taggedTypeObj is Type taggedType)
+        {
+            // The tagged type may be a registered DbContext abstraction (WithDbContextAbstraction<,>)
+            // rather than the concrete DbContext itself - Clean Architecture handlers depend on the
+            // abstraction, never on the concrete EF Core type.
+            var resolvedType = _abstractions.TryFind(taggedType, out var concreteFromAbstraction)
+                ? concreteFromAbstraction
+                : taggedType;
+
+            if (!contextTypes.Contains(resolvedType))
+            {
+                throw new InvalidOperationException(
+                    $"The [Transactional] DbContextType {taggedType.FullNameInCode()} on {chain.Description} is not one of this chain's dependencies (directly or via a registered DbContext abstraction). Detected {nameof(DbContext)} types: {(contextTypes.Length == 0 ? "none" : contextTypes.Select(x => x.Name).Join(", "))}");
+            }
+
+            return resolvedType;
+        }
+
         if (contextTypes.Length == 0)
         {
             var sagaType = chain.HandlerCalls().SelectMany(x => x.Creates)
@@ -489,7 +508,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
             {
                 return DetermineDbContextType(sagaType, container);
             }
-            
+
             throw new InvalidOperationException(
                 $"Cannot determine the {nameof(DbContext)} type for {chain.Description}");
         }
@@ -497,7 +516,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
         if (contextTypes.Length > 1)
         {
             throw new InvalidOperationException(
-                $"Cannot determine the {nameof(DbContext)} type for {chain.Description}, multiple {nameof(DbContext)} types detected: {contextTypes.Select(x => x.Name).Join(", ")}");
+                $"Cannot determine the {nameof(DbContext)} type for {chain.Description}, multiple {nameof(DbContext)} types detected: {contextTypes.Select(x => x.Name).Join(", ")}. Use [Transactional(typeof(YourDbContext))] to select which one is transactional for this handler.");
         }
 
         return contextTypes.Single();

--- a/src/Persistence/Wolverine.EntityFrameworkCore/EFCoreTransactionConfiguration.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/EFCoreTransactionConfiguration.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Wolverine.Configuration;
 using Wolverine.EntityFrameworkCore.Codegen;
 
 namespace Wolverine.EntityFrameworkCore;
@@ -25,5 +29,37 @@ public class EFCoreTransactionConfiguration
         _options.CodeGeneration.AlwaysUseServiceLocationFor<TAbstraction>();
 
         return this;
+    }
+
+    /// <summary>
+    /// Select, at registration time, which DbContext is the transactional one for handlers that
+    /// depend on more than one DbContext-shaped service (e.g. one write context plus a read-only
+    /// lookup or another module's context). This is the Clean Architecture / modular-monolith path:
+    /// the handler needs no [Transactional] attribute and no reference to any DbContext type.
+    /// <para>
+    /// <typeparamref name="TDbContext"/> may be a concrete DbContext or a type registered via
+    /// <see cref="WithDbContextAbstraction{TAbstraction,TDbContext}"/>. By default the selection
+    /// applies to every chain that depends on that context; pass <paramref name="appliesTo"/> to
+    /// scope it (for example to a single module's handlers).
+    /// </para>
+    /// </summary>
+    /// <param name="appliesTo">Optional predicate restricting which handler chains this selection applies to.</param>
+    public EFCoreTransactionConfiguration WithTransactionalDbContext<TDbContext>(Func<IChain, bool>? appliesTo = null)
+    {
+        _provider.RegisterTransactionalSelection(typeof(TDbContext), appliesTo);
+        return this;
+    }
+
+    /// <summary>
+    /// Select the transactional DbContext for every handler defined in <paramref name="forHandlersIn"/>.
+    /// The natural modular-monolith form: each module declares its own write context for its own
+    /// handler assembly, so a handler that writes its module's context while reading another module's
+    /// context enrolls only the former.
+    /// </summary>
+    /// <param name="forHandlersIn">The module/handler assembly this selection applies to.</param>
+    public EFCoreTransactionConfiguration WithTransactionalDbContext<TDbContext>(Assembly forHandlersIn)
+    {
+        return WithTransactionalDbContext<TDbContext>(
+            chain => chain.HandlerCalls().Any(call => call.HandlerType.Assembly == forHandlersIn));
     }
 }

--- a/src/Wolverine/Attributes/TransactionalAttribute.cs
+++ b/src/Wolverine/Attributes/TransactionalAttribute.cs
@@ -28,6 +28,11 @@ public class TransactionalAttribute : ModifyChainAttribute
             chain.Tags["TransactionMiddlewareMode"] = Mode;
         }
 
+        if (DbContextType != null)
+        {
+            chain.Tags["TransactionalDbContextType"] = DbContextType;
+        }
+
         chain.ApplyImpliedMiddlewareFromHandlers(rules);
         var transactionFrameProvider = rules.As<GenerationRules>().GetPersistenceProviders(chain, container);
         transactionFrameProvider.ApplyTransactionSupport(chain, container);
@@ -60,6 +65,14 @@ public class TransactionalAttribute : ModifyChainAttribute
     /// </summary>
     public bool IsModeExplicitlySet => _modeExplicitlySet;
 
+    /// <summary>
+    /// Optionally selects which of this handler chain's DbContext-shaped dependencies is the
+    /// single transactional one. Required when a chain has more than one DbContext-shaped
+    /// dependency (e.g. a read-only lookup context alongside the one that owns the write) -
+    /// without it, the persistence provider cannot tell them apart and throws.
+    /// </summary>
+    public Type? DbContextType { get; set; }
+
     public TransactionalAttribute()
     {
     }
@@ -67,5 +80,10 @@ public class TransactionalAttribute : ModifyChainAttribute
     public TransactionalAttribute(IdempotencyStyle idempotency)
     {
         Idempotency = idempotency;
+    }
+
+    public TransactionalAttribute(Type dbContextType)
+    {
+        DbContextType = dbContextType;
     }
 }


### PR DESCRIPTION
# Allow `[Transactional]` to select the DbContext for multi-DbContext handlers

## Problem

A Wolverine handler chain can only have one *transactional* DbContext. But a
handler is often perfectly valid with **two** DbContext-shaped dependencies —
one it writes through (must be enrolled in the transaction + outbox), and
one it only reads from (e.g. a shared read-only lookup database, or a
different bounded context/module in a modular monolith).

Today, `EFCorePersistenceFrameProvider.DetermineDbContextType` throws the
moment it sees more than one DbContext-shaped dependency on a chain:

```
Cannot determine the DbContext type for ..., multiple DbContext types
detected: AppDbContext, CommonDbContext
```

There was no way to tell Wolverine which one is "the" transactional context
for that handler.

## Solution

`[Transactional]` gains an optional `DbContextType`:

```csharp
public class GrantAccessHandler
{
    [Transactional(typeof(AppDbContext))]
    public static void Handle(GrantAccess message, AppDbContext users, CommonDbContext lookup)
    {
        // users.SaveChanges() is enrolled in the transaction + outbox.
        // lookup is just an ordinary injected read-only dependency.
    }
}
```

- Only needed when a chain has more than one DbContext-shaped dependency —
  single-DbContext handlers are unaffected.
- The type can also be a DbContext **abstraction** registered via
  `WithDbContextAbstraction<TAbstraction, TDbContext>()`, so Clean
  Architecture / Application-layer handlers never need to reference the
  concrete EF Core type at all — see `USAGE.md`.
- A tag that doesn't match any of the chain's actual dependencies fails
  loudly at startup, naming the offending type, rather than silently
  picking a default.

## Changes

- `Wolverine/Attributes/TransactionalAttribute.cs` — new `DbContextType`
  property + `Type`-based constructor, stored as a chain tag (same pattern
  already used for `Mode`).
- `Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs`
  — `DetermineDbContextType` resolves that tag before the ambiguity check,
  including resolving through registered DbContext abstractions.
- `EfCoreTests/transactional_dbcontext_selection_tests.cs` — coverage for:
  disambiguation with a concrete type, disambiguation through a registered
  abstraction, and the mismatched-tag error path.

## Backward compatibility

Fully additive. Existing single-DbContext handlers and existing
`[Transactional(Mode = ...)]` usages are unaffected; the ambiguity error
for un-tagged multi-DbContext chains is unchanged.
