### PR TITLE
Refuse a competing Marten daemon under managed distribution (GH-3388)

### DIFF
--- a/src/Persistence/MartenTests/Bugs/Bug_3290_misleading_daemon_disabled_warning.cs
+++ b/src/Persistence/MartenTests/Bugs/Bug_3290_misleading_daemon_disabled_warning.cs
@@ -122,21 +122,51 @@ public class Bug_3290_misleading_daemon_disabled_warning : PostgresqlContext
         console.ShouldContain("The async daemon is disabled");
     }
 
+    // GH-3388 — these two used to assert that an explicit Solo/HotCold daemon choice SURVIVES
+    // alongside Wolverine-managed distribution ("an explicit user choice is never overwritten").
+    // That contract turned out to be the footgun: the combination is never valid. Marten hosts its
+    // own ProjectionCoordinator (an IHostedService) which starts the shards, while Wolverine's
+    // distribution drives the same daemon through its own coordinator. The two compete, and the
+    // symptom is not an error but a HANG — a tracked catch-up that never completes. A user lost a
+    // day to it, and nothing in the stalling code points back at the registration that caused it.
+    // Preserving the choice silently is strictly worse than refusing it, so it is now refused.
+    // Rejected at host START, not at store construction: Marten applies AddAsyncDaemon's mode
+    // through ConfigureMarten, which runs in registration order, so a daemon choice made AFTER
+    // IntegrateWithWolverine is not yet visible while the integration configures. By start-up the
+    // options are final — which is why BOTH call orders below are caught.
     [Fact]
-    public void explicit_add_async_daemon_choice_after_integration_is_not_overwritten()
+    public async Task explicit_solo_daemon_after_integration_is_rejected()
     {
         using var host = configureHost(useWolverineManagedDistribution: true, DaemonMode.Solo).Build();
 
-        var (store, _) = buildStoreCapturingConsole(host);
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() => host.StartAsync());
 
-        store.Options.Projections.AsyncMode.ShouldBe(DaemonMode.Solo);
+        ex.Message.ShouldContain("UseWolverineManagedEventSubscriptionDistribution");
+        ex.Message.ShouldContain("MartenDaemonModeIsSolo");
     }
 
     [Fact]
-    public void explicit_add_async_daemon_choice_before_integration_is_not_overwritten()
+    public async Task explicit_solo_daemon_before_integration_is_rejected()
     {
         using var host = configureHost(useWolverineManagedDistribution: true, DaemonMode.Solo,
             explicitDaemonBeforeIntegration: true).Build();
+
+        await Should.ThrowAsync<InvalidOperationException>(() => host.StartAsync());
+    }
+
+    [Fact]
+    public async Task explicit_hotcold_daemon_is_rejected_too()
+    {
+        using var host = configureHost(useWolverineManagedDistribution: true, DaemonMode.HotCold).Build();
+
+        await Should.ThrowAsync<InvalidOperationException>(() => host.StartAsync());
+    }
+
+    [Fact]
+    public void an_explicit_daemon_choice_is_fine_without_managed_distribution()
+    {
+        // Nothing to compete with, so the user's choice stands exactly as before.
+        using var host = configureHost(useWolverineManagedDistribution: false, DaemonMode.Solo).Build();
 
         var (store, _) = buildStoreCapturingConsole(host);
 

--- a/src/Persistence/MartenTests/TestHelpers/catch_up_and_then_do_nothing.cs
+++ b/src/Persistence/MartenTests/TestHelpers/catch_up_and_then_do_nothing.cs
@@ -40,7 +40,9 @@ public class catch_up_and_then_do_nothing : IAsyncLifetime
                     m.DatabaseSchemaName = "letters3";
 
                     m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
-                }).AddAsyncDaemon(DaemonMode.Solo).IntegrateWithWolverine();
+                }).IntegrateWithWolverine(); // GH-3388: no AddAsyncDaemon here — this is the SAME main store
+                              // that enabled UseWolverineManagedEventSubscriptionDistribution above,
+                              // and Wolverine runs its daemon.
                 
                 opts.Services.AddMartenStore<ILetterStore>(m =>
                 {

--- a/src/Persistence/MartenTests/TestHelpers/catch_up_then_restart.cs
+++ b/src/Persistence/MartenTests/TestHelpers/catch_up_then_restart.cs
@@ -40,7 +40,9 @@ public class catch_up_then_restart : IAsyncLifetime
                     m.DatabaseSchemaName = "letters3";
 
                     m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
-                }).AddAsyncDaemon(DaemonMode.Solo).IntegrateWithWolverine();
+                }).IntegrateWithWolverine(); // GH-3388: no AddAsyncDaemon here — this is the SAME main store
+                              // that enabled UseWolverineManagedEventSubscriptionDistribution above,
+                              // and Wolverine runs its daemon.
                 
                 opts.Services.AddMartenStore<ILetterStore>(m =>
                 {

--- a/src/Persistence/MartenTests/TestHelpers/reset_data_first.cs
+++ b/src/Persistence/MartenTests/TestHelpers/reset_data_first.cs
@@ -40,7 +40,9 @@ public class reset_data_first : IAsyncLifetime
                     m.DatabaseSchemaName = "letters";
 
                     m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
-                }).AddAsyncDaemon(DaemonMode.Solo).IntegrateWithWolverine();
+                }).IntegrateWithWolverine(); // GH-3388: no AddAsyncDaemon here — this is the SAME main store
+                              // that enabled UseWolverineManagedEventSubscriptionDistribution above,
+                              // and Wolverine runs its daemon.
                 
                 opts.Services.AddMartenStore<ILetterStore>(m =>
                 {

--- a/src/Persistence/MartenTests/TestHelpers/second_stage_waiting.cs
+++ b/src/Persistence/MartenTests/TestHelpers/second_stage_waiting.cs
@@ -45,7 +45,9 @@ public class second_stage_waiting : IAsyncLifetime
                     m.DatabaseSchemaName = "letters3";
 
                     m.Projections.Add<LetterCountsProjectionWithSideEffects>(ProjectionLifecycle.Async);
-                }).AddAsyncDaemon(DaemonMode.Solo).IntegrateWithWolverine();
+                }).IntegrateWithWolverine(); // GH-3388: no AddAsyncDaemon here — this is the SAME main store
+                              // that enabled UseWolverineManagedEventSubscriptionDistribution above,
+                              // and Wolverine runs its daemon.
                 
                 opts.Services.AddMartenStore<ILetterStore>(m =>
                 {

--- a/src/Persistence/MartenTests/TestHelpers/wait_for_non_stale_data_after.cs
+++ b/src/Persistence/MartenTests/TestHelpers/wait_for_non_stale_data_after.cs
@@ -40,7 +40,9 @@ public class wait_for_non_stale_data_after : IAsyncLifetime
                     m.DatabaseSchemaName = "letters3";
 
                     m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
-                }).AddAsyncDaemon(DaemonMode.Solo).IntegrateWithWolverine();
+                }).IntegrateWithWolverine(); // GH-3388: no AddAsyncDaemon here — this is the SAME main store
+                              // that enabled UseWolverineManagedEventSubscriptionDistribution above,
+                              // and Wolverine runs its daemon.
                 
                 opts.Services.AddMartenStore<ILetterStore>(m =>
                 {

--- a/src/Persistence/Wolverine.Marten/Distribution/ManagedDistributionDaemonModeValidator.cs
+++ b/src/Persistence/Wolverine.Marten/Distribution/ManagedDistributionDaemonModeValidator.cs
@@ -1,0 +1,45 @@
+using JasperFx.Events.Daemon;
+using Marten;
+using Microsoft.Extensions.Hosting;
+
+namespace Wolverine.Marten.Distribution;
+
+/// <summary>
+/// GH-3388: refuses a store that combines Wolverine-managed event subscription distribution with an
+/// explicit Marten-side daemon (<c>MartenDaemonModeIsSolo()</c> / <c>AddAsyncDaemon(Solo|HotCold)</c>).
+///
+/// That combination is never valid. Marten hosts its own <c>ProjectionCoordinator</c> — an
+/// <c>IHostedService</c> that starts the shards — while Wolverine's distribution drives the same
+/// daemon through its own coordinator. The two compete, and the symptom is not an error but a HANG:
+/// a tracked catch-up that never completes. It cost a user a day to find, and nothing in the code
+/// that stalls points back at the registration that caused it.
+///
+/// This is checked at host start rather than in <see cref="MartenIntegration"/> because Marten
+/// applies <c>AddAsyncDaemon</c>'s mode through <c>ConfigureMarten</c>, which runs in registration
+/// order — so a daemon choice made AFTER <c>IntegrateWithWolverine</c> is not yet visible while the
+/// integration is configuring. By start-up the store's options are final, whatever the call order.
+/// </summary>
+internal class ManagedDistributionDaemonModeValidator : IHostedService
+{
+    private readonly DocumentStore _store;
+
+    public ManagedDistributionDaemonModeValidator(IDocumentStore store)
+    {
+        _store = (DocumentStore)store;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var mode = _store.Options.Projections.AsyncMode;
+
+        if (mode is DaemonMode.Solo or DaemonMode.HotCold)
+        {
+            throw new InvalidOperationException(
+                $"Marten's async daemon is set to {mode}, but this store also uses Wolverine-managed event subscription distribution (UseWolverineManagedEventSubscriptionDistribution = true). Wolverine replaces Marten's daemon coordination outright, so the two would run competing coordinators against the same daemon — the projections stall rather than fail, which is very hard to diagnose. Remove the Marten-side daemon choice (MartenDaemonModeIsSolo() / AddAsyncDaemon(DaemonMode.{mode})) and let Wolverine's distribution run the daemon, or turn UseWolverineManagedEventSubscriptionDistribution off.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Persistence/Wolverine.Marten/MartenIntegration.cs
+++ b/src/Persistence/Wolverine.Marten/MartenIntegration.cs
@@ -179,6 +179,15 @@ internal class MartenOverrides : IConfigureMarten
         // identical to Disabled (no Marten-side coordination starts) while suppressing the
         // warning. Only upgrades from Disabled — an explicit user AddAsyncDaemon() choice
         // is never overwritten, regardless of call order relative to IntegrateWithWolverine.
+        // Marten's only knowledge of the daemon state is Projections.AsyncMode; left at Disabled,
+        // DocumentStore writes a misleading "The async daemon is disabled ... projections will not
+        // be executed" warning at startup. Record the real state: ExternallyManaged keeps Marten's
+        // runtime posture identical to Disabled (no Marten-side coordination starts) while
+        // suppressing the warning. Only upgrades from Disabled — an explicit Solo/HotCold choice is
+        // left alone HERE because AddAsyncDaemon applies its mode through ConfigureMarten, which
+        // runs in registration order, so a choice made after IntegrateWithWolverine is not yet
+        // visible at this point. That combination is invalid and is rejected at host start by
+        // ManagedDistributionDaemonModeValidator (GH-3388), where the options are final.
         var integration = services.GetService<MartenIntegration>();
         if (integration is { UseWolverineManagedEventSubscriptionDistribution: true }
             && options.Projections.AsyncMode == DaemonMode.Disabled)

--- a/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
@@ -10,6 +10,7 @@ using Marten.Events.Daemon.Coordination;
 using Marten.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using Weasel.Core;
@@ -146,6 +147,10 @@ public static class WolverineOptionsMartenExtensions
             expression.Services.AddSingleton<IAgentFamily>(s => s.GetRequiredService<EventSubscriptionAgentFamily>());
             expression.Services.AddSingleton<IEventSubscriptionAgentFamily>(s => s.GetRequiredService<EventSubscriptionAgentFamily>());
             expression.Services.AddSingleton<IProjectionCoordinator, WolverineProjectionCoordinator>();
+
+            // GH-3388 — refuse a competing Marten-side daemon (Solo/HotCold) at host start, where
+            // the store's options are final regardless of the order AddAsyncDaemon() was called in.
+            expression.Services.AddSingleton<IHostedService, ManagedDistributionDaemonModeValidator>();
         }
 
         expression.Services.AddType(typeof(IDatabaseSource), typeof(MessageDatabaseDiscovery),


### PR DESCRIPTION
Refs #3388. For **6.18.0**.

## Why

Combining Wolverine-managed event subscription distribution with an explicit Marten-side daemon — `MartenDaemonModeIsSolo()`, or `AddAsyncDaemon(Solo|HotCold)` — is **never valid**. Marten hosts its own `ProjectionCoordinator` (an `IHostedService` that starts the shards) while Wolverine's distribution drives the same daemon through *its* coordinator. The two compete, and the symptom is **not an error but a hang**: a tracked catch-up that never completes.

This is what @uniquelau spent a day chasing in #3388 — his fixture had exactly this pair, and nothing in the code that stalls points back at the registration that caused it. His own ask when he found it:

> "when `UseWolverineManagedEventSubscriptionDistribution` is set together with a non-`Disabled` `AsyncMode`, the result is a silent stall rather than a startup diagnostic. A one-line warning … would have saved me a day."

It now fails at startup, naming the call to remove.

## Where the check lives, and why

**At host start**, not in `MartenIntegration.Configure`. Marten applies `AddAsyncDaemon`'s mode through `Services.ConfigureMarten(...)`, which runs in **registration order** — so a daemon choice made *after* `IntegrateWithWolverine` is not yet visible while the integration is configuring. (I tried the obvious in-`Configure` check first; it caught the before-order and silently missed the after-order.) By start-up the store's options are final whatever the call order, and **both orders are covered by tests**.

## This reverses a GH-3290 contract

`Bug_3290` previously asserted that an explicit daemon choice is *"never overwritten"*, in both call orders. Those two tests are now flipped to assert the throw. Preserving the user's choice silently is strictly worse than refusing it, because **what it preserves is a deadlock**. An explicit daemon choice *without* managed distribution is untouched and still honored — there is nothing to compete with.

## The uncomfortable part: our own fixtures were misconfigured

The guard immediately failed **five of our own `TestHelpers` fixtures**. Each called `AddMarten()` a **second time on the same main store** and hung `AddAsyncDaemon(DaemonMode.Solo)` off it, having already enabled managed distribution on the first call:

```csharp
opts.Services.AddMarten(...).IntegrateWithWolverine(x => x.UseWolverineManagedEventSubscriptionDistribution = true);
opts.Services.AddMarten(...).AddAsyncDaemon(DaemonMode.Solo).IntegrateWithWolverine();   // SAME main store
```

They passed only because those tests **warm the daemon before driving it** — which is precisely why the cold path in #3388 went unnoticed for so long. Fixed here. The guard is what surfaced them, which is a decent argument that it earns its keep.

## Verification

- `Bug_3290` 7/7 (both call orders rejected; Solo *without* managed distribution still honored).
- **Full `MartenTests` 518/518.**
- Full `wolverine.slnx` Release build clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)