### PR TITLE
feat(redis): named-broker and broker-per-tenant support (GH-3309)

### DIFF
--- a/docs/guide/messaging/transports/redis.md
+++ b/docs/guide/messaging/transports/redis.md
@@ -76,7 +76,7 @@ using var host = await Host.CreateDefaultBuilder()
         opts.Services.AddResourceSetupOnStartup();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs#L19-L79' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_with_redis' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs#L20-L80' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_with_redis' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Connection Options <Badge type="tip" text="6.9" />
@@ -165,7 +165,7 @@ using var host = await Host.CreateDefaultBuilder()
             .UseDurableInbox();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs#L84-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_redis_database_configuration' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs#L85-L110' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_redis_database_configuration' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To work with multiple databases in one application, see this sample:
@@ -197,8 +197,95 @@ using var host = await Host.CreateDefaultBuilder()
         opts.ListenToRedisStream("analytics", "analytics-processors", 3);
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs#L138-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_multiple_database_usage' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs#L139-L164' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_multiple_database_usage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Connecting to Multiple Brokers <Badge type="tip" text="6.9" />
+
+If a single Wolverine application needs to talk to more than one Redis broker, register the additional
+broker(s) with `AddNamedRedisBroker` using a `BrokerName`, then pin publishing or listening to a specific
+broker with the `*OnNamedBroker` overloads:
+
+<!-- snippet: sample_redis_named_broker -->
+<a id='snippet-sample_redis_named_broker'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        // The default Redis broker
+        opts.UseRedisTransport("localhost:6379");
+
+        // An additional, independent Redis broker identified by name
+        opts.AddNamedRedisBroker(new BrokerName("secondary"), "localhost:6399");
+
+        // Publish a message type to a stream on the named broker
+        opts.PublishMessage<OrderCreated>()
+            .ToRedisStreamOnNamedBroker(new BrokerName("secondary"), "orders");
+
+        // Listen to a stream on the named broker
+        opts.ListenToRedisStreamOnNamedBroker(new BrokerName("secondary"), "orders", "order-processors");
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs#L169-L187' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_redis_named_broker' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: info
+The Wolverine `Uri` scheme for any endpoint on a named broker is the broker name itself, so in the example
+above you would see endpoint URIs like `secondary://stream/0/orders`. The default broker keeps the canonical
+`redis://` scheme, which keeps the two brokers' endpoints from colliding.
+:::
+
+`AddNamedRedisBroker` has the same connection-source overloads as `UseRedisTransport`: a connection string,
+a `ConfigurationOptions`, a caller-managed `IConnectionMultiplexer`, or a factory that resolves one from the
+IoC container.
+
+Connecting to multiple named brokers is distinct from [Multi-Tenancy](#multi-tenancy): a named broker is a
+statically-addressed second connection that you target explicitly, whereas per-tenant connections are
+selected at runtime from each message's tenant id.
+
+## Multi-Tenancy <Badge type="tip" text="6.9" />
+
+The Redis transport supports *broker-per-tenant* multi-tenancy: each tenant talks to its own dedicated Redis
+server while sharing the same stream topology. Register a dedicated connection per tenant with `AddTenant`,
+and Wolverine routes each message to the correct server from its `Envelope.TenantId`:
+
+<!-- snippet: sample_redis_multi_tenancy -->
+<a id='snippet-sample_redis_multi_tenancy'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseRedisTransport("localhost:6379")
+            .AutoProvision()
+
+            // Route messages that carry a tenant id to that tenant's own Redis server;
+            // messages with no (or an unknown) tenant id fall back to the shared connection
+            .ConfigureMultiTenancy(TenantedIdBehavior.FallbackToDefault)
+
+            // Each tenant gets its own dedicated Redis server
+            .AddTenant("tenant1", "redis-tenant1:6379")
+            .AddTenant("tenant2", "redis-tenant2:6379");
+
+        // The stream topology is shared; the connection is chosen per message from Envelope.TenantId
+        opts.PublishMessage<OrderCreated>().ToRedisStream("orders");
+        opts.ListenToRedisStream("orders", "order-processors");
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs#L192-L212' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_redis_multi_tenancy' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Outbound sends are routed by tenant id through the framework's `TenantedSender`; inbound, Wolverine runs one
+listener per tenant connection and stamps each received envelope with its tenant id. `ConfigureMultiTenancy`
+controls what happens for a message whose tenant id is unknown:
+
+* `FallbackToDefault` (the default) — use the shared/default connection.
+* `TenantIdRequired` — reject a message that has no tenant id.
+* `IgnoreUnknownTenants` — silently drop messages for tenants that were never registered.
+
+Each tenant is an independent Redis server, so the same stream key and consumer group are created separately
+on each tenant's connection without colliding. As with named brokers, `AddTenant` accepts a connection
+string, a `ConfigurationOptions`, or a caller-managed `IConnectionMultiplexer`; Wolverine disposes only the
+multiplexers it builds itself.
 
 ## Interoperability
 
@@ -270,7 +357,7 @@ public class OurRedisJsonMapper<TMessage> : EnvelopeMapper<StreamEntry, List<Nam
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs#L181-L242' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ourredisjsonmapper' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs#L230-L291' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ourredisjsonmapper' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Scheduled Messaging <Badge type="tip" text="5.10" />

--- a/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs
@@ -9,6 +9,7 @@ using StackExchange.Redis;
 using Wolverine.Configuration;
 using Wolverine.Redis.Internal;
 using Wolverine.Transports;
+using Wolverine.Transports.Sending;
 
 namespace Wolverine.Redis.Tests;
 
@@ -158,6 +159,54 @@ public class DocumentationSamples
                 // Database 3: Analytics and reporting
                 opts.PublishMessage<AnalyticsEvent>().ToRedisStream("analytics", 3);
                 opts.ListenToRedisStream("analytics", "analytics-processors", 3);
+            }).StartAsync();
+
+        #endregion
+    }
+
+    public static async Task named_broker()
+    {
+        #region sample_redis_named_broker
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // The default Redis broker
+                opts.UseRedisTransport("localhost:6379");
+
+                // An additional, independent Redis broker identified by name
+                opts.AddNamedRedisBroker(new BrokerName("secondary"), "localhost:6399");
+
+                // Publish a message type to a stream on the named broker
+                opts.PublishMessage<OrderCreated>()
+                    .ToRedisStreamOnNamedBroker(new BrokerName("secondary"), "orders");
+
+                // Listen to a stream on the named broker
+                opts.ListenToRedisStreamOnNamedBroker(new BrokerName("secondary"), "orders", "order-processors");
+            }).StartAsync();
+
+        #endregion
+    }
+
+    public static async Task multi_tenancy()
+    {
+        #region sample_redis_multi_tenancy
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRedisTransport("localhost:6379")
+                    .AutoProvision()
+
+                    // Route messages that carry a tenant id to that tenant's own Redis server;
+                    // messages with no (or an unknown) tenant id fall back to the shared connection
+                    .ConfigureMultiTenancy(TenantedIdBehavior.FallbackToDefault)
+
+                    // Each tenant gets its own dedicated Redis server
+                    .AddTenant("tenant1", "redis-tenant1:6379")
+                    .AddTenant("tenant2", "redis-tenant2:6379");
+
+                // The stream topology is shared; the connection is chosen per message from Envelope.TenantId
+                opts.PublishMessage<OrderCreated>().ToRedisStream("orders");
+                opts.ListenToRedisStream("orders", "order-processors");
             }).StartAsync();
 
         #endregion

--- a/src/Transports/Redis/Wolverine.Redis.Tests/RedisMultiBrokerHelpers.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/RedisMultiBrokerHelpers.cs
@@ -1,0 +1,93 @@
+using StackExchange.Redis;
+using Testcontainers.Redis;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+/// <summary>
+/// Shared helpers for the multi-broker (named broker + broker-per-tenant) Redis integration tests. These
+/// tests need a second, genuinely distinct Redis server so "the message landed on the tenant's / named
+/// broker's own server and not the shared one" is a provable assertion, so they spin up a second Redis
+/// container (server B) alongside the shared container fixture (server A).
+/// </summary>
+internal static class RedisMultiBrokerHelpers
+{
+    /// <summary>
+    /// Read every entry currently in a stream on the target server via a raw XREAD (no consumer group), so a
+    /// test can prove the exact server a message was published to. Returns an empty array when the stream key
+    /// does not exist on that server.
+    /// </summary>
+    public static async Task<StreamEntry[]> ReadStreamAsync(string connectionString, string streamKey)
+    {
+        var mux = await ConnectionMultiplexer.ConnectAsync(connectionString);
+        await using (mux.ConfigureAwait(false))
+        {
+            var db = mux.GetDatabase();
+            return await db.StreamReadAsync(streamKey, "0-0");
+        }
+    }
+
+    /// <summary>
+    /// Poll a stream on the target server until at least one entry is present or the timeout elapses.
+    /// </summary>
+    public static async Task<StreamEntry[]> WaitForStreamAsync(string connectionString, string streamKey, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var entries = await ReadStreamAsync(connectionString, streamKey);
+            if (entries.Length > 0) return entries;
+            await Task.Delay(100);
+        }
+
+        return await ReadStreamAsync(connectionString, streamKey);
+    }
+}
+
+/// <summary>
+/// An xUnit class fixture that starts a single second Redis server (server B) shared across all the test
+/// methods of a class. Sharing one container per class (rather than one per test method) keeps the whole
+/// suite's Docker footprint small and avoids broker-init timeouts under load. When Docker is unavailable
+/// <see cref="ConnectionString"/> is null so the tests skip. GH-3309.
+/// </summary>
+public sealed class SecondRedisServerFixture : IAsyncLifetime
+{
+    private RedisContainer? _container;
+
+    public string? ConnectionString { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            _container = new RedisBuilder().WithImage("redis:7-alpine").Build();
+            await _container.StartAsync();
+            ConnectionString = _container.GetConnectionString();
+        }
+        catch
+        {
+            ConnectionString = null;
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_container != null)
+        {
+            await _container.DisposeAsync();
+        }
+    }
+}
+
+/// <summary>
+/// Message used by the Redis multi-broker integration tests.
+/// </summary>
+public record RedisBrokerMessage(string Id);
+
+public class RedisBrokerMessageHandler
+{
+    // No-op: receivers only need this so Wolverine tracking counts the message as "received".
+    public void Handle(RedisBrokerMessage message)
+    {
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis.Tests/RedisNamedBrokerTests.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/RedisNamedBrokerTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Redis.Internal;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+/// <summary>
+/// Registration-level coverage for named Redis brokers that needs no running broker, so it always runs in
+/// CI. A named broker is a second, independent <see cref="RedisTransport"/> whose <c>Protocol</c> (and
+/// therefore its endpoints' URI scheme) is the broker name, so its endpoints never collide with the default
+/// <c>redis://</c> broker.
+/// </summary>
+public class RedisNamedBrokerRegistrationTests
+{
+    private readonly BrokerName theName = new("secondary");
+
+    [Fact]
+    public void adds_a_distinct_transport_instance_per_broker()
+    {
+        var options = new WolverineOptions();
+        options.UseRedisTransport("localhost:6379");
+        options.AddNamedRedisBroker(theName, "localhost:6399");
+
+        var transports = options.Transports.OfType<RedisTransport>().ToList();
+        transports.Count.ShouldBe(2);
+        transports.Select(x => x.Protocol).OrderBy(x => x).ShouldBe(["redis", "secondary"]);
+    }
+
+    [Fact]
+    public void named_broker_endpoints_use_the_broker_name_as_their_uri_scheme()
+    {
+        var options = new WolverineOptions();
+        options.UseRedisTransport("localhost:6379");
+        options.AddNamedRedisBroker(theName, "localhost:6399");
+
+        var named = options.Transports.OfType<RedisTransport>().Single(x => x.Protocol == "secondary");
+        named.StreamEndpoint("orders").Uri.ShouldBe(new Uri("secondary://stream/0/orders"));
+
+        // ...and the default broker keeps the canonical redis:// scheme.
+        var @default = options.Transports.OfType<RedisTransport>().Single(x => x.Protocol == "redis");
+        @default.StreamEndpoint("orders").Uri.ShouldBe(new Uri("redis://stream/0/orders"));
+    }
+
+    [Fact]
+    public void listening_on_an_unregistered_named_broker_throws()
+    {
+        var options = new WolverineOptions();
+        options.UseRedisTransport("localhost:6379");
+
+        Should.Throw<InvalidOperationException>(() =>
+            options.ListenToRedisStreamOnNamedBroker(theName, "orders", "g1"));
+    }
+}
+
+/// <summary>
+/// End-to-end coverage that a named Redis broker actually talks to a <em>different</em> server than the
+/// default one. The default broker is server A (the shared container fixture) and the named broker is a
+/// second Testcontainers Redis (server B). Proves:
+/// <list type="bullet">
+/// <item>a message published on the named broker lands on <b>server B</b> and not server A,</item>
+/// <item>a default publish lands on <b>server A</b> and not server B, and</item>
+/// <item>a message published <b>and consumed</b> on the named broker round-trips and arrives stamped with
+/// the broker's own URI scheme (the receive pipeline sets <c>Destination</c> from the listener endpoint's
+/// URI).</item>
+/// </list>
+/// </summary>
+public class RedisNamedBrokerTests : IClassFixture<SecondRedisServerFixture>
+{
+    private readonly BrokerName theName = new("secondary");
+    private readonly string _serverAConn = RedisContainerFixture.ConnectionString;
+    private readonly string _serverBConn;
+    private readonly bool _skip;
+
+    public RedisNamedBrokerTests(SecondRedisServerFixture serverB)
+    {
+        _serverBConn = serverB.ConnectionString!;
+        _skip = serverB.ConnectionString == null;
+    }
+
+    [Fact]
+    public async Task named_broker_send_lands_on_the_named_broker()
+    {
+        if (_skip) return;
+
+        var streamKey = $"named-{Guid.NewGuid():N}";
+
+        using var host = await BuildSenderAsync(streamKey, useNamedBroker: true);
+
+        await host.MessageBus().SendAsync(new RedisBrokerMessage("on-named-broker"));
+
+        // Landed on server B (the named broker's connection)...
+        var onB = await RedisMultiBrokerHelpers.WaitForStreamAsync(_serverBConn, streamKey, 15.Seconds());
+        onB.Length.ShouldBe(1);
+
+        // ...and NOT on the default server A.
+        var onA = await RedisMultiBrokerHelpers.ReadStreamAsync(_serverAConn, streamKey);
+        onA.Length.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task default_broker_send_lands_on_the_default_broker()
+    {
+        if (_skip) return;
+
+        var streamKey = $"named-{Guid.NewGuid():N}";
+
+        using var host = await BuildSenderAsync(streamKey, useNamedBroker: false);
+
+        await host.MessageBus().SendAsync(new RedisBrokerMessage("on-default-broker"));
+
+        var onA = await RedisMultiBrokerHelpers.WaitForStreamAsync(_serverAConn, streamKey, 15.Seconds());
+        onA.Length.ShouldBe(1);
+
+        var onB = await RedisMultiBrokerHelpers.ReadStreamAsync(_serverBConn, streamKey);
+        onB.Length.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task round_trips_a_message_over_the_named_broker()
+    {
+        if (_skip) return;
+
+        var streamKey = $"named-{Guid.NewGuid():N}";
+
+        // A single host both publishes and listens on the named broker (server B). On receipt the pipeline
+        // stamps Destination from the listener endpoint's URI, so the consumed envelope carries the named
+        // broker's "secondary" scheme rather than the default "redis".
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "NamedBrokerInbound";
+                opts.UseRedisTransport(_serverAConn).AutoProvision();
+                opts.AddNamedRedisBroker(theName, _serverBConn).AutoProvision();
+
+                opts.PublishMessage<RedisBrokerMessage>().ToRedisStreamOnNamedBroker(theName, streamKey).SendInline();
+                opts.ListenToRedisStreamOnNamedBroker(theName, streamKey, "named-group");
+            })
+            .StartAsync();
+
+        var session = await host
+            .TrackActivity()
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<RedisBrokerMessage>(host)
+            .ExecuteAndWaitAsync(c => c.SendAsync(new RedisBrokerMessage("round-trip")));
+
+        var received = session.Received.SingleEnvelope<RedisBrokerMessage>();
+        received.Message.ShouldBeOfType<RedisBrokerMessage>().Id.ShouldBe("round-trip");
+        received.Destination!.Scheme.ShouldBe("secondary");
+    }
+
+    /// <summary>
+    /// Both brokers are always registered and connected (server A default, server B named), so "not on the
+    /// other server" is a meaningful assertion. Only <b>one</b> publish rule is registered per host — to the
+    /// named broker or the default — so a single message send targets exactly one server.
+    /// </summary>
+    private Task<IHost> BuildSenderAsync(string streamKey, bool useNamedBroker)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "NamedBrokerSender";
+                opts.UseRedisTransport(_serverAConn).AutoProvision();
+                opts.AddNamedRedisBroker(theName, _serverBConn).AutoProvision();
+
+                opts.Policies.DisableConventionalLocalRouting();
+
+                if (useNamedBroker)
+                {
+                    opts.PublishMessage<RedisBrokerMessage>().ToRedisStreamOnNamedBroker(theName, streamKey).SendInline();
+                }
+                else
+                {
+                    opts.PublishMessage<RedisBrokerMessage>().ToRedisStream(streamKey).SendInline();
+                }
+            })
+            .StartAsync();
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis.Tests/RedisPerTenantConnectionTests.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/RedisPerTenantConnectionTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Transports.Sending;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+/// <summary>
+/// Integration coverage for broker-per-tenant Redis <em>connections</em>: each tenant talks to its own
+/// dedicated Redis server. To prove a tenant uses its <em>own</em> connection, that connection must point at
+/// a genuinely distinguishable server, so this test spins up a second Redis server (server B) via
+/// Testcontainers alongside the shared server (server A) and asserts:
+/// <list type="bullet">
+/// <item>a message for the tenant with a dedicated connection is published to <b>server B</b> and not server A,</item>
+/// <item>a default (no-tenant) message is published to <b>server A</b> (the shared connection), and</item>
+/// <item>a message tagged for the tenant is <b>consumed</b> back over the tenant's own connection (server B),
+/// arriving stamped with its tenant id.</item>
+/// </list>
+///
+/// The publish-side assertions use a raw <c>XREAD</c> against each server so the exact target is provable;
+/// the inbound test uses a single Wolverine host plus the tracking API.
+/// </summary>
+public class RedisPerTenantConnectionTests : IClassFixture<SecondRedisServerFixture>
+{
+    private readonly string _serverAConn = RedisContainerFixture.ConnectionString;
+    private readonly string _serverBConn;
+    private readonly bool _skip;
+
+    public RedisPerTenantConnectionTests(SecondRedisServerFixture serverB)
+    {
+        _serverBConn = serverB.ConnectionString!;
+        _skip = serverB.ConnectionString == null;
+    }
+
+    [Fact]
+    public async Task tenant_message_is_published_over_the_tenants_own_connection()
+    {
+        if (_skip) return;
+
+        // Same stream key on both servers — the tenant's dedicated multiplexer, not any key rewriting, is
+        // what isolates the two.
+        var streamKey = $"pertenant-{Guid.NewGuid():N}";
+
+        using var host = await BuildSenderAsync(streamKey);
+
+        await host.MessageBus().SendAsync(new RedisBrokerMessage("for-tenant-b"),
+            new DeliveryOptions { TenantId = "tenantB" });
+
+        // Landed on server B (the tenant's dedicated connection)...
+        var onB = await RedisMultiBrokerHelpers.WaitForStreamAsync(_serverBConn, streamKey, 15.Seconds());
+        onB.Length.ShouldBe(1);
+
+        // ...and NOT on the shared server A.
+        var onA = await RedisMultiBrokerHelpers.ReadStreamAsync(_serverAConn, streamKey);
+        onA.Length.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task default_message_uses_the_shared_connection()
+    {
+        if (_skip) return;
+
+        var streamKey = $"pertenant-{Guid.NewGuid():N}";
+
+        using var host = await BuildSenderAsync(streamKey);
+
+        await host.MessageBus().SendAsync(new RedisBrokerMessage("no-tenant"));
+
+        var onA = await RedisMultiBrokerHelpers.WaitForStreamAsync(_serverAConn, streamKey, 15.Seconds());
+        onA.Length.ShouldBe(1);
+
+        var onB = await RedisMultiBrokerHelpers.ReadStreamAsync(_serverBConn, streamKey);
+        onB.Length.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task tenant_message_is_consumed_over_the_tenants_own_connection()
+    {
+        if (_skip) return;
+
+        var streamKey = $"pertenant-{Guid.NewGuid():N}";
+
+        // A single host both publishes and listens. The tenant listener runs on server B (the dedicated
+        // connection), so a message tagged for tenantB round-trips back through it, stamped with the tenant id.
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "PerTenantInbound";
+                opts.UseRedisTransport(_serverAConn)
+                    .AutoProvision()
+                    .ConfigureMultiTenancy(TenantedIdBehavior.FallbackToDefault)
+                    .AddTenant("tenantB", _serverBConn);
+
+                opts.PublishMessage<RedisBrokerMessage>().ToRedisStream(streamKey).SendInline();
+                opts.ListenToRedisStream(streamKey, "tenant-group");
+            })
+            .StartAsync();
+
+        var session = await host
+            .TrackActivity()
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<RedisBrokerMessage>(host)
+            .ExecuteAndWaitAsync(c =>
+                c.SendAsync(new RedisBrokerMessage("for-tenant-b"), new DeliveryOptions { TenantId = "tenantB" }));
+
+        var received = session.Received.SingleEnvelope<RedisBrokerMessage>();
+        received.TenantId.ShouldBe("tenantB");
+        received.Message.ShouldBeOfType<RedisBrokerMessage>().Id.ShouldBe("for-tenant-b");
+    }
+
+    private Task<IHost> BuildSenderAsync(string streamKey)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "PerTenantSender";
+                opts.UseRedisTransport(_serverAConn)
+                    .AutoProvision()
+                    .ConfigureMultiTenancy(TenantedIdBehavior.FallbackToDefault)
+                    // The tenant gets its own dedicated connection to server B.
+                    .AddTenant("tenantB", _serverBConn);
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.PublishMessage<RedisBrokerMessage>().ToRedisStream(streamKey).SendInline();
+            })
+            .StartAsync();
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis/Internal/InlineRedisStreamSender.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/InlineRedisStreamSender.cs
@@ -12,14 +12,23 @@ public class InlineRedisStreamSender : ISender
     private readonly RedisStreamEndpoint _endpoint;
     private readonly IWolverineRuntime _runtime;
     private readonly ILogger _logger;
-    
-    public InlineRedisStreamSender(RedisTransport transport, RedisStreamEndpoint endpoint, IWolverineRuntime runtime)
+
+    // When non-null, this sender targets a tenant's dedicated multiplexer (broker-per-tenant) instead of the
+    // transport's shared connection. GH-3309.
+    private readonly IConnectionMultiplexer? _connection;
+
+    public InlineRedisStreamSender(RedisTransport transport, RedisStreamEndpoint endpoint, IWolverineRuntime runtime,
+        IConnectionMultiplexer? connection = null)
     {
         _transport = transport;
         _endpoint = endpoint;
         _runtime = runtime;
+        _connection = connection;
         _logger = runtime.LoggerFactory.CreateLogger<InlineRedisStreamSender>();
     }
+
+    private IDatabase getDatabase() =>
+        _connection?.GetDatabase(_endpoint.DatabaseId) ?? _transport.GetDatabase(database: _endpoint.DatabaseId);
 
     public Uri Destination => _endpoint.Uri;
     
@@ -29,7 +38,7 @@ public class InlineRedisStreamSender : ISender
     {
         try
         {
-            var database = _transport.GetDatabase(database: _endpoint.DatabaseId);
+            var database = getDatabase();
             // Simple ping to check if Redis is available
             await database.PingAsync();
             return true;
@@ -45,7 +54,7 @@ public class InlineRedisStreamSender : ISender
     {
         try
         {
-            var database = _transport.GetDatabase(database: _endpoint.DatabaseId);
+            var database = getDatabase();
             
             // Check if this is a scheduled message
             if (envelope.IsScheduledForLater(DateTimeOffset.UtcNow))

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisHealthCheck.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisHealthCheck.cs
@@ -9,7 +9,7 @@ internal class RedisHealthCheck : WolverineTransportHealthCheck
     public RedisHealthCheck(RedisTransport transport) => _transport = transport;
 
     public override string TransportName => "Redis";
-    public override string Protocol => "redis";
+    public override string Protocol => _transport.Protocol;
 
     public override Task<TransportHealthResult> CheckHealthAsync(CancellationToken cancellationToken = default)
     {
@@ -41,7 +41,7 @@ internal class RedisHealthCheck : WolverineTransportHealthCheck
     public override async Task<long?> GetBrokerQueueDepthAsync(Uri endpointUri,
         CancellationToken cancellationToken = default)
     {
-        if (endpointUri.Scheme != "redis") return null;
+        if (endpointUri.Scheme != _transport.Protocol) return null;
 
         var streamKey = endpointUri.Segments.LastOrDefault()?.TrimEnd('/');
         if (string.IsNullOrEmpty(streamKey)) return null;

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamEndpoint.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamEndpoint.cs
@@ -1,5 +1,7 @@
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
+using Wolverine;
 using Wolverine.Configuration;
 using Wolverine.Redis;
 using Wolverine.Runtime;
@@ -153,9 +155,37 @@ public class RedisStreamEndpoint : Endpoint<IRedisEnvelopeMapper, RedisEnvelopeM
             throw new InvalidOperationException($"Consumer group is required for listening to Redis stream '{StreamKey}'");
         }
 
-        var listener = new RedisStreamListener(_transport, this, runtime, receiver);
-        await listener.InitializeAsync();
-        return listener;
+        // The shared listener consumes the default connection (plus every tenant that reuses it).
+        var sharedListener = new RedisStreamListener(_transport, this, runtime, receiver);
+        await sharedListener.InitializeAsync();
+
+        // Broker-per-tenant: each tenant with its own connection publishes to a separate Redis server the
+        // shared listener can't see, so consume each over its own connection and stamp the tenant id onto
+        // inbound envelopes via a TenantIdRule. Mirrors the NATS / RabbitMQ CompoundListener pattern;
+        // per-envelope completion routes back to the right connection via Envelope.Listener. GH-3309.
+        var tenantAware = _transport.Tenants.Any() && TenancyBehavior == TenancyBehavior.TenantAware;
+        var dedicatedTenants = tenantAware
+            ? _transport.Tenants.Where(t => t.HasOwnConnection).ToArray()
+            : [];
+
+        if (dedicatedTenants.Length == 0)
+        {
+            return sharedListener;
+        }
+
+        var compound = new CompoundListener(Uri);
+        compound.Inner.Add(sharedListener);
+
+        foreach (var tenant in dedicatedTenants)
+        {
+            var tenantReceiver = new ReceiverWithRules(receiver, [new TenantIdRule(tenant.TenantId)]);
+            var tenantListener = new RedisStreamListener(_transport, this, runtime, tenantReceiver,
+                _transport.GetTenantConnection(tenant));
+            await tenantListener.InitializeAsync();
+            compound.Inner.Add(tenantListener);
+        }
+
+        return compound;
     }
     
     public override bool TryBuildDeadLetterSender(IWolverineRuntime runtime, out ISender? deadLetterSender)
@@ -214,7 +244,26 @@ public class RedisStreamEndpoint : Endpoint<IRedisEnvelopeMapper, RedisEnvelopeM
     protected override ISender CreateSender(IWolverineRuntime runtime)
     {
         EnvelopeMapper ??= BuildMapper(runtime);
-        
+
+        if (_transport.Tenants.Any() && TenancyBehavior == TenancyBehavior.TenantAware)
+        {
+            // Broker-per-tenant: route by Envelope.TenantId. Both the tenant senders and the default
+            // fallback MUST be the fire-and-forget InlineRedisStreamSender — TenantedSender does not
+            // forward RegisterCallback, so a BatchedSender under it would silently drop every message
+            // (GH-2361). Each tenant sender targets its own dedicated multiplexer.
+            var defaultSender = new InlineRedisStreamSender(_transport, this, runtime);
+            var tenantedSender = new TenantedSender(Uri, _transport.TenantedIdBehavior, defaultSender);
+
+            foreach (var tenant in _transport.Tenants)
+            {
+                var tenantConnection = tenant.HasOwnConnection ? _transport.GetTenantConnection(tenant) : null;
+                var tenantSender = new InlineRedisStreamSender(_transport, this, runtime, tenantConnection);
+                tenantedSender.RegisterSender(tenant.TenantId, tenantSender);
+            }
+
+            return tenantedSender;
+        }
+
         return Mode == EndpointMode.Inline
             ? new InlineRedisStreamSender(_transport, this, runtime)
             : new BatchedSender(this, new RedisSenderProtocol(_transport, this), runtime.Cancellation,

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
@@ -28,13 +28,19 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
     private Task? _scheduledTask;
     private ListeningStatus _status = ListeningStatus.Stopped;
     private string _consumerName;
+
+    // When non-null, this listener consumes over a tenant's dedicated multiplexer (broker-per-tenant)
+    // instead of the transport's shared connection. GH-3309.
+    private readonly IConnectionMultiplexer? _connection;
+
     public RedisStreamListener(RedisTransport transport, RedisStreamEndpoint endpoint,
-        IWolverineRuntime runtime, IReceiver receiver)
+        IWolverineRuntime runtime, IReceiver receiver, IConnectionMultiplexer? connection = null)
     {
         _transport = transport;
         _endpoint = endpoint;
         _runtime = runtime;
         _receiver = receiver;
+        _connection = connection;
         _logger = runtime.LoggerFactory.CreateLogger<RedisStreamListener>();
         _settings = runtime.DurabilitySettings;
 
@@ -53,9 +59,12 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
     // long-lived, auto-reconnecting multiplexer, so this lets external monitors see a listener whose multiplexer is
     // down even though ListeningStatus still reports Accepting.
     public TransportConnectionState ConnectionState =>
-        _transport.GetDatabase(database: _endpoint.DatabaseId).Multiplexer.IsConnected
+        getDatabase().Multiplexer.IsConnected
             ? TransportConnectionState.Connected
             : TransportConnectionState.Disconnected;
+
+    private IDatabase getDatabase() =>
+        _connection?.GetDatabase(_endpoint.DatabaseId) ?? _transport.GetDatabase(database: _endpoint.DatabaseId);
 
     // GH-3236: surface the consumer loop's liveness (heartbeat + faulted/hung detection) for EndpointHealthSnapshot.
     public ReceiveLoopStatus ReceiveLoopStatus => _loop?.ReceiveLoopStatus ?? ReceiveLoopStatus.NotStarted;
@@ -70,7 +79,7 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
     {
         try
         {
-            var database = _transport.GetDatabase(database: _endpoint.DatabaseId);
+            var database = getDatabase();
             
             // Serialize the envelope
             var serializedEnvelope = EnvelopeSerializer.Serialize(envelope);
@@ -121,10 +130,12 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
     // ISupportNativeScheduling implementation
     public async ValueTask InitializeAsync()
     {
-        // Only create resources at listener init time if AutoProvision is enabled.
+        // Only create resources at listener init time if AutoProvision is enabled. Provision the consumer
+        // group over THIS listener's connection so a tenant listener creates its group on the tenant's own
+        // server (broker-per-tenant), not the shared one. GH-3309.
         if (_transport.AutoProvision)
         {
-            await _endpoint.SetupAsync(_logger);
+            await EnsureGroupExistsAsync(getDatabase());
         }
         else
         {
@@ -133,7 +144,7 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
             {
                 try
                 {
-                    var db = _transport.GetDatabase(database: _endpoint.DatabaseId);
+                    var db = getDatabase();
                     var groups = await db.StreamGroupInfoAsync(_endpoint.StreamKey);
                     var exists = groups?.Any(g => g.Name == _endpoint.ConsumerGroup) ?? false;
                     if (!exists)
@@ -212,7 +223,7 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
                 return;
             }
 
-            var db = _transport.GetDatabase(database: _endpoint.DatabaseId);
+            var db = getDatabase();
             if (DeleteOnAck)
                 await db.StreamAcknowledgeAndDeleteAsync(_endpoint.StreamKey, _endpoint.ConsumerGroup!, StreamTrimMode.Acknowledged, idString!);
             else
@@ -229,7 +240,7 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
     {
         try
         {
-            var db = _transport.GetDatabase(database: _endpoint.DatabaseId);
+            var db = getDatabase();
 
             // 1) Ack the current pending entry if we can
             if (envelope.Headers.TryGetValue(RedisEnvelopeMapper.RedisEntryIdHeader, out var idString) && !string.IsNullOrEmpty(idString))
@@ -328,7 +339,7 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
     // fail-fast behavior as before. Other exceptions propagate to BackgroundReceiveLoop's log-and-backoff policy.
     private async Task<bool> pollOnceAsync(CancellationToken token)
     {
-        var database = _transport.GetDatabase(database: _endpoint.DatabaseId);
+        var database = getDatabase();
 
         try
         {
@@ -474,7 +485,7 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
 
     public async Task<long> MoveScheduledToReadyStreamAsync(CancellationToken cancellationToken)
     {
-        var database = _transport.GetDatabase(database: _endpoint.DatabaseId);
+        var database = getDatabase();
         var scheduledKey = _endpoint.ScheduledMessagesKey;
 
         try
@@ -560,7 +571,7 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
     {
         try
         {
-            var database = _transport.GetDatabase(database: _endpoint.DatabaseId);
+            var database = getDatabase();
             var scheduledKey = _endpoint.ScheduledMessagesKey;
             
             // Get all messages from the scheduled set to check their expiration

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisTenant.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisTenant.cs
@@ -1,0 +1,65 @@
+using StackExchange.Redis;
+
+namespace Wolverine.Redis.Internal;
+
+/// <summary>
+/// Describes a tenant that talks to its own dedicated Redis server (broker-per-tenant). Exactly one of the
+/// connection sources — connection string, <see cref="ConfigurationOptions"/>, or a caller-managed
+/// <see cref="IConnectionMultiplexer"/> — is populated when the tenant has its own connection. Mirrors
+/// <c>NatsTenant</c>. GH-3309.
+/// </summary>
+public class RedisTenant
+{
+    public RedisTenant(string tenantId)
+    {
+        TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));
+    }
+
+    public string TenantId { get; }
+
+    /// <summary>
+    /// The tenant's own connection string when it should use a dedicated Redis connection.
+    /// </summary>
+    internal string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// The tenant's own <see cref="ConfigurationOptions"/> when it should use a dedicated Redis connection.
+    /// </summary>
+    internal ConfigurationOptions? ConfigurationOptions { get; set; }
+
+    /// <summary>
+    /// A caller-managed multiplexer for the tenant. Wolverine uses it as-is and never disposes it.
+    /// </summary>
+    internal IConnectionMultiplexer? ExternalConnection { get; set; }
+
+    /// <summary>
+    /// The tenant's dedicated multiplexer when <see cref="HasOwnConnection"/> is true. Lazily created and
+    /// cached by <c>RedisTransport.GetTenantConnection</c>, and disposed with the transport when
+    /// <see cref="OwnsConnection"/> is true. Null when the tenant reuses the shared transport connection.
+    /// </summary>
+    internal IConnectionMultiplexer? Connection { get; set; }
+
+    /// <summary>
+    /// True when this tenant declares its own connection, and therefore gets a dedicated Redis connection
+    /// rather than sharing the transport's connection.
+    /// </summary>
+    public bool HasOwnConnection =>
+        ConnectionString != null || ConfigurationOptions != null || ExternalConnection != null;
+
+    /// <summary>
+    /// True when Wolverine built the tenant's multiplexer itself (from a connection string /
+    /// ConfigurationOptions) and is therefore responsible for disposing it. A caller-managed multiplexer is
+    /// owned elsewhere and must not be disposed.
+    /// </summary>
+    internal bool OwnsConnection => ExternalConnection == null;
+
+    /// <summary>
+    /// Build the tenant's dedicated multiplexer from whichever connection source is populated.
+    /// </summary>
+    internal IConnectionMultiplexer BuildConnection()
+    {
+        if (ExternalConnection != null) return ExternalConnection;
+        if (ConfigurationOptions != null) return ConnectionMultiplexer.Connect(ConfigurationOptions);
+        return ConnectionMultiplexer.Connect(ConnectionString!);
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
@@ -14,10 +14,21 @@ namespace Wolverine.Redis.Internal;
 public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDisposable
 {
     public const string ProtocolName = "redis";
-    
+
+    // The URI scheme for this transport instance's endpoints. Equal to ProtocolName ("redis") for the
+    // default broker, or the BrokerName for an additional named broker (AddNamedRedisBroker), so named
+    // brokers' endpoints never collide with the default redis:// broker. GH-3309.
+    private readonly string _protocol;
+
     private readonly LightweightCache<string, RedisStreamEndpoint> _streams;
     private readonly ConcurrentDictionary<string, IConnectionMultiplexer> _connections = new();
     private readonly Lazy<IConnectionMultiplexer> _defaultConnection;
+
+    /// <summary>
+    /// Tenants that declare their own dedicated Redis connection (broker-per-tenant). Keyed by tenant id.
+    /// GH-3309.
+    /// </summary>
+    internal LightweightCache<string, RedisTenant> Tenants { get; } = new(id => new RedisTenant(id));
 
     // Exactly one of these four connection sources is populated, used in precedence order: a
     // caller-managed multiplexer, a factory that resolves one from the IoC container, caller-supplied
@@ -53,18 +64,42 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     /// <summary>
     /// Default constructor for GetOrCreate pattern - uses localhost:6379
     /// </summary>
-    public RedisTransport() : this("localhost:6379")
+    public RedisTransport() : this(ProtocolName, "localhost:6379")
     {
         // Default constructor for GetOrCreate<T>()
     }
-    
+
+    /// <summary>
+    /// Constructor used when connecting to more than one Redis broker from a single application. The
+    /// <paramref name="protocol"/> doubles as the additional broker's URI scheme so its endpoints don't
+    /// collide with the default <c>redis://</c> broker. Reached through
+    /// <see cref="AddNamedRedisBroker(WolverineOptions, BrokerName, string)"/>. Wolverine owns the
+    /// underlying <see cref="ConnectionMultiplexer"/> and disposes it on shutdown.
+    /// </summary>
+    public RedisTransport(string protocol, string connectionString) : base(protocol, "Redis Streams Transport", [protocol])
+    {
+        _protocol = protocol;
+        _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+        _streams = buildStreamCache();
+        _defaultConnection = new Lazy<IConnectionMultiplexer>(createDefaultConnection);
+    }
+
     /// <summary>
     /// Connect to Redis with a StackExchange.Redis connection string. Wolverine owns the underlying
     /// <see cref="ConnectionMultiplexer"/> and disposes it on shutdown.
     /// </summary>
-    public RedisTransport(string connectionString) : base(ProtocolName, "Redis Streams Transport", ["redis"])
+    public RedisTransport(string connectionString) : this(ProtocolName, connectionString)
     {
-        _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+    }
+
+    /// <summary>
+    /// Connect to a named Redis broker with a caller-supplied <see cref="ConfigurationOptions"/>. The
+    /// <paramref name="protocol"/> doubles as the broker's URI scheme. GH-3110.
+    /// </summary>
+    public RedisTransport(string protocol, ConfigurationOptions configurationOptions) : base(protocol, "Redis Streams Transport", [protocol])
+    {
+        _protocol = protocol;
+        _configurationOptions = configurationOptions ?? throw new ArgumentNullException(nameof(configurationOptions));
         _streams = buildStreamCache();
         _defaultConnection = new Lazy<IConnectionMultiplexer>(createDefaultConnection);
     }
@@ -75,9 +110,19 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     /// this to wire up StackExchange.Redis extensions (e.g. Microsoft.Azure.StackExchangeRedis for Entra
     /// ID / Managed Identity token refresh) that augment <see cref="ConfigurationOptions"/>. GH-3110.
     /// </summary>
-    public RedisTransport(ConfigurationOptions configurationOptions) : base(ProtocolName, "Redis Streams Transport", ["redis"])
+    public RedisTransport(ConfigurationOptions configurationOptions) : this(ProtocolName, configurationOptions)
     {
-        _configurationOptions = configurationOptions ?? throw new ArgumentNullException(nameof(configurationOptions));
+    }
+
+    /// <summary>
+    /// Connect to a named Redis broker with a caller-managed <see cref="IConnectionMultiplexer"/>. The
+    /// <paramref name="protocol"/> doubles as the broker's URI scheme. Wolverine does NOT dispose the
+    /// supplied multiplexer. GH-3110.
+    /// </summary>
+    public RedisTransport(string protocol, IConnectionMultiplexer connection) : base(protocol, "Redis Streams Transport", [protocol])
+    {
+        _protocol = protocol;
+        _externalConnection = connection ?? throw new ArgumentNullException(nameof(connection));
         _streams = buildStreamCache();
         _defaultConnection = new Lazy<IConnectionMultiplexer>(createDefaultConnection);
     }
@@ -87,9 +132,19 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     /// supplied multiplexer as-is and does NOT dispose it — the caller owns its lifetime (and any token
     /// refresh / reconnect policy wired into it). GH-3110.
     /// </summary>
-    public RedisTransport(IConnectionMultiplexer connection) : base(ProtocolName, "Redis Streams Transport", ["redis"])
+    public RedisTransport(IConnectionMultiplexer connection) : this(ProtocolName, connection)
     {
-        _externalConnection = connection ?? throw new ArgumentNullException(nameof(connection));
+    }
+
+    /// <summary>
+    /// Connect to a named Redis broker with an <see cref="IConnectionMultiplexer"/> resolved from the
+    /// application's IoC container at runtime. The <paramref name="protocol"/> doubles as the broker's URI
+    /// scheme. Wolverine does NOT dispose the resolved multiplexer. GH-3110.
+    /// </summary>
+    public RedisTransport(string protocol, Func<IServiceProvider, IConnectionMultiplexer> connectionFactory) : base(protocol, "Redis Streams Transport", [protocol])
+    {
+        _protocol = protocol;
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
         _streams = buildStreamCache();
         _defaultConnection = new Lazy<IConnectionMultiplexer>(createDefaultConnection);
     }
@@ -101,11 +156,8 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     /// the application. The resolved multiplexer is assumed to be owned by the container — Wolverine uses
     /// it as-is and does NOT dispose it. GH-3110.
     /// </summary>
-    public RedisTransport(Func<IServiceProvider, IConnectionMultiplexer> connectionFactory) : base(ProtocolName, "Redis Streams Transport", ["redis"])
+    public RedisTransport(Func<IServiceProvider, IConnectionMultiplexer> connectionFactory) : this(ProtocolName, connectionFactory)
     {
-        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
-        _streams = buildStreamCache();
-        _defaultConnection = new Lazy<IConnectionMultiplexer>(createDefaultConnection);
     }
 
     private LightweightCache<string, RedisStreamEndpoint> buildStreamCache()
@@ -121,7 +173,7 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
                 }
                 var streamKey = parts[1];
                 return new RedisStreamEndpoint(
-                    new Uri($"{ProtocolName}://stream/{databaseId}/{streamKey}"),
+                    new Uri($"{_protocol}://stream/{databaseId}/{streamKey}"),
                     this,
                     EndpointRole.Application);
             });
@@ -159,10 +211,10 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
 
             if (endpoint == null)
             {
-                return new Uri($"{ProtocolName}://localhost:6379");
+                return new Uri($"{_protocol}://localhost:6379");
             }
 
-            return new Uri($"{ProtocolName}://{endpoint}");
+            return new Uri($"{_protocol}://{endpoint}");
         }
     }
 
@@ -222,6 +274,21 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
         return _defaultConnection.Value;
     }
 
+    /// <summary>
+    /// Resolve the Redis connection for a tenant: the tenant's own dedicated multiplexer when it declares
+    /// its own connection string / <see cref="ConfigurationOptions"/> / <see cref="IConnectionMultiplexer"/>,
+    /// otherwise the shared transport connection. Each dedicated tenant is an independent Redis server, so
+    /// the same stream key + consumer group live on each without collision. GH-3309.
+    /// </summary>
+    internal IConnectionMultiplexer GetTenantConnection(RedisTenant tenant)
+    {
+        if (!tenant.HasOwnConnection) return GetConnection();
+
+        // Lazily build (and cache on the tenant) so the connection resolves correctly regardless of whether
+        // ConnectAsync has run yet.
+        return tenant.Connection ??= tenant.BuildConnection();
+    }
+
     public override async ValueTask ConnectAsync(IWolverineRuntime runtime)
     {
         // Capture the IoC container so a factory-based connection can be resolved. ConnectAsync runs
@@ -238,8 +305,17 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
             // Test the connection
             var db = connection.GetDatabase();
             await db.PingAsync();
-            
+
             runtime.Logger.LogInformation("Successfully connected to Redis");
+
+            // Tenants that declare their own connection get a dedicated multiplexer they own for the lifetime
+            // of the transport. Eagerly connect and ping each so a misconfigured tenant fails fast at startup.
+            foreach (var tenant in Tenants.Where(x => x.HasOwnConnection))
+            {
+                var tenantConnection = GetTenantConnection(tenant);
+                await tenantConnection.GetDatabase().PingAsync();
+                runtime.Logger.LogInformation("Created dedicated Redis connection for tenant {TenantId}", tenant.TenantId);
+            }
         }
         catch (Exception ex)
         {
@@ -267,7 +343,7 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
 
     protected override RedisStreamEndpoint findEndpointByUri(Uri uri)
     {
-        if (uri.Scheme != ProtocolName)
+        if (uri.Scheme != Protocol)
         {
             throw new ArgumentException($"Invalid scheme for Redis transport: {uri.Scheme}");
         }
@@ -360,6 +436,13 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
                 owned.Add(_defaultConnection.Value);
             }
 
+            // Dispose only the tenant multiplexers Wolverine built itself (from a connection string /
+            // ConfigurationOptions). A caller-managed tenant IConnectionMultiplexer is owned elsewhere. GH-3309.
+            foreach (var tenant in Tenants.Where(x => x is { Connection: not null, OwnsConnection: true }))
+            {
+                owned.Add(tenant.Connection!);
+            }
+
             foreach (var connection in owned.Distinct())
             {
                 await connection.CloseAsync();
@@ -436,7 +519,7 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
         var replyStreamKey = $"wolverine.response.{runtime.Options.ServiceName}.{replyNode}".ToLowerInvariant();
         var cacheKey = $"{ReplyDatabaseId}:{replyStreamKey}";
         var replyEndpoint = new RedisStreamEndpoint(
-            new Uri($"{ProtocolName}://stream/{ReplyDatabaseId}/{replyStreamKey}?consumerGroup=wolverine-replies"),
+            new Uri($"{Protocol}://stream/{ReplyDatabaseId}/{replyStreamKey}?consumerGroup=wolverine-replies"),
             this,
             EndpointRole.System)
         {

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransportExpression.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransportExpression.cs
@@ -1,6 +1,8 @@
+using StackExchange.Redis;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Transports;
+using Wolverine.Transports.Sending;
 
 namespace Wolverine.Redis.Internal;
 
@@ -59,6 +61,57 @@ public class RedisTransportExpression : BrokerExpression<RedisTransport, RedisSt
     
     public RedisTransportExpression DeleteStreamEntryOnAck(bool deleteStreamEntryOnAck){
         _transport.DeleteStreamEntryOnAck = deleteStreamEntryOnAck;
+        return this;
+    }
+
+    /// <summary>
+    /// Configure how Wolverine routes messages that carry a tenant id when broker-per-tenant connections
+    /// have been registered with <see cref="AddTenant(string,string)"/>. GH-3309.
+    /// </summary>
+    public RedisTransportExpression ConfigureMultiTenancy(
+        TenantedIdBehavior behavior = TenantedIdBehavior.FallbackToDefault)
+    {
+        _transport.TenantedIdBehavior = behavior;
+        return this;
+    }
+
+    /// <summary>
+    /// Add a tenant that uses its own dedicated Redis server, addressed by a StackExchange.Redis connection
+    /// string. Messages tagged with this tenant id are published and consumed over the tenant's own
+    /// connection. GH-3309.
+    /// </summary>
+    public RedisTransportExpression AddTenant(string tenantId, string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        _transport.Tenants[tenantId] = new RedisTenant(tenantId) { ConnectionString = connectionString };
+        return this;
+    }
+
+    /// <summary>
+    /// Add a tenant that uses its own dedicated Redis server, addressed by caller-supplied
+    /// <see cref="ConfigurationOptions"/>. Wolverine builds and owns (disposes) the tenant multiplexer. GH-3309.
+    /// </summary>
+    public RedisTransportExpression AddTenant(string tenantId, ConfigurationOptions configurationOptions)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        ArgumentNullException.ThrowIfNull(configurationOptions);
+
+        _transport.Tenants[tenantId] = new RedisTenant(tenantId) { ConfigurationOptions = configurationOptions };
+        return this;
+    }
+
+    /// <summary>
+    /// Add a tenant that uses a caller-managed <see cref="IConnectionMultiplexer"/>. Wolverine uses it as-is
+    /// and does NOT dispose it — the caller owns its lifetime. GH-3309.
+    /// </summary>
+    public RedisTransportExpression AddTenant(string tenantId, IConnectionMultiplexer connectionMultiplexer)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        ArgumentNullException.ThrowIfNull(connectionMultiplexer);
+
+        _transport.Tenants[tenantId] = new RedisTenant(tenantId) { ExternalConnection = connectionMultiplexer };
         return this;
     }
 }

--- a/src/Transports/Redis/Wolverine.Redis/WolverineOptionsExtensions.cs
+++ b/src/Transports/Redis/Wolverine.Redis/WolverineOptionsExtensions.cs
@@ -101,6 +101,118 @@ public static class WolverineOptionsExtensions
     }
 
     /// <summary>
+    /// Locate the Redis transport for this application. Pass a <paramref name="name"/> to resolve an
+    /// additional, named Redis broker registered via <see cref="AddNamedRedisBroker(WolverineOptions, BrokerName, string)"/>.
+    /// GH-3309.
+    /// </summary>
+    internal static RedisTransport RedisTransport(this WolverineOptions options, BrokerName? name = null)
+    {
+        if (name == null)
+        {
+            return options.Transports.GetOrCreate<RedisTransport>();
+        }
+
+        var existing = options.Transports.OfType<RedisTransport>().FirstOrDefault(x => x.Protocol == name.Name);
+        if (existing == null)
+        {
+            throw new InvalidOperationException(
+                $"No named Redis broker '{name.Name}' has been registered. Call AddNamedRedisBroker(new BrokerName(\"{name.Name}\"), connectionString) before publishing or listening on it.");
+        }
+
+        return existing;
+    }
+
+    /// <summary>
+    /// Register an additional, independent Redis broker addressed by a StackExchange.Redis connection string.
+    /// Only use this if your Wolverine application needs to talk to two or more Redis brokers. The
+    /// <paramref name="name"/> doubles as the URI scheme for the additional broker's endpoints, so pin
+    /// publishing / listening to it with <see cref="ToRedisStreamOnNamedBroker"/> /
+    /// <see cref="ListenToRedisStreamOnNamedBroker(WolverineOptions, BrokerName, string, string)"/>. GH-3309.
+    /// </summary>
+    public static RedisTransportExpression AddNamedRedisBroker(this WolverineOptions options, BrokerName name, string connectionString)
+    {
+        var transport = new RedisTransport(name.Name, connectionString);
+        options.Transports.Add(transport);
+        return new RedisTransportExpression(transport, options);
+    }
+
+    /// <summary>
+    /// Register an additional, independent Redis broker addressed by caller-supplied
+    /// <see cref="ConfigurationOptions"/>. See <see cref="AddNamedRedisBroker(WolverineOptions, BrokerName, string)"/>. GH-3309.
+    /// </summary>
+    public static RedisTransportExpression AddNamedRedisBroker(this WolverineOptions options, BrokerName name, ConfigurationOptions configurationOptions)
+    {
+        var transport = new RedisTransport(name.Name, configurationOptions);
+        options.Transports.Add(transport);
+        return new RedisTransportExpression(transport, options);
+    }
+
+    /// <summary>
+    /// Register an additional, independent Redis broker addressed by a caller-managed
+    /// <see cref="IConnectionMultiplexer"/> (which Wolverine does NOT dispose).
+    /// See <see cref="AddNamedRedisBroker(WolverineOptions, BrokerName, string)"/>. GH-3309.
+    /// </summary>
+    public static RedisTransportExpression AddNamedRedisBroker(this WolverineOptions options, BrokerName name, IConnectionMultiplexer connectionMultiplexer)
+    {
+        var transport = new RedisTransport(name.Name, connectionMultiplexer);
+        options.Transports.Add(transport);
+        return new RedisTransportExpression(transport, options);
+    }
+
+    /// <summary>
+    /// Register an additional, independent Redis broker addressed by an <see cref="IConnectionMultiplexer"/>
+    /// resolved from the IoC container at runtime (which Wolverine does NOT dispose).
+    /// See <see cref="AddNamedRedisBroker(WolverineOptions, BrokerName, string)"/>. GH-3309.
+    /// </summary>
+    public static RedisTransportExpression AddNamedRedisBroker(this WolverineOptions options, BrokerName name, Func<IServiceProvider, IConnectionMultiplexer> connectionFactory)
+    {
+        var transport = new RedisTransport(name.Name, connectionFactory);
+        options.Transports.Add(transport);
+        return new RedisTransportExpression(transport, options);
+    }
+
+    /// <summary>
+    /// Publish messages to a Redis stream on an additional, named broker registered via
+    /// <see cref="AddNamedRedisBroker(WolverineOptions, BrokerName, string)"/>. GH-3309.
+    /// </summary>
+    /// <param name="publishing">Publishing configuration</param>
+    /// <param name="name">Identity of the additional Redis broker</param>
+    /// <param name="streamKey">Redis stream key name</param>
+    /// <param name="databaseId">Redis database ID (default 0)</param>
+    public static RedisSubscriberConfiguration ToRedisStreamOnNamedBroker(this IPublishToExpression publishing, BrokerName name, string streamKey, int databaseId = 0)
+    {
+        var transport = publishing.As<PublishingExpression>().Parent.RedisTransport(name);
+
+        var endpoint = transport.StreamEndpoint(streamKey, databaseId);
+
+        publishing.To(endpoint.Uri);
+
+        return new RedisSubscriberConfiguration(endpoint);
+    }
+
+    /// <summary>
+    /// Listen to a Redis stream on an additional, named broker registered via
+    /// <see cref="AddNamedRedisBroker(WolverineOptions, BrokerName, string)"/>. GH-3309.
+    /// </summary>
+    /// <param name="options">Wolverine configuration options</param>
+    /// <param name="name">Identity of the additional Redis broker</param>
+    /// <param name="streamKey">Redis stream key name</param>
+    /// <param name="consumerGroup">Consumer group name</param>
+    /// <param name="databaseId">Redis database ID (default 0)</param>
+    public static RedisListenerConfiguration ListenToRedisStreamOnNamedBroker(this WolverineOptions options, BrokerName name, string streamKey, string consumerGroup, int databaseId = 0)
+    {
+        var transport = options.RedisTransport(name);
+
+        var endpoint = transport.StreamEndpoint(streamKey, databaseId, e =>
+        {
+            e.ConsumerGroup = consumerGroup;
+            e.IsListener = true;
+        });
+
+        return new RedisListenerConfiguration(endpoint);
+    }
+
+    /// <summary>
     /// Configure Wolverine to publish messages to the specified Redis stream (uses database 0)
     /// </summary>
     /// <param name="publishing">Publishing configuration</param>


### PR DESCRIPTION
Closes #3309

Brings the **Redis Streams** transport (`Wolverine.Redis`) up to parity with RabbitMQ / NATS on the two established multi-broker features. It had neither before.

## Feature 1 — Named broker
- `RedisTransport` now stores an instance `Protocol` (heaviest part of this change): protocol-carrying constructors for every connection source, and all endpoint-URI construction + scheme checks (`buildStreamCache`, `ResourceUri`, `findEndpointByUri`, `tryBuildSystemEndpoints`, `RedisHealthCheck`) use it instead of the hard-coded `"redis"` literal. A named broker's endpoints therefore carry the broker name as their URI **scheme** (`secondary://stream/0/orders`) and never collide with the default `redis://` broker.
- `AddNamedRedisBroker(BrokerName, …)` with connection-string / `ConfigurationOptions` / `IConnectionMultiplexer` / factory overloads. Because Redis needs connection info, it constructs `new RedisTransport(name.Name, …)` and `Transports.Add(...)` directly rather than relying on `GetOrCreate`'s reflective ctor.
- `ListenToRedisStreamOnNamedBroker` / `ToRedisStreamOnNamedBroker` pin endpoints to a named broker (throws a helpful error if the broker wasn't registered first).

## Feature 2 — Broker-per-tenant (modeled after NATS)
- New `RedisTenant` — a dedicated, lazily-built `IConnectionMultiplexer` per tenant (connection string / `ConfigurationOptions` / caller-managed multiplexer). `RedisTransport.Tenants` + `GetTenantConnection`; eager connect+ping in `ConnectAsync`; disposal in `DisposeAsync` of **only** the multiplexers Wolverine built itself.
- `AddTenant(tenantId, …)` + `ConfigureMultiTenancy(TenantedIdBehavior)` on the expression.
- `CreateSender` fans out to a framework `TenantedSender`, routed by `Envelope.TenantId`; `BuildListenerAsync` builds a `CompoundListener` with one listener per dedicated-connection tenant wrapped in `ReceiverWithRules` + `TenantIdRule`. The sender/listener take an optional tenant multiplexer and target their own database on it. Tenant listeners provision their consumer group on their own server.

### GH-2361
Both the tenant senders and the default fallback under `TenantedSender` are the fire-and-forget `InlineRedisStreamSender` — **not** `BatchedSender` + `RedisSenderProtocol`. `TenantedSender` doesn't forward `RegisterCallback`, so a callback-requiring sender under it would silently drop every message. Verified by the inbound tenant round-trip test (a silent drop would surface as a timeout).

## Tests
- `RedisNamedBrokerRegistrationTests` (no broker; always runs in CI) — distinct transport per broker, endpoints use the broker name as scheme, unregistered-broker throws.
- `RedisNamedBrokerTests` + `RedisPerTenantConnectionTests` — spin up a **second** Redis container (server B) via a shared `IClassFixture`; raw `XREAD` proves a `…OnNamedBroker` / `TenantId`-tagged message lands on server B (and a default on server A), plus an inbound round-trip stamped with the broker scheme / tenant id.
- Full `Wolverine.Redis.Tests` green (131 passed). `dotnet build wolverine.slnx -c Release` clean (0 warnings, 0 errors).

## Docs
Added "Connecting to Multiple Brokers" and "Multi-Tenancy" sections to `docs/guide/messaging/transports/redis.md` with compiling `snippet` samples; reverted unrelated mdsnippets churn.

## Caveats
- Each tenant is an independent Redis server, so the same stream key + consumer group are created separately per tenant multiplexer — no collision (dedicated multiplexer per tenant is the spec, not shared-server-different-DB).
- The two integration test classes need a second Redis container, so they skip cleanly when Docker is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)