### PR TITLE
OpenAPI: derive parameters from the full binding chain, plus a shape-test harness (GH-3380)

### DIFF
--- a/src/Http/Wolverine.Http.Tests.DifferentAssembly/OpenApiShapeEndpoints.cs
+++ b/src/Http/Wolverine.Http.Tests.DifferentAssembly/OpenApiShapeEndpoints.cs
@@ -1,0 +1,136 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine.Http;
+
+namespace Wolverine.Http.Tests.DifferentAssembly.OpenApi;
+
+// Endpoint shapes used by the `openapi_shape_tests` harness, which renders the *real*
+// Microsoft.AspNetCore.OpenApi document for a host built on this assembly and asserts on the rendered
+// operation (parameters + request body). These live here — rather than in WolverineWebApi — because
+// this assembly has no database/Marten/EF dependencies, so the document can be generated from a host
+// that never touches infrastructure.
+//
+// To add a shape: add an endpoint below, then add a [Fact] to openapi_shape_tests.cs. The Swashbuckle
+// side of the same coverage lives in WolverineWebApi (see the Expect* attributes and
+// open_api_generation.verify_open_api_expectations).
+
+public record OrderLine(long OrderId, long OrderLineId);
+
+#region GH-3380: route values bound ONLY by a compound handler
+
+// The GH-3380 reproduction: both route ids are consumed by LoadAsync and never appear in the endpoint
+// method signature. They still have to be declared as required path parameters.
+public static class CompoundRouteOnlyEndpoint
+{
+    public static OrderLine LoadAsync([FromRoute] long orderId, [FromRoute] long orderLineId)
+        => new(orderId, orderLineId);
+
+    [WolverineGet("/shapes/orders/{orderId:long}/order-lines/{orderLineId:long}")]
+    public static string Get(OrderLine line) => $"{line.OrderId}:{line.OrderLineId}";
+}
+
+// Same, but the route token is UNCONSTRAINED — so the parameter type can only come from the binding
+// chain (the LoadAsync argument), not from a route constraint.
+public static class CompoundUnconstrainedRouteEndpoint
+{
+    public static OrderLine Before([FromRoute] long orderId) => new(orderId, 0);
+
+    [WolverineGet("/shapes/unconstrained/orders/{orderId}")]
+    public static string Get(OrderLine line) => line.OrderId.ToString();
+}
+
+// A route token bound by a renamed [FromRoute(Name = "order-id")] argument on the compound handler.
+public static class CompoundRenamedRouteEndpoint
+{
+    public static OrderLine Load([FromRoute(Name = "order-id")] long orderId) => new(orderId, 0);
+
+    [WolverineGet("/shapes/renamed/orders/{order-id:long}")]
+    public static string Get(OrderLine line) => line.OrderId.ToString();
+}
+
+// Query string + header values bound only by a compound handler method.
+public record RequestContext(string? Name, string? Tenant);
+
+public static class CompoundQueryAndHeaderEndpoint
+{
+    public static RequestContext Load([FromQuery] string? name, [FromHeader(Name = "x-tenant")] string? tenant)
+        => new(name, tenant);
+
+    [WolverineGet("/shapes/compound-query-header")]
+    public static string Get(RequestContext context) => $"{context.Name}:{context.Tenant}";
+}
+
+// A query string value bound only by an After/Finally postprocessor. Postprocessor arguments are part of
+// the endpoint's contract too.
+public static class PostprocessorQueryEndpoint
+{
+    [WolverineGet("/shapes/postprocessor/{orderId:long}")]
+    public static string Get() => "ok";
+
+    public static void After([FromQuery] string? audit)
+    {
+    }
+}
+
+#endregion
+
+#region baseline shapes: plain handler signature bindings
+
+public record CreateOrderLine(string Description, int Quantity);
+
+// Route + query bound the plain way, straight off the endpoint method signature.
+public static class PlainRouteAndQueryEndpoint
+{
+    [WolverineGet("/shapes/plain/orders/{orderId:long}")]
+    public static string Get([FromRoute] long orderId, [FromQuery] string? filter) => $"{orderId}:{filter}";
+}
+
+// A JSON request body alongside a route value that is bound only by the compound handler.
+public static class BodyWithCompoundRouteEndpoint
+{
+    public static OrderLine LoadAsync([FromRoute] long orderId) => new(orderId, 0);
+
+    [WolverinePost("/shapes/body/orders/{orderId:long}/order-lines")]
+    public static string Post(CreateOrderLine body, OrderLine line) => $"{line.OrderId}:{body.Description}";
+}
+
+// Nothing in the chain binds {code} at all — it still has to be declared as a required path parameter,
+// falling back to string.
+public static class UnboundRouteValueEndpoint
+{
+    [WolverineGet("/shapes/unbound/{code}")]
+    public static string Get() => "ok";
+}
+
+#endregion
+
+#region [AsParameters] shapes
+
+public record OrderLineQuery([FromRoute] long OrderId, [FromQuery] string? Filter);
+
+public static class AsParametersEndpoint
+{
+    [WolverineGet("/shapes/asparameters/orders/{orderId:long}")]
+    public static string Get([AsParameters] OrderLineQuery query) => $"{query.OrderId}:{query.Filter}";
+}
+
+// An [AsParameters] container on the endpoint whose route value is *also* bound by the compound handler.
+public static class AsParametersWithCompoundEndpoint
+{
+    public static OrderLine LoadAsync([FromRoute(Name = "order-id")] long orderId) => new(orderId, 0);
+
+    [WolverineGet("/shapes/asparameters-compound/orders/{order-id:long}")]
+    public static string Get([AsParameters] RenamedOrderQuery query, OrderLine line)
+        => $"{query.OrderId}:{line.OrderLineId}";
+}
+
+public class RenamedOrderQuery
+{
+    [FromRoute(Name = "order-id")]
+    public long OrderId { get; set; }
+
+    [FromQuery]
+    public string? Filter { get; set; }
+}
+
+#endregion

--- a/src/Http/Wolverine.Http.Tests/open_api_generation.cs
+++ b/src/Http/Wolverine.Http.Tests/open_api_generation.cs
@@ -8,6 +8,18 @@ using WolverineWebApi.TestSupport;
 
 namespace Wolverine.Http.Tests;
 
+/// <summary>
+/// The attribute-driven OpenAPI *shape* harness on the Swashbuckle stack: any endpoint in WolverineWebApi
+/// annotated with an <see cref="OpenApiExpectationAttribute"/> ([ExpectParameter], [ExpectParameterCount],
+/// [ExpectRequestBody], [ExpectNoRequestBody], [ExpectProduces], [ExpectStatusCodes], [ExpectMatch]) is fed
+/// through <see cref="verify_open_api_expectations"/>, which resolves the *rendered* OpenAPI document and
+/// validates the expectations against the real operation.
+///
+/// TO ADD A SHAPE: annotate an endpoint method in WolverineWebApi with the Expect* attributes describing
+/// what the operation must look like. No test code required — this theory picks it up automatically.
+///
+/// The Microsoft.AspNetCore.OpenApi half of the shape coverage lives in openapi_shape_tests.cs.
+/// </summary>
 public class open_api_generation : IntegrationContext
 {
     public open_api_generation(AppFixture fixture) : base(fixture)

--- a/src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs
@@ -1,0 +1,270 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.Http.Tests.DifferentAssembly.OpenApi;
+
+namespace Wolverine.Http.Tests;
+
+/// <summary>
+/// OpenAPI *shape* coverage: renders the real Microsoft.AspNetCore.OpenApi document for a host built on
+/// the database-free "DifferentAssembly" endpoints and asserts on what actually lands in the document —
+/// the operation's <c>parameters</c> and <c>requestBody</c>, not just that the route shows up.
+///
+/// This is the harness that GH-3380 (and the GH-3135 audit before it) said was missing: OpenAPI metadata
+/// used to be derived from the endpoint method signature, so anything bound elsewhere in the chain (a
+/// compound handler's Load/LoadAsync/Before, an After postprocessor, middleware from a policy) could go
+/// undeclared without a single test noticing.
+///
+/// TO ADD A SHAPE:
+///   1. Add an endpoint to Wolverine.Http.Tests.DifferentAssembly/OpenApiShapeEndpoints.cs
+///      (keep it free of database/broker dependencies so the document renders with no infrastructure).
+///   2. Add a [Fact] below using the ParametersFor / RequestBodyPropertiesFor / HasRequestBody helpers.
+///
+/// The Swashbuckle half of this coverage lives in WolverineWebApi as attribute-driven expectations
+/// ([ExpectParameter] / [ExpectRequestBody] / [ExpectNoRequestBody], validated by
+/// open_api_generation.verify_open_api_expectations), so the two OpenAPI stacks Wolverine supports are
+/// both exercised.
+/// </summary>
+public class OpenApiShapeFixture : IAsyncLifetime
+{
+    public JsonDocument Document { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            // Pin endpoint discovery to the isolated, infrastructure-free assembly
+            opts.ApplicationAssembly = typeof(CompoundRouteOnlyEndpoint).Assembly;
+        });
+
+        builder.Services.AddOpenApi();
+        builder.Services.AddWolverineHttp();
+
+        await using var app = builder.Build();
+        app.MapWolverineEndpoints();
+
+        // Generate the document exactly like the `openapi` command does — no host start required
+        var documentProvider = OpenApiCommand.PrepareDocumentProvider(app);
+        documentProvider.ShouldNotBeNull();
+
+        var writer = new StringWriter();
+        await documentProvider!.GenerateAsync("v1", writer);
+
+        Document = JsonDocument.Parse(writer.ToString());
+    }
+
+    public Task DisposeAsync()
+    {
+        Document?.Dispose();
+        return Task.CompletedTask;
+    }
+}
+
+public record ParameterShape(string Name, string In, bool Required, string? Type, string? Format);
+
+public class openapi_shape_tests : IClassFixture<OpenApiShapeFixture>
+{
+    private readonly OpenApiShapeFixture _fixture;
+
+    public openapi_shape_tests(OpenApiShapeFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void compound_handler_route_values_are_declared_as_required_path_parameters()
+    {
+        // GH-3380: both ids are bound by LoadAsync and appear nowhere in the endpoint method signature
+        ParametersFor("/shapes/orders/{orderId}/order-lines/{orderLineId}", "get")
+            .ShouldBe([
+                new ParameterShape("orderId", "path", true, "integer", "int64"),
+                new ParameterShape("orderLineId", "path", true, "integer", "int64")
+            ]);
+
+        HasRequestBody("/shapes/orders/{orderId}/order-lines/{orderLineId}", "get").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void compound_handler_types_an_unconstrained_route_value_from_the_binding_chain()
+    {
+        // No route constraint to fall back on: the type can only come from the Before() argument
+        ParametersFor("/shapes/unconstrained/orders/{orderId}", "get")
+            .ShouldBe([new ParameterShape("orderId", "path", true, "integer", "int64")]);
+    }
+
+    [Fact]
+    public void compound_handler_honors_a_renamed_route_binding()
+    {
+        ParametersFor("/shapes/renamed/orders/{order-id}", "get")
+            .ShouldBe([new ParameterShape("order-id", "path", true, "integer", "int64")]);
+    }
+
+    [Fact]
+    public void query_and_header_values_bound_only_by_a_compound_handler_are_declared()
+    {
+        ParametersFor("/shapes/compound-query-header", "get")
+            .ShouldBe([
+                new ParameterShape("name", "query", false, "string", null),
+                new ParameterShape("x-tenant", "header", false, "string", null)
+            ]);
+    }
+
+    [Fact]
+    public void query_values_bound_only_by_a_postprocessor_are_declared()
+    {
+        ParametersFor("/shapes/postprocessor/{orderId}", "get")
+            .ShouldBe([
+                new ParameterShape("orderId", "path", true, "integer", "int64"),
+                new ParameterShape("audit", "query", false, "string", null)
+            ]);
+    }
+
+    [Fact]
+    public void plain_handler_signature_route_and_query_bindings()
+    {
+        ParametersFor("/shapes/plain/orders/{orderId}", "get")
+            .ShouldBe([
+                new ParameterShape("orderId", "path", true, "integer", "int64"),
+                new ParameterShape("filter", "query", false, "string", null)
+            ]);
+    }
+
+    [Fact]
+    public void request_body_alongside_a_compound_handler_route_binding()
+    {
+        ParametersFor("/shapes/body/orders/{orderId}/order-lines", "post")
+            .ShouldBe([new ParameterShape("orderId", "path", true, "integer", "int64")]);
+
+        HasRequestBody("/shapes/body/orders/{orderId}/order-lines", "post").ShouldBeTrue();
+
+        RequestBodyPropertiesFor("/shapes/body/orders/{orderId}/order-lines", "post", "application/json")
+            .ShouldBe(["description", "quantity"], ignoreOrder: true);
+    }
+
+    [Fact]
+    public void unbound_route_values_are_still_declared_and_fall_back_to_string()
+    {
+        ParametersFor("/shapes/unbound/{code}", "get")
+            .ShouldBe([new ParameterShape("code", "path", true, "string", null)]);
+    }
+
+    [Fact]
+    public void as_parameters_route_and_query_members()
+    {
+        ParametersFor("/shapes/asparameters/orders/{orderId}", "get")
+            .ShouldBe([
+                new ParameterShape("orderId", "path", true, "integer", "int64"),
+                new ParameterShape("Filter", "query", false, "string", null)
+            ]);
+
+        HasRequestBody("/shapes/asparameters/orders/{orderId}", "get").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void as_parameters_container_sharing_a_route_value_with_a_compound_handler()
+    {
+        // The route value is bound twice (the [AsParameters] member and LoadAsync), but the parameter is
+        // declared exactly once
+        ParametersFor("/shapes/asparameters-compound/orders/{order-id}", "get")
+            .ShouldBe([
+                new ParameterShape("order-id", "path", true, "integer", "int64"),
+                new ParameterShape("Filter", "query", false, "string", null)
+            ]);
+    }
+
+    #region harness helpers
+
+    private JsonElement operationFor(string path, string httpMethod)
+    {
+        var paths = _fixture.Document.RootElement.GetProperty("paths");
+
+        paths.TryGetProperty(path, out var pathItem).ShouldBeTrue(
+            $"No path '{path}' in the generated document. Known paths: " +
+            string.Join(", ", paths.EnumerateObject().Select(x => x.Name)));
+
+        pathItem.TryGetProperty(httpMethod, out var operation).ShouldBeTrue(
+            $"No '{httpMethod}' operation on path '{path}'");
+
+        return operation;
+    }
+
+    /// <summary>
+    /// The rendered <c>parameters</c> of an operation, in document order.
+    /// </summary>
+    public IReadOnlyList<ParameterShape> ParametersFor(string path, string httpMethod)
+    {
+        var operation = operationFor(path, httpMethod);
+
+        if (!operation.TryGetProperty("parameters", out var parameters))
+        {
+            return [];
+        }
+
+        return parameters.EnumerateArray().Select(x =>
+        {
+            string? type = null;
+            string? format = null;
+
+            if (x.TryGetProperty("schema", out var schema))
+            {
+                type = schema.TryGetProperty("type", out var t) ? t.GetString() : null;
+                format = schema.TryGetProperty("format", out var f) ? f.GetString() : null;
+            }
+
+            var required = x.TryGetProperty("required", out var r) && r.GetBoolean();
+
+            return new ParameterShape(x.GetProperty("name").GetString()!, x.GetProperty("in").GetString()!,
+                required, type, format);
+        }).ToList();
+    }
+
+    public bool HasRequestBody(string path, string httpMethod)
+    {
+        var operation = operationFor(path, httpMethod);
+        return operation.TryGetProperty("requestBody", out var body) &&
+               body.TryGetProperty("content", out var content) &&
+               content.EnumerateObject().Any();
+    }
+
+    /// <summary>
+    /// The property names of the request body schema for a content type, resolving a top level $ref
+    /// against the document's components.
+    /// </summary>
+    public IReadOnlyList<string> RequestBodyPropertiesFor(string path, string httpMethod, string contentType)
+    {
+        var operation = operationFor(path, httpMethod);
+
+        operation.TryGetProperty("requestBody", out var requestBody).ShouldBeTrue(
+            $"Operation {httpMethod} {path} has no request body");
+
+        var content = requestBody.GetProperty("content");
+        content.TryGetProperty(contentType, out var media).ShouldBeTrue(
+            $"No '{contentType}' content on the request body of {httpMethod} {path}");
+
+        var schema = media.GetProperty("schema");
+        schema = resolveSchema(schema);
+
+        return schema.TryGetProperty("properties", out var properties)
+            ? properties.EnumerateObject().Select(x => x.Name).ToList()
+            : [];
+    }
+
+    private JsonElement resolveSchema(JsonElement schema)
+    {
+        if (schema.TryGetProperty("$ref", out var reference))
+        {
+            var id = reference.GetString()!.Split('/').Last();
+            return _fixture.Document.RootElement
+                .GetProperty("components")
+                .GetProperty("schemas")
+                .GetProperty(id);
+        }
+
+        return schema;
+    }
+
+    #endregion
+}

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -118,6 +118,11 @@ public partial class HttpChain
 
         fillKnownHeaderParameters(apiDescription);
 
+        // Query string and header values that are only ever bound by another method in the chain
+        // (a compound handler's Load/LoadAsync/Before, an After/Finally postprocessor, a middleware
+        // method applied by a policy) are still part of this endpoint's contract. See GH-3380.
+        fillChainBoundParameters(apiDescription);
+
         fillResponseTypes(apiDescription);
 
         foreach (var parameter in FileParameters)
@@ -446,6 +451,27 @@ public partial class HttpChain
         }
     }
 
+    /// <summary>
+    /// Every method that participates in this endpoint's binding chain: the endpoint method itself plus
+    /// every middleware / postprocessor <see cref="MethodCall"/> — compound handler Load/LoadAsync/Before
+    /// methods, After/Finally postprocessors, and middleware applied by attributes or policies. The
+    /// OpenAPI description is derived from all of them, not just the endpoint method signature. See GH-3380.
+    /// </summary>
+    private IEnumerable<MethodCall> allMethodCalls()
+    {
+        yield return Method;
+
+        foreach (var call in Middleware.OfType<MethodCall>())
+        {
+            yield return call;
+        }
+
+        foreach (var call in Postprocessors.OfType<MethodCall>())
+        {
+            yield return call;
+        }
+    }
+
     private ApiParameterDescription buildParameterDescription(RoutePatternParameterPart routeParameter)
     {
         // Match the bound route variable case-insensitively: route tokens are conventionally
@@ -455,11 +481,21 @@ public partial class HttpChain
         var variable = _routeVariables.OfType<CodeGen.HttpElementVariable>()
             .FirstOrDefault(x => x.Name.EqualsIgnoreCase(routeParameter.Name));
 
-        // When no typed argument is bound to the route value (e.g. a plain complex-body endpoint
-        // whose body property overlaps a route token, or an aggregate-id route), fall back to the
-        // route constraint (`{id:guid}`, `{n:int}`, ...) so the parameter still gets its real
-        // type/format instead of defaulting to string. Both OpenAPI stacks schematize from .Type.
-        var parameterType = variable?.VariableType ?? TypeFromRouteConstraint(routeParameter) ?? typeof(string);
+        // Route values may also be bound *only* by another method in the chain (a compound handler's
+        // LoadAsync, an After postprocessor, middleware applied by a policy). Those frames may not have
+        // been resolved yet when the API description is assembled — ASP.NET Core caches the first
+        // ApiExplorer read, which can happen long before codegen — so read the binding straight off the
+        // method signatures rather than relying on a resolved variable. See GH-3380.
+        //
+        // When nothing in the chain binds the route value (e.g. a plain complex-body endpoint whose body
+        // property overlaps a route token, or a Marten aggregate-id route resolved during codegen), fall
+        // back to the route constraint (`{id:guid}`, `{n:int}`, ...) so the parameter still gets its real
+        // type/format, and finally to string. Both OpenAPI stacks schematize from .Type.
+        var parameterType = variable?.VariableType
+                            ?? typeFromBindingChain(routeParameter.Name)
+                            ?? TypeFromRouteConstraint(routeParameter)
+                            ?? typeof(string);
+
         var parameter = new ApiParameterDescription
         {
             Name = routeParameter.Name,
@@ -475,6 +511,144 @@ public partial class HttpChain
             }
         };
         return parameter;
+    }
+
+    /// <summary>
+    /// Walks every method in the binding chain looking for an argument — or an [AsParameters] container
+    /// member — bound to the named route value, and returns the CLR type it binds to. See GH-3380.
+    /// </summary>
+    private Type? typeFromBindingChain(string routeName)
+    {
+        foreach (var call in allMethodCalls())
+        {
+            foreach (var parameter in call.Method.GetParameters())
+            {
+                if (parameter.HasAttribute<AsParametersAttribute>())
+                {
+                    var memberType = routeTypeFromAsParametersMembers(parameter.ParameterType, routeName);
+                    if (memberType != null)
+                    {
+                        return memberType;
+                    }
+
+                    continue;
+                }
+
+                if (tryDetermineRouteBinding(parameter, routeName, out var parameterType))
+                {
+                    return parameterType;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static Type? routeTypeFromAsParametersMembers(Type containerType, string routeName)
+    {
+        foreach (var property in containerType.GetProperties().Where(x => x.CanRead))
+        {
+            if (matchesRouteName(property, property.Name, routeName) && isBindableRouteType(property.PropertyType))
+            {
+                return unwrapNullable(property.PropertyType);
+            }
+        }
+
+        foreach (var field in containerType.GetFields())
+        {
+            if (matchesRouteName(field, field.Name, routeName) && isBindableRouteType(field.FieldType))
+            {
+                return unwrapNullable(field.FieldType);
+            }
+        }
+
+        return null;
+    }
+
+    private static bool tryDetermineRouteBinding(ParameterInfo parameter, string routeName, out Type? parameterType)
+    {
+        parameterType = null;
+
+        if (!matchesRouteName(parameter, parameter.Name, routeName))
+        {
+            return false;
+        }
+
+        // Only a type that Wolverine could actually bind from a route value counts. This guards against
+        // a coincidental name collision with a service or HttpContext element argument.
+        if (!isBindableRouteType(parameter.ParameterType))
+        {
+            return false;
+        }
+
+        parameterType = unwrapNullable(parameter.ParameterType);
+        return true;
+    }
+
+    // An explicit [FromRoute(Name = "order-id")] wins over the member name, matching the runtime binding.
+    private static bool matchesRouteName(ICustomAttributeProvider provider, string? memberName, string routeName)
+    {
+        var attribute = provider.GetCustomAttributes(typeof(FromRouteAttribute), true)
+            .OfType<FromRouteAttribute>().FirstOrDefault();
+
+        var boundName = attribute?.Name.IsNotEmpty() == true ? attribute.Name : memberName;
+
+        return boundName != null && boundName.EqualsIgnoreCase(routeName);
+    }
+
+    private static bool isBindableRouteType(Type type)
+    {
+        var inner = unwrapNullable(type);
+        return inner == typeof(string) || CodeGen.RouteParameterStrategy.CanParse(inner);
+    }
+
+    private static Type unwrapNullable(Type type)
+    {
+        return type.IsNullable() ? type.GetInnerTypeFromNullable() : type;
+    }
+
+    /// <summary>
+    /// Adds query string and header parameters that are bound *only* by another method in the binding
+    /// chain — a compound handler's Load/LoadAsync/Before, an After/Finally postprocessor, or a middleware
+    /// method applied by a policy — and therefore never show up in the endpoint method's own variables.
+    /// See GH-3380.
+    /// </summary>
+    private void fillChainBoundParameters(ApiDescription apiDescription)
+    {
+        foreach (var call in allMethodCalls())
+        {
+            foreach (var parameter in call.Method.GetParameters())
+            {
+                if (parameter.TryGetAttribute<FromQueryAttribute>(out var fromQuery))
+                {
+                    var name = fromQuery.Name.IsNotEmpty() ? fromQuery.Name! : parameter.Name!;
+                    addChainBoundParameter(apiDescription, name, parameter.ParameterType, BindingSource.Query);
+                }
+                else if (parameter.TryGetAttribute<FromHeaderAttribute>(out var fromHeader))
+                {
+                    var name = fromHeader.Name.IsNotEmpty() ? fromHeader.Name! : parameter.Name!;
+                    addChainBoundParameter(apiDescription, name, parameter.ParameterType, BindingSource.Header);
+                }
+            }
+        }
+    }
+
+    private static void addChainBoundParameter(ApiDescription apiDescription, string name, Type parameterType,
+        BindingSource source)
+    {
+        if (apiDescription.ParameterDescriptions.Any(x => x.Source == source && x.Name.EqualsIgnoreCase(name)))
+        {
+            return;
+        }
+
+        apiDescription.ParameterDescriptions.Add(new ApiParameterDescription
+        {
+            Name = name,
+            ModelMetadata = new EndpointModelMetadata(parameterType),
+            Source = source,
+            Type = parameterType,
+            IsRequired = false
+        });
     }
 
     // Maps an inline route constraint to the CLR type ASP.NET's own route binding would use, so the

--- a/src/Http/WolverineWebApi/CompoundHandlerOpenApiEndpoints.cs
+++ b/src/Http/WolverineWebApi/CompoundHandlerOpenApiEndpoints.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.OpenApi.Models;
+using Wolverine.Http;
+using WolverineWebApi.TestSupport;
+
+namespace WolverineWebApi;
+
+// GH-3380 OpenAPI-shape coverage for compound handlers on the *Swashbuckle* stack: route/query/header
+// values bound ONLY by a Load/LoadAsync/Before middleware method or an After/Finally postprocessor —
+// values that never appear in the endpoint method signature — must still be declared on the generated
+// operation. The expectations below are validated by open_api_generation.verify_open_api_expectations.
+//
+// The Microsoft.AspNetCore.OpenApi half of the same coverage (plus more shapes) lives in
+// Wolverine.Http.Tests/openapi_shape_tests.cs.
+//
+// These endpoints are deliberately free of database dependencies so they participate in the
+// Swashbuckle-driven open_api_generation harness.
+
+public record Bug3380OrderLine(long OrderId, long OrderLineId);
+
+// The GH-3380 reproduction: BOTH route ids are consumed only by LoadAsync
+public static class CompoundHandlerRouteOnlyEndpoint
+{
+    public static Bug3380OrderLine LoadAsync([FromRoute] long orderId, [FromRoute] long orderLineId)
+    {
+        return new Bug3380OrderLine(orderId, orderLineId);
+    }
+
+    [WolverineGet("/api/3380/orders/{orderId:long}/order-lines/{orderLineId:long}")]
+    [ExpectParameter("orderId", ParameterLocation.Path, Type = "integer", Format = "int64", Required = true)]
+    [ExpectParameter("orderLineId", ParameterLocation.Path, Type = "integer", Format = "int64", Required = true)]
+    [ExpectParameterCount(2)]
+    [ExpectNoRequestBody]
+    public static string Get(Bug3380OrderLine line) => $"{line.OrderId}:{line.OrderLineId}";
+}
+
+// Query + header bound only by a compound handler, and a query value bound only by an After postprocessor
+public record Bug3380Context(string? Name, string? Tenant);
+
+public static class CompoundHandlerQueryHeaderEndpoint
+{
+    public static Bug3380Context Load([FromQuery] string? name, [FromHeader(Name = "x-tenant")] string? tenant)
+    {
+        return new Bug3380Context(name, tenant);
+    }
+
+    [WolverineGet("/api/3380/context")]
+    [ExpectParameter("name", ParameterLocation.Query, Type = "string", Required = false)]
+    [ExpectParameter("x-tenant", ParameterLocation.Header, Type = "string", Required = false)]
+    [ExpectParameter("audit", ParameterLocation.Query, Type = "string", Required = false)]
+    [ExpectParameterCount(3)]
+    [ExpectNoRequestBody]
+    public static string Get(Bug3380Context context) => $"{context.Name}:{context.Tenant}";
+
+    public static void After([FromQuery] string? audit)
+    {
+    }
+}
+
+// A JSON request body alongside a route value bound only by the compound handler
+public record Bug3380CreateLine(string Description, int Quantity);
+
+public static class CompoundHandlerWithBodyEndpoint
+{
+    public static Bug3380OrderLine LoadAsync([FromRoute] long orderId) => new(orderId, 0);
+
+    [WolverinePost("/api/3380/orders/{orderId:long}/order-lines")]
+    [ExpectParameter("orderId", ParameterLocation.Path, Type = "integer", Format = "int64", Required = true)]
+    [ExpectParameterCount(1)]
+    [ExpectRequestBody("application/json", "description", "quantity", ForbiddenProperties = ["orderId"])]
+    public static string Post(Bug3380CreateLine body, Bug3380OrderLine line) => $"{line.OrderId}:{body.Description}";
+}

--- a/src/Http/WolverineWebApi/TestSupport/ExpectParameterAttribute.cs
+++ b/src/Http/WolverineWebApi/TestSupport/ExpectParameterAttribute.cs
@@ -20,6 +20,20 @@ public class ExpectParameterAttribute : OpenApiExpectationAttribute
     /// <summary>Expected schema <c>format</c> (e.g. "uuid", "int32", "date-time"). Null = don't assert.</summary>
     public string? Format { get; set; }
 
+    /// <summary>When set, asserts the parameter's <c>required</c> flag. Unset = don't assert.</summary>
+    public bool RequiredSet { get; private set; }
+    private bool _required;
+
+    public bool Required
+    {
+        get => _required;
+        set
+        {
+            _required = value;
+            RequiredSet = true;
+        }
+    }
+
     public ExpectParameterAttribute(string name, ParameterLocation @in)
     {
         Name = name;
@@ -44,6 +58,11 @@ public class ExpectParameterAttribute : OpenApiExpectationAttribute
         {
             parameter.Schema.ShouldNotBeNull($"Parameter '{Name}' has no schema");
             parameter.Schema.Format.ShouldBe(Format, $"Parameter '{Name}' schema format");
+        }
+
+        if (RequiredSet)
+        {
+            parameter.Required.ShouldBe(Required, $"Parameter '{Name}' required flag");
         }
     }
 }

--- a/src/Http/WolverineWebApi/TestSupport/ExpectParameterCountAttribute.cs
+++ b/src/Http/WolverineWebApi/TestSupport/ExpectParameterCountAttribute.cs
@@ -1,0 +1,30 @@
+using Microsoft.OpenApi.Models;
+using Shouldly;
+
+namespace WolverineWebApi.TestSupport;
+
+/// <summary>
+/// Asserts the exact number of parameters on the generated OpenAPI operation. Pair this with
+/// [ExpectParameter] to lock down the operation's parameter list completely — [ExpectParameter] alone
+/// only proves a parameter is present, not that a phantom or duplicated one is absent. See GH-3380.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public class ExpectParameterCountAttribute : OpenApiExpectationAttribute
+{
+    public int Count { get; }
+
+    public ExpectParameterCountAttribute(int count)
+    {
+        Count = count;
+    }
+
+    public override void Validate(OpenApiPathItem item, OpenApiOperation op, IOpenApiSource openApi)
+    {
+        var actual = op.Parameters?.Count ?? 0;
+
+        actual.ShouldBe(Count, "Actual parameters: " +
+                               (op.Parameters == null || op.Parameters.Count == 0
+                                   ? "<none>"
+                                   : string.Join(", ", op.Parameters.Select(p => $"{p.Name}({p.In})"))));
+    }
+}


### PR DESCRIPTION
Fixes #3380

## What was actually wrong (and what wasn't)

Being straight about the repro first: **the literal `parameters: []` symptom in the issue does not reproduce on `main` (6.17.2)**. `CreateApiDescription` has always looped `RoutePattern.Parameters`, so a route token is emitted no matter which method binds it. I reproduced every reported shape — compound `LoadAsync` binding both ids (with a service + `CancellationToken`), kebab-case `{order-id:long}` + `[FromRoute(Name = ...)]`, `[AsParameters]` + `LoadAsync` combinations — against **both** OpenAPI stacks (Swashbuckle and Microsoft.AspNetCore.OpenApi), and the path parameters were present and correctly typed in all of them. My best guess is the reporter's document predates the GH-3374 fix (their host wasn't starting) — but I could not confirm it.

What the investigation *did* turn up is the real version of the root cause the issue describes — the API description was derived from the endpoint method signature plus its own resolved binding variables, not from the full chain:

1. **Query string / header values bound only by an `After`/`Finally` postprocessor were omitted from the operation entirely.** This is a genuine, reproducing bug (the new `query_values_bound_only_by_a_postprocessor_are_declared` test fails on `main`).
2. **Route parameter types were read off *resolved* binding variables**, so they degraded to the route constraint (or `string`) whenever the description was assembled before those frames were resolved. ASP.NET Core caches the first ApiExplorer read, and that read can happen long before codegen (build-time OpenAPI generation, the `openapi` command, monitoring snapshots).

## The fix

`HttpChain.CreateApiDescription` now walks **every `MethodCall` in the chain** — the endpoint method, all middleware (compound handler `Load`/`LoadAsync`/`Before`, attribute- and policy-applied middleware) and all postprocessors — plus their `[AsParameters]` container members:

- Every `RoutePattern` parameter is declared as a **required path parameter**, with its type resolved in order: resolved route variable → the binding chain (honoring `[FromRoute(Name = "order-id")]`, ignoring name collisions with non-bindable types like services) → the route constraint (`{id:guid}`) → `string`. That is the non-negotiable floor, now structurally guaranteed rather than dependent on codegen having run.
- `[FromQuery]` / `[FromHeader]` arguments *anywhere* in the chain are declared, deduplicated by name + binding source.

## The shape-test harness (the actual gap)

There were essentially no assertions on the rendered document's `parameters`/`requestBody`. Now there are, on both stacks:

**1. `src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs` — Microsoft.AspNetCore.OpenApi.** Renders the *real* OpenAPI document (same path the `openapi` command uses, no host start, no database) for a host pinned to the infrastructure-free `Wolverine.Http.Tests.DifferentAssembly`, and asserts on it via `ParametersFor(path, method)` / `HasRequestBody(...)` / `RequestBodyPropertiesFor(...)`.

*To add a shape:* add an endpoint to `Wolverine.Http.Tests.DifferentAssembly/OpenApiShapeEndpoints.cs`, then add a `[Fact]` using those helpers.

Covered today: compound-handler-only route bindings (the #3380 case), an unconstrained route token typed purely from the binding chain, a renamed `[FromRoute(Name = ...)]` compound binding, compound-handler-only query + header, postprocessor-only query, plain handler-signature route + query, a request body alongside a compound route binding, a route value nothing binds (floor → required `string`), `[AsParameters]` route + query, and an `[AsParameters]` container sharing a route value with a compound handler (declared exactly once).

**2. WolverineWebApi `Expect*` attributes — Swashbuckle.** Folded into the existing GH-3135 harness (`open_api_generation.verify_open_api_expectations`) rather than duplicated. Added `[ExpectParameterCount]` (so `[ExpectParameter]` can't miss a phantom/duplicate parameter) and `ExpectParameter.Required`, plus `CompoundHandlerOpenApiEndpoints.cs` with the #3380 shapes.

*To add a shape:* annotate an endpoint method in WolverineWebApi with the `Expect*` attributes. No test code required — the theory picks it up automatically.

## Known gap (not fixed here)

Route ids bound *only* by a Marten aggregate frame on an **unconstrained** route (e.g. `[AggregateHandler] [WolverinePost("/orders/{id}/confirm")]`) still render as `string` rather than `uuid` — that binding is decided during codegen, after the description is cached, and the id type is Marten-domain knowledge that `Wolverine.Http` can't infer from the method signatures. Worth a follow-up issue.

## Tests

- `Wolverine.Http.Tests`: 857 passed, 0 failed, 10 skipped (net9.0)
- `Wolverine.Http.AspVersioning.Tests`: 66 passed (net10.0)
- `dotnet build wolverine.slnx -c Release`: succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)