### PR TITLE
feat(sns): named-broker and broker-per-tenant support (GH-3305)

### DIFF
--- a/docs/guide/messaging/transports/sns.md
+++ b/docs/guide/messaging/transports/sns.md
@@ -29,7 +29,7 @@ var host = await Host.CreateDefaultBuilder()
             .AutoProvision();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L25-L37' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_simplistic_aws_sns_setup' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L97-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_simplistic_aws_sns_setup' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -55,7 +55,7 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L42-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_config_aws_sns_connection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L114-L134' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_config_aws_sns_connection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -73,7 +73,7 @@ var host = await Host.CreateDefaultBuilder()
         opts.UseAmazonSnsTransportLocally();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L11-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_connect_to_sns_and_localstack' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L83-L92' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_connect_to_sns_and_localstack' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And lastly, if you want to explicitly supply an access and secret key for your credentials to SNS, you can use this syntax:
@@ -103,7 +103,7 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L67-L90' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_setting_aws_sns_credentials' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L139-L162' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_setting_aws_sns_credentials' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Publishing
@@ -131,8 +131,129 @@ var host = await Host.CreateDefaultBuilder()
             });
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L95-L113' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_subscriber_rules_for_sns' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L167-L185' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_subscriber_rules_for_sns' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Connecting to Multiple Brokers <Badge type="tip" text="6.17" />
+
+If you need to connect to more than one Amazon SNS broker (a different AWS account, region, or endpoint) from a single
+Wolverine application, register additional, *named* brokers alongside the default one and pin publishing rules to a
+specific broker by name:
+
+<!-- snippet: sample_using_multiple_sns_brokers -->
+<a id='snippet-sample_using_multiple_sns_brokers'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        // The "default" broker
+        opts.UseAmazonSnsTransport();
+
+        // Add a second, named Amazon SNS broker that connects to a
+        // different account or region
+        opts.AddNamedAmazonSnsBroker(new BrokerName("americas"), snsConfig =>
+        {
+            snsConfig.RegionEndpoint = RegionEndpoint.USEast1;
+        }).AutoProvision();
+
+        // Publish to a topic on the named broker. The Uri scheme for these
+        // endpoints is the broker name, so you'd see "americas://colors".
+        opts.PublishMessage<Message1>()
+            .ToSnsTopicOnNamedBroker(new BrokerName("americas"), "colors");
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L13-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multiple_sns_brokers' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Note that the `Uri` scheme within Wolverine for any endpoints from a "named" Amazon SNS broker is the name that you
+supply for the broker. So in the example above, you would see `Uri` values like `americas://colors`.
+
+::: tip
+Because SNS is publish-only, the receiving side of a named SNS broker is handled by an SQS queue subscribed to the
+topic. A named SNS broker and a same-named SQS broker cannot share a single `BrokerName` (Wolverine keys transports by
+their `Uri` scheme, and the SNS broker owns that name), so run the SQS listener that drains the subscribed queue on the
+*default* (or a differently-named) SQS broker. The SNS-side subscription provisioning uses its own paired SQS client
+that targets the same account/region as the named SNS broker.
+:::
+
+## Multi-Tenancy with a Broker per Tenant <Badge type="tip" text="6.17" />
+
+Wolverine can give each tenant its own dedicated Amazon SNS connection (a distinct AWS account/credentials, region, or
+`ServiceURL`) while sharing one declared topic topology. Which connection a message is published to is decided at
+runtime by the message's [tenant id](/guide/handlers/multi-tenancy), typically set through `DeliveryOptions.TenantId`:
+
+<!-- snippet: sample_sns_broker_per_tenant -->
+<a id='snippet-sample_sns_broker_per_tenant'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        // The "default" / shared SNS connection
+        opts.UseAmazonSnsTransport(config =>
+        {
+            config.RegionEndpoint = RegionEndpoint.USEast1;
+        })
+            .AutoProvision()
+
+            // How should Wolverine route a message whose TenantId is null or
+            // unknown? FallbackToDefault (the default) uses the shared connection;
+            // TenantIdRequired throws; IgnoreUnknownTenants silently drops it.
+            .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+
+            // Each tenant gets its OWN dedicated SNS connection, but shares the
+            // topic topology declared below. This tenant inherits the parent's
+            // AWS credentials, and just re-points at its own region.
+            .AddTenant("tenant-west", config =>
+            {
+                config.RegionEndpoint = RegionEndpoint.USWest2;
+            })
+
+            // Or give the tenant its own dedicated AWS account by supplying
+            // its own credentials (optionally with its own region/endpoint too):
+            .AddTenant("tenant-eu", new BasicAWSCredentials("tenant-eu-key", "tenant-eu-secret"),
+                config =>
+                {
+                    config.RegionEndpoint = RegionEndpoint.EUWest1;
+                });
+
+        // SNS is publish-only, so broker-per-tenant means tenant-specific PUBLISHERS.
+        // A message is published to the right tenant's connection at runtime by its
+        // Envelope.TenantId (e.g. new DeliveryOptions { TenantId = "tenant-west" }).
+        opts.PublishMessage<Message1>().ToSnsTopic("colors");
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L39-L78' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sns_broker_per_tenant' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+To route a specific message to a tenant's connection, stamp the tenant id on the send:
+
+```csharp
+await bus.SendAsync(new ColorMessage("blue"), new DeliveryOptions { TenantId = "tenant-west" });
+```
+
+::: warning SNS is publish-only
+SNS has no listening surface in Wolverine, so broker-per-tenant support here means **tenant-specific publishers only** —
+Wolverine wraps the outbound topic in a `TenantedSender` that dispatches on `Envelope.TenantId` to a per-tenant SNS
+client. There is no per-tenant listener.
+
+The *receiving* side is handled exactly as it is for a single-tenant SNS setup: by subscribing an SQS queue to the
+tenant's topic and listening on the SQS side. For full per-tenant **consumption**, pair this with
+[Amazon SQS broker-per-tenant](/guide/messaging/transports/sqs/) multi-tenancy so that each tenant's subscribed queue is
+consumed on that tenant's own SQS connection. Each SNS tenant already provisions its topic subscription and queue policy
+through its own paired SQS client, so the SNS and SQS tenant connections line up on the same account/region.
+:::
+
+`TenantIdBehavior(...)` controls what happens when a message has a null or unregistered tenant id:
+
+* `FallbackToDefault` (the default) — publish it to the shared/default connection (the one passed to `UseAmazonSnsTransport`).
+* `TenantIdRequired` — throw; every message must carry a known tenant id.
+* `IgnoreUnknownTenants` — silently drop the message.
+
+::: tip Named broker vs. broker-per-tenant
+Use a **named broker** when a *fixed set of endpoints* should always publish to a *specific* broker. Use
+**broker-per-tenant** when the *same logical topic* should be transparently routed to a *different connection per tenant*
+based on the runtime tenant id. They are independent features and can be combined.
+:::
 
 ## Topic Subscriptions
 
@@ -188,7 +309,7 @@ var host = await Host.CreateDefaultBuilder()
                 });
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L118-L165' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sns_topic_subscriptions_creation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs#L190-L237' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sns_topic_subscriptions_creation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Interoperability

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/AmazonSnsPerTenantConfigurationTests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/AmazonSnsPerTenantConfigurationTests.cs
@@ -1,0 +1,147 @@
+using Amazon;
+using Amazon.Runtime;
+using Shouldly;
+using Wolverine.AmazonSns.Internal;
+using Wolverine.Configuration;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace Wolverine.AmazonSns.Tests;
+
+// Broker-per-tenant (GH-3305) unit coverage that needs NO SNS broker/LocalStack: it exercises the tenant
+// registration / compile / sender-resolution wiring, not live publishing. Live tenant routing behavior is
+// covered by AmazonSnsPerTenantConnectionTests.
+public class AmazonSnsPerTenantConfigurationTests
+{
+    [Fact]
+    public void add_tenant_registers_a_tenant_with_its_own_region()
+    {
+        var options = new WolverineOptions();
+        var sns = options.UseAmazonSnsTransport(c => c.RegionEndpoint = RegionEndpoint.USEast1);
+        sns.AddTenant("tenantB", c => c.RegionEndpoint = RegionEndpoint.USWest2);
+
+        var transport = options.AmazonSnsTransport();
+        transport.Tenants.Count().ShouldBe(1);
+
+        var tenant = transport.Tenants["tenantB"];
+        tenant.Compile(transport, null!);
+
+        tenant.Transport.SnsConfig.RegionEndpoint.ShouldBe(RegionEndpoint.USWest2);
+    }
+
+    [Fact]
+    public void add_tenant_with_credentials_sets_a_dedicated_credential_source()
+    {
+        var options = new WolverineOptions();
+        var sns = options.UseAmazonSnsTransport(c => c.RegionEndpoint = RegionEndpoint.USEast1);
+
+        var credentials = new BasicAWSCredentials("tenant-key", "tenant-secret");
+        sns.AddTenant("tenantB", credentials, c => c.RegionEndpoint = RegionEndpoint.EUWest1);
+
+        var transport = options.AmazonSnsTransport();
+        var tenant = transport.Tenants["tenantB"];
+        tenant.Compile(transport, null!);
+
+        var credentialSource = tenant.Transport.CredentialSource;
+        credentialSource.ShouldNotBeNull();
+        credentialSource(null!).ShouldBeSameAs(credentials);
+        tenant.Transport.SnsConfig.RegionEndpoint.ShouldBe(RegionEndpoint.EUWest1);
+    }
+
+    [Fact]
+    public void tenant_inherits_parent_credentials_when_not_overridden()
+    {
+        var options = new WolverineOptions();
+        var parentCredentials = new BasicAWSCredentials("parent-key", "parent-secret");
+        var sns = options.UseAmazonSnsTransport(c => c.RegionEndpoint = RegionEndpoint.USEast1);
+        sns.Credentials(parentCredentials);
+        sns.AddTenant("tenantB", c => c.RegionEndpoint = RegionEndpoint.USWest2);
+
+        var transport = options.AmazonSnsTransport();
+        var tenant = transport.Tenants["tenantB"];
+        tenant.Compile(transport, null!);
+
+        // Inherited the parent credential source (dedicated-region tenant, shared account)...
+        tenant.Transport.CredentialSource.ShouldBeSameAs(transport.CredentialSource);
+        // ...but kept its own region.
+        tenant.Transport.SnsConfig.RegionEndpoint.ShouldBe(RegionEndpoint.USWest2);
+    }
+
+    [Fact]
+    public void tenant_inherits_parent_region_and_provisioning_when_it_sets_nothing()
+    {
+        var options = new WolverineOptions();
+        var sns = options.UseAmazonSnsTransport(c => c.RegionEndpoint = RegionEndpoint.USEast1);
+        sns.AutoProvision();
+        // Register a tenant that only supplies credentials, no region/endpoint of its own.
+        sns.AddTenant("tenantB", new BasicAWSCredentials("k", "s"));
+
+        var transport = options.AmazonSnsTransport();
+        var tenant = transport.Tenants["tenantB"];
+        tenant.Compile(transport, null!);
+
+        tenant.Transport.SnsConfig.RegionEndpoint.ShouldBe(RegionEndpoint.USEast1);
+        tenant.Transport.AutoProvision.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void paired_sqs_client_tracks_the_tenant_sns_account()
+    {
+        var options = new WolverineOptions();
+        var sns = options.UseAmazonSnsTransport(c => c.ServiceURL = "http://localhost:4566");
+        sns.AddTenant("tenantB", c => c.AuthenticationRegion = "us-west-2");
+
+        var transport = options.AmazonSnsTransport();
+        var tenant = transport.Tenants["tenantB"];
+        tenant.Compile(transport, null!);
+
+        // The paired SQS client used for subscription provisioning must sign for the same account/region as the
+        // tenant's SNS topic so cross-partition provisioning targets the tenant's own store.
+        tenant.Transport.SQS.Config.ServiceURL.ShouldBe(tenant.Transport.SnsConfig.ServiceURL);
+        tenant.Transport.SQS.Config.ServiceURL.ShouldStartWith("http://localhost:4566");
+        tenant.Transport.SQS.Config.AuthenticationRegion.ShouldBe("us-west-2");
+    }
+
+    [Fact]
+    public void sns_topics_are_tenant_aware_by_default()
+    {
+        var transport = new AmazonSnsTransport();
+        var topic = transport.Topics["orders"];
+        topic.TenancyBehavior.ShouldBe(TenancyBehavior.TenantAware);
+    }
+
+    [Fact]
+    public void build_tenant_sibling_copies_configuration_but_uses_the_tenant_transport()
+    {
+        var transport = new AmazonSnsTransport { SQS = new AmazonSqs.Internal.AmazonSqsTransport() };
+        var tenant = transport.Tenants["tenantB"];
+
+        var topic = transport.Topics["orders"];
+        topic.TopicSubscriptions.Add(new AmazonSnsSubscription("some-queue", AmazonSnsSubscriptionType.Sqs,
+            new AmazonSnsSubscriptionAttributes { RawMessageDelivery = true }));
+
+        var sibling = topic.BuildTenantSibling(tenant);
+
+        sibling.ShouldNotBeSameAs(topic);
+        sibling.TopicName.ShouldBe("orders");
+        // Subscriptions are deep-copied, not shared (SubscriptionArn is stamped per account).
+        sibling.TopicSubscriptions.ShouldNotBeSameAs(topic.TopicSubscriptions);
+        sibling.TopicSubscriptions.Single().Endpoint.ShouldBe("some-queue");
+        sibling.TopicSubscriptions.Single().Attributes.RawMessageDelivery.ShouldBeTrue();
+        // Resolved from the tenant transport's own (isolated) topic cache.
+        tenant.Transport.Topics["orders"].ShouldBeSameAs(sibling);
+    }
+
+    [Fact]
+    public void tenant_id_behavior_defaults_to_fallback_and_is_overridable()
+    {
+        var options = new WolverineOptions();
+        var sns = options.UseAmazonSnsTransport();
+
+        var transport = options.AmazonSnsTransport();
+        transport.TenantedIdBehavior.ShouldBe(TenantedIdBehavior.FallbackToDefault);
+
+        sns.TenantIdBehavior(TenantedIdBehavior.TenantIdRequired);
+        transport.TenantedIdBehavior.ShouldBe(TenantedIdBehavior.TenantIdRequired);
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/AmazonSnsPerTenantConnectionTests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/AmazonSnsPerTenantConnectionTests.cs
@@ -1,0 +1,238 @@
+using Amazon.Runtime;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.AmazonSns.Internal;
+using Wolverine.Tracking;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace Wolverine.AmazonSns.Tests;
+
+/// <summary>
+/// Integration coverage for broker-per-tenant Amazon SNS (GH-3305). SNS is publish-only, so this proves the
+/// tenant-specific PUBLISHER: a message stamped with a tenant id is published to the tenant's own SNS connection
+/// and NOT the shared/default one, and a default message goes to the shared connection.
+///
+/// LocalStack is a single container and does not enforce AWS account boundaries, so these tests cannot prove
+/// <em>separate accounts</em>. They instead simulate a tenant with its own dedicated connection by pointing the
+/// tenant at a different signing region (<c>AuthenticationRegion</c>) on the same LocalStack endpoint — LocalStack
+/// partitions SNS topics (and SQS queues) per region, so the tenant's "colors" topic is genuinely a different
+/// physical topic from the shared/default one. We observe delivery by raw-subscribing an SQS queue to the topic in
+/// each region and reading it directly.
+///
+/// Full per-tenant CONSUMPTION (tenant SNS topic -> tenant SQS queue -> Wolverine listener) composes with the
+/// Amazon SQS broker-per-tenant support (PR #3316) and is intentionally out of scope here.
+///
+/// Guarded to skip when LocalStack/Docker is unavailable.
+/// </summary>
+public class AmazonSnsPerTenantConnectionTests : IAsyncLifetime
+{
+    private const string ServiceUrl = "http://localhost:4566";
+    private const string SharedRegion = "us-east-1";
+    private const string TenantRegion = "us-west-2";
+
+    private bool _skip;
+
+    public async Task InitializeAsync()
+    {
+        _skip = !await SnsTestingExtensions.IsLocalStackAvailable();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // NOTE on the test design: these two routing tests each provision a subscription observation in only ONE region.
+    // We deliberately do NOT stand up same-named observation topics in BOTH regions at once and assert the negative
+    // ("and NOT the other region"): LocalStack's community SNS implementation delivers unreliably when a topic of the
+    // same name exists in two regions simultaneously (a single-region observation delivers deterministically; a
+    // dual-region one drops). SQS partitioning is solid, but the SNS->SQS fan-out across same-named cross-region
+    // topics is not. Instead, the pair below proves routing DIVERGES by tenant: the SAME shared topology publishes a
+    // tenant message to the TENANT region and a default message to the SHARED region, selected solely by
+    // Envelope.TenantId. The tenant-vs-default sender wiring itself is additionally asserted (without a broker) in
+    // tenant_aware_topic_resolves_a_TenantedSender and in AmazonSnsPerTenantConfigurationTests.
+
+    [Fact]
+    public async Task tenant_message_is_published_to_the_tenant_region()
+    {
+        if (_skip) return;
+
+        var topic = $"snspertenant-{Guid.NewGuid():N}";
+        var queue = $"snspertenant-{Guid.NewGuid():N}";
+
+        var tenantQueueUrl = await provisionObservationAsync(TenantRegion, topic, queue);
+
+        using var host = await buildSenderAsync(topic);
+
+        await host.MessageBus().SendAsync(new TenantColorMessage("for-tenant-b"),
+            new DeliveryOptions { TenantId = "tenantB" });
+
+        // The tenant's dedicated connection (tenant region) published to the tenant-region topic -> tenant queue.
+        (await consumeOne(TenantRegion, tenantQueueUrl, 20.Seconds())).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task default_message_is_published_to_the_shared_region()
+    {
+        if (_skip) return;
+
+        var topic = $"snspertenant-{Guid.NewGuid():N}";
+        var queue = $"snspertenant-{Guid.NewGuid():N}";
+
+        var sharedQueueUrl = await provisionObservationAsync(SharedRegion, topic, queue);
+
+        using var host = await buildSenderAsync(topic);
+
+        // No tenant id -> FallbackToDefault -> shared/default connection (shared region).
+        await host.MessageBus().SendAsync(new TenantColorMessage("no-tenant"));
+
+        (await consumeOne(SharedRegion, sharedQueueUrl, 20.Seconds())).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task tenant_aware_topic_resolves_a_TenantedSender()
+    {
+        if (_skip) return;
+
+        var topic = $"snspertenant-{Guid.NewGuid():N}";
+        await provisionObservationAsync(SharedRegion, topic, $"snspertenant-{Guid.NewGuid():N}");
+        await provisionObservationAsync(TenantRegion, topic, $"snspertenant-{Guid.NewGuid():N}");
+
+        using var host = await buildSenderAsync(topic);
+
+        var runtime = host.GetRuntime();
+        var transport = runtime.Options.Transports.GetOrCreate<AmazonSnsTransport>();
+        var endpoint = transport.Topics[topic];
+
+        // buildSenderAsync publishes inline, so the endpoint resolves an InlineSendingAgent around our sender.
+        var agent = (InlineSendingAgent)runtime.Endpoints.GetOrBuildSendingAgent(endpoint.Uri);
+        agent.Sender.ShouldBeOfType<TenantedSender>();
+
+        // Each tenant got its own compiled child transport with its own SNS + paired SQS clients.
+        transport.Tenants["tenantB"].Transport.SnsClient.ShouldNotBeNull();
+        transport.Tenants["tenantB"].Transport.SqsClient.ShouldNotBeNull();
+    }
+
+    private static void configureTransport(WolverineOptions opts)
+    {
+        opts.UseAmazonSnsTransport(c =>
+            {
+                c.ServiceURL = ServiceUrl;
+                c.AuthenticationRegion = SharedRegion;
+            })
+            .Credentials(new BasicAWSCredentials("ignore", "ignore"))
+            .AutoProvision()
+            .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+            // The tenant shares the LocalStack endpoint but signs for a different region, which LocalStack
+            // partitions into its own physical topic store — standing in for a dedicated tenant connection.
+            .AddTenant("tenantB", c =>
+            {
+                c.ServiceURL = ServiceUrl;
+                c.AuthenticationRegion = TenantRegion;
+            });
+    }
+
+    private static Task<IHost> buildSenderAsync(string topic)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "SnsPerTenantSender";
+                configureTransport(opts);
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.PublishMessage<TenantColorMessage>().ToSnsTopic(topic).SendInline();
+            })
+            .StartAsync();
+    }
+
+    private static AmazonSimpleNotificationServiceClient rawSns(string region)
+    {
+        return new AmazonSimpleNotificationServiceClient(new BasicAWSCredentials("ignore", "ignore"),
+            new AmazonSimpleNotificationServiceConfig { ServiceURL = ServiceUrl, AuthenticationRegion = region });
+    }
+
+    private static AmazonSQSClient rawSqs(string region)
+    {
+        return new AmazonSQSClient(new BasicAWSCredentials("ignore", "ignore"),
+            new AmazonSQSConfig { ServiceURL = ServiceUrl, AuthenticationRegion = region });
+    }
+
+    // Create the topic + an SQS queue subscribed to it (raw message delivery) in the given region, and return the
+    // queue url so the test can read what actually got published to the region's topic.
+    private static async Task<string> provisionObservationAsync(string region, string topicName, string queueName)
+    {
+        using var sns = rawSns(region);
+        using var sqs = rawSqs(region);
+
+        var topicArn = (await sns.CreateTopicAsync(topicName)).TopicArn;
+        var queueUrl = (await sqs.CreateQueueAsync(queueName)).QueueUrl;
+
+        var queueArn = (await sqs.GetQueueAttributesAsync(new GetQueueAttributesRequest
+        {
+            QueueUrl = queueUrl,
+            AttributeNames = [QueueAttributeName.QueueArn]
+        })).QueueARN;
+
+        var policy = $$"""
+                       {
+                         "Version": "2012-10-17",
+                         "Statement": [{
+                             "Effect": "Allow",
+                             "Principal": { "Service": "sns.amazonaws.com" },
+                             "Action": "sqs:SendMessage",
+                             "Resource": "{{queueArn}}",
+                             "Condition": { "ArnEquals": { "aws:SourceArn": "{{topicArn}}" } }
+                         }]
+                       }
+                       """;
+
+        await sqs.SetQueueAttributesAsync(new SetQueueAttributesRequest
+        {
+            QueueUrl = queueUrl,
+            Attributes = new Dictionary<string, string> { { "Policy", policy } }
+        });
+
+        var subscribe = new SubscribeRequest(topicArn, "sqs", queueArn);
+        subscribe.Attributes = new Dictionary<string, string> { { "RawMessageDelivery", "true" } };
+        await sns.SubscribeAsync(subscribe);
+
+        return queueUrl;
+    }
+
+    private static async Task<Message?> consumeOne(string region, string queueUrl, TimeSpan timeout)
+    {
+        using var client = rawSqs(region);
+
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        do
+        {
+            var response = await client.ReceiveMessageAsync(new ReceiveMessageRequest
+            {
+                QueueUrl = queueUrl,
+                MaxNumberOfMessages = 1,
+                WaitTimeSeconds = 1
+            });
+
+            if (response.Messages is { Count: > 0 })
+            {
+                return response.Messages[0];
+            }
+        } while (DateTimeOffset.UtcNow < deadline);
+
+        return null;
+    }
+}
+
+public record TenantColorMessage(string Color);
+
+public static class TenantColorMessageHandler
+{
+    public static void Handle(TenantColorMessage message)
+    {
+        // no-op; presence lets Wolverine discover a handler
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/Samples/Bootstrapping.cs
@@ -1,11 +1,83 @@
-﻿using Amazon.Runtime;
+﻿using Amazon;
+using Amazon.Runtime;
 using Microsoft.Extensions.Hosting;
 using Wolverine.ComplianceTests.Compliance;
+using Wolverine.Transports.Sending;
 
 namespace Wolverine.AmazonSns.Tests.Samples;
 
 public class Bootstrapping
 {
+    public async Task use_named_brokers()
+    {
+        #region sample_using_multiple_sns_brokers
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // The "default" broker
+                opts.UseAmazonSnsTransport();
+
+                // Add a second, named Amazon SNS broker that connects to a
+                // different account or region
+                opts.AddNamedAmazonSnsBroker(new BrokerName("americas"), snsConfig =>
+                {
+                    snsConfig.RegionEndpoint = RegionEndpoint.USEast1;
+                }).AutoProvision();
+
+                // Publish to a topic on the named broker. The Uri scheme for these
+                // endpoints is the broker name, so you'd see "americas://colors".
+                opts.PublishMessage<Message1>()
+                    .ToSnsTopicOnNamedBroker(new BrokerName("americas"), "colors");
+            }).StartAsync();
+
+        #endregion
+    }
+
+    public async Task broker_per_tenant()
+    {
+        #region sample_sns_broker_per_tenant
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // The "default" / shared SNS connection
+                opts.UseAmazonSnsTransport(config =>
+                {
+                    config.RegionEndpoint = RegionEndpoint.USEast1;
+                })
+                    .AutoProvision()
+
+                    // How should Wolverine route a message whose TenantId is null or
+                    // unknown? FallbackToDefault (the default) uses the shared connection;
+                    // TenantIdRequired throws; IgnoreUnknownTenants silently drops it.
+                    .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+
+                    // Each tenant gets its OWN dedicated SNS connection, but shares the
+                    // topic topology declared below. This tenant inherits the parent's
+                    // AWS credentials, and just re-points at its own region.
+                    .AddTenant("tenant-west", config =>
+                    {
+                        config.RegionEndpoint = RegionEndpoint.USWest2;
+                    })
+
+                    // Or give the tenant its own dedicated AWS account by supplying
+                    // its own credentials (optionally with its own region/endpoint too):
+                    .AddTenant("tenant-eu", new BasicAWSCredentials("tenant-eu-key", "tenant-eu-secret"),
+                        config =>
+                        {
+                            config.RegionEndpoint = RegionEndpoint.EUWest1;
+                        });
+
+                // SNS is publish-only, so broker-per-tenant means tenant-specific PUBLISHERS.
+                // A message is published to the right tenant's connection at runtime by its
+                // Envelope.TenantId (e.g. new DeliveryOptions { TenantId = "tenant-west" }).
+                opts.PublishMessage<Message1>().ToSnsTopic("colors");
+            }).StartAsync();
+
+        #endregion
+    }
+
     public async Task for_local_development()
     {
         #region sample_connect_to_sns_and_localstack

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/end_to_end_with_named_broker.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/end_to_end_with_named_broker.cs
@@ -1,0 +1,120 @@
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine.AmazonSns.Internal;
+using Wolverine.AmazonSqs;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.AmazonSns.Tests;
+
+// Named-broker (GH-3305) end-to-end coverage. The SNS side is publish-only: we publish to an SNS topic ON A NAMED
+// broker, whose standalone paired SQS client provisions the SNS->SQS subscription, and a Wolverine SQS listener on
+// the default broker consumes it. Proves the named SNS topic carries the broker name as its URI scheme (not the
+// hard-coded "sns"), and that publish -> subscribed SQS queue -> handler works on the named broker.
+//
+// NOTE: the receiving SQS listener runs on the DEFAULT SQS broker, not a same-named SQS broker. A named SNS broker
+// and a same-named SQS broker cannot coexist because the TransportCollection keys transports by Protocol (== the
+// broker name); the named SNS holds that key. The SNS-side subscription provisioning uses a standalone paired SQS
+// client seeded from the SNS connection, so it still targets the same LocalStack account.
+//
+// Guarded to skip when LocalStack/Docker is unavailable.
+public class end_to_end_with_named_broker : IAsyncLifetime
+{
+    private readonly BrokerName theName = new("other");
+    private bool _skip;
+
+    public async Task InitializeAsync()
+    {
+        _skip = !await SnsTestingExtensions.IsLocalStackAvailable();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void named_broker_topic_uri_uses_the_broker_name_as_scheme()
+    {
+        // Pure wiring assertion (no broker needed): the topic URI scheme must be the broker Protocol (== name),
+        // NOT the hard-coded "sns" literal, or findEndpointByUri would mismatch on a named broker.
+        var options = new WolverineOptions();
+        options.AddNamedAmazonSnsBroker(theName);
+
+        var transport = options.AmazonSnsTransport(theName);
+        transport.Protocol.ShouldBe("other");
+
+        var topic = transport.Topics["colors"];
+        topic.Uri.Scheme.ShouldBe("other");
+        topic.Uri.ShouldBe(new Uri("other://colors"));
+    }
+
+    [Fact]
+    public async Task publish_to_named_sns_topic_and_receive_via_named_sqs_subscription()
+    {
+        if (_skip) return;
+
+        var topic = $"named-{Guid.NewGuid():N}";
+        var queue = $"named-{Guid.NewGuid():N}";
+
+        NamedBrokerHandler.Received = new();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Receiving side runs on the DEFAULT SQS broker (see the class note on the protocol-key constraint).
+                opts.UseAmazonSqsTransportLocally()
+                    .AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToSqsQueue(queue).ReceiveSnsTopicMessage();
+
+                // Publishing side runs on the NAMED SNS broker.
+                opts.UseAmazonSnsTransportLocallyAsNamedBroker(theName)
+                    .AutoProvision();
+
+                opts.PublishMessage<NamedBrokerMessage>()
+                    .ToSnsTopicOnNamedBroker(theName, topic)
+                    .SubscribeSqsQueue(queue);
+            }).StartAsync();
+
+        await host.MessageBus().PublishAsync(new NamedBrokerMessage("blue"));
+
+        var received = await NamedBrokerHandler.Received.Task.TimeoutAfterAsync(30000);
+        received.Color.ShouldBe("blue");
+    }
+}
+
+public record NamedBrokerMessage(string Color);
+
+public static class NamedBrokerHandler
+{
+    public static TaskCompletionSource<NamedBrokerMessage> Received { get; set; } = new();
+
+    public static void Handle(NamedBrokerMessage message)
+    {
+        Received.TrySetResult(message);
+    }
+}
+
+internal static class SnsTestingExtensions
+{
+    private const string ServiceUrl = "http://localhost:4566";
+
+    public static async Task<bool> IsLocalStackAvailable()
+    {
+        try
+        {
+            using var client = new AmazonSQSClient(new Amazon.Runtime.BasicAWSCredentials("ignore", "ignore"),
+                new AmazonSQSConfig { ServiceURL = ServiceUrl, AuthenticationRegion = "us-east-1" });
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await client.ListQueuesAsync(new ListQueuesRequest(), cts.Token);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSns/AmazonSnsTransportExtensions.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/AmazonSnsTransportExtensions.cs
@@ -15,12 +15,30 @@ public static class AmazonSnsTransportExtensions
     /// </summary>
     /// <param name="endpoints"></param>
     /// <returns></returns>
-    internal static AmazonSnsTransport AmazonSnsTransport(this WolverineOptions endpoints)
+    internal static AmazonSnsTransport AmazonSnsTransport(this WolverineOptions endpoints, BrokerName? name = null)
     {
         var transports = endpoints.As<WolverineOptions>().Transports;
 
-        var transport = transports.GetOrCreate<AmazonSnsTransport>();
-        transport.SQS ??= transports.GetOrCreate<AmazonSqsTransport>();
+        var transport = transports.GetOrCreate<AmazonSnsTransport>(name);
+
+        if (name == null)
+        {
+            // Default broker: pair the SNS-side SQS client + subscription-queue provisioning with the shared
+            // default SQS transport so both target the same account/region and share the user's SQS config.
+            transport.SQS ??= transports.GetOrCreate<AmazonSqsTransport>();
+        }
+        else if (transport.SQS == null)
+        {
+            // Named broker (GH-3305): the SNS transport holds this broker's Protocol key (== the name), so its
+            // topic URIs are "{name}://topic". A paired SQS transport registered under the SAME key would evict the
+            // SNS from the TransportCollection (which keys transports by Protocol). Since the paired SQS is only used
+            // internally for the SNS-side client + SNS->SQS subscription provisioning (never as a registered
+            // listener/sender surface), give it a standalone, unregistered transport that ConnectAsync seeds from the
+            // SNS connection so it targets the same account/region. A user who also wants to LISTEN on the
+            // subscribed queue does so through a separate (default or differently-named) SQS broker.
+            transport.SQS = new AmazonSqsTransport();
+            transport.PairedSqsIsStandalone = true;
+        }
 
         return transport;
     }
@@ -75,6 +93,50 @@ public static class AmazonSnsTransportExtensions
     }
 
     /// <summary>
+    /// Add an additional, named broker connection to Amazon SNS
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    public static AmazonSnsTransportConfiguration AddNamedAmazonSnsBroker(this WolverineOptions options, BrokerName name)
+    {
+        var transport = options.AmazonSnsTransport(name);
+        return new AmazonSnsTransportConfiguration(transport, options);
+    }
+
+    /// <summary>
+    /// Add an additional, named broker connection to Amazon SNS
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="name"></param>
+    /// <param name="configuration"></param>
+    /// <returns></returns>
+    public static AmazonSnsTransportConfiguration AddNamedAmazonSnsBroker(this WolverineOptions options, BrokerName name,
+        Action<AmazonSimpleNotificationServiceConfig> configuration)
+    {
+        var transport = options.AmazonSnsTransport(name);
+        configuration(transport.SnsConfig);
+        return new AmazonSnsTransportConfiguration(transport, options);
+    }
+
+    /// <summary>
+    ///     Sets up a connection to a locally running Amazon SNS LocalStack broker as a named broker
+    ///     for development or testing purposes
+    /// </summary>
+    /// <param name="name">The name of the additional broker</param>
+    /// <param name="port">Port for SNS. Default is 4566</param>
+    /// <returns></returns>
+    public static AmazonSnsTransportConfiguration UseAmazonSnsTransportLocallyAsNamedBroker(this WolverineOptions options,
+        BrokerName name, int port = 4566)
+    {
+        var transport = options.AmazonSnsTransport(name);
+
+        transport.ConnectToLocalStack(port);
+
+        return new AmazonSnsTransportConfiguration(transport, options);
+    }
+
+    /// <summary>
     ///     Publish matching messages to AWS SNS using the topic name
     /// </summary>
     /// <param name="publishing"></param>
@@ -84,6 +146,29 @@ public static class AmazonSnsTransportExtensions
     {
         var transports = publishing.As<PublishingExpression>().Parent.Transports;
         var transport = transports.GetOrCreate<AmazonSnsTransport>();
+
+        var corrected = transport.MaybeCorrectName(topicName);
+
+        var endpoint = transport.EndpointForTopic(corrected);
+        endpoint.EndpointName = topicName;
+
+        // This is necessary unfortunately to hook up the subscription rules
+        publishing.To(endpoint.Uri);
+
+        return new AmazonSnsSubscriberConfiguration(endpoint);
+    }
+
+    /// <summary>
+    ///     Publish matching messages to AWS SNS using the topic name on a specific, named broker
+    /// </summary>
+    /// <param name="publishing"></param>
+    /// <param name="name">The name of the additional Amazon SNS broker</param>
+    /// <param name="topicName">The name of the AWS SNS topic</param>
+    /// <returns></returns>
+    public static AmazonSnsSubscriberConfiguration ToSnsTopicOnNamedBroker(this IPublishToExpression publishing,
+        BrokerName name, string topicName)
+    {
+        var transport = publishing.As<PublishingExpression>().Parent.AmazonSnsTransport(name);
 
         var corrected = transport.MaybeCorrectName(topicName);
 

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTenant.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTenant.cs
@@ -1,0 +1,103 @@
+using Amazon.SimpleNotificationService;
+using JasperFx.Core;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Runtime;
+
+namespace Wolverine.AmazonSns.Internal;
+
+/// <summary>
+/// Represents a single Wolverine tenant that is served by its own dedicated Amazon SNS connection (distinct AWS
+/// account/credentials, region, or ServiceURL) while sharing the topic topology declared on the parent transport.
+/// Because SNS is publish-only, a tenant needs only a tenant-specific publisher — no listener. Each tenant owns a
+/// child <see cref="AmazonSnsTransport"/> whose SNS config is seeded from the parent and then re-pointed at the
+/// tenant's own account/region, giving the tenant its own SNS client <em>and</em> its own topic (and TopicArn)
+/// cache. It also carries a paired SQS client whose connection tracks the tenant's SNS account so that per-tenant
+/// SQS subscription/queue-policy provisioning targets the same partition. Outbound routing is by
+/// <see cref="Envelope.TenantId"/> via the framework's <see cref="Wolverine.Transports.Sending.TenantedSender"/>.
+/// Mirrors the Amazon SQS tenant model (GH-3304).
+/// </summary>
+internal class AmazonSnsTenant
+{
+    public AmazonSnsTenant(string tenantId)
+    {
+        TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));
+        Transport = new AmazonSnsTransport
+        {
+            // The child transport needs its own paired SQS transport for subscription provisioning.
+            SQS = new AmazonSqsTransport()
+        };
+    }
+
+    public string TenantId { get; }
+
+    /// <summary>
+    /// The child transport that provides this tenant's dedicated SNS client (and paired SQS client) plus its own
+    /// topic/TopicArn cache. Its connection config is seeded from the parent's and re-pointed at the tenant's own
+    /// account/region during <see cref="Compile"/>.
+    /// </summary>
+    public AmazonSnsTransport Transport { get; }
+
+    /// <summary>
+    /// Optional configuration hook applied to the tenant's own <see cref="AmazonSimpleNotificationServiceConfig"/>
+    /// during <see cref="Compile"/>, <em>after</em> the parent's connection settings have been seeded onto it — so
+    /// the tenant only overrides the axes it actually sets (typically region / ServiceURL / AuthenticationRegion).
+    /// Runs at compile time rather than registration time because the parent connection is not fully configured
+    /// until bootstrap completes. Null when the tenant is configured purely by supplying its own credentials.
+    /// </summary>
+    public Action<AmazonSimpleNotificationServiceConfig>? Configure { get; set; }
+
+    /// <summary>
+    /// Seed the tenant's child transport from the parent (credentials + connection endpoint + provisioning + queue
+    /// policy), apply the tenant's own <see cref="Configure"/> overrides, align the paired SQS client to the tenant's
+    /// final SNS account/region, then build the tenant's SNS and SQS clients. Called from
+    /// <see cref="AmazonSnsTransport.ConnectAsync"/> once the parent connection has been fully resolved. The
+    /// seed-then-override order (mirroring the SQS tenant model) is what lets a tenant re-point a single axis — e.g.
+    /// just its region — while inheriting everything else from the parent. Note that
+    /// <see cref="AmazonSimpleNotificationServiceConfig.RegionEndpoint"/> lazily resolves to an ambient default, so
+    /// inheritance cannot rely on a null check for that axis.
+    /// </summary>
+    public AmazonSnsTransport Compile(AmazonSnsTransport parent, IWolverineRuntime runtime)
+    {
+        // Inherit the parent credential source unless the tenant supplied its own (dedicated-account case).
+        Transport.CredentialSource ??= parent.CredentialSource;
+
+        // Seed the parent's SNS connection endpoint. ServiceURL and RegionEndpoint are mutually exclusive on the
+        // config (setting one clears the other), so copy whichever the parent is actually using; AuthenticationRegion
+        // is independent (it lets a shared endpoint like LocalStack sign for a distinct region).
+        if (parent.SnsConfig.ServiceURL.IsNotEmpty())
+        {
+            Transport.SnsConfig.ServiceURL = parent.SnsConfig.ServiceURL;
+        }
+        else if (parent.SnsConfig.RegionEndpoint != null)
+        {
+            Transport.SnsConfig.RegionEndpoint = parent.SnsConfig.RegionEndpoint;
+        }
+
+        Transport.SnsConfig.AuthenticationRegion = parent.SnsConfig.AuthenticationRegion;
+
+        // The tenant's own overrides win over the seeded parent settings.
+        Configure?.Invoke(Transport.SnsConfig);
+
+        // Align the paired SQS client with the tenant's FINAL SNS connection so subscription + queue-policy
+        // provisioning targets the same account/region/partition as the tenant's topic.
+        if (Transport.SnsConfig.ServiceURL.IsNotEmpty())
+        {
+            Transport.SQS.Config.ServiceURL = Transport.SnsConfig.ServiceURL;
+        }
+        else if (Transport.SnsConfig.RegionEndpoint != null)
+        {
+            Transport.SQS.Config.RegionEndpoint = Transport.SnsConfig.RegionEndpoint;
+        }
+
+        Transport.SQS.Config.AuthenticationRegion = Transport.SnsConfig.AuthenticationRegion;
+
+        // Provisioning + queue policy must match the parent so tenant topics/subscriptions are created the same way.
+        Transport.AutoProvision = parent.AutoProvision;
+        Transport.QueuePolicyBuilder = parent.QueuePolicyBuilder;
+
+        Transport.SnsClient ??= Transport.BuildSnsClient(runtime);
+        Transport.SqsClient ??= Transport.BuildSqsClient(runtime);
+
+        return Transport;
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTopic.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTopic.cs
@@ -17,8 +17,8 @@ public class AmazonSnsTopic : Endpoint, IBrokerQueue
 {
     private bool _initialized;
 
-    internal AmazonSnsTopic(string topicName, AmazonSnsTransport parent) 
-        : base(new Uri($"{AmazonSnsTransport.SnsProtocol}://{topicName}"), EndpointRole.Application)
+    internal AmazonSnsTopic(string topicName, AmazonSnsTransport parent)
+        : base(new Uri($"{parent.Protocol}://{topicName}"), EndpointRole.Application)
     {
         Parent = parent;
 
@@ -159,16 +159,76 @@ public class AmazonSnsTopic : Endpoint, IBrokerQueue
     protected override ISender CreateSender(IWolverineRuntime runtime)
     {
         Mapper ??= BuildMapper(runtime);
-        
+
+        // Broker-per-tenant (GH-3305): route by Envelope.TenantId to a per-tenant publisher bound to that tenant's
+        // own SNS account, falling back to the shared account for the default/untenanted path. SNS is publish-only,
+        // so there is no CompoundListener — only a TenantedSender.
+        //
+        // Both the tenant senders AND the default sender they fall back to must be fire-and-forget ISenders:
+        // TenantedSender intentionally does NOT implement ISenderRequiresCallback (GH-2361) and does not forward
+        // RegisterCallback to the senders beneath it. A BatchedSender (SnsSenderProtocol) registered under it would
+        // therefore never receive its ISenderCallback and would silently drop every message. InlineSnsSender sends
+        // directly and needs no callback — the same fire-and-forget model the SQS / RabbitMQ / NATS per-tenant
+        // senders use.
+        if (Parent.Tenants.Any() && TenancyBehavior == TenancyBehavior.TenantAware)
+        {
+            var tenantedSender = new TenantedSender(Uri, Parent.TenantedIdBehavior, new InlineSnsSender(runtime, this));
+            foreach (var tenant in Parent.Tenants)
+            {
+                var tenantTopic = BuildTenantSibling(tenant);
+                tenantedSender.RegisterSender(tenant.TenantId, new InlineSnsSender(runtime, tenantTopic));
+            }
+
+            return tenantedSender;
+        }
+
         if (Mode == EndpointMode.Inline)
         {
             return new InlineSnsSender(runtime, this);
         }
-        
+
         var protocol = new SnsSenderProtocol(runtime, this,
             Parent.SnsClient ?? throw new InvalidOperationException("Parent transport has not been initialized"));
         return new BatchedSender(this, protocol, runtime.Cancellation,
             runtime.LoggerFactory.CreateLogger<SnsSenderProtocol>());
+    }
+
+    /// <summary>
+    /// Broker-per-tenant (GH-3305): materialize this topic's tenant-specific twin on the given tenant's child
+    /// transport — same topic name and configuration, but bound to the tenant's own SNS client and its own TopicArn
+    /// cache (which is why a fresh endpoint is required rather than reusing this one, and why the subscriptions are
+    /// deep-copied — SubscriptionArn is stamped per account). The tenant twin is cached on the tenant transport's
+    /// <see cref="AmazonSnsTransport.Topics"/> so repeated sender builds resolve the same instance.
+    /// </summary>
+    internal AmazonSnsTopic BuildTenantSibling(AmazonSnsTenant tenant)
+    {
+        var sibling = tenant.Transport.Topics[TopicName];
+
+        sibling.Mode = Mode;
+        sibling.EndpointName = EndpointName;
+        sibling.Role = Role;
+
+        // Share the interop mapper strategy so tenant traffic serializes identically to the shared account.
+        sibling.Mapper = Mapper;
+        sibling.MapperFactory = MapperFactory;
+
+        // Preserve topic-creation attributes (FIFO, etc.) for AutoProvision on the tenant account.
+        sibling.Configuration.Attributes = Configuration.Attributes is { Count: > 0 }
+            ? new Dictionary<string, string>(Configuration.Attributes)
+            : sibling.Configuration.Attributes;
+
+        // Deep-copy subscriptions so each tenant provisions its own SQS subscription (and stamps its own
+        // SubscriptionArn) against its own paired SQS client, rather than sharing the parent's list/ARNs.
+        sibling.TopicSubscriptions = TopicSubscriptions
+            .Select(x => new AmazonSnsSubscription(x.Endpoint, x.Type, new AmazonSnsSubscriptionAttributes
+            {
+                RawMessageDelivery = x.Attributes.RawMessageDelivery,
+                FilterPolicy = x.Attributes.FilterPolicy,
+                RedrivePolicy = x.Attributes.RedrivePolicy
+            }))
+            .ToList();
+
+        return sibling;
     }
 
     public override  async ValueTask InitializeAsync(ILogger logger)

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTransport.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTransport.cs
@@ -9,19 +9,23 @@ using Wolverine.Transports;
 
 namespace Wolverine.AmazonSns.Internal;
 
-public class AmazonSnsTransport : BrokerTransport<AmazonSnsTopic>
+public class AmazonSnsTransport : BrokerTransport<AmazonSnsTopic>, IAsyncDisposable
 {
     public const string SnsProtocol = "sns";
-    
+
     public const char Separator = '-';
-    
-    public AmazonSnsTransport() : base(SnsProtocol, "Amazon SNS", ["aws", "sns"])
+
+    public AmazonSnsTransport(string protocol) : base(protocol, "Amazon SNS", ["aws", "sns"])
     {
         Topics = new LightweightCache<string, AmazonSnsTopic>(name => new AmazonSnsTopic(name, this));
-        
+
         IdentifierDelimiter = "-";
     }
-    
+
+    public AmazonSnsTransport() : this(SnsProtocol)
+    {
+    }
+
     internal AmazonSnsTransport(IAmazonSimpleNotificationService snsClient, IAmazonSQS sqsClient) : this()
     {
         SnsClient = snsClient;
@@ -63,10 +67,20 @@ public class AmazonSnsTransport : BrokerTransport<AmazonSnsTopic>
     [IgnoreDescription]
     public LightweightCache<string, AmazonSnsTopic> Topics { get; }
 
+    /// <summary>
+    /// Broker-per-tenant registrations (GH-3305). Each tenant owns a child transport pointed at its own SNS
+    /// account/region/endpoint (and its own paired SQS client for subscription provisioning); outbound is routed by
+    /// <see cref="Envelope.TenantId"/> through a <see cref="Wolverine.Transports.Sending.TenantedSender"/>. SNS is
+    /// publish-only, so there is no per-tenant listener — inbound tenant traffic is consumed by the paired per-tenant
+    /// SQS subscriptions (see the Amazon SQS broker-per-tenant support).
+    /// </summary>
+    [IgnoreDescription]
+    internal LightweightCache<string, AmazonSnsTenant> Tenants { get; } = new(name => new AmazonSnsTenant(name));
+
     [ChildDescription]
     public AmazonSimpleNotificationServiceConfig SnsConfig { get; } = new();
-    internal IAmazonSimpleNotificationService? SnsClient { get; private set; }
-    internal IAmazonSQS? SqsClient { get; private set; }
+    internal IAmazonSimpleNotificationService? SnsClient { get; set; }
+    internal IAmazonSQS? SqsClient { get; set; }
 
     public override string? DescribeEndpoint()
     {
@@ -90,6 +104,14 @@ public class AmazonSnsTransport : BrokerTransport<AmazonSnsTopic>
 
     public bool UseLocalStackInDevelopment { get; set; }
     internal AmazonSqsTransport SQS { get; set; } = null!;
+
+    /// <summary>
+    /// True when <see cref="SQS"/> is a standalone helper transport (named-broker case, GH-3305) rather than a
+    /// transport registered in the <see cref="TransportCollection"/>. When true, its connection config is seeded
+    /// from this transport's own SNS connection in <see cref="ConnectAsync"/> so the subscription-provisioning
+    /// client targets the same account/region as the named SNS broker.
+    /// </summary>
+    internal bool PairedSqsIsStandalone { get; set; }
 
     // TODO duplicated code in SqsTransport
     public static string SanitizeSnsName(string identifier)
@@ -133,8 +155,34 @@ public class AmazonSnsTransport : BrokerTransport<AmazonSnsTopic>
 
     public override ValueTask ConnectAsync(IWolverineRuntime runtime)
     {
-        SnsClient ??= buildSnsClient(runtime);
-        SqsClient ??= buildSqsClient(runtime);
+        // Named broker (GH-3305): the standalone paired SQS transport is not user-configured, so align its
+        // connection with this SNS broker's own so subscription provisioning targets the same account/region.
+        if (PairedSqsIsStandalone)
+        {
+            if (SnsConfig.ServiceURL.IsNotEmpty())
+            {
+                SQS.Config.ServiceURL = SnsConfig.ServiceURL;
+            }
+            else if (SnsConfig.RegionEndpoint != null)
+            {
+                SQS.Config.RegionEndpoint = SnsConfig.RegionEndpoint;
+            }
+
+            SQS.Config.AuthenticationRegion = SnsConfig.AuthenticationRegion;
+        }
+
+        SnsClient ??= BuildSnsClient(runtime);
+        SqsClient ??= BuildSqsClient(runtime);
+
+        // Broker-per-tenant (GH-3305): now that the parent connection is fully resolved, seed each tenant's child
+        // transport from it and build the tenant's own SNS + paired SQS clients. There is no listener to start (SNS
+        // is publish-only); the tenant's topic + subscriptions are provisioned lazily on first publish through the
+        // tenant's own clients (AmazonSnsTopic.InitializeAsync).
+        foreach (var tenant in Tenants)
+        {
+            tenant.Compile(this, runtime);
+        }
+
         return ValueTask.CompletedTask;
     }
 
@@ -155,7 +203,7 @@ public class AmazonSnsTransport : BrokerTransport<AmazonSnsTopic>
         SQS.Config.ServiceURL = $"http://localhost:{port}";
     }
     
-    private IAmazonSimpleNotificationService buildSnsClient(IWolverineRuntime runtime)
+    internal IAmazonSimpleNotificationService BuildSnsClient(IWolverineRuntime runtime)
     {
         if (CredentialSource == null)
         {
@@ -165,8 +213,8 @@ public class AmazonSnsTransport : BrokerTransport<AmazonSnsTopic>
         var credentials = CredentialSource(runtime);
         return new AmazonSimpleNotificationServiceClient(credentials, SnsConfig);
     }
-    
-    private AmazonSQSClient buildSqsClient(IWolverineRuntime runtime)
+
+    internal AmazonSQSClient BuildSqsClient(IWolverineRuntime runtime)
     {
         if (CredentialSource == null)
         {
@@ -175,6 +223,18 @@ public class AmazonSnsTransport : BrokerTransport<AmazonSnsTopic>
 
         var credentials = CredentialSource(runtime);
         return new AmazonSQSClient(credentials, SQS.Config);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        SnsClient?.Dispose();
+        SqsClient?.Dispose();
+
+        // Broker-per-tenant (GH-3305): each tenant owns its own SNS + paired SQS clients through its child transport.
+        foreach (var tenant in Tenants)
+        {
+            await tenant.Transport.DisposeAsync();
+        }
     }
 
     /// <summary>

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTransportConfiguration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTransportConfiguration.cs
@@ -1,6 +1,9 @@
 using Amazon.Runtime;
+using Amazon.SimpleNotificationService;
+using JasperFx.Core;
 using Wolverine.Runtime;
 using Wolverine.Transports;
+using Wolverine.Transports.Sending;
 
 namespace Wolverine.AmazonSns.Internal;
 
@@ -68,6 +71,73 @@ public class AmazonSnsTransportConfiguration : BrokerExpression<AmazonSnsTranspo
     {
         Transport.LocalStackPort = port;
         Transport.UseLocalStackInDevelopment = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Override the sending behavior for unknown or missing tenant ids when using broker-per-tenant Amazon SNS
+    /// multi-tenancy (GH-3305). See <see cref="TenantedIdBehavior"/>. Default is
+    /// <see cref="Wolverine.Transports.Sending.TenantedIdBehavior.FallbackToDefault"/> unless changed.
+    /// </summary>
+    /// <param name="behavior"></param>
+    /// <returns></returns>
+    public AmazonSnsTransportConfiguration TenantIdBehavior(TenantedIdBehavior behavior)
+    {
+        Transport.TenantedIdBehavior = behavior;
+        return this;
+    }
+
+    /// <summary>
+    /// Register a tenant that is served by its own dedicated Amazon SNS connection (typically a distinct region or
+    /// <c>ServiceURL</c>) while sharing the topic topology declared on this transport. The tenant inherits the
+    /// parent's AWS credentials and provisioning behavior; use <paramref name="configure"/> to point the tenant at
+    /// its own region or endpoint. Outbound messages carrying a matching <see cref="Envelope.TenantId"/> are
+    /// published to this tenant's connection.
+    ///
+    /// SNS is publish-only, so this adds a tenant-specific <em>publisher</em>. Inbound tenant traffic is consumed by
+    /// the paired per-tenant Amazon SQS subscriptions — see the Amazon SQS broker-per-tenant support.
+    /// </summary>
+    /// <param name="tenantId"></param>
+    /// <param name="configure">Configuration applied to the tenant's own <see cref="AmazonSimpleNotificationServiceConfig"/>.</param>
+    /// <returns></returns>
+    public AmazonSnsTransportConfiguration AddTenant(string tenantId,
+        Action<AmazonSimpleNotificationServiceConfig> configure)
+    {
+        if (tenantId.IsEmpty()) throw new ArgumentOutOfRangeException(nameof(tenantId), "Empty or null tenantId");
+        ArgumentNullException.ThrowIfNull(configure);
+
+        // Deferred: applied in AmazonSnsTenant.Compile() after the parent connection is seeded onto the tenant, so
+        // the tenant only overrides the axes it sets and inherits the rest.
+        Transport.Tenants[tenantId].Configure = configure;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Register a tenant that is served by its own dedicated Amazon SNS account, identified by its own
+    /// <paramref name="credentials"/>, while sharing the topic topology declared on this transport. Use the optional
+    /// <paramref name="configure"/> to also point the tenant at its own region or <c>ServiceURL</c>; if omitted the
+    /// tenant inherits the parent's region/endpoint. Outbound messages carrying a matching
+    /// <see cref="Envelope.TenantId"/> are published to this tenant's account.
+    ///
+    /// SNS is publish-only, so this adds a tenant-specific <em>publisher</em>. Inbound tenant traffic is consumed by
+    /// the paired per-tenant Amazon SQS subscriptions — see the Amazon SQS broker-per-tenant support.
+    /// </summary>
+    /// <param name="tenantId"></param>
+    /// <param name="credentials">The AWS credentials for the tenant's dedicated account.</param>
+    /// <param name="configure">Optional configuration applied to the tenant's own <see cref="AmazonSimpleNotificationServiceConfig"/>.</param>
+    /// <returns></returns>
+    public AmazonSnsTransportConfiguration AddTenant(string tenantId, AWSCredentials credentials,
+        Action<AmazonSimpleNotificationServiceConfig>? configure = null)
+    {
+        if (tenantId.IsEmpty()) throw new ArgumentOutOfRangeException(nameof(tenantId), "Empty or null tenantId");
+        ArgumentNullException.ThrowIfNull(credentials);
+
+        var tenant = Transport.Tenants[tenantId];
+        tenant.Transport.CredentialSource = _ => credentials;
+        // Deferred: applied in AmazonSnsTenant.Compile() after the parent connection is seeded onto the tenant.
+        tenant.Configure = configure;
+
         return this;
     }
 }


### PR DESCRIPTION
Closes #3305

Brings the AWS SNS transport (`Wolverine.AmazonSns`) up to multi-broker parity with SQS/Kafka/RabbitMQ/Azure Service Bus. SNS previously had **neither** feature. This PR adds **both**.

## Named broker

- Add `public AmazonSnsTransport(string protocol)` ctor (required by `TransportCollection.GetOrCreate<T>(BrokerName)`); the parameterless ctor delegates to it.
- **Fix the topic URI scheme:** `AmazonSnsTopic` built its `Uri` from a hard-coded `"sns"` literal, so a named broker's topics carried scheme `sns` while `Protocol` was the name → `findEndpointByUri` mismatch. The scheme is now built from `parent.Protocol` (mirroring `AmazonSqsQueue`).
- New API: `AddNamedAmazonSnsBroker(BrokerName[, Action<AmazonSimpleNotificationServiceConfig>])`, `ToSnsTopicOnNamedBroker(BrokerName, string)`, `UseAmazonSnsTransportLocallyAsNamedBroker(BrokerName, int port = 4566)`.

### SNS↔SQS pairing caveat (design note)
`TransportCollection` keys transports by `Protocol`, so a named SNS broker and a **same-named** SQS broker cannot coexist under one `BrokerName` (they'd evict each other) — the named SNS owns that key. Since the SNS-side SQS is used only internally (the SNS client + SNS→SQS subscription/queue-policy provisioning), a **named** SNS broker pairs with a *standalone, unregistered* `AmazonSqsTransport` that `ConnectAsync` seeds from the SNS connection so it targets the same account/region. A user who also wants to **listen** on the subscribed queue does so through the default (or a differently-named) SQS broker. The default (unnamed) broker still pairs with the shared default SQS transport as before.

## Broker-per-tenant (publish side)

SNS is **publish-only** (`BuildListenerAsync` throws `NotSupportedException`; consumption happens by subscribing an SQS queue to the topic). So broker-per-tenant here needs only a `TenantedSender` — **never** a `CompoundListener`.

- New `AmazonSnsTenant`: a child `AmazonSnsTransport` with its own `SnsConfig` / `CredentialSource` / SNS client **and** its own paired SQS client for subscription provisioning. `Compile(parent, runtime)` seeds credentials + connection from the parent, applies the tenant's overrides, aligns the paired SQS client to the tenant's final SNS account/region, then builds both clients.
- `AmazonSnsTransport`: `Tenants` cache, per-tenant client build in `ConnectAsync`, and `IAsyncDisposable` to dispose tenant clients.
- `AmazonSnsTopic.CreateSender`: when tenants exist and the endpoint is tenant-aware, wrap the default in a `TenantedSender` and register a per-tenant `InlineSnsSender` bound (via `BuildTenantSibling`) to each tenant's SNS client. Both the tenant senders **and** the default fallback are fire-and-forget `InlineSnsSender` (never `BatchedSender`), per **GH-2361** — `TenantedSender` does not forward `RegisterCallback`, so a batched sender under it would silently drop every message.
- New config API: `AddTenant(string, Action<AmazonSimpleNotificationServiceConfig>)` + credentials overload, and `TenantIdBehavior(TenantedIdBehavior)`.

### Scope: full per-tenant consumption composes with SQS #3316
This PR implements SNS broker-per-tenant on the **send + subscription-provisioning** side. Full per-tenant **consumption** (tenant SNS topic → tenant SQS queue → Wolverine listener) requires SQS **tenant listeners**, which live in the separate SQS broker-per-tenant PR **#3316** (open, not in this base). Each SNS tenant already provisions its subscription/queue-policy through its own paired SQS client that lines up on the same account/region, so the two compose directly.

## Tests

Unit (no broker/Docker) — `AmazonSnsPerTenantConfigurationTests` (8) + the named-broker Uri-scheme assertion: tenant registration/compile/credential inheritance, paired-SQS alignment, tenant-aware default, `BuildTenantSibling` (deep-copies subscriptions), `TenantIdBehavior` default/override, and that a named broker's topic Uri scheme is the broker name.

Integration (LocalStack, skip-guarded) — `end_to_end_with_named_broker`: publish to a named SNS topic → subscribed SQS queue on the default broker → handler. `AmazonSnsPerTenantConnectionTests`: a tenant message publishes to the tenant region and a default message to the shared region (routing diverges by `Envelope.TenantId`), plus `TenantedSender` + per-tenant client resolution.

### LocalStack note
Like the SQS PR, tenant separation is simulated via signing region (`AuthenticationRegion`) on the single LocalStack endpoint, which partitions SNS/SQS per region — LocalStack cannot enforce separate *accounts*. The two routing tests each provision an observation in **only one** region and assert the positive: LocalStack community SNS delivers unreliably when a topic of the same name exists in **both** regions at once, so the pair (tenant→west, default→east) proves divergence without a flaky cross-region negative. The sender wiring is additionally proven broker-free in the unit tests.

## Verification
- `dotnet build wolverine.slnx -c Release` → **0 errors, 0 warnings**.
- New SNS tests: 13 passing (8 unit + 5 integration on LocalStack). Existing SNS suites (endpoint-uri, transport, send/receive, inline compliance) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)