### PR TITLE
Fix metrics sweeper unregistration race + guard non-positive UpdateMetricsPeriod

### DIFF
--- a/src/Testing/CoreTests/Persistence/persistence_metrics_sweeper_tests.cs
+++ b/src/Testing/CoreTests/Persistence/persistence_metrics_sweeper_tests.cs
@@ -18,6 +18,11 @@ public class persistence_metrics_sweeper_tests
 {
     private readonly MockWolverineRuntime theRuntime = new();
 
+    // Scoped per test, deliberately NOT static: a sweeper loop started by an earlier test
+    // keeps running (nothing cancels MockWolverineRuntime), so cross-test static counters
+    // would let a stale loop's in-flight fetch inflate this test's observed concurrency.
+    private readonly ConcurrencyTracker theTracker = new();
+
     public persistence_metrics_sweeper_tests()
     {
         // keep passes short so the tests observe multiple sweeps quickly; the jittered
@@ -27,7 +32,7 @@ public class persistence_metrics_sweeper_tests
 
     private (IMessageStore store, PersistenceMetrics metrics, ConcurrencyTrackingAdmin admin) buildStore(string name)
     {
-        var admin = new ConcurrencyTrackingAdmin();
+        var admin = new ConcurrencyTrackingAdmin(theTracker);
         var store = Substitute.For<IMessageStore>();
         store.Uri.Returns(new Uri($"wolverinedb://test/{name}"));
         store.Admin.Returns(admin);
@@ -91,6 +96,48 @@ public class persistence_metrics_sweeper_tests
     }
 
     [Fact]
+    public async Task a_replacement_registration_for_the_same_database_survives_the_old_agents_dispose()
+    {
+        var sweeper = PersistenceMetricsSweeper.For(theRuntime);
+
+        // Same database URI, two successive agents — an agent for this database is stopping on
+        // this node while a replacement for it starts (agent redistribution). Both admins are
+        // distinct instances, so we can tell which registration the sweep is actually polling.
+        var stopping = buildStore("shared");
+        var replacement = buildStore("shared");
+        stopping.store.Uri.ShouldBe(replacement.store.Uri);
+
+        var stoppingRegistration = sweeper.Register(stopping.store, stopping.metrics);
+        var replacementRegistration = sweeper.Register(replacement.store, replacement.metrics);
+
+        try
+        {
+            // The stopping agent disposes AFTER the replacement registered. Removing by URI
+            // alone would evict the live registration and silently stop polling the database.
+            stoppingRegistration.Dispose();
+
+            await waitUntil(() => replacement.admin.Fetches >= 2);
+            replacement.metrics.Counts.Incoming.ShouldBe(ConcurrencyTrackingAdmin.TheCounts.Incoming);
+        }
+        finally
+        {
+            replacementRegistration.Dispose();
+        }
+    }
+
+    [Fact]
+    public void a_non_positive_update_metrics_period_is_rejected()
+    {
+        // A zero/negative period would hot-spin the sweep loop rather than fail, so it is
+        // rejected at configuration time. DurabilityMetricsEnabled is the way to turn it off.
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            theRuntime.Options.Durability.UpdateMetricsPeriod = TimeSpan.Zero);
+
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            theRuntime.Options.Durability.UpdateMetricsPeriod = -1.Seconds());
+    }
+
+    [Fact]
     public async Task polls_one_store_at_a_time()
     {
         var sweeper = PersistenceMetricsSweeper.For(theRuntime);
@@ -123,47 +170,58 @@ public class persistence_metrics_sweeper_tests
         }
     }
 
-    // Counts concurrent + total FetchCountsAsync calls across ALL instances so the
-    // sequential guarantee can be asserted; everything else is unused by the sweeper.
-    private class ConcurrencyTrackingAdmin : IMessageStoreAdmin
+    // Concurrent + peak FetchCountsAsync counts shared by every admin built for ONE test,
+    // so the sequential guarantee can be asserted without leaking across tests.
+    private class ConcurrencyTracker
     {
-        public static readonly PersistedCounts TheCounts = new() { Incoming = 42, Scheduled = 3, Outgoing = 7 };
+        private int _inFlight;
+        private int _maxObserved;
 
-        private static int _inFlight;
-        private static int _maxObserved;
+        public int MaxObservedConcurrency => Volatile.Read(ref _maxObserved);
 
-        public int Fetches;
-        public int MaxObservedConcurrency => _maxObserved;
-        public TimeSpan FetchDelay = TimeSpan.Zero;
-
-        public async Task<PersistedCounts> FetchCountsAsync()
+        public IDisposable Enter()
         {
             var current = Interlocked.Increment(ref _inFlight);
-            InterlockedMax(ref _maxObserved, current);
-
-            try
-            {
-                if (FetchDelay > TimeSpan.Zero)
-                {
-                    await Task.Delay(FetchDelay);
-                }
-
-                Interlocked.Increment(ref Fetches);
-                return TheCounts;
-            }
-            finally
-            {
-                Interlocked.Decrement(ref _inFlight);
-            }
+            interlockedMax(ref _maxObserved, current);
+            return new Exit(this);
         }
 
-        private static void InterlockedMax(ref int location, int value)
+        private static void interlockedMax(ref int location, int value)
         {
             int current;
             while (value > (current = Volatile.Read(ref location)))
             {
                 Interlocked.CompareExchange(ref location, value, current);
             }
+        }
+
+        private sealed class Exit(ConcurrencyTracker parent) : IDisposable
+        {
+            public void Dispose() => Interlocked.Decrement(ref parent._inFlight);
+        }
+    }
+
+    // Counts total FetchCountsAsync calls for one store and feeds the test's shared
+    // concurrency tracker; everything else is unused by the sweeper.
+    private class ConcurrencyTrackingAdmin(ConcurrencyTracker tracker) : IMessageStoreAdmin
+    {
+        public static readonly PersistedCounts TheCounts = new() { Incoming = 42, Scheduled = 3, Outgoing = 7 };
+
+        public int Fetches;
+        public int MaxObservedConcurrency => tracker.MaxObservedConcurrency;
+        public TimeSpan FetchDelay = TimeSpan.Zero;
+
+        public async Task<PersistedCounts> FetchCountsAsync()
+        {
+            using var _ = tracker.Enter();
+
+            if (FetchDelay > TimeSpan.Zero)
+            {
+                await Task.Delay(FetchDelay);
+            }
+
+            Interlocked.Increment(ref Fetches);
+            return TheCounts;
         }
 
         public Task DeleteAllHandledAsync() => Task.CompletedTask;

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -253,11 +253,31 @@ public class DurabilitySettings : IDescribeMyself
     /// </summary>
     public TimeSpan TenantCheckPeriod { get; set; } = 5.Seconds();
 
+    private TimeSpan _updateMetricsPeriod = 5.Seconds();
+
     /// <summary>
     /// If using any kind of message persistence, this is the polling time
-    /// to update the metrics on the persisted envelope counts. Default is 5 seconds
+    /// to update the metrics on the persisted envelope counts. Default is 5 seconds.
+    /// Must be greater than zero. Use <see cref="DurabilityMetricsEnabled"/> to turn
+    /// the polling off entirely.
     /// </summary>
-    public TimeSpan UpdateMetricsPeriod { get; set; } = 5.Seconds();
+    public TimeSpan UpdateMetricsPeriod
+    {
+        get => _updateMetricsPeriod;
+        set
+        {
+            // The metrics sweeper paces its pass with Task.Delay, so a non-positive period
+            // would hot-spin the sweep loop against every registered database rather than
+            // fail. Reject it at configuration time instead.
+            if (value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(UpdateMetricsPeriod), value,
+                    $"{nameof(UpdateMetricsPeriod)} must be greater than zero. Set {nameof(DurabilityMetricsEnabled)} to false to disable durability metrics polling.");
+            }
+
+            _updateMetricsPeriod = value;
+        }
+    }
 
     /// <summary>
     /// Is the polling for durability metrics enabled? Default is true

--- a/src/Wolverine/Persistence/PersistenceMetricsSweeper.cs
+++ b/src/Wolverine/Persistence/PersistenceMetricsSweeper.cs
@@ -39,7 +39,15 @@ public class PersistenceMetricsSweeper
         _logger = runtime.LoggerFactory.CreateLogger<PersistenceMetricsSweeper>();
     }
 
-    private sealed record Registration(IMessageStore Store, PersistenceMetrics Metrics);
+    // A class, not a record: unregistration removes the exact registration *instance* it
+    // created, and that identity check relies on reference equality. A record's value
+    // equality would let a stale agent's Dispose match — and drop — the live registration
+    // that replaced it for the same database.
+    private sealed class Registration(IMessageStore store, PersistenceMetrics metrics)
+    {
+        public IMessageStore Store { get; } = store;
+        public PersistenceMetrics Metrics { get; } = metrics;
+    }
 
     /// <summary>
     /// Add a store to the node's metrics sweep. Dispose the returned handle to remove it
@@ -48,9 +56,10 @@ public class PersistenceMetricsSweeper
     /// </summary>
     public IDisposable Register(IMessageStore store, PersistenceMetrics metrics)
     {
-        _registrations[store.Uri] = new Registration(store, metrics);
+        var registration = new Registration(store, metrics);
+        _registrations[store.Uri] = registration;
         ensureStarted();
-        return new Unregistration(this, store.Uri);
+        return new Unregistration(this, store.Uri, registration);
     }
 
     private void ensureStarted()
@@ -139,16 +148,23 @@ public class PersistenceMetricsSweeper
     {
         private readonly PersistenceMetricsSweeper _parent;
         private readonly Uri _uri;
+        private readonly Registration _registration;
 
-        public Unregistration(PersistenceMetricsSweeper parent, Uri uri)
+        public Unregistration(PersistenceMetricsSweeper parent, Uri uri, Registration registration)
         {
             _parent = parent;
             _uri = uri;
+            _registration = registration;
         }
 
         public void Dispose()
         {
-            _parent._registrations.TryRemove(_uri, out _);
+            // Remove only if this exact registration is still the live one. A blind
+            // remove-by-URI would silently evict a newer agent's registration for the same
+            // database when a stopping agent's Dispose interleaves after the replacement
+            // registers — and that database would then go unpolled until the next restart.
+            _parent._registrations.TryRemove(
+                new KeyValuePair<Uri, Registration>(_uri, _registration));
         }
     }
 }


### PR DESCRIPTION
Follow-ups from the post-merge review of #3384 (GH-3375, the node-wide durability metrics sweeper). Both are small; targeting 6.17.3.

## 1. Unregistration race — a database can silently stop being polled

`Unregistration.Dispose` removed the registration by **URI alone**:

```csharp
_parent._registrations.TryRemove(_uri, out _);
```

The sweeper is keyed by database URI, and durability agents register/unregister as they start and stop. If an agent for a database stops on this node *after* a replacement agent for the **same database** has already registered — which is exactly what agent redistribution does — the stopping agent's `Dispose` evicts the **live** registration. That database then stops being polled from this node until it restarts, and its inbox/outbox/scheduled gauges silently flatline.

`Dispose` now removes only if the exact registration instance it created is still the live one:

```csharp
_parent._registrations.TryRemove(new KeyValuePair<Uri, Registration>(_uri, _registration));
```

`Registration` changes from a `record` to a `class` so that identity check is **reference** equality. This matters: `ConcurrentDictionary.TryRemove(KeyValuePair)` compares the value with `EqualityComparer<TValue>.Default`, and a record's value equality would let a stale agent's `Dispose` match — and drop — the replacement registration anyway, defeating the fix.

## 2. `UpdateMetricsPeriod = TimeSpan.Zero` hot-spins

The sweeper paces its pass with `Task.Delay(period)`. A zero/negative period no longer fails — it **hot-spins the sweep loop** against every registered database. The pre-#3384 per-agent path used `new PeriodicTimer(period)`, which threw on a non-positive value, so this guard was lost in the rewrite.

Restored as a validating setter, so it fires at configuration time and covers both the sweeper and the `PersistenceMetrics.StartPolling` path that CosmosDb/RavenDb single-store agents still use. `DurabilityMetricsEnabled = false` remains the way to turn metrics polling off, and the exception message says so.

Nothing in the repo or docs ever assigns a non-positive period, so this breaks no existing configuration.

## Tests

- `a_replacement_registration_for_the_same_database_survives_the_old_agents_dispose` — the race. **Verified it has teeth**: red against the by-URI removal (times out — the database stops being polled, precisely the bug), green with the fix.
- `a_non_positive_update_metrics_period_is_rejected` — the guard.
- Test hygiene: the suite's concurrency counters were `static` and leaked across tests. Nothing cancels `MockWolverineRuntime`, so a sweeper loop started by an earlier test keeps running, and a stale in-flight fetch could inflate the observed concurrency and spuriously fail `polls_one_store_at_a_time`. Now scoped per test.

Sweeper suite 5/5 green; full `wolverine.slnx` Release build clean.

Refs #3375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)