### PR TITLE
Opt-in strict query string binding: 400 + ProblemDetails for unparseable query values (GH-3372)

### DIFF
--- a/docs/guide/http/as-parameters.md
+++ b/docs/guide/http/as-parameters.md
@@ -218,6 +218,47 @@ public static class AsParameterRecordEndpoint
 <!-- endSnippet -->
 
 
+## Strict Query String Binding <Badge type="tip" text="6.18" />
+
+By default in Wolverine 6.x, a query string value that is *present* but cannot be parsed to the
+target member type (an enum, `int`, `Guid`, etc.) is silently ignored — the member simply keeps
+its default or property initializer value. ASP.NET Core's own minimal API `[AsParameters]` binder
+returns `400 Bad Request` for the same input, and the lenient behavior makes a typo'd query value
+indistinguishable from an absent one (not even FluentValidation can catch it downstream, because
+the bound value looks legitimate).
+
+You can opt into the strict, minimal-API-compatible behavior with
+`WolverineHttpOptions.RejectUnparseableQueryValues`:
+
+```cs
+app.MapWolverineEndpoints(opts =>
+{
+    // Return 400 with a ProblemDetails body naming the offending parameter
+    // when a query string value is present but unparseable
+    opts.RejectUnparseableQueryValues = true;
+});
+```
+
+The behavior matrix for a bound query string member (for example
+`[FromQuery] public SortField SortBy { get; set; } = SortField.Date;` on `GET /search`):
+
+| Request | Flag off (default) | Flag on |
+| --- | --- | --- |
+| `GET /search?SortBy=Name` | `200` — binds `Name` | `200` — binds `Name` |
+| `GET /search` (missing) | `200` — keeps the initializer (`Date`) | `200` — keeps the initializer (`Date`) |
+| `GET /search?SortBy=bogus` (malformed) | `200` — keeps the initializer (`Date`) | `400` — ProblemDetails naming `SortBy` |
+
+Only a *present but unparseable* value triggers the `400`; a *missing* query string value keeps the
+member's default / initializer in both modes. The flag applies to query string binding for
+`[AsParameters]` members and for endpoint method arguments bound from the query string alike.
+Route argument binding is unaffected (an unparseable route value already returns `404`).
+
+::: warning
+`RejectUnparseableQueryValues` is opt-in (defaults to `false`) throughout Wolverine 6.x to preserve
+the previous lenient behavior, but the default flips to `true` (strict) in Wolverine 7.0. If you
+depend on the lenient behavior, set the flag explicitly to be ready for 7.0.
+:::
+
 The [Fluent Validation middleware](./fluentvalidation) for Wolverine.HTTP is able to validate against request types
 bound with `[AsParameters]`:
 

--- a/docs/guide/http/querystring.md
+++ b/docs/guide/http/querystring.md
@@ -4,7 +4,11 @@
 Wolverine can handle both nullable types and the primitive values here. So
 `int` and `int?` are both valid. In all cases, if the query string does not exist -- or
 cannot be parsed -- the value passed to your method will be the `default` for whatever that
-type is.
+type is. If you want a *present but unparseable* query string value to return a `400 Bad Request`
+instead (matching ASP.NET Core minimal APIs), opt into
+`WolverineHttpOptions.RejectUnparseableQueryValues` — see
+[Strict Query String Binding](./as-parameters#strict-query-string-binding). The strict behavior
+becomes the default in Wolverine 7.0.
 :::
 
 Wolverine supports passing query string values to your HTTP method arguments for

--- a/src/Http/Wolverine.Http.Tests/strict_query_string_binding.cs
+++ b/src/Http/Wolverine.Http.Tests/strict_query_string_binding.cs
@@ -1,0 +1,294 @@
+using Alba;
+using IntegrationTests;
+using Marten;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.Http.Tests.Bugs;
+using Wolverine.Marten;
+
+namespace Wolverine.Http.Tests;
+
+// GH-3372: [AsParameters] / query string binding silently ignored unparseable values,
+// leaving the property at its initializer where ASP.NET Core minimal APIs would 400.
+// WolverineHttpOptions.RejectUnparseableQueryValues opts into the strict (minimal API)
+// behavior; the default flips to strict in Wolverine 7.0.
+public class StrictQueryBindingFixture : IAsyncLifetime
+{
+    public IAlbaHost StrictHost { get; private set; } = null!;
+    public IAlbaHost LenientHost { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        StrictHost = await buildHost(rejectUnparseable: true);
+        LenientHost = await buildHost(rejectUnparseable: false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await StrictHost.DisposeAsync();
+        await LenientHost.DisposeAsync();
+    }
+
+    private static Task<IAlbaHost> buildHost(bool rejectUnparseable)
+    {
+        var builder = WebApplication.CreateBuilder([]);
+        builder.Services.AddScoped<IUserService, UserService>();
+
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(Servers.PostgresConnectionString);
+            opts.DisableNpgsqlLogging = true;
+        }).IntegrateWithWolverine();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.Discovery.IncludeAssembly(typeof(StrictQueryBindingFixture).Assembly);
+            opts.Durability.Mode = DurabilityMode.MediatorOnly;
+        });
+
+        builder.Services.AddWolverineHttp();
+
+        return AlbaHost.For(builder, app =>
+        {
+            app.MapWolverineEndpoints(opts => opts.RejectUnparseableQueryValues = rejectUnparseable);
+        });
+    }
+}
+
+public class strict_query_string_binding : IClassFixture<StrictQueryBindingFixture>
+{
+    private readonly StrictQueryBindingFixture _fixture;
+
+    public strict_query_string_binding(StrictQueryBindingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private Task<IScenarioResult> expect400(string key, string value)
+    {
+        return _fixture.StrictHost.Scenario(x =>
+        {
+            x.Get.Url("/strict/asparameters").QueryString(key, value);
+            x.StatusCodeShouldBe(400);
+            x.ContentTypeShouldBe("application/problem+json");
+        });
+    }
+
+    [Fact]
+    public async Task malformed_enum_returns_400_with_problem_details_naming_the_parameter()
+    {
+        var result = await expect400("sort-by", "bogus");
+
+        var text = await result.ReadAsTextAsync();
+        text.ShouldContain("sort-by");
+        text.ShouldContain("bogus");
+    }
+
+    [Fact]
+    public async Task malformed_int_returns_400_with_problem_details_naming_the_parameter()
+    {
+        var result = await expect400("PageSize", "abc");
+
+        var text = await result.ReadAsTextAsync();
+        text.ShouldContain("PageSize");
+    }
+
+    [Fact]
+    public async Task malformed_guid_returns_400_with_problem_details_naming_the_parameter()
+    {
+        var result = await expect400("Token", "not-a-guid");
+
+        var text = await result.ReadAsTextAsync();
+        text.ShouldContain("Token");
+    }
+
+    [Fact]
+    public async Task malformed_nullable_enum_returns_400()
+    {
+        await expect400("MaybeSort", "sideways");
+    }
+
+    [Fact]
+    public async Task malformed_nullable_int_returns_400()
+    {
+        await expect400("MaybePage", "abc");
+    }
+
+    [Fact]
+    public async Task malformed_nullable_guid_returns_400()
+    {
+        await expect400("MaybeToken", "not-a-guid");
+    }
+
+    [Fact]
+    public async Task missing_values_keep_initializers_in_strict_mode()
+    {
+        var result = await _fixture.StrictHost.Scenario(x =>
+        {
+            x.Get.Url("/strict/asparameters");
+            x.StatusCodeShouldBe(200);
+        });
+
+        var response = await result.ReadAsJsonAsync<StrictQueryModel>();
+        response.SortBy.ShouldBe(StrictSortOrder.Date);
+        response.PageSize.ShouldBe(5);
+        response.Token.ShouldBe(StrictQueryModel.DefaultToken);
+        response.MaybeSort.ShouldBeNull();
+        response.MaybePage.ShouldBeNull();
+        response.MaybeToken.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task valid_values_bind_in_strict_mode()
+    {
+        var token = Guid.NewGuid();
+        var maybeToken = Guid.NewGuid();
+
+        var result = await _fixture.StrictHost.Scenario(x =>
+        {
+            x.Get.Url("/strict/asparameters")
+                .QueryString("sort-by", "Name")
+                .QueryString("PageSize", "20")
+                .QueryString("Token", token.ToString())
+                .QueryString("MaybeSort", "Date")
+                .QueryString("MaybePage", "3")
+                .QueryString("MaybeToken", maybeToken.ToString());
+            x.StatusCodeShouldBe(200);
+        });
+
+        var response = await result.ReadAsJsonAsync<StrictQueryModel>();
+        response.SortBy.ShouldBe(StrictSortOrder.Name);
+        response.PageSize.ShouldBe(20);
+        response.Token.ShouldBe(token);
+        response.MaybeSort.ShouldBe(StrictSortOrder.Date);
+        response.MaybePage.ShouldBe(3);
+        response.MaybeToken.ShouldBe(maybeToken);
+    }
+
+    [Fact]
+    public async Task malformed_direct_method_argument_returns_400()
+    {
+        // The same generated query binder handles direct endpoint method arguments,
+        // so the strict behavior covers those too
+        var result = await _fixture.StrictHost.Scenario(x =>
+        {
+            x.Get.Url("/strict/direct").QueryString("number", "abc");
+            x.StatusCodeShouldBe(400);
+            x.ContentTypeShouldBe("application/problem+json");
+        });
+
+        var text = await result.ReadAsTextAsync();
+        text.ShouldContain("number");
+    }
+
+    [Fact]
+    public async Task valid_direct_method_argument_binds_in_strict_mode()
+    {
+        var result = await _fixture.StrictHost.Scenario(x =>
+        {
+            x.Get.Url("/strict/direct").QueryString("number", "42");
+            x.StatusCodeShouldBe(200);
+        });
+
+        (await result.ReadAsTextAsync()).ShouldBe("42");
+    }
+
+    [Fact]
+    public async Task missing_direct_method_argument_keeps_default_in_strict_mode()
+    {
+        var result = await _fixture.StrictHost.Scenario(x =>
+        {
+            x.Get.Url("/strict/direct");
+            x.StatusCodeShouldBe(200);
+        });
+
+        (await result.ReadAsTextAsync()).ShouldBe("0");
+    }
+
+    [Fact]
+    public async Task malformed_values_keep_initializers_when_flag_is_off()
+    {
+        // The pre-3372 lenient behavior is preserved by default in 6.x
+        var result = await _fixture.LenientHost.Scenario(x =>
+        {
+            x.Get.Url("/strict/asparameters")
+                .QueryString("sort-by", "bogus")
+                .QueryString("PageSize", "abc")
+                .QueryString("Token", "not-a-guid")
+                .QueryString("MaybeSort", "sideways")
+                .QueryString("MaybePage", "abc")
+                .QueryString("MaybeToken", "not-a-guid");
+            x.StatusCodeShouldBe(200);
+        });
+
+        var response = await result.ReadAsJsonAsync<StrictQueryModel>();
+        response.SortBy.ShouldBe(StrictSortOrder.Date);
+        response.PageSize.ShouldBe(5);
+        response.Token.ShouldBe(StrictQueryModel.DefaultToken);
+        response.MaybeSort.ShouldBeNull();
+        response.MaybePage.ShouldBeNull();
+        response.MaybeToken.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task missing_values_keep_initializers_when_flag_is_off()
+    {
+        var result = await _fixture.LenientHost.Scenario(x =>
+        {
+            x.Get.Url("/strict/asparameters");
+            x.StatusCodeShouldBe(200);
+        });
+
+        var response = await result.ReadAsJsonAsync<StrictQueryModel>();
+        response.SortBy.ShouldBe(StrictSortOrder.Date);
+        response.PageSize.ShouldBe(5);
+        response.Token.ShouldBe(StrictQueryModel.DefaultToken);
+    }
+}
+
+public enum StrictSortOrder
+{
+    Name = 1,
+    Date = 2
+}
+
+public class StrictQueryModel
+{
+    public static readonly Guid DefaultToken = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    [FromQuery(Name = "sort-by")]
+    public StrictSortOrder SortBy { get; set; } = StrictSortOrder.Date;
+
+    [FromQuery]
+    public int PageSize { get; set; } = 5;
+
+    [FromQuery]
+    public Guid Token { get; set; } = DefaultToken;
+
+    [FromQuery]
+    public StrictSortOrder? MaybeSort { get; set; }
+
+    [FromQuery]
+    public int? MaybePage { get; set; }
+
+    [FromQuery]
+    public Guid? MaybeToken { get; set; }
+}
+
+public static class StrictQueryBindingEndpoints
+{
+    [WolverineGet("/strict/asparameters")]
+    public static StrictQueryModel Get([AsParameters] StrictQueryModel query)
+    {
+        return query;
+    }
+
+    [WolverineGet("/strict/direct")]
+    public static string GetDirect(int number)
+    {
+        return number.ToString();
+    }
+}

--- a/src/Http/Wolverine.Http/CodeGen/IReadHttpFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/IReadHttpFrame.cs
@@ -25,7 +25,8 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
 {
     private readonly BindingSource _source;
 
-    public ReadHttpFrame(BindingSource source, Type parameterType, string parameterName, bool isOptional = false)
+    public ReadHttpFrame(BindingSource source, Type parameterType, string parameterName, bool isOptional = false,
+        bool rejectUnparseableValue = false)
     {
         _source = source;
         Variable = new HttpElementVariable(parameterType, parameterName!.SanitizeFormNameForVariable(), this);
@@ -33,6 +34,16 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
         _isOptional = isOptional;
         _isNullable = parameterType.IsNullable();
         _rawType = _isNullable ? parameterType.GetInnerTypeFromNullable() : parameterType;
+
+        // GH-3372 strict query string binding: only applies to parsed (non-string) query string
+        // values. The 400 + ProblemDetails short circuit writes the response asynchronously,
+        // so the frame has to force the generated method into async mode.
+        _rejectUnparseableValue = rejectUnparseableValue && source == BindingSource.QueryString &&
+                                  _rawType != typeof(string);
+        if (_rejectUnparseableValue)
+        {
+            IsAsync = true;
+        }
     }
 
     public HttpElementVariable Variable { get; }
@@ -148,6 +159,12 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
 
     private void writeParsedValueFSharp(GeneratedMethod method, ISourceWriter writer)
     {
+        if (_rejectUnparseableValue)
+        {
+            throw new NotSupportedException(
+                "F# code generation does not yet support strict query string binding (WolverineHttpOptions.RejectUnparseableQueryValues).");
+        }
+
         if (_isNullable || _isOptional)
         {
             throw new NotSupportedException(
@@ -284,8 +301,21 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
         writer.Write("");
         writer.Write($"BLOCK:if ({tryParseExpression(outUsage)})");
         writer.Write(assignmentLine);
-        
+
         writer.FinishBlock();
+
+        if (_rejectUnparseableValue)
+        {
+            // GH-3372 strict query binding: a query string value that is *present* but unparseable
+            // short-circuits the request with a 400 ProblemDetails naming the offending parameter,
+            // matching ASP.NET Core minimal API binding. A *missing* value falls through and keeps
+            // the parameter's default / property initializer in both modes.
+            writer.Write($"BLOCK:else if (!string.IsNullOrEmpty({Variable.Usage}_rawValue))");
+            writer.Write(
+                $"await {nameof(HttpHandler.WriteQueryValueParsingProblem)}(httpContext, \"{Key}\", {Variable.Usage}_rawValue, \"{_rawType.FullNameInCode()}\").ConfigureAwait(false);");
+            writer.Write(method.ToExitStatement());
+            writer.FinishBlock();
+        }
 
         if (_source == BindingSource.RouteValue)
         {
@@ -310,6 +340,7 @@ internal class ReadHttpFrame : SyncFrame, IReadHttpFrame
     private readonly bool _isOptional;
     private readonly bool _isNullable;
     private readonly Type _rawType;
+    private readonly bool _rejectUnparseableValue;
 
     public void AssignToProperty(string usage)
     {

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -703,7 +703,8 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
                 if (RouteParameterStrategy.CanParse(inner))
                 {
                     //variable = new ParsedNullableQueryStringValue(parameterType, parameterName).Variable;
-                    variable = new ReadHttpFrame(BindingSource.QueryString, parameterType, key).Variable;
+                    variable = new ReadHttpFrame(BindingSource.QueryString, parameterType, key,
+                        rejectUnparseableValue: _parent.RejectUnparseableQueryValues).Variable;
                     variable.Name = key;
                     _querystringVariables.Add(variable);
                 }
@@ -726,7 +727,8 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
             if (RouteParameterStrategy.CanParse(parameterType))
             {
                 //variable = new ParsedQueryStringValue(parameterType, parameterName).Variable;
-                variable = new ReadHttpFrame(BindingSource.QueryString, parameterType, parameterName).Variable;
+                variable = new ReadHttpFrame(BindingSource.QueryString, parameterType, parameterName,
+                    rejectUnparseableValue: _parent.RejectUnparseableQueryValues).Variable;
                 variable.Name = key;
                 _querystringVariables.Add(variable);
             }

--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -61,6 +61,14 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
     /// </summary>
     internal bool AutoAntiforgeryOnFormEndpoints { get; set; }
 
+    /// <summary>
+    /// When true, generated query string binding emits a 400 + ProblemDetails short circuit
+    /// for query string values that are present but unparseable. Mirrors
+    /// <see cref="WolverineHttpOptions.RejectUnparseableQueryValues"/>; transferred before
+    /// endpoint discovery so chain construction sees the final value. GH-3372.
+    /// </summary>
+    internal bool RejectUnparseableQueryValues { get; set; }
+
     internal IEnumerable<IResourceWriterPolicy> WriterPolicies => _optionsWriterPolicies.Concat(_builtInWriterPolicies);
 
     public override IReadOnlyList<Endpoint> Endpoints => _endpoints;

--- a/src/Http/Wolverine.Http/HttpHandler.cs
+++ b/src/Http/Wolverine.Http/HttpHandler.cs
@@ -232,4 +232,26 @@ public abstract class HttpHandler
     {
         return Results.Problem(details).ExecuteAsync(context);
     }
+
+    /// <summary>
+    /// Called by generated code when <see cref="WolverineHttpOptions.RejectUnparseableQueryValues"/>
+    /// is enabled and a query string value is present but cannot be parsed to the expected
+    /// parameter type. Writes a 400 ProblemDetails response naming the offending query string
+    /// parameter, matching ASP.NET Core minimal API binding behavior. GH-3372.
+    /// </summary>
+    public static Task WriteQueryValueParsingProblem(HttpContext context, string parameterName, string? rawValue,
+        string expectedType)
+    {
+        var details = new ProblemDetails
+        {
+            Status = 400,
+            Title = "Invalid query string value",
+            Detail =
+                $"Query string parameter '{parameterName}' has the value '{rawValue}' which cannot be parsed to the expected type {expectedType}"
+        };
+
+        details.Extensions["parameter"] = parameterName;
+
+        return Results.Problem(details).ExecuteAsync(context);
+    }
 }

--- a/src/Http/Wolverine.Http/WolverineHttpEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpEndpointRouteBuilderExtensions.cs
@@ -252,6 +252,7 @@ public static class WolverineHttpEndpointRouteBuilderExtensions
         options.JsonSerializerOptions = new Lazy<JsonSerializerOptions>(() => serviceProvider.GetService<IOptions<JsonOptions>>()?.Value?.SerializerOptions ?? new JsonSerializerOptions());
 
         options.Endpoints.AutoAntiforgeryOnFormEndpoints = options._autoAntiforgeryOnFormEndpoints;
+        options.Endpoints.RejectUnparseableQueryValues = options.RejectUnparseableQueryValues;
         options.Endpoints.DiscoverEndpoints(options);
         runtime.Options.Parts.Add(options.Endpoints);
 

--- a/src/Http/Wolverine.Http/WolverineHttpOptions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpOptions.cs
@@ -199,6 +199,19 @@ public class WolverineHttpOptions
     /// </summary>
     public RouteWarmup WarmUpRoutes { get; set; } = RouteWarmup.Lazy;
 
+    /// <summary>
+    /// When true, a query string value that is <b>present</b> but cannot be parsed to the expected
+    /// endpoint parameter type (enum, int, Guid, etc.) short-circuits the request with a
+    /// 400 Bad Request and a ProblemDetails body naming the offending query string parameter.
+    /// This matches the behavior of ASP.NET Core minimal API parameter binding. A <b>missing</b>
+    /// query string value still binds the parameter's default / property initializer value in
+    /// either mode. Applies to query string binding for endpoint method arguments and for
+    /// [AsParameters] members bound from the query string. This is currently opt-in
+    /// (default false) to preserve the previous lenient behavior, but the default flips
+    /// to true (strict) in Wolverine 7.0. See https://github.com/JasperFx/wolverine/issues/3372
+    /// </summary>
+    public bool RejectUnparseableQueryValues { get; set; }
+
     internal TenantIdDetection TenantIdDetection { get; } = new();
 
     internal Lazy<JsonSerializerOptions> JsonSerializerOptions { get; set; } = new(() => new JsonSerializerOptions());


### PR DESCRIPTION
Closes GH-3372

## What

Wolverine.HTTP's generated query string binder silently ignored a query string value that was *present* but unparseable (enum/int/Guid/etc.), leaving the bound member at its default / property initializer — where ASP.NET Core minimal APIs return `400 Bad Request`. Downstream validation could never catch it because the bound value looks legitimate.

Per the decision posted on the issue:

- **Now (6.x):** opt-in flag `WolverineHttpOptions.RejectUnparseableQueryValues` (default `false`, preserving the lenient behavior). With the flag on, a `TryParse` failure on a *present* query string value short-circuits the endpoint with a `400` and a `ProblemDetails` body naming the offending parameter (`title`, `detail`, and a `parameter` extension member) — the same contract as minimal APIs.
- **7.0:** the default flips to strict. The flip is a one-line change: the `RejectUnparseableQueryValues` property initializer in `src/Http/Wolverine.Http/WolverineHttpOptions.cs`.

## Behavior matrix

For `[FromQuery] public SortField SortBy { get; set; } = SortField.Date;`:

| Request | Flag off (default) | Flag on |
| --- | --- | --- |
| `?SortBy=Name` | 200 — binds `Name` | 200 — binds `Name` |
| *(missing)* | 200 — keeps initializer | 200 — keeps initializer |
| `?SortBy=bogus` | 200 — keeps initializer | **400 — ProblemDetails naming `SortBy`** |

Only *present but unparseable* triggers the 400; a *missing* (or empty) query string value keeps the member's initializer in both modes.

## Scope

- Applies to scalar query string binding — both `[AsParameters]` members bound from the query string and plain endpoint method arguments, which share the same `ReadHttpFrame` emission.
- Route value binding is untouched (an unparseable route value already 404s); form and header binding are untouched per the issue's scope.
- Follow-ups deliberately not expanded here:
  - collection/array query binding (`ParsedCollectionQueryStringValue` / `ParsedArrayQueryStringValue`) still silently skips unparseable *elements*;
  - form value binding shares the lenient TryParse pattern and could grow an analogous flag;
  - F# code generation throws a clear `NotSupportedException` if the flag is enabled for an F#-emitted endpoint (F# emit already doesn't support enum/nullable binding).

## Implementation

- `WolverineHttpOptions.RejectUnparseableQueryValues` → mirrored onto `HttpGraph` in `MapWolverineEndpoints` before endpoint discovery, so chain construction sees the final value.
- `ReadHttpFrame` (the shared query string emission) takes a `rejectUnparseableValue` flag: with it on, the generated code gets an `else if (!string.IsNullOrEmpty(<raw>))` branch that awaits the new `HttpHandler.WriteQueryValueParsingProblem(...)` helper (a `Results.Problem(...)` write) and exits. The frame forces itself async since the short circuit writes the response body.
- Docs: new "Strict Query String Binding" section in `docs/guide/http/as-parameters.md` (flag, behavior matrix, 7.0 default-flip warning) plus a cross-reference in `docs/guide/http/querystring.md`.

## Tests

`src/Http/Wolverine.Http.Tests/strict_query_string_binding.cs` — two Alba hosts sharing the same endpoints, differing only in the flag:

- strict: malformed enum / int / Guid, nullable and non-nullable → 400 `application/problem+json`, body names the parameter and echoes the raw value
- strict: missing values keep initializers (nullable stays null); valid values bind
- strict: direct method argument (`int number`) — malformed 400 / valid binds / missing keeps default
- lenient: malformed and missing both keep initializers (pre-existing behavior locked in)

Full `Wolverine.Http.Tests` suite on net9.0: 831 passed / 0 failed / 10 skipped. Full `wolverine.slnx` Release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
