### PR TITLE
Cold-path catch-up coverage + honor the tracked session timeout (GH-3388)

### DIFF
--- a/src/Persistence/MartenTests/TestHelpers/cold_catch_up_with_second_subscription_consumer.cs
+++ b/src/Persistence/MartenTests/TestHelpers/cold_catch_up_with_second_subscription_consumer.cs
@@ -1,0 +1,109 @@
+using IntegrationTests;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests.TestHelpers;
+
+/// <summary>
+/// GH-3388, second hypothesis: a SECOND consumer of the Wolverine-managed event subscription
+/// distribution (the reporter runs CritterWatch, whose subscription agents share the same
+/// EventSubscriptionAgentFamily) leaves the app's projection shard un-started, so the COLD
+/// PauseThenCatchUp never gets driven. Simulated here with an extra Wolverine-distributed
+/// ancillary store, running under Balanced durability so real agent assignment happens.
+/// </summary>
+public interface IWatcherStore : IDocumentStore;
+
+public class cold_catch_up_with_second_subscription_consumer : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "letters_cold5";
+
+                    m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
+                }).IntegrateWithWolverine(x => x.UseWolverineManagedEventSubscriptionDistribution = true);
+
+                // The application's ancillary store with the async projection under test
+                opts.Services.AddMartenStore<ILetterStore>(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "letters_cold6";
+
+                    m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
+                }).IntegrateWithWolverine();
+
+                // Stand-in for CritterWatch: a SECOND store contributing async subscription agents
+                // to the same Wolverine-managed distribution
+                opts.Services.AddMartenStore<IWatcherStore>(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "letters_cold7";
+
+                    m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
+                }).IntegrateWithWolverine();
+
+                // Real agent assignment, not Solo
+                opts.Durability.Mode = DurabilityMode.Balanced;
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task cold_catch_up_on_ancillary_store_with_second_consumer()
+    {
+        var id = Guid.NewGuid();
+
+        var tracked = await _host.TrackActivity()
+            .ResetAllMartenDataFirst<ILetterStore>()
+            .PauseThenCatchUpOnMartenDaemonActivity<ILetterStore>(CatchUpMode.AndDoNothing)
+            .InvokeMessageAndWaitAsync(new AppendLetters2(id, ["AAAACCCCBDEEE", "ABCDECCC", "BBBA", "DDDAE"]));
+
+        await using var session = _host.DocumentStore<ILetterStore>().LightweightSession();
+        var counts = (await session.Query<LetterCounts>().ToListAsync()).Single();
+        counts.Id.ShouldBe(id);
+
+        counts.ACount.ShouldBe(7);
+        counts.BCount.ShouldBe(5);
+        counts.CCount.ShouldBe(8);
+    }
+
+    [Fact]
+    public async Task cold_catch_up_on_main_store_with_second_consumer()
+    {
+        var id = Guid.NewGuid();
+
+        var tracked = await _host.TrackActivity()
+            .ResetAllMartenDataFirst()
+            .PauseThenCatchUpOnMartenDaemonActivity(CatchUpMode.AndDoNothing)
+            .InvokeMessageAndWaitAsync(new AppendLetters(id, ["AAAACCCCBDEEE", "ABCDECCC", "BBBA", "DDDAE"]));
+
+        await using var session = _host.DocumentStore().LightweightSession();
+        var counts = (await session.Query<LetterCounts>().ToListAsync()).Single();
+        counts.Id.ShouldBe(id);
+
+        counts.ACount.ShouldBe(7);
+        counts.BCount.ShouldBe(5);
+        counts.CCount.ShouldBe(8);
+    }
+}

--- a/src/Persistence/MartenTests/TestHelpers/cold_catch_up_with_wolverine_distribution.cs
+++ b/src/Persistence/MartenTests/TestHelpers/cold_catch_up_with_wolverine_distribution.cs
@@ -1,0 +1,96 @@
+using IntegrationTests;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests.TestHelpers;
+
+/// <summary>
+/// GH-3388: the tracked PauseThenCatchUpOnMartenDaemonActivity is the very FIRST daemon interaction
+/// against a COLD daemon whose shards were never started. No warming seed, no prior
+/// WaitForNonStaleProjectionDataAsync.
+/// </summary>
+public class cold_catch_up_with_wolverine_distribution : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "letters_cold3";
+
+                    m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
+                }).IntegrateWithWolverine(x => x.UseWolverineManagedEventSubscriptionDistribution = true);
+
+                opts.Services.AddMartenStore<ILetterStore>(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "letters_cold4";
+
+                    m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
+                }).IntegrateWithWolverine();
+
+                opts.Durability.Mode = DurabilityMode.Solo;
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task cold_catch_up_with_main_store()
+    {
+        var id = Guid.NewGuid();
+
+        // NO warming. This is the first daemon interaction of the host.
+        var tracked = await _host.TrackActivity()
+            .ResetAllMartenDataFirst()
+            .PauseThenCatchUpOnMartenDaemonActivity(CatchUpMode.AndDoNothing)
+            .InvokeMessageAndWaitAsync(new AppendLetters(id, ["AAAACCCCBDEEE", "ABCDECCC", "BBBA", "DDDAE"]));
+
+        await using var session = _host.DocumentStore().LightweightSession();
+        var counts = (await session.Query<LetterCounts>().ToListAsync()).Single();
+        counts.Id.ShouldBe(id);
+
+        counts.ACount.ShouldBe(7);
+        counts.BCount.ShouldBe(5);
+        counts.CCount.ShouldBe(8);
+    }
+
+    [Fact]
+    public async Task cold_catch_up_with_ancillary_store()
+    {
+        var id = Guid.NewGuid();
+
+        var tracked = await _host.TrackActivity()
+            .ResetAllMartenDataFirst<ILetterStore>()
+            .PauseThenCatchUpOnMartenDaemonActivity<ILetterStore>(CatchUpMode.AndDoNothing)
+            .InvokeMessageAndWaitAsync(new AppendLetters2(id, ["AAAACCCCBDEEE", "ABCDECCC", "BBBA", "DDDAE"]));
+
+        await using var session = _host.DocumentStore<ILetterStore>().LightweightSession();
+        var counts = (await session.Query<LetterCounts>().ToListAsync()).Single();
+        counts.Id.ShouldBe(id);
+
+        counts.ACount.ShouldBe(7);
+        counts.BCount.ShouldBe(5);
+        counts.CCount.ShouldBe(8);
+    }
+}

--- a/src/Persistence/Wolverine.Marten/TestingExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/TestingExtensions.cs
@@ -74,7 +74,8 @@ public static class TestingExtensions
             var coordinator = runtime.Services.GetRequiredService<IProjectionCoordinator>();
 
             await catchUpThroughCoordinatorAsync(runtime, envelope, coordinator,
-                () => runtime.Services.DocumentStore().WaitForNonStaleProjectionDataAsync(CatchUpTimeout), mode);
+                () => runtime.Services.DocumentStore().WaitForNonStaleProjectionDataAsync(CatchUpTimeout), mode,
+                "the main Marten store", cancellation);
         });
     }
 
@@ -114,7 +115,8 @@ public static class TestingExtensions
             var coordinator = runtime.Services.GetRequiredService<IProjectionCoordinator<T>>();
 
             await catchUpThroughCoordinatorAsync(runtime, envelope, coordinator,
-                () => runtime.Services.DocumentStore<T>().WaitForNonStaleProjectionDataAsync(CatchUpTimeout), mode);
+                () => runtime.Services.DocumentStore<T>().WaitForNonStaleProjectionDataAsync(CatchUpTimeout), mode,
+                $"the ancillary Marten store {typeof(T).NameInCode()}", cancellation);
         });
     }
 
@@ -136,7 +138,9 @@ public static class TestingExtensions
         Envelope envelope,
         global::Marten.Events.Daemon.Coordination.IProjectionCoordinator coordinator,
         Func<Task> waitForNonStale,
-        CatchUpMode mode)
+        CatchUpMode mode,
+        string storeDescription,
+        CancellationToken cancellation)
     {
         runtime.MessageTracking.ExecutionStarted(envelope);
 
@@ -153,7 +157,21 @@ public static class TestingExtensions
                 subscriptions.Add(daemon.Tracker.Subscribe(observer));
             }
 
-            await waitForNonStale().ConfigureAwait(false);
+            // GH-3388: the tracked session that owns this stage cancels at its OWN timeout
+            // (TrackedSession.Timeout, 5 seconds by default), which is far shorter than
+            // CatchUpTimeout. Waiting on the un-cancellable inner task meant the session gave up
+            // first and the catch-up envelope was simply left un-finished — surfacing as an opaque
+            // "started but never finished" hang rather than something a user could act on. Honor
+            // the session's token and say plainly what to do about it.
+            try
+            {
+                await waitForNonStale().WaitAsync(cancellation).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"The tracked session timed out before the Marten projections for {storeDescription} caught up. The catch-up itself is allowed {CatchUpTimeout.TotalSeconds:N0} seconds, but the tracked session's own Timeout governs it. Raise it with TrackActivity().Timeout(...) — projection catch-up on a cold daemon, a large event backlog, or a busy CI machine routinely needs more than the 5 second default.");
+            }
 
             if (mode == CatchUpMode.AndDoNothing)
             {


### PR DESCRIPTION
Investigating #3388. Two outcomes: the alleged regression **does not reproduce**, but the reporter did surface a real defect — just not the one they diagnosed. Targeting 6.17.3.

## The reported mechanism is disproven

The claim is that `coordinator.ResumeAsync()` does not *start* shards that were never started, so a cold first catch-up blocks to the timeout.

Under `UseWolverineManagedEventSubscriptionDistribution`, `IProjectionCoordinator` is **not** Marten's `ProjectionCoordinator` — it is `WolverineProjectionCoordinator`. Its `ResumeAsync()` → `StartAsync()` → `EventStoreAgents.StartAllAsync()`, which for **every** database calls `FindDaemonAsync(id)` (which *builds* the daemon lazily if it never existed) and then `daemon.StartAllAsync()`, starting all async shards directly on the local daemon. It bypasses agent assignment entirely.

So there is no "resume only what was already started" semantic to fall through. That is why the cold path works, and why a second consumer of the agent family (CritterWatch's `EventSubscriptionAgentFamily`, the reporter's suspected trigger) cannot starve it — `ResumeAsync` never consults assignments. This matches the reporter's own finding that a minimal clean host would not reproduce it either.

## But the cold path really was untested

The reporter was right about that. Every existing `TestHelpers` test seeds streams and then warms with `WaitForNonStaleProjectionDataAsync(...)` **before** the tracked pause-then-catch-up, so the cold first catch-up was never exercised.

Added, per the issue's suggestion #1:
- `cold_catch_up_with_wolverine_distribution` — tracked `PauseThenCatchUpOnMartenDaemonActivity` as the **very first** daemon interaction (no seed, no warm), for the main store and an ancillary store.
- `cold_catch_up_with_second_subscription_consumer` — the reporter's hypothesis: a **second** Wolverine-distributed store contributing async subscription agents to the same `EventSubscriptionAgentFamily`, under `DurabilityMode.Balanced` so real agent assignment runs.

All pass, in ~1–2s rather than stalling. Full `TestHelpers` namespace: **16/16 green** (12 existing + 4 new).

## The real defect: the catch-up ignored the session's own timeout

This explains the reported symptom exactly.

`AddStage` runs inside a **child `TrackedSession`** whose cancellation token fires at `TrackedSession.Timeout` — **5 seconds by default**. But `catchUpThroughCoordinatorAsync` ignored that token and waited on an inner `CatchUpTimeout` of **60 seconds**. The session therefore gave up first, leaving the `CatchUp:Marten:DaemonActivity:<store>` envelope **started but never finished** — precisely the "records ExecutionStarted and never finishes" the issue describes. It reads like a hang; it is really "the inner wait outlived the outer budget."

And it is a genuine 6.16.0 → 6.17.0 behavior change: the old active `ForceAll` drove catch-up fast enough to fit inside the 5s default. The resume-and-wait path on a cold daemon, a large backlog, or a loaded CI machine does not.

The catch-up now honors the session's cancellation token, and when the session's budget expires first it raises a `TimeoutException` that names the store and points at the actual lever:

> The tracked session timed out before the Marten projections for *the ancillary Marten store IWatcherStore* caught up. The catch-up itself is allowed 60 seconds, but the tracked session's own Timeout governs it. Raise it with `TrackActivity().Timeout(...)` — projection catch-up on a cold daemon, a large event backlog, or a busy CI machine routinely needs more than the 5 second default.

The envelope is also no longer left dangling, so the failure surfaces as this message rather than an opaque incomplete-envelope timeout dump.

Honest limitation: the diagnostic path itself is not unit-tested — forcing it deterministically needs a timing-dependent setup, and I would rather not add a flaky test. The behavior change is small and the message is the payload.

## Does this close #3388?

Not on its own — I would keep it open until the reporter re-verifies. Their stall was against a real CritterWatch-monitored host, and if raising the tracked-session timeout resolves it, that confirms this was the cause. If it does not, we still need their environment to go further, since neither their minimal host nor this in-tree simulation reproduces the stall.

Full `wolverine.slnx` Release build clean (0 warnings, 0 errors).

Refs #3388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)