### PR TITLE
Describe the whole route table on a pre-start ApiExplorer read (GH-3421)

### DIFF
--- a/docs/guide/http/metadata.md
+++ b/docs/guide/http/metadata.md
@@ -299,11 +299,31 @@ asynchronous Wolverine extension) will not appear. This matches the goal of buil
 is worth knowing if you add endpoints dynamically.
 :::
 
-The same holds in-process: Wolverine's endpoint descriptions are complete on the very first
-ApiExplorer read after `MapWolverineEndpoints()` has run, even before the host starts. Only
-Wolverine's descriptions are start-independent — ASP.NET's own minimal API descriptions still
-compose at server start — so applications mixing the two should defer early ApiExplorer reads
-until after startup.
+## Reading the ApiExplorer Before the Host Starts
+
+The `openapi` command is one case of a more general rule: the API descriptions are complete on the very
+first ApiExplorer read after `MapWolverineEndpoints()` has run, even before the host starts.
+
+This matters because ASP.NET Core **caches the first ApiExplorer read for the lifetime of the host** —
+nothing that happens later, host startup included, invalidates it. Whatever that first read sees is what
+your application serves from then on, and the read can happen surprisingly early: build-time OpenAPI
+generation, a monitoring agent taking a capability snapshot, or the `openapi` command above.
+
+The completeness covers the whole route table, not just Wolverine's share of it. On a **hybrid host** —
+Wolverine HTTP endpoints alongside minimal API and/or MVC routes — ASP.NET Core does not publish the
+application's endpoints to its own description providers until the server starts, so a read before that
+would otherwise describe Wolverine's endpoints while silently omitting every other route. Wolverine
+publishes them ahead of the read instead, exactly as ASP.NET Core's `UseEndpoints()` does at startup, so
+an early read still yields every route in the application.
+
+::: warning
+This one shape is the exception: if you call `MapWolverineEndpoints()` on a **route group** rather than on
+the `WebApplication` itself, Wolverine cannot publish the application's endpoints early — a group only
+knows its own, and ASP.NET Core publishes those itself at startup. An ApiExplorer read before the host
+starts will then describe Wolverine's endpoints and omit the rest, and Wolverine logs a warning saying so.
+Either map Wolverine's endpoints on the `WebApplication` (using `RoutePrefix()` if you wanted the prefix a
+group would have given you), or read the ApiExplorer after the host has started.
+:::
 
 ## With Microsoft.Extensions.ApiDescription.Server
 

--- a/src/Http/Wolverine.Http.Tests/api_explorer_before_host_start.cs
+++ b/src/Http/Wolverine.Http.Tests/api_explorer_before_host_start.cs
@@ -1,6 +1,10 @@
+using IntegrationTests;
 using Marten;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Wolverine.Http.Tests.DifferentAssembly.Validation;
@@ -16,15 +20,126 @@ public class api_explorer_before_host_start
     [Fact]
     public async Task api_descriptions_are_complete_before_the_host_starts()
     {
+        await using var app = buildHybridHost();
+
+        // Note: no app.StartAsync(). This is the first ApiExplorer read, which ASP.NET Core
+        // caches for the lifetime of the host
+        var relativePaths = readDescriptions(app)
+            .Where(x => x.ActionDescriptor is WolverineActionDescriptor)
+            .Select(x => x.RelativePath)
+            .ToList();
+
+        relativePaths.ShouldContain("validate2/customer");
+        relativePaths.ShouldContain("validate2/user");
+    }
+
+    // GH-3421. Making Wolverine's own descriptions start-independent (GH-3373) left a hybrid host —
+    // Wolverine HTTP endpoints alongside minimal API or MVC routes — describing only half of itself on
+    // a pre-start read: Wolverine's routes present, everybody else's silently missing. A document that
+    // lists a plausible subset of an application's routes reads as correct, so the omission surfaces far
+    // downstream — a client team that cannot find an endpoint, a generated SDK quietly lacking one.
+    [Fact]
+    public async Task minimal_api_endpoints_are_described_before_the_host_starts()
+    {
+        await using var app = buildHybridHost();
+
+        var descriptions = readDescriptions(app);
+
+        var minimalApiRoutes = descriptions
+            .Where(x => x.ActionDescriptor is not WolverineActionDescriptor)
+            .Select(x => $"{x.HttpMethod} {x.RelativePath}")
+            .ToList();
+
+        // Mapped before MapWolverineEndpoints()...
+        minimalApiRoutes.ShouldContain("GET minimal/hello");
+        // ...and after it. Both land in the route builder's live DataSources collection, so the order
+        // MapWolverineEndpoints() is called in must not matter.
+        minimalApiRoutes.ShouldContain("POST minimal/goodbye");
+
+        // And Wolverine's own endpoints are still described exactly once, not doubled by ASP.NET Core's
+        // providers now that they can see the HttpGraph too
+        descriptions.Count(x => x.RelativePath == "validate2/customer").ShouldBe(1);
+    }
+
+    // The route builder's data sources are published into ASP.NET Core's global collection ahead of the
+    // description providers that read it. That collection is what UseEndpoints() fills at start, so a
+    // double registration here would mean every endpoint in the application matching twice.
+    [Fact]
+    public async Task publishing_endpoints_early_does_not_duplicate_them_when_the_host_starts()
+    {
+        await using var app = buildHybridHost(useRealDatabase: true);
+
+        // Forces the early publish, exactly as a build-time OpenAPI read or a monitoring snapshot would
+        readDescriptions(app).ShouldNotBeEmpty();
+
+        await app.StartAsync();
+
+        var routes = app.Services.GetRequiredService<EndpointDataSource>().Endpoints
+            .OfType<RouteEndpoint>()
+            .Select(x => x.RoutePattern.RawText)
+            .ToList();
+
+        routes.Count(x => x == "/minimal/hello").ShouldBe(1);
+        routes.Count(x => x == "/validate2/customer").ShouldBe(1);
+
+        // The proof that matters: an ambiguous match would throw here rather than answer
+        var client = app.GetTestServer().CreateClient();
+        (await client.GetAsync("/minimal/hello")).EnsureSuccessStatusCode();
+
+        await app.StopAsync();
+    }
+
+    // Endpoints are only ever published from the application's root route builder. MapWolverineEndpoints()
+    // can also be called on a route group, and a group's DataSources are its *inner* sources — ASP.NET Core
+    // publishes those itself, prefixed and carrying the group's conventions, through the GroupDataSource on
+    // the outer builder. Publishing them a second time would register every endpoint in the group again,
+    // un-prefixed and stripped of conventions such as the group's RequireAuthorization(), at a URL the
+    // application never mapped.
+    [Fact]
+    public async Task wolverine_endpoints_mapped_into_a_route_group_are_registered_exactly_once()
+    {
+        await using var app = buildHybridHost(useRealDatabase: true, mapWolverineInto: app => app.MapGroup("/api"));
+
+        // Forces the publish, exactly as a build-time OpenAPI read or a monitoring snapshot would
+        readDescriptions(app).ShouldNotBeEmpty();
+
+        await app.StartAsync();
+
+        var routes = app.Services.GetRequiredService<EndpointDataSource>().Endpoints
+            .OfType<RouteEndpoint>()
+            .Select(x => x.RoutePattern.RawText)
+            .ToList();
+
+        routes.Count(x => x == "/api/validate2/customer").ShouldBe(1);
+        routes.ShouldNotContain("/validate2/customer");
+
+        await app.StopAsync();
+    }
+
+    // Wolverine reaches RouteOptions.EndpointDataSources — internal to Microsoft.AspNetCore.Routing —
+    // to publish the host's endpoints before it starts. Fail here, in Wolverine's own build, if a future
+    // ASP.NET Core moves it, rather than silently reverting to serving partial documents.
+    [Fact]
+    public void the_aspnetcore_endpoint_data_source_collection_is_still_reachable()
+    {
+        HostEndpointDataSources.EndpointDataSourcesProperty.ShouldNotBeNull();
+    }
+
+    private static WebApplication buildHybridHost(bool useRealDatabase = false,
+        Func<WebApplication, IEndpointRouteBuilder>? mapWolverineInto = null)
+    {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = "Development" });
+        builder.WebHost.UseTestServer();
 
         // "DifferentAssembly" also carries the Marten aggregate endpoints used by openapi_shape_tests, so
-        // any host discovering it needs Marten registered to resolve the aggregates' id types. Pointed at
-        // an unreachable database (nothing listens on port 9999) to keep this test free of infrastructure.
+        // any host discovering it needs Marten registered to resolve the aggregates' id types. Unless the
+        // host is actually going to be started, point it at an unreachable database (nothing listens on
+        // port 9999) to keep the test free of infrastructure.
         builder.Services.AddMarten(opts =>
         {
-            opts.Connection(
-                "Host=localhost;Port=9999;Database=does_not_exist;Username=nobody;Password=nobody;Timeout=2;Command Timeout=2");
+            opts.Connection(useRealDatabase
+                ? Servers.PostgresConnectionString
+                : "Host=localhost;Port=9999;Database=does_not_exist;Username=nobody;Password=nobody;Timeout=2;Command Timeout=2");
         }).IntegrateWithWolverine();
 
         builder.Host.UseWolverine(opts =>
@@ -37,20 +152,20 @@ public class api_explorer_before_host_start
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddWolverineHttp();
 
-        await using var app = builder.Build();
-        app.MapWolverineEndpoints();
+        var app = builder.Build();
 
-        // Note: no app.StartAsync(). This is the first ApiExplorer read, which ASP.NET Core
-        // caches for the lifetime of the host
-        var provider = app.Services.GetRequiredService<IApiDescriptionGroupCollectionProvider>();
+        app.MapGet("/minimal/hello", () => "Hello");
+        (mapWolverineInto?.Invoke(app) ?? app).MapWolverineEndpoints();
+        app.MapPost("/minimal/goodbye", () => "Goodbye");
 
-        var relativePaths = provider.ApiDescriptionGroups.Items
+        return app;
+    }
+
+    private static List<ApiDescription> readDescriptions(WebApplication app)
+    {
+        return app.Services.GetRequiredService<IApiDescriptionGroupCollectionProvider>()
+            .ApiDescriptionGroups.Items
             .SelectMany(x => x.Items)
-            .Where(x => x.ActionDescriptor is WolverineActionDescriptor)
-            .Select(x => x.RelativePath)
             .ToList();
-
-        relativePaths.ShouldContain("validate2/customer");
-        relativePaths.ShouldContain("validate2/user");
     }
 }

--- a/src/Http/Wolverine.Http.Tests/generate_openapi_without_database.cs
+++ b/src/Http/Wolverine.Http.Tests/generate_openapi_without_database.cs
@@ -24,6 +24,24 @@ public class generate_openapi_without_database
         json.ShouldContain("/validate2/user");
     }
 
+    // The command never starts the host, and ASP.NET Core does not surface an application's endpoints to
+    // its own description providers until it does — so a hybrid host (Wolverine HTTP endpoints alongside
+    // minimal API routes) is where a document quietly reduced to "Wolverine's routes only" would show up.
+    // The command already merged the endpoint data sources itself to avoid that; GH-3421 lifted that merge
+    // into HostEndpointDataSources so an in-process ApiExplorer read gets it too. Pin the behavior here,
+    // now that the command depends on shared code to keep it.
+    [Fact]
+    public async Task generates_the_whole_route_table_on_a_hybrid_host()
+    {
+        var json = await GenerateDocumentWithoutDatabaseAsync(app =>
+        {
+            app.MapGet("/minimal/hello", () => "Hello");
+        });
+
+        json.ShouldContain("/validate2/customer");
+        json.ShouldContain("/minimal/hello");
+    }
+
     [Fact]
     public async Task route_filter_keeps_only_matching_routes_and_their_schemas()
     {
@@ -52,7 +70,7 @@ public class generate_openapi_without_database
         OpenApiRouteFilter.ListPaths(json).ShouldContain("/validate2/customer");
     }
 
-    private static async Task<string> GenerateDocumentWithoutDatabaseAsync()
+    private static async Task<string> GenerateDocumentWithoutDatabaseAsync(Action<WebApplication>? configure = null)
     {
         // Build in the Development environment, which is what the CI runner uses and which turns on DI
         // scope validation by default. This reproduces GH-2911: the Microsoft.AspNetCore.OpenApi
@@ -89,6 +107,8 @@ public class generate_openapi_without_database
 
         await using var app = builder.Build();
         app.MapWolverineEndpoints();
+
+        configure?.Invoke(app);
 
         // Exercise the exact no-startup path the `openapi` command uses. Note: no app.StartAsync().
         var documentProvider = OpenApiCommand.PrepareDocumentProvider(app);

--- a/src/Http/Wolverine.Http/Commands/OpenApiCommand.cs
+++ b/src/Http/Wolverine.Http/Commands/OpenApiCommand.cs
@@ -1,12 +1,7 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Text;
 using JasperFx.CommandLine;
 using JasperFx.Core;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 using Spectre.Console;
 using Wolverine.Http.Commands;
 
@@ -174,7 +169,18 @@ public class OpenApiCommand : JasperFxAsyncCommand<OpenApiInput>
         // MapWolverineEndpoints) are normally merged into the global EndpointDataSource by the
         // routing middleware's UseEndpoints step, which only runs once the host starts. We replicate
         // just that merge here so generation sees every endpoint while skipping host startup entirely.
-        ComposeEndpointDataSources(host);
+        if (!HostEndpointDataSources.TryPublish(host))
+        {
+            // Refuse rather than write a document that would omit every minimal API and MVC route while
+            // looking perfectly well-formed. This command exists to be run in a build, and a partial spec
+            // that exits 0 is exactly how a generated client SDK silently loses half an API.
+            throw new InvalidOperationException(
+                "Wolverine could not make this application's endpoints visible to the OpenAPI document " +
+                "provider without starting the host, so the generated document would describe Wolverine's " +
+                "HTTP endpoints while silently omitting any minimal API or MVC endpoint. This means ASP.NET " +
+                "Core has moved the internal collection Wolverine publishes to; please report it against " +
+                "Wolverine.");
+        }
 
         return OpenApiDocumentProvider.Resolve(host.Services);
     }
@@ -211,40 +217,6 @@ public class OpenApiCommand : JasperFxAsyncCommand<OpenApiInput>
         foreach (var path in paths)
         {
             AnsiConsole.MarkupLine($"  [grey]{Markup.Escape(path)}[/]");
-        }
-    }
-
-    [UnconditionalSuppressMessage("Trimming", "IL2075",
-        Justification = "Dev/build-time 'openapi' CLI command. RouteOptions.EndpointDataSources is an internal collection populated identically by ASP.NET Core's own UseEndpoints; reflecting it here only runs interactively, never on an AOT-published hot path.")]
-    private static void ComposeEndpointDataSources(IHost host)
-    {
-        if (host is not IEndpointRouteBuilder routeBuilder || routeBuilder.DataSources.Count == 0)
-        {
-            return;
-        }
-
-        var routeOptions = host.Services.GetService<IOptions<RouteOptions>>();
-        if (routeOptions?.Value == null)
-        {
-            return;
-        }
-
-        var property = typeof(RouteOptions).GetProperty("EndpointDataSources",
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-
-        if (property?.GetValue(routeOptions.Value) is not ICollection<EndpointDataSource> sources)
-        {
-            return;
-        }
-
-        // Mirror EndpointRoutingApplicationBuilderExtensions.UseEndpoints: add every data source the
-        // application mapped, de-duplicating so a later real start (if any) stays correct.
-        foreach (var dataSource in routeBuilder.DataSources)
-        {
-            if (!sources.Contains(dataSource))
-            {
-                sources.Add(dataSource);
-            }
         }
     }
 

--- a/src/Http/Wolverine.Http/HostEndpointDataSources.cs
+++ b/src/Http/Wolverine.Http/HostEndpointDataSources.cs
@@ -1,0 +1,154 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Wolverine.Http;
+
+/// <summary>
+/// Makes every endpoint the host has mapped — minimal API, MVC, gRPC, Wolverine's own — visible to
+/// ASP.NET Core's ApiExplorer before the host has started.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ASP.NET Core routes ApiExplorer through a single <see cref="EndpointDataSource" /> singleton: a
+/// CompositeEndpointDataSource wrapping the collection held by the (internal)
+/// RouteOptions.EndpointDataSources. Endpoints mapped on an <see cref="IEndpointRouteBuilder" />
+/// (<c>app.MapGet()</c>, <c>app.MapControllers()</c>, <c>app.MapWolverineEndpoints()</c>) land in that
+/// builder's own DataSources immediately, but only reach the global collection when
+/// <c>UseEndpoints()</c> runs — and on a <c>WebApplication</c> that happens inside StartAsync().
+/// </para>
+/// <para>
+/// So an ApiExplorer read before the host starts sees an *empty* global collection. Worse, ASP.NET Core
+/// caches the resulting ApiDescription collection against the MVC action-descriptor version, which
+/// endpoint registration never bumps — so that first, premature read is what the host serves for the rest
+/// of its life. Wolverine's own descriptions are start-independent (GH-3373: they are read straight off
+/// the HttpGraph), which on a hybrid host turns the old empty document into something more dangerous: a
+/// document listing every Wolverine route and silently omitting every minimal API and MVC one. See
+/// GH-3421.
+/// </para>
+/// <para>
+/// Publishing the route builder's data sources into the global collection ahead of the read closes the
+/// gap. It is the same operation <c>UseEndpoints()</c> performs at start, with the same data source
+/// instances — and UseEndpoints() de-dupes by reference, so it is a no-op there afterwards.
+/// </para>
+/// </remarks>
+internal static class HostEndpointDataSources
+{
+    // RouteOptions.EndpointDataSources is internal to Microsoft.AspNetCore.Routing. It has been the
+    // observable collection backing the EndpointDataSource singleton since it was introduced in .NET 6.
+    // `the_aspnetcore_endpoint_data_source_collection_is_still_reachable` fails loudly if a future
+    // ASP.NET Core moves it, rather than letting Wolverine quietly go back to serving partial documents.
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "RouteOptions.EndpointDataSources is an internal collection ASP.NET Core's own ConfigureRouteOptions/UseEndpoints write to and read from, so the property is always rooted by live framework code. TryPublish() degrades to a logged warning if it is ever unreachable.")]
+    internal static PropertyInfo? EndpointDataSourcesProperty { get; } =
+        typeof(RouteOptions).GetProperty("EndpointDataSources",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+    // Serializes Wolverine's own writers against each other: ApiDescriptionGroupCollectionProvider caches
+    // without synchronizing, so two simultaneous cold ApiExplorer reads both run the description providers
+    // and hence both land here. It cannot exclude ASP.NET Core's UseEndpoints(), which writes the same
+    // collection unlocked — but that writer only runs while the host is starting, and an ApiExplorer read
+    // concurrent with host start is already unsafe in ASP.NET Core (it enumerates the very collection
+    // UseEndpoints is mutating), with or without Wolverine. Uncontended in practice, and taken once per
+    // ApiExplorer composition rather than per request.
+    private static readonly object _lock = new();
+
+    /// <summary>
+    /// Publish the endpoints a host has mapped. Nothing to do for a host that is not an
+    /// <see cref="IEndpointRouteBuilder" /> — a <c>WebApplication</c> is both.
+    /// </summary>
+    public static bool TryPublish(IHost host)
+    {
+        if (host is IEndpointRouteBuilder routeBuilder)
+        {
+            return TryPublish(routeBuilder);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Add every data source the route builder knows about to the global collection ASP.NET Core's
+    /// ApiExplorer reads, skipping the ones already there. Safe to call repeatedly, and a no-op once the
+    /// host has started and UseEndpoints() has published them itself.
+    /// </summary>
+    /// <param name="routeBuilder">
+    /// The application's <em>root</em> route builder — the <c>WebApplication</c> — and never a nested one.
+    /// A <c>RouteGroupBuilder</c>'s DataSources are the group's <em>inner</em> sources, which ASP.NET Core
+    /// already publishes on the group's behalf (prefixed, and carrying the group's conventions) through the
+    /// GroupDataSource it registered on the outer builder. Publishing those inner sources as well would
+    /// register every endpoint in the group a second time, stripped of the prefix and the conventions — at
+    /// a URL the application never mapped. <see cref="IsRoot" /> is the guard.
+    /// </param>
+    /// <returns>False if ASP.NET Core's internals could not be reached, meaning a pre-start read of the
+    /// ApiExplorer would be missing the host's non-Wolverine endpoints.</returns>
+    public static bool TryPublish(IEndpointRouteBuilder routeBuilder)
+    {
+        if (!tryGetGlobalDataSources(routeBuilder.ServiceProvider, out var global))
+        {
+            return false;
+        }
+
+        lock (_lock)
+        {
+            foreach (var dataSource in routeBuilder.DataSources)
+            {
+                // Reference equality, matching UseEndpoints(). Publishing anything other than the very
+                // instances the route builder holds would leave UseEndpoints() to add them a second time
+                // at start, and the router would then see every endpoint twice.
+                if (!global.Contains(dataSource))
+                {
+                    global.Add(dataSource);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Is this the application's root route builder — the one holding the host's endpoints — rather than a
+    /// nested builder such as a route group? A <c>WebApplication</c> is the root, and is also the IHost.
+    /// </summary>
+    public static bool IsRoot(IEndpointRouteBuilder routeBuilder)
+    {
+        return routeBuilder is IHost;
+    }
+
+    /// <summary>
+    /// Has anything reached the global collection yet? Nothing has before the host starts, which is exactly
+    /// when a read of it yields an incomplete document.
+    /// </summary>
+    public static bool AnyPublished(IServiceProvider services)
+    {
+        return tryGetGlobalDataSources(services, out var global) && global.Count > 0;
+    }
+
+    private static bool tryGetGlobalDataSources(IServiceProvider services,
+        out ICollection<EndpointDataSource> dataSources)
+    {
+        dataSources = default!;
+
+        if (EndpointDataSourcesProperty == null)
+        {
+            return false;
+        }
+
+        if (services.GetService<IOptions<RouteOptions>>()?.Value is not { } routeOptions)
+        {
+            return false;
+        }
+
+        if (EndpointDataSourcesProperty.GetValue(routeOptions) is not ICollection<EndpointDataSource> collection
+            || collection.IsReadOnly)
+        {
+            return false;
+        }
+
+        dataSources = collection;
+        return true;
+    }
+}

--- a/src/Http/Wolverine.Http/WolverineApiDescriptionProvider.cs
+++ b/src/Http/Wolverine.Http/WolverineApiDescriptionProvider.cs
@@ -1,16 +1,20 @@
 using JasperFx.Core.Reflection;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 
 namespace Wolverine.Http;
 
 internal class WolverineApiDescriptionProvider : IApiDescriptionProvider
 {
     private readonly WolverineHttpOptions _options;
+    private readonly ILogger<WolverineApiDescriptionProvider> _logger;
 
-    public WolverineApiDescriptionProvider(WolverineHttpOptions options)
+    public WolverineApiDescriptionProvider(WolverineHttpOptions options,
+        ILogger<WolverineApiDescriptionProvider> logger)
     {
         _options = options;
+        _logger = logger;
     }
 
     public void OnProvidersExecuting(ApiDescriptionProviderContext context)
@@ -22,6 +26,8 @@ internal class WolverineApiDescriptionProvider : IApiDescriptionProvider
         {
             return;
         }
+
+        publishHostEndpoints();
 
         foreach (var chain in graph.Chains)
         {
@@ -56,9 +62,57 @@ internal class WolverineApiDescriptionProvider : IApiDescriptionProvider
         }
     }
 
+    /// <summary>
+    /// Making Wolverine's own descriptions start-independent (GH-3373) is only half an answer on a
+    /// hybrid host: the minimal API and MVC providers that run after this one read the host's endpoints
+    /// through an EndpointDataSource that ASP.NET Core does not fill until the server starts. Left alone,
+    /// a pre-start read caches a document carrying every Wolverine route and none of theirs — which reads
+    /// as correct and is not. Publish the host's endpoints first so that whatever is described here is the
+    /// whole route table. See GH-3421.
+    /// </summary>
+    private void publishHostEndpoints()
+    {
+        if (_options.RouteBuilder is not { } routeBuilder)
+        {
+            return;
+        }
+
+        // Only ever publish from the application's root route builder. MapWolverineEndpoints() can also be
+        // called on a route group, whose DataSources are the group's *inner* sources — ASP.NET Core already
+        // publishes those on the group's behalf, prefixed and carrying the group's conventions. Publishing
+        // them again here would register every endpoint in the group a second time, un-prefixed and stripped
+        // of conventions like the group's RequireAuthorization(), at a URL the application never mapped.
+        if (HostEndpointDataSources.IsRoot(routeBuilder) && HostEndpointDataSources.TryPublish(routeBuilder))
+        {
+            return;
+        }
+
+        // The host has started, so ASP.NET Core has published its own endpoints and this read is complete
+        // whatever Wolverine did or did not do above.
+        if (HostEndpointDataSources.AnyPublished(routeBuilder.ServiceProvider))
+        {
+            return;
+        }
+
+        // Left: a pre-start read that Wolverine cannot complete — Wolverine's endpoints were mapped into a
+        // route group, or a future ASP.NET Core moved RouteOptions.EndpointDataSources. ASP.NET Core caches
+        // this read for the lifetime of the host, so say out loud that what it cached is partial. Discovering
+        // that downstream — in a client team that cannot find an endpoint, or a generated SDK silently
+        // missing one — costs far more than a warning here.
+        _logger.LogWarning(
+            "Wolverine could not publish this application's endpoints to ASP.NET Core's ApiExplorer, which " +
+            "was read before the host started. ASP.NET Core caches that first read for the lifetime of the " +
+            "host, and it describes Wolverine's HTTP endpoints while omitting any minimal API or MVC endpoint " +
+            "in this application. Either read the ApiExplorer (OpenAPI/Swagger document generation) after " +
+            "IHost.StartAsync(), or call MapWolverineEndpoints() on the WebApplication itself rather than on " +
+            "a route group, which is the one shape Wolverine cannot publish from.");
+    }
+
     public void OnProvidersExecuted(ApiDescriptionProviderContext context)
     {
     }
 
-    public int Order => -2000; // Get this before MVC
+    // Ahead of ASP.NET Core's own providers (EndpointMetadataApiDescriptionProvider at -1100, MVC's
+    // DefaultApiDescriptionProvider at -1000), so publishHostEndpoints() lands before they read.
+    public int Order => -2000;
 }

--- a/src/Http/Wolverine.Http/WolverineHttpEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpEndpointRouteBuilderExtensions.cs
@@ -229,6 +229,10 @@ public static class WolverineHttpEndpointRouteBuilderExtensions
         options.TenantIdDetection.Services = serviceProvider; // Hokey, but let this go
         options.Endpoints = new HttpGraph(runtime.Options, serviceProvider.GetRequiredService<IServiceContainer>());
 
+        // Held rather than read now: endpoints mapped *after* this call still land in the same live
+        // DataSources collection, and an ApiExplorer read is the only thing that needs them. See GH-3421.
+        options.RouteBuilder = endpoints;
+
         configure?.Invoke(options);
 
         options.Policies.Add(new ProblemDetailsFromMiddleware());

--- a/src/Http/Wolverine.Http/WolverineHttpOptions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpOptions.cs
@@ -5,6 +5,7 @@ using JasperFx.Core.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Wolverine.Http.Antiforgery;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Wolverine.Configuration;
 using Wolverine.Http.ApiVersioning;
 using Wolverine.Http.CodeGen;
@@ -232,6 +233,13 @@ public class WolverineHttpOptions
     internal object? NewtonsoftSettingsConfiguration { get; set; }
 
     internal HttpGraph? Endpoints { get; set; }
+
+    /// <summary>
+    ///     The route builder MapWolverineEndpoints() was called on. Its DataSources collection is the
+    ///     only place the host's minimal API / MVC endpoints can be seen before the host starts, which
+    ///     an ApiExplorer read that early depends on. See <see cref="HostEndpointDataSources" />.
+    /// </summary>
+    internal IEndpointRouteBuilder? RouteBuilder { get; set; }
 
     internal MiddlewarePolicy Middleware { get; } = new();
 


### PR DESCRIPTION
GH-3373 made Wolverine's own endpoint descriptions start-independent, but that only half-closed the freeze. ASP.NET Core surfaces endpoints to its own description providers through an EndpointDataSource that UseEndpoints() does not fill until the server starts, and it caches the first ApiExplorer read for the lifetime of the host. So on a hybrid host, a pre-start read cached a document carrying every Wolverine route and silently omitting every minimal API and MVC one — a plausible-looking subset, which is worse than the empty document it replaced.

Publish the application's endpoints ahead of that read rather than refusing to serve it. It is the same merge UseEndpoints() performs at startup, with the same data source instances, so UseEndpoints() de-dupes it away and the router is untouched. The `openapi` command already did this merge privately (GH-2903, which is why it was never affected); lift it into HostEndpointDataSources so the in-process read shares it, and fail that command loudly instead of writing a partial spec at exit 0 if the merge ever stops working.

Publish only from the root route builder: a route group's DataSources are its inner, un-prefixed sources that ASP.NET Core already publishes via the outer GroupDataSource, so republishing them would register every endpoint in the group a second time without its prefix or conventions. Wolverine warns rather than serve a partial document for that shape.

Fixes #3421