### PR TITLE
Nine GenerateFSharpCode methods

### DIFF
--- a/src/Http/Wolverine.Http/AssemblyAttributes.cs
+++ b/src/Http/Wolverine.Http/AssemblyAttributes.cs
@@ -11,6 +11,7 @@ using JasperFx.Core.TypeScanning;
 [assembly: InternalsVisibleTo("Wolverine.Http.AspVersioning.Tests")]
 
 [assembly: InternalsVisibleTo("Wolverine.Http.Tests")]
+[assembly: InternalsVisibleTo("Wolverine.Http.FSharpTests")]
 // WolverineFx.Http.Newtonsoft's UseNewtonsoftJsonForSerialization extension
 // needs to call HttpGraph.UseNewtonsoftJson(INewtonsoftHttpCodeGen) and
 // implement INewtonsoftHttpCodeGen — both internal so the public surface

--- a/src/Http/Wolverine.Http/CodeGen/MessageBusSource.cs
+++ b/src/Http/Wolverine.Http/CodeGen/MessageBusSource.cs
@@ -68,6 +68,17 @@ internal class CreateMessageContextWithMaybeTenantFrame : SyncFrame
         Next?.GenerateCode(method, writer);
     }
 
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write($"{Variable.FSharpAssignmentUsage} = {typeof(MessageContext).FSharpName()}({_runtime!.FSharpUsage})");
+        if (_tenantId != null)
+        {
+            writer.Write($"{Variable.FSharpUsage}.{nameof(IMessageBus.TenantId)} <- {_tenantId.FSharpUsage}");
+        }
+
+        Next?.GenerateFSharpCode(method, writer);
+    }
+
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
         _runtime = chain.FindVariable(typeof(IWolverineRuntime));

--- a/src/Http/Wolverine.Http/CodeGen/MessageBusStrategy.cs
+++ b/src/Http/Wolverine.Http/CodeGen/MessageBusStrategy.cs
@@ -37,6 +37,11 @@ internal class UseMessageBusFrame : SyncFrame
         Next?.GenerateCode(method, writer);
     }
 
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        Next?.GenerateFSharpCode(method, writer);
+    }
+
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
         yield return chain.FindVariable(typeof(MessageContext));

--- a/src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
@@ -96,8 +96,23 @@ internal class QueryStringBindingFrame : SyncFrame
         {
             frame.GenerateCode(method, writer);
         }
-        
+
         Next?.GenerateCode(method, writer);
+    }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment("Binding QueryString values to the argument marked with [FromQuery]");
+        var arguments = _parameters.Select(x => x.FSharpUsage).Join(", ");
+
+        writer.Write($"{Variable.FSharpAssignmentUsage} = {Variable.VariableType.FSharpName()}({arguments})");
+
+        foreach (var frame in _props.OfType<Frame>())
+        {
+            frame.GenerateFSharpCode(method, writer);
+        }
+
+        Next?.GenerateFSharpCode(method, writer);
     }
 
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)

--- a/src/Http/Wolverine.Http/CodeGen/ResultContinuationPolicy.cs
+++ b/src/Http/Wolverine.Http/CodeGen/ResultContinuationPolicy.cs
@@ -74,8 +74,22 @@ public class MaybeEndWithResultFrame : AsyncFrame
         Next?.GenerateCode(method, writer);
     }
 
-    // NOTE: F# emit for MaybeEndWithResultFrame is deferred. The frame is added by ResultContinuationPolicy
-    // during a full endpoint compile (MapWolverineEndpoints); the no-host ChainFor harness used by the F#
-    // fixture doesn't apply continuation policies, so it can't exercise this frame yet. It will be done
-    // with the behavioural (host-based) harness (GH-2969).
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (Next is MaybeEndWithResultFrame next && ReferenceEquals(next.Result, Result))
+        {
+            Next?.GenerateFSharpCode(method, writer);
+            return;
+        }
+
+        writer.WriteComment("Evaluate whether or not the execution should be stopped based on the IResult value");
+        writer.Write(
+            $"BLOCK:if not (isNull ({Result.FSharpUsage} :> obj)) && not ({Result.FSharpUsage} :? {typeof(WolverineContinue).FSharpName()}) then");
+        writer.Write($"do! {Result.FSharpUsage}.{nameof(IResult.ExecuteAsync)}({_context!.FSharpUsage})");
+        writer.Write("return ()");
+        writer.FinishBlock();
+        writer.BlankLine();
+
+        Next?.GenerateFSharpCode(method, writer);
+    }
 }

--- a/src/Http/Wolverine.Http/CodeGen/TagHttpHandlerPolicy.cs
+++ b/src/Http/Wolverine.Http/CodeGen/TagHttpHandlerPolicy.cs
@@ -35,4 +35,14 @@ internal class TagHttpHandlerFrame : SyncFrame
 
         Next?.GenerateCode(method, writer);
     }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        var handlerTypeName = _chain.Method.HandlerType.FSharpName();
+        var current = $"{typeof(Activity).FSharpName()}.{nameof(Activity.Current)}";
+        writer.Write(
+            $"if not (isNull {current}) then {current}.{nameof(Activity.SetTag)}(\"{WolverineTracing.HandlerType}\", \"{handlerTypeName}\") |> ignore");
+
+        Next?.GenerateFSharpCode(method, writer);
+    }
 }

--- a/src/Http/Wolverine.Http/HttpEndpointRegistry.cs
+++ b/src/Http/Wolverine.Http/HttpEndpointRegistry.cs
@@ -142,4 +142,19 @@ internal class WriteEndpointTypesFrame : SyncFrame
 
         Next?.GenerateCode(method, writer);
     }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_types.Length == 0)
+        {
+            writer.Write($"System.Array.Empty<{typeof(Type).FSharpName()}>()");
+        }
+        else
+        {
+            var literals = string.Join("; ", _types.Select(t => $"typeof<{t.FSharpName()}>"));
+            writer.Write($"[| {literals} |]");
+        }
+
+        Next?.GenerateFSharpCode(method, writer);
+    }
 }

--- a/src/Http/Wolverine.Http/Resources/EmptyBody204Policy.cs
+++ b/src/Http/Wolverine.Http/Resources/EmptyBody204Policy.cs
@@ -32,6 +32,17 @@ internal class WriteEmptyBodyStatusCode : SyncFrame
         Next?.GenerateCode(method, writer);
     }
 
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment("Wolverine automatically sets the status code to 204 for empty responses");
+        var response = $"{_context!.FSharpUsage}.{nameof(HttpContext.Response)}";
+        writer.Write(
+            $"BLOCK:if not {response}.{nameof(HttpResponse.HasStarted)} && {response}.{nameof(HttpResponse.StatusCode)} = 200 then");
+        writer.Write($"{response}.{nameof(HttpResponse.StatusCode)} <- 204");
+        writer.FinishBlock();
+        Next?.GenerateFSharpCode(method, writer);
+    }
+
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
         _context = chain.FindVariable(typeof(HttpContext));

--- a/src/Http/Wolverine.Http/Runtime/MultiTenancy/DetectTenantIdFrame.cs
+++ b/src/Http/Wolverine.Http/Runtime/MultiTenancy/DetectTenantIdFrame.cs
@@ -49,4 +49,26 @@ internal class DetectTenantIdFrame : AsyncFrame
 
         Next?.GenerateCode(method, writer);
     }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.BlankLine();
+        writer.WriteComment("Tenant Id detection");
+        for (int i = 0; i < _options.Strategies.Count; i++)
+        {
+            writer.WriteComment($"{i + 1}. {_options.Strategies[i]}");
+        }
+
+        writer.Write($"let! {TenantId.Usage} = this.{nameof(HttpHandler.TryDetectTenantId)}({_httpContext!.Usage})");
+
+        if (_options.ShouldAssertTenantIdExists(_chain))
+        {
+            writer.Write($"BLOCK:if System.String.{nameof(string.IsNullOrEmpty)}({TenantId.Usage}) then");
+            writer.Write($"do! this.{nameof(HttpHandler.WriteTenantIdNotFound)}({_httpContext.Usage})");
+            writer.Write("return ()");
+            writer.FinishBlock();
+        }
+
+        Next?.GenerateFSharpCode(method, writer);
+    }
 }

--- a/src/Testing/Wolverine.Core.FSharpContracts/Contracts.cs
+++ b/src/Testing/Wolverine.Core.FSharpContracts/Contracts.cs
@@ -105,6 +105,31 @@ public class GateHandler
 // against the default in-memory saga store — no external persistence.
 // -----------------------------------------------------------------------------
 
+// -----------------------------------------------------------------------------
+// TryFinallyWrapperFrame exercise (issue GH-2969): registering TickMiddleware
+// with both Before and Finally methods against TickHandler triggers the
+// TryFinallyWrapperFrame code path in MiddlewarePolicy.wrapBeforeFrame.
+// -----------------------------------------------------------------------------
+
+/// <summary>Command handled by <see cref="TickHandler" />.</summary>
+public record Tick(int Id);
+
+/// <summary>
+///     Middleware with a <c>Finally</c> method; when registered against <see cref="TickHandler" />
+///     it causes <see cref="Wolverine.Middleware.TryFinallyWrapperFrame" /> to wrap the Before call.
+/// </summary>
+public class TickMiddleware
+{
+    public void Before() { }
+    public void Finally() { }
+}
+
+/// <summary>Minimal handler to produce a chain that receives <see cref="TickMiddleware" />.</summary>
+public class TickHandler
+{
+    public void Handle(Tick command) { }
+}
+
 /// <summary>Starts a <see cref="CountingSaga" />.</summary>
 public record StartCount(string Id);
 

--- a/src/Testing/Wolverine.Core.FSharpFixture/Generated.fs
+++ b/src/Testing/Wolverine.Core.FSharpFixture/Generated.fs
@@ -149,3 +149,26 @@ type StartCountHandler1561563330(inMemorySagaPersistor: Wolverine.Persistence.Sa
         // No unit of work
         System.Threading.Tasks.Task.CompletedTask
 
+type TickHandler1778389912() =
+    inherit Wolverine.Runtime.Handlers.MessageHandler()
+    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+        // The actual message body
+        let tick = context.Envelope.Message :?> Wolverine.Core.FSharpContracts.Tick
+
+        Wolverine.Runtime.WolverineTracing.ApplyExecutionDiagnosticTags(System.Diagnostics.Activity.Current, context.Envelope)
+        let tickMiddleware = Wolverine.Core.FSharpContracts.TickMiddleware()
+        tickMiddleware.Before()
+        try
+            if not (isNull System.Diagnostics.Activity.Current) then
+                System.Diagnostics.Activity.Current.SetTag("message.handler", "Wolverine.Core.FSharpContracts.TickHandler") |> ignore
+                System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Core.FSharpContracts.TickHandler") |> ignore
+            let tickHandler = Wolverine.Core.FSharpContracts.TickHandler()
+            
+            // The actual message execution
+            tickHandler.Handle(tick)
+
+            this.RecordCauseAndEffect(context, context.Runtime.Observer)
+        finally
+            tickMiddleware.Finally()
+        System.Threading.Tasks.Task.CompletedTask
+

--- a/src/Testing/Wolverine.Core.FSharpTests/FSharpCodegenSample.cs
+++ b/src/Testing/Wolverine.Core.FSharpTests/FSharpCodegenSample.cs
@@ -35,6 +35,11 @@ public static class FSharpCodegenSample
                     opts.Discovery.IncludeType<CheckThingHandler>();
                     opts.Discovery.IncludeType<GateHandler>();
                     opts.Discovery.IncludeType<CountingSaga>();
+                    opts.Discovery.IncludeType<TickHandler>();
+
+                    // TickMiddleware has both Before() and Finally() methods. When applied to
+                    // the TickHandler chain it triggers TryFinallyWrapperFrame code generation.
+                    opts.Policies.AddMiddleware<TickMiddleware>(c => c.MessageType == typeof(Tick));
 
                     // Inserts ApplyExecutionDiagnosticTagsFrame at the head of every chain.
                     opts.Tracking.HandlerExecutionDiagnosticsEnabled = true;

--- a/src/Testing/Wolverine.Http.FSharpContracts/Endpoints.cs
+++ b/src/Testing/Wolverine.Http.FSharpContracts/Endpoints.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine;
 
 namespace Wolverine.Http.FSharpContracts;
 
@@ -7,6 +9,9 @@ public record CreateThing(string Name);
 
 /// <summary>The JSON result returned by <see cref="ThingEndpoints.Create" />.</summary>
 public record ThingCreated(string Name);
+
+/// <summary>Complex query string type exercising <c>QueryStringBindingFrame</c>.</summary>
+public record ThingFilter(string? Name, int MaxResults);
 
 /// <summary>
 ///     The "smallest viable" Wolverine.Http endpoints for the F# code-generation audit
@@ -63,4 +68,42 @@ public class ThingEndpoints
     {
         return string.IsNullOrEmpty(id) ? Results.NotFound() : Results.Ok($"thing {id}");
     }
+
+    // Void (204) return: exercises WriteEmptyBodyStatusCode.GenerateFSharpCode.
+    [WolverineDelete("/fsharp/things/{id}")]
+    public void Delete(string id) { }
+
+    // IMessageBus parameter: exercises UseMessageBusFrame and CreateMessageContextWithMaybeTenantFrame.
+    [WolverinePost("/fsharp/publish")]
+    public ThingCreated Publish(CreateThing command, IMessageBus bus)
+    {
+        return new ThingCreated(command.Name);
+    }
+
+    // Complex [FromQuery] type: exercises QueryStringBindingFrame.
+    [WolverineGet("/fsharp/filter")]
+    public ThingCreated Filter([FromQuery] ThingFilter filter)
+    {
+        return new ThingCreated(filter.Name ?? "");
+    }
+}
+
+/// <summary>
+///     A minimal endpoint for exercising <c>MaybeEndWithResultFrame.GenerateFSharpCode</c>:
+///     the codegen sample manually prepends a static auth-check call and wraps its IResult
+///     return in <c>MaybeEndWithResultFrame</c>.
+/// </summary>
+public class AuthedEndpoints
+{
+    [WolverineGet("/fsharp/authed")]
+    public string Get() => "authed";
+}
+
+/// <summary>
+///     Static helper whose return value (<c>IResult</c>) is used by the codegen sample to
+///     construct a <c>MaybeEndWithResultFrame</c> without registering <c>ResultContinuationPolicy</c>.
+/// </summary>
+public static class AuthHelpers
+{
+    public static IResult CheckAuth() => WolverineContinue.Result();
 }

--- a/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
+++ b/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
@@ -8,6 +8,7 @@ open System
 open System.Linq
 open System.Threading.Tasks
 open Wolverine.Http
+open Wolverine.Runtime
 
 type GET_fsharp_hello(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions) =
     inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
@@ -15,6 +16,11 @@ type GET_fsharp_hello(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions)
 
     override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
         task {
+
+            // Tenant Id detection
+            // 1. Tenant Id is request header 'x-tenant-id'
+            let! tenantId = this.TryDetectTenantId(httpContext)
+            if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
             let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
             
             // The actual HTTP request handler execution
@@ -29,6 +35,11 @@ type POST_fsharp_things(wolverineHttpOptions: Wolverine.Http.WolverineHttpOption
 
     override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
         task {
+
+            // Tenant Id detection
+            // 1. Tenant Id is request header 'x-tenant-id'
+            let! tenantId = this.TryDetectTenantId(httpContext)
+            if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
             // Reading the request body via JSON deserialization
             let! (command, jsonContinue) = this.ReadJsonAsync<Wolverine.Http.FSharpContracts.CreateThing>(httpContext)
             if jsonContinue = Wolverine.HandlerContinuation.Stop then
@@ -49,6 +60,11 @@ type GET_fsharp_things_id(wolverineHttpOptions: Wolverine.Http.WolverineHttpOpti
 
     override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
         task {
+
+            // Tenant Id detection
+            // 1. Tenant Id is request header 'x-tenant-id'
+            let! tenantId = this.TryDetectTenantId(httpContext)
+            if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
             let id = (httpContext.GetRouteValue("id") :?> string)
             if isNull id then
                 httpContext.Response.StatusCode <- 404
@@ -68,6 +84,11 @@ type GET_fsharp_search(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions
 
     override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
         task {
+
+            // Tenant Id detection
+            // 1. Tenant Id is request header 'x-tenant-id'
+            let! tenantId = this.TryDetectTenantId(httpContext)
+            if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
             let q = httpContext.Request.Query.["q"].ToString()
             let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
             
@@ -83,6 +104,11 @@ type GET_fsharp_things_id_items_count(wolverineHttpOptions: Wolverine.Http.Wolve
 
     override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
         task {
+
+            // Tenant Id detection
+            // 1. Tenant Id is request header 'x-tenant-id'
+            let! tenantId = this.TryDetectTenantId(httpContext)
+            if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
             let id = (httpContext.GetRouteValue("id") :?> string)
             if isNull id then
                 httpContext.Response.StatusCode <- 404
@@ -112,6 +138,11 @@ type GET_fsharp_paged(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions)
 
     override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
         task {
+
+            // Tenant Id detection
+            // 1. Tenant Id is request header 'x-tenant-id'
+            let! tenantId = this.TryDetectTenantId(httpContext)
+            if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
             let page_rawValue = httpContext.Request.Query.["page"].ToString()
             let page = match System.Int32.TryParse(page_rawValue, System.Globalization.CultureInfo.InvariantCulture) with | true, v -> v | _ -> Unchecked.defaultof<int>
             let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
@@ -127,15 +158,135 @@ type GET_fsharp_result_id(wolverineHttpOptions: Wolverine.Http.WolverineHttpOpti
     let _wolverineHttpOptions = wolverineHttpOptions
 
     override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
-        let id = (httpContext.GetRouteValue("id") :?> string)
-        if isNull id then
-            httpContext.Response.StatusCode <- 404
-            System.Threading.Tasks.Task.CompletedTask
-        else
+        task {
+
+            // Tenant Id detection
+            // 1. Tenant Id is request header 'x-tenant-id'
+            let! tenantId = this.TryDetectTenantId(httpContext)
+            if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
+            let id = (httpContext.GetRouteValue("id") :?> string)
+            if isNull id then
+                httpContext.Response.StatusCode <- 404
+                ()
+            else
+                let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
+                
+                // The actual HTTP request handler execution
+                let result = thingEndpoints.GetResult(id)
+
+                do! result.ExecuteAsync(httpContext)
+        }
+
+type DELETE_fsharp_things_id(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions) =
+    inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
+    let _wolverineHttpOptions = wolverineHttpOptions
+
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+        task {
+
+            // Tenant Id detection
+            // 1. Tenant Id is request header 'x-tenant-id'
+            let! tenantId = this.TryDetectTenantId(httpContext)
+            if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
+            let id = (httpContext.GetRouteValue("id") :?> string)
+            if isNull id then
+                httpContext.Response.StatusCode <- 404
+                ()
+            else
+                let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
+                
+                // The actual HTTP request handler execution
+                thingEndpoints.Delete(id)
+
+                // Wolverine automatically sets the status code to 204 for empty responses
+                if not httpContext.Response.HasStarted && httpContext.Response.StatusCode = 200 then
+                    httpContext.Response.StatusCode <- 204
+        }
+
+type POST_fsharp_publish(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions, wolverineRuntime: Wolverine.Runtime.IWolverineRuntime) =
+    inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
+    let _wolverineHttpOptions = wolverineHttpOptions
+    let _wolverineRuntime = wolverineRuntime
+
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+        task {
+
+            // Tenant Id detection
+            // 1. Tenant Id is request header 'x-tenant-id'
+            let! tenantId = this.TryDetectTenantId(httpContext)
+            let messageContext = Wolverine.Runtime.MessageContext(_wolverineRuntime)
+            messageContext.TenantId <- tenantId
+            if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
+            // Reading the request body via JSON deserialization
+            let! (command, jsonContinue) = this.ReadJsonAsync<Wolverine.Http.FSharpContracts.CreateThing>(httpContext)
+            if jsonContinue = Wolverine.HandlerContinuation.Stop then
+                ()
+            else
+                let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
+                
+                // The actual HTTP request handler execution
+                let thingCreated_response = thingEndpoints.Publish(command, messageContext)
+
+                // Writing the response body to JSON because this was the first 'return variable' in the method signature
+                do! this.WriteJsonAsync(httpContext, thingCreated_response)
+                
+                // Have to flush outgoing messages just in case Marten did nothing because of https://github.com/JasperFx/wolverine/issues/536
+                do! messageContext.FlushOutgoingMessagesAsync()
+
+        }
+
+type GET_fsharp_filter(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions) =
+    inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
+    let _wolverineHttpOptions = wolverineHttpOptions
+
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+        task {
+            let MaxResults_rawValue = httpContext.Request.Query.["MaxResults"].ToString()
+            let MaxResults = match System.Int32.TryParse(MaxResults_rawValue, System.Globalization.CultureInfo.InvariantCulture) with | true, v -> v | _ -> Unchecked.defaultof<int>
+            let Name = httpContext.Request.Query.["Name"].ToString()
+
+            // Tenant Id detection
+            // 1. Tenant Id is request header 'x-tenant-id'
+            let! tenantId = this.TryDetectTenantId(httpContext)
+            if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
+            // Binding QueryString values to the argument marked with [FromQuery]
+            let thingFilter = Wolverine.Http.FSharpContracts.ThingFilter(Name, MaxResults)
             let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
             
             // The actual HTTP request handler execution
-            let result = thingEndpoints.GetResult(id)
+            let thingCreated_response = thingEndpoints.Filter(thingFilter)
 
-            result.ExecuteAsync(httpContext)
+            // Writing the response body to JSON because this was the first 'return variable' in the method signature
+            do! this.WriteJsonAsync(httpContext, thingCreated_response)
+        }
+
+type GET_fsharp_authed(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions) =
+    inherit Wolverine.Http.HttpHandler(wolverineHttpOptions)
+    let _wolverineHttpOptions = wolverineHttpOptions
+
+    override this.Handle(httpContext: Microsoft.AspNetCore.Http.HttpContext) : System.Threading.Tasks.Task =
+        task {
+
+            // Tenant Id detection
+            // 1. Tenant Id is request header 'x-tenant-id'
+            let! tenantId = this.TryDetectTenantId(httpContext)
+            if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.AuthedEndpoints") |> ignore
+            let result1 = Wolverine.Http.FSharpContracts.AuthHelpers.CheckAuth()
+            // Evaluate whether or not the execution should be stopped based on the IResult value
+            if not (isNull (result1 :> obj)) && not (result1 :? Wolverine.Http.WolverineContinue) then
+                do! result1.ExecuteAsync(httpContext)
+                return ()
+
+            let authedEndpoints = Wolverine.Http.FSharpContracts.AuthedEndpoints()
+            
+            // The actual HTTP request handler execution
+            let result_of_Get = authedEndpoints.Get()
+
+            do! Wolverine.Http.HttpHandler.WriteString(httpContext, result_of_Get)
+        }
+
+type GeneratedHttpEndpointRegistry() =
+    inherit Wolverine.Http.HttpEndpointRegistry()
+    override this.EndpointTypes() : System.Type[] =
+        [| typeof<Wolverine.Http.FSharpContracts.AuthedEndpoints>; typeof<Wolverine.Http.FSharpContracts.ThingEndpoints> |]
 

--- a/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCodegenSample.cs
+++ b/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpCodegenSample.cs
@@ -2,10 +2,14 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using JasperFx;
 using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.CodeGeneration.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Wolverine.Http.CodeGen;
 using Wolverine.Http.FSharpContracts;
+using Wolverine.Http.Runtime.MultiTenancy;
+using Wolverine.Runtime;
 
 namespace Wolverine.Http.FSharpTests;
 
@@ -23,6 +27,10 @@ public static class HttpFSharpCodegenSample
         // No-host container setup mirroring Wolverine.Http.Tests.initializing_endpoints_from_method_call.
         var registry = new ServiceCollection();
         registry.AddSingleton<JsonSerializerOptions>();
+        // IWolverineRuntime is needed as a constructor parameter for chains that use IMessageBus.
+        // Register a placeholder so the ServiceCollectionServerVariableSource can resolve the type;
+        // the F# fixture only compiles the generated code, it never executes it.
+        registry.AddSingleton<IWolverineRuntime>(_ => null!);
 
         var container = new ServiceContainer(registry, registry.BuildServiceProvider());
         var httpGraph = new HttpGraph(new WolverineOptions { ApplicationAssembly = typeof(ThingEndpoints).Assembly }, container);
@@ -30,22 +38,60 @@ public static class HttpFSharpCodegenSample
         // GET (static string response) + POST (JSON body bind + JSON response). The JSON path calls
         // the inherited instance HttpHandler methods ReadJsonAsync/WriteJsonAsync, now qualified with
         // the generated member's `this` self identifier (JasperFx 2.2.4 / jasperfx#393).
+        var helloChain    = HttpChain.ChainFor<ThingEndpoints>(x => x.Hello(), httpGraph);
+        var createChain   = HttpChain.ChainFor<ThingEndpoints>(x => x.Create(null!), httpGraph);
+        var getByIdChain  = HttpChain.ChainFor<ThingEndpoints>(x => x.GetById(null!), httpGraph);
+        var searchChain   = HttpChain.ChainFor<ThingEndpoints>(x => x.Search(null!), httpGraph);
+        var getItemsChain = HttpChain.ChainFor<ThingEndpoints>(x => x.GetItems(null!, 0), httpGraph);
+        var pagedChain    = HttpChain.ChainFor<ThingEndpoints>(x => x.Paged(0), httpGraph);
+        var resultChain   = HttpChain.ChainFor<ThingEndpoints>(x => x.GetResult(null!), httpGraph);
+
+        // WriteEmptyBodyStatusCode.GenerateFSharpCode — void-returning endpoint yields 204.
+        var deleteChain  = HttpChain.ChainFor<ThingEndpoints>(x => x.Delete(null!), httpGraph);
+
+        // UseMessageBusFrame + CreateMessageContextWithMaybeTenantFrame.GenerateFSharpCode —
+        // the IMessageBus parameter causes a MessageContext to be constructed in the handler.
+        var publishChain = HttpChain.ChainFor<ThingEndpoints>(x => x.Publish(null!, null!), httpGraph);
+
+        // QueryStringBindingFrame.GenerateFSharpCode — [FromQuery] complex type is bound from
+        // individual query-string variables and passed to the record constructor.
+        var filterChain  = HttpChain.ChainFor<ThingEndpoints>(x => x.Filter(null!), httpGraph);
+
+        // MaybeEndWithResultFrame.GenerateFSharpCode — a static auth-check call whose IResult
+        // return is wrapped in MaybeEndWithResultFrame to short-circuit when the check fails.
+        var authedChain  = HttpChain.ChainFor<AuthedEndpoints>(x => x.Get(), httpGraph);
+        var checkCall    = new MethodCall(typeof(AuthHelpers), nameof(AuthHelpers.CheckAuth));
+        var maybeEnd     = new MaybeEndWithResultFrame(checkCall.ReturnVariable!);
+        authedChain.Middleware.Add(checkCall);
+        authedChain.Middleware.Add(maybeEnd);
+
         var chains = new[]
         {
-            HttpChain.ChainFor<ThingEndpoints>(x => x.Hello(), httpGraph),
-            HttpChain.ChainFor<ThingEndpoints>(x => x.Create(null!), httpGraph),
-            HttpChain.ChainFor<ThingEndpoints>(x => x.GetById(null!), httpGraph),
-            HttpChain.ChainFor<ThingEndpoints>(x => x.Search(null!), httpGraph),
-            HttpChain.ChainFor<ThingEndpoints>(x => x.GetItems(null!, 0), httpGraph), // typed int route value
-            HttpChain.ChainFor<ThingEndpoints>(x => x.Paged(0), httpGraph),           // typed int query value
-            HttpChain.ChainFor<ThingEndpoints>(x => x.GetResult(null!), httpGraph)    // terminal IResult + route value
+            helloChain, createChain, getByIdChain, searchChain, getItemsChain,
+            pagedChain, resultChain, deleteChain, publishChain, filterChain, authedChain
         };
+
+        // TagHttpHandlerFrame.GenerateFSharpCode — applied to all chains via TagHttpHandlerPolicy.
+        // DetectTenantIdFrame.GenerateFSharpCode — applied to all chains when at least one
+        // tenant-detection strategy is configured.
+        var tagPolicy = new TagHttpHandlerPolicy();
+        tagPolicy.Apply(chains, httpGraph.Rules, container);
+
+        var tenantDetection = new TenantIdDetection();
+        tenantDetection.IsRequestHeaderValue("x-tenant-id");
+        ((IHttpPolicy)tenantDetection).Apply(chains, httpGraph.Rules, container);
 
         var generatedAssembly = httpGraph.StartAssembly(httpGraph.Rules);
         foreach (var chain in chains)
         {
             ((ICodeFile)chain).AssembleTypes(generatedAssembly);
         }
+
+        // WriteEndpointTypesFrame.GenerateFSharpCode — emitted by HttpEndpointRegistryCodeFile as
+        // the body of GeneratedHttpEndpointRegistry.EndpointTypes().
+        var allEndpointTypes = new[] { typeof(ThingEndpoints), typeof(AuthedEndpoints) };
+        var registryFile = new HttpEndpointRegistryCodeFile(allEndpointTypes);
+        ((ICodeFile)registryFile).AssembleTypes(generatedAssembly);
 
         var serviceVariableSource = new ServiceCollectionServerVariableSource(container);
         return generatedAssembly.GenerateFSharpCode(serviceVariableSource);

--- a/src/Wolverine/AssemblyAttributes.cs
+++ b/src/Wolverine/AssemblyAttributes.cs
@@ -44,6 +44,7 @@ using Wolverine.Attributes;
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: InternalsVisibleTo("Wolverine.Http")]
 [assembly: InternalsVisibleTo("Wolverine.Http.Tests")]
+[assembly: InternalsVisibleTo("Wolverine.Core.FSharpTests")]
 [assembly: InternalsVisibleTo("Wolverine.Grpc")]
 [assembly: InternalsVisibleTo("Wolverine.Grpc.Tests")]
 [assembly: InternalsVisibleTo("Wolverine.Kafka.Tests")]

--- a/src/Wolverine/Middleware/MiddlewarePolicy.cs
+++ b/src/Wolverine/Middleware/MiddlewarePolicy.cs
@@ -442,6 +442,29 @@ public class TryFinallyWrapperFrame : Frame
         writer.FinishBlock();
     }
 
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        _inner.GenerateFSharpCode(method, writer);
+        writer.Write("BLOCK:try");
+
+        Next?.GenerateFSharpCode(method, writer);
+
+        writer.FinishBlock();
+        writer.Write("BLOCK:finally");
+
+        if (_finallys.Length > 1)
+        {
+            for (var i = 1; i < _finallys.Length; i++)
+            {
+                _finallys[i - 1].Next = _finallys[i];
+            }
+        }
+
+        _finallys[0].GenerateFSharpCode(method, writer);
+
+        writer.FinishBlock();
+    }
+
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
         foreach (var variable in _inner.FindVariables(chain))


### PR DESCRIPTION
Wolverine's code generation has two paths: C# (used at runtime) and F# (used by F#-first projects). Every frame needs both GenerateCode and GenerateFSharpCode. Several frames were missing the F# version, so codegen write --language fsharp produced invalid output. These were added to fix that:

- TryFinallyWrapperFrame — emits try/finally for middleware that has a Finally() method
- TagHttpHandlerFrame — emits the OpenTelemetry SetTag("handler.type", ...) line
- DetectTenantIdFrame — emits the let! tenantId = this.TryDetectTenantId(httpContext) call for multi-tenant apps
- UseMessageBusFrame — pass-through; just delegates to the next frame
- CreateMessageContextWithMaybeTenantFrame — emits let messageContext = MessageContext(runtime) for endpoints that take IMessageBus
- WriteEmptyBodyStatusCode — emits the 204 guard for void-returning endpoints
- MaybeEndWithResultFrame — emits the auth short-circuit (return () if the middleware result is not WolverineContinue)
- QueryStringBindingFrame — emits binding of [FromQuery] complex types from individual query string params
- WriteEndpointTypesFrame — emits the [| typeof<A>; typeof<B> |] array in GeneratedHttpEndpointRegistry

InternalsVisibleTo on Wolverine and Wolverine.Http

Added so the test driver projects can reference internal types (TagHttpHandlerPolicy, TenantIdDetection, HttpEndpointRegistryCodeFile, TryFinallyWrapperFrame) needed to construct the chains that exercise the new frames.

New types in Wolverine.Core.FSharpContracts and Wolverine.Http.FSharpContracts

Added Tick/TickMiddleware/TickHandler in Core, and several new endpoint shapes in Http (Delete, Publish, Filter, GetResult, AuthedEndpoints). Each one targets a specific frame — without an endpoint of the right shape, the corresponding frame never gets included in the generated output and the test wouldn't cover it.

Extended test driver code in FSharpCodegenSample.cs and HttpFSharpCodegenSample.cs

Added chain registrations and policy applications for each new frame. The Http driver also manually applies TagHttpHandlerPolicy, TenantIdDetection, and HttpEndpointRegistryCodeFile directly (rather than going through the full WolverineHttpOptions.Policies pipeline, which requires a real web host).

Updated Generated.fs in both fixture projects

Regenerated after the new frames were implemented — these are the checked-in baseline files that the compile-gate tests build against.