### PR TITLE
Correct QUERY verb docs: transactional middleware is dependency-based, not verb-based

### DIFF
--- a/docs/guide/http/endpoints.md
+++ b/docs/guide/http/endpoints.md
@@ -199,8 +199,9 @@ criteria are too large or too structured to encode in the query string:
 ```cs
 // QUERY (RFC 10008) is safe and idempotent like GET, but carries a request body — ideal for
 // search endpoints whose criteria are too large or structured for the query string. Wolverine
-// binds the request body just like it would for POST, and — because the endpoint takes no
-// message-bus dependency — no transactional/outbox middleware is applied.
+// binds the request body just like it would for POST. Note that Wolverine's middleware rules
+// are not verb-aware: this endpoint stays free of transactional middleware because it takes
+// no IDocumentSession/DbContext dependency, not because it is a QUERY.
 [WolverineQuery("/search")]
 public static SearchResults Search(SearchRequest request)
 {
@@ -211,16 +212,20 @@ public static SearchResults Search(SearchRequest request)
     return new SearchResults(request.Term, request.Page, hits);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/QueryEndpoints.cs#L11-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_query_endpoint' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/QueryEndpoints.cs#L14-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_wolverine_query_endpoint' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The request body binds exactly as it would for a `POST` endpoint.
 
 ::: tip
-Because `QUERY` is a *safe* method, a `QUERY` endpoint follows the same dependency-based rule as every
-other verb for transactional middleware: Wolverine only wraps a handler in transactional/outbox
-middleware when it depends on `IMessageBus`/`IMessageContext`. A plain `QUERY` search endpoint is
-therefore never transactional, even when `AutoApplyTransactions()` is enabled.
+Wolverine applies no verb-specific middleware rules to `QUERY` — the same dependency-based rules apply
+as for every other verb. Outbox middleware is gated on an `IMessageBus`/`IMessageContext` dependency,
+and transactional middleware is gated on a persistence dependency: a `QUERY` endpoint that takes an
+`IDocumentSession` (Marten) or a `DbContext` (EF Core) **is** wrapped in transactional middleware under
+`AutoApplyTransactions()`, exactly as a `POST` with the same dependency would be. To keep a `QUERY`
+endpoint that reads the database free of transactional middleware, take Marten's read-only
+`IQuerySession` instead of an `IDocumentSession`, or decorate the endpoint with `[NonTransactional]`
+when using EF Core.
 :::
 
 ::: warning OpenAPI limitation

--- a/src/Http/Wolverine.Http.Tests/query_verb_support.cs
+++ b/src/Http/Wolverine.Http.Tests/query_verb_support.cs
@@ -50,12 +50,34 @@ public class query_verb_support : IntegrationContext
     [Fact]
     public void query_endpoint_is_not_wrapped_in_transactional_middleware()
     {
-        // QUERY is safe, so it must not be enrolled in transactional/outbox middleware. Wolverine's
-        // rule is dependency-based (no IMessageBus/MessageContext dependency => no outbox), so a plain
-        // QUERY search endpoint stays non-transactional even with AutoApplyTransactions turned on.
+        // Wolverine's middleware rules are dependency-based, not verb-based. This endpoint stays
+        // non-transactional under AutoApplyTransactions because it takes no persistence dependency
+        // (IDocumentSession/DbContext), and outbox-free because it takes no IMessageBus/MessageContext —
+        // NOT because QUERY is a safe verb. See the two tests below for the flip side.
         var chain = HttpChains.Chains.Single(x => x.RoutePattern!.RawText == "/search");
         chain.RequiresOutbox().ShouldBeFalse();
         chain.IsTransactional.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void query_endpoint_with_document_session_is_transactional()
+    {
+        // The dependency-based rule cuts both ways: an IDocumentSession dependency attracts
+        // AutoApplyTransactions on a QUERY endpoint exactly as it would on a POST. There is no
+        // verb-based exemption, and this pins that no verb-based special case sneaks in later.
+        var chain = HttpChains.Chains.Single(x => x.RoutePattern!.RawText == "/search/audited");
+        chain.IsTransactional.ShouldBeTrue();
+        chain.RequiresOutbox().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void query_endpoint_with_query_session_stays_non_transactional()
+    {
+        // IQuerySession is Marten's read-only session — MartenPersistenceFrameProvider.CanApply
+        // ignores it, so this is the dependency to use for a QUERY endpoint that reads the database.
+        var chain = HttpChains.Chains.Single(x => x.RoutePattern!.RawText == "/search/readonly");
+        chain.IsTransactional.ShouldBeFalse();
+        chain.RequiresOutbox().ShouldBeFalse();
     }
 
     [Fact]

--- a/src/Http/Wolverine.Http/ModifyHttpChainAttribute.cs
+++ b/src/Http/Wolverine.Http/ModifyHttpChainAttribute.cs
@@ -204,9 +204,10 @@ public class WolverineOptionsAttribute : WolverineHttpMethodAttribute
 ///     Marks a method on a Wolverine endpoint as being a QUERY route. QUERY (RFC 10008) is a safe,
 ///     idempotent method — like GET — that additionally carries a request body, so it is well suited
 ///     to search/query endpoints whose parameters are too large or structured for the query string.
-///     Because it is safe, a QUERY endpoint is not wrapped in transactional/outbox middleware unless it
-///     takes a message-bus dependency (the same dependency-based rule as every other verb); unlike GET,
-///     it is allowed to bind a request body.
+///     Wolverine applies no verb-specific middleware rules: outbox middleware still requires an
+///     IMessageBus/IMessageContext dependency, and transactional middleware is still applied when the
+///     handler takes an IDocumentSession or DbContext dependency. Prefer IQuerySession (Marten) or
+///     [NonTransactional] (EF Core) to keep a QUERY endpoint free of transactional middleware.
 /// </summary>
 public class WolverineQueryAttribute : WolverineHttpMethodAttribute
 {

--- a/src/Http/WolverineWebApi/QueryEndpoints.cs
+++ b/src/Http/WolverineWebApi/QueryEndpoints.cs
@@ -1,3 +1,4 @@
+using Marten;
 using Wolverine.Http;
 
 namespace WolverineWebApi;
@@ -6,13 +7,16 @@ public record SearchRequest(string Term, int Page);
 
 public record SearchResults(string Term, int Page, string[] Hits);
 
+public record SearchAudit(Guid Id, string Term);
+
 public static class QueryEndpoints
 {
     #region sample_wolverine_query_endpoint
     // QUERY (RFC 10008) is safe and idempotent like GET, but carries a request body — ideal for
     // search endpoints whose criteria are too large or structured for the query string. Wolverine
-    // binds the request body just like it would for POST, and — because the endpoint takes no
-    // message-bus dependency — no transactional/outbox middleware is applied.
+    // binds the request body just like it would for POST. Note that Wolverine's middleware rules
+    // are not verb-aware: this endpoint stays free of transactional middleware because it takes
+    // no IDocumentSession/DbContext dependency, not because it is a QUERY.
     [WolverineQuery("/search")]
     public static SearchResults Search(SearchRequest request)
     {
@@ -24,4 +28,21 @@ public static class QueryEndpoints
     }
 
     #endregion
+
+    // Middleware rules are dependency-based, not verb-based: taking an IDocumentSession attracts
+    // AutoApplyTransactions on a QUERY endpoint exactly as it would on a POST.
+    [WolverineQuery("/search/audited")]
+    public static SearchResults SearchAudited(SearchRequest request, IDocumentSession session)
+    {
+        session.Store(new SearchAudit(Guid.NewGuid(), request.Term));
+        return new SearchResults(request.Term, request.Page, []);
+    }
+
+    // IQuerySession is Marten's read-only session and does not trigger transactional middleware,
+    // so this is the right dependency for a QUERY endpoint that reads the database.
+    [WolverineQuery("/search/readonly")]
+    public static SearchResults SearchReadonly(SearchRequest request, IQuerySession session)
+    {
+        return new SearchResults(request.Term, request.Page, []);
+    }
 }


### PR DESCRIPTION
Closes #3355.

A QUERY endpoint **is** wrapped in transactional middleware when it takes an `IDocumentSession`/`DbContext` under `AutoApplyTransactions()` — nothing in Wolverine keys off the HTTP verb. The `WolverineQueryAttribute` XML doc, the `sample_wolverine_query_endpoint` comment, and the "HTTP QUERY Method" docs tip all implied a verb-based exemption that doesn't exist, and the existing `query_endpoint_is_not_wrapped_in_transactional_middleware` test only exercised an endpoint with no dependencies at all, so it couldn't catch the misstatement.

## Changes

- **`WolverineQueryAttribute` XML doc** (what users see in IntelliSense): states the actual rules — outbox middleware requires an `IMessageBus`/`IMessageContext` dependency; transactional middleware applies when the handler takes an `IDocumentSession` or `DbContext`; prefer `IQuerySession` (Marten) or `[NonTransactional]` (EF Core) for read-only QUERY endpoints.
- **`sample_wolverine_query_endpoint`** comment (surfaces in the docs via mdsnippets): attributes the endpoint's non-transactional status to the absence of a persistence dependency, not to the verb.
- **`docs/guide/http/endpoints.md`** tip: same correction, with the `IQuerySession` / `[NonTransactional]` guidance.
- **Tests**: two new WolverineWebApi QUERY endpoints — `/search/audited` taking `IDocumentSession` (asserted `IsTransactional == true`) and `/search/readonly` taking `IQuerySession` (asserted `false`) — pin the dependency-based rule so a verb-based special case can't be introduced silently. The existing test's comment now explains what it actually demonstrates.

## Verification

- New + existing `query_verb_support` tests green (6/6)
- Full `Wolverine.Http.Tests` suite green: **813 passed / 0 failed / 10 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)