### PR TITLE
Fix invalid generated class name for batched (array) message types (GH-3399)

### DIFF
--- a/docs/guide/grpc/sagas.md
+++ b/docs/guide/grpc/sagas.md
@@ -176,13 +176,24 @@ Wolverine has two ways to resolve which saga state a message belongs to:
 2. **Header-identified** — the message carries no identity member, and Wolverine falls back to the
    envelope's `saga-id` header.
 
-**Only message-identified sagas are supported over a gRPC service hop today.** The `saga-id`
-envelope header does not cross the hop — neither the client nor server propagation interceptor
-carries it, so a header-identified saga invoked through a gRPC service fails with an
-`IndeterminateSagaStateIdException` (surfaced to the caller as a `StatusCode.Internal`
-`RpcException`). This is tracked in
-[GH-3385](https://github.com/JasperFx/wolverine/issues/3385); the practical guidance is simple and
-is the better design anyway:
+**Only message-identified sagas are supported over a gRPC service hop.** The `saga-id` envelope
+header does not cross the hop — neither the client nor server propagation interceptor carries it —
+so a header-identified saga invoked through a gRPC service cannot resolve an id at all.
+
+As of 6.18.0 that fails with an explicit diagnostic rather than an opaque one: the caller gets a
+`StatusCode.InvalidArgument` `RpcException` whose detail names both the cause and the fix.
+
+> Could not determine a saga id for this request. A saga started or continued over a gRPC hop must
+> carry its identity ON THE MESSAGE BODY: the 'saga-id' envelope header is not propagated across a
+> gRPC call, so a header-identified saga cannot work over gRPC. Put the saga identity on the request
+> message itself (a property Wolverine can match to the saga id, or one marked with
+> `[SagaIdentity]`).
+
+`InvalidArgument` rather than `Internal` is deliberate ([AIP-193](https://google.aip.dev/193)): the
+request cannot succeed as sent, and no amount of retrying will change that — it is a contract
+problem, not a transient server fault.
+
+The practical guidance is simple, and is the better design anyway:
 
 ::: tip
 Put the saga identity on the request DTO. It makes the contract self-describing for non-Wolverine

--- a/src/Wolverine.Grpc.Tests/SagaOverGrpc/saga_over_grpc_tests.cs
+++ b/src/Wolverine.Grpc.Tests/SagaOverGrpc/saga_over_grpc_tests.cs
@@ -60,17 +60,24 @@ public class saga_over_grpc_tests : IClassFixture<SagaOverGrpcFixture>
     #endregion
 
     [Fact]
-    public async Task starting_a_header_identified_saga_over_grpc_fails_with_opaque_status_today()
+    public async Task starting_a_header_identified_saga_over_grpc_fails_with_an_actionable_diagnostic()
     {
         var client = _fixture.CreateClient();
 
         var ex = await Should.ThrowAsync<RpcException>(async () =>
             await client.Start(new StartCountingRequest { Label = "first" }));
 
-        // CHARACTERIZATION of current behavior (GH-3385). saga-id is not propagated across a gRPC
-        // hop, so PullSagaIdFromEnvelopeFrame throws IndeterminateSagaStateIdException, which maps to
-        // Internal with a message that doesn't tell the developer what to do about it.
-        ex.StatusCode.ShouldBe(StatusCode.Internal);
-        ex.Status.Detail.ShouldContain("saga state id");
+        // GH-3385. A header-identified saga still cannot work over a gRPC hop — the 'saga-id' header
+        // is not propagated across the call, so no id can be resolved. That is a caller-side contract
+        // problem, not a transient server fault, so it is InvalidArgument (AIP-193) rather than the
+        // Internal it used to report...
+        ex.StatusCode.ShouldBe(StatusCode.InvalidArgument);
+
+        // ...and the detail now names the cause AND the remedy, instead of the bare
+        // "Could not determine a valid saga state id for Envelope ..." that told the developer
+        // nothing they could act on.
+        ex.Status.Detail.ShouldContain("ON THE MESSAGE BODY");
+        ex.Status.Detail.ShouldContain("[SagaIdentity]");
+        ex.Status.Detail.ShouldContain("wolverinefx.net/guide/grpc/sagas");
     }
 }

--- a/src/Wolverine.Grpc/WolverineGrpcExceptionMapper.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcExceptionMapper.cs
@@ -1,4 +1,5 @@
 using Grpc.Core;
+using Wolverine.Persistence.Sagas;
 
 namespace Wolverine.Grpc;
 
@@ -33,6 +34,14 @@ public static class WolverineGrpcExceptionMapper
             RpcException rpc => rpc.StatusCode,
             OperationCanceledException => StatusCode.Cancelled,
             TimeoutException => StatusCode.DeadlineExceeded,
+
+            // GH-3385. The request reached a saga handler that identifies its saga from the envelope
+            // (a `saga-id` header or [SagaIdentity] on a header), and no saga id could be resolved.
+            // Over a gRPC hop that is not a transient server fault — it is a contract problem that
+            // the caller cannot fix by retrying, because the header never crosses the hop at all.
+            // InvalidArgument per AIP-193, with a detail that says what to do about it.
+            IndeterminateSagaStateIdException => StatusCode.InvalidArgument,
+
             ArgumentException => StatusCode.InvalidArgument,
             KeyNotFoundException => StatusCode.NotFound,
             FileNotFoundException => StatusCode.NotFound,
@@ -59,8 +68,23 @@ public static class WolverineGrpcExceptionMapper
             return existing;
         }
 
-        var status = new Status(Map(exception), exception.Message);
+        var status = new Status(Map(exception), detailFor(exception));
         return new RpcException(status);
+    }
+
+    // GH-3385: the core exception's message ("Could not determine a valid saga state id for
+    // Envelope ...") is true but useless to someone calling a gRPC service — it names no cause and
+    // no remedy, and the remedy is not obvious, because the reason the id is missing is that the
+    // saga-id header does not cross a gRPC hop at all. Say that, and say what to do instead.
+    private static string detailFor(Exception exception)
+    {
+        if (exception is IndeterminateSagaStateIdException)
+        {
+            return
+                "Could not determine a saga id for this request. A saga started or continued over a gRPC hop must carry its identity ON THE MESSAGE BODY: the 'saga-id' envelope header is not propagated across a gRPC call, so a header-identified saga cannot work over gRPC. Put the saga identity on the request message itself (a property Wolverine can match to the saga id, or one marked with [SagaIdentity]). See https://wolverinefx.net/guide/grpc/sagas.html";
+        }
+
+        return exception.Message;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #3399. Reported by @outofrange-consulting — thank you for the repro sample, it made this quick to pin down.

## The bug: an illegal C# identifier, at startup

`HandlerGraph`'s duplicate-`TypeName` disambiguation composed the generated handler class name straight off the message type:

```csharp
chain.TypeName =
    $"{chain.MessageType.ToSuffixedTypeName("")}_{chain.HandlerCalls().First().HandlerType.ToSuffixedTypeName("Handler")}";
```

`ToSuffixedTypeName` only strips the *generic arity* (the backtick suffix) — it does nothing about arrays. `BatchMessagesOf<T>()` makes `T[]` the handled message type, so this produced:

```
ItemDeleted[]1177234954_TelemetryHandlerHandler550305999
```

which is not a valid C# identifier. Codegen failed with `CS1514: { expected` / `CS1513: } expected` / `CS1001: Identifier expected` → `Compilation failures!` → **the app dies at startup**. This is startup-fatal, and any batched message type can reach it.

Not a 6.17.3 regression — the disambiguation path is old.

## The trigger, and why existing batch tests missed it

Three things have to line up, and it was the *third* that our coverage lacked:

1. `MultipleHandlerBehavior.Separated`, and
2. one handler class handling **two** message types, one of them batched, where
3. each of those message types also has a **second** handler.

(3) is what pushes each message type's grouping past 1 (`HandlerChain.cs:114`), which is the gate for creating sticky per-endpoint chains. Sticky chains are named off the **handler type** (`HandlerChain.cs:85`), so the shared handler class ends up with two sticky chains carrying the *same* `TypeName` — and only then does the duplicate-disambiguation path run and rebuild the name off the message type.

We already had `Separated` + batching coverage (`separated_batch_routing.cs`, `batching_with_separated_handlers.cs`), but every handler class there handles exactly one message type, so the sticky `TypeName`s never collided and the disambiguation branch was never exercised. Batching alone was never the missing ingredient — the `Separated` split with a *shared* handler class was.

## The fix

Centralized the codegen-safe name composition that `HandlerChain` was already doing ad hoc (`.Replace("[]", "Array")`, in three places) into one helper, and used it on the disambiguation path that was missing it:

```csharp
internal static string GeneratedTypeNameFor(Type type, string suffix)
{
    return type.ToSuffixedTypeName(suffix).Replace("[]", "Array").Sanitize();
}
```

`Sanitize()` is the existing `JasperFx.Core.Reflection` helper, added as a belt-and-braces pass for any other punctuation rather than hand-rolling a new sanitizer.

**Collisions remain impossible.** `ToSuffixedTypeName` appends a stable hash of the type's *full* name, and `T` and `T[]` have different full names — so `ItemDeleted` and `ItemDeleted[]` carry different hashes and cannot collide after sanitizing. The new test asserts distinctness explicitly, not just legality.

Applied the helper to `SagaChain` too, which carried the same idiom.

## Red → green

New test `src/Testing/CoreTests/Bugs/Bug_3399_batched_message_separated_handler_codegen.cs` reproduces the reporter's shape and asserts every generated class name is a legal C# identifier *and* that names stay distinct.

Before the fix (the reporter's exact errors):

```
Bug_3399...can_start_up_with_separated_batched_handler [FAIL]
Bug_3399...batched_handler_actually_executes [FAIL]
  System.InvalidOperationException : Compilation failures!
  CS1514: { expected
  CS1513: } expected
  CS1001: Identifier expected
Failed! - Failed: 2, Passed: 0
```

After:

```
Passed! - Failed: 0, Passed: 2
```

- Full `CoreTests` (net9.0): **1923 passed, 0 failed** (2 pre-existing skips)
- Batching + saga + separated filter: **183 passed, 0 failed**
- `dotnet build wolverine.slnx -c Release`: **0 Warning(s), 0 Error(s)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)