### PR TITLE
fix(tests): deterministically gate the DoHealthChecksAsync reentrancy-guard test

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/leader_election_self_visibility_tests.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/leader_election_self_visibility_tests.cs
@@ -166,19 +166,27 @@ public class leader_election_self_visibility_tests
     public async Task reentrancy_guard_prevents_concurrent_DoHealthChecksAsync()
     {
         // Regression coverage for the _lastLockIndex race in lease-based
-        // backends (RavenDB, CosmosDB). The heartbeat loop and 
+        // backends (RavenDB, CosmosDB). The heartbeat loop and
         // CheckAgentHealth message can call DoHealthChecksAsync concurrently.
         // The Interlocked.CompareExchange guard must let only one execution
         // through; the other calls must return AgentCommands.Empty
         // immediately instead of racing on shared mutable state.
 
+        // Park the winning execution inside TryAttainLeadershipLockAsync so
+        // the guard is provably held while the competing calls are made. An
+        // earlier version used Task.Yield() here, but that only *usually*
+        // kept the winner in flight — with a warm thread pool the yielded
+        // continuation could finish and release the guard before the later
+        // calls even started, letting a second call through legitimately.
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
         _persistence.HasLeadershipLock().Returns(false);
         _persistence.TryAttainLeadershipLockAsync(Arg.Any<CancellationToken>())
             .Returns(async _ =>
             {
-                // Yield so the other concurrent DoHealthChecksAsync calls
-                // start before this one completes, exercising the guard.
-                await Task.Yield();
+                entered.TrySetResult();
+                await release.Task;
                 return true;
             });
         _persistence.LoadNodeAgentStateAsync(Arg.Any<CancellationToken>())
@@ -186,11 +194,32 @@ public class leader_election_self_visibility_tests
                 [SelfRow(DateTimeOffset.UtcNow)],
                 new AgentRestrictions()));
 
-        await Task.WhenAll(Enumerable.Repeat(1, 10)
+        var winner = _controller.DoHealthChecksAsync();
+        await entered.Task.WaitAsync(5.Seconds());
+
+        // While the winner is parked inside the guarded section, every other
+        // call must bounce off the guard with AgentCommands.Empty instead of
+        // reaching TryAttainLeadershipLockAsync.
+        var blocked = await Task.WhenAll(Enumerable.Repeat(1, 9)
             .Select(_ => _controller.DoHealthChecksAsync()));
+
+        foreach (var commands in blocked)
+        {
+            commands.ShouldBeEmpty();
+        }
 
         await _persistence.Received(1)
             .TryAttainLeadershipLockAsync(Arg.Any<CancellationToken>());
+
+        release.SetResult();
+        await winner.WaitAsync(5.Seconds());
         _controller.IsLeader.ShouldBeTrue();
+
+        // The guard must be released once the winner completes — a
+        // subsequent health check goes all the way through again.
+        _persistence.HasLeadershipLock().Returns(true);
+        await _controller.DoHealthChecksAsync();
+        await _persistence.Received(2)
+            .TryAttainLeadershipLockAsync(Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## What

`CoreTests.Runtime.Agents.leader_election_self_visibility_tests.reentrancy_guard_prevents_concurrent_DoHealthChecksAsync` failed in **full-suite net10.0** runs with:

```
Expected to receive exactly 1 call matching: TryAttainLeadershipLockAsync(any CancellationToken)
Actually received 2 matching calls
```

while passing in isolation and in full-suite net9.0 runs.

## Diagnosis

The reentrancy guard in `NodeAgentController.DoHealthChecksAsync` (from #2999) was never broken — the race was in the test's synchronization. The test parked the winning call inside the guard with `await Task.Yield()` in the mocked `TryAttainLeadershipLockAsync`, assuming the other nine competing calls would launch before the winner resumed. `Task.Yield()` gives no such guarantee: the yielded continuation lands on an xUnit sync-context worker thread and can finish the entire mocked election path — releasing the guard — before the test thread even starts the second call. That second call then *legitimately* re-enters the guard and acquires the lock a second time. A warm thread pool plus net10.0 scheduling made the window reliable in full-suite runs; cold isolated runs and net9.0 timing happened to stay on the lucky side.

## Fix (test only)

Park the winner on `TaskCompletionSource`s instead — the mock signals `entered` and awaits `release` — so the guard is *provably* held while the nine competitors run. The test now also asserts:

- competitors bounce off the guard with the `AgentCommands.Empty` singleton and never reach `TryAttainLeadershipLockAsync`
- the winner still elects leadership after release
- **new coverage:** the `finally` block frees the guard — a subsequent health check goes all the way through again

## Verification

- Full CoreTests suite, net10.0 (the previously failing configuration): 1860 passed, 0 failed
- Test class in isolation: green on net10.0 and net9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)