### PR TITLE
Emit [AsParameters] binding frames once per chain with compound handlers (GH-3374)

### DIFF
--- a/src/Http/Wolverine.Http.Tests.EfCoreOnly/Bug3374LoadAsyncAsParametersEndpoints.cs
+++ b/src/Http/Wolverine.Http.Tests.EfCoreOnly/Bug3374LoadAsyncAsParametersEndpoints.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Wolverine.Http;
+
+namespace Wolverine.Http.Tests.EfCoreOnly;
+
+// Reproducers for GH-3374: an [AsParameters] endpoint whose compound-handler LoadAsync
+// binds the same route variable made the runtime codegen emit the route-binding frames
+// once per consuming method scope. The duplicated locals (order_id_rawValue / order_id,
+// and for the [AsParameters]-on-LoadAsync variant the request variable itself) meant the
+// generated class did not compile, so the host failed at startup.
+
+public class Bug3374DbContext : DbContext
+{
+    public Bug3374DbContext(DbContextOptions<Bug3374DbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Bug3374Order> Orders => Set<Bug3374Order>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Bug3374Order>(map =>
+        {
+            map.ToTable("bug3374_orders", "bug3374");
+            map.HasKey(x => x.Id);
+        });
+    }
+}
+
+public class Bug3374Order
+{
+    public long Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public sealed class Bug3374UpsertLinesRequest
+{
+    [FromRoute(Name = "order-id")]
+    public long OrderId { get; set; }
+
+    [FromBody]
+    public Bug3374LinesBody Body { get; set; } = new([]);
+}
+
+public sealed record Bug3374LinesBody(List<string> Lines);
+
+public sealed record Bug3374Response(long OrderId, string OrderName, int LineCount);
+
+// Variant 1 from GH-3374: LoadAsync binds the raw route value while the HTTP handler
+// binds the same route value through an [AsParameters] container.
+public static class Bug3374RouteLoadEndpoint
+{
+    public static async Task<Bug3374Order> LoadAsync(
+        [FromRoute(Name = "order-id")] long orderId,
+        Bug3374DbContext dbContext,
+        CancellationToken cancellationToken)
+        => await dbContext.Orders.FirstOrDefaultAsync(o => o.Id == orderId, cancellationToken)
+           ?? throw new InvalidOperationException($"No order with id {orderId}");
+
+    [WolverinePut("/bug3374/route-load/orders/{order-id:long}/lines")]
+    public static Bug3374Response Put(
+        [AsParameters] Bug3374UpsertLinesRequest request,
+        [NotBody] Bug3374Order order,
+        [NotBody] Bug3374DbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        return new Bug3374Response(request.OrderId, order.Name, request.Body.Lines.Count);
+    }
+}
+
+// Variant 2 from GH-3374: LoadAsync binds the same [AsParameters] container as the HTTP
+// handler, which additionally collided on the container variable itself.
+public static class Bug3374AsParametersLoadEndpoint
+{
+    public static async Task<Bug3374Order> LoadAsync(
+        [AsParameters] Bug3374UpsertLinesRequest request,
+        Bug3374DbContext dbContext,
+        CancellationToken cancellationToken)
+        => await dbContext.Orders.FirstOrDefaultAsync(o => o.Id == request.OrderId, cancellationToken)
+           ?? throw new InvalidOperationException($"No order with id {request.OrderId}");
+
+    [WolverinePut("/bug3374/asparameters-load/orders/{order-id:long}/lines")]
+    public static Bug3374Response Put(
+        [AsParameters] Bug3374UpsertLinesRequest request,
+        [NotBody] Bug3374Order order,
+        [NotBody] Bug3374DbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        return new Bug3374Response(request.OrderId, order.Name, request.Body.Lines.Count);
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/Bug_3374_asparameters_with_loadasync_route_binding.cs
+++ b/src/Http/Wolverine.Http.Tests/Bug_3374_asparameters_with_loadasync_route_binding.cs
@@ -1,0 +1,131 @@
+using Alba;
+using IntegrationTests;
+using JasperFx;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Postgresql;
+using Wolverine.Http.Tests.EfCoreOnly;
+using Xunit;
+
+namespace Wolverine.Http.Tests;
+
+// Reproducer for GH-3374. An HTTP endpoint using [AsParameters] combined with a
+// compound-handler LoadAsync that binds the same route variable had the route-binding
+// frames emitted once per consuming method scope instead of once per chain. The
+// duplicated locals (order_id_rawValue / order_id, plus the [AsParameters] container
+// variable itself in the second variant) meant the generated class did not compile and
+// the host failed at startup with "Compilation failures!".
+//
+// Like GH-3353/GH-3358, the endpoints live in the Marten-free Wolverine.Http.Tests.EfCoreOnly
+// assembly and endpoint discovery is pinned there, because the main test assembly's endpoints
+// assume Marten is registered.
+public class Bug_3374_asparameters_with_loadasync_route_binding : IAsyncLifetime
+{
+    private IAlbaHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+
+        builder.Services.AddDbContextWithWolverineIntegration<Bug3374DbContext>(x =>
+            x.UseNpgsql(Servers.PostgresConnectionString));
+
+        // The EfCoreOnly assembly also holds the GH-3353/GH-3358 endpoints, which need their
+        // own DbContext registered for endpoint discovery to succeed in this host
+        builder.Services.AddDbContextWithWolverineIntegration<Bug3353DbContext>(x =>
+            x.UseNpgsql(Servers.PostgresConnectionString));
+
+        builder.Host.UseWolverine(opts =>
+        {
+            // Pin endpoint discovery to the EF-Core-only assembly; see the class comment
+            opts.ApplicationAssembly = typeof(Bug3374RouteLoadEndpoint).Assembly;
+
+            opts.Durability.Mode = DurabilityMode.Solo;
+
+            // The Wolverine-integrated DbContexts pull DatabaseSettings from the message store
+            opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "bug3374");
+
+            // Registers the EF Core persistence frame provider, which both resolves the
+            // LoadAsync compound handlers here and satisfies the sibling GH-3353 endpoint's
+            // storage action during endpoint discovery
+            opts.UseEntityFrameworkCoreTransactions();
+
+            opts.Discovery.DisableConventionalDiscovery();
+        });
+
+        builder.Services.AddWolverineHttp();
+
+        // Before the fix this was already enough to fail intermittently depending on codegen
+        // mode, but the deterministic failure is triggered by exercising the endpoints below
+        _host = await AlbaHost.For(builder, app => app.MapWolverineEndpoints());
+
+        // The chains never write, so create the backing table by hand and seed the order rows
+        using var scope = _host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<Bug3374DbContext>();
+        await db.Database.ExecuteSqlRawAsync(
+            """
+            create schema if not exists bug3374;
+            create table if not exists bug3374.bug3374_orders ("Id" bigint primary key, "Name" varchar(200) not null);
+            delete from bug3374.bug3374_orders;
+            insert into bug3374.bug3374_orders ("Id", "Name") values (42, 'route-load'), (43, 'asparameters-load');
+            """);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task loadasync_binding_the_raw_route_value_compiles_and_runs()
+    {
+        // Executing the endpoint forces the codegen + compilation that blew up before the fix
+        var result = await _host.Scenario(x =>
+        {
+            x.Put.Json(new Bug3374LinesBody(["one", "two", "three"]))
+                .ToUrl("/bug3374/route-load/orders/42/lines");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var response = await result.ReadAsJsonAsync<Bug3374Response>();
+        response.ShouldNotBeNull();
+        response.OrderId.ShouldBe(42);
+        response.OrderName.ShouldBe("route-load");
+        response.LineCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task loadasync_binding_the_same_asparameters_container_compiles_and_runs()
+    {
+        var result = await _host.Scenario(x =>
+        {
+            x.Put.Json(new Bug3374LinesBody(["one", "two"]))
+                .ToUrl("/bug3374/asparameters-load/orders/43/lines");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var response = await result.ReadAsJsonAsync<Bug3374Response>();
+        response.ShouldNotBeNull();
+        response.OrderId.ShouldBe(43);
+        response.OrderName.ShouldBe("asparameters-load");
+        response.LineCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task missing_order_id_route_value_still_404s()
+    {
+        // Guard: an unparseable order id still 404s. The :long route constraint rejects this
+        // at the routing layer; the generated route-binding frame (now emitted inside the
+        // [AsParameters] binding block) keeps its own 404 short-circuit as the second line of
+        // defense, which the compilation of the two endpoints above already proves out.
+        await _host.Scenario(x =>
+        {
+            x.Put.Json(new Bug3374LinesBody(["one"]))
+                .ToUrl("/bug3374/route-load/orders/not-a-number/lines");
+            x.StatusCodeShouldBe(404);
+        });
+    }
+}

--- a/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
@@ -30,6 +30,17 @@ internal class AsParamatersAttributeUsage : IParameterStrategy
             return false;
         }
 
+        // A chain gets exactly one binding frame per [AsParameters] type. A second consumer —
+        // typically a compound handler LoadAsync/Before method taking the same [AsParameters]
+        // parameter as the main endpoint method — must reuse the already-built variable, or the
+        // binding frame is emitted once per consuming method scope and the duplicated locals
+        // don't compile. See GH-3374.
+        if (chain.AsParametersVariable != null && chain.AsParametersVariable.VariableType == parameter.ParameterType)
+        {
+            variable = chain.AsParametersVariable;
+            return true;
+        }
+
         if (IsClassOrNullableClassNotCollection(parameter.ParameterType))
         {
             chain.RequestType = parameter.ParameterType;
@@ -111,6 +122,7 @@ internal class AsParametersBindingFrame : SyncFrame
                 if (variable!.Creator != null)
                 {
                     _parameterFrames.Add(variable.Creator);
+                    absorbBindingFrame(variable);
                 }
             }
         }
@@ -123,6 +135,7 @@ internal class AsParametersBindingFrame : SyncFrame
                 {
                     frame.AssignToProperty($"{Variable.Usage}.{propertyInfo.Name}");
                     _props.Add(variable.Creator);
+                    absorbBindingFrame(variable);
                 }
                 else
                 {
@@ -149,6 +162,21 @@ internal class AsParametersBindingFrame : SyncFrame
         }
     }
     
+    /// <summary>
+    /// This frame generates any absorbed ReadHttpFrame (route/query string/form/header binding)
+    /// inline, so the variable it reads must be re-homed to this frame. Otherwise a second consumer
+    /// of the same variable — a compound handler LoadAsync/Before method binding the same route
+    /// value, for example — makes the arranger schedule the absorbed frame a second time as a
+    /// top-level frame, and the duplicated locals don't compile. See GH-3374.
+    /// </summary>
+    private void absorbBindingFrame(Variable variable)
+    {
+        if (variable is HttpElementVariable element && variable.Creator != null)
+        {
+            element.ReassignCreator(this);
+        }
+    }
+
     private bool tryCreateFrame(ParameterInfo parameter, HttpChain chain, IServiceContainer container, out Variable? variable)
     {
         variable = default;

--- a/src/Http/Wolverine.Http/CodeGen/HttpElementVariable.cs
+++ b/src/Http/Wolverine.Http/CodeGen/HttpElementVariable.cs
@@ -15,4 +15,16 @@ public class HttpElementVariable : Variable
 
     public string Name { get; set; }
 
+    /// <summary>
+    /// Re-home this variable to a different creating frame. Used when AsParametersBindingFrame
+    /// absorbs the original binding frame and generates it inline: any other consumer of the
+    /// variable (e.g. a compound handler LoadAsync/Before method binding the same route value)
+    /// must be ordered after the [AsParameters] binding frame instead of re-scheduling the
+    /// absorbed frame as a second top-level frame, which emitted the binding code once per
+    /// consuming scope and produced uncompilable duplicate locals. See GH-3374.
+    /// </summary>
+    internal void ReassignCreator(Frame creator)
+    {
+        Creator = creator;
+    }
 }


### PR DESCRIPTION
Fixes #3374 — an HTTP endpoint combining `[AsParameters]` with a compound-handler `LoadAsync`/`Before` method that binds the same route variable failed at startup with `InvalidOperationException: Compilation failures!` (duplicate `order_id_rawValue` / `order_id` locals, `CS0136`/`CS0841`/`CS0128`).

## Root cause

`AsParametersBindingFrame` absorbs the `ReadHttpFrame` for each bound member (`[FromRoute]`/`[FromQuery]`/`[FromForm]`/`[FromHeader]`) and generates it **inline**, but the member variable's `Creator` still pointed at the absorbed `ReadHttpFrame`. When a second consumer used the same chain-cached variable — here `LoadAsync([FromRoute(Name = "order-id")] long orderId, AppDbContext db, ...)` resolved through the EF Core persistence provider path — the frame arranger scheduled the absorbed frame a *second* time as a top-level frame. Worse, being placed at two positions mangled the frame's `Next` chain, so the entire tail of the chain (`LoadAsync` → handler → response write) was emitted twice:

```csharp
// Binding Form & Querystring values to the argument marked with [AsParameters]
var request = new UpsertLinesRequest();
string order_id_rawValue = (string?)httpContext.GetRouteValue("order-id");   // emission 1 (inline)
...
var order = await LoadAsync(order_id, dbContext, ...);
var response = Put(request, order, dbContext, ...);
await WriteJsonAsync(httpContext, response);
request.Body = body;
string order_id_rawValue = (string?)httpContext.GetRouteValue("order-id");   // emission 2 (top-level) — CS0128
...
```

The second reported variant — `LoadAsync([AsParameters] UpsertLinesRequest request, ...)` — additionally built a brand-new `AsParametersBindingFrame` for the second consumer, colliding on the `request` variable itself.

## Relationship to GH-3135

This is the compound-handler analogue of the GH-3135 `[WriteAggregate]`+`[AsParameters]` defect. The 3135 mechanism is chain-level variable reuse: route/query/form/header variables are cached on the `HttpChain` (`FindRouteVariable` et al.) so every consumer shares one `Variable`. That reuse worked here too — but sharing the variable is not enough when its *creator frame* has been absorbed into the `[AsParameters]` binding frame for inline generation. This PR extends the dedup to frame ownership:

- **`HttpElementVariable.ReassignCreator`** (new, internal): re-homes a variable to a different creating frame, using `Variable`'s protected `Creator` setter.
- **`AsParametersBindingFrame`** now re-homes every absorbed `HttpElementVariable` to itself, so any other consumer (the `LoadAsync` middleware `MethodCall`) orders after the single inline emission instead of re-scheduling the absorbed frame as a duplicate top-level frame.
- **`AsParamatersAttributeUsage`** reuses `chain.AsParametersVariable` when a second parameter of the same `[AsParameters]` type is matched (the variant-2 collision), instead of constructing a second binding frame with duplicate side effects.

## Both reported variants covered

- `LoadAsync([FromRoute(Name = "order-id")] long orderId, DbContext, CancellationToken)` — collides on the route-binding locals.
- `LoadAsync([AsParameters] UpsertLinesRequest request, DbContext, CancellationToken)` — additionally collides on the `request` container variable.

## Tests

`Bug_3374_asparameters_with_loadasync_route_binding` (Wolverine.Http.Tests) runs both variants end-to-end against a Marten-free EF Core host — endpoints live in the `Wolverine.Http.Tests.EfCoreOnly` assembly with a pinned `ApplicationAssembly`, per the GH-3353 precedent. The tests prove the host starts, the generated chains compile, and the loaded entity plus `[AsParameters]` values (route id + `[FromBody]` payload) round-trip correctly, plus a 404 guard.

- Wolverine.Http.Tests (net9.0): **821 passed, 0 failed, 10 skipped**
- Wolverine.Http.AspVersioning.Tests (net10.0): 66 passed
- Full `dotnet build wolverine.slnx -c Release`: 0 warnings, 0 errors

## Side note from the issue

Route parameters consumed only by `LoadAsync` missing from the OpenAPI operation (`"parameters": []`) is deliberately **not** fixed here — filed separately as #3380 (OpenAPI parameters derived from the handler signature rather than the route template + full binding chain, per the GH-3135 audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
