### PR TITLE
Honor MessageStoreRole for tenanted message stores

### DIFF
--- a/src/Persistence/MySql/Wolverine.MySql/MySqlBackedPersistence.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlBackedPersistence.cs
@@ -223,8 +223,6 @@ internal class MySqlBackedPersistence : IMySqlBackedPersistence, IWolverineExten
                 new MySqlTenantedMessageStore(runtime, this, sagaTables));
         }
 
-        settings.Role = Role;
-
         return new MySqlMessageStore(settings, runtime.DurabilitySettings, mainSource,
             logger, sagaTables);
     }
@@ -236,7 +234,7 @@ internal class MySqlBackedPersistence : IMySqlBackedPersistence, IWolverineExten
         var settings = new DatabaseSettings
         {
             CommandQueuesEnabled = CommandQueuesEnabled,
-            Role = MessageStoreRole.Main,
+            Role = Role,
             ConnectionString = ConnectionString,
             DataSource = DataSource,
             ScheduledJobLockId = ScheduledJobLockId,

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleBackedPersistence.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleBackedPersistence.cs
@@ -183,8 +183,6 @@ internal class OracleBackedPersistence : IOracleBackedPersistence, IWolverineExt
                 new OracleTenantedMessageStore(runtime, this, sagaTables));
         }
 
-        settings.Role = Role;
-
         return new OracleMessageStore(settings, runtime.DurabilitySettings, dataSource,
             logger, sagaTables);
     }
@@ -196,7 +194,7 @@ internal class OracleBackedPersistence : IOracleBackedPersistence, IWolverineExt
         var settings = new DatabaseSettings
         {
             CommandQueuesEnabled = CommandQueuesEnabled,
-            Role = MessageStoreRole.Main,
+            Role = Role,
             ConnectionString = ConnectionString,
             ScheduledJobLockId = ScheduledJobLockId,
             SchemaName = EnvelopeStorageSchemaName,

--- a/src/Persistence/PostgresqlTests/message_store_role_registration.cs
+++ b/src/Persistence/PostgresqlTests/message_store_role_registration.cs
@@ -1,0 +1,65 @@
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace PostgresqlTests;
+
+public class message_store_role_registration
+{
+    private static IWolverineRuntime buildRuntime()
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Options.Returns(new WolverineOptions());
+        runtime.LoggerFactory.Returns(NullLoggerFactory.Instance);
+        runtime.DurabilitySettings.Returns(new DurabilitySettings());
+        runtime.Services.Returns(new ServiceCollection().BuildServiceProvider());
+
+        return runtime;
+    }
+
+    [Fact]
+    public void ancillary_role_is_honored_for_a_single_database()
+    {
+        var options = new WolverineOptions();
+        var persistence = (PostgresqlBackedPersistence)options.PersistMessagesWithPostgresql(
+            Servers.PostgresConnectionString, "wolverine", MessageStoreRole.Ancillary);
+
+        persistence.BuildMessageStore(buildRuntime())
+            .Role.ShouldBe(MessageStoreRole.Ancillary);
+    }
+
+    [Fact]
+    public void ancillary_role_is_honored_with_statically_registered_tenants()
+    {
+        var options = new WolverineOptions();
+        var persistence = (PostgresqlBackedPersistence)options
+            .PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine", MessageStoreRole.Ancillary)
+            .RegisterStaticTenants(tenants => tenants.Register("one", Servers.PostgresConnectionString));
+
+        var store = persistence.BuildMessageStore(buildRuntime()).ShouldBeOfType<MultiTenantedMessageStore>();
+
+        // The composite store itself is always Composite. The role that MessageStoreCollection
+        // keys off of lives on the inner, main database
+        store.Main.Role.ShouldBe(MessageStoreRole.Ancillary);
+    }
+
+    [Fact]
+    public void main_is_still_the_default_role_with_statically_registered_tenants()
+    {
+        var options = new WolverineOptions();
+        var persistence = (PostgresqlBackedPersistence)options
+            .PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "wolverine")
+            .RegisterStaticTenants(tenants => tenants.Register("one", Servers.PostgresConnectionString));
+
+        var store = persistence.BuildMessageStore(buildRuntime()).ShouldBeOfType<MultiTenantedMessageStore>();
+
+        store.Main.Role.ShouldBe(MessageStoreRole.Main);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
@@ -263,8 +263,6 @@ internal class PostgresqlBackedPersistence : IPostgresqlBackedPersistence, IWolv
             return new MultiTenantedMessageStore(defaultStore, runtime,
                 new PostgresqlTenantedMessageStore(runtime, this, sagaTables));
         }
-        
-        settings.Role = Role;
 
         return new PostgresqlMessageStore(settings, runtime.DurabilitySettings, mainSource,
             logger, sagaTables);
@@ -277,7 +275,7 @@ internal class PostgresqlBackedPersistence : IPostgresqlBackedPersistence, IWolv
         var settings = new DatabaseSettings
         {
             CommandQueuesEnabled = CommandQueuesEnabled,
-            Role = MessageStoreRole.Main,
+            Role = Role,
             ConnectionString = ConnectionString,
             DataSource = DataSource,
             ScheduledJobLockId = ScheduledJobLockId,

--- a/src/Persistence/Wolverine.SqlServer/SqlServerBackedPersistence.cs
+++ b/src/Persistence/Wolverine.SqlServer/SqlServerBackedPersistence.cs
@@ -233,8 +233,6 @@ internal class SqlServerBackedPersistence : IWolverineExtension, ISqlServerBacke
             return new MultiTenantedMessageStore(defaultStore, runtime,
                 new SqlServerTenantedMessageStore(runtime, this, sagaTables){DataSource = ConnectionStringTenancy});
         }
-
-        settings.Role = Role;
         
         var store = new SqlServerMessageStore(settings, runtime.DurabilitySettings,
             logger, sagaTables);
@@ -260,7 +258,7 @@ internal class SqlServerBackedPersistence : IWolverineExtension, ISqlServerBacke
         return new DatabaseSettings
         {
             CommandQueuesEnabled = CommandQueuesEnabled,
-            Role = MessageStoreRole.Main,
+            Role = Role,
             ConnectionString = ConnectionString,
             ScheduledJobLockId = ScheduledJobLockId,
             SchemaName = EnvelopeStorageSchemaName,

--- a/src/Persistence/Wolverine.Sqlite/SqliteBackedPersistence.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteBackedPersistence.cs
@@ -207,8 +207,6 @@ internal class SqliteBackedPersistence : ISqliteBackedPersistence, IWolverineExt
                 new SqliteTenantedMessageStore(runtime, this, sagaTables));
         }
 
-        settings.Role = Role;
-
         return new SqliteMessageStore(settings, runtime.DurabilitySettings, mainSource,
             logger, sagaTables);
     }
@@ -220,7 +218,7 @@ internal class SqliteBackedPersistence : ISqliteBackedPersistence, IWolverineExt
         var settings = new DatabaseSettings
         {
             CommandQueuesEnabled = CommandQueuesEnabled,
-            Role = MessageStoreRole.Main,
+            Role = Role,
             ConnectionString = ConnectionString,
             DataSource = DataSource,
             ScheduledJobLockId = ScheduledJobLockId,


### PR DESCRIPTION
## The bug

`PersistMessagesWithPostgresql(cs, "wolverine", role: MessageStoreRole.Ancillary).RegisterStaticTenants(...)` produces a store that reports `Main`, not `Ancillary`.

`BuildMessageStore()` applies the configured `Role` only on the *non-tenanted* return path:

```csharp
var settings = buildMainDatabaseSettings();   // Role = MessageStoreRole.Main, hardcoded

if (UseMasterTableTenancy)           return new MultiTenantedMessageStore(...);  // Role never applied
if (ConnectionStringTenancy != null) return new MultiTenantedMessageStore(...);  // Role never applied

settings.Role = Role;                                                            // only here
return new PostgresqlMessageStore(settings, ...);
```

## Why it hurts

In a modular monolith where a module registers an ancillary, statically-tenanted store, the host now has two `Main` stores. `MessageStoreCollection`'s constructor takes the `mains.Length == 1` branch, finds two, and leaves `Main` as the initial `NullMessageStore` — no exception, no log line.

From there:

- `WolverineRuntime.tryMigrateStorage()` returns early on `Storage is NullMessageStore`, so the envelope schema is never built;
- `startMessagingTransportsAsync()` and the durability agent start anyway.

On PostgreSQL the app then loops forever on `42P01: relation "wolverine.wolverine_nodes" does not exist`. The only workaround today is to reach for the store's `DemoteToAncillary()` after the fact.

## The fix

Set `Role` in `buildMainDatabaseSettings()` so every return path sees it, and drop the late assignment. `Role` already defaults to `MessageStoreRole.Main`, so nothing changes for callers that don't ask for `Ancillary`.

The same defect is present verbatim in all five relational providers (PostgreSQL, Sql Server, Sqlite, Oracle, MySql); all are fixed here.

## Tests

`PostgresqlTests/message_store_role_registration.cs` — three cases, no database required: ancillary single-database, ancillary with static tenants, and the `Main` default with static tenants. Mutation-checked: reverting the PostgreSQL fix fails the ancillary-with-tenants test and leaves the other two green.