### PR TITLE
Bump JasperFx + JasperFx.Events to 2.24.0 (cross-product rebuild cap, jasperfx#498)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,8 +35,8 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.23.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.23.0" />
+    <PackageVersion Include="JasperFx" Version="2.24.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.24.0" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.19.1" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->


### PR DESCRIPTION
Consumes **JasperFx 2.24.0** — the intra-projection tenant/shard cross-product rebuild cap (jasperfx#497 / jasperfx#498, epic jasperfx#486 WS3 follow-up), which also unlocked intra-database rebuild replay that had been serialized at 1.

Pure pin bump (`JasperFx` + `JasperFx.Events` 2.23.0 → 2.24.0; source-generator pins unchanged). Full `wolverine.slnx` Release build clean locally (the only build errors were in an unrelated uncommitted local sample file, not on this branch).

Marten companion: JasperFx/marten#4899.

🤖 Generated with [Claude Code](https://claude.com/claude-code)