### PR TITLE
Read HttpGraph instead of EndpointDataSource in WolverineApiDescriptionProvider. Closes GH-3371

### DIFF
--- a/docs/guide/http/metadata.md
+++ b/docs/guide/http/metadata.md
@@ -299,6 +299,12 @@ asynchronous Wolverine extension) will not appear. This matches the goal of buil
 is worth knowing if you add endpoints dynamically.
 :::
 
+The same holds in-process: Wolverine's endpoint descriptions are complete on the very first
+ApiExplorer read after `MapWolverineEndpoints()` has run, even before the host starts. Only
+Wolverine's descriptions are start-independent — ASP.NET's own minimal API descriptions still
+compose at server start — so applications mixing the two should defer early ApiExplorer reads
+until after startup.
+
 ## With Microsoft.Extensions.ApiDescription.Server
 
 ::: tip

--- a/src/Http/Wolverine.Http.Tests/api_explorer_before_host_start.cs
+++ b/src/Http/Wolverine.Http.Tests/api_explorer_before_host_start.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.Http.Tests.DifferentAssembly.Validation;
+
+namespace Wolverine.Http.Tests;
+
+// ASP.NET Core caches the first ApiExplorer read for the lifetime of the host, and a host can
+// be read before it starts (build-time OpenAPI generation, monitoring snapshots). Wolverine's
+// descriptions must be complete on that first read, however early it happens.
+public class api_explorer_before_host_start
+{
+    [Fact]
+    public async Task api_descriptions_are_complete_before_the_host_starts()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = "Development" });
+
+        builder.Host.UseWolverine(opts =>
+        {
+            // Pin endpoint discovery to the small, isolated "DifferentAssembly" so the test is
+            // deterministic and does not pick up the rest of the test suite's endpoints.
+            opts.ApplicationAssembly = typeof(Validated2Endpoint).Assembly;
+        });
+
+        builder.Services.AddEndpointsApiExplorer();
+        builder.Services.AddWolverineHttp();
+
+        await using var app = builder.Build();
+        app.MapWolverineEndpoints();
+
+        // Note: no app.StartAsync(). This is the first ApiExplorer read, which ASP.NET Core
+        // caches for the lifetime of the host
+        var provider = app.Services.GetRequiredService<IApiDescriptionGroupCollectionProvider>();
+
+        var relativePaths = provider.ApiDescriptionGroups.Items
+            .SelectMany(x => x.Items)
+            .Where(x => x.ActionDescriptor is WolverineActionDescriptor)
+            .Select(x => x.RelativePath)
+            .ToList();
+
+        relativePaths.ShouldContain("validate2/customer");
+        relativePaths.ShouldContain("validate2/user");
+    }
+}

--- a/src/Http/Wolverine.Http/WolverineApiDescriptionProvider.cs
+++ b/src/Http/Wolverine.Http/WolverineApiDescriptionProvider.cs
@@ -1,50 +1,57 @@
 using JasperFx.Core.Reflection;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Hosting;
 
 namespace Wolverine.Http;
 
 internal class WolverineApiDescriptionProvider : IApiDescriptionProvider
 {
-    private readonly EndpointDataSource _endpointDataSource;
-    private readonly IHostEnvironment _environment;
+    private readonly WolverineHttpOptions _options;
 
-    public WolverineApiDescriptionProvider(
-        EndpointDataSource endpointDataSource,
-        IHostEnvironment environment)
+    public WolverineApiDescriptionProvider(WolverineHttpOptions options)
     {
-        _endpointDataSource = endpointDataSource;
-        _environment = environment;
+        _options = options;
     }
 
     public void OnProvidersExecuting(ApiDescriptionProviderContext context)
     {
-        foreach (var endpoint in _endpointDataSource.Endpoints)
+        // Read the HttpGraph: it is complete as soon as MapWolverineEndpoints() has run,
+        // while the composite EndpointDataSource only fills at server start — and ASP.NET
+        // Core caches the first ApiExplorer read for the host lifetime, however early it is.
+        if (_options.Endpoints is not { } graph)
         {
-            if (endpoint is RouteEndpoint routeEndpoint && routeEndpoint.Metadata.GetMetadata<HttpChain>() is {} chain)
+            return;
+        }
+
+        foreach (var chain in graph.Chains)
+        {
+            // A chain added to the graph after MapWolverineEndpoints() has run never gets a
+            // built RouteEndpoint, and CreateApiDescription() requires one
+            if (chain.Endpoint == null)
             {
-                if (chain.Method.HandlerType.HasAttribute<ExcludeFromDescriptionAttribute>() ||
-                    chain.Method.Method.HasAttribute<ExcludeFromDescriptionAttribute>())
+                continue;
+            }
+
+            if (chain.Method.HandlerType.HasAttribute<ExcludeFromDescriptionAttribute>() ||
+                chain.Method.Method.HasAttribute<ExcludeFromDescriptionAttribute>())
+            {
+                continue;
+            }
+
+            foreach (var httpMethod in chain.HttpMethods)
+            {
+                // OpenAPI 3.1 (and the Swashbuckle / Microsoft.OpenApi stack Wolverine emits with)
+                // has no representation for the QUERY verb (RFC 10008) — Swashbuckle throws a
+                // KeyNotFoundException mapping the method, which would break document generation for
+                // the whole app. Gracefully omit QUERY endpoints from the API description, matching
+                // ASP.NET Core's own behavior on OpenAPI 3.1. QUERY becomes a first-class operation
+                // in OpenAPI 3.2; first-class documentation can follow once the stack supports it.
+                if (string.Equals(httpMethod, "QUERY", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }
 
-                foreach (var httpMethod in chain.HttpMethods)
-                {
-                    // OpenAPI 3.1 (and the Swashbuckle / Microsoft.OpenApi stack Wolverine emits with)
-                    // has no representation for the QUERY verb (RFC 10008) — Swashbuckle throws a
-                    // KeyNotFoundException mapping the method, which would break document generation for
-                    // the whole app. Gracefully omit QUERY endpoints from the API description, matching
-                    // ASP.NET Core's own behavior on OpenAPI 3.1. QUERY becomes a first-class operation
-                    // in OpenAPI 3.2; first-class documentation can follow once the stack supports it.
-                    if (string.Equals(httpMethod, "QUERY", StringComparison.OrdinalIgnoreCase))
-                    {
-                        continue;
-                    }
-
-                    context.Results.Add(chain.CreateApiDescription(httpMethod));
-                }
+                context.Results.Add(chain.CreateApiDescription(httpMethod));
             }
         }
     }


### PR DESCRIPTION

Fixes GH-3371: ASP.NET Core caches the first ApiExplorer read for the lifetime of the host (keyed on `ActionDescriptorCollection.Version`, which endpoint routing never bumps), and Wolverine endpoints only reach the DI `EndpointDataSource` at server start — so any earlier read permanently empties every OpenAPI document.

## The change

`WolverineApiDescriptionProvider` enumerates `WolverineHttpOptions.Endpoints` (the `HttpGraph`) instead of the injected `EndpointDataSource`. The graph — including each chain's built `RouteEndpoint` — is complete as soon as `MapWolverineEndpoints()` returns, so the provider's answer is the same before and after server start.

This is behavior-preserving: every value in the produced `ApiDescription` already comes from `chain.Endpoint`; the data source enumeration only ever recovered the chain from endpoint metadata. The `ExcludeFromDescription` filter and the QUERY-verb skip are unchanged. Chains are enumerated rather than `graph.Endpoints` because the chain is what descriptions are built from — happy to switch if you'd rather keep the endpoint-shaped loop.

`OpenApiCommand.ComposeEndpointDataSources` is intentionally untouched: ASP.NET's own minimal-API provider still reads the composite source, so the CLI's merge is still needed for non-Wolverine endpoints.

## Behavior notes

- A read before `MapWolverineEndpoints()` returns still sees nothing — unchanged.
- Only Wolverine's descriptions become start-independent. Minimal-API descriptions still compose at server start, so a pre-start read on a hybrid host now freezes a document with Wolverine endpoints but no minimal-API ones, where previously it froze fully empty. Hybrid apps with boot-time ApiExplorer readers should still defer them.
- Calling `MapWolverineEndpoints()` twice now describes only the last graph. Double-mapping duplicates every route and was never a supported configuration.
- A `chain.Endpoint == null` guard skips chains added to the graph after mapping — they never reached the data source either.

## Testing

- New regression test `api_explorer_before_host_start`: maps endpoints, never starts the host, asserts descriptions are complete on the first ApiExplorer read. Fails on the old provider, passes on the new one.
- `Wolverine.Http.Tests` 818/818 and `Wolverine.Http.AspVersioning.Tests` 66/66, including `generate_openapi_without_database` (GH-2903). The `openapi` command emits the same document with no database running.
- Verified in a consuming application (Wolverine.HTTP + Marten + CritterWatch + per-surface OpenAPI documents): full suite green against packages built from this branch, generated OpenAPI spec byte-identical, and the empty-document failure no longer reproduces even with the application's interim workaround removed.
