### PR TITLE
docs(batching): settlement model + durability requirement (GH-3289 Phase 0)

### DIFF
--- a/docs/guide/handlers/batching.md
+++ b/docs/guide/handlers/batching.md
@@ -189,11 +189,61 @@ Under `Separated` mode each `Handle(Item[])` handler is given its own sticky que
 batch out to every one of them and each runs independently. (Under the default `Classic` behavior the multiple
 `Handle(Item[])` handlers are instead combined into a single logical handler that invokes each one in turn.)
 
+## Durability and message settlement
+
+::: warning
+**A durable (persistent) listener is required for guaranteed delivery of batched processing.** With an
+inline or buffered listener, the individual messages are settled (acknowledged / marked handled) *before*
+the batch they belong to actually runs, so a process crash while a batch is still accumulating loses those
+messages. If you cannot afford to lose messages, batch behind a [durable inbox](/guide/durability/).
+:::
+
+Batching accumulates incoming messages in memory before forwarding them to your batch handler as a single
+`T[]` (or custom batch) message. The important question is *when the original member messages are settled*
+with the inbox or the broker, because anything accumulated but not yet run is only as safe as that settlement
+timing. This differs by [endpoint mode](/guide/messaging/listeners):
+
+| Endpoint mode | When the member messages are settled | Crash while a batch is accumulating |
+|---|---|---|
+| **Durable** | *After* the batch succeeds — members are held `InBatch` and only marked handled in the message store once the batch message completes | Members are recovered from the inbox and reprocessed — **no loss** |
+| **Inline** | The moment each message is absorbed into the batcher — *before* the batch runs | Accumulated members are already settled and are **lost** |
+| **Buffered** | At receipt — *before* the batch runs | Accumulated members are already settled and are **lost** |
+
+In other words, deferred settlement is exactly what makes batching loss-proof, and the durable inbox is the
+*only* mode that provides it. This is a deliberate design choice: holding a broker lease open across an entire
+accumulation window (with per-transport lock renewal) is inherently transport-specific, whereas the durable
+inbox already solves the loss problem uniformly across every transport.
+
+The mechanics: a batched member is flagged `Envelope.InBatch = true` when it enters the batcher. On a durable
+listener, `DurableReceiver.CompleteAsync` early-returns for any `InBatch` envelope, so the member stays
+un-settled in the message store; only when the assembled batch message completes are all of its members marked
+handled together. On inline and buffered listeners there is no inbox to defer to, so the member is settled as
+soon as the batching handler absorbs it.
+
+### The lock window caveat (lock-based transports)
+
+On transports that hand out a time-bounded lock or lease per message — Azure Service Bus peek-lock, Amazon SQS
+visibility timeout, and similar — the **accumulation window plus the batch processing time must fit inside that
+lock duration**. Wolverine's broker listeners do not renew these locks for messages that are sitting inside a
+batch waiting to be flushed.
+
+If your `TriggerTime` (or the time to fill a `BatchSize` worth of messages) approaches or exceeds the broker's
+lock/visibility window, the broker will consider the lock expired and **redeliver** those messages while they
+are still buffered. The symptoms are silent duplicate processing and a `DeliveryCount` that climbs toward the
+dead-letter threshold, with nothing logged by Wolverine to explain it. Guidance:
+
+- Keep `TriggerTime` comfortably below the transport's lock/visibility duration (leaving headroom for the batch
+  handler's own execution time), **or**
+- Use a durable listener, where members are pulled from the persistent inbox rather than held under a broker
+  lock, so the accumulation window is no longer bounded by the broker lease.
+
 ## What about durable messaging ("inbox")?
 
 The durable inbox behaves just a little bit differently for message batching. Wolverine will technically
 "handle" the individual messages, but does not mark them as handled in the message store until a batch message
-that refers to the original message is completely processed. 
+that refers to the original message is completely processed. See [Durability and message
+settlement](#durability-and-message-settlement) above for the full settlement model and why a durable listener
+is required for guaranteed delivery.
 
 ## Custom Batching Strategies
 


### PR DESCRIPTION
Phase 0 of the [#3289 batch-processing plan](https://github.com/JasperFx/wolverine/issues/3289#issuecomment-4887409431). Documentation only.

## What & why

The single most surprising thing in the #3289 proposal is that **batched member messages are settled at different times depending on endpoint mode**, and only the durable inbox defers settlement until the batch actually succeeds. Today that is undocumented, so users reasonably (but wrongly) assume peek-lock semantics carry through batching. This PR closes that gap.

Adds a **"Durability and message settlement"** section to `docs/guide/handlers/batching.md`:

- **Settlement table** — durable defers settlement until the batch succeeds (loss-proof); inline/buffered settle members *before* the batch runs, so a crash mid-accumulation loses them.
- States prominently that **a durable/persistent listener is required for guaranteed delivery of batched processing.**
- Explains the mechanics (`Envelope.InBatch` + `DurableReceiver.CompleteAsync` early-return at `src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs:196`) and notes that deferred inline settlement is deliberately *not* offered (it would need transport-specific lock renewal; the durable inbox already solves loss uniformly).
- **Lock-window caveat** (covers the deferred item 4 as prose): on lock-based transports the accumulation window + processing time must fit inside the broker lock/visibility duration, or messages are redelivered while still buffered — silent duplicate processing and a climbing `DeliveryCount`.

## Scope

No code changes. Subsequent phases (IBatchContext, CoalesceBy, the collision diagnostic, and the partial-failure isolation family) will land as separate PRs per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)