### PR TITLE
Explicit transactional DbContext selection for multi-DbContext handlers (supersedes #3284)

### DIFF
--- a/docs/guide/durability/efcore/transactional-middleware.md
+++ b/docs/guide/durability/efcore/transactional-middleware.md
@@ -174,6 +174,12 @@ await host.StartAsync();
 
 With this option, you will no longer need to decorate handler methods with the `[Transactional]` attribute.
 
+::: tip
+If an auto-transaction handler depends on **more than one** `DbContext` type, Wolverine cannot infer
+which one owns the transaction and will fail fast at startup. See
+[Selecting the Transactional DbContext](#selecting-the-transactional-dbcontext) for how to designate it.
+:::
+
 ## Transaction Middleware Mode
 
 By default, the EF Core transactional middleware uses `TransactionMiddlewareMode.Eager`, which eagerly opens an
@@ -384,3 +390,87 @@ opts.UseEntityFrameworkCoreTransactions()
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests/dbContext_abstraction_scenarios.cs#L62-L83' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_register_mixed_dbcontexts' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Selecting the Transactional DbContext <Badge type="tip" text="6.17" />
+
+A handler chain can only have **one** transactional `DbContext` — the one Wolverine enrolls in the
+transaction and uses for the outbox. But a handler is often legitimately given more than one
+`DbContext`-shaped dependency: one it writes through, plus one it only *reads* from — a shared
+read-only lookup database, or another module's context in a modular monolith.
+
+This applies uniformly to every kind of Wolverine chain — message handlers, HTTP endpoints, and gRPC
+endpoints — since they all resolve their transactional storage the same way. The attributes below can
+be placed on the handler method or the containing class (for HTTP, on the endpoint method).
+
+When a chain depends on more than one `DbContext`-shaped service, Wolverine will **not** guess which
+one is transactional. There is no automatic selection and no "magic" — you designate it explicitly, or
+Wolverine fails fast at startup:
+
+```
+Cannot determine the DbContext type for <handler>, multiple DbContext types detected:
+AppDbContext, LookupDbContext. Wolverine will not guess which one owns the transaction. Either
+remove the automatic transactional middleware from this handler (e.g. with [NonTransactional] or
+by not calling AutoApplyTransactions), or explicitly designate the transactional DbContext with
+[Transactional(typeof(YourDbContext))] or [Storage(typeof(YourDbContext))] on the handler.
+```
+
+You have three ways to resolve it.
+
+### 1. `[Transactional(typeof(TDbContext))]`
+
+Name the write context on the handler. The other `DbContext` is simply an ordinary injected read
+dependency:
+
+```csharp
+public class GrantAccessHandler
+{
+    [Transactional(typeof(AppDbContext))]
+    public static void Handle(GrantAccess message, AppDbContext users, LookupDbContext lookup)
+    {
+        // users.SaveChanges() is enrolled in the transaction + outbox.
+        // lookup is just an ordinary injected read-only dependency.
+    }
+}
+```
+
+`[Transactional]` lives in the core `Wolverine` assembly and only stores a `System.Type`, so neither the
+attribute nor your handler assembly needs to reference anything EF-Core-specific beyond `typeof`. The
+type may also be a **DbContext abstraction** registered via `WithDbContextAbstraction<TAbstraction,
+TDbContext>()`, so a Clean Architecture handler can name the abstraction it depends on rather than the
+concrete EF Core type:
+
+```csharp
+opts.UseEntityFrameworkCoreTransactions()
+    .WithDbContextAbstraction<IAppStore, AppDbContext>();
+
+// ...
+
+[Transactional(typeof(IAppStore))]
+public static void Handle(GrantAccess message, IAppStore users, LookupDbContext lookup) { }
+```
+
+### 2. `[Storage(typeof(TDbContext))]`
+
+The provider-agnostic `[Storage]` attribute — the same one used to route a handler to a Marten or
+Polecat ancillary store — can equally designate the transactional `DbContext`:
+
+```csharp
+[Storage(typeof(AppDbContext))]
+public static void Handle(GrantAccess message, AppDbContext users, LookupDbContext lookup) { }
+```
+
+This behaves identically to `[Transactional(typeof(AppDbContext))]` for the purpose of choosing the
+transactional context. Use whichever attribute reads better in your codebase.
+
+### 3. Opt the handler out
+
+If a multi-`DbContext` handler should not be transactional at all, mark it `[NonTransactional]` (or
+don't apply `AutoApplyTransactions`). Wolverine then leaves both contexts as plain injected
+dependencies.
+
+### No guessing
+
+A designation that names a type the handler does **not** actually depend on — directly or via a
+registered abstraction — fails loudly at startup and names the offending type, rather than silently
+falling back to a default. Single-`DbContext` handlers are unaffected by any of this: there is exactly
+one candidate, so no attribute is needed.

--- a/src/Persistence/EfCoreTests/storage_dbcontext_selection_tests.cs
+++ b/src/Persistence/EfCoreTests/storage_dbcontext_selection_tests.cs
@@ -1,0 +1,218 @@
+using IntegrationTests;
+using JasperFx.CodeGeneration.Frames;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore.Codegen;
+using Wolverine.Persistence;
+using Wolverine.Postgresql;
+using Wolverine.Tracking;
+
+namespace EfCoreTests;
+
+// Companion to transactional_dbcontext_selection_tests.cs. That file proves the [Transactional(typeof(X))]
+// path; this one proves the alternative the architecture review asked for: reusing the provider-agnostic
+// [Storage(typeof(X))] attribute to designate which DbContext owns the transaction on a handler that
+// depends on more than one. It also pins the "no magic" contract: an ambiguous chain with no explicit
+// designation fails fast with a message that names both escape hatches.
+public class storage_dbcontext_selection_tests
+{
+    [Fact]
+    public async Task storage_attribute_disambiguates_and_only_enrolls_that_context()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync("invoice_storage_schema");
+            await conn.CreateCommand(
+                    """
+                    CREATE SCHEMA "invoice_storage_schema";
+                    CREATE TABLE invoice_storage_schema.invoices (
+                        "Id" uuid PRIMARY KEY,
+                        "Memo" text NOT NULL
+                    );
+                    """)
+                .ExecuteNonQueryAsync();
+        }
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<InvoiceDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                // A second, read-only DbContext dependency that must never be enrolled.
+                opts.Services.AddDbContext<PricingDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_invoice_storage");
+
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<CreateInvoiceHandler>();
+            }).StartAsync();
+
+        host.GetRuntime().Handlers.HandlerFor<CreateInvoice>();
+        var chain = host.GetRuntime().Handlers.ChainFor<CreateInvoice>();
+        chain.ShouldNotBeNull();
+
+        // [Storage(typeof(InvoiceDbContext))] set AncillaryStoreType; DetermineDbContextType honored it,
+        // so only InvoiceDbContext is enrolled — PricingDbContext stays an ordinary read dependency.
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ToArray().Length.ShouldBe(1);
+
+        var saveChanges = chain.Postprocessors.OfType<MethodCall>()
+            .Single(x => x.Method.Name == nameof(DbContext.SaveChangesAsync));
+        saveChanges.HandlerType.ShouldBe(typeof(InvoiceDbContext));
+
+        var invoiceId = Guid.NewGuid();
+        await host.InvokeMessageAndWaitAsync(new CreateInvoice(invoiceId, "opening balance"));
+
+        await using var scope = host.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<InvoiceDbContext>();
+        (await db.Invoices.AnyAsync(i => i.Id == invoiceId)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task storage_attribute_that_is_not_a_dependency_throws_clear_error()
+    {
+        async Task startBadHost()
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Durability.Mode = DurabilityMode.Solo;
+
+                    opts.Services.AddDbContextWithWolverineIntegration<InvoiceDbContext>(x =>
+                        x.UseNpgsql(Servers.PostgresConnectionString));
+                    opts.Services.AddDbContext<PricingDbContext>(x =>
+                        x.UseNpgsql(Servers.PostgresConnectionString));
+
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_invoice_storage_err");
+
+                    opts.UseEntityFrameworkCoreTransactions();
+                    opts.Policies.AutoApplyTransactions();
+
+                    opts.Discovery.DisableConventionalDiscovery()
+                        .IncludeType<CreateInvoiceWithBadStorageHandler>();
+                }).StartAsync();
+
+            host.GetRuntime().Handlers.HandlerFor<CreateInvoiceWithBadStorage>();
+        }
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(startBadHost);
+        ex.Message.ShouldContain("is not one of this chain's dependencies");
+    }
+
+    [Fact]
+    public async Task ambiguous_multi_dbcontext_without_designation_throws_helpful_error()
+    {
+        async Task startBadHost()
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Durability.Mode = DurabilityMode.Solo;
+
+                    opts.Services.AddDbContextWithWolverineIntegration<InvoiceDbContext>(x =>
+                        x.UseNpgsql(Servers.PostgresConnectionString));
+                    // A second Wolverine-enabled context so there is genuinely no single default.
+                    opts.Services.AddDbContextWithWolverineIntegration<AuditingDbContext>(x =>
+                        x.UseNpgsql(Servers.PostgresConnectionString));
+
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_ambiguous");
+
+                    opts.UseEntityFrameworkCoreTransactions();
+                    opts.Policies.AutoApplyTransactions();
+
+                    opts.Discovery.DisableConventionalDiscovery()
+                        .IncludeType<AmbiguousHandler>();
+                }).StartAsync();
+
+            host.GetRuntime().Handlers.HandlerFor<AmbiguousCommand>();
+        }
+
+        // No [Transactional]/[Storage] designation and two candidates => no magic, fail fast, and the
+        // message must point the user at both escape hatches.
+        var ex = await Should.ThrowAsync<InvalidOperationException>(startBadHost);
+        ex.Message.ShouldContain("multiple DbContext types detected");
+        ex.Message.ShouldContain("[Transactional(typeof(YourDbContext))]");
+        ex.Message.ShouldContain("[Storage(typeof(YourDbContext))]");
+    }
+}
+
+public class Invoice
+{
+    public Guid Id { get; set; }
+    public string Memo { get; set; } = string.Empty;
+}
+
+public class InvoiceDbContext(DbContextOptions<InvoiceDbContext> options) : DbContext(options)
+{
+    public DbSet<Invoice> Invoices => Set<Invoice>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("invoice_storage_schema");
+        modelBuilder.MapWolverineEnvelopeStorage("invoice_storage_schema");
+        modelBuilder.Entity<Invoice>().ToTable("invoices");
+    }
+}
+
+// Read-only lookup context: no overlapping entities, exists only to add a second DbContext dependency.
+public class PricingDbContext(DbContextOptions<PricingDbContext> options) : DbContext(options);
+
+// A second Wolverine-enabled write context used to force genuine ambiguity.
+public class AuditingDbContext(DbContextOptions<AuditingDbContext> options) : DbContext(options)
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("invoice_storage_schema");
+        modelBuilder.MapWolverineEnvelopeStorage("invoice_storage_schema");
+    }
+}
+
+public record CreateInvoice(Guid Id, string Memo);
+
+[WolverineIgnore]
+public class CreateInvoiceHandler
+{
+    [Storage(typeof(InvoiceDbContext))]
+    public static void Handle(CreateInvoice cmd, InvoiceDbContext invoices, PricingDbContext pricing)
+    {
+        invoices.Invoices.Add(new Invoice { Id = cmd.Id, Memo = cmd.Memo });
+    }
+}
+
+public record CreateInvoiceWithBadStorage(Guid Id);
+
+[WolverineIgnore]
+public class CreateInvoiceWithBadStorageHandler
+{
+    // Names PricingDbContext, which this handler does not depend on.
+    [Storage(typeof(PricingDbContext))]
+    public static void Handle(CreateInvoiceWithBadStorage cmd, InvoiceDbContext invoices)
+    {
+        invoices.Invoices.Add(new Invoice { Id = cmd.Id, Memo = "n/a" });
+    }
+}
+
+public record AmbiguousCommand(Guid Id);
+
+[WolverineIgnore]
+public class AmbiguousHandler
+{
+    public static void Handle(AmbiguousCommand cmd, InvoiceDbContext invoices, AuditingDbContext audit)
+    {
+        invoices.Invoices.Add(new Invoice { Id = cmd.Id, Memo = "ambiguous" });
+    }
+}

--- a/src/Persistence/EfCoreTests/transactional_dbcontext_selection_tests.cs
+++ b/src/Persistence/EfCoreTests/transactional_dbcontext_selection_tests.cs
@@ -1,0 +1,267 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.CodeGeneration.Frames;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore.Codegen;
+using Wolverine.Postgresql;
+using Wolverine.Tracking;
+
+namespace EfCoreTests;
+
+// Reproduces the scenario from the "per-handler transactional DbContext" architecture review:
+// a single handler depends on two different DbContext types - one that owns the write/aggregate
+// and must be enrolled in the transaction + outbox, and one that is only used for read-only
+// lookups and must never be wrapped in a transaction. Today `EFCorePersistenceFrameProvider.
+// DetermineDbContextType(IChain, ...)` throws `InvalidOperationException` the moment it sees more
+// than one DbContext-shaped dependency (EFCorePersistenceFrameProvider.cs:497-501) - it has no way
+// to know which one is "the" transactional context for this chain. `[Transactional(typeof(TDbContext))]`
+// disambiguates that per-chain.
+public class transactional_dbcontext_selection_tests
+{
+    [Fact]
+    public async Task explicit_dbcontext_type_disambiguates_and_only_enrolls_that_context()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync("widget_selection_schema");
+            await conn.CreateCommand(
+                    """
+                    CREATE SCHEMA "widget_selection_schema";
+                    CREATE TABLE widget_selection_schema.widgets (
+                        "Id" uuid PRIMARY KEY,
+                        "Name" text NOT NULL
+                    );
+                    """)
+                .ExecuteNonQueryAsync();
+        }
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<WidgetDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                // A second, unrelated DbContext used only for read-only lookups. It must never
+                // participate in the transaction/outbox even though it's also DbContext-shaped.
+                opts.Services.AddDbContext<LookupDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_widget_sel");
+
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<CreateWidgetHandler>();
+            }).StartAsync();
+
+        // [Transactional]-attributed chains apply their attribute lazily on first compile, so force
+        // it the same way transaction_middleware_mode_tests.cs does before inspecting Middleware.
+        host.GetRuntime().Handlers.HandlerFor<CreateWidget>();
+        var chain = host.GetRuntime().Handlers.ChainFor<CreateWidget>();
+        chain.ShouldNotBeNull();
+
+        // Only the tagged DbContext should be enrolled in the transaction.
+        var enrollFrames = chain.Middleware.OfType<EnrollDbContextInTransaction>().ToArray();
+        enrollFrames.Length.ShouldBe(1);
+
+        var saveChanges = chain.Postprocessors.OfType<JasperFx.CodeGeneration.Frames.MethodCall>()
+            .Single(x => x.Method.Name == nameof(DbContext.SaveChangesAsync));
+        saveChanges.HandlerType.ShouldBe(typeof(WidgetDbContext));
+
+        var widgetId = Guid.NewGuid();
+        await host.InvokeMessageAndWaitAsync(new CreateWidget(widgetId, "gizmo"));
+
+        await using var scope = host.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<WidgetDbContext>();
+        (await db.Widgets.AnyAsync(w => w.Id == widgetId)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task explicit_dbcontext_type_that_is_not_a_dependency_throws_clear_error()
+    {
+        async Task startBadHost()
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Durability.Mode = DurabilityMode.Solo;
+
+                    opts.Services.AddDbContextWithWolverineIntegration<WidgetDbContext>(x =>
+                        x.UseNpgsql(Servers.PostgresConnectionString));
+
+                    opts.Services.AddDbContext<LookupDbContext>(x =>
+                        x.UseNpgsql(Servers.PostgresConnectionString));
+
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_widget_sel_err");
+
+                    opts.UseEntityFrameworkCoreTransactions();
+                    opts.Policies.AutoApplyTransactions();
+
+                    opts.Discovery.DisableConventionalDiscovery()
+                        .IncludeType<CreateWidgetWithBadTagHandler>();
+                }).StartAsync();
+
+            // [Transactional] is applied lazily on first compile - force it.
+            host.GetRuntime().Handlers.HandlerFor<CreateWidgetWithBadTag>();
+        }
+
+        // The attribute references LookupDbContext, but this handler doesn't depend on it - only
+        // on WidgetDbContext. That mismatch must fail loudly and name the offending type, rather
+        // than silently falling back to some default DbContext.
+        var ex = await Should.ThrowAsync<InvalidOperationException>(startBadHost);
+        ex.Message.ShouldContain("is not one of this chain's dependencies");
+    }
+
+    // Clean Architecture handlers can't reference the concrete DbContext type at all (it lives in
+    // Infrastructure). They depend on a repository abstraction registered via
+    // `WithDbContextAbstraction<TAbstraction, TDbContext>()` instead, so [Transactional] must accept
+    // that abstraction type and resolve it to the concrete DbContext internally.
+    [Fact]
+    public async Task explicit_dbcontext_type_can_be_a_registered_abstraction()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync("gadget_selection_schema");
+            await conn.CreateCommand(
+                    """
+                    CREATE SCHEMA "gadget_selection_schema";
+                    CREATE TABLE gadget_selection_schema.gadgets (
+                        "Id" uuid PRIMARY KEY,
+                        "Name" text NOT NULL
+                    );
+                    """)
+                .ExecuteNonQueryAsync();
+        }
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddDbContextWithWolverineIntegration<GadgetDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+                opts.Services.AddScoped<IGadgetRepository>(sp => sp.GetRequiredService<GadgetDbContext>());
+
+                opts.Services.AddDbContext<LookupDbContext>(x =>
+                    x.UseNpgsql(Servers.PostgresConnectionString));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine_gadget_sel");
+
+                opts.UseEntityFrameworkCoreTransactions()
+                    .WithDbContextAbstraction<IGadgetRepository, GadgetDbContext>();
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<CreateGadgetHandler>();
+            }).StartAsync();
+
+        host.GetRuntime().Handlers.HandlerFor<CreateGadget>();
+        var chain = host.GetRuntime().Handlers.ChainFor<CreateGadget>();
+        chain.ShouldNotBeNull();
+
+        chain.Middleware.OfType<EnrollDbContextInTransaction>().ToArray().Length.ShouldBe(1);
+
+        var saveChanges = chain.Postprocessors.OfType<JasperFx.CodeGeneration.Frames.MethodCall>()
+            .Single(x => x.Method.Name == nameof(DbContext.SaveChangesAsync));
+        saveChanges.HandlerType.ShouldBe(typeof(GadgetDbContext));
+
+        var gadgetId = Guid.NewGuid();
+        await host.InvokeMessageAndWaitAsync(new CreateGadget(gadgetId, "sprocket"));
+
+        await using var scope = host.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<GadgetDbContext>();
+        (await db.Gadgets.AnyAsync(g => g.Id == gadgetId)).ShouldBeTrue();
+    }
+}
+
+public class Widget
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class WidgetDbContext(DbContextOptions<WidgetDbContext> options) : DbContext(options)
+{
+    public DbSet<Widget> Widgets => Set<Widget>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("widget_selection_schema");
+        modelBuilder.MapWolverineEnvelopeStorage("widget_selection_schema");
+        modelBuilder.Entity<Widget>().ToTable("widgets");
+    }
+}
+
+// Deliberately has no entities mapped that overlap with WidgetDbContext - it exists purely to
+// prove a second, unrelated DbContext dependency doesn't have to participate in the transaction.
+public class LookupDbContext(DbContextOptions<LookupDbContext> options) : DbContext(options);
+
+public record CreateWidget(Guid Id, string Name);
+
+public class CreateWidgetHandler
+{
+    [Transactional(typeof(WidgetDbContext))]
+    public static void Handle(CreateWidget cmd, WidgetDbContext widgets, LookupDbContext lookup)
+    {
+        widgets.Widgets.Add(new Widget { Id = cmd.Id, Name = cmd.Name });
+    }
+}
+
+public record CreateWidgetWithBadTag(Guid Id);
+
+public class CreateWidgetWithBadTagHandler
+{
+    [Transactional(typeof(LookupDbContext))]
+    public static void Handle(CreateWidgetWithBadTag cmd, WidgetDbContext widgets)
+    {
+        widgets.Widgets.Add(new Widget { Id = cmd.Id, Name = "n/a" });
+    }
+}
+
+public class GadgetEntity
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+// The Application-layer-facing abstraction - the only thing the handler is allowed to depend on.
+public interface IGadgetRepository
+{
+    DbSet<GadgetEntity> Gadgets { get; }
+}
+
+public class GadgetDbContext(DbContextOptions<GadgetDbContext> options) : DbContext(options), IGadgetRepository
+{
+    public DbSet<GadgetEntity> Gadgets => Set<GadgetEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("gadget_selection_schema");
+        modelBuilder.MapWolverineEnvelopeStorage("gadget_selection_schema");
+        modelBuilder.Entity<GadgetEntity>().ToTable("gadgets");
+    }
+}
+
+public record CreateGadget(Guid Id, string Name);
+
+public class CreateGadgetHandler
+{
+    [Transactional(typeof(IGadgetRepository))]
+    public static void Handle(CreateGadget cmd, IGadgetRepository gadgets, LookupDbContext lookup)
+    {
+        gadgets.Gadgets.Add(new GadgetEntity { Id = cmd.Id, Name = cmd.Name });
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCoreDbContextStorageFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCoreDbContextStorageFrameProvider.cs
@@ -1,0 +1,37 @@
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.Core.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Wolverine.Persistence;
+
+namespace Wolverine.EntityFrameworkCore.Codegen;
+
+/// <summary>
+/// Teaches the provider-agnostic <see cref="StorageAttribute"/> (<c>[Storage(typeof(MyDbContext))]</c>)
+/// how to designate the transactional DbContext for an EF Core handler. This is the EF Core sibling of
+/// <see cref="Wolverine.Marten.MartenAncillaryStoreFrameProvider"/> — its only job is to claim
+/// DbContext-shaped store types so <c>[Storage]</c> resolves instead of throwing "no integration owns
+/// this store".
+/// <para>
+/// The actual selection is made by <c>EFCorePersistenceFrameProvider.DetermineDbContextType(IChain, ...)</c>,
+/// which reads <c>chain.AncillaryStoreType</c> (set by <c>[Storage]</c>) and enrolls that DbContext
+/// through the ordinary EF Core transaction middleware. There is therefore no separate ancillary
+/// outbox session to build — unlike Marten/Polecat, a designated DbContext is resolved from the
+/// container the same way as any other — so the inserted frame is intentionally a no-op marker.
+/// </para>
+/// </summary>
+internal class EFCoreDbContextStorageFrameProvider : IAncillaryStoreFrameProvider
+{
+    private readonly EFCorePersistenceFrameProvider _provider;
+
+    public EFCoreDbContextStorageFrameProvider(EFCorePersistenceFrameProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public bool Matches(Type storeType)
+        => storeType.CanBeCastTo<DbContext>() || _provider.IsRegisteredAbstraction(storeType);
+
+    public Frame BuildOutboxFactoryFrame(Type storeType)
+        => new CommentFrame(
+            $"[Storage(typeof({storeType.FullNameInCode()}))] designates the transactional DbContext; enrollment is handled by the EF Core transaction middleware.");
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -52,6 +52,14 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
         _abstractions = _abstractions.AddOrUpdate(abstractionType, dbContextType);
     }
 
+    /// <summary>
+    /// True when <paramref name="type"/> is a DbContext abstraction registered via
+    /// <c>WithDbContextAbstraction&lt;TAbstraction, TDbContext&gt;()</c>. Lets the EF Core
+    /// <see cref="Wolverine.Persistence.IAncillaryStoreFrameProvider"/> accept a <c>[Storage(typeof(abstraction))]</c>
+    /// designation without depending on this provider's private abstraction map.
+    /// </summary>
+    internal bool IsRegisteredAbstraction(Type type) => _abstractions.Contains(type);
+
     public bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService)
     {
         var dbContextType = TryDetermineDbContextType(entityType, container);
@@ -478,6 +486,17 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 
         var contextTypes = FindDbContextTypes().ToArray();
 
+        // Explicit, no-magic disambiguation. When a chain depends on more than one DbContext-shaped
+        // service, the developer designates the transactional one with either [Transactional(typeof(X))]
+        // (carried as a chain tag) or [Storage(typeof(X))] (carried as chain.AncillaryStoreType). X may
+        // be a concrete DbContext or a registered DbContext abstraction. A designation that names a type
+        // the chain does not actually depend on fails loudly rather than silently picking a default.
+        var designated = resolveDesignatedDbContext(chain, contextTypes);
+        if (designated != null)
+        {
+            return designated;
+        }
+
         if (contextTypes.Length == 0)
         {
             var sagaType = chain.HandlerCalls().SelectMany(x => x.Creates)
@@ -489,7 +508,7 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
             {
                 return DetermineDbContextType(sagaType, container);
             }
-            
+
             throw new InvalidOperationException(
                 $"Cannot determine the {nameof(DbContext)} type for {chain.Description}");
         }
@@ -497,10 +516,84 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
         if (contextTypes.Length > 1)
         {
             throw new InvalidOperationException(
-                $"Cannot determine the {nameof(DbContext)} type for {chain.Description}, multiple {nameof(DbContext)} types detected: {contextTypes.Select(x => x.Name).Join(", ")}");
+                $"Cannot determine the {nameof(DbContext)} type for {chain.Description}, multiple {nameof(DbContext)} types detected: {contextTypes.Select(x => x.Name).Join(", ")}. " +
+                $"Wolverine will not guess which one owns the transaction. Either remove the automatic transactional middleware from this handler (e.g. with [NonTransactional] or by not calling AutoApplyTransactions), " +
+                $"or explicitly designate the transactional {nameof(DbContext)} with [Transactional(typeof(YourDbContext))] or [Storage(typeof(YourDbContext))] on the handler.");
         }
 
         return contextTypes.Single();
+    }
+
+    /// <summary>
+    /// Resolve an explicit transactional-DbContext designation for this chain, or null when there is
+    /// none. Two equivalent, EF-Core-agnostic markers are honored:
+    /// <list type="bullet">
+    /// <item><c>[Transactional(typeof(X))]</c> — carried as the <see cref="TransactionalAttribute.TransactionalDbContextTypeKey"/> chain tag.</item>
+    /// <item><c>[Storage(typeof(X))]</c> — carried as <see cref="IChain.AncillaryStoreType"/>.</item>
+    /// </list>
+    /// X may be a concrete DbContext or a registered DbContext abstraction. A designation that names a
+    /// type the chain does not depend on throws; a <see cref="IChain.AncillaryStoreType"/> that names a
+    /// non-DbContext ancillary store (a genuine Marten/Polecat secondary store) is ignored here.
+    /// </summary>
+    private Type? resolveDesignatedDbContext(IChain chain, Type[] contextTypes)
+    {
+        if (chain.Tags.TryGetValue(TransactionalAttribute.TransactionalDbContextTypeKey, out var tagged)
+            && tagged is Type taggedType)
+        {
+            return validateDesignation(taggedType, chain, contextTypes, "[Transactional]");
+        }
+
+        // [Storage(typeof(X))] designation. We read the attribute directly off the handler rather than
+        // relying on chain.AncillaryStoreType, because DetermineDbContextType runs from
+        // AutoApplyTransactions before the StorageAttribute's eager policy / Modify has populated
+        // AncillaryStoreType. Only honored when X resolves to one of this chain's DbContext candidates;
+        // a [Storage] that names a genuine Marten/Polecat ancillary store on some other chain is ignored
+        // here and left to that integration.
+        var storageType = findStorageAttributeType(chain) ?? chain.AncillaryStoreType;
+        if (storageType != null)
+        {
+            var resolved = _abstractions.TryFind(storageType, out var concrete) ? concrete : storageType;
+
+            // If it names a DbContext-shaped type (or registered abstraction) but isn't actually a
+            // dependency, fail loudly the same way the [Transactional] tag does — a typo shouldn't
+            // silently fall through to the ambiguity error.
+            if (resolved.CanBeCastTo<DbContext>() || _abstractions.Contains(storageType))
+            {
+                return validateDesignation(storageType, chain, contextTypes, "[Storage]");
+            }
+        }
+
+        return null;
+    }
+
+    private static Type? findStorageAttributeType(IChain chain)
+    {
+        foreach (var call in chain.HandlerCalls())
+        {
+            var att = call.Method.GetCustomAttribute<StorageAttribute>(inherit: true)
+                      ?? call.HandlerType.GetCustomAttribute<StorageAttribute>(inherit: true);
+
+            if (att != null)
+            {
+                return att.StoreType;
+            }
+        }
+
+        return null;
+    }
+
+    private Type validateDesignation(Type designated, IChain chain, Type[] contextTypes, string source)
+    {
+        var resolved = _abstractions.TryFind(designated, out var concrete) ? concrete : designated;
+
+        if (!contextTypes.Contains(resolved))
+        {
+            throw new InvalidOperationException(
+                $"The {source} DbContextType {designated.FullNameInCode()} on {chain.Description} is not one of this chain's dependencies (directly or via a registered DbContext abstraction). " +
+                $"Detected {nameof(DbContext)} types: {(contextTypes.Length == 0 ? "none" : contextTypes.Select(x => x.Name).Join(", "))}");
+        }
+
+        return resolved;
     }
 
     public class CastDbContextFrame : SyncFrame

--- a/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
@@ -325,6 +325,16 @@ public static class WolverineEntityCoreExtensions
             throw new Exception($"Unable to find any ${typeof(EFCorePersistenceFrameProvider)}");
         }
         efProvider.DefaultMode = mode;
+
+        // Let [Storage(typeof(MyDbContext))] designate the transactional DbContext on a multi-DbContext
+        // handler, the same way [Transactional(typeof(MyDbContext))] does. Registered once; harmless if
+        // no handler uses [Storage]. See EFCoreDbContextStorageFrameProvider.
+        if (!options.Services.Any(x => x.ServiceType == typeof(IAncillaryStoreFrameProvider)
+                                       && x.ImplementationInstance is EFCoreDbContextStorageFrameProvider))
+        {
+            options.Services.AddSingleton<IAncillaryStoreFrameProvider>(new EFCoreDbContextStorageFrameProvider(efProvider));
+        }
+
         return new EFCoreTransactionConfiguration(options, efProvider);
     }
 

--- a/src/Wolverine/Attributes/TransactionalAttribute.cs
+++ b/src/Wolverine/Attributes/TransactionalAttribute.cs
@@ -14,6 +14,13 @@ namespace Wolverine.Attributes;
 /// </summary>
 public class TransactionalAttribute : ModifyChainAttribute
 {
+    /// <summary>
+    /// Chain tag key carrying the persistence storage type (e.g. a specific EF Core DbContext)
+    /// that a <see cref="TransactionalAttribute"/> designates as the transactional one. Read by
+    /// persistence providers to disambiguate multi-storage handler chains.
+    /// </summary>
+    public const string TransactionalDbContextTypeKey = "TransactionalDbContextType";
+
     private bool _modeExplicitlySet;
 
     public override void Modify(IChain chain, GenerationRules rules, IServiceContainer container)
@@ -26,6 +33,15 @@ public class TransactionalAttribute : ModifyChainAttribute
         if (_modeExplicitlySet)
         {
             chain.Tags["TransactionMiddlewareMode"] = Mode;
+        }
+
+        if (DbContextType != null)
+        {
+            // Consumed by the persistence provider (e.g. EF Core's
+            // EFCorePersistenceFrameProvider) to disambiguate which storage type owns the
+            // transaction when a chain depends on more than one. Kept as a chain tag so this
+            // attribute — and the core Wolverine assembly — never reference EF Core.
+            chain.Tags[TransactionalDbContextTypeKey] = DbContextType;
         }
 
         chain.ApplyImpliedMiddlewareFromHandlers(rules);
@@ -60,6 +76,18 @@ public class TransactionalAttribute : ModifyChainAttribute
     /// </summary>
     public bool IsModeExplicitlySet => _modeExplicitlySet;
 
+    /// <summary>
+    /// Optionally designate which persistence storage type owns the transaction for this handler
+    /// when its chain depends on more than one candidate (for example two EF Core DbContext types —
+    /// one written through, one read-only). This may be the concrete type or an abstraction the
+    /// provider has been taught to resolve (e.g. a DbContext abstraction registered via
+    /// <c>WithDbContextAbstraction&lt;TAbstraction, TDbContext&gt;()</c>). It is only consulted when a
+    /// chain is otherwise ambiguous; single-candidate handlers ignore it. The value is carried as a
+    /// plain <see cref="Type"/>, so neither this attribute nor the core Wolverine assembly reference
+    /// any specific persistence technology.
+    /// </summary>
+    public Type? DbContextType { get; set; }
+
     public TransactionalAttribute()
     {
     }
@@ -67,5 +95,15 @@ public class TransactionalAttribute : ModifyChainAttribute
     public TransactionalAttribute(IdempotencyStyle idempotency)
     {
         Idempotency = idempotency;
+    }
+
+    /// <summary>
+    /// Designate which persistence storage type (e.g. a specific EF Core DbContext, or a registered
+    /// DbContext abstraction) owns the transaction for this handler, for chains that depend on more
+    /// than one candidate. See <see cref="DbContextType"/>.
+    /// </summary>
+    public TransactionalAttribute(Type dbContextType)
+    {
+        DbContextType = dbContextType;
     }
 }


### PR DESCRIPTION
Supersedes #3284 (by @KhaledZaabat, preserved as a co-author). Same core need — let a handler that depends on more than one `DbContext` say which one is transactional — but reworked to be **explicit only, no magic**, per review.

## Problem

A handler / HTTP endpoint / gRPC endpoint can legitimately depend on two `DbContext`-shaped services: one it writes through (must be enrolled in the transaction + outbox) and one it only reads from. `EFCorePersistenceFrameProvider` used to throw the moment it saw a second one, with no way to disambiguate.

## Solution — explicit designation, no inference

Two equivalent, EF-Core-agnostic markers designate the transactional context:

- **`[Transactional(typeof(MyDbContext))]`** — carried as a chain tag. The attribute lives in the core `Wolverine` assembly and only stores a `System.Type`, so neither it nor your handler assembly references EF Core.
- **`[Storage(typeof(MyDbContext))]`** — the provider-agnostic storage attribute (the same one used for Marten/Polecat ancillary stores), now taught to designate an EF Core `DbContext` via a new `EFCoreDbContextStorageFrameProvider` (`IAncillaryStoreFrameProvider`). It's read directly off the handler so it's honored even under `AutoApplyTransactions`, whose policy runs before `AncillaryStoreType` is populated.

Either may name a concrete `DbContext` **or** a registered abstraction (`WithDbContextAbstraction<TAbstraction, TDbContext>()`), so Clean Architecture handlers never touch the concrete EF type.

When a chain has >1 `DbContext` and **no** designation, Wolverine **fails fast at startup**:

> Cannot determine the DbContext type for `<handler>`, multiple DbContext types detected: … Wolverine will not guess which one owns the transaction. Either remove the automatic transactional middleware from this handler (e.g. with `[NonTransactional]` or by not calling `AutoApplyTransactions`), or explicitly designate the transactional DbContext with `[Transactional(typeof(YourDbContext))]` or `[Storage(typeof(YourDbContext))]` on the handler.

A designation naming a type the chain doesn't actually depend on also fails loudly.

## What changed vs #3284

- **Kept** the `[Transactional(typeof(X))]` tag mechanism and its tests (`transactional_dbcontext_selection_tests.cs`).
- **Dropped** the registration-side `WithTransactionalDbContext<T>()` selection and the automatic "single Wolverine-enabled candidate" inference — that's the "magic" the review asked to remove.
- **Added** `[Storage(typeof(X))]` support + the ambiguity-validation test (`storage_dbcontext_selection_tests.cs`).
- **Docs**: new "Selecting the Transactional DbContext" section (applies uniformly to message/HTTP/gRPC) + a cross-link from Auto-Apply.

## Verification (local, net9.0, Postgres + SQL Server)

- `transactional_dbcontext_selection_tests` (3) + `storage_dbcontext_selection_tests` (3): **6/6**.
- `transaction_middleware_mode_tests`: **8/8**.
- Full `EfCoreTests`: 183/186; the 3 stragglers are pre-existing environmental flakiness (verified: one passes in isolation, one fails on clean `main`, one flakes) — none touch DbContext selection.
- Release builds of `Wolverine` + `Wolverine.EntityFrameworkCore` clean.

Closing #3284 in favor of this. Full credit to @KhaledZaabat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)