### PR TITLE
Bump JasperFx to 2.21.1 (per-tenant HWM poll cadence, jasperfx#492/#493)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,8 +35,8 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.21.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.21.0" />
+    <PackageVersion Include="JasperFx" Version="2.21.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.21.1" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.19.1" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->


### PR DESCRIPTION
Consumes JasperFx **2.21.1** (jasperfx#493): the vectorized per-tenant high-water poll now runs on the daemon's own `SlowPollingTime` timer rather than solely on store-global mark publications, so a lagging tenant appending below the global max converges without unrelated activity. Part of epic jasperfx#486 (WS1 residue); the marten twin is marten#4876.

No Wolverine code changes — the failover e2e here never needed the seed-above-global-mark workaround that the marten dynamic-lifecycle tests carried.

Verified locally: full `wolverine.slnx` Release build + the `MartenTests.Distribution` folder (31 tests, net9.0) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)