### PR TITLE
Fix invalid generated class name for batched (array) message types (GH-3399)

### DIFF
--- a/src/Testing/CoreTests/Bugs/Bug_3399_batched_message_separated_handler_codegen.cs
+++ b/src/Testing/CoreTests/Bugs/Bug_3399_batched_message_separated_handler_codegen.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+// GH-3399: with MultipleHandlerBehavior.Separated, a handler class that handles two message types where
+// one of them is batched (BatchMessagesOf<T>() makes T[] the handled message type) produced duplicate
+// HandlerChain.TypeNames -- both sticky chains are named off the *handler type*. The duplicate
+// disambiguation in HandlerGraph then rebuilt the generated class name straight off the message type,
+// yielding "ItemDeleted[]1177234954_TelemetryHandlerHandler550305999", which is not a valid C#
+// identifier -> "Compilation failures!" and the app dies at startup.
+public class Bug_3399_batched_message_separated_handler_codegen
+{
+    [Fact]
+    public async Task can_start_up_with_separated_batched_handler()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Discovery.IncludeType<TelemetryHandler3399>();
+                opts.Discovery.IncludeType<OtherCreatedHandler3399>();
+                opts.Discovery.IncludeType<OtherDeletedHandler3399>();
+
+                opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+
+                opts.BatchMessagesOf<ItemDeleted3399>();
+            }).StartAsync();
+
+        var runtime = host.GetRuntime();
+
+        // Both the batched (array) chain and the single-message chain exist...
+        var chains = runtime.Handlers.Chains
+            .SelectMany(x => x.ByEndpoint.Any() ? x.ByEndpoint : [x])
+            .Where(x => x.Handlers.Any())
+            .ToArray();
+
+        // ...and every generated class name is a legal C# identifier. Before the fix, the chain for
+        // ItemDeleted3399[] was named "ItemDeleted3399[]<hash>_TelemetryHandler3399Handler<hash>".
+        foreach (var chain in chains)
+        {
+            chain.TypeName.ShouldNotContain("[");
+            chain.TypeName.ShouldNotContain("]");
+            isValidIdentifier(chain.TypeName).ShouldBeTrue($"'{chain.TypeName}' is not a valid C# identifier");
+        }
+
+        // The array chain and the single chain must NOT collide after sanitizing
+        chains.Select(x => x.TypeName).Distinct().Count().ShouldBe(chains.Length);
+    }
+
+    [Fact]
+    public async Task batched_handler_actually_executes()
+    {
+        TelemetryHandler3399.Batched = 0;
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Discovery.IncludeType<TelemetryHandler3399>();
+                opts.Discovery.IncludeType<OtherCreatedHandler3399>();
+                opts.Discovery.IncludeType<OtherDeletedHandler3399>();
+
+                opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+
+                opts.BatchMessagesOf<ItemDeleted3399>();
+            }).StartAsync();
+
+        await host.TrackActivity()
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<ItemDeleted3399[]>(host)
+            .SendMessageAndWaitAsync(new ItemDeleted3399(Guid.NewGuid()));
+
+        TelemetryHandler3399.Batched.ShouldBeGreaterThan(0);
+    }
+
+    private static bool isValidIdentifier(string name)
+    {
+        if (name.IsEmpty()) return false;
+        if (!char.IsLetter(name[0]) && name[0] != '_') return false;
+
+        return name.All(c => char.IsLetterOrDigit(c) || c == '_');
+    }
+}
+
+public record ItemDeleted3399(Guid Id);
+
+public record ItemCreated3399(Guid Id);
+
+// The trigger: ONE handler class handling TWO message types, one of which is batched, where each of
+// those message types ALSO has a second handler. The second handler is what pushes each message type's
+// grouping past 1 (HandlerChain.cs:114), so under MultipleHandlerBehavior.Separated both of
+// TelemetryHandler3399's calls get a sticky chain -- and sticky chains are named off the HANDLER type
+// (HandlerChain.cs:85). The two sticky chains therefore share a TypeName, which drives HandlerGraph's
+// duplicate disambiguation to rebuild the name off the message type: "ItemDeleted3399[]<hash>_...".
+[WolverineIgnore]
+public class TelemetryHandler3399
+{
+    public static int Batched;
+
+    public void Handle(ItemCreated3399 created)
+    {
+    }
+
+    public void Handle(ItemDeleted3399[] deleted)
+    {
+        Interlocked.Add(ref Batched, deleted.Length);
+    }
+}
+
+[WolverineIgnore]
+public class OtherCreatedHandler3399
+{
+    public void Handle(ItemCreated3399 created)
+    {
+    }
+}
+
+[WolverineIgnore]
+public class OtherDeletedHandler3399
+{
+    public void Handle(ItemDeleted3399[] deleted)
+    {
+    }
+}

--- a/src/Wolverine/Persistence/Sagas/SagaChain.cs
+++ b/src/Wolverine/Persistence/Sagas/SagaChain.cs
@@ -163,7 +163,7 @@ public class SagaChain : HandlerChain
             AuditedMembers.Add(new AuditedMember(SagaIdMember, SagaIdMember.Name, SagaIdMember.Name));
         }
 
-        TypeName = saga.HandlerType.ToSuffixedTypeName(HandlerSuffix).Replace("[]", "Array");
+        TypeName = GeneratedTypeNameFor(saga.HandlerType, HandlerSuffix);
     }
 
     public override bool TryInferMessageIdentity(out PropertyInfo? property)

--- a/src/Wolverine/Runtime/Handlers/HandlerChain.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerChain.cs
@@ -49,6 +49,21 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
 
     protected readonly List<HandlerChain> _byEndpoint = [];
 
+    /// <summary>
+    /// Compose the name of a generated handler class for a type in a way that is guaranteed to be a legal
+    /// C# identifier. <see cref="TypeNameExtensions.ToSuffixedTypeName"/> only strips the generic arity
+    /// (the backtick suffix), so array types like <c>ItemDeleted[]</c> would otherwise leak the brackets
+    /// straight into the generated class name and fail compilation. See GH-3399.
+    /// </summary>
+    /// <remarks>
+    /// Uniqueness is unaffected: ToSuffixedTypeName appends a stable hash of the type's *full* name, and
+    /// T and T[] have different full names, so their generated names cannot collide after sanitizing.
+    /// </remarks>
+    internal static string GeneratedTypeNameFor(Type type, string suffix)
+    {
+        return type.ToSuffixedTypeName(suffix).Replace("[]", "Array").Sanitize();
+    }
+
     private readonly List<Endpoint> _endpoints = [];
 
     private readonly HandlerGraph _parent;
@@ -66,7 +81,7 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
         _parent = parent;
         MessageType = messageType ?? throw new ArgumentNullException(nameof(messageType));
 
-        TypeName = messageType.ToSuffixedTypeName(HandlerSuffix).Replace("[]", "Array");
+        TypeName = GeneratedTypeNameFor(messageType, HandlerSuffix);
 
         Description = "Message Handler for " + MessageType.FullNameInCode();
 
@@ -82,7 +97,7 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
     {
         foreach (var endpoint in endpoints) RegisterEndpoint(endpoint);
 
-        TypeName = call.HandlerType.ToSuffixedTypeName(HandlerSuffix).Replace("[]", "Array");
+        TypeName = GeneratedTypeNameFor(call.HandlerType, HandlerSuffix);
 
         Description = $"Message Handler for {MessageType.FullNameInCode()} using {call}";
     }

--- a/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
@@ -386,8 +386,11 @@ public partial class HandlerGraph : ICodeFileCollectionWithServices, IWithFailur
         {
             foreach (var chain in @group)
             {
+                // Both halves have to be sanitized into legal C# identifiers -- the message type may well be
+                // an array (batched messages are handled as T[]), which would otherwise emit brackets into
+                // the generated class name and blow up compilation. See GH-3399.
                 chain.TypeName =
-                    $"{chain.MessageType.ToSuffixedTypeName("")}_{chain.HandlerCalls().First().HandlerType.ToSuffixedTypeName("Handler")}";
+                    $"{HandlerChain.GeneratedTypeNameFor(chain.MessageType, "")}_{HandlerChain.GeneratedTypeNameFor(chain.HandlerCalls().First().HandlerType, "Handler")}";
             }
         }
 


### PR DESCRIPTION
Closes #3399. For **6.18.0**. Reported by @outofrange-consulting — thank you, the repro was exact. (Supersedes #3405, which had the wrong commit pushed to its branch from a shared working tree; the fix itself is unchanged.)

## Startup-fatal

`HandlerGraph.cs:389-390` composed the generated class name straight off the message type when disambiguating duplicate `TypeName`s:

```csharp
chain.TypeName =
    $"{chain.MessageType.ToSuffixedTypeName("")}_{chain.HandlerCalls().First().HandlerType.ToSuffixedTypeName("Handler")}";
```

`ToSuffixedTypeName` strips *generic arity* but does nothing about **arrays**. Since `BatchMessagesOf<T>()` makes `T[]` the handled message type, that emitted:

```
ItemDeleted[]1177234954_TelemetryHandlerHandler550305999
```

— not a legal C# identifier → `CS1514`/`CS1513`/`CS1001` → **the application dies at startup**.

Tellingly, `HandlerChain.cs:69/85` and `SagaChain.cs:166` **already** guarded this with an ad-hoc `.Replace("[]", "Array")`. The disambiguation path was the one site that didn't.

## The trigger — and why our tests missed it

Two conditions were obvious. A **third** was not, and it is the reason this went unnoticed:

1. `MultipleHandlerBehavior.Separated`, **and**
2. a handler class handling two message types, one of them batched, **and**
3. **each of those two message types must also have a second handler.**

`HandlerChain.cs:114` gates sticky-chain creation on `grouping.Count() > 1`. Without a second handler there are no sticky chains, so the disambiguation branch never runs — condition (3) is load-bearing. With it, the shared handler class gets two sticky chains both named off the *handler* type (`HandlerChain.cs:85`), the `TypeName`s collide, and the duplicate path fires.

That pins the coverage gap exactly: `separated_batch_routing.cs` and `batching_with_separated_handlers.cs` **do** exercise `Separated` + batching, but every handler class in them handles exactly one message type — so sticky `TypeName`s never collide.

Not a 6.17.x regression; the disambiguation path is old.

## Fix

Centralized the scattered `.Replace("[]", "Array")` idiom into `HandlerChain.GeneratedTypeNameFor(Type, string)`, reusing the existing `JasperFx.Core.Reflection.Sanitize()` helper rather than hand-rolling one, and applied it at the disambiguation site **plus the three pre-existing sites** that had each solved it locally.

**Collisions remain impossible**: `ToSuffixedTypeName` appends a hash of the type's *full* name, and `T` vs `T[]` differ there. The test asserts distinctness, not merely that the name is legal.

## Verification

- **Red first**: both new tests failed with the reporter's exact `Compilation failures! CS1514/CS1513/CS1001`, then green.
- Full **`CoreTests` 1923 passed, 0 failed** (net9.0).
- Batching / saga / separated filter: **183 passed, 0 failed**.
- Full `wolverine.slnx` Release build: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)