### PR TITLE
gRPC: server-side envelope propagation + correct false docs/sample claims (GH-3368)

### DIFF
--- a/docs/guide/grpc/client.md
+++ b/docs/guide/grpc/client.md
@@ -106,9 +106,23 @@ builder.Services.AddWolverineGrpcClient<IPingService>(o =>
 });
 ```
 
-On the server side of a Wolverine→Wolverine hop, the envelope headers are read back in the
-`WolverineGrpcServicePropagationInterceptor` already shipped with the adapter, so a call chain
-spanning multiple Wolverine services keeps a single correlation identity without any user wiring.
+On the server side of a Wolverine→Wolverine hop, `WolverineGrpcServicePropagationInterceptor`
+(registered automatically by `AddWolverineGrpc()`) reads the `correlation-id` and `tenant-id`
+headers back off the inbound call and applies them to the ambient `IMessageContext` before the
+service method runs. Only those two identifiers round-trip this way — `parent-id` and
+`conversation-id` live on an `Envelope`, and there is no envelope yet at this point in the
+pipeline (`IMessageContext.Envelope` is null outside of message handling). Once the service
+method calls `Bus.InvokeAsync(...)`, Wolverine copies the now-set `CorrelationId`/`TenantId` onto
+the freshly created envelope automatically, and Marten/Polecat tenant-scoped session frames pick
+it up the same way they would for any other transport — no further wiring needed.
+
+Cross-process parent/trace correlation for gRPC hops is handled separately by OpenTelemetry
+`Activity` propagation over HTTP/2 (W3C traceparent) — see [How gRPC Handlers Work](./handlers).
+The `parent-id`/`conversation-id` headers still go out on the wire for diagnostic/non-Wolverine
+consumers, but nothing on the Wolverine side reads them back in.
+
+Server-side propagation can be disabled with `WolverineGrpcOptions.PropagateEnvelopeHeaders =
+false`, the counterpart to the client-side `PropagateEnvelopeHeaders` option above.
 
 ## `RpcException` → typed-exception translation
 
@@ -226,6 +240,8 @@ it lands inside both Wolverine interceptors, which is what you almost always wan
 | `WolverineGrpcClientPropagationInterceptor`           | Stamps envelope headers on each call.                                                  |
 | `WolverineGrpcClientExceptionInterceptor`             | Translates `RpcException` to typed .NET exceptions per `MapRpcException` + the default table. |
 | `WolverineGrpcExceptionMapper.MapToException(rpc)`    | Public default mapping table; use from custom interceptors if needed.                  |
+| `WolverineGrpcServicePropagationInterceptor`          | Server-side counterpart — reads `correlation-id`/`tenant-id` off inbound calls onto `IMessageContext`. Registered by `AddWolverineGrpc()`. |
+| `WolverineGrpcOptions.PropagateEnvelopeHeaders`       | Server-side off-switch for the interceptor above. Defaults to `true`.                  |
 
 ## See also
 

--- a/src/Samples/OrderChainWithGrpc/InventoryServer/ReserveStockHandler.cs
+++ b/src/Samples/OrderChainWithGrpc/InventoryServer/ReserveStockHandler.cs
@@ -7,11 +7,14 @@ namespace OrderChainWithGrpc.InventoryServer;
 ///     Wolverine handler for <see cref="ReserveStock"/>. The gRPC service forwards to the bus
 ///     and the bus invokes this handler — the handler itself has no gRPC coupling.
 ///     <para>
-///         The envelope identifiers read from <see cref="IMessageContext"/> below were *not*
-///         stamped by code in this process. They were unpacked from inbound gRPC metadata by
-///         <c>WolverineGrpcServicePropagationInterceptor</c>, which is wired up automatically
-///         by <c>AddWolverineGrpc()</c>. Echoing them back on the reply is what lets the sample
-///         visually prove the chain preserved identity end-to-end.
+///         <see cref="IMessageContext.CorrelationId"/> and <see cref="IMessageContext.TenantId"/>
+///         below were *not* stamped by code in this process. They were unpacked from inbound gRPC
+///         metadata by <c>WolverineGrpcServicePropagationInterceptor</c>, which is wired up
+///         automatically by <c>AddWolverineGrpc()</c>, before <c>Bus.InvokeAsync</c> ran this
+///         handler. Echoing them back on the reply is what lets the sample visually prove those two
+///         identifiers preserved identity end-to-end. <c>ParentIdFromUpstream</c> is a different
+///         mechanism — it reflects OpenTelemetry <see cref="System.Diagnostics.Activity"/>
+///         propagation over the HTTP/2 <c>traceparent</c> header, not this interceptor.
 ///     </para>
 /// </summary>
 public static class ReserveStockHandler

--- a/src/Wolverine.Grpc.Tests/ServerPropagation/DisabledPropagationFixture.cs
+++ b/src/Wolverine.Grpc.Tests/ServerPropagation/DisabledPropagationFixture.cs
@@ -1,0 +1,61 @@
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using ProtoBuf.Grpc.Client;
+using ProtoBuf.Grpc.Server;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.ServerPropagation;
+
+/// <summary>
+///     A standalone in-process host (not the shared <see cref="Client.WolverineGrpcClientFixture"/>)
+///     with <see cref="WolverineGrpcOptions.PropagateEnvelopeHeaders"/> turned off, so tests can
+///     prove the interceptor honors the off-switch without affecting the shared fixture's
+///     default-on host used by every other propagation test.
+/// </summary>
+public class DisabledPropagationFixture : IAsyncLifetime
+{
+    private WebApplication? _app;
+    public GrpcChannel? Channel { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+        builder.WebHost.UseTestServer();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.ApplicationAssembly = typeof(DisabledPropagationFixture).Assembly;
+            opts.Discovery.DisableConventionalDiscovery();
+            opts.Discovery.IncludeType(typeof(PropagationEchoHandler));
+        });
+
+        builder.Services.AddCodeFirstGrpc();
+        builder.Services.AddWolverineGrpc(o => o.PropagateEnvelopeHeaders = false);
+
+        _app = builder.Build();
+        _app.UseRouting();
+        _app.MapGrpcService<PropagationEchoGrpcService>();
+
+        await _app.StartAsync();
+
+        var handler = _app.GetTestServer().CreateHandler();
+        Channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+        {
+            HttpHandler = handler
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        Channel?.Dispose();
+        if (_app != null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+
+    public IPropagationEchoService CreateClient() => Channel!.CreateGrpcService<IPropagationEchoService>();
+}

--- a/src/Wolverine.Grpc.Tests/ServerPropagation/PropagationEchoContracts.cs
+++ b/src/Wolverine.Grpc.Tests/ServerPropagation/PropagationEchoContracts.cs
@@ -1,0 +1,33 @@
+using ProtoBuf;
+using ProtoBuf.Grpc;
+using System.ServiceModel;
+
+namespace Wolverine.Grpc.Tests.ServerPropagation;
+
+/// <summary>
+///     Code-first gRPC contract whose server implementation forwards to the Wolverine bus. The
+///     invoked handler reads the ambient <see cref="IMessageContext"/> and echoes back whatever
+///     <see cref="WolverineGrpcServicePropagationInterceptor"/> put there from inbound headers —
+///     used to prove the server-side half of a Wolverine-to-Wolverine propagation hop actually
+///     lands in the handler, not just on the wire.
+/// </summary>
+[ServiceContract]
+public interface IPropagationEchoService
+{
+    Task<PropagationEchoReply> Echo(PropagationEchoRequest request, CallContext context = default);
+}
+
+[ProtoContract]
+public class PropagationEchoRequest
+{
+}
+
+[ProtoContract]
+public class PropagationEchoReply
+{
+    [ProtoMember(1)]
+    public string? CorrelationId { get; set; }
+
+    [ProtoMember(2)]
+    public string? TenantId { get; set; }
+}

--- a/src/Wolverine.Grpc.Tests/ServerPropagation/PropagationEchoGrpcService.cs
+++ b/src/Wolverine.Grpc.Tests/ServerPropagation/PropagationEchoGrpcService.cs
@@ -1,0 +1,35 @@
+using ProtoBuf.Grpc;
+using Wolverine.Grpc;
+
+namespace Wolverine.Grpc.Tests.ServerPropagation;
+
+/// <summary>
+///     Code-first gRPC service that delegates to the Wolverine bus. The "GrpcService" suffix lets
+///     <c>MapWolverineGrpcServices()</c> discover and map this type automatically.
+/// </summary>
+public class PropagationEchoGrpcService : WolverineGrpcServiceBase, IPropagationEchoService
+{
+    public PropagationEchoGrpcService(IMessageBus bus) : base(bus)
+    {
+    }
+
+    public Task<PropagationEchoReply> Echo(PropagationEchoRequest request, CallContext context = default)
+        => Bus.InvokeAsync<PropagationEchoReply>(request, context.CancellationToken);
+}
+
+/// <summary>
+///     Wolverine handler for <see cref="PropagationEchoRequest"/>. Reads whatever
+///     <see cref="WolverineGrpcServicePropagationInterceptor"/> already stamped onto the ambient
+///     <see cref="IMessageContext"/> before this handler ran.
+/// </summary>
+public static class PropagationEchoHandler
+{
+    public static PropagationEchoReply Handle(PropagationEchoRequest request, IMessageContext context)
+    {
+        return new PropagationEchoReply
+        {
+            CorrelationId = context.CorrelationId,
+            TenantId = context.TenantId
+        };
+    }
+}

--- a/src/Wolverine.Grpc.Tests/ServerPropagation/server_propagation_disabled_tests.cs
+++ b/src/Wolverine.Grpc.Tests/ServerPropagation/server_propagation_disabled_tests.cs
@@ -1,0 +1,38 @@
+using Grpc.Core;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.ServerPropagation;
+
+/// <summary>
+///     Proves <see cref="WolverineGrpcOptions.PropagateEnvelopeHeaders"/> = false actually turns the
+///     server-side interceptor off, even when a caller sends the envelope headers on the wire.
+/// </summary>
+public class server_propagation_disabled_tests : IClassFixture<DisabledPropagationFixture>
+{
+    private readonly DisabledPropagationFixture _fixture;
+
+    public server_propagation_disabled_tests(DisabledPropagationFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task handler_does_not_see_headers_when_propagation_is_disabled()
+    {
+        var headers = new Metadata
+        {
+            { EnvelopeConstants.CorrelationIdKey, "corr-should-be-ignored" },
+            { EnvelopeConstants.TenantIdKey, "tenant-should-be-ignored" }
+        };
+
+        var client = _fixture.CreateClient();
+        var reply = await client.Echo(new PropagationEchoRequest(), new CallOptions(headers: headers));
+
+        // Neither field is null/empty by default — MessageBus always auto-assigns a CorrelationId,
+        // and an untenanted context reads back Wolverine's internal default-tenant sentinel rather
+        // than null. The meaningful assertion is that neither header's specific value won.
+        reply.CorrelationId.ShouldNotBe("corr-should-be-ignored");
+        reply.TenantId.ShouldNotBe("tenant-should-be-ignored");
+    }
+}

--- a/src/Wolverine.Grpc.Tests/ServerPropagation/server_propagation_interceptor_tests.cs
+++ b/src/Wolverine.Grpc.Tests/ServerPropagation/server_propagation_interceptor_tests.cs
@@ -1,0 +1,132 @@
+using Grpc.Core;
+using Grpc.Net.Client;
+using Microsoft.Extensions.DependencyInjection;
+using ProtoBuf.Grpc.Client;
+using Shouldly;
+using Wolverine.Grpc.Client;
+using Wolverine.Grpc.Tests.Client;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.ServerPropagation;
+
+/// <summary>
+///     End-to-end tests for <see cref="WolverineGrpcServicePropagationInterceptor"/>. Unlike
+///     <see cref="Client.propagation_interceptor_tests"/> (which only asserts what lands on the
+///     wire), these assert what the invoked Wolverine <em>handler</em> actually sees on
+///     <see cref="IMessageContext"/> after both the client-side and server-side interceptors have
+///     run — this is the full Wolverine-to-Wolverine hop the OrderChainWithGrpc sample and the
+///     gRPC client docs describe.
+/// </summary>
+[Collection("grpc-client")]
+public class server_propagation_interceptor_tests
+{
+    private readonly WolverineGrpcClientFixture _fixture;
+
+    public server_propagation_interceptor_tests(WolverineGrpcClientFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private ServiceProvider BuildContainer(TestMessageContext? ctx)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        if (ctx != null)
+        {
+            services.AddScoped<IMessageContext>(_ => ctx);
+            services.AddScoped<IMessageBus>(sp => sp.GetRequiredService<IMessageContext>());
+        }
+
+        services.AddWolverineGrpcClient<IPropagationEchoService>(o =>
+        {
+            o.Address = new Uri("http://localhost");
+        }).ConfigureChannel(c => c.HttpHandler = _fixture.ServerHandler);
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task handler_sees_correlation_and_tenant_id_propagated_from_the_caller()
+    {
+        var ctx = new TestMessageContext
+        {
+            CorrelationId = "corr-hop-1",
+            TenantId = "tenant-hop-1"
+        };
+
+        await using var provider = BuildContainer(ctx);
+        using var scope = provider.CreateScope();
+        var client = scope.ServiceProvider.GetRequiredService<IPropagationEchoService>();
+
+        var reply = await client.Echo(new PropagationEchoRequest());
+
+        // These values only round-trip if the client interceptor stamped the headers AND the
+        // server interceptor read them back onto the ambient IMessageContext BEFORE Bus.InvokeAsync
+        // ran the handler — proving the full hop, not just the wire format.
+        reply.CorrelationId.ShouldBe("corr-hop-1");
+        reply.TenantId.ShouldBe("tenant-hop-1");
+    }
+
+    [Fact]
+    public async Task handler_does_not_see_a_specific_tenant_id_when_caller_has_no_message_context_in_scope()
+    {
+        await using var provider = BuildContainer(ctx: null);
+        using var scope = provider.CreateScope();
+        var client = scope.ServiceProvider.GetRequiredService<IPropagationEchoService>();
+
+        var reply = await client.Echo(new PropagationEchoRequest());
+
+        // Neither field is asserted as null/empty here: MessageBus always assigns a CorrelationId
+        // from Activity.Current?.RootId (or a fresh GUID), and an untenanted context reads back
+        // Wolverine's internal default-tenant sentinel rather than null — neither is something this
+        // interceptor controls or suppresses. What it does control is whether a *specific* caller
+        // value shows up uninvited, which is what the round-trip tests above already prove positively.
+        reply.TenantId.ShouldNotBe("tenant-hop-1");
+        reply.TenantId.ShouldNotBe("tenant-only");
+    }
+
+    [Fact]
+    public async Task tenant_id_alone_propagates_without_a_correlation_id_header()
+    {
+        // TestMessageContext's parameterless constructor auto-generates a CorrelationId — clear
+        // it explicitly so this test isolates tenant-id propagation on its own (no correlation-id
+        // header goes out on the wire).
+        var ctx = new TestMessageContext
+        {
+            CorrelationId = null,
+            TenantId = "tenant-only"
+        };
+
+        await using var provider = BuildContainer(ctx);
+        using var scope = provider.CreateScope();
+        var client = scope.ServiceProvider.GetRequiredService<IPropagationEchoService>();
+
+        var reply = await client.Echo(new PropagationEchoRequest());
+
+        reply.TenantId.ShouldBe("tenant-only");
+    }
+
+    [Fact]
+    public async Task an_arbitrary_non_wolverine_caller_can_also_drive_tenant_id_via_the_raw_header()
+    {
+        // No AddWolverineGrpcClient, no IMessageContext anywhere in this process — an ordinary
+        // grpc-dotnet caller setting the header by hand, same as an external service or gateway
+        // would. This is the scenario from the original Discord question: does something read
+        // an inbound tenant-id header at all? It does, independent of who sent it.
+        using var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+        {
+            HttpHandler = _fixture.ServerHandler
+        });
+        var client = channel.CreateGrpcService<IPropagationEchoService>();
+
+        var headers = new Metadata
+        {
+            { EnvelopeConstants.TenantIdKey, "external-caller-tenant" }
+        };
+
+        var reply = await client.Echo(new PropagationEchoRequest(), new CallOptions(headers: headers));
+
+        reply.TenantId.ShouldBe("external-caller-tenant");
+    }
+}

--- a/src/Wolverine.Grpc.Tests/add_wolverine_grpc_idempotency_tests.cs
+++ b/src/Wolverine.Grpc.Tests/add_wolverine_grpc_idempotency_tests.cs
@@ -47,6 +47,63 @@ public class add_wolverine_grpc_idempotency_tests
     }
 
     [Fact]
+    public void single_call_registers_propagation_interceptor_exactly_once()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddWolverineGrpc();
+
+        var grpcOptions = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<GrpcServiceOptions>>().Value;
+
+        grpcOptions.Interceptors.Count(r => r.Type == typeof(WolverineGrpcServicePropagationInterceptor))
+            .ShouldBe(1);
+    }
+
+    [Fact]
+    public void repeat_calls_do_not_stack_the_propagation_interceptor()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddWolverineGrpc();
+        services.AddWolverineGrpc();
+        services.AddWolverineGrpc();
+
+        var grpcOptions = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<GrpcServiceOptions>>().Value;
+
+        grpcOptions.Interceptors.Count(r => r.Type == typeof(WolverineGrpcServicePropagationInterceptor))
+            .ShouldBe(1);
+    }
+
+    [Fact]
+    public void exception_interceptor_runs_outermost_of_the_propagation_interceptor()
+    {
+        // Registration order determines wrapping order for grpc-dotnet server interceptors — the
+        // first-added interceptor is outermost. Exception translation must stay outermost so it
+        // can also translate anything the propagation interceptor itself throws, symmetric to the
+        // client-side interceptor order (docs/guide/grpc/client.md "Ordering and composition").
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddWolverineGrpc();
+
+        var grpcOptions = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<GrpcServiceOptions>>().Value;
+
+        var exceptionIndex = grpcOptions.Interceptors
+            .ToList()
+            .FindIndex(r => r.Type == typeof(WolverineGrpcExceptionInterceptor));
+        var propagationIndex = grpcOptions.Interceptors
+            .ToList()
+            .FindIndex(r => r.Type == typeof(WolverineGrpcServicePropagationInterceptor));
+
+        exceptionIndex.ShouldBeLessThan(propagationIndex);
+    }
+
+    [Fact]
     public void repeat_calls_do_not_stack_the_grpc_graph_registration()
     {
         var services = new ServiceCollection();

--- a/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
@@ -84,9 +84,14 @@ public static class WolverineGrpcExtensions
             new GrpcEndpointDescriptorSource(sp.GetRequiredService<IGrpcEndpointManifest>()));
 
         services.AddSingleton<WolverineGrpcExceptionInterceptor>();
+        services.AddSingleton<WolverineGrpcServicePropagationInterceptor>();
         services.Configure<GrpcServiceOptions>(opts =>
         {
+            // Exception translation stays outermost so it can also translate anything thrown by
+            // the propagation interceptor itself, symmetric to the client-side interceptor order
+            // (see docs/guide/grpc/client.md "Ordering and composition").
             opts.Interceptors.Add<WolverineGrpcExceptionInterceptor>();
+            opts.Interceptors.Add<WolverineGrpcServicePropagationInterceptor>();
         });
 
         configure?.Invoke(options);

--- a/src/Wolverine.Grpc/WolverineGrpcOptions.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcOptions.cs
@@ -17,6 +17,14 @@ public sealed class WolverineGrpcOptions
     internal MiddlewarePolicy Middleware { get; } = new();
 
     /// <summary>
+    ///     Whether <see cref="WolverineGrpcServicePropagationInterceptor"/> reads the
+    ///     <c>correlation-id</c>/<c>tenant-id</c> envelope headers off inbound calls onto the
+    ///     ambient <see cref="IMessageContext"/> before the service method runs. Defaults to
+    ///     <c>true</c>. The client-side counterpart is <c>WolverineGrpcClientOptions.PropagateEnvelopeHeaders</c>.
+    /// </summary>
+    public bool PropagateEnvelopeHeaders { get; set; } = true;
+
+    /// <summary>
     ///     Structural policies applied to all discovered gRPC chains during bootstrapping.
     ///     Analogous to <c>WolverineHttpOptions.Policies</c> — use when you need typed access
     ///     to chain properties beyond what <see cref="AddMiddleware{T}(Func{IChain,bool}?)"/>

--- a/src/Wolverine.Grpc/WolverineGrpcServicePropagationInterceptor.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcServicePropagationInterceptor.cs
@@ -1,0 +1,134 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Wolverine.Grpc;
+
+/// <summary>
+///     Server-side gRPC interceptor that reads the <c>correlation-id</c> and <c>tenant-id</c>
+///     envelope headers off an inbound call and applies them to the ambient, request-scoped
+///     <see cref="IMessageContext"/> before the service method runs. The client-side counterpart is
+///     <see cref="Client.WolverineGrpcClientPropagationInterceptor"/> — this is what actually reads
+///     those headers back on the receiving end of a Wolverine-to-Wolverine hop.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Only <c>correlation-id</c> and <c>tenant-id</c> are round-tripped this way.
+///         <see cref="IMessageContext.CorrelationId"/> and <see cref="IMessageBus.TenantId"/> are the
+///         only envelope identifiers that can be set on the ambient context <em>before</em> a message
+///         has been invoked — <c>parent-id</c> and <c>conversation-id</c> only exist on an
+///         <see cref="Envelope"/>, and there is no envelope yet at this point (<see
+///         cref="IMessageContext.Envelope"/> is null outside of message handling). Once the service
+///         method calls <c>Bus.InvokeAsync(...)</c>, Wolverine copies the now-set
+///         <c>CorrelationId</c>/<c>TenantId</c> onto the freshly created envelope automatically — no
+///         further wiring needed, and Marten/Polecat tenant-scoped session frames pick it up the same
+///         way they would for any other transport.
+///     </para>
+///     <para>
+///         Cross-process parent/trace correlation for gRPC hops is handled separately by
+///         OpenTelemetry <c>Activity</c> propagation over HTTP/2 (W3C traceparent) — see
+///         <a href="https://wolverine.netlify.app/guide/grpc/handlers.html">How gRPC Handlers Work</a>.
+///     </para>
+///     <para>
+///         Both fields are set unconditionally when the corresponding header is present — the same
+///         convention every other Wolverine transport uses for a freshly received message (see
+///         <c>MessageContext.ReadEnvelope</c>: <c>CorrelationId = originalEnvelope.CorrelationId</c>,
+///         no "only if empty" check). This matters for <c>correlation-id</c> specifically: a brand
+///         new <see cref="IMessageBus"/>/<see cref="IMessageContext"/> already has a non-empty,
+///         auto-generated <see cref="IMessageContext.CorrelationId"/> (seeded from
+///         <see cref="System.Diagnostics.Activity.Current"/>'s root id, or a fresh GUID) before this
+///         interceptor ever runs — gating on "currently empty" would silently never apply an inbound
+///         header.
+///     </para>
+///     <para>
+///         Registered automatically by <see
+///         cref="WolverineGrpcExtensions.AddWolverineGrpc(Microsoft.Extensions.DependencyInjection.IServiceCollection)"/>,
+///         and runs inside <see cref="WolverineGrpcExceptionInterceptor"/> so an exception it throws
+///         is still translated, symmetric to how propagation sits inside exception translation on the
+///         client.
+///     </para>
+/// </remarks>
+public sealed class WolverineGrpcServicePropagationInterceptor : Interceptor
+{
+    private readonly WolverineGrpcOptions _options;
+
+    public WolverineGrpcServicePropagationInterceptor(WolverineGrpcOptions options)
+    {
+        _options = options;
+    }
+
+    public override Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+        TRequest request,
+        ServerCallContext context,
+        UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        Propagate(context);
+        return continuation(request, context);
+    }
+
+    public override Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(
+        IAsyncStreamReader<TRequest> requestStream,
+        ServerCallContext context,
+        ClientStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        Propagate(context);
+        return continuation(requestStream, context);
+    }
+
+    public override Task ServerStreamingServerHandler<TRequest, TResponse>(
+        TRequest request,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        ServerStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        Propagate(context);
+        return continuation(request, responseStream, context);
+    }
+
+    public override Task DuplexStreamingServerHandler<TRequest, TResponse>(
+        IAsyncStreamReader<TRequest> requestStream,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        Propagate(context);
+        return continuation(requestStream, responseStream, context);
+    }
+
+    private void Propagate(ServerCallContext context)
+    {
+        if (!_options.PropagateEnvelopeHeaders) return;
+
+        var services = context.GetHttpContext().RequestServices;
+
+        // IMessageContext is a scoped service — bail cleanly when there is no active Wolverine scope.
+        var ctx = services.GetService(typeof(IMessageContext)) as IMessageContext;
+        if (ctx == null) return;
+
+        var correlationId = Find(context.RequestHeaders, EnvelopeConstants.CorrelationIdKey);
+        if (!string.IsNullOrEmpty(correlationId))
+        {
+            ctx.CorrelationId = correlationId;
+        }
+
+        var tenantId = Find(context.RequestHeaders, EnvelopeConstants.TenantIdKey);
+        if (!string.IsNullOrEmpty(tenantId))
+        {
+            ctx.TenantId = tenantId;
+        }
+    }
+
+    private static string? Find(Metadata headers, string key)
+    {
+        foreach (var entry in headers)
+        {
+            if (string.Equals(entry.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                return entry.Value;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

- `Wolverine.Grpc`'s client interceptor already stamped `correlation-id`/`tenant-id` onto outgoing calls, but nothing on the server side read them back — despite `docs/guide/grpc/client.md` and the `OrderChainWithGrpc` sample's XML comments claiming a `WolverineGrpcServicePropagationInterceptor` already existed and did exactly this. It didn't; grepping `src/Wolverine.Grpc` confirmed `AddWolverineGrpc()` only ever registered the exception interceptor.
- Adds the real `WolverineGrpcServicePropagationInterceptor` (registered automatically by `AddWolverineGrpc()`, positioned inside the exception interceptor to mirror the client-side ordering). It reads `correlation-id`/`tenant-id` off inbound gRPC metadata and applies them to the ambient `IMessageContext` **unconditionally** when present — matching the convention every other Wolverine transport uses on a freshly received envelope (`MessageContext.ReadEnvelope`), rather than a "set only if empty" guard (a fresh `IMessageContext.CorrelationId` is never actually empty — it's pre-seeded from `Activity.Current` — so that guard would have silently no-op'd, and an earlier draft of this change caught exactly that bug via its own tests).
- Adds `WolverineGrpcOptions.PropagateEnvelopeHeaders` (default `true`) as the server-side off-switch, mirroring the existing client-side option.
- `parent-id`/`conversation-id` are deliberately **not** propagated this way — they live on an `Envelope`, and there is no envelope yet at the point this interceptor runs (`IMessageContext.Envelope` is null outside of message handling). Cross-process parent/trace correlation for gRPC hops already happens separately via OpenTelemetry `Activity` propagation over HTTP/2.
- Corrects the false claims: `docs/guide/grpc/client.md` and the `OrderChainWithGrpc` sample's `ReserveStockHandler.cs` XML comment now describe what's actually implemented instead of a type that never existed.

Related to #3368 (the original Discord question was about tenant-id detection for external gRPC callers; this closes the Wolverine-to-Wolverine hop half of that gap and fixes the docs/sample along the way). External-caller *detection* strategies — analogous to `Wolverine.Http`'s `ITenantDetectionPolicies` (route/claim/subdomain-based) — are still open in #3368.

## Test plan

- [x] `dotnet build wolverine.slnx -c Release` — full solution, 0 errors/warnings
- [x] `dotnet test src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj` — 255/255 passing, including 8 new tests:
  - Full Wolverine-to-Wolverine hop: client stamps headers → server interceptor reads them → invoked handler sees them via `IMessageContext` → echoed back (proves the actual bug the docs/sample claimed was already fixed)
  - Tenant-id propagates independent of correlation-id
  - An arbitrary non-Wolverine caller manually setting the raw header also works (the original Discord scenario)
  - `PropagateEnvelopeHeaders = false` actually disables it, verified against a dedicated in-process host
  - DI-registration idempotency guards for the new interceptor (repeat `AddWolverineGrpc()` calls don't double-stack it) + interceptor ordering assertion (exception interceptor stays outermost)
- [x] Verified the `OrderChainWithGrpc` sample separately does *not* actually run today (`Dynamic` codegen mode throws — the sample projects don't reference `Wolverine.RuntimeCompilation`), confirming it was never actually executed/verified before — a pre-existing, unrelated issue left out of scope here. The in-process test suite exercises the identical code path (real Kestrel `TestServer`, real interceptors, real `Bus.InvokeAsync`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)