### PR TITLE
Split the CIAWS and CIPolecat suites across parallel CI jobs (GH-3350)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,16 +15,19 @@ jobs:
   test:
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
-    # CIPolecat is the heaviest persistence suite (234 serial SqlServer integration tests incl. DCB +
-    # distribution + sagas). It passes in ~10 min in the good case but can exceed 20 when a couple of
-    # flaky saga/storage tests retry on a slow runner (the tests themselves pass — no hang; ~7.5 min
-    # locally). Give it more wall-clock so the retry logic can finish instead of being cut off. See #3350.
-    timeout-minutes: ${{ matrix.target == 'CIPolecat' && 30 || 20 }}
+    # The 20 minute cap is deliberately a REAL signal: a job that needs longer than this is a job that
+    # needs to be split, not a job that needs a bigger number. The two suites that used to blow through it
+    # (CIAWS and CIPolecat) are now sharded across parallel jobs instead. See #3350.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         target:
-          - CIAWS
+          # AWS is split three ways: the SQS project is far and away the heavier of the two, so it is further
+          # split into its compliance batteries and everything else. See #3350.
+          - CIAWSSqs
+          - CIAWSSqsCompliance
+          - CIAWSSns
           - CIAzureServiceBus
           - CICosmosDb
           - CIEfCore
@@ -36,7 +39,11 @@ jobs:
           - CINATS
           - CIOracle
           - CIPersistence
+          # PolecatTests is one serial SqlServer project sharded three ways by namespace. CIPolecat is the
+          # "everything else" shard, so a newly added namespace still runs somewhere. See #3350.
           - CIPolecat
+          - CIPolecatWorkflow
+          - CIPolecatSagas
           - CIPubsub
           - CIPulsar
           - CIRabbitMQ

--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -348,18 +348,61 @@ partial class Build
 
     // ─── Transport CI Targets ──────────────────────────────────────────
 
+    // ─── AWS CI Targets ────────────────────────────────────────────────
+    //
+    // CIAWS used to run the SQS project and then the SNS project back to back in a single job, which chronically
+    // blew past the 20 minute job timeout on CI runners. It is now split three ways so the shards run as parallel
+    // jobs. Measured locally (Release, net9.0, serial, LocalStack in docker):
+    //
+    //   whole SQS project  199 tests  6m27s   <- the real hog
+    //   whole SNS project  118 tests  1m30s
+    //
+    // Within SQS, the wall-clock is concentrated in a handful of end-to-end classes (send_and_receive alone is
+    // ~121s for 2 tests, end_to_end_with_named_broker ~60s for 1), while the four *SendingAndReceivingCompliance
+    // batteries are ~93 tests / ~77s. Peeling the compliance batteries off into their own shard splits the project
+    // into ~191s + ~77s of test time. CIAWS is retained as an aggregate so "./build.sh CIAWS" still runs everything.
+    // See #3350.
+
+    // The four batteries are named Buffered/Inline/Durable/PrefixedSendingAndReceivingCompliance, so a single
+    // substring selects (and its negation excludes) all of them.
+    const string ComplianceBatteries = "FullyQualifiedName~SendingAndReceivingCompliance";
+    const string NotComplianceBatteries = "FullyQualifiedName!~SendingAndReceivingCompliance";
+
+    AbsolutePath AmazonSqsTests => RootDirectory / "src" / "Transports" / "AWS" / "Wolverine.AmazonSqs.Tests" / "Wolverine.AmazonSqs.Tests.csproj";
+    AbsolutePath AmazonSnsTests => RootDirectory / "src" / "Transports" / "AWS" / "Wolverine.AmazonSns.Tests" / "Wolverine.AmazonSns.Tests.csproj";
+
+    void runAwsShard(AbsolutePath project, string testFilter = null)
+    {
+        BuildTestProjects(project);
+        StartDockerServices("localstack", "postgresql");
+
+        RunTestProject(project, testFilter: testFilter);
+    }
+
+    /// <summary>
+    /// AWS shard 1: the SQS project, minus the sending/receiving compliance batteries.
+    /// </summary>
+    Target CIAWSSqs => _ => _
+        .ProceedAfterFailure()
+        .Executes(() => runAwsShard(AmazonSqsTests, NotComplianceBatteries));
+
+    /// <summary>
+    /// AWS shard 2: the SQS Buffered/Inline/Durable/Prefixed sending and receiving compliance batteries.
+    /// </summary>
+    Target CIAWSSqsCompliance => _ => _
+        .ProceedAfterFailure()
+        .Executes(() => runAwsShard(AmazonSqsTests, ComplianceBatteries));
+
+    /// <summary>
+    /// AWS shard 3: the whole SNS project, which is small enough not to need splitting.
+    /// </summary>
+    Target CIAWSSns => _ => _
+        .ProceedAfterFailure()
+        .Executes(() => runAwsShard(AmazonSnsTests));
+
     Target CIAWS => _ => _
         .ProceedAfterFailure()
-        .Executes(() =>
-        {
-            var sqsTests = RootDirectory / "src" / "Transports" / "AWS" / "Wolverine.AmazonSqs.Tests" / "Wolverine.AmazonSqs.Tests.csproj";
-            var snsTests = RootDirectory / "src" / "Transports" / "AWS" / "Wolverine.AmazonSns.Tests" / "Wolverine.AmazonSns.Tests.csproj";
-
-            BuildTestProjects(sqsTests, snsTests);
-            StartDockerServices("localstack", "postgresql");
-
-            RunTestProjects([sqsTests, snsTests]);
-        });
+        .DependsOn(CIAWSSqs, CIAWSSqsCompliance, CIAWSSns);
 
     Target CIKafka => _ => _
         .ProceedAfterFailure()
@@ -587,15 +630,81 @@ partial class Build
             RunTestProject(tests);
         });
 
+    // ─── Polecat CI Targets ────────────────────────────────────────────
+    //
+    // PolecatTests is a single project of serial (NoParallelization) SqlServer integration tests. As one job it sat
+    // right at — and frequently over — the 20 minute CI job timeout, so it is sharded across three parallel jobs.
+    //
+    // Measured locally (Release, net10.0, serial, SqlServer in docker): the whole project is 235 tests in 8m14s,
+    // but the test bodies themselves only account for ~173s of that. The other ~2/3 of the wall-clock is per-CLASS
+    // fixture cost (Wolverine + Polecat host bootstrap and SqlServer schema application). The shards are therefore
+    // balanced by test-CLASS count, not by test count or test duration:
+    //
+    //   CIPolecatWorkflow   AggregateHandlerWorkflow + Bugs                            20 classes / 82 tests
+    //   CIPolecatSagas      Sagas, Distribution, Subscriptions, Dcb, Publishing        19 classes / 70 tests
+    //   CIPolecat           everything else (root namespace, AncillaryStores, ...)     18 classes / 83 tests
+    //
+    // The shards are defined ONCE below: the two named shards list their namespaces, and CIPolecat is the
+    // *negation* of both lists. A brand new namespace therefore lands in CIPolecat automatically rather than
+    // being silently dropped from CI. See #3350.
+
+    AbsolutePath PolecatTests => RootDirectory / "src" / "Persistence" / "PolecatTests" / "PolecatTests.csproj";
+
+    static readonly string[] PolecatWorkflowNamespaces =
+    [
+        "PolecatTests.AggregateHandlerWorkflow",
+        "PolecatTests.Bugs"
+    ];
+
+    static readonly string[] PolecatSagaNamespaces =
+    [
+        "PolecatTests.Sagas",
+        "PolecatTests.Distribution",
+        "PolecatTests.Subscriptions",
+        "PolecatTests.Dcb",
+        "PolecatTests.Publishing"
+    ];
+
+    // A trailing '.' keeps "PolecatTests.Sagas" from also matching a future "PolecatTests.SagasSomethingElse".
+    static string includeNamespaces(params string[] namespaces)
+    {
+        return string.Join("|", namespaces.Select(n => $"FullyQualifiedName~{n}."));
+    }
+
+    static string excludeNamespaces(params string[] namespaces)
+    {
+        return string.Join("&", namespaces.Select(n => $"FullyQualifiedName!~{n}."));
+    }
+
+    void runPolecatShard(string testFilter)
+    {
+        BuildTestProjectsWithFramework("net10.0", PolecatTests);
+        StartDockerServices("sqlserver");
+
+        RunTestProject(PolecatTests, frameworkOverride: "net10.0", testFilter: testFilter);
+    }
+
+    /// <summary>
+    /// Polecat shard 1: the aggregate handler workflow tests and the Bugs regressions (mostly aggregate handler
+    /// regressions themselves).
+    /// </summary>
+    Target CIPolecatWorkflow => _ => _
+        .ProceedAfterFailure()
+        .Executes(() => runPolecatShard(includeNamespaces(PolecatWorkflowNamespaces)));
+
+    /// <summary>
+    /// Polecat shard 2: sagas, multi-node distribution, subscriptions, DCB and outbox publishing.
+    /// </summary>
+    Target CIPolecatSagas => _ => _
+        .ProceedAfterFailure()
+        .Executes(() => runPolecatShard(includeNamespaces(PolecatSagaNamespaces)));
+
+    /// <summary>
+    /// Polecat shard 3: everything not claimed by CIPolecatWorkflow or CIPolecatSagas — including any newly
+    /// added namespace, which lands here by default.
+    /// </summary>
     Target CIPolecat => _ => _
         .ProceedAfterFailure()
-        .Executes(() =>
-        {
-            var polecatTests = RootDirectory / "src" / "Persistence" / "PolecatTests" / "PolecatTests.csproj";
-
-            BuildTestProjectsWithFramework("net10.0", polecatTests);
-            StartDockerServices("sqlserver");
-
-            RunTestProject(polecatTests, frameworkOverride: "net10.0");
-        });
+        .Executes(() => runPolecatShard(
+            excludeNamespaces([..PolecatWorkflowNamespaces, ..PolecatSagaNamespaces])));
 }

--- a/build/TestAllPersistence.cs
+++ b/build/TestAllPersistence.cs
@@ -84,12 +84,16 @@ partial class Build
     /// <summary>
     /// Runs multiple test project with flaky retry.
     /// </summary>
-    void RunTestProjects(string[] projectPaths, string frameworkOverride = null)
+    /// <param name="testFilter">
+    /// Optional vstest filter expression ANDed onto the standard <c>Category!=Flaky</c> filter. Used by the
+    /// sharded CI targets (see #3350) to split one heavy test project across several parallel CI jobs.
+    /// </param>
+    void RunTestProjects(string[] projectPaths, string frameworkOverride = null, string testFilter = null)
     {
         var failedProjects = new List<string>();
         foreach (var projectPath in projectPaths)
         {
-            if (!RunWithFlakyRetry(projectPath, frameworkOverride: frameworkOverride))
+            if (!RunWithFlakyRetry(projectPath, frameworkOverride: frameworkOverride, testFilter: testFilter))
                 failedProjects.Add(projectPath);
         }
 
@@ -100,9 +104,19 @@ partial class Build
     /// <summary>
     /// Runs single test project with flaky retry.
     /// </summary>
-    void RunTestProject(string projectPath, string frameworkOverride = null)
+    void RunTestProject(string projectPath, string frameworkOverride = null, string testFilter = null)
     {
-        RunTestProjects([projectPath], frameworkOverride: frameworkOverride);
+        RunTestProjects([projectPath], frameworkOverride: frameworkOverride, testFilter: testFilter);
+    }
+
+    /// <summary>
+    /// Combines the always-on "skip the Flaky category" filter with an optional shard filter.
+    /// </summary>
+    static string combineFilters(string testFilter)
+    {
+        return string.IsNullOrWhiteSpace(testFilter)
+            ? "Category!=Flaky"
+            : $"Category!=Flaky&({testFilter})";
     }
 
     /// <summary>
@@ -154,12 +168,14 @@ partial class Build
     /// Flaky tests (pass on retry) are logged separately from hard failures.
     /// Returns true only if all tests pass (possibly after retries).
     /// </summary>
-    bool RunWithFlakyRetry(string projectPath, int maxAttempts = 2, string frameworkOverride = null)
+    bool RunWithFlakyRetry(string projectPath, int maxAttempts = 2, string frameworkOverride = null,
+        string testFilter = null)
     {
         var projectName = Path.GetFileNameWithoutExtension(projectPath);
         var framework = frameworkOverride ?? Framework;
+        var filter = combineFilters(testFilter);
 
-        Log.Information("=== {Project}: Running all tests ===", projectName);
+        Log.Information("=== {Project}: Running all tests (filter: {Filter}) ===", projectName, filter);
         try
         {
             DotNetTest(c => c
@@ -168,7 +184,7 @@ partial class Build
                 .EnableNoBuild()
                 .EnableNoRestore()
                 .SetFramework(framework)
-                .SetFilter("Category!=Flaky")
+                .SetFilter(filter)
                 .AddLoggers($"trx;LogFilePrefix={projectName}"));
 
             Log.Information("=== {Project}: All tests passed ===", projectName);


### PR DESCRIPTION
## Problem

`CIAWS` and `CIPolecat` chronically hit the 20 minute GitHub Actions job execution timeout. Real failures became indistinguishable from timeouts without opening each job log, and "merge when green" was unachievable. `CIAWS` had been commented out of the matrix entirely to unblock the release; `CIPolecat` had been given a one-off `timeout-minutes: 30`.

## Approach

Per maintainer direction: **split the slow suites, do not raise the cap.** Raising `timeout-minutes` turns the number into a meaningless rubber stamp. This PR attacks the actual wall-clock so that a job exceeding 20 minutes remains a real signal — the special-cased 30 minute cap for CIPolecat is **removed** and every job is back on a uniform `timeout-minutes: 20`.

## Result: measured on this PR's CI run

All six shards are green, and **the slowest is 5m9s against the 20 minute cap** — roughly 4x headroom, where the two original jobs were being killed at 20m.

| new job | CI wall-clock | contents |
|---|---|---|
| `CIAWSSqs` | **5m9s** | SQS minus the compliance batteries (106 tests) |
| `CIAWSSqsCompliance` | **4m23s** | the four `*SendingAndReceivingCompliance` batteries (93 tests) |
| `CIAWSSns` | **3m29s** | the whole SNS project (118 tests) |
| `CIPolecatWorkflow` | **5m0s** | `AggregateHandlerWorkflow` + `Bugs` (20 classes / 82 tests) |
| `CIPolecatSagas` | **4m24s** | `Sagas`, `Distribution`, `Subscriptions`, `Dcb`, `Publishing` (19 classes / 70 tests) |
| `CIPolecat` | **4m55s** | everything else (18 classes / 83 tests) |

## How the shard boundaries were chosen

Local baseline (Release, serial / `NoParallelization`, docker infra):

| suite (before) | tests | local wall-clock |
|---|---|---|
| whole SQS project | 199 | **6m27s** |
| whole SNS project | 118 | 1m30s |
| whole Polecat project | 235 | **8m14s** |

Two findings drove the split:

**1. The issue's hypothesis about the SNS per-tenant tests is wrong (post-#3364).** `AmazonSnsPerTenantConnectionTests` is **0.5s for 3 tests** — not a hot spot at all. The whole SNS project is only 90s locally. The real AWS hog is the **SQS** project, where wall-clock concentrates in a few end-to-end classes (`send_and_receive` alone is ~121s for 2 tests; `end_to_end_with_named_broker` ~60s for 1) plus the four compliance batteries (~93 tests / ~77s). There was no LocalStack setup-per-test bug left to fix — #3364 already fixed the SNS per-tenant setup.

**2. Polecat's cost is per-CLASS, not per-test.** The test bodies sum to only ~173s of the project's 8m14s; the other **~2/3 of the wall-clock is fixture cost** — Wolverine + Polecat host bootstrap and SqlServer schema application, once per test class. The Polecat shards are therefore balanced by **test-class count** (20 / 19 / 18), not by test count or test duration.

## Coverage is provably complete

The shards are defined once in `build/CITargets.cs`: the two named Polecat shards list their namespaces and `CIPolecat` is the **negation** of both lists, so a newly added namespace lands in `CIPolecat` automatically rather than being silently dropped from CI.

I verified the partition against the TRX output of a full baseline run — every test lands in **exactly one** shard, no gaps and no overlaps:

- Polecat: 82 + 70 + 83 = **235 / 235**
- SQS: 93 + 106 = **199 / 199**

Each shard's real filter expression was also run end-to-end locally before pushing; all five came back green with exactly the predicted counts (83, 82, 70, 93, 106), confirming the vstest filter syntax including the 7-term negation.

## Implementation

`RunTestProject(s)` / `RunWithFlakyRetry` gain an optional `testFilter` that is ANDed onto the standing `Category!=Flaky` filter — that is what makes a single project shardable. The existing flaky-retry logic is untouched. `CIAWS` is retained as an aggregate target (`.DependsOn(CIAWSSqs, CIAWSSqsCompliance, CIAWSSns)`) so `./build.sh CIAWS` still runs the whole AWS suite locally.

## Notes

- The old CIAWS/CIPolecat timeouts were likely made worse by the flaky-retry second round (each retried test pays a fresh test-host + LocalStack/SqlServer bootstrap). Sharding shrinks the blast radius of that but does not remove it — a shard that goes badly flaky can still burn wall-clock, it just has ~15 minutes of headroom to do it in now.
- Local `./build.sh CIPolecat` could not complete a full docker round-trip in my worktree because another checkout already held port 1434, so locally I drove the exact filter strings the targets emit against already-running containers. The target wiring is confirmed by this PR's CI run.

Refs #3350

🤖 Generated with [Claude Code](https://claude.com/claude-code)