### PR TITLE
Bump Marten to 9.15.0 and JasperFx to 2.27.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,20 +35,20 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.24.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.24.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.24.1" />
+    <PackageVersion Include="JasperFx" Version="2.27.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.27.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.27.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.24.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.27.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
-    <PackageVersion Include="Marten" Version="9.14.1" />
+    <PackageVersion Include="Marten" Version="9.15.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="[4.8.0,6.0.0)" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.14.1" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.14.1" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.15.0" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.15.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />


### PR DESCRIPTION
Pin bumps to the releases from today's community-issue sweep (template: #3363):

- **JasperFx 2.27.0** — `Block<T>` fault semantics + daemon `OnError` wiring (jasperfx#506), classified teardown catch clauses (jasperfx#507), source-gen evolver cast fix (jasperfx#505).
- **Marten 9.15.0** — sharded-tenancy auto-assign provisioning repair (marten#4942, root cause of the marten#4941 two-day silent outage), consumes JasperFx 2.27.0 and re-bundles the fixed source-gen analyzer.

Both releases were verified against Wolverine **before** publishing via the local-feed gate: full `wolverine.slnx` Release build 0 errors/0 warnings, CoreTests 1910/0, full MartenTests 512/0, managed-distribution subset 31/0, Wolverine.Http.Tests 817/0. This PR's CI re-validates against the published packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)