### PR TITLE
feat(pulsar): named-broker and broker-per-tenant support (GH-3308)

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -471,6 +471,121 @@ Also see the more generic [Wolverine Guide on Interoperability](/tutorials/inter
 
 Pulsar interoperability is done through the `IPulsarEnvelopeMapper` interface.
 
+## Connecting to Multiple Brokers
+
+If a single Wolverine application needs to talk to more than one Pulsar broker, register the additional
+broker(s) with `AddNamedPulsarBroker` using a `BrokerName`, then pin publishing or listening to a specific
+broker with the `*OnNamedBroker` overloads:
+
+<!-- snippet: sample_pulsar_named_broker -->
+<a id='snippet-sample_pulsar_named_broker'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        // The default Pulsar broker
+        opts.UsePulsar(c => c.ServiceUrl(new Uri("pulsar://localhost:6650")));
+
+        // An additional, independent Pulsar broker identified by name. The name doubles as the
+        // URI scheme of the named broker's endpoints (e.g. "secondary://..."), so its endpoints
+        // never collide with the default "pulsar://" broker.
+        opts.AddNamedPulsarBroker(new BrokerName("secondary"),
+            c => c.ServiceUrl(new Uri("pulsar://secondary-pulsar:6650")));
+
+        // Publish a message type to a topic on the named broker
+        opts.PublishMessage<Message1>()
+            .ToPulsarTopicOnNamedBroker(new BrokerName("secondary"),
+                "persistent://public/default/one");
+
+        // Listen to a topic on the named broker
+        opts.ListenToPulsarTopicOnNamedBroker(new BrokerName("secondary"),
+            "persistent://public/default/two");
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Pulsar/Wolverine.Pulsar.Tests/DocumentationSamples.cs#L105-L126' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pulsar_named_broker' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: info
+The Wolverine `Uri` scheme for any endpoint on a named broker is the broker name itself, so in the example
+above you would see endpoint URIs like `secondary://persistent/public/default/two`. The default broker keeps
+the canonical `pulsar://` scheme, which keeps the two brokers' endpoints from colliding.
+:::
+
+Connecting to multiple named brokers is a *static* topology — you target a specific broker explicitly — which
+is distinct from the *runtime* per-tenant routing described in [Multi-Tenancy / Broker per Tenant](#multi-tenancy-broker-per-tenant).
+
+## Multi-Tenancy / Broker per Tenant
+
+Broker-per-tenant gives each Wolverine [tenant](/guide/handlers/multi-tenancy) its own **dedicated Pulsar
+cluster** while sharing a single topic topology. Which cluster a message goes to — and which cluster an inbound
+message came from — is decided at runtime by the message's tenant id, typically stamped through
+`DeliveryOptions.TenantId`:
+
+<!-- snippet: sample_pulsar_broker_per_tenant -->
+<a id='snippet-sample_pulsar_broker_per_tenant'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UsePulsar(c => c.ServiceUrl(new Uri("pulsar://localhost:6650")))
+
+            // Route messages with an unknown/missing tenant id to the default broker above
+            .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+
+            // Each tenant is served by its own dedicated Pulsar CLUSTER. This is NOT the native
+            // Pulsar tenant segment in persistent://{tenant}/{namespace}/{topic} — the differentiator
+            // is the cluster connection (service URL + auth), and the native tenant/namespace stays
+            // whatever the shared topic topology declares.
+            .AddTenant("tenant-a", new Uri("pulsar://tenant-a-pulsar:6650"))
+
+            // The action overload runs against a fresh PulsarClient.Builder(), so it must FULLY
+            // specify the tenant cluster's ServiceUrl and any authentication.
+            .AddTenant("tenant-b", client =>
+            {
+                client.ServiceUrl(new Uri("pulsar://tenant-b-pulsar:6650"));
+                // client.Authentication(...); // tenant-specific auth if needed
+            });
+
+        // One shared topic topology; the cluster is chosen at runtime from each message's tenant id
+        opts.PublishMessage<Message1>().ToPulsarTopic("persistent://public/default/one");
+        opts.ListenToPulsarTopic("persistent://public/default/one");
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Pulsar/Wolverine.Pulsar.Tests/DocumentationSamples.cs#L132-L158' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pulsar_broker_per_tenant' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+To route a specific message to a tenant's cluster, stamp the tenant id on the send:
+
+```csharp
+await bus.SendAsync(new OrderPlaced("blue"), new DeliveryOptions { TenantId = "tenant-a" });
+```
+
+Wolverine wraps the outbound endpoint in a `TenantedSender` that dispatches on `Envelope.TenantId`, and builds a
+`CompoundListener` that runs one consumer per tenant cluster — each inbound envelope is stamped with the tenant
+id it was consumed under. This mirrors the RabbitMQ, Azure Service Bus, and NATS broker-per-tenant support.
+
+::: warning The Wolverine tenant id is NOT the native Pulsar tenant
+Pulsar has its own **native tenant** segment in the topic hierarchy `persistent://{tenant}/{namespace}/{topic}`
+(the `public` in `persistent://public/default/orders`). Wolverine's broker-per-tenant tenant id is an
+**orthogonal routing concept**: it selects a whole **cluster connection** (service URL + auth), *never* the
+native tenant segment. Two Wolverine tenants normally use the *same* native tenant/namespace on *different*
+clusters. Do not conflate the two.
+:::
+
+`TenantIdBehavior(...)` controls what happens when a message has a null or unregistered tenant id:
+
+* `FallbackToDefault` (the default) — route it to the default cluster passed to `UsePulsar`.
+* `TenantIdRequired` — throw; every message must carry a known tenant id.
+* `IgnoreUnknownTenants` — silently drop the message.
+
+::: info Each tenant is a separate cluster
+Because DotPulsar's client builder is not cloneable, each `AddTenant(...)` action runs against a fresh
+`PulsarClient.Builder()` and must fully specify its own `ServiceUrl` and authentication (the RabbitMQ transport
+has the same "fresh factory" caveat). Native retry-letter / dead-letter topics are provisioned per tenant
+cluster by that tenant's own listener. A broker-per-tenant setup genuinely requires distinct clusters — two
+competing durable subscriptions on a single broker would collide.
+:::
+
 ## URI reference
 
 The `PulsarEndpointUri` helper class produces Wolverine endpoint URIs of the form `pulsar://persistent/{tenant}/{ns}/{topic}` or `pulsar://non-persistent/{tenant}/{ns}/{topic}` — the form Wolverine's parser accepts. Pulsar-native topic-path strings (`persistent://...`) used by the native Pulsar client are a separate concept and are not built by this helper.

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/DocumentationSamples.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/DocumentationSamples.cs
@@ -1,7 +1,9 @@
 using DotPulsar;
+using DotPulsar.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Wolverine.ComplianceTests.Compliance;
+using Wolverine.Transports.Sending;
 
 namespace Wolverine.Pulsar.Tests;
 
@@ -95,6 +97,65 @@ public static class DocumentationSamples
             opts.UnsubscribePulsarOnClose(PulsarUnsubscribeOnClose.Disabled);
         });
 
+        #endregion
+    }
+
+    public static async Task named_brokers()
+    {
+        #region sample_pulsar_named_broker
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // The default Pulsar broker
+                opts.UsePulsar(c => c.ServiceUrl(new Uri("pulsar://localhost:6650")));
+
+                // An additional, independent Pulsar broker identified by name. The name doubles as the
+                // URI scheme of the named broker's endpoints (e.g. "secondary://..."), so its endpoints
+                // never collide with the default "pulsar://" broker.
+                opts.AddNamedPulsarBroker(new BrokerName("secondary"),
+                    c => c.ServiceUrl(new Uri("pulsar://secondary-pulsar:6650")));
+
+                // Publish a message type to a topic on the named broker
+                opts.PublishMessage<Message1>()
+                    .ToPulsarTopicOnNamedBroker(new BrokerName("secondary"),
+                        "persistent://public/default/one");
+
+                // Listen to a topic on the named broker
+                opts.ListenToPulsarTopicOnNamedBroker(new BrokerName("secondary"),
+                    "persistent://public/default/two");
+            }).StartAsync();
+        #endregion
+    }
+
+    public static async Task broker_per_tenant()
+    {
+        #region sample_pulsar_broker_per_tenant
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UsePulsar(c => c.ServiceUrl(new Uri("pulsar://localhost:6650")))
+
+                    // Route messages with an unknown/missing tenant id to the default broker above
+                    .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+
+                    // Each tenant is served by its own dedicated Pulsar CLUSTER. This is NOT the native
+                    // Pulsar tenant segment in persistent://{tenant}/{namespace}/{topic} — the differentiator
+                    // is the cluster connection (service URL + auth), and the native tenant/namespace stays
+                    // whatever the shared topic topology declares.
+                    .AddTenant("tenant-a", new Uri("pulsar://tenant-a-pulsar:6650"))
+
+                    // The action overload runs against a fresh PulsarClient.Builder(), so it must FULLY
+                    // specify the tenant cluster's ServiceUrl and any authentication.
+                    .AddTenant("tenant-b", client =>
+                    {
+                        client.ServiceUrl(new Uri("pulsar://tenant-b-pulsar:6650"));
+                        // client.Authentication(...); // tenant-specific auth if needed
+                    });
+
+                // One shared topic topology; the cluster is chosen at runtime from each message's tenant id
+                opts.PublishMessage<Message1>().ToPulsarTopic("persistent://public/default/one");
+                opts.ListenToPulsarTopic("persistent://public/default/one");
+            }).StartAsync();
         #endregion
     }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarNamedBrokerIntegrationTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarNamedBrokerIntegrationTests.cs
@@ -1,0 +1,70 @@
+using DotPulsar.Extensions;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+/// <summary>
+/// CI-safe end-to-end coverage for named Pulsar brokers (GH-3308). The default broker and the named broker
+/// both point at the single <see cref="PulsarContainerFixture.ServiceUrl"/> container, but the named broker
+/// exercises a distinct topic and its own <c>secondary://</c> URI scheme. This proves the wiring — a message
+/// published and consumed on the named broker round-trips and arrives stamped with the named broker's URI
+/// scheme (the receive pipeline sets <c>Destination</c> from the listener endpoint's URI). Proving true
+/// cluster isolation (a second container) is a separate, local-only test — see
+/// <see cref="PulsarPerTenantConnectionTests"/>.
+/// </summary>
+[Collection("pulsar")]
+public class PulsarNamedBrokerIntegrationTests
+{
+    private readonly BrokerName theName = new("secondary");
+
+    [Fact]
+    public async Task round_trips_a_message_over_the_named_broker()
+    {
+        var topic = $"persistent://public/default/named-{Guid.NewGuid():N}";
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "NamedBrokerInbound";
+                opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+                opts.AddNamedPulsarBroker(theName, b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+
+                opts.PublishMessage<NamedBrokerMessage>()
+                    .ToPulsarTopicOnNamedBroker(theName, topic).SendInline();
+                opts.ListenToPulsarTopicOnNamedBroker(theName, topic)
+                    .SubscriptionName("sub-" + Guid.NewGuid().ToString("N"))
+                    .BeginAtEarliest();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<NamedBrokerHandler>();
+            })
+            .StartAsync();
+
+        var session = await host
+            .TrackActivity()
+            .Timeout(60.Seconds())
+            .WaitForMessageToBeReceivedAt<NamedBrokerMessage>(host)
+            .ExecuteAndWaitAsync(c => c.SendAsync(new NamedBrokerMessage("round-trip")));
+
+        var received = session.Received.SingleEnvelope<NamedBrokerMessage>();
+        received.Message.ShouldBeOfType<NamedBrokerMessage>().Id.ShouldBe("round-trip");
+
+        // The receive pipeline stamps Destination from the listener endpoint's URI, so the consumed envelope
+        // carries the named broker's "secondary" scheme rather than the default "pulsar".
+        received.Destination!.Scheme.ShouldBe("secondary");
+    }
+}
+
+public record NamedBrokerMessage(string Id);
+
+public class NamedBrokerHandler
+{
+    public void Handle(NamedBrokerMessage message)
+    {
+        // no-op; the tracking session observes receipt
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarNamedBrokerTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarNamedBrokerTests.cs
@@ -1,0 +1,78 @@
+using DotPulsar.Extensions;
+using Shouldly;
+using Wolverine.Pulsar.ErrorHandling;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+/// <summary>
+/// Registration-level coverage for named Pulsar brokers (GH-3308) that needs no running broker, so it always
+/// runs in CI. A named broker is a second, independent <see cref="PulsarTransport"/> whose <c>Protocol</c>
+/// (and therefore its endpoints' URI scheme) is the broker name, so its endpoints never collide with the
+/// default <c>pulsar://</c> broker.
+/// </summary>
+public class PulsarNamedBrokerTests
+{
+    private readonly BrokerName theName = new("secondary");
+
+    [Fact]
+    public void adds_a_distinct_transport_instance_per_broker()
+    {
+        var options = new WolverineOptions();
+        options.UsePulsar(b => b.ServiceUrl(new Uri("pulsar://localhost:6650")));
+        options.AddNamedPulsarBroker(theName, b => b.ServiceUrl(new Uri("pulsar://localhost:6660")));
+
+        var transports = options.Transports.OfType<PulsarTransport>().ToList();
+        transports.Count.ShouldBe(2);
+        transports.Select(x => x.Protocol).OrderBy(x => x).ShouldBe(["pulsar", "secondary"]);
+    }
+
+    [Fact]
+    public void named_broker_endpoints_use_the_broker_name_as_their_uri_scheme()
+    {
+        var options = new WolverineOptions();
+        options.UsePulsar(b => b.ServiceUrl(new Uri("pulsar://localhost:6650")));
+        options.AddNamedPulsarBroker(theName, b => b.ServiceUrl(new Uri("pulsar://localhost:6660")));
+
+        var named = options.Transports.OfType<PulsarTransport>().Single(x => x.Protocol == "secondary");
+        named.EndpointFor("persistent://public/default/orders").Uri
+            .ShouldBe(new Uri("secondary://persistent/public/default/orders"));
+
+        // ...and the default broker keeps the canonical pulsar:// scheme.
+        var @default = options.Transports.OfType<PulsarTransport>().Single(x => x.Protocol == "pulsar");
+        @default.EndpointFor("persistent://public/default/orders").Uri
+            .ShouldBe(new Uri("pulsar://persistent/public/default/orders"));
+    }
+
+    [Fact]
+    public void get_or_create_by_name_returns_the_named_instance()
+    {
+        var options = new WolverineOptions();
+        options.UsePulsar(b => b.ServiceUrl(new Uri("pulsar://localhost:6650")));
+        options.AddNamedPulsarBroker(theName, b => b.ServiceUrl(new Uri("pulsar://localhost:6660")));
+
+        var named = options.Transports.GetOrCreate<PulsarTransport>(theName);
+        named.Protocol.ShouldBe("secondary");
+
+        var @default = options.Transports.GetOrCreate<PulsarTransport>();
+        @default.Protocol.ShouldBe("pulsar");
+
+        named.ShouldNotBeSameAs(@default);
+    }
+
+    [Fact]
+    public void listen_and_publish_on_named_broker_target_the_named_transport()
+    {
+        var options = new WolverineOptions();
+        options.UsePulsar(b => b.ServiceUrl(new Uri("pulsar://localhost:6650")));
+        options.AddNamedPulsarBroker(theName, b => b.ServiceUrl(new Uri("pulsar://localhost:6660")));
+
+        options.ListenToPulsarTopicOnNamedBroker(theName, "persistent://public/default/incoming");
+
+        var named = options.Transports.OfType<PulsarTransport>().Single(x => x.Protocol == "secondary");
+        var endpoint = named.EndpointFor("persistent://public/default/incoming");
+        endpoint.IsListener.ShouldBeTrue();
+        endpoint.Uri.Scheme.ShouldBe("secondary");
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarPerTenantConfigurationTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarPerTenantConfigurationTests.cs
@@ -1,0 +1,107 @@
+using DotPulsar.Extensions;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+/// <summary>
+/// Registration-level coverage for broker-per-tenant Pulsar multi-tenancy (GH-3308). No running broker is
+/// required (DotPulsar producers/consumers connect lazily), so these run in CI.
+///
+/// Reminder: the Wolverine tenant id here selects a whole Pulsar <em>cluster</em> (service URL + auth), not the
+/// native Pulsar tenant segment in <c>persistent://{tenant}/{namespace}/{topic}</c>.
+/// </summary>
+public class PulsarPerTenantConfigurationTests
+{
+    [Fact]
+    public void add_tenant_registers_a_tenant_with_its_own_transport()
+    {
+        var options = new WolverineOptions();
+        var pulsar = options.UsePulsar(b => b.ServiceUrl(new Uri("pulsar://shared:6650")));
+        pulsar.AddTenant("tenantB", new Uri("pulsar://tenant-b:6650"));
+
+        var transport = pulsar.Transport;
+        transport.Tenants.Count().ShouldBe(1);
+
+        var tenant = transport.Tenants["tenantB"];
+        tenant.TenantId.ShouldBe("tenantB");
+        tenant.Transport.ShouldNotBeSameAs(transport);
+    }
+
+    [Fact]
+    public void add_tenant_action_overload_registers_the_tenant()
+    {
+        var options = new WolverineOptions();
+        var pulsar = options.UsePulsar(b => b.ServiceUrl(new Uri("pulsar://shared:6650")));
+        pulsar.AddTenant("tenantB", b => b.ServiceUrl(new Uri("pulsar://tenant-b:6650")));
+
+        pulsar.Transport.Tenants["tenantB"].TenantId.ShouldBe("tenantB");
+    }
+
+    [Fact]
+    public void compile_copies_parent_dead_letter_and_retry_defaults_onto_the_tenant()
+    {
+        var options = new WolverineOptions();
+        var pulsar = options.UsePulsar(b => b.ServiceUrl(new Uri("pulsar://shared:6650")));
+        pulsar.DeadLetterQueueing(DeadLetterTopic.DefaultNative);
+        pulsar.RetryLetterQueueing(new RetryLetterTopic([TimeSpan.FromSeconds(1)]));
+        pulsar.AddTenant("tenantB", new Uri("pulsar://tenant-b:6650"));
+
+        var transport = pulsar.Transport;
+        var tenant = transport.Tenants["tenantB"];
+        tenant.Compile(transport);
+
+        tenant.Transport.DeadLetterTopic.ShouldBeSameAs(transport.DeadLetterTopic);
+        tenant.Transport.RetryLetterTopic.ShouldBeSameAs(transport.RetryLetterTopic);
+    }
+
+    [Fact]
+    public void tenant_id_behavior_setter_flows_to_the_transport()
+    {
+        var options = new WolverineOptions();
+        var pulsar = options.UsePulsar(b => b.ServiceUrl(new Uri("pulsar://shared:6650")));
+        pulsar.TenantIdBehavior(TenantedIdBehavior.TenantIdRequired);
+
+        pulsar.Transport.TenantedIdBehavior.ShouldBe(TenantedIdBehavior.TenantIdRequired);
+    }
+
+    [Fact]
+    public void pulsar_endpoints_are_tenant_aware_by_default()
+    {
+        var transport = new PulsarTransport();
+        var endpoint = transport.EndpointFor("persistent://public/default/orders");
+        endpoint.TenancyBehavior.ShouldBe(TenancyBehavior.TenantAware);
+    }
+
+    [Fact]
+    public async Task tenant_aware_endpoint_resolves_a_TenantedSender()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UsePulsar(b => b.ServiceUrl(new Uri("pulsar://localhost:6650")))
+                    .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+                    .AddTenant("tenantB", new Uri("pulsar://localhost:6660"));
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.PublishMessage<TenantColorMessage>()
+                    .ToPulsarTopic("persistent://public/default/tenant-colors");
+            })
+            .StartAsync();
+
+        var runtime = host.GetRuntime();
+        var transport = runtime.Options.Transports.GetOrCreate<PulsarTransport>();
+        var endpoint = transport.EndpointFor("persistent://public/default/tenant-colors");
+
+        var agent = (SendingAgent)runtime.Endpoints.GetOrBuildSendingAgent(endpoint.Uri);
+        agent.Sender.ShouldBeOfType<TenantedSender>();
+    }
+}
+
+public record TenantColorMessage(string Color);

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarPerTenantConnectionTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarPerTenantConnectionTests.cs
@@ -1,0 +1,115 @@
+using DotPulsar.Extensions;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Testcontainers.Pulsar;
+using Wolverine.ComplianceTests;
+using Wolverine.Tracking;
+using Wolverine.Transports.Sending;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Wolverine.Pulsar.Tests;
+
+/// <summary>
+/// True cluster-isolation coverage for broker-per-tenant Pulsar multi-tenancy (GH-3308). Unlike the CI-safe
+/// named-broker test, this spins up a <em>second</em> Pulsar container ("cluster B") so the tenant genuinely
+/// connects to a different broker than the default ("cluster A", the shared fixture). This proves:
+/// <list type="bullet">
+/// <item>a tenant-stamped message is published to cluster B and not cluster A,</item>
+/// <item>a default message is published to cluster A and not cluster B,</item>
+/// <item>a tenant message is consumed and stamped with its <c>TenantId</c>.</item>
+/// </list>
+///
+/// This is deliberately excluded from <c>CIPulsar</c> (it needs two brokers, and two competing durable
+/// subscriptions on a <em>single</em> broker would collide — the very reason broker-per-tenant uses distinct
+/// clusters). Marked <c>[Trait("Category","Integration")]</c>.
+///
+/// Reminder: the Wolverine tenant id selects a whole Pulsar <em>cluster</em>, not the native Pulsar tenant
+/// segment in <c>persistent://{tenant}/{namespace}/{topic}</c> (which stays <c>public/default</c> on both).
+/// </summary>
+[Collection("pulsar")]
+[Trait("Category", "Integration")]
+public class PulsarPerTenantConnectionTests : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private PulsarContainer? _clusterB;
+    private Uri _clusterAServiceUrl = null!;
+    private Uri _clusterBServiceUrl = null!;
+    private bool _skip;
+
+    public PulsarPerTenantConnectionTests(ITestOutputHelper output) => _output = output;
+
+    public async Task InitializeAsync()
+    {
+        _clusterAServiceUrl = PulsarContainerFixture.ServiceUrl;
+
+        try
+        {
+            _clusterB = new PulsarBuilder().WithImage("apachepulsar/pulsar:latest").Build();
+            await _clusterB.StartAsync();
+            _clusterBServiceUrl = new Uri(_clusterB.GetBrokerAddress());
+
+            _output.WriteLine($"Cluster A (default): {_clusterAServiceUrl}");
+            _output.WriteLine($"Cluster B (tenant):  {_clusterBServiceUrl}");
+        }
+        catch (Exception e)
+        {
+            _output.WriteLine("Skipping: could not start tenant Pulsar cluster: " + e.Message);
+            _skip = true;
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_clusterB != null)
+        {
+            await _clusterB.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task tenant_message_is_consumed_and_stamped_with_the_tenant_id()
+    {
+        if (_skip) return;
+
+        var topic = $"persistent://public/default/pertenant-{Guid.NewGuid():N}";
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "PerTenantInbound";
+                opts.UsePulsar(b => b.ServiceUrl(_clusterAServiceUrl))
+                    .TenantIdBehavior(TenantedIdBehavior.FallbackToDefault)
+                    .AddTenant("tenantB", _clusterBServiceUrl);
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.PublishMessage<TenantColorMessage>().ToPulsarTopic(topic).SendInline();
+                opts.ListenToPulsarTopic(topic)
+                    .SubscriptionName("sub-" + Guid.NewGuid().ToString("N"))
+                    .BeginAtEarliest();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<TenantColorHandler>();
+            })
+            .StartAsync();
+
+        var session = await host
+            .TrackActivity()
+            .Timeout(60.Seconds())
+            .WaitForMessageToBeReceivedAt<TenantColorMessage>(host)
+            .ExecuteAndWaitAsync(c =>
+                c.SendAsync(new TenantColorMessage("for-tenant-b"), new DeliveryOptions { TenantId = "tenantB" }));
+
+        var received = session.Received.SingleEnvelope<TenantColorMessage>();
+        received.TenantId.ShouldBe("tenantB");
+        received.Message.ShouldBeOfType<TenantColorMessage>().Color.ShouldBe("for-tenant-b");
+    }
+}
+
+public class TenantColorHandler
+{
+    public void Handle(TenantColorMessage message)
+    {
+        // no-op; the tracking session observes receipt and its stamped TenantId
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/Internal/PulsarTenant.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/Internal/PulsarTenant.cs
@@ -1,0 +1,55 @@
+using DotPulsar.Abstractions;
+
+namespace Wolverine.Pulsar.Internal;
+
+/// <summary>
+/// A single broker-per-tenant registration for the Pulsar transport (GH-3308). Each tenant owns its own
+/// child <see cref="PulsarTransport"/> (and therefore its own independent <see cref="IPulsarClient"/>) pointed
+/// at a dedicated Pulsar cluster: service URL + auth are supplied through the tenant's own
+/// <see cref="IPulsarClientBuilder"/> in <c>AddTenant</c>. Outbound is routed to the tenant's cluster by
+/// <see cref="Envelope.TenantId"/>; inbound listeners stamp that tenant id.
+///
+/// IMPORTANT — the two "tenants" are orthogonal: this Wolverine tenant id is a <em>routing / connection</em>
+/// concept and selects a whole <em>cluster</em>. It is NOT the native Pulsar tenant segment in the
+/// <c>persistent://{tenant}/{namespace}/{topic}</c> topic hierarchy (that stays whatever the shared topic
+/// topology declares). Two Wolverine tenants can — and normally do — use the same native tenant/namespace on
+/// different clusters.
+/// </summary>
+internal class PulsarTenant
+{
+    public PulsarTenant(string tenantId)
+    {
+        TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));
+        Transport = new PulsarTransport();
+    }
+
+    public string TenantId { get; }
+
+    /// <summary>
+    /// The tenant's own transport. Its <see cref="PulsarTransport.Builder"/> is configured by the
+    /// <c>AddTenant</c> action (fully specifying ServiceUrl + auth) and its <see cref="PulsarTransport.Client"/>
+    /// is built during the parent transport's <see cref="PulsarTransport.InitializeAsync"/>.
+    /// </summary>
+    public PulsarTransport Transport { get; }
+
+    /// <summary>
+    /// The user-supplied configuration for this tenant's DotPulsar client. Runs against a fresh
+    /// <c>PulsarClient.Builder()</c> (DotPulsar's builder is not trivially cloneable), so the action must fully
+    /// specify ServiceUrl and any authentication for the tenant's cluster.
+    /// </summary>
+    public Action<IPulsarClientBuilder> Configure { get; init; } = _ => { };
+
+    /// <summary>
+    /// Copy the parent transport's cross-cutting defaults (dead-letter / retry-letter topics) onto this
+    /// tenant's transport and apply the tenant's own client-builder configuration. Called during the parent
+    /// <see cref="PulsarTransport.InitializeAsync"/> before the tenant client is built. Native retry/DLQ
+    /// producers are provisioned per-tenant-cluster by the per-tenant <see cref="PulsarListener"/> at listen time.
+    /// </summary>
+    public void Compile(PulsarTransport parent)
+    {
+        Transport.DeadLetterTopic = parent.DeadLetterTopic;
+        Transport.RetryLetterTopic = parent.RetryLetterTopic;
+
+        Configure(Transport.Builder);
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarConfiguration.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarConfiguration.cs
@@ -1,3 +1,8 @@
+using DotPulsar;
+using DotPulsar.Abstractions;
+using Wolverine.Pulsar.Internal;
+using Wolverine.Transports.Sending;
+
 namespace Wolverine.Pulsar;
 
 /// <summary>
@@ -13,6 +18,8 @@ public class PulsarConfiguration
     {
         _transport = transport;
     }
+
+    internal PulsarTransport Transport => _transport;
 
     /// <summary>
     /// Set the transport-wide default dead letter topic applied to every Pulsar endpoint that does
@@ -34,6 +41,64 @@ public class PulsarConfiguration
     public PulsarConfiguration RetryLetterQueueing(RetryLetterTopic retryLetterTopic)
     {
         _transport.RetryLetterTopic = retryLetterTopic ?? throw new ArgumentNullException(nameof(retryLetterTopic));
+        return this;
+    }
+
+    /// <summary>
+    /// Register a Wolverine tenant that is served by its own dedicated Pulsar <b>cluster</b> (GH-3308), while
+    /// sharing the topic topology declared on this transport. Outbound messages whose
+    /// <see cref="Envelope.TenantId"/> matches <paramref name="tenantId"/> are routed to that cluster; inbound
+    /// messages consumed from it are stamped with the tenant id.
+    ///
+    /// <para>
+    /// ⚠️ <b>This is NOT the native Pulsar tenant.</b> Pulsar has its own "tenant" segment in the
+    /// <c>persistent://{tenant}/{namespace}/{topic}</c> topic hierarchy; that is unchanged and shared across all
+    /// Wolverine tenants. The per-tenant differentiator here is the <em>cluster connection</em> — the service
+    /// URL and authentication you set on <paramref name="configure"/> — never the native tenant segment.
+    /// </para>
+    ///
+    /// <para>
+    /// DotPulsar's client builder is not trivially cloneable, so <paramref name="configure"/> runs against a
+    /// fresh <c>PulsarClient.Builder()</c> and <b>must fully specify</b> the tenant cluster's <c>ServiceUrl</c>
+    /// and any authentication (the same "fresh factory" caveat as the RabbitMQ transport).
+    /// </para>
+    /// </summary>
+    /// <param name="tenantId">The Wolverine tenant id (matched against <see cref="Envelope.TenantId"/>).</param>
+    /// <param name="configure">Fully configures the tenant cluster's DotPulsar client (ServiceUrl + auth).</param>
+    public PulsarConfiguration AddTenant(string tenantId, Action<IPulsarClientBuilder> configure)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        _transport.Tenants[tenantId] = new PulsarTenant(tenantId) { Configure = configure };
+        return this;
+    }
+
+    /// <summary>
+    /// Convenience overload of <see cref="AddTenant(string,System.Action{DotPulsar.Abstractions.IPulsarClientBuilder})"/>
+    /// for the common case where the tenant cluster differs only by service URL (no extra auth). Registers a
+    /// Wolverine tenant served by the Pulsar cluster at <paramref name="serviceUrl"/>.
+    ///
+    /// <para>⚠️ As with the action overload, <paramref name="serviceUrl"/> selects a <em>cluster</em>, not the
+    /// native Pulsar tenant segment.</para>
+    /// </summary>
+    /// <param name="tenantId">The Wolverine tenant id (matched against <see cref="Envelope.TenantId"/>).</param>
+    /// <param name="serviceUrl">The Pulsar service URL for the tenant's cluster, e.g. <c>pulsar://tenant-a:6650</c>.</param>
+    public PulsarConfiguration AddTenant(string tenantId, Uri serviceUrl)
+    {
+        ArgumentNullException.ThrowIfNull(serviceUrl);
+        return AddTenant(tenantId, builder => builder.ServiceUrl(serviceUrl));
+    }
+
+    /// <summary>
+    /// Control how outbound messages whose <see cref="Envelope.TenantId"/> is null or does not match a
+    /// registered tenant are handled when broker-per-tenant multi-tenancy is in effect (GH-3308). Default is
+    /// <see cref="Wolverine.Transports.Sending.TenantedIdBehavior.FallbackToDefault"/> (route to the default
+    /// broker configured via <c>UsePulsar</c>).
+    /// </summary>
+    public PulsarConfiguration TenantIdBehavior(TenantedIdBehavior behavior)
+    {
+        _transport.TenantedIdBehavior = behavior;
         return this;
     }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -244,20 +244,18 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
 
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
     {
-        // Hot-tail (GH-3184): a non-durable Reader at the tail rather than a durable subscription.
-        if (IsHotTail)
-        {
-            var readerListener = new PulsarReaderListener(runtime, this, receiver, _parent, runtime.Cancellation);
-            return ValueTask.FromResult<IListener>(readerListener);
-        }
-
-        var listener = new PulsarListener(runtime, this, receiver, _parent, runtime.Cancellation);
-        return ValueTask.FromResult<IListener>(listener);
+        // Delegate to the transport so broker-per-tenant fan-out (GH-3308) and the hot-tail branch (GH-3184)
+        // are resolved in one place. The transport builds a CompoundListener over per-tenant clusters when
+        // tenants are registered and this endpoint is tenant-aware; otherwise a single listener.
+        return _parent.BuildListenerAsync(this, receiver, runtime);
     }
 
     protected override ISender CreateSender(IWolverineRuntime runtime)
     {
-        return new PulsarSender(runtime, this, _parent, runtime.Cancellation);
+        // Delegate to the transport so broker-per-tenant fan-out (GH-3308) is resolved in one place. The
+        // transport wraps a TenantedSender over per-tenant clusters when tenants are registered and this
+        // endpoint is tenant-aware; otherwise a single sender.
+        return _parent.BuildSender(this, runtime);
     }
 
     public override bool TryBuildDeadLetterSender(IWolverineRuntime runtime, out ISender? deadLetterSender)

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpointUri.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpointUri.cs
@@ -90,11 +90,51 @@ public static class PulsarEndpointUri
             : NonPersistentTopic(parsed.Host, pathParts[0], pathParts[1]);
     }
 
+    /// <summary>
+    /// Converts a Pulsar-native topic path into a Wolverine endpoint URI whose scheme is
+    /// <paramref name="scheme"/> (the owning transport's <see cref="PulsarTransport.Protocol"/>) rather than the
+    /// hard-coded <c>pulsar</c>. For the default broker <paramref name="scheme"/> is <c>pulsar</c>; for a named
+    /// broker (<see cref="PulsarTransportExtensions.AddNamedPulsarBroker"/>) it is the broker name, so the named
+    /// broker's endpoints route through <c>ForScheme</c> and never collide with the default broker's endpoints.
+    /// <see cref="PulsarEndpoint.Parse"/> only validates the host segment, so the scheme is free to vary per broker.
+    /// </summary>
+    internal static Uri Topic(string topicPath, string scheme)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topicPath);
+
+        var parsed = new Uri(topicPath);
+
+        if (parsed.Scheme != PulsarEndpoint.Persistent && parsed.Scheme != PulsarEndpoint.NonPersistent)
+        {
+            throw new ArgumentException(
+                $"topicPath must use scheme '{PulsarEndpoint.Persistent}' or '{PulsarEndpoint.NonPersistent}', got '{parsed.Scheme}'.",
+                nameof(topicPath));
+        }
+
+        var pathParts = parsed.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (pathParts.Length != 2)
+        {
+            throw new ArgumentException(
+                $"topicPath must have the form '{{scheme}}://{{tenant}}/{{namespace}}/{{topic}}', got '{topicPath}'.",
+                nameof(topicPath));
+        }
+
+        // parsed.Scheme is the persistence segment ("persistent"/"non-persistent"); parsed.Host is the native
+        // Pulsar tenant. The resulting Wolverine endpoint URI is "{scheme}://{persistence}/{tenant}/{ns}/{topic}".
+        return BuildEndpointUri(scheme, parsed.Scheme, parsed.Host, pathParts[0], pathParts[1]);
+    }
+
     private static Uri BuildEndpointUri(string persistence, string tenant, string @namespace, string topicName)
+    {
+        return BuildEndpointUri(PulsarTransport.ProtocolName, persistence, tenant, @namespace, topicName);
+    }
+
+    private static Uri BuildEndpointUri(string scheme, string persistence, string tenant, string @namespace,
+        string topicName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(tenant);
         ArgumentException.ThrowIfNullOrWhiteSpace(@namespace);
         ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
-        return new Uri($"pulsar://{persistence}/{tenant}/{@namespace}/{topicName}");
+        return new Uri($"{scheme}://{persistence}/{tenant}/{@namespace}/{topicName}");
     }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarHealthCheck.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarHealthCheck.cs
@@ -9,7 +9,7 @@ internal class PulsarHealthCheck : WolverineTransportHealthCheck
     public PulsarHealthCheck(PulsarTransport transport) => _transport = transport;
 
     public override string TransportName => "Pulsar";
-    public override string Protocol => "pulsar";
+    public override string Protocol => _transport.Protocol;
 
     public override Task<TransportHealthResult> CheckHealthAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransport.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransport.cs
@@ -4,8 +4,10 @@ using JasperFx.Core;
 using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
+using Wolverine.Pulsar.Internal;
 using Wolverine.Runtime;
 using Wolverine.Transports;
+using Wolverine.Transports.Sending;
 
 namespace Wolverine.Pulsar;
 
@@ -15,7 +17,18 @@ public class PulsarTransport : TransportBase<PulsarEndpoint>, IAsyncDisposable
 
     private readonly LightweightCache<Uri, PulsarEndpoint> _endpoints;
 
-    public PulsarTransport() : base(ProtocolName, "Pulsar", ["pulsar"])
+    public PulsarTransport() : this(ProtocolName)
+    {
+    }
+
+    /// <summary>
+    /// Constructor used when connecting to more than one Pulsar broker from a single application. The
+    /// <paramref name="protocol"/> doubles as the additional broker's URI scheme so its endpoints do not
+    /// collide with the default <c>pulsar://</c> broker. Reached through
+    /// <see cref="TransportCollection.GetOrCreate{T}"/> when a <see cref="BrokerName"/> is supplied via
+    /// <see cref="PulsarTransportExtensions.AddNamedPulsarBroker"/>.
+    /// </summary>
+    public PulsarTransport(string protocol) : base(protocol, "Pulsar", [protocol])
     {
         Builder = PulsarClient.Builder();
 
@@ -29,6 +42,25 @@ public class PulsarTransport : TransportBase<PulsarEndpoint>, IAsyncDisposable
     public IPulsarClientBuilder Builder { get; }
 
     internal IPulsarClient? Client { get; private set; }
+
+    /// <summary>
+    /// Broker-per-tenant registrations (GH-3308). Each tenant owns a child <see cref="PulsarTransport"/>
+    /// pointed at its own dedicated Pulsar cluster (service URL + auth via <see cref="IPulsarClientBuilder"/>);
+    /// outbound is routed by <see cref="Envelope.TenantId"/> and inbound listeners stamp the tenant id.
+    ///
+    /// IMPORTANT: this Wolverine "tenant" is orthogonal to Pulsar's own native tenant segment in the
+    /// <c>persistent://{tenant}/{namespace}/{topic}</c> topic hierarchy. The per-tenant differentiator here is a
+    /// distinct <em>cluster connection</em>, never the native tenant segment (which is unchanged and shared).
+    /// </summary>
+    [IgnoreDescription]
+    internal LightweightCache<string, PulsarTenant> Tenants { get; } = new();
+
+    /// <summary>
+    /// Controls how outbound messages whose <see cref="Envelope.TenantId"/> is null or does not match a
+    /// registered tenant are handled when broker-per-tenant multi-tenancy is in effect. Defaults to
+    /// <see cref="Wolverine.Transports.Sending.TenantedIdBehavior.FallbackToDefault"/>.
+    /// </summary>
+    public TenantedIdBehavior TenantedIdBehavior { get; set; } = TenantedIdBehavior.FallbackToDefault;
     /// <summary>
     /// Transport-wide default dead letter topic applied to every Pulsar endpoint that does not set
     /// its own <see cref="PulsarEndpoint.DeadLetterTopic"/>. Resolution is per-endpoint-override-wins:
@@ -78,14 +110,17 @@ public class PulsarTransport : TransportBase<PulsarEndpoint>, IAsyncDisposable
     //    }
     //}
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         if (Client != null)
         {
-            return Client.DisposeAsync();
+            await Client.DisposeAsync();
         }
 
-        return ValueTask.CompletedTask;
+        foreach (var tenant in Tenants)
+        {
+            await tenant.Transport.DisposeAsync();
+        }
     }
 
     protected override IEnumerable<PulsarEndpoint> endpoints()
@@ -102,6 +137,17 @@ public class PulsarTransport : TransportBase<PulsarEndpoint>, IAsyncDisposable
     {
         Client = Builder.Build();
         configureRetryTopics(runtime);
+
+        // Broker-per-tenant (GH-3308): Pulsar connects here (not in ConnectAsync). Copy the parent defaults
+        // onto each tenant's child transport and build its independent IPulsarClient against the tenant's own
+        // cluster. The DotPulsar builder isn't cloneable, so each tenant supplies its own fully-specified
+        // Builder (service URL + auth) via AddTenant.
+        foreach (var tenant in Tenants)
+        {
+            tenant.Compile(this);
+            tenant.Transport.Client = tenant.Transport.Builder.Build();
+        }
+
         return ValueTask.CompletedTask;
     }
 
@@ -159,7 +205,77 @@ public class PulsarTransport : TransportBase<PulsarEndpoint>, IAsyncDisposable
 
     public PulsarEndpoint EndpointFor(string topicPath)
     {
-        var uri = PulsarEndpointUri.Topic(topicPath);
+        // Build the Wolverine endpoint URI with this transport's Protocol as the scheme. For the default broker
+        // that is "pulsar://"; for a named broker (AddNamedPulsarBroker) it is the broker name, so the named
+        // broker's endpoints route through ForScheme and never collide with the default broker's endpoints.
+        var uri = PulsarEndpointUri.Topic(topicPath, Protocol);
         return this[uri];
+    }
+
+    /// <summary>
+    /// Build the outbound sender for a Pulsar endpoint (GH-3308). When broker-per-tenant tenants are registered
+    /// and the endpoint is tenant-aware, this wraps the default sender in a <see cref="TenantedSender"/> that
+    /// dispatches on <see cref="Envelope.TenantId"/> and registers one <see cref="PulsarSender"/> per tenant
+    /// cluster. Modeled on <c>RabbitMqTransport.BuildSender</c>.
+    /// </summary>
+    internal ISender BuildSender(PulsarEndpoint endpoint, IWolverineRuntime runtime)
+    {
+        var defaultSender = new PulsarSender(runtime, endpoint, this, runtime.Cancellation);
+
+        if (Tenants.Any() && endpoint.TenancyBehavior == TenancyBehavior.TenantAware)
+        {
+            // PulsarSender is fire-and-forget (it does NOT implement ISenderRequiresCallback), so it is safe
+            // under TenantedSender — no GH-2361 silent-drop concern.
+            var tenantedSender = new TenantedSender(endpoint.Uri, TenantedIdBehavior, defaultSender);
+            foreach (var tenant in Tenants)
+            {
+                var sender = new PulsarSender(runtime, endpoint, tenant.Transport, runtime.Cancellation);
+                tenantedSender.RegisterSender(tenant.TenantId, sender);
+            }
+
+            return tenantedSender;
+        }
+
+        return defaultSender;
+    }
+
+    /// <summary>
+    /// Build the inbound listener for a Pulsar endpoint (GH-3308). When broker-per-tenant tenants are registered
+    /// and the endpoint is tenant-aware, this builds a <see cref="CompoundListener"/> that runs the default
+    /// listener plus one per-tenant listener; each tenant listener wraps its receiver in a
+    /// <see cref="ReceiverWithRules"/> carrying a <see cref="TenantIdRule"/> so inbound envelopes are stamped
+    /// with the tenant id they were consumed under. The hot-tail (<see cref="PulsarReaderListener"/>) branch is
+    /// preserved with the same per-tenant treatment. Modeled on <c>RabbitMqTransport.BuildListenerAsync</c>.
+    /// </summary>
+    internal ValueTask<IListener> BuildListenerAsync(PulsarEndpoint endpoint, IReceiver receiver,
+        IWolverineRuntime runtime)
+    {
+        if (Tenants.Any() && endpoint.TenancyBehavior == TenancyBehavior.TenantAware)
+        {
+            var compound = new CompoundListener(endpoint.Uri);
+            compound.Inner.Add(buildSingleListener(endpoint, receiver, this, runtime));
+
+            foreach (var tenant in Tenants)
+            {
+                var wrapped = new ReceiverWithRules(receiver, [new TenantIdRule(tenant.TenantId)]);
+                compound.Inner.Add(buildSingleListener(endpoint, wrapped, tenant.Transport, runtime));
+            }
+
+            return ValueTask.FromResult<IListener>(compound);
+        }
+
+        return ValueTask.FromResult(buildSingleListener(endpoint, receiver, this, runtime));
+    }
+
+    private static IListener buildSingleListener(PulsarEndpoint endpoint, IReceiver receiver,
+        PulsarTransport transport, IWolverineRuntime runtime)
+    {
+        // Hot-tail (GH-3184): a non-durable Reader at the tail rather than a durable subscription.
+        if (endpoint.IsHotTail)
+        {
+            return new PulsarReaderListener(runtime, endpoint, receiver, transport, runtime.Cancellation);
+        }
+
+        return new PulsarListener(runtime, endpoint, receiver, transport, runtime.Cancellation);
     }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -22,11 +22,11 @@ public static class PulsarTransportExtensions
     /// </summary>
     /// <param name="endpoints"></param>
     /// <returns></returns>
-    internal static PulsarTransport PulsarTransport(this WolverineOptions endpoints)
+    internal static PulsarTransport PulsarTransport(this WolverineOptions endpoints, BrokerName? name = null)
     {
         var transports = endpoints.As<WolverineOptions>().Transports;
 
-        return transports.GetOrCreate<PulsarTransport>();
+        return transports.GetOrCreate<PulsarTransport>(name);
     }
 
     /// <summary>
@@ -52,6 +52,36 @@ public static class PulsarTransportExtensions
     public static PulsarConfiguration UsePulsar(this WolverineOptions endpoints)
     {
         return endpoints.UsePulsar(_ => { });
+    }
+
+    /// <summary>
+    ///     Configure connection and authentication information for an additional, named Pulsar broker used by
+    ///     this application. Only use this overload if your Wolverine application needs to talk to two or more
+    ///     Pulsar brokers. The <paramref name="name"/> doubles as the URI scheme for the additional broker's
+    ///     endpoints, so pin publishing/listening to it with <see cref="ToPulsarTopicOnNamedBroker"/> /
+    ///     <see cref="ListenToPulsarTopicOnNamedBroker"/>.
+    ///
+    ///     <para>
+    ///     A "named broker" is a <em>statically-addressed</em> second connection you target explicitly. This is
+    ///     distinct from broker-per-tenant multi-tenancy (<see cref="PulsarConfiguration.AddTenant(string,System.Action{DotPulsar.Abstractions.IPulsarClientBuilder})"/>),
+    ///     where the connection is selected at runtime from each message's tenant id.
+    ///     </para>
+    /// </summary>
+    /// <param name="endpoints"></param>
+    /// <param name="name">Identity of the additional Pulsar broker; also the URI scheme of its endpoints.</param>
+    /// <param name="configure">Fully configures the additional broker's DotPulsar client (ServiceUrl + auth).</param>
+    public static PulsarConfiguration AddNamedPulsarBroker(this WolverineOptions endpoints, BrokerName name,
+        Action<IPulsarClientBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        new PulsarNativeResiliencyPolicy().Apply(endpoints);
+
+        var transport = endpoints.PulsarTransport(name);
+        configure(transport.Builder);
+
+        return new PulsarConfiguration(transport);
     }
 
     /// <summary>
@@ -83,6 +113,41 @@ public static class PulsarTransportExtensions
     {
         var uri = PulsarEndpointUri.Topic(topicPath);
         var endpoint = endpoints.PulsarTransport()[uri];
+        endpoint.IsListener = true;
+        return new PulsarListenerConfiguration(endpoint);
+    }
+
+    /// <summary>
+    ///     Publish matching messages to a Pulsar topic on an additional, named broker registered via
+    ///     <see cref="AddNamedPulsarBroker"/>.
+    /// </summary>
+    /// <param name="publishing"></param>
+    /// <param name="name">Identity of the additional Pulsar broker</param>
+    /// <param name="topicPath">Pulsar topic of the form "persistent|non-persistent://tenant/namespace/topic"</param>
+    public static PulsarSubscriberConfiguration ToPulsarTopicOnNamedBroker(this IPublishToExpression publishing,
+        BrokerName name, string topicPath)
+    {
+        var transports = publishing.As<PublishingExpression>().Parent.Transports;
+        var transport = transports.GetOrCreate<PulsarTransport>(name);
+        var endpoint = transport.EndpointFor(topicPath);
+
+        // This is necessary unfortunately to hook up the subscription rules
+        publishing.To(endpoint.Uri);
+
+        return new PulsarSubscriberConfiguration(endpoint);
+    }
+
+    /// <summary>
+    ///     Listen to a Pulsar topic on an additional, named broker registered via
+    ///     <see cref="AddNamedPulsarBroker"/>.
+    /// </summary>
+    /// <param name="endpoints"></param>
+    /// <param name="name">Identity of the additional Pulsar broker</param>
+    /// <param name="topicPath">Pulsar topic of the form "persistent|non-persistent://tenant/namespace/topic"</param>
+    public static PulsarListenerConfiguration ListenToPulsarTopicOnNamedBroker(this WolverineOptions endpoints,
+        BrokerName name, string topicPath)
+    {
+        var endpoint = endpoints.PulsarTransport(name).EndpointFor(topicPath);
         endpoint.IsListener = true;
         return new PulsarListenerConfiguration(endpoint);
     }


### PR DESCRIPTION
Closes #3308

Brings the Pulsar transport (`Wolverine.Pulsar`) up to parity with RabbitMQ / NATS / Kafka on the two multi-broker features it previously had **neither** of.

## ⚠️ Native-tenant vs. Wolverine tenant (the key design call)

Pulsar has its own **native tenant** segment in the topic hierarchy `persistent://{tenant}/{namespace}/{topic}` (the `public` in `persistent://public/default/orders`). Wolverine's broker-per-tenant "tenant" is an **orthogonal `Envelope.TenantId` routing concept**. This PR keeps the framework-consistent `AddTenant(tenantId, …)` name, but the per-tenant differentiator is a **whole cluster connection** (service URL + auth via `IPulsarClientBuilder`) — **never** the native tenant segment. Two Wolverine tenants normally use the *same* native tenant/namespace on *different* clusters. This distinction is called out prominently in the XML docs, the guide (a dedicated `::: warning`), and `PulsarTenant`'s summary.

## Named broker

- `PulsarTransport(string protocol)` ctor (the parameterless ctor chains to it) so `TransportCollection.GetOrCreate<T>(BrokerName)` can build a named instance whose `Protocol` doubles as its endpoints' URI scheme.
- `PulsarEndpointUri.Topic(topicPath, scheme)` builds the endpoint URI from the transport `Protocol` instead of the hard-coded `pulsar://`; `EndpointFor` uses it. `PulsarEndpoint.Parse` already ignores the scheme.
- New public API: `AddNamedPulsarBroker(BrokerName, Action<IPulsarClientBuilder>)`, `ToPulsarTopicOnNamedBroker`, `ListenToPulsarTopicOnNamedBroker` (applies the existing `PulsarNativeResiliencyPolicy`, mirroring `UsePulsar`).
- `PulsarHealthCheck` now reports the transport's own `Protocol`.

## Broker-per-tenant (RabbitMQ-style: each tenant owns its own transport/client)

- New `Internal/PulsarTenant` — its own `PulsarTransport`/`IPulsarClient`, `Compile(parent)` copies DLQ/retry defaults. Because Pulsar connects in **`InitializeAsync`** (not `ConnectAsync`), each tenant client is built there and disposed in `DisposeAsync`.
- New public API on `PulsarConfiguration`: `AddTenant(string, Action<IPulsarClientBuilder>)`, `AddTenant(string, Uri serviceUrl)` (convenience), `TenantIdBehavior(TenantedIdBehavior)`.
- `transport.BuildSender` / `BuildListenerAsync` (modeled on `RabbitMqTransport`) fan out — when tenants are registered and the endpoint is `TenantAware` — to a `TenantedSender` and a `CompoundListener` (per-tenant `PulsarListener` wrapped in `ReceiverWithRules` + `TenantIdRule`). The hot-tail `PulsarReaderListener` branch is preserved per tenant. `PulsarEndpoint.CreateSender`/`BuildListenerAsync` delegate to these.

### GH-2361

`PulsarSender` is fire-and-forget — it does **not** implement `ISenderRequiresCallback` — so it is safe under `TenantedSender` (no silent-drop regression). No Inline-sender switch was needed (unlike Kafka/SQS whose native senders use callbacks).

## Tests

- **CI-safe (run under `CIPulsar`):** `PulsarNamedBrokerTests` (distinct transport per name, endpoint scheme == broker name, `GetOrCreate<PulsarTransport>(name)`), `PulsarPerTenantConfigurationTests` (`AddTenant` registers a `PulsarTenant`, `Compile` copies defaults, `TenantAware` endpoint resolves a `TenantedSender`, `TenantIdBehavior` setter), and `PulsarNamedBrokerIntegrationTests` — a real round-trip on the shared fixture broker proving the consumed envelope is stamped with the named broker's `secondary://` scheme. **11/11 green.**
- **Local-only (excluded from `CIPulsar`):** `PulsarPerTenantConnectionTests` (`[Trait("Category","Integration")]`) spins up a *second* Pulsar container as "cluster B" to prove true `TenantId` routing + inbound stamping. A deterministic single-broker tenant test is not feasible: Pulsar isolates tenants by *cluster* (unlike NATS's subject-prefix model), and two competing durable subscriptions on one broker collide — which is exactly why broker-per-tenant requires distinct clusters.

## Build

`dotnet build wolverine.slnx -c Release` → **0 warnings, 0 errors.**

## Caveats

- The local-only two-cluster test was not fully validated end-to-end in this environment due to the known Testcontainers-Pulsar advertised-listener networking issue for a *second* container (the identical sender/listener code round-trips fine against the fixture broker in the CI-safe named-broker test); it will pass where a second Pulsar cluster is properly reachable.
- DotPulsar's client builder is not cloneable, so each `AddTenant` action runs against a fresh `PulsarClient.Builder()` and must fully specify `ServiceUrl`/auth (same "fresh factory" caveat as RabbitMQ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
