### PR TITLE
Re-consume on a successful eager RabbitMQ channel restart + pin the ConnectionMonitor tracking invariant (GH-3391)

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_3391_callback_exception_restart.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_3391_callback_exception_restart.cs
@@ -1,0 +1,199 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using RabbitMQ.Client;
+using Shouldly;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests.Bugs;
+
+/// <summary>
+/// Regression coverage for #3391, the two follow-ups from the #3370 review of the
+/// callback-exception eager restart in RabbitMqChannelAgent:
+///
+/// 1. The ConnectionMonitor tracking invariant. An agent MUST stay tracked across a
+///    callback-exception restart, success or failure — only tracked agents are rebuilt by
+///    connection recovery, so an untracked agent is one connection drop away from ghosting.
+///    Before #3370 even a SUCCESSFUL restart left the agent untracked.
+///
+/// 2. The eager restart of a *listener* used to only swap in a fresh channel — no re-declare,
+///    no BasicConsume. That left an open channel with ZERO consumers while State == Connected:
+///    a silently dead listener.
+///
+/// Both are driven by a genuine channel callback exception: RabbitMQ.Client surfaces an
+/// exception thrown from one of its own event handlers as Channel.CallbackExceptionAsync, and
+/// an unroutable mandatory publish is a deterministic way to get one of those handlers invoked.
+/// Note that the channel itself stays open, so the #3171/#3187 shutdown push-heal does NOT fire
+/// here — the eager restart path is on its own, which is exactly the point.
+/// </summary>
+public class Bug_3391_callback_exception_restart : IAsyncLifetime
+{
+    private readonly string _queueName = $"bug3391-{Guid.NewGuid():N}";
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "Bug3391";
+                opts.UseRabbitMq()
+                    .AutoProvision()
+                    .AutoPurgeOnStartup();
+
+                opts.PublishMessage<Bug3391Message>().ToRabbitQueue(_queueName);
+                opts.ListenToRabbitQueue(_queueName);
+
+                opts.LocalRoutingConventionDisabled = true;
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private RabbitMqListener findListener()
+    {
+        var runtime = _host.GetRuntime();
+        var agent = runtime.Endpoints.ActiveListeners()
+            .Single(x => x.Uri == new Uri($"rabbitmq://queue/{_queueName}"));
+        return ((ListeningAgent)agent).Listener.ShouldBeOfType<RabbitMqListener>();
+    }
+
+    private ConnectionMonitor listeningConnection()
+    {
+        var transport = _host.GetRuntime().Options.RabbitMqTransport();
+        return transport.UseSenderConnectionOnly ? transport.SendingConnection : transport.ListeningConnection;
+    }
+
+    private static async Task<bool> waitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(100);
+        }
+
+        return condition();
+    }
+
+    private async Task publishAndExpectHandledAsync(string value)
+    {
+        await _host.MessageBus().PublishAsync(new Bug3391Message(value));
+
+        var handled = await waitForAsync(() =>
+        {
+            lock (Bug3391MessageHandler.Received)
+            {
+                return Bug3391MessageHandler.Received.Contains(value);
+            }
+        }, 30.Seconds());
+
+        handled.ShouldBeTrue($"Expected the message '{value}' to be received and handled");
+    }
+
+    /// <summary>
+    /// Provoke a real callback exception on the agent's channel without killing the channel:
+    /// subscribe a handler to BasicReturnAsync that throws, then publish a mandatory message to
+    /// a routing key that resolves to nothing. The broker returns it, our handler throws, and
+    /// RabbitMQ.Client raises CallbackExceptionAsync on the channel.
+    /// </summary>
+    private static async Task provokeCallbackExceptionAsync(IChannel channel)
+    {
+        channel.BasicReturnAsync += (_, _) => throw new DivideByZeroException("Boom, from a Rabbit MQ callback");
+
+        var properties = new BasicProperties();
+        await channel.BasicPublishAsync("", $"nowhere-{Guid.NewGuid():N}", true, properties,
+            ReadOnlyMemory<byte>.Empty, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// The number of consumers the broker sees on the queue, read over a throwaway channel.
+    /// </summary>
+    private async Task<uint> consumerCountAsync()
+    {
+        await using var channel = await listeningConnection().CreateChannelAsync();
+        var result = await channel.QueueDeclarePassiveAsync(_queueName);
+        return result.ConsumerCount;
+    }
+
+    [Fact]
+    public async Task agent_stays_tracked_by_the_connection_monitor_across_a_callback_exception_restart()
+    {
+        var listener = findListener();
+        var monitor = listeningConnection();
+
+        monitor.TrackedAgents.ShouldContain(listener);
+
+        var originalChannel = listener.Channel!;
+        originalChannel.IsOpen.ShouldBeTrue();
+
+        await provokeCallbackExceptionAsync(originalChannel);
+
+        var restarted = await waitForAsync(
+            () => listener.Channel is { IsOpen: true } && !ReferenceEquals(listener.Channel, originalChannel),
+            30.Seconds());
+        restarted.ShouldBeTrue("The agent should have eagerly restarted its channel after a callback exception");
+        listener.State.ShouldBe(AgentState.Connected);
+
+        // The invariant. Only agents tracked by the ConnectionMonitor are rebuilt by
+        // connectionOnRecoverySucceededAsync, so dropping one here — even on a restart that
+        // SUCCEEDED — leaves it one connection drop away from being ghosted forever (#3370).
+        monitor.TrackedAgents.ShouldContain(listener);
+    }
+
+    [Fact]
+    public async Task listener_still_consumes_after_a_successful_eager_restart()
+    {
+        // Prove the pipe works before we break anything.
+        await publishAndExpectHandledAsync("before-callback-exception");
+
+        var listener = findListener();
+        var originalChannel = listener.Channel!;
+
+        (await consumerCountAsync()).ShouldBe(1u);
+
+        await provokeCallbackExceptionAsync(originalChannel);
+
+        var restarted = await waitForAsync(
+            () => listener.Channel is { IsOpen: true } && !ReferenceEquals(listener.Channel, originalChannel),
+            30.Seconds());
+        restarted.ShouldBeTrue("The listener should have eagerly restarted its channel after a callback exception");
+        listener.State.ShouldBe(AgentState.Connected);
+
+        // The bug: the eager restart only opened a fresh channel. No re-declare, no BasicConsume.
+        // The queue was left with ZERO consumers while the agent happily reported Connected.
+        var deadline = DateTimeOffset.UtcNow + 30.Seconds();
+        uint consumers;
+        while ((consumers = await consumerCountAsync()) != 1u && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(250);
+        }
+
+        consumers.ShouldBe(1u, "The restarted listener should be consuming from the queue again");
+
+        // ...and the real proof: messages still flow, with no process restart.
+        await publishAndExpectHandledAsync("after-callback-exception");
+    }
+}
+
+public record Bug3391Message(string Value);
+
+public static class Bug3391MessageHandler
+{
+    public static readonly List<string> Received = new();
+
+    public static void Handle(Bug3391Message message)
+    {
+        lock (Received)
+        {
+            Received.Add(message.Value);
+        }
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs
@@ -110,6 +110,21 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
             _agents.Add(agent);
     }
 
+    /// <summary>
+    /// The channel agents currently tracked by this monitor. Only agents in this list are
+    /// rebuilt by <see cref="connectionOnRecoverySucceededAsync"/>, so an agent that falls out
+    /// of it is one connection drop away from being permanently ghosted (see #3370). Exposed
+    /// for regression coverage of that invariant.
+    /// </summary>
+    internal IReadOnlyList<RabbitMqChannelAgent> TrackedAgents
+    {
+        get
+        {
+            lock (_agentsLock)
+                return [.. _agents];
+        }
+    }
+
     private async Task connectionOnRecoverySucceededAsync(object sender, AsyncEventArgs @event)
     {
         IsConnected = true;

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
@@ -116,23 +116,9 @@ internal abstract class RabbitMqChannelAgent : IAsyncDisposable, IReportConnecti
         Task.Run(async () =>
 #pragma warning restore VSTHRD110
         {
-            await Locker.WaitAsync();
             try
             {
-                try
-                {
-                    await teardownChannel();
-                }
-                catch (Exception e)
-                {
-                    Logger.LogError(e, "Error when trying to tear down a blocked channel");
-                }
-
-                Channel = null;
-
-                // EnsureInitiated can be used here as Locker(SemaphoreSlim) is not re-entrant
-                await startNewChannel();
-                State = AgentState.Connected;
+                await restartAfterCallbackExceptionAsync();
 
                 Logger.LogInformation("Restarted the Rabbit MQ channel");
             }
@@ -148,13 +134,41 @@ internal abstract class RabbitMqChannelAgent : IAsyncDisposable, IReportConnecti
                 Logger.LogWarning(e,
                     "Could not eagerly restart the Rabbit MQ channel; leaving it for connection recovery");
             }
-            finally
-            {
-                Locker.Release();
-            }
         });
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Eagerly rebuild this agent after a channel callback exception. The base behavior is
+    /// sender-shaped: a fresh channel is all a sender needs. Agents that own broker-side state
+    /// on the channel — a listener's consumer, above all — must override this, because a bare
+    /// channel swap would leave them "Connected" on an open channel with nothing consuming.
+    /// </summary>
+    protected virtual async Task restartAfterCallbackExceptionAsync()
+    {
+        await Locker.WaitAsync();
+        try
+        {
+            try
+            {
+                await teardownChannel();
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Error when trying to tear down a blocked channel");
+            }
+
+            Channel = null;
+
+            // EnsureInitiated cannot be used here as Locker(SemaphoreSlim) is not re-entrant
+            await startNewChannel();
+            State = AgentState.Connected;
+        }
+        finally
+        {
+            Locker.Release();
+        }
     }
 
     private Task HandleChannelShutdownAsync(object? sender, ShutdownEventArgs e)

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -55,6 +55,11 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
     private readonly IWolverineRuntime _runtime;
     private readonly Lazy<ISender> _sender;
     private readonly RabbitMqTransport _transport;
+
+    // Serializes the three rebuild triggers -- connection recovery, an unexpected channel-only
+    // shutdown (#3171), and a channel callback exception (#3391). A burst of callback exceptions
+    // otherwise races two rebuilds onto the same channel and leaves duplicate consumers behind.
+    private readonly SemaphoreSlim _reconnectLock = new(1, 1);
     private WorkerQueueMessageConsumer? _consumer;
     private string? _consumerId;
 
@@ -252,25 +257,46 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
         });
     }
 
+    /// <summary>
+    /// Defer the callback-exception eager restart to the full listener rebuild (#3391). The base
+    /// implementation only swaps in a fresh channel, which is enough for a sender but leaves a
+    /// listener sitting on an open channel with ZERO consumers while reporting Connected — a
+    /// silently dead listener. ReconnectedAsync already does the correct work (cancel any surviving
+    /// consumer, tear the channel down, re-declare and re-consume), so we route through it rather
+    /// than duplicating a consume path here.
+    /// </summary>
+    protected override Task restartAfterCallbackExceptionAsync()
+    {
+        return ReconnectedAsync();
+    }
+
     internal override async Task ReconnectedAsync()
     {
+        await _reconnectLock.WaitAsync();
         try
         {
-            await StopAsync();
+            try
+            {
+                await StopAsync();
+            }
+            catch (Exception e)
+            {
+                // The channel may already be dead, in which case cancelling the consumers throws.
+                // That's fine — we're about to tear it down and rebuild anyway.
+                Logger.LogDebug(e,
+                    "Error cancelling consumers on a dead channel for {Uri} during reconnect; continuing with rebuild",
+                    Address);
+            }
+
+            await teardownChannel();
+            await CreateAsync();
+
+            await base.ReconnectedAsync();
         }
-        catch (Exception e)
+        finally
         {
-            // The channel may already be dead, in which case cancelling the consumers throws.
-            // That's fine — we're about to tear it down and rebuild anyway.
-            Logger.LogDebug(e,
-                "Error cancelling consumers on a dead channel for {Uri} during reconnect; continuing with rebuild",
-                Address);
+            _reconnectLock.Release();
         }
-
-        await teardownChannel();
-        await CreateAsync();
-
-        await base.ReconnectedAsync();
     }
 
     public override string ToString()


### PR DESCRIPTION
Fixes #3391.

Two follow-ups from the review of #3370 (the RabbitMQ listener ghosting fix). One is a real behavioral bug; the other is test-only. They're separated below.

---

## Part 1 (behavioral fix) — a successful eager restart of a listener never re-consumed

`RabbitMqChannelAgent.HandleChannelExceptionAsync` handled a channel callback exception by running `teardownChannel()` + `startNewChannel()`. That gives you a **fresh channel and nothing else** — no re-declare, no `BasicConsumeAsync`.

The `#3171`/`#3187` shutdown push-heal does not cover this, because `teardownChannel()` **unsubscribes the shutdown handler before closing the channel**. So a callback-exception-only failure (the channel itself survives) left the listener in exactly the state the issue describes:

> an **open channel with ZERO consumers** while `State = Connected`

A silently dead listener on an apparently healthy process. Nothing pulls from the queue and nothing reports a problem.

### Reproduced

The new `listener_still_consumes_after_a_successful_eager_restart` test fails on the pre-fix code precisely as predicted — after the eager restart the channel is open, the agent reports `Connected`, and the broker reports **0 consumers** on the queue:

```
Shouldly.ShouldAssertException : consumers
    should be
1u
    but was
0u

Additional Info:
    The restarted listener should be consuming from the queue again
```

### The fix

The eager restart is now a `protected virtual restartAfterCallbackExceptionAsync()`:

- **`RabbitMqChannelAgent`** keeps the existing sender-shaped behavior as the base implementation — a fresh channel is all a sender needs, and `RabbitMqSender` is the only other subclass. The failure path is unchanged: an exception still leaves the agent tracked and `Disconnected` for connection recovery to rebuild (that's #3370's fix).
- **`RabbitMqListener`** overrides it to defer to its existing `ReconnectedAsync()`, which already does the correct work — cancel any surviving consumer, tear the channel down, re-declare, re-consume. No duplicate consume path was added; `ReconnectedAsync()` is the right authority and every other listener-rebuild trigger already routes through it.
- **`RabbitMqListener.ReconnectedAsync()`** is now serialized behind a `_reconnectLock`. It has three triggers (connection recovery, unexpected channel-only shutdown, and now callback exception), and callback exceptions arrive in **bursts** — that's the shape reported in #3370 (`N × "Callback error in Rabbit Mq agent"`). Without the gate, two concurrent rebuilds can race onto the same channel and leave duplicate consumers behind.

## Part 2 (test-only) — pinning the ConnectionMonitor tracking invariant

The invariant: **an agent must remain tracked by `ConnectionMonitor` after a callback-exception-triggered restart, whether that restart succeeds or fails.** Only tracked agents are iterated by `connectionOnRecoverySucceededAsync`, so an agent that falls out of `_agents` is never rebuilt on reconnect.

Before #3370, `_monitor.Remove(this)` had no compensating re-`Track()` anywhere — so even a **successful** eager restart left the agent permanently untracked and one connection drop away from ghosting. #3370 fixed it; nothing pinned it.

- New `internal ConnectionMonitor.TrackedAgents` accessor over `_agents` (returns a snapshot under the existing lock).
- New `agent_stays_tracked_by_the_connection_monitor_across_a_callback_exception_restart` test.

This part changes no runtime behavior.

## How the tests drive it

Both tests provoke a **genuine** channel callback exception against the live broker rather than reaching in and invoking the handler: subscribe a throwing handler to `BasicReturnAsync`, then publish a mandatory message to a routing key that resolves to nothing. The broker returns it, the handler throws, and RabbitMQ.Client raises `CallbackExceptionAsync` on the channel — while leaving the channel open, which is exactly the scenario the push-heal misses.

Following the `Bug_3171_channel_only_shutdown_recovery` pattern: internal-state assertions against a live broker, poll-based waits, unique queue names, no shared `fan_out`/`direct_exchange` state.

## Test results

`Wolverine.RabbitMQ.Tests`, full suite, live broker: **473 passed / 477, 13m16s.** The 4 failures are pre-existing shared-broker flakes unrelated to this change — `use_fan_out_exchange`, `multi_tenancy_through_virtual_hosts.send_message_to_a_specific_tenant`, and `Bug_1594_ReplayDeadLetterQueue` (both modes). **All 4 pass in isolation** with this change applied, and the vhost test also passes on unmodified `main` only when run alone — i.e. ordering/shared-state, not a regression.

Full solution builds clean: `dotnet build wolverine.slnx -c Release` → 0 warnings, 0 errors.

## #3137 assessment — leaving the circuit-breaking tests quarantined

`CircuitBreakingTests` passes **24/24 (3m59s)** on this branch, but I am **not** un-quarantining it, for two reasons:

1. **This fix doesn't touch the implicated code.** #3137 localizes the remaining flakiness to the interplay between broker back-pressure and Wolverine's `BufferedReceiver` drain / `Restarter` timing (`buffered_not_parallelized`, `buffered_and_parallel`). This PR changes the channel **callback-exception restart** path — a different subsystem. There's no mechanism by which it would fix a pause/drain timing race.
2. **One green run is not evidence against an intermittent flake.** That's precisely the failure mode #3137 exists to track, and the issue is explicit that un-quarantining should wait on a root cause.

Un-quarantining here would be guesswork of exactly the kind #3137 warns against, so #3137 stays open and `circuit-breaking.yml` stays informational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
