### PR TITLE
feat(mqtt): named-broker and broker-per-tenant support (GH-3307)

### DIFF
--- a/docs/guide/messaging/transports/mqtt.md
+++ b/docs/guide/messaging/transports/mqtt.md
@@ -62,6 +62,40 @@ The MQTT transport does not really support the "Requeue" error handling policy i
 effectively an inline "Retry"
 :::
 
+## Connecting to Multiple MQTT Brokers
+
+If a single Wolverine application needs to talk to more than one MQTT broker, register the additional broker(s)
+with `AddNamedMqttBroker` using a `BrokerName`, then pin publishing or listening to a specific broker with the
+`*OnNamedBroker` overloads:
+
+```csharp
+opts.UseMqtt(mqtt => mqtt.WithClientOptions(client => client.WithTcpServer("primary-broker")));
+
+// An additional, independent MQTT broker identified by name
+opts.AddNamedMqttBroker(new BrokerName("secondary"),
+    mqtt => mqtt.WithClientOptions(client => client.WithTcpServer("secondary-broker")));
+
+// Publish a message type to a topic on a named broker
+opts.PublishMessage<OrderPlaced>()
+    .ToMqttTopicOnNamedBroker(new BrokerName("secondary"), "orders");
+
+// Listen to a topic on a named broker
+opts.ListenToMqttTopicOnNamedBroker(new BrokerName("secondary"), "orders");
+```
+
+::: info
+The Wolverine `Uri` scheme for any endpoint on a named broker is the broker name itself, so in the example above
+you would see endpoint URIs like `secondary://topic/orders`. The default broker keeps the canonical `mqtt://`
+scheme, which keeps the two brokers' endpoints from colliding.
+:::
+
+Each named broker is a completely separate `IManagedMqttClient` with its own per-node response topic, so
+request/reply works independently over each broker.
+
+Connecting to multiple named brokers is distinct from [broker-per-tenant multi-tenancy](#broker-per-tenant): a
+named broker is a statically-addressed second connection that you target explicitly, whereas per-tenant
+connections are selected at runtime from each message's tenant id.
+
 ## Broadcast to User Defined Topics
 
 As long as the MQTT transport is enabled in your application, you can explicitly publish messages to any named topic
@@ -387,6 +421,67 @@ builder.UseWolverine(opts =>
             30.Minutes()));
 });
 ```
+
+## Broker per Tenant
+
+Named brokers (above) are a *static* topology: you pin specific endpoints to a specific broker by name at
+configuration time. **Broker-per-tenant** is different — it is *runtime* routing. You declare one shared topic
+topology, and each tenant is served by its **own dedicated MQTT connection** (a distinct broker). Which
+connection a message goes to (and which connection an inbound message came from) is decided at runtime by the
+message's [tenant id](/guide/handlers/multi-tenancy), typically set through `DeliveryOptions.TenantId`:
+
+```csharp
+opts.UseMqtt(mqtt => mqtt.WithClientOptions(client => client.WithTcpServer("shared-broker")))
+
+    // How should Wolverine route a message whose TenantId is null or unknown?
+    // FallbackToDefault (the default) uses the shared connection; TenantIdRequired
+    // throws; IgnoreUnknownTenants silently drops it.
+    .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+
+    // Each tenant gets its OWN dedicated MQTT connection, but shares the
+    // topic topology declared below.
+    .AddTenant("tenant-west",
+        mqtt => mqtt.WithClientOptions(client => client.WithTcpServer("west-broker")))
+
+    .AddTenant("tenant-east",
+        mqtt => mqtt.WithClientOptions(client => client.WithTcpServer("east-broker")));
+
+// One shared topology; messages are routed to the right connection at runtime by
+// Envelope.TenantId (e.g. new DeliveryOptions { TenantId = "tenant-west" }).
+opts.PublishMessage<OrderPlaced>().ToMqttTopic("orders");
+opts.ListenToMqttTopic("orders");
+```
+
+To route a specific message to a tenant's connection, stamp the tenant id on the send:
+
+```csharp
+await bus.SendAsync(new OrderPlaced("blue"), new DeliveryOptions { TenantId = "tenant-west" });
+```
+
+Wolverine wraps the outbound endpoint in a `TenantedSender` that dispatches on `Envelope.TenantId`, and builds a
+compound listener that runs one subscription per tenant connection — each inbound envelope is stamped with the
+tenant id of the connection it was consumed from. This mirrors the
+[RabbitMQ](/guide/messaging/transports/rabbitmq/multi-tenancy) and
+[Azure Service Bus](/guide/messaging/transports/azureservicebus/multitenancy) broker-per-tenant support.
+
+::: warning Unique ClientId per tenant (mandatory)
+MQTT brokers forcibly disconnect a second connection that shares a `ClientId`. Wolverine therefore always gives
+each tenant connection a **unique** `ClientId` derived from the tenant id (`<clientId>-tenant-<tenantId>`), even
+if you pre-set one on the tenant options. This is required so tenant connections never kick each other.
+:::
+
+::: info Shared topology, isolated broker
+Unlike a shared-broker/topic-prefix multi-tenancy model, MQTT tenants use the **same topic string** on each
+tenant's **own broker** — isolation is purely a matter of which broker the tenant's connection points at. One
+consequence: [retained messages](#clearing-out-retained-messages) are per-broker, so a retained message on one
+tenant's broker is not visible to any other tenant.
+:::
+
+::: tip Named broker vs. broker-per-tenant
+Use a **named broker** when a *fixed set of endpoints* should always talk to a *specific* broker. Use
+**broker-per-tenant** when the *same logical endpoints* should be transparently routed to a *different connection
+per tenant* based on the runtime tenant id. They are independent features and can be combined.
+:::
 
 ## Interoperability
 

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/mqtt_per_tenant_broker_tests.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/mqtt_per_tenant_broker_tests.cs
@@ -1,0 +1,182 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.MQTT.Internals;
+using Wolverine.Tracking;
+using Wolverine.Transports.Sending;
+using Wolverine.Util;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Wolverine.MQTT.Tests;
+
+/// <summary>
+/// Integration coverage for broker-per-tenant MQTT (GH-3307). Two in-process <see cref="LocalMqttBroker"/>
+/// instances stand in for two brokers on two free ports — broker A is the default/shared connection and broker B
+/// is tenant "tenantB"'s own dedicated connection. Because MQTT tenants are always own-connection (no
+/// topic-prefix equivalent), isolation is purely by which broker the tenant's client is connected to. Proves:
+/// <list type="bullet">
+/// <item>a tenant message lands on the tenant's broker (B) and NOT the shared broker (A),</item>
+/// <item>a default/untenanted message falls back to the shared broker (A) and NOT the tenant broker (B),</item>
+/// <item>an inbound tenant message is consumed and stamped with its <c>TenantId</c>, and</item>
+/// <item>each tenant connection is given a unique ClientId so the broker never kicks it.</item>
+/// </list>
+/// </summary>
+[Collection("acceptance")]
+public class mqtt_per_tenant_broker_tests : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private LocalMqttBroker _brokerA = null!;
+    private LocalMqttBroker _brokerB = null!;
+    private int _portA;
+    private int _portB;
+
+    public mqtt_per_tenant_broker_tests(ITestOutputHelper output) => _output = output;
+
+    public async Task InitializeAsync()
+    {
+        _portA = PortFinder.GetAvailablePort();
+        _portB = PortFinder.GetAvailablePort();
+
+        _brokerA = new LocalMqttBroker(_portA) { Logger = new XUnitLogger(_output, "MQTT-A") };
+        _brokerB = new LocalMqttBroker(_portB) { Logger = new XUnitLogger(_output, "MQTT-B") };
+
+        await _brokerA.StartAsync();
+        await _brokerB.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _brokerA.DisposeAsync();
+        await _brokerB.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task tenant_message_is_published_to_the_tenant_broker_and_not_the_default()
+    {
+        var topic = $"tenant/{Guid.NewGuid():N}";
+
+        await using var subOnB = await RawMqttSubscriber.StartAsync(_portB, topic);
+        await using var subOnA = await RawMqttSubscriber.StartAsync(_portA, topic);
+
+        using var host = await buildSenderAsync(topic);
+
+        await host.MessageBus().SendAsync(new TenantColor("for-tenant-b"),
+            new DeliveryOptions { TenantId = "tenantB" });
+
+        // Landed on the tenant's broker (B)...
+        (await subOnB.WaitForMessageAsync(15.Seconds())).ShouldBeTrue();
+        // ...and NOT on the shared/default broker (A).
+        (await subOnA.WaitForMessageAsync(2.Seconds())).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task default_message_falls_back_to_the_shared_broker()
+    {
+        var topic = $"tenant/{Guid.NewGuid():N}";
+
+        await using var subOnA = await RawMqttSubscriber.StartAsync(_portA, topic);
+        await using var subOnB = await RawMqttSubscriber.StartAsync(_portB, topic);
+
+        using var host = await buildSenderAsync(topic);
+
+        await host.MessageBus().SendAsync(new TenantColor("no-tenant"));
+
+        // Falls back to the shared/default broker (TenantedIdBehavior.FallbackToDefault)...
+        (await subOnA.WaitForMessageAsync(15.Seconds())).ShouldBeTrue();
+        // ...and NOT the tenant broker.
+        (await subOnB.WaitForMessageAsync(2.Seconds())).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task tenant_message_is_consumed_and_stamped_with_the_tenant_id()
+    {
+        var topic = $"tenant/{Guid.NewGuid():N}";
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "PerTenantInbound";
+                configureTransport(opts, topic);
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.PublishMessage<TenantColor>().ToMqttTopic(topic).SendInline();
+                opts.ListenToMqttTopic(topic);
+            }).StartAsync();
+
+        // The default listener consumes broker A and the tenant listener consumes broker B; the message only
+        // exists on broker B, so only the tenant listener consumes it and stamps the tenant id.
+        var session = await host
+            .TrackActivity()
+            .Timeout(60.Seconds())
+            .WaitForMessageToBeReceivedAt<TenantColor>(host)
+            .ExecuteAndWaitAsync(c =>
+                c.SendAsync(new TenantColor("for-tenant-b"), new DeliveryOptions { TenantId = "tenantB" }));
+
+        var received = session.Received.SingleEnvelope<TenantColor>();
+        received.TenantId.ShouldBe("tenantB");
+        received.Message.ShouldBeOfType<TenantColor>().Color.ShouldBe("for-tenant-b");
+    }
+
+    [Fact]
+    public async Task tenant_client_gets_a_unique_client_id()
+    {
+        var topic = $"tenant/{Guid.NewGuid():N}";
+        using var host = await buildSenderAsync(topic);
+
+        var transport = host.GetRuntime().Options.Transports.GetOrCreate<MqttTransport>();
+
+        var tenant = transport.Tenants["tenantB"];
+        tenant.Client.ShouldNotBeNull();
+
+        // The tenant ClientId is unique and identifiable — required so the broker doesn't kick a duplicate.
+        tenant.Options.ClientOptions.ClientId.ShouldEndWith("-tenant-tenantB");
+        tenant.Options.ClientOptions.ClientId.ShouldNotBe(transport.Options.ClientOptions.ClientId);
+    }
+
+    [Fact]
+    public async Task tenant_aware_endpoint_resolves_a_TenantedSender()
+    {
+        var topic = $"tenant/{Guid.NewGuid():N}";
+        using var host = await buildSenderAsync(topic);
+
+        var runtime = host.GetRuntime();
+        var transport = runtime.Options.Transports.GetOrCreate<MqttTransport>();
+        var endpoint = transport.Topics[topic];
+
+        // buildSenderAsync publishes inline, so the endpoint resolves an InlineSendingAgent around our sender.
+        var agent = (InlineSendingAgent)runtime.Endpoints.GetOrBuildSendingAgent(endpoint.Uri);
+        agent.Sender.ShouldBeOfType<TenantedSender>();
+    }
+
+    private void configureTransport(WolverineOptions opts, string topic)
+    {
+        opts.UseMqttWithLocalBroker(_portA)
+            .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+            .AddTenant("tenantB", builder =>
+                builder.WithClientOptions(o => o.WithTcpServer("127.0.0.1", _portB)));
+    }
+
+    private Task<IHost> buildSenderAsync(string topic)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "PerTenantSender";
+                configureTransport(opts, topic);
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.PublishMessage<TenantColor>().ToMqttTopic(topic).SendInline();
+            }).StartAsync();
+    }
+}
+
+public record TenantColor(string Color);
+
+public static class TenantColorHandler
+{
+    public static void Handle(TenantColor message)
+    {
+        // no-op; presence lets Wolverine discover a handler so receive tests can track processing
+    }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/named_broker_tests.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/named_broker_tests.cs
@@ -1,0 +1,304 @@
+using System.Text;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using MQTTnet;
+using MQTTnet.Extensions.ManagedClient;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.MQTT.Internals;
+using Wolverine.Tracking;
+using Wolverine.Util;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Wolverine.MQTT.Tests;
+
+/// <summary>
+/// Registration-level coverage for named MQTT brokers that needs no running broker, so it always runs in CI.
+/// A named broker is a second, independent <see cref="MqttTransport"/> whose <c>Protocol</c> (and therefore its
+/// endpoints' URI scheme) is the broker name, so its endpoints never collide with the default <c>mqtt://</c>
+/// broker.
+/// </summary>
+public class NamedMqttBrokerRegistrationTests
+{
+    private readonly BrokerName theName = new("secondary");
+
+    [Fact]
+    public void adds_a_distinct_transport_instance_per_broker()
+    {
+        var options = new WolverineOptions();
+        options.UseMqttWithLocalBroker(1883);
+        options.AddNamedMqttBroker(theName, builder =>
+            builder.WithClientOptions(o => o.WithTcpServer("127.0.0.1", 1884)));
+
+        var transports = options.Transports.OfType<MqttTransport>().ToList();
+        transports.Count.ShouldBe(2);
+        transports.Select(x => x.Protocol).OrderBy(x => x).ShouldBe(["mqtt", "secondary"]);
+    }
+
+    [Fact]
+    public void named_broker_endpoints_use_the_broker_name_as_their_uri_scheme()
+    {
+        var options = new WolverineOptions();
+        options.UseMqttWithLocalBroker(1883);
+        options.AddNamedMqttBroker(theName, builder =>
+            builder.WithClientOptions(o => o.WithTcpServer("127.0.0.1", 1884)));
+
+        var named = options.Transports.OfType<MqttTransport>().Single(x => x.Protocol == "secondary");
+        named.Topics["incoming/one"].Uri.ShouldBe(new Uri("secondary://topic/incoming/one"));
+
+        // ...and the default broker keeps the canonical mqtt:// scheme.
+        var @default = options.Transports.OfType<MqttTransport>().Single(x => x.Protocol == "mqtt");
+        @default.Topics["incoming/one"].Uri.ShouldBe(new Uri("mqtt://topic/incoming/one"));
+    }
+
+    [Fact]
+    public void listen_on_named_broker_registers_the_listener_on_the_named_transport_only()
+    {
+        var options = new WolverineOptions();
+        options.UseMqttWithLocalBroker(1883);
+        options.AddNamedMqttBroker(theName, builder =>
+            builder.WithClientOptions(o => o.WithTcpServer("127.0.0.1", 1884)));
+
+        options.ListenToMqttTopicOnNamedBroker(theName, "incoming/one");
+
+        var named = options.Transports.OfType<MqttTransport>().Single(x => x.Protocol == "secondary");
+        named.Topics["incoming/one"].IsListener.ShouldBeTrue();
+    }
+}
+
+/// <summary>
+/// End-to-end coverage that a named MQTT broker actually talks to a <em>different</em> broker than the default
+/// one. Two in-process <see cref="LocalMqttBroker"/> instances stand in for two brokers (A = default, B = named)
+/// on two free ports — no Docker needed. Proves:
+/// <list type="bullet">
+/// <item>a message published on the named broker lands on <b>broker B</b> and not broker A,</item>
+/// <item>a default publish lands on <b>broker A</b> and not broker B,</item>
+/// <item>a message published <b>and consumed</b> on the named broker round-trips and arrives stamped with the
+/// broker's own URI scheme (the receive pipeline sets <c>Destination</c> from the listener endpoint's URI), and</item>
+/// <item>a full request/reply round-trips over the named broker, proving the reply is routed back to broker B
+/// rather than the default broker A.</item>
+/// </list>
+/// </summary>
+[Collection("acceptance")]
+public class named_broker_tests : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private readonly BrokerName theName = new("secondary");
+    private LocalMqttBroker _brokerA = null!;
+    private LocalMqttBroker _brokerB = null!;
+    private int _portA;
+    private int _portB;
+
+    public named_broker_tests(ITestOutputHelper output) => _output = output;
+
+    public async Task InitializeAsync()
+    {
+        _portA = PortFinder.GetAvailablePort();
+        _portB = PortFinder.GetAvailablePort();
+
+        _brokerA = new LocalMqttBroker(_portA) { Logger = new XUnitLogger(_output, "MQTT-A") };
+        _brokerB = new LocalMqttBroker(_portB) { Logger = new XUnitLogger(_output, "MQTT-B") };
+
+        await _brokerA.StartAsync();
+        await _brokerB.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _brokerA.DisposeAsync();
+        await _brokerB.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task named_broker_send_lands_on_the_named_broker()
+    {
+        var topic = $"named/{Guid.NewGuid():N}";
+
+        await using var subOnB = await RawMqttSubscriber.StartAsync(_portB, topic);
+        await using var subOnA = await RawMqttSubscriber.StartAsync(_portA, topic);
+
+        using var host = await buildSenderAsync(topic, useNamedBroker: true);
+
+        await host.MessageBus().SendAsync(new NamedColor("on-named-broker"));
+
+        // Landed on broker B (the named broker's connection)...
+        (await subOnB.WaitForMessageAsync(15.Seconds())).ShouldBeTrue();
+        // ...and NOT on the default broker A.
+        (await subOnA.WaitForMessageAsync(2.Seconds())).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task default_broker_send_lands_on_the_default_broker()
+    {
+        var topic = $"named/{Guid.NewGuid():N}";
+
+        await using var subOnA = await RawMqttSubscriber.StartAsync(_portA, topic);
+        await using var subOnB = await RawMqttSubscriber.StartAsync(_portB, topic);
+
+        using var host = await buildSenderAsync(topic, useNamedBroker: false);
+
+        await host.MessageBus().SendAsync(new NamedColor("on-default-broker"));
+
+        (await subOnA.WaitForMessageAsync(15.Seconds())).ShouldBeTrue();
+        (await subOnB.WaitForMessageAsync(2.Seconds())).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task round_trips_a_message_over_the_named_broker()
+    {
+        var topic = $"named/{Guid.NewGuid():N}";
+
+        // A single host both publishes and listens on the named broker (broker B). On receipt the pipeline stamps
+        // Destination from the listener endpoint's URI, so the consumed envelope carries the named broker's
+        // "secondary" scheme rather than the default "mqtt".
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseMqttWithLocalBroker(_portA);
+                opts.AddNamedMqttBroker(theName, builder =>
+                    builder.WithClientOptions(o => o.WithTcpServer("127.0.0.1", _portB)));
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.PublishMessage<NamedColor>().ToMqttTopicOnNamedBroker(theName, topic).SendInline();
+                opts.ListenToMqttTopicOnNamedBroker(theName, topic);
+            }).StartAsync();
+
+        var session = await host
+            .TrackActivity()
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<NamedColor>(host)
+            .ExecuteAndWaitAsync(c => c.SendAsync(new NamedColor("round-trip")));
+
+        var received = session.Received.SingleEnvelope<NamedColor>();
+        received.Message.ShouldBeOfType<NamedColor>().Color.ShouldBe("round-trip");
+        received.Destination!.Scheme.ShouldBe("secondary");
+    }
+
+    [Fact]
+    public async Task request_reply_round_trips_over_the_named_broker()
+    {
+        var topic = $"named/rr/{Guid.NewGuid():N}";
+
+        // Request/reply entirely over the named broker (broker B). The reply is routed by the reply-uri's scheme,
+        // which the pipeline corrects to the receiving endpoint's scheme ("secondary") — so the response travels
+        // back over broker B, not the default broker A. If reply routing resolved to the default broker,
+        // InvokeAndWaitAsync would time out.
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseMqttWithLocalBroker(_portA);
+                opts.AddNamedMqttBroker(theName, builder =>
+                    builder.WithClientOptions(o => o.WithTcpServer("127.0.0.1", _portB)));
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.PublishMessage<NamedPing>().ToMqttTopicOnNamedBroker(theName, topic);
+                opts.ListenToMqttTopicOnNamedBroker(theName, topic);
+            }).StartAsync();
+
+        var (_, response) = await host
+            .TrackActivity()
+            .Timeout(30.Seconds())
+            .InvokeAndWaitAsync<NamedPong>(new NamedPing("named-rr"));
+
+        response.ShouldNotBeNull();
+        response.Name.ShouldBe("named-rr");
+    }
+
+    private Task<IHost> buildSenderAsync(string topic, bool useNamedBroker)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseMqttWithLocalBroker(_portA);
+                opts.AddNamedMqttBroker(theName, builder =>
+                    builder.WithClientOptions(o => o.WithTcpServer("127.0.0.1", _portB)));
+
+                opts.Policies.DisableConventionalLocalRouting();
+
+                if (useNamedBroker)
+                {
+                    opts.PublishMessage<NamedColor>().ToMqttTopicOnNamedBroker(theName, topic).SendInline();
+                }
+                else
+                {
+                    opts.PublishMessage<NamedColor>().ToMqttTopic(topic).SendInline();
+                }
+            }).StartAsync();
+    }
+}
+
+/// <summary>
+/// A minimal raw MQTTnet subscriber used to assert which physical broker a Wolverine publish actually reached,
+/// independent of Wolverine's own routing.
+/// </summary>
+internal class RawMqttSubscriber : IAsyncDisposable
+{
+    private readonly IManagedMqttClient _client;
+    private readonly List<string> _messages = new();
+
+    private RawMqttSubscriber(IManagedMqttClient client) => _client = client;
+
+    public static async Task<RawMqttSubscriber> StartAsync(int port, string topic)
+    {
+        var client = new MqttFactory().CreateManagedMqttClient();
+        var subscriber = new RawMqttSubscriber(client);
+
+        client.ApplicationMessageReceivedAsync += e =>
+        {
+            lock (subscriber._messages)
+            {
+                subscriber._messages.Add(Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment));
+            }
+
+            return Task.CompletedTask;
+        };
+
+        await client.StartAsync(new ManagedMqttClientOptionsBuilder()
+            .WithClientOptions(o => o.WithTcpServer("127.0.0.1", port)).Build());
+        await client.SubscribeAsync(topic);
+
+        return subscriber;
+    }
+
+    public async Task<bool> WaitForMessageAsync(TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            lock (_messages)
+            {
+                if (_messages.Count > 0) return true;
+            }
+
+            await Task.Delay(50);
+        }
+
+        return false;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _client.StopAsync();
+        _client.Dispose();
+    }
+}
+
+public record NamedColor(string Color);
+
+public static class NamedColorHandler
+{
+    public static void Handle(NamedColor message)
+    {
+        // no-op; presence lets Wolverine discover a handler so receive tests can track processing
+    }
+}
+
+public record NamedPing(string Name);
+
+public record NamedPong(string Name);
+
+public class NamedPingHandler
+{
+    public NamedPong Handle(NamedPing ping) => new(ping.Name);
+}

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttHealthCheck.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttHealthCheck.cs
@@ -9,7 +9,7 @@ internal class MqttHealthCheck : WolverineTransportHealthCheck
     public MqttHealthCheck(MqttTransport transport) => _transport = transport;
 
     public override string TransportName => "MQTT";
-    public override string Protocol => "mqtt";
+    public override string Protocol => _transport.Protocol;
 
     public override Task<TransportHealthResult> CheckHealthAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttListener.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttListener.cs
@@ -3,6 +3,7 @@ using JasperFx.Blocks;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
 using MQTTnet.Client;
+using MQTTnet.Extensions.ManagedClient;
 using Wolverine.Runtime;
 using Wolverine.Transports;
 
@@ -18,17 +19,24 @@ internal class MqttListener : IListener, IReportConnectionState
     private readonly IReceiver _receiver;
     private readonly MqttTopic _topic;
 
+    // Broker-per-tenant (GH-3307): the managed client this listener consumes from — the default/shared client
+    // for the untenanted listener, or a tenant's own dedicated client. ConnectionState reports on this specific
+    // connection so a dropped tenant connection is surfaced independently of the default one.
+    private readonly IManagedMqttClient _client;
+
     // GH-3231: surface the managed MQTT client's connection state so external monitors can detect a listener whose
     // broker connection has dropped (and not resubscribed) while it still reports Accepting.
     public TransportConnectionState ConnectionState =>
-        _broker.Client.IsConnected ? TransportConnectionState.Connected : TransportConnectionState.Disconnected;
+        _client.IsConnected ? TransportConnectionState.Connected : TransportConnectionState.Disconnected;
 
-    public MqttListener(MqttTransport broker, ILogger logger, MqttTopic topic, IReceiver receiver)
+    public MqttListener(MqttTransport broker, ILogger logger, MqttTopic topic, IReceiver receiver,
+        IManagedMqttClient client)
     {
         _broker = broker;
         _logger = logger;
         _topic = topic;
         _receiver = receiver;
+        _client = client;
         Address = topic.Uri;
 
         TopicName = topic.ListeningTopic;

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTenant.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTenant.cs
@@ -1,0 +1,40 @@
+using MQTTnet.Extensions.ManagedClient;
+
+namespace Wolverine.MQTT.Internals;
+
+/// <summary>
+/// Represents a single Wolverine tenant that is served by its own dedicated MQTT connection while sharing the
+/// topic topology declared on the parent transport. Unlike NATS, MQTT tenants are <em>always</em>
+/// own-connection: there is no subject/topic-prefix equivalent, so isolation is purely a matter of which broker
+/// the tenant's dedicated <see cref="IManagedMqttClient"/> is connected to. Outbound routing is by
+/// <see cref="Envelope.TenantId"/> via the framework's
+/// <see cref="Wolverine.Transports.Sending.TenantedSender"/>; inbound the tenant's own listener stamps the
+/// tenant id. Mirrors the RabbitMQ / Azure Service Bus tenant model.
+/// </summary>
+internal class MqttTenant
+{
+    public MqttTenant(string tenantId)
+    {
+        TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));
+    }
+
+    public string TenantId { get; }
+
+    /// <summary>
+    /// The tenant's own connection options. Seeded from the parent transport at registration time and then
+    /// overridden with the tenant-specific broker configuration.
+    /// </summary>
+    public ManagedMqttClientOptions Options { get; set; } = new()
+        { ClientOptions = new MQTTnet.Client.MqttClientOptions() };
+
+    /// <summary>
+    /// Optional JWT authentication configuration for the tenant's own connection.
+    /// </summary>
+    public MqttJwtAuthenticationOptions? Jwt { get; set; }
+
+    /// <summary>
+    /// The tenant's dedicated managed MQTT client. Created and owned by the transport during
+    /// <see cref="MqttTransport.InitializeAsync"/>, and stopped with the transport.
+    /// </summary>
+    internal IManagedMqttClient? Client { get; set; }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTopicSender.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTopicSender.cs
@@ -1,0 +1,47 @@
+using MQTTnet.Extensions.ManagedClient;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.MQTT.Internals;
+
+/// <summary>
+/// A standalone <see cref="ISender"/> bound to a specific <see cref="IManagedMqttClient"/>. Broker-per-tenant
+/// (GH-3307) uses one of these per tenant (bound to the tenant's dedicated client) beneath a
+/// <see cref="TenantedSender"/>, plus one bound to the default client as the fallback path.
+///
+/// It enqueues directly to the managed client (fire-and-forget) and deliberately does NOT implement
+/// <see cref="ISenderRequiresCallback"/>: <see cref="TenantedSender"/> does not forward RegisterCallback to the
+/// senders beneath it, so a callback-requiring sender there would silently drop every message (GH-2361).
+/// </summary>
+internal class MqttTopicSender : ISender
+{
+    private readonly MqttTopic _topic;
+    private readonly IManagedMqttClient _client;
+
+    public MqttTopicSender(MqttTopic topic, IManagedMqttClient client)
+    {
+        _topic = topic;
+        _client = client;
+    }
+
+    public bool SupportsNativeScheduledSend => false;
+    public Uri Destination => _topic.Uri;
+
+    public async Task<bool> PingAsync()
+    {
+        try
+        {
+            await _client.PingAsync();
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    public ValueTask SendAsync(Envelope envelope)
+    {
+        var message = _topic.BuildMessage(envelope);
+        return new ValueTask(_client.EnqueueAsync(message));
+    }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTransport.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTransport.cs
@@ -10,6 +10,7 @@ using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Routing;
 using Wolverine.Transports;
+using Wolverine.Transports.Sending;
 
 namespace Wolverine.MQTT.Internals;
 
@@ -17,11 +18,17 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
 {
     [IgnoreDescription]
     public LightweightCache<string, MqttTopic> Topics { get; } = new();
-    private List<MqttListener> _listeners = new();
-    private ImHashMap<string, MqttListener> _topicListeners = ImHashMap<string, MqttListener>.Empty;
-    private bool _subscribed;
+
+    // Named broker + broker-per-tenant (GH-3307): listener bookkeeping is per-managed-client rather than
+    // transport-global, because each tenant runs on its own IManagedMqttClient and messages received on a
+    // tenant connection must resolve to that tenant's (tenant-id stamping) listener, not the default one.
+    private readonly Dictionary<IManagedMqttClient, ClientListenerGroup> _clientGroups = new();
     private ILogger<MqttTransport> _logger = null!;
     private CancellationTokenSource? _refreshCts;
+
+    // Broker-per-tenant (GH-3307): CancellationTokenSources for each tenant client's JWT re-auth loop, so they
+    // can be cancelled on shutdown.
+    private readonly List<CancellationTokenSource> _tenantRefreshCts = new();
 
     public static string TopicForUri(Uri uri)
     {
@@ -29,9 +36,57 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
         return uri.LocalPath.Trim('/');
     }
 
-    public MqttTransport() : base("mqtt", "MQTT Transport", ["mqtt"])
+    public MqttTransport() : this("mqtt")
+    {
+    }
+
+    /// <summary>
+    /// Constructor used when connecting to more than one MQTT broker from a single application. The
+    /// <paramref name="protocol"/> doubles as the additional broker's URI scheme so its endpoints don't
+    /// collide with the default <c>mqtt://</c> broker. Reached through
+    /// <see cref="TransportCollection.GetOrCreate{T}"/> when a <see cref="BrokerName"/> is supplied.
+    /// </summary>
+    public MqttTransport(string protocol) : base(protocol, "MQTT Transport", [protocol])
     {
         Topics.OnMissing = topicName => new MqttTopic(topicName, this, EndpointRole.Application);
+    }
+
+    /// <summary>
+    /// Broker-per-tenant registrations (GH-3307). Each tenant owns its own dedicated <see cref="IManagedMqttClient"/>
+    /// pointed at its own broker while sharing the topic topology declared on the parent transport; outbound is
+    /// routed by <see cref="Envelope.TenantId"/> and inbound listeners stamp the tenant id.
+    /// </summary>
+    [IgnoreDescription]
+    internal LightweightCache<string, MqttTenant> Tenants { get; } = new(name => new MqttTenant(name));
+
+    /// <summary>
+    /// Controls how an outbound message whose tenant id is null or unregistered is routed when broker-per-tenant
+    /// multi-tenancy is in effect. Defaults to <see cref="TenantedIdBehavior.FallbackToDefault"/>.
+    /// </summary>
+    public TenantedIdBehavior TenantedIdBehavior { get; set; } = TenantedIdBehavior.FallbackToDefault;
+
+    /// <summary>
+    /// The managed client that a tenant's traffic should flow over, falling back to the default/shared client for
+    /// tenants that were never registered (or the untenanted path).
+    /// </summary>
+    internal IManagedMqttClient GetTenantClient(MqttTenant tenant) => tenant.Client ?? Client;
+
+    private sealed class ClientListenerGroup
+    {
+        public List<MqttListener> Listeners { get; } = new();
+        public ImHashMap<string, MqttListener> TopicListeners = ImHashMap<string, MqttListener>.Empty;
+        public bool Subscribed;
+    }
+
+    private ClientListenerGroup groupFor(IManagedMqttClient client)
+    {
+        if (!_clientGroups.TryGetValue(client, out var group))
+        {
+            group = new ClientListenerGroup();
+            _clientGroups[client] = group;
+        }
+
+        return group;
     }
 
     protected override IEnumerable<MqttTopic> endpoints()
@@ -83,10 +138,100 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
         Client.ConnectedAsync += onClientConnected;
         Client.DisconnectedAsync += onClientDisconnected;
         await Client.StartAsync(Options);
+
+        // Broker-per-tenant (GH-3307): each tenant gets its own dedicated managed client, connected to the
+        // tenant's own broker. MQTT brokers forcibly disconnect a second connection that shares a ClientId, so
+        // each tenant client is given a UNIQUE ClientId derived from the tenant id (see buildTenantClientAsync).
+        foreach (var tenant in Tenants)
+        {
+            tenant.Client = await buildTenantClientAsync(runtime, mqttFactory, tenant);
+        }
+
         foreach (var endpoint in Topics)
         {
             endpoint.Compile(runtime);
         }
+    }
+
+    private async Task<IManagedMqttClient> buildTenantClientAsync(IWolverineRuntime runtime, MqttFactory mqttFactory,
+        MqttTenant tenant)
+    {
+        var logger = new MqttNetLogger(runtime.LoggerFactory.CreateLogger<MqttClient>());
+        var client = mqttFactory.CreateManagedMqttClient(logger);
+
+        var options = tenant.Options;
+        options.ClientOptions.ProtocolVersion = MqttProtocolVersion.V500;
+
+        // Enforce a unique ClientId for the tenant connection even if the user pre-set one on the tenant options.
+        // Two managed clients sharing a ClientId make the broker kick one of them, so tenant traffic would drop.
+        var baseClientId = options.ClientOptions.ClientId;
+        options.ClientOptions.ClientId =
+            (string.IsNullOrEmpty(baseClientId) ? Guid.NewGuid().ToString("N") : baseClientId)
+            + "-tenant-" + tenant.TenantId;
+
+        if (tenant.Jwt is not null)
+        {
+            options.ClientOptions.AuthenticationMethod = "OAUTH2-JWT";
+            options.ClientOptions.AuthenticationData = await tenant.Jwt.GetTokenCallBack();
+            client.ConnectedAsync += buildTenantJwtRefreshHandler(client, tenant.Jwt);
+        }
+
+        await client.StartAsync(options);
+
+        return client;
+    }
+
+    // Broker-per-tenant JWT re-authentication loop, scoped to a single tenant client. Mirrors the default
+    // client's onClientConnected refresh, but keyed to the tenant's own connection and token callback.
+    private Func<MqttClientConnectedEventArgs, Task> buildTenantJwtRefreshHandler(IManagedMqttClient client,
+        MqttJwtAuthenticationOptions jwt)
+    {
+        CancellationTokenSource? refreshCts = null;
+        return async arg =>
+        {
+            if (arg.ConnectResult.ResultCode != MqttClientConnectResultCode.Success)
+            {
+                return;
+            }
+
+            if (refreshCts is not null)
+            {
+                await refreshCts.CancelAsync();
+                refreshCts.Dispose();
+            }
+
+            refreshCts = new CancellationTokenSource();
+            lock (_tenantRefreshCts)
+            {
+                _tenantRefreshCts.Add(refreshCts);
+            }
+
+            var ct = refreshCts.Token;
+            _ = Task.Run(async () =>
+            {
+                using var periodicTimer = new PeriodicTimer(jwt.RefreshPeriod);
+                try
+                {
+                    while (await periodicTimer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+                    {
+                        if (!client.IsConnected) continue;
+
+                        await client.InternalClient
+                            .SendExtendedAuthenticationExchangeDataAsync(
+                                new MqttExtendedAuthenticationExchangeData
+                                {
+                                    AuthenticationData = await jwt.GetTokenCallBack(),
+                                    ReasonCode = MQTTnet.Protocol.MqttAuthenticateReasonCode.ReAuthenticate
+                                }, ct)
+                            .ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Shutdown requested
+                }
+            }, ct);
+        };
     }
 
     public WolverineTransportHealthCheck BuildHealthCheck(IWolverineRuntime runtime)
@@ -94,18 +239,19 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
         return new MqttHealthCheck(this);
     }
 
-    private void startSubscribing()
+    private void startSubscribing(IManagedMqttClient client)
     {
-        if (_subscribed) return;
+        var group = groupFor(client);
+        if (group.Subscribed) return;
 
-        Client.ApplicationMessageReceivedAsync += receiveAsync;
-        _subscribed = true;
+        client.ApplicationMessageReceivedAsync += arg => receiveAsync(client, arg);
+        group.Subscribed = true;
     }
 
-    private Task receiveAsync(MqttApplicationMessageReceivedEventArgs arg)
+    private Task receiveAsync(IManagedMqttClient client, MqttApplicationMessageReceivedEventArgs arg)
     {
         var topicName = arg.ApplicationMessage.Topic;
-        if (tryFindListener(topicName, out var listener))
+        if (tryFindListener(client, topicName, out var listener))
         {
             return listener.ReceiveAsync(arg);
         }
@@ -168,17 +314,18 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
         }
     }
 
-    internal bool tryFindListener(string topicName, out MqttListener listener)
+    internal bool tryFindListener(IManagedMqttClient client, string topicName, out MqttListener listener)
     {
-        if (_topicListeners.TryFind(topicName, out listener))
+        var group = groupFor(client);
+        if (group.TopicListeners.TryFind(topicName, out listener))
         {
             return listener is not null;
         }
 
-        listener = (_listeners.FirstOrDefault(x => x.TopicName == topicName) ?? _listeners.FirstOrDefault(x =>
+        listener = (group.Listeners.FirstOrDefault(x => x.TopicName == topicName) ?? group.Listeners.FirstOrDefault(x =>
             MqttTopicFilterComparer.Compare(topicName, x.TopicName) == MqttTopicFilterCompareResult.IsMatch))!;
 
-        _topicListeners = _topicListeners.AddOrUpdate(topicName, listener!);
+        group.TopicListeners = group.TopicListeners.AddOrUpdate(topicName, listener!);
 
 
         return listener is not null;
@@ -223,21 +370,52 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
                 await _refreshCts.CancelAsync();
                 _refreshCts.Dispose();
             }
+
+            CancellationTokenSource[] tenantCts;
+            lock (_tenantRefreshCts)
+            {
+                tenantCts = _tenantRefreshCts.ToArray();
+                _tenantRefreshCts.Clear();
+            }
+
+            foreach (var cts in tenantCts)
+            {
+                try
+                {
+                    await cts.CancelAsync();
+                    cts.Dispose();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
+            }
+
             if (Client is not null)
                 await Client.StopAsync();
+
+            // Broker-per-tenant (GH-3307): each tenant owns its own managed client; stop them too.
+            foreach (var tenant in Tenants)
+            {
+                if (tenant.Client is not null)
+                {
+                    await tenant.Client.StopAsync();
+                }
+            }
         }
         catch (ObjectDisposedException)
         {
         }
     }
 
-    internal async ValueTask SubscribeToTopicAsync(string topicName, MqttListener listener, MqttTopic mqttTopic)
+    internal async ValueTask SubscribeToTopicAsync(string topicName, MqttListener listener, MqttTopic mqttTopic,
+        IManagedMqttClient client)
     {
-        _listeners.Add(listener);
+        var group = groupFor(client);
+        group.Listeners.Add(listener);
 
-        await Client.SubscribeAsync(topicName, mqttTopic.QualityOfServiceLevel);
+        await client.SubscribeAsync(topicName, mqttTopic.QualityOfServiceLevel);
 
-        startSubscribing();
+        startSubscribing(client);
     }
 
     private int _senderIndex = 0;

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttEndpointUri.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttEndpointUri.cs
@@ -16,7 +16,23 @@ public static class MqttEndpointUri
     /// <exception cref="ArgumentException">Thrown when <paramref name="topicName"/> is null, empty, or whitespace.</exception>
     public static Uri Topic(string topicName)
     {
+        return Topic("mqtt", topicName);
+    }
+
+    /// <summary>
+    /// Builds a URI referencing an MQTT topic endpoint in the canonical form
+    /// <c>{protocol}://topic/{topicName}</c>. The <paramref name="protocol"/> is the transport's URI scheme,
+    /// which for a named broker (see <c>AddNamedMqttBroker</c>) is the broker name rather than <c>mqtt</c>.
+    /// Slashes inside the topic name are preserved as path separators.
+    /// </summary>
+    /// <param name="protocol">The transport's URI scheme (e.g. <c>mqtt</c> or a named broker's name).</param>
+    /// <param name="topicName">The MQTT topic name (may contain slashes).</param>
+    /// <returns>A <see cref="Uri"/> of the form <c>{protocol}://topic/{topicName}</c>.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="protocol"/> or <paramref name="topicName"/> is null, empty, or whitespace.</exception>
+    public static Uri Topic(string protocol, string topicName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(protocol);
         ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
-        return new Uri("mqtt://topic/" + topicName.Trim('/'));
+        return new Uri($"{protocol}://topic/" + topicName.Trim('/'));
     }
 }

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttTopic.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttTopic.cs
@@ -19,7 +19,7 @@ public class MqttTopic : Endpoint, ISender, ITopicEndpoint
     public string TopicName { get; }
     private CancellationToken _cancellation;
 
-    public MqttTopic(string topicName, MqttTransport parent, EndpointRole role) : base(new Uri("mqtt://topic/" + topicName.Trim('/')), role)
+    public MqttTopic(string topicName, MqttTransport parent, EndpointRole role) : base(MqttEndpointUri.Topic(parent.Protocol, topicName), role)
     {
         TopicName = topicName.Trim('/');
         Parent = parent;
@@ -76,8 +76,29 @@ public class MqttTopic : Endpoint, ISender, ITopicEndpoint
 
         var logger = runtime.LoggerFactory.CreateLogger<MqttListener>();
 
-        var listener = new MqttListener(Parent, logger, this, receiver);
-        await Parent.SubscribeToTopicAsync(TopicName, listener, this);
+        var listener = new MqttListener(Parent, logger, this, receiver, Parent.Client);
+        await Parent.SubscribeToTopicAsync(TopicName, listener, this, Parent.Client);
+
+        // Broker-per-tenant (GH-3307): the shared listener consumes the default connection. Each tenant runs its
+        // own listener on its own dedicated client, stamping the tenant id onto inbound envelopes via
+        // TenantIdRule. Per-envelope completion routes back over the receiving connection through
+        // Envelope.Listener — the same CompoundListener multi-tenancy pattern used by RabbitMQ / NATS / SQS.
+        if (Parent.Tenants.Any() && TenancyBehavior == TenancyBehavior.TenantAware)
+        {
+            var compound = new CompoundListener(Uri);
+            compound.Inner.Add(listener);
+
+            foreach (var tenant in Parent.Tenants)
+            {
+                var client = Parent.GetTenantClient(tenant);
+                var tenantReceiver = new ReceiverWithRules(receiver, [new TenantIdRule(tenant.TenantId)]);
+                var tenantListener = new MqttListener(Parent, logger, this, tenantReceiver, client);
+                await Parent.SubscribeToTopicAsync(TopicName, tenantListener, this, client);
+                compound.Inner.Add(tenantListener);
+            }
+
+            return compound;
+        }
 
         return listener;
     }
@@ -87,6 +108,27 @@ public class MqttTopic : Endpoint, ISender, ITopicEndpoint
     protected override ISender CreateSender(IWolverineRuntime runtime)
     {
         Compile(runtime);
+
+        // Broker-per-tenant (GH-3307): route by Envelope.TenantId to a per-tenant sender bound to that tenant's
+        // own connection, falling back to the shared/default connection for the untenanted path.
+        //
+        // Both the tenant senders AND the default sender they fall back to are simple fire-and-forget
+        // MqttTopicSenders: TenantedSender intentionally does NOT implement ISenderRequiresCallback (GH-2361) and
+        // does not forward RegisterCallback to the senders beneath it.
+        if (Parent.Tenants.Any() && TenancyBehavior == TenancyBehavior.TenantAware)
+        {
+            var defaultSender = new MqttTopicSender(this, Parent.Client);
+            var tenantedSender = new TenantedSender(Uri, Parent.TenantedIdBehavior, defaultSender);
+
+            foreach (var tenant in Parent.Tenants)
+            {
+                tenantedSender.RegisterSender(tenant.TenantId,
+                    new MqttTopicSender(this, Parent.GetTenantClient(tenant)));
+            }
+
+            return tenantedSender;
+        }
+
         return this;
     }
 

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttTransportExpression.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttTransportExpression.cs
@@ -1,7 +1,9 @@
 using JasperFx.Core.Reflection;
+using MQTTnet.Extensions.ManagedClient;
 using Wolverine.Configuration;
 using Wolverine.MQTT.Internals;
 using Wolverine.Runtime;
+using Wolverine.Transports.Sending;
 
 namespace Wolverine.MQTT;
 
@@ -74,5 +76,74 @@ public class MqttTransportExpression
         _options.Policies.Add(policy);
 
         return this.As<MqttTransportExpression>();
+    }
+
+    /// <summary>
+    /// Override the routing behavior for unknown or missing tenant ids when using broker-per-tenant MQTT
+    /// multi-tenancy (GH-3307). See <see cref="TenantedIdBehavior"/>. Default is
+    /// <see cref="TenantedIdBehavior.FallbackToDefault"/>.
+    /// </summary>
+    /// <param name="behavior"></param>
+    /// <returns></returns>
+    public MqttTransportExpression TenantIdBehavior(TenantedIdBehavior behavior)
+    {
+        _transport.TenantedIdBehavior = behavior;
+        return this;
+    }
+
+    /// <summary>
+    /// Register a tenant that is served by its own dedicated MQTT connection (its own broker) while sharing the
+    /// topic topology declared on this transport. Outbound messages carrying a matching
+    /// <see cref="Envelope.TenantId"/> are routed to this tenant's connection; inbound messages consumed from it
+    /// are stamped with the tenant id. The tenant connection is always given a unique ClientId derived from the
+    /// tenant id, because MQTT brokers forcibly disconnect a second connection sharing a ClientId.
+    /// </summary>
+    /// <param name="tenantId"></param>
+    /// <param name="configure">Configuration for the tenant's own broker connection</param>
+    /// <param name="jwt">Optional OAUTH2-JWT authentication for the tenant's own connection.</param>
+    /// <returns></returns>
+    public MqttTransportExpression AddTenant(string tenantId, Action<ManagedMqttClientOptionsBuilder> configure,
+        MqttJwtAuthenticationOptions? jwt = null)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            throw new ArgumentOutOfRangeException(nameof(tenantId), "Empty or null tenantId");
+        }
+
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var builder = new ManagedMqttClientOptionsBuilder();
+        configure(builder);
+
+        var tenant = _transport.Tenants[tenantId];
+        tenant.Options = builder.Build();
+        tenant.Jwt = jwt;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Register a tenant that is served by its own dedicated MQTT connection (its own broker), bypassing the
+    /// fluent builder. See <see cref="AddTenant(string, Action{ManagedMqttClientOptionsBuilder}, MqttJwtAuthenticationOptions)"/>.
+    /// </summary>
+    /// <param name="tenantId"></param>
+    /// <param name="mqttOptions">The connection options for the tenant's own broker</param>
+    /// <param name="jwt">Optional OAUTH2-JWT authentication for the tenant's own connection.</param>
+    /// <returns></returns>
+    public MqttTransportExpression AddTenant(string tenantId, ManagedMqttClientOptions mqttOptions,
+        MqttJwtAuthenticationOptions? jwt = null)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            throw new ArgumentOutOfRangeException(nameof(tenantId), "Empty or null tenantId");
+        }
+
+        ArgumentNullException.ThrowIfNull(mqttOptions);
+
+        var tenant = _transport.Tenants[tenantId];
+        tenant.Options = mqttOptions;
+        tenant.Jwt = jwt;
+
+        return this;
     }
 }

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttTransportExtensions.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttTransportExtensions.cs
@@ -14,11 +14,11 @@ public static class MqttTransportExtensions
     /// </summary>
     /// <param name="endpoints"></param>
     /// <returns></returns>
-    internal static MqttTransport MqttTransport(this WolverineOptions endpoints)
+    internal static MqttTransport MqttTransport(this WolverineOptions endpoints, BrokerName? name = null)
     {
         var transports = endpoints.As<WolverineOptions>().Transports;
 
-        return transports.GetOrCreate<MqttTransport>();
+        return transports.GetOrCreate<MqttTransport>(name);
     }
 
     /// <summary>
@@ -78,6 +78,52 @@ public static class MqttTransportExtensions
     }
 
     /// <summary>
+    /// Configure a connection to a secondary, named MQTT broker used by this application. Only use this overload if
+    /// your Wolverine application needs to talk to two or more MQTT brokers. The <paramref name="name"/> doubles as
+    /// the URI scheme for the additional broker's endpoints, so pin publishing/listening to it with
+    /// <see cref="ToMqttTopicOnNamedBroker"/> / <see cref="ListenToMqttTopicOnNamedBroker"/>.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="name">Identity of the additional MQTT broker</param>
+    /// <param name="configure">Configuration for the additional broker's connection</param>
+    /// <param name="jwtAuthenticationOptions">Optional OAUTH2-JWT authentication for the additional broker.</param>
+    public static MqttTransportExpression AddNamedMqttBroker(this WolverineOptions options,
+        BrokerName name,
+        Action<ManagedMqttClientOptionsBuilder> configure,
+        MqttJwtAuthenticationOptions? jwtAuthenticationOptions = null)
+    {
+        var transport = options.MqttTransport(name);
+        var builder = new ManagedMqttClientOptionsBuilder();
+        configure(builder);
+
+        transport.Options = builder.Build();
+        transport.JwtAuthenticationOptions = jwtAuthenticationOptions;
+
+        return new MqttTransportExpression(transport, options);
+    }
+
+    /// <summary>
+    /// Configure a connection to a secondary, named MQTT broker used by this application, bypassing the fluent
+    /// builder. Only use this overload if your Wolverine application needs to talk to two or more MQTT brokers.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="name">Identity of the additional MQTT broker</param>
+    /// <param name="mqttOptions">The connection options for the additional broker</param>
+    /// <param name="jwtAuthenticationOptions">Optional OAUTH2-JWT authentication for the additional broker.</param>
+    public static MqttTransportExpression AddNamedMqttBroker(this WolverineOptions options,
+        BrokerName name,
+        ManagedMqttClientOptions mqttOptions,
+        MqttJwtAuthenticationOptions? jwtAuthenticationOptions = null)
+    {
+        var transport = options.MqttTransport(name);
+
+        transport.Options = mqttOptions;
+        transport.JwtAuthenticationOptions = jwtAuthenticationOptions;
+
+        return new MqttTransportExpression(transport, options);
+    }
+
+    /// <summary>
     ///     Listen for incoming messages at the designated MQTT topic name
     /// </summary>
     /// <param name="endpoints"></param>
@@ -119,6 +165,25 @@ public static class MqttTransportExtensions
     }
 
     /// <summary>
+    /// Listen for incoming messages at the designated MQTT topic name on an additional, named broker registered via
+    /// <see cref="AddNamedMqttBroker(WolverineOptions, BrokerName, Action{ManagedMqttClientOptionsBuilder}, MqttJwtAuthenticationOptions)"/>.
+    /// </summary>
+    /// <param name="endpoints"></param>
+    /// <param name="name">Identity of the additional MQTT broker</param>
+    /// <param name="topicName">The MQTT topic name to listen to</param>
+    public static MqttListenerConfiguration ListenToMqttTopicOnNamedBroker(this WolverineOptions endpoints,
+        BrokerName name, string topicName)
+    {
+        var transport = endpoints.MqttTransport(name);
+
+        var endpoint = transport.Topics[topicName];
+        endpoint.EndpointName = topicName;
+        endpoint.IsListener = true;
+
+        return new MqttListenerConfiguration(endpoint);
+    }
+
+    /// <summary>
     /// Publish messages to an MQTT topic
     /// </summary>
     /// <param name="publishing"></param>
@@ -128,6 +193,27 @@ public static class MqttTransportExtensions
     {
         var transports = publishing.As<PublishingExpression>().Parent.Transports;
         var transport = transports.GetOrCreate<MqttTransport>();
+
+        var topic = transport.Topics[topicName];
+
+        // This is necessary unfortunately to hook up the subscription rules
+        publishing.To(topic.Uri);
+
+        return new MqttSubscriberConfiguration(topic);
+    }
+
+    /// <summary>
+    /// Publish messages to an MQTT topic on an additional, named broker registered via
+    /// <see cref="AddNamedMqttBroker(WolverineOptions, BrokerName, Action{ManagedMqttClientOptionsBuilder}, MqttJwtAuthenticationOptions)"/>.
+    /// </summary>
+    /// <param name="publishing"></param>
+    /// <param name="name">Identity of the additional MQTT broker</param>
+    /// <param name="topicName">The MQTT topic name</param>
+    public static MqttSubscriberConfiguration ToMqttTopicOnNamedBroker(this IPublishToExpression publishing,
+        BrokerName name, string topicName)
+    {
+        var transports = publishing.As<PublishingExpression>().Parent.Transports;
+        var transport = transports.GetOrCreate<MqttTransport>(name);
 
         var topic = transport.Topics[topicName];
 

--- a/src/Wolverine/AssemblyAttributes.cs
+++ b/src/Wolverine/AssemblyAttributes.cs
@@ -49,6 +49,7 @@ using Wolverine.Attributes;
 [assembly: InternalsVisibleTo("Wolverine.Kafka.Tests")]
 [assembly: InternalsVisibleTo("Wolverine.Kafka")]
 [assembly: InternalsVisibleTo("Wolverine.Nats")]
+[assembly: InternalsVisibleTo("Wolverine.MQTT")]
 [assembly: InternalsVisibleTo("Wolverine.Redis")]
 [assembly: InternalsVisibleTo("Wolverine.Pubsub")]
 [assembly: InternalsVisibleTo("MetricsTests")]


### PR DESCRIPTION
Closes #3307

Brings the **MQTT transport** up to parity with RabbitMQ / NATS / SQS on the two established multi-broker features. MQTT had **neither** before; this adds **both**.

## Named broker
- `MqttTransport(string protocol)` ctor (+ `MqttTransport() : this("mqtt")`), reached via `TransportCollection.GetOrCreate<T>(BrokerName)`.
- **`MqttTopic`/`MqttEndpointUri` build the endpoint URI from `parent.Protocol`** instead of a hard-coded `mqtt://` literal — the key change so a named broker's endpoints get their own URI scheme and don't collide with the default broker.
- New API: `AddNamedMqttBroker(BrokerName, …)` (builder + `ManagedMqttClientOptions` overloads), `ListenToMqttTopicOnNamedBroker`, `ToMqttTopicOnNamedBroker`; internal `MqttTransport(this WolverineOptions, BrokerName?)` accessor.
- `MqttHealthCheck.Protocol` now follows the transport's `Protocol`.

## Broker-per-tenant
- New `MqttTenant` (own `ManagedMqttClientOptions` / `IManagedMqttClient`) and `MqttTopicSender` (a fire-and-forget `ISender` bound to a specific client; kept callback-free per GH-2361 since `TenantedSender` doesn't forward `RegisterCallback`).
- `MqttTransport` gains a per-tenant client cache + `TenantedIdBehavior`. Each tenant client is created in `InitializeAsync` with a **unique `ClientId`** (`<id>-tenant-<tenantId>`) — enforced even if the user pre-set one, because MQTT brokers kick a duplicate ClientId — and stopped in `DisposeAsync`. Listener bookkeeping is now **per-managed-client** so messages arriving on a tenant connection resolve that tenant's own (tenant-id-stamping) listener.
- `MqttTopic.CreateSender` returns a `TenantedSender` when tenants exist; `BuildListenerAsync` builds a `CompoundListener` with one `ReceiverWithRules([new TenantIdRule(tenant)])` listener per tenant client.
- `MqttTransportExpression.TenantIdBehavior(...)` + `AddTenant(...)` overloads.
- Adds `Wolverine.MQTT` to `InternalsVisibleTo` for `TenantIdRule` / `ReceiverWithRules`.

## Tests
No Docker needed — two in-process `LocalMqttBroker` instances on free ports simulate two brokers.
- **Named broker** (`named_broker_tests.cs` + registration tests): distinct transport per broker, broker-name URI scheme, publish lands on the named broker (raw MQTTnet subscriber) not the default and vice-versa, a consumed message is stamped with the named broker's scheme, and a full **request/reply round-trips over the named broker**.
- **Broker-per-tenant** (`mqtt_per_tenant_broker_tests.cs`): a `DeliveryOptions { TenantId }` message lands on the tenant's broker not the shared one, default falls back to the shared broker, inbound tenant message consumed and stamped with `TenantId`, unique tenant ClientId, and the endpoint resolves a `TenantedSender`.

All 12 new tests pass; both existing compliance suites (47 tests) pass in isolation. `dotnet build wolverine.slnx -c Release` is clean (0 warnings, 0 errors).

## Caveats (documented)
- MQTT tenants are always own-connection (no topic-prefix model) — isolation is purely which broker the tenant client points at; retained messages are per-broker.
- Unique ClientId per tenant is mandatory and enforced automatically.

Docs: adds "Connecting to Multiple MQTT Brokers" and "Broker per Tenant" sections to `docs/guide/messaging/transports/mqtt.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)