### PR TITLE
Bump JasperFx to 2.22.0 — daemon connection governors (jasperfx#494–#496)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,8 +35,8 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.21.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.21.1" />
+    <PackageVersion Include="JasperFx" Version="2.22.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.22.0" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.19.1" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->


### PR DESCRIPTION
Part of epic jasperfx#486 (WS2 + WS3); the marten twin is marten#4877. Consumes JasperFx **2.22.0**, which bounds the async daemon's database connection footprint per database — on by default, no configuration required:

- `MaxConcurrentEventLoadsPerDatabase` (default 4) — event-load throttle (jasperfx#495)
- `MaxConcurrentBatchWritesPerDatabase` (default 4) — projection batch-write governor (jasperfx#496)
- `CrossTenantRebuild.RebuildEverywhereAsync` now defaults `maxParallelism` to 4 (was unbounded)

This directly benefits Wolverine-managed event-subscription distribution under per-tenant partitioning: each node's daemon now holds O(databases) connections instead of O(assigned tenant agents). Measured at 200 per-tenant agents on one database: peak connections drop from 47–99 (racy) to a deterministic 12–14 with unchanged throughput and 100/100 tenant catch-up (record on jasperfx#494).

Verified locally against the published packages: full `wolverine.slnx` Release build + `MartenTests.Distribution` 31/31 (net9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)