### PR TITLE
GH-3408: filter reserved keys when writing Envelope.Headers to the wire format

### DIFF
--- a/src/Testing/CoreTests/Serialization/reserved_header_key_filtering.cs
+++ b/src/Testing/CoreTests/Serialization/reserved_header_key_filtering.cs
@@ -1,0 +1,166 @@
+using System.Reflection;
+using JasperFx.Core;
+using Shouldly;
+using Wolverine.Runtime.Serialization;
+using Xunit;
+
+namespace CoreTests.Serialization;
+
+/// <summary>
+///     Regression coverage for GH-3408. A reserved key sitting in the loose <see cref="Envelope.Headers" />
+///     used to be appended to the wire format *after* the typed properties, and the reader promotes reserved
+///     keys straight back into those typed properties -- so the stray header silently overwrote the real
+///     TenantId / SagaId / Id / MessageType on the next trip through the durable inbox, outbox, or scheduled
+///     message store.
+/// </summary>
+public class reserved_header_key_filtering
+{
+    private static Envelope roundTrip(Envelope outgoing)
+    {
+        return EnvelopeSerializer.Deserialize(EnvelopeSerializer.Serialize(outgoing));
+    }
+
+    private static Envelope theOutgoingEnvelope()
+    {
+        return new Envelope
+        {
+            SentAt = DateTime.Today.ToUniversalTime(),
+            Data = [1, 2, 3],
+            Destination = "tcp://localhost:2222/incoming".ToUri(),
+            MessageType = "real-message-type",
+            TenantId = "real-tenant",
+            SagaId = "real-saga",
+            Id = Guid.NewGuid()
+        };
+    }
+
+    [Fact]
+    public void a_tenant_id_header_does_not_overwrite_the_typed_tenant_id()
+    {
+        var outgoing = theOutgoingEnvelope();
+        outgoing.Headers[EnvelopeConstants.TenantIdKey] = "hijacked-tenant";
+
+        var incoming = roundTrip(outgoing);
+
+        incoming.TenantId.ShouldBe("real-tenant");
+        incoming.Headers.ContainsKey(EnvelopeConstants.TenantIdKey).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_saga_id_header_does_not_overwrite_the_typed_saga_id()
+    {
+        var outgoing = theOutgoingEnvelope();
+        outgoing.Headers[EnvelopeConstants.SagaIdKey] = "hijacked-saga";
+
+        var incoming = roundTrip(outgoing);
+
+        incoming.SagaId.ShouldBe("real-saga");
+    }
+
+    [Fact]
+    public void an_id_header_does_not_overwrite_the_envelope_id()
+    {
+        var outgoing = theOutgoingEnvelope();
+        outgoing.Headers[EnvelopeConstants.IdKey] = Guid.NewGuid().ToString();
+
+        var incoming = roundTrip(outgoing);
+
+        incoming.Id.ShouldBe(outgoing.Id);
+    }
+
+    [Fact]
+    public void a_message_type_header_does_not_overwrite_the_typed_message_type()
+    {
+        var outgoing = theOutgoingEnvelope();
+        outgoing.Headers[EnvelopeConstants.MessageTypeKey] = "hijacked-message-type";
+
+        var incoming = roundTrip(outgoing);
+
+        incoming.MessageType.ShouldBe("real-message-type");
+    }
+
+    [Fact]
+    public void all_the_reserved_keys_at_once_leave_every_typed_property_alone()
+    {
+        var outgoing = theOutgoingEnvelope();
+        foreach (var key in EnvelopeSerializer.ReservedHeaderKeys)
+        {
+            outgoing.Headers[key] = "hijacked";
+        }
+
+        var incoming = roundTrip(outgoing);
+
+        incoming.TenantId.ShouldBe("real-tenant");
+        incoming.SagaId.ShouldBe("real-saga");
+        incoming.MessageType.ShouldBe("real-message-type");
+        incoming.Id.ShouldBe(outgoing.Id);
+        incoming.Destination.ShouldBe(outgoing.Destination);
+    }
+
+    [Fact]
+    public void non_reserved_custom_headers_still_round_trip()
+    {
+        var outgoing = theOutgoingEnvelope();
+        outgoing.Headers["name"] = "Jeremy";
+        outgoing.Headers["state"] = "Texas";
+        outgoing.Headers[EnvelopeConstants.TenantIdKey] = "hijacked-tenant";
+
+        var incoming = roundTrip(outgoing);
+
+        incoming.Headers["name"].ShouldBe("Jeremy");
+        incoming.Headers["state"].ShouldBe("Texas");
+    }
+
+    [Fact]
+    public void the_causation_id_header_is_not_filtered_out()
+    {
+        // DeliveryOptions deliberately stashes CausationId as a loose header, and the reader
+        // never promotes it to a typed property -- so it must NOT be treated as reserved.
+        var outgoing = theOutgoingEnvelope();
+        outgoing.Headers[EnvelopeConstants.CausationIdKey] = "the-cause";
+
+        roundTrip(outgoing).Headers[EnvelopeConstants.CausationIdKey].ShouldBe("the-cause");
+    }
+
+    /// <summary>
+    ///     Guards the invariant directly rather than trusting a hand-maintained list: every
+    ///     <see cref="EnvelopeConstants" /> key that the reader promotes into a typed property
+    ///     (i.e. one that does NOT land in Headers) must be in the write-side reserved filter.
+    ///     A newly added constant with a reader case that nobody adds to the filter fails here.
+    /// </summary>
+    [Fact]
+    public void every_key_promoted_by_the_reader_is_in_the_reserved_set()
+    {
+        var keys = typeof(EnvelopeConstants)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(x => x.IsLiteral && x.FieldType == typeof(string))
+            .Select(x => (string)x.GetRawConstantValue()!);
+
+        foreach (var key in keys)
+        {
+            var envelope = new Envelope();
+
+            var promoted = false;
+            try
+            {
+                EnvelopeSerializer.ReadDataElement(envelope, key, "1");
+
+                // Anything the reader handled by a real case never lands in Headers
+                promoted = !envelope.Headers.ContainsKey(key);
+            }
+            catch (InvalidOperationException)
+            {
+                // The reader hit a typed case and choked on the sample value (a Uri or a date,
+                // say). Reaching a typed case at all means the key is promoted.
+                promoted = true;
+            }
+
+            if (promoted)
+            {
+                EnvelopeSerializer.ReservedHeaderKeys.ShouldContain(key,
+                    $"'{key}' is promoted into a typed Envelope property by the reader, so it must be " +
+                    "skipped when Envelope.Headers is written to the wire format. See GH-3408.");
+            }
+        }
+    }
+}

--- a/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Globalization;
 using System.Xml;
 
@@ -5,6 +6,44 @@ namespace Wolverine.Runtime.Serialization;
 
 public static class EnvelopeSerializer
 {
+    /// <summary>
+    ///     The header keys that <see cref="ReadDataElement" /> promotes straight back into a typed
+    ///     <see cref="Envelope" /> property instead of leaving in <see cref="Envelope.Headers" />.
+    ///     These are skipped when the loose <see cref="Envelope.Headers" /> are written to the wire
+    ///     format so that a reserved key sitting in <c>Headers</c> — put there by a custom
+    ///     <c>IEnvelopeMapper</c> copying raw broker headers, or by user code — can never overwrite
+    ///     the authoritative typed property on the next read. See GH-3408.
+    ///     Note that this deliberately does NOT include every constant on <see cref="EnvelopeConstants" />:
+    ///     <c>causation-id</c> is intentionally carried in <c>Headers</c> (see <c>DeliveryOptions</c>) and
+    ///     is never promoted by the reader, so it must keep round-tripping as an ordinary header.
+    /// </summary>
+    internal static readonly FrozenSet<string> ReservedHeaderKeys = new[]
+    {
+        EnvelopeConstants.SourceKey,
+        EnvelopeConstants.MessageTypeKey,
+        EnvelopeConstants.ReplyUriKey,
+        EnvelopeConstants.ContentTypeKey,
+        EnvelopeConstants.CorrelationIdKey,
+        EnvelopeConstants.SagaIdKey,
+        EnvelopeConstants.ConversationIdKey,
+        EnvelopeConstants.DestinationKey,
+        EnvelopeConstants.AcceptedContentTypesKey,
+        EnvelopeConstants.IdKey,
+        EnvelopeConstants.ParentIdKey,
+        EnvelopeConstants.GroupIdKey,
+        EnvelopeConstants.ReplyRequestedKey,
+        EnvelopeConstants.AckRequestedKey,
+        EnvelopeConstants.IsResponseKey,
+        EnvelopeConstants.ExecutionTimeKey,
+        EnvelopeConstants.KeepUntilKey,
+        EnvelopeConstants.AttemptsKey,
+        EnvelopeConstants.DeliverByKey,
+        EnvelopeConstants.TenantIdKey,
+        EnvelopeConstants.TopicNameKey,
+        EnvelopeConstants.UserNameKey,
+        EnvelopeConstants.PartitionKey
+    }.ToFrozenSet(StringComparer.Ordinal);
+
     /// <summary>
     /// Caps applied to inbound envelopes during deserialization. Defaults to
     /// <see cref="EnvelopeReaderLimits.Default"/>. Wolverine publishes the
@@ -338,6 +377,15 @@ public static class EnvelopeSerializer
         foreach (var pair in env.Headers)
         {
             if (pair.Value is null)
+            {
+                continue;
+            }
+
+            // A reserved key sitting in the loose Headers would be written *after* the typed
+            // properties above, and the reader promotes reserved keys straight back into those
+            // typed properties -- so writing it would let the header silently overwrite the real
+            // TenantId/SagaId/Id/etc. Skip it instead. See GH-3408.
+            if (ReservedHeaderKeys.Contains(pair.Key))
             {
                 continue;
             }


### PR DESCRIPTION
Fixes #3408.

## The escalation path

`EnvelopeSerializer.writeHeaders` wrote the typed envelope properties first, then appended **every** `env.Headers` entry verbatim with no reserved-key filter — and the appended entries came *last*. The reader (`ReadDataElement`) switches reserved keys straight back into the typed properties, in order. So an entry sitting in `env.Headers` under a reserved key **overwrote the real typed property** on the next read.

Concretely:

1. Something puts `tenant-id: acme` into `envelope.Headers` — a custom `IEnvelopeMapper` copying raw broker headers (this is how #3407 surfaced it), `MassTransitEnvelope.TransferData` copying incoming MT headers, or plain user code.
2. The value is inert while the envelope is in memory — nothing promotes `Headers` → typed props on the receive path.
3. It stops being inert the instant the envelope crosses `EnvelopeSerializer`: a **durable** listener, the inbox/outbox, or the scheduled-message store. `writeHeaders` appends `tenant-id = acme` *after* the (possibly null) typed prop.
4. On read back, `env.TenantId = "acme"`.

The envelope now carries a TenantId it was never receive-mapped with. `saga-id` reaches another saga's state, and `id` rewrites `Envelope.Id` — the inbox's dedupe identity. Where the header value originates with an untrusted external producer (raw-JSON broker interop), that is a privilege boundary, not a cosmetic bug.

## The fix

A `static readonly FrozenSet<string>` of the reserved keys (ordinal), skipped in the bulk `foreach` over `env.Headers`. The typed property stays authoritative; a reserved key sitting in `Headers` becomes a no-op rather than a silent override.

**Skip, not throw.** The failure mode of throwing during a durable persist is far worse than the failure mode of ignoring a header nobody should have set — a throw would turn a stray header into a poisoned message on a write path with no good recovery. Skipping is also backward-compatible for everyone who *isn't* colliding.

`writeHeaders` is the only bulk `Headers`-to-wire write path in the file (both `Serialize` overloads funnel through `writeSingle` → `writeHeaders`); the read side is `ReadDataElement`, reached both from `readEnvelopeBody` and directly from the NATS/MQTT mappers. The read-side promotion is left alone on purpose — that's the intended behavior for genuine Wolverine headers coming off the wire. The fix belongs on the write side, where the ambiguity is introduced.

## The reserved set is *not* every `EnvelopeConstants` member

The set is exactly the keys `ReadDataElement` promotes into a typed property. That distinction is load-bearing:

- `EnvelopeConstants.CausationIdKey` is **deliberately** carried in `Headers` (`DeliveryOptions.cs:154` stashes it there precisely because Wolverine's native causation chain is the Guid-typed `ConversationId`, and `Wolverine.Marten`'s `OutboxedSessionFactory` reads it back out as a header). It has no reader case, so it is not promotable and must keep round-tripping as an ordinary header. Filtering it would have broken it.
- `SentAtKey` likewise has no reader case (`SentAt` is written separately in the binary preamble), and `JsonContentType` is a content-type *value*, not a header key.

To keep a future constant from being forgotten, `every_key_promoted_by_the_reader_is_in_the_reserved_set` reflects over the public string constants on `EnvelopeConstants`, feeds each through `ReadDataElement`, and asserts that any key the reader promotes (i.e. one that does not land in `Headers`) is present in the write-side filter. That tests the invariant directly rather than trusting a hand-maintained list.

## No existing caller relied on the old promotion

I swept every place `Headers` is bulk-copied (`MassTransitEnvelope.TransferData`, `FanoutMessageHandler`, the Marten/Polecat outbox batches, and each transport's `IEnvelopeMapper`). None of them depend on a reserved key in `Headers` being promoted to a typed property — they either write to *transport* headers (a different dictionary) or, in the MassTransit case, map tenancy explicitly through the supported `MapTenantIdFrom` hook. `MassTransitEnvelope.TransferData` copying an untrusted external `tenant-id` into `envelope.Headers` is an instance of the hazard, not a legitimate use of it.

## Tests

New `src/Testing/CoreTests/Serialization/reserved_header_key_filtering.cs`: `Headers["tenant-id"]` / `["saga-id"]` / `["id"]` / `["message-type"]` (individually and all reserved keys at once) round-trip with the typed `TenantId` / `SagaId` / `Id` / `MessageType` **unchanged**; non-reserved custom headers still round-trip; `causation-id` is explicitly *not* filtered; plus the reflection guard above.

5 of the 8 new tests fail without the write-side skip, and pass with it. Full `CoreTests` suite: **1930 passed, 0 failed, 2 skipped**. Full `wolverine.slnx` builds clean in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)