### PR TITLE
Stop IntegrationContext from disposing a class fixture it doesn't own (GH-3423)

### DIFF
--- a/src/Testing/CoreTests/Configuration/find_handlers_with_the_default_handler_discovery.cs
+++ b/src/Testing/CoreTests/Configuration/find_handlers_with_the_default_handler_discovery.cs
@@ -17,7 +17,6 @@ public class find_handlers_with_the_default_handler_discovery : IntegrationConte
     public find_handlers_with_the_default_handler_discovery(DefaultApp @default, ITestOutputHelper output) : base(@default)
     {
         _output = output;
-        @default.RecycleIfNecessary();
     }
 
     [Fact]

--- a/src/Testing/CoreTests/IntegrationContext.cs
+++ b/src/Testing/CoreTests/IntegrationContext.cs
@@ -45,16 +45,7 @@ public class DefaultApp : IDisposable
 
     public void Dispose()
     {
-        Host?.Dispose();
-        Host = null!;
-    }
-
-    public void RecycleIfNecessary()
-    {
-        if (Host == null)
-        {
-            Host = WolverineHost.Basic();
-        }
+        Host.Dispose();
     }
 
     public HandlerChain ChainFor<T>()
@@ -67,10 +58,13 @@ public class IntegrationContext : IDisposable, IClassFixture<DefaultApp>
 {
     private readonly DefaultApp _default;
 
+    // Only set when a test opts out of the shared fixture via with(). That host belongs to the
+    // test and has to be disposed with it; the DefaultApp fixture does not, and must not be.
+    private IHost? _ownedHost;
+
     public IntegrationContext(DefaultApp @default)
     {
         _default = @default;
-        _default.RecycleIfNecessary();
 
         Host = _default.Host;
     }
@@ -84,12 +78,21 @@ public class IntegrationContext : IDisposable, IClassFixture<DefaultApp>
 
     public virtual void Dispose()
     {
-        _default.Dispose();
+        // Dispose only what this test built for itself. DefaultApp is an IClassFixture, so xUnit
+        // owns its lifetime and disposes it once the class finishes. Tearing it down here — after
+        // every test method — left the *shared* host disposed for the tests that followed, and the
+        // guard that papered over that silently rebuilt it as a WolverineHost.Basic() carrying none
+        // of DefaultApp's handler/service registrations. Tests then passed or failed on ordering.
+        // See GH-3423.
+        _ownedHost?.Dispose();
     }
 
     protected async Task with(Action<WolverineOptions> configuration)
     {
-        Host = await WolverineHost.ForAsync(configuration);
+        _ownedHost?.Dispose();
+
+        _ownedHost = await WolverineHost.ForAsync(configuration);
+        Host = _ownedHost;
     }
 
     protected HandlerChain chainFor<T>()


### PR DESCRIPTION
Partial fix for #3423. **This does not close the issue** — see "What this doesn't fix" below. I'd rather land the correct-ownership change on its own merits than bundle it with a cause I haven't pinned yet.

## The defect

`DefaultApp` is an xUnit **class fixture** — xUnit owns its lifetime and disposes it when the test class finishes. `IntegrationContext.Dispose()` disposed it anyway, after **every test method**:

```csharp
public virtual void Dispose()
{
    _default.Dispose();   // disposing a fixture this class does not own
}
```

`DefaultApp.Dispose()` nulls the host, and the guard that papered over the resulting damage silently substituted a **differently-configured** host:

```csharp
public void RecycleIfNecessary()
{
    if (Host == null) Host = WolverineHost.Basic();   // NOT the DefaultApp configuration
}
```

`WolverineHost.Basic()` has none of `DefaultApp`'s `IncludeType<MessageConsumer>()`, `IncludeType<InvokedMessageHandler>()`, `RegisterMessageType(...)` calls, or the `IAdditionService`/`IIdentityService`/`ITrackedTaskRepository` registrations. So from the second test method in a class onward, tests could be running against a host they were never written for — and whether any given test passed came down to ordering.

The ownership was **backwards in the other direction too**: `with(...)` builds a host *for the test*, and that one was never disposed at all — a straight leak of a started `IHost` per call.

## The fix

The test disposes what it built; the fixture is left to xUnit.

```csharp
private IHost? _ownedHost;   // only set by with()

public virtual void Dispose() => _ownedHost?.Dispose();

protected async Task with(Action<WolverineOptions> configuration)
{
    _ownedHost?.Dispose();
    _ownedHost = await WolverineHost.ForAsync(configuration);
    Host = _ownedHost;
}
```

`RecycleIfNecessary()` and the `Host = null!` dance are deleted rather than kept as a band-aid — with the fixture no longer torn down mid-class, there's nothing to recycle. The one caller (`find_handlers_with_the_default_handler_discovery`) was already a no-op and is removed.

## What this fixes

- The `NullReferenceException`s out of `DefaultApp.ChainFor<T>()` (a null `Host`)
- The leaked `with()` hosts
- The xUnit fixture-lifetime violation itself

## What this doesn't fix

**19 of the 20** filtered-subset failures survive this change, with a separate cause. Running a `StorageActionCompliance`-derived class before another `IntegrationContext` class leaves the later host's `HandlerGraph` unable to handle conventionally-discovered messages — `HandlerGraph.CanHandle(...)` returns false, so `findInvoker` falls through to routing and throws `IndeterminateRoutesException`.

Deterministic repro:

```bash
# green
--filter "FullyQualifiedName~CoreTests.Persistence.using_multiple_storage_actions"
# 2 failures
--filter "...using_multiple_storage_actions|...using_storage_return_types_and_entity_attributes"
```

The obvious explanation — `DisableConventionalDiscovery()` on the compliance host leaking into hosts built later — **is disproven**: I built a host with `DisableConventionalDiscovery()`, disposed it, then built a plain host, and conventional discovery worked fine. Mechanism still unidentified. Written up on #3423 so the next person doesn't re-run the same dead end.

## Verification

- Full `CoreTests` assembly: **1931 passed, 0 failed** (unchanged — this is what CI runs)
- `CoreTests.Persistence` subset: **20 → 19** failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)