### PR TITLE
test(aws): fix SNS per-tenant LocalStack setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          # CIAWS temporarily disabled: the LocalStack SNS/SQS suite chronically exceeds the 20-minute
-          # job timeout on CI runners (the tests themselves pass — verified locally). Tracked in #3350;
-          # re-enable once the AWS job timing is addressed.
-          # - CIAWS
+          - CIAWS
           - CIAzureServiceBus
           - CICosmosDb
           - CIEfCore

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/AmazonSnsPerTenantConnectionTests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/AmazonSnsPerTenantConnectionTests.cs
@@ -118,10 +118,12 @@ public class AmazonSnsPerTenantConnectionTests : IAsyncLifetime
 
     private static void configureTransport(WolverineOptions opts)
     {
-        opts.UseAmazonSnsTransport(c =>
+        opts.UseAmazonSnsTransport((sns, sqs) =>
             {
-                c.ServiceURL = ServiceUrl;
-                c.AuthenticationRegion = SharedRegion;
+                sns.ServiceURL = ServiceUrl;
+                sns.AuthenticationRegion = SharedRegion;
+                sqs.ServiceURL = ServiceUrl;
+                sqs.AuthenticationRegion = SharedRegion;
             })
             .Credentials(new BasicAWSCredentials("ignore", "ignore"))
             .AutoProvision()


### PR DESCRIPTION
## Summary

Fixes #3332 by configuring the paired SQS client required by the SNS transport in the per-tenant LocalStack tests.

The tests previously configured only `AmazonSimpleNotificationServiceConfig`. `AmazonSnsTransport.ConnectAsync()` also creates its paired SQS client, whose empty configuration caused `No RegionEndpoint or ServiceURL configured`. Broker startup retried that deterministic configuration error 20 times, turning each test failure into roughly 96 seconds and exhausting the CIAWS job timeout.

This also re-enables CIAWS at its existing 20-minute timeout.

Refs #3350 for the broader CIAWS/CIPolecat timeout tracking issue.

## Changes

- configure both SNS and its paired SQS client through the existing public overload;
- re-enable CIAWS in the test matrix;
- keep the existing timeout and AWS runtime behavior unchanged.

## Validation

- fail-before: the isolated test failed in 1m36s with `No RegionEndpoint or ServiceURL configured`;
- isolated test after the change: passed in 408ms;
- `AmazonSnsPerTenantConnectionTests`: 3/3 passed in 0.71s;
- CIAWS SQS phase: 193 passed, 6 skipped in 3m11s;
- no AWS runtime, retry, LocalStack infrastructure, job split, or timeout changes.

The complete CIAWS target did not finish locally under macOS ARM while running net9 through .NET 10 roll-forward, so the GitHub Actions Ubuntu net9 run remains the authoritative wall-clock validation.
