### PR TITLE
GH-3365: stop double-registering the primary Polecat IEventStore

### DIFF
--- a/src/Persistence/PolecatTests/AncillaryStores/bootstrapping_ancillary_polecat_stores_with_wolverine.cs
+++ b/src/Persistence/PolecatTests/AncillaryStores/bootstrapping_ancillary_polecat_stores_with_wolverine.cs
@@ -97,6 +97,27 @@ public class bootstrapping_ancillary_polecat_stores_with_wolverine : IAsyncLifet
     }
 
     [Fact]
+    public void does_not_register_any_event_store_twice()
+    {
+        // GH-3365: the primary Polecat store used to surface TWICE from GetServices<IEventStore>() as the
+        // very same DocumentStore instance — Polecat's own AddPolecat() registers IEventStore, and
+        // Wolverine's IntegrateWithWolverine() was bridging it a second time. Anything enumerating the
+        // registered stores then double-counted the primary. Assert on REFERENCE distinctness, not just
+        // the count, so a genuinely distinct store never trips this and a duplicated instance always does.
+        var stores = theHost.Services.GetServices<IEventStore>().ToArray();
+
+        var primary = (IEventStore)theHost.Services.GetRequiredService<IDocumentStore>();
+        var ancillary = (IEventStore)theHost.Services.GetRequiredService<IPlayerStore>();
+
+        stores.Cast<object>().Distinct(ReferenceEqualityComparer.Instance).Count()
+            .ShouldBe(stores.Length);
+
+        stores.Count(x => ReferenceEquals(x, primary)).ShouldBe(1);
+        stores.Count(x => ReferenceEquals(x, ancillary)).ShouldBe(1);
+        stores.Length.ShouldBe(2);
+    }
+
+    [Fact]
     public async Task try_to_use_the_session_transactional_middleware_end_to_end()
     {
         var message = new PlayerMessage(Guid.NewGuid().ToString());

--- a/src/Persistence/Wolverine.Polecat/WolverineOptionsPolecatExtensions.cs
+++ b/src/Persistence/Wolverine.Polecat/WolverineOptionsPolecatExtensions.cs
@@ -106,14 +106,20 @@ public static class WolverineOptionsPolecatExtensions
                 s.GetRequiredService<IWolverineRuntime>(),
                 (IMessageDatabase)s.GetRequiredService<IMessageStore>()));
 
-        // GH-3133 / GH-3219, Gap 2: Polecat's AddPolecat registers IDocumentStore but not the
-        // store-agnostic JasperFx.Events.IEventStore (the Polecat DocumentStore implements
-        // IEventStore<IDocumentSession, IQuerySession>). Bridge it UNCONDITIONALLY so the store is
-        // discoverable via GetServices<IEventStore>() regardless of whether managed distribution is
-        // enabled — the EventSubscriptionAgentFamily resolves stores this way (when managed distribution
-        // is on) AND so does the read-only capabilities / CritterWatch projection-explorer surface
-        // (always). Marten registers IEventStore unconditionally in its own AddMarten.
-        expression.Services.AddSingleton<IEventStore>(s => (IEventStore)s.GetRequiredService<IDocumentStore>());
+        // GH-3365: do NOT bridge the primary store to the store-agnostic JasperFx.Events.IEventStore
+        // here. Polecat's own AddPolecat() registers IEventStore for the primary DocumentStore on every
+        // overload (verified against the 4.8.0 floor of our package range), exactly the way AddMarten
+        // does — which is why Wolverine.Marten registers nothing of the sort for its primary store
+        // either. An earlier Polecat did not, so GH-3133 / GH-3219 added a bridge here; once Polecat
+        // started registering it, the two stacked and GetServices<IEventStore>() handed back the very
+        // same DocumentStore instance twice. Everything enumerating the registered stores then
+        // double-counted the primary (e.g. CritterWatch's EventProgressionPoller polling it twice per
+        // pass). `bootstrapping_ancillary_polecat_stores_with_wolverine` pins the resulting shape —
+        // primary once, each ancillary once — so this fails loudly should Polecat ever drop its own
+        // registration.
+        //
+        // The ancillary bridge in AncillaryWolverineOptionsPolecatExtensions IS still required:
+        // AddPolecatStore<T>() does not register IEventStore for the T store.
 
         if (integration.UseWolverineManagedEventSubscriptionDistribution)
         {


### PR DESCRIPTION
## Root cause (not the one suspected in the issue)

The issue guessed that `WolverineOptionsPolecatExtensions.IntegrateWithWolverine()` was *executing twice* — once explicitly, once from an internal integration pass. **That is wrong.** `IntegrateWithWolverine()` runs exactly once.

The duplicate comes from **Polecat itself**. Dumping the `IServiceCollection` for the reported host shape produces three `IEventStore` descriptors with these implementation factories:

```
IEventStore -> Polecat.PolecatServiceCollectionExtensions+<>c.<AddPolecat>b__3_4                    <-- Polecat's own
IEventStore -> Wolverine.Polecat.WolverineOptionsPolecatExtensions+<>c.<IntegrateWithWolverine>b__0_3  <-- ours, redundant
IEventStore -> Wolverine.Polecat.AncillaryWolverineOptionsPolecatExtensions+<>c__0`1[ICritterWatchStore]...
```

`AddPolecat()` now registers the store-agnostic `JasperFx.Events.IEventStore` for the primary `DocumentStore` on its own — verified against **all four** `AddPolecat` overloads (`Action<StoreOptions>`, `string`, `StoreOptions`, `Func<IServiceProvider, StoreOptions>`) at Polecat **4.8.0**, the floor of our package range. Both factories resolve the same `IDocumentStore` singleton, hence the reference-equal duplicate.

Wolverine's bridge dates to GH-3133 / GH-3219, when `AddPolecat` genuinely did *not* register `IEventStore`. Once Polecat started doing so, the two stacked.

## Fix

Delete the redundant primary bridge in `WolverineOptionsPolecatExtensions.IntegrateWithWolverine()`. This restores parity with `Wolverine.Marten`, which registers nothing equivalent for its primary store precisely because `AddMarten` handles it.

`TryAddEnumerable` is not usable here: it throws when the descriptor's implementation type equals its service type, which is the case for an `AddSingleton<IEventStore>(sp => ...)` factory registration on both sides.

The **ancillary** bridge in `AncillaryWolverineOptionsPolecatExtensions` is untouched and still required — `AddPolecatStore<T>()` does *not* register `IEventStore` for the `T` store.

## Test

New `does_not_register_any_event_store_twice` in `bootstrapping_ancillary_polecat_stores_with_wolverine` (primary + ancillary host shape from the issue) asserts **reference-distinctness**, not just a count: every resolved store is a distinct instance, the primary appears exactly once, each ancillary exactly once. It fails loudly if Polecat ever drops its own registration.

- Full `PolecatTests` suite: **241 passed, 4 skipped, 0 failed**
- `dotnet build wolverine.slnx -c Release`: clean, 0 warnings

Fixes #3365

🤖 Generated with [Claude Code](https://claude.com/claude-code)