### PR TITLE
docs: Integration with Sagas for gRPC (follow-up to #3386)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -298,6 +298,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                                 {text: 'Streaming', link: '/guide/grpc/streaming'},
                                 {text: 'Typed gRPC Clients', link: '/guide/grpc/client'},
                                 {text: 'Multi-Tenancy', link: '/guide/grpc/multi-tenancy'},
+                                {text: 'Integration with Sagas', link: '/guide/grpc/sagas'},
                                 {text: 'Samples', link: '/guide/grpc/samples'}
                             ]
                         }

--- a/docs/guide/grpc/index.md
+++ b/docs/guide/grpc/index.md
@@ -40,6 +40,8 @@ building:
 - [Multi-Tenancy](./multi-tenancy) — server-side tenant id detection (metadata headers, claims, or
   custom strategies) mirroring Wolverine.HTTP's `TenantId` API, including the zero-config
   round-trip default for Wolverine-to-Wolverine hops.
+- [Integration with Sagas](./sagas) — starting and continuing Wolverine sagas through gRPC calls
+  with message-carried saga identity, and the one identity model that doesn't cross the hop.
 - [Samples](./samples) — runnable end-to-end samples with pointers to the equivalent official
   [grpc-dotnet examples](https://github.com/grpc/grpc-dotnet/tree/master/examples) for comparison.
 

--- a/docs/guide/grpc/sagas.md
+++ b/docs/guide/grpc/sagas.md
@@ -1,0 +1,201 @@
+# Integration with Sagas
+
+gRPC services can start and continue [Wolverine sagas](/guide/durability/sagas), and doing so takes
+no gRPC-specific code at all: the service shim forwards the request to `IMessageBus.InvokeAsync<T>`,
+and the saga on the other side is an ordinary Wolverine saga handler. Everything saga-related —
+identity resolution, persistence, `MarkCompleted()` — happens in the same handler pipeline an HTTP
+endpoint or a message listener would use.
+
+There is one difference from [Wolverine.HTTP's saga integration](/guide/http/sagas) worth
+understanding up front. HTTP endpoints can *create* a saga by returning a `Saga`-derived value from
+the endpoint method, because Wolverine generates the endpoint chain itself and applies return-value
+mechanics to it. A gRPC service method is a thin shim in front of `Bus.InvokeAsync<T>` — the chain
+that runs is the *handler's* chain, so the saga is started the way any message starts a saga: by a
+`Start`/`Starts` method on the saga type, with the saga identity resolved **from the message body**.
+
+## An example saga
+
+Let's adapt the same reservation example the HTTP documentation uses. The saga is started by a
+`StartReservationRequest` and continued (and completed) by a `BookReservationRequest`:
+
+<!-- snippet: sample_grpc_reservation_saga -->
+<a id='snippet-sample_grpc_reservation_saga'></a>
+```cs
+public class ReservationSaga : Saga
+{
+    public string Id { get; set; } = string.Empty;
+    public bool Booked { get; set; }
+
+    // Starts the saga. The saga id comes off the message body
+    // (StartReservationRequest.ReservationId), so no envelope header
+    // is needed for this to work over a gRPC hop
+    public ReservationBookedReply Start(StartReservationRequest start)
+    {
+        Id = start.ReservationId!;
+        return new ReservationBookedReply { ReservationId = start.ReservationId };
+    }
+
+    public BookReservationReply Handle(BookReservationRequest book)
+    {
+        Booked = true;
+
+        // That's it, we're done. Delete the saga state after the message is done.
+        MarkCompleted();
+
+        return new BookReservationReply { Completed = true };
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSaga.cs#L10-L37' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_grpc_reservation_saga' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Note that there is nothing gRPC-flavored here — this is exactly the saga you would write for
+messaging or HTTP usage.
+
+## The contracts
+
+The gRPC request DTOs double as the saga messages. The important detail is that each message
+**carries the saga identity on the body**, using Wolverine's standard saga identity conventions
+(`Id`, `[SagaTypeName]Id`, or a `[SagaIdentity]`-decorated member):
+
+<!-- snippet: sample_grpc_saga_contracts -->
+<a id='snippet-sample_grpc_saga_contracts'></a>
+```cs
+[ServiceContract]
+public interface IReservationSagaService
+{
+    Task<ReservationBookedReply> Start(StartReservationRequest request, CallContext context = default);
+    Task<BookReservationReply> Book(BookReservationRequest request, CallContext context = default);
+}
+
+[ProtoContract]
+public class StartReservationRequest
+{
+    // "ReservationId" matches the ReservationSaga type name minus the "Saga"
+    // suffix, so Wolverine resolves the saga identity from this member
+    [ProtoMember(1)]
+    public string? ReservationId { get; set; }
+}
+
+[ProtoContract]
+public class ReservationBookedReply
+{
+    [ProtoMember(1)]
+    public string? ReservationId { get; set; }
+}
+
+[ProtoContract]
+public class BookReservationRequest
+{
+    // "Id" is also matched as the saga identity by convention
+    [ProtoMember(1)]
+    public string? Id { get; set; }
+}
+
+[ProtoContract]
+public class BookReservationReply
+{
+    [ProtoMember(1)]
+    public bool Completed { get; set; }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSagaContracts.cs#L15-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_grpc_saga_contracts' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## The service shim
+
+The service class just forwards to the bus, exactly like every other Wolverine gRPC service:
+
+<!-- snippet: sample_grpc_saga_service -->
+<a id='snippet-sample_grpc_saga_service'></a>
+```cs
+public class ReservationSagaGrpcService : WolverineGrpcServiceBase, IReservationSagaService
+{
+    public ReservationSagaGrpcService(IMessageBus bus) : base(bus)
+    {
+    }
+
+    // Nothing here is saga-aware -- the saga mechanics all happen
+    // in the Wolverine handler pipeline behind InvokeAsync()
+    public Task<ReservationBookedReply> Start(StartReservationRequest request, CallContext context = default)
+        => Bus.InvokeAsync<ReservationBookedReply>(request, context.CancellationToken);
+
+    public Task<BookReservationReply> Book(BookReservationRequest request, CallContext context = default)
+        => Bus.InvokeAsync<BookReservationReply>(request, context.CancellationToken);
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSagaGrpcService.cs#L12-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_grpc_saga_service' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Putting it together
+
+Starting the saga, observing its persisted state, continuing it, and completing it — all through
+gRPC calls:
+
+<!-- snippet: sample_starting_and_continuing_saga_over_grpc -->
+<a id='snippet-sample_starting_and_continuing_saga_over_grpc'></a>
+```cs
+[Fact]
+public async Task can_start_and_continue_a_message_identified_saga_over_grpc()
+{
+    var client = _fixture.CreateReservationClient();
+    var persistor = _fixture.Services.GetRequiredService<InMemorySagaPersistor>();
+
+    // Start the saga over gRPC — same InvokeAsync path a WolverinePost endpoint would take.
+    var booked = await client.Start(new StartReservationRequest { ReservationId = "dinner" });
+    booked.ReservationId.ShouldBe("dinner");
+
+    // The saga was persisted by its message-supplied id, no saga-id header required.
+    var saved = persistor.Load<ReservationSaga>("dinner");
+    saved.ShouldNotBeNull();
+    saved.Booked.ShouldBeFalse();
+
+    // Continue the saga over gRPC — id comes off the follow-up message.
+    var result = await client.Book(new BookReservationRequest { Id = "dinner" });
+    result.Completed.ShouldBeTrue();
+
+    // Handle(BookReservationRequest) marked the saga completed, so its state is deleted.
+    persistor.Load<ReservationSaga>("dinner").ShouldBeNull();
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine.Grpc.Tests/SagaOverGrpc/saga_over_grpc_tests.cs#L35-L60' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_starting_and_continuing_saga_over_grpc' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The example above uses Wolverine's default in-memory saga persistence for clarity. With
+[Marten](/guide/durability/marten/sagas), [EF Core](/guide/durability/efcore/), or
+[RavenDb](/guide/durability/ravendb) saga persistence configured, the same flow persists the saga
+state durably with no change to the saga, the contracts, or the service shim.
+
+## Saga identity must ride on the message
+
+Wolverine has two ways to resolve which saga state a message belongs to:
+
+1. **Message-identified** — the identity is a member on the message body (`Id`,
+   `ReservationId` for a `ReservationSaga`, or any member marked with `[SagaIdentity]`). This is
+   what the samples above use, and it works over gRPC exactly like it works over HTTP and messaging.
+2. **Header-identified** — the message carries no identity member, and Wolverine falls back to the
+   envelope's `saga-id` header.
+
+**Only message-identified sagas are supported over a gRPC service hop today.** The `saga-id`
+envelope header does not cross the hop — neither the client nor server propagation interceptor
+carries it, so a header-identified saga invoked through a gRPC service fails with an
+`IndeterminateSagaStateIdException` (surfaced to the caller as a `StatusCode.Internal`
+`RpcException`). This is tracked in
+[GH-3385](https://github.com/JasperFx/wolverine/issues/3385); the practical guidance is simple and
+is the better design anyway:
+
+::: tip
+Put the saga identity on the request DTO. It makes the contract self-describing for non-Wolverine
+gRPC clients too — a Go or Java caller can start or continue the saga without knowing anything
+about Wolverine envelope headers.
+:::
+
+## What about cascading messages?
+
+Because the saga runs in the ordinary handler pipeline, all the usual saga behaviors work unchanged
+over a gRPC hop: additional return values become [cascading messages](/guide/handlers/cascading),
+[saga timeouts](/guide/durability/sagas.html#timeout-messages) can be scheduled, and
+`MarkCompleted()` deletes the saga state when the work is done. The only rule specific to gRPC is
+the one shown above: when the service method uses `Bus.InvokeAsync<TResponse>(request)`, the
+handler's **response value** is what travels back to the RPC caller, and other return values cascade
+as messages.

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSaga.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSaga.cs
@@ -7,11 +7,16 @@ namespace Wolverine.Grpc.Tests.SagaOverGrpc;
 ///     over a gRPC hop. Both handlers return a reply so the forwarding
 ///     <c>Bus.InvokeAsync&lt;TResponse&gt;</c> has a response to hand back to the RPC caller.
 /// </summary>
+#region sample_grpc_reservation_saga
+
 public class ReservationSaga : Saga
 {
     public string Id { get; set; } = string.Empty;
     public bool Booked { get; set; }
 
+    // Starts the saga. The saga id comes off the message body
+    // (StartReservationRequest.ReservationId), so no envelope header
+    // is needed for this to work over a gRPC hop
     public ReservationBookedReply Start(StartReservationRequest start)
     {
         Id = start.ReservationId!;
@@ -22,9 +27,11 @@ public class ReservationSaga : Saga
     {
         Booked = true;
 
-        // Done — Wolverine deletes the saga state at the end of message handling.
+        // That's it, we're done. Delete the saga state after the message is done.
         MarkCompleted();
 
         return new BookReservationReply { Completed = true };
     }
 }
+
+#endregion

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSagaContracts.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSagaContracts.cs
@@ -12,6 +12,8 @@ namespace Wolverine.Grpc.Tests.SagaOverGrpc;
 ///     <c>InvokeAsync</c> pipeline. Mirrors
 ///     <c>Wolverine.Http.Tests.building_a_saga_and_publishing_other_messages_from_http_endpoint</c>.
 /// </summary>
+#region sample_grpc_saga_contracts
+
 [ServiceContract]
 public interface IReservationSagaService
 {
@@ -22,8 +24,8 @@ public interface IReservationSagaService
 [ProtoContract]
 public class StartReservationRequest
 {
-    // Resolves to the saga id: "Reservation" is the ReservationSaga name minus the "Saga" suffix,
-    // so "ReservationId" is matched by SagaChain.DetermineSagaIdMember off the message body.
+    // "ReservationId" matches the ReservationSaga type name minus the "Saga"
+    // suffix, so Wolverine resolves the saga identity from this member
     [ProtoMember(1)]
     public string? ReservationId { get; set; }
 }
@@ -38,6 +40,7 @@ public class ReservationBookedReply
 [ProtoContract]
 public class BookReservationRequest
 {
+    // "Id" is also matched as the saga identity by convention
     [ProtoMember(1)]
     public string? Id { get; set; }
 }
@@ -48,3 +51,5 @@ public class BookReservationReply
     [ProtoMember(1)]
     public bool Completed { get; set; }
 }
+
+#endregion

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSagaGrpcService.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/ReservationSagaGrpcService.cs
@@ -9,15 +9,21 @@ namespace Wolverine.Grpc.Tests.SagaOverGrpc;
 ///     message-identified saga can be started and continued over gRPC exactly like the HTTP endpoint
 ///     equivalent.
 /// </summary>
+#region sample_grpc_saga_service
+
 public class ReservationSagaGrpcService : WolverineGrpcServiceBase, IReservationSagaService
 {
     public ReservationSagaGrpcService(IMessageBus bus) : base(bus)
     {
     }
 
+    // Nothing here is saga-aware -- the saga mechanics all happen
+    // in the Wolverine handler pipeline behind InvokeAsync()
     public Task<ReservationBookedReply> Start(StartReservationRequest request, CallContext context = default)
         => Bus.InvokeAsync<ReservationBookedReply>(request, context.CancellationToken);
 
     public Task<BookReservationReply> Book(BookReservationRequest request, CallContext context = default)
         => Bus.InvokeAsync<BookReservationReply>(request, context.CancellationToken);
 }
+
+#endregion

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/saga_over_grpc_tests.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/saga_over_grpc_tests.cs
@@ -32,6 +32,8 @@ public class saga_over_grpc_tests : IClassFixture<SagaOverGrpcFixture>
         _fixture = fixture;
     }
 
+    #region sample_starting_and_continuing_saga_over_grpc
+
     [Fact]
     public async Task can_start_and_continue_a_message_identified_saga_over_grpc()
     {
@@ -54,6 +56,8 @@ public class saga_over_grpc_tests : IClassFixture<SagaOverGrpcFixture>
         // Handle(BookReservationRequest) marked the saga completed, so its state is deleted.
         persistor.Load<ReservationSaga>("dinner").ShouldBeNull();
     }
+
+    #endregion
 
     [Fact]
     public async Task starting_a_header_identified_saga_over_grpc_fails_with_opaque_status_today()


### PR DESCRIPTION
Follow-up to #3386: adapts the [HTTP + Sagas documentation](https://wolverinefx.net/guide/http/sagas.html) content for gRPC.

## What's here

- New `docs/guide/grpc/sagas.md` page, added to the sidebar and the gRPC section index.
- All samples are **mdsnippets regions sourced from real, tested code** — the `SagaOverGrpc` suite merged in #3386 (`ReservationSaga`, contracts, service shim, and the end-to-end start → persist → continue → complete test).
- Covers:
  - how the gRPC saga story differs from HTTP (no return-value `Saga` creation — the shim forwards to `Bus.InvokeAsync<T>`, so the saga starts via its `Start` method with **message-carried identity**);
  - the saga identity conventions on the request DTOs;
  - the header-identified limitation (GH-3385) as an explicit callout, with the put-the-id-on-the-message guidance;
  - cascading messages / timeouts / `MarkCompleted()` working unchanged over the hop.
- Snippet-region annotations added to the four `SagaOverGrpc` test files (comment tweaks only — no behavior change; the suite still passes 2/2 locally, build clean).

Note: `mdsnippets` also wanted to refresh line-number links in ~58 unrelated pages from today's merges; those were deliberately left out to keep this diff reviewable — they'll regenerate on the next docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)