### PR TITLE
ApplyRestrictionsAsync never dispatched the commands it computed (GH-698)

### DIFF
--- a/src/Testing/Wolverine.ComplianceTests/LeadershipElectionCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/LeadershipElectionCompliance.cs
@@ -141,6 +141,35 @@ public abstract class LeadershipElectionCompliance : IAsyncLifetime
         }, 60.Seconds());
     }
 
+    [Fact]
+    public async Task pausing_an_agent_stops_it_immediately()
+    {
+        await _originalHost.WaitUntilAssignmentsChangeTo(w => w.ExpectRunningAgents(_originalHost, 12), 30.Seconds());
+
+        var runtime = _originalHost.GetRuntime();
+
+        // Health checks are disabled for the rest of this test on purpose. The health-check loop
+        // re-reads restrictions from the database and would eventually stop the agent anyway, which
+        // would mask the defect: GH-698 / CritterWatch#698 is that ApplyRestrictionsAsync persisted
+        // the restriction and then DISCARDED the StopRemoteAgent that EvaluateAssignmentsAsync
+        // returned, so the pause had no *immediate* effect. Isolating that path is the whole point.
+        runtime.Agents.DisableHealthChecks();
+
+        var uri = runtime.Agents.AllRunningAgentUris().First();
+
+        var restrictions = new AgentRestrictions([]);
+        restrictions.PauseAgent(uri);
+
+        await runtime.Agents.ApplyRestrictionsAsync(restrictions, CancellationToken.None);
+
+        // No polling: by the time ApplyRestrictionsAsync returns, the stop must have been carried out.
+        runtime.Agents.AllRunningAgentUris().ShouldNotContain(uri);
+
+        // ...and the in-memory copy that ListeningAgent consults must reflect it too, otherwise a
+        // paused listener would just restart itself on the next attempt.
+        runtime.Restrictions.FindPausedAgentUris().ShouldContain(uri);
+    }
+
     /***** NEW TESTS END HERE **********************************************/
 
     [Fact]

--- a/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
@@ -134,12 +134,41 @@ public partial class WolverineRuntime : IAgentRuntime
     public async Task ApplyRestrictionsAsync(AgentRestrictions restrictions, CancellationToken cancellationToken)
     {
         await KickstartHealthDetectionAsync();
-        
+
         var (nodes, assignments) = await Storage.Nodes.LoadNodeAgentStateAsync(cancellationToken);
         assignments.MergeChanges(restrictions);
         await Storage.Nodes.PersistAgentRestrictionsAsync(assignments.FindChanges(), cancellationToken);
 
-        await NodeController!.EvaluateAssignmentsAsync(nodes, assignments);
+        // GH-3396 / CritterWatch GH-698: EvaluateAssignmentsAsync *returns* the commands that carry
+        // the restriction out to the cluster — pausing an agent detaches it from the grid, which
+        // produces a StopRemoteAgent. Discarding that return value meant the pause was persisted and
+        // then had NO immediate effect: the agent kept running until some later leader heartbeat
+        // happened to re-read restrictions from the database. Every other caller of
+        // EvaluateAssignmentsAsync pumps these commands; so does this one now.
+        var commands = await NodeController!.EvaluateAssignmentsAsync(nodes, assignments);
+        await executeAgentCommandsAsync(commands, cancellationToken);
+
+        // The in-memory copy is otherwise only ever loaded at startup, but ListeningAgent reads it
+        // on every start attempt to decide whether a listener is meant to stay paused — so without
+        // this a listener paused through restrictions would keep restarting until the node did.
+        Restrictions = assignments;
+    }
+
+    // Drains an AgentCommands cascade through the message bus. Commands can yield further commands,
+    // so this keeps pumping until the queue is empty.
+    private async Task executeAgentCommandsAsync(AgentCommands commands, CancellationToken cancellationToken)
+    {
+        var bus = new MessageBus(this);
+
+        while (commands.Any())
+        {
+            var command = commands.Pop();
+            var additional = await bus.InvokeAsync<AgentCommands>(command, cancellationToken);
+            if (additional != null)
+            {
+                commands.AddRange(additional);
+            }
+        }
     }
 
     public bool TryFindActiveAgent<T>(Uri agentUri, out T agent) where T : class
@@ -244,19 +273,9 @@ public partial class WolverineRuntime : IAgentRuntime
                 try
                 {
 
-                    var commands = await NodeController.DoHealthChecksAsync();
-                    var bus = new MessageBus(this);
-
                     // TODO -- try to parallelize this later!!!
-                    while (commands.Any())
-                    {
-                        var command = commands.Pop();
-                        var additional = await bus.InvokeAsync<AgentCommands>(command, Cancellation);
-                        if (additional != null)
-                        {
-                            commands.AddRange(additional);
-                        }
-                    }
+                    var commands = await NodeController.DoHealthChecksAsync();
+                    await executeAgentCommandsAsync(commands, Cancellation);
                 }
                 catch (OperationCanceledException)
                 {


### PR DESCRIPTION
Upstream half of [CritterWatch#698](https://github.com/JasperFx/CritterWatch/issues/698) (@erdtsieck — the console's "pause projection" acks Succeeded but the agent never pauses). Targeting 6.18.0.

## The bug

`IAgentRuntime.ApplyRestrictionsAsync` persisted the restriction row and then **had no immediate effect** — the agent kept running.

`EvaluateAssignmentsAsync` **returns** the commands that carry a restriction out to the cluster: pausing an agent detaches it from the assignment grid, which produces a `StopRemoteAgent`. Every other caller pumps that return value through a `MessageBus` — the health-check loop does exactly this. `ApplyRestrictionsAsync` threw it away:

```csharp
await NodeController!.EvaluateAssignmentsAsync(nodes, assignments);   // <-- return value discarded
```

So the pause only took hold whenever some later *leader* heartbeat happened to re-read restrictions from the database. Any caller that treated the method returning as "it is paused now" — which is exactly what CritterWatch's pause handler does — was acking a no-op.

## Second defect, same method

The in-memory `WolverineRuntime.Restrictions` was **never refreshed**. It is otherwise only loaded once at startup (`WolverineRuntime.HostService.cs`), but `ListeningAgent` reads it on **every** start attempt to decide whether a listener is meant to stay paused. So a *listener* paused through restrictions would keep restarting itself until the node restarted.

## The fix

`ApplyRestrictionsAsync` now drains the returned `AgentCommands` cascade (commands can yield further commands) and refreshes the in-memory copy. The drain loop is shared with the health-check loop rather than copied a third time.

## Test

`pausing_an_agent_stops_it_immediately`, added to `LeadershipElectionCompliance` so it runs for **every** provider.

It **disables health checks first, on purpose.** The health-check loop re-reads restrictions from the database and would eventually stop the agent anyway — a polling assertion would therefore pass even against the broken code and prove nothing. The defect is the absence of an *immediate* effect, so the test asserts synchronously once `ApplyRestrictionsAsync` returns.

- **Verified red** against the old code (fails), **green** with the fix.
- Full Postgres leader-election suite **14/14 green** — that covers the health-check/agent-distribution path the shared drain loop touches.
- Full `wolverine.slnx` Release build clean.

`ApplyRestrictionsAsync` had **zero** test coverage before this, which is what let it ship.

## Does this close CritterWatch#698?

It fixes a real defect that produces exactly the reported symptom, but **not necessarily the reporter's `wolverine_agent_restrictions` = 0 rows.** The persist path is unconditional and agent-family-agnostic, so I cannot statically explain zero rows; the restriction should have been written even before this fix. The leading remaining hypothesis is that the command executed against a *different* Wolverine runtime than the one inspected (the console has its own compiled `PauseProjectionHandler`), which would put the row in the console's database. That is being followed up on the CritterWatch side, along with verify-before-ack so a green ack can never again mean nothing happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)