### PR TITLE
Let CosmosDB sagas take a logical partition of their own, keyed by the saga id (GH-3415)

### DIFF
--- a/docs/guide/durability/cosmosdb.md
+++ b/docs/guide/durability/cosmosdb.md
@@ -163,11 +163,69 @@ and the ability to replay designated messages in the dead letter queue storage.
 ## Saga Persistence
 
 The CosmosDB integration can serve as a [Wolverine Saga persistence mechanism](/guide/durability/sagas). The only limitation is that
-all saga identity values must be `string` types. The saga id is used as both the CosmosDB document id and partition key.
+all saga identity values must be `string` types. The saga id is used as the CosmosDB document id.
 
 Because it is the document id, the saga's identity member has to serialize as the lowercase `id` CosmosDB
 requires — which means the registered `CosmosClient` needs the camel case naming policy described in
 [Serializer Configuration](#serializer-configuration). Wolverine enforces this at startup.
+
+### Saga Partitioning
+
+By default, **every saga in your application shares a single logical partition**. A saga is your own class, so
+nothing writes the container's `/partitionKey` property into it, and CosmosDB puts a document with no partition
+key value into one "undefined" partition. Wolverine reads and writes sagas there consistently, so this works —
+but a CosmosDB logical partition is capped at **20 GB** and **10,000 RU/s**, and that cap therefore applies to
+your application's entire saga workload no matter how far the container itself is scaled out. The symptom, if
+you reach it, is 429 throttling that does *not* improve when you add RU/s, because the limit is per logical
+partition rather than per container.
+
+Opt into a partition per saga, keyed by the saga id, with `PartitionSagasById()`:
+
+```csharp
+builder.UseWolverine(opts =>
+{
+    opts.UseCosmosDbPersistence("your-database-name", cosmos =>
+    {
+        // Each saga document gets its own logical partition, keyed by the saga id
+        cosmos.PartitionSagasById();
+    });
+});
+```
+
+With this on, Wolverine stamps `partitionKey` = the saga id onto the document as it writes it, so loading,
+updating and deleting a saga is a single-partition point operation — the access pattern CosmosDB is at its best
+on — and sagas spread across every physical partition the container has.
+
+::: warning
+This changes **where a saga document lives**, so it is opt in rather than the default. Saga documents written
+before you turned it on stay in the undefined partition, where a point read keyed on the saga id will not find
+them: an in-flight saga would look like it had never been started. Turn it on for a new application, or migrate
+your existing saga documents first.
+:::
+
+Migrating means rewriting each existing saga document with its partition key, then removing the copy in the
+undefined partition. Wolverine deliberately does not do this for you: saga documents carry no `docType`
+discriminator, so nothing in the container distinguishes them from the documents your own code and
+`Storage.Store()` side effects put in that same undefined partition, and a blanket migration would re-home
+those too. Only your application knows which documents are its sagas — for example, by saga id:
+
+```csharp
+async Task MigrateSagaAsync<T>(Container container, string sagaId)
+{
+    // The legacy copy, in the undefined partition
+    var response = await container.ReadItemAsync<JObject>(sagaId, PartitionKey.None);
+    var document = response.Resource;
+
+    document["partitionKey"] = sagaId;
+
+    await container.UpsertItemAsync(document, new PartitionKey(sagaId));
+    await container.DeleteItemAsync<JObject>(sagaId, PartitionKey.None,
+        new ItemRequestOptions { IfMatchEtag = response.ETag });
+}
+```
+
+Run it with the application's saga traffic stopped, so that nothing writes a new revision of the legacy document
+between the copy and the delete.
 
 ### Optimistic Concurrency
 

--- a/src/Persistence/CosmosDbTests/saga_partitioning.cs
+++ b/src/Persistence/CosmosDbTests/saga_partitioning.cs
@@ -1,0 +1,228 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.CosmosDb;
+using Wolverine.CosmosDb.Internals;
+using Wolverine.Persistence;
+
+namespace CosmosDbTests;
+
+/// <summary>
+///     GH-3415. A saga is a user's own POCO, so nothing writes the container's <c>/partitionKey</c> property into
+///     it and every saga in the application lands in CosmosDB's single "undefined" logical partition — capped at
+///     20 GB and 10,000 RU/s no matter how far the container is scaled out. Opting into
+///     <see cref="CosmosDbConfiguration.PartitionSagasById" /> gives each saga a partition of its own, keyed by the
+///     saga id, so that every saga operation is a single-partition point operation.
+///     <para>
+///         Because that moves where a saga document lives, the default has to stay where it was, and these tests
+///         pin both.
+///     </para>
+/// </summary>
+[Collection("cosmosdb")]
+public class saga_partitioning
+{
+    private readonly AppFixture _fixture;
+
+    public saga_partitioning(AppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task partitioned_saga_lives_in_the_partition_keyed_by_its_own_id()
+    {
+        using var host = await buildHostAsync(partitionById: true);
+
+        var id = Guid.NewGuid().ToString();
+        await host.MessageBus().InvokeAsync(new StartPartitioned(id));
+
+        // The point read CosmosDB is at its best on: id and partition key are the same value
+        var saga = await loadAsync(id, new PartitionKey(id));
+        saga.ShouldNotBeNull();
+
+        // ...and the document carries the partition key that put it there
+        var document = await readRawAsync(id, new PartitionKey(id));
+        document["partitionKey"]!.ToString().ShouldBe(id);
+
+        // ...and it is no longer sharing the undefined partition with every other saga in the application
+        (await loadAsync(id, PartitionKey.None)).ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     Saga documents written before the flag was turned on stay where they are, so the default cannot move —
+    ///     an application that upgrades and does not opt in has to keep finding its sagas
+    /// </summary>
+    [Fact]
+    public async Task saga_stays_in_the_undefined_partition_by_default()
+    {
+        using var host = await buildHostAsync(partitionById: false);
+
+        var id = Guid.NewGuid().ToString();
+        await host.MessageBus().InvokeAsync(new StartPartitioned(id));
+
+        (await loadAsync(id, PartitionKey.None)).ShouldNotBeNull();
+        (await loadAsync(id, new PartitionKey(id))).ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     The write goes through the CosmosDB stream API to stamp the partition key onto the document, so the
+    ///     whole saga lifecycle — insert, update, delete — has to be re-proven through it
+    /// </summary>
+    [Fact]
+    public async Task partitioned_saga_can_be_updated_and_completed()
+    {
+        using var host = await buildHostAsync(partitionById: true);
+
+        var id = Guid.NewGuid().ToString();
+        await host.MessageBus().InvokeAsync(new StartPartitioned(id));
+        await host.MessageBus().InvokeAsync(new IncrementPartitioned(id));
+        await host.MessageBus().InvokeAsync(new IncrementPartitioned(id));
+
+        var saga = await loadAsync(id, new PartitionKey(id));
+        saga!.Count.ShouldBe(2);
+
+        await host.MessageBus().InvokeAsync(new CompletePartitioned(id));
+
+        (await loadAsync(id, new PartitionKey(id))).ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     GH-3414's compare-and-swap has to survive the switch to the stream API: the ETag captured on the read
+    ///     is still passed back as an IfMatchEtag, and CosmosDB's 412 still surfaces as a SagaConcurrencyException
+    /// </summary>
+    [Fact]
+    public async Task optimistic_concurrency_still_holds_for_a_partitioned_saga()
+    {
+        using var host = await buildHostAsync(partitionById: true);
+        var bus = host.MessageBus();
+
+        var id = Guid.NewGuid().ToString();
+        await bus.InvokeAsync(new StartPartitioned(id));
+
+        // Commit a competing revision of the document between this message's read and its write, exactly as a
+        // second node handling another message for this saga would
+        await Should.ThrowAsync<SagaConcurrencyException>(() =>
+            bus.InvokeAsync(new IncrementPartitioned(id) { InterfereEveryAttempt = true }));
+
+        var saga = await loadAsync(id, new PartitionKey(id));
+        saga!.Count.ShouldBe(PartitionedSaga.InterferingCount);
+    }
+
+    /// <summary>
+    ///     A saga can also be written by an explicit storage action rather than by the saga chain, and that write
+    ///     has to land in the partition the saga loader will look in — otherwise turning partitioning on would
+    ///     quietly hide the saga from every message that follows
+    /// </summary>
+    [Fact]
+    public async Task saga_stored_through_a_storage_action_lands_in_its_own_partition()
+    {
+        using var host = await buildHostAsync(partitionById: true);
+
+        var id = Guid.NewGuid().ToString();
+        await host.MessageBus().InvokeAsync(new StorePartitionedDirectly(id));
+
+        var saga = await loadAsync(id, new PartitionKey(id));
+        saga!.Count.ShouldBe(StorePartitionedDirectlyHandler.StoredCount);
+
+        (await loadAsync(id, PartitionKey.None)).ShouldBeNull();
+    }
+
+    private Task<IHost> buildHostAsync(bool partitionById)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddSingleton(_fixture.Client);
+                opts.UseCosmosDbPersistence(AppFixture.DatabaseName, cosmos =>
+                {
+                    if (partitionById)
+                    {
+                        cosmos.PartitionSagasById();
+                    }
+                });
+
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Discovery.IncludeType<PartitionedSaga>();
+                opts.Discovery.IncludeType(typeof(StorePartitionedDirectlyHandler));
+            }).StartAsync();
+    }
+
+    private async Task<PartitionedSaga?> loadAsync(string id, PartitionKey partitionKey)
+    {
+        try
+        {
+            var response = await _fixture.Container.ReadItemAsync<PartitionedSaga>(id, partitionKey);
+            return response.Resource;
+        }
+        catch (CosmosException e) when (e.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    private async Task<Dictionary<string, object>> readRawAsync(string id, PartitionKey partitionKey)
+    {
+        var response = await _fixture.Container.ReadItemAsync<Dictionary<string, object>>(id, partitionKey);
+        return response.Resource;
+    }
+}
+
+public record StartPartitioned(string Id);
+
+public record IncrementPartitioned(string Id)
+{
+    /// <summary>
+    ///     Commit a competing revision of the saga document on every attempt, so the pending write can never win
+    /// </summary>
+    public bool InterfereEveryAttempt { get; init; }
+}
+
+public record CompletePartitioned(string Id);
+
+public record StorePartitionedDirectly(string Id);
+
+public static class StorePartitionedDirectlyHandler
+{
+    public const int StoredCount = 5;
+
+    public static IStorageAction<PartitionedSaga> Handle(StorePartitionedDirectly command)
+    {
+        return Storage.Store(new PartitionedSaga { Id = command.Id, Count = StoredCount });
+    }
+}
+
+public class PartitionedSaga : Saga
+{
+    internal const int InterferingCount = 100;
+
+    public string Id { get; set; } = string.Empty;
+    public int Count { get; set; }
+
+    public static PartitionedSaga Start(StartPartitioned command)
+    {
+        return new PartitionedSaga { Id = command.Id };
+    }
+
+    public async Task Handle(IncrementPartitioned command, Container container, CancellationToken cancellationToken)
+    {
+        if (command.InterfereEveryAttempt)
+        {
+            // Bump the stored document's ETag out from under the saga that is mid-flight. Written the same way
+            // Wolverine writes it, so that it lands in the same partition
+            await CosmosSagaStorage.UpsertAsync(container,
+                new PartitionedSaga { Id = command.Id, Count = InterferingCount }, null, cancellationToken);
+        }
+
+        Count++;
+    }
+
+    public void Handle(CompletePartitioned command)
+    {
+        MarkCompleted();
+    }
+}

--- a/src/Persistence/Wolverine.CosmosDb/CosmosDbConfiguration.cs
+++ b/src/Persistence/Wolverine.CosmosDb/CosmosDbConfiguration.cs
@@ -1,0 +1,43 @@
+namespace Wolverine.CosmosDb;
+
+/// <summary>
+///     Optional configuration for Wolverine's CosmosDB integration, supplied through
+///     <see cref="WolverineCosmosDbExtensions.UseCosmosDbPersistence(WolverineOptions,string,Action{CosmosDbConfiguration})" />.
+/// </summary>
+public class CosmosDbConfiguration
+{
+    /// <summary>
+    ///     Is each saga document stored in its own logical partition, keyed by the saga id? False by default.
+    ///     See <see cref="PartitionSagasById" />.
+    /// </summary>
+    public bool SagasArePartitionedById { get; private set; }
+
+    /// <summary>
+    ///     GH-3415. Store every saga document in its own logical partition, keyed by the saga id, instead of
+    ///     leaving them all in CosmosDB's single "undefined" partition.
+    ///     <para>
+    ///         A saga is a user's own POCO, so nothing writes the container's <c>/partitionKey</c> property into
+    ///         it, and a document with no partition key value lands in the undefined partition. Wolverine reads
+    ///         and writes sagas there consistently, so it works — but a logical partition is capped at 20 GB and
+    ///         10,000 RU/s, and that cap is then the ceiling for the application's entire saga workload no matter
+    ///         how far the container is scaled out. The symptom is 429 throttling that does not improve when you
+    ///         add RU/s, because the limit is per logical partition, not per container.
+    ///     </para>
+    ///     <para>
+    ///         With this on, Wolverine stamps <c>partitionKey</c> = the saga id onto the document as it writes it,
+    ///         and reads, updates and deletes the saga as a single-partition point operation — the access pattern
+    ///         CosmosDB is at its best on. Sagas then spread across every physical partition the container has.
+    ///     </para>
+    ///     <para>
+    ///         This changes where a saga document lives, so it is opt in: saga documents written before it was
+    ///         turned on stay in the undefined partition, where a point read keyed on the saga id will not find
+    ///         them. Turn it on for a new application, or migrate existing saga documents first — see the
+    ///         "Saga Partitioning" section of the CosmosDB documentation.
+    ///     </para>
+    /// </summary>
+    public CosmosDbConfiguration PartitionSagasById()
+    {
+        SagasArePartitionedById = true;
+        return this;
+    }
+}

--- a/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbPersistenceFrameProvider.cs
@@ -4,6 +4,7 @@ using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
 using Wolverine.Configuration;
 using Wolverine.Persistence;
 using Wolverine.Persistence.Sagas;
@@ -66,13 +67,13 @@ public class CosmosDbPersistenceFrameProvider : IPersistenceFrameProvider
 
     public Frame DetermineLoadFrame(IServiceContainer container, Type sagaType, Variable sagaId)
     {
-        return new LoadDocumentFrame(sagaType, sagaId);
+        return new LoadDocumentFrame(sagaType, sagaId, PartitionsById(sagaType, container));
     }
 
     public Frame DetermineInsertFrame(Variable saga, IServiceContainer container)
     {
         // A brand new document has no ETag to match against, so there is nothing to be optimistic about
-        return new CosmosDbUpsertFrame(saga);
+        return new CosmosDbUpsertFrame(saga, PartitionsById(saga.VariableType, container));
     }
 
     public Frame CommitUnitOfWorkFrame(Variable saga, IServiceContainer container)
@@ -86,19 +87,21 @@ public class CosmosDbPersistenceFrameProvider : IPersistenceFrameProvider
         // Updating a saga document is a compare-and-swap against the ETag captured by LoadDocumentFrame
         // when the saga was read. Without it, two messages for the same saga id racing on separate nodes
         // both upsert blindly and the second one silently overwrites the first. See GH-3414.
-        return new CosmosDbUpsertFrame(saga, LoadDocumentFrame.UsesOptimisticConcurrency(saga));
+        return new CosmosDbUpsertFrame(saga, PartitionsById(saga.VariableType, container),
+            LoadDocumentFrame.UsesOptimisticConcurrency(saga));
     }
 
     public Frame DetermineDeleteFrame(Variable sagaId, Variable saga, IServiceContainer container)
     {
-        return new CosmosDbDeleteDocumentFrame(sagaId, saga, LoadDocumentFrame.UsesOptimisticConcurrency(saga));
+        return new CosmosDbDeleteDocumentFrame(sagaId, saga, PartitionsById(saga.VariableType, container),
+            LoadDocumentFrame.UsesOptimisticConcurrency(saga));
     }
 
     public Frame DetermineStoreFrame(Variable saga, IServiceContainer container)
     {
         // Storage.Store() is an explicit "just write it" side effect on an arbitrary document, not the
         // saga update path, so it deliberately stays a blind upsert
-        return new CosmosDbUpsertFrame(saga);
+        return new CosmosDbUpsertFrame(saga, PartitionsById(saga.VariableType, container));
     }
 
     public Frame DetermineDeleteFrame(Variable variable, IServiceContainer container)
@@ -108,13 +111,42 @@ public class CosmosDbPersistenceFrameProvider : IPersistenceFrameProvider
 
     public Frame DetermineStorageActionFrame(Type entityType, Variable action, IServiceContainer container)
     {
-        var method = typeof(CosmosDbStorageActionApplier).GetMethod("ApplyAction")!
+        // A saga written through an explicit storage action has to land in the same partition the saga
+        // loader will read it back from, or turning saga partitioning on would quietly hide it (GH-3415)
+        var methodName = PartitionsById(entityType, container)
+            ? nameof(CosmosDbStorageActionApplier.ApplyPartitionedSagaAction)
+            : nameof(CosmosDbStorageActionApplier.ApplyAction);
+
+        var method = typeof(CosmosDbStorageActionApplier).GetMethod(methodName)!
             .MakeGenericMethod(entityType);
 
         var call = new MethodCall(typeof(CosmosDbStorageActionApplier), method);
         call.Arguments[1] = action;
 
         return call;
+    }
+
+    /// <summary>
+    ///     GH-3415. Does this document get a logical partition of its own, keyed by its id? Only sagas, and only
+    ///     when the application asked for it with <see cref="CosmosDbConfiguration.PartitionSagasById" />.
+    ///     <para>
+    ///         Deliberately sagas only. The same frames load and store the arbitrary documents behind
+    ///         <c>[Entity]</c> parameters and <c>Storage.Store()</c> side effects, and those may well already carry
+    ///         a partition key of the user's own choosing, or be written by the user's own code straight through
+    ///         the injected <see cref="Container" />. Wolverine is not entitled to re-home them.
+    ///     </para>
+    /// </summary>
+    internal static bool PartitionsById(Type documentType, IServiceContainer container)
+    {
+        if (!documentType.CanBeCastTo<Saga>())
+        {
+            return false;
+        }
+
+        // Absent for an application that wired the persistence strategy up by hand rather than through
+        // UseCosmosDbPersistence(), in which case it did not ask for saga partitioning either
+        var configuration = container.Services.GetService<CosmosDbConfiguration>();
+        return configuration is { SagasArePartitionedById: true };
     }
 }
 
@@ -143,6 +175,38 @@ public static class CosmosDbStorageActionApplier
             case StorageAction.Store:
             case StorageAction.Update:
                 await container.UpsertItemAsync(action.Entity);
+                break;
+        }
+    }
+
+    /// <summary>
+    ///     The same storage actions against a saga in an application that opted into
+    ///     <see cref="CosmosDbConfiguration.PartitionSagasById" />: every write carries the saga's partition key,
+    ///     and the delete is keyed by the saga's own document id rather than <c>ToString()</c>, because that id is
+    ///     now the partition to delete from.
+    /// </summary>
+    public static async Task ApplyPartitionedSagaAction<T>(Container container, IStorageAction<T> action,
+        CancellationToken cancellationToken)
+    {
+        if (action.Entity == null) return;
+
+        switch (action.Action)
+        {
+            case StorageAction.Delete:
+                try
+                {
+                    await CosmosSagaStorage.DeleteAsync(container, action.Entity, cancellationToken);
+                }
+                catch (CosmosException)
+                {
+                    // Best effort, exactly as the unpartitioned delete above
+                }
+
+                break;
+            case StorageAction.Insert:
+            case StorageAction.Store:
+            case StorageAction.Update:
+                await CosmosSagaStorage.UpsertAsync(container, action.Entity, null, cancellationToken);
                 break;
         }
     }
@@ -192,11 +256,14 @@ internal class CosmosDbUpsertFrame : AsyncFrame
 {
     private readonly Variable _document;
     private readonly bool _optimisticConcurrency;
+    private readonly bool _partitionById;
+    private Variable? _cancellation;
     private Variable? _container;
 
-    public CosmosDbUpsertFrame(Variable document, bool optimisticConcurrency = false)
+    public CosmosDbUpsertFrame(Variable document, bool partitionById = false, bool optimisticConcurrency = false)
     {
         _document = document;
+        _partitionById = partitionById;
         _optimisticConcurrency = optimisticConcurrency;
         uses.Add(_document);
     }
@@ -205,24 +272,36 @@ internal class CosmosDbUpsertFrame : AsyncFrame
     {
         _container = chain.FindVariable(typeof(Container));
         yield return _container;
+
+        if (_partitionById)
+        {
+            _cancellation = chain.FindVariable(typeof(CancellationToken));
+            yield return _cancellation;
+        }
     }
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
+        var etag = _optimisticConcurrency ? LoadDocumentFrame.EtagVariableName(_document) : "null";
+
+        // The partitioned write has to go through the JSON itself to stamp the partition key onto the
+        // document, so it cannot use the typed UpsertItemAsync<T>. See CosmosSagaStorage (GH-3415)
+        var upsert = _partitionById
+            ? $"await {typeof(CosmosSagaStorage).FullNameInCode()}.UpsertAsync({_container!.Usage}, {_document.Usage}, {etag}, {_cancellation!.Usage}).ConfigureAwait(false);"
+            : _optimisticConcurrency
+                ? $"await {_container!.Usage}.UpsertItemAsync({_document.Usage}, {CosmosDbConcurrency.RequestOptions(etag)}).ConfigureAwait(false);"
+                : $"await {_container!.Usage}.UpsertItemAsync({_document.Usage}).ConfigureAwait(false);";
+
         if (_optimisticConcurrency)
         {
-            var etag = LoadDocumentFrame.EtagVariableName(_document);
-
             writer.Write("BLOCK:try");
-            writer.Write(
-                $"await {_container!.Usage}.UpsertItemAsync({_document.Usage}, {CosmosDbConcurrency.RequestOptions(etag)}).ConfigureAwait(false);");
+            writer.Write(upsert);
             writer.FinishBlock();
             CosmosDbConcurrency.WriteCatchBlock(writer, _document.VariableType, SagaChain.SagaIdVariableName);
         }
         else
         {
-            writer.Write(
-                $"await {_container!.Usage}.UpsertItemAsync({_document.Usage}).ConfigureAwait(false);");
+            writer.Write(upsert);
         }
 
         Next?.GenerateCode(method, writer);
@@ -230,22 +309,36 @@ internal class CosmosDbUpsertFrame : AsyncFrame
 
     public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
     {
+        var etag = _optimisticConcurrency ? LoadDocumentFrame.EtagVariableName(_document) : "null";
+
         // UpsertItemAsync returns Task<ItemResponse<T>>, not Task; use let! _ = to discard the result.
+        // CosmosSagaStorage.UpsertAsync returns a plain Task, which the task builder binds with do!
+        var upsert = _partitionById
+            ? [
+                $"do! {typeof(CosmosSagaStorage).FSharpName()}.UpsertAsync({_container!.FSharpUsage}, {_document.FSharpUsage}, {etag}, {_cancellation!.FSharpUsage})"
+            ]
+            : _optimisticConcurrency
+                ? new[]
+                {
+                    $"let! _ = {_container!.FSharpUsage}.UpsertItemAsync({_document.FSharpUsage}, {CosmosDbConcurrency.FSharpRequestOptions(etag)})",
+                    "()"
+                }
+                : new[]
+                {
+                    $"let! _ = {_container!.FSharpUsage}.UpsertItemAsync({_document.FSharpUsage})",
+                    "()"
+                };
+
         if (_optimisticConcurrency)
         {
-            var etag = LoadDocumentFrame.EtagVariableName(_document);
-
             writer.Write("BLOCK:try");
-            writer.Write(
-                $"let! _ = {_container!.FSharpUsage}.UpsertItemAsync({_document.FSharpUsage}, {CosmosDbConcurrency.FSharpRequestOptions(etag)})");
-            writer.Write("()");
+            foreach (var line in upsert) writer.Write(line);
             writer.FinishBlock();
             CosmosDbConcurrency.WriteFSharpCatchBlock(writer, _document.VariableType, SagaChain.SagaIdVariableName);
         }
         else
         {
-            writer.Write($"let! _ = {_container!.FSharpUsage}.UpsertItemAsync({_document.FSharpUsage})");
-            writer.Write("()");
+            foreach (var line in upsert) writer.Write(line);
         }
 
         Next?.GenerateFSharpCode(method, writer);
@@ -257,12 +350,15 @@ internal class CosmosDbDeleteDocumentFrame : AsyncFrame
     private readonly Variable _sagaId;
     private readonly Variable _saga;
     private readonly bool _optimisticConcurrency;
+    private readonly bool _partitionById;
     private Variable? _container;
 
-    public CosmosDbDeleteDocumentFrame(Variable sagaId, Variable saga, bool optimisticConcurrency = false)
+    public CosmosDbDeleteDocumentFrame(Variable sagaId, Variable saga, bool partitionById = false,
+        bool optimisticConcurrency = false)
     {
         _sagaId = sagaId;
         _saga = saga;
+        _partitionById = partitionById;
         _optimisticConcurrency = optimisticConcurrency;
         uses.Add(_sagaId);
         uses.Add(_saga);
@@ -276,6 +372,8 @@ internal class CosmosDbDeleteDocumentFrame : AsyncFrame
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
+        var partition = LoadDocumentFrame.PartitionKeyExpression(_sagaId, _partitionById);
+
         if (_optimisticConcurrency)
         {
             // Completing a saga is just as destructive as updating it: a blind delete would drop a
@@ -284,14 +382,14 @@ internal class CosmosDbDeleteDocumentFrame : AsyncFrame
 
             writer.Write("BLOCK:try");
             writer.Write(
-                $"await {_container!.Usage}.DeleteItemAsync<{_saga.VariableType.FullNameInCode()}>({_sagaId.Usage}, {typeof(PartitionKey).FullNameInCode()}.None, {CosmosDbConcurrency.RequestOptions(etag)}).ConfigureAwait(false);");
+                $"await {_container!.Usage}.DeleteItemAsync<{_saga.VariableType.FullNameInCode()}>({_sagaId.Usage}, {partition}, {CosmosDbConcurrency.RequestOptions(etag)}).ConfigureAwait(false);");
             writer.FinishBlock();
             CosmosDbConcurrency.WriteCatchBlock(writer, _saga.VariableType, _sagaId.Usage);
         }
         else
         {
             writer.Write(
-                $"await {_container!.Usage}.DeleteItemAsync<{_saga.VariableType.FullNameInCode()}>({_sagaId.Usage}, {typeof(PartitionKey).FullNameInCode()}.None).ConfigureAwait(false);");
+                $"await {_container!.Usage}.DeleteItemAsync<{_saga.VariableType.FullNameInCode()}>({_sagaId.Usage}, {partition}).ConfigureAwait(false);");
         }
 
         Next?.GenerateCode(method, writer);
@@ -299,6 +397,8 @@ internal class CosmosDbDeleteDocumentFrame : AsyncFrame
 
     public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
     {
+        var partition = LoadDocumentFrame.FSharpPartitionKeyExpression(_sagaId, _partitionById);
+
         // DeleteItemAsync returns Task<ItemResponse<T>>, not Task; use let! _ = to discard the result.
         if (_optimisticConcurrency)
         {
@@ -306,7 +406,7 @@ internal class CosmosDbDeleteDocumentFrame : AsyncFrame
 
             writer.Write("BLOCK:try");
             writer.Write(
-                $"let! _ = {_container!.FSharpUsage}.DeleteItemAsync<{_saga.VariableType.FSharpName()}>({_sagaId.FSharpUsage}, {typeof(PartitionKey).FSharpName()}.None, {CosmosDbConcurrency.FSharpRequestOptions(etag)})");
+                $"let! _ = {_container!.FSharpUsage}.DeleteItemAsync<{_saga.VariableType.FSharpName()}>({_sagaId.FSharpUsage}, {partition}, {CosmosDbConcurrency.FSharpRequestOptions(etag)})");
             writer.Write("()");
             writer.FinishBlock();
             CosmosDbConcurrency.WriteFSharpCatchBlock(writer, _saga.VariableType, _sagaId.FSharpUsage);
@@ -314,7 +414,7 @@ internal class CosmosDbDeleteDocumentFrame : AsyncFrame
         else
         {
             writer.Write(
-                $"let! _ = {_container!.FSharpUsage}.DeleteItemAsync<{_saga.VariableType.FSharpName()}>({_sagaId.FSharpUsage}, {typeof(PartitionKey).FSharpName()}.None)");
+                $"let! _ = {_container!.FSharpUsage}.DeleteItemAsync<{_saga.VariableType.FSharpName()}>({_sagaId.FSharpUsage}, {partition})");
             writer.Write("()");
         }
 

--- a/src/Persistence/Wolverine.CosmosDb/Internals/CosmosSagaStorage.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/CosmosSagaStorage.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Microsoft.Azure.Cosmos;
+
+namespace Wolverine.CosmosDb.Internals;
+
+/// <summary>
+///     GH-3415. Writes a saga document into the logical partition keyed by its own id, for applications that
+///     opted into <see cref="CosmosDbConfiguration.PartitionSagasById" />.
+///     <para>
+///         CosmosDB takes a document's partition key from the document body, not from the request — hand it a
+///         <see cref="PartitionKey" /> the body does not carry and it answers 400. A saga is the user's own POCO
+///         and knows nothing about the container's <c>/partitionKey</c> path, so Wolverine has to put the value
+///         there itself: serialize the saga with the CosmosClient's own serializer, add <c>partitionKey</c> = the
+///         document's <c>id</c>, and write the resulting JSON. Reads and deletes need none of this — they already
+///         have the id, and the id is the partition key.
+///     </para>
+///     <para>
+///         Going through the stream API rather than <c>UpsertItemAsync&lt;T&gt;</c> is what makes that possible
+///         without asking every user to add a partition key property to their saga. It costs one parse of the JSON
+///         the serializer just produced, which is nothing next to the round trip that follows.
+///     </para>
+/// </summary>
+public static class CosmosSagaStorage
+{
+    /// <summary>
+    ///     Upsert a saga document into the partition keyed by its id. Pass the ETag captured when the saga was
+    ///     read to make the write a compare-and-swap, or null for a saga being inserted for the first time.
+    /// </summary>
+    public static async Task UpsertAsync<T>(Container container, T saga, string? etag,
+        CancellationToken cancellationToken)
+    {
+        var document = serialize(container, saga);
+        var id = identityOf<T>(document);
+
+        document[DocumentTypes.PartitionKeyProperty] = id;
+
+        var options = etag.IsEmpty() ? null : new ItemRequestOptions { IfMatchEtag = etag };
+
+        using var body = write(document);
+        using var response = await container
+            .UpsertItemStreamAsync(body, new PartitionKey(id), options, cancellationToken)
+            .ConfigureAwait(false);
+
+        // The stream API reports failures on the response instead of throwing. Turn them back into the
+        // CosmosException the typed API would have raised, so that a 412 still reaches the saga frames'
+        // catch block and becomes a SagaConcurrencyException
+        response.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>
+    ///     Delete a saga document from the partition keyed by its id. Only used by the storage action path, where
+    ///     the saga itself is in hand but its id is not — the saga chain deletes by id directly.
+    /// </summary>
+    public static Task DeleteAsync<T>(Container container, T saga, CancellationToken cancellationToken)
+    {
+        var id = identityOf<T>(serialize(container, saga));
+
+        return container.DeleteItemAsync<T>(id, new PartitionKey(id), cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    ///     The saga as the registered CosmosClient itself would write it. Asking the client's own serializer is
+    ///     the only way to know what the document really looks like: naming policies, [JsonProperty] mappings and
+    ///     custom CosmosSerializer implementations all change the answer.
+    /// </summary>
+    private static JsonObject serialize<T>(Container container, T saga)
+    {
+        var serializer = container.Database.Client.ClientOptions.Serializer;
+        if (serializer == null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot determine how the registered CosmosClient serializes {typeof(T).FullNameInCode()}, so Wolverine cannot write the partition key that {nameof(CosmosDbConfiguration.PartitionSagasById)}() asks for.");
+        }
+
+        using var raw = serializer.ToStream(saga);
+
+        return JsonNode.Parse(raw) as JsonObject ??
+               throw new InvalidOperationException(
+                   $"The registered CosmosClient's serializer does not write {typeof(T).FullNameInCode()} as a JSON object, so it cannot be stored as a CosmosDB document.");
+    }
+
+    /// <summary>
+    ///     The document id, which is also the partition to store the saga in. Guaranteed to be there by
+    ///     <see cref="CosmosDbSagaSerializationValidator" />, which refuses at startup any saga the registered
+    ///     client would not write an "id" for (GH-3416).
+    /// </summary>
+    private static string identityOf<T>(JsonObject document)
+    {
+        var id = document[CosmosSagaIdentity.CosmosIdProperty] is JsonValue value &&
+                 value.TryGetValue<string>(out var identity)
+            ? identity
+            : null;
+
+        if (id.IsEmpty())
+        {
+            throw new InvalidOperationException(
+                $"The registered CosmosClient's serializer does not write a '{CosmosSagaIdentity.CosmosIdProperty}' property for {typeof(T).FullNameInCode()}, so the saga has no identity to partition by.");
+        }
+
+        return id!;
+    }
+
+    private static MemoryStream write(JsonObject document)
+    {
+        var stream = new MemoryStream();
+
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            document.WriteTo(writer);
+        }
+
+        stream.Position = 0;
+
+        return stream;
+    }
+}

--- a/src/Persistence/Wolverine.CosmosDb/Internals/DocumentTypes.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/DocumentTypes.cs
@@ -14,6 +14,7 @@ public static class DocumentTypes
 
     public const string ContainerName = "wolverine";
     public const string PartitionKeyPath = "/partitionKey";
+    public const string PartitionKeyProperty = "partitionKey";
 
     public const string ControlMessage = "control-message";
     public const string ControlPartitionPrefix = "control-";

--- a/src/Persistence/Wolverine.CosmosDb/Internals/LoadDocumentFrame.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/LoadDocumentFrame.cs
@@ -8,17 +8,38 @@ namespace Wolverine.CosmosDb.Internals;
 
 internal class LoadDocumentFrame : AsyncFrame
 {
+    private readonly bool _partitionById;
     private readonly Variable _sagaId;
     private Variable? _cancellation;
     private Variable? _container;
 
-    public LoadDocumentFrame(Type sagaType, Variable sagaId)
+    public LoadDocumentFrame(Type sagaType, Variable sagaId, bool partitionById = false)
     {
         _sagaId = sagaId;
+        _partitionById = partitionById;
         Saga = new Variable(sagaType, this);
     }
 
     public Variable Saga { get; }
+
+    /// <summary>
+    ///     The partition the document lives in: its own, keyed by the saga id, when the application opted into
+    ///     <see cref="CosmosDbConfiguration.PartitionSagasById" /> — otherwise CosmosDB's single "undefined"
+    ///     partition, which is where a document with no partition key value lands (GH-3415).
+    /// </summary>
+    public static string PartitionKeyExpression(Variable id, bool partitionById)
+    {
+        return partitionById
+            ? $"new {typeof(PartitionKey).FullNameInCode()}({id.Usage})"
+            : $"{typeof(PartitionKey).FullNameInCode()}.None";
+    }
+
+    public static string FSharpPartitionKeyExpression(Variable id, bool partitionById)
+    {
+        return partitionById
+            ? $"{typeof(PartitionKey).FSharpName()}({id.FSharpUsage})"
+            : $"{typeof(PartitionKey).FSharpName()}.None";
+    }
 
     /// <summary>
     ///     Name of the local variable that carries the CosmosDB ETag captured when the saga document
@@ -73,7 +94,7 @@ internal class LoadDocumentFrame : AsyncFrame
         writer.Write($"try");
         writer.Write($"{{");
         writer.Write(
-            $"    var _cosmosResponse = await {_container!.Usage}.ReadItemAsync<{Saga.VariableType.FullNameInCode()}>({_sagaId.Usage}, {typeof(PartitionKey).FullNameInCode()}.None, cancellationToken: {_cancellation!.Usage}).ConfigureAwait(false);");
+            $"    var _cosmosResponse = await {_container!.Usage}.ReadItemAsync<{Saga.VariableType.FullNameInCode()}>({_sagaId.Usage}, {PartitionKeyExpression(_sagaId, _partitionById)}, cancellationToken: {_cancellation!.Usage}).ConfigureAwait(false);");
         writer.Write($"    {Saga.Usage} = _cosmosResponse.Resource;");
 
         if (capturesEtag)
@@ -110,7 +131,7 @@ internal class LoadDocumentFrame : AsyncFrame
 
         writer.Write("BLOCK:try");
         writer.Write(
-            $"let! _cosmosResponse = {_container!.FSharpUsage}.ReadItemAsync<{Saga.VariableType.FSharpName()}>({_sagaId.FSharpUsage}, {typeof(PartitionKey).FSharpName()}.None, cancellationToken = {_cancellation!.FSharpUsage})");
+            $"let! _cosmosResponse = {_container!.FSharpUsage}.ReadItemAsync<{Saga.VariableType.FSharpName()}>({_sagaId.FSharpUsage}, {FSharpPartitionKeyExpression(_sagaId, _partitionById)}, cancellationToken = {_cancellation!.FSharpUsage})");
         writer.Write($"{Saga.FSharpUsage} <- _cosmosResponse.Resource");
 
         if (capturesEtag)

--- a/src/Persistence/Wolverine.CosmosDb/WolverineCosmosDbExtensions.cs
+++ b/src/Persistence/Wolverine.CosmosDb/WolverineCosmosDbExtensions.cs
@@ -18,6 +18,26 @@ public static class WolverineCosmosDbExtensions
     /// <returns></returns>
     public static WolverineOptions UseCosmosDbPersistence(this WolverineOptions options, string databaseName)
     {
+        return options.UseCosmosDbPersistence(databaseName, _ => { });
+    }
+
+    /// <summary>
+    /// Utilize CosmosDb for envelope and saga storage with this system.
+    /// Requires a CosmosClient and database name to be configured.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="databaseName">The CosmosDB database name to use</param>
+    /// <param name="configure">Optional configuration of the CosmosDB integration itself</param>
+    /// <returns></returns>
+    public static WolverineOptions UseCosmosDbPersistence(this WolverineOptions options, string databaseName,
+        Action<CosmosDbConfiguration> configure)
+    {
+        var configuration = new CosmosDbConfiguration();
+        configure(configuration);
+
+        // Read back by CosmosDbPersistenceFrameProvider when the saga frames are generated
+        options.Services.AddSingleton(configuration);
+
         options.Services.AddSingleton<IMessageStore>(sp =>
         {
             var client = sp.GetRequiredService<CosmosClient>();

--- a/src/Testing/Wolverine.Cosmos.FSharpTests/CosmosFSharpCodegenSample.cs
+++ b/src/Testing/Wolverine.Cosmos.FSharpTests/CosmosFSharpCodegenSample.cs
@@ -28,7 +28,13 @@ public static class CosmosFSharpCodegenSample
     private const string ConnectionString =
         "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 
-    public static string GenerateCode()
+    /// <param name="partitionSagasById">
+    ///     Render the saga frames as they are emitted for an application that opted into
+    ///     <see cref="CosmosDbConfiguration.PartitionSagasById" /> (GH-3415), which reads and deletes the saga in
+    ///     the partition keyed by its id and writes it through <c>CosmosSagaStorage</c> rather than the typed
+    ///     <c>UpsertItemAsync&lt;T&gt;</c>. Different F#, so it needs the same compile gate as the default.
+    /// </param>
+    public static string GenerateCode(bool partitionSagasById = false)
     {
         DynamicCodeBuilder.WithinCodegenCommand = true;
         try
@@ -40,7 +46,13 @@ public static class CosmosFSharpCodegenSample
                     opts.Services.AddScoped<IValidator<CreateThing>, CreateThingValidator>();
 
                     opts.UseFluentValidation();
-                    opts.UseCosmosDbPersistence("wolverine_fsharp_cosmos");
+                    opts.UseCosmosDbPersistence("wolverine_fsharp_cosmos", cosmos =>
+                    {
+                        if (partitionSagasById)
+                        {
+                            cosmos.PartitionSagasById();
+                        }
+                    });
                     opts.Policies.AutoApplyTransactions();
 
                     opts.Discovery.DisableConventionalDiscovery();

--- a/src/Testing/Wolverine.Cosmos.FSharpTests/CosmosFSharpCompileGate.cs
+++ b/src/Testing/Wolverine.Cosmos.FSharpTests/CosmosFSharpCompileGate.cs
@@ -23,11 +23,21 @@ public class CosmosFSharpCompileGate
     [Fact]
     public async Task generated_fsharp_compiles_via_dotnet_build()
     {
-        var code = CosmosFSharpCodegenSample.GenerateCode();
+        // Both saga storage layouts, because they emit different F#: the partitioned one (GH-3415) reads and
+        // deletes the saga in the partition keyed by its id and writes it through CosmosSagaStorage. The
+        // default is rendered last so that the checked-in Generated.fs stays the one the fixture describes.
+        await assertCompilesAsync(partitionSagasById: true);
+        await assertCompilesAsync(partitionSagasById: false);
+    }
+
+    private async Task assertCompilesAsync(bool partitionSagasById)
+    {
+        var code = CosmosFSharpCodegenSample.GenerateCode(partitionSagasById);
         var generatedFile = CosmosFSharpCodegenSample.DefaultGeneratedFilePath();
         File.WriteAllText(generatedFile, code);
 
         File.Exists(generatedFile).ShouldBeTrue();
+        _output.WriteLine($"PartitionSagasById: {partitionSagasById}");
         _output.WriteLine(code);
 
         var fixtureProject = CosmosFSharpCodegenSample.FixtureProjectPath();


### PR DESCRIPTION
A saga is the user's own POCO, so nothing writes the container's /partitionKey property into it, and CosmosDB files a document with no partition key value under one "undefined" partition. Read and write agree on it, so this is self-consistent and not a correctness bug -- but it means every saga in the application shares a single logical partition, and a logical partition is capped at 20 GB and 10,000 RU/s regardless of how far the container is scaled out. The failure mode is 429 throttling that does not improve when RU/s are added, because the ceiling is per logical partition rather than per container.

CosmosDbConfiguration.PartitionSagasById() opts a saga workload out of that: the saga id becomes the document's partition key, so loading, updating and deleting a saga is a single-partition point operation and sagas spread across every physical partition the container has.

CosmosDB takes the partition key from the document body, not from the request, so the value has to be in the saga's JSON. CosmosSagaStorage serializes the saga with the registered CosmosClient's own serializer, stamps partitionKey = id onto it, and writes it through the stream API -- which is what makes this possible without asking every user to add a partition key property to their saga class. GH-3414's ETag compare-and-swap rides along on that write unchanged.

Opt in rather than the default, because it moves where a saga document lives: sagas written before it was turned on stay in the undefined partition, where a point read keyed on the saga id will not find them. Migration is documented rather than automated -- saga documents carry no docType discriminator, so nothing in the container tells them apart from the documents a user's own code and Storage.Store() side effects leave in that same undefined partition, and a blanket migration would re-home those too.

Fixes #3415 