### PR TITLE
Type a Marten/Polecat aggregate-id route parameter in OpenAPI instead of falling back to string (GH-3420)

### DIFF
--- a/src/Http/Wolverine.Http.Tests.DifferentAssembly/MartenAggregateShapeEndpoints.cs
+++ b/src/Http/Wolverine.Http.Tests.DifferentAssembly/MartenAggregateShapeEndpoints.cs
@@ -1,0 +1,54 @@
+using Wolverine.Marten;
+
+namespace Wolverine.Http.Tests.DifferentAssembly.OpenApi;
+
+// GH-3420 shapes: the aggregate id is resolved by the Marten aggregate handler workflow, not by the
+// endpoint method signature, and the route token carries no constraint. Only Marten knows the aggregate's
+// identity type, so without a seam back into the chain's ApiDescription these route parameters degrade to
+// `string` in the generated OpenAPI document.
+//
+// These live alongside the other shape endpoints (see OpenApiShapeEndpoints.cs) — Marten's IDocumentStore
+// is built to answer "what is this aggregate's id type?" but never connects to a database, so the
+// openapi_shape_tests harness still renders its document with no infrastructure running.
+
+public record ShapeOrderConfirmed;
+
+public record ShapeOrderShipped;
+
+public record ConfirmShapeOrder(Guid ShapeOrderId);
+
+public class ShapeOrder
+{
+    public Guid Id { get; set; }
+    public int Version { get; set; }
+    public bool IsConfirmed { get; set; }
+    public bool HasShipped { get; set; }
+
+    public void Apply(ShapeOrderConfirmed _) => IsConfirmed = true;
+    public void Apply(ShapeOrderShipped _) => HasShipped = true;
+}
+
+// The issue's shape: {id} is unconstrained and appears nowhere in the signature. The id is read off the
+// command by the [AggregateHandler] workflow.
+public static class MartenAggregateHandlerShapeEndpoint
+{
+    [AggregateHandler]
+    [WolverinePost("/shapes/marten/orders/{id}/confirm")]
+    public static ShapeOrderConfirmed Confirm(ConfirmShapeOrder command, ShapeOrder order) => new();
+}
+
+// The conventional {aggregate}Id route token, again unconstrained and absent from the signature.
+public static class MartenAggregateHandlerConventionalRouteShapeEndpoint
+{
+    [AggregateHandler]
+    [WolverinePost("/shapes/marten/orders/{shapeOrderId}/confirm-by-convention")]
+    public static ShapeOrderConfirmed Confirm(ConfirmShapeOrder command, ShapeOrder order) => new();
+}
+
+// [WriteAggregate] binds the route value itself, so this already typed correctly before GH-3420. Pinned
+// here so the aggregate shapes stay covered as one family.
+public static class MartenWriteAggregateShapeEndpoint
+{
+    [WolverinePost("/shapes/marten/orders/{id}/ship")]
+    public static ShapeOrderShipped Ship([WriteAggregate] ShapeOrder order) => new();
+}

--- a/src/Http/Wolverine.Http.Tests.DifferentAssembly/Wolverine.Http.Tests.DifferentAssembly.csproj
+++ b/src/Http/Wolverine.Http.Tests.DifferentAssembly/Wolverine.Http.Tests.DifferentAssembly.csproj
@@ -3,6 +3,9 @@
     <ItemGroup>
         <ProjectReference Include="..\Wolverine.Http\Wolverine.Http.csproj"/>
         <ProjectReference Include="..\Wolverine.Http.FluentValidation\Wolverine.Http.FluentValidation.csproj"/>
+        <!-- For the GH-3420 aggregate OpenAPI shapes. Marten's IDocumentStore answers "what is this
+             aggregate's id type?" without ever connecting, so the shape harness stays infrastructure-free. -->
+        <ProjectReference Include="..\Wolverine.Http.Marten\Wolverine.Http.Marten.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/src/Http/Wolverine.Http.Tests/api_explorer_before_host_start.cs
+++ b/src/Http/Wolverine.Http.Tests/api_explorer_before_host_start.cs
@@ -1,8 +1,10 @@
+using Marten;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Wolverine.Http.Tests.DifferentAssembly.Validation;
+using Wolverine.Marten;
 
 namespace Wolverine.Http.Tests;
 
@@ -15,6 +17,15 @@ public class api_explorer_before_host_start
     public async Task api_descriptions_are_complete_before_the_host_starts()
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = "Development" });
+
+        // "DifferentAssembly" also carries the Marten aggregate endpoints used by openapi_shape_tests, so
+        // any host discovering it needs Marten registered to resolve the aggregates' id types. Pointed at
+        // an unreachable database (nothing listens on port 9999) to keep this test free of infrastructure.
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(
+                "Host=localhost;Port=9999;Database=does_not_exist;Username=nobody;Password=nobody;Timeout=2;Command Timeout=2");
+        }).IntegrateWithWolverine();
 
         builder.Host.UseWolverine(opts =>
         {

--- a/src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
+using Marten;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Wolverine.Http.Tests.DifferentAssembly.OpenApi;
+using Wolverine.Marten;
 
 namespace Wolverine.Http.Tests;
 
@@ -39,6 +41,16 @@ public class OpenApiShapeFixture : IAsyncLifetime
             // Pin endpoint discovery to the isolated, infrastructure-free assembly
             opts.ApplicationAssembly = typeof(CompoundRouteOnlyEndpoint).Assembly;
         });
+
+        // The GH-3420 aggregate shapes need Marten to answer "what is this aggregate's id type?" while the
+        // chains are built. Point it at an unreachable database (nothing listens on port 9999) so this
+        // fixture stays infrastructure-free by construction: if rendering the document ever opened a
+        // connection, every test in here would fail rather than quietly depend on a running Postgres.
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(
+                "Host=localhost;Port=9999;Database=does_not_exist;Username=nobody;Password=nobody;Timeout=2;Command Timeout=2");
+        }).IntegrateWithWolverine();
 
         builder.Services.AddOpenApi();
         builder.Services.AddWolverineHttp();
@@ -173,6 +185,31 @@ public class openapi_shape_tests : IClassFixture<OpenApiShapeFixture>
                 new ParameterShape("order-id", "path", true, "integer", "int64"),
                 new ParameterShape("Filter", "query", false, "string", null)
             ]);
+    }
+
+    [Fact]
+    public void marten_aggregate_handler_types_an_unconstrained_route_id_from_the_aggregate()
+    {
+        // GH-3420: {id} carries no route constraint and appears nowhere in the endpoint signature. Its type
+        // is the Order aggregate's identity, which only Marten knows about.
+        ParametersFor("/shapes/marten/orders/{id}/confirm", "post")
+            .ShouldBe([new ParameterShape("id", "path", true, "string", "uuid")]);
+
+        HasRequestBody("/shapes/marten/orders/{id}/confirm", "post").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void marten_aggregate_handler_types_the_conventional_aggregate_id_route_token()
+    {
+        ParametersFor("/shapes/marten/orders/{shapeOrderId}/confirm-by-convention", "post")
+            .ShouldBe([new ParameterShape("shapeOrderId", "path", true, "string", "uuid")]);
+    }
+
+    [Fact]
+    public void write_aggregate_binds_and_types_the_route_id_itself()
+    {
+        ParametersFor("/shapes/marten/orders/{id}/ship", "post")
+            .ShouldBe([new ParameterShape("id", "path", true, "string", "uuid")]);
     }
 
     #region harness helpers

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -488,12 +488,18 @@ public partial class HttpChain
         // method signatures rather than relying on a resolved variable. See GH-3380.
         //
         // When nothing in the chain binds the route value (e.g. a plain complex-body endpoint whose body
-        // property overlaps a route token, or a Marten aggregate-id route resolved during codegen), fall
-        // back to the route constraint (`{id:guid}`, `{n:int}`, ...) so the parameter still gets its real
-        // type/format, and finally to string. Both OpenAPI stacks schematize from .Type.
+        // property overlaps a route token), fall back to the route constraint (`{id:guid}`, `{n:int}`, ...)
+        // so the parameter still gets its real type/format.
+        //
+        // Failing that, honor any type declared through IRoutedChain by middleware that binds the route
+        // value through its own frames — the Marten/Polecat aggregate handler workflow declaring the
+        // aggregate's identity type for an unconstrained {id}, which is domain knowledge Wolverine.Http
+        // cannot infer from the method signatures. Then, finally, string. See GH-3380 and GH-3420.
+        // Both OpenAPI stacks schematize from .Type.
         var parameterType = variable?.VariableType
                             ?? typeFromBindingChain(routeParameter.Name)
                             ?? TypeFromRouteConstraint(routeParameter)
+                            ?? declaredRouteParameterType(routeParameter.Name)
                             ?? typeof(string);
 
         var parameter = new ApiParameterDescription

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -32,7 +32,7 @@ using ServiceContainer = JasperFx.ServiceContainer;
 
 namespace Wolverine.Http;
 
-public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICodeFile, IEndpointNameMetadata, IEndpointSummaryMetadata, IEndpointDescriptionMetadata, IDescribeMyself
+public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICodeFile, IEndpointNameMetadata, IEndpointSummaryMetadata, IEndpointDescriptionMetadata, IDescribeMyself, IRoutedChain
 {
     public static bool IsValidResponseType(Type type)
     {
@@ -742,6 +742,29 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
         }
 
         return variable;
+    }
+
+    private readonly Dictionary<string, Type> _declaredRouteParameterTypes = new(StringComparer.OrdinalIgnoreCase);
+
+    IReadOnlyList<string> IRoutedChain.RouteParameterNames =>
+        RoutePattern?.Parameters.Select(x => x.Name).ToArray() ?? [];
+
+    void IRoutedChain.DeclareRouteParameterType(string routeParameterName, Type parameterType)
+    {
+        if (RoutePattern == null) return;
+        if (!RoutePattern.Parameters.Any(x => x.Name.EqualsIgnoreCase(routeParameterName))) return;
+
+        _declaredRouteParameterTypes[routeParameterName] = parameterType;
+    }
+
+    /// <summary>
+    /// The CLR type declared for a route parameter by middleware that binds it outside of the endpoint
+    /// method signature — see <see cref="IRoutedChain.DeclareRouteParameterType"/>. Only consulted when
+    /// nothing else in the chain, and no route constraint, can type the parameter. See GH-3420.
+    /// </summary>
+    private Type? declaredRouteParameterType(string routeParameterName)
+    {
+        return _declaredRouteParameterTypes.TryGetValue(routeParameterName, out var type) ? type : null;
     }
 
     public bool FindRouteVariable(ParameterInfo parameter, [NotNullWhen(true)]out Variable? variable)

--- a/src/Http/WolverineWebApi/Marten/Orders.cs
+++ b/src/Http/WolverineWebApi/Marten/Orders.cs
@@ -6,12 +6,14 @@ using Marten.Events;
 using Marten.Linq;
 using Marten.Pagination;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.OpenApi.Models;
 using Wolverine.Attributes;
 using Wolverine.ErrorHandling;
 using Wolverine.Http;
 using Wolverine.Http.Marten;
 using Wolverine.Marten;
 using Wolverine.Runtime.Handlers;
+using WolverineWebApi.TestSupport;
 
 namespace WolverineWebApi.Marten;
 
@@ -280,8 +282,12 @@ public static class MarkItemEndpoint
         );
     }
 
+    // GH-3420: {id} has no route constraint and appears nowhere in the method signature -- it is the
+    // Order aggregate's identity, which only the Marten aggregate workflow knows about.
     [AggregateHandler]
     [WolverinePost("/orders/{id}/confirm")]
+    [ExpectParameter("id", ParameterLocation.Path, Type = "string", Format = "uuid", Required = true)]
+    [ExpectParameterCount(1)]
     public static (AcceptResponse, Events) Confirm(ConfirmOrder command, Order order)
     {
         return (

--- a/src/Persistence/Wolverine.Marten/AggregateHandling.cs
+++ b/src/Persistence/Wolverine.Marten/AggregateHandling.cs
@@ -40,6 +40,8 @@ internal record AggregateHandling(IDataRequirement Requirement)
     {
         Store(chain);
 
+        declareAggregateIdRouteParameter(chain);
+
         new MartenPersistenceFrameProvider().ApplyTransactionSupport(chain, container);
 
         var loader = new LoadAggregateFrame(this);
@@ -71,6 +73,44 @@ internal record AggregateHandling(IDataRequirement Requirement)
         }
         
         return aggregate;
+    }
+
+    /// <summary>
+    /// Tell an HTTP chain the CLR type of the route parameter that names this aggregate, so that the
+    /// generated OpenAPI parameter carries the identity's real schema.
+    ///
+    /// On the <c>[AggregateHandler]</c> shape the aggregate id is read off the command rather than off the
+    /// route, so an unconstrained token — the <c>{id}</c> in <c>[WolverinePost("/orders/{id}/confirm")]</c>
+    /// paired with <c>Handle(ConfirmOrder command, Order order)</c> — is bound by nothing in the endpoint
+    /// signature and would otherwise be described as a plain <c>string</c>. The identity type is Marten
+    /// domain knowledge that Wolverine.Http cannot infer on its own. See GH-3420.
+    /// </summary>
+    private void declareAggregateIdRouteParameter(IChain chain)
+    {
+        if (chain is not IRoutedChain routed || AggregateId == null || AggregateType == null) return;
+
+        var routeParameterNames = routed.RouteParameterNames;
+        if (routeParameterNames.Count == 0) return;
+
+        // Same precedence as WriteAggregateAttribute.FindIdentity()
+        string?[] candidates =
+        [
+            (Requirement as WriteAggregateAttribute)?.RouteOrParameterName,
+            $"{AggregateType.Name.ToCamelCase()}Id",
+            "id"
+        ];
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate.IsEmpty()) continue;
+
+            var match = routeParameterNames.FirstOrDefault(x => x.EqualsIgnoreCase(candidate!));
+            if (match != null)
+            {
+                routed.DeclareRouteParameterType(match, AggregateId.VariableType);
+                return;
+            }
+        }
     }
 
     public void Store(IChain chain)

--- a/src/Persistence/Wolverine.Polecat/AggregateHandling.cs
+++ b/src/Persistence/Wolverine.Polecat/AggregateHandling.cs
@@ -38,6 +38,8 @@ internal record AggregateHandling(IDataRequirement Requirement)
     {
         Store(chain);
 
+        declareAggregateIdRouteParameter(chain);
+
         new PolecatPersistenceFrameProvider().ApplyTransactionSupport(chain, container);
 
         var loader = new LoadAggregateFrame(this);
@@ -69,6 +71,44 @@ internal record AggregateHandling(IDataRequirement Requirement)
         }
 
         return aggregate;
+    }
+
+    /// <summary>
+    /// Tell an HTTP chain the CLR type of the route parameter that names this aggregate, so that the
+    /// generated OpenAPI parameter carries the identity's real schema.
+    ///
+    /// On the <c>[AggregateHandler]</c> shape the aggregate id is read off the command rather than off the
+    /// route, so an unconstrained token — the <c>{id}</c> in <c>[WolverinePost("/orders/{id}/confirm")]</c>
+    /// paired with <c>Handle(ConfirmOrder command, Order order)</c> — is bound by nothing in the endpoint
+    /// signature and would otherwise be described as a plain <c>string</c>. The identity type is Polecat
+    /// domain knowledge that Wolverine.Http cannot infer on its own. See GH-3420.
+    /// </summary>
+    private void declareAggregateIdRouteParameter(IChain chain)
+    {
+        if (chain is not IRoutedChain routed) return;
+
+        var routeParameterNames = routed.RouteParameterNames;
+        if (routeParameterNames.Count == 0) return;
+
+        // Same precedence as WriteAggregateAttribute.FindIdentity()
+        string?[] candidates =
+        [
+            (Requirement as WriteAggregateAttribute)?.RouteOrParameterName,
+            $"{AggregateType.Name.ToCamelCase()}Id",
+            "id"
+        ];
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate.IsEmpty()) continue;
+
+            var match = routeParameterNames.FirstOrDefault(x => x.EqualsIgnoreCase(candidate!));
+            if (match != null)
+            {
+                routed.DeclareRouteParameterType(match, AggregateId.VariableType);
+                return;
+            }
+        }
     }
 
     public void Store(IChain chain)

--- a/src/Wolverine/Configuration/IRoutedChain.cs
+++ b/src/Wolverine/Configuration/IRoutedChain.cs
@@ -1,0 +1,31 @@
+namespace Wolverine.Configuration;
+
+/// <summary>
+///     Implemented by chains that are matched from a URL route template — today only Wolverine.Http's
+///     <c>HttpChain</c>. Middleware that resolves a route value through its own frames instead of through
+///     the endpoint method signature uses this to tell the chain the real CLR type behind a route
+///     parameter, so that the generated OpenAPI metadata for that parameter isn't degraded to
+///     <c>string</c>.
+/// </summary>
+/// <remarks>
+///     The motivating case is the Marten/Polecat aggregate handler workflow (see GH-3420): given
+///     <c>[AggregateHandler, WolverinePost("/orders/{id}/confirm")] Handle(ConfirmOrder command, Order order)</c>,
+///     nothing in the endpoint signature binds <c>{id}</c> — the aggregate id is resolved from the command
+///     during code generation — and the aggregate's identity type is domain knowledge that Wolverine.Http
+///     cannot infer on its own.
+/// </remarks>
+public interface IRoutedChain
+{
+    /// <summary>
+    ///     The names of the parameters declared in this chain's route template. "/orders/{id}/confirm"
+    ///     yields "id".
+    /// </summary>
+    IReadOnlyList<string> RouteParameterNames { get; }
+
+    /// <summary>
+    ///     Tell this chain the CLR type behind a named route parameter. Purely descriptive: this creates no
+    ///     binding and does not affect the generated code. Ignored when the route template has no parameter
+    ///     by that name.
+    /// </summary>
+    void DeclareRouteParameterType(string routeParameterName, Type parameterType);
+}


### PR DESCRIPTION
On the [AggregateHandler] shape:

    [AggregateHandler]
    [WolverinePost("/orders/{id}/confirm")]
    public static OrderConfirmed Handle(ConfirmOrder command, Order order)

nothing in the endpoint signature binds {id} -- the aggregate id is read off the command by the aggregate workflow during codegen -- so with no route constraint to fall back on, GH-3418's resolution ladder (route variable -> binding chain -> route constraint -> string) came up empty on every rung and the operation declared `id` as `string` rather than `uuid`.

The aggregate's identity type is Marten/Polecat domain knowledge that Wolverine.Http cannot infer from method signatures, so this adds a seam for the aggregate workflow to hand that type back:

- IRoutedChain (Wolverine core, so Wolverine.Marten/Wolverine.Polecat can reach it without referencing Wolverine.Http) exposes the chain's route parameter names and lets middleware declare the CLR type behind one. It is purely descriptive: it creates no binding and does not affect generated code.
- HttpChain implements it, and CreateApiDescription consults declared types *after* the route constraint -- an explicit {id:guid} is what ASP.NET Core actually enforces, so a declared type can only ever improve on the `string` fallback and cannot change an endpoint that already resolves a type.
- AggregateHandling.Apply (Marten and Polecat both) declares the aggregate id's type against the first route token matching WriteAggregateAttribute.FindIdentity's own precedence: RouteOrParameterName, then {aggregate}Id, then id.

[WriteAggregate]/[ReadAggregate]/[Aggregate] already bound the route value themselves and were unaffected; they are now pinned by tests as part of the same family.

Coverage on both OpenAPI stacks: openapi_shape_tests grows Marten aggregate shapes (Microsoft.AspNetCore.OpenApi) and /orders/{id}/confirm in WolverineWebApi grows an [ExpectParameter] expectation (Swashbuckle). The shape harness registers Marten against an unreachable database (port 9999, per generate_openapi_without_database) so it stays infrastructure-free by construction -- verified by running it with the Postgres container stopped. api_explorer_before_host_start builds a second host over that same assembly and needs the same registration.

Fixes #3420