### PR TITLE
Fix Endpoint.DescribeProperties value bug and report buffering/circuit breaker settings

### DIFF
--- a/src/Testing/CoreTests/Configuration/EndpointTests.cs
+++ b/src/Testing/CoreTests/Configuration/EndpointTests.cs
@@ -1,7 +1,9 @@
+using JasperFx.Core;
 using NSubstitute;
 using Wolverine.ComplianceTests;
 using Wolverine.ComplianceTests.Compliance;
 using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
 using Wolverine.Runtime;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
@@ -97,6 +99,83 @@ public class EndpointTests
         
         endpoint.MaybeWrapReceiver(inner)
             .ShouldBeSameAs(inner);
+    }
+
+    [Fact]
+    public void describe_properties_reports_the_failure_count_before_circuit_breaks()
+    {
+        var endpoint = new TestEndpoint(EndpointRole.Application)
+        {
+            FailuresBeforeCircuitBreaks = 7,
+            PingIntervalForCircuitResume = 9.Seconds()
+        };
+
+        var properties = endpoint.DescribeProperties();
+
+        properties[nameof(Endpoint.FailuresBeforeCircuitBreaks)].ShouldBe(7);
+        properties[nameof(Endpoint.PingIntervalForCircuitResume)].ShouldBe(9.Seconds());
+    }
+
+    [Theory]
+    [InlineData(EndpointMode.BufferedInMemory)]
+    [InlineData(EndpointMode.Durable)]
+    public void describe_properties_includes_buffering_limits_when_back_pressure_applies(EndpointMode mode)
+    {
+        var endpoint = new TestEndpoint(EndpointRole.Application)
+        {
+            Mode = mode,
+            BufferingLimits = new BufferingLimits(2000, 800)
+        };
+
+        var properties = endpoint.DescribeProperties();
+
+        properties["BufferingLimits.Maximum"].ShouldBe(2000);
+        properties["BufferingLimits.Restart"].ShouldBe(800);
+    }
+
+    [Fact]
+    public void describe_properties_omits_buffering_limits_for_inline_endpoints()
+    {
+        var endpoint = new TestEndpoint(EndpointRole.Application)
+        {
+            SupportsInlineListeners = true,
+            Mode = EndpointMode.Inline
+        };
+
+        var properties = endpoint.DescribeProperties();
+
+        properties.ContainsKey("BufferingLimits.Maximum").ShouldBeFalse();
+        properties.ContainsKey("BufferingLimits.Restart").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void describe_properties_includes_circuit_breaker_options_when_configured()
+    {
+        var endpoint = new TestEndpoint(EndpointRole.Application)
+        {
+            CircuitBreakerOptions = new CircuitBreakerOptions
+            {
+                FailurePercentageThreshold = 40,
+                PauseTime = 2.Minutes()
+            }
+        };
+
+        var properties = endpoint.DescribeProperties();
+
+        properties["CircuitBreakerOptions.FailurePercentageThreshold"].ShouldBe(40);
+        properties["CircuitBreakerOptions.PauseTime"].ShouldBe(2.Minutes());
+    }
+
+    [Fact]
+    public void describe_properties_omits_circuit_breaker_options_when_not_configured()
+    {
+        var endpoint = new TestEndpoint(EndpointRole.Application);
+        endpoint.CircuitBreakerOptions.ShouldBeNull();
+
+        var properties = endpoint.DescribeProperties();
+
+        properties.ContainsKey("CircuitBreakerOptions.FailurePercentageThreshold").ShouldBeFalse();
+        properties.ContainsKey("CircuitBreakerOptions.PauseTime").ShouldBeFalse();
     }
 
     [Fact]

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -455,12 +455,26 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
             { nameof(EndpointName), EndpointName },
             { nameof(Mode), Mode },
             { nameof(PingIntervalForCircuitResume), PingIntervalForCircuitResume },
-            { nameof(FailuresBeforeCircuitBreaks), PingIntervalForCircuitResume }
+            { nameof(FailuresBeforeCircuitBreaks), FailuresBeforeCircuitBreaks }
         };
 
         if (Mode == EndpointMode.BufferedInMemory)
         {
             dict.Add(nameof(MaximumEnvelopeRetryStorage), MaximumEnvelopeRetryStorage);
+        }
+
+        if (ShouldEnforceBackPressure())
+        {
+            dict.Add($"{nameof(BufferingLimits)}.{nameof(BufferingLimits.Maximum)}", BufferingLimits.Maximum);
+            dict.Add($"{nameof(BufferingLimits)}.{nameof(BufferingLimits.Restart)}", BufferingLimits.Restart);
+        }
+
+        if (CircuitBreakerOptions != null)
+        {
+            dict.Add($"{nameof(CircuitBreakerOptions)}.{nameof(CircuitBreakerOptions.FailurePercentageThreshold)}",
+                CircuitBreakerOptions.FailurePercentageThreshold);
+            dict.Add($"{nameof(CircuitBreakerOptions)}.{nameof(CircuitBreakerOptions.PauseTime)}",
+                CircuitBreakerOptions.PauseTime);
         }
 
         return dict;


### PR DESCRIPTION
Found during a CritterWatch issue triage (JasperFx/CritterWatch#664):

- **Copy-paste value bug**: the `FailuresBeforeCircuitBreaks` entry in `Endpoint.DescribeProperties()` was populated with `PingIntervalForCircuitResume`'s value instead of its own.
- **Missing values**: the method never emitted `BufferingLimits.Maximum`, `BufferingLimits.Restart`, `CircuitBreakerOptions.FailurePercentageThreshold`, or `CircuitBreakerOptions.PauseTime`, so CritterWatch's cached `EndpointPropertiesReported` tree had no current values and the endpoint performance-threshold edit drawer fell back to hardcoded defaults (500/250/25/60).

Changes:

- `FailuresBeforeCircuitBreaks` now reports its own value
- `BufferingLimits.Maximum` / `BufferingLimits.Restart` are emitted when `ShouldEnforceBackPressure()` is true — the same condition under which `ListeningAgent` wires up a `BackPressureAgent`, so it covers `BufferedInMemory`/`Durable` modes, excludes `Inline`, and respects overrides like `LocalQueue`
- `CircuitBreakerOptions.FailurePercentageThreshold` / `CircuitBreakerOptions.PauseTime` are emitted when circuit breaking is configured
- New unit tests in `CoreTests.Configuration.EndpointTests` covering the corrected value and presence/absence of the new keys per mode/configuration

Closes JasperFx/CritterWatch#664

🤖 Generated with [Claude Code](https://claude.com/claude-code)