### PR TITLE
Sweep durability metrics sequentially per node instead of per-database timers (#3375)

### DIFF
--- a/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
+++ b/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
@@ -27,6 +27,7 @@ internal class DurabilityAgent : IAgent
     private readonly DurabilitySettings _settings;
     private Timer? _expirationTimer;
     private PersistenceMetrics _metrics = null!;
+    private IDisposable? _metricsRegistration;
     private Timer? _recoveryTimer;
     private Timer? _scheduledJobTimer;
     private Timer? _handledCleanupTimer;
@@ -80,7 +81,11 @@ internal class DurabilityAgent : IAgent
 
         if (_settings.DurabilityMetricsEnabled)
         {
-            _metrics.StartPolling(_runtime.LoggerFactory.CreateLogger<PersistenceMetrics>(), _database);
+            // GH-3375: register with the node's single sequential metrics sweeper instead of
+            // running a per-database PeriodicTimer. At high database counts the in-phase
+            // per-agent pollers each pinned a pooled connection; the sweeper walks the node's
+            // databases one at a time across the UpdateMetricsPeriod window.
+            _metricsRegistration = PersistenceMetricsSweeper.For(_runtime).Register(_database, _metrics);
         }
 
         var recoveryStart = _settings.ScheduledJobFirstExecution.Add(new Random().Next(0, 1000).Milliseconds());
@@ -140,6 +145,7 @@ internal class DurabilityAgent : IAgent
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         _runningBlock.Complete();
+        _metricsRegistration?.Dispose();
         _metrics.SafeDispose();
 
         if (_scheduledJobTimer != null)

--- a/src/Testing/CoreTests/Persistence/persistence_metrics_sweeper_tests.cs
+++ b/src/Testing/CoreTests/Persistence/persistence_metrics_sweeper_tests.cs
@@ -1,0 +1,189 @@
+using CoreTests.Runtime;
+using JasperFx.Core;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Logging;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Durability;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+// Unit tests for the node-wide sequential metrics sweeper added for GH-3375. Durability
+// agents register their store instead of running a per-database PeriodicTimer; the sweeper
+// walks the node's registered databases one at a time across the UpdateMetricsPeriod window
+// and re-reads the registration set every pass, so databases whose agents start or stop
+// join and leave the sweep without a restart.
+public class persistence_metrics_sweeper_tests
+{
+    private readonly MockWolverineRuntime theRuntime = new();
+
+    public persistence_metrics_sweeper_tests()
+    {
+        // keep passes short so the tests observe multiple sweeps quickly; the jittered
+        // start delays the first pass by at most one period
+        theRuntime.Options.Durability.UpdateMetricsPeriod = 100.Milliseconds();
+    }
+
+    private (IMessageStore store, PersistenceMetrics metrics, ConcurrencyTrackingAdmin admin) buildStore(string name)
+    {
+        var admin = new ConcurrencyTrackingAdmin();
+        var store = Substitute.For<IMessageStore>();
+        store.Uri.Returns(new Uri($"wolverinedb://test/{name}"));
+        store.Admin.Returns(admin);
+
+        var metrics = new PersistenceMetrics(theRuntime, theRuntime.Options.Durability, name);
+        return (store, metrics, admin);
+    }
+
+    [Fact]
+    public async Task sweeps_every_registered_store_and_publishes_counts()
+    {
+        var sweeper = PersistenceMetricsSweeper.For(theRuntime);
+
+        var stores = new[] { buildStore("one"), buildStore("two"), buildStore("three") };
+        var registrations = stores.Select(x => sweeper.Register(x.store, x.metrics)).ToArray();
+
+        try
+        {
+            await waitUntil(() => stores.All(x => x.admin.Fetches > 0));
+
+            foreach (var (store, metrics, _) in stores)
+            {
+                metrics.Counts.Incoming.ShouldBe(ConcurrencyTrackingAdmin.TheCounts.Incoming);
+                theRuntime.Observer.Received().PersistedCounts(store.Uri, Arg.Any<PersistedCounts>());
+            }
+        }
+        finally
+        {
+            foreach (var registration in registrations) registration.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task a_disposed_registration_leaves_the_sweep()
+    {
+        var sweeper = PersistenceMetricsSweeper.For(theRuntime);
+
+        var staying = buildStore("staying");
+        var leaving = buildStore("leaving");
+
+        var stayingRegistration = sweeper.Register(staying.store, staying.metrics);
+        var leavingRegistration = sweeper.Register(leaving.store, leaving.metrics);
+
+        try
+        {
+            await waitUntil(() => leaving.admin.Fetches > 0 && staying.admin.Fetches > 0);
+
+            leavingRegistration.Dispose();
+            var fetchesAtRemoval = leaving.admin.Fetches;
+            var stayingFetches = staying.admin.Fetches;
+
+            // the set is re-read per pass, so after a couple more passes for the store that
+            // stayed, the removed store must not have been polled again
+            await waitUntil(() => staying.admin.Fetches >= stayingFetches + 2);
+            leaving.admin.Fetches.ShouldBe(fetchesAtRemoval);
+        }
+        finally
+        {
+            stayingRegistration.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task polls_one_store_at_a_time()
+    {
+        var sweeper = PersistenceMetricsSweeper.For(theRuntime);
+
+        // slow fetches would overlap under per-store timers; the sequential sweep may not
+        // ever have more than one in flight
+        var stores = Enumerable.Range(0, 4).Select(i => buildStore($"seq{i}")).ToArray();
+        foreach (var (_, _, admin) in stores) admin.FetchDelay = 30.Milliseconds();
+
+        var registrations = stores.Select(x => sweeper.Register(x.store, x.metrics)).ToArray();
+
+        try
+        {
+            await waitUntil(() => stores.All(x => x.admin.Fetches >= 2));
+            stores.Max(x => x.admin.MaxObservedConcurrency).ShouldBe(1);
+        }
+        finally
+        {
+            foreach (var registration in registrations) registration.Dispose();
+        }
+    }
+
+    private static async Task waitUntil(Func<bool> condition)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        while (!condition())
+        {
+            DateTimeOffset.UtcNow.ShouldBeLessThan(deadline, "timed out waiting for the sweeper");
+            await Task.Delay(25);
+        }
+    }
+
+    // Counts concurrent + total FetchCountsAsync calls across ALL instances so the
+    // sequential guarantee can be asserted; everything else is unused by the sweeper.
+    private class ConcurrencyTrackingAdmin : IMessageStoreAdmin
+    {
+        public static readonly PersistedCounts TheCounts = new() { Incoming = 42, Scheduled = 3, Outgoing = 7 };
+
+        private static int _inFlight;
+        private static int _maxObserved;
+
+        public int Fetches;
+        public int MaxObservedConcurrency => _maxObserved;
+        public TimeSpan FetchDelay = TimeSpan.Zero;
+
+        public async Task<PersistedCounts> FetchCountsAsync()
+        {
+            var current = Interlocked.Increment(ref _inFlight);
+            InterlockedMax(ref _maxObserved, current);
+
+            try
+            {
+                if (FetchDelay > TimeSpan.Zero)
+                {
+                    await Task.Delay(FetchDelay);
+                }
+
+                Interlocked.Increment(ref Fetches);
+                return TheCounts;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _inFlight);
+            }
+        }
+
+        private static void InterlockedMax(ref int location, int value)
+        {
+            int current;
+            while (value > (current = Volatile.Read(ref location)))
+            {
+                Interlocked.CompareExchange(ref location, value, current);
+            }
+        }
+
+        public Task DeleteAllHandledAsync() => Task.CompletedTask;
+
+        public Task ClearAllAsync() => Task.CompletedTask;
+
+        public Task<int> MarkDeadLetterEnvelopesAsReplayableAsync(string exceptionType) => Task.FromResult(0);
+
+        public Task RebuildAsync() => Task.CompletedTask;
+
+        public Task<IReadOnlyList<Envelope>> AllIncomingAsync() => Task.FromResult((IReadOnlyList<Envelope>)[]);
+
+        public Task<IReadOnlyList<Envelope>> AllOutgoingAsync() => Task.FromResult((IReadOnlyList<Envelope>)[]);
+
+        public Task ReleaseAllOwnershipAsync() => Task.CompletedTask;
+
+        public Task ReleaseAllOwnershipAsync(int ownerId) => Task.CompletedTask;
+
+        public Task CheckConnectivityAsync(CancellationToken token) => Task.CompletedTask;
+
+        public Task MigrateAsync() => Task.CompletedTask;
+    }
+}

--- a/src/Wolverine/Persistence/PersistenceMetricsSweeper.cs
+++ b/src/Wolverine/Persistence/PersistenceMetricsSweeper.cs
@@ -1,0 +1,143 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Node-wide sequential sweeper for the durability metrics (GH-3375). Instead of every
+/// durability agent running its own in-phase <c>PeriodicTimer</c> — which pins a pooled
+/// connection per database per node and, at high database counts, turns the metrics
+/// polling itself into significant connection pressure — each agent registers its store
+/// here and a single loop walks the node's registered databases sequentially, spreading
+/// the <see cref="DurabilitySettings.UpdateMetricsPeriod"/> window across them. That
+/// bounds the simultaneous metrics connections to one per node regardless of database
+/// count. The registration set is re-read every pass, so databases whose agents start or
+/// stop (e.g. agent redistribution) join and leave the sweep without a restart.
+/// </summary>
+public class PersistenceMetricsSweeper
+{
+    private static readonly ConditionalWeakTable<IWolverineRuntime, PersistenceMetricsSweeper> _perRuntime = new();
+
+    public static PersistenceMetricsSweeper For(IWolverineRuntime runtime)
+    {
+        return _perRuntime.GetValue(runtime, r => new PersistenceMetricsSweeper(r));
+    }
+
+    private readonly IWolverineRuntime _runtime;
+    private readonly ILogger<PersistenceMetricsSweeper> _logger;
+    private readonly ConcurrentDictionary<Uri, Registration> _registrations = new();
+    private readonly object _startLock = new();
+    private Task? _loop;
+
+    private PersistenceMetricsSweeper(IWolverineRuntime runtime)
+    {
+        _runtime = runtime;
+        _logger = runtime.LoggerFactory.CreateLogger<PersistenceMetricsSweeper>();
+    }
+
+    private sealed record Registration(IMessageStore Store, PersistenceMetrics Metrics);
+
+    /// <summary>
+    /// Add a store to the node's metrics sweep. Dispose the returned handle to remove it
+    /// again — durability agents do this when they stop, so a database that moves to
+    /// another node stops being polled from this one.
+    /// </summary>
+    public IDisposable Register(IMessageStore store, PersistenceMetrics metrics)
+    {
+        _registrations[store.Uri] = new Registration(store, metrics);
+        ensureStarted();
+        return new Unregistration(this, store.Uri);
+    }
+
+    private void ensureStarted()
+    {
+        if (_loop is not null)
+        {
+            return;
+        }
+
+        lock (_startLock)
+        {
+            _loop ??= Task.Run(() => sweepAsync(_runtime.Cancellation), _runtime.Cancellation);
+        }
+    }
+
+    private async Task sweepAsync(CancellationToken cancellation)
+    {
+        try
+        {
+            // Jittered start (mirrors ScheduledJobFirstExecution) so multiple nodes don't
+            // sweep in phase against the same database server.
+            var period = _runtime.Options.Durability.UpdateMetricsPeriod;
+            var jitter = TimeSpan.FromMilliseconds(Random.Shared.NextDouble() * period.TotalMilliseconds);
+            await Task.Delay(jitter, cancellation).ConfigureAwait(false);
+
+            await runPassesAsync(cancellation).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // node shutting down
+        }
+    }
+
+    private async Task runPassesAsync(CancellationToken cancellation)
+    {
+        while (!cancellation.IsCancellationRequested)
+        {
+            var period = _runtime.Options.Durability.UpdateMetricsPeriod;
+            // Re-read the registration set every pass: agents come and go with ownership
+            // changes, and the set must reflect what this node currently runs.
+            var pass = _registrations.Values.ToArray();
+
+            if (pass.Length == 0)
+            {
+                await Task.Delay(period, cancellation).ConfigureAwait(false);
+                continue;
+            }
+
+            // One database at a time, spaced so the pass fills the UpdateMetricsPeriod window:
+            // at most one metrics query (and its pooled connection) is in flight per node.
+            var spacing = period / pass.Length;
+            foreach (var registration in pass)
+            {
+                try
+                {
+                    var counts = await registration.Store.Admin.FetchCountsAsync().ConfigureAwait(false);
+                    registration.Metrics.Counts = counts;
+                    _runtime.Observer.PersistedCounts(registration.Store.Uri, counts);
+                }
+                catch (OperationCanceledException)
+                {
+                    // shutting down; the loop condition handles it
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Error trying to update the metrics on envelope storage for {Store}",
+                        registration.Store.Uri);
+                }
+
+                await Task.Delay(spacing, cancellation).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private sealed class Unregistration : IDisposable
+    {
+        private readonly PersistenceMetricsSweeper _parent;
+        private readonly Uri _uri;
+
+        public Unregistration(PersistenceMetricsSweeper parent, Uri uri)
+        {
+            _parent = parent;
+            _uri = uri;
+        }
+
+        public void Dispose()
+        {
+            _parent._registrations.TryRemove(_uri, out _);
+        }
+    }
+}

--- a/src/Wolverine/Persistence/PersistenceMetricsSweeper.cs
+++ b/src/Wolverine/Persistence/PersistenceMetricsSweeper.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using Wolverine.Persistence.Durability;
@@ -98,11 +99,17 @@ public class PersistenceMetricsSweeper
                 continue;
             }
 
-            // One database at a time, spaced so the pass fills the UpdateMetricsPeriod window:
-            // at most one metrics query (and its pooled connection) is in flight per node.
+            // One database at a time, paced against deadlines so the pass fills the
+            // UpdateMetricsPeriod window: at most one metrics query (and its pooled
+            // connection) is in flight per node. Each store's next-poll target is
+            // passStart + (i + 1) * (period / count), so fetch time is absorbed into the
+            // spacing rather than stretching the effective polling interval, and the last
+            // target IS the end of the pass — no extra idle delay on top of the period.
             var spacing = period / pass.Length;
-            foreach (var registration in pass)
+            var passStart = Stopwatch.GetTimestamp();
+            for (var i = 0; i < pass.Length; i++)
             {
+                var registration = pass[i];
                 try
                 {
                     var counts = await registration.Store.Admin.FetchCountsAsync().ConfigureAwait(false);
@@ -119,7 +126,11 @@ public class PersistenceMetricsSweeper
                         registration.Store.Uri);
                 }
 
-                await Task.Delay(spacing, cancellation).ConfigureAwait(false);
+                var remaining = spacing * (i + 1) - Stopwatch.GetElapsedTime(passStart);
+                if (remaining > TimeSpan.Zero)
+                {
+                    await Task.Delay(remaining, cancellation).ConfigureAwait(false);
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #3375, following the preferred direction laid out there.

## What changed

- **`PersistenceMetricsSweeper`** (new, Wolverine core): one sequential sweep loop per node. RDBMS `DurabilityAgent`s no longer start a per-database `PeriodicTimer`; they register their store with the sweeper on `StartAsync` and unregister on `StopAsync`. The sweeper walks the node's registered databases one at a time, spaced to fill the `UpdateMetricsPeriod` window — bounding simultaneous metrics connections to **one per node** regardless of database count, instead of one pinned pooled connection per database per node.
- **Jittered start**: the sweep's first pass is delayed by a random fraction of `UpdateMetricsPeriod` (mirroring how `ScheduledJobFirstExecution` randomizes) so multiple nodes don't sweep in phase against the same database server.
- **Dynamic database set**: the registration set (and the period) is re-read every pass, so databases whose agents start or stop — e.g. under agent redistribution, and the future owned-agent scoping of #3376 — join and leave the sweep without any restart or captured-at-startup list.
- `PersistenceMetrics` keeps owning the per-database OTel gauges and the `IWolverineObserver.PersistedCounts` feed gets the same per-store updates as before, so CritterWatch and the metrics tags are unchanged. Its `StartPolling` remains for the CosmosDb/RavenDb durability agents, which host a single store and don't have this problem.

## Tests

`persistence_metrics_sweeper_tests` (CoreTests): every registered store gets swept and its counts published; a disposed registration leaves the sweep on the next pass; and — with deliberately slow `FetchCountsAsync` fakes that track concurrency — at most one fetch is ever in flight, which per-store timers would fail.

## Background

Production measurement that motivated this (512 tenant databases, 2 nodes): ~180 permanently-pinned metrics connections and constant reconnect churn from the in-phase pollers, on a server already carrying ~1,300 connections. Details in #3375.
