### PR TITLE
Dead letter recovered envelopes whose transport cannot be resolved (GH-3432, GH-3413)

### DIFF
--- a/src/Persistence/PersistenceTests/Durability/CheckRecoverableOutgoingMessagesOperationTests.cs
+++ b/src/Persistence/PersistenceTests/Durability/CheckRecoverableOutgoingMessagesOperationTests.cs
@@ -1,0 +1,74 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Durability;
+using Wolverine.Runtime;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace PersistenceTests.Durability;
+
+public class CheckRecoverableOutgoingMessagesOperationTests
+{
+    private static readonly Uri TheUnknownDestination = "rabbitmq://queue/items".ToUri();
+    private static readonly Uri TheKnownDestination = "stub://one".ToUri();
+
+    private readonly IEndpointCollection theEndpoints = Substitute.For<IEndpointCollection>();
+    private readonly IWolverineRuntime theRuntime = Substitute.For<IWolverineRuntime>();
+    private readonly CheckRecoverableOutgoingMessagesOperation theOperation;
+
+    public CheckRecoverableOutgoingMessagesOperationTests()
+    {
+        theRuntime.Endpoints.Returns(theEndpoints);
+
+        theOperation = new CheckRecoverableOutgoingMessagesOperation(Substitute.For<IMessageDatabase>(), theRuntime,
+            NullLogger.Instance);
+    }
+
+    /// <summary>
+    /// A leftover outbox row for a transport this node does not have registered used to abort
+    /// the recovery of every *other* destination in the same sweep.
+    /// See https://github.com/JasperFx/wolverine/issues/3413.
+    /// </summary>
+    [Fact]
+    public async Task keep_recovering_other_destinations_when_one_transport_cannot_be_resolved()
+    {
+        theEndpoints.GetOrBuildSendingAgent(TheUnknownDestination)
+            .Throws(new UnknownTransportException(
+                $"There is no known transport type that can send to the Destination {TheUnknownDestination}"));
+
+        var knownAgent = Substitute.For<ISendingAgent>();
+        knownAgent.Latched.Returns(false);
+        knownAgent.Destination.Returns(TheKnownDestination);
+        theEndpoints.GetOrBuildSendingAgent(TheKnownDestination).Returns(knownAgent);
+
+        await theOperation.ReadResultsAsync(readerFor(TheUnknownDestination, TheKnownDestination), [],
+            CancellationToken.None);
+
+        var commands = theOperation.PostProcessingCommands().ToArray();
+
+        commands.ShouldHaveSingleItem()
+            .ShouldBeOfType<RecoverOutgoingMessagesCommand>();
+    }
+
+    private static DbDataReader readerFor(params Uri[] destinations)
+    {
+        var reader = Substitute.For<DbDataReader>();
+
+        var reads = destinations.Select(_ => true).Append(false).ToArray();
+        reader.ReadAsync(Arg.Any<CancellationToken>())
+            .Returns(reads[0], reads.Skip(1).ToArray());
+
+        var raw = destinations.Select(x => x.ToString()).ToArray();
+        reader.GetFieldValueAsync<string>(0, Arg.Any<CancellationToken>())
+            .Returns(raw[0], raw.Skip(1).ToArray());
+
+        return reader;
+    }
+}

--- a/src/Persistence/PersistenceTests/ModularMonoliths/end_to_end_modular_monolith.cs
+++ b/src/Persistence/PersistenceTests/ModularMonoliths/end_to_end_modular_monolith.cs
@@ -32,6 +32,15 @@ namespace PersistenceTests.ModularMonoliths;
 
 public class MonolithFixture : IAsyncLifetime
 {
+    /// <summary>
+    /// Deliberately NOT the default "wolverine" schema. This fixture schedules a message bound for
+    /// rabbitmq://queue/items, so any row it leaves behind names a transport that other suites do not
+    /// register. Sharing the default schema on the same database server -- as every suite here does --
+    /// meant such an orphan surfaced as a phantom failure in whichever suite next ran its durability
+    /// agent against it. See https://github.com/JasperFx/wolverine/issues/3413.
+    /// </summary>
+    public const string SchemaName = "modular_monolith";
+
     public MonolithFixture()
     {
         ItemsTable = new Table(new DbObjectName("mt_items", "items"));
@@ -54,7 +63,7 @@ public class MonolithFixture : IAsyncLifetime
         Host = await Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.Durability.MessageStorageSchemaName = "wolverine";
+                opts.Durability.MessageStorageSchemaName = SchemaName;
                 opts.Policies.UseDurableLocalQueues();
                 opts.Policies.UseDurableOutboxOnAllSendingEndpoints();
                 opts.Policies.AutoApplyTransactions();
@@ -169,9 +178,9 @@ public class end_to_end_modular_monolith : IClassFixture<MonolithFixture>, IAsyn
 
         capabilities.MessageStores.Select(x => x.Uri)
              .ShouldBe([
-                 new Uri("wolverinedb://postgresql/localhost/postgres/wolverine"),
-                 new Uri("wolverinedb://postgresql/localhost/things/wolverine"),
-                 new Uri("wolverinedb://sqlserver/localhost/master/wolverine")
+                 new Uri($"wolverinedb://postgresql/localhost/postgres/{MonolithFixture.SchemaName}"),
+                 new Uri($"wolverinedb://postgresql/localhost/things/{MonolithFixture.SchemaName}"),
+                 new Uri($"wolverinedb://sqlserver/localhost/master/{MonolithFixture.SchemaName}")
              ]);
     }
 
@@ -206,9 +215,9 @@ public class end_to_end_modular_monolith : IClassFixture<MonolithFixture>, IAsyn
         var databases = (await runtime.Stores.FindAllAsync()).Select(x => x.Uri).OrderBy(x => x.ToString()).ToArray();
         
         databases.ShouldBe([
-            new Uri("wolverinedb://postgresql/localhost/postgres/wolverine"),
-            new Uri("wolverinedb://postgresql/localhost/things/wolverine"),
-            new Uri("wolverinedb://sqlserver/localhost/master/wolverine"),
+            new Uri($"wolverinedb://postgresql/localhost/postgres/{MonolithFixture.SchemaName}"),
+            new Uri($"wolverinedb://postgresql/localhost/things/{MonolithFixture.SchemaName}"),
+            new Uri($"wolverinedb://sqlserver/localhost/master/{MonolithFixture.SchemaName}"),
             
             ]
         );
@@ -240,7 +249,7 @@ public class end_to_end_modular_monolith : IClassFixture<MonolithFixture>, IAsyn
         var session = await theHost.SendMessageAndWaitAsync(message);
 
         var envelope = session.Sent.SingleEnvelope<ApproveItem1>();
-        envelope.Store!.Uri.ShouldBe(new Uri("wolverinedb://sqlserver/localhost/master/wolverine"));
+        envelope.Store!.Uri.ShouldBe(new Uri($"wolverinedb://sqlserver/localhost/master/{MonolithFixture.SchemaName}"));
         var messageId = envelope.Id;
 
         // Message should have been deleted
@@ -255,7 +264,7 @@ public class end_to_end_modular_monolith : IClassFixture<MonolithFixture>, IAsyn
         var session = await theHost.SendMessageAndWaitAsync(message);
         var scheduledEnvelope = session.Scheduled.SingleEnvelope<Envelope>();
 
-        scheduledEnvelope.Store!.Uri.ShouldBe(new Uri("wolverinedb://sqlserver/localhost/master/wolverine"));
+        scheduledEnvelope.Store!.Uri.ShouldBe(new Uri($"wolverinedb://sqlserver/localhost/master/{MonolithFixture.SchemaName}"));
 
         var stored = await scheduledEnvelope.Store.Admin.AllIncomingAsync();
         var persisted = stored.Where(x => x.MessageType == TransportConstants.ScheduledEnvelope).Single();
@@ -281,7 +290,7 @@ public class end_to_end_modular_monolith : IClassFixture<MonolithFixture>, IAsyn
         var session = await theHost.SendMessageAndWaitAsync(message);
 
         var envelope = session.Sent.SingleEnvelope<ApproveThing>();
-        envelope.Store!.Uri.ShouldBe(new Uri("wolverinedb://postgresql/localhost/postgres/wolverine"));
+        envelope.Store!.Uri.ShouldBe(new Uri($"wolverinedb://postgresql/localhost/postgres/{MonolithFixture.SchemaName}"));
         var messageId = envelope.Id;
 
         // Message should have been deleted
@@ -296,7 +305,7 @@ public class end_to_end_modular_monolith : IClassFixture<MonolithFixture>, IAsyn
         var session = await theHost.SendMessageAndWaitAsync(message);
         var scheduledEnvelope = session.Scheduled.SingleEnvelope<Envelope>();
         
-        scheduledEnvelope.Store!.Uri.ShouldBe(new Uri("wolverinedb://postgresql/localhost/postgres/wolverine"));
+        scheduledEnvelope.Store!.Uri.ShouldBe(new Uri($"wolverinedb://postgresql/localhost/postgres/{MonolithFixture.SchemaName}"));
 
         var stored = await scheduledEnvelope.Store.Admin.AllIncomingAsync();
         var persisted = stored.Where(x => x.MessageType == TransportConstants.ScheduledEnvelope).Single();

--- a/src/Persistence/PersistenceTests/ModularMonoliths/registration_of_message_stores.cs
+++ b/src/Persistence/PersistenceTests/ModularMonoliths/registration_of_message_stores.cs
@@ -236,8 +236,14 @@ public class registration_of_message_stores : IAsyncLifetime
     [Fact]
     public async Task using_dynamic_multi_tenancy()
     {
-        // THIS SHOULD TAKE CARE OF THE TEST RERUNS, but for some reason doesn't
         await dropWolverineSchema();
+
+        // This test ends by registering t3 and t4, so it poisons its own next run. Marten reads the
+        // master tenant table as the host boots and MessageStoreCollection.InitializeAsync() caches
+        // whatever it finds, so clearing the records *after* startHost() -- which is what this test
+        // used to do -- is already too late: the leftover tenant databases are in memory by then.
+        // Reset the table before anything reads it.
+        await dropTenantDatabaseTable();
 
         var collection = await startHost(opts =>
         {
@@ -245,12 +251,10 @@ public class registration_of_message_stores : IAsyncLifetime
             opts.Services.AddMarten(m =>
             {
                 m.MultiTenantedDatabasesWithMasterDatabaseTable(Servers.PostgresConnectionString);
-                
+
 
             }).IntegrateWithWolverine(w => w.MainDatabaseConnectionString = Servers.PostgresConnectionString);
         });
-
-        await _host.ClearAllTenantDatabaseRecordsAsync();
 
         await _host.AddTenantDatabaseAsync("t1", connectionString1);
         await _host.AddTenantDatabaseAsync("t2", connectionString2);
@@ -289,6 +293,19 @@ public class registration_of_message_stores : IAsyncLifetime
         using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
         await conn.OpenAsync();
         await conn.DropSchemaAsync("wolverine");
+        await conn.CloseAsync();
+    }
+
+    /// <summary>
+    /// Marten recreates this on startup through AddResourceSetupOnStartup(). This test is the only
+    /// user of the master tenant table in the default schema -- the Marten suite's tenancy tests all
+    /// pin their own "tenants" schema -- so dropping it cannot disturb anything else.
+    /// </summary>
+    private static async Task dropTenantDatabaseTable()
+    {
+        using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await conn.CreateCommand("drop table if exists public.mt_tenant_databases;").ExecuteNonQueryAsync();
         await conn.CloseAsync();
     }
 

--- a/src/Persistence/Wolverine.RDBMS/Durability/CheckRecoverableOutgoingMessagesOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/CheckRecoverableOutgoingMessagesOperation.cs
@@ -54,8 +54,11 @@ internal class CheckRecoverableOutgoingMessagesOperation : IDatabaseOperation
             }
             catch (Exception e)
             {
+                // Keep going. A destination this node cannot resolve -- say, a leftover row for a
+                // transport that was removed -- should not stop the other destinations in the
+                // outbox from being recovered. See https://github.com/JasperFx/wolverine/issues/3413.
                 _logger.LogError(e, "Error trying to find a sending agent for {Destination}", destination);
-                yield break;
+                continue;
             }
 
             if (!sendingAgent.Latched)

--- a/src/Testing/CoreTests/Bugs/Bug_3413_unknown_destination_on_scheduled_recovery.cs
+++ b/src/Testing/CoreTests/Bugs/Bug_3413_unknown_destination_on_scheduled_recovery.cs
@@ -1,0 +1,105 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+/// <summary>
+/// Reproduction for https://github.com/JasperFx/wolverine/issues/3413.
+///
+/// <para>
+/// The scheduled message poller in every RDBMS message store reads a batch of due
+/// envelopes out of the incoming table, reassigns them to this node, commits, and then
+/// hands the batch to <see cref="WolverineRuntime.EnqueueDirectlyAsync"/>. If any envelope
+/// in that batch names a destination whose transport is not registered on this node —
+/// a row left behind by an older deployment, or by another test suite sharing the schema —
+/// <c>GetOrBuildSendingAgent</c> threw <see cref="UnknownTransportException"/>.
+/// </para>
+///
+/// <para>
+/// That throw came *after* the reassigning commit, so the rest of the batch was lost, and
+/// the poller rediscovered and rethrew on the offending row on every subsequent run. Such a
+/// destination can never become sendable on this node, so the envelope is dead lettered
+/// instead and the rest of the batch goes through.
+/// </para>
+/// </summary>
+public class Bug_3413_unknown_destination_on_scheduled_recovery : IAsyncLifetime
+{
+    private static readonly Uri TheUnknownDestination = "rabbitmq://queue/items".ToUri();
+    private static readonly Uri TheLocalDestination = "local://items".ToUri();
+
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        // Note that there is no Rabbit MQ transport registered in this application
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType<OrphanedMessageHandler>())
+            .StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private (Envelope, IMessageInbox) orphanedEnvelope()
+    {
+        var inbox = Substitute.For<IMessageInbox>();
+        var store = Substitute.For<IMessageStore>();
+        store.Inbox.Returns(inbox);
+
+        var envelope = new Envelope(new OrphanedMessage("stale"))
+        {
+            Destination = TheUnknownDestination,
+
+            // The scheduled poller stamps the owning store on every envelope it recovers
+            Store = store
+        };
+
+        return (envelope, inbox);
+    }
+
+    [Fact]
+    public async Task dead_letter_an_envelope_whose_transport_cannot_be_resolved()
+    {
+        var (envelope, inbox) = orphanedEnvelope();
+
+        await _host.GetRuntime().EnqueueDirectlyAsync([envelope]);
+
+        await inbox.Received().MoveToDeadLetterStorageAsync(envelope, Arg.Any<UnknownTransportException>());
+    }
+
+    [Fact]
+    public async Task still_deliver_the_rest_of_the_batch()
+    {
+        var (orphan, _) = orphanedEnvelope();
+
+        var good = new Envelope(new OrphanedMessage("deliver me"))
+        {
+            Destination = TheLocalDestination
+        };
+
+        var session = await _host.ExecuteAndWaitAsync(
+            () => _host.GetRuntime().EnqueueDirectlyAsync([orphan, good]).AsTask());
+
+        session.Received.SingleMessage<OrphanedMessage>()
+            .Name.ShouldBe("deliver me");
+    }
+}
+
+public record OrphanedMessage(string Name);
+
+public class OrphanedMessageHandler
+{
+    public void Handle(OrphanedMessage message)
+    {
+    }
+}

--- a/src/Wolverine/Runtime/WolverineRuntime.EnqueueDirectly.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.EnqueueDirectly.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.Logging;
 using Wolverine.Transports;
+using Wolverine.Transports.Sending;
 
 namespace Wolverine.Runtime;
 
@@ -18,11 +20,50 @@ public sealed partial class WolverineRuntime
             {
                 // For send-only endpoints (e.g. Azure Service Bus topics),
                 // there is no listener circuit. Send through the sending agent instead.
-                var sender = Endpoints.GetOrBuildSendingAgent(group.Key);
+                ISendingAgent sender;
+                try
+                {
+                    sender = Endpoints.GetOrBuildSendingAgent(group.Key);
+                }
+                catch (UnknownTransportException e)
+                {
+                    // The envelopes here have already been read out of persistence and
+                    // reassigned to this node, so throwing would both lose the rest of
+                    // this batch and leave the offending rows stranded -- and the poller
+                    // would rediscover them and throw again on every subsequent run. A
+                    // destination whose transport this node cannot resolve is never going
+                    // to become sendable here, so dead letter the envelopes instead.
+                    // See https://github.com/JasperFx/wolverine/issues/3413.
+                    await deadLetterUnknownDestinationAsync(group, e);
+                    continue;
+                }
+
                 foreach (var envelope in group)
                 {
                     await sender.EnqueueOutgoingAsync(envelope);
                 }
+            }
+        }
+    }
+
+    private async Task deadLetterUnknownDestinationAsync(IEnumerable<Envelope> envelopes, UnknownTransportException exception)
+    {
+        foreach (var envelope in envelopes)
+        {
+            Logger.LogError(exception,
+                "Moving envelope {Id} ({MessageType}) to dead letter storage because this node has no transport registered that can send to its destination {Destination}",
+                envelope.Id, envelope.MessageType, envelope.Destination);
+
+            try
+            {
+                var inbox = envelope.Store?.Inbox ?? Storage.Inbox;
+                await inbox.MoveToDeadLetterStorageAsync(envelope, exception);
+                MessageTracking.MovedToErrorQueue(envelope, exception);
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Error trying to move envelope {Id} with the unknown destination {Destination} to dead letter storage",
+                    envelope.Id, envelope.Destination);
             }
         }
     }


### PR DESCRIPTION
Fixes #3432. Also removes the test pollution that surfaced it in #3413.

## The product bug (#3432)

Every RDBMS message store's scheduled poller selects a batch of due envelopes,
reassigns them to this node, **commits**, and only then hands the batch to
`WolverineRuntime.EnqueueDirectlyAsync`. If any envelope named a destination whose
transport is not registered on this node, `GetOrBuildSendingAgent` threw
`UnknownTransportException` — after the commit. So:

- the rest of the batch was left owned by this node, marked `Incoming`, and never
  enqueued — silently lost, with no dead-letter row and no path back (incoming
  recovery only picks up `owner_id = 0`);
- the offending row is the oldest, so it is re-selected on every subsequent poll and
  throws again. The node's scheduled-message poller is wedged for good, eating a fresh
  batch of good messages each time it fires.

An unregistered URI scheme is never going to become sendable on this node, so
`EnqueueDirectlyAsync` now logs it, moves those envelopes to dead letter storage, and
carries on with the rest of the batch. The catch is deliberately narrow — a broker that
*is* registered but temporarily unreachable still throws and retries exactly as before.

`CheckRecoverableOutgoingMessagesOperation` had the same call already guarded, but its
`catch` did `yield break`, so one unresolvable destination aborted outbox recovery for
every *other* destination in the sweep. Now `continue`.

## The test pollution (#3413)

`MonolithFixture` is the only place in the codebase publishing to `rabbitmq://queue/items`,
and it *schedules* that message so the envelope lands in the incoming table. It also pinned
the default `wolverine` schema — the same one PolecatTests' ancillary-store fixtures use on
the same Postgres server, and the same one PostgresqlTests sees when it runs after
PersistenceTests inside the `CIPersistence` job. It now has its own schema, so the orphan
cannot reach the shared namespace at all.

While verifying, `registration_of_message_stores.using_dynamic_multi_tenancy` turned out to
poison its own next run: it ends by registering tenants t3/t4, and on the next run Marten
reads those records at boot and `MessageStoreCollection.InitializeAsync()` caches them, so
the first assertion sees five stores instead of three. The existing
`ClearAllTenantDatabaseRecordsAsync()` call ran *after* `startHost()` and could never have
helped — hence the `// THIS SHOULD TAKE CARE OF THE TEST RERUNS, but for some reason doesn't`
comment. The table is now reset before the host boots. This one is pre-existing on `main`;
it only bites on a re-run against a warm database, which is why CI never saw it.

## Verification

- Both new tests confirmed red without the fix, green with it.
- CoreTests: 1955 passing.
- PersistenceTests: 70/70, twice consecutively, against a database that still holds the
  leftover t3/t4 tenant records — the test is now immune to them rather than merely tidying
  up. `main` gives 68 passed / 1 failed on the same run.
- `dotnet build wolverine.slnx -c Release` clean.

Fixes #3432
Fixes #3413 