### PR TITLE
Measure and surface per-server database connection budgets (GH-3397)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -310,6 +310,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                     items: [
                         {text: 'Durable Inbox and Outbox Messaging', link: '/guide/durability/'},
                         {text: 'Troubleshooting and Leadership Election', link: '/guide/durability/leadership-and-troubleshooting'},
+                        {text: 'Connection Budgets', link: '/guide/durability/connection-budgets'},
                         {text: 'Sagas', link: '/guide/durability/sagas'},
                         {text: 'Marten Integration', link: '/guide/durability/marten/',  collapsed: false, items: [
                                 {text: 'Transactional Middleware', link: '/guide/durability/marten/transactional-middleware'},

--- a/docs/guide/durability/connection-budgets.md
+++ b/docs/guide/durability/connection-budgets.md
@@ -1,0 +1,128 @@
+# Connection Budgets
+
+::: tip
+Introduced in Wolverine 6.19. This is a measurement feature — Wolverine reports connection pressure,
+it does not yet react to it.
+:::
+
+Database connections are a resource of the **server**, not of a logical database. That distinction
+does not matter much when your application talks to one database, but it matters a great deal in a
+sharded multi-tenancy deployment, where hundreds of tenant databases can live on a handful of
+Postgres clusters and every node in your cluster is drawing from the same finite pool. When that
+pool runs dry the failures are ugly and diffuse: schema migrations that can't get a connection,
+projection daemons that stall, health checks that flap.
+
+A *connection budget* makes that pressure visible. Wolverine reports, per database server:
+
+| Value | Meaning |
+|-------|---------|
+| **used** | Connections currently open on the server, by every application sharing it |
+| **max** | The budget you declared for that server |
+
+## Turning it on
+
+The budget machinery is on automatically when your message stores span statically-known multiple
+databases — Marten's `MultiTenantedWithShardedDatabases`, the many-databases-per-server shape the
+feature exists for. It is off for a single database, where a per-server number tells you nothing a
+per-database number doesn't.
+
+Declaring a budget is itself an opt-in, so this is all you normally write:
+
+```csharp
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.Durability.ConnectionBudgets
+            .ForServer("pg-shard-a", 5432, maxConnections: 400)
+            .ForServer("pg-shard-b", 5432, maxConnections: 200);
+    }).StartAsync();
+```
+
+Budgets are declared per server because one deployment routinely spans servers with different
+limits. The port is part of the key, so two clusters co-hosted on one host stay distinct.
+
+For SQL Server, pass the `Data Source` verbatim — it already carries the port or named instance:
+
+```csharp
+opts.Durability.ConnectionBudgets.ForServer("sql-1,1433", maxConnections: 500);
+```
+
+`opts.Durability.ConnectionBudgets.Enabled` forces the whole thing on or off if you disagree with
+the automatic rule.
+
+## Why the max is configuration and not `max_connections`
+
+Wolverine deliberately does **not** treat the server's own `max_connections` as your budget.
+
+If there is any pooler in front of the database — pgBouncer being the usual one — the server's limit
+describes how many connections *the pooler* may open, which is not remotely the same question as how
+many your application is entitled to take. Charting utilization against it would be reassuring and
+wrong.
+
+So the budget is something you declare, and the probe supplies only the `used` side. When you
+haven't declared one, Wolverine falls back to reading the server's limit
+(`max_connections` / `@@MAX_CONNECTIONS`) and labels the reading as *probed* so you can tell a
+declared budget from a guessed one. If even that can't be read, the budget is reported as *unknown*
+— the used count is still published, but no utilization is computed.
+
+## What the numbers actually mean in your topology
+
+::: warning
+Read this before you alert on the number.
+:::
+
+**The used count is server-wide and includes other applications.** It comes from
+`sum(numbackends)` on PostgreSQL and `count(*) from sys.dm_exec_connections` on SQL Server. That is
+the point — the connections are a shared resource and the contention is real regardless of who is
+causing it — but do not read the number as "connections Wolverine is using."
+
+**Behind a transaction-pooling pgBouncer, the used count is not your client connections.** It counts
+pgBouncer's backend connections to Postgres, which is exactly what you want to watch (that is the
+scarce pool), but it will look far smaller than the number of client sessions your application
+believes it has. In session-pooling mode the two track much more closely. In a direct-connection
+topology, the used count *is* your connections plus everyone else's.
+
+## Permissions
+
+The PostgreSQL probe reads `pg_catalog.pg_stat_database`, which is visible to any user without
+special grants.
+
+The SQL Server probe reads `sys.dm_exec_connections`, which requires **`VIEW SERVER STATE`**. Some
+locked-down hosting does not grant it. When it is missing, Wolverine logs a single warning per server
+and reports that server's budget as unknown rather than failing the metrics sweep.
+
+## What gets published
+
+**OpenTelemetry**, as gauges tagged by `server`:
+
+| Instrument | Meaning |
+|------------|---------|
+| `wolverine-database-connection-count` | Connections currently open on the server |
+| `wolverine-database-connection-budget` | The budget, omitted entirely when unknown |
+
+**`IWolverineObserver.ConnectionBudget`**, which is how CritterWatch surfaces it:
+
+```csharp
+public record ConnectionBudgetSnapshot(
+    DatabaseServerId Server,
+    int Used,
+    int? Max,
+    ConnectionBudgetSource Source); // Configured | Probed | Unknown
+```
+
+## Cost
+
+The probe rides the existing durability metrics sweep (`Durability.UpdateMetricsPeriod`, 5 seconds
+by default) and is deduplicated by server: **one query per server per sweep**, however many tenant
+databases the node happens to own. A node owning 200 tenant databases across 2 servers issues 2
+connection probes per sweep, not 200. Probing per database would multiply the very pressure the
+number exists to reveal.
+
+The whole feature is silent when `Durability.DurabilityMetricsEnabled` is `false`.
+
+## Reacting to pressure
+
+Not yet. Today Wolverine measures and reports; it does not throttle itself when the budget gets
+tight. Adaptive back-off — scaling daemon polling and concurrency down under pressure, with
+hysteresis so a single threshold doesn't flap — is planned as a follow-up and will be opt-in. See
+[GH-3397](https://github.com/JasperFx/wolverine/issues/3397).

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -12,6 +12,7 @@ using Weasel.Core;
 using Weasel.Core.Migrations;
 using Weasel.Postgresql;
 using Wolverine.Logging;
+using Wolverine.Persistence;
 using Wolverine.Persistence.Durability;
 using Wolverine.Postgresql.Schema;
 using Wolverine.Postgresql.Util;
@@ -28,12 +29,13 @@ using Table = Weasel.Postgresql.Tables.Table;
 
 namespace Wolverine.Postgresql;
 
-internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>
+internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>, IConnectionBudgetProbe
 {
     private readonly string _deleteOutgoingEnvelopesSql;
     private readonly string _discardAndReassignOutgoingSql;
     private readonly string _findAtLargeEnvelopesSql;
     private readonly string _reassignIncomingSql;
+    private DatabaseServerId? _serverId;
 
     private readonly List<ISchemaObject> _externalTables = new();
 
@@ -547,6 +549,48 @@ join pg_catalog.pg_namespace n on n.oid = c.relnamespace and n.nspname = '{Schem
         }
         
         await conn.CloseAsync();
+    }
+
+    /// <summary>
+    /// The Postgres cluster this database lives on (#3397). The port is carried explicitly rather
+    /// than left implicit in the host, because <see cref="DatabaseDescriptor.ServerName"/> is
+    /// host-only and two clusters co-hosted on one box would otherwise collide onto a single budget.
+    /// </summary>
+    public DatabaseServerId ServerId
+    {
+        get
+        {
+            if (_serverId.HasValue)
+            {
+                return _serverId.Value;
+            }
+
+            var builder = new NpgsqlConnectionStringBuilder(DataSource?.ConnectionString ?? Settings.ConnectionString);
+            _serverId = new DatabaseServerId("PostgreSQL", builder.Host ?? string.Empty, builder.Port);
+
+            return _serverId.Value;
+        }
+    }
+
+    public async ValueTask<int> CountServerConnectionsAsync(CancellationToken token)
+    {
+        // Server-wide, and deliberately not filtered to this database or this application:
+        // connections are a resource of the cluster, and a budget that ignored the other tenants
+        // (or the other applications) sharing it would be measuring the wrong thing. Note that
+        // behind a transaction-pooling pgBouncer this counts pooler-to-server backends rather than
+        // client sessions — see the connection-budget docs.
+        var raw = await CreateCommand("select coalesce(sum(numbackends), 0)::int from pg_catalog.pg_stat_database")
+            .ExecuteScalarAsync(token).ConfigureAwait(false);
+
+        return raw is int count ? count : 0;
+    }
+
+    public async ValueTask<int?> ProbeMaxConnectionsAsync(CancellationToken token)
+    {
+        var raw = await CreateCommand("select current_setting('max_connections')::int")
+            .ExecuteScalarAsync(token).ConfigureAwait(false);
+
+        return raw is int max && max > 0 ? max : null;
     }
 
     public override DatabaseDescriptor Describe()

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Weasel.Core;
 using Weasel.SqlServer;
 using Wolverine.Logging;
+using Wolverine.Persistence;
 using Wolverine.Persistence.Durability;
 using Wolverine.Persistence.Durability.DeadLetterManagement;
 using Wolverine.Persistence.Durability.ScheduledMessageManagement;
@@ -30,10 +31,11 @@ using Table = Weasel.SqlServer.Tables.Table;
 
 namespace Wolverine.SqlServer.Persistence;
 
-public class SqlServerMessageStore : MessageDatabase<SqlConnection>
+public class SqlServerMessageStore : MessageDatabase<SqlConnection>, IConnectionBudgetProbe
 {
     private readonly string _findAtLargeEnvelopesSql;
     private readonly string _scheduledLockId;
+    private DatabaseServerId? _serverId;
     private ImHashMap<Type, IDatabaseSagaSchema> _sagaStorage = ImHashMap<Type, IDatabaseSagaSchema>.Empty;
     
     private readonly List<ISchemaObject> _externalTables = new();
@@ -457,6 +459,53 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>
         {
             await conn.CloseAsync();
         }
+    }
+
+    /// <summary>
+    /// The SQL Server instance this database lives on (#3397). Unlike PostgreSQL, the port is left
+    /// null: SQL Server's <c>Data Source</c> already carries it (<c>host,1433</c>) or a named
+    /// instance (<c>host\SQLEXPRESS</c>), so it is kept whole and is already unique.
+    /// </summary>
+    public DatabaseServerId ServerId
+    {
+        get
+        {
+            if (_serverId.HasValue)
+            {
+                return _serverId.Value;
+            }
+
+            var builder = new SqlConnectionStringBuilder(_settings.ConnectionString);
+            _serverId = new DatabaseServerId("SqlServer", builder.DataSource ?? string.Empty, null);
+
+            return _serverId.Value;
+        }
+    }
+
+    /// <summary>
+    /// Note that this needs the <c>VIEW SERVER STATE</c> permission, which locked-down hosting does
+    /// not always grant. The sweeper degrades to "budget unknown" (one warning, then silence) rather
+    /// than failing the metrics pass when it is missing — see #3397.
+    /// </summary>
+    public async ValueTask<int> CountServerConnectionsAsync(CancellationToken token)
+    {
+        // Server-wide, across every database and application on the instance — connections are an
+        // instance-scoped resource, so scoping the count to this database would measure the wrong
+        // thing.
+        var raw = await CreateCommand("select count(*) from sys.dm_exec_connections")
+            .ExecuteScalarAsync(token).ConfigureAwait(false);
+
+        return raw is int count ? count : 0;
+    }
+
+    public async ValueTask<int?> ProbeMaxConnectionsAsync(CancellationToken token)
+    {
+        var raw = await CreateCommand("select @@MAX_CONNECTIONS")
+            .ExecuteScalarAsync(token).ConfigureAwait(false);
+
+        // Zero means "unlimited, SQL Server sizes it dynamically" — which is not a budget, so report
+        // it as unknown rather than charting a limit of nothing.
+        return raw is int max && max > 0 ? max : null;
     }
 
     public override DatabaseDescriptor Describe()

--- a/src/Testing/CoreTests/Persistence/connection_budget_sweeper_tests.cs
+++ b/src/Testing/CoreTests/Persistence/connection_budget_sweeper_tests.cs
@@ -1,0 +1,340 @@
+using CoreTests.Runtime;
+using JasperFx.Core;
+using JasperFx.Events;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+using Wolverine.Logging;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime.Agents;
+using Wolverine.Runtime.Metrics;
+using Wolverine.Runtime.Routing;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+// The connection-budget half of the metrics sweep (GH-3397). Connections are a resource of the
+// database *server*, not of a logical database, so in the sharded-tenancy deployment this exists
+// for — hundreds of tenant databases spread over a handful of servers — the probe has to run once
+// per server per pass. Probing per database would multiply the very pressure the number is meant
+// to reveal.
+public class connection_budget_sweeper_tests
+{
+    private readonly MockWolverineRuntime theRuntime = new();
+    private readonly BudgetRecordingObserver theObserver = new();
+
+    private static readonly DatabaseServerId ServerA = new("PostgreSQL", "shard-a", 5432);
+    private static readonly DatabaseServerId ServerB = new("PostgreSQL", "shard-b", 5432);
+
+    public connection_budget_sweeper_tests()
+    {
+        theRuntime.Options.Durability.UpdateMetricsPeriod = 100.Milliseconds();
+        theRuntime.Observer = theObserver;
+
+        // MockWolverineRuntime reports no databases at all, so the automatic activation rule
+        // (sharded tenancy) can never fire here. Turn the machinery on explicitly; the rule
+        // itself is asserted in connection_budgets_tests.
+        theRuntime.Options.Durability.ConnectionBudgets.Enabled = true;
+    }
+
+    private FakeBudgetStore buildStore(string name, DatabaseServerId serverId)
+    {
+        var fake = new FakeBudgetStore(new Uri($"wolverinedb://test/{name}"), serverId);
+        var metrics = new PersistenceMetrics(theRuntime, theRuntime.Options.Durability, name);
+        fake.Registration = PersistenceMetricsSweeper.For(theRuntime).Register(fake.Store, metrics);
+
+        return fake;
+    }
+
+    [Fact]
+    public async Task probes_once_per_server_however_many_databases_are_on_it()
+    {
+        // Five tenant databases, one server. This is the whole point of the feature.
+        var stores = Enumerable.Range(0, 5).Select(i => buildStore($"tenant{i}", ServerA)).ToArray();
+
+        try
+        {
+            // Every database fetched at least twice => at least two full passes have run.
+            await waitUntil(() => stores.All(x => x.Fetches >= 2));
+
+            var probes = stores.Sum(x => x.ConnectionCounts);
+
+            // Per pass: five FetchCounts, but exactly one connection probe. Without the dedupe
+            // this would already be >= 10.
+            probes.ShouldBeGreaterThanOrEqualTo(2);
+            probes.ShouldBeLessThan(stores.Sum(x => x.Fetches));
+
+            // Each successful probe publishes exactly one snapshot for the server.
+            theObserver.SnapshotsFor(ServerA).Count.ShouldBe(probes);
+        }
+        finally
+        {
+            disposeAll(stores);
+        }
+    }
+
+    [Fact]
+    public async Task probes_each_server_separately()
+    {
+        // Four databases on A, one on B. Both servers get probed on the same cadence — the count
+        // tracks servers, not databases.
+        var onA = Enumerable.Range(0, 4).Select(i => buildStore($"a{i}", ServerA)).ToArray();
+        var onB = new[] { buildStore("b0", ServerB) };
+
+        try
+        {
+            await waitUntil(() => theObserver.SnapshotsFor(ServerA).Count >= 2
+                                  && theObserver.SnapshotsFor(ServerB).Count >= 2);
+
+            var probesOnA = onA.Sum(x => x.ConnectionCounts);
+            var probesOnB = onB.Sum(x => x.ConnectionCounts);
+
+            // A has 4x the databases of B, but is probed the same number of times (allowing for
+            // one pass of skew between the two sampling points).
+            Math.Abs(probesOnA - probesOnB).ShouldBeLessThanOrEqualTo(1);
+        }
+        finally
+        {
+            disposeAll(onA.Concat(onB));
+        }
+    }
+
+    [Fact]
+    public async Task a_configured_budget_wins_over_the_servers_own_limit()
+    {
+        // Decision from the issue: behind a pooler the server's max_connections describes what the
+        // *pooler* may open, not what this application is entitled to. Configuration is the truth.
+        theRuntime.Options.Durability.ConnectionBudgets.ForServer("shard-a", 5432, 400);
+
+        var store = buildStore("tenant", ServerA);
+        store.MaxConnections = 100;
+
+        try
+        {
+            await waitUntil(() => theObserver.SnapshotsFor(ServerA).Any());
+
+            var snapshot = theObserver.SnapshotsFor(ServerA).Last();
+            snapshot.Max.ShouldBe(400);
+            snapshot.Source.ShouldBe(ConnectionBudgetSource.Configured);
+
+            // ...and the server was never even asked for its own limit.
+            store.MaxProbes.ShouldBe(0);
+        }
+        finally
+        {
+            disposeAll([store]);
+        }
+    }
+
+    [Fact]
+    public async Task falls_back_to_the_probed_limit_and_only_reads_it_once()
+    {
+        var store = buildStore("tenant", ServerA);
+        store.MaxConnections = 100;
+        store.OpenConnections = 25;
+
+        try
+        {
+            await waitUntil(() => theObserver.SnapshotsFor(ServerA).Count >= 3);
+
+            var snapshot = theObserver.SnapshotsFor(ServerA).Last();
+            snapshot.Max.ShouldBe(100);
+            snapshot.Used.ShouldBe(25);
+            snapshot.Source.ShouldBe(ConnectionBudgetSource.Probed);
+            snapshot.Utilization.ShouldBe(0.25);
+
+            // The server's limit doesn't move at runtime, so it is read once per process however
+            // many passes run.
+            store.MaxProbes.ShouldBe(1);
+        }
+        finally
+        {
+            disposeAll([store]);
+        }
+    }
+
+    [Fact]
+    public async Task reports_the_budget_as_unknown_when_the_limit_cannot_be_read()
+    {
+        // SQL Server without VIEW SERVER STATE, say. The used count is still worth having; the
+        // budget is honestly reported as unknown rather than guessed at.
+        var store = buildStore("tenant", ServerA);
+        store.MaxConnections = null;
+        store.OpenConnections = 25;
+
+        try
+        {
+            await waitUntil(() => theObserver.SnapshotsFor(ServerA).Any());
+
+            var snapshot = theObserver.SnapshotsFor(ServerA).Last();
+            snapshot.Max.ShouldBeNull();
+            snapshot.Source.ShouldBe(ConnectionBudgetSource.Unknown);
+            snapshot.Used.ShouldBe(25);
+            snapshot.Utilization.ShouldBeNull();
+        }
+        finally
+        {
+            disposeAll([store]);
+        }
+    }
+
+    [Fact]
+    public async Task a_failing_probe_publishes_nothing_and_leaves_the_rest_of_the_sweep_alone()
+    {
+        var failing = buildStore("failing", ServerA);
+        failing.FailConnectionCount = true;
+
+        var healthy = buildStore("healthy", ServerB);
+
+        try
+        {
+            await waitUntil(() => theObserver.SnapshotsFor(ServerB).Count >= 2 && failing.Fetches >= 2);
+
+            // Phase 1 is observability only: a probe that can't answer publishes nothing rather
+            // than publishing a fabricated zero.
+            theObserver.SnapshotsFor(ServerA).ShouldBeEmpty();
+
+            // ...and the failure is contained. The envelope counts for the failing server's own
+            // database still get swept, as does the other server.
+            failing.Fetches.ShouldBeGreaterThanOrEqualTo(2);
+            healthy.Fetches.ShouldBeGreaterThanOrEqualTo(2);
+        }
+        finally
+        {
+            disposeAll([failing, healthy]);
+        }
+    }
+
+    [Fact]
+    public async Task does_not_probe_at_all_when_the_budget_machinery_is_off()
+    {
+        theRuntime.Options.Durability.ConnectionBudgets.Enabled = false;
+
+        var store = buildStore("tenant", ServerA);
+
+        try
+        {
+            // The envelope-count sweep still runs; only the budget probing is silent.
+            await waitUntil(() => store.Fetches >= 3);
+
+            store.ConnectionCounts.ShouldBe(0);
+            store.MaxProbes.ShouldBe(0);
+            theObserver.SnapshotsFor(ServerA).ShouldBeEmpty();
+        }
+        finally
+        {
+            disposeAll([store]);
+        }
+    }
+
+    private static void disposeAll(IEnumerable<FakeBudgetStore> stores)
+    {
+        foreach (var store in stores) store.Registration?.Dispose();
+    }
+
+    private static async Task waitUntil(Func<bool> condition)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        while (!condition())
+        {
+            DateTimeOffset.UtcNow.ShouldBeLessThan(deadline, "timed out waiting for the sweeper");
+            await Task.Delay(25);
+        }
+    }
+
+    // A substituted message store that also answers for its server's connections, wrapped so the
+    // tests can read call counts. The sweeper picks the probe out with an `OfType` over the
+    // registered stores, so the one object has to wear both interfaces.
+    private class FakeBudgetStore
+    {
+        private int _fetches;
+        private int _connectionCounts;
+        private int _maxProbes;
+
+        public FakeBudgetStore(Uri uri, DatabaseServerId serverId)
+        {
+            var store = Substitute.For<IMessageStore, IConnectionBudgetProbe>();
+            store.Uri.Returns(uri);
+
+            var admin = Substitute.For<IMessageStoreAdmin>();
+            admin.FetchCountsAsync().Returns(_ =>
+            {
+                Interlocked.Increment(ref _fetches);
+                return Task.FromResult(new PersistedCounts { Incoming = 42 });
+            });
+            store.Admin.Returns(admin);
+
+            var probe = (IConnectionBudgetProbe)store;
+            probe.ServerId.Returns(serverId);
+
+            probe.CountServerConnectionsAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+            {
+                Interlocked.Increment(ref _connectionCounts);
+
+                if (FailConnectionCount)
+                {
+                    throw new InvalidOperationException("No connection available");
+                }
+
+                return new ValueTask<int>(OpenConnections);
+            });
+
+            probe.ProbeMaxConnectionsAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+            {
+                Interlocked.Increment(ref _maxProbes);
+                return new ValueTask<int?>(MaxConnections);
+            });
+
+            Store = store;
+        }
+
+        public IMessageStore Store { get; }
+        public IDisposable? Registration { get; set; }
+
+        public int Fetches => Volatile.Read(ref _fetches);
+        public int ConnectionCounts => Volatile.Read(ref _connectionCounts);
+        public int MaxProbes => Volatile.Read(ref _maxProbes);
+
+        public int OpenConnections { get; set; } = 10;
+        public int? MaxConnections { get; set; } = 100;
+        public bool FailConnectionCount { get; set; }
+    }
+
+    // Deliberately a real implementation rather than a substitute: ConnectionBudget is a default
+    // interface member, and this proves an observer that never heard of it still compiles and runs.
+    private class BudgetRecordingObserver : IWolverineObserver
+    {
+        private readonly List<ConnectionBudgetSnapshot> _snapshots = [];
+
+        public void ConnectionBudget(ConnectionBudgetSnapshot snapshot)
+        {
+            lock (_snapshots) _snapshots.Add(snapshot);
+        }
+
+        public IReadOnlyList<ConnectionBudgetSnapshot> SnapshotsFor(DatabaseServerId server)
+        {
+            lock (_snapshots) return _snapshots.Where(x => x.Server == server).ToList();
+        }
+
+        public Task AssumedLeadership() => Task.CompletedTask;
+        public Task NodeStarted() => Task.CompletedTask;
+        public Task NodeStopped() => Task.CompletedTask;
+        public Task AgentStarted(Uri agentUri) => Task.CompletedTask;
+        public Task AgentStopped(Uri agentUri) => Task.CompletedTask;
+        public Task AssignmentsChanged(AssignmentGrid grid, AgentCommands commands) => Task.CompletedTask;
+        public Task StaleNodes(IReadOnlyList<WolverineNode> staleNodes) => Task.CompletedTask;
+        public Task RuntimeIsFullyStarted() => Task.CompletedTask;
+        public void EndpointAdded(Endpoint endpoint) { }
+        public void MessageRouted(Type messageType, IMessageRouter router) { }
+        public Task BackPressureTriggered(Endpoint endpoint, IListeningAgent agent) => Task.CompletedTask;
+        public Task BackPressureLifted(Endpoint endpoint) => Task.CompletedTask;
+        public Task ListenerLatched(Endpoint endpoint) => Task.CompletedTask;
+        public Task CircuitBreakerTripped(Endpoint endpoint, CircuitBreakerOptions options) => Task.CompletedTask;
+        public Task CircuitBreakerReset(Endpoint endpoint) => Task.CompletedTask;
+        public void PersistedCounts(Uri storeUri, PersistedCounts counts) { }
+        public void MessageHandlingMetricsExported(MessageHandlingMetrics metrics) { }
+    }
+}

--- a/src/Testing/CoreTests/Persistence/connection_budgets_tests.cs
+++ b/src/Testing/CoreTests/Persistence/connection_budgets_tests.cs
@@ -1,0 +1,149 @@
+using JasperFx.Descriptors;
+using Shouldly;
+using Wolverine.Persistence;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+public class connection_budgets_tests
+{
+    private readonly ConnectionBudgets theBudgets = new();
+
+    [Fact]
+    public void no_budget_for_an_unknown_server()
+    {
+        theBudgets.MaxFor(new DatabaseServerId("PostgreSQL", "shard-a", 5432)).ShouldBeNull();
+        theBudgets.HasAny.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void find_the_budget_for_a_server_by_host_and_port()
+    {
+        theBudgets
+            .ForServer("shard-a", 5432, 400)
+            .ForServer("shard-b", 5432, 200);
+
+        theBudgets.MaxFor(new DatabaseServerId("PostgreSQL", "shard-a", 5432)).ShouldBe(400);
+        theBudgets.MaxFor(new DatabaseServerId("PostgreSQL", "shard-b", 5432)).ShouldBe(200);
+    }
+
+    [Fact]
+    public void the_port_is_part_of_the_key()
+    {
+        // Two clusters co-hosted on one box. Keying on the host alone would collide them onto a
+        // single budget — the gap that made the port part of DatabaseServerId in the first place.
+        theBudgets
+            .ForServer("localhost", 5432, 400)
+            .ForServer("localhost", 5433, 100);
+
+        theBudgets.MaxFor(new DatabaseServerId("PostgreSQL", "localhost", 5432)).ShouldBe(400);
+        theBudgets.MaxFor(new DatabaseServerId("PostgreSQL", "localhost", 5433)).ShouldBe(100);
+    }
+
+    [Fact]
+    public void host_names_are_matched_case_insensitively()
+    {
+        theBudgets.ForServer("Shard-A", 5432, 400);
+
+        theBudgets.MaxFor(new DatabaseServerId("PostgreSQL", "shard-a", 5432)).ShouldBe(400);
+    }
+
+    [Fact]
+    public void a_portless_registration_covers_the_whole_host()
+    {
+        // How SQL Server registers: its Data Source already carries the port or named instance, so
+        // DatabaseServerId leaves Port null.
+        theBudgets.ForServer("sql-1,1433", 500);
+
+        theBudgets.MaxFor(new DatabaseServerId("SqlServer", "sql-1,1433", null)).ShouldBe(500);
+    }
+
+    [Fact]
+    public void an_exact_match_beats_a_host_wide_registration()
+    {
+        theBudgets
+            .ForServer("shard-a", 250)
+            .ForServer("shard-a", 5432, 400);
+
+        theBudgets.MaxFor(new DatabaseServerId("PostgreSQL", "shard-a", 5432)).ShouldBe(400);
+
+        // ...and the host-wide budget still covers the other ports on that host.
+        theBudgets.MaxFor(new DatabaseServerId("PostgreSQL", "shard-a", 5433)).ShouldBe(250);
+    }
+
+    [Fact]
+    public void the_last_registration_for_a_server_wins()
+    {
+        theBudgets
+            .ForServer("shard-a", 5432, 400)
+            .ForServer("shard-a", 5432, 150);
+
+        theBudgets.MaxFor(new DatabaseServerId("PostgreSQL", "shard-a", 5432)).ShouldBe(150);
+    }
+
+    [Fact]
+    public void reject_a_nonsense_budget()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => theBudgets.ForServer("shard-a", 5432, 0));
+        Should.Throw<ArgumentOutOfRangeException>(() => theBudgets.ForServer("shard-a", 5432, -1));
+        Should.Throw<ArgumentException>(() => theBudgets.ForServer("", 5432, 100));
+    }
+
+    [Fact]
+    public void off_by_default_for_a_single_database()
+    {
+        // A per-server budget tells you nothing a per-database count doesn't when there's only the
+        // one database. No probe, no cost.
+        theBudgets.IsActive(DatabaseCardinality.Single).ShouldBeFalse();
+        theBudgets.IsActive(DatabaseCardinality.None).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void on_for_the_sharded_shape()
+    {
+        // Marten's MultiTenantedWithShardedDatabases — many databases, few servers. The shape the
+        // whole feature exists for.
+        theBudgets.IsActive(DatabaseCardinality.StaticMultiple).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void declaring_a_budget_is_itself_an_opt_in()
+    {
+        theBudgets.ForServer("shard-a", 5432, 400);
+
+        theBudgets.IsActive(DatabaseCardinality.Single).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void an_explicit_setting_overrides_the_automatic_rule_in_both_directions()
+    {
+        theBudgets.Enabled = false;
+        theBudgets.ForServer("shard-a", 5432, 400);
+        theBudgets.IsActive(DatabaseCardinality.StaticMultiple).ShouldBeFalse();
+
+        theBudgets.Enabled = true;
+        theBudgets.IsActive(DatabaseCardinality.Single).ShouldBeTrue();
+    }
+}
+
+public class database_server_id_tests
+{
+    [Fact]
+    public void the_port_makes_co_hosted_clusters_distinct()
+    {
+        new DatabaseServerId("PostgreSQL", "localhost", 5432)
+            .ShouldNotBe(new DatabaseServerId("PostgreSQL", "localhost", 5433));
+    }
+
+    [Fact]
+    public void render_host_and_port_for_the_metric_tag()
+    {
+        new DatabaseServerId("PostgreSQL", "shard-a", 5432).ToString().ShouldBe("shard-a:5432");
+    }
+
+    [Fact]
+    public void render_the_bare_server_name_when_the_port_is_folded_into_it()
+    {
+        new DatabaseServerId("SqlServer", @"sql-1\SQLEXPRESS", null).ToString().ShouldBe(@"sql-1\SQLEXPRESS");
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -1,6 +1,7 @@
 using JasperFx.Core;
 using JasperFx.Descriptors;
 using JasperFx.MultiTenancy;
+using Wolverine.Persistence;
 
 namespace Wolverine;
 
@@ -283,6 +284,20 @@ public class DurabilitySettings : IDescribeMyself
     /// Is the polling for durability metrics enabled? Default is true
     /// </summary>
     public bool DurabilityMetricsEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Declares how many connections this application may take against each database server, and
+    /// surfaces how many are actually in use. Rides the same sweep as the durability metrics, so
+    /// it is silent unless <see cref="DurabilityMetricsEnabled"/> is true. See #3397.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// opts.Durability.ConnectionBudgets
+    ///     .ForServer("pg-shard-a", 5432, maxConnections: 400)
+    ///     .ForServer("pg-shard-b", 5432, maxConnections: 200);
+    /// </code>
+    /// </example>
+    public ConnectionBudgets ConnectionBudgets { get; } = new();
 
     /// <summary>
     /// If DeadLetterQueueExpirationEnabled is true, this governs how long persisted

--- a/src/Wolverine/MetricsConstants.cs
+++ b/src/Wolverine/MetricsConstants.cs
@@ -11,10 +11,16 @@ public class MetricsConstants
 
     public const string Milliseconds = "Milliseconds";
     public const string Messages = "Messages";
+    public const string Connections = "Connections";
 
     public const string InboxCount = "wolverine-inbox-count";
     public const string OutboxCount = "wolverine-outbox-count";
     public const string ScheduledCount = "wolverine-scheduled-count";
+
+    // Connection budget, tagged by ServerKey. Server-scoped rather than database-scoped: the
+    // connections are a resource of the server, shared by every database on it. See #3397.
+    public const string DatabaseConnectionCount = "wolverine-database-connection-count";
+    public const string DatabaseConnectionBudget = "wolverine-database-connection-budget";
 
     public const string MessageTypeKey = "message.type";
     public const string MessageDestinationKey = "message.destination";
@@ -24,4 +30,5 @@ public class MetricsConstants
     public const string ExceptionType = "exception.type";
     public const string SourceKey = "source";
     public const string DatabaseKey = "database";
+    public const string ServerKey = "server";
 }

--- a/src/Wolverine/Persistence/ConnectionBudgetMetrics.cs
+++ b/src/Wolverine/Persistence/ConnectionBudgetMetrics.cs
@@ -1,0 +1,67 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using Wolverine.Runtime;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Publishes the per-server connection budget as OpenTelemetry gauges. One instrument pair covers
+/// every server, sliced by the <c>server</c> tag, so a deployment that spans shards with different
+/// budgets stays queryable as one series. See wolverine#3397.
+/// </summary>
+internal class ConnectionBudgetMetrics
+{
+    private readonly ConcurrentDictionary<DatabaseServerId, ConnectionBudgetSnapshot> _snapshots = new();
+    private readonly string _serviceName;
+
+    // Held so the meter keeps the instruments alive for the life of the runtime; the callbacks are
+    // what actually do the work on each export.
+    private readonly ObservableGauge<int> _used;
+    private readonly ObservableGauge<int> _budget;
+
+    public ConnectionBudgetMetrics(IWolverineRuntime runtime)
+    {
+        _serviceName = runtime.Options.ServiceName;
+
+        _used = runtime.Meter.CreateObservableGauge(MetricsConstants.DatabaseConnectionCount,
+            observeUsed, MetricsConstants.Connections, "Connections currently open on the database server");
+
+        _budget = runtime.Meter.CreateObservableGauge(MetricsConstants.DatabaseConnectionBudget,
+            observeBudget, MetricsConstants.Connections, "Connection budget for the database server");
+    }
+
+    public void Update(ConnectionBudgetSnapshot snapshot)
+    {
+        _snapshots[snapshot.Server] = snapshot;
+    }
+
+    private IEnumerable<Measurement<int>> observeUsed()
+    {
+        foreach (var snapshot in _snapshots.Values)
+        {
+            yield return new Measurement<int>(snapshot.Used, tagsFor(snapshot.Server));
+        }
+    }
+
+    private IEnumerable<Measurement<int>> observeBudget()
+    {
+        foreach (var snapshot in _snapshots.Values)
+        {
+            // A server whose budget is Unknown emits no budget measurement at all. Emitting a zero
+            // or a sentinel would be worse than silence: a dashboard would happily chart it as a
+            // real limit and compute a utilization of infinity against it.
+            if (snapshot.Max is null) continue;
+
+            yield return new Measurement<int>(snapshot.Max.Value, tagsFor(snapshot.Server));
+        }
+    }
+
+    private KeyValuePair<string, object?>[] tagsFor(DatabaseServerId server)
+    {
+        return
+        [
+            new KeyValuePair<string, object?>(MetricsConstants.SourceKey, _serviceName),
+            new KeyValuePair<string, object?>(MetricsConstants.ServerKey, server.ToString())
+        ];
+    }
+}

--- a/src/Wolverine/Persistence/ConnectionBudgetSnapshot.cs
+++ b/src/Wolverine/Persistence/ConnectionBudgetSnapshot.cs
@@ -1,0 +1,54 @@
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Where the <see cref="ConnectionBudgetSnapshot.Max"/> side of a connection budget came from.
+/// </summary>
+public enum ConnectionBudgetSource
+{
+    /// <summary>
+    /// Declared by the application through <see cref="ConnectionBudgets.ForServer(string,int,int)"/>. This is the
+    /// authoritative source: behind a pooler (pgBouncer et al.) the server's own
+    /// <c>max_connections</c> says nothing about how many connections the *application* may take.
+    /// </summary>
+    Configured,
+
+    /// <summary>
+    /// Read off the server itself (<c>max_connections</c> / <c>@@MAX_CONNECTIONS</c>) because
+    /// nothing was configured for this server. A fallback, and labelled as one so operators can
+    /// tell a declared budget from a guessed one.
+    /// </summary>
+    Probed,
+
+    /// <summary>
+    /// No budget could be established — nothing configured, and the probe for the server's own
+    /// limit failed or was denied (SQL Server's <c>VIEW SERVER STATE</c> is a common casualty of
+    /// locked-down hosting). <see cref="ConnectionBudgetSnapshot.Used"/> is still meaningful;
+    /// <see cref="ConnectionBudgetSnapshot.Max"/> is null and no utilization can be computed.
+    /// </summary>
+    Unknown
+}
+
+/// <summary>
+/// A single observation of one database server's connection budget, published once per server per
+/// metrics sweep. See wolverine#3397.
+/// </summary>
+/// <param name="Server">The server this budget belongs to.</param>
+/// <param name="Used">
+/// Connections currently open on the server, across *all* applications — this is a server-scoped
+/// resource, so the number deliberately is not Wolverine-only. Behind a transaction-pooling
+/// pgBouncer it counts pooler-to-server backends, not client sessions.
+/// </param>
+/// <param name="Max">The budget, or null when <paramref name="Source"/> is <see cref="ConnectionBudgetSource.Unknown"/>.</param>
+/// <param name="Source">Where <paramref name="Max"/> came from.</param>
+public record ConnectionBudgetSnapshot(
+    DatabaseServerId Server,
+    int Used,
+    int? Max,
+    ConnectionBudgetSource Source)
+{
+    /// <summary>
+    /// Used/Max as a fraction, or null when there is no known budget to measure against. The
+    /// hysteresis thresholds of the (not yet shipped) adaptive back-off phase key off this.
+    /// </summary>
+    public double? Utilization => Max is > 0 ? Used / (double)Max.Value : null;
+}

--- a/src/Wolverine/Persistence/ConnectionBudgets.cs
+++ b/src/Wolverine/Persistence/ConnectionBudgets.cs
@@ -1,0 +1,127 @@
+using JasperFx.Descriptors;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Declares the connection budget for each database server this application talks to, and decides
+/// whether the budget machinery runs at all. Reached through
+/// <see cref="DurabilitySettings.ConnectionBudgets"/>. See wolverine#3397.
+/// </summary>
+/// <remarks>
+/// The <c>max</c> side of the budget is configuration rather than a probed <c>max_connections</c>
+/// on purpose. Any pooler in front of the database — pgBouncer being the common one — makes the
+/// server's own limit a poor description of what the application is allowed to take, so the budget
+/// is declared and the probe supplies only the <c>used</c> side.
+/// </remarks>
+public class ConnectionBudgets
+{
+    private readonly List<Registration> _registrations = new();
+
+    private sealed record Registration(string ServerName, int? Port, int MaxConnections);
+
+    /// <summary>
+    /// Force the connection-budget probing on or off. Leave null (the default) to let Wolverine
+    /// decide: probing is on when the message stores span statically-known multiple databases
+    /// (Marten's <c>MultiTenantedWithShardedDatabases</c> — the many-databases-per-server shape
+    /// that per-server budgeting exists to serve), or when any budget has been declared below.
+    /// </summary>
+    public bool? Enabled { get; set; }
+
+    /// <summary>
+    /// Declare the connection budget for a server that carries its port separately — PostgreSQL.
+    /// The port is part of the key, so two clusters co-hosted on one box get their own budgets.
+    /// </summary>
+    /// <param name="serverName">The host, as it appears in the connection string.</param>
+    /// <param name="port">The port, as it appears in the connection string.</param>
+    /// <param name="maxConnections">How many connections this application may take against the server.</param>
+    public ConnectionBudgets ForServer(string serverName, int port, int maxConnections)
+    {
+        return register(serverName, port, maxConnections);
+    }
+
+    /// <summary>
+    /// Declare the connection budget for a server addressed by name alone. Use this for SQL Server,
+    /// whose <c>Data Source</c> already carries the port or named instance
+    /// (<c>host,1433</c> / <c>host\SQLEXPRESS</c>) — pass that string verbatim.
+    /// </summary>
+    /// <remarks>
+    /// For PostgreSQL this registers a *host-wide* budget covering every port on the host. An exact
+    /// host+port registration always wins over it.
+    /// </remarks>
+    public ConnectionBudgets ForServer(string serverName, int maxConnections)
+    {
+        return register(serverName, null, maxConnections);
+    }
+
+    private ConnectionBudgets register(string serverName, int? port, int maxConnections)
+    {
+        if (string.IsNullOrWhiteSpace(serverName))
+        {
+            throw new ArgumentException("The server name is required", nameof(serverName));
+        }
+
+        if (maxConnections <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxConnections), maxConnections,
+                "The connection budget must be greater than zero.");
+        }
+
+        // Last registration wins, so re-declaring a server (say, from a later configuration
+        // callback) overrides rather than silently ending up with two budgets for one key.
+        _registrations.RemoveAll(x =>
+            string.Equals(x.ServerName, serverName, StringComparison.OrdinalIgnoreCase) && x.Port == port);
+
+        _registrations.Add(new Registration(serverName, port, maxConnections));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Any budget declared at all?
+    /// </summary>
+    public bool HasAny => _registrations.Count > 0;
+
+    /// <summary>
+    /// The declared budget for a server, or null when nothing covers it. An exact host+port match
+    /// wins over a host-wide registration.
+    /// </summary>
+    public int? MaxFor(DatabaseServerId server)
+    {
+        var exact = _registrations.FirstOrDefault(x =>
+            string.Equals(x.ServerName, server.ServerName, StringComparison.OrdinalIgnoreCase)
+            && x.Port == server.Port);
+
+        if (exact is not null)
+        {
+            return exact.MaxConnections;
+        }
+
+        var hostWide = _registrations.FirstOrDefault(x =>
+            string.Equals(x.ServerName, server.ServerName, StringComparison.OrdinalIgnoreCase)
+            && x.Port is null);
+
+        return hostWide?.MaxConnections;
+    }
+
+    /// <summary>
+    /// Should the metrics sweeper probe connection budgets in this application?
+    /// </summary>
+    internal bool IsActive(DatabaseCardinality cardinality)
+    {
+        if (Enabled.HasValue)
+        {
+            return Enabled.Value;
+        }
+
+        // Declaring a budget is itself an opt-in — an operator who names a server's limit wants to
+        // see it tracked, whatever the tenancy shape.
+        if (HasAny)
+        {
+            return true;
+        }
+
+        // Otherwise only the many-databases-on-one-server shape, where a per-server budget tells
+        // you something a per-database count cannot. A single database has nothing to aggregate.
+        return cardinality == DatabaseCardinality.StaticMultiple;
+    }
+}

--- a/src/Wolverine/Persistence/DatabaseServerId.cs
+++ b/src/Wolverine/Persistence/DatabaseServerId.cs
@@ -1,0 +1,28 @@
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Identifies a database *server* — as opposed to a logical database. Connections are a
+/// server-scoped resource, so any budgeting of them has to be keyed here rather than by
+/// <see cref="JasperFx.Descriptors.DatabaseId"/>: in a sharded-tenancy deployment, hundreds of
+/// tenant databases can share one server and one connection budget.
+/// </summary>
+/// <param name="Engine">Matches <see cref="JasperFx.Descriptors.DatabaseDescriptor.Engine"/>, e.g. "PostgreSQL".</param>
+/// <param name="ServerName">The host. Matches <see cref="JasperFx.Descriptors.DatabaseDescriptor.ServerName"/>.</param>
+/// <param name="Port">
+/// Null when the engine folds the port into <paramref name="ServerName"/> — SQL Server's
+/// <c>Data Source</c> already carries the port (<c>host,1433</c>) or a named instance
+/// (<c>host\SQLEXPRESS</c>), so splitting it back out would only invent ambiguity. PostgreSQL
+/// carries the port separately, and it matters: without it, two clusters co-hosted on one box
+/// collide onto a single budget.
+/// </param>
+public readonly record struct DatabaseServerId(string Engine, string ServerName, int? Port)
+{
+    /// <summary>
+    /// The value used as the <c>server</c> metric tag and in diagnostic output. The engine is
+    /// deliberately left out — a host:port pair is already unique, and operators recognize it.
+    /// </summary>
+    public override string ToString()
+    {
+        return Port.HasValue ? $"{ServerName}:{Port}" : ServerName;
+    }
+}

--- a/src/Wolverine/Persistence/IConnectionBudgetProbe.cs
+++ b/src/Wolverine/Persistence/IConnectionBudgetProbe.cs
@@ -1,0 +1,34 @@
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Optional capability for a message store whose backing engine can report how many connections
+/// are currently open against its *server*. Implemented alongside
+/// <see cref="Durability.IMessageStore"/> — the metrics sweeper looks for it and skips stores that
+/// don't have it, so a provider without a cheap server-wide connection count simply doesn't
+/// participate. See wolverine#3397.
+/// </summary>
+public interface IConnectionBudgetProbe
+{
+    /// <summary>
+    /// The server this store lives on. Many stores share one <see cref="DatabaseServerId"/> in a
+    /// sharded deployment; the sweeper dedupes on it so the probe runs once per server per pass
+    /// no matter how many tenant databases this node happens to own.
+    /// </summary>
+    DatabaseServerId ServerId { get; }
+
+    /// <summary>
+    /// Count the connections currently open on the server. Must be one cheap query — it runs every
+    /// metrics sweep, and a probe that is itself expensive under connection pressure would be
+    /// making the problem it measures worse.
+    /// </summary>
+    ValueTask<int> CountServerConnectionsAsync(CancellationToken token);
+
+    /// <summary>
+    /// Read the server's own connection limit, for use only when the application hasn't declared a
+    /// budget for this server. Return null when the value can't be read (e.g. SQL Server without
+    /// <c>VIEW SERVER STATE</c>), which surfaces as <see cref="ConnectionBudgetSource.Unknown"/>
+    /// rather than an error. Callers invoke this at most once per server per process — the limit
+    /// doesn't move at runtime.
+    /// </summary>
+    ValueTask<int?> ProbeMaxConnectionsAsync(CancellationToken token);
+}

--- a/src/Wolverine/Persistence/PersistenceMetricsSweeper.cs
+++ b/src/Wolverine/Persistence/PersistenceMetricsSweeper.cs
@@ -33,10 +33,26 @@ public class PersistenceMetricsSweeper
     private readonly object _startLock = new();
     private Task? _loop;
 
+    // Connection-budget state (#3397). Only ever touched from the single sweep loop, so a plain
+    // Dictionary is right — no concurrency to defend against.
+    private readonly Dictionary<DatabaseServerId, ServerBudgetState> _servers = new();
+    private ConnectionBudgetMetrics? _budgetMetrics;
+
     private PersistenceMetricsSweeper(IWolverineRuntime runtime)
     {
         _runtime = runtime;
         _logger = runtime.LoggerFactory.CreateLogger<PersistenceMetricsSweeper>();
+    }
+
+    private sealed class ServerBudgetState
+    {
+        /// <summary>The server's own limit, read at most once per process — it doesn't move at runtime.</summary>
+        public int? ProbedMax { get; set; }
+
+        public bool HasProbedMax { get; set; }
+
+        /// <summary>Latches the "couldn't count connections" log so a persistently failing probe doesn't flood.</summary>
+        public bool CountFailureLogged { get; set; }
     }
 
     // A class, not a record: unregistration removes the exact registration *instance* it
@@ -108,6 +124,12 @@ public class PersistenceMetricsSweeper
                 continue;
             }
 
+            // Connection budgets first, and deliberately outside the deadline window below: this is
+            // one query per *server*, not per database, so it costs a fixed handful of queries no
+            // matter how many tenant databases this node owns. Doing it before passStart leaves the
+            // database pacing exactly as it was.
+            await probeConnectionBudgetsAsync(pass, cancellation).ConfigureAwait(false);
+
             // One database at a time, paced against deadlines so the pass fills the
             // UpdateMetricsPeriod window: at most one metrics query (and its pooled
             // connection) is in flight per node. Each store's next-poll target is
@@ -142,6 +164,145 @@ public class PersistenceMetricsSweeper
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Probe each distinct database server behind this pass's registrations exactly once and publish
+    /// its connection budget. The dedupe is the entire point: in the sharded-tenancy deployment this
+    /// exists for (#3397), a node can own hundreds of tenant databases that all live on a handful of
+    /// servers, and connections are a resource of the server. Probing per database would multiply
+    /// the very pressure the number is meant to reveal.
+    /// </summary>
+    private async Task probeConnectionBudgetsAsync(Registration[] pass, CancellationToken cancellation)
+    {
+        var budgets = _runtime.Options.Durability.ConnectionBudgets;
+        if (!budgets.IsActive(_runtime.Stores.Cardinality()))
+        {
+            return;
+        }
+
+        // Distinct servers, not distinct stores. A provider with no cheap server-wide connection
+        // count simply doesn't implement the probe and drops out here.
+        var probes = pass
+            .Select(x => x.Store)
+            .OfType<IConnectionBudgetProbe>()
+            .GroupBy(x => x.ServerId)
+            .ToArray();
+
+        if (probes.Length == 0)
+        {
+            return;
+        }
+
+        _budgetMetrics ??= new ConnectionBudgetMetrics(_runtime);
+
+        foreach (var group in probes)
+        {
+            cancellation.ThrowIfCancellationRequested();
+
+            var serverId = group.Key;
+
+            // Any one of the stores on this server can answer for it; they share the connection
+            // pool's destination. Take the first — if it's unhealthy the whole server is suspect
+            // anyway, and that's a signal, not an accident.
+            var probe = group.First();
+
+            if (!_servers.TryGetValue(serverId, out var state))
+            {
+                state = new ServerBudgetState();
+                _servers[serverId] = state;
+            }
+
+            int used;
+            try
+            {
+                used = await probe.CountServerConnectionsAsync(cancellation).ConfigureAwait(false);
+                state.CountFailureLogged = false;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                // Phase 1 is observability only, so a failed probe publishes nothing and the sweep
+                // carries on. (The adaptive phase will read repeated failure here as *maximal*
+                // pressure rather than missing data — a probe that cannot get a connection is the
+                // strongest signal there is. Deliberately not acted on yet.)
+                if (!state.CountFailureLogged)
+                {
+                    state.CountFailureLogged = true;
+                    _logger.LogWarning(e,
+                        "Unable to count the open connections on database server {Server}. The connection budget for this server will not be reported until the probe succeeds.",
+                        serverId);
+                }
+
+                continue;
+            }
+
+            var (max, source) = await resolveBudgetAsync(serverId, probe, state, budgets, cancellation)
+                .ConfigureAwait(false);
+
+            var snapshot = new ConnectionBudgetSnapshot(serverId, used, max, source);
+
+            _budgetMetrics.Update(snapshot);
+
+            try
+            {
+                _runtime.Observer.ConnectionBudget(snapshot);
+            }
+            catch (Exception e)
+            {
+                // A misbehaving observer must not take down the metrics sweep for every database
+                // on the node.
+                _logger.LogError(e, "Error publishing the connection budget for database server {Server}", serverId);
+            }
+        }
+    }
+
+    private async ValueTask<(int? Max, ConnectionBudgetSource Source)> resolveBudgetAsync(
+        DatabaseServerId serverId,
+        IConnectionBudgetProbe probe,
+        ServerBudgetState state,
+        ConnectionBudgets budgets,
+        CancellationToken cancellation)
+    {
+        // Configuration wins, always. Behind a pooler the server's own max_connections describes
+        // what the *pooler* may open, not what this application is entitled to — so a declared
+        // budget is the only one that means anything in that topology.
+        var configured = budgets.MaxFor(serverId);
+        if (configured.HasValue)
+        {
+            return (configured.Value, ConnectionBudgetSource.Configured);
+        }
+
+        if (!state.HasProbedMax)
+        {
+            state.HasProbedMax = true;
+
+            try
+            {
+                state.ProbedMax = await probe.ProbeMaxConnectionsAsync(cancellation).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Leave HasProbedMax latched false-ish for the next pass rather than caching a
+                // shutdown as a permanent "unknown".
+                state.HasProbedMax = false;
+                throw;
+            }
+            catch (Exception e)
+            {
+                state.ProbedMax = null;
+                _logger.LogWarning(e,
+                    "Unable to read the connection limit from database server {Server}. Reporting its connection budget as unknown. Declare one explicitly with Durability.ConnectionBudgets.ForServer(...) to get a utilization reading.",
+                    serverId);
+            }
+        }
+
+        return state.ProbedMax.HasValue
+            ? (state.ProbedMax, ConnectionBudgetSource.Probed)
+            : (null, ConnectionBudgetSource.Unknown);
     }
 
     private sealed class Unregistration : IDisposable

--- a/src/Wolverine/Runtime/Agents/IWolverineObserver.cs
+++ b/src/Wolverine/Runtime/Agents/IWolverineObserver.cs
@@ -2,6 +2,7 @@ using JasperFx.Events;
 using Wolverine.Configuration;
 using Wolverine.ErrorHandling;
 using Wolverine.Logging;
+using Wolverine.Persistence;
 using Wolverine.Runtime.Metrics;
 using Wolverine.Runtime.Routing;
 using Wolverine.Transports;
@@ -62,6 +63,20 @@ public interface IWolverineObserver
     /// existing observers are unaffected.
     /// </summary>
     void EventsAppended(IReadOnlyList<IEvent> events)
+    {
+        // Default no-op implementation
+    }
+
+    /// <summary>
+    /// Called once per database *server* per metrics sweep with the connections currently open on
+    /// it and the budget they're measured against. A sibling of <see cref="PersistedCounts"/> rather
+    /// than a member of it, because connections are a server-scoped resource while the envelope
+    /// counts are database-scoped — in a sharded deployment many databases report against one
+    /// budget. Only fired when the budget machinery is active (see
+    /// <c>DurabilitySettings.ConnectionBudgets</c>). Default no-op so existing observers are
+    /// unaffected. See #3397.
+    /// </summary>
+    void ConnectionBudget(ConnectionBudgetSnapshot snapshot)
     {
         // Default no-op implementation
     }


### PR DESCRIPTION
Phase 1 of [#3397](https://github.com/JasperFx/wolverine/issues/3397) — **measure and surface only**. Wolverine reports database connection pressure; it does not yet react to it. Targets 6.19.0.

## Why per-*server*

Connections are a resource of the database **server**, not of a logical database. That distinction is invisible when an app talks to one database, and load-bearing in the deployment #3397 comes from: ~512 tenant databases spread over a handful of Postgres clusters, every node drawing on the same finite pool. The reporter's actual failure was a schema-apply job that couldn't get a connection.

So the budget is keyed by server, and — critically — the probe is **deduped by server**: one query per server per metrics sweep, however many tenant databases the node happens to own. A node owning 200 databases across 2 servers issues 2 probes per sweep, not 200. Probing per database would multiply the very pressure the number exists to reveal. There's a test that pins this.

## What's here

| | |
|---|---|
| `DatabaseServerId` | Keys the budget by (engine, host, port). `DatabaseDescriptor.ServerName` is **host-only**, so two clusters co-hosted on one box would otherwise collide onto one budget. SQL Server leaves `Port` null — its `Data Source` already carries the port or named instance. |
| `IConnectionBudgetProbe` | Optional store capability. Implemented for PostgreSQL (`sum(numbackends)`) and SQL Server (`sys.dm_exec_connections`). Providers without a cheap server-wide count don't implement it and drop out. |
| `ConnectionBudgets` | Fluent per-server config on `DurabilitySettings`. |
| `ConnectionBudgetSnapshot` | Published per server per sweep via a new **default no-op** `IWolverineObserver.ConnectionBudget` — existing observers (incl. CritterWatch) are unaffected. |
| OTel | `wolverine-database-connection-count` / `-budget`, tagged by `server`. |

```csharp
opts.Durability.ConnectionBudgets
    .ForServer("pg-shard-a", 5432, maxConnections: 400)
    .ForServer("pg-shard-b", 5432, maxConnections: 200);
```

## The one design decision worth arguing about

**The max side is explicit configuration, not the probed `max_connections`.** Behind a pooler (pgBouncer et al.) the server's limit describes what *the pooler* may open, not what the application is entitled to take — charting utilization against it would be reassuring and wrong. A probed limit is a clearly-labelled fallback when nothing is declared, and `Unknown` is reported honestly when neither exists. SQL Server without `VIEW SERVER STATE` degrades to a single warning per server, not a failed metrics sweep.

The used count is deliberately server-wide and **includes other applications** — that's the point (shared resource), but it's documented so nobody reads it as "connections Wolverine is using." The pooler caveat gets its own section in the docs, since `numbackends` behind a transaction-pooling pgBouncer means something quite different from what most people will assume.

## Activation

On automatically only for the statically-known-multiple-databases shape (Marten's `MultiTenantedWithShardedDatabases`) — where a per-server number tells you something a per-database count can't. Off for a single database. Declaring a budget is itself an opt-in, and `ConnectionBudgets.Enabled` forces it either way. Silent entirely when `DurabilityMetricsEnabled` is false.

## Not in scope

The **adaptive** half (back off polling/concurrency under pressure) is deliberately not here. The knobs #3397 names — `SlowPollingTime`/`FastPollingTime`, the #486 concurrency governors — live in JasperFx.Events' `DaemonSettings`, not Wolverine, so the back-off hooks have to ship in a JasperFx release. And it wants #3376 resolved first, since owned-agent scoping changes the baseline any tuning would work against. Phase 1 is independent of both, and happens to be the instrument that answers the connection-breakdown question still open on #3376 — which is why it ships first.

Workstream P resolved as **(b)**: SQL Server gets the probe plumbing and gauge parity now; activation follows Polecat's tenancy roadmap (it has no sharded-database tenancy today). No Polecat changes needed.

## Testing

22 new tests. `dotnet build wolverine.slnx -c Release` is clean.

- N databases on one server ⇒ 1 probe per pass (the definition-of-done assertion)
- 4 databases on server A + 1 on server B ⇒ both probed on the same cadence
- configured budget beats the server's own limit, which is then never even read
- probed fallback is read exactly once per process, not once per pass
- unknown budget reported honestly; utilization null
- a failing probe publishes nothing and leaves the rest of the sweep running
- the existing 5 `persistence_metrics_sweeper` tests still pass

Note: `CoreTests.Persistence` has 20 pre-existing `ClaimCheck` failures when the group is run together (verified identical on a clean `main`) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)