### PR TITLE
TrackedSession: distinguish 'not tracked' from 'not routed' via ISystemCommand

### DIFF
--- a/src/Testing/CoreTests/Tracking/ignoring_framework_and_telemetry_messages.cs
+++ b/src/Testing/CoreTests/Tracking/ignoring_framework_and_telemetry_messages.cs
@@ -32,14 +32,34 @@ public class ignoring_framework_and_telemetry_messages : IDisposable
     }
 
     [Fact]
-    public void telemetry_messages_marked_with_INotToBeRouted_are_not_tracked()
+    public void system_commands_are_not_tracked_by_default()
     {
-        // Continuously published framework telemetry (e.g. the CritterWatch
-        // monitoring messages) would otherwise hold a tracked session open
-        // until it times out
-        record(new FakeTelemetryMessage());
+        // Continuously published system/monitoring telemetry (e.g. the CritterWatch monitoring
+        // messages) would otherwise hold a tracked session open until it times out.
+        record(new FakeSystemCommand());
 
         theSession.AllRecordsInOrder().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void system_commands_are_tracked_once_included()
+    {
+        theSession.IncludeSystemCommands();
+
+        record(new FakeSystemCommand());
+
+        theSession.AllRecordsInOrder().Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public void not_to_be_routed_is_not_by_itself_a_reason_to_ignore()
+    {
+        // INotToBeRouted governs conventional routing, NOT tracking. A real message can be
+        // explicitly routed while carrying it (CritterWatch's monitoring commands do), and such a
+        // message must remain trackable. Only ISystemCommand suppresses tracking.
+        record(new FakeNotRoutedMessage());
+
+        theSession.AllRecordsInOrder().Length.ShouldBe(1);
     }
 
     [Fact]
@@ -51,11 +71,20 @@ public class ignoring_framework_and_telemetry_messages : IDisposable
     }
 
     [Fact]
+    public void agent_commands_are_ignored_even_when_system_commands_are_included()
+    {
+        theSession.IncludeSystemCommands();
+
+        record(new FakeAgentCommand());
+
+        theSession.AllRecordsInOrder().ShouldBeEmpty();
+    }
+
+    [Fact]
     public void acknowledgements_are_still_tracked()
     {
         // The tracked session has first-class acknowledgement semantics
-        // (SendMessageAndWaitForAcknowledgementAsync), so acks must keep
-        // being recorded even though Acknowledgement is INotToBeRouted
+        // (SendMessageAndWaitForAcknowledgementAsync), so acks must keep being recorded.
         record(new Acknowledgement());
 
         theSession.AllRecordsInOrder().Length.ShouldBe(1);
@@ -78,7 +107,9 @@ public class ignoring_framework_and_telemetry_messages : IDisposable
         theSession.AllRecordsInOrder().Length.ShouldBe(1);
     }
 
-    private class FakeTelemetryMessage : INotToBeRouted;
+    private class FakeSystemCommand : ISystemCommand;
+
+    private class FakeNotRoutedMessage : INotToBeRouted;
 
     private class FakeApplicationMessage;
 

--- a/src/Wolverine/Runtime/ISystemCommand.cs
+++ b/src/Wolverine/Runtime/ISystemCommand.cs
@@ -1,0 +1,16 @@
+namespace Wolverine.Runtime;
+
+/// <summary>
+/// Marker interface for a message that is infrastructure/system traffic rather than
+/// application activity — e.g. continuously-published monitoring telemetry. A
+/// <see cref="Wolverine.Tracking.TrackedSession"/> ignores these by default so a never-ending
+/// system feed cannot keep the session from ever completing. A test that specifically wants to
+/// assert on system traffic opts it back in with
+/// <see cref="Wolverine.Tracking.TrackedSessionConfiguration.IncludeSystemCommands"/>.
+///
+/// <para>
+/// This is orthogonal to <see cref="INotToBeRouted"/>: that marker governs conventional message
+/// <em>routing</em>, this one governs test <em>tracking</em>. A message can be one, both, or neither.
+/// </para>
+/// </summary>
+public interface ISystemCommand;

--- a/src/Wolverine/Tracking/TrackedSession.Execution.cs
+++ b/src/Wolverine/Tracking/TrackedSession.Execution.cs
@@ -14,6 +14,7 @@ internal partial class TrackedSession
         _otherHosts.AddRange(parent._otherHosts);
         _primaryLogger = parent._primaryLogger;
         _ignoreMessageRules.AddRange(parent._ignoreMessageRules);
+        _ignoreSystemCommands = parent._ignoreSystemCommands;
         _source = new();
 
         AssertAnyFailureAcknowledgements = parent.AssertAnyFailureAcknowledgements;

--- a/src/Wolverine/Tracking/TrackedSession.cs
+++ b/src/Wolverine/Tracking/TrackedSession.cs
@@ -34,25 +34,56 @@ internal partial class TrackedSession : ITrackedSession
 
     private Stopwatch _stopwatch = new();
 
-    private readonly List<Func<Type, bool>> _ignoreMessageRules = [isFrameworkTraffic];
+    // Custom, test-supplied ignore rules (via IgnoreMessageTypes). Framework + system-command
+    // filtering is handled directly in isIgnoredMessageType so the system-command rule can be
+    // toggled off by IncludeSystemCommands().
+    private readonly List<Func<Type, bool>> _ignoreMessageRules = [];
+    private bool _ignoreSystemCommands = true;
     private CancellationTokenSource _cancellation = new();
 
     private TrackingStatus _status = TrackingStatus.Active;
 
-    // Framework/infrastructure traffic should never hold a tracked session open. That's
-    // Wolverine's own agent commands plus anything marked INotToBeRouted — which covers
-    // continuously-published telemetry like the CritterWatch monitoring messages that would
-    // otherwise keep IsCompleted() false until the session times out. Acknowledgements are
-    // deliberately still tracked: the session has first-class acknowledgement semantics
-    // (SendMessageAndWaitForAcknowledgementAsync, AssertAnyFailureAcknowledgements).
-    private static bool isFrameworkTraffic(Type type)
+    // Framework/infrastructure traffic should never hold a tracked session open.
+    private bool isIgnoredMessageType(Type? messageType)
     {
-        if (type == typeof(Acknowledgement) || type == typeof(FailureAcknowledgement))
+        if (messageType == null)
         {
             return false;
         }
 
-        return type.CanBeCastTo<IAgentCommand>() || type.CanBeCastTo<INotToBeRouted>();
+        // Acknowledgements are always tracked: the session's acknowledgement APIs
+        // (SendMessageAndWaitForAcknowledgementAsync, AssertAnyFailureAcknowledgements) depend on them.
+        if (messageType == typeof(Acknowledgement) || messageType == typeof(FailureAcknowledgement))
+        {
+            return false;
+        }
+
+        // Wolverine's own agent commands are framework chatter, never test-relevant activity.
+        if (messageType.CanBeCastTo<IAgentCommand>())
+        {
+            return true;
+        }
+
+        // System commands — e.g. continuously-published monitoring telemetry — are ignored by default
+        // so a never-ending feed can't keep IsCompleted() false until the session times out.
+        // IncludeSystemCommands() opts them back in for tests that assert on that traffic. NOTE: this is
+        // deliberately NOT keyed off INotToBeRouted; that marker governs conventional routing, not
+        // tracking, and real messages (e.g. CritterWatch's monitoring commands) legitimately carry it
+        // while still needing to be trackable.
+        if (_ignoreSystemCommands && messageType.CanBeCastTo<ISystemCommand>())
+        {
+            return true;
+        }
+
+        return _ignoreMessageRules.Any(x => x(messageType));
+    }
+
+    /// <summary>
+    /// Stop ignoring <see cref="ISystemCommand"/> traffic so this session tracks and can assert on it.
+    /// </summary>
+    public void IncludeSystemCommands()
+    {
+        _ignoreSystemCommands = false;
     }
 
     public TrackedSession(IHost host)
@@ -474,11 +505,11 @@ internal partial class TrackedSession : ITrackedSession
 
         // Ignore these
         var messageType = envelope.Message?.GetType();
-        if (_ignoreMessageRules.Any(x => x(messageType!)))
+        if (isIgnoredMessageType(messageType))
         {
             return;
         }
-        
+
         // Really just doing this idempotently
         var history = _envelopes[envelope.Id];
         if (history.Records.Any(r =>
@@ -495,7 +526,7 @@ internal partial class TrackedSession : ITrackedSession
     {
         // Ignore these
         var messageType = envelope.Message?.GetType();
-        if (messageType != null && _ignoreMessageRules.Any(x => x(messageType)))
+        if (isIgnoredMessageType(messageType))
         {
             return;
         }

--- a/src/Wolverine/Tracking/TrackedSessionConfiguration.cs
+++ b/src/Wolverine/Tracking/TrackedSessionConfiguration.cs
@@ -80,9 +80,22 @@ public class TrackedSessionConfiguration
     /// </summary>
     /// <param name="filter"></param>
     /// <returns></returns>
-    public TrackedSessionConfiguration IgnoreMessagesMatchingType(Func<Type, bool> filter)  
+    public TrackedSessionConfiguration IgnoreMessagesMatchingType(Func<Type, bool> filter)
     {
         Session.IgnoreMessageTypes(filter);
+        return this;
+    }
+
+    /// <summary>
+    /// Track — and allow assertions on — messages marked <see cref="ISystemCommand"/>, which a tracked
+    /// session ignores by default. Use this when the traffic under test IS the system/monitoring traffic
+    /// (e.g. asserting a monitoring host received a telemetry message). A never-ending system feed can
+    /// still hold the session open, so pair this with <see cref="IgnoreMessagesMatchingType"/> for any
+    /// continuously-published types you don't want to wait on.
+    /// </summary>
+    public TrackedSessionConfiguration IncludeSystemCommands()
+    {
+        Session.IncludeSystemCommands();
         return this;
     }
 


### PR DESCRIPTION
## Problem

#3390 made `TrackedSession` ignore any message marked `INotToBeRouted`, to stop continuously-published monitoring telemetry from holding a tracked session open until it times out. The motivating case was Wolverine.CritterWatch's outbound telemetry.

But `INotToBeRouted` is the wrong lever. It governs conventional **routing** ("don't let the routing convention fan this out"), not test **tracking**. Real, first-class messages legitimately carry it while still needing to be trackable — CritterWatch's monitoring messages are the concrete example: `ICritterWatchMessage` and `IServiceMessage` both extend `INotToBeRouted` because CritterWatch addresses them explicitly rather than via a convention, yet its own test suite must assert on them (`ServiceUpdates`, command acks, inbound commands).

The result of #3390: a downstream running CritterWatch monitoring could no longer observe **any** of its own traffic in a tracked session. Every `WaitForMessageToBeReceivedAt<ServiceUpdates>` (and every `Sent.MessagesOf<…>()` on those types) silently returned nothing and timed out — with no way to opt back in, because `TrackedSession`'s ignore rules are append-only.

## Fix

Introduce a dedicated marker, `ISystemCommand`, that means exactly "system/infrastructure traffic a tracked session should ignore by default." This separates the two concerns cleanly — a message can be `INotToBeRouted` (don't route), `ISystemCommand` (don't track), both, or neither.

- `TrackedSession` now ignores `IAgentCommand` **plus** `ISystemCommand` (unless included), and **no longer keys off `INotToBeRouted`**.
- New `TrackedSessionConfiguration.IncludeSystemCommands()` opts system traffic back in for tests that specifically assert on it — the escape hatch the `INotToBeRouted`-based rule never had.
- Acknowledgements remain tracked (the session's acknowledgement APIs depend on them); agent commands remain ignored even with system commands included.

A monitoring library like CritterWatch then marks its own message hierarchy `ISystemCommand` (so it never holds a *consumer's* session open) and, in its own tests, calls `IncludeSystemCommands()` to assert on that traffic.

## Behavior change

`INotToBeRouted` alone is no longer a reason for a tracked session to ignore a message. Anything that was relying on #3390's behavior should mark the relevant telemetry types `ISystemCommand` instead. Within Wolverine itself the only `INotToBeRouted` types are non-traveling return types (`ISideEffect`, `OutgoingMessages`, `ValidationOutcome`) and the deliberately-carved-out acknowledgements, so nothing framework-internal regresses.

## Tests

Rewrote `CoreTests/Tracking/ignoring_framework_and_telemetry_messages.cs` (8 tests): `ISystemCommand` is ignored by default and tracked after `IncludeSystemCommands()`; `INotToBeRouted` alone is **not** a reason to ignore; agent commands stay ignored even when system commands are included; acks stay tracked. Green on net9.0 and net10.0.

Verified end-to-end against the downstream that surfaced this (CritterWatch): the integration suite that was fully broken on WolverineFx 6.18.0 is green again once its messages are marked `ISystemCommand` and its harness uses `IncludeSystemCommands()`.

Refs #3390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
