### PR TITLE
Bump Marten to 9.15.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,12 +43,12 @@
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
     <PackageVersion Include="JasperFx.SourceGenerator" Version="2.27.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
-    <PackageVersion Include="Marten" Version="9.15.0" />
+    <PackageVersion Include="Marten" Version="9.15.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="[4.8.0,6.0.0)" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.15.0" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.15.0" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.15.1" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.15.1" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />


### PR DESCRIPTION
Picks up **[Marten 9.15.1](https://github.com/JasperFx/marten/releases/tag/9.15.1)**, a patch for [marten#4947](https://github.com/JasperFx/marten/issues/4947).

`ForTenant()` on an identity- or dirty-tracked session had stopped returning **tenancy-neutral (global) documents** tracked by the parent session — `LoadAsync` returned `null` for a document that exists. A silent wrong answer, not an error. Broken since Marten **9.13.0**, so our current 9.15.0 pin is on an affected line.

Wolverine does not itself call `ForTenant()` on an identity session, so this is **not** a fix for a Wolverine bug. It keeps our pin off a line with a known data-correctness defect, and hands the fix to Wolverine users on a transitive upgrade.

Bumps `Marten`, `Marten.AspNetCore` and `Marten.Newtonsoft`. Full `wolverine.slnx` Release build clean (0 warnings, 0 errors) — and the same build was verified against a locally-packed 9.15.1 candidate before the release was published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)