### PR TITLE
Evaluate the EF Core persistence provider before Marten regardless of registration order

### DIFF
--- a/docs/guide/durability/efcore/index.md
+++ b/docs/guide/durability/efcore/index.md
@@ -89,6 +89,18 @@ builder.UseWolverine(opts =>
 
 Right now, we've tested Wolverine with EF Core using both [SQL Server](/guide/durability/sqlserver) and [PostgreSQL](/guide/durability/postgresql) persistence. 
 
+## Combining EF Core with Marten <Badge type="tip" text="6.18" />
+
+It's completely valid to use both the EF Core and [Marten](/guide/durability/marten) integrations in
+the same application — say, Marten for event sourcing and EF Core for flat relational tables. When
+Wolverine needs a persistence provider for an entity (for [storage side effects](/guide/handlers/side-effects),
+`[Entity]` loading, or [saga](/guide/durability/sagas.html) persistence), the EF Core integration is
+always consulted **before** Marten, no matter which integration was registered first in your
+`Program.cs`: an entity mapped in one of your registered `DbContext` models deterministically
+resolves to EF Core, and every other document falls through to Marten. Marten can genuinely persist
+*any* document, so it acts as the catch-all; EF Core only claims the types its `DbContext` models
+actually map.
+
 ## Development-time usage <Badge type="tip" text="5.32" />
 
 Wolverine + EF Core is designed to keep the dev loop short: fast schema iteration, cheap per-test database resets, declarative seed data. The three pillars below all work together — and all come for free the moment you call `UseEntityFrameworkCoreTransactions()`.

--- a/src/Persistence/PersistenceTests/persistence_provider_precedence_permutations.cs
+++ b/src/Persistence/PersistenceTests/persistence_provider_precedence_permutations.cs
@@ -1,0 +1,108 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore.Codegen;
+using Wolverine.Marten;
+using Wolverine.Marten.Persistence.Sagas;
+using Wolverine.Persistence.Sagas;
+using Wolverine.Postgresql;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace PersistenceTests;
+
+// GH-3359: in a mixed Marten + EF Core application, an entity mapped in a registered
+// DbContext must resolve to the EF Core persistence provider no matter which integration
+// the application registered first. MartenPersistenceFrameProvider.CanPersist claims every
+// type (Marten genuinely can persist any document), so before the IsCatchAll ordering rule
+// the winner was whichever integration happened to register last (InsertFirstPersistenceStrategy
+// puts the last-applied extension at index 0). Both permutations below must behave identically.
+public class persistence_provider_precedence_permutations
+{
+    // Deliberately NOT mapped in SampleDbContext, so only Marten can claim it
+    public class MartenOnlyDocument
+    {
+        public Guid Id { get; set; }
+    }
+
+    private static async Task assertResolutionIsOrderIndependent(IHost host)
+    {
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        var rules = runtime.Options.CodeGeneration;
+        var container = host.Services.GetRequiredService<IServiceContainer>();
+
+        // Item is mapped in SampleDbContext, so the selective EF Core provider owns it
+        rules.TryFindPersistenceFrameProvider(container, typeof(Item), out var forItem)
+            .ShouldBeTrue();
+        forItem.ShouldBeOfType<EFCorePersistenceFrameProvider>();
+
+        // Anything the DbContext model does not map still falls through to Marten
+        rules.TryFindPersistenceFrameProvider(container, typeof(MartenOnlyDocument), out var forDocument)
+            .ShouldBeTrue();
+        forDocument.ShouldBeOfType<MartenPersistenceFrameProvider>();
+
+        await host.StopAsync();
+    }
+
+    private static IHostBuilder builderWith(Action<WolverineOptions> registrations)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Durability.DurabilityAgentEnabled = false;
+                opts.Discovery.DisableConventionalDiscovery();
+
+                registrations(opts);
+
+                opts.Services.AddResourceSetupOnStartup();
+            });
+    }
+
+    [Fact]
+    public async Task efcore_owns_its_mapped_entity_when_marten_registers_last()
+    {
+        // Marten last = Marten's extension applies last = MartenPersistenceFrameProvider at
+        // index 0. This is the registration order that used to hand EF-mapped entities to Marten.
+        using var host = await builderWith(opts =>
+        {
+            opts.Services.AddDbContextWithWolverineIntegration<SampleDbContext>(x =>
+                x.UseSqlServer(Servers.SqlServerConnectionString));
+
+            opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "provider_precedence";
+                })
+                .IntegrateWithWolverine(x => x.MessageStorageSchemaName = "provider_precedence");
+        }).StartAsync();
+
+        await assertResolutionIsOrderIndependent(host);
+    }
+
+    [Fact]
+    public async Task efcore_owns_its_mapped_entity_when_marten_registers_first()
+    {
+        using var host = await builderWith(opts =>
+        {
+            opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "provider_precedence";
+                })
+                .IntegrateWithWolverine(x => x.MessageStorageSchemaName = "provider_precedence");
+
+            opts.Services.AddDbContextWithWolverineIntegration<SampleDbContext>(x =>
+                x.UseSqlServer(Servers.SqlServerConnectionString));
+        }).StartAsync();
+
+        await assertResolutionIsOrderIndependent(host);
+    }
+}

--- a/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbPersistenceFrameProvider.cs
@@ -48,6 +48,11 @@ public class CosmosDbPersistenceFrameProvider : IPersistenceFrameProvider
         return serviceDependencies.Any(x => x == typeof(Container));
     }
 
+    // CosmosDb can persist any document, so CanPersist claims every type. Yield to selective
+    // providers (EF Core) for the entity types they actually map, regardless of the order the
+    // integrations were registered in
+    public bool IsCatchAll => true;
+
     public bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService)
     {
         persistenceService = typeof(Container);

--- a/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
@@ -184,7 +184,14 @@ public static class WolverineEntityCoreExtensions
             b.ReplaceService<IModelCustomizer, WolverineModelCustomizer>();
         }, ServiceLifetime.Scoped, ServiceLifetime.Singleton);
 
-        services.TryAddSingleton<IWolverineExtension, EntityFrameworkCoreBackedPersistence>();
+        // TryAddEnumerable, NOT TryAddSingleton: TryAddSingleton gates on the service type alone,
+        // so any other integration that had already registered an IWolverineExtension (e.g. Marten's
+        // IntegrateWithWolverine) would silently swallow this registration and the EF Core codegen
+        // integration - persistence provider, batching, query-spec policies - would never apply.
+        // TryAddEnumerable dedupes on the (service, implementation) pair, which is exactly the
+        // idempotency wanted across repeated AddDbContextWithWolverineIntegration calls. See GH-3359.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IWolverineExtension, EntityFrameworkCoreBackedPersistence>());
 
         services.TryAddScoped(typeof(IDbContextOutbox<>), typeof(DbContextOutbox<>));
         services.TryAddScoped<IDbContextOutbox, DbContextOutbox>();

--- a/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenPersistenceFrameProvider.cs
@@ -21,6 +21,11 @@ namespace Wolverine.Marten.Persistence.Sagas;
 
 internal class MartenPersistenceFrameProvider : IPersistenceFrameProvider
 {
+    // Marten can persist any document, so CanPersist claims every type. Yield to selective
+    // providers (EF Core) for the entity types they actually map, regardless of the order the
+    // integrations were registered in
+    public bool IsCatchAll => true;
+
     public bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService)
     {
         persistenceService = typeof(IDocumentSession);

--- a/src/Persistence/Wolverine.Polecat/Persistence/Sagas/PolecatPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.Polecat/Persistence/Sagas/PolecatPersistenceFrameProvider.cs
@@ -18,6 +18,11 @@ namespace Wolverine.Polecat.Persistence.Sagas;
 
 internal class PolecatPersistenceFrameProvider : IPersistenceFrameProvider
 {
+    // Polecat can persist any document, so CanPersist claims every type. Yield to selective
+    // providers (EF Core) for the entity types they actually map, regardless of the order the
+    // integrations were registered in
+    public bool IsCatchAll => true;
+
     public bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService)
     {
         persistenceService = typeof(IDocumentSession);

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbPersistenceFrameProvider.cs
@@ -53,6 +53,11 @@ public class RavenDbPersistenceFrameProvider : IPersistenceFrameProvider
         return serviceDependencies.Any(x => x == typeof(IAsyncDocumentSession));
     }
 
+    // RavenDb can persist any document, so CanPersist claims every type. Yield to selective
+    // providers (EF Core) for the entity types they actually map, regardless of the order the
+    // integrations were registered in
+    public bool IsCatchAll => true;
+
     public bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService)
     {
         persistenceService = typeof(IAsyncDocumentSession);

--- a/src/Testing/CoreTests/Persistence/persistence_provider_precedence.cs
+++ b/src/Testing/CoreTests/Persistence/persistence_provider_precedence.cs
@@ -1,0 +1,180 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Sagas;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+// Unit tests for the GH-3359 consultation-order rule: selective persistence providers
+// (whose CanPersist checks the entity type against their own model, like EF Core) are
+// consulted ahead of catch-all document stores (whose CanPersist claims any type, like
+// Marten) regardless of the order the integrations were registered in. Within each
+// group, registration order is preserved.
+public class persistence_provider_precedence
+{
+    private static GenerationRules rulesWith(params IPersistenceFrameProvider[] providers)
+    {
+        var rules = new GenerationRules();
+        rules.Properties[GenerationRulesExtensions.PersistenceKey] = providers.ToList();
+        return rules;
+    }
+
+    [Fact]
+    public void selective_provider_wins_for_its_entity_even_when_the_catch_all_registered_after_it()
+    {
+        var selective = new SelectiveProvider(typeof(MappedEntity));
+        var catchAll = new CatchAllProvider();
+
+        // The catch-all integration registered last, so InsertFirstPersistenceStrategy put it
+        // at index 0 - the registration order that used to steal the entity from the selective
+        // provider
+        var rules = rulesWith(catchAll, selective);
+
+        rules.TryFindPersistenceFrameProvider(null!, typeof(MappedEntity), out var provider)
+            .ShouldBeTrue();
+
+        provider.ShouldBeSameAs(selective);
+    }
+
+    [Fact]
+    public void selective_provider_wins_for_its_entity_when_it_registered_last_too()
+    {
+        var selective = new SelectiveProvider(typeof(MappedEntity));
+        var catchAll = new CatchAllProvider();
+
+        var rules = rulesWith(selective, catchAll);
+
+        rules.TryFindPersistenceFrameProvider(null!, typeof(MappedEntity), out var provider)
+            .ShouldBeTrue();
+
+        provider.ShouldBeSameAs(selective);
+    }
+
+    [Fact]
+    public void unmapped_entity_still_falls_through_to_the_catch_all()
+    {
+        var selective = new SelectiveProvider(typeof(MappedEntity));
+        var catchAll = new CatchAllProvider();
+
+        var rules = rulesWith(catchAll, selective);
+
+        // Nothing the selective provider maps, so the catch-all keeps everything else
+        rules.TryFindPersistenceFrameProvider(null!, typeof(UnmappedDocument), out var provider)
+            .ShouldBeTrue();
+
+        provider.ShouldBeSameAs(catchAll);
+    }
+
+    [Fact]
+    public void registration_order_is_preserved_within_each_group()
+    {
+        var selective1 = new SelectiveProvider(typeof(MappedEntity));
+        var selective2 = new SelectiveProvider(typeof(MappedEntity));
+        var catchAll1 = new CatchAllProvider();
+        var catchAll2 = new CatchAllProvider();
+
+        var rules = rulesWith(catchAll1, selective1, catchAll2, selective2);
+
+        var ordered = rules.OrderedPersistenceProviders();
+
+        // OrderBy is a stable sort: selective providers first in their original relative
+        // order, catch-alls after in theirs
+        ordered.ShouldBe([selective1, selective2, catchAll1, catchAll2]);
+    }
+
+    [Fact]
+    public void a_lone_catch_all_is_still_found()
+    {
+        var catchAll = new CatchAllProvider();
+        var rules = rulesWith(catchAll);
+
+        rules.TryFindPersistenceFrameProvider(null!, typeof(MappedEntity), out var provider)
+            .ShouldBeTrue();
+
+        provider.ShouldBeSameAs(catchAll);
+    }
+
+    public class MappedEntity;
+
+    public class UnmappedDocument;
+
+    // Claims only the single entity type it was constructed with, like EF Core claiming
+    // only the types mapped in a registered DbContext model
+    private class SelectiveProvider : StubProviderBase
+    {
+        private readonly Type _entityType;
+
+        public SelectiveProvider(Type entityType)
+        {
+            _entityType = entityType;
+        }
+
+        public override bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService)
+        {
+            persistenceService = GetType();
+            return entityType == _entityType;
+        }
+    }
+
+    // Claims every type it is asked about, like Marten
+    private class CatchAllProvider : StubProviderBase
+    {
+        public override bool IsCatchAll => true;
+
+        public override bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService)
+        {
+            persistenceService = GetType();
+            return true;
+        }
+    }
+
+    private abstract class StubProviderBase : IPersistenceFrameProvider
+    {
+        public virtual bool IsCatchAll => false;
+
+        public abstract bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService);
+
+        public void ApplyTransactionSupport(IChain chain, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public void ApplyTransactionSupport(IChain chain, IServiceContainer container, Type entityType) =>
+            throw new NotSupportedException();
+
+        public bool CanApply(IChain chain, IServiceContainer container) => false;
+
+        public Type DetermineSagaIdType(Type sagaType, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineLoadFrame(IServiceContainer container, Type sagaType, Variable sagaId) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineInsertFrame(Variable saga, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame CommitUnitOfWorkFrame(Variable saga, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineUpdateFrame(Variable saga, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineDeleteFrame(Variable sagaId, Variable saga, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineStoreFrame(Variable saga, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineDeleteFrame(Variable variable, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineStorageActionFrame(Type entityType, Variable action, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame[] DetermineFrameToNullOutMaybeSoftDeleted(Variable entity) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/Wolverine/Configuration/Capabilities/ServiceCapabilities.cs
+++ b/src/Wolverine/Configuration/Capabilities/ServiceCapabilities.cs
@@ -289,7 +289,7 @@ public class ServiceCapabilities : OptionsDescription
             .ToArray();
         if (sagaTypes.Length == 0) return;
 
-        var providers = runtime.Options.CodeGeneration.PersistenceProviders();
+        var providers = runtime.Options.CodeGeneration.OrderedPersistenceProviders();
         var container = runtime.Options.HandlerGraph.Container;
 
         foreach (var sagaType in sagaTypes)

--- a/src/Wolverine/Configuration/SagaPersistenceChainPolicy.cs
+++ b/src/Wolverine/Configuration/SagaPersistenceChainPolicy.cs
@@ -13,7 +13,7 @@ internal class SagaPersistenceChainPolicy : IChainPolicy
 {
     public void Apply(IReadOnlyList<IChain> chains, GenerationRules rules, IServiceContainer container)
     {
-        var providers = rules.PersistenceProviders();
+        var providers = rules.OrderedPersistenceProviders();
 
         foreach (var chain in chains)
         {
@@ -30,7 +30,7 @@ internal class SagaPersistenceChainPolicy : IChainPolicy
         }
     }
 
-    private static bool attachSagaPersistenceFrame(IServiceContainer container, List<IPersistenceFrameProvider> providers,
+    private static bool attachSagaPersistenceFrame(IServiceContainer container, IReadOnlyList<IPersistenceFrameProvider> providers,
         Variable saga, IChain chain)
     {
         foreach (var provider in providers)

--- a/src/Wolverine/Persistence/IPersistenceFrameProvider.cs
+++ b/src/Wolverine/Persistence/IPersistenceFrameProvider.cs
@@ -9,6 +9,17 @@ namespace Wolverine.Persistence;
 
 public interface IPersistenceFrameProvider
 {
+    /// <summary>
+    ///     Whether this provider's <see cref="CanPersist"/> claims every entity type it is asked
+    ///     about — a "catch-all" document store like Marten that can genuinely persist any document —
+    ///     rather than checking the type against its own mapping or model (like EF Core, which only
+    ///     claims types mapped in a registered DbContext). Catch-all providers are consulted after
+    ///     selective providers regardless of registration order, so that an entity mapped by a
+    ///     selective provider deterministically resolves to that provider in mixed-persistence
+    ///     applications.
+    /// </summary>
+    bool IsCatchAll => false;
+
     void ApplyTransactionSupport(IChain chain, IServiceContainer container);
     void ApplyTransactionSupport(IChain chain, IServiceContainer container, Type entityType);
     bool CanApply(IChain chain, IServiceContainer container);

--- a/src/Wolverine/Persistence/Sagas/GenerationRulesExtensions.cs
+++ b/src/Wolverine/Persistence/Sagas/GenerationRulesExtensions.cs
@@ -62,19 +62,34 @@ public static class GenerationRulesExtensions
         out IPersistenceFrameProvider provider)
     {
         provider = default!;
-        var providers = rules.PersistenceProviders();
+        var providers = rules.OrderedPersistenceProviders();
         if (providers.Any())
         {
             var candidates = providers.Where(x => x.CanPersist(entityType, container, out var _)).ToArray();
-            
+
             if (candidates.Any())
             {
                 provider = candidates.First();
                 return true;
             }
         }
-        
+
         return false;
+    }
+
+    /// <summary>
+    ///     The registered persistence providers in deterministic consultation order: selective
+    ///     providers (whose CanPersist checks the entity type against their own model, like EF Core)
+    ///     ahead of catch-all document stores (whose CanPersist claims any type, like Marten —
+    ///     see <see cref="IPersistenceFrameProvider.IsCatchAll"/>), preserving registration order
+    ///     within each group. Use this instead of PersistenceProviders() whenever the first matching
+    ///     provider wins, so mixed-persistence applications resolve independently of the order in
+    ///     which the integrations were registered.
+    /// </summary>
+    public static IReadOnlyList<IPersistenceFrameProvider> OrderedPersistenceProviders(this GenerationRules rules)
+    {
+        var providers = rules.PersistenceProviders();
+        return providers.Count <= 1 ? providers : providers.OrderBy(x => x.IsCatchAll ? 1 : 0).ToList();
     }
 
     public static List<IPersistenceFrameProvider> PersistenceProviders(this GenerationRules rules)
@@ -94,9 +109,9 @@ public static class GenerationRulesExtensions
     public static IPersistenceFrameProvider GetPersistenceProviders(this GenerationRules rules, IChain chain,
         IServiceContainer container)
     {
-        if (rules.Properties.TryGetValue(PersistenceKey, out var raw) && raw is List<IPersistenceFrameProvider> list)
+        if (rules.Properties.TryGetValue(PersistenceKey, out var raw) && raw is List<IPersistenceFrameProvider>)
         {
-            return list.FirstOrDefault(x => x.CanApply(chain, container)) ?? _nullo;
+            return rules.OrderedPersistenceProviders().FirstOrDefault(x => x.CanApply(chain, container)) ?? _nullo;
         }
 
         return _nullo;

--- a/src/Wolverine/Persistence/Sagas/InMemoryPersistenceFrameProvider.cs
+++ b/src/Wolverine/Persistence/Sagas/InMemoryPersistenceFrameProvider.cs
@@ -26,6 +26,10 @@ public class InMemoryPersistenceFrameProvider : IPersistenceFrameProvider
         return false;
     }
 
+    // In-memory storage accepts any entity type, so CanPersist claims everything. Yield to
+    // selective providers for the entity types they actually map
+    public bool IsCatchAll => true;
+
     public bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService)
     {
         persistenceService = GetType();


### PR DESCRIPTION
Closes #3359. Follow-up to #3353/#3357.

In a mixed Marten + EF Core application, which persistence provider owned an entity for storage actions, `[Entity]` loading, and saga persistence silently depended on the order the two integrations were registered in `Program.cs`. Writing the registration-order permutation tests surfaced **two** root causes, not one:

1. **Ordering**: `MartenPersistenceFrameProvider.CanPersist` claims every type (Marten genuinely can persist any document) and `TryFindPersistenceFrameProvider` takes `candidates.First()` — so whichever integration registered last sat at index 0 via `InsertFirstPersistenceStrategy` and claimed everything, including EF-mapped entities.
2. **Registration swallow**: `AddDbContextWithWolverineIntegration` registered its Wolverine extension with `TryAddSingleton<IWolverineExtension, …>`, which gates on the *service type* alone. If any other integration (e.g. Marten's `IntegrateWithWolverine()`) had already registered an `IWolverineExtension`, the EF Core codegen integration — persistence provider, batching policy, query-spec policy — was **never registered at all**. This went unnoticed because `UseEntityFrameworkCoreTransactions()` applies the same extension eagerly via `options.Include<>()`; only apps relying on `AddDbContextWithWolverineIntegration` alone were bitten.

## Changes

- New `IPersistenceFrameProvider.IsCatchAll` default-interface member (default `false`). The catch-all document stores override it to `true`: Marten, Polecat, RavenDb, CosmosDb, and the in-memory provider. EF Core stays selective — it only claims types actually mapped in a registered `DbContext` model.
- New `GenerationRulesExtensions.OrderedPersistenceProviders()`: selective providers first, catch-alls last, registration order preserved within each group (stable sort). Consumed by `TryFindPersistenceFrameProvider`, `GetPersistenceProviders`, `SagaPersistenceChainPolicy`, and the service-capabilities saga tagger (which documents that it mirrors the codegen precedence). `AutoApplyTransactions` is untouched — it already only applies when exactly one provider matches.
- `AddDbContextWithWolverineIntegration` now uses `TryAddEnumerable(ServiceDescriptor.Singleton<IWolverineExtension, EntityFrameworkCoreBackedPersistence>())`, which dedupes on the (service, implementation) pair — idempotent across repeated calls without being swallowed by other integrations' extensions.
- Docs: new "Combining EF Core with Marten" section in the EF Core integration guide stating the deterministic rule.

With EF Core first, EF-mapped entities deterministically resolve to their `DbContext` and every other document still falls through to Marten — nothing only Marten can persist is taken away from it.

## Tests

- `PersistenceTests.persistence_provider_precedence_permutations`: Marten-then-EFCore and EFCore-then-Marten hosts, each asserting an `Item` mapped in `SampleDbContext` resolves to `EFCorePersistenceFrameProvider` and an unmapped document resolves to `MartenPersistenceFrameProvider`. **Red-first verified**: with the production changes stashed, *both* permutations fail (one via ordering, one via the swallowed registration).
- `CoreTests.Persistence.persistence_provider_precedence`: 5 unit tests for the ordering primitive with fake selective/catch-all providers, including stable-order-within-group.

## Verification

- CoreTests full: **1905 passed / 0 failed**
- EfCoreTests full: **186/187** (lone failure is the documented `Bug_1846` load-flake; passes isolated)
- PersistenceTests full: **68/69** (lone failure `using_dynamic_multi_tenancy` is a pre-existing full-suite flake — it also fails on unfixed baseline binaries and passes in isolation)
- Full `wolverine.slnx` Release build: **0 warnings / 0 errors**
- Rebased on main including #3357; permutation + unit tests re-verified green post-rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)