### PR TITLE
Add optimistic concurrency to CosmosDB saga persistence (GH-3414)

### DIFF
--- a/docs/guide/durability/cosmosdb.md
+++ b/docs/guide/durability/cosmosdb.md
@@ -94,6 +94,25 @@ and the ability to replay designated messages in the dead letter queue storage.
 The CosmosDB integration can serve as a [Wolverine Saga persistence mechanism](/guide/durability/sagas). The only limitation is that
 all saga identity values must be `string` types. The saga id is used as both the CosmosDB document id and partition key.
 
+### Optimistic Concurrency
+
+Saga writes are protected by optimistic concurrency. Wolverine captures the document's `ETag` when it reads the saga
+and passes it back as an `IfMatchEtag` on the subsequent write, so updating (or deleting, when the saga completes)
+a saga is a compare-and-swap rather than a blind upsert. If another message changed the same saga in between,
+CosmosDB rejects the write with a `412 Precondition Failed` and Wolverine raises a `SagaConcurrencyException`.
+Without this, two messages for one saga id arriving at the same time on two nodes would both read the same
+revision and the slower write would silently overwrite the faster one.
+
+Because a concurrency violation just means "you read a stale copy, go read it again", the usual response is to
+retry the message — the retry re-reads the saga and re-applies the change against the current state:
+
+```cs
+opts.Policies.OnException<SagaConcurrencyException>().RetryTimes(3);
+```
+
+If you do not configure a policy for it, `SagaConcurrencyException` is treated like any other unhandled exception
+and the message will eventually be moved to the dead letter queue.
+
 ## Transactional Middleware
 
 Wolverine's CosmosDB integration supports [transactional middleware](/guide/durability/marten/transactional-middleware)

--- a/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/CompleteFourHandler1230864511.cs
+++ b/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/CompleteFourHandler1230864511.cs
@@ -30,10 +30,13 @@ namespace Internal.Generated.WolverineHandlers
             
             // Try to load the existing saga document from CosmosDB
             Wolverine.ComplianceTests.Sagas.StringBasicWorkflow stringBasicWorkflow = default;
+            // Capture the ETag so the eventual write can be a compare-and-swap against this exact revision
+            string stringBasicWorkflow_Etag = null;
             try
             {
                 var _cosmosResponse = await _container.ReadItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, cancellationToken: cancellation).ConfigureAwait(false);
                 stringBasicWorkflow = _cosmosResponse.Resource;
+                stringBasicWorkflow_Etag = _cosmosResponse.ETag;
             }
             catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
@@ -47,6 +50,8 @@ namespace Internal.Generated.WolverineHandlers
             else
             {
                 context.SetSagaId(sagaId);
+                System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.id", sagaId.ToString());
+                System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.type", "Wolverine.ComplianceTests.Sagas.StringBasicWorkflow");
                 
                 // The actual message execution
                 stringBasicWorkflow.Handle(completeFour);
@@ -54,12 +59,32 @@ namespace Internal.Generated.WolverineHandlers
                 // Delete the saga if completed, otherwise update it
                 if (stringBasicWorkflow.IsCompleted())
                 {
-                    await _container.DeleteItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None).ConfigureAwait(false);
+                    try
+                    {
+                        await _container.DeleteItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, requestOptions: new Microsoft.Azure.Cosmos.ItemRequestOptions{ IfMatchEtag = stringBasicWorkflow_Etag }).ConfigureAwait(false);
+                    }
+
+                    catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                    {
+                        // The saga document was changed by another message since it was read
+                        throw new Wolverine.SagaConcurrencyException($"Saga of type Wolverine.ComplianceTests.Sagas.StringBasicWorkflow and id {sagaId} cannot be updated because of optimistic concurrency violations", e);
+                    }
+
                 }
 
                 else
                 {
-                    await _container.UpsertItemAsync(stringBasicWorkflow).ConfigureAwait(false);
+                    try
+                    {
+                        await _container.UpsertItemAsync(stringBasicWorkflow, requestOptions: new Microsoft.Azure.Cosmos.ItemRequestOptions{ IfMatchEtag = stringBasicWorkflow_Etag }).ConfigureAwait(false);
+                    }
+
+                    catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                    {
+                        // The saga document was changed by another message since it was read
+                        throw new Wolverine.SagaConcurrencyException($"Saga of type Wolverine.ComplianceTests.Sagas.StringBasicWorkflow and id {sagaId} cannot be updated because of optimistic concurrency violations", e);
+                    }
+
                 }
 
                 

--- a/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/CompleteOneHandler1612253335.cs
+++ b/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/CompleteOneHandler1612253335.cs
@@ -30,10 +30,13 @@ namespace Internal.Generated.WolverineHandlers
             
             // Try to load the existing saga document from CosmosDB
             Wolverine.ComplianceTests.Sagas.StringBasicWorkflow stringBasicWorkflow = default;
+            // Capture the ETag so the eventual write can be a compare-and-swap against this exact revision
+            string stringBasicWorkflow_Etag = null;
             try
             {
                 var _cosmosResponse = await _container.ReadItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, cancellationToken: cancellation).ConfigureAwait(false);
                 stringBasicWorkflow = _cosmosResponse.Resource;
+                stringBasicWorkflow_Etag = _cosmosResponse.ETag;
             }
             catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
@@ -47,6 +50,8 @@ namespace Internal.Generated.WolverineHandlers
             else
             {
                 context.SetSagaId(sagaId);
+                System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.id", sagaId.ToString());
+                System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.type", "Wolverine.ComplianceTests.Sagas.StringBasicWorkflow");
                 
                 // The actual message execution
                 var outgoing1 = stringBasicWorkflow.Handle(completeOne);
@@ -58,12 +63,32 @@ namespace Internal.Generated.WolverineHandlers
                 // Delete the saga if completed, otherwise update it
                 if (stringBasicWorkflow.IsCompleted())
                 {
-                    await _container.DeleteItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None).ConfigureAwait(false);
+                    try
+                    {
+                        await _container.DeleteItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, requestOptions: new Microsoft.Azure.Cosmos.ItemRequestOptions{ IfMatchEtag = stringBasicWorkflow_Etag }).ConfigureAwait(false);
+                    }
+
+                    catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                    {
+                        // The saga document was changed by another message since it was read
+                        throw new Wolverine.SagaConcurrencyException($"Saga of type Wolverine.ComplianceTests.Sagas.StringBasicWorkflow and id {sagaId} cannot be updated because of optimistic concurrency violations", e);
+                    }
+
                 }
 
                 else
                 {
-                    await _container.UpsertItemAsync(stringBasicWorkflow).ConfigureAwait(false);
+                    try
+                    {
+                        await _container.UpsertItemAsync(stringBasicWorkflow, requestOptions: new Microsoft.Azure.Cosmos.ItemRequestOptions{ IfMatchEtag = stringBasicWorkflow_Etag }).ConfigureAwait(false);
+                    }
+
+                    catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                    {
+                        // The saga document was changed by another message since it was read
+                        throw new Wolverine.SagaConcurrencyException($"Saga of type Wolverine.ComplianceTests.Sagas.StringBasicWorkflow and id {sagaId} cannot be updated because of optimistic concurrency violations", e);
+                    }
+
                 }
 
                 

--- a/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/CompleteTwoHandler402398939.cs
+++ b/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/CompleteTwoHandler402398939.cs
@@ -30,10 +30,13 @@ namespace Internal.Generated.WolverineHandlers
             
             // Try to load the existing saga document from CosmosDB
             Wolverine.ComplianceTests.Sagas.StringBasicWorkflow stringBasicWorkflow = default;
+            // Capture the ETag so the eventual write can be a compare-and-swap against this exact revision
+            string stringBasicWorkflow_Etag = null;
             try
             {
                 var _cosmosResponse = await _container.ReadItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, cancellationToken: cancellation).ConfigureAwait(false);
                 stringBasicWorkflow = _cosmosResponse.Resource;
+                stringBasicWorkflow_Etag = _cosmosResponse.ETag;
             }
             catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
@@ -47,6 +50,8 @@ namespace Internal.Generated.WolverineHandlers
             else
             {
                 context.SetSagaId(sagaId);
+                System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.id", sagaId.ToString());
+                System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.type", "Wolverine.ComplianceTests.Sagas.StringBasicWorkflow");
                 
                 // The actual message execution
                 stringBasicWorkflow.Handle(completeTwo);
@@ -54,12 +59,32 @@ namespace Internal.Generated.WolverineHandlers
                 // Delete the saga if completed, otherwise update it
                 if (stringBasicWorkflow.IsCompleted())
                 {
-                    await _container.DeleteItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None).ConfigureAwait(false);
+                    try
+                    {
+                        await _container.DeleteItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, requestOptions: new Microsoft.Azure.Cosmos.ItemRequestOptions{ IfMatchEtag = stringBasicWorkflow_Etag }).ConfigureAwait(false);
+                    }
+
+                    catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                    {
+                        // The saga document was changed by another message since it was read
+                        throw new Wolverine.SagaConcurrencyException($"Saga of type Wolverine.ComplianceTests.Sagas.StringBasicWorkflow and id {sagaId} cannot be updated because of optimistic concurrency violations", e);
+                    }
+
                 }
 
                 else
                 {
-                    await _container.UpsertItemAsync(stringBasicWorkflow).ConfigureAwait(false);
+                    try
+                    {
+                        await _container.UpsertItemAsync(stringBasicWorkflow, requestOptions: new Microsoft.Azure.Cosmos.ItemRequestOptions{ IfMatchEtag = stringBasicWorkflow_Etag }).ConfigureAwait(false);
+                    }
+
+                    catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                    {
+                        // The saga document was changed by another message since it was read
+                        throw new Wolverine.SagaConcurrencyException($"Saga of type Wolverine.ComplianceTests.Sagas.StringBasicWorkflow and id {sagaId} cannot be updated because of optimistic concurrency violations", e);
+                    }
+
                 }
 
                 

--- a/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/FinishItAllHandler1534262635.cs
+++ b/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/FinishItAllHandler1534262635.cs
@@ -30,10 +30,13 @@ namespace Internal.Generated.WolverineHandlers
             
             // Try to load the existing saga document from CosmosDB
             Wolverine.ComplianceTests.Sagas.StringBasicWorkflow stringBasicWorkflow = default;
+            // Capture the ETag so the eventual write can be a compare-and-swap against this exact revision
+            string stringBasicWorkflow_Etag = null;
             try
             {
                 var _cosmosResponse = await _container.ReadItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, cancellationToken: cancellation).ConfigureAwait(false);
                 stringBasicWorkflow = _cosmosResponse.Resource;
+                stringBasicWorkflow_Etag = _cosmosResponse.ETag;
             }
             catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
@@ -47,6 +50,8 @@ namespace Internal.Generated.WolverineHandlers
             else
             {
                 context.SetSagaId(sagaId);
+                System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.id", sagaId.ToString());
+                System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.type", "Wolverine.ComplianceTests.Sagas.StringBasicWorkflow");
                 
                 // The actual message execution
                 stringBasicWorkflow.Handle(finishItAll);
@@ -54,12 +59,32 @@ namespace Internal.Generated.WolverineHandlers
                 // Delete the saga if completed, otherwise update it
                 if (stringBasicWorkflow.IsCompleted())
                 {
-                    await _container.DeleteItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None).ConfigureAwait(false);
+                    try
+                    {
+                        await _container.DeleteItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, requestOptions: new Microsoft.Azure.Cosmos.ItemRequestOptions{ IfMatchEtag = stringBasicWorkflow_Etag }).ConfigureAwait(false);
+                    }
+
+                    catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                    {
+                        // The saga document was changed by another message since it was read
+                        throw new Wolverine.SagaConcurrencyException($"Saga of type Wolverine.ComplianceTests.Sagas.StringBasicWorkflow and id {sagaId} cannot be updated because of optimistic concurrency violations", e);
+                    }
+
                 }
 
                 else
                 {
-                    await _container.UpsertItemAsync(stringBasicWorkflow).ConfigureAwait(false);
+                    try
+                    {
+                        await _container.UpsertItemAsync(stringBasicWorkflow, requestOptions: new Microsoft.Azure.Cosmos.ItemRequestOptions{ IfMatchEtag = stringBasicWorkflow_Etag }).ConfigureAwait(false);
+                    }
+
+                    catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                    {
+                        // The saga document was changed by another message since it was read
+                        throw new Wolverine.SagaConcurrencyException($"Saga of type Wolverine.ComplianceTests.Sagas.StringBasicWorkflow and id {sagaId} cannot be updated because of optimistic concurrency violations", e);
+                    }
+
                 }
 
                 

--- a/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/StringCompleteThreeHandler606415888.cs
+++ b/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/StringCompleteThreeHandler606415888.cs
@@ -32,10 +32,13 @@ namespace Internal.Generated.WolverineHandlers
             
             // Try to load the existing saga document from CosmosDB
             Wolverine.ComplianceTests.Sagas.StringBasicWorkflow stringBasicWorkflow = default;
+            // Capture the ETag so the eventual write can be a compare-and-swap against this exact revision
+            string stringBasicWorkflow_Etag = null;
             try
             {
                 var _cosmosResponse = await _container.ReadItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, cancellationToken: cancellation).ConfigureAwait(false);
                 stringBasicWorkflow = _cosmosResponse.Resource;
+                stringBasicWorkflow_Etag = _cosmosResponse.ETag;
             }
             catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
@@ -49,6 +52,8 @@ namespace Internal.Generated.WolverineHandlers
             else
             {
                 context.SetSagaId(sagaId);
+                System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.id", sagaId.ToString());
+                System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.type", "Wolverine.ComplianceTests.Sagas.StringBasicWorkflow");
                 
                 // The actual message execution
                 stringBasicWorkflow.Handle(stringCompleteThree);
@@ -56,12 +61,32 @@ namespace Internal.Generated.WolverineHandlers
                 // Delete the saga if completed, otherwise update it
                 if (stringBasicWorkflow.IsCompleted())
                 {
-                    await _container.DeleteItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None).ConfigureAwait(false);
+                    try
+                    {
+                        await _container.DeleteItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, requestOptions: new Microsoft.Azure.Cosmos.ItemRequestOptions{ IfMatchEtag = stringBasicWorkflow_Etag }).ConfigureAwait(false);
+                    }
+
+                    catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                    {
+                        // The saga document was changed by another message since it was read
+                        throw new Wolverine.SagaConcurrencyException($"Saga of type Wolverine.ComplianceTests.Sagas.StringBasicWorkflow and id {sagaId} cannot be updated because of optimistic concurrency violations", e);
+                    }
+
                 }
 
                 else
                 {
-                    await _container.UpsertItemAsync(stringBasicWorkflow).ConfigureAwait(false);
+                    try
+                    {
+                        await _container.UpsertItemAsync(stringBasicWorkflow, requestOptions: new Microsoft.Azure.Cosmos.ItemRequestOptions{ IfMatchEtag = stringBasicWorkflow_Etag }).ConfigureAwait(false);
+                    }
+
+                    catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                    {
+                        // The saga document was changed by another message since it was read
+                        throw new Wolverine.SagaConcurrencyException($"Saga of type Wolverine.ComplianceTests.Sagas.StringBasicWorkflow and id {sagaId} cannot be updated because of optimistic concurrency violations", e);
+                    }
+
                 }
 
                 

--- a/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/StringDoThreeHandler1820069266.cs
+++ b/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/StringDoThreeHandler1820069266.cs
@@ -32,10 +32,13 @@ namespace Internal.Generated.WolverineHandlers
             
             // Try to load the existing saga document from CosmosDB
             Wolverine.ComplianceTests.Sagas.StringBasicWorkflow stringBasicWorkflow = default;
+            // Capture the ETag so the eventual write can be a compare-and-swap against this exact revision
+            string stringBasicWorkflow_Etag = null;
             try
             {
                 var _cosmosResponse = await _container.ReadItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, cancellationToken: cancellation).ConfigureAwait(false);
                 stringBasicWorkflow = _cosmosResponse.Resource;
+                stringBasicWorkflow_Etag = _cosmosResponse.ETag;
             }
             catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
@@ -49,6 +52,8 @@ namespace Internal.Generated.WolverineHandlers
             else
             {
                 context.SetSagaId(sagaId);
+                System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.id", sagaId.ToString());
+                System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.type", "Wolverine.ComplianceTests.Sagas.StringBasicWorkflow");
                 
                 // The actual message execution
                 stringBasicWorkflow.Handles(stringDoThree);
@@ -56,12 +61,32 @@ namespace Internal.Generated.WolverineHandlers
                 // Delete the saga if completed, otherwise update it
                 if (stringBasicWorkflow.IsCompleted())
                 {
-                    await _container.DeleteItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None).ConfigureAwait(false);
+                    try
+                    {
+                        await _container.DeleteItemAsync<Wolverine.ComplianceTests.Sagas.StringBasicWorkflow>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, requestOptions: new Microsoft.Azure.Cosmos.ItemRequestOptions{ IfMatchEtag = stringBasicWorkflow_Etag }).ConfigureAwait(false);
+                    }
+
+                    catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                    {
+                        // The saga document was changed by another message since it was read
+                        throw new Wolverine.SagaConcurrencyException($"Saga of type Wolverine.ComplianceTests.Sagas.StringBasicWorkflow and id {sagaId} cannot be updated because of optimistic concurrency violations", e);
+                    }
+
                 }
 
                 else
                 {
-                    await _container.UpsertItemAsync(stringBasicWorkflow).ConfigureAwait(false);
+                    try
+                    {
+                        await _container.UpsertItemAsync(stringBasicWorkflow, requestOptions: new Microsoft.Azure.Cosmos.ItemRequestOptions{ IfMatchEtag = stringBasicWorkflow_Etag }).ConfigureAwait(false);
+                    }
+
+                    catch (Microsoft.Azure.Cosmos.CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                    {
+                        // The saga document was changed by another message since it was read
+                        throw new Wolverine.SagaConcurrencyException($"Saga of type Wolverine.ComplianceTests.Sagas.StringBasicWorkflow and id {sagaId} cannot be updated because of optimistic concurrency violations", e);
+                    }
+
                 }
 
                 

--- a/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/StringStartHandler2085759971.cs
+++ b/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/StringStartHandler2085759971.cs
@@ -33,6 +33,8 @@ namespace Internal.Generated.WolverineHandlers
             stringBasicWorkflow.Start(stringStart);
 
             context.SetSagaId(stringStart.Id);
+            System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.id", stringStart.Id.ToString());
+            System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.type", "Wolverine.ComplianceTests.Sagas.StringBasicWorkflow");
             if (!stringBasicWorkflow.IsCompleted())
             {
                 await _container.UpsertItemAsync(stringBasicWorkflow).ConfigureAwait(false);

--- a/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/WildcardStartHandler784149372.cs
+++ b/src/Persistence/CosmosDbTests/Internal/Generated/WolverineHandlers/WildcardStartHandler784149372.cs
@@ -33,6 +33,8 @@ namespace Internal.Generated.WolverineHandlers
             stringBasicWorkflow.Starts(wildcardStart);
 
             context.SetSagaId(wildcardStart.Id);
+            System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.id", wildcardStart.Id.ToString());
+            System.Diagnostics.Activity.Current?.SetTag("wolverine.saga.type", "Wolverine.ComplianceTests.Sagas.StringBasicWorkflow");
             if (!stringBasicWorkflow.IsCompleted())
             {
                 await _container.UpsertItemAsync(stringBasicWorkflow).ConfigureAwait(false);

--- a/src/Persistence/CosmosDbTests/saga_optimistic_concurrency.cs
+++ b/src/Persistence/CosmosDbTests/saga_optimistic_concurrency.cs
@@ -1,0 +1,185 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.CosmosDb;
+using Wolverine.ErrorHandling;
+
+namespace CosmosDbTests;
+
+/// <summary>
+///     GH-3414. The CosmosDB saga frames used to persist with a blind <c>UpsertItemAsync</c>: no ETag was
+///     captured on the point read and no <c>IfMatchEtag</c> was set on the write, so two messages for the
+///     same saga id could both read the same revision and the second write would silently overwrite the
+///     first. The saga now reads its ETag and writes compare-and-swap, surfacing CosmosDB's 412 as a
+///     <see cref="SagaConcurrencyException" /> that Wolverine's existing retry machinery can act on.
+/// </summary>
+[Collection("cosmosdb")]
+public class saga_optimistic_concurrency
+{
+    private readonly AppFixture _fixture;
+
+    public saga_optimistic_concurrency(AppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private Task<IHost> buildHostAsync(Action<WolverineOptions>? configure = null)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddSingleton(_fixture.Client);
+                opts.UseCosmosDbPersistence(AppFixture.DatabaseName);
+
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Discovery.IncludeType<CounterSaga>();
+
+                configure?.Invoke(opts);
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task stale_write_is_surfaced_as_SagaConcurrencyException()
+    {
+        await _fixture.ClearAll();
+
+        using var host = await buildHostAsync();
+        var bus = host.MessageBus();
+
+        var id = Guid.NewGuid().ToString();
+        await bus.InvokeAsync(new StartCounter(id));
+
+        // Interfere exactly the way a second node would: the handler reads the saga, then another writer
+        // commits a new revision of the same document before this message gets to write. Without the
+        // IfMatchEtag the upsert below would happily clobber that revision.
+        await Should.ThrowAsync<SagaConcurrencyException>(() =>
+            bus.InvokeAsync(new IncrementCounter(id) { InterfereEveryAttempt = true }));
+
+        // The interfering writer's value survived — nothing was silently overwritten
+        var saga = await loadAsync(id);
+        saga!.Count.ShouldBe(InterferingCount);
+    }
+
+    [Fact]
+    public async Task concurrent_messages_against_one_saga_both_get_applied()
+    {
+        await _fixture.ClearAll();
+
+        using var host = await buildHostAsync(opts =>
+            opts.Policies.OnException<SagaConcurrencyException>().RetryTimes(5));
+
+        var id = Guid.NewGuid().ToString();
+        await host.MessageBus().InvokeAsync(new StartCounter(id));
+
+        // Both handlers pause between the saga read and the saga write, so both genuinely read Count = 0.
+        // Pre-fix, the loser's blind upsert overwrote the winner and Count ended at 1 with no error at all.
+        // A bus per invocation because IMessageBus carries per-message context and is not meant to be
+        // driven concurrently.
+        var pause = TimeSpan.FromMilliseconds(500);
+        await Task.WhenAll(
+            host.MessageBus().InvokeAsync(new IncrementCounter(id) { Delay = pause }),
+            host.MessageBus().InvokeAsync(new IncrementCounter(id) { Delay = pause }));
+
+        var saga = await loadAsync(id);
+        saga!.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task stale_delete_of_a_completed_saga_is_surfaced_as_SagaConcurrencyException()
+    {
+        await _fixture.ClearAll();
+
+        using var host = await buildHostAsync();
+        var bus = host.MessageBus();
+
+        var id = Guid.NewGuid().ToString();
+        await bus.InvokeAsync(new StartCounter(id));
+
+        // Completing a saga deletes the document. A blind delete would drop the interfering writer's
+        // revision just as silently as a blind upsert would.
+        await Should.ThrowAsync<SagaConcurrencyException>(() =>
+            bus.InvokeAsync(new CompleteCounter(id)));
+
+        (await loadAsync(id)).ShouldNotBeNull();
+    }
+
+    internal const int InterferingCount = 100;
+
+    private async Task<CounterSaga?> loadAsync(string id)
+    {
+        try
+        {
+            var response = await _fixture.Container.ReadItemAsync<CounterSaga>(id, PartitionKey.None);
+            return response.Resource;
+        }
+        catch (CosmosException e) when (e.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+}
+
+public record StartCounter(string Id);
+
+public record IncrementCounter(string Id)
+{
+    /// <summary>
+    ///     Commit a competing revision of the saga document on every attempt, so the pending write can
+    ///     never win. Used to assert the violation is reported rather than swallowed.
+    /// </summary>
+    public bool InterfereEveryAttempt { get; init; }
+
+    /// <summary>
+    ///     Held between the saga read and the saga write, which is where a competing message's write lands
+    /// </summary>
+    public TimeSpan Delay { get; init; } = TimeSpan.Zero;
+}
+
+public record CompleteCounter(string Id);
+
+public class CounterSaga : Saga
+{
+    public string Id { get; set; } = string.Empty;
+    public int Count { get; set; }
+
+    public static CounterSaga Start(StartCounter command)
+    {
+        return new CounterSaga { Id = command.Id };
+    }
+
+    public async Task Handle(IncrementCounter command, Container container)
+    {
+        if (command.InterfereEveryAttempt)
+        {
+            await writeCompetingRevisionAsync(container, command.Id);
+        }
+
+        if (command.Delay > TimeSpan.Zero)
+        {
+            await Task.Delay(command.Delay);
+        }
+
+        Count++;
+    }
+
+    public async Task Handle(CompleteCounter command, Container container)
+    {
+        await writeCompetingRevisionAsync(container, command.Id);
+        MarkCompleted();
+    }
+
+    // Bumps the stored document's ETag out from under the saga that is mid-flight, exactly as a second
+    // node handling another message for this saga id would
+    private static Task writeCompetingRevisionAsync(Container container, string id)
+    {
+        return container.UpsertItemAsync(new CounterSaga
+        {
+            Id = id,
+            Count = saga_optimistic_concurrency.InterferingCount
+        });
+    }
+}

--- a/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbPersistenceFrameProvider.cs
@@ -71,6 +71,7 @@ public class CosmosDbPersistenceFrameProvider : IPersistenceFrameProvider
 
     public Frame DetermineInsertFrame(Variable saga, IServiceContainer container)
     {
+        // A brand new document has no ETag to match against, so there is nothing to be optimistic about
         return new CosmosDbUpsertFrame(saga);
     }
 
@@ -82,17 +83,22 @@ public class CosmosDbPersistenceFrameProvider : IPersistenceFrameProvider
 
     public Frame DetermineUpdateFrame(Variable saga, IServiceContainer container)
     {
-        return new CosmosDbUpsertFrame(saga);
+        // Updating a saga document is a compare-and-swap against the ETag captured by LoadDocumentFrame
+        // when the saga was read. Without it, two messages for the same saga id racing on separate nodes
+        // both upsert blindly and the second one silently overwrites the first. See GH-3414.
+        return new CosmosDbUpsertFrame(saga, LoadDocumentFrame.UsesOptimisticConcurrency(saga));
     }
 
     public Frame DetermineDeleteFrame(Variable sagaId, Variable saga, IServiceContainer container)
     {
-        return new CosmosDbDeleteDocumentFrame(sagaId, saga);
+        return new CosmosDbDeleteDocumentFrame(sagaId, saga, LoadDocumentFrame.UsesOptimisticConcurrency(saga));
     }
 
     public Frame DetermineStoreFrame(Variable saga, IServiceContainer container)
     {
-        return DetermineUpdateFrame(saga, container);
+        // Storage.Store() is an explicit "just write it" side effect on an arbitrary document, not the
+        // saga update path, so it deliberately stays a blind upsert
+        return new CosmosDbUpsertFrame(saga);
     }
 
     public Frame DetermineDeleteFrame(Variable variable, IServiceContainer container)
@@ -142,14 +148,56 @@ public static class CosmosDbStorageActionApplier
     }
 }
 
+/// <summary>
+///     Emits the compare-and-swap plumbing that turns a 412 Precondition Failed from CosmosDB into the
+///     <see cref="SagaConcurrencyException" /> Wolverine's saga retry machinery already understands. Shared
+///     by the saga upsert and delete frames so both report the violation identically.
+/// </summary>
+internal static class CosmosDbConcurrency
+{
+    public static string RequestOptions(string etagVariable)
+    {
+        return
+            $"requestOptions: new {typeof(ItemRequestOptions).FullNameInCode()}{{ IfMatchEtag = {etagVariable} }}";
+    }
+
+    public static string FSharpRequestOptions(string etagVariable)
+    {
+        return
+            $"requestOptions = {typeof(ItemRequestOptions).FSharpName()}(IfMatchEtag = {etagVariable})";
+    }
+
+    public static void WriteCatchBlock(ISourceWriter writer, Type sagaType, string identityExpression)
+    {
+        writer.Write(
+            $"BLOCK:catch ({typeof(CosmosException).FullNameInCode()} e) when (e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)");
+        writer.WriteComment("The saga document was changed by another message since it was read");
+        writer.Write(
+            $"throw new {typeof(SagaConcurrencyException).FullNameInCode()}($\"Saga of type {sagaType.FullNameInCode()} and id {{{identityExpression}}} cannot be updated because of optimistic concurrency violations\", e);");
+        writer.FinishBlock();
+    }
+
+    public static void WriteFSharpCatchBlock(ISourceWriter writer, Type sagaType, string identityExpression)
+    {
+        writer.Write(
+            $"BLOCK:with :? {typeof(CosmosException).FSharpName()} as e when e.StatusCode = System.Net.HttpStatusCode.PreconditionFailed ->");
+        writer.WriteComment("The saga document was changed by another message since it was read");
+        writer.Write(
+            $"raise ({typeof(SagaConcurrencyException).FSharpName()}(sprintf \"Saga of type {sagaType.FullNameInCode()} and id %O cannot be updated because of optimistic concurrency violations\" {identityExpression}, e))");
+        writer.FinishBlock();
+    }
+}
+
 internal class CosmosDbUpsertFrame : AsyncFrame
 {
     private readonly Variable _document;
+    private readonly bool _optimisticConcurrency;
     private Variable? _container;
 
-    public CosmosDbUpsertFrame(Variable document)
+    public CosmosDbUpsertFrame(Variable document, bool optimisticConcurrency = false)
     {
         _document = document;
+        _optimisticConcurrency = optimisticConcurrency;
         uses.Add(_document);
     }
 
@@ -161,16 +209,45 @@ internal class CosmosDbUpsertFrame : AsyncFrame
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
-        writer.Write(
-            $"await {_container!.Usage}.UpsertItemAsync({_document.Usage}).ConfigureAwait(false);");
+        if (_optimisticConcurrency)
+        {
+            var etag = LoadDocumentFrame.EtagVariableName(_document);
+
+            writer.Write("BLOCK:try");
+            writer.Write(
+                $"await {_container!.Usage}.UpsertItemAsync({_document.Usage}, {CosmosDbConcurrency.RequestOptions(etag)}).ConfigureAwait(false);");
+            writer.FinishBlock();
+            CosmosDbConcurrency.WriteCatchBlock(writer, _document.VariableType, SagaChain.SagaIdVariableName);
+        }
+        else
+        {
+            writer.Write(
+                $"await {_container!.Usage}.UpsertItemAsync({_document.Usage}).ConfigureAwait(false);");
+        }
+
         Next?.GenerateCode(method, writer);
     }
 
     public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
     {
         // UpsertItemAsync returns Task<ItemResponse<T>>, not Task; use let! _ = to discard the result.
-        writer.Write($"let! _ = {_container!.FSharpUsage}.UpsertItemAsync({_document.FSharpUsage})");
-        writer.Write("()");
+        if (_optimisticConcurrency)
+        {
+            var etag = LoadDocumentFrame.EtagVariableName(_document);
+
+            writer.Write("BLOCK:try");
+            writer.Write(
+                $"let! _ = {_container!.FSharpUsage}.UpsertItemAsync({_document.FSharpUsage}, {CosmosDbConcurrency.FSharpRequestOptions(etag)})");
+            writer.Write("()");
+            writer.FinishBlock();
+            CosmosDbConcurrency.WriteFSharpCatchBlock(writer, _document.VariableType, SagaChain.SagaIdVariableName);
+        }
+        else
+        {
+            writer.Write($"let! _ = {_container!.FSharpUsage}.UpsertItemAsync({_document.FSharpUsage})");
+            writer.Write("()");
+        }
+
         Next?.GenerateFSharpCode(method, writer);
     }
 }
@@ -179,12 +256,14 @@ internal class CosmosDbDeleteDocumentFrame : AsyncFrame
 {
     private readonly Variable _sagaId;
     private readonly Variable _saga;
+    private readonly bool _optimisticConcurrency;
     private Variable? _container;
 
-    public CosmosDbDeleteDocumentFrame(Variable sagaId, Variable saga)
+    public CosmosDbDeleteDocumentFrame(Variable sagaId, Variable saga, bool optimisticConcurrency = false)
     {
         _sagaId = sagaId;
         _saga = saga;
+        _optimisticConcurrency = optimisticConcurrency;
         uses.Add(_sagaId);
         uses.Add(_saga);
     }
@@ -197,17 +276,48 @@ internal class CosmosDbDeleteDocumentFrame : AsyncFrame
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
-        writer.Write(
-            $"await {_container!.Usage}.DeleteItemAsync<{_saga.VariableType.FullNameInCode()}>({_sagaId.Usage}, {typeof(PartitionKey).FullNameInCode()}.None).ConfigureAwait(false);");
+        if (_optimisticConcurrency)
+        {
+            // Completing a saga is just as destructive as updating it: a blind delete would drop a
+            // concurrent write that landed after this message read the document
+            var etag = LoadDocumentFrame.EtagVariableName(_saga);
+
+            writer.Write("BLOCK:try");
+            writer.Write(
+                $"await {_container!.Usage}.DeleteItemAsync<{_saga.VariableType.FullNameInCode()}>({_sagaId.Usage}, {typeof(PartitionKey).FullNameInCode()}.None, {CosmosDbConcurrency.RequestOptions(etag)}).ConfigureAwait(false);");
+            writer.FinishBlock();
+            CosmosDbConcurrency.WriteCatchBlock(writer, _saga.VariableType, _sagaId.Usage);
+        }
+        else
+        {
+            writer.Write(
+                $"await {_container!.Usage}.DeleteItemAsync<{_saga.VariableType.FullNameInCode()}>({_sagaId.Usage}, {typeof(PartitionKey).FullNameInCode()}.None).ConfigureAwait(false);");
+        }
+
         Next?.GenerateCode(method, writer);
     }
 
     public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
     {
         // DeleteItemAsync returns Task<ItemResponse<T>>, not Task; use let! _ = to discard the result.
-        writer.Write(
-            $"let! _ = {_container!.FSharpUsage}.DeleteItemAsync<{_saga.VariableType.FSharpName()}>({_sagaId.FSharpUsage}, {typeof(PartitionKey).FSharpName()}.None)");
-        writer.Write("()");
+        if (_optimisticConcurrency)
+        {
+            var etag = LoadDocumentFrame.EtagVariableName(_saga);
+
+            writer.Write("BLOCK:try");
+            writer.Write(
+                $"let! _ = {_container!.FSharpUsage}.DeleteItemAsync<{_saga.VariableType.FSharpName()}>({_sagaId.FSharpUsage}, {typeof(PartitionKey).FSharpName()}.None, {CosmosDbConcurrency.FSharpRequestOptions(etag)})");
+            writer.Write("()");
+            writer.FinishBlock();
+            CosmosDbConcurrency.WriteFSharpCatchBlock(writer, _saga.VariableType, _sagaId.FSharpUsage);
+        }
+        else
+        {
+            writer.Write(
+                $"let! _ = {_container!.FSharpUsage}.DeleteItemAsync<{_saga.VariableType.FSharpName()}>({_sagaId.FSharpUsage}, {typeof(PartitionKey).FSharpName()}.None)");
+            writer.Write("()");
+        }
+
         Next?.GenerateFSharpCode(method, writer);
     }
 }

--- a/src/Persistence/Wolverine.CosmosDb/Internals/LoadDocumentFrame.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/LoadDocumentFrame.cs
@@ -20,6 +20,30 @@ internal class LoadDocumentFrame : AsyncFrame
 
     public Variable Saga { get; }
 
+    /// <summary>
+    ///     Name of the local variable that carries the CosmosDB ETag captured when the saga document
+    ///     was read. <see cref="CosmosDbUpsertFrame" /> and <see cref="CosmosDbDeleteDocumentFrame" />
+    ///     feed it back as an <see cref="ItemRequestOptions.IfMatchEtag" /> so the write becomes a
+    ///     compare-and-swap. Derived from the document variable so that two loads in one method
+    ///     (say, two <c>[Entity]</c> parameters) cannot collide.
+    /// </summary>
+    public static string EtagVariableName(Variable document)
+    {
+        return $"{document.Usage}_Etag";
+    }
+
+    /// <summary>
+    ///     Optimistic concurrency applies to saga documents, and only to documents Wolverine read into
+    ///     a local through this frame — that read is what declares the ETag local the write depends on.
+    ///     Entity storage actions (<c>Storage.Update()</c>, <c>Storage.Store()</c>) hand the provider a
+    ///     synthetic member access like <c>update1.Entity</c> with no preceding read, so they stay
+    ///     last-write-wins exactly as they were.
+    /// </summary>
+    public static bool UsesOptimisticConcurrency(Variable document)
+    {
+        return document.VariableType.CanBeCastTo<Saga>() && !document.Usage.Contains('.');
+    }
+
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
         _container = chain.FindVariable(typeof(Container));
@@ -31,15 +55,32 @@ internal class LoadDocumentFrame : AsyncFrame
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
+        var capturesEtag = UsesOptimisticConcurrency(Saga);
+        var etag = EtagVariableName(Saga);
+
         writer.WriteLine("");
         writer.WriteComment("Try to load the existing saga document from CosmosDB");
         writer.Write(
             $"{Saga.VariableType.FullNameInCode()} {Saga.Usage} = default;");
+
+        if (capturesEtag)
+        {
+            writer.WriteComment(
+                "Capture the ETag so the eventual write can be a compare-and-swap against this exact revision");
+            writer.Write($"string {etag} = null;");
+        }
+
         writer.Write($"try");
         writer.Write($"{{");
         writer.Write(
             $"    var _cosmosResponse = await {_container!.Usage}.ReadItemAsync<{Saga.VariableType.FullNameInCode()}>({_sagaId.Usage}, {typeof(PartitionKey).FullNameInCode()}.None, cancellationToken: {_cancellation!.Usage}).ConfigureAwait(false);");
         writer.Write($"    {Saga.Usage} = _cosmosResponse.Resource;");
+
+        if (capturesEtag)
+        {
+            writer.Write($"    {etag} = _cosmosResponse.ETag;");
+        }
+
         writer.Write($"}}");
         writer.Write(
             $"catch ({typeof(CosmosException).FullNameInCode()} e) when (e.StatusCode == System.Net.HttpStatusCode.NotFound)");
@@ -52,14 +93,31 @@ internal class LoadDocumentFrame : AsyncFrame
 
     public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
     {
+        var capturesEtag = UsesOptimisticConcurrency(Saga);
+        var etag = EtagVariableName(Saga);
+
         writer.BlankLine();
         writer.WriteComment("Try to load the existing saga document from CosmosDB");
         // Declare as mutable so it can be assigned in either the try or the with branch.
         writer.Write($"let mutable {Saga.FSharpUsage} = Unchecked.defaultof<{Saga.VariableType.FSharpName()}>");
+
+        if (capturesEtag)
+        {
+            writer.WriteComment(
+                "Capture the ETag so the eventual write can be a compare-and-swap against this exact revision");
+            writer.Write($"let mutable {etag} : string = null");
+        }
+
         writer.Write("BLOCK:try");
         writer.Write(
             $"let! _cosmosResponse = {_container!.FSharpUsage}.ReadItemAsync<{Saga.VariableType.FSharpName()}>({_sagaId.FSharpUsage}, {typeof(PartitionKey).FSharpName()}.None, cancellationToken = {_cancellation!.FSharpUsage})");
         writer.Write($"{Saga.FSharpUsage} <- _cosmosResponse.Resource");
+
+        if (capturesEtag)
+        {
+            writer.Write($"{etag} <- _cosmosResponse.ETag");
+        }
+
         writer.FinishBlock();
         // Single-case with; guard ensures non-404 CosmosExceptions propagate.
         writer.Write(

--- a/src/Testing/Wolverine.Cosmos.FSharpFixture/Generated.fs
+++ b/src/Testing/Wolverine.Cosmos.FSharpFixture/Generated.fs
@@ -31,9 +31,12 @@ type ContinueThingHandler603355368(container: Microsoft.Azure.Cosmos.Container) 
 
             // Try to load the existing saga document from CosmosDB
             let mutable thingSaga = Unchecked.defaultof<WolverineCosmosFSharpSample.ThingSaga>
+            // Capture the ETag so the eventual write can be a compare-and-swap against this exact revision
+            let mutable thingSaga_Etag : string = null
             try
                 let! _cosmosResponse = _container.ReadItemAsync<WolverineCosmosFSharpSample.ThingSaga>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, cancellationToken = cancellation)
                 thingSaga <- _cosmosResponse.Resource
+                thingSaga_Etag <- _cosmosResponse.ETag
             with :? Microsoft.Azure.Cosmos.CosmosException as e when e.StatusCode = System.Net.HttpStatusCode.NotFound ->
                 ()
             if isNull thingSaga then
@@ -49,11 +52,19 @@ type ContinueThingHandler603355368(container: Microsoft.Azure.Cosmos.Container) 
 
                 // Delete the saga if completed, otherwise update it
                 if thingSaga.IsCompleted() then
-                    let! _ = _container.DeleteItemAsync<WolverineCosmosFSharpSample.ThingSaga>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None)
-                    ()
+                    try
+                        let! _ = _container.DeleteItemAsync<WolverineCosmosFSharpSample.ThingSaga>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, requestOptions = Microsoft.Azure.Cosmos.ItemRequestOptions(IfMatchEtag = thingSaga_Etag))
+                        ()
+                    with :? Microsoft.Azure.Cosmos.CosmosException as e when e.StatusCode = System.Net.HttpStatusCode.PreconditionFailed ->
+                        // The saga document was changed by another message since it was read
+                        raise (Wolverine.SagaConcurrencyException(sprintf "Saga of type WolverineCosmosFSharpSample.ThingSaga and id %O cannot be updated because of optimistic concurrency violations" sagaId, e))
                 else
-                    let! _ = _container.UpsertItemAsync(thingSaga)
-                    ()
+                    try
+                        let! _ = _container.UpsertItemAsync(thingSaga, requestOptions = Microsoft.Azure.Cosmos.ItemRequestOptions(IfMatchEtag = thingSaga_Etag))
+                        ()
+                    with :? Microsoft.Azure.Cosmos.CosmosException as e when e.StatusCode = System.Net.HttpStatusCode.PreconditionFailed ->
+                        // The saga document was changed by another message since it was read
+                        raise (Wolverine.SagaConcurrencyException(sprintf "Saga of type WolverineCosmosFSharpSample.ThingSaga and id %O cannot be updated because of optimistic concurrency violations" sagaId, e))
                 
                 // Have to flush outgoing messages just in case Marten did nothing because of https://github.com/JasperFx/wolverine/issues/536
                 do! context.FlushOutgoingMessagesAsync()

--- a/src/Wolverine/Saga.cs
+++ b/src/Wolverine/Saga.cs
@@ -49,6 +49,14 @@ public class SagaConcurrencyException : Exception
     public SagaConcurrencyException(string message) : base(message)
     {
     }
+
+    /// <summary>
+    /// Keeps the underlying store's own concurrency failure (say, a CosmosDB 412 Precondition Failed)
+    /// attached, so error handling policies and logs can still see what the database actually said
+    /// </summary>
+    public SagaConcurrencyException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
 }
 
 public interface SequencedMessage


### PR DESCRIPTION
Saga writes used a blind UpsertItemAsync: no ETag captured on the point read, no IfMatchEtag on the write. Two messages for the same saga id landing at once both read the same revision and the slower write silently overwrote the faster one.

LoadDocumentFrame now captures the document ETag, and the upsert/delete frames pass it back as IfMatchEtag so the write is a compare-and-swap. CosmosDB answers a stale write with a 412, which the frames translate into SagaConcurrencyException so Wolverine's existing saga retry machinery can handle it, same as the RDBMS and EF Core providers do via row versions. Deletes are guarded too, since completing a saga drops the document and would discard a concurrent write just as silently.

Entity storage actions (Storage.Update()/Store()) stay last-write-wins — they have no preceding read, so there is no ETag to swap against.

Also regenerates the checked-in CosmosDbTests handlers. TypeLoadMode.Auto compiles and attaches them at runtime, so without this the saga compliance suite would have kept running the pre-fix blind upserts.

Fixes #3414