### PR TITLE
fix: per-topic Kafka builder methods drop SASL_SSL credentials from ConsumerConfig/ProducerConfig

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaTransportTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/KafkaTransportTests.cs
@@ -246,6 +246,142 @@ public class KafkaListenerConfigurationTests
         effective.GroupId.ShouldBe("topic-group");
         effective.AutoOffsetReset.ShouldBe(AutoOffsetReset.Earliest);
     }
+
+    // The methods below (BeginAtEarliest/BeginAtLatest/UseReadCommitted/UseCooperativeStickyAssignment/
+    // UseStaticMembership/TailFromLatest) all build a fresh per-topic ConsumerConfig containing only the
+    // one property they set, the same as BeginAtEarliest() did for GroupId before it was fixed above.
+    // GetEffectiveConsumerConfig() previously only backfilled BootstrapServers/GroupId from the parent,
+    // silently dropping SecurityProtocol/SaslMechanism/SaslUsername/SaslPassword -- a listener using any
+    // of these methods without a subsequent ExtendConsumerConfiguration() call would connect to a
+    // SASL_SSL broker without credentials and be disconnected during the initial handshake.
+
+    [Fact]
+    public void begin_at_earliest_inherits_sasl_ssl_settings_from_parent_transport()
+    {
+        var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.SecurityProtocol = SecurityProtocol.SaslSsl;
+        topic.Parent.ConsumerConfig.SaslMechanism = SaslMechanism.Plain;
+        topic.Parent.ConsumerConfig.SaslUsername = "api-key";
+        topic.Parent.ConsumerConfig.SaslPassword = "api-secret";
+
+        var config = new KafkaListenerConfiguration(topic)
+            .BeginAtEarliest();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var effective = topic.GetEffectiveConsumerConfig();
+        effective.SecurityProtocol.ShouldBe(SecurityProtocol.SaslSsl);
+        effective.SaslMechanism.ShouldBe(SaslMechanism.Plain);
+        effective.SaslUsername.ShouldBe("api-key");
+        effective.SaslPassword.ShouldBe("api-secret");
+    }
+
+    [Fact]
+    public void begin_at_latest_inherits_sasl_ssl_settings_from_parent_transport()
+    {
+        var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.SecurityProtocol = SecurityProtocol.SaslSsl;
+        topic.Parent.ConsumerConfig.SaslMechanism = SaslMechanism.Plain;
+        topic.Parent.ConsumerConfig.SaslUsername = "api-key";
+        topic.Parent.ConsumerConfig.SaslPassword = "api-secret";
+
+        var config = new KafkaListenerConfiguration(topic)
+            .BeginAtLatest();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var effective = topic.GetEffectiveConsumerConfig();
+        effective.SecurityProtocol.ShouldBe(SecurityProtocol.SaslSsl);
+        effective.SaslMechanism.ShouldBe(SaslMechanism.Plain);
+        effective.SaslUsername.ShouldBe("api-key");
+        effective.SaslPassword.ShouldBe("api-secret");
+    }
+
+    [Fact]
+    public void use_read_committed_inherits_sasl_ssl_settings_from_parent_transport()
+    {
+        var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.SecurityProtocol = SecurityProtocol.SaslSsl;
+        topic.Parent.ConsumerConfig.SaslUsername = "api-key";
+        topic.Parent.ConsumerConfig.SaslPassword = "api-secret";
+
+        var config = new KafkaListenerConfiguration(topic)
+            .UseReadCommitted();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var effective = topic.GetEffectiveConsumerConfig();
+        effective.SecurityProtocol.ShouldBe(SecurityProtocol.SaslSsl);
+        effective.SaslUsername.ShouldBe("api-key");
+        effective.SaslPassword.ShouldBe("api-secret");
+    }
+
+    [Fact]
+    public void use_cooperative_sticky_assignment_inherits_sasl_ssl_settings_from_parent_transport()
+    {
+        var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.SecurityProtocol = SecurityProtocol.SaslSsl;
+        topic.Parent.ConsumerConfig.SaslUsername = "api-key";
+        topic.Parent.ConsumerConfig.SaslPassword = "api-secret";
+
+        var config = new KafkaListenerConfiguration(topic)
+            .UseCooperativeStickyAssignment();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var effective = topic.GetEffectiveConsumerConfig();
+        effective.SecurityProtocol.ShouldBe(SecurityProtocol.SaslSsl);
+        effective.SaslUsername.ShouldBe("api-key");
+        effective.SaslPassword.ShouldBe("api-secret");
+    }
+
+    [Fact]
+    public void use_static_membership_inherits_sasl_ssl_settings_from_parent_transport()
+    {
+        var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.SecurityProtocol = SecurityProtocol.SaslSsl;
+        topic.Parent.ConsumerConfig.SaslUsername = "api-key";
+        topic.Parent.ConsumerConfig.SaslPassword = "api-secret";
+
+        var config = new KafkaListenerConfiguration(topic)
+            .UseStaticMembership("node-1");
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var effective = topic.GetEffectiveConsumerConfig();
+        effective.SecurityProtocol.ShouldBe(SecurityProtocol.SaslSsl);
+        effective.SaslUsername.ShouldBe("api-key");
+        effective.SaslPassword.ShouldBe("api-secret");
+    }
+
+    [Fact]
+    public void tail_from_latest_inherits_sasl_ssl_settings_from_parent_transport()
+    {
+        var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.SecurityProtocol = SecurityProtocol.SaslSsl;
+        topic.Parent.ConsumerConfig.SaslUsername = "api-key";
+        topic.Parent.ConsumerConfig.SaslPassword = "api-secret";
+
+        var config = new KafkaListenerConfiguration(topic)
+            .TailFromLatest();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var effective = topic.GetEffectiveConsumerConfig();
+        effective.SecurityProtocol.ShouldBe(SecurityProtocol.SaslSsl);
+        effective.SaslUsername.ShouldBe("api-key");
+        effective.SaslPassword.ShouldBe("api-secret");
+    }
+
+    [Fact]
+    public void begin_at_earliest_does_not_override_explicitly_set_sasl_username()
+    {
+        var topic = BuildTopic();
+        topic.Parent.ConsumerConfig.SaslUsername = "parent-key";
+
+        var config = new KafkaListenerConfiguration(topic)
+            .ConfigureConsumer(c => c.SaslUsername = "topic-key")
+            .BeginAtEarliest();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var effective = topic.GetEffectiveConsumerConfig();
+        effective.SaslUsername.ShouldBe("topic-key");
+        effective.AutoOffsetReset.ShouldBe(AutoOffsetReset.Earliest);
+    }
 }
 
 public class UseKafkaUsingNamedConnectionTests

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/kafka_eos_building_blocks.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/kafka_eos_building_blocks.cs
@@ -51,6 +51,48 @@ public class kafka_eos_building_blocks
     }
 
     [Fact]
+    public void subscriber_idempotent_producer_inherits_sasl_ssl_settings_from_parent_transport()
+    {
+        // UseIdempotentProducer() builds a fresh per-topic ProducerConfig containing only
+        // EnableIdempotence, the same pattern as the per-topic ConsumerConfig builders above.
+        // GetEffectiveProducerConfig() previously only backfilled BootstrapServers from the parent,
+        // silently dropping SecurityProtocol/SaslMechanism/SaslUsername/SaslPassword.
+        var transport = new KafkaTransport();
+        transport.ProducerConfig.SecurityProtocol = SecurityProtocol.SaslSsl;
+        transport.ProducerConfig.SaslMechanism = SaslMechanism.Plain;
+        transport.ProducerConfig.SaslUsername = "api-key";
+        transport.ProducerConfig.SaslPassword = "api-secret";
+
+        var topic = transport.Topics["events"];
+        var config = new KafkaSubscriberConfiguration(topic);
+        config.UseIdempotentProducer();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var effective = topic.GetEffectiveProducerConfig();
+        effective.SecurityProtocol.ShouldBe(SecurityProtocol.SaslSsl);
+        effective.SaslMechanism.ShouldBe(SaslMechanism.Plain);
+        effective.SaslUsername.ShouldBe("api-key");
+        effective.SaslPassword.ShouldBe("api-secret");
+    }
+
+    [Fact]
+    public void subscriber_idempotent_producer_does_not_override_explicitly_set_sasl_username()
+    {
+        var transport = new KafkaTransport();
+        transport.ProducerConfig.SaslUsername = "parent-key";
+
+        var topic = transport.Topics["events"];
+        var config = new KafkaSubscriberConfiguration(topic);
+        config.ConfigureProducer(c => c.SaslUsername = "topic-key");
+        config.UseIdempotentProducer();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        var effective = topic.GetEffectiveProducerConfig();
+        effective.SaslUsername.ShouldBe("topic-key");
+        effective.EnableIdempotence.ShouldBe(true);
+    }
+
+    [Fact]
     public void defaults_are_unchanged()
     {
         // Opt-in: a vanilla transport touches neither setting.

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -138,7 +138,9 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     }
 
     /// <summary>
-    /// Gets the effective ConsumerConfig for this topic, ensuring BootstrapServers is inherited from parent if not set
+    /// Gets the effective ConsumerConfig for this topic, ensuring BootstrapServers, GroupId, and the
+    /// security/SASL settings (SecurityProtocol, SaslMechanism, SaslUsername, SaslPassword) are
+    /// inherited from parent if not set
     /// </summary>
     internal ConsumerConfig GetEffectiveConsumerConfig()
     {
@@ -152,17 +154,59 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
             ConsumerConfig.GroupId = Parent.ConsumerConfig.GroupId;
         }
 
+        if (ConsumerConfig != null && ConsumerConfig.SecurityProtocol == null)
+        {
+            ConsumerConfig.SecurityProtocol = Parent.ConsumerConfig.SecurityProtocol;
+        }
+
+        if (ConsumerConfig != null && ConsumerConfig.SaslMechanism == null)
+        {
+            ConsumerConfig.SaslMechanism = Parent.ConsumerConfig.SaslMechanism;
+        }
+
+        if (ConsumerConfig != null && string.IsNullOrEmpty(ConsumerConfig.SaslUsername))
+        {
+            ConsumerConfig.SaslUsername = Parent.ConsumerConfig.SaslUsername;
+        }
+
+        if (ConsumerConfig != null && string.IsNullOrEmpty(ConsumerConfig.SaslPassword))
+        {
+            ConsumerConfig.SaslPassword = Parent.ConsumerConfig.SaslPassword;
+        }
+
         return ConsumerConfig ?? Parent.ConsumerConfig;
     }
 
     /// <summary>
-    /// Gets the effective ProducerConfig for this topic, ensuring BootstrapServers is inherited from parent if not set
+    /// Gets the effective ProducerConfig for this topic, ensuring BootstrapServers and the
+    /// security/SASL settings (SecurityProtocol, SaslMechanism, SaslUsername, SaslPassword) are
+    /// inherited from parent if not set
     /// </summary>
     internal ProducerConfig GetEffectiveProducerConfig()
     {
         if (ProducerConfig != null && string.IsNullOrEmpty(ProducerConfig.BootstrapServers))
         {
             ProducerConfig.BootstrapServers = Parent.ProducerConfig.BootstrapServers;
+        }
+
+        if (ProducerConfig != null && ProducerConfig.SecurityProtocol == null)
+        {
+            ProducerConfig.SecurityProtocol = Parent.ProducerConfig.SecurityProtocol;
+        }
+
+        if (ProducerConfig != null && ProducerConfig.SaslMechanism == null)
+        {
+            ProducerConfig.SaslMechanism = Parent.ProducerConfig.SaslMechanism;
+        }
+
+        if (ProducerConfig != null && string.IsNullOrEmpty(ProducerConfig.SaslUsername))
+        {
+            ProducerConfig.SaslUsername = Parent.ProducerConfig.SaslUsername;
+        }
+
+        if (ProducerConfig != null && string.IsNullOrEmpty(ProducerConfig.SaslPassword))
+        {
+            ProducerConfig.SaslPassword = Parent.ProducerConfig.SaslPassword;
         }
 
         return ProducerConfig ?? Parent.ProducerConfig;


### PR DESCRIPTION
## Description

`GetEffectiveConsumerConfig()` already inherited `BootstrapServers` and `GroupId` from the parent transport config (the latter fixed in #3174), but not `SecurityProtocol`/`SaslMechanism`/`SaslUsername`/`SaslPassword`.

`BeginAtEarliest()`/`BeginAtLatest()`/`UseReadCommitted()`/`UseCooperativeStickyAssignment()` (listener-level)/`UseStaticMembership()`/`TailFromLatest()` all build a fresh per-topic `ConsumerConfig` containing only the one property each sets (e.g. `topic.ConsumerConfig ??= new ConsumerConfig(); topic.ConsumerConfig.AutoOffsetReset = ...`). A listener that uses any of these without a trailing `ExtendConsumerConfiguration(...)` call therefore ends up with a `ConsumerConfig` missing the transport's security settings entirely.

**This is a real production incident, not a theoretical gap.** Against a SASL_SSL-secured broker (Confluent Cloud, in our case), the resulting client silently attempts a plaintext connection. The broker can't parse the plaintext bytes as TLS and closes the connection during the very first, pre-auth step (`APIVERSION_QUERY`) — logged as a `Local_AllBrokersDown`/`"1/1 brokers are down"` cycle that repeats indefinitely since the bootstrap connection never progresses past the handshake. This ran undetected in our deployment for about two weeks: outbound publishing was unaffected (producers use the fully-configured parent `ProducerConfig`), the admin-client-based health check uses a separate, fully-explicit config path, and downstream consumers just kept serving stale data instead of erroring.

The identical pattern exists on the producer side: `UseIdempotentProducer()` builds a fresh `ProducerConfig` containing only `EnableIdempotence`, and `GetEffectiveProducerConfig()` only backfilled `BootstrapServers`.

## Fix

Add `SecurityProtocol`/`SaslMechanism`/`SaslUsername`/`SaslPassword` backfill to both `GetEffectiveConsumerConfig()` and `GetEffectiveProducerConfig()`, using the exact same pattern already used for `BootstrapServers`/`GroupId` (only backfill when the topic-level value is unset, so explicit per-topic overrides still win).

## Tests

Added coverage for every affected builder method on both the consumer and producer side, following the existing `begin_at_earliest_inherits_group_id_from_parent_transport`-style pattern in `KafkaTransportTests.cs`, plus a producer-side case in `kafka_eos_building_blocks.cs` alongside the existing `subscriber_idempotent_producer` test.

## Test plan

- [x] `dotnet test` on `Wolverine.Kafka.Tests` (net10.0) — all tests pass, including the new SASL_SSL inheritance cases
- [x] Verified against a real SASL_SSL-secured Confluent Cloud cluster: reproduced the exact `APIVERSION_QUERY`/`Local_AllBrokersDown` failure signature with the bug present, confirmed clean connection with the fix