### PR TITLE
gRPC saga coverage: message-identified sagas work like HTTP; header-identified gap pinned (refs #3385)

### DIFF
--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/CountingSaga.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/CountingSaga.cs
@@ -1,0 +1,22 @@
+namespace Wolverine.Grpc.Tests.SagaOverGrpc;
+
+/// <summary>
+///     A <em>header-identified</em> saga: <see cref="StartCountingRequest"/> carries no id member,
+///     so Wolverine resolves the saga id from the inbound envelope's <c>saga-id</c> header. Over a
+///     gRPC service hop that header is never populated — neither the client nor server propagation
+///     interceptor carries <c>saga-id</c>, and <c>Executor.InvokeAsync&lt;T&gt;</c> does not seed it
+///     onto the invoked envelope — so this saga reproduces the <c>IndeterminateSagaStateIdException</c>
+///     gap (GH-3385). <c>StartOrHandle</c> takes the "maybe-existing" code path, which pulls the id
+///     from the envelope on the very first call, so a single RPC is enough to reproduce.
+/// </summary>
+public class CountingSaga : Saga
+{
+    public string Id { get; set; } = string.Empty;
+    public int Count { get; set; }
+
+    public StartCountingReply StartOrHandle(StartCountingRequest request)
+    {
+        Count++;
+        return new StartCountingReply { SagaId = Id };
+    }
+}

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/CountingSagaGrpcService.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/CountingSagaGrpcService.cs
@@ -1,0 +1,19 @@
+using ProtoBuf.Grpc;
+using Wolverine.Grpc;
+
+namespace Wolverine.Grpc.Tests.SagaOverGrpc;
+
+/// <summary>
+///     Code-first gRPC service that forwards <see cref="StartCountingRequest"/> to the Wolverine bus
+///     exactly the way the docs show — <c>Bus.InvokeAsync&lt;TResponse&gt;(request, ct)</c>. The saga
+///     on the other side is an ordinary Wolverine handler; nothing here is saga-aware.
+/// </summary>
+public class CountingSagaGrpcService : WolverineGrpcServiceBase, ICountingSagaService
+{
+    public CountingSagaGrpcService(IMessageBus bus) : base(bus)
+    {
+    }
+
+    public Task<StartCountingReply> Start(StartCountingRequest request, CallContext context = default)
+        => Bus.InvokeAsync<StartCountingReply>(request, context.CancellationToken);
+}

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSaga.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSaga.cs
@@ -1,0 +1,30 @@
+namespace Wolverine.Grpc.Tests.SagaOverGrpc;
+
+/// <summary>
+///     A message-identified saga: it is started by <see cref="StartReservationRequest"/> (id from the
+///     message) and continued by <see cref="BookReservationRequest"/> (id from the message). No
+///     envelope <c>saga-id</c> header is involved, so this is the case that "works just like HTTP"
+///     over a gRPC hop. Both handlers return a reply so the forwarding
+///     <c>Bus.InvokeAsync&lt;TResponse&gt;</c> has a response to hand back to the RPC caller.
+/// </summary>
+public class ReservationSaga : Saga
+{
+    public string Id { get; set; } = string.Empty;
+    public bool Booked { get; set; }
+
+    public ReservationBookedReply Start(StartReservationRequest start)
+    {
+        Id = start.ReservationId!;
+        return new ReservationBookedReply { ReservationId = start.ReservationId };
+    }
+
+    public BookReservationReply Handle(BookReservationRequest book)
+    {
+        Booked = true;
+
+        // Done — Wolverine deletes the saga state at the end of message handling.
+        MarkCompleted();
+
+        return new BookReservationReply { Completed = true };
+    }
+}

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSagaContracts.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSagaContracts.cs
@@ -1,0 +1,50 @@
+using ProtoBuf;
+using ProtoBuf.Grpc;
+using System.ServiceModel;
+
+namespace Wolverine.Grpc.Tests.SagaOverGrpc;
+
+/// <summary>
+///     Code-first gRPC contract for a <em>message-identified</em> saga — the id rides on the request
+///     DTO (<see cref="StartReservationRequest.ReservationId"/> / <see cref="BookReservationRequest.Id"/>),
+///     exactly like the HTTP saga sample (<c>WolverineWebApi.SagaExample</c>). This is the case Jeremy
+///     expects to "work just like HTTP", and it does — the gRPC shim forwards to the same
+///     <c>InvokeAsync</c> pipeline. Mirrors
+///     <c>Wolverine.Http.Tests.building_a_saga_and_publishing_other_messages_from_http_endpoint</c>.
+/// </summary>
+[ServiceContract]
+public interface IReservationSagaService
+{
+    Task<ReservationBookedReply> Start(StartReservationRequest request, CallContext context = default);
+    Task<BookReservationReply> Book(BookReservationRequest request, CallContext context = default);
+}
+
+[ProtoContract]
+public class StartReservationRequest
+{
+    // Resolves to the saga id: "Reservation" is the ReservationSaga name minus the "Saga" suffix,
+    // so "ReservationId" is matched by SagaChain.DetermineSagaIdMember off the message body.
+    [ProtoMember(1)]
+    public string? ReservationId { get; set; }
+}
+
+[ProtoContract]
+public class ReservationBookedReply
+{
+    [ProtoMember(1)]
+    public string? ReservationId { get; set; }
+}
+
+[ProtoContract]
+public class BookReservationRequest
+{
+    [ProtoMember(1)]
+    public string? Id { get; set; }
+}
+
+[ProtoContract]
+public class BookReservationReply
+{
+    [ProtoMember(1)]
+    public bool Completed { get; set; }
+}

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSagaGrpcService.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSagaGrpcService.cs
@@ -1,0 +1,23 @@
+using ProtoBuf.Grpc;
+using Wolverine.Grpc;
+
+namespace Wolverine.Grpc.Tests.SagaOverGrpc;
+
+/// <summary>
+///     Code-first gRPC service that forwards both saga messages to the Wolverine bus with the
+///     canonical <c>Bus.InvokeAsync&lt;TResponse&gt;</c> shim — nothing here is saga-aware. Proves a
+///     message-identified saga can be started and continued over gRPC exactly like the HTTP endpoint
+///     equivalent.
+/// </summary>
+public class ReservationSagaGrpcService : WolverineGrpcServiceBase, IReservationSagaService
+{
+    public ReservationSagaGrpcService(IMessageBus bus) : base(bus)
+    {
+    }
+
+    public Task<ReservationBookedReply> Start(StartReservationRequest request, CallContext context = default)
+        => Bus.InvokeAsync<ReservationBookedReply>(request, context.CancellationToken);
+
+    public Task<BookReservationReply> Book(BookReservationRequest request, CallContext context = default)
+        => Bus.InvokeAsync<BookReservationReply>(request, context.CancellationToken);
+}

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/SagaOverGrpcContracts.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/SagaOverGrpcContracts.cs
@@ -1,0 +1,39 @@
+using ProtoBuf;
+using ProtoBuf.Grpc;
+using System.ServiceModel;
+
+namespace Wolverine.Grpc.Tests.SagaOverGrpc;
+
+/// <summary>
+///     Code-first gRPC contract whose server implementation forwards a saga message to the
+///     Wolverine bus. Used to characterize what happens when a <em>header-identified</em> saga
+///     (one whose id is resolved from the envelope <c>saga-id</c> header, not the message body)
+///     is driven over a gRPC service hop — see <see cref="CountingSaga"/> for why this message
+///     deliberately carries no id member.
+/// </summary>
+[ServiceContract]
+public interface ICountingSagaService
+{
+    Task<StartCountingReply> Start(StartCountingRequest request, CallContext context = default);
+}
+
+/// <summary>
+///     Saga start message with <b>no</b> id-like member — no <c>Id</c>, <c>SagaId</c>,
+///     <c>CountingSagaId</c>, nor <c>[SagaIdentity]</c>. This forces
+///     <c>SagaChain.DetermineSagaIdMember</c> to return null, which routes identity resolution onto
+///     the envelope <c>saga-id</c> header (<c>PullSagaIdFromEnvelopeFrame</c>) instead of the
+///     message body.
+/// </summary>
+[ProtoContract]
+public class StartCountingRequest
+{
+    [ProtoMember(1)]
+    public string? Label { get; set; }
+}
+
+[ProtoContract]
+public class StartCountingReply
+{
+    [ProtoMember(1)]
+    public string? SagaId { get; set; }
+}

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/SagaOverGrpcFixture.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/SagaOverGrpcFixture.cs
@@ -1,0 +1,62 @@
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ProtoBuf.Grpc.Client;
+using ProtoBuf.Grpc.Server;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.SagaOverGrpc;
+
+/// <summary>
+///     A standalone in-process host (not the shared <see cref="Client.WolverineGrpcClientFixture"/>)
+///     that wires only <see cref="CountingSaga"/> as a handler and maps
+///     <see cref="CountingSagaGrpcService"/>. Uses Wolverine's default in-memory saga persistence,
+///     so no database is required to exercise the saga path.
+/// </summary>
+public class SagaOverGrpcFixture : IAsyncLifetime
+{
+    private WebApplication? _app;
+    public GrpcChannel? Channel { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+        builder.WebHost.UseTestServer();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.ApplicationAssembly = typeof(SagaOverGrpcFixture).Assembly;
+            opts.Discovery.DisableConventionalDiscovery();
+            opts.Discovery.IncludeType(typeof(CountingSaga));
+        });
+
+        builder.Services.AddCodeFirstGrpc();
+        builder.Services.AddWolverineGrpc();
+
+        _app = builder.Build();
+        _app.UseRouting();
+        _app.MapGrpcService<CountingSagaGrpcService>();
+
+        await _app.StartAsync();
+
+        var handler = _app.GetTestServer().CreateHandler();
+        Channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+        {
+            HttpHandler = handler
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        Channel?.Dispose();
+        if (_app != null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+
+    public ICountingSagaService CreateClient() => Channel!.CreateGrpcService<ICountingSagaService>();
+}

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/SagaOverGrpcFixture.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/SagaOverGrpcFixture.cs
@@ -10,14 +10,22 @@ namespace Wolverine.Grpc.Tests.SagaOverGrpc;
 
 /// <summary>
 ///     A standalone in-process host (not the shared <see cref="Client.WolverineGrpcClientFixture"/>)
-///     that wires only <see cref="CountingSaga"/> as a handler and maps
-///     <see cref="CountingSagaGrpcService"/>. Uses Wolverine's default in-memory saga persistence,
-///     so no database is required to exercise the saga path.
+///     that wires the saga handlers used by these tests and maps their gRPC services:
+///     <see cref="CountingSaga"/> (header-identified, reproduces the GH-3385 gap) and
+///     <see cref="ReservationSaga"/> (message-identified, the HTTP-parity happy path). Uses
+///     Wolverine's default in-memory saga persistence, so no database is required.
 /// </summary>
 public class SagaOverGrpcFixture : IAsyncLifetime
 {
     private WebApplication? _app;
     public GrpcChannel? Channel { get; private set; }
+
+    /// <summary>
+    ///     The server host's service provider — used by tests to resolve
+    ///     <c>InMemorySagaPersistor</c> and assert saga persistence directly, the in-memory
+    ///     equivalent of the HTTP saga test's Marten <c>LoadAsync</c>.
+    /// </summary>
+    public IServiceProvider Services => _app!.Services;
 
     public async Task InitializeAsync()
     {
@@ -29,6 +37,7 @@ public class SagaOverGrpcFixture : IAsyncLifetime
             opts.ApplicationAssembly = typeof(SagaOverGrpcFixture).Assembly;
             opts.Discovery.DisableConventionalDiscovery();
             opts.Discovery.IncludeType(typeof(CountingSaga));
+            opts.Discovery.IncludeType(typeof(ReservationSaga));
         });
 
         builder.Services.AddCodeFirstGrpc();
@@ -37,6 +46,7 @@ public class SagaOverGrpcFixture : IAsyncLifetime
         _app = builder.Build();
         _app.UseRouting();
         _app.MapGrpcService<CountingSagaGrpcService>();
+        _app.MapGrpcService<ReservationSagaGrpcService>();
 
         await _app.StartAsync();
 
@@ -58,4 +68,6 @@ public class SagaOverGrpcFixture : IAsyncLifetime
     }
 
     public ICountingSagaService CreateClient() => Channel!.CreateGrpcService<ICountingSagaService>();
+
+    public IReservationSagaService CreateReservationClient() => Channel!.CreateGrpcService<IReservationSagaService>();
 }

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/SagaOverGrpcFixture.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/SagaOverGrpcFixture.cs
@@ -2,7 +2,6 @@ using Grpc.Net.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using ProtoBuf.Grpc.Client;
 using ProtoBuf.Grpc.Server;
 using Xunit;

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/saga_over_grpc_tests.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/saga_over_grpc_tests.cs
@@ -1,23 +1,26 @@
 using Grpc.Core;
+using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
+using Wolverine.Persistence.Sagas;
 using Xunit;
 
 namespace Wolverine.Grpc.Tests.SagaOverGrpc;
 
 /// <summary>
-///     Characterization tests for driving a Wolverine saga over a gRPC service hop.
+///     Tests for driving a Wolverine saga over a gRPC service hop, covering both identity models.
 ///     <para>
-///         The <b>message-identified</b> saga case (id on the request DTO) already works today and is
-///         covered elsewhere by the ordinary saga compliance suites — the gRPC shim just forwards to
-///         <c>InvokeAsync</c> and Wolverine reads the id out of the message body.
+///         <b>Message-identified</b> sagas (id on the request DTO) work over gRPC just like they do
+///         over HTTP — the gRPC shim forwards to the same <c>InvokeAsync</c> pipeline that a
+///         <c>[WolverinePost]</c> endpoint uses. <see cref="can_start_and_continue_a_message_identified_saga_over_grpc"/>
+///         is the gRPC parallel of
+///         <c>Wolverine.Http.Tests.building_a_saga_and_publishing_other_messages_from_http_endpoint</c>.
 ///     </para>
 ///     <para>
-///         This test pins the <b>header-identified</b> gap: a saga whose id comes from the envelope
-///         <c>saga-id</c> header can't resolve its id over gRPC, because nothing carries <c>saga-id</c>
-///         across the hop. The failure currently surfaces as an opaque <see cref="StatusCode.Internal"/>
-///         (because <c>IndeterminateSagaStateIdException</c> is a bare <see cref="Exception"/> and
-///         <c>WolverineGrpcExceptionMapper</c> falls through to its default). When the scoped diagnostic
-///         lands, flip the assertions below to the actionable status/message.
+///         <b>Header-identified</b> sagas (id from the envelope <c>saga-id</c> header) can't resolve
+///         their id over gRPC, because nothing carries <c>saga-id</c> across the hop — the same
+///         limitation HTTP endpoints have. That gap (GH-3385) is pinned by
+///         <see cref="starting_a_header_identified_saga_over_grpc_fails_with_opaque_status_today"/>;
+///         when the scoped diagnostic lands, flip its assertions to the actionable status/message.
 ///     </para>
 /// </summary>
 public class saga_over_grpc_tests : IClassFixture<SagaOverGrpcFixture>
@@ -27,6 +30,29 @@ public class saga_over_grpc_tests : IClassFixture<SagaOverGrpcFixture>
     public saga_over_grpc_tests(SagaOverGrpcFixture fixture)
     {
         _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task can_start_and_continue_a_message_identified_saga_over_grpc()
+    {
+        var client = _fixture.CreateReservationClient();
+        var persistor = _fixture.Services.GetRequiredService<InMemorySagaPersistor>();
+
+        // Start the saga over gRPC — same InvokeAsync path a WolverinePost endpoint would take.
+        var booked = await client.Start(new StartReservationRequest { ReservationId = "dinner" });
+        booked.ReservationId.ShouldBe("dinner");
+
+        // The saga was persisted by its message-supplied id, no saga-id header required.
+        var saved = persistor.Load<ReservationSaga>("dinner");
+        saved.ShouldNotBeNull();
+        saved.Booked.ShouldBeFalse();
+
+        // Continue the saga over gRPC — id comes off the follow-up message.
+        var result = await client.Book(new BookReservationRequest { Id = "dinner" });
+        result.Completed.ShouldBeTrue();
+
+        // Handle(BookReservationRequest) marked the saga completed, so its state is deleted.
+        persistor.Load<ReservationSaga>("dinner").ShouldBeNull();
     }
 
     [Fact]

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/saga_over_grpc_tests.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/saga_over_grpc_tests.cs
@@ -1,0 +1,46 @@
+using Grpc.Core;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.SagaOverGrpc;
+
+/// <summary>
+///     Characterization tests for driving a Wolverine saga over a gRPC service hop.
+///     <para>
+///         The <b>message-identified</b> saga case (id on the request DTO) already works today and is
+///         covered elsewhere by the ordinary saga compliance suites — the gRPC shim just forwards to
+///         <c>InvokeAsync</c> and Wolverine reads the id out of the message body.
+///     </para>
+///     <para>
+///         This test pins the <b>header-identified</b> gap: a saga whose id comes from the envelope
+///         <c>saga-id</c> header can't resolve its id over gRPC, because nothing carries <c>saga-id</c>
+///         across the hop. The failure currently surfaces as an opaque <see cref="StatusCode.Internal"/>
+///         (because <c>IndeterminateSagaStateIdException</c> is a bare <see cref="Exception"/> and
+///         <c>WolverineGrpcExceptionMapper</c> falls through to its default). When the scoped diagnostic
+///         lands, flip the assertions below to the actionable status/message.
+///     </para>
+/// </summary>
+public class saga_over_grpc_tests : IClassFixture<SagaOverGrpcFixture>
+{
+    private readonly SagaOverGrpcFixture _fixture;
+
+    public saga_over_grpc_tests(SagaOverGrpcFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task starting_a_header_identified_saga_over_grpc_fails_with_opaque_status_today()
+    {
+        var client = _fixture.CreateClient();
+
+        var ex = await Should.ThrowAsync<RpcException>(async () =>
+            await client.Start(new StartCountingRequest { Label = "first" }));
+
+        // CHARACTERIZATION of current behavior (GH-3385). saga-id is not propagated across a gRPC
+        // hop, so PullSagaIdFromEnvelopeFrame throws IndeterminateSagaStateIdException, which maps to
+        // Internal with a message that doesn't tell the developer what to do about it.
+        ex.StatusCode.ShouldBe(StatusCode.Internal);
+        ex.Status.Detail.ShouldContain("saga state id");
+    }
+}


### PR DESCRIPTION
Refs #3385.

Adds gRPC saga tests that mirror the existing HTTP endpoint + saga coverage, proving sagas work over gRPC the same way they do over HTTP — and documenting the one case that doesn't (which HTTP shares). See the findings summary on #3385.

### What's here

**Happy path — message-identified sagas work over gRPC (green).**
`can_start_and_continue_a_message_identified_saga_over_grpc` is the gRPC parallel of `Wolverine.Http.Tests.building_a_saga_and_publishing_other_messages_from_http_endpoint`: a saga whose id rides on the request DTO is started, persisted, continued, completed, and its state deleted — all through the same `Bus.InvokeAsync` pipeline a `[WolverinePost]` endpoint uses. Persistence is asserted via the in-memory saga persistor, so **no database is required**.

**Characterization — header-identified sagas hit the same limitation HTTP has.**
`starting_a_header_identified_saga_over_grpc_fails_with_opaque_status_today` pins the current behavior: a saga whose id is resolved from the envelope `saga-id` header can't resolve it over a gRPC service hop (nothing carries `saga-id` across), surfacing as an opaque `StatusCode.Internal`. When we land the scoped diagnostic (or full propagation) from #3385, this test's assertions flip.

### Notes
- Test-only — no production change. It's the no-regret groundwork that holds whichever direction #3385 takes.
- Uses a standalone in-process host modeled on the existing `ServerPropagation` fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
