### PR TITLE
Named load policy for [Entity] with EFCore

### DIFF
--- a/src/Http/Wolverine.Http.Tests.LoadProfileOnly/LoadProfileEndpoints.cs
+++ b/src/Http/Wolverine.Http.Tests.LoadProfileOnly/LoadProfileEndpoints.cs
@@ -1,0 +1,68 @@
+using Microsoft.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Http;
+using Wolverine.Persistence;
+
+namespace Wolverine.Http.Tests.LoadProfileOnly;
+
+// Endpoints exercising named EF Core load profiles ([Entity(Profile = "...")] +
+// modelBuilder.Entity<T>().HasLoadProfile(...)). Isolated in its own Marten-free assembly so the
+// eager [Entity] parameter matching (which resolves the owning DbContext at discovery time) does
+// not force LoadProfileDbContext onto the sibling GH-3353/3358/3374 hosts.
+
+public class LoadProfileDbContext : DbContext
+{
+    public LoadProfileDbContext(DbContextOptions<LoadProfileDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<ProfileOrder> Orders => Set<ProfileOrder>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ProfileOrder>(map =>
+        {
+            map.ToTable("profile_orders", "loadprofile");
+            map.HasKey(x => x.Id);
+            map.HasMany(x => x.Lines).WithOne().HasForeignKey(x => x.OrderId);
+        });
+
+        modelBuilder.Entity<ProfileOrderLine>(map =>
+        {
+            map.ToTable("profile_order_lines", "loadprofile");
+            map.HasKey(x => x.Id);
+        });
+
+        // Named load profiles declared on the model — selected per call site with [Entity(Profile=...)].
+        modelBuilder.Entity<ProfileOrder>()
+            .HasLoadProfile("summary", q => q)                        // root-only
+            .HasLoadProfile("full", q => q.Include(o => o.Lines));    // with children
+    }
+}
+
+public class ProfileOrder
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public List<ProfileOrderLine> Lines { get; set; } = new();
+}
+
+public class ProfileOrderLine
+{
+    public Guid Id { get; set; }
+    public Guid OrderId { get; set; }
+    public string Product { get; set; } = string.Empty;
+}
+
+public sealed record ProfileLoadResponse(Guid Id, string Name, int LineCount);
+
+public static class LoadProfileEndpoints
+{
+    [WolverineGet("/loadprofile/full/{id}")]
+    public static ProfileLoadResponse Full([Entity(Profile = "full")] ProfileOrder order)
+        => new(order.Id, order.Name, order.Lines.Count);
+
+    [WolverineGet("/loadprofile/summary/{id}")]
+    public static ProfileLoadResponse Summary([Entity(Profile = "summary")] ProfileOrder order)
+        => new(order.Id, order.Name, order.Lines.Count);
+}

--- a/src/Http/Wolverine.Http.Tests.LoadProfileOnly/Wolverine.Http.Tests.LoadProfileOnly.csproj
+++ b/src/Http/Wolverine.Http.Tests.LoadProfileOnly/Wolverine.Http.Tests.LoadProfileOnly.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <ProjectReference Include="..\Wolverine.Http\Wolverine.Http.csproj"/>
+        <ProjectReference Include="..\..\Persistence\Wolverine.EntityFrameworkCore\Wolverine.EntityFrameworkCore.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/src/Http/Wolverine.Http.Tests/LoadProfile_integration.cs
+++ b/src/Http/Wolverine.Http.Tests/LoadProfile_integration.cs
@@ -1,0 +1,114 @@
+using Alba;
+using IntegrationTests;
+using JasperFx;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Postgresql;
+using Wolverine.Http.Tests.LoadProfileOnly;
+using Xunit;
+
+namespace Wolverine.Http.Tests;
+
+// End-to-end coverage for named EF Core load profiles: [Entity(Profile = "...")] selects a
+// pre-declared include graph (HasLoadProfile) at the call site. The "full" profile pulls the
+// child Lines; the "summary" profile loads the root only; a missing id still 404s.
+//
+// Endpoints live in their own Marten-free assembly (Wolverine.Http.Tests.LoadProfileOnly),
+// discovery is pinned there.
+public class LoadProfile_integration : IAsyncLifetime
+{
+    private IAlbaHost _host = null!;
+    private readonly Guid _orderId = Guid.NewGuid();
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+
+        builder.Services.AddDbContextWithWolverineIntegration<LoadProfileDbContext>(x =>
+            x.UseNpgsql(Servers.PostgresConnectionString));
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.ApplicationAssembly = typeof(LoadProfileEndpoints).Assembly;
+            opts.Durability.Mode = DurabilityMode.Solo;
+            opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "loadprofile");
+            opts.UseEntityFrameworkCoreTransactions();
+            opts.Discovery.DisableConventionalDiscovery();
+        });
+
+        builder.Services.AddWolverineHttp();
+
+        _host = await AlbaHost.For(builder, app => app.MapWolverineEndpoints());
+
+        using var scope = _host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<LoadProfileDbContext>();
+        await db.Database.ExecuteSqlRawAsync(
+            """
+            create schema if not exists loadprofile;
+            create table if not exists loadprofile.profile_orders ("Id" uuid primary key, "Name" varchar(200) not null);
+            create table if not exists loadprofile.profile_order_lines ("Id" uuid primary key, "OrderId" uuid not null references loadprofile.profile_orders("Id"), "Product" varchar(200) not null);
+            delete from loadprofile.profile_order_lines;
+            delete from loadprofile.profile_orders;
+            """);
+
+        db.Orders.Add(new ProfileOrder
+        {
+            Id = _orderId,
+            Name = "Acme",
+            Lines =
+            {
+                new ProfileOrderLine { Id = Guid.NewGuid(), Product = "Widget" },
+                new ProfileOrderLine { Id = Guid.NewGuid(), Product = "Gadget" }
+            }
+        });
+        await db.SaveChangesAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task full_profile_loads_the_child_collection()
+    {
+        var result = await _host.Scenario(x =>
+        {
+            x.Get.Url($"/loadprofile/full/{_orderId}");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var response = await result.ReadAsJsonAsync<ProfileLoadResponse>();
+        response.ShouldNotBeNull();
+        response.Id.ShouldBe(_orderId);
+        response.LineCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task summary_profile_loads_the_root_only()
+    {
+        var result = await _host.Scenario(x =>
+        {
+            x.Get.Url($"/loadprofile/summary/{_orderId}");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var response = await result.ReadAsJsonAsync<ProfileLoadResponse>();
+        response.ShouldNotBeNull();
+        response.Id.ShouldBe(_orderId);
+        response.LineCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task missing_entity_404s()
+    {
+        await _host.Scenario(x =>
+        {
+            x.Get.Url($"/loadprofile/full/{Guid.NewGuid()}");
+            x.StatusCodeShouldBe(404);
+        });
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/Wolverine.Http.Tests.csproj
+++ b/src/Http/Wolverine.Http.Tests/Wolverine.Http.Tests.csproj
@@ -27,6 +27,7 @@
         <ProjectReference Include="..\..\Testing\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj" />
         <ProjectReference Include="..\Wolverine.Http.Tests.DifferentAssembly\Wolverine.Http.Tests.DifferentAssembly.csproj" />
         <ProjectReference Include="..\Wolverine.Http.Tests.EfCoreOnly\Wolverine.Http.Tests.EfCoreOnly.csproj" />
+        <ProjectReference Include="..\Wolverine.Http.Tests.LoadProfileOnly\Wolverine.Http.Tests.LoadProfileOnly.csproj" />
         <ProjectReference Include="..\Wolverine.Http\Wolverine.Http.csproj" />
         <!-- using_newtonsoft_for_serialization.cs exercises the moved Newtonsoft HTTP surface. -->
         <ProjectReference Include="..\..\Extensions\Wolverine.Http.Newtonsoft\Wolverine.Http.Newtonsoft.csproj" />

--- a/src/Persistence/EfCoreTests/LoadProfileTests.cs
+++ b/src/Persistence/EfCoreTests/LoadProfileTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Wolverine.EntityFrameworkCore;
+
+namespace EfCoreTests;
+
+public class LoadProfileTests
+{
+    private static DbContextOptions<ProfileDbContext> InMemory(string name) =>
+        new DbContextOptionsBuilder<ProfileDbContext>().UseInMemoryDatabase(name).Options;
+
+    private static async Task<(DbContextOptions<ProfileDbContext> options, Guid id)> SeededStore()
+    {
+        var options = InMemory(Guid.NewGuid().ToString());
+        var id = Guid.NewGuid();
+
+        await using var db = new ProfileDbContext(options);
+        db.Orders.Add(new ProfileOrder
+        {
+            Id = id,
+            Lines = { new ProfileLine { Id = Guid.NewGuid(), Product = "Widget" } }
+        });
+        await db.SaveChangesAsync();
+
+        return (options, id);
+    }
+
+    [Fact]
+    public async Task named_profile_applies_its_include_graph()
+    {
+        var (options, id) = await SeededStore();
+
+        // Fresh context so navigation fixup can't mask the include.
+        await using var db = new ProfileDbContext(options);
+        var order = await EntityFrameworkQueryableExtensions.FirstOrDefaultAsync(
+            EfCoreLoadProfiles.QueryFor<ProfileOrder>(db, "full"), o => o.Id == id);
+
+        order.ShouldNotBeNull();
+        order.Lines.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task profile_without_include_loads_the_root_only()
+    {
+        var (options, id) = await SeededStore();
+
+        await using var db = new ProfileDbContext(options);
+        var order = await EntityFrameworkQueryableExtensions.FirstOrDefaultAsync(
+            EfCoreLoadProfiles.QueryFor<ProfileOrder>(db, "summary"), o => o.Id == id);
+
+        order.ShouldNotBeNull();
+        order.Lines.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task unknown_profile_throws()
+    {
+        var (options, _) = await SeededStore();
+
+        await using var db = new ProfileDbContext(options);
+        Should.Throw<InvalidOperationException>(() => EfCoreLoadProfiles.QueryFor<ProfileOrder>(db, "does-not-exist"));
+    }
+
+    public class ProfileOrder
+    {
+        public Guid Id { get; set; }
+        public List<ProfileLine> Lines { get; set; } = new();
+    }
+
+    public class ProfileLine
+    {
+        public Guid Id { get; set; }
+        public string? Product { get; set; }
+    }
+
+    public class ProfileDbContext : DbContext
+    {
+        public ProfileDbContext(DbContextOptions<ProfileDbContext> options) : base(options)
+        {
+        }
+
+        public DbSet<ProfileOrder> Orders => Set<ProfileOrder>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ProfileOrder>().HasMany(o => o.Lines).WithOne();
+
+            modelBuilder.Entity<ProfileOrder>()
+                .HasLoadProfile("summary", q => q)
+                .HasLoadProfile("full", q => q.Include(o => o.Lines));
+        }
+    }
+}

--- a/src/Persistence/EfCoreTests/batch_query_tests.cs
+++ b/src/Persistence/EfCoreTests/batch_query_tests.cs
@@ -155,6 +155,23 @@ public class batched_load_entity_frame_codegen_tests
     }
 
     [Fact]
+    public void batched_load_frame_accepts_a_load_profile()
+    {
+        var sagaIdVar = Variable.For<Guid>();
+        var frame = new BatchedLoadEntityFrame(
+            typeof(ItemsDbContext),
+            typeof(Item),
+            sagaIdVar,
+            "Id",
+            profile: "full");
+
+        // Profiled batched loads still create the same Saga / pending-Task variables as the
+        // plain batched load; the profile only changes the root query the by-key filter runs on.
+        frame.Saga.VariableType.ShouldBe(typeof(Item));
+        frame.SagaTask.VariableType.ShouldBe(typeof(Task<Item>));
+    }
+
+    [Fact]
     public void create_batch_query_frame_creates_batch_variable()
     {
         var frame = new CreateBatchQueryFrame(typeof(ItemsDbContext));

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/BatchedLoadEntityFrame.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/BatchedLoadEntityFrame.cs
@@ -28,14 +28,16 @@ internal class BatchedLoadEntityFrame : SyncFrame
     private readonly Type _dbContextType;
     private readonly Variable _sagaId;
     private readonly string _pkPropertyName;
+    private readonly string? _profile;
     private Variable? _context;
     private Variable? _batchQuery;
 
-    public BatchedLoadEntityFrame(Type dbContextType, Type sagaType, Variable sagaId, string pkPropertyName)
+    public BatchedLoadEntityFrame(Type dbContextType, Type sagaType, Variable sagaId, string pkPropertyName, string? profile = null)
     {
         _dbContextType = dbContextType;
         _sagaId = sagaId;
         _pkPropertyName = pkPropertyName;
+        _profile = profile;
 
         Saga = new Variable(sagaType, this);
         // The task that will be awaited by ExecuteBatchQueryFrame
@@ -73,7 +75,7 @@ internal class BatchedLoadEntityFrame : SyncFrame
         {
             writer.WriteLine(
                 $"var {SagaTask.Usage} = {_batchQuery.Usage}.{nameof(BatchedQuery.QuerySingle)}(" +
-                $"{_context!.Usage}.{nameof(DbContext.Set)}<{Saga.VariableType.FullNameInCode()}>().Where(x => x.{_pkPropertyName} == {_sagaId.Usage}));");
+                $"{rootQuery()}.Where(x => x.{_pkPropertyName} == {_sagaId.Usage}));");
         }
         else
         {
@@ -82,10 +84,23 @@ internal class BatchedLoadEntityFrame : SyncFrame
                 $"var {Saga.VariableType.Name.ToLowerInvariant()}Batch = {_context!.Usage}.{nameof(BatchQueryExtensions.CreateBatchQuery)}();");
             writer.WriteLine(
                 $"var {SagaTask.Usage} = {Saga.VariableType.Name.ToLowerInvariant()}Batch.{nameof(BatchedQuery.QuerySingle)}(" +
-                $"{_context!.Usage}.{nameof(DbContext.Set)}<{Saga.VariableType.FullNameInCode()}>().Where(x => x.{_pkPropertyName} == {_sagaId.Usage}));");
+                $"{rootQuery()}.Where(x => x.{_pkPropertyName} == {_sagaId.Usage}));");
         }
 
         Next?.GenerateCode(method, writer);
+    }
+
+    // Root query the by-key filter is applied to: the plain DbSet, or — when a load profile is
+    // requested — the profile's include graph via EfCoreLoadProfiles.QueryFor. Both are IQueryable<T>,
+    // so batching (QuerySingle) is identical either way.
+    private string rootQuery()
+    {
+        if (_profile is null)
+        {
+            return $"{_context!.Usage}.{nameof(DbContext.Set)}<{Saga.VariableType.FullNameInCode()}>()";
+        }
+
+        return $"{typeof(EfCoreLoadProfiles).FullNameInCode()}.{nameof(EfCoreLoadProfiles.QueryFor)}<{Saga.VariableType.FullNameInCode()}>({_context!.Usage}, \"{_profile}\")";
     }
 }
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -40,7 +40,7 @@ namespace Wolverine.EntityFrameworkCore.Codegen;
     Justification = "EFCore codegen frame provider — DbContext.SaveChangesAsync etc. lookups on statically-rooted DbContext types. See AOT guide.")]
 [UnconditionalSuppressMessage("AOT", "IL3050",
     Justification = "EFCore codegen frame provider — closed generics over runtime DbContext / entity types at codegen time. See AOT guide.")]
-internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
+internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider, ILoadProfileFrameProvider
 {
     public const string UsingEfCoreTransaction = "uses_efcore_transaction";
     public const string TransactionModeKey = "TransactionMiddlewareMode";
@@ -132,6 +132,42 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
     {
         var dbContextType = DetermineDbContextType(sagaType, container);
         return new LoadEntityFrame(dbContextType, sagaType, sagaId);
+    }
+
+    // ILoadProfileFrameProvider — profile-aware load for [Entity(Profile = "...")]. Validates the
+    // profile against the EF model NOW (codegen/startup) so an unknown name fails fast instead of
+    // silently loading nothing, then rides the same AsyncFrame emission as the plain load.
+    public Frame DetermineLoadFrame(IServiceContainer container, Type entityType, Variable identity, string profile)
+    {
+        var dbContextType = DetermineDbContextType(entityType, container);
+
+        using var scope = container.Services.CreateScope();
+        var context = (DbContext)scope.ServiceProvider.GetRequiredService(dbContextType);
+
+        var config = context.Model.FindEntityType(entityType)
+                     ?? throw new InvalidOperationException(
+                         $"Could not find entity configuration for {entityType.FullNameInCode()} in DbContext {dbContextType.Name}");
+
+        var profiles = config.LoadProfiles();
+        if (profiles is null || !profiles.ContainsKey(profile))
+        {
+            var known = profiles is null || profiles.Count == 0
+                ? "none are declared"
+                : "known: " + string.Join(", ", profiles.Keys);
+            throw new InvalidOperationException(
+                $"No '{profile}' load profile is declared for {entityType.FullNameInCode()} ({known}). " +
+                $"Declare it on the model, e.g. modelBuilder.Entity<{entityType.Name}>().HasLoadProfile(\"{profile}\", q => q.Include(...)).");
+        }
+
+        var key = config.FindPrimaryKey()
+                  ?? throw new InvalidOperationException($"No known primary key for {entityType.FullNameInCode()}");
+        if (key.Properties.Count != 1)
+        {
+            throw new InvalidOperationException(
+                $"[Entity(Profile = \"{profile}\")] on {entityType.FullNameInCode()} requires a single-column primary key.");
+        }
+
+        return new ProfileLoadEntityFrame(dbContextType, entityType, identity, profile, key.Properties[0].Name);
     }
 
     public Frame DetermineInsertFrame(Variable saga, IServiceContainer container)

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/ProfileLoadEntityFrame.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/ProfileLoadEntityFrame.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.EntityFrameworkCore.Codegen;
+
+/// <summary>
+/// Loads an entity with a named load profile applied — the profile-aware analogue of
+/// <see cref="LoadEntityFrame" />. The include graph comes from <see cref="EfCoreLoadProfiles.QueryFor{TEntity}" />
+/// and the by-key filter is emitted inline against the statically-known key property.
+/// </summary>
+internal class ProfileLoadEntityFrame : AsyncFrame
+{
+    private readonly Type _dbContextType;
+    private readonly Variable _id;
+    private readonly string _profile;
+    private readonly string _keyPropertyName;
+    private Variable? _context;
+    private Variable? _cancellation;
+
+    public ProfileLoadEntityFrame(Type dbContextType, Type entityType, Variable id, string profile, string keyPropertyName)
+    {
+        _dbContextType = dbContextType;
+        _id = id;
+        _profile = profile;
+        _keyPropertyName = keyPropertyName;
+
+        Entity = new Variable(entityType, this);
+    }
+
+    public Variable Entity { get; }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _context = chain.FindVariable(_dbContextType);
+        yield return _context;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteLine("");
+        writer.WriteComment($"Loading {Entity.VariableType.NameInCode()} with the '{_profile}' load profile");
+        writer.Write(
+            $"var {Entity.Usage} = await {typeof(Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions).FullNameInCode()}.{nameof(Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.FirstOrDefaultAsync)}(" +
+            $"{typeof(EfCoreLoadProfiles).FullNameInCode()}.{nameof(EfCoreLoadProfiles.QueryFor)}<{Entity.VariableType.FullNameInCode()}>({_context!.Usage}, \"{_profile}\"), " +
+            $"__eager => __eager.{_keyPropertyName} == {_id.Usage}, {_cancellation!.Usage}).ConfigureAwait(false);");
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/LoadProfiles/EfCoreLoadProfileExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/LoadProfiles/EfCoreLoadProfileExtensions.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Wolverine.EntityFrameworkCore;
+
+/// <summary>
+/// Declares named "load profiles" — include/fetch graphs applied when an aggregate is loaded via
+/// <c>[Entity(Profile = "...")]</c>. Profiles live on the EF Core model configuration so they are
+/// declared once, next to the mapping, and validated against the model at startup/codegen.
+/// </summary>
+public static class EfCoreLoadProfileExtensions
+{
+    internal const string AnnotationKey = "Wolverine:LoadProfiles";
+
+    /// <summary>
+    /// Declare a named load profile for this entity. The <paramref name="include"/> transform is applied
+    /// to the root <c>DbSet&lt;T&gt;</c> query before the by-key filter, e.g.
+    /// <c>q =&gt; q.Include(o =&gt; o.Lines).ThenInclude(l =&gt; l.Product)</c>. Call sites opt in with
+    /// <c>[Entity(Profile = "name")]</c>; different handlers on the same aggregate can select different graphs.
+    /// </summary>
+    public static EntityTypeBuilder<T> HasLoadProfile<T>(
+        this EntityTypeBuilder<T> builder, string name, Func<IQueryable<T>, IQueryable<T>> include)
+        where T : class
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Load profile name must be non-empty.", nameof(name));
+        ArgumentNullException.ThrowIfNull(include);
+
+        var map = builder.Metadata.FindAnnotation(AnnotationKey)?.Value as Dictionary<string, Func<IQueryable, IQueryable>>
+                  ?? new Dictionary<string, Func<IQueryable, IQueryable>>(StringComparer.Ordinal);
+
+        map[name] = q => include((IQueryable<T>)q);
+        builder.Metadata.SetAnnotation(AnnotationKey, map);
+
+        return builder;
+    }
+
+    /// <summary>The load profiles declared for this entity type, or null if none.</summary>
+    internal static IReadOnlyDictionary<string, Func<IQueryable, IQueryable>>? LoadProfiles(this IReadOnlyEntityType entityType)
+        => entityType.FindAnnotation(AnnotationKey)?.Value as Dictionary<string, Func<IQueryable, IQueryable>>;
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/LoadProfiles/EfCoreLoadProfiles.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/LoadProfiles/EfCoreLoadProfiles.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolverine.EntityFrameworkCore;
+
+/// <summary>
+/// Runtime companion to <see cref="EfCoreLoadProfileExtensions" />: returns the root query for an
+/// entity with a named load profile's include graph applied. Generated code appends the by-key
+/// <c>FirstOrDefaultAsync(x =&gt; x.Key == id, ct)</c> filter inline, so the key predicate stays
+/// statically compiled (trim/AOT friendly) and this helper never builds an expression tree.
+/// </summary>
+public static class EfCoreLoadProfiles
+{
+    public static IQueryable<TEntity> QueryFor<
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors |
+            DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields |
+            DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties |
+            DynamicallyAccessedMemberTypes.Interfaces)] TEntity>(DbContext db, string profile)
+        where TEntity : class
+    {
+        var entityType = db.Model.FindEntityType(typeof(TEntity))
+                         ?? throw new InvalidOperationException($"{typeof(TEntity).Name} is not mapped.");
+
+        var profiles = entityType.LoadProfiles();
+        if (profiles is null || !profiles.TryGetValue(profile, out var include))
+        {
+            // Should have been caught at codegen; guard defensively.
+            throw new InvalidOperationException(
+                $"No '{profile}' load profile is registered for {typeof(TEntity).Name}.");
+        }
+
+        return (IQueryable<TEntity>)include(db.Set<TEntity>());
+    }
+}

--- a/src/Wolverine/Persistence/EntityAttribute.cs
+++ b/src/Wolverine/Persistence/EntityAttribute.cs
@@ -110,6 +110,16 @@ public class EntityAttribute : WolverineParameterAttribute, IDataRequirement
     /// </summary>
     public bool Required { get; set; } = true;
 
+    /// <summary>
+    /// Optional named "load profile" — selects which pre-declared include/fetch graph to apply when
+    /// loading this entity, so different handlers on the same aggregate can pull different depths of
+    /// the graph. Only supported by persistence providers that implement
+    /// <see cref="ILoadProfileFrameProvider" /> (currently EF Core, via
+    /// <c>modelBuilder.Entity&lt;T&gt;().HasLoadProfile("name", q =&gt; q.Include(...))</c>). An unknown
+    /// profile fails fast at codegen.
+    /// </summary>
+    public string? Profile { get; set; }
+
     public string MissingMessage { get; set; } = null!;
 
     public OnMissing OnMissing
@@ -162,7 +172,24 @@ public class EntityAttribute : WolverineParameterAttribute, IDataRequirement
             chain.Middleware.Add(identity.Creator);
         }
 
-        var frame = provider.DetermineLoadFrame(container, parameter.ParameterType, identity);
+        Frame frame;
+        if (!string.IsNullOrEmpty(Profile))
+        {
+            if (provider is ILoadProfileFrameProvider profiled)
+            {
+                frame = profiled.DetermineLoadFrame(container, parameter.ParameterType, identity, Profile);
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    $"[Entity(Profile = \"{Profile}\")] on {parameter.ParameterType.FullNameInCode()} requires a persistence " +
+                    $"provider with load-profile support (EF Core). {provider.GetType().Name} does not support load profiles.");
+            }
+        }
+        else
+        {
+            frame = provider.DetermineLoadFrame(container, parameter.ParameterType, identity);
+        }
 
         var entity = frame.Creates.First(x => x.VariableType == parameter.ParameterType);
         entity.OverrideName(parameter.Name!);

--- a/src/Wolverine/Persistence/ILoadProfileFrameProvider.cs
+++ b/src/Wolverine/Persistence/ILoadProfileFrameProvider.cs
@@ -1,0 +1,23 @@
+using System;
+using JasperFx;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Opt-in extension of a persistence provider that supports named, declarative "load profiles" —
+/// pre-declared include/fetch graphs selected per call site with <c>[Entity(Profile = "...")]</c>.
+/// Only providers that can vary the loaded object graph (currently EF Core) implement this; when an
+/// <c>[Entity]</c> carries a Profile and the resolved provider does not implement this interface,
+/// <see cref="EntityAttribute"/> fails fast at codegen.
+/// </summary>
+public interface ILoadProfileFrameProvider
+{
+    /// <summary>
+    /// Build the load frame for <paramref name="entityType"/> applying the named <paramref name="profile"/>.
+    /// Implementations should validate the profile exists at codegen time and throw a descriptive
+    /// exception if it does not, rather than silently loading nothing.
+    /// </summary>
+    Frame DetermineLoadFrame(IServiceContainer container, Type entityType, Variable identity, string profile);
+}

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -54,6 +54,7 @@
     <Project Path="src/Http/Wolverine.Http.Marten/Wolverine.Http.Marten.csproj" />
     <Project Path="src/Http/Wolverine.Http.Tests.DifferentAssembly/Wolverine.Http.Tests.DifferentAssembly.csproj" />
     <Project Path="src/Http/Wolverine.Http.Tests.EfCoreOnly/Wolverine.Http.Tests.EfCoreOnly.csproj" />
+    <Project Path="src/Http/Wolverine.Http.Tests.LoadProfileOnly/Wolverine.Http.Tests.LoadProfileOnly.csproj" />
     <Project Path="src/Http/Wolverine.Http.Tests/Wolverine.Http.Tests.csproj" />
     <Project Path="src/Http/Wolverine.Http/Wolverine.Http.csproj" />
     <Project Path="src/Http/WolverineWebApi/WolverineWebApi.csproj" />


### PR DESCRIPTION
Implements caller-selectable, declarative include/fetch graphs for EF Core `[Entity]` loading, following the design conversation in JasperFx/wolverine#3367. Draft — happy to change API/naming.

> **Note on the diff:** this branch is based on upstream `main` @ `60fe59e` (which already includes #3374). This fork's `main` trails that, so the PR currently also lists the intervening upstream commits. The actual change is the **3 commits** `0ffbc1c` / `76d32ce` / `28586d3`; opened against `JasperFx:main` the diff is just those.

## Usage

Declared on the EF model configuration side (validated against the model):

```csharp
modelBuilder.Entity<Order>()
    .HasLoadProfile("summary", q => q.Include(o => o.Lines))
    .HasLoadProfile("full",    q => q.Include(o => o.Lines).ThenInclude(l => l.Product));
```

Selected per call site:

```csharp
public static ShipmentCreated Handle(ShipOrder cmd, [Entity(Profile = "full")] Order order) => ...;

[WolverineGet("/orders/{id}")]
public static Order Get([Entity(Profile = "summary")] Order order) => order;
```

No profile ⇒ the existing `FindAsync` load, unchanged.

## Design

- **Minimal core surface.** `EntityAttribute` gains an optional `Profile`. An opt-in `ILoadProfileFrameProvider` is consulted *only* when a profile is set; only EF Core implements it, and a profile on any other provider fails fast. The shared `IPersistenceFrameProvider.DetermineLoadFrame` and the other eight providers are untouched.
- **Rides the existing `[Entity]` machinery.** Identity resolution (route value / message member, kebab-safe via the recent `[FromRoute]`/route-arg fixes), the `Required`/`OnMissing` stop condition, and the soft-delete null-out are all reused — only the load *frame* changes.
- **Fail-fast.** An unknown profile throws at codegen/startup with a descriptive message (`No 'x' load profile is declared for Order (known: summary, full)…`), never a silent empty load.
- **Trim/AOT.** Profiles apply the include graph to a real query via `EfCoreLoadProfiles.QueryFor<T>`; the by-key predicate is emitted **inline** against the statically-known key property, so no expression tree is built at runtime.

Generated (profile) vs unchanged (plain):

```csharp
// [Entity(Profile = "full")]
var order = await EntityFrameworkQueryableExtensions.FirstOrDefaultAsync(
    EfCoreLoadProfiles.QueryFor<Order>(dbContext, "full"), __eager => __eager.Id == id, cancellation);

// [Entity]
var order = await dbContext.FindAsync<Order>(id);
```

## Batched load path

`BatchedLoadEntityFrame` already loads via a query (`Set<T>().Where(pk == id)`), so it now sources the root from `EfCoreLoadProfiles.QueryFor<T>` when a profile is set — the single-load and batched-load paths stay consistent. Note batched entity loads are currently **dormant infrastructure** (test-only; no production policy wires `BatchedLoadEntityFrame`), so this is forward-looking; `EFCoreBatchingPolicy` only batches query-spec frames, never `[Entity]` loads.

## Files

- `src/Wolverine/Persistence/ILoadProfileFrameProvider.cs` — opt-in provider hook (core)
- `src/Wolverine/Persistence/EntityAttribute.cs` — `Profile` + branch to the hook
- `.../Wolverine.EntityFrameworkCore/LoadProfiles/EfCoreLoadProfileExtensions.cs` — `HasLoadProfile(...)` model API
- `.../Wolverine.EntityFrameworkCore/LoadProfiles/EfCoreLoadProfiles.cs` — runtime `QueryFor<T>`
- `.../Wolverine.EntityFrameworkCore/Codegen/ProfileLoadEntityFrame.cs` — profile-aware load frame
- `.../Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs` — implements the hook + codegen validation
- `.../Wolverine.EntityFrameworkCore/Codegen/BatchedLoadEntityFrame.cs` — batched load honors profiles too
- `src/Persistence/EfCoreTests/LoadProfileTests.cs`, `batch_query_tests.cs` — InMemory + batched-frame unit tests
- `src/Http/Wolverine.Http.Tests.LoadProfileOnly/` — isolated Marten-free endpoints assembly
- `src/Http/Wolverine.Http.Tests/LoadProfile_integration.cs` — Alba/Postgres end-to-end test

## Open questions

1. **Storage of the include lambdas as EF model annotations** (`Dictionary<string, Func<IQueryable,IQueryable>>` on the entity type). Runtime-only; works, but a side registry keyed by entity type is an easy alternative.
2. **Naming** (`HasLoadProfile` / `[Entity(Profile=...)]` / `ILoadProfileFrameProvider`) — placeholder.

## Verification

- `wolverine.slnx` builds Release (net9.0 + net10.0, warnings-as-errors incl. trim analyzers).
- Codegen inspected: profile query + inline predicate for endpoints and handlers; plain `[Entity]` unchanged; kebab route; unknown profile → codegen throw.
- `EfCoreTests` — `LoadProfileTests` 3/3 (InMemory), batched-frame unit tests 4/4.
- `LoadProfile_integration` (Alba + real Postgres) — 3/3: `full` loads the child collection, `summary` root-only, missing id 404s. Sibling `Bug_3374_asparameters…` still 3/3 (endpoints isolated in their own assembly).