### PR TITLE
Allow configuring ServiceBusProcessorOptions for Azure Service Bus listeners

### DIFF
--- a/docs/guide/messaging/transports/azureservicebus/listening.md
+++ b/docs/guide/messaging/transports/azureservicebus/listening.md
@@ -45,6 +45,62 @@ await host.StartAsync();
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L87-L119' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_an_azure_service_bus_listener' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Configuring the ServiceBusProcessor
+
+When a listener runs [inline](/guide/messaging/endpoints.html#endpoint-types) (`ProcessInline()`), Wolverine
+creates an Azure Service Bus `ServiceBusProcessor` for the queue or subscription. You can customize the
+underlying `ServiceBusProcessorOptions` with `ConfigureProcessor()` on either a queue or a subscription
+listener.
+
+The most common reason to reach for this is a long-running inline handler. The Azure SDK only renews a
+message's lock for five minutes by default (`MaxAutoLockRenewalDuration`). Any inline handler that runs
+longer than that loses the lock, so the completion acknowledgement silently fails and Azure Service Bus
+redelivers the message — resulting in duplicate work until the message is finally dead-lettered. Raising
+`MaxAutoLockRenewalDuration` keeps the lock alive for the length of your handler:
+
+<!-- snippet: sample_configuring_azure_service_bus_processor_options -->
+<a id='snippet-sample_configuring_azure_service_bus_processor_options'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.UseWolverine(opts =>
+{
+    // One way or another, you're probably pulling the Azure Service Bus
+    // connection string out of configuration
+    var azureServiceBusConnectionString = builder
+        .Configuration
+        .GetConnectionString("azure-service-bus")!;
+
+    opts.UseAzureServiceBus(azureServiceBusConnectionString).AutoProvision();
+
+    opts.ListenToAzureServiceBusQueue("incoming")
+
+        // Inline listeners create an Azure Service Bus ServiceBusProcessor. By default the
+        // Azure SDK only renews the message lock for five minutes, so an inline handler that
+        // runs longer than that loses its lock and the message is redelivered. Raise the
+        // renewal window here so long-running inline handlers keep their lock.
+        .ConfigureProcessor(processorOptions =>
+        {
+            processorOptions.MaxAutoLockRenewalDuration = TimeSpan.FromMinutes(30);
+        })
+
+        // Run the handler inline against the ServiceBusProcessor
+        .ProcessInline();
+});
+
+using var host = builder.Build();
+await host.StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L124-L153' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_azure_service_bus_processor_options' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: warning
+Wolverine's inline listener acknowledges, defers, and dead letters messages against the message lock, so it
+requires the peek-lock receive model. The `ReceiveMode` you set in `ConfigureProcessor()` is therefore
+ignored and always re-asserted to `ServiceBusReceiveMode.PeekLock`. All other `ServiceBusProcessorOptions`
+properties are honored. Session-based listeners (`RequireSessions()`) do not use a `ServiceBusProcessor` and
+are not affected by this option.
+:::
+
 ## Conventional Listener Configuration
 
 In the case of listening to a large number of queues, it may be beneficial

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs
@@ -119,6 +119,41 @@ public class DocumentationSamples
         #endregion
     }
 
+    public async Task configuring_processor_options()
+    {
+        #region sample_configuring_azure_service_bus_processor_options
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            // One way or another, you're probably pulling the Azure Service Bus
+            // connection string out of configuration
+            var azureServiceBusConnectionString = builder
+                .Configuration
+                .GetConnectionString("azure-service-bus")!;
+
+            opts.UseAzureServiceBus(azureServiceBusConnectionString).AutoProvision();
+
+            opts.ListenToAzureServiceBusQueue("incoming")
+
+                // Inline listeners create an Azure Service Bus ServiceBusProcessor. By default the
+                // Azure SDK only renews the message lock for five minutes, so an inline handler that
+                // runs longer than that loses its lock and the message is redelivered. Raise the
+                // renewal window here so long-running inline handlers keep their lock.
+                .ConfigureProcessor(processorOptions =>
+                {
+                    processorOptions.MaxAutoLockRenewalDuration = TimeSpan.FromMinutes(30);
+                })
+
+                // Run the handler inline against the ServiceBusProcessor
+                .ProcessInline();
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        #endregion
+    }
+
     public async Task configure_buffered_listener()
     {
         var builder = Host.CreateApplicationBuilder();

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/configuring_processor_options.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/configuring_processor_options.cs
@@ -1,0 +1,85 @@
+using Azure.Messaging.ServiceBus;
+using JasperFx.Core;
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Wolverine.Configuration;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+public class configuring_processor_options
+{
+    [Fact]
+    public void configure_processor_action_is_stored_on_the_queue_endpoint()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+
+        var configuration = new AzureServiceBusQueueListenerConfiguration(queue);
+        configuration.ConfigureProcessor(o => o.MaxAutoLockRenewalDuration = 30.Minutes());
+
+        // Apply the delayed configuration as Wolverine would at bootstrapping time
+        ((IDelayedEndpointConfiguration)configuration).Apply();
+
+        queue.ConfigureProcessor.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void configure_processor_action_is_stored_on_the_subscription_endpoint()
+    {
+        var transport = new AzureServiceBusTransport();
+        var topic = transport.Topics["topic1"];
+        var subscription = topic.FindOrCreateSubscription("sub1");
+
+        var configuration = new AzureServiceBusSubscriptionListenerConfiguration(subscription);
+        configuration.ConfigureProcessor(o => o.MaxAutoLockRenewalDuration = 30.Minutes());
+
+        ((IDelayedEndpointConfiguration)configuration).Apply();
+
+        subscription.ConfigureProcessor.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void build_processor_options_applies_the_configured_action()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+        queue.ConfigureProcessor = o =>
+        {
+            o.MaxAutoLockRenewalDuration = 30.Minutes();
+            o.PrefetchCount = 12;
+        };
+
+        var options = AzureServiceBusTransport.BuildProcessorOptions(queue);
+
+        options.MaxAutoLockRenewalDuration.ShouldBe(30.Minutes());
+        options.PrefetchCount.ShouldBe(12);
+    }
+
+    [Fact]
+    public void build_processor_options_reasserts_peek_lock_receive_mode()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+
+        // A user trying to switch to ReceiveAndDelete would break Wolverine's
+        // inline acknowledgement, so the transport must re-assert PeekLock.
+        queue.ConfigureProcessor = o => o.ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete;
+
+        var options = AzureServiceBusTransport.BuildProcessorOptions(queue);
+
+        options.ReceiveMode.ShouldBe(ServiceBusReceiveMode.PeekLock);
+    }
+
+    [Fact]
+    public void build_processor_options_is_valid_when_no_action_is_configured()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+
+        var options = AzureServiceBusTransport.BuildProcessorOptions(queue);
+
+        options.ShouldNotBeNull();
+        options.ReceiveMode.ShouldBe(ServiceBusReceiveMode.PeekLock);
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusQueueListenerConfiguration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusQueueListenerConfiguration.cs
@@ -1,3 +1,4 @@
+using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using Wolverine.AzureServiceBus.Internal;
 using Wolverine.Configuration;
@@ -61,6 +62,22 @@ public class
     public AzureServiceBusQueueListenerConfiguration ConfigureQueue(Action<CreateQueueOptions> configure)
     {
         add(e => configure(e.Options));
+        return this;
+    }
+
+    /// <summary>
+    ///     Customize the Azure Service Bus <see cref="ServiceBusProcessorOptions" /> used by this
+    ///     listener when running in the inline (<c>ProcessInline()</c>) mode. This is the way to raise
+    ///     <see cref="ServiceBusProcessorOptions.MaxAutoLockRenewalDuration" /> for inline handlers that
+    ///     run longer than the Azure SDK's default of five minutes. Wolverine reserves control of the
+    ///     properties it depends on for message acknowledgement (currently <c>ReceiveMode</c>), which are
+    ///     re-asserted after this action runs.
+    /// </summary>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public AzureServiceBusQueueListenerConfiguration ConfigureProcessor(Action<ServiceBusProcessorOptions> configure)
+    {
+        add(e => e.ConfigureProcessor = configure);
         return this;
     }
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusSubscriptionListenerConfiguration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusSubscriptionListenerConfiguration.cs
@@ -1,3 +1,4 @@
+using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using Wolverine.AzureServiceBus.Internal;
 using Wolverine.Configuration;
@@ -60,6 +61,22 @@ public class AzureServiceBusSubscriptionListenerConfiguration : InteroperableLis
     public AzureServiceBusSubscriptionListenerConfiguration ConfigureSubscription(Action<CreateSubscriptionOptions> configure)
     {
         add(e => configure(e.Options));
+        return this;
+    }
+
+    /// <summary>
+    ///     Customize the Azure Service Bus <see cref="ServiceBusProcessorOptions" /> used by this
+    ///     subscription listener when running in the inline (<c>ProcessInline()</c>) mode. This is the way
+    ///     to raise <see cref="ServiceBusProcessorOptions.MaxAutoLockRenewalDuration" /> for inline handlers
+    ///     that run longer than the Azure SDK's default of five minutes. Wolverine reserves control of the
+    ///     properties it depends on for message acknowledgement (currently <c>ReceiveMode</c>), which are
+    ///     re-asserted after this action runs.
+    /// </summary>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public AzureServiceBusSubscriptionListenerConfiguration ConfigureProcessor(Action<ServiceBusProcessorOptions> configure)
+    {
+        add(e => e.ConfigureProcessor = configure);
         return this;
     }
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.Listening.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.Listening.cs
@@ -66,7 +66,7 @@ public partial class AzureServiceBusTransport
 
         if (queue.Mode == EndpointMode.Inline)
         {
-            var messageProcessor = BusClient.CreateProcessor(queue.QueueName);
+            var messageProcessor = BusClient.CreateProcessor(queue.QueueName, BuildProcessorOptions(queue));
 
             var inlineListener = new InlineAzureServiceBusListener(queue,
                 runtime.LoggerFactory.CreateLogger<InlineAzureServiceBusListener>(), messageProcessor, receiver,
@@ -122,7 +122,7 @@ public partial class AzureServiceBusTransport
 
         if (subscription.Mode == EndpointMode.Inline)
         {
-            var messageProcessor = BusClient.CreateProcessor(subscription.Topic.TopicName, subscription.SubscriptionName);
+            var messageProcessor = BusClient.CreateProcessor(subscription.Topic.TopicName, subscription.SubscriptionName, BuildProcessorOptions(subscription));
             var inlineListener = new InlineAzureServiceBusListener(subscription,
                 runtime.LoggerFactory.CreateLogger<InlineAzureServiceBusListener>(), messageProcessor, receiver, mapper,  requeue
             );
@@ -137,5 +137,24 @@ public partial class AzureServiceBusTransport
         var listener = new BatchedAzureServiceBusListener(subscription, runtime.LoggerFactory.CreateLogger<BatchedAzureServiceBusListener>(), receiver, messageReceiver, mapper, requeue);
 
         return listener;
+    }
+
+    // Builds the ServiceBusProcessorOptions for an inline listener, applying any user supplied
+    // customization and then re-asserting the properties that Wolverine's inline acknowledgement
+    // logic depends on. InlineAzureServiceBusListener explicitly completes, defers, and dead
+    // letters messages against the message lock, so the processor must run in PeekLock mode; the
+    // ReceiveAndDelete mode would remove messages before Wolverine can process them and would break
+    // dead lettering and deferral.
+    internal static ServiceBusProcessorOptions BuildProcessorOptions(AzureServiceBusEndpoint endpoint)
+    {
+        var options = new ServiceBusProcessorOptions();
+
+        endpoint.ConfigureProcessor?.Invoke(options);
+
+        // Reserved by Wolverine: the inline listener relies on the peek-lock model to complete,
+        // defer, and dead letter messages, so this cannot be honored from user configuration.
+        options.ReceiveMode = ServiceBusReceiveMode.PeekLock;
+
+        return options;
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
@@ -49,6 +49,15 @@ public abstract class AzureServiceBusEndpoint : Endpoint<IAzureServiceBusEnvelop
     /// </summary>
     public TimeSpan MaximumWaitTime { get; set; } = 5.Seconds();
 
+    /// <summary>
+    ///     Optional customization of the Azure Service Bus <see cref="ServiceBusProcessorOptions" /> used
+    ///     by inline listeners for this endpoint. Wolverine reserves control of the properties it depends
+    ///     on for correct message acknowledgement (see AzureServiceBusTransport.Listening), so those will
+    ///     be re-asserted after this action runs.
+    /// </summary>
+    [IgnoreDescription]
+    public Action<ServiceBusProcessorOptions>? ConfigureProcessor { get; set; }
+
     public abstract ValueTask<bool> CheckAsync();
     public abstract ValueTask TeardownAsync(ILogger logger);
     public abstract ValueTask SetupAsync(ILogger logger);


### PR DESCRIPTION
## Motivation

The Azure Service Bus transport currently creates the inline listener's `ServiceBusProcessor` with no options, so `ServiceBusProcessorOptions.MaxAutoLockRenewalDuration` is stuck at the Azure SDK default of five minutes. Any inline handler that runs longer than five minutes loses the message lock. When Wolverine then tries to complete the message, `AzureServiceBusEnvelope.CompleteAsync` swallows the "The lock supplied is invalid" `ServiceBusException`, so the ack silently fails and Azure Service Bus redelivers the message — duplicate work until `MaxDeliveryCount` finally dead-letters it.

There was previously no way to configure the underlying `ServiceBusProcessorOptions` at all. Jeremy invited this contribution in [#2112](https://github.com/JasperFx/wolverine/discussions/2112) (originally #2110): *"adding the ability to configure the ServiceBusProcessor objects would be a simple pull request."*

## What this adds

A `ConfigureProcessor(Action<ServiceBusProcessorOptions>)` fluent method on both:

- `AzureServiceBusQueueListenerConfiguration.ConfigureProcessor(Action<ServiceBusProcessorOptions>)`
- `AzureServiceBusSubscriptionListenerConfiguration.ConfigureProcessor(Action<ServiceBusProcessorOptions>)`

The action is stored on the endpoint (`AzureServiceBusEndpoint.ConfigureProcessor`) following the existing `ConfigureQueue(Action<CreateQueueOptions>)` / `DelayedEndpointConfiguration.add(...)` pattern. It is applied when the inline `ServiceBusProcessor` is created for both the queue and topic-subscription paths in `AzureServiceBusTransport.Listening.cs` via a new `BuildProcessorOptions` helper.

Typical use — raising the lock-renewal window for long-running inline handlers:

```csharp
opts.ListenToAzureServiceBusQueue("incoming")
    .ConfigureProcessor(o => o.MaxAutoLockRenewalDuration = TimeSpan.FromMinutes(30))
    .ProcessInline();
```

## Honored vs. reserved properties

`BuildProcessorOptions` invokes the user callback first, then **re-asserts `ReceiveMode = ServiceBusReceiveMode.PeekLock`**. The inline listener (`InlineAzureServiceBusListener`) completes, defers, and dead letters messages against the message lock, so `ReceiveAndDelete` would break acknowledgement, deferral, and dead lettering. `ReceiveMode` is therefore the one property the transport reserves; every other `ServiceBusProcessorOptions` property (including `MaxAutoLockRenewalDuration`, `PrefetchCount`, `MaxConcurrentCalls`, `AutoCompleteMessages`, etc.) is honored as configured.

## Scope

Scoped to the non-session inline processor paths. Session-based listeners (`RequireSessions()`) do **not** use a `ServiceBusProcessor` at all — they use `AcceptNextSessionAsync` plus a manual `ServiceBusSessionReceiver` loop (`AzureServiceBusSessionListener` / `SessionSpecificListener`), so `ServiceBusProcessorOptions` / `ServiceBusSessionProcessorOptions` don't apply there. Extending session configuration would be a separate change against a different code path and is intentionally left out.

## Tests

Added `configuring_processor_options.cs` (broker-free config-level tests, following the existing `AzureServiceBusTransportTests` pattern):

- the configured action is stored on the queue endpoint after delayed config is applied
- the configured action is stored on the subscription endpoint
- `BuildProcessorOptions` applies the configured action (`MaxAutoLockRenewalDuration`, `PrefetchCount`)
- `BuildProcessorOptions` re-asserts `PeekLock` even when the user sets `ReceiveAndDelete`
- `BuildProcessorOptions` produces valid `PeekLock` options when no action is configured

Ran locally on `net10.0` (the full ASB integration suite needs the emulator/a live namespace, which I did not run):

- new `configuring_processor_options` tests: **5 passed**
- existing broker-free `AzureServiceBusTransportTests` + `AzureServiceBusEndpointUriTests`: **27 passed**
- `Wolverine.AzureServiceBus` and `Wolverine.AzureServiceBus.Tests` both build clean (0 warnings, 0 errors)

## Docs

Added a "Configuring the ServiceBusProcessor" section to `docs/guide/messaging/transports/azureservicebus/listening.md` with a `MaxAutoLockRenewalDuration` sample sourced from `DocumentationSamples.cs` (region `sample_configuring_azure_service_bus_processor_options`), plus a note on the reserved `ReceiveMode` and the session-listener exclusion. (I couldn't run `mdsnippets` locally — it isn't installed in the environment — so the snippet source line link may need a regen pass.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
