### PR TITLE
feat(kafka): broker-per-tenant multi-tenancy (dedicated cluster per tenant)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -112,6 +112,7 @@
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageVersion Include="Testcontainers" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.CosmosDb" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.Kafka" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.LocalStack" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.Nats" Version="4.12.0" />

--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -161,7 +161,18 @@ using var host = await Host.CreateDefaultBuilder()
 
                 // Other configuration
             })
-            
+            // Extends the consumer configuration for this topic only.
+            // Unlike ConfigureConsumer(), this preserves any existing topic-level
+            // ConsumerConfig and only applies the changes below.
+            .ExtendConsumerConfiguration(config =>
+            {
+                // This also sets Envelope.GroupId for any messages received
+                // from this topic.
+                config.GroupId = "foo";
+                config.BootstrapServers = KafkaContainerFixture.ConnectionString;
+
+                // Other additive configuration
+            })
             // Configure circuit breaker behavior for
             // this specific Kafka listener
             .CircuitBreaker(cb =>
@@ -169,7 +180,6 @@ using var host = await Host.CreateDefaultBuilder()
                 cb.MinimumThreshold = 10;
                 cb.PauseTime = TimeSpan.FromMinutes(1);
             })
-            
             // Fine tune how the Kafka Topic is declared by Wolverine
             .Specification(spec =>
             {
@@ -186,7 +196,7 @@ using var host = await Host.CreateDefaultBuilder()
         opts.Services.AddResourceSetupOnStartup();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L14-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_with_kafka' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L15-L144' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_with_kafka' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The various `Configure*****()` methods provide quick access to the full API of the Confluent Kafka library for security
@@ -739,7 +749,7 @@ public static class KafkaInstrumentation
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L183-L195' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_kafkainstrumentation_middleware' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L232-L244' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_kafkainstrumentation_middleware' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Connecting to Multiple Brokers <Badge type="tip" text="4.7" />
@@ -770,11 +780,101 @@ using var host = await Host.CreateDefaultBuilder()
         // Other configuration
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L157-L179' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multiple_kafka_brokers' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L168-L190' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multiple_kafka_brokers' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note that the `Uri` scheme within Wolverine for any endpoints from a "named" Kafka broker is the name that you supply
 for the broker. So in the example above, you might see `Uri` values for `emea://colors` or `americas://red`.
+
+## Multi-Tenancy with a Broker per Tenant <Badge type="tip" text="6.9" />
+
+Named brokers (above) are a *static* topology: you pin specific endpoints to a specific broker by name at
+configuration time. **Broker-per-tenant** is different — it is *runtime* routing. You declare one shared topic
+topology, and each tenant is served by its **own dedicated Kafka cluster**. Which cluster a message goes to (and
+which cluster an inbound message came from) is decided at runtime by the message's
+[tenant id](/guide/handlers/multi-tenancy), typically set through `DeliveryOptions.TenantId`:
+
+<!-- snippet: sample_kafka_broker_per_tenant -->
+<a id='snippet-sample_kafka_broker_per_tenant'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        // The "default" / shared Kafka cluster
+        opts.UseKafka(KafkaContainerFixture.ConnectionString)
+            .AutoProvision()
+
+            // How should Wolverine route a message whose TenantId is null or
+            // unknown? FallbackToDefault (the default) uses the shared cluster;
+            // TenantIdRequired throws; IgnoreUnknownTenants silently drops it.
+            .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+
+            // Each tenant gets its OWN dedicated Kafka cluster, but shares the
+            // topic topology declared below. The tenant inherits the parent's
+            // client configuration (auth, SASL/SSL, idempotence, DLQ topic, ...)
+            // with just the bootstrap servers re-pointed.
+            .AddTenant("tenant-a", "tenant-a-kafka:9092")
+
+            // Or configure the tenant cluster through the full Kafka surface,
+            // seeded from the parent settings, when it needs its own credentials:
+            .AddTenant("tenant-b", tenant => tenant.ConfigureClient(client =>
+            {
+                client.BootstrapServers = "tenant-b-kafka:9092";
+                client.SaslUsername = "tenant-b-user";
+                client.SaslPassword = "tenant-b-secret";
+            }));
+
+        // One shared topology; messages are routed to the right cluster at
+        // runtime by Envelope.TenantId (e.g. new DeliveryOptions { TenantId = "tenant-a" }).
+        opts.PublishMessage<ColorMessage>().ToKafkaTopic("colors");
+        opts.ListenToKafkaTopic("colors");
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L195-L228' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_kafka_broker_per_tenant' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+To route a specific message to a tenant's cluster, stamp the tenant id on the send:
+
+```csharp
+await bus.SendAsync(new ColorMessage("blue"), new DeliveryOptions { TenantId = "tenant-a" });
+```
+
+Wolverine wraps the outbound endpoint in a `TenantedSender` that dispatches on `Envelope.TenantId`, and builds a
+compound listener that runs one consumer per tenant cluster — each inbound envelope is stamped with the tenant id
+it was consumed under. This mirrors the [RabbitMQ](/guide/messaging/transports/rabbitmq/multi-tenancy) and
+[NATS](/guide/messaging/transports/nats) broker-per-tenant support.
+
+::: tip Named broker vs. broker-per-tenant
+Use a **named broker** when a *fixed set of endpoints* should always talk to a *specific* broker. Use
+**broker-per-tenant** when the *same logical endpoints* should be transparently routed to a *different cluster per
+tenant* based on the runtime tenant id. They are independent features and can be combined.
+:::
+
+### Choosing the unknown-tenant behavior
+
+`TenantIdBehavior(...)` controls what happens when a message has a null or unregistered tenant id:
+
+* `FallbackToDefault` (the default) — route it to the shared/default cluster (the one passed to `UseKafka`).
+* `TenantIdRequired` — throw; every message must carry a known tenant id.
+* `IgnoreUnknownTenants` — silently drop the message.
+
+### Consumer groups are *not* suffixed per tenant
+
+Because each tenant is a **separate Kafka cluster**, consumer offsets live in that tenant's own cluster. Wolverine
+therefore keeps the **same consumer group id** across all tenant listeners rather than suffixing it per tenant —
+there is no offset collision to avoid. (This is deliberately different from transports like NATS that isolate
+tenants by subject prefix on a *shared* connection.)
+
+### Auto-provisioning per cluster
+
+When [`AutoProvision()`](#) is enabled, Wolverine provisions the shared topic topology — including the dead letter
+queue topic — on **every** tenant cluster, not just the default one, since each is an independent broker. A tenant
+listener's dead-lettered messages are likewise produced to the DLQ topic on that tenant's own cluster.
+
+::: warning Out of scope
+Per-tenant [non-blocking retry topics](#non-blocking-retry-topics) and [topic replay](#replaying-a-topic) are bound
+to the default cluster only; they are not currently fanned out per tenant.
+:::
 
 ## Non-Blocking Retry Topics <Badge type="tip" text="6.8" />
 
@@ -1011,7 +1111,7 @@ using var host = await Host.CreateDefaultBuilder()
         
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L138-L152' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_all_kafka_sending' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs#L149-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_all_kafka_sending' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Publisher Batching

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/DocumentationSamples.cs
@@ -3,6 +3,7 @@ using Confluent.Kafka;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using JasperFx.Resources;
+using Wolverine.Transports.Sending;
 using Wolverine.Util;
 
 namespace Wolverine.Kafka.Tests;
@@ -186,6 +187,44 @@ public class DocumentationSamples
                 // Other configuration
             }).StartAsync();
 
+        #endregion
+    }
+
+    public static async Task broker_per_tenant()
+    {
+        #region sample_kafka_broker_per_tenant
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // The "default" / shared Kafka cluster
+                opts.UseKafka(KafkaContainerFixture.ConnectionString)
+                    .AutoProvision()
+
+                    // How should Wolverine route a message whose TenantId is null or
+                    // unknown? FallbackToDefault (the default) uses the shared cluster;
+                    // TenantIdRequired throws; IgnoreUnknownTenants silently drops it.
+                    .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+
+                    // Each tenant gets its OWN dedicated Kafka cluster, but shares the
+                    // topic topology declared below. The tenant inherits the parent's
+                    // client configuration (auth, SASL/SSL, idempotence, DLQ topic, ...)
+                    // with just the bootstrap servers re-pointed.
+                    .AddTenant("tenant-a", "tenant-a-kafka:9092")
+
+                    // Or configure the tenant cluster through the full Kafka surface,
+                    // seeded from the parent settings, when it needs its own credentials:
+                    .AddTenant("tenant-b", tenant => tenant.ConfigureClient(client =>
+                    {
+                        client.BootstrapServers = "tenant-b-kafka:9092";
+                        client.SaslUsername = "tenant-b-user";
+                        client.SaslPassword = "tenant-b-secret";
+                    }));
+
+                // One shared topology; messages are routed to the right cluster at
+                // runtime by Envelope.TenantId (e.g. new DeliveryOptions { TenantId = "tenant-a" }).
+                opts.PublishMessage<ColorMessage>().ToKafkaTopic("colors");
+                opts.ListenToKafkaTopic("colors");
+            }).StartAsync();
         #endregion
     }
 }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaPerTenantConfigurationTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaPerTenantConfigurationTests.cs
@@ -1,0 +1,131 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Kafka.Internals;
+using Wolverine.Tracking;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace Wolverine.Kafka.Tests;
+
+// Broker-per-tenant (GH-3303) unit coverage that needs NO Kafka broker: it exercises the tenant compile /
+// sender-resolution wiring, not live produce/consume. Live cluster-routing behavior is covered by
+// KafkaPerTenantConnectionTests.
+public class KafkaPerTenantConfigurationTests
+{
+    [Fact]
+    public void add_tenant_registers_a_tenant_with_its_own_bootstrap_servers()
+    {
+        var options = new WolverineOptions();
+        var kafka = options.UseKafka("shared:9092");
+        kafka.ConfigureConsumers(c => c.GroupId = "shared-group");
+        kafka.AddTenant("tenantB", "tenant-b:9092");
+
+        var transport = kafka.Transport;
+        transport.Tenants.Count().ShouldBe(1);
+
+        var tenant = transport.Tenants["tenantB"];
+        tenant.Compile(transport, options);
+
+        tenant.Transport.ProducerConfig.BootstrapServers.ShouldBe("tenant-b:9092");
+        tenant.Transport.ConsumerConfig.BootstrapServers.ShouldBe("tenant-b:9092");
+        tenant.Transport.AdminClientConfig.BootstrapServers.ShouldBe("tenant-b:9092");
+    }
+
+    [Fact]
+    public void tenant_consumer_group_id_is_NOT_suffixed_per_tenant()
+    {
+        // Each tenant is a separate cluster, so offsets are isolated and the group id must stay identical to
+        // the shared cluster's — suffixing it per tenant would be a bug (unlike NATS subject prefixing).
+        var options = new WolverineOptions();
+        var kafka = options.UseKafka("shared:9092");
+        kafka.ConfigureConsumers(c => c.GroupId = "shared-group");
+        kafka.AddTenant("tenantB", "tenant-b:9092");
+
+        var transport = kafka.Transport;
+        var tenant = transport.Tenants["tenantB"];
+        tenant.Compile(transport, options);
+
+        tenant.Transport.ConsumerConfig.GroupId.ShouldBe("shared-group");
+        tenant.Transport.ConsumerConfig.GroupId.ShouldBe(transport.ConsumerConfig.GroupId);
+    }
+
+    [Fact]
+    public void tenant_inherits_parent_client_configuration()
+    {
+        // SASL / SSL / idempotence / DLQ topic name and other parent settings must carry over to the tenant
+        // cluster; only the bootstrap servers differ.
+        var options = new WolverineOptions();
+        var kafka = options.UseKafka("shared:9092");
+        kafka.ConfigureProducers(p => p.EnableIdempotence = true);
+        kafka.ConfigureClient(c => c.SaslUsername = "shared-user");
+        kafka.DeadLetterQueueTopicName("shared-dlq");
+        kafka.AddTenant("tenantB", "tenant-b:9092");
+
+        var transport = kafka.Transport;
+        var tenant = transport.Tenants["tenantB"];
+        tenant.Compile(transport, options);
+
+        tenant.Transport.ProducerConfig.EnableIdempotence.ShouldBe(true);
+        tenant.Transport.ProducerConfig.SaslUsername.ShouldBe("shared-user");
+        tenant.Transport.DeadLetterQueueTopicName.ShouldBe("shared-dlq");
+    }
+
+    [Fact]
+    public void add_tenant_with_configure_action_is_seeded_from_parent_and_can_override()
+    {
+        var options = new WolverineOptions();
+        var kafka = options.UseKafka("shared:9092");
+        kafka.ConfigureClient(c => c.SaslUsername = "shared-user");
+        kafka.AddTenant("tenantB", t => t.ConfigureClient(c =>
+        {
+            c.BootstrapServers = "tenant-b:9092";
+            c.SaslUsername = "tenant-b-user";
+        }));
+
+        var transport = kafka.Transport;
+        var tenant = transport.Tenants["tenantB"];
+        tenant.Compile(transport, options);
+
+        // seeded from parent...
+        tenant.Transport.ProducerConfig.BootstrapServers.ShouldBe("tenant-b:9092");
+        // ...and overridden by the tenant action
+        tenant.Transport.ProducerConfig.SaslUsername.ShouldBe("tenant-b-user");
+        tenant.Transport.ConsumerConfig.SaslUsername.ShouldBe("tenant-b-user");
+    }
+
+    [Fact]
+    public void kafka_topics_are_tenant_aware_by_default()
+    {
+        var transport = new KafkaTransport();
+        var topic = transport.Topics["orders"];
+        topic.TenancyBehavior.ShouldBe(TenancyBehavior.TenantAware);
+    }
+
+    [Fact]
+    public async Task tenant_aware_endpoint_resolves_a_TenantedSender()
+    {
+        // No broker needed: resolving the sender builds (lazy) Confluent producers but never connects.
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka("localhost:9092")
+                    .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+                    .AddTenant("tenantB", "localhost:9192");
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.PublishMessage<TenantColor>().ToKafkaTopic("tenant-colors");
+            })
+            .StartAsync();
+
+        var runtime = host.GetRuntime();
+        var transport = runtime.Options.Transports.GetOrCreate<KafkaTransport>();
+        var topic = transport.Topics["tenant-colors"];
+
+        var agent = (SendingAgent)runtime.Endpoints.GetOrBuildSendingAgent(topic.Uri);
+        agent.Sender.ShouldBeOfType<TenantedSender>();
+    }
+}
+
+public record TenantColor(string Color);

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaPerTenantConnectionTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaPerTenantConnectionTests.cs
@@ -1,0 +1,225 @@
+using Confluent.Kafka;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Testcontainers.Kafka;
+using Wolverine.Tracking;
+using Wolverine.Transports.Sending;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Wolverine.Kafka.Tests;
+
+/// <summary>
+/// Integration coverage for broker-per-tenant Kafka (GH-3303): each tenant is served by its own dedicated Kafka
+/// cluster while sharing the topic topology. To prove a tenant message uses its <em>own</em> cluster, that
+/// cluster must be genuinely distinguishable, so this test runs a second Kafka broker (cluster B) via
+/// Testcontainers alongside the docker-compose broker (cluster A, localhost:9092) and asserts:
+/// <list type="bullet">
+/// <item>a <c>DeliveryOptions{TenantId="tenantB"}</c> message lands on cluster B and NOT cluster A,</item>
+/// <item>a default (no-tenant) message lands on cluster A (the shared cluster),</item>
+/// <item>a message tagged for the tenant is consumed back over the tenant cluster, stamped with its tenant id.</item>
+/// </list>
+///
+/// The publish-side assertions use raw Confluent consumers per bootstrap-servers so the exact target cluster is
+/// provable. This test needs two brokers, so it is a local sanity check and is <b>not</b> required to run in CI.
+/// </summary>
+[Collection("Kafka Integration")]
+[Trait("Category", "Integration")]
+public class KafkaPerTenantConnectionTests : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private KafkaContainer? _clusterB;
+    private string _clusterAServers = KafkaContainerFixture.ConnectionString; // docker-compose kafka (localhost:9092)
+    private string _clusterBServers = null!;
+    private bool _skip;
+
+    public KafkaPerTenantConnectionTests(ITestOutputHelper output) => _output = output;
+
+    public async Task InitializeAsync()
+    {
+        if (!IsKafkaAvailable(_clusterAServers))
+        {
+            _skip = true;
+            return;
+        }
+
+        try
+        {
+            _clusterB = new KafkaBuilder().WithImage("confluentinc/cp-kafka:7.6.1").Build();
+            await _clusterB.StartAsync();
+            _clusterBServers = StripScheme(_clusterB.GetBootstrapAddress());
+
+            _output.WriteLine($"Cluster A (shared): {_clusterAServers}");
+            _output.WriteLine($"Cluster B (tenant): {_clusterBServers}");
+        }
+        catch (Exception e)
+        {
+            // Docker not available for the second cluster — skip rather than fail CI.
+            _output.WriteLine("Skipping: could not start tenant Kafka cluster: " + e.Message);
+            _skip = true;
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_clusterB != null)
+        {
+            await _clusterB.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task tenant_message_is_published_to_the_tenant_cluster_and_not_the_default()
+    {
+        if (_skip) return;
+
+        var topic = $"pertenant.{Guid.NewGuid():N}";
+
+        using var host = await BuildSenderAsync(topic);
+
+        await host.MessageBus().SendAsync(new TenantColor("for-tenant-b"),
+            new DeliveryOptions { TenantId = "tenantB" });
+
+        // Landed on cluster B (the tenant's dedicated cluster)...
+        (await ConsumeOne(_clusterBServers, topic, 20.Seconds())).ShouldNotBeNull();
+        // ...and NOT on the shared cluster A.
+        (await ConsumeOne(_clusterAServers, topic, 3.Seconds())).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task default_message_is_published_to_the_shared_cluster()
+    {
+        if (_skip) return;
+
+        var topic = $"pertenant.{Guid.NewGuid():N}";
+
+        using var host = await BuildSenderAsync(topic);
+
+        await host.MessageBus().SendAsync(new TenantColor("no-tenant"));
+
+        // Falls back to the default/shared cluster A (TenantedIdBehavior.FallbackToDefault)...
+        (await ConsumeOne(_clusterAServers, topic, 20.Seconds())).ShouldNotBeNull();
+        // ...and NOT the tenant cluster B.
+        (await ConsumeOne(_clusterBServers, topic, 3.Seconds())).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task tenant_message_is_consumed_and_stamped_with_the_tenant_id()
+    {
+        if (_skip) return;
+
+        var topic = $"pertenant.{Guid.NewGuid():N}";
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "PerTenantInbound";
+                opts.UseKafka(_clusterAServers)
+                    .AutoProvision()
+                    // Read from earliest so a just-produced record is caught even if the consumer group's
+                    // partition assignment lands after the send (a Latest consumer would race the producer).
+                    .BeginAtEarliest()
+                    .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+                    .AddTenant("tenantB", _clusterBServers);
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.PublishMessage<TenantColor>().ToKafkaTopic(topic);
+                opts.ListenToKafkaTopic(topic);
+
+                opts.Discovery.IncludeAssembly(GetType().Assembly);
+                opts.Services.AddSingleton<Microsoft.Extensions.Logging.ILoggerProvider>(new OutputLoggerProvider(_output));
+            })
+            .StartAsync();
+
+        // Single host both publishes (to the tenant cluster) and listens (on the tenant cluster), so the
+        // message round-trips back stamped with the tenant id.
+        var session = await host
+            .TrackActivity()
+            .Timeout(60.Seconds())
+            .WaitForMessageToBeReceivedAt<TenantColor>(host)
+            .ExecuteAndWaitAsync(c =>
+                c.SendAsync(new TenantColor("for-tenant-b"), new DeliveryOptions { TenantId = "tenantB" }));
+
+        var received = session.Received.SingleEnvelope<TenantColor>();
+        received.TenantId.ShouldBe("tenantB");
+        received.Message.ShouldBeOfType<TenantColor>().Color.ShouldBe("for-tenant-b");
+    }
+
+    private Task<IHost> BuildSenderAsync(string topic)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "PerTenantSender";
+                opts.UseKafka(_clusterAServers)
+                    .AutoProvision()
+                    .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+                    .AddTenant("tenantB", _clusterBServers);
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.PublishMessage<TenantColor>().ToKafkaTopic(topic).SendInline();
+            })
+            .StartAsync();
+    }
+
+    // Read a single record from the given cluster/topic within the timeout, or null if none arrives. Uses a
+    // fresh consumer group + Earliest so a just-produced record is caught regardless of subscribe timing.
+    private static async Task<ConsumeResult<string, byte[]>?> ConsumeOne(string bootstrapServers, string topic, TimeSpan timeout)
+    {
+        return await Task.Run(() =>
+        {
+            using var consumer = new ConsumerBuilder<string, byte[]>(new ConsumerConfig
+            {
+                BootstrapServers = bootstrapServers,
+                GroupId = $"verify-{Guid.NewGuid():N}",
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                EnableAutoCommit = false,
+                AllowAutoCreateTopics = true
+            }).Build();
+
+            consumer.Subscribe(topic);
+            try
+            {
+                return consumer.Consume(timeout);
+            }
+            finally
+            {
+                consumer.Close();
+            }
+        });
+    }
+
+    private static bool IsKafkaAvailable(string bootstrapServers)
+    {
+        try
+        {
+            using var admin = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build();
+            admin.GetMetadata(TimeSpan.FromSeconds(5));
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    // Testcontainers' GetBootstrapAddress() returns a scheme-prefixed address (e.g. "PLAINTEXT://127.0.0.1:port");
+    // Confluent's BootstrapServers wants a bare host:port list.
+    private static string StripScheme(string address)
+    {
+        var idx = address.IndexOf("://", StringComparison.Ordinal);
+        var hostPort = idx >= 0 ? address[(idx + 3)..] : address;
+        return hostPort.TrimEnd('/');
+    }
+}
+
+public static class TenantColorHandler
+{
+    public static void Handle(TenantColor message)
+    {
+        // no-op; presence lets Wolverine discover a handler so the receive test can track processing
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
@@ -20,6 +20,7 @@
         </PackageReference>
         <PackageReference Include="Alba" />
         <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Testcontainers.Kafka" />
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/InlineKafkaSender.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/InlineKafkaSender.cs
@@ -10,12 +10,22 @@ public class InlineKafkaSender : ISender, IDisposable
     private readonly bool _fixedDestination;
 
     public InlineKafkaSender(KafkaTopic topic, bool fixedDestination = false)
+        : this(topic, topic.Parent, fixedDestination)
+    {
+    }
+
+    // Broker-per-tenant (GH-3303): produce over an explicit transport (a tenant's child transport pointed at
+    // its own cluster) rather than always the topic's parent. When it *is* the parent, behaves exactly as
+    // before, honoring any topic-level producer overrides via GetEffectiveProducerConfig().
+    internal InlineKafkaSender(KafkaTopic topic, KafkaTransport producerTransport, bool fixedDestination = false)
     {
         _topic = topic;
         _fixedDestination = fixedDestination;
         Destination = topic.Uri;
-        Config = topic.GetEffectiveProducerConfig();
-        _producer = _topic.Parent.CreateProducer(Config);
+        Config = ReferenceEquals(producerTransport, topic.Parent)
+            ? topic.GetEffectiveProducerConfig()
+            : producerTransport.ProducerConfig;
+        _producer = producerTransport.CreateProducer(Config);
     }
 
     public ProducerConfig Config { get; }

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -21,13 +21,17 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue, IR
     private readonly string? _messageTypeName;
     private readonly ILogger _logger;
     private readonly KafkaOffsetCommitter _committer;
+    // Broker-per-tenant (GH-3303): the cluster this listener's DLQ records are produced to. Null for the shared
+    // (default-cluster) listener, which falls back to the topic's parent transport.
+    private readonly KafkaTransport? _tenantTransport;
 
     public KafkaListener(KafkaTopic topic, ConsumerConfig config,
         IConsumer<string, byte[]> consumer, IReceiver receiver,
-        ILogger<KafkaListener> logger)
+        ILogger<KafkaListener> logger, KafkaTransport? tenantTransport = null)
     {
         _endpoint = topic;
         _logger = logger;
+        _tenantTransport = tenantTransport;
         Address = topic.Uri;
         _consumer = consumer;
 
@@ -160,8 +164,12 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue, IR
 
     public async Task MoveToErrorsAsync(Envelope envelope, Exception exception)
     {
-        var transport = _endpoint.Parent;
+        // Broker-per-tenant (GH-3303): a tenant listener must DLQ onto its own cluster, not the shared one.
+        var transport = _tenantTransport ?? _endpoint.Parent;
         var dlqTopicName = transport.DeadLetterQueueTopicName;
+        var producerConfig = _tenantTransport != null
+            ? _tenantTransport.ProducerConfig
+            : _endpoint.GetEffectiveProducerConfig();
 
         try
         {
@@ -173,7 +181,7 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue, IR
             message.Headers.Add(DeadLetterQueueConstants.ExceptionStackHeader, Encoding.UTF8.GetBytes(exception.StackTrace ?? ""));
             message.Headers.Add(DeadLetterQueueConstants.FailedAtHeader, Encoding.UTF8.GetBytes(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()));
 
-            using var producer = transport.CreateProducer(_endpoint.GetEffectiveProducerConfig());
+            using var producer = transport.CreateProducer(producerConfig);
             await producer.ProduceAsync(dlqTopicName, message);
             producer.Flush();
 

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTenant.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTenant.cs
@@ -1,0 +1,98 @@
+using Confluent.Kafka;
+using JasperFx.Core;
+
+namespace Wolverine.Kafka.Internals;
+
+/// <summary>
+/// Represents a single Wolverine tenant that is served by its own dedicated Kafka cluster/connection while
+/// sharing the topic topology declared on the parent transport. A Kafka "connection" is config-only (three
+/// Confluent config bags plus builder callbacks), so — mirroring the RabbitMQ tenant model — each tenant owns
+/// a child <see cref="KafkaTransport"/> whose config is cloned from the parent and then re-pointed at the
+/// tenant's own <c>BootstrapServers</c>. Outbound routing is by <see cref="Envelope.TenantId"/> via the
+/// framework's <see cref="Wolverine.Transports.Sending.TenantedSender"/>; inbound the tenant's own listener
+/// stamps the tenant id.
+/// </summary>
+internal class KafkaTenant
+{
+    public KafkaTenant(string tenantId)
+    {
+        TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));
+        Transport = new KafkaTransport();
+    }
+
+    public string TenantId { get; }
+
+    /// <summary>
+    /// The child transport that provides this tenant's dedicated producer/consumer/admin clients. Its config
+    /// is a clone of the parent's, re-pointed at the tenant's own cluster during <see cref="Compile"/>.
+    /// </summary>
+    public KafkaTransport Transport { get; }
+
+    /// <summary>
+    /// The tenant cluster's bootstrap servers. Applied over the cloned parent config in <see cref="Compile"/>.
+    /// Null when the tenant is configured entirely through <see cref="Configure"/>.
+    /// </summary>
+    public string? BootstrapServers { get; set; }
+
+    /// <summary>
+    /// Optional full configuration hook (auth / SASL / SSL / advanced client options) run against the tenant's
+    /// child transport after the parent config has been cloned. Lets a tenant override anything the parent set.
+    /// </summary>
+    public Action<KafkaTransportExpression>? Configure { get; set; }
+
+    /// <summary>
+    /// Clone the parent's three Confluent config bags, the three <c>Configure*Builders</c> callbacks, and the
+    /// DLQ topic name onto this tenant's child transport, then re-point it at the tenant's own cluster. The
+    /// child-transport approach inherits EOS / idempotence / static-membership flags and gets
+    /// <c>CreateProducer</c>/<c>CreateConsumer</c>/<c>CreateAdminClient</c> for free.
+    ///
+    /// NOTE (consumer group id): each tenant is a <em>separate</em> Kafka cluster, so offsets live in that
+    /// cluster and the group id is intentionally cloned unchanged from the parent — it is <b>not</b> suffixed
+    /// per tenant. Suffixing would be wrong here (unlike NATS subject prefixing on a shared connection).
+    /// </summary>
+    public KafkaTransport Compile(KafkaTransport parent, WolverineOptions options)
+    {
+        copyInto(parent.ProducerConfig, Transport.ProducerConfig);
+        copyInto(parent.ConsumerConfig, Transport.ConsumerConfig);
+        copyInto(parent.AdminClientConfig, Transport.AdminClientConfig);
+
+        Transport.ConfigureProducerBuilders = parent.ConfigureProducerBuilders;
+        Transport.ConfigureConsumerBuilders = parent.ConfigureConsumerBuilders;
+        Transport.ConfigureAdminClientBuilders = parent.ConfigureAdminClientBuilders;
+
+        Transport.DeadLetterQueueTopicName = parent.DeadLetterQueueTopicName;
+        Transport.Usage = parent.Usage;
+        Transport.AutoProvision = parent.AutoProvision;
+
+        if (BootstrapServers.IsNotEmpty())
+        {
+            Transport.ProducerConfig.BootstrapServers = BootstrapServers;
+            Transport.ConsumerConfig.BootstrapServers = BootstrapServers;
+            Transport.AdminClientConfig.BootstrapServers = BootstrapServers;
+        }
+
+        if (Configure != null)
+        {
+            var expression = new KafkaTransportExpression(Transport, options);
+            Configure(expression);
+        }
+
+        // Same cluster-independent identities the parent resolves in tryBuildSystemEndpoints. Crucially the
+        // GroupId is inherited, NOT suffixed — offsets are per-cluster so tenant consumers can share it.
+        Transport.ConsumerConfig.GroupId ??= parent.ConsumerConfig.GroupId ?? options.ServiceName;
+        Transport.ProducerConfig.ClientId ??= parent.ProducerConfig.ClientId ?? options.ServiceName;
+
+        return Transport;
+    }
+
+    // Confluent's Producer/Consumer/AdminClient configs all derive from ClientConfig, which is an
+    // IEnumerable<KeyValuePair<string,string>> over its property bag with a public Set(key, val). Copying the
+    // raw property bag preserves every configured option (SASL/SSL/idempotence/static-membership/…) generically.
+    private static void copyInto(ClientConfig source, ClientConfig target)
+    {
+        foreach (var pair in source)
+        {
+            target.Set(pair.Key, pair.Value);
+        }
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
@@ -20,13 +20,17 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
     private readonly IReceiver _receiver;
     private readonly ILogger _logger;
     private readonly KafkaOffsetCommitter _committer;
+    // Broker-per-tenant (GH-3303): the cluster this listener's DLQ records are produced to. Null for the shared
+    // (default-cluster) listener, which falls back to the endpoint's parent transport.
+    private readonly KafkaTransport? _tenantTransport;
 
     public KafkaTopicGroupListener(KafkaTopicGroup endpoint, ConsumerConfig config,
         IConsumer<string, byte[]> consumer, IReceiver receiver,
-        ILogger<KafkaTopicGroupListener> logger)
+        ILogger<KafkaTopicGroupListener> logger, KafkaTransport? tenantTransport = null)
     {
         _endpoint = endpoint;
         _logger = logger;
+        _tenantTransport = tenantTransport;
         Address = endpoint.Uri;
         _consumer = consumer;
 
@@ -143,7 +147,8 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
 
     public async Task MoveToErrorsAsync(Envelope envelope, Exception exception)
     {
-        var transport = _endpoint.Parent;
+        // Broker-per-tenant (GH-3303): a tenant listener must DLQ onto its own cluster, not the shared one.
+        var transport = _tenantTransport ?? _endpoint.Parent;
         var dlqTopicName = transport.DeadLetterQueueTopicName;
 
         try

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -30,6 +30,13 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
 
     internal List<KafkaTopicGroup> TopicGroups { get; } = new();
 
+    /// <summary>
+    /// Broker-per-tenant registrations (GH-3303). Each tenant owns a child transport pointed at its own Kafka
+    /// cluster; outbound is routed by <see cref="Envelope.TenantId"/> and inbound listeners stamp the tenant id.
+    /// </summary>
+    [IgnoreDescription]
+    internal LightweightCache<string, KafkaTenant> Tenants { get; } = new();
+
     // GH-3269: Confluent's ProducerConfig/ConsumerConfig/AdminClientConfig (ClientConfig) expose SaslUsername,
     // SaslPassword, SslKeyPassword, SslKeystorePassword, … as public properties. Reflecting them into the diagnostic
     // tree (the old [ChildDescription]) leaks those secrets to monitoring consumers, so they are suppressed.
@@ -122,7 +129,7 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
             new TopicRoutingRule()); // t
     }
 
-    public override ValueTask ConnectAsync(IWolverineRuntime runtime)
+    public override async ValueTask ConnectAsync(IWolverineRuntime runtime)
     {
         var namedConnection = runtime.Services.GetService<KafkaNamedConnectionSource>();
         if (namedConnection != null)
@@ -155,7 +162,48 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
         warnOnStaticMembership(runtime);
         registerRetryTopicListeners(runtime);
 
-        return ValueTask.CompletedTask;
+        // Broker-per-tenant (GH-3303): clone the (now fully resolved) parent config onto each tenant's child
+        // transport, re-pointing it at the tenant's own cluster. Producers/consumers/admin clients are lazy,
+        // so there is no live connection to open here — but when AutoProvision is on we must create the shared
+        // topic topology (including the DLQ topic) on every tenant cluster, since each is a separate broker.
+        if (Tenants.Any())
+        {
+            foreach (var tenant in Tenants)
+            {
+                tenant.Compile(this, runtime.Options);
+            }
+
+            if (AutoProvision)
+            {
+                await provisionTenantTopicsAsync(runtime);
+            }
+        }
+    }
+
+    // Create the shared application topics (and the DLQ topic) on each tenant's own cluster. Mirrors the specs
+    // the parent would provision via KafkaTopic.SetupAsync, but runs against the tenant admin client.
+    private async Task provisionTenantTopicsAsync(IWolverineRuntime runtime)
+    {
+        var logger = runtime.LoggerFactory.CreateLogger<KafkaTransport>();
+
+        var singleTopics = Topics
+            .Where(t => t.TopicName != KafkaTopic.WolverineTopicsName && !t.IsExternallyOwned)
+            .ToArray();
+
+        foreach (var tenant in Tenants)
+        {
+            using var adminClient = tenant.Transport.CreateAdminClient();
+
+            foreach (var topic in singleTopics)
+            {
+                await topic.SetupOnAsync(adminClient, logger);
+            }
+
+            foreach (var group in TopicGroups.Where(g => !g.IsExternallyOwned))
+            {
+                await group.SetupOnAsync(adminClient, logger);
+            }
+        }
     }
 
     // GH-3148: discover the non-blocking retry-topic policy (MoveToKafkaRetryTopic) in the global failure

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaSenderProtocol.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaSenderProtocol.cs
@@ -1,4 +1,5 @@
 using Confluent.Kafka;
+using Wolverine.Kafka.Internals;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
 
@@ -10,9 +11,19 @@ public class KafkaSenderProtocol : ISenderProtocol, IDisposable
     private readonly IProducer<string, byte[]> _producer;
 
     public KafkaSenderProtocol(KafkaTopic topic)
+        : this(topic, topic.Parent)
+    {
+    }
+
+    // Broker-per-tenant (GH-3303): batch over an explicit transport (a tenant's child transport pointed at its
+    // own cluster) rather than always the topic's parent. When it *is* the parent, behaves exactly as before.
+    internal KafkaSenderProtocol(KafkaTopic topic, KafkaTransport producerTransport)
     {
         _topic = topic;
-        _producer = _topic.Parent.CreateProducer(_topic.GetEffectiveProducerConfig());
+        var config = ReferenceEquals(producerTransport, topic.Parent)
+            ? topic.GetEffectiveProducerConfig()
+            : producerTransport.ProducerConfig;
+        _producer = producerTransport.CreateProducer(config);
     }
 
     public async Task SendBatchAsync(ISenderCallback callback, OutgoingMessageBatch batch)

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -192,7 +192,45 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
 
         var listener = new KafkaListener(this, config,
             Parent.CreateConsumer(config), receiver, runtime.LoggerFactory.CreateLogger<KafkaListener>());
+
+        // Broker-per-tenant (GH-3303): the shared listener consumes the default cluster. Each tenant runs its
+        // own listener on its own cluster, stamping the tenant id onto inbound envelopes via TenantIdRule.
+        // Per-envelope completion routes back over the receiving connection through Envelope.Listener — mirrors
+        // the RabbitMQ / NATS CompoundListener multi-tenancy pattern.
+        if (Parent.Tenants.Any() && TenancyBehavior == TenancyBehavior.TenantAware)
+        {
+            var compound = new CompoundListener(Uri);
+            compound.Inner.Add(listener);
+
+            foreach (var tenant in Parent.Tenants)
+            {
+                var tenantConfig = cloneConsumerConfigForTenant(config, tenant);
+                var tenantReceiver = new ReceiverWithRules(receiver, [new TenantIdRule(tenant.TenantId)]);
+                var tenantListener = new KafkaListener(this, tenantConfig,
+                    tenant.Transport.CreateConsumer(tenantConfig), tenantReceiver,
+                    runtime.LoggerFactory.CreateLogger<KafkaListener>(), tenant.Transport);
+                compound.Inner.Add(tenantListener);
+            }
+
+            return ValueTask.FromResult((IListener)compound);
+        }
+
         return ValueTask.FromResult((IListener)listener);
+    }
+
+    /// <summary>
+    /// Clone an already-resolved effective consumer config (commit strategy + hot-tail already applied) and
+    /// re-point it at the tenant's cluster. The GroupId is deliberately preserved unchanged — each tenant is a
+    /// separate cluster, so offsets are isolated and there is no reason to suffix the group id (GH-3303).
+    /// </summary>
+    internal static ConsumerConfig cloneConsumerConfigForTenant(ConsumerConfig source, KafkaTenant tenant)
+    {
+        var clone = new ConsumerConfig(new Dictionary<string, string>(source))
+        {
+            BootstrapServers = tenant.Transport.ConsumerConfig.BootstrapServers
+        };
+
+        return clone;
     }
 
     /// <summary>
@@ -214,7 +252,27 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     protected override ISender CreateSender(IWolverineRuntime runtime)
     {
         EnvelopeMapper ??= BuildMapper(runtime);
-        
+
+        // Broker-per-tenant (GH-3303): route by Envelope.TenantId to a per-tenant sender bound to that tenant's
+        // own cluster, falling back to the shared cluster for the default/untenanted path.
+        //
+        // Both the tenant senders AND the default sender they fall back to must be simple fire-and-forget
+        // ISenders here: TenantedSender intentionally does NOT implement ISenderRequiresCallback (GH-2361), and
+        // it does not forward RegisterCallback to the senders beneath it. A BatchedSender registered under it
+        // would therefore never receive its ISenderCallback and would silently drop every message. InlineKafka-
+        // Sender produces + flushes directly and needs no callback — the same fire-and-forget model the RabbitMQ
+        // and NATS broker-per-tenant senders use.
+        if (Parent.Tenants.Any() && TenancyBehavior == TenancyBehavior.TenantAware)
+        {
+            var tenantedSender = new TenantedSender(Uri, Parent.TenantedIdBehavior, new InlineKafkaSender(this, Parent));
+            foreach (var tenant in Parent.Tenants)
+            {
+                tenantedSender.RegisterSender(tenant.TenantId, new InlineKafkaSender(this, tenant.Transport));
+            }
+
+            return tenantedSender;
+        }
+
         return Mode == EndpointMode.Inline
             ? new InlineKafkaSender(this)
             : new BatchedSender(this, new KafkaSenderProtocol(this), runtime.Cancellation,
@@ -276,6 +334,19 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
         if (IsExternallyOwned) return;
 
         using var adminClient = Parent.CreateAdminClient();
+        await SetupOnAsync(adminClient, logger);
+    }
+
+    /// <summary>
+    /// Create this topic on the supplied admin client. Split out from <see cref="SetupAsync"/> so the same
+    /// spec/creation logic can be applied against a tenant cluster's admin client (broker-per-tenant, GH-3303).
+    /// </summary>
+    internal async ValueTask SetupOnAsync(IAdminClient adminClient, ILogger logger)
+    {
+        if (TopicName == WolverineTopicsName) return; // don't care, this is just a marker
+
+        if (IsExternallyOwned) return;
+
         Specification.Name = TopicName;
 
         try

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
@@ -50,6 +50,27 @@ public class KafkaTopicGroup : KafkaTopic, IBrokerEndpoint
 
         var listener = new KafkaTopicGroupListener(this, config,
             Parent.CreateConsumer(config), receiver, runtime.LoggerFactory.CreateLogger<KafkaTopicGroupListener>());
+
+        // Broker-per-tenant (GH-3303): mirror the single-topic listener treatment — a shared listener on the
+        // default cluster plus one per-tenant listener on each tenant cluster, stamping the tenant id inbound.
+        if (Parent.Tenants.Any() && TenancyBehavior == TenancyBehavior.TenantAware)
+        {
+            var compound = new CompoundListener(Uri);
+            compound.Inner.Add(listener);
+
+            foreach (var tenant in Parent.Tenants)
+            {
+                var tenantConfig = cloneConsumerConfigForTenant(config, tenant);
+                var tenantReceiver = new ReceiverWithRules(receiver, [new TenantIdRule(tenant.TenantId)]);
+                var tenantListener = new KafkaTopicGroupListener(this, tenantConfig,
+                    tenant.Transport.CreateConsumer(tenantConfig), tenantReceiver,
+                    runtime.LoggerFactory.CreateLogger<KafkaTopicGroupListener>(), tenant.Transport);
+                compound.Inner.Add(tenantListener);
+            }
+
+            return ValueTask.FromResult((IListener)compound);
+        }
+
         return ValueTask.FromResult((IListener)listener);
     }
 
@@ -123,6 +144,16 @@ public class KafkaTopicGroup : KafkaTopic, IBrokerEndpoint
         if (IsExternallyOwned) return;
 
         using var adminClient = Parent.CreateAdminClient();
+        await SetupOnAsync(adminClient, logger);
+    }
+
+    /// <summary>
+    /// Create every topic in this group on the supplied admin client. Split out from <see cref="SetupAsync"/>
+    /// so the same multi-topic creation logic can be applied against a tenant cluster (broker-per-tenant, GH-3303).
+    /// </summary>
+    internal new async ValueTask SetupOnAsync(IAdminClient adminClient, ILogger logger)
+    {
+        if (IsExternallyOwned) return;
 
         foreach (var topicName in TopicNames)
         {

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
@@ -1,6 +1,7 @@
 using Confluent.Kafka;
 using Wolverine.Kafka.Internals;
 using Wolverine.Transports;
+using Wolverine.Transports.Sending;
 
 namespace Wolverine.Kafka;
 
@@ -197,6 +198,47 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     public KafkaTransportExpression DeadLetterQueueTopicName(string topicName)
     {
         _transport.DeadLetterQueueTopicName = topicName;
+        return this;
+    }
+
+    /// <summary>
+    /// Override the sending behavior for unknown or missing tenant ids when using broker-per-tenant Kafka
+    /// multi-tenancy (GH-3303). See <see cref="TenantedIdBehavior"/>. Default is
+    /// <see cref="Wolverine.Transports.Sending.TenantedIdBehavior.FallbackToDefault"/> unless changed.
+    /// </summary>
+    public KafkaTransportExpression TenantIdBehavior(TenantedIdBehavior behavior)
+    {
+        _transport.TenantedIdBehavior = behavior;
+        return this;
+    }
+
+    /// <summary>
+    /// Register a tenant that is served by its own dedicated Kafka cluster identified by
+    /// <paramref name="bootstrapServers"/>, while sharing the topic topology declared on this transport. The
+    /// tenant inherits the parent's producer/consumer/admin configuration (auth, SASL/SSL, idempotence, static
+    /// membership, DLQ topic name, …) with only the bootstrap servers re-pointed. Outbound messages carrying a
+    /// matching <see cref="Envelope.TenantId"/> are routed to this cluster; inbound messages consumed from it
+    /// are stamped with the tenant id.
+    ///
+    /// The consumer group id is intentionally inherited unchanged — each tenant is a separate cluster with its
+    /// own offsets, so there is no need (and it would be incorrect) to suffix the group id per tenant.
+    /// </summary>
+    public KafkaTransportExpression AddTenant(string tenantId, string bootstrapServers)
+    {
+        _transport.Tenants[tenantId] = new KafkaTenant(tenantId) { BootstrapServers = bootstrapServers };
+        return this;
+    }
+
+    /// <summary>
+    /// Register a tenant served by its own dedicated Kafka cluster, configured through the full Kafka transport
+    /// surface (auth, SASL/SSL, advanced client options). The <paramref name="configure"/> action runs against a
+    /// configuration seeded from this transport's own settings, so you only override what differs for the tenant
+    /// (typically <c>ConfigureClient(c =&gt; c.BootstrapServers = ...)</c> plus any tenant-specific credentials).
+    /// </summary>
+    public KafkaTransportExpression AddTenant(string tenantId, Action<KafkaTransportExpression> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        _transport.Tenants[tenantId] = new KafkaTenant(tenantId) { Configure = configure };
         return this;
     }
 


### PR DESCRIPTION
Closes #3303

Kafka already supported **named brokers**; this PR adds the missing **broker-per-tenant** feature. Each Wolverine tenant is served by its own dedicated Kafka cluster while sharing the topic topology, routed at runtime by `Envelope.TenantId`.

## Approach
A Kafka "connection" is config-only (three Confluent config bags + builder callbacks), so — mirroring the RabbitMQ tenant model — each tenant owns a child `KafkaTransport` whose config is cloned from the parent and re-pointed at the tenant's own `BootstrapServers` (`KafkaTenant.Compile`). The child transport gets `CreateProducer/Consumer/AdminClient` for free and inherits EOS / idempotence / static-membership / SASL/SSL config.

## Changes
- **`KafkaTenant`** (new) + `KafkaTransport.Tenants` cache. `ConnectAsync` compiles each tenant and, under `AutoProvision`, provisions the shared topics **and the DLQ** on every tenant cluster (each is an independent broker).
- **`KafkaTopic` / `KafkaTopicGroup`** fan out to a framework `TenantedSender` (outbound) and a `CompoundListener` with one `KafkaListener` per tenant cluster, stamping the tenant id inbound via `ReceiverWithRules([new TenantIdRule(...)])`. Dead-lettered messages are produced to the tenant's own cluster.
- **New public API** on `KafkaTransportExpression`: `TenantIdBehavior(...)`, `AddTenant(id, bootstrapServers)`, `AddTenant(id, Action<KafkaTransportExpression>)` (full auth/SASL/SSL, seeded from parent).
- Tenant/default senders under `TenantedSender` use fire-and-forget `InlineKafkaSender`. `TenantedSender` is intentionally **not** `ISenderRequiresCallback` (GH-2361) and does not forward `RegisterCallback`, so a `BatchedSender` registered beneath it would never get its callback and would silently drop messages — inline production is the correct fire-and-forget model (same as the RabbitMQ / NATS tenant senders).

## Consumer-group caveat
Because each tenant is a **separate cluster** with its own offsets, tenant listeners keep the **same** consumer `GroupId` — it is deliberately **not** suffixed per tenant (that would be wrong here, unlike NATS subject prefixing). Per-tenant retry topics / replay remain bound to the default cluster and are documented as out of scope.

## Tests
- **6 CI-safe unit tests** (`KafkaPerTenantConfigurationTests`, no broker): tenant compile clones config + re-points bootstrap servers, group id is not suffixed, parent config (SASL/idempotence/DLQ) inherited, `Action`-configured tenant seeded-from-parent-and-overridable, topics tenant-aware by default, a TenantAware endpoint resolves a `TenantedSender`.
- **3 integration tests** (`KafkaPerTenantConnectionTests`, `[Trait("Category","Integration")]`, second cluster via `Testcontainers.Kafka`, skips if Docker/broker unavailable): a `DeliveryOptions{TenantId="tenantB"}` message lands on the tenant cluster and **not** the default; a default message lands on the shared cluster; a tenant message round-trips back stamped with its `TenantId`.
- Full Kafka test project green (213 passed, 0 failed; pre-existing `Flaky` excluded). `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors).

## Docs
New "Multi-Tenancy with a Broker per Tenant" section in `kafka.md` contrasting named-broker (static) vs tenant-routed (runtime `DeliveryOptions.TenantId`), with a compiling mdsnippets sample and the group-id / auto-provision caveats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
