### PR TITLE
Bound the Kafka listener shutdown drain instead of awaiting forever (GH-3434)

### DIFF
--- a/src/Testing/CoreTests/Transports/background_receive_loop_3236.cs
+++ b/src/Testing/CoreTests/Transports/background_receive_loop_3236.cs
@@ -112,6 +112,38 @@ public class background_receive_loop_3236
         await theLoop.DisposeAsync();
     }
 
+    // GH-3434: the Kafka listener used to await this loop with Timeout.InfiniteTimeSpan, so a consume loop wedged
+    // in a blocking IConsumer.Consume(token) that never observed cancellation hung host shutdown forever. StopAsync
+    // must honor its finite budget and return even when the iteration ignores the token entirely.
+    [Fact]
+    public async Task stop_async_returns_within_budget_when_iteration_ignores_cancellation()
+    {
+        using var release = new ManualResetEventSlim(false);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var theLoop = loop(_ =>
+        {
+            entered.TrySetResult();
+            // Block synchronously, ignoring the cancellation token — exactly the wedged Consume shape.
+            release.Wait();
+            return Task.FromResult(true);
+        });
+
+        theLoop.Start();
+        await entered.Task.WaitAsync(5.Seconds());
+
+        var stopwatch = Stopwatch.StartNew();
+        await theLoop.StopAsync(200.Milliseconds());
+        stopwatch.Stop();
+
+        // Before the fix an infinite await never returned; now the finite budget bounds it.
+        stopwatch.Elapsed.ShouldBeLessThan(2.Seconds());
+
+        // Let the wedged iteration unwind so the background task can exit cleanly.
+        release.Set();
+        await theLoop.DisposeAsync();
+    }
+
     private static async Task waitUntil(Func<bool> condition, int timeoutMs = 5000)
     {
         var stopwatch = Stopwatch.StartNew();

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -21,16 +21,21 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue, IR
     private readonly string? _messageTypeName;
     private readonly ILogger _logger;
     private readonly KafkaOffsetCommitter _committer;
+    // GH-3434: bounded drain budget for shutdown so StopAsync/Dispose can never block forever waiting on a
+    // consume loop whose blocking IConsumer.Consume(token) hasn't observed cancellation. Sourced from
+    // DurabilitySettings.DrainTimeout (default 30s), matching the SQS and RDBMS listeners.
+    private readonly TimeSpan _drainTimeout;
     // Broker-per-tenant (GH-3303): the cluster this listener's DLQ records are produced to. Null for the shared
     // (default-cluster) listener, which falls back to the topic's parent transport.
     private readonly KafkaTransport? _tenantTransport;
 
     public KafkaListener(KafkaTopic topic, ConsumerConfig config,
         IConsumer<string, byte[]> consumer, IReceiver receiver,
-        ILogger<KafkaListener> logger, KafkaTransport? tenantTransport = null)
+        ILogger<KafkaListener> logger, TimeSpan drainTimeout, KafkaTransport? tenantTransport = null)
     {
         _endpoint = topic;
         _logger = logger;
+        _drainTimeout = drainTimeout;
         _tenantTransport = tenantTransport;
         Address = topic.Uri;
         _consumer = consumer;
@@ -145,9 +150,11 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue, IR
     public async ValueTask StopAsync()
     {
         await _cancellation.CancelAsync();
-        // Await the loop fully (Infinite) so the consume loop has exited and consumer access is single-threaded
-        // before we flush offsets and close (GH-3150) — matching the previous "await _runner" semantics.
-        await _loop.StopAsync(Timeout.InfiniteTimeSpan);
+        // Drain the loop within a bounded budget so shutdown can never hang (GH-3434). On a clean drain the consume
+        // loop has exited and consumer access is single-threaded before we flush + close (GH-3150). If the loop is
+        // wedged in a blocking Consume that ignored cancellation, the drain logs and returns, and the _consumer.Close()
+        // below forces that Consume to unwind — bounded teardown instead of an infinite await.
+        await _loop.StopAsync(_drainTimeout);
 
         _committer.Flush();
         try
@@ -208,7 +215,7 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue, IR
     {
         _cancellation.Cancel();
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-        _loop.StopAsync(Timeout.InfiniteTimeSpan).GetAwaiter().GetResult();
+        _loop.StopAsync(_drainTimeout).GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         _committer.Flush();
         _cancellation.Dispose();

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
@@ -20,16 +20,21 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
     private readonly IReceiver _receiver;
     private readonly ILogger _logger;
     private readonly KafkaOffsetCommitter _committer;
+    // GH-3434: bounded drain budget for shutdown so StopAsync/Dispose can never block forever waiting on a
+    // consume loop whose blocking IConsumer.Consume(token) hasn't observed cancellation. Sourced from
+    // DurabilitySettings.DrainTimeout (default 30s), matching the SQS and RDBMS listeners.
+    private readonly TimeSpan _drainTimeout;
     // Broker-per-tenant (GH-3303): the cluster this listener's DLQ records are produced to. Null for the shared
     // (default-cluster) listener, which falls back to the endpoint's parent transport.
     private readonly KafkaTransport? _tenantTransport;
 
     public KafkaTopicGroupListener(KafkaTopicGroup endpoint, ConsumerConfig config,
         IConsumer<string, byte[]> consumer, IReceiver receiver,
-        ILogger<KafkaTopicGroupListener> logger, KafkaTransport? tenantTransport = null)
+        ILogger<KafkaTopicGroupListener> logger, TimeSpan drainTimeout, KafkaTransport? tenantTransport = null)
     {
         _endpoint = endpoint;
         _logger = logger;
+        _drainTimeout = drainTimeout;
         _tenantTransport = tenantTransport;
         Address = endpoint.Uri;
         _consumer = consumer;
@@ -128,9 +133,11 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
     public async ValueTask StopAsync()
     {
         await _cancellation.CancelAsync();
-        // Await the loop fully (Infinite) so the consume loop has exited and consumer access is single-threaded
-        // before we flush offsets and close (GH-3150).
-        await _loop.StopAsync(Timeout.InfiniteTimeSpan);
+        // Drain the loop within a bounded budget so shutdown can never hang (GH-3434). On a clean drain the consume
+        // loop has exited and consumer access is single-threaded before we flush + close (GH-3150). If the loop is
+        // wedged in a blocking Consume that ignored cancellation, the drain logs and returns, and the _consumer.Close()
+        // below forces that Consume to unwind — bounded teardown instead of an infinite await.
+        await _loop.StopAsync(_drainTimeout);
 
         _committer.Flush();
         try
@@ -188,7 +195,7 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
     {
         _cancellation.Cancel();
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-        _loop.StopAsync(Timeout.InfiniteTimeSpan).GetAwaiter().GetResult();
+        _loop.StopAsync(_drainTimeout).GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         _committer.Flush();
         _cancellation.Dispose();

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -235,7 +235,8 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
         KafkaOffsetCommitter.ApplyTo(config, CommitMode);
 
         var listener = new KafkaListener(this, config,
-            Parent.CreateConsumer(config), receiver, runtime.LoggerFactory.CreateLogger<KafkaListener>());
+            Parent.CreateConsumer(config), receiver, runtime.LoggerFactory.CreateLogger<KafkaListener>(),
+            runtime.DurabilitySettings.DrainTimeout);
 
         // Broker-per-tenant (GH-3303): the shared listener consumes the default cluster. Each tenant runs its
         // own listener on its own cluster, stamping the tenant id onto inbound envelopes via TenantIdRule.
@@ -252,7 +253,8 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
                 var tenantReceiver = new ReceiverWithRules(receiver, [new TenantIdRule(tenant.TenantId)]);
                 var tenantListener = new KafkaListener(this, tenantConfig,
                     tenant.Transport.CreateConsumer(tenantConfig), tenantReceiver,
-                    runtime.LoggerFactory.CreateLogger<KafkaListener>(), tenant.Transport);
+                    runtime.LoggerFactory.CreateLogger<KafkaListener>(), runtime.DurabilitySettings.DrainTimeout,
+                    tenant.Transport);
                 compound.Inner.Add(tenantListener);
             }
 

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
@@ -49,7 +49,8 @@ public class KafkaTopicGroup : KafkaTopic, IBrokerEndpoint
         KafkaOffsetCommitter.ApplyTo(config, CommitMode);
 
         var listener = new KafkaTopicGroupListener(this, config,
-            Parent.CreateConsumer(config), receiver, runtime.LoggerFactory.CreateLogger<KafkaTopicGroupListener>());
+            Parent.CreateConsumer(config), receiver, runtime.LoggerFactory.CreateLogger<KafkaTopicGroupListener>(),
+            runtime.DurabilitySettings.DrainTimeout);
 
         // Broker-per-tenant (GH-3303): mirror the single-topic listener treatment — a shared listener on the
         // default cluster plus one per-tenant listener on each tenant cluster, stamping the tenant id inbound.
@@ -64,7 +65,8 @@ public class KafkaTopicGroup : KafkaTopic, IBrokerEndpoint
                 var tenantReceiver = new ReceiverWithRules(receiver, [new TenantIdRule(tenant.TenantId)]);
                 var tenantListener = new KafkaTopicGroupListener(this, tenantConfig,
                     tenant.Transport.CreateConsumer(tenantConfig), tenantReceiver,
-                    runtime.LoggerFactory.CreateLogger<KafkaTopicGroupListener>(), tenant.Transport);
+                    runtime.LoggerFactory.CreateLogger<KafkaTopicGroupListener>(),
+                    runtime.DurabilitySettings.DrainTimeout, tenant.Transport);
                 compound.Inner.Add(tenantListener);
             }
 


### PR DESCRIPTION
Fixes #3434.

## Problem

Since 6.6.0, an app using the Kafka transport never completes graceful shutdown — `IHost.StopAsync()` blocks forever, so the process only terminates on a force-kill (e.g. Kubernetes `SIGKILL` after the grace period). Reproduced through 6.19.0.

`KafkaListener.StopAsync` (and `Dispose`, and their `KafkaTopicGroupListener` twins) drained the shared `BackgroundReceiveLoop` with `Timeout.InfiniteTimeSpan`. When the loop was parked inside a blocking `IConsumer.Consume(token)` that hadn't observed cancellation, the drain — and therefore host shutdown — never returned. `HostOptions.ShutdownTimeout` couldn't help because the blocking overload takes no `CancellationToken`.

## Fix

Drain with the configurable, bounded `DurabilitySettings.DrainTimeout` (default 30s) instead of `Timeout.InfiniteTimeSpan`, in both `StopAsync` and `Dispose`. This matches the convention the SQS (`_drainTimeout`) and RDBMS (`_settings.DrainTimeout`) listeners already follow — Kafka was the lone `Infinite` outlier.

`BackgroundReceiveLoop.StopAsync` already catches the `TimeoutException` and logs, so this gives clean bounded teardown. On a timed-out drain, the existing `_consumer.Close()` that runs next forces a wedged `Consume` to unwind (the issue's alternative suggestion, for free). The timeout is plumbed through all four build sites, so per-tenant (broker-per-tenant) listeners get bounded shutdown as well. Configurable via `opts.Durability.DrainTimeout`.

## Tests

Adds a `BackgroundReceiveLoop` regression test: an iteration that blocks while ignoring its cancellation token (the wedged-`Consume` shape) still lets `StopAsync(finiteBudget)` return within budget instead of hanging — an infinite await would never return.

Full local `Wolverine.Kafka.Tests` run against the docker-compose broker: 230 passed, 2 skipped, 1 pre-existing `[Flaky]` failure (`batch_processing_with_kafka.end_to_end`, a batch-composition timing assertion) that fails identically on pristine `main` and is unrelated to the shutdown path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)