### PR TITLE
Server-side tenant id detection for Wolverine.Grpc (GH-3368)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -297,6 +297,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                                 {text: 'Error Handling', link: '/guide/grpc/errors'},
                                 {text: 'Streaming', link: '/guide/grpc/streaming'},
                                 {text: 'Typed gRPC Clients', link: '/guide/grpc/client'},
+                                {text: 'Multi-Tenancy', link: '/guide/grpc/multi-tenancy'},
                                 {text: 'Samples', link: '/guide/grpc/samples'}
                             ]
                         }

--- a/docs/guide/grpc/client.md
+++ b/docs/guide/grpc/client.md
@@ -106,15 +106,25 @@ builder.Services.AddWolverineGrpcClient<IPingService>(o =>
 });
 ```
 
-On the server side of a Wolverine→Wolverine hop, `WolverineGrpcServicePropagationInterceptor`
-(registered automatically by `AddWolverineGrpc()`) reads the `correlation-id` and `tenant-id`
-headers back off the inbound call and applies them to the ambient `IMessageContext` before the
-service method runs. Only those two identifiers round-trip this way — `parent-id` and
-`conversation-id` live on an `Envelope`, and there is no envelope yet at this point in the
-pipeline (`IMessageContext.Envelope` is null outside of message handling). Once the service
-method calls `Bus.InvokeAsync(...)`, Wolverine copies the now-set `CorrelationId`/`TenantId` onto
-the freshly created envelope automatically, and Marten/Polecat tenant-scoped session frames pick
-it up the same way they would for any other transport — no further wiring needed.
+On the server side of a Wolverine→Wolverine hop, propagation is fully **round-trip** — two
+complementary server-side mechanisms read the stamped headers back in:
+
+1. `WolverineGrpcServicePropagationInterceptor` (registered automatically by `AddWolverineGrpc()`)
+   reads the `correlation-id` and `tenant-id` headers off the inbound call and applies them to the
+   ambient `IMessageContext` before the service method runs. Only those two identifiers round-trip
+   this way — `parent-id` and `conversation-id` live on an `Envelope`, and there is no envelope yet
+   at this point in the pipeline (`IMessageContext.Envelope` is null outside of message handling).
+   Once the service method calls `Bus.InvokeAsync(...)`, Wolverine copies the now-set
+   `CorrelationId`/`TenantId` onto the freshly created envelope automatically, and Marten/Polecat
+   tenant-scoped session frames pick it up the same way they would for any other transport — no
+   further wiring needed.
+2. For the tenant id specifically, Wolverine-generated gRPC service wrappers additionally run
+   [server-side tenant id detection](./multi-tenancy) as part of the generated code. With no
+   configuration at all, the detection defaults to reading the same `tenant-id` header the client
+   interceptor stamps, assigning it to the scoped `IMessageBus.TenantId` and to the `tenantId`
+   code-generation variable that persistence middleware consumes — structurally, without relying
+   on the ambient context. Custom detection (other headers, claims, your own strategy) is
+   configured on `WolverineGrpcOptions.TenantId`.
 
 Cross-process parent/trace correlation for gRPC hops is handled separately by OpenTelemetry
 `Activity` propagation over HTTP/2 (W3C traceparent) — see [How gRPC Handlers Work](./handlers).
@@ -122,7 +132,10 @@ The `parent-id`/`conversation-id` headers still go out on the wire for diagnosti
 consumers, but nothing on the Wolverine side reads them back in.
 
 Server-side propagation can be disabled with `WolverineGrpcOptions.PropagateEnvelopeHeaders =
-false`, the counterpart to the client-side `PropagateEnvelopeHeaders` option above.
+false`, the counterpart to the client-side `PropagateEnvelopeHeaders` option above. Disabling it
+turns off both the server interceptor and the zero-config `tenant-id` detection default — though
+explicitly configured tenant detection strategies keep working (see
+[Multi-Tenancy and gRPC](./multi-tenancy)).
 
 ## `RpcException` → typed-exception translation
 

--- a/docs/guide/grpc/index.md
+++ b/docs/guide/grpc/index.md
@@ -37,6 +37,9 @@ building:
 - [Typed gRPC Clients](./client) — `AddWolverineGrpcClient<T>()`, the Wolverine-flavored wrapper over
   `Grpc.Net.ClientFactory` that adds envelope-header propagation and `RpcException` → typed-exception
   translation on the consuming side.
+- [Multi-Tenancy](./multi-tenancy) — server-side tenant id detection (metadata headers, claims, or
+  custom strategies) mirroring Wolverine.HTTP's `TenantId` API, including the zero-config
+  round-trip default for Wolverine-to-Wolverine hops.
 - [Samples](./samples) — runnable end-to-end samples with pointers to the equivalent official
   [grpc-dotnet examples](https://github.com/grpc/grpc-dotnet/tree/master/examples) for comparison.
 

--- a/docs/guide/grpc/multi-tenancy.md
+++ b/docs/guide/grpc/multi-tenancy.md
@@ -1,0 +1,157 @@
+# Multi-Tenancy and gRPC
+
+::: tip
+For a holistic overview of multi-tenancy across all of Wolverine, see the [Multi-Tenancy Tutorial](/tutorials/multi-tenancy).
+The equivalent feature for HTTP endpoints is described in [Multi-Tenancy and ASP.Net Core](/guide/http/multi-tenancy).
+:::
+
+::: info
+Server-side tenant id detection for Wolverine.Grpc was added for
+[GH-3368](https://github.com/JasperFx/wolverine/issues/3368). It mirrors the
+`ITenantDetectionPolicies` API that Wolverine.HTTP has had since 1.7.0.
+:::
+
+The first part of any multi-tenancy approach in gRPC services is detecting which tenant should be
+active for the current call. Wolverine.Grpc calls this "tenant id detection," and it works the same
+way as [Wolverine.HTTP's version](/guide/http/multi-tenancy): you configure one or more detection
+strategies, Wolverine weaves a detection step into the *generated* service wrapper for every
+Wolverine-managed gRPC service (proto-first, code-first, and hand-written delegation wrappers
+alike), and the detected tenant id:
+
+1. Is assigned to the scoped `IMessageBus.TenantId` **before** the RPC forwards to
+   `InvokeAsync`/`StreamAsync`, so the envelope — and any Marten/Polecat tenant-scoped session the
+   handler uses — carries the right tenant.
+2. Declares the same `tenantId` code-generation variable that Marten's and Polecat's
+   session-opening frames look for, so persistence middleware woven into the gRPC chain itself
+   gets the tenant structurally, without relying on the ambient `IMessageContext`.
+
+## Tenant Id Detection
+
+Configure detection on `WolverineGrpcOptions.TenantId` inside `AddWolverineGrpc()`:
+
+```csharp
+builder.Services.AddWolverineGrpc(grpc =>
+{
+    // The tenant detection is fall through, so the first strategy
+    // that finds anything wins!
+
+    // Use the value of a named request metadata header
+    // (matched case-insensitively)
+    grpc.TenantId.IsRequestHeaderValue("tenant-id");
+
+    // Detect the tenant id from an expected claim on the
+    // authenticated ClaimsPrincipal of the current call
+    grpc.TenantId.IsClaimTypeNamed("tenant-id");
+
+    // If the tenant id cannot be detected otherwise, fall back
+    // to a designated tenant id
+    grpc.TenantId.DefaultIs("default_tenant");
+});
+```
+
+The built-in strategies are:
+
+| Strategy                          | Reads from                                                                                    |
+|-----------------------------------|-----------------------------------------------------------------------------------------------|
+| `IsRequestHeaderValue(headerKey)` | Inbound request metadata (`ServerCallContext.RequestHeaders`), case-insensitive               |
+| `IsClaimTypeNamed(claimType)`     | The authenticated `ClaimsPrincipal` (`context.GetHttpContext().User`, where grpc-aspnetcore surfaces authentication results) |
+| `DefaultIs(tenantId)`             | Nothing — always returns the fallback value. Register it last.                                |
+
+There are no gRPC equivalents of HTTP's route-argument, query-string, or sub-domain strategies —
+those concepts don't exist on a gRPC call. Metadata headers and claims are the idiomatic carriers,
+and anything else can be plugged in with a custom strategy.
+
+## Zero-Config Default
+
+If you never configure `TenantId` at all and `WolverineGrpcOptions.PropagateEnvelopeHeaders`
+is `true` (its default), Wolverine automatically detects the tenant from the `tenant-id` request
+metadata header — the exact header that [`AddWolverineGrpcClient<T>()`](./client)'s propagation
+interceptor stamps on outgoing calls from `IMessageContext.TenantId`. In other words, a
+Wolverine-to-Wolverine gRPC hop round-trips the tenant id **with zero server configuration**:
+
+```
+caller handler (TenantId = "tenant1")
+  → Wolverine gRPC client stamps 'tenant-id: tenant1' metadata
+    → generated server wrapper detects it and sets bus.TenantId = "tenant1"
+      → server handler + tenant-scoped sessions run as "tenant1"
+```
+
+Explicitly configuring any `TenantId` strategy replaces the zero-config default (register
+`grpc.TenantId.IsRequestHeaderValue("tenant-id")` yourself if you want it *in addition to* your
+own strategies), and setting `PropagateEnvelopeHeaders = false` suppresses it entirely.
+
+Note that the zero-config default overlaps with the runtime
+[`WolverineGrpcServicePropagationInterceptor`](./client#envelope-header-propagation), which also
+copies the `tenant-id` header onto the scoped `IMessageContext`. The two are complementary: the
+interceptor covers *every* mapped gRPC service (including services Wolverine did not generate)
+at runtime, while the detection frame makes the tenant a structural part of the generated code —
+visible in `codegen preview`, available to persistence frames as the `tenantId` variable, and
+independent of the ambient message context.
+
+## Custom Tenant Detection
+
+For anything beyond headers and claims, implement `IGrpcTenantDetection`:
+
+```csharp
+public class MyCustomDetection : IGrpcTenantDetection
+{
+    // Return the tenant id, or null for "not found" so the
+    // next strategy gets a chance
+    public ValueTask<string?> DetectTenant(ServerCallContext context)
+    {
+        var value = context.RequestHeaders
+            .FirstOrDefault(e => e.Key == "x-account-key")?.Value;
+
+        return new ValueTask<string?>(value is null ? null : Lookup(value));
+    }
+}
+```
+
+and register it either as an instance or by type:
+
+```csharp
+builder.Services.AddWolverineGrpc(grpc =>
+{
+    // Direct instance
+    grpc.TenantId.DetectWith(new MyCustomDetection());
+
+    // Or by type — the instance is built from your application's
+    // IoC container during bootstrapping, with singleton scoping
+    grpc.TenantId.DetectWith<MyCustomDetection>();
+});
+```
+
+## Requiring a Tenant Id
+
+To make the tenant id mandatory, add `AssertExists()`:
+
+```csharp
+builder.Services.AddWolverineGrpc(grpc =>
+{
+    grpc.TenantId.IsRequestHeaderValue("tenant-id");
+    grpc.TenantId.AssertExists();
+});
+```
+
+When no strategy detects a tenant id, the generated service throws an `RpcException` with status
+`InvalidArgument` and the detail message
+`"No mandatory tenant id could be detected for this gRPC call"` before the call ever reaches a
+Wolverine handler. `InvalidArgument` is the [canonical gRPC mapping](https://google.aip.dev/193)
+of the **400 Bad Request** that Wolverine.HTTP's `AssertExists()` returns for the same condition —
+the caller sent a structurally incomplete request. If your security model treats a missing tenant
+as an authentication failure instead, skip `AssertExists()` and enforce the claim through ASP.NET
+Core authorization, which will surface as `Unauthenticated`/`PermissionDenied`.
+
+## Scope and Limitations
+
+- Detection is woven into Wolverine-*generated* service wrappers only: proto-first stubs,
+  code-first `[WolverineGrpcService]` contracts, and hand-written service classes that receive a
+  generated delegation wrapper. Services you map directly with `MapGrpcService<T>()` (without a
+  Wolverine wrapper) are still covered by the runtime propagation interceptor for the `tenant-id`
+  header, but do not run custom detection strategies — read the header yourself there.
+- For **code-first and hand-written** services, detection requires the RPC method to declare a
+  `CallContext` parameter — that's the only route to the underlying `ServerCallContext` and its
+  request metadata. Methods without one fall back to the runtime interceptor.
+- Code-first **server-streaming** methods (returning `IAsyncEnumerable<T>` directly) can't host
+  the async detection step; proto-first server-streaming and bidirectional methods (returning
+  `Task`) are fully covered.

--- a/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/policy_leak_tests.cs
+++ b/src/Wolverine.Grpc.Tests/GrpcMiddlewareScoping/policy_leak_tests.cs
@@ -89,13 +89,18 @@ public sealed class HandlerOnlyMiddleware
 /// </summary>
 public class wolverine_grpc_options_add_policy_tests
 {
+    // GH-3368: WolverineGrpcOptions now registers the built-in tenant id detection policy in its
+    // constructor (mirroring WolverineHttpOptions registering TenantIdDetection), so user-added
+    // policies land AFTER that built-in entry.
+
     [Fact]
     public void add_policy_generic_registers_instance_in_policies_list()
     {
         var opts = new WolverineGrpcOptions();
         opts.AddPolicy<RecordingGrpcChainPolicy>();
 
-        opts.Policies.ShouldHaveSingleItem().ShouldBeOfType<RecordingGrpcChainPolicy>();
+        opts.Policies.OfType<RecordingGrpcChainPolicy>().ShouldHaveSingleItem();
+        opts.Policies.Last().ShouldBeOfType<RecordingGrpcChainPolicy>();
     }
 
     [Fact]
@@ -105,7 +110,7 @@ public class wolverine_grpc_options_add_policy_tests
         var policy = new RecordingGrpcChainPolicy();
         opts.AddPolicy(policy);
 
-        opts.Policies.ShouldHaveSingleItem().ShouldBeSameAs(policy);
+        opts.Policies.OfType<RecordingGrpcChainPolicy>().ShouldHaveSingleItem().ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -124,9 +129,10 @@ public class wolverine_grpc_options_add_policy_tests
 
         opts.AddPolicy(first).AddPolicy(second);
 
-        opts.Policies.Count.ShouldBe(2);
-        opts.Policies[0].ShouldBeSameAs(first);
-        opts.Policies[1].ShouldBeSameAs(second);
+        var userPolicies = opts.Policies.OfType<RecordingGrpcChainPolicy>().ToArray();
+        userPolicies.Length.ShouldBe(2);
+        userPolicies[0].ShouldBeSameAs(first);
+        userPolicies[1].ShouldBeSameAs(second);
     }
 }
 

--- a/src/Wolverine.Grpc.Tests/MultiTenancy/TenantDetectionHost.cs
+++ b/src/Wolverine.Grpc.Tests/MultiTenancy/TenantDetectionHost.cs
@@ -1,0 +1,79 @@
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using ProtoBuf.Grpc.Client;
+using ProtoBuf.Grpc.Server;
+
+namespace Wolverine.Grpc.Tests.MultiTenancy;
+
+/// <summary>
+///     Boots a standalone in-process ASP.NET Core + Wolverine gRPC host for a single tenant
+///     detection configuration. Each GH-3368 test permutation needs its own
+///     <see cref="WolverineGrpcOptions"/> (tenant detection is baked into generated code at
+///     bootstrap), so this is a disposable per-configuration host rather than a shared fixture.
+/// </summary>
+public sealed class TenantDetectionHost : IAsyncDisposable
+{
+    private WebApplication? _app;
+
+    public GrpcChannel? Channel { get; private set; }
+
+    public IServiceProvider Services => _app?.Services
+        ?? throw new InvalidOperationException("Host has not been started yet.");
+
+    public static async Task<TenantDetectionHost> StartAsync(
+        Action<WolverineGrpcOptions>? configureGrpc = null,
+        Action<WebApplication>? configureApp = null)
+    {
+        var host = new TenantDetectionHost();
+
+        var builder = WebApplication.CreateBuilder([]);
+        builder.WebHost.UseTestServer();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.ApplicationAssembly = typeof(TenantDetectionHost).Assembly;
+            opts.Discovery.DisableConventionalDiscovery();
+            opts.Discovery.IncludeType(typeof(TenantEchoHandler));
+            // For the hand-written-flavor test: PropagationEchoGrpcService delegates to the bus,
+            // whose handler must be discoverable in this host too.
+            opts.Discovery.IncludeType(typeof(ServerPropagation.PropagationEchoHandler));
+        });
+
+        builder.Services.AddCodeFirstGrpc();
+        builder.Services.AddWolverineGrpc(configureGrpc);
+
+        host._app = builder.Build();
+
+        // e.g. a fake-authentication middleware stamping HttpContext.User for claim detection —
+        // must run before routing/gRPC dispatch.
+        configureApp?.Invoke(host._app);
+
+        host._app.UseRouting();
+        host._app.MapWolverineGrpcServices();
+
+        await host._app.StartAsync();
+
+        var handler = host._app.GetTestServer().CreateHandler();
+        host.Channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+        {
+            HttpHandler = handler
+        });
+
+        return host;
+    }
+
+    public TService CreateClient<TService>() where TService : class
+        => Channel!.CreateGrpcService<TService>();
+
+    public async ValueTask DisposeAsync()
+    {
+        Channel?.Dispose();
+        if (_app != null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+}

--- a/src/Wolverine.Grpc.Tests/MultiTenancy/TenantEchoContracts.cs
+++ b/src/Wolverine.Grpc.Tests/MultiTenancy/TenantEchoContracts.cs
@@ -1,0 +1,64 @@
+using System.ServiceModel;
+using Grpc.Core;
+using ProtoBuf;
+using ProtoBuf.Grpc;
+using Wolverine.Grpc.MultiTenancy;
+
+namespace Wolverine.Grpc.Tests.MultiTenancy;
+
+/// <summary>
+///     Code-first gRPC contract marked for Wolverine code generation
+///     (<see cref="WolverineGrpcServiceAttribute"/> on the interface — the
+///     <see cref="CodeFirstGrpcServiceChain"/> path). The generated implementation is where the
+///     GH-3368 tenant detection frame is woven, so calls through this service prove the
+///     codegen-level detection end-to-end: strategy output → <c>tenantId</c> codegen variable →
+///     <c>bus.TenantId</c> → envelope → handler's <see cref="IMessageContext.TenantId"/>.
+/// </summary>
+[ServiceContract]
+[WolverineGrpcService]
+public interface ITenantEchoService
+{
+    Task<TenantEchoReply> Echo(TenantEchoRequest request, CallContext context = default);
+}
+
+[ProtoContract]
+public class TenantEchoRequest
+{
+}
+
+[ProtoContract]
+public class TenantEchoReply
+{
+    [ProtoMember(1)]
+    public string? TenantId { get; set; }
+}
+
+/// <summary>
+///     Echoes the tenant id the Wolverine handler actually observed — the observable end of the
+///     detection pipeline.
+/// </summary>
+public static class TenantEchoHandler
+{
+    public static TenantEchoReply Handle(TenantEchoRequest request, IMessageContext context)
+    {
+        return new TenantEchoReply { TenantId = context.TenantId };
+    }
+}
+
+/// <summary>
+///     Custom strategy for the <c>DetectWith&lt;T&gt;()</c> tests — reads a bespoke metadata
+///     header no built-in strategy knows about, proving user-supplied detection logic runs
+///     inside the generated service wrapper.
+/// </summary>
+public class CustomHeaderTenantDetection : IGrpcTenantDetection
+{
+    public const string HeaderName = "x-custom-tenant-source";
+
+    public ValueTask<string?> DetectTenant(ServerCallContext context)
+    {
+        var entry = context.RequestHeaders.FirstOrDefault(e =>
+            !e.IsBinary && string.Equals(e.Key, HeaderName, StringComparison.OrdinalIgnoreCase));
+
+        return new ValueTask<string?>(entry?.Value is { Length: > 0 } value ? $"custom-{value}" : null);
+    }
+}

--- a/src/Wolverine.Grpc.Tests/MultiTenancy/tenant_detection_codegen_tests.cs
+++ b/src/Wolverine.Grpc.Tests/MultiTenancy/tenant_detection_codegen_tests.cs
@@ -1,0 +1,129 @@
+using Grpc.Core;
+using Microsoft.Extensions.DependencyInjection;
+using ProtoBuf.Grpc;
+using Shouldly;
+using Wolverine.Grpc.Tests.ServerPropagation;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.MultiTenancy;
+
+/// <summary>
+///     Structural tests for GH-3368: proves the tenant detection frame lands in the generated
+///     source of all three gRPC chain flavors, and that the zero-config default is applied (or
+///     suppressed) exactly as documented. These assertions are on the generated code itself, so
+///     they cannot be satisfied by the runtime propagation interceptor — which is the whole point
+///     of the codegen-level detection.
+/// </summary>
+[Collection("grpc-tenant-detection")]
+public class tenant_detection_codegen_tests
+{
+    [Fact]
+    public async Task zero_config_default_weaves_detection_into_all_three_chain_flavors()
+    {
+        // The test assembly conveniently contains all three flavors: proto-first stubs
+        // (GreeterMiddlewareTestStub, ValidateGreeterStub), code-first contracts
+        // (ITenantEchoService, ICodeFirstTestService...), and hand-written service classes
+        // (PropagationEchoGrpcService).
+        await using var host = await TenantDetectionHost.StartAsync();
+
+        var graph = host.Services.GetRequiredService<GrpcGraph>();
+        var options = host.Services.GetRequiredService<WolverineGrpcOptions>();
+
+        options.TenantIdDetection.ZeroConfigDefaultApplied.ShouldBeTrue();
+
+        graph.Chains.ShouldNotBeEmpty();
+        foreach (var chain in graph.Chains)
+        {
+            chain.SourceCode.ShouldNotBeNull();
+            chain.SourceCode!.ShouldContain("TryDetectTenantIdAsync");
+            chain.SourceCode.ShouldContain("var tenantId = await");
+        }
+
+        graph.CodeFirstChains.ShouldNotBeEmpty();
+        var echoChain = graph.CodeFirstChains.Single(c => c.ServiceContractType == typeof(ITenantEchoService));
+        echoChain.SourceCode.ShouldNotBeNull();
+        echoChain.SourceCode!.ShouldContain("TryDetectTenantIdAsync");
+        // The detected value must land on the wrapper's scoped bus so InvokeAsync carries it
+        // onto the envelope — structurally, without relying on the ambient IMessageContext.
+        echoChain.SourceCode.ShouldContain(".TenantId = tenantId");
+
+        graph.HandWrittenChains.ShouldNotBeEmpty();
+        var handWritten = graph.HandWrittenChains.Single(c => c.ServiceClassType == typeof(PropagationEchoGrpcService));
+        handWritten.SourceCode.ShouldNotBeNull();
+        handWritten.SourceCode!.ShouldContain("TryDetectTenantIdAsync");
+        // Hand-written delegation wrappers have no bus field — the tenant is applied to the
+        // request-scoped IMessageContext instead.
+        handWritten.SourceCode.ShouldContain("TryApplyToAmbientContext");
+    }
+
+    [Fact]
+    public async Task detection_declares_the_persistence_tenant_id_codegen_variable()
+    {
+        await using var host = await TenantDetectionHost.StartAsync();
+
+        var graph = host.Services.GetRequiredService<GrpcGraph>();
+        var echoChain = graph.CodeFirstChains.Single(c => c.ServiceContractType == typeof(ITenantEchoService));
+
+        // PersistenceConstants.TenantIdVariableName is 'tenantId' — the exact variable name that
+        // Marten's OpenMartenSessionFrame and Polecat's OpenPolecatSessionFrame look up via
+        // TryFindVariableByName to open tenant-scoped sessions.
+        echoChain.SourceCode!.ShouldContain(
+            $"var {Wolverine.Persistence.PersistenceConstants.TenantIdVariableName} = await");
+    }
+
+    [Fact]
+    public async Task disabling_envelope_header_propagation_suppresses_the_zero_config_default()
+    {
+        await using var host = await TenantDetectionHost.StartAsync(o => o.PropagateEnvelopeHeaders = false);
+
+        var graph = host.Services.GetRequiredService<GrpcGraph>();
+        var options = host.Services.GetRequiredService<WolverineGrpcOptions>();
+
+        options.TenantIdDetection.ZeroConfigDefaultApplied.ShouldBeFalse();
+        options.TenantIdDetection.Strategies.ShouldBeEmpty();
+
+        var echoChain = graph.CodeFirstChains.Single(c => c.ServiceContractType == typeof(ITenantEchoService));
+        echoChain.SourceCode!.ShouldNotContain("TryDetectTenantIdAsync");
+    }
+
+    [Fact]
+    public async Task explicit_detection_works_even_with_the_propagation_interceptor_disabled()
+    {
+        // Proves the codegen path is fully independent of the runtime interceptor: with
+        // PropagateEnvelopeHeaders off, only the generated detection frame can move a header
+        // value onto the handler's IMessageContext.
+        await using var host = await TenantDetectionHost.StartAsync(o =>
+        {
+            o.PropagateEnvelopeHeaders = false;
+            o.TenantId.IsRequestHeaderValue("x-tenant");
+        });
+
+        var client = host.CreateClient<ITenantEchoService>();
+
+        var reply = await client.Echo(new TenantEchoRequest(),
+            new CallContext(new CallOptions(headers: new Metadata { { "x-tenant", "structural" } })));
+
+        reply.TenantId.ShouldBe("structural");
+    }
+
+    [Fact]
+    public async Task hand_written_service_detection_reaches_the_ambient_context_end_to_end()
+    {
+        // PropagationEchoGrpcService is the hand-written flavor (concrete class + [ServiceContract]
+        // interface without [WolverineGrpcService]); the generated delegation wrapper applies the
+        // detected tenant to the request-scoped IMessageContext, which the user's service (and the
+        // bus it resolves) observes. 'x-tenant' is unknown to the propagation interceptor, so only
+        // the woven detection frame can make this pass.
+        await using var host = await TenantDetectionHost.StartAsync(o =>
+        {
+            o.TenantId.IsRequestHeaderValue("x-tenant");
+        });
+
+        var client = host.CreateClient<IPropagationEchoService>();
+
+        var reply = await client.Echo(new PropagationEchoRequest(),
+            new CallContext(new CallOptions(headers: new Metadata { { "x-tenant", "hand-written-tenant" } })));
+
+        reply.TenantId.ShouldBe("hand-written-tenant");
+    }
+}

--- a/src/Wolverine.Grpc.Tests/MultiTenancy/tenant_detection_tests.cs
+++ b/src/Wolverine.Grpc.Tests/MultiTenancy/tenant_detection_tests.cs
@@ -1,0 +1,223 @@
+using System.Security.Claims;
+using Grpc.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using ProtoBuf.Grpc;
+using Shouldly;
+using Wolverine.Grpc.MultiTenancy;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.MultiTenancy;
+
+/// <summary>
+///     End-to-end tests for GH-3368 server-side tenant id detection: each test boots a host with
+///     one detection configuration and proves the tenant id detected by the generated service
+///     wrapper reaches the Wolverine handler's <see cref="IMessageContext.TenantId"/>. All tests
+///     go through a custom header/claim/strategy that the runtime propagation interceptor does
+///     NOT read (it only knows 'tenant-id'), so a passing test can only be explained by the
+///     codegen-level detection frame.
+/// </summary>
+[Collection("grpc-tenant-detection")]
+public class tenant_detection_tests
+{
+    private static CallContext headers(params (string Key, string Value)[] entries)
+    {
+        var metadata = new Metadata();
+        foreach (var (key, value) in entries)
+        {
+            metadata.Add(key, value);
+        }
+
+        return new CallContext(new CallOptions(headers: metadata));
+    }
+
+    [Fact]
+    public async Task detects_tenant_id_from_a_custom_request_header()
+    {
+        await using var host = await TenantDetectionHost.StartAsync(o =>
+        {
+            o.TenantId.IsRequestHeaderValue("x-tenant");
+        });
+
+        var client = host.CreateClient<ITenantEchoService>();
+
+        var reply = await client.Echo(new TenantEchoRequest(), headers(("x-tenant", "green")));
+
+        reply.TenantId.ShouldBe("green");
+    }
+
+    [Fact]
+    public async Task header_detection_is_case_insensitive_on_the_configured_name()
+    {
+        await using var host = await TenantDetectionHost.StartAsync(o =>
+        {
+            // Configured with casing that never matches the lowercased wire form directly
+            o.TenantId.IsRequestHeaderValue("X-Tenant");
+        });
+
+        var client = host.CreateClient<ITenantEchoService>();
+
+        var reply = await client.Echo(new TenantEchoRequest(), headers(("x-tenant", "blue")));
+
+        reply.TenantId.ShouldBe("blue");
+    }
+
+    [Fact]
+    public async Task detects_tenant_id_from_a_claim_on_the_authenticated_principal()
+    {
+        await using var host = await TenantDetectionHost.StartAsync(
+            o => o.TenantId.IsClaimTypeNamed("tenant-claim"),
+            app =>
+            {
+                // Fake authentication: stamp a principal carrying the tenant claim onto every call
+                app.Use(async (HttpContext ctx, RequestDelegate next) =>
+                {
+                    ctx.User = new ClaimsPrincipal(new ClaimsIdentity(
+                        [new Claim("tenant-claim", "claim-tenant")], "test-auth"));
+                    await next(ctx);
+                });
+            });
+
+        var client = host.CreateClient<ITenantEchoService>();
+
+        var reply = await client.Echo(new TenantEchoRequest());
+
+        reply.TenantId.ShouldBe("claim-tenant");
+    }
+
+    [Fact]
+    public async Task detects_tenant_id_with_a_custom_strategy_built_from_the_container()
+    {
+        await using var host = await TenantDetectionHost.StartAsync(o =>
+        {
+            o.TenantId.DetectWith<CustomHeaderTenantDetection>();
+        });
+
+        var client = host.CreateClient<ITenantEchoService>();
+
+        var reply = await client.Echo(new TenantEchoRequest(),
+            headers((CustomHeaderTenantDetection.HeaderName, "special")));
+
+        reply.TenantId.ShouldBe("custom-special");
+    }
+
+    [Fact]
+    public async Task strategies_run_in_order_and_first_non_empty_wins()
+    {
+        await using var host = await TenantDetectionHost.StartAsync(o =>
+        {
+            o.TenantId.IsRequestHeaderValue("x-primary-tenant");
+            o.TenantId.IsRequestHeaderValue("x-secondary-tenant");
+        });
+
+        var client = host.CreateClient<ITenantEchoService>();
+
+        var both = await client.Echo(new TenantEchoRequest(),
+            headers(("x-primary-tenant", "first"), ("x-secondary-tenant", "second")));
+        both.TenantId.ShouldBe("first");
+
+        var secondaryOnly = await client.Echo(new TenantEchoRequest(),
+            headers(("x-secondary-tenant", "second")));
+        secondaryOnly.TenantId.ShouldBe("second");
+    }
+
+    [Fact]
+    public async Task default_is_supplies_a_fallback_tenant_when_nothing_was_detected()
+    {
+        await using var host = await TenantDetectionHost.StartAsync(o =>
+        {
+            o.TenantId.IsRequestHeaderValue("x-tenant");
+            o.TenantId.DefaultIs("fallback-tenant");
+        });
+
+        var client = host.CreateClient<ITenantEchoService>();
+
+        var withHeader = await client.Echo(new TenantEchoRequest(), headers(("x-tenant", "explicit")));
+        withHeader.TenantId.ShouldBe("explicit");
+
+        var withoutHeader = await client.Echo(new TenantEchoRequest());
+        withoutHeader.TenantId.ShouldBe("fallback-tenant");
+    }
+
+    [Fact]
+    public async Task assert_exists_rejects_calls_without_a_detectable_tenant_id()
+    {
+        await using var host = await TenantDetectionHost.StartAsync(o =>
+        {
+            o.TenantId.IsRequestHeaderValue("x-tenant");
+            o.TenantId.AssertExists();
+        });
+
+        var client = host.CreateClient<ITenantEchoService>();
+
+        // The gRPC mapping of Wolverine.Http's 400 Bad Request for a missing mandatory tenant id
+        var ex = await Should.ThrowAsync<RpcException>(async () =>
+            await client.Echo(new TenantEchoRequest()));
+
+        ex.StatusCode.ShouldBe(StatusCode.InvalidArgument);
+        ex.Status.Detail.ShouldBe(GrpcTenantDetection.NoMandatoryTenantIdCouldBeDetectedForThisGrpcCall);
+    }
+
+    [Fact]
+    public async Task assert_exists_still_lets_tenanted_calls_through()
+    {
+        await using var host = await TenantDetectionHost.StartAsync(o =>
+        {
+            o.TenantId.IsRequestHeaderValue("x-tenant");
+            o.TenantId.AssertExists();
+        });
+
+        var client = host.CreateClient<ITenantEchoService>();
+
+        var reply = await client.Echo(new TenantEchoRequest(), headers(("x-tenant", "allowed")));
+
+        reply.TenantId.ShouldBe("allowed");
+    }
+
+    [Fact]
+    public async Task missing_tenant_without_assert_exists_flows_through_untenanted()
+    {
+        await using var host = await TenantDetectionHost.StartAsync(o =>
+        {
+            o.TenantId.IsRequestHeaderValue("x-tenant");
+        });
+
+        var client = host.CreateClient<ITenantEchoService>();
+
+        var reply = await client.Echo(new TenantEchoRequest());
+
+        // No RpcException, and no phantom tenant shows up — the call proceeds untenanted.
+        // (Not asserted as null: an untenanted IMessageContext may surface Wolverine's internal
+        // default-tenant sentinel rather than null, which detection neither causes nor controls.)
+        reply.TenantId.ShouldNotBe("green");
+    }
+
+    [Fact]
+    public async Task zero_config_default_detects_the_tenant_id_header_stamped_by_wolverine_clients()
+    {
+        // No o.TenantId configuration at all — PropagateEnvelopeHeaders defaults to true, so the
+        // server should detect the same 'tenant-id' metadata header the Wolverine gRPC client
+        // propagation interceptor stamps on outgoing calls.
+        await using var host = await TenantDetectionHost.StartAsync();
+
+        var client = host.CreateClient<ITenantEchoService>();
+
+        var reply = await client.Echo(new TenantEchoRequest(), headers(("tenant-id", "hop-tenant")));
+
+        reply.TenantId.ShouldBe("hop-tenant");
+    }
+
+    [Fact]
+    public async Task explicit_configuration_replaces_the_zero_config_default()
+    {
+        await using var host = await TenantDetectionHost.StartAsync(o =>
+        {
+            o.TenantId.IsRequestHeaderValue("x-tenant");
+        });
+
+        var options = host.Services.GetService(typeof(WolverineGrpcOptions)) as WolverineGrpcOptions;
+        options!.TenantIdDetection.ZeroConfigDefaultApplied.ShouldBeFalse();
+        options.TenantIdDetection.Strategies.ShouldHaveSingleItem()
+            .ShouldBeOfType<MetadataHeaderDetection>();
+    }
+}

--- a/src/Wolverine.Grpc/CodeFirstGrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/CodeFirstGrpcServiceChain.cs
@@ -8,6 +8,7 @@ using JasperFx.Core.Reflection;
 using ProtoBuf.Grpc;
 using Wolverine.Attributes;
 using Wolverine.Configuration;
+using Wolverine.Grpc.MultiTenancy;
 using Wolverine.Middleware;
 using Wolverine.Persistence;
 
@@ -122,6 +123,17 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
     public override string Description { get; }
     public override MiddlewareScoping Scoping => MiddlewareScoping.Grpc;
     public override IdempotencyStyle Idempotency { get; set; } = IdempotencyStyle.None;
+
+    /// <summary>
+    ///     Set by <see cref="GrpcTenantIdDetection"/> (the built-in <see cref="IGrpcChainPolicy"/>
+    ///     behind <see cref="WolverineGrpcOptions.TenantId"/>) when tenant detection strategies are
+    ///     active. Detection is woven into unary methods that declare a <see cref="CallContext"/>
+    ///     parameter — that is the only route to the underlying <see cref="ServerCallContext"/>
+    ///     (and its request metadata) in the code-first shape. Server-streaming methods return
+    ///     <see cref="IAsyncEnumerable{T}"/> directly and cannot host the async detection call.
+    /// </summary>
+    internal GrpcTenantIdDetection? TenantDetection { get; set; }
+
     public override Type? InputType() => null;
     public override bool ShouldFlushOutgoingMessages() => false;
     public override bool RequiresOutbox() => false;
@@ -165,6 +177,8 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
         var busField = new InjectedField(typeof(IMessageBus), "bus");
         _generatedType.AllInjectedFields.Add(busField);
 
+        InjectedField? tenantOptionsField = null;
+
         foreach (var rpc in SupportedMethods)
         {
             var generatedMethod = _generatedType.MethodFor(rpc.Method.Name);
@@ -178,6 +192,25 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
 
             if (contextArg != null)
                 generatedMethod.Sources.Add(new CallContextCancellationTokenSource(contextArg));
+
+            // Tenant detection first. Only unary methods with a CallContext parameter qualify:
+            // the CallContext is the sole route to ServerCallContext/request metadata here, and a
+            // server-streaming method returns IAsyncEnumerable<T> directly so its body cannot
+            // await the detection call.
+            var detectTenantId = TenantDetection != null
+                                 && rpc.Kind == CodeFirstMethodKind.Unary
+                                 && contextArg != null;
+
+            if (detectTenantId)
+            {
+                tenantOptionsField ??= addTenantOptionsField(_generatedType);
+
+                // Detection awaits, so the method body must be async even when the forward
+                // frame would otherwise return the bus task directly.
+                generatedMethod.AsyncMode = AsyncMode.AsyncTask;
+                generatedMethod.Frames.Add(new DetectGrpcTenantIdFrame(TenantDetection!, tenantOptionsField,
+                    $"{contextArg!.Usage}.{nameof(CallContext.ServerCallContext)}", busField, null));
+            }
 
             // Global middleware befores (from grpc.AddMiddleware<T>()) — cloned per method
             // because Frame instances hold per-method mutable state (Next pointer, variable bindings).
@@ -223,7 +256,12 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
             switch (rpc.Kind)
             {
                 case CodeFirstMethodKind.Unary:
-                    generatedMethod.Frames.Add(new ForwardCodeFirstUnaryFrame(rpc.Method, busField));
+                    generatedMethod.Frames.Add(new ForwardCodeFirstUnaryFrame(rpc.Method, busField)
+                    {
+                        // When tenant detection made the method async, 'return _bus.InvokeAsync(...)'
+                        // would no longer compile — the forward frame must await instead.
+                        ForceAwait = detectTenantId
+                    });
                     break;
 
                 case CodeFirstMethodKind.ServerStreaming:
@@ -261,6 +299,18 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
                                 ?? assembly.GetTypes().FirstOrDefault(x => x.Name == TypeName);
 
         return _generatedRuntimeType != null;
+    }
+
+    /// <summary>
+    ///     Adds the <see cref="WolverineGrpcOptions"/> constructor-injected field that the tenant
+    ///     detection frame calls <c>TryDetectTenantIdAsync</c> on. Created lazily — only when at
+    ///     least one RPC method actually receives a detection frame.
+    /// </summary>
+    private static InjectedField addTenantOptionsField(GeneratedType generatedType)
+    {
+        var field = new InjectedField(typeof(WolverineGrpcOptions), "grpcOptions");
+        generatedType.AllInjectedFields.Add(field);
+        return field;
     }
 
     /// <summary>
@@ -477,6 +527,13 @@ internal sealed class ForwardCodeFirstUnaryFrame : SyncFrame
         _busField = busField;
     }
 
+    /// <summary>
+    ///     Set when an earlier frame (tenant detection) forced the generated method into
+    ///     <see cref="AsyncMode.AsyncTask"/> — the frame must then await the bus call rather than
+    ///     returning the task directly, even when it is the last frame in the method.
+    /// </summary>
+    public bool ForceAwait { get; init; }
+
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
         _cancellationToken = chain.FindVariable(typeof(CancellationToken));
@@ -492,15 +549,16 @@ internal sealed class ForwardCodeFirstUnaryFrame : SyncFrame
         var busInvoke =
             $"{_busField.Usage}.{nameof(IMessageBus.InvokeAsync)}<{responseType.FullNameInCode()}>({requestName}, {_cancellationToken!.Usage})";
 
-        if (Next == null)
+        if (Next == null && !ForceAwait)
         {
             writer.Write($"return {busInvoke};");
         }
         else
         {
-            // After-frames are present — await so they can run before the response is returned.
+            // After-frames are present (or an earlier async frame forced AsyncMode) —
+            // await so the method body stays valid and after-frames can run before the return.
             writer.Write($"var result = await {busInvoke};");
-            Next.GenerateCode(method, writer);
+            Next?.GenerateCode(method, writer);
             writer.Write("return result;");
         }
     }

--- a/src/Wolverine.Grpc/GrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/GrpcServiceChain.cs
@@ -7,6 +7,7 @@ using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
 using Wolverine.Attributes;
 using Wolverine.Configuration;
+using Wolverine.Grpc.MultiTenancy;
 using Wolverine.Middleware;
 using Wolverine.Persistence;
 
@@ -144,6 +145,14 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
     public override IdempotencyStyle Idempotency { get; set; } = IdempotencyStyle.None;
 
     /// <summary>
+    ///     Set by <see cref="GrpcTenantIdDetection"/> (the built-in <see cref="IGrpcChainPolicy"/>
+    ///     behind <see cref="WolverineGrpcOptions.TenantId"/>) when tenant detection strategies are
+    ///     active, so <c>AssembleTypes</c> weaves a <see cref="DetectGrpcTenantIdFrame"/> at the
+    ///     top of every generated RPC method.
+    /// </summary>
+    internal GrpcTenantIdDetection? TenantDetection { get; set; }
+
+    /// <summary>
     ///     Applies a disambiguated <see cref="TypeName"/> on a chain whose default name collides
     ///     with another discovered chain. Called exclusively from
     ///     <see cref="GrpcGraph.DisambiguateCollidingTypeNames"/>.
@@ -213,12 +222,34 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
         var busField = new InjectedField(typeof(IMessageBus), "bus");
         _generatedType.AllInjectedFields.Add(busField);
 
+        InjectedField? tenantOptionsField = null;
+        if (TenantDetection != null)
+        {
+            tenantOptionsField = new InjectedField(typeof(WolverineGrpcOptions), "grpcOptions");
+            _generatedType.AllInjectedFields.Add(tenantOptionsField);
+        }
+
         var befores = DiscoveredBefores;
         var afters = DiscoveredAfters;
 
         foreach (var rpc in SupportedMethods)
         {
             var generatedMethod = _generatedType.MethodFor(rpc.Method.Name);
+
+            // Tenant detection runs first — every proto-first RPC shape ends with a
+            // ServerCallContext parameter, so detection applies to all of them (including bidi,
+            // which otherwise skips per-call middleware: detection needs no TRequest in scope).
+            if (tenantOptionsField != null)
+            {
+                var rpcParameters = rpc.Method.GetParameters();
+                var contextName = ForwardUnaryToMessageBusFrame.ParameterName(rpcParameters, rpcParameters.Length - 1);
+
+                // The detection frame awaits, so the method body must be async even for the
+                // unary shape that would otherwise return the bus task directly.
+                generatedMethod.AsyncMode = AsyncMode.AsyncTask;
+                generatedMethod.Frames.Add(new DetectGrpcTenantIdFrame(TenantDetection!, tenantOptionsField,
+                    contextName, busField, null));
+            }
 
             // Before-frames (including Validate short-circuit) require a concrete TRequest
             // in scope when the method begins. Bidi methods start with an IAsyncStreamReader<T>
@@ -246,7 +277,12 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
                 case GrpcMethodKind.Unary:
                     if (afters.Count > 0 || Postprocessors.Count > 0)
                         generatedMethod.AsyncMode = AsyncMode.AsyncTask;
-                    generatedMethod.Frames.Add(new ForwardUnaryToMessageBusFrame(rpc.Method, busField));
+                    generatedMethod.Frames.Add(new ForwardUnaryToMessageBusFrame(rpc.Method, busField)
+                    {
+                        // When tenant detection made the method async, 'return _bus.InvokeAsync(...)'
+                        // would no longer compile — the forward frame must await instead.
+                        ForceAwait = tenantOptionsField != null
+                    });
                     break;
 
                 case GrpcMethodKind.ServerStreaming:
@@ -504,6 +540,13 @@ internal sealed class ForwardUnaryToMessageBusFrame : SyncFrame
         _busField = busField;
     }
 
+    /// <summary>
+    ///     Set when an earlier frame (tenant detection) forced the generated method into
+    ///     <see cref="AsyncMode.AsyncTask"/> — the frame must then await the bus call rather than
+    ///     returning the task directly, even when it is the last frame in the method.
+    /// </summary>
+    public bool ForceAwait { get; init; }
+
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
         var parameters = _rpc.GetParameters();
@@ -514,15 +557,16 @@ internal sealed class ForwardUnaryToMessageBusFrame : SyncFrame
         var busInvoke =
             $"{_busField.Usage}.{nameof(IMessageBus.InvokeAsync)}<{responseType.FullNameInCode()}>({requestName}, {cancellation})";
 
-        if (Next == null)
+        if (Next == null && !ForceAwait)
         {
             writer.Write($"return {busInvoke};");
         }
         else
         {
-            // After-frames are present — await so they can run before the return.
+            // After-frames are present (or an earlier async frame forced AsyncMode) —
+            // await so the method body stays valid and after-frames can run before the return.
             writer.Write($"var result = await {busInvoke};");
-            Next.GenerateCode(method, writer);
+            Next?.GenerateCode(method, writer);
             writer.Write("return result;");
         }
     }

--- a/src/Wolverine.Grpc/HandWrittenGrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/HandWrittenGrpcServiceChain.cs
@@ -9,6 +9,7 @@ using JasperFx.Core.Reflection;
 using ProtoBuf.Grpc;
 using Wolverine.Attributes;
 using Wolverine.Configuration;
+using Wolverine.Grpc.MultiTenancy;
 using Wolverine.Middleware;
 using Wolverine.Persistence;
 
@@ -70,6 +71,18 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
     public override string Description { get; }
     public override MiddlewareScoping Scoping => MiddlewareScoping.Grpc;
     public override IdempotencyStyle Idempotency { get; set; } = IdempotencyStyle.None;
+
+    /// <summary>
+    ///     Set by <see cref="GrpcTenantIdDetection"/> (the built-in <see cref="IGrpcChainPolicy"/>
+    ///     behind <see cref="WolverineGrpcOptions.TenantId"/>) when tenant detection strategies are
+    ///     active. Detection is woven into unary methods that declare a <see cref="CallContext"/>
+    ///     parameter. Because the delegation wrapper has no <see cref="IMessageBus"/> field of its
+    ///     own, the detected tenant is applied to the request-scoped <see cref="IMessageContext"/>
+    ///     via the wrapper's <see cref="IServiceProvider"/> so the user's inner service (and any
+    ///     bus it resolves) observes it.
+    /// </summary>
+    internal GrpcTenantIdDetection? TenantDetection { get; set; }
+
     public override Type? InputType() => null;
     public override bool ShouldFlushOutgoingMessages() => false;
     public override bool RequiresOutbox() => false;
@@ -142,12 +155,39 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
         var spField = new InjectedField(typeof(IServiceProvider), "serviceProvider");
         _generatedType.AllInjectedFields.Add(spField);
 
+        InjectedField? tenantOptionsField = null;
+
         var befores = DiscoveredBefores;
         var afters = DiscoveredAfters;
 
         foreach (var rpc in SupportedMethods)
         {
             var generatedMethod = _generatedType.MethodFor(rpc.Method.Name);
+
+            // Tenant detection first. Only unary methods with a CallContext parameter qualify:
+            // the CallContext is the sole route to ServerCallContext/request metadata in the
+            // code-first shape, and streaming/bidi methods return IAsyncEnumerable<T> directly so
+            // their bodies cannot await the detection call.
+            var contextParam = rpc.Method.GetParameters()
+                .FirstOrDefault(p => p.ParameterType == typeof(CallContext));
+            var detectTenantId = TenantDetection != null
+                                 && rpc.Kind == HandWrittenMethodKind.Unary
+                                 && contextParam != null;
+
+            if (detectTenantId)
+            {
+                if (tenantOptionsField == null)
+                {
+                    tenantOptionsField = new InjectedField(typeof(WolverineGrpcOptions), "grpcOptions");
+                    _generatedType.AllInjectedFields.Add(tenantOptionsField);
+                }
+
+                // Detection awaits, so the method body must be async — the delegation frame is
+                // told to await the inner call rather than returning its task directly.
+                generatedMethod.AsyncMode = AsyncMode.AsyncTask;
+                generatedMethod.Frames.Add(new DetectGrpcTenantIdFrame(TenantDetection!, tenantOptionsField,
+                    $"{contextParam!.Name}.{nameof(CallContext.ServerCallContext)}", null, spField));
+            }
 
             // Before-frames require a concrete TRequest in scope. Skip for bidi methods where
             // the first parameter is IAsyncEnumerable<T> rather than a single message instance.
@@ -178,7 +218,10 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
             if (hasAfters)
                 generatedMethod.AsyncMode = AsyncMode.AsyncTask;
 
-            generatedMethod.Frames.Add(new DelegateToInnerServiceFrame(rpc.Method, spField, ServiceClassType, hasAfters));
+            // Tenant detection forces the method async, so the delegation frame must await the
+            // inner call even when there are no after-frames.
+            generatedMethod.Frames.Add(new DelegateToInnerServiceFrame(rpc.Method, spField, ServiceClassType,
+                hasAfters || detectTenantId));
 
             if (hasAfters)
             {

--- a/src/Wolverine.Grpc/MultiTenancy/ClaimsPrincipalDetection.cs
+++ b/src/Wolverine.Grpc/MultiTenancy/ClaimsPrincipalDetection.cs
@@ -1,0 +1,37 @@
+using Grpc.Core;
+using Microsoft.AspNetCore.Http;
+
+namespace Wolverine.Grpc.MultiTenancy;
+
+/// <summary>
+///     Detects the tenant id from the authenticated <c>ClaimsPrincipal</c> of the current call.
+///     grpc-aspnetcore surfaces authentication results on the underlying ASP.NET Core
+///     <see cref="HttpContext.User"/> (the <c>ServerCallContext.AuthContext</c> only carries peer
+///     certificate properties), so this reads <c>context.GetHttpContext().User</c> — the same
+///     source Wolverine.Http's claim detection uses.
+/// </summary>
+internal class ClaimsPrincipalDetection : IGrpcTenantDetection, ISynchronousGrpcTenantDetection
+{
+    private readonly string _claimType;
+
+    public ClaimsPrincipalDetection(string claimType)
+    {
+        _claimType = claimType;
+    }
+
+    public ValueTask<string?> DetectTenant(ServerCallContext context)
+        => new(DetectTenantSynchronously(context));
+
+    public string? DetectTenantSynchronously(ServerCallContext context)
+    {
+        var principal = context.GetHttpContext()?.User;
+        var claim = principal?.Claims.FirstOrDefault(x => x.Type == _claimType);
+
+        return claim?.Value?.Trim();
+    }
+
+    public override string ToString()
+    {
+        return $"Tenant Id is value of claim '{_claimType}'";
+    }
+}

--- a/src/Wolverine.Grpc/MultiTenancy/DetectGrpcTenantIdFrame.cs
+++ b/src/Wolverine.Grpc/MultiTenancy/DetectGrpcTenantIdFrame.cs
@@ -1,0 +1,93 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Wolverine.Persistence;
+
+namespace Wolverine.Grpc.MultiTenancy;
+
+/// <summary>
+///     Code-generation frame that runs the configured tenant detection strategies at the top of a
+///     generated gRPC service method. The gRPC counterpart to Wolverine.Http's
+///     <c>DetectTenantIdFrame</c>. Emits:
+///     <list type="number">
+///         <item><c>var tenantId = await _grpcOptions.TryDetectTenantIdAsync(...)</c> — declaring
+///             the <c>tenantId</c> variable (<see cref="PersistenceConstants.TenantIdVariableName"/>)
+///             that Marten's <c>OpenMartenSessionFrame</c> and Polecat's
+///             <c>OpenPolecatSessionFrame</c> already look for, so tenant-scoped sessions opened by
+///             middleware frames in the same generated method pick the tenant up structurally,
+///             without relying on the ambient <see cref="IMessageContext"/>.</item>
+///         <item>Optionally an <c>AssertExists()</c> guard throwing
+///             <c>RpcException(InvalidArgument)</c>.</item>
+///         <item>Application of the detected tenant to the scoped bus — either directly on the
+///             wrapper's injected <see cref="IMessageBus"/> field (proto-first and code-first
+///             wrappers, whose subsequent <c>InvokeAsync</c>/<c>StreamAsync</c> then carries the
+///             tenant onto the envelope) or via the request-scoped <see cref="IMessageContext"/>
+///             (hand-written delegation wrappers, which have no bus field).</item>
+///     </list>
+///     One instance is created per generated RPC method by each chain's <c>AssembleTypes</c> —
+///     frames hold per-method mutable state and cannot be shared across method bodies.
+/// </summary>
+internal sealed class DetectGrpcTenantIdFrame : AsyncFrame
+{
+    private readonly GrpcTenantIdDetection _detection;
+    private readonly InjectedField _optionsField;
+    private readonly string _serverCallContextExpression;
+    private readonly InjectedField? _busField;
+    private readonly InjectedField? _serviceProviderField;
+
+    public DetectGrpcTenantIdFrame(GrpcTenantIdDetection detection, InjectedField optionsField,
+        string serverCallContextExpression, InjectedField? busField, InjectedField? serviceProviderField)
+    {
+        _detection = detection;
+        _optionsField = optionsField;
+        _serverCallContextExpression = serverCallContextExpression;
+        _busField = busField;
+        _serviceProviderField = serviceProviderField;
+
+        TenantId = new Variable(typeof(string), PersistenceConstants.TenantIdVariableName, this);
+    }
+
+    public Variable TenantId { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.BlankLine();
+        writer.WriteComment("Tenant Id detection");
+        if (_detection.ZeroConfigDefaultApplied)
+        {
+            writer.WriteComment(
+                "(zero-config default: no explicit TenantId configuration, detecting the 'tenant-id' metadata header stamped by the Wolverine gRPC client interceptor)");
+        }
+
+        for (var i = 0; i < _detection.Strategies.Count; i++)
+        {
+            writer.WriteComment($"{i + 1}. {_detection.Strategies[i]}");
+        }
+
+        writer.Write(
+            $"var {TenantId.Usage} = await {_optionsField.Usage}.{nameof(WolverineGrpcOptions.TryDetectTenantIdAsync)}({_serverCallContextExpression});");
+
+        if (_detection.AssertTenantExists)
+        {
+            writer.Write(
+                $"{typeof(GrpcTenantDetection).FullNameInCode()}.{nameof(GrpcTenantDetection.AssertTenantIdExists)}({TenantId.Usage});");
+        }
+
+        if (_busField != null)
+        {
+            writer.Write($"BLOCK:if (!string.{nameof(string.IsNullOrEmpty)}({TenantId.Usage}))");
+            writer.Write($"{_busField.Usage}.{nameof(IMessageBus.TenantId)} = {TenantId.Usage};");
+            writer.FinishBlock();
+        }
+        else if (_serviceProviderField != null)
+        {
+            writer.Write(
+                $"{typeof(GrpcTenantDetection).FullNameInCode()}.{nameof(GrpcTenantDetection.TryApplyToAmbientContext)}({_serviceProviderField.Usage}, {TenantId.Usage});");
+        }
+
+        writer.BlankLine();
+
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Wolverine.Grpc/MultiTenancy/FallbackDefault.cs
+++ b/src/Wolverine.Grpc/MultiTenancy/FallbackDefault.cs
@@ -1,0 +1,31 @@
+using Grpc.Core;
+
+namespace Wolverine.Grpc.MultiTenancy;
+
+/// <summary>
+///     Terminal detection strategy that always returns a fixed tenant id. Registered by
+///     <see cref="IGrpcTenantDetectionPolicies.DefaultIs"/> as the fallback when no earlier
+///     strategy detected a tenant.
+/// </summary>
+internal class FallbackDefault : IGrpcTenantDetection, ISynchronousGrpcTenantDetection
+{
+    public string TenantId { get; }
+
+    public FallbackDefault(string tenantId)
+    {
+        TenantId = tenantId;
+    }
+
+    public ValueTask<string?> DetectTenant(ServerCallContext context)
+        => new(DetectTenantSynchronously(context));
+
+    public string? DetectTenantSynchronously(ServerCallContext context)
+    {
+        return TenantId;
+    }
+
+    public override string ToString()
+    {
+        return $"Fallback tenant id is '{TenantId}'";
+    }
+}

--- a/src/Wolverine.Grpc/MultiTenancy/GrpcTenantDetection.cs
+++ b/src/Wolverine.Grpc/MultiTenancy/GrpcTenantDetection.cs
@@ -1,0 +1,49 @@
+using Grpc.Core;
+
+namespace Wolverine.Grpc.MultiTenancy;
+
+/// <summary>
+///     Runtime helpers called from Wolverine's generated gRPC service wrappers for server-side
+///     tenant id detection. Public only so generated code can reach them — not intended to be
+///     called from application code.
+/// </summary>
+public static class GrpcTenantDetection
+{
+    public const string NoMandatoryTenantIdCouldBeDetectedForThisGrpcCall =
+        "No mandatory tenant id could be detected for this gRPC call";
+
+    /// <summary>
+    ///     Throws an <see cref="RpcException"/> with status <see cref="StatusCode.InvalidArgument"/>
+    ///     when no tenant id was detected and <c>TenantId.AssertExists()</c> was configured.
+    ///     <c>InvalidArgument</c> is the gRPC mapping of the 400 Bad Request that Wolverine.Http's
+    ///     <c>AssertExists()</c> writes for the same condition.
+    /// </summary>
+    public static void AssertTenantIdExists(string? tenantId)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument,
+                NoMandatoryTenantIdCouldBeDetectedForThisGrpcCall));
+        }
+    }
+
+    /// <summary>
+    ///     Applies a detected tenant id to the scoped <see cref="IMessageContext"/> resolved from
+    ///     the current request's service provider. Used by generated wrappers for hand-written
+    ///     services, which delegate to user code that resolves its own <see cref="IMessageBus"/>
+    ///     rather than receiving one from the wrapper. No-ops when the tenant id is empty or no
+    ///     Wolverine scope is active.
+    /// </summary>
+    public static void TryApplyToAmbientContext(IServiceProvider services, string? tenantId)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            return;
+        }
+
+        if (services.GetService(typeof(IMessageContext)) is IMessageContext context)
+        {
+            context.TenantId = tenantId;
+        }
+    }
+}

--- a/src/Wolverine.Grpc/MultiTenancy/GrpcTenantIdDetection.cs
+++ b/src/Wolverine.Grpc/MultiTenancy/GrpcTenantIdDetection.cs
@@ -1,0 +1,119 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+
+namespace Wolverine.Grpc.MultiTenancy;
+
+/// <summary>
+///     The configured tenant detection strategies for Wolverine-managed gRPC services, plus the
+///     <see cref="IGrpcChainPolicy"/> that weaves a <see cref="DetectGrpcTenantIdFrame"/> into
+///     every applicable gRPC chain during bootstrapping. The gRPC counterpart to Wolverine.Http's
+///     <c>TenantIdDetection : ITenantDetectionPolicies, IHttpPolicy</c>. Registered as a policy by
+///     the <see cref="WolverineGrpcOptions"/> constructor and exposed for configuration as
+///     <see cref="WolverineGrpcOptions.TenantId"/>.
+/// </summary>
+internal class GrpcTenantIdDetection : IGrpcTenantDetectionPolicies, IGrpcChainPolicy
+{
+    private readonly WolverineGrpcOptions _parent;
+
+    // DetectWith<T>() registrations are recorded as types and built from the application
+    // container at policy-Apply time. Unlike Wolverine.Http — whose TenantId API is configured
+    // inside MapWolverineEndpoints() when the container already exists — the gRPC options are
+    // configured during AddWolverineGrpc() service registration, before any container is built,
+    // so eager resolution is impossible here.
+    private readonly List<Type> _deferredDetectionTypes = [];
+
+    public GrpcTenantIdDetection(WolverineGrpcOptions parent)
+    {
+        _parent = parent;
+    }
+
+    public List<IGrpcTenantDetection> Strategies { get; } = [];
+
+    public bool AssertTenantExists { get; private set; }
+
+    /// <summary>
+    ///     True when no strategy was configured explicitly and the zero-config default
+    ///     (detect the <c>tenant-id</c> metadata header stamped by
+    ///     <c>WolverineGrpcClientPropagationInterceptor</c>) was applied instead.
+    /// </summary>
+    public bool ZeroConfigDefaultApplied { get; private set; }
+
+    public void IsRequestHeaderValue(string headerKey)
+    {
+        Strategies.Add(new MetadataHeaderDetection(headerKey));
+    }
+
+    public void IsClaimTypeNamed(string claimType)
+    {
+        Strategies.Add(new ClaimsPrincipalDetection(claimType));
+    }
+
+    public void AssertExists()
+    {
+        AssertTenantExists = true;
+    }
+
+    public void DefaultIs(string defaultTenantId)
+    {
+        Strategies.Add(new FallbackDefault(defaultTenantId));
+    }
+
+    public void DetectWith(IGrpcTenantDetection detection)
+    {
+        Strategies.Add(detection);
+    }
+
+    public void DetectWith<T>() where T : IGrpcTenantDetection
+    {
+        _deferredDetectionTypes.Add(typeof(T));
+    }
+
+    private bool hasExplicitConfiguration => Strategies.Count > 0 || _deferredDetectionTypes.Count > 0;
+
+    void IGrpcChainPolicy.Apply(
+        IReadOnlyList<GrpcServiceChain> protoFirstChains,
+        IReadOnlyList<CodeFirstGrpcServiceChain> codeFirstChains,
+        IReadOnlyList<HandWrittenGrpcServiceChain> handWrittenChains,
+        GenerationRules rules,
+        IServiceContainer container)
+    {
+        // Zero-config default: when the user never configured tenancy detection but the
+        // server-side propagation interceptor is active, detect the same 'tenant-id' metadata
+        // header the Wolverine gRPC client interceptor stamps on outgoing calls — so a
+        // Wolverine-to-Wolverine hop round-trips the tenant id with no server configuration,
+        // structurally in generated code rather than relying on the ambient IMessageContext.
+        if (!hasExplicitConfiguration && _parent.PropagateEnvelopeHeaders)
+        {
+            Strategies.Add(new MetadataHeaderDetection(EnvelopeConstants.TenantIdKey));
+            ZeroConfigDefaultApplied = true;
+        }
+
+        foreach (var type in _deferredDetectionTypes)
+        {
+            Strategies.Add((IGrpcTenantDetection)container.QuickBuild(type));
+        }
+
+        _deferredDetectionTypes.Clear();
+
+        // Mirrors Wolverine.Http: no strategies (even with AssertExists()) means no frames.
+        if (Strategies.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var chain in protoFirstChains)
+        {
+            chain.TenantDetection = this;
+        }
+
+        foreach (var chain in codeFirstChains)
+        {
+            chain.TenantDetection = this;
+        }
+
+        foreach (var chain in handWrittenChains)
+        {
+            chain.TenantDetection = this;
+        }
+    }
+}

--- a/src/Wolverine.Grpc/MultiTenancy/IGrpcTenantDetection.cs
+++ b/src/Wolverine.Grpc/MultiTenancy/IGrpcTenantDetection.cs
@@ -1,0 +1,30 @@
+using Grpc.Core;
+
+namespace Wolverine.Grpc.MultiTenancy;
+
+#region sample_igrpctenantdetection
+
+/// <summary>
+///     Used to create new strategies to detect the tenant id from the
+///     <see cref="ServerCallContext"/> of the current gRPC call. The gRPC counterpart to
+///     Wolverine.Http's <c>ITenantDetection</c>.
+/// </summary>
+public interface IGrpcTenantDetection
+{
+    /// <summary>
+    ///     This method can return the actual tenant id or null to represent "not found"
+    /// </summary>
+    /// <param name="context">The server call context of the current gRPC call</param>
+    ValueTask<string?> DetectTenant(ServerCallContext context);
+}
+
+#endregion
+
+/// <summary>
+///     Optional, synchronous variant of <see cref="IGrpcTenantDetection"/> for strategies that
+///     never need to await anything. All built-in strategies implement both.
+/// </summary>
+public interface ISynchronousGrpcTenantDetection
+{
+    string? DetectTenantSynchronously(ServerCallContext context);
+}

--- a/src/Wolverine.Grpc/MultiTenancy/IGrpcTenantDetectionPolicies.cs
+++ b/src/Wolverine.Grpc/MultiTenancy/IGrpcTenantDetectionPolicies.cs
@@ -1,0 +1,57 @@
+namespace Wolverine.Grpc.MultiTenancy;
+
+/// <summary>
+///     Configuration API for server-side tenant id detection on Wolverine-managed gRPC services,
+///     exposed as <see cref="WolverineGrpcOptions.TenantId"/>. The gRPC counterpart to
+///     Wolverine.Http's <c>ITenantDetectionPolicies</c>. Strategies are tried in registration
+///     order; the first non-empty tenant id wins. The detected value is written to the
+///     <c>tenantId</c> code-generation variable (so Marten/Polecat session-opening frames can
+///     consume it) and applied to the scoped <see cref="IMessageBus"/> before the RPC forwards
+///     to any Wolverine handler.
+/// </summary>
+public interface IGrpcTenantDetectionPolicies
+{
+    /// <summary>
+    ///     Try to detect the tenant id from a request metadata header on the inbound call
+    ///     (<c>ServerCallContext.RequestHeaders</c>). Header name matching is case-insensitive.
+    /// </summary>
+    /// <param name="headerKey">The metadata header name, e.g. "tenant-id"</param>
+    void IsRequestHeaderValue(string headerKey);
+
+    /// <summary>
+    ///     Try to detect the tenant id from the authenticated <c>ClaimsPrincipal</c> for the
+    ///     current call (read from the underlying ASP.NET Core <c>HttpContext.User</c>, which is
+    ///     where grpc-aspnetcore surfaces authentication results).
+    /// </summary>
+    /// <param name="claimType">The claim type to read the tenant id from</param>
+    void IsClaimTypeNamed(string claimType);
+
+    /// <summary>
+    ///     Assert that the tenant id was successfully detected. When no tenant id is found the
+    ///     generated service throws an <c>RpcException</c> with status
+    ///     <c>InvalidArgument</c> — the gRPC equivalent of the 400 Bad Request that
+    ///     Wolverine.Http's <c>AssertExists()</c> returns.
+    /// </summary>
+    void AssertExists();
+
+    /// <summary>
+    ///     Fallback tenant id used when no earlier strategy found one. Register this last —
+    ///     strategies run in order and this one always "succeeds".
+    /// </summary>
+    /// <param name="defaultTenantId">The fallback tenant id</param>
+    void DefaultIs(string defaultTenantId);
+
+    /// <summary>
+    ///     Register a custom tenant detection strategy instance.
+    /// </summary>
+    /// <param name="detection">The strategy to add</param>
+    void DetectWith(IGrpcTenantDetection detection);
+
+    /// <summary>
+    ///     Register a custom tenant detection strategy by type. The instance is built from your
+    ///     application container during bootstrapping (with singleton scoping), immediately before
+    ///     code generation runs.
+    /// </summary>
+    /// <typeparam name="T">The custom strategy type</typeparam>
+    void DetectWith<T>() where T : IGrpcTenantDetection;
+}

--- a/src/Wolverine.Grpc/MultiTenancy/MetadataHeaderDetection.cs
+++ b/src/Wolverine.Grpc/MultiTenancy/MetadataHeaderDetection.cs
@@ -1,0 +1,40 @@
+using Grpc.Core;
+
+namespace Wolverine.Grpc.MultiTenancy;
+
+/// <summary>
+///     Detects the tenant id from an inbound request metadata header
+///     (<see cref="ServerCallContext.RequestHeaders"/>). Matching is case-insensitive —
+///     gRPC lowercases metadata keys on the wire, but callers may register the header
+///     name in any casing.
+/// </summary>
+internal class MetadataHeaderDetection : IGrpcTenantDetection, ISynchronousGrpcTenantDetection
+{
+    private readonly string _headerName;
+
+    public MetadataHeaderDetection(string headerName)
+    {
+        _headerName = headerName;
+    }
+
+    public ValueTask<string?> DetectTenant(ServerCallContext context)
+        => new(DetectTenantSynchronously(context));
+
+    public string? DetectTenantSynchronously(ServerCallContext context)
+    {
+        foreach (var entry in context.RequestHeaders)
+        {
+            if (!entry.IsBinary && string.Equals(entry.Key, _headerName, StringComparison.OrdinalIgnoreCase))
+            {
+                return entry.Value;
+            }
+        }
+
+        return null;
+    }
+
+    public override string ToString()
+    {
+        return $"Tenant Id is request metadata header '{_headerName}'";
+    }
+}

--- a/src/Wolverine.Grpc/WolverineGrpcOptions.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcOptions.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
 using Grpc.Core;
+using JasperFx.Core;
 using Wolverine.Configuration;
+using Wolverine.Grpc.MultiTenancy;
 using Wolverine.Middleware;
 
 namespace Wolverine.Grpc;
@@ -14,7 +17,58 @@ namespace Wolverine.Grpc;
 /// </summary>
 public sealed class WolverineGrpcOptions
 {
+    public WolverineGrpcOptions()
+    {
+        TenantIdDetection = new GrpcTenantIdDetection(this);
+        Policies.Add(TenantIdDetection);
+    }
+
     internal MiddlewarePolicy Middleware { get; } = new();
+
+    internal GrpcTenantIdDetection TenantIdDetection { get; }
+
+    /// <summary>
+    ///     Configure server-side tenant id detection for Wolverine-managed gRPC services — the
+    ///     gRPC counterpart to <c>WolverineHttpOptions.TenantId</c>. Strategies are tried in
+    ///     registration order and the first non-empty tenant id wins; the detected value is
+    ///     written to the <c>tenantId</c> code-generation variable consumed by Marten/Polecat
+    ///     session-opening frames and applied to the scoped <see cref="IMessageBus"/> before the
+    ///     RPC forwards to any Wolverine handler.
+    ///     <para>
+    ///         Zero-config default: when nothing is configured here and
+    ///         <see cref="PropagateEnvelopeHeaders"/> is <c>true</c> (the default), Wolverine
+    ///         detects the <c>tenant-id</c> metadata header that
+    ///         <c>WolverineGrpcClientPropagationInterceptor</c> stamps on outgoing calls — so a
+    ///         Wolverine-to-Wolverine hop round-trips the tenant id with no server configuration.
+    ///     </para>
+    /// </summary>
+    public IGrpcTenantDetectionPolicies TenantId => TenantIdDetection;
+
+    /// <summary>
+    ///     Runs the configured tenant detection strategies against the current call and returns
+    ///     the first non-empty tenant id found, or null. Called from generated gRPC service
+    ///     wrappers; accepts null (a code-first <c>CallContext</c> outside a server call has no
+    ///     <see cref="ServerCallContext"/>) and returns null in that case.
+    /// </summary>
+    public async ValueTask<string?> TryDetectTenantIdAsync(ServerCallContext? callContext)
+    {
+        if (callContext == null)
+        {
+            return null;
+        }
+
+        foreach (var strategy in TenantIdDetection.Strategies)
+        {
+            var tenantId = await strategy.DetectTenant(callContext);
+            if (tenantId.IsNotEmpty())
+            {
+                Activity.Current?.SetTag(MetricsConstants.TenantIdKey, tenantId);
+                return tenantId;
+            }
+        }
+
+        return null;
+    }
 
     /// <summary>
     ///     Whether <see cref="WolverineGrpcServicePropagationInterceptor"/> reads the


### PR DESCRIPTION
Closes GH-3368

Builds on #3369 (the runtime `WolverineGrpcServicePropagationInterceptor`): this adds the **codegen-level** server-side tenant id detection mirroring Wolverine.Http's `ITenantDetectionPolicies`, so Marten/Polecat session-opening frames and the forwarded envelope get the tenant structurally — without relying on the ambient `IMessageContext` — plus claims and custom detection that the interceptor cannot do.

## What's here

### API (`WolverineGrpcOptions.TenantId`, `IGrpcTenantDetectionPolicies`)
```csharp
builder.Services.AddWolverineGrpc(grpc =>
{
    grpc.TenantId.IsRequestHeaderValue("tenant-id"); // ServerCallContext.RequestHeaders, case-insensitive
    grpc.TenantId.IsClaimTypeNamed("tenant-id");     // context.GetHttpContext().User
    grpc.TenantId.DetectWith<MyDetection>();         // custom IGrpcTenantDetection, built from the container
    grpc.TenantId.DefaultIs("default_tenant");
    grpc.TenantId.AssertExists();                    // missing tenant → RpcException(InvalidArgument)
});
```
`AssertExists()` maps to gRPC status **`InvalidArgument`** — the canonical (AIP-193) equivalent of the 400 Bad Request Wolverine.Http returns for the same condition; documented in the new docs page, including when `Unauthenticated`/`PermissionDenied` via regular authorization is the better fit.

### Detection frame across all three chain flavors
`GrpcTenantIdDetection : IGrpcChainPolicy` is registered by the `WolverineGrpcOptions` constructor (exactly like `WolverineHttpOptions` registers its `TenantIdDetection`) and marks every discovered chain. Each chain's `AssembleTypes` weaves a per-method `DetectGrpcTenantIdFrame` that:
1. declares the `tenantId` variable (`PersistenceConstants.TenantIdVariableName`) consumed by `OpenMartenSessionFrame`/`OpenPolecatSessionFrame`,
2. optionally enforces `AssertExists()`,
3. assigns the detected tenant to the wrapper's scoped `IMessageBus` before `InvokeAsync`/`StreamAsync` (proto-first + code-first), or to the request-scoped `IMessageContext` via the wrapper's `IServiceProvider` (hand-written delegation wrappers, which carry no bus field).

Coverage by flavor: proto-first = all RPC shapes (they all end in `ServerCallContext`); code-first & hand-written = unary methods declaring a `CallContext` parameter (the only route to `ServerCallContext` there; `IAsyncEnumerable`-returning methods can't host the awaited detection call). Fallback for the uncovered shapes is the #3369 interceptor, and the limits are documented.

### Zero-config default
With no explicit `TenantId` configuration and `PropagateEnvelopeHeaders == true` (default), the policy auto-registers `IsRequestHeaderValue("tenant-id")` — the exact header the Wolverine gRPC client interceptor stamps — so a Wolverine→Wolverine hop round-trips the tenant with zero server config. Explicit configuration replaces the default; `PropagateEnvelopeHeaders = false` suppresses it. Surfaced explicitly via `ZeroConfigDefaultApplied` and a comment line in the generated source.

### Docs
- New `docs/guide/grpc/multi-tenancy.md` (modeled on the HTTP page): three detection modes, zero-config default, interplay with the propagation interceptor, `InvalidArgument` mapping rationale, scope/limitations.
- Nav entry in `.vitepress/config.mts`; section index updated.
- `client.md` propagation section now describes the **round-trip** story with both server-side mechanisms (interceptor + codegen detection).

### Tests (`src/Wolverine.Grpc.Tests/MultiTenancy`)
- End-to-end (per-configuration disposable host): header detection (incl. case-insensitivity), claim detection via a stamped `ClaimsPrincipal`, `DetectWith<T>` custom strategy, strategy ordering, `DefaultIs` fallback, `AssertExists` rejection (`InvalidArgument` + detail message) and pass-through, missing-tenant flow, zero-config round-trip, and explicit detection **with the interceptor disabled** (proving the codegen path is independent of #3369). Non-`tenant-id` headers are used wherever the interceptor could otherwise mask the result.
- Structural: generated source of all three chain flavors contains the detection call; the `tenantId` codegen variable name is pinned; `PropagateEnvelopeHeaders = false` suppresses the default; hand-written wrapper e2e through the ambient context.
- 3 existing `AddPolicy` unit tests updated: `Policies` now always contains the built-in detection policy (same situation as HTTP's always-registered policies).

## Deviations from a literal HTTP mirror (and why)
- **Frames are woven in `AssembleTypes`, not inserted into `chain.Middleware`**: gRPC chains clone middleware frames per generated RPC method (`CloneFrames`), which only knows `ConstructorFrame`/`MethodCall` and would share a single detection frame instance (mutable `Next`) across N methods. The policy marks the chain; each flavor creates one frame per method with the right context expression (`context` vs `context.ServerCallContext`).
- **`DetectWith<T>()` is deferred**: HTTP configures `TenantId` inside `MapWolverineEndpoints()` when the container exists; gRPC options are configured during `AddWolverineGrpc()` service registration, so the type is recorded and `QuickBuild`-resolved at policy-apply time.
- **No route/query-string/sub-domain strategies**: those concepts don't exist on a gRPC call; metadata headers, claims, and custom strategies cover the surface.
- **`AssertExists()` throws `RpcException(InvalidArgument)`** instead of writing a 400 ProblemDetails.

## Verification
- `Wolverine.Grpc.Tests` (net9.0): **271/271 passing** (255 existing + 16 new)
- `dotnet build wolverine.slnx -c Release`: **0 errors, 0 warnings**

🤖 Generated with [Claude Code](https://claude.com/claude-code)