### PR TITLE
GH-3366: ship a real UseAzureServiceBusEmulator() API

### DIFF
--- a/docs/guide/messaging/transports/azureservicebus/conventional-routing.md
+++ b/docs/guide/messaging/transports/azureservicebus/conventional-routing.md
@@ -54,7 +54,7 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L386-L430' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conventional_routing_for_azure_service_bus' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L578-L622' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conventional_routing_for_azure_service_bus' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Route to Topics and Subscriptions <Badge type="tip" text="1.6.0" />
@@ -65,7 +65,7 @@ message type names like this:
 <!-- snippet: sample_using_topic_and_subscription_conventional_routing_with_azure_service_bus -->
 <a id='snippet-sample_using_topic_and_subscription_conventional_routing_with_azure_service_bus'></a>
 ```cs
-opts.UseAzureServiceBusTesting()
+opts.UseAzureServiceBusEmulator()
     .UseTopicAndSubscriptionConventionalRouting(convention =>
     {
         // Optionally control every aspect of the convention and
@@ -82,7 +82,7 @@ opts.UseAzureServiceBusTesting()
     .AutoProvision()
     .AutoPurgeOnStartup();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/Broadcasting/end_to_end_with_conventional_routing.cs#L33-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_topic_and_subscription_conventional_routing_with_azure_service_bus' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L180-L199' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_topic_and_subscription_conventional_routing_with_azure_service_bus' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Handler Type Naming <Badge type="tip" text="5.25" />

--- a/docs/guide/messaging/transports/azureservicebus/deadletterqueues.md
+++ b/docs/guide/messaging/transports/azureservicebus/deadletterqueues.md
@@ -30,7 +30,7 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L528-L549' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asb_inline_dlq' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L720-L741' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asb_inline_dlq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Buffered Endpoints
@@ -62,7 +62,7 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L554-L576' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asb_buffered_dlq' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L746-L768' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asb_buffered_dlq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Durable Endpoints
@@ -93,7 +93,7 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L581-L602' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asb_durable_dlq' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L773-L794' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asb_durable_dlq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Disabling Dead Letter Queues
@@ -121,7 +121,7 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L607-L627' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_asb_dlq' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L799-L819' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_asb_dlq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Recovering Native Dead Letters to Durable Storage <Badge type="tip" text="6.9" />

--- a/docs/guide/messaging/transports/azureservicebus/emulator.md
+++ b/docs/guide/messaging/transports/azureservicebus/emulator.md
@@ -1,6 +1,8 @@
 # Using the Azure Service Bus Emulator
 
-The [Azure Service Bus Emulator](https://learn.microsoft.com/en-us/azure/service-bus-messaging/overview-emulator) allows you to run integration tests against a local emulator instance instead of a real Azure Service Bus namespace. This is exactly what Wolverine uses internally for its own test suite.
+The [Azure Service Bus Emulator](https://learn.microsoft.com/en-us/azure/service-bus-messaging/overview-emulator) lets you run
+Wolverine against a local emulator instance instead of a real Azure Service Bus namespace, either for local development or for
+integration testing. This is exactly what Wolverine uses internally for its own test suite.
 
 ## Docker Compose Setup
 
@@ -24,7 +26,7 @@ services:
     volumes:
       - ./docker/asb/Config.json:/ServiceBus_Emulator/ConfigFiles/Config.json
     ports:
-      - "5673:5672"   # AMQP messaging
+      - "5672:5672"   # AMQP messaging
       - "5300:5300"   # HTTP management
     environment:
       SQL_SERVER: asb-sql
@@ -38,7 +40,9 @@ services:
 ```
 
 ::: tip
-The emulator exposes two ports: the AMQP port (5672) for sending and receiving messages, and an HTTP management port (5300) for queue/topic administration. These must be mapped to different host ports.
+The emulator exposes two ports: the AMQP port (5672) for sending and receiving messages, and an HTTP management port (5300) for
+queue and topic administration. Wolverine's own `docker-compose.yml` maps the AMQP port to host port **5673** to avoid colliding
+with RabbitMQ, which is why Wolverine's own tests pass explicit connection strings as shown below.
 :::
 
 ## Emulator Configuration File
@@ -101,101 +105,119 @@ You can also pre-configure queues and topics in this file if needed:
 }
 ```
 
-## Connection Strings
+## Connecting Wolverine to the Emulator <Badge type="tip" text="6.18" />
 
-The emulator uses standard Azure Service Bus connection strings with `UseDevelopmentEmulator=true`:
+The emulator uses one connection string for messaging (AMQP) and a *separate* one for management (HTTP), where real Azure Service
+Bus uses a single connection string for both. `UseAzureServiceBusEmulator()` hides that split. With the standard emulator ports it
+takes no arguments at all:
 
-```cs
-// AMQP connection for sending/receiving messages
-var messagingConnectionString =
-    "Endpoint=sb://localhost:5673;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
-
-// HTTP connection for management operations (creating queues, topics, etc.)
-var managementConnectionString =
-    "Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
-```
-
-::: warning
-The emulator uses separate ports for messaging (AMQP) and management (HTTP) operations. In production Azure Service Bus, a single connection string handles both, but the emulator requires you to configure these separately.
-:::
-
-## Configuring Wolverine with the Emulator
-
-The key to using the emulator with Wolverine is setting both the primary connection string (for AMQP messaging) and the `ManagementConnectionString` (for HTTP administration) on the transport:
-
+<!-- snippet: sample_using_azure_service_bus_emulator -->
+<a id='snippet-sample_using_azure_service_bus_emulator'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.UseWolverine(opts =>
 {
-    opts.UseAzureServiceBus(messagingConnectionString)
+    // Connect to a locally running Azure Service Bus emulator using the
+    // standard emulator ports (AMQP on 5672, management on 5300)
+    opts.UseAzureServiceBusEmulator()
+
+        // The emulator starts out empty, so let Wolverine build
+        // any queues, topics, or subscriptions it needs
         .AutoProvision()
         .AutoPurgeOnStartup();
 
-    // Required for the emulator: set the management connection string
-    // to the HTTP port since it differs from the AMQP port
-    var transport = opts.Transports.GetOrCreate<AzureServiceBusTransport>();
-    transport.ManagementConnectionString = managementConnectionString;
-
-    // Configure your queues, topics, etc. as normal
     opts.ListenToAzureServiceBusQueue("my-queue");
     opts.PublishAllMessages().ToAzureServiceBusQueue("my-queue");
 });
+
+using var host = builder.Build();
+await host.StartAsync();
 ```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L48-L69' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_azure_service_bus_emulator' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
-## Creating a Test Helper
+The parameterless version uses the defaults below, which are also exposed as the constants
+`AzureServiceBusEmulatorExtensions.DefaultEmulatorConnectionString` and
+`AzureServiceBusEmulatorExtensions.DefaultEmulatorManagementConnectionString`:
 
-Wolverine's own test suite uses a static helper extension method to standardize emulator configuration across all tests. Here's the pattern:
+| Purpose | Default connection string |
+| --- | --- |
+| Messaging (AMQP) | `Endpoint=sb://localhost:5672;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;` |
+| Management (HTTP) | `Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;` |
+
+If you have mapped the emulator to different host ports, pass both connection strings explicitly:
+
+<!-- snippet: sample_using_azure_service_bus_emulator_with_connection_strings -->
+<a id='snippet-sample_using_azure_service_bus_emulator_with_connection_strings'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.UseWolverine(opts =>
+{
+    // If you've mapped the emulator to non-standard ports, pass both the
+    // messaging (AMQP) and management (HTTP) connection strings explicitly
+    opts.UseAzureServiceBusEmulator(
+            "Endpoint=sb://localhost:5673;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+            "Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")
+        .AutoProvision()
+        .AutoPurgeOnStartup();
+});
+
+using var host = builder.Build();
+await host.StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L74-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_azure_service_bus_emulator_with_connection_strings' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+`UseAzureServiceBusEmulator()` returns the same `AzureServiceBusConfiguration` as `UseAzureServiceBus()`, so everything else --
+`AutoProvision()`, `AutoPurgeOnStartup()`, conventional routing, queue and topic configuration -- chains off of it exactly as it
+would against a real namespace.
+
+## Deleting All Existing Objects at Startup
+
+The emulator is a long lived, shared resource, and leftover queues or topics from earlier runs can leak into later ones. Wolverine
+can wipe the namespace clean at application startup, but this behavior is strictly **opt in**:
+
+<!-- snippet: sample_using_azure_service_bus_emulator_with_cleanup -->
+<a id='snippet-sample_using_azure_service_bus_emulator_with_cleanup'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.UseWolverine(opts =>
+{
+    opts.UseAzureServiceBusEmulator()
+
+        // CAUTION! This deletes *every* queue and topic in the connected
+        // namespace at startup. It is opt in, and is only meant for the
+        // emulator or a throwaway namespace. Never turn this on against
+        // a real Azure Service Bus namespace you care about
+        .DeleteAllExistingObjectsOnStartup()
+
+        .AutoProvision();
+});
+
+using var host = builder.Build();
+await host.StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L96-L115' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_azure_service_bus_emulator_with_cleanup' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: danger
+`DeleteAllExistingObjectsOnStartup()` deletes **every** queue and topic -- and therefore every message and subscription -- in the
+connected namespace each time the application starts. It is irreversible, and it is never turned on for you. It exists for the
+emulator and for throwaway namespaces. Never enable it against a real Azure Service Bus namespace that holds anything you care
+about. If you only want to drain messages out of the endpoints Wolverine itself knows about, use `AutoPurgeOnStartup()` instead.
+:::
+
+If you would rather clean up out of band -- say, once per test run rather than once per host -- call the standalone helper. It
+takes the *management* connection string, and defaults to the standard emulator one:
 
 ```cs
-public static class AzureServiceBusTesting
-{
-    // Connection strings pointing at the emulator
-    public static readonly string MessagingConnectionString =
-        "Endpoint=sb://localhost:5673;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
-
-    public static readonly string ManagementConnectionString =
-        "Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
-
-    private static bool _cleaned;
-
-    public static AzureServiceBusConfiguration UseAzureServiceBusTesting(
-        this WolverineOptions options)
-    {
-        // Delete all queues and topics on first usage to start clean
-        if (!_cleaned)
-        {
-            _cleaned = true;
-            DeleteAllEmulatorObjectsAsync().GetAwaiter().GetResult();
-        }
-
-        var config = options.UseAzureServiceBus(MessagingConnectionString);
-
-        var transport = options.Transports.GetOrCreate<AzureServiceBusTransport>();
-        transport.ManagementConnectionString = ManagementConnectionString;
-
-        return config.AutoProvision();
-    }
-
-    public static async Task DeleteAllEmulatorObjectsAsync()
-    {
-        var client = new ServiceBusAdministrationClient(ManagementConnectionString);
-
-        await foreach (var topic in client.GetTopicsAsync())
-        {
-            await client.DeleteTopicAsync(topic.Name);
-        }
-
-        await foreach (var queue in client.GetQueuesAsync())
-        {
-            await client.DeleteQueueAsync(queue.Name);
-        }
-    }
-}
+// Same destructive semantics: this drops every queue and topic in the namespace
+await AzureServiceBusEmulatorExtensions.DeleteAllAzureServiceBusObjectsAsync();
 ```
 
 ## Writing Integration Tests
 
-With the helper in place, integration tests become straightforward:
+Integration tests against the emulator are just normal Wolverine tests:
 
 ```cs
 public class when_sending_messages : IAsyncLifetime
@@ -207,7 +229,8 @@ public class when_sending_messages : IAsyncLifetime
         _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.UseAzureServiceBusTesting()
+                opts.UseAzureServiceBusEmulator()
+                    .AutoProvision()
                     .AutoPurgeOnStartup();
 
                 opts.ListenToAzureServiceBusQueue("send_and_receive");
@@ -238,12 +261,14 @@ public class when_sending_messages : IAsyncLifetime
 ```
 
 ::: tip
-Use `.IncludeExternalTransports()` on the tracked session so Wolverine waits for messages that travel through Azure Service Bus rather than only tracking in-memory activity.
+Use `.IncludeExternalTransports()` on the tracked session so Wolverine waits for messages that travel through Azure Service Bus
+rather than only tracking in-memory activity.
 :::
 
 ## Disabling Parallel Test Execution
 
-Because the emulator is a shared resource, tests that create and tear down queues or topics can interfere with each other when run in parallel. Wolverine's own test suite disables parallel execution for its Azure Service Bus tests:
+Because the emulator is a shared resource, tests that create and tear down queues or topics can interfere with each other when run
+in parallel. Wolverine's own test suite disables parallel execution for its Azure Service Bus tests:
 
 ```cs
 // Add to a file like NoParallelization.cs in your test project

--- a/docs/guide/messaging/transports/azureservicebus/index.md
+++ b/docs/guide/messaging/transports/azureservicebus/index.md
@@ -90,14 +90,37 @@ builder.UseWolverine(opts =>
 });
 ```
 
-When using the Azure Service Bus emulator for local development, use `UseAzureServiceBusTesting()` instead:
+When using the [Azure Service Bus emulator](/guide/messaging/transports/azureservicebus/emulator) for local development or testing,
+use `UseAzureServiceBusEmulator()` instead. It connects to the emulator's messaging (AMQP) port *and* its separate management (HTTP)
+port for you:
 
-```csharp
-// For local development with the Azure Service Bus emulator
-opts.UseAzureServiceBusTesting()
-    .AutoProvision()
-    .AutoPurgeOnStartup();
+<!-- snippet: sample_using_azure_service_bus_emulator -->
+<a id='snippet-sample_using_azure_service_bus_emulator'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.UseWolverine(opts =>
+{
+    // Connect to a locally running Azure Service Bus emulator using the
+    // standard emulator ports (AMQP on 5672, management on 5300)
+    opts.UseAzureServiceBusEmulator()
+
+        // The emulator starts out empty, so let Wolverine build
+        // any queues, topics, or subscriptions it needs
+        .AutoProvision()
+        .AutoPurgeOnStartup();
+
+    opts.ListenToAzureServiceBusQueue("my-queue");
+    opts.PublishAllMessages().ToAzureServiceBusQueue("my-queue");
+});
+
+using var host = builder.Build();
+await host.StartAsync();
 ```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L48-L69' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_azure_service_bus_emulator' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+See [Using the Azure Service Bus Emulator](/guide/messaging/transports/azureservicebus/emulator) for the Docker Compose setup, the
+overload that takes explicit connection strings, and the opt in namespace cleanup.
 
 ## Request/Reply
 
@@ -138,7 +161,7 @@ builder.UseWolverine(opts =>
 
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L187-L209' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_azure_service_bus_control_queues' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L379-L401' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_azure_service_bus_control_queues' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Disabling System Queues
@@ -149,10 +172,10 @@ to disable system queues to avoid having some annoying error messages popping up
 <!-- snippet: sample_disable_system_queues_in_azure_service_bus -->
 <a id='snippet-sample_disable_system_queues_in_azure_service_bus'></a>
 ```cs
-var host = await Host.CreateDefaultBuilder()
+using var host = await Host.CreateDefaultBuilder()
     .UseWolverine(opts =>
     {
-        opts.UseAzureServiceBusTesting()
+        opts.UseAzureServiceBus("some connection string")
             .AutoProvision().AutoPurgeOnStartup()
             .SystemQueuesAreEnabled(false);
 
@@ -161,7 +184,7 @@ var host = await Host.CreateDefaultBuilder()
         opts.PublishAllMessages().ToAzureServiceBusQueue("send_and_receive");
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end.cs#L86-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_system_queues_in_azure_service_bus' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L158-L172' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_system_queues_in_azure_service_bus' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Connecting To Multiple Namespaces <Badge type="tip" text="5.0" />

--- a/docs/guide/messaging/transports/azureservicebus/listening.md
+++ b/docs/guide/messaging/transports/azureservicebus/listening.md
@@ -42,7 +42,7 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L87-L119' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_an_azure_service_bus_listener' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L244-L276' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_an_azure_service_bus_listener' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Configuring the ServiceBusProcessor
@@ -90,7 +90,7 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L124-L153' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_azure_service_bus_processor_options' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L281-L311' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_azure_service_bus_processor_options' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: warning
@@ -129,7 +129,7 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L306-L327' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conventional_listener_configuration_for_azure_service_bus' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L498-L519' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conventional_listener_configuration_for_azure_service_bus' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note that any of these settings would be overridden by specific configuration to

--- a/docs/guide/messaging/transports/azureservicebus/object-management.md
+++ b/docs/guide/messaging/transports/azureservicebus/object-management.md
@@ -131,6 +131,6 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L48-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_azure_service_bus_queues' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L205-L239' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_azure_service_bus_queues' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 

--- a/docs/guide/messaging/transports/azureservicebus/publishing.md
+++ b/docs/guide/messaging/transports/azureservicebus/publishing.md
@@ -28,7 +28,7 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L247-L270' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_publishing_to_specific_azure_service_bus_queue' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L439-L462' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_publishing_to_specific_azure_service_bus_queue' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -60,7 +60,7 @@ builder.UseWolverine(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L332-L353' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conventional_subscriber_configuration_for_azure_service_bus' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L524-L545' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conventional_subscriber_configuration_for_azure_service_bus' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note that any of these settings would be overridden by specific configuration to

--- a/docs/guide/messaging/transports/azureservicebus/session-identifiers.md
+++ b/docs/guide/messaging/transports/azureservicebus/session-identifiers.md
@@ -10,15 +10,16 @@ Wolverine when sessions are required on any listening endpoint so that it can op
 :::
 
 You can now take advantage of [sessions and first-in, first out queues in Azure Service Bus](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-sessions) with Wolverine. 
-To tell Wolverine that an Azure Service Bus queue or subscription should require sessions, you have this syntax shown in an internal test:
+To tell Wolverine that an Azure Service Bus queue or subscription should require sessions, use this syntax (shown here against the
+[Azure Service Bus emulator](/guide/messaging/transports/azureservicebus/emulator), but identical against a real namespace):
 
 <!-- snippet: sample_using_azure_service_bus_session_identifiers -->
 <a id='snippet-sample_using_azure_service_bus_session_identifiers'></a>
 ```cs
-_host = await Host.CreateDefaultBuilder()
+using var host = await Host.CreateDefaultBuilder()
     .UseWolverine(opts =>
     {
-        opts.UseAzureServiceBusTesting()
+        opts.UseAzureServiceBusEmulator()
             .AutoProvision().AutoPurgeOnStartup();
 
         opts.ListenToAzureServiceBusQueue("send_and_receive");
@@ -44,18 +45,9 @@ _host = await Host.CreateDefaultBuilder()
             .RequireSessions(1)
 
             .ProcessInline();
-
-        opts.PublishMessage<AsbMessage4>().ToAzureServiceBusTopic("asb4").BufferedInMemory();
-        opts.ListenToAzureServiceBusSubscription("asb4")
-            .FromTopic("asb4")
-
-            // Require sessions on this subscription
-            .RequireSessions(1)
-
-            .ProcessInline();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end.cs#L19-L60' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_azure_service_bus_session_identifiers' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L120-L153' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_azure_service_bus_session_identifiers' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To publish messages to Azure Service Bus with a session id, you will need to of course supply the session id:
@@ -68,7 +60,7 @@ await bus.SendAsync(new AsbMessage3("Red"), new DeliveryOptions { GroupId = "2" 
 await bus.SendAsync(new AsbMessage3("Green"), new DeliveryOptions { GroupId = "2" });
 await bus.SendAsync(new AsbMessage3("Refactor"), new DeliveryOptions { GroupId = "2" });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end.cs#L151-L157' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sending_with_session_identifier' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end.cs#L144-L150' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sending_with_session_identifier' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: info

--- a/docs/guide/messaging/transports/azureservicebus/topics.md
+++ b/docs/guide/messaging/transports/azureservicebus/topics.md
@@ -62,7 +62,7 @@ opts.ListenToAzureServiceBusSubscription(
         })
     .FromTopic("topic1");
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L169-L178' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_azure_service_bus_subscription_filter' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L361-L370' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_azure_service_bus_subscription_filter' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The default filter if not customized is a simple `1=1` (always true) filter.

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/AzureServiceBusTesting.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/AzureServiceBusTesting.cs
@@ -1,4 +1,3 @@
-using Azure.Messaging.ServiceBus.Administration;
 using IntegrationTests;
 
 namespace Wolverine.AzureServiceBus.Tests;
@@ -7,6 +6,11 @@ public static class AzureServiceBusTesting
 {
     private static bool _cleaned;
 
+    /// <summary>
+    /// Connect to the Azure Service Bus emulator from Wolverine's own docker-compose setup. This delegates
+    /// to the shipping UseAzureServiceBusEmulator() API, but adds a one time cleanup of any objects left
+    /// behind by previous test runs.
+    /// </summary>
     public static AzureServiceBusConfiguration UseAzureServiceBusTesting(this WolverineOptions options)
     {
         if (!_cleaned)
@@ -17,32 +21,21 @@ public static class AzureServiceBusTesting
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
-        var config = options.UseAzureServiceBus(Servers.AzureServiceBusConnectionString);
-
-        var transport = options.Transports.GetOrCreate<AzureServiceBusTransport>();
-        transport.ManagementConnectionString = Servers.AzureServiceBusManagementConnectionString;
-
-        return config.AutoProvision();
+        return options
+            .UseAzureServiceBusEmulator(Servers.AzureServiceBusConnectionString,
+                Servers.AzureServiceBusManagementConnectionString)
+            .AutoProvision();
     }
 
-    public static async Task DeleteAllEmulatorObjectsAsync()
-        => await DeleteAllEmulatorObjectsAsync(Servers.AzureServiceBusManagementConnectionString);
+    public static Task DeleteAllEmulatorObjectsAsync()
+    {
+        return DeleteAllEmulatorObjectsAsync(Servers.AzureServiceBusManagementConnectionString);
+    }
 
     public static async Task DeleteAllEmulatorObjectsAsync(string connectionString)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        var ct = cts.Token;
 
-        var client = new ServiceBusAdministrationClient(connectionString);
-
-        await foreach (var topic in client.GetTopicsAsync().WithCancellation(ct))
-        {
-            await client.DeleteTopicAsync(topic.Name, ct);
-        }
-
-        await foreach (var queue in client.GetQueuesAsync().WithCancellation(ct))
-        {
-            await client.DeleteQueueAsync(queue.Name, ct);
-        }
+        await AzureServiceBusEmulatorExtensions.DeleteAllAzureServiceBusObjectsAsync(connectionString, cts.Token);
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/Broadcasting/end_to_end_with_conventional_routing.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/Broadcasting/end_to_end_with_conventional_routing.cs
@@ -30,7 +30,6 @@ public class end_to_end_with_conventional_routing : IAsyncLifetime
 
         _receiver = await WolverineHost.ForAsync(opts =>
         {
-            #region sample_using_topic_and_subscription_conventional_routing_with_azure_service_bus
             opts.UseAzureServiceBusTesting()
                 .UseTopicAndSubscriptionConventionalRouting(convention =>
                 {
@@ -47,8 +46,6 @@ public class end_to_end_with_conventional_routing : IAsyncLifetime
 
                 .AutoProvision()
                 .AutoPurgeOnStartup();
-
-            #endregion
 
             opts.ServiceName = "Receiver";
         });

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs
@@ -43,6 +43,163 @@ public class DocumentationSamples
         #endregion
     }
 
+    public async Task bootstrapping_with_the_emulator()
+    {
+        #region sample_using_azure_service_bus_emulator
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            // Connect to a locally running Azure Service Bus emulator using the
+            // standard emulator ports (AMQP on 5672, management on 5300)
+            opts.UseAzureServiceBusEmulator()
+
+                // The emulator starts out empty, so let Wolverine build
+                // any queues, topics, or subscriptions it needs
+                .AutoProvision()
+                .AutoPurgeOnStartup();
+
+            opts.ListenToAzureServiceBusQueue("my-queue");
+            opts.PublishAllMessages().ToAzureServiceBusQueue("my-queue");
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        #endregion
+    }
+
+    public async Task bootstrapping_with_the_emulator_and_explicit_connection_strings()
+    {
+        #region sample_using_azure_service_bus_emulator_with_connection_strings
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            // If you've mapped the emulator to non-standard ports, pass both the
+            // messaging (AMQP) and management (HTTP) connection strings explicitly
+            opts.UseAzureServiceBusEmulator(
+                    "Endpoint=sb://localhost:5673;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+                    "Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")
+                .AutoProvision()
+                .AutoPurgeOnStartup();
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        #endregion
+    }
+
+    public async Task bootstrapping_with_the_emulator_and_cleanup()
+    {
+        #region sample_using_azure_service_bus_emulator_with_cleanup
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            opts.UseAzureServiceBusEmulator()
+
+                // CAUTION! This deletes *every* queue and topic in the connected
+                // namespace at startup. It is opt in, and is only meant for the
+                // emulator or a throwaway namespace. Never turn this on against
+                // a real Azure Service Bus namespace you care about
+                .DeleteAllExistingObjectsOnStartup()
+
+                .AutoProvision();
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        #endregion
+    }
+
+    public async Task azure_service_bus_session_identifiers()
+    {
+        #region sample_using_azure_service_bus_session_identifiers
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAzureServiceBusEmulator()
+                    .AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToAzureServiceBusQueue("send_and_receive");
+                opts.PublishMessage<AsbMessage1>().ToAzureServiceBusQueue("send_and_receive");
+
+                opts.ListenToAzureServiceBusQueue("fifo1")
+
+                    // Require session identifiers with this queue
+                    .RequireSessions()
+
+                    // This controls the Wolverine handling to force it to process
+                    // messages sequentially
+                    .Sequential();
+
+                opts.PublishMessage<AsbMessage2>()
+                    .ToAzureServiceBusQueue("fifo1");
+
+                opts.PublishMessage<AsbMessage3>().ToAzureServiceBusTopic("asb3").SendInline();
+                opts.ListenToAzureServiceBusSubscription("asb3")
+                    .FromTopic("asb3")
+
+                    // Require sessions on this subscription
+                    .RequireSessions(1)
+
+                    .ProcessInline();
+            }).StartAsync();
+
+        #endregion
+    }
+
+    public async Task disable_system_queues()
+    {
+        #region sample_disable_system_queues_in_azure_service_bus
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAzureServiceBus("some connection string")
+                    .AutoProvision().AutoPurgeOnStartup()
+                    .SystemQueuesAreEnabled(false);
+
+                opts.ListenToAzureServiceBusQueue("send_and_receive");
+
+                opts.PublishAllMessages().ToAzureServiceBusQueue("send_and_receive");
+            }).StartAsync();
+
+        #endregion
+    }
+
+    public async Task topic_and_subscription_conventional_routing()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                #region sample_using_topic_and_subscription_conventional_routing_with_azure_service_bus
+
+                opts.UseAzureServiceBusEmulator()
+                    .UseTopicAndSubscriptionConventionalRouting(convention =>
+                    {
+                        // Optionally control every aspect of the convention and
+                        // its applicability to types
+                        // as well as overriding any listener, sender, topic, or subscription
+                        // options
+
+                        // Can't use the full name because of limitations on name length
+                        convention.SubscriptionNameForListener(t => t.Name.ToLowerInvariant());
+                        convention.TopicNameForListener(t => t.Name.ToLowerInvariant());
+                        convention.TopicNameForSender(t => t.Name.ToLowerInvariant());
+                    })
+
+                    .AutoProvision()
+                    .AutoPurgeOnStartup();
+
+                #endregion
+            }).StartAsync();
+    }
+
     public async Task configuring_queues()
     {
         #region sample_configuring_azure_service_bus_queues

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/emulator_configuration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/emulator_configuration.cs
@@ -1,0 +1,51 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+public class emulator_configuration
+{
+    [Fact]
+    public void use_the_default_emulator_connection_strings()
+    {
+        var options = new WolverineOptions();
+        options.UseAzureServiceBusEmulator();
+
+        var transport = options.AzureServiceBusTransport();
+
+        transport.ConnectionString.ShouldBe(AzureServiceBusEmulatorExtensions.DefaultEmulatorConnectionString);
+        transport.ManagementConnectionString
+            .ShouldBe(AzureServiceBusEmulatorExtensions.DefaultEmulatorManagementConnectionString);
+    }
+
+    [Fact]
+    public void use_explicit_emulator_connection_strings()
+    {
+        var options = new WolverineOptions();
+        options.UseAzureServiceBusEmulator("Endpoint=sb://localhost:5673;UseDevelopmentEmulator=true;",
+            "Endpoint=sb://localhost:5301;UseDevelopmentEmulator=true;");
+
+        var transport = options.AzureServiceBusTransport();
+
+        transport.ConnectionString.ShouldBe("Endpoint=sb://localhost:5673;UseDevelopmentEmulator=true;");
+        transport.ManagementConnectionString.ShouldBe("Endpoint=sb://localhost:5301;UseDevelopmentEmulator=true;");
+    }
+
+    [Fact]
+    public void the_destructive_cleanup_is_not_enabled_by_default()
+    {
+        var options = new WolverineOptions();
+        options.UseAzureServiceBusEmulator();
+
+        options.AzureServiceBusTransport().DeleteAllExistingObjectsOnStartup.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void opt_into_the_destructive_cleanup()
+    {
+        var options = new WolverineOptions();
+        options.UseAzureServiceBusEmulator().DeleteAllExistingObjectsOnStartup();
+
+        options.AzureServiceBusTransport().DeleteAllExistingObjectsOnStartup.ShouldBeTrue();
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end.cs
@@ -15,7 +15,6 @@ public class end_to_end : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        #region sample_using_azure_service_bus_session_identifiers
         _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
@@ -55,8 +54,6 @@ public class end_to_end : IAsyncLifetime
 
                     .ProcessInline();
             }).StartAsync();
-
-        #endregion
     }
 
     public async Task DisposeAsync()
@@ -82,7 +79,6 @@ public class end_to_end : IAsyncLifetime
     [Fact]
     public async Task disable_system_queues()
     {
-        #region sample_disable_system_queues_in_azure_service_bus
         using var host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
@@ -94,8 +90,6 @@ public class end_to_end : IAsyncLifetime
 
                 opts.PublishAllMessages().ToAzureServiceBusQueue("send_and_receive");
             }).StartAsync();
-
-        #endregion
 
         var transport = host.GetRuntime().Options.Transports.GetOrCreate<AzureServiceBusTransport>();
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusConfiguration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusConfiguration.cs
@@ -30,6 +30,20 @@ public class AzureServiceBusConfiguration : BrokerExpression<AzureServiceBusTran
     }
     
     /// <summary>
+    /// CAUTION!!! This directs Wolverine to delete *every* queue and topic in the connected Azure Service
+    /// Bus namespace at application start up, before any objects are provisioned. This is destructive and
+    /// irreversible, and is only meant for local development or automated testing against the Azure Service
+    /// Bus emulator. Never enable this against a real Azure Service Bus namespace that holds anything you
+    /// care about.
+    /// </summary>
+    /// <returns></returns>
+    public AzureServiceBusConfiguration DeleteAllExistingObjectsOnStartup()
+    {
+        Transport.DeleteAllExistingObjectsOnStartup = true;
+        return this;
+    }
+
+    /// <summary>
     /// Override the sending logic behavior for unknown or missing tenant ids when
     /// using multi-tenanted namespaces
     /// </summary>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusEmulatorExtensions.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusEmulatorExtensions.cs
@@ -1,0 +1,90 @@
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+
+namespace Wolverine.AzureServiceBus;
+
+/// <summary>
+/// Helpers for connecting Wolverine to a locally running
+/// <a href="https://learn.microsoft.com/en-us/azure/service-bus-messaging/overview-emulator">Azure Service Bus emulator</a>.
+/// The emulator exposes messaging (AMQP) and management (HTTP) on two different ports, so it requires
+/// both a messaging connection string and a separate management connection string.
+/// </summary>
+public static class AzureServiceBusEmulatorExtensions
+{
+    /// <summary>
+    /// The default messaging (AMQP) connection string for a locally hosted Azure Service Bus emulator
+    /// listening on the standard port 5672
+    /// </summary>
+    public const string DefaultEmulatorConnectionString =
+        "Endpoint=sb://localhost:5672;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
+
+    /// <summary>
+    /// The default management (HTTP) connection string for a locally hosted Azure Service Bus emulator
+    /// listening on the standard port 5300
+    /// </summary>
+    public const string DefaultEmulatorManagementConnectionString =
+        "Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
+
+    /// <summary>
+    /// Connect to a locally running Azure Service Bus emulator using the standard emulator connection
+    /// strings (AMQP on localhost:5672, management on localhost:5300). Use the overload with explicit
+    /// connection strings if you have mapped the emulator to different ports.
+    /// </summary>
+    /// <param name="endpoints"></param>
+    /// <param name="configure">Optionally configure the underlying <see cref="ServiceBusClientOptions"/></param>
+    /// <returns></returns>
+    public static AzureServiceBusConfiguration UseAzureServiceBusEmulator(this WolverineOptions endpoints,
+        Action<ServiceBusClientOptions>? configure = null)
+    {
+        return endpoints.UseAzureServiceBusEmulator(DefaultEmulatorConnectionString,
+            DefaultEmulatorManagementConnectionString, configure);
+    }
+
+    /// <summary>
+    /// Connect to a locally running Azure Service Bus emulator with explicit messaging (AMQP) and
+    /// management (HTTP) connection strings
+    /// </summary>
+    /// <param name="endpoints"></param>
+    /// <param name="connectionString">The messaging (AMQP) connection string</param>
+    /// <param name="managementConnectionString">The management (HTTP) connection string used for administration</param>
+    /// <param name="configure">Optionally configure the underlying <see cref="ServiceBusClientOptions"/></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static AzureServiceBusConfiguration UseAzureServiceBusEmulator(this WolverineOptions endpoints,
+        string connectionString, string managementConnectionString, Action<ServiceBusClientOptions>? configure = null)
+    {
+        if (managementConnectionString == null)
+        {
+            throw new ArgumentNullException(nameof(managementConnectionString));
+        }
+
+        var configuration = endpoints.UseAzureServiceBus(connectionString, configure);
+
+        endpoints.AzureServiceBusTransport().ManagementConnectionString = managementConnectionString;
+
+        return configuration;
+    }
+
+    /// <summary>
+    /// CAUTION!!! This deletes every queue and topic in the targeted Azure Service Bus namespace. This is
+    /// meant strictly for local development and testing against the Azure Service Bus emulator.
+    /// </summary>
+    /// <param name="managementConnectionString">The management (HTTP) connection string of the emulator</param>
+    /// <param name="token"></param>
+    public static async Task DeleteAllAzureServiceBusObjectsAsync(
+        string managementConnectionString = DefaultEmulatorManagementConnectionString,
+        CancellationToken token = default)
+    {
+        var client = new ServiceBusAdministrationClient(managementConnectionString);
+
+        await foreach (var topic in client.GetTopicsAsync(token).WithCancellation(token))
+        {
+            await client.DeleteTopicAsync(topic.Name, token);
+        }
+
+        await foreach (var queue in client.GetQueuesAsync(token).WithCancellation(token))
+        {
+            await client.DeleteQueueAsync(queue.Name, token);
+        }
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
@@ -42,6 +42,14 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
         IdentifierDelimiter = ".";
     }
 
+    /// <summary>
+    /// CAUTION!!! If set to true, Wolverine will delete *every* queue and topic in the connected
+    /// Azure Service Bus namespace at application start up before provisioning any objects. This is
+    /// opt in, and is only intended for local development or testing against the Azure Service Bus
+    /// emulator. See <see cref="AzureServiceBusConfiguration.DeleteAllExistingObjectsOnStartup"/>
+    /// </summary>
+    public bool DeleteAllExistingObjectsOnStartup { get; set; }
+
     public async Task DeleteAllObjectsAsync()
     {
         var topics = _managementClient.Value.GetTopicsAsync();
@@ -324,10 +332,18 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
         throw new ArgumentOutOfRangeException(nameof(uri));
     }
 
-    public override ValueTask ConnectAsync(IWolverineRuntime runtime)
+    public override async ValueTask ConnectAsync(IWolverineRuntime runtime)
     {
-        // we're going to use a client per endpoint
-        return ValueTask.CompletedTask;
+        if (DeleteAllExistingObjectsOnStartup)
+        {
+            runtime.Logger.LogWarning(
+                "Deleting all existing queues and topics in the Azure Service Bus namespace at {Broker} because DeleteAllExistingObjectsOnStartup() was enabled",
+                DescribeEndpoint());
+
+            await DeleteAllObjectsAsync();
+        }
+
+        // otherwise, we're going to use a client per endpoint
     }
 
     public WolverineTransportHealthCheck BuildHealthCheck(IWolverineRuntime runtime)


### PR DESCRIPTION
## Problem

Several Azure Service Bus doc pages told readers to call `UseAzureServiceBusTesting()`, but that extension method was never in the shipping `WolverineFx.AzureServiceBus` package -- it lived only in `Wolverine.AzureServiceBus.Tests` and depended on the test-infrastructure `Servers` type. Readers following the docs got a compile error.

Per the maintainer decision on the issue, this takes **Option 1**: promote a real API into the shipping package rather than walking the docs back.

## New public API surface (`Wolverine.AzureServiceBus`)

`AzureServiceBusEmulatorExtensions` (new):

```csharp
public const string DefaultEmulatorConnectionString =
    "Endpoint=sb://localhost:5672;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";

public const string DefaultEmulatorManagementConnectionString =
    "Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";

public static AzureServiceBusConfiguration UseAzureServiceBusEmulator(
    this WolverineOptions endpoints,
    Action<ServiceBusClientOptions>? configure = null);

public static AzureServiceBusConfiguration UseAzureServiceBusEmulator(
    this WolverineOptions endpoints,
    string connectionString,
    string managementConnectionString,
    Action<ServiceBusClientOptions>? configure = null);

public static Task DeleteAllAzureServiceBusObjectsAsync(
    string managementConnectionString = DefaultEmulatorManagementConnectionString,
    CancellationToken token = default);
```

`AzureServiceBusConfiguration` (new method):

```csharp
public AzureServiceBusConfiguration DeleteAllExistingObjectsOnStartup();
```

`AzureServiceBusTransport` (new property, honored in `ConnectAsync`):

```csharp
public bool DeleteAllExistingObjectsOnStartup { get; set; }
```

Both `UseAzureServiceBusEmulator()` overloads set `ManagementConnectionString` and return the same `AzureServiceBusConfiguration` as `UseAzureServiceBus()`, so `AutoProvision()`, `AutoPurgeOnStartup()`, conventional routing, etc. all chain off of them.

## Opt-in cleanup decision

The test-only helper unconditionally deleted every queue and topic in the namespace. That is far too dangerous to make default behavior in a shipped API -- someone who points `UseAzureServiceBusEmulator()` at a real namespace by mistake (or with a copy/pasted connection string) must not lose their entities. So the wipe is **opt in only**, via `DeleteAllExistingObjectsOnStartup()`, and it is documented as destructive and irreversible with a `::: danger` callout. `DeleteAllAzureServiceBusObjectsAsync(...)` is also available for out-of-band cleanup (e.g. once per test run rather than once per host start), which is exactly how Wolverine's own test suite now uses it.

## Tests and docs

- `Wolverine.AzureServiceBus.Tests/AzureServiceBusTesting.cs` now delegates to the shipping API -- no duplicate implementation. The whole ASB suite still goes through it, so the new API is exercised end-to-end on CI.
- New `emulator_configuration.cs` unit tests cover both overloads and assert the destructive cleanup is off by default.
- `emulator.md` rewritten around the now-real API (compiled `<!-- snippet: ... -->` blocks from `DocumentationSamples.cs`), plus fixes to `index.md`, `session-identifiers.md`, and `conventional-routing.md`. The doc-facing samples that previously pulled from tests calling `UseAzureServiceBusTesting()` were moved into `DocumentationSamples.cs` and now show `UseAzureServiceBusEmulator()`. No `UseAzureServiceBusTesting()` references remain anywhere in `docs/`.

## Verification

- `dotnet build wolverine.slnx -c Release` -- clean, 0 warnings / 0 errors.
- New `emulator_configuration` tests pass locally (4/4).
- The broker-backed ASB tests were **not** run locally -- they need the Azure Service Bus emulator container -- so I am relying on CI for those.

Fixes #3366

🤖 Generated with [Claude Code](https://claude.com/claude-code)