### PR TITLE
docs: link the community Salesforce Pub/Sub transport

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -240,7 +240,8 @@ const config: UserConfig<DefaultTheme.Config> = {
                                 {text: 'Kafka', link: '/guide/messaging/transports/kafka'},
                                 {text: 'SignalR', link: '/guide/messaging/transports/signalr'},
                                 {text: 'Redis', link: '/guide/messaging/transports/redis'},
-                                {text: 'External Database Tables', link: '/guide/messaging/transports/external-tables'}
+                                {text: 'External Database Tables', link: '/guide/messaging/transports/external-tables'},
+                                {text: 'Salesforce Pub/Sub (community)', link: 'https://github.com/meyc-v1/wolverinefxcontrib-salesforcepubsub'}
                             ]
                         },
                         {text: 'Partitioned Sequential Messaging', link: '/guide/messaging/partitioning'},

--- a/docs/guide/messaging/transports/index.md
+++ b/docs/guide/messaging/transports/index.md
@@ -1,6 +1,12 @@
 # Messaging Transports
 
+## Community Transports
 
+Community-built transports maintained outside this repository:
+
+* [Salesforce Pub/Sub](https://github.com/meyc-v1/wolverinefxcontrib-salesforcepubsub) — listen to
+  Salesforce platform events (topics, custom channels, and managed event subscriptions) as ordinary
+  Wolverine messages
 
 ## Building a new Transport
 


### PR DESCRIPTION
Adds a Community Transports section to the transports overview and a sidebar entry pointing at the community-built Salesforce Pub/Sub transport (listen-only: platform events, custom channels, and managed event subscriptions as Wolverine messages). Per the maintainer invitation in discussion #3325.