### PR TITLE
fix(RavenDB): Node sequence startup race

### DIFF
--- a/src/Persistence/RavenDbTests/node_persistence_compliance.cs
+++ b/src/Persistence/RavenDbTests/node_persistence_compliance.cs
@@ -1,7 +1,9 @@
 using Raven.Embedded;
+using Shouldly;
 using Wolverine;
 using Wolverine.ComplianceTests;
 using Wolverine.Persistence.Durability;
+using Wolverine.Runtime.Agents;
 using Wolverine.RavenDb.Internals;
 
 namespace RavenDbTests;
@@ -20,5 +22,39 @@ public class node_persistence_compliance : NodePersistenceCompliance
     {
         var store = _fixture.StartRavenStore();
         return new RavenDbMessageStore(store, new WolverineOptions());
+    }
+
+    [Fact]
+    public async Task concurrently_persisting_nodes_assigns_unique_node_numbers()
+    {
+        await using var messageStore = await buildCleanMessageStore();
+
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var nodes = Enumerable.Range(0, 20).Select(_ =>
+        {
+            var id = Guid.NewGuid();
+            return new WolverineNode
+            {
+                NodeId = id,
+                ControlUri = new Uri($"dbcontrol://{id}"),
+                Description = Environment.MachineName,
+                Version = new Version(1, 2, 3, 0)
+            };
+        }).ToArray();
+
+        var tasks = nodes.Select(async node =>
+        {
+            await start.Task;
+            return await messageStore.Nodes.PersistAsync(node, CancellationToken.None);
+        }).ToArray();
+
+        start.SetResult();
+
+        var assignedNodeNumbers = await Task.WhenAll(tasks);
+
+        assignedNodeNumbers.OrderBy(x => x).ShouldBe(Enumerable.Range(1, nodes.Length).ToArray());
+
+        var persisted = await messageStore.Nodes.LoadAllNodesAsync(CancellationToken.None);
+        persisted.Select(x => x.AssignedNodeNumber).OrderBy(x => x).ShouldBe(assignedNodeNumbers.OrderBy(x => x));
     }
 }

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.NodeAgents.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.NodeAgents.cs
@@ -58,7 +58,7 @@ public partial class RavenDbMessageStore : INodeAgentPersistence
 
                 return node.AssignedNodeNumber;
             }
-            catch (Exception e) when (IsNodeSequenceConcurrencyConflict(e))
+            catch (Exception e) when (isNodeSequenceConcurrencyConflict(e))
             {
                 lastConflict = e;
 
@@ -67,7 +67,10 @@ public partial class RavenDbMessageStore : INodeAgentPersistence
                     break;
                 }
 
-                await Task.Delay(TimeSpan.FromMilliseconds(20 * attempt), cancellationToken);
+                // Linear backoff with jitter to avoid synchronized retries (thundering herd)
+                // when many nodes contend for the sequence at startup.
+                var jitter = Random.Shared.Next(0, 20);
+                await Task.Delay(TimeSpan.FromMilliseconds(20 * attempt + jitter), cancellationToken);
             }
         }
 
@@ -76,7 +79,7 @@ public partial class RavenDbMessageStore : INodeAgentPersistence
             lastConflict);
     }
 
-    private static bool IsNodeSequenceConcurrencyConflict(Exception exception)
+    private static bool isNodeSequenceConcurrencyConflict(Exception exception)
     {
         return exception is ClusterTransactionConcurrencyException or ConcurrencyException;
     }

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.NodeAgents.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.NodeAgents.cs
@@ -3,12 +3,16 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Documents.Session;
 using Wolverine.Runtime.Agents;
 
 namespace Wolverine.RavenDb.Internals;
 
 public partial class RavenDbMessageStore : INodeAgentPersistence
 {
+    private const int NodePersistenceMaxAttempts = 25;
+
     public async Task ClearAllAsync(CancellationToken cancellationToken)
     {
         // Shouldn't really get called at runtime, so we're doing it crudely
@@ -29,24 +33,52 @@ public partial class RavenDbMessageStore : INodeAgentPersistence
 
     public async Task<int> PersistAsync(WolverineNode node, CancellationToken cancellationToken)
     {
-        using var session = _store.OpenAsyncSession(new SessionOptions
+        Exception? lastConflict = null;
+
+        for (var attempt = 1; attempt <= NodePersistenceMaxAttempts; attempt++)
         {
-            TransactionMode = TransactionMode.ClusterWide
-        });
-        // RavenDB rejects cluster-wide transactions combined with optimistic concurrency.
-        // Disable it explicitly so a consumer-enabled convention doesn't break this session.
-        session.Advanced.UseOptimisticConcurrency = false;
+            try
+            {
+                using var session = _store.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                });
+                // RavenDB rejects cluster-wide transactions combined with optimistic concurrency.
+                // Disable it explicitly so a consumer-enabled convention doesn't break this session.
+                session.Advanced.UseOptimisticConcurrency = false;
 
-        var sequence = await session.LoadAsync<NodeSequence>(NodeSequence.SequenceId, cancellationToken);
-        sequence ??= new NodeSequence();
+                var sequence = await session.LoadAsync<NodeSequence>(NodeSequence.SequenceId, cancellationToken);
+                sequence ??= new NodeSequence();
 
-        node.AssignedNodeNumber = ++sequence.Count;
+                node.AssignedNodeNumber = ++sequence.Count;
 
-        await session.StoreAsync(sequence, cancellationToken);
-        await session.StoreAsync(node, cancellationToken);
-        await session.SaveChangesAsync(cancellationToken);
+                await session.StoreAsync(sequence, cancellationToken);
+                await session.StoreAsync(node, cancellationToken);
+                await session.SaveChangesAsync(cancellationToken);
 
-        return node.AssignedNodeNumber;
+                return node.AssignedNodeNumber;
+            }
+            catch (Exception e) when (IsNodeSequenceConcurrencyConflict(e))
+            {
+                lastConflict = e;
+
+                if (attempt == NodePersistenceMaxAttempts)
+                {
+                    break;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(20 * attempt), cancellationToken);
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Unable to persist Wolverine node {node.NodeId} after {NodePersistenceMaxAttempts} attempts because RavenDB node sequence allocation kept conflicting.",
+            lastConflict);
+    }
+
+    private static bool IsNodeSequenceConcurrencyConflict(Exception exception)
+    {
+        return exception is ClusterTransactionConcurrencyException or ConcurrencyException;
     }
 
     public async Task DeleteAsync(Guid nodeId, int assignedNodeNumber)


### PR DESCRIPTION
### Problem
During startup, when multiple Wolverine nodes registered concurrently against RavenDB, `PersistAsync` could hand out **duplicate `AssignedNodeNumber`s**. Each concurrent call loaded the same `NodeSequence` document, incremented `Count` to the same value, and committed — so two nodes could end up with the same assigned number.

### Fix
`RavenDbMessageStore.PersistAsync` now retries the load/increment/store cycle inside a bounded loop, relying on RavenDB cluster-wide transaction concurrency (compare-exchange atomic guards on `nodes/sequence`) to detect the collision:

- Catches `ClusterTransactionConcurrencyException` / `ConcurrencyException` and retries (up to 25 attempts).
- Uses linear backoff with jitter to avoid synchronized retries (thundering herd) under startup contention.
- Throws a clear `InvalidOperationException` (with the last conflict as inner exception) if the sequence keeps conflicting past the attempt limit.

### Tests
Added `concurrently_persisting_nodes_assigns_unique_node_numbers` to the RavenDB node-persistence compliance suite. It fires 20 `PersistAsync` calls simultaneously (released via a shared `TaskCompletionSource`) and asserts the returned numbers — and the persisted DB state — form exactly `1..20` with no duplicates.

### Notes
- No public API changes; behavior change is limited to node registration retry semantics.
- Cluster-wide transactions still enforce per-document atomic guards even with `UseOptimisticConcurrency = false`, which is the mechanism the retry leans on.

Want me to commit and push this, or adjust the tone/length for the repo's PR conventions?