### PR TITLE
Allow special characters in Wolverine.HTTP route templates (fixes #3282)

### DIFF
--- a/docs/guide/http/routing.md
+++ b/docs/guide/http/routing.md
@@ -223,6 +223,36 @@ public string Post()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/NamedRouteEndpoint.cs#L7-L14' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_route_name' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Special Characters in Routes <Badge type="tip" text="6.17" />
+
+Wolverine generates a C# type for each HTTP endpoint, and it derives that type's name from the route
+template. A route can legally contain characters that are valid in a URL path but not in a C# identifier
+— for example a `$` used to mark an RPC-style action:
+
+```csharp
+[WolverinePut("/assets/$action")]
+public static string TriggerAction() => "triggered";
+```
+
+Wolverine handles this for you: any character in the route that isn't a valid C# identifier character is
+replaced with `_` when building the generated type name, so routes like `/assets/$action` "just work"
+(earlier versions failed to compile with `CS1056: Unexpected character '$'`). Two routes that would
+otherwise sanitize to the *same* type name (for example `/a$b` and `/a-b`) are automatically given a
+short deterministic suffix so they stay unique.
+
+### Overriding the generated type name
+
+If you'd rather control the generated type name explicitly — for a nicer name, or to disambiguate an
+edge case yourself — every route attribute exposes a `TypeName` property as an escape hatch:
+
+```csharp
+[WolverinePut("/assets/$action", TypeName = "TriggerAssetAction")]
+public static string TriggerAction() => "triggered";
+```
+
+The value you supply is still sanitized to a valid identifier, so it can never produce code that fails to
+compile.
+
 
 
 

--- a/src/Http/Wolverine.Http.Tests/special_characters_in_route_templates.cs
+++ b/src/Http/Wolverine.Http.Tests/special_characters_in_route_templates.cs
@@ -1,0 +1,155 @@
+using System.Text.RegularExpressions;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.CodeGeneration.Services;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace Wolverine.Http.Tests;
+
+// Reproduces GH-3282: a route template may contain characters that are legal in a URL path but not
+// in a C# identifier (e.g. '$' in "/assets/$action"). Wolverine derives the generated handler *type
+// name* from the route pattern (HttpChain.Codegen.determineFileName -> assembly.AddType(_fileName)),
+// but only strips Path.GetInvalidPathChars() — which does NOT include '$' — so the generated type is
+// named "GET_assets_$action" and codegen fails to compile with CS1056 "Unexpected character '$'".
+public class special_characters_in_route_templates
+{
+    private static readonly Regex ValidCSharpIdentifier = new("^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.Compiled);
+
+    private static HttpGraph BuildGraph()
+    {
+        var registry = new ServiceCollection();
+        registry.AddSingleton<WolverineHttpOptions>();
+        registry.AddTransient<IServiceVariableSource>(c =>
+            new ServiceCollectionServerVariableSource((ServiceContainer)c.GetRequiredService<IServiceContainer>()));
+        registry.AddSingleton<IServiceCollection>(registry);
+        registry.AddSingleton<IServiceContainer, ServiceContainer>();
+        registry.AddSingleton<IAssemblyGenerator, JasperFx.RuntimeCompiler.AssemblyGenerator>();
+
+        var container = registry.BuildServiceProvider().GetRequiredService<IServiceContainer>();
+        return new HttpGraph(
+            new WolverineOptions { ApplicationAssembly = typeof(special_characters_in_route_templates).Assembly },
+            container);
+    }
+
+    [Fact]
+    public void generated_type_name_for_a_dollar_sign_route_is_a_valid_csharp_identifier()
+    {
+        var chain = HttpChain.ChainFor<RpcStyleEndpoint>(x => x.TriggerAction());
+
+        // Description is the value handed verbatim to assembly.AddType() as the generated C# type name.
+        var typeName = chain.Description;
+
+        typeName.ShouldNotContain("$");
+        ValidCSharpIdentifier.IsMatch(typeName)
+            .ShouldBeTrue($"Generated type name '{typeName}' is not a valid C# identifier");
+    }
+
+    [Fact]
+    public void endpoint_with_a_dollar_sign_route_compiles()
+    {
+        var parent = BuildGraph();
+        var method = typeof(RpcStyleEndpoint).GetMethod(nameof(RpcStyleEndpoint.TriggerAction))!;
+        var chain = new HttpChain(new MethodCall(typeof(RpcStyleEndpoint), method), parent);
+
+        // Forces real code generation + compilation of just this endpoint. Before GH-3282 this threw a
+        // CompilationException wrapping CS1056 "Unexpected character '$'".
+        Should.NotThrow(() =>
+            chain.As<ICodeFile>().InitializeSynchronously(parent.Rules, parent, parent.Container.Services));
+    }
+
+    [Fact]
+    public void type_name_override_wins_and_is_used()
+    {
+        var chain = HttpChain.ChainFor<RpcStyleEndpoint>(x => x.WithExplicitName());
+        chain.Description.ShouldBe("AssetsRpcEndpoint");
+    }
+
+    [Fact]
+    public void type_name_override_is_still_sanitized()
+    {
+        // Even an override can't smuggle an invalid identifier into codegen.
+        var chain = HttpChain.ChainFor<RpcStyleEndpoint>(x => x.WithMessyName());
+        chain.Description.ShouldNotContain("$");
+        ValidCSharpIdentifier.IsMatch(chain.Description).ShouldBeTrue($"'{chain.Description}' is not a valid identifier");
+    }
+
+    [Fact]
+    public void colliding_type_names_are_disambiguated_and_both_compile()
+    {
+        var parent = BuildGraph();
+
+        var dollar = new HttpChain(
+            new MethodCall(typeof(CollisionEndpoints), typeof(CollisionEndpoints).GetMethod(nameof(CollisionEndpoints.Dollar))!), parent);
+        var dash = new HttpChain(
+            new MethodCall(typeof(CollisionEndpoints), typeof(CollisionEndpoints).GetMethod(nameof(CollisionEndpoints.Dash))!), parent);
+
+        // Both routes sanitize to the same generated type name before disambiguation.
+        dollar.Description.ShouldBe(dash.Description);
+
+        HttpGraph.ResolveDuplicateTypeNames([dollar, dash]);
+
+        dollar.Description.ShouldNotBe(dash.Description);
+        ValidCSharpIdentifier.IsMatch(dollar.Description).ShouldBeTrue();
+        ValidCSharpIdentifier.IsMatch(dash.Description).ShouldBeTrue();
+
+        // Both must still generate compilable code with their now-distinct names.
+        Should.NotThrow(() =>
+        {
+            dollar.As<ICodeFile>().InitializeSynchronously(parent.Rules, parent, parent.Container.Services);
+            dash.As<ICodeFile>().InitializeSynchronously(parent.Rules, parent, parent.Container.Services);
+        });
+    }
+
+    [Fact]
+    public void disambiguation_suffix_is_deterministic()
+    {
+        var parent1 = BuildGraph();
+        var parent2 = BuildGraph();
+
+        HttpChain Build(HttpGraph parent, string methodName) =>
+            new(new MethodCall(typeof(CollisionEndpoints), typeof(CollisionEndpoints).GetMethod(methodName)!), parent);
+
+        var a1 = Build(parent1, nameof(CollisionEndpoints.Dollar));
+        var a2 = Build(parent1, nameof(CollisionEndpoints.Dash));
+        HttpGraph.ResolveDuplicateTypeNames([a1, a2]);
+
+        var b1 = Build(parent2, nameof(CollisionEndpoints.Dollar));
+        var b2 = Build(parent2, nameof(CollisionEndpoints.Dash));
+        HttpGraph.ResolveDuplicateTypeNames([b1, b2]);
+
+        // Stable across runs — required for TypeLoadMode.Static codegen.
+        a1.Description.ShouldBe(b1.Description);
+        a2.Description.ShouldBe(b2.Description);
+    }
+}
+
+public class RpcStyleEndpoint
+{
+    // '$action' marks an RPC-style route. Legal URL path, illegal C# identifier character.
+    [WolverineGet("/assets/$action")]
+    public string TriggerAction() => "triggered";
+
+    // The escape hatch: name the generated type explicitly for an otherwise-awkward route.
+    [WolverineGet("/assets/$explicit", TypeName = "AssetsRpcEndpoint")]
+    public string WithExplicitName() => "explicit";
+
+    // Even an override is sanitized.
+    [WolverineGet("/assets/$messy", TypeName = "Assets$Rpc")]
+    public string WithMessyName() => "messy";
+}
+
+public class CollisionEndpoints
+{
+    // Both of these routes sanitize to the same generated type name (GET_widgets_special).
+    [WolverineGet("/widgets/$special")]
+    public string Dollar() => "dollar";
+
+    [WolverineGet("/widgets/-special")]
+    public string Dash() => "dash";
+}

--- a/src/Http/Wolverine.Http/HttpChain.Codegen.cs
+++ b/src/Http/Wolverine.Http/HttpChain.Codegen.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Text;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
@@ -224,9 +225,15 @@ public partial class HttpChain
 
     private string determineFileName()
     {
+        // Escape hatch (GH-3282): an explicit [WolverineVerb(..., TypeName = "...")] override wins over
+        // the route-derived name. Still sanitized so a careless override can't produce invalid code.
+        if (_typeNameOverride.IsNotEmpty())
+        {
+            return SanitizeToTypeName(_typeNameOverride!);
+        }
+
         var parts = RoutePattern!.RawText!.Replace("{", "").Replace("*", "").Replace(".", "_").Replace("?", "").Replace("}", "").Split('/').Select(x => x.Split(':').First());
 
-        char[] invalidPathChars = Path.GetInvalidPathChars();
         var fileName = _httpMethods.Select(x => x.ToUpper()).Concat(parts).Join("_").Replace('-', '_').Replace("__", "_");
 
         // Append content type suffix to make endpoint names unique when using [AcceptsContentType]
@@ -237,15 +244,33 @@ public partial class HttpChain
             fileName = $"{fileName}_{suffix}";
         }
 
-        var characters = fileName.ToCharArray();
-        for (int i = 0; i < characters.Length; i++)
+        return SanitizeToTypeName(fileName);
+    }
+
+    // The result is used verbatim as the generated C# type name (assembly.AddType(_fileName, ...)), so
+    // it must be a legal C# identifier. Route templates can contain characters that are legal in a URL
+    // path but not in an identifier (e.g. '$' in "/assets/$action", which previously produced CS1056).
+    // Map every character that isn't a valid identifier character to '_', collapse the runs of '_' that
+    // creates, and prefix '_' when the result would start with a digit. See GH-3282.
+    internal static string SanitizeToTypeName(string raw)
+    {
+        var builder = new StringBuilder(raw.Length);
+        foreach (var c in raw)
         {
-            if (invalidPathChars.Contains(characters[i]))
-            {
-                characters[i] = '_';
-            }
+            builder.Append(char.IsLetterOrDigit(c) || c == '_' ? c : '_');
         }
 
-        return new string(characters);
+        var name = builder.ToString();
+        while (name.Contains("__"))
+        {
+            name = name.Replace("__", "_");
+        }
+
+        if (name.Length == 0)
+        {
+            return "_";
+        }
+
+        return char.IsDigit(name[0]) ? "_" + name : name;
     }
 }

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -71,6 +71,7 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
     internal bool RequestBodyIsOptional { get; set; }
 
     private string? _fileName;
+    private string? _typeNameOverride;
     private readonly List<string> _httpMethods = [];
 
     private readonly List<Variable> _routeVariables = [];
@@ -131,6 +132,7 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
         if (method.Method.TryGetAttribute<WolverineHttpMethodAttribute>(out var att))
         {
+            _typeNameOverride = att.TypeName;
             MapToRoute(att.HttpMethod, att.Template, att.Order);
             if (att.Name.IsNotEmpty())
             {
@@ -238,6 +240,17 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
         // Doing this prevents middleware policies
         // from doing something stupid
         RequestType ??= typeof(void);
+    }
+
+    /// <summary>
+    /// Append a deterministic suffix to the generated C# type name so two routes that would otherwise
+    /// derive the same identifier (e.g. "/a$b" and "/a-b" both sanitizing to "a_b") stay unique. Called
+    /// by <see cref="HttpGraph"/> only for chains whose generated name actually collides.
+    /// </summary>
+    internal void DisambiguateTypeName(string suffix)
+    {
+        _fileName = $"{_fileName}_{suffix}";
+        _description = _fileName;
     }
 
     [IgnoreDescription]

--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -144,6 +144,11 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
 
         _chains.AddRange(calls.Select(x => new HttpChain(x, this){ServiceProviderSource = wolverineHttpOptions.ServiceProviderSource}));
 
+        // Two different routes can sanitize to the same generated C# type name (e.g. "/a$b" and "/a-b"
+        // both -> "a_b"). Append a deterministic suffix to any that actually collide so codegen stays
+        // valid. See GH-3282.
+        ResolveDuplicateTypeNames(_chains);
+
         // Expand multi-version handlers before any policy runs, so middleware, route prefix,
         // and other policies are applied uniformly to every per-version clone. Without this,
         // clones would miss whatever the policies subsequently mutate.
@@ -166,6 +171,34 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
         foreach (var policy in wolverineHttpOptions.Policies) policy.Apply(_chains, Rules, Container);
 
         _endpoints.AddRange(_chains.Select(x => x.BuildEndpoint(wolverineHttpOptions.WarmUpRoutes)));
+    }
+
+    internal static void ResolveDuplicateTypeNames(IReadOnlyList<HttpChain> chains)
+    {
+        foreach (var group in chains.GroupBy(x => x.Description).Where(g => g.Count() > 1))
+        {
+            foreach (var chain in group)
+            {
+                chain.DisambiguateTypeName(deterministicSuffix(chain));
+            }
+        }
+    }
+
+    // A stable (process-independent) FNV-1a hash of what actually distinguishes two colliding chains,
+    // so the generated type names stay deterministic across builds — important for TypeLoadMode.Static
+    // where the codegen-time names must match what was written to disk.
+    private static string deterministicSuffix(HttpChain chain)
+    {
+        var key = $"{chain.Method.HandlerType.FullName}.{chain.Method.Method.Name}|{chain.HttpMethods.Join(",")}|{chain.RoutePattern?.RawText}";
+
+        uint hash = 2166136261u;
+        foreach (var b in System.Text.Encoding.UTF8.GetBytes(key))
+        {
+            hash ^= b;
+            hash *= 16777619u;
+        }
+
+        return hash.ToString("x8");
     }
 
     public override IChangeToken GetChangeToken()

--- a/src/Http/Wolverine.Http/ModifyHttpChainAttribute.cs
+++ b/src/Http/Wolverine.Http/ModifyHttpChainAttribute.cs
@@ -85,6 +85,15 @@ public abstract class WolverineHttpMethodAttribute : Attribute
     /// Sets the description for this endpoint in OpenAPI documentation
     /// </summary>
     public string? Description { get; set; }
+
+    /// <summary>
+    /// Optionally override the name of the C# type Wolverine generates for this endpoint. Wolverine
+    /// normally derives that type name from the route template, but a route may contain characters that
+    /// are legal in a URL yet not in a C# identifier (for example <c>"/assets/$action"</c>). Wolverine
+    /// sanitizes those automatically, but this is the escape hatch when you want an explicit, readable
+    /// generated type name for such routes. The value is still sanitized to a valid identifier.
+    /// </summary>
+    public string? TypeName { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
Fixes #3282.

## Problem

Wolverine derives the generated handler **C# type name** from an endpoint's route template. A route can legally contain characters that are valid in a URL path but not in a C# identifier — most notably `$` in an RPC-style route like `/assets/$action`. The name-derivation only stripped `Path.GetInvalidPathChars()` (a *filesystem* concept), so `$` survived into `assembly.AddType(...)` and codegen failed:

```
CS1056: Unexpected character '$'
```

## Fix (A + B + disambiguator)

**A — Sanitize to a valid C# identifier.** In `HttpChain.Codegen.determineFileName`, any character that isn't a valid identifier char (`letter`/`digit`/`_`) becomes `_`, underscore runs are collapsed, and a leading digit is prefixed with `_`. Routes with special characters now just work — no user action needed.

**B — `TypeName` escape hatch.** All `[WolverineVerb]` attributes gain an optional `TypeName` property to set the generated type name explicitly for edge cases. The override is itself sanitized, so it can never smuggle invalid code into codegen.

```csharp
[WolverinePut("/assets/$action", TypeName = "TriggerAssetAction")]
public static string TriggerAction() => "triggered";
```

**Collision disambiguator (built in from the start).** Two routes that sanitize to the same type name (e.g. `/a$b` and `/a-b` → `a_b`) now receive a short, **deterministic** FNV-1a suffix in `HttpGraph`, applied only to chains that actually collide. Determinism matters for `TypeLoadMode.Static`, where codegen-time names must match what was written to disk.

## Tests (`special_characters_in_route_templates.cs`)

- Reproduce the original `CS1056` (route + **real codegen** via `InitializeSynchronously`) — now passes.
- The generated type name is a valid C# identifier.
- `TypeName` override is used, and is still sanitized.
- Colliding routes get distinct names and **both compile**.
- The disambiguation suffix is deterministic across graph builds.

## Docs

New "Special Characters in Routes" section in `guide/http/routing.md` covering the automatic sanitization and the `TypeName` escape hatch.

## Verification

Full `Wolverine.Http.Tests`: **802 passed / 0 failed / 10 skipped** — no regressions (normal routes derive the same names as before; sanitization is a superset of the old replacements). Release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)