### PR TITLE
Retrofit MessageStoreRole registration tests to all relational providers (#3351 follow-up)

### DIFF
--- a/src/Persistence/MySql/MySqlTests/message_store_role_registration.cs
+++ b/src/Persistence/MySql/MySqlTests/message_store_role_registration.cs
@@ -1,0 +1,65 @@
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.MySql;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace MySqlTests;
+
+public class message_store_role_registration
+{
+    private static IWolverineRuntime buildRuntime()
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Options.Returns(new WolverineOptions());
+        runtime.LoggerFactory.Returns(NullLoggerFactory.Instance);
+        runtime.DurabilitySettings.Returns(new DurabilitySettings());
+        runtime.Services.Returns(new ServiceCollection().BuildServiceProvider());
+
+        return runtime;
+    }
+
+    [Fact]
+    public void ancillary_role_is_honored_for_a_single_database()
+    {
+        var options = new WolverineOptions();
+        var persistence = (MySqlBackedPersistence)options.PersistMessagesWithMySql(
+            Servers.MySqlConnectionString, "wolverine", MessageStoreRole.Ancillary);
+
+        persistence.BuildMessageStore(buildRuntime())
+            .Role.ShouldBe(MessageStoreRole.Ancillary);
+    }
+
+    [Fact]
+    public void ancillary_role_is_honored_with_statically_registered_tenants()
+    {
+        var options = new WolverineOptions();
+        var persistence = (MySqlBackedPersistence)options
+            .PersistMessagesWithMySql(Servers.MySqlConnectionString, "wolverine", MessageStoreRole.Ancillary)
+            .RegisterStaticTenants(tenants => tenants.Register("one", Servers.MySqlConnectionString));
+
+        var store = persistence.BuildMessageStore(buildRuntime()).ShouldBeOfType<MultiTenantedMessageStore>();
+
+        // The composite store itself is always Composite. The role that MessageStoreCollection
+        // keys off of lives on the inner, main database
+        store.Main.Role.ShouldBe(MessageStoreRole.Ancillary);
+    }
+
+    [Fact]
+    public void main_is_still_the_default_role_with_statically_registered_tenants()
+    {
+        var options = new WolverineOptions();
+        var persistence = (MySqlBackedPersistence)options
+            .PersistMessagesWithMySql(Servers.MySqlConnectionString, "wolverine")
+            .RegisterStaticTenants(tenants => tenants.Register("one", Servers.MySqlConnectionString));
+
+        var store = persistence.BuildMessageStore(buildRuntime()).ShouldBeOfType<MultiTenantedMessageStore>();
+
+        store.Main.Role.ShouldBe(MessageStoreRole.Main);
+    }
+}

--- a/src/Persistence/Oracle/OracleTests/message_store_role_registration.cs
+++ b/src/Persistence/Oracle/OracleTests/message_store_role_registration.cs
@@ -1,0 +1,65 @@
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.Oracle;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace OracleTests;
+
+public class message_store_role_registration
+{
+    private static IWolverineRuntime buildRuntime()
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Options.Returns(new WolverineOptions());
+        runtime.LoggerFactory.Returns(NullLoggerFactory.Instance);
+        runtime.DurabilitySettings.Returns(new DurabilitySettings());
+        runtime.Services.Returns(new ServiceCollection().BuildServiceProvider());
+
+        return runtime;
+    }
+
+    [Fact]
+    public void ancillary_role_is_honored_for_a_single_database()
+    {
+        var options = new WolverineOptions();
+        var persistence = (OracleBackedPersistence)options.PersistMessagesWithOracle(
+            Servers.OracleConnectionString, "wolverine", MessageStoreRole.Ancillary);
+
+        persistence.BuildMessageStore(buildRuntime())
+            .Role.ShouldBe(MessageStoreRole.Ancillary);
+    }
+
+    [Fact]
+    public void ancillary_role_is_honored_with_statically_registered_tenants()
+    {
+        var options = new WolverineOptions();
+        var persistence = (OracleBackedPersistence)options
+            .PersistMessagesWithOracle(Servers.OracleConnectionString, "wolverine", MessageStoreRole.Ancillary)
+            .RegisterStaticTenants(tenants => tenants.Register("one", Servers.OracleConnectionString));
+
+        var store = persistence.BuildMessageStore(buildRuntime()).ShouldBeOfType<MultiTenantedMessageStore>();
+
+        // The composite store itself is always Composite. The role that MessageStoreCollection
+        // keys off of lives on the inner, main database
+        store.Main.Role.ShouldBe(MessageStoreRole.Ancillary);
+    }
+
+    [Fact]
+    public void main_is_still_the_default_role_with_statically_registered_tenants()
+    {
+        var options = new WolverineOptions();
+        var persistence = (OracleBackedPersistence)options
+            .PersistMessagesWithOracle(Servers.OracleConnectionString, "wolverine")
+            .RegisterStaticTenants(tenants => tenants.Register("one", Servers.OracleConnectionString));
+
+        var store = persistence.BuildMessageStore(buildRuntime()).ShouldBeOfType<MultiTenantedMessageStore>();
+
+        store.Main.Role.ShouldBe(MessageStoreRole.Main);
+    }
+}

--- a/src/Persistence/SqlServerTests/message_store_role_registration.cs
+++ b/src/Persistence/SqlServerTests/message_store_role_registration.cs
@@ -1,0 +1,65 @@
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.SqlServer;
+using Xunit;
+
+namespace SqlServerTests;
+
+public class message_store_role_registration
+{
+    private static IWolverineRuntime buildRuntime()
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Options.Returns(new WolverineOptions());
+        runtime.LoggerFactory.Returns(NullLoggerFactory.Instance);
+        runtime.DurabilitySettings.Returns(new DurabilitySettings());
+        runtime.Services.Returns(new ServiceCollection().BuildServiceProvider());
+
+        return runtime;
+    }
+
+    [Fact]
+    public void ancillary_role_is_honored_for_a_single_database()
+    {
+        var options = new WolverineOptions();
+        var persistence = (SqlServerBackedPersistence)options.PersistMessagesWithSqlServer(
+            Servers.SqlServerConnectionString, "wolverine", MessageStoreRole.Ancillary);
+
+        persistence.BuildMessageStore(buildRuntime())
+            .Role.ShouldBe(MessageStoreRole.Ancillary);
+    }
+
+    [Fact]
+    public void ancillary_role_is_honored_with_statically_registered_tenants()
+    {
+        var options = new WolverineOptions();
+        var persistence = (SqlServerBackedPersistence)options
+            .PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "wolverine", MessageStoreRole.Ancillary)
+            .RegisterStaticTenants(tenants => tenants.Register("one", Servers.SqlServerConnectionString));
+
+        var store = persistence.BuildMessageStore(buildRuntime()).ShouldBeOfType<MultiTenantedMessageStore>();
+
+        // The composite store itself is always Composite. The role that MessageStoreCollection
+        // keys off of lives on the inner, main database
+        store.Main.Role.ShouldBe(MessageStoreRole.Ancillary);
+    }
+
+    [Fact]
+    public void main_is_still_the_default_role_with_statically_registered_tenants()
+    {
+        var options = new WolverineOptions();
+        var persistence = (SqlServerBackedPersistence)options
+            .PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "wolverine")
+            .RegisterStaticTenants(tenants => tenants.Register("one", Servers.SqlServerConnectionString));
+
+        var store = persistence.BuildMessageStore(buildRuntime()).ShouldBeOfType<MultiTenantedMessageStore>();
+
+        store.Main.Role.ShouldBe(MessageStoreRole.Main);
+    }
+}

--- a/src/Persistence/SqliteTests/message_store_role_registration.cs
+++ b/src/Persistence/SqliteTests/message_store_role_registration.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Sqlite;
+using Xunit;
+
+namespace SqliteTests;
+
+public class message_store_role_registration : IDisposable
+{
+    // SQLite persistence requires file-based connection strings, so use throwaway
+    // database files instead of the shared docker-compose servers
+    private readonly SqliteTestDatabase _main = Servers.CreateDatabase("role_main");
+    private readonly SqliteTestDatabase _tenant = Servers.CreateDatabase("role_tenant");
+
+    public void Dispose()
+    {
+        _main.Dispose();
+        _tenant.Dispose();
+    }
+
+    private static IWolverineRuntime buildRuntime()
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Options.Returns(new WolverineOptions());
+        runtime.LoggerFactory.Returns(NullLoggerFactory.Instance);
+        runtime.DurabilitySettings.Returns(new DurabilitySettings());
+        runtime.Services.Returns(new ServiceCollection().BuildServiceProvider());
+
+        return runtime;
+    }
+
+    [Fact]
+    public void ancillary_role_is_honored_for_a_single_database()
+    {
+        var options = new WolverineOptions();
+        var persistence = (SqliteBackedPersistence)options.PersistMessagesWithSqlite(
+            _main.ConnectionString, role: MessageStoreRole.Ancillary);
+
+        persistence.BuildMessageStore(buildRuntime())
+            .Role.ShouldBe(MessageStoreRole.Ancillary);
+    }
+
+    [Fact]
+    public void ancillary_role_is_honored_with_statically_registered_tenants()
+    {
+        var options = new WolverineOptions();
+        var persistence = (SqliteBackedPersistence)options
+            .PersistMessagesWithSqlite(_main.ConnectionString, role: MessageStoreRole.Ancillary)
+            .RegisterStaticTenants(tenants => tenants.Register("one", _tenant.ConnectionString));
+
+        var store = persistence.BuildMessageStore(buildRuntime()).ShouldBeOfType<MultiTenantedMessageStore>();
+
+        // The composite store itself is always Composite. The role that MessageStoreCollection
+        // keys off of lives on the inner, main database
+        store.Main.Role.ShouldBe(MessageStoreRole.Ancillary);
+    }
+
+    [Fact]
+    public void main_is_still_the_default_role_with_statically_registered_tenants()
+    {
+        var options = new WolverineOptions();
+        var persistence = (SqliteBackedPersistence)options
+            .PersistMessagesWithSqlite(_main.ConnectionString)
+            .RegisterStaticTenants(tenants => tenants.Register("one", _tenant.ConnectionString));
+
+        var store = persistence.BuildMessageStore(buildRuntime()).ShouldBeOfType<MultiTenantedMessageStore>();
+
+        store.Main.Role.ShouldBe(MessageStoreRole.Main);
+    }
+}


### PR DESCRIPTION
## What

Follow-up to #3351, which fixed the `MessageStoreRole`-ignored-on-tenanted-paths defect in all five relational providers (PostgreSQL, Sql Server, Sqlite, MySql, Oracle) but only added regression tests for PostgreSQL.

This retrofits the same three-case test to the other four providers:

- `SqlServerTests/message_store_role_registration.cs`
- `SqliteTests/message_store_role_registration.cs`
- `MySqlTests/message_store_role_registration.cs`
- `OracleTests/message_store_role_registration.cs`

Each covers: ancillary single-database, ancillary with statically registered tenants, and the `Main` default with statically registered tenants. All are pure configuration tests over `BuildMessageStore()` — no database connection is opened, so they run without docker infrastructure. The SQLite variant uses throwaway file-based connection strings via the existing `SqliteTests.Servers` helper because SQLite persistence rejects non-file connection strings.

## Verification

All 12 new tests pass locally. Mutation-checked on Sql Server: reverting the `Role` propagation in `buildMainDatabaseSettings()` fails both ancillary tests and leaves the Main-default test green — same kill pattern as the original PostgreSQL tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)