### PR TITLE
Support the HTTP QUERY verb (RFC 10008) in Wolverine.HTTP

### DIFF
--- a/docs/guide/http/endpoints.md
+++ b/docs/guide/http/endpoints.md
@@ -187,6 +187,51 @@ public static OrderShipped Ship(ShipOrder command, Order order)
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L122-L134' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_emptyresponse' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## The HTTP QUERY Method <Badge type="tip" text="6.17" />
+
+Wolverine.HTTP supports the [HTTP `QUERY` method (RFC 10008)](https://www.rfc-editor.org/rfc/rfc10008.html)
+through the `[WolverineQuery]` attribute. `QUERY` is a **safe, idempotent** method — like `GET` — but,
+unlike `GET`, it is allowed to carry a **request body**. It's intended for search/query endpoints whose
+criteria are too large or too structured to encode in the query string:
+
+<!-- snippet: sample_wolverine_query_endpoint -->
+<a id='snippet-sample_wolverine_query_endpoint'></a>
+```cs
+// QUERY (RFC 10008) is safe and idempotent like GET, but carries a request body — ideal for
+// search endpoints whose criteria are too large or structured for the query string. Wolverine
+// binds the request body just like it would for POST, and — because the endpoint takes no
+// message-bus dependency — no transactional/outbox middleware is applied.
+[WolverineQuery("/search")]
+public static SearchResults Search(SearchRequest request)
+{
+    var hits = Enumerable.Range(1, request.Page)
+        .Select(i => $"{request.Term}-{i}")
+        .ToArray();
+
+    return new SearchResults(request.Term, request.Page, hits);
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/QueryEndpoints.cs#L11-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_query_endpoint' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The request body binds exactly as it would for a `POST` endpoint.
+
+::: tip
+Because `QUERY` is a *safe* method, a `QUERY` endpoint follows the same dependency-based rule as every
+other verb for transactional middleware: Wolverine only wraps a handler in transactional/outbox
+middleware when it depends on `IMessageBus`/`IMessageContext`. A plain `QUERY` search endpoint is
+therefore never transactional, even when `AutoApplyTransactions()` is enabled.
+:::
+
+::: warning OpenAPI limitation
+`QUERY` only became a first-class operation in **OpenAPI 3.2**. The OpenAPI 3.1 document produced by the
+Swashbuckle / `Microsoft.OpenApi` stack cannot represent it, so — matching ASP.NET Core's own behavior on
+OpenAPI 3.1 — Wolverine **gracefully omits `QUERY` endpoints from the generated OpenAPI document** rather
+than break generation for the rest of the application. The endpoints are fully routable and functional;
+they are simply not described in the OpenAPI 3.1 output. First-class OpenAPI documentation can follow once
+the underlying OpenAPI stack emits 3.2.
+:::
+
 ## JSON Handling
 
 See [JSON serialization for more information](/guide/http/json)

--- a/src/Http/Wolverine.Http.Tests/query_verb_support.cs
+++ b/src/Http/Wolverine.Http.Tests/query_verb_support.cs
@@ -1,0 +1,72 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Swashbuckle.AspNetCore.Swagger;
+using WolverineWebApi;
+using Xunit;
+
+namespace Wolverine.Http.Tests;
+
+public class query_verb_support : IntegrationContext
+{
+    public query_verb_support(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task query_endpoint_reads_request_body_and_returns_result()
+    {
+        // QUERY carries a request body (unlike GET). Alba's scenario helpers assume standard verbs,
+        // so drive a genuine QUERY request through the test server's HttpClient.
+        var client = Host.GetTestServer().CreateClient();
+
+        var request = new HttpRequestMessage(new HttpMethod("QUERY"), "/search")
+        {
+            Content = JsonContent.Create(new SearchRequest("widget", 3))
+        };
+
+        var response = await client.SendAsync(request);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var results = await response.Content.ReadFromJsonAsync<SearchResults>();
+        results.ShouldNotBeNull();
+        results.Term.ShouldBe("widget");
+        results.Page.ShouldBe(3);
+        results.Hits.ShouldBe(["widget-1", "widget-2", "widget-3"]);
+    }
+
+    [Fact]
+    public void query_route_is_registered_with_QUERY_method_metadata()
+    {
+        var endpoint = EndpointFor("/search");
+        var methods = endpoint.Metadata.GetMetadata<HttpMethodMetadata>();
+        methods.ShouldNotBeNull();
+        methods.HttpMethods.ShouldContain("QUERY");
+    }
+
+    [Fact]
+    public void query_endpoint_is_not_wrapped_in_transactional_middleware()
+    {
+        // QUERY is safe, so it must not be enrolled in transactional/outbox middleware. Wolverine's
+        // rule is dependency-based (no IMessageBus/MessageContext dependency => no outbox), so a plain
+        // QUERY search endpoint stays non-transactional even with AutoApplyTransactions turned on.
+        var chain = HttpChains.Chains.Single(x => x.RoutePattern!.RawText == "/search");
+        chain.RequiresOutbox().ShouldBeFalse();
+        chain.IsTransactional.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void swagger_generation_still_succeeds_with_a_query_endpoint()
+    {
+        // A QUERY endpoint must not break OpenAPI generation for the rest of the app. OpenAPI 3.1
+        // (what Swashbuckle emits here) has no QUERY operation, so the endpoint is gracefully omitted
+        // from the document rather than throwing.
+        var generator = Host.Services.GetRequiredService<ISwaggerProvider>();
+        var doc = generator.GetSwagger("default");
+
+        doc.Paths.ContainsKey("/search").ShouldBeFalse();
+    }
+}

--- a/src/Http/Wolverine.Http/ModifyHttpChainAttribute.cs
+++ b/src/Http/Wolverine.Http/ModifyHttpChainAttribute.cs
@@ -190,3 +190,18 @@ public class WolverineOptionsAttribute : WolverineHttpMethodAttribute
     {
     }
 }
+
+/// <summary>
+///     Marks a method on a Wolverine endpoint as being a QUERY route. QUERY (RFC 10008) is a safe,
+///     idempotent method — like GET — that additionally carries a request body, so it is well suited
+///     to search/query endpoints whose parameters are too large or structured for the query string.
+///     Because it is safe, a QUERY endpoint is not wrapped in transactional/outbox middleware unless it
+///     takes a message-bus dependency (the same dependency-based rule as every other verb); unlike GET,
+///     it is allowed to bind a request body.
+/// </summary>
+public class WolverineQueryAttribute : WolverineHttpMethodAttribute
+{
+    public WolverineQueryAttribute([StringSyntax("Route")]string template) : base("QUERY", template)
+    {
+    }
+}

--- a/src/Http/Wolverine.Http/WolverineApiDescriptionProvider.cs
+++ b/src/Http/Wolverine.Http/WolverineApiDescriptionProvider.cs
@@ -32,6 +32,17 @@ internal class WolverineApiDescriptionProvider : IApiDescriptionProvider
 
                 foreach (var httpMethod in chain.HttpMethods)
                 {
+                    // OpenAPI 3.1 (and the Swashbuckle / Microsoft.OpenApi stack Wolverine emits with)
+                    // has no representation for the QUERY verb (RFC 10008) — Swashbuckle throws a
+                    // KeyNotFoundException mapping the method, which would break document generation for
+                    // the whole app. Gracefully omit QUERY endpoints from the API description, matching
+                    // ASP.NET Core's own behavior on OpenAPI 3.1. QUERY becomes a first-class operation
+                    // in OpenAPI 3.2; first-class documentation can follow once the stack supports it.
+                    if (string.Equals(httpMethod, "QUERY", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
                     context.Results.Add(chain.CreateApiDescription(httpMethod));
                 }
             }

--- a/src/Http/WolverineWebApi/QueryEndpoints.cs
+++ b/src/Http/WolverineWebApi/QueryEndpoints.cs
@@ -1,0 +1,27 @@
+using Wolverine.Http;
+
+namespace WolverineWebApi;
+
+public record SearchRequest(string Term, int Page);
+
+public record SearchResults(string Term, int Page, string[] Hits);
+
+public static class QueryEndpoints
+{
+    #region sample_wolverine_query_endpoint
+    // QUERY (RFC 10008) is safe and idempotent like GET, but carries a request body — ideal for
+    // search endpoints whose criteria are too large or structured for the query string. Wolverine
+    // binds the request body just like it would for POST, and — because the endpoint takes no
+    // message-bus dependency — no transactional/outbox middleware is applied.
+    [WolverineQuery("/search")]
+    public static SearchResults Search(SearchRequest request)
+    {
+        var hits = Enumerable.Range(1, request.Page)
+            .Select(i => $"{request.Term}-{i}")
+            .ToArray();
+
+        return new SearchResults(request.Term, request.Page, hits);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Adds `[WolverineQuery("/route")]` for the HTTP **QUERY** method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html), June 2026).

## What QUERY is

QUERY is a **safe, idempotent** method — like GET — that additionally **carries a request body**. It's the "GET with a body" for search/query endpoints whose criteria are too large or structured for the query string.

## What changed

Wolverine.HTTP's endpoint machinery is almost entirely verb-agnostic, so QUERY needed just one new attribute plus one OpenAPI fix:

- **Attribute**: `WolverineQueryAttribute : WolverineHttpMethodAttribute` (`base("QUERY", template)`), discovered generically like every other verb. Uses the literal `"QUERY"` so it works on net9.0 and net10.0 alike (the net10-only `HttpMethods.Query` isn't required).
- **Routing** *(no change needed)*: the verb flows to ASP.NET Core as `HttpMethodMetadata`; there's no verb allow-list, so `"QUERY"` matches.
- **Request body** *(no change needed)*: body binding is skipped only for `"GET"` (`JsonHandling.cs`), so QUERY binds a body exactly like POST.
- **Transactions** *(no change needed)*: exemption is **dependency-based** (`HttpChain.RequiresOutbox()` → outbox only when the handler depends on `IMessageBus`/`MessageContext`). A safe QUERY endpoint is therefore never wrapped in transactional/outbox middleware — even under `AutoApplyTransactions()` — with no verb special-casing.
- **OpenAPI** *(the one real fix)*: OpenAPI 3.1 (what the Swashbuckle / `Microsoft.OpenApi` stack emits) has no QUERY operation — Swashbuckle throws a `KeyNotFoundException` mapping the method, which would break document generation **for the whole app**. `WolverineApiDescriptionProvider` now **gracefully omits QUERY endpoints** from the API description, matching ASP.NET Core's own OpenAPI 3.1 behavior. Endpoints stay fully routable; first-class OpenAPI **3.2** documentation can follow once the stack supports it.

## Tests (`query_verb_support.cs`)

- Reads a request body and returns the result (driven via a real `QUERY` request through the test server's `HttpClient`, since Alba's scenario helpers assume standard verbs).
- Route carries the correct `HttpMethodMetadata` (`"QUERY"`).
- Not wrapped in transactional middleware (`RequiresOutbox()` false) even with `AutoApplyTransactions()` on.
- `swagger.json` generation still succeeds with a QUERY endpoint present (QUERY gracefully omitted).

## Research notes

- ASP.NET Core (.NET 10) exposes `HttpMethods.Query`/`IsQuery` and registers QUERY via `MapMethods`, but deliberately **cut** `MapQuery` and `[HttpQuery]` in API review — so a `[WolverineQuery]` attribute is the natural Wolverine equivalent.
- QUERY becomes a first-class operation in **OpenAPI 3.2**; .NET 11 preview emits it (via `x-oai-additionalOperations` for 3.1). This PR targets parity with .NET 10 (graceful omission on 3.1).

Docs: new "The HTTP QUERY Method" section in `guide/http/endpoints.md` (usage + the transaction and OpenAPI notes). Follow-up AI-skill coverage tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)