### PR TITLE
Don't override pipeline Error status in InlineReceiver (GH-3288)

### DIFF
--- a/src/Testing/CoreTests/Runtime/WorkerQueues/inline_receiver_activity_status.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/inline_receiver_activity_status.cs
@@ -1,0 +1,74 @@
+using System.Diagnostics;
+using NSubstitute;
+using Wolverine.ComplianceTests;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+public class inline_receiver_activity_status : IDisposable
+{
+    private readonly IListener theListener = Substitute.For<IListener>();
+    private readonly IHandlerPipeline thePipeline = Substitute.For<IHandlerPipeline>();
+    private readonly MockWolverineRuntime theRuntime = new();
+    private readonly InlineReceiver theReceiver;
+    private readonly List<Activity> _stopped = new();
+    private readonly ActivityListener _listener;
+
+    public inline_receiver_activity_status()
+    {
+        // Capture the "receive" activity started inside InlineReceiver
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Wolverine",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity => _stopped.Add(activity)
+        };
+        ActivitySource.AddActivityListener(_listener);
+
+        var stubEndpoint = new StubEndpoint("one", new StubTransport());
+        theReceiver = new InlineReceiver(stubEndpoint, theRuntime, thePipeline);
+        theListener.Address.Returns(new Uri("stub://one"));
+    }
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+    }
+
+    [Fact]
+    public async Task does_not_override_error_status_set_by_the_pipeline()
+    {
+        // Simulate a contained failure: the HandlerPipeline / Executor flags the
+        // receive activity as Error but does NOT rethrow (the failure was handled
+        // by an error-handling continuation such as dead-letter or discard).
+        thePipeline
+            .InvokeAsync(Arg.Any<Envelope>(), Arg.Any<IChannelCallback>(), Arg.Any<Activity>())
+            .Returns(ci =>
+            {
+                ci.Arg<Activity>().SetStatus(ActivityStatusCode.Error, "boom");
+                return Task.CompletedTask;
+            });
+
+        await theReceiver.ReceivedAsync(theListener, ObjectMother.Envelope());
+
+        var receive = _stopped.Single(a => a.OperationName == "receive");
+        receive.Status.ShouldBe(ActivityStatusCode.Error);
+    }
+
+    [Fact]
+    public async Task marks_ok_on_the_happy_path()
+    {
+        thePipeline
+            .InvokeAsync(Arg.Any<Envelope>(), Arg.Any<IChannelCallback>(), Arg.Any<Activity>())
+            .Returns(Task.CompletedTask);
+
+        await theReceiver.ReceivedAsync(theListener, ObjectMother.Envelope());
+
+        var receive = _stopped.Single(a => a.OperationName == "receive");
+        receive.Status.ShouldBe(ActivityStatusCode.Ok);
+    }
+}

--- a/src/Wolverine/Runtime/WorkerQueues/InlineReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/InlineReceiver.cs
@@ -121,7 +121,15 @@ internal class InlineReceiver : IReceiver
             await _pipeline.InvokeAsync(envelope, listener, activity!);
             _logger.IncomingReceived(envelope, listener.Address);
 
-            activity?.SetStatus(ActivityStatusCode.Ok);
+            // Don't clobber an Error status already set by the HandlerPipeline / Executor.
+            // When a message fails but the failure is contained by an error-handling
+            // continuation (dead-letter, discard, retries exhausted, ...), no exception
+            // propagates out of InvokeAsync, so this success path still runs. Only mark
+            // Ok when the activity isn't already flagged as an Error. See GH-3288.
+            if (activity is { Status: not ActivityStatusCode.Error })
+            {
+                activity.SetStatus(ActivityStatusCode.Ok);
+            }
         }
         catch (Exception? e)
         {


### PR DESCRIPTION
Fixes #3288

## Problem

`InlineReceiver` starts a `"receive"` activity and threads it into `HandlerPipeline.InvokeAsync(envelope, listener, activity)`. When a handler throws, `Executor.ExecuteAsync` sets `Activity.Current` (which **is** that receive activity) to `Error` — but rather than rethrow, it returns an error-handling continuation (dead-letter / discard / retries exhausted). The failure is contained, so **no exception propagates out of `InvokeAsync`**.

Back in `InlineReceiver`, the success path then ran `activity?.SetStatus(ActivityStatusCode.Ok)` **unconditionally**, clobbering the `Error` status the pipeline had already set. With a batch export processor this also races the export and the span can ship as `Ok`.

## Fix

Only mark the activity `Ok` when it isn't already flagged as an `Error`:

```csharp
if (activity is { Status: not ActivityStatusCode.Error })
{
    activity.SetStatus(ActivityStatusCode.Ok);
}
```

## Reproduction / tests

Added `inline_receiver_activity_status.cs` (broker-free unit tests):

- `does_not_override_error_status_set_by_the_pipeline` — a substitute `IHandlerPipeline` flags the passed-in activity `Error` without throwing (simulating a contained failure); an `ActivityListener` captures the stopped `"receive"` activity. **Fails on `main`** (span ends `Ok`), passes with the fix.
- `marks_ok_on_the_happy_path` — guards the normal success path.

All 14 `inline_receiver` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)