### PR TITLE
Set Kafka timestamps and expose record headers

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperTimestampTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperTimestampTests.cs
@@ -143,15 +143,15 @@ public class JsonOnlyMapperTimestampTests
             Timestamp = Timestamp.Default,
             Headers = new Headers
             {
-                { "tenant-id", "from-kafka"u8.ToArray() }
+                { "color-source", "from-kafka"u8.ToArray() }
             }
         };
         var envelope = new Envelope();
-        envelope.Headers["tenant-id"] = "already-set";
+        envelope.Headers["color-source"] = "already-set";
 
         buildMapper().MapIncomingToEnvelope(envelope, incoming);
 
-        envelope.Headers["tenant-id"].ShouldBe("already-set");
+        envelope.Headers["color-source"].ShouldBe("already-set");
     }
 
     [Fact]

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperTimestampTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperTimestampTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Confluent.Kafka;
 using Shouldly;
 using Wolverine.Kafka.Internals;
@@ -40,13 +41,69 @@ public class JsonOnlyMapperTimestampTests
         envelope.SentAt.ShouldBe(originalSentAt);
     }
 
+    [Fact]
+    public void CopiesIncomingKafkaHeadersToEnvelope()
+    {
+        var incoming = new Message<string, byte[]>
+        {
+            Value = [],
+            Timestamp = Timestamp.Default,
+            Headers = new Headers
+            {
+                { "tenant-id", "acme"u8.ToArray() },
+                { "correlation", "abc-123"u8.ToArray() }
+            }
+        };
+        var envelope = new Envelope();
+
+        buildMapper().MapIncomingToEnvelope(envelope, incoming);
+
+        envelope.Headers["tenant-id"].ShouldBe("acme");
+        envelope.Headers["correlation"].ShouldBe("abc-123");
+    }
+
+    [Fact]
+    public void DoesNotOverwriteExistingEnvelopeHeaders()
+    {
+        var incoming = new Message<string, byte[]>
+        {
+            Value = [],
+            Timestamp = Timestamp.Default,
+            Headers = new Headers
+            {
+                { "tenant-id", "from-kafka"u8.ToArray() }
+            }
+        };
+        var envelope = new Envelope();
+        envelope.Headers["tenant-id"] = "already-set";
+
+        buildMapper().MapIncomingToEnvelope(envelope, incoming);
+
+        envelope.Headers["tenant-id"].ShouldBe("already-set");
+    }
+
+    [Fact]
+    public void LeavesEnvelopeHeadersUntouchedWhenIncomingHasNone()
+    {
+        var incoming = new Message<string, byte[]>
+        {
+            Value = [],
+            Timestamp = Timestamp.Default
+        };
+        var envelope = new Envelope();
+
+        buildMapper().MapIncomingToEnvelope(envelope, incoming);
+
+        envelope.Headers.ShouldBeEmpty();
+    }
+
     private static JsonOnlyMapper buildMapper()
     {
         var topic = new KafkaTopic(
             new KafkaTransport(),
             "timestamp-mapping",
-            Wolverine.Configuration.EndpointRole.Application);
+            Configuration.EndpointRole.Application);
 
-        return new JsonOnlyMapper(topic, new System.Text.Json.JsonSerializerOptions());
+        return new JsonOnlyMapper(topic, new JsonSerializerOptions());
     }
 }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperTimestampTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperTimestampTests.cs
@@ -1,0 +1,52 @@
+using Confluent.Kafka;
+using Shouldly;
+using Wolverine.Kafka.Internals;
+
+namespace Wolverine.Kafka.Tests;
+
+public class JsonOnlyMapperTimestampTests
+{
+    [Theory]
+    [InlineData(TimestampType.CreateTime)]
+    [InlineData(TimestampType.LogAppendTime)]
+    public void MapsAvailableKafkaTimestampToEnvelopeSentAt(TimestampType timestampType)
+    {
+        var timestamp = new DateTime(2026, 7, 13, 11, 15, 30, DateTimeKind.Utc);
+        var incoming = new Message<string, byte[]>
+        {
+            Value = [],
+            Timestamp = new Timestamp(timestamp, timestampType)
+        };
+        var envelope = new Envelope { SentAt = DateTimeOffset.MinValue };
+
+        buildMapper().MapIncomingToEnvelope(envelope, incoming);
+
+        envelope.SentAt.ShouldBe(new DateTimeOffset(timestamp));
+    }
+
+    [Fact]
+    public void LeavesEnvelopeSentAtUnchangedWhenKafkaTimestampIsUnavailable()
+    {
+        var originalSentAt = new DateTimeOffset(2026, 7, 13, 10, 0, 0, TimeSpan.Zero);
+        var incoming = new Message<string, byte[]>
+        {
+            Value = [],
+            Timestamp = Timestamp.Default
+        };
+        var envelope = new Envelope { SentAt = originalSentAt };
+
+        buildMapper().MapIncomingToEnvelope(envelope, incoming);
+
+        envelope.SentAt.ShouldBe(originalSentAt);
+    }
+
+    private static JsonOnlyMapper buildMapper()
+    {
+        var topic = new KafkaTopic(
+            new KafkaTransport(),
+            "timestamp-mapping",
+            Wolverine.Configuration.EndpointRole.Application);
+
+        return new JsonOnlyMapper(topic, new System.Text.Json.JsonSerializerOptions());
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperTimestampTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperTimestampTests.cs
@@ -115,6 +115,25 @@ public class JsonOnlyMapperTimestampTests
         envelope.Headers.ContainsKey(EnvelopeConstants.TenantIdKey).ShouldBeFalse();
     }
 
+    [Fact]
+    public void null_custom_header_maps_to_envelope_without_failing()
+    {
+        var incoming = new Message<string, byte[]>
+        {
+            Value = [],
+            Headers = new Headers
+            {
+                { "optional-header", null! }
+            }
+        };
+        var envelope = new Envelope();
+
+        buildMapper().MapIncomingToEnvelope(envelope, incoming);
+
+        envelope.Headers.ContainsKey("optional-header").ShouldBeTrue();
+        envelope.Headers["optional-header"].ShouldBeNull();
+    }
+
     [Theory]
     [MemberData(nameof(ReservedHeaderKeys))]
     public void each_reserved_kafka_header_is_skipped(string key)

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperTimestampTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperTimestampTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Confluent.Kafka;
 using Shouldly;
 using Wolverine.Kafka.Internals;
+using Wolverine.Runtime.Serialization;
 
 namespace Wolverine.Kafka.Tests;
 
@@ -10,7 +11,7 @@ public class JsonOnlyMapperTimestampTests
     [Theory]
     [InlineData(TimestampType.CreateTime)]
     [InlineData(TimestampType.LogAppendTime)]
-    public void MapsAvailableKafkaTimestampToEnvelopeSentAt(TimestampType timestampType)
+    public void maps_available_kafka_timestamp_to_envelope_sent_at(TimestampType timestampType)
     {
         var timestamp = new DateTime(2026, 7, 13, 11, 15, 30, DateTimeKind.Utc);
         var incoming = new Message<string, byte[]>
@@ -26,7 +27,7 @@ public class JsonOnlyMapperTimestampTests
     }
 
     [Fact]
-    public void LeavesEnvelopeSentAtUnchangedWhenKafkaTimestampIsUnavailable()
+    public void leaves_envelope_sent_at_unchanged_when_kafka_timestamp_is_unavailable()
     {
         var originalSentAt = new DateTimeOffset(2026, 7, 13, 10, 0, 0, TimeSpan.Zero);
         var incoming = new Message<string, byte[]>
@@ -42,7 +43,57 @@ public class JsonOnlyMapperTimestampTests
     }
 
     [Fact]
-    public void CopiesIncomingKafkaHeadersToEnvelope()
+    public void all_reserved_kafka_headers_leave_every_typed_property_alone()
+    {
+        var headers = new Headers();
+        foreach (var key in EnvelopeSerializer.ReservedHeaderKeys)
+        {
+            headers.Add(key, "hijacked"u8.ToArray());
+        }
+
+        var timestamp = new DateTime(2026, 7, 13, 11, 15, 30, DateTimeKind.Utc);
+        var incoming = new Message<string, byte[]>
+        {
+            Value = [],
+            Timestamp = new Timestamp(timestamp, TimestampType.CreateTime),
+            Headers = headers
+        };
+        var id = Guid.NewGuid();
+        var destination = new Uri("kafka://localhost/expected");
+        var expected = new Envelope
+        {
+            Id = id,
+            Destination = destination,
+            TenantId = "real-tenant",
+            SagaId = "real-saga"
+        };
+        var actual = new Envelope
+        {
+            Id = id,
+            Destination = destination,
+            TenantId = "real-tenant",
+            SagaId = "real-saga"
+        };
+        var mapper = buildMapper(typeof(JsonOnlyMapperTimestampTests));
+
+        mapper.MapIncomingToEnvelope(expected, new Message<string, byte[]>
+        {
+            Value = [],
+            Timestamp = incoming.Timestamp
+        });
+        mapper.MapIncomingToEnvelope(actual, incoming);
+
+        actual.TenantId.ShouldBe(expected.TenantId);
+        actual.SagaId.ShouldBe(expected.SagaId);
+        actual.MessageType.ShouldBe(expected.MessageType);
+        actual.Id.ShouldBe(expected.Id);
+        actual.Destination.ShouldBe(expected.Destination);
+        actual.SentAt.ShouldBe(expected.SentAt);
+        actual.Headers.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void non_reserved_custom_headers_still_map_to_envelope()
     {
         var incoming = new Message<string, byte[]>
         {
@@ -50,20 +101,41 @@ public class JsonOnlyMapperTimestampTests
             Timestamp = Timestamp.Default,
             Headers = new Headers
             {
-                { "tenant-id", "acme"u8.ToArray() },
-                { "correlation", "abc-123"u8.ToArray() }
+                { "name", "Jeremy"u8.ToArray() },
+                { "state", "Texas"u8.ToArray() },
+                { EnvelopeConstants.TenantIdKey, "hijacked-tenant"u8.ToArray() }
             }
         };
         var envelope = new Envelope();
 
         buildMapper().MapIncomingToEnvelope(envelope, incoming);
 
-        envelope.Headers["tenant-id"].ShouldBe("acme");
-        envelope.Headers["correlation"].ShouldBe("abc-123");
+        envelope.Headers["name"].ShouldBe("Jeremy");
+        envelope.Headers["state"].ShouldBe("Texas");
+        envelope.Headers.ContainsKey(EnvelopeConstants.TenantIdKey).ShouldBeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(ReservedHeaderKeys))]
+    public void each_reserved_kafka_header_is_skipped(string key)
+    {
+        var incoming = new Message<string, byte[]>
+        {
+            Value = [],
+            Headers = new Headers
+            {
+                { key, "hijacked"u8.ToArray() }
+            }
+        };
+        var envelope = new Envelope();
+
+        buildMapper().MapIncomingToEnvelope(envelope, incoming);
+
+        envelope.Headers.ContainsKey(key).ShouldBeFalse();
     }
 
     [Fact]
-    public void DoesNotOverwriteExistingEnvelopeHeaders()
+    public void does_not_overwrite_existing_envelope_headers()
     {
         var incoming = new Message<string, byte[]>
         {
@@ -83,7 +155,7 @@ public class JsonOnlyMapperTimestampTests
     }
 
     [Fact]
-    public void LeavesEnvelopeHeadersUntouchedWhenIncomingHasNone()
+    public void leaves_envelope_headers_untouched_when_incoming_has_none()
     {
         var incoming = new Message<string, byte[]>
         {
@@ -97,12 +169,20 @@ public class JsonOnlyMapperTimestampTests
         envelope.Headers.ShouldBeEmpty();
     }
 
-    private static JsonOnlyMapper buildMapper()
+    public static IEnumerable<object[]> ReservedHeaderKeys()
+    {
+        return EnvelopeSerializer.ReservedHeaderKeys.Select(key => new object[] { key });
+    }
+
+    private static JsonOnlyMapper buildMapper(Type? messageType = null)
     {
         var topic = new KafkaTopic(
             new KafkaTransport(),
             "timestamp-mapping",
-            Configuration.EndpointRole.Application);
+            Configuration.EndpointRole.Application)
+        {
+            MessageType = messageType
+        };
 
         return new JsonOnlyMapper(topic, new JsonSerializerOptions());
     }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/publish_and_receive_raw_json.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/publish_and_receive_raw_json.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using Confluent.Kafka;
 using IntegrationTests;
@@ -71,6 +72,48 @@ public class publish_and_receive_raw_json : IAsyncLifetime
 
         session.Received.SingleMessage<ColorMessage>()
             .Color.ShouldBe("yellow");
+    }
+
+    [Fact]
+    public async Task stamps_envelope_sent_at_from_the_kafka_record_timestamp()
+    {
+        var session = await _sender.TrackActivity()
+            .AlsoTrack(_receiver)
+            .WaitForMessageToBeReceivedAt<ColorMessage>(_receiver)
+            .PublishMessageAndWaitAsync(new ColorMessage("yellow"));
+
+        // The JsonOnlyMapper stamps Envelope.SentAt from the Kafka record timestamp,
+        // which the broker assigns at produce time, so it should be a recent instant.
+        var received = session.Received.SingleEnvelope<ColorMessage>();
+        received.SentAt.ShouldBeGreaterThan(DateTimeOffset.UtcNow.Subtract(5.Minutes()));
+    }
+
+    [Fact]
+    public async Task copies_kafka_headers_onto_the_received_envelope()
+    {
+        // PublishRawJson only writes the body, so an external producer is used here to
+        // put a custom header on the Kafka record. The JsonOnlyMapper should copy that
+        // header onto the received Envelope without clobbering anything Wolverine set.
+        var transport = _receiver.GetRuntime().Options.Transports.GetOrCreate<KafkaTransport>();
+
+        var session = await _receiver.TrackActivity()
+            .WaitForMessageToBeReceivedAt<ColorMessage>(_receiver)
+            .ExecuteAndWaitAsync((Func<IMessageContext, Task>)(async _ =>
+            {
+                using var producer = new ProducerBuilder<string, byte[]>(transport.ProducerConfig).Build();
+                await producer.ProduceAsync("json", new Message<string, byte[]>
+                {
+                    Value = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new ColorMessage("green"))),
+                    Headers = new Headers
+                    {
+                        { "tenant-id", "acme"u8.ToArray() }
+                    }
+                });
+                producer.Flush();
+            }));
+
+        var received = session.Received.SingleEnvelope<ColorMessage>();
+        received.Headers["tenant-id"].ShouldBe("acme");
     }
 
     [Fact]

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/publish_and_receive_raw_json.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/publish_and_receive_raw_json.cs
@@ -77,15 +77,28 @@ public class publish_and_receive_raw_json : IAsyncLifetime
     [Fact]
     public async Task stamps_envelope_sent_at_from_the_kafka_record_timestamp()
     {
-        var session = await _sender.TrackActivity()
-            .AlsoTrack(_receiver)
-            .WaitForMessageToBeReceivedAt<ColorMessage>(_receiver)
-            .PublishMessageAndWaitAsync(new ColorMessage("yellow"));
+        // Envelope.SentAt defaults to UtcNow at construction, so a "recent" assertion would
+        // pass without this mapper. Produce with an explicit CreateTime an hour ago so we
+        // can distinguish broker-record time from the constructor default.
+        var transport = _receiver.GetRuntime().Options.Transports.GetOrCreate<KafkaTransport>();
+        var sentAt = DateTimeOffset.UtcNow.Subtract(1.Hours()).ToUnixTimeMilliseconds();
+        var expectedSentAt = DateTimeOffset.FromUnixTimeMilliseconds(sentAt);
 
-        // The JsonOnlyMapper stamps Envelope.SentAt from the Kafka record timestamp,
-        // which the broker assigns at produce time, so it should be a recent instant.
+        var session = await _receiver.TrackActivity()
+            .WaitForMessageToBeReceivedAt<ColorMessage>(_receiver)
+            .ExecuteAndWaitAsync((Func<IMessageContext, Task>)(async _ =>
+            {
+                using var producer = new ProducerBuilder<string, byte[]>(transport.ProducerConfig).Build();
+                await producer.ProduceAsync("json", new Message<string, byte[]>
+                {
+                    Value = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new ColorMessage("yellow"))),
+                    Timestamp = new Timestamp(sentAt, TimestampType.CreateTime)
+                });
+                producer.Flush();
+            }));
+
         var received = session.Received.SingleEnvelope<ColorMessage>();
-        received.SentAt.ShouldBeGreaterThan(DateTimeOffset.UtcNow.Subtract(5.Minutes()));
+        received.SentAt.ShouldBe(expectedSentAt);
     }
 
     [Fact]
@@ -94,6 +107,8 @@ public class publish_and_receive_raw_json : IAsyncLifetime
         // PublishRawJson only writes the body, so an external producer is used here to
         // put a custom header on the Kafka record. The JsonOnlyMapper should copy that
         // header onto the received Envelope without clobbering anything Wolverine set.
+        // Use a non-reserved key — reserved Wolverine keys (tenant-id, saga-id, id, ...)
+        // are deliberately skipped so an untrusted producer cannot hijack typed props.
         var transport = _receiver.GetRuntime().Options.Transports.GetOrCreate<KafkaTransport>();
 
         var session = await _receiver.TrackActivity()
@@ -106,14 +121,22 @@ public class publish_and_receive_raw_json : IAsyncLifetime
                     Value = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new ColorMessage("green"))),
                     Headers = new Headers
                     {
-                        { "tenant-id", "acme"u8.ToArray() }
+                        { "color-source", "acme"u8.ToArray() },
+                        { "tenant-id", "hijacked"u8.ToArray() },
+                        { "saga-id", "hijacked"u8.ToArray() },
+                        { "id", Encoding.UTF8.GetBytes(Guid.NewGuid().ToString()) }
                     }
                 });
                 producer.Flush();
             }));
 
         var received = session.Received.SingleEnvelope<ColorMessage>();
-        received.Headers["tenant-id"].ShouldBe("acme");
+        received.Headers["color-source"].ShouldBe("acme");
+        received.Headers.ContainsKey("tenant-id").ShouldBeFalse();
+        received.Headers.ContainsKey("saga-id").ShouldBeFalse();
+        received.Headers.ContainsKey("id").ShouldBeFalse();
+        received.TenantId.ShouldBeNull();
+        received.SagaId.ShouldBeNull();
     }
 
     [Fact]

--- a/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
@@ -60,6 +60,22 @@ internal class JsonOnlyMapper : IKafkaEnvelopeMapper
 
         envelope.Data = incoming.Value;
         envelope.MessageType = _messageTypeName;
+
+        if (incoming.Timestamp.Type is TimestampType.CreateTime or TimestampType.LogAppendTime)
+        {
+            envelope.SentAt = incoming.Timestamp.UtcDateTime;
+        }
+
+        if (incoming.Headers is null)
+            return;
+
+        foreach (var header in incoming.Headers)
+        {
+            if (TryReadHeader(incoming, header.Key, out var headerValue))
+            {
+                envelope.Headers.TryAdd(header.Key, headerValue);
+            }
+        }
     }
 
     private static bool TryReadHeader(Message<string, byte[]> incoming, string key, out string value)

--- a/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
@@ -68,7 +68,9 @@ internal class JsonOnlyMapper : IKafkaEnvelopeMapper
         }
 
         if (incoming.Headers is null)
+        {
             return;
+        }
 
         foreach (var header in incoming.Headers)
         {

--- a/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using Confluent.Kafka;
+using Wolverine.Runtime.Serialization;
 using Wolverine.Transports;
 using Wolverine.Util;
 
@@ -71,6 +72,11 @@ internal class JsonOnlyMapper : IKafkaEnvelopeMapper
 
         foreach (var header in incoming.Headers)
         {
+            if (EnvelopeSerializer.ReservedHeaderKeys.Contains(header.Key))
+            {
+                continue;
+            }
+
             if (TryReadHeader(incoming, header.Key, out var headerValue))
             {
                 envelope.Headers.TryAdd(header.Key, headerValue);

--- a/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
@@ -86,15 +86,15 @@ internal class JsonOnlyMapper : IKafkaEnvelopeMapper
         }
     }
 
-    private static bool TryReadHeader(Message<string, byte[]> incoming, string key, out string value)
+    private static bool TryReadHeader(Message<string, byte[]> incoming, string key, out string? value)
     {
         if (incoming.Headers != null && incoming.Headers.TryGetLastBytes(key, out var bytes))
         {
-            value = Encoding.UTF8.GetString(bytes);
+            value = bytes is null ? null : Encoding.UTF8.GetString(bytes);
             return true;
         }
 
-        value = default!;
+        value = null;
         return false;
     }
 }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -273,7 +273,7 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
     public KafkaListenerConfiguration ReceiveRawJson(Type messageType, JsonSerializerOptions? options = null)
     {
         DefaultIncomingMessage(messageType);
-        return UseInterop((e, _) => new JsonOnlyMapper(e, options ?? new()));
+        return UseInterop((_, e) => new JsonOnlyMapper(e, options ?? new()));
     }
     
     /// <summary>


### PR DESCRIPTION
### Summary

- Set Envelope.SentAt from the native Kafka record timestamp when available.

- Copy Kafka record headers into Wolverine envelope headers without overwriting existing values.

### Why
Using Kafka’s record timestamp gives consumers an accurate transport-level reference point for measuring end-to-end message latency. It also distinguishes message production or broker-append time from business-event and consumer-processing timestamps.

Exposing Kafka headers through the Wolverine envelope makes broker metadata readily available to handlers and middleware without requiring direct access to Kafka-specific APIs.