### PR TITLE
TrackedSession ignores framework telemetry (INotToBeRouted) — fixes CritterWatch-monitored test hangs

### DIFF
--- a/src/Testing/CoreTests/Tracking/ignoring_framework_and_telemetry_messages.cs
+++ b/src/Testing/CoreTests/Tracking/ignoring_framework_and_telemetry_messages.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.Hosting;
+using Wolverine.ComplianceTests;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Wolverine.Runtime.RemoteInvocation;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Tracking;
+
+public class ignoring_framework_and_telemetry_messages : IDisposable
+{
+    private readonly IHost _host;
+    private readonly TrackedSession theSession;
+
+    public ignoring_framework_and_telemetry_messages()
+    {
+        _host = WolverineHost.Basic();
+        theSession = new TrackedSession(_host);
+    }
+
+    public void Dispose()
+    {
+        _host?.Dispose();
+    }
+
+    private void record(object message)
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Message = message;
+        theSession.Record(MessageEventType.Sent, envelope, "service", Guid.NewGuid());
+    }
+
+    [Fact]
+    public void telemetry_messages_marked_with_INotToBeRouted_are_not_tracked()
+    {
+        // Continuously published framework telemetry (e.g. the CritterWatch
+        // monitoring messages) would otherwise hold a tracked session open
+        // until it times out
+        record(new FakeTelemetryMessage());
+
+        theSession.AllRecordsInOrder().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void agent_commands_are_still_ignored()
+    {
+        record(new FakeAgentCommand());
+
+        theSession.AllRecordsInOrder().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void acknowledgements_are_still_tracked()
+    {
+        // The tracked session has first-class acknowledgement semantics
+        // (SendMessageAndWaitForAcknowledgementAsync), so acks must keep
+        // being recorded even though Acknowledgement is INotToBeRouted
+        record(new Acknowledgement());
+
+        theSession.AllRecordsInOrder().Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public void failure_acknowledgements_are_still_tracked()
+    {
+        // AssertAnyFailureAcknowledgements reads FailureAcknowledgement records
+        record(new FailureAcknowledgement { RequestId = Guid.NewGuid(), Message = "boom" });
+
+        theSession.AllRecordsInOrder().Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ordinary_application_messages_are_still_tracked()
+    {
+        record(new FakeApplicationMessage());
+
+        theSession.AllRecordsInOrder().Length.ShouldBe(1);
+    }
+
+    private class FakeTelemetryMessage : INotToBeRouted;
+
+    private class FakeApplicationMessage;
+
+    private class FakeAgentCommand : IAgentCommand
+    {
+        public Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(AgentCommands.Empty);
+        }
+    }
+}

--- a/src/Wolverine/Tracking/TrackedSession.cs
+++ b/src/Wolverine/Tracking/TrackedSession.cs
@@ -34,10 +34,26 @@ internal partial class TrackedSession : ITrackedSession
 
     private Stopwatch _stopwatch = new();
 
-    private readonly List<Func<Type, bool>> _ignoreMessageRules = [t => t.CanBeCastTo<IAgentCommand>()];
+    private readonly List<Func<Type, bool>> _ignoreMessageRules = [isFrameworkTraffic];
     private CancellationTokenSource _cancellation = new();
 
     private TrackingStatus _status = TrackingStatus.Active;
+
+    // Framework/infrastructure traffic should never hold a tracked session open. That's
+    // Wolverine's own agent commands plus anything marked INotToBeRouted — which covers
+    // continuously-published telemetry like the CritterWatch monitoring messages that would
+    // otherwise keep IsCompleted() false until the session times out. Acknowledgements are
+    // deliberately still tracked: the session has first-class acknowledgement semantics
+    // (SendMessageAndWaitForAcknowledgementAsync, AssertAnyFailureAcknowledgements).
+    private static bool isFrameworkTraffic(Type type)
+    {
+        if (type == typeof(Acknowledgement) || type == typeof(FailureAcknowledgement))
+        {
+            return false;
+        }
+
+        return type.CanBeCastTo<IAgentCommand>() || type.CanBeCastTo<INotToBeRouted>();
+    }
 
     public TrackedSession(IHost host)
     {


### PR DESCRIPTION
Fixes [ProductSupport#33](https://github.com/JasperFx/ProductSupport/issues/33): with `AddCritterWatchMonitoring` enabled, the monitored host's outbound telemetry (`Wolverine.CritterWatch.Messages.Outbound.*`, published on the heartbeat/poller cadence) was recorded by tracked sessions and never completed inside the window, so `TrackActivity()…ExecuteAndWaitAsync` blocked until timeout.

## The fix

`TrackedSession`'s default ignore rule grows from `IAgentCommand` to a `isFrameworkTraffic` predicate: `IAgentCommand` **or** `INotToBeRouted` (every CritterWatch telemetry type implements `ICritterWatchMessage : INotToBeRouted`), with an explicit carve-out keeping `Acknowledgement` / `FailureAcknowledgement` tracked — the session has first-class ack semantics (`SendMessageAndWaitForAcknowledgementAsync`, `AssertAnyFailureAcknowledgements`) that must not regress.

## Blast radius (checked)

Core `INotToBeRouted` implementors are: `ISideEffect`, `ValidationOutcome`, `OutgoingMessages` (return-value types that never become envelopes), and the two ack types (carved out). The only envelope-borne `INotToBeRouted` traffic in practice is framework telemetry — which is exactly what should never hold a tracked session open. This matches the semantics `SystemMessageTypeExtensions.IsSystemMessageType` already asserts for observability surfaces.

## Tests

New `ignoring_framework_and_telemetry_messages` (5 tests): telemetry ignored, agent commands still ignored, both ack types still tracked, ordinary app messages still tracked. Full CoreTests suite: **1919 passed / 0 failed** locally on net9.0.

Ships in the next patch; the `IgnoreMessagesMatchingType(t => t.Namespace?.StartsWith("Wolverine.CritterWatch") == true)` workaround remains valid for older versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)