### PR TITLE
fix(http): honor the Name on [FromRoute] for endpoint method parameters

### DIFF
--- a/repro/Directory.Build.props
+++ b/repro/Directory.Build.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/repro/README.md
+++ b/repro/README.md
@@ -1,0 +1,18 @@
+# Reproductions
+
+Self-verifying [file-based apps](https://learn.microsoft.com/dotnet/core/whats-new/dotnet-10/sdk#file-based-apps).
+Each prints `PASS`/`FAIL` per assertion and exits non-zero on failure:
+
+```bash
+dotnet run repro/kebab-cased-route-parameter.cs
+```
+
+`Directory.Build.props` is intentionally empty — it stops the repo-wide
+props (multi-targeting, warnings-as-errors, versioning) from reaching these
+single-file apps.
+
+## kebab-cased-route-parameter.cs
+
+`[FromRoute(Name = "journey-id")]` on an endpoint method parameter. Against
+`main` the first assertion fails with `0`, because the attribute's name was
+ignored and the argument was bound from the query string instead.

--- a/repro/kebab-cased-route-parameter.cs
+++ b/repro/kebab-cased-route-parameter.cs
@@ -1,0 +1,81 @@
+#:sdk Microsoft.NET.Sdk.Web
+#:project ../src/Http/Wolverine.Http/Wolverine.Http.csproj
+#:project ../src/Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj
+#:property TargetFramework=net10.0
+#:property PublishAot=false
+#:property JsonSerializerIsReflectionEnabledByDefault=true
+
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Wolverine;
+using Wolverine.Http;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseUrls("http://127.0.0.1:5399");
+builder.Host.UseWolverine();
+builder.Services.AddWolverineHttp();
+
+var app = builder.Build();
+app.MapWolverineEndpoints();
+
+await app.StartAsync();
+
+using var client = new HttpClient { BaseAddress = new Uri("http://127.0.0.1:5399") };
+
+var failures = 0;
+
+await expect("GET /journeys/42/legs", "42", () => client.GetStringAsync("/journeys/42/legs"));
+
+await expect("POST /journeys/7/passengers", "7:Maverick", async () =>
+{
+    var response = await client.PostAsJsonAsync("/journeys/7/passengers", new AddPassengerPayload("Maverick"));
+    return await response.Content.ReadAsStringAsync();
+});
+
+await app.StopAsync();
+
+return failures;
+
+async Task expect(string description, string expected, Func<Task<string>> call)
+{
+    string actual;
+    try
+    {
+        actual = await call();
+    }
+    catch (Exception e)
+    {
+        actual = $"<{e.GetType().Name}: {e.Message}>";
+    }
+
+    if (actual == expected)
+    {
+        Console.WriteLine($"PASS  {description} -> \"{actual}\"");
+    }
+    else
+    {
+        failures++;
+        Console.WriteLine($"FAIL  {description} -> expected \"{expected}\", got \"{actual}\"");
+    }
+}
+
+public record AddPassengerPayload(string Name);
+
+public record AddPassengerCommand([FromRoute(Name = "journey-id")] int JourneyId, [FromBody] AddPassengerPayload Payload);
+
+public static class JourneyEndpoints
+{
+    [WolverineGet("/journeys/{journey-id}/legs")]
+    public static string CountLegs([FromRoute(Name = "journey-id")] int journeyId)
+    {
+        return journeyId.ToString();
+    }
+
+    [WolverinePost("/journeys/{journey-id}/passengers")]
+    public static string AddPassenger([AsParameters] AddPassengerCommand command)
+    {
+        return $"{command.JourneyId}:{command.Payload.Name}";
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/named_route_parameter_binding.cs
+++ b/src/Http/Wolverine.Http.Tests/named_route_parameter_binding.cs
@@ -1,0 +1,97 @@
+using Alba;
+using IntegrationTests;
+using Marten;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Wolverine.Marten;
+
+namespace Wolverine.Http.Tests;
+
+public class named_route_parameter_binding
+{
+    private static async Task<IAlbaHost> hostFor(Type endpointType)
+    {
+        var builder = WebApplication.CreateBuilder([]);
+
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(Servers.PostgresConnectionString);
+            opts.DisableNpgsqlLogging = true;
+        }).IntegrateWithWolverine();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.Discovery.DisableConventionalDiscovery().IncludeType(endpointType);
+            opts.ApplicationAssembly = typeof(named_route_parameter_binding).Assembly;
+        });
+
+        builder.Services.AddWolverineHttp();
+
+        return await AlbaHost.For(builder, app => app.MapWolverineEndpoints());
+    }
+
+    [Fact]
+    public async Task bind_kebab_cased_route_argument_to_a_method_parameter()
+    {
+        await using var host = await hostFor(typeof(NamedRouteEndpoints));
+
+        await host.Scenario(x =>
+        {
+            x.Get.Url("/named-route/direct/42");
+            x.ContentShouldBe("42");
+        });
+    }
+
+    [Fact]
+    public async Task bind_kebab_cased_route_argument_to_a_string_method_parameter()
+    {
+        await using var host = await hostFor(typeof(NamedRouteEndpoints));
+
+        await host.Scenario(x =>
+        {
+            x.Get.Url("/named-route/direct-string/Aubrey");
+            x.ContentShouldBe("Aubrey");
+        });
+    }
+
+    [Fact]
+    public async Task bind_kebab_cased_route_argument_through_as_parameters_with_a_body()
+    {
+        await using var host = await hostFor(typeof(NamedRouteEndpoints));
+
+        await host.Scenario(x =>
+        {
+            x.Post.Json(new NamedRouteBody("Maverick")).ToUrl("/named-route/as-parameters/11");
+            x.ContentShouldBe("11:Maverick");
+        });
+    }
+
+}
+
+public record NamedRouteBody(string Name);
+
+public record NamedRouteRequest([FromRoute(Name = "my-id")] int Id, [FromBody] NamedRouteBody Body);
+
+public static class NamedRouteEndpoints
+{
+    [WolverineGet("/named-route/direct/{my-id}")]
+    public static string Direct([FromRoute(Name = "my-id")] int id)
+    {
+        return id.ToString();
+    }
+
+    [WolverineGet("/named-route/direct-string/{my-name}")]
+    public static string DirectString([FromRoute(Name = "my-name")] string name)
+    {
+        return name;
+    }
+
+    [WolverinePost("/named-route/as-parameters/{my-id}")]
+    public static string WithBody([AsParameters] NamedRouteRequest request)
+    {
+        return $"{request.Id}:{request.Body.Name}";
+    }
+}
+

--- a/src/Http/Wolverine.Http/CodeGen/RouteHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/RouteHandling.cs
@@ -4,8 +4,10 @@ using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
+using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Wolverine.Runtime;
 
 namespace Wolverine.Http.CodeGen;
@@ -51,6 +53,17 @@ internal class RouteParameterStrategy : IParameterStrategy
 
     public bool TryMatch(HttpChain chain, IServiceContainer container, ParameterInfo parameter, out Variable? variable)
     {
+        if (parameter.TryGetAttribute<FromRouteAttribute>(out var att) && att.Name.IsNotEmpty())
+        {
+            if (chain.FindRouteVariable(parameter.ParameterType, att.Name!, out variable))
+            {
+                return true;
+            }
+
+            throw new InvalidOperationException(
+                $"Unable to find a route argument '{att.Name}' specified on parameter '{parameter.Name}' of {chain.Method.HandlerType.FullNameInCode()}.{chain.Method.Method.Name}()");
+        }
+
         return chain.FindRouteVariable(parameter, out variable);
     }
 

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -452,7 +452,8 @@ public partial class HttpChain
         // lower-cased (e.g. {journeyId}) while the bound member/argument is PascalCased
         // (JourneyId). A case-sensitive match here silently misses and falls back to string,
         // losing the real type (e.g. Guid/int) on the generated OpenAPI parameter. See GH-3135.
-        var variable = _routeVariables.FirstOrDefault(x => x.Usage.EqualsIgnoreCase(routeParameter.Name));
+        var variable = _routeVariables.OfType<CodeGen.HttpElementVariable>()
+            .FirstOrDefault(x => x.Name.EqualsIgnoreCase(routeParameter.Name));
 
         // When no typed argument is bound to the route value (e.g. a plain complex-body endpoint
         // whose body property overlaps a route token, or an aggregate-id route), fall back to the

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -788,8 +788,8 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
     public bool FindRouteVariable(Type variableType, string routeOrParameterName, [NotNullWhen(true)]out Variable? variable)
     {
-        var matched =
-            _routeVariables.FirstOrDefault(x => x.VariableType == variableType && x.Usage.EqualsIgnoreCase(routeOrParameterName));
+        var matched = _routeVariables.OfType<HttpElementVariable>()
+            .FirstOrDefault(x => x.VariableType == variableType && x.Name.EqualsIgnoreCase(routeOrParameterName));
         if (matched is not null)
         {
             variable = matched;


### PR DESCRIPTION
## Problem

`[FromRoute(Name = "...")]` is only read inside `AsParametersBindingFrame`. On a plain endpoint method parameter the attribute's `Name` is ignored — `RouteParameterStrategy` matches on `ParameterInfo.Name` only:

```csharp
var matchingRouteParameter = RoutePattern!.Parameters.FirstOrDefault(x => x.Name == parameter.Name);
```

So for `/journeys/{journey-id}/legs` + `[FromRoute(Name = "journey-id")] int journeyId`:

* `RouteParameterStrategy` misses (`"journeyId" != "journey-id"`)
* matching falls through the strategy list to `QueryStringParameterStrategy`, which claims any parseable type
* the generated handler reads `httpContext.Request.Query["journeyId"]`, so the argument binds to `0`

Silent wrong binding, no exception. And a kebab-cased route token can't be bound by convention at all, because `journey-id` isn't a legal C# identifier — so the attribute was the only way to reach it.

## Fix

`RouteParameterStrategy.TryMatch` now resolves the route argument by the attribute's `Name` when one is supplied, and throws when no such route argument exists rather than letting the parameter be quietly bound from somewhere else — mirroring the existing `[AsParameters]` behaviour.

Two related lookups matched route variables on `Variable.Usage` (the sanitized C# identifier, `journey_id`) instead of `HttpElementVariable.Name` (the route key, `journey-id`):

* `HttpChain.FindRouteVariable(Type, string)` — the de-dupe check never hit for a sanitized name, so two members bound to the same route token emitted the same local twice (`CS0128`).
* `HttpChain.buildParameterDescription` — the OpenAPI parameter lost its real type and fell back to `string` unless the route carried an inline constraint.

Both now compare against the route key.

## Tests

`named_route_parameter_binding` covers a kebab-cased route token bound to an `int` method parameter, to a `string` method parameter, and through `[AsParameters]` alongside a `[FromBody]` member. The two direct-parameter cases fail on `main`; all three pass with the fix.

Full `Wolverine.Http.Tests` green (811 passed, 10 skipped), and `dotnet build wolverine.slnx -c Release` succeeds.

## Repro

The second commit adds `repro/kebab-cased-route-parameter.cs`, a .NET 10 file-based app that boots a real Wolverine HTTP host, exercises both shapes over HTTP, and exits non-zero on failure. It's self-contained (`dotnet run repro/kebab-cased-route-parameter.cs`) and needs no test framework.

With the fix:

```
PASS  GET /journeys/42/legs -> "42"
PASS  POST /journeys/7/passengers -> "7:Maverick"
```

Against `main`:

```
FAIL  GET /journeys/42/legs -> expected "42", got "0"
PASS  POST /journeys/7/passengers -> "7:Maverick"
```

Happy to drop that commit if a top-level `repro/` directory isn't a convention you want — the fix and the xUnit coverage stand on their own without it.
