### PR TITLE
Fix [Entity]/storage-action regression for non-EFCore-persisted sagas (#3342)

### DIFF
--- a/src/Persistence/EfCoreTests/Bugs/Bug_3342_saga_entity_and_storage_action.cs
+++ b/src/Persistence/EfCoreTests/Bugs/Bug_3342_saga_entity_and_storage_action.cs
@@ -1,0 +1,178 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.ComplianceTests;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Sagas;
+using Wolverine.SqlServer;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace EfCoreTests.Bugs;
+
+// GH-3342: a saga whose Start returns Storage.Insert<T> of a NON-saga entity, then cascades a command whose
+// handler loads that same entity via [Entity], regressed at 6.5.0. The [Entity] load came back null (so a
+// Required=false handler NRE'd on it, and a Required handler was silently skipped) because the storage
+// action written by an earlier handler in the flow was not persisted before the cascaded message was
+// handled. Reproduces 6.4.3-vs-6.5.0 without Kafka (transports are local) and without OnException.Discard
+// so the real failure surfaces.
+public class Bug_3342_saga_entity_and_storage_action : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.DisableConventionalDiscovery().IncludeType<OrderSaga3342>();
+
+                opts.Services.AddDbContextWithWolverineIntegration<Order3342DbContext>(x =>
+                    x.UseSqlServer(Servers.SqlServerConnectionString));
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString);
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Services.AddResourceSetupOnStartup();
+
+                opts.PublishAllMessages().Locally();
+            }).StartAsync();
+
+        await _host.ResetResourceState();
+
+        // Seed the source Order the saga reads from.
+        using var scope = _host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<Order3342DbContext>();
+        db.Orders.Add(new Order3342 { Id = TheOrderId, StockCheckNeeded = true });
+        await db.SaveChangesAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private static readonly Guid TheOrderId = Guid.NewGuid();
+
+    [Fact]
+    public async Task cascaded_handler_sees_the_persisted_entity()
+    {
+        var session = await _host
+            .TrackActivity()
+            .Timeout(30.Seconds())
+            .InvokeMessageAndWaitAsync(new OrderCheckedOut3342(TheOrderId));
+
+        // The Handles(ProcessOrder) chain must cascade OrderProcessed, which requires it to have loaded the
+        // OrderProcessRecord that Start inserted.
+        session.Sent.AllMessages().OfType<OrderProcessed3342>().Any(x => x.Id == TheOrderId)
+            .ShouldBeTrue("the ProcessOrder handler must load the inserted record and cascade OrderProcessed");
+
+        // And the record persisted by the Update in the ProcessOrder handler must be up to date.
+        using var scope = _host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<Order3342DbContext>();
+        var record = await db.OrderProcessRecords.FirstOrDefaultAsync(x => x.Id == TheOrderId);
+        record.ShouldNotBeNull("Start's Storage.Insert must be persisted");
+        record.StockChecked.ShouldBeTrue("the ProcessOrder handler's Storage.Update must be persisted");
+    }
+}
+
+public record OrderCheckedOut3342(Guid Id);
+
+public record ProcessOrder3342(Guid Id);
+
+public record OrderProcessed3342(Guid Id);
+
+// [WolverineIgnore] keeps conventional discovery in OTHER tests in this assembly from picking up this saga
+// (and failing on its unmapped storage action); the test's own host forces it in via IncludeType.
+[WolverineIgnore]
+public class OrderSaga3342 : Saga
+{
+    [SagaIdentity] public Guid Id { get; set; }
+
+    public static (Insert<OrderProcessRecord3342>, ProcessOrder3342, OrderSaga3342) Start(OrderCheckedOut3342 message)
+    {
+        return
+        (
+            Storage.Insert(new OrderProcessRecord3342 { Id = message.Id, StockChecked = false }),
+            new ProcessOrder3342(message.Id),
+            new OrderSaga3342 { Id = message.Id }
+        );
+    }
+
+    public (IStorageAction<OrderProcessRecord3342>, OrderProcessed3342) Handles(
+        ProcessOrder3342 command,
+        [Entity(Required = false)] OrderProcessRecord3342 orderProcessRecord,
+        ILogger<OrderSaga3342> logger,
+        Order3342DbContext db)
+    {
+        var order = db.Orders.First(o => o.Id == command.Id);
+        orderProcessRecord.StockChecked = order.StockCheckNeeded;
+
+        return
+        (
+            Storage.Update(orderProcessRecord),
+            new OrderProcessed3342(command.Id)
+        );
+    }
+
+    public void Handles(OrderProcessed3342 message, [Entity] OrderProcessRecord3342 orderProcessRecord)
+    {
+        // The required [Entity] load here was returning null in 6.5.0+, so this handler was silently skipped.
+        if (!orderProcessRecord.StockChecked)
+        {
+            MarkCompleted();
+        }
+    }
+}
+
+public class Order3342
+{
+    public Guid Id { get; set; }
+    public bool StockCheckNeeded { get; set; }
+}
+
+public class OrderProcessRecord3342
+{
+    public Guid Id { get; set; }
+    public bool StockChecked { get; set; }
+}
+
+public class Order3342DbContext : DbContext
+{
+    public Order3342DbContext(DbContextOptions<Order3342DbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Order3342> Orders { get; set; }
+    public DbSet<OrderProcessRecord3342> OrderProcessRecords { get; set; }
+
+    // NOTE: the OrderSaga3342 is deliberately NOT mapped here — it is persisted by the SqlServer message
+    // store, exactly like the reporter's setup. Only the storage-action entity uses EF Core. That mix is
+    // what #3040's `if (chain is SagaChain) return;` broke.
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Order3342>(map =>
+        {
+            map.ToTable("orders_3342", "bug3342");
+            map.HasKey(x => x.Id);
+        });
+
+        modelBuilder.Entity<OrderProcessRecord3342>(map =>
+        {
+            map.ToTable("order_process_records_3342", "bug3342");
+            map.HasKey(x => x.Id);
+        });
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -350,16 +350,25 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
 
     public void ApplyTransactionSupport(IChain chain, IServiceContainer container, Type entityType)
     {
-        // GH-3039: For saga chains, defer to the saga's own transaction-support application at codegen
-        // time (SagaChain.DetermineFrames -> the no-entity ApplyTransactionSupport below). That runs
-        // AFTER every IHandlerPolicy, so a transaction mode set on the chain by a user policy
-        // (chain.Tags["TransactionMiddlewareMode"]) is honored. This entity overload is otherwise
-        // invoked by SideEffectPolicy when a handler returns a storage action (Insert<T>/Update<T>/
-        // UnitOfWork<T>/...), which happens DURING policy application - before a marker-interface
-        // IHandlerPolicy has had a chance to set the mode tag. Applying it here would lock in DefaultMode
-        // and the UsingEfCoreTransaction idempotency guard would then block the later, correctly-moded
-        // application - silently dropping the eager transaction for storage-action saga handlers.
-        if (chain is SagaChain) return;
+        // GH-3039: For a saga whose OWN state is persisted by EF Core, defer to the saga's transaction-
+        // support application at codegen time (SagaChain.DetermineFrames -> the no-entity
+        // ApplyTransactionSupport below). That runs AFTER every IHandlerPolicy, so a transaction mode set
+        // on the chain by a user policy (chain.Tags["TransactionMiddlewareMode"]) is honored. This entity
+        // overload is otherwise invoked by SideEffectPolicy when a handler returns a storage action
+        // (Insert<T>/Update<T>/UnitOfWork<T>/...), which happens DURING policy application - before a
+        // marker-interface IHandlerPolicy has had a chance to set the mode tag. Applying it here would
+        // lock in DefaultMode and the UsingEfCoreTransaction idempotency guard would then block the later,
+        // correctly-moded application - silently dropping the eager transaction for storage-action saga
+        // handlers.
+        //
+        // GH-3342: but ONLY defer when EF Core actually persists the saga. When the saga's state lives in
+        // another store (e.g. the SqlServer message store) and it merely RETURNS an EF Core storage
+        // action, SagaChain.DetermineFrames applies THAT other provider's transaction support, never EF
+        // Core's - so this is the only place EF Core's SaveChanges/transaction for the storage action
+        // gets applied. Skipping it there dropped the entity write entirely, and a later [Entity] load of
+        // that entity came back null (a Required=false handler NRE'd on it; a Required handler was
+        // silently skipped). Fall through and apply EF Core's transaction support in that case.
+        if (chain is SagaChain saga && TryDetermineDbContextType(saga.SagaType, container) != null) return;
 
         if (chain.Tags.ContainsKey(UsingEfCoreTransaction)) return;
         chain.Tags.Add(UsingEfCoreTransaction, true);


### PR DESCRIPTION
Closes #3342.

## Symptom (regression 6.4.3 → 6.5.0+)

A saga whose handler returns an EF Core storage action (`Insert<T>`/`Update<T>`/…) of a
**non-saga** entity, then cascades a message whose handler loads that same entity via
`[Entity]`, broke at 6.5.0. The `[Entity]` load came back **null**:

- a `[Entity(Required = false)]` handler threw a `NullReferenceException` on it, and
- a `Required` `[Entity]` handler was **silently skipped** (so the cascade downstream never ran).

The reporter's `OnException(...).Discard()` masked the NRE, making it look like "the handler just
didn't execute."

## Root cause

#3040 (GH-3039) made `EFCorePersistenceFrameProvider`'s **entity** overload of
`ApplyTransactionSupport` a no-op for **all** saga chains:

```csharp
if (chain is SagaChain) return;
```

The intent: defer to the **no-entity** overload that `SagaChain.DetermineFrames` calls *after* every
`IHandlerPolicy`, so a policy-set transaction mode is honored. But `DetermineFrames` calls the
persistence provider that owns the **saga's own state**. When the saga is persisted by a **different**
store (here the SqlServer message store) and only its *storage action* uses EF Core, EF Core's
no-entity overload is **never** called — so the blanket early-return dropped EF Core's
`SaveChanges`/transaction for the storage action entirely, and the entity write was lost. A later
`[Entity]` load of that entity then found nothing.

This only affected sagas **not** persisted by EF Core; EF-Core-persisted sagas (the GH-3039 case)
were fine because their own provider IS EF Core.

## Fix

Defer **only when EF Core actually persists the saga**:

```csharp
if (chain is SagaChain saga && TryDetermineDbContextType(saga.SagaType, container) != null) return;
```

Otherwise fall through and apply EF Core's transaction support for the storage action as before. The
GH-3039 fix is preserved (EF-Core-persisted sagas still defer, honoring policy-set modes).

## Tests

- Reproducing test `Bug_3342_saga_entity_and_storage_action`: a saga persisted by the **SqlServer
  message store** whose `Start` does `Storage.Insert<OrderProcessRecord>` and cascades a command whose
  handler loads that record via `[Entity]`. **Fails on `main`** (NRE — the inserted record is null),
  passes with the fix. Kafka-free (transports are local) and without `OnException.Discard`, so the real
  failure surfaces. The saga is `[WolverineIgnore]` + `IncludeType` so its unmapped storage action does
  not pollute sibling tests' conventional discovery.
- GH-3039 regression suite (`transaction_middleware_mode_tests`) and the EFCore
  saga / storage-action / dbcontext-selection suites stay green (80 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)