### PR TITLE
RavenDb control transport: TransportCompliance + leadership compliance, make ravendb:// first-class

### DIFF
--- a/src/Persistence/LeaderElection/RavenDbTests.LeaderElection/control_queue_leadership_election_compliance.cs
+++ b/src/Persistence/LeaderElection/RavenDbTests.LeaderElection/control_queue_leadership_election_compliance.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.DependencyInjection;
+using Raven.Client.Documents;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.RavenDb;
+using Xunit.Abstractions;
+using RavenDbTests;
+
+namespace RavenDbTests.LeaderElection;
+
+/// <summary>
+/// Runs the full leadership-election compliance battery while relying on the
+/// native RavenDB control queue (ravendb://) for inter-node control
+/// messaging, rather than <c>UseTcpForControlEndpoint()</c>. This exercises the
+/// RavenDbControlTransport added in #3285 under real multi-node fan-out,
+/// send-to-node, and leader-failover scenarios.
+/// </summary>
+[Collection("raven")]
+public class control_queue_leadership_election_compliance : LeadershipElectionCompliance
+{
+    private readonly DatabaseFixture _fixture;
+    private IDocumentStore _store = null!;
+
+    public control_queue_leadership_election_compliance(ITestOutputHelper output, DatabaseFixture fixture) : base(output)
+    {
+        _fixture = fixture;
+    }
+
+    protected override Task beforeBuildingHost()
+    {
+        _store = _fixture.StartRavenStore();
+        return Task.CompletedTask;
+    }
+
+    protected override void configureNode(WolverineOptions options)
+    {
+        // Deliberately NOT calling UseTcpForControlEndpoint() — the RavenDb
+        // persistence registers its native control queue transport as the
+        // NodeControlEndpoint when none is otherwise supplied.
+        options.ServiceName = "raven";
+
+        options.Services.AddSingleton(_store);
+        options.UseRavenDbPersistence();
+    }
+}

--- a/src/Persistence/RavenDbTests/control_queue_tests.cs
+++ b/src/Persistence/RavenDbTests/control_queue_tests.cs
@@ -50,7 +50,7 @@ public class control_queue_tests : IAsyncLifetime
             }).StartAsync();
 
         var nodeId = _receiver.GetRuntime().Options.UniqueNodeId;
-        _receiverUri = new Uri($"ravencontrol://{nodeId}");
+        _receiverUri = new Uri($"ravendb://{nodeId}");
     }
 
     public async Task DisposeAsync()
@@ -68,7 +68,7 @@ public class control_queue_tests : IAsyncLifetime
         // WolverineNode.For to throw "ControlEndpoint cannot be null for this usage".
         var endpoint = _sender.GetRuntime().Options.Transports.NodeControlEndpoint;
         endpoint.ShouldNotBeNull();
-        endpoint.Uri.Scheme.ShouldBe("ravencontrol");
+        endpoint.Uri.Scheme.ShouldBe("ravendb");
     }
 
     [Fact]

--- a/src/Persistence/RavenDbTests/control_transport_compliance.cs
+++ b/src/Persistence/RavenDbTests/control_transport_compliance.cs
@@ -1,0 +1,79 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Raven.Client.Documents;
+using Wolverine;
+using Wolverine.ComplianceTests.Compliance;
+using Wolverine.RavenDb;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace RavenDbTests;
+
+public class RavenDbControlTransportFixture : TransportComplianceFixture, IAsyncLifetime
+{
+    private DatabaseFixture _databases = null!;
+    private IDocumentStore _store = null!;
+
+    public RavenDbControlTransportFixture() : base(new Uri("ravendb://placeholder"), 30)
+    {
+        // The RavenDb control queue only registers its NodeControlEndpoint under
+        // Balanced durability, so the compliance hosts must run Balanced.
+        Mode = DurabilityMode.Balanced;
+
+        // Control messages are transient and each test tracks its own envelopes;
+        // resetting the shared store between every test would wipe the running
+        // nodes' identity/leadership records out from under them.
+        MustReset = false;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _databases = new DatabaseFixture();
+        _store = _databases.StartRavenStore();
+
+        await ReceiverIs(opts =>
+        {
+            opts.Services.AddSingleton(_store);
+            opts.UseRavenDbPersistence();
+            tightenClusterCadence(opts);
+        });
+
+        var receiverNodeId = Receiver.Services.GetRequiredService<IWolverineRuntime>().Options.UniqueNodeId;
+        OutboundAddress = new Uri($"ravendb://{receiverNodeId}");
+
+        await SenderIs(opts =>
+        {
+            opts.Services.AddSingleton(_store);
+            opts.UseRavenDbPersistence();
+            tightenClusterCadence(opts);
+        });
+    }
+
+    // The compliance battery runs against a freshly-started two-node Balanced
+    // cluster. With the production defaults (CheckAssignmentPeriod 30s,
+    // ScheduledJobPollingTime 5s) the leader-assigned scheduled-job agent may not
+    // even be assigned inside a single test's timeout — which is what makes
+    // schedule_send flap. Tighten the coordination cadence so agent assignment and
+    // scheduled-message release happen promptly, mirroring the leadership suite.
+    private static void tightenClusterCadence(WolverineOptions opts)
+    {
+        opts.Durability.CheckAssignmentPeriod = 1.Seconds();
+        opts.Durability.HealthCheckPollingTime = 1.Seconds();
+        opts.Durability.ScheduledJobPollingTime = 1.Seconds();
+        opts.Durability.ScheduledJobFirstExecution = 0.Seconds();
+    }
+
+    protected override Task AfterDisposeAsync()
+    {
+        _store?.Dispose();
+        _databases?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    // Satisfy IAsyncLifetime; real teardown (stopping hosts + store cleanup) runs
+    // through the base IAsyncDisposable.DisposeAsync/AfterDisposeAsync path.
+    public new Task DisposeAsync() => Task.CompletedTask;
+}
+
+[Collection("raven")]
+public class control_transport_compliance : TransportCompliance<RavenDbControlTransportFixture>;

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.cs
@@ -80,7 +80,12 @@ public partial class RavenDbMessageStore : IMessageStoreWithAgentSupport
             && runtime.Options.Transports.NodeControlEndpoint == null
             && runtime.Options.Durability.Mode == DurabilityMode.Balanced)
         {
-            var transport = new Transport.RavenDbControlTransport(_store, runtime.Options);
+            // The transport itself is registered eagerly in UseRavenDbPersistence so
+            // its "ravendb://" scheme resolves for publishing rules. Here we promote
+            // its control endpoint to the NodeControlEndpoint, which marks it as a
+            // live listener — only under Balanced, so Solo hosts never poll.
+            var transport = runtime.Options.Transports.OfType<Transport.RavenDbControlTransport>().FirstOrDefault()
+                            ?? new Transport.RavenDbControlTransport(_store, runtime.Options);
             runtime.Options.Transports.Add(transport);
             runtime.Options.Transports.NodeControlEndpoint = transport.ControlEndpoint;
         }

--- a/src/Persistence/Wolverine.RavenDb/Internals/Transport/RavenDbControlTransport.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/Transport/RavenDbControlTransport.cs
@@ -12,11 +12,20 @@ namespace Wolverine.RavenDb.Internals.Transport;
 
 internal class RavenDbControlTransport : ITransport, IAsyncDisposable
 {
-    public const string ProtocolName = "ravencontrol";
+    public const string ProtocolName = "ravendb";
 
     private readonly Cache<Guid, RavenDbControlEndpoint> _endpoints;
     private readonly WolverineOptions _options;
     private RetryBlock<List<Envelope>>? _deleteBlock;
+
+    // Registered eagerly at configuration time (UseRavenDbPersistence) so the
+    // "ravendb://" scheme resolves for publishing rules. The IDocumentStore isn't
+    // resolvable until the container is built, so it's supplied lazily in
+    // InitializeAsync. The ControlEndpoint is only promoted to a live listener when
+    // the message store wires it as the NodeControlEndpoint (Balanced mode).
+    public RavenDbControlTransport(WolverineOptions options) : this(null!, options)
+    {
+    }
 
     public RavenDbControlTransport(IDocumentStore store, WolverineOptions options)
     {
@@ -29,7 +38,6 @@ internal class RavenDbControlTransport : ITransport, IAsyncDisposable
         });
 
         ControlEndpoint = _endpoints[_options.UniqueNodeId];
-        ControlEndpoint.IsListener = true;
     }
 
     public bool TryBuildBrokerUsage(out BrokerDescription description)
@@ -40,7 +48,7 @@ internal class RavenDbControlTransport : ITransport, IAsyncDisposable
 
     public RavenDbControlEndpoint ControlEndpoint { get; }
 
-    public IDocumentStore Store { get; }
+    public IDocumentStore Store { get; private set; }
 
     public WolverineOptions Options => _options;
 
@@ -87,6 +95,10 @@ internal class RavenDbControlTransport : ITransport, IAsyncDisposable
 
     public ValueTask InitializeAsync(IWolverineRuntime runtime)
     {
+        // The store isn't available when the transport is registered at config time;
+        // resolve it now from the built container.
+        Store ??= (IDocumentStore)runtime.Services.GetService(typeof(IDocumentStore))!;
+
         foreach (var endpoint in Endpoints()) endpoint.Compile(runtime);
 
         _deleteBlock = new RetryBlock<List<Envelope>>(deleteEnvelopesAsync,

--- a/src/Persistence/Wolverine.RavenDb/WolverineRavenDbExtensions.cs
+++ b/src/Persistence/Wolverine.RavenDb/WolverineRavenDbExtensions.cs
@@ -20,6 +20,18 @@ public static class WolverineRavenDbExtensions
     public static WolverineOptions UseRavenDbPersistence(this WolverineOptions options)
     {
         options.Services.AddSingleton<IMessageStore, RavenDbMessageStore>();
+
+        // Register the native RavenDB control-queue transport eagerly so the
+        // "ravendb://" scheme resolves for publishing rules configured at bootstrap.
+        // The endpoint only becomes a live listener when the message store promotes
+        // it to the NodeControlEndpoint under Balanced durability (see
+        // RavenDbMessageStore.Initialize). The store is resolved later, in the
+        // transport's InitializeAsync.
+        if (!options.Transports.OfType<Internals.Transport.RavenDbControlTransport>().Any())
+        {
+            options.Transports.Add(new Internals.Transport.RavenDbControlTransport(options));
+        }
+
         options.CodeGeneration.InsertFirstPersistenceStrategy<RavenDbPersistenceFrameProvider>();
         options.CodeGeneration.Sources.Add(new AsyncDocumentSessionSource());
         options.Services.AddHostedService<DeadLetterQueueReplayer>();

--- a/src/Testing/Wolverine.ComplianceTests/Compliance/TransportCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/Compliance/TransportCompliance.cs
@@ -34,8 +34,17 @@ public abstract class TransportComplianceFixture : IDisposable, IAsyncDisposable
     public bool AllLocally { get; set; }
 
     public bool MustReset { get; set; } = true;
-    
+
     public bool IsSenderOnlyTransport { get; set; }
+
+    /// <summary>
+    /// Durability mode applied to the sender and receiver hosts. Defaults to Solo,
+    /// which is correct for the vast majority of broker transports. Control-plane
+    /// transports that only register in a clustered mode (e.g. the RavenDB control
+    /// queue, which wires its NodeControlEndpoint only under Balanced) can override
+    /// this to DurabilityMode.Balanced.
+    /// </summary>
+    public DurabilityMode Mode { get; set; } = DurabilityMode.Solo;
 
     public async ValueTask DisposeAsync()
     {
@@ -86,7 +95,7 @@ public abstract class TransportComplianceFixture : IDisposable, IAsyncDisposable
             .UseWolverine(options =>
             {
                 configure(options);
-                options.Durability.Mode = DurabilityMode.Solo;
+                options.Durability.Mode = Mode;
                 configureReceiver(options);
                 configureSender(options);
             }).StartAsync();
@@ -99,7 +108,7 @@ public abstract class TransportComplianceFixture : IDisposable, IAsyncDisposable
             {
                 configure(opts);
                 configureSender(opts);
-                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Durability.Mode = Mode;
             }).StartAsync();
 
     }
@@ -117,7 +126,7 @@ public abstract class TransportComplianceFixture : IDisposable, IAsyncDisposable
         options.Services.AddSingleton<IMessageSerializer, GreenTextWriter>();
         //options.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
 
-        options.Durability.Mode = DurabilityMode.Solo;
+        options.Durability.Mode = Mode;
 
         options.UseNewtonsoftForSerialization();
     }
@@ -127,7 +136,7 @@ public abstract class TransportComplianceFixture : IDisposable, IAsyncDisposable
         Receiver = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Durability.Mode = Mode;
                 configure(opts);
                 configureReceiver(opts);
             }).StartAsync();


### PR DESCRIPTION
Builds on the native RavenDB control queue merged in #3285 by (a) adding full compliance coverage and (b) promoting it to a first-class `ravendb://` transport.

## Compliance suites

- **`control_transport_compliance`** — the standard `TransportCompliance<T>` battery over a Balanced two-node fixture sharing one embedded RavenDB store. **22/22, no skips** (send-by-destination, publishing-rule, request/reply, dead-letter, requeue, scheduled retry, scheduled send, content-type serializer swap, endpoint health, …).
- **`control_queue_leadership_election_compliance`** — the full `LeadershipElectionCompliance` battery over `ravendb://` instead of `UseTcpForControlEndpoint()`. **13/13**, covering fan-out, send-to-node, and leader failover on the native control queue.

## Framework changes

**Scheme rename** `ravencontrol` → `ravendb`.

**First-class transport registration.** The control transport used to register lazily in `RavenDbMessageStore.Initialize`, so a config-time `PublishAllMessages().To("ravendb://…")` threw *"Unknown Transport scheme"*. It's now registered eagerly in `UseRavenDbPersistence` (scheme resolves at bootstrap); the `IDocumentStore` is resolved lazily in the transport's `InitializeAsync`. The control endpoint only becomes a **live listener** when the message store promotes it to the `NodeControlEndpoint` under **Balanced** durability — so **Solo hosts never poll** and behavior is unchanged there.

**Compliance harness.** `TransportComplianceFixture` gains an overridable `Mode` (default `Solo`) so a control-plane transport that only wires its `NodeControlEndpoint` under Balanced can run the standard suite. Purely additive — every existing fixture stays `Solo`.

## Note on `schedule_send`

Initially flapped because the leader-assigned scheduled-job agent wasn't assigned within the test window (default `CheckAssignmentPeriod` is 30s). Root cause was cadence, not the transport — the fixture tightens `CheckAssignmentPeriod`/`ScheduledJobPollingTime`, and it passes reliably.

## Verification (local, embedded RavenDB, net9.0)

- `control_transport_compliance`: **22/22**
- `control_queue_leadership_election_compliance`: **13/13**
- Regressions: existing `control_queue_tests` 3/3, TCP-based + control-queue leadership subset 6/6, core RavenDb durability/store suites **110/110**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)