### PR TITLE
Bump JasperFx + JasperFx.Events to 2.23.0 (rebuild cap, jasperfx#420/#463)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,8 +35,8 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.22.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.22.0" />
+    <PackageVersion Include="JasperFx" Version="2.23.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.23.0" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.19.1" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->


### PR DESCRIPTION
Consumes **JasperFx 2.23.0** — the `MaxConcurrentRebuildsPerDatabase` rebuild cap (jasperfx#420 / jasperfx#463, epic jasperfx#486 WS3 remainder):

- `DaemonSettings.MaxConcurrentRebuildsPerDatabase` (int?, null = store-derived) beside the existing WS2/WS3 governors
- `IEventStore.MaxConcurrentRebuildsPerDatabase` DIM read by the `projections rebuild` CLI fan-out
- `EventStoreUsage.MaxConcurrentRebuildsPerDatabase` descriptor field (jasperfx#434)

Pure pin bump — no Wolverine code changes needed (all additions are DIMs / additive members). Full `wolverine.slnx` Release build clean locally.

Marten companion: JasperFx/marten#4878.

🤖 Generated with [Claude Code](https://claude.com/claude-code)