### PR TITLE
Scope tenant scheduled job polling to the owning node (GH-3376)

### DIFF
--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
@@ -179,13 +179,24 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
 
     public IAgent BuildAgent(IWolverineRuntime runtime)
     {
-        return new DurabilityAgent(runtime, this);
+        return new DurabilityAgent(runtime, this)
+        {
+            // GH-3376: polling rides the distributed agent, one node per database
+            AutoStartScheduledJobPolling = true
+        };
     }
 
     public IAgent StartScheduledJobs(IWolverineRuntime runtime)
     {
         var agent = new DurabilityAgent(runtime, this);
-        agent.StartScheduledJobPolling();
+
+        // GH-3376: see MessageDatabase.StartScheduledJobs - this node-wide fan-out would otherwise
+        // poll every database from every node. Only hosts without durability agents still need it.
+        if (!runtime.Options.Durability.DurabilityAgentEnabled)
+        {
+            agent.StartScheduledJobPolling();
+        }
+
         return agent;
     }
 

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
@@ -181,8 +181,8 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
     {
         return new DurabilityAgent(runtime, this)
         {
-            // GH-3376: polling rides the distributed agent, one node per database
-            AutoStartScheduledJobPolling = true
+            // GH-3376: a tenant database's polling rides the distributed agent, one node per database
+            AutoStartScheduledJobPolling = Role == MessageStoreRole.Tenant
         };
     }
 
@@ -190,9 +190,11 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
     {
         var agent = new DurabilityAgent(runtime, this);
 
-        // GH-3376: see MessageDatabase.StartScheduledJobs - this node-wide fan-out would otherwise
-        // poll every database from every node. Only hosts without durability agents still need it.
-        if (!runtime.Options.Durability.DurabilityAgentEnabled)
+        // GH-3376: see MessageDatabase.StartScheduledJobs - this node-wide fan-out would otherwise poll
+        // every tenant database from every node. Main / ancillary stores keep polling here (every node
+        // already connects to them, and this starts at boot rather than after agent assignment), as do
+        // hosts running without durability agents, where this is the only pump.
+        if (!runtime.Options.Durability.DurabilityAgentEnabled || Role != MessageStoreRole.Tenant)
         {
             agent.StartScheduledJobPolling();
         }

--- a/src/Persistence/PostgresqlTests/MultiTenancy/multi_node_tenant_database_connections.cs
+++ b/src/Persistence/PostgresqlTests/MultiTenancy/multi_node_tenant_database_connections.cs
@@ -1,0 +1,255 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Wolverine;
+using Wolverine.Persistence;
+using Wolverine.Postgresql;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+using Xunit.Abstractions;
+
+namespace PostgresqlTests.MultiTenancy;
+
+// GH-3376: with multi-tenancy, every node was polling every tenant database for scheduled messages
+// every ScheduledJobPollingTime, completely outside the agent distribution machinery. The per-database
+// advisory lock deduped the WORK across nodes but not the CONNECTION - the losing node still opened a
+// pooled connection, began a transaction, failed the lock, and rolled back. At 512 tenants x N nodes
+// that parks ~512 connections per node, which is what was reported on the issue.
+//
+// This test attributes connections to nodes by stamping a distinct ApplicationName into each host's
+// connection strings, which is the only way pg_stat_activity can tell two Wolverine nodes apart.
+public class multi_node_tenant_database_connections : PostgresqlContext, IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private readonly List<IHost> _hosts = [];
+
+    // Shared across both hosts so "exactly once" counts executions on either node.
+    private readonly TenantMessageTracker theTracker = new();
+
+    // Unique per run: leftover databases/schemas from a prior run otherwise break resource setup.
+    private readonly string theSuffix = Guid.NewGuid().ToString("N")[..8];
+    private readonly string[] theTenants = ["red", "blue", "green"];
+
+    private string MainSchema => $"mt3376_{theSuffix}";
+    private string TenantDatabase(string tenant) => $"w3376_{tenant}_{theSuffix}";
+
+    public multi_node_tenant_database_connections(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private string ConnectionStringFor(string database, string nodeName)
+    {
+        return new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString)
+        {
+            Database = database,
+
+            // The whole point: pg_stat_activity has no idea which Wolverine node owns a backend,
+            // so tag every connection this host opens with the node's name.
+            ApplicationName = nodeName
+        }.ConnectionString;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        foreach (var tenant in theTenants)
+        {
+            var databaseName = TenantDatabase(tenant);
+            if (!await conn.DatabaseExists(databaseName))
+            {
+                await new DatabaseSpecification().BuildDatabase(conn, databaseName);
+            }
+        }
+
+        await conn.CloseAsync();
+    }
+
+    private async Task<IHost> StartHostAsync(string nodeName)
+    {
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Balanced;
+
+                // Tighten the loops so distribution settles and polling is observable
+                // well inside the test's patience.
+                opts.Durability.HealthCheckPollingTime = 1.Seconds();
+                opts.Durability.CheckAssignmentPeriod = 1.Seconds();
+                opts.Durability.ScheduledJobPollingTime = 1.Seconds();
+                opts.Durability.ScheduledJobFirstExecution = 500.Milliseconds();
+
+                opts.PersistMessagesWithPostgresql(
+                        ConnectionStringFor("postgres", nodeName), MainSchema)
+                    .RegisterStaticTenants(tenants =>
+                    {
+                        foreach (var tenant in theTenants)
+                        {
+                            tenants.Register(tenant, ConnectionStringFor(TenantDatabase(tenant), nodeName));
+                        }
+                    });
+
+                opts.Services.AddResourceSetupOnStartup();
+                opts.Services.AddSingleton(theTracker);
+
+                opts.Policies.UseDurableLocalQueues();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<TenantScheduledMessageHandler>();
+            }).StartAsync();
+
+        _hosts.Add(host);
+        return host;
+    }
+
+    public async Task DisposeAsync()
+    {
+        foreach (var host in _hosts)
+        {
+            host.GetRuntime().Agents.DisableHealthChecks();
+        }
+
+        foreach (var host in _hosts)
+        {
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task tenant_databases_are_only_polled_by_their_owning_node()
+    {
+        var leader = await StartHostAsync("node-A");
+        await leader.WaitUntilAssumesLeadershipAsync(30.Seconds());
+
+        var second = await StartHostAsync("node-B");
+
+        // main + one per tenant == 4 durability agents, distributed evenly across two nodes
+        var settled = await leader.WaitUntilAssignmentsChangeTo(w =>
+        {
+            w.AgentScheme = PersistenceConstants.AgentScheme;
+            w.ExpectRunningAgents(leader, 2);
+            w.ExpectRunningAgents(second, 2);
+        }, 60.Seconds());
+
+        settled.ShouldBeTrue("Durability agents never distributed evenly across the two nodes");
+
+        foreach (var host in _hosts)
+        {
+            foreach (var uri in host.RunningAgents().Where(x => x.Scheme == PersistenceConstants.AgentScheme))
+            {
+                _output.WriteLine($"{host.GetRuntime().Options.Durability.AssignedNodeNumber}: {uri}");
+            }
+        }
+
+        // Open a measurement window and let the scheduled-job pollers (1s cadence) turn over
+        // several times inside it.
+        var windowStart = await ServerNowAsync();
+        await Task.Delay(6.Seconds());
+
+        var offenders = new List<string>();
+
+        foreach (var tenant in theTenants)
+        {
+            var databaseName = TenantDatabase(tenant);
+            var nodes = await FindActiveNodesSinceAsync(databaseName, windowStart);
+
+            _output.WriteLine($"{databaseName}: queried by [{nodes.Join(", ")}]");
+
+            if (nodes.Count > 1)
+            {
+                offenders.Add($"{databaseName} was queried by {nodes.Count} nodes: {nodes.Join(", ")}");
+            }
+        }
+
+        offenders.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task scheduled_tenant_message_still_executes_exactly_once()
+    {
+        var leader = await StartHostAsync("node-A");
+        await leader.WaitUntilAssumesLeadershipAsync(30.Seconds());
+        var second = await StartHostAsync("node-B");
+
+        await leader.WaitUntilAssignmentsChangeTo(w =>
+        {
+            w.AgentScheme = PersistenceConstants.AgentScheme;
+            w.ExpectRunningAgents(leader, 2);
+            w.ExpectRunningAgents(second, 2);
+        }, 60.Seconds());
+
+        var messageId = Guid.NewGuid();
+        await leader.MessageBus().ScheduleAsync(new TenantScheduledMessage(messageId), 1.Seconds(),
+            new DeliveryOptions { TenantId = "red" });
+
+        var handled = await Poll(30.Seconds(), () => theTracker.Received.Any(r => r.Id == messageId));
+        handled.ShouldBeTrue($"Scheduled message {messageId} for tenant 'red' was never executed");
+
+        // Give the losing node's poller every chance to run it a second time before counting.
+        await Task.Delay(5.Seconds());
+
+        theTracker.Received.Count(r => r.Id == messageId).ShouldBe(1);
+    }
+
+    private static async Task<bool> Poll(TimeSpan timeout, Func<bool> condition)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        while (!cts.IsCancellationRequested)
+        {
+            if (condition()) return true;
+            await Task.Delay(250.Milliseconds());
+        }
+
+        return condition();
+    }
+
+    private async Task<DateTime> ServerNowAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select clock_timestamp()";
+        return (DateTime)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    // Which of our nodes actually issued a query against this database inside the window?
+    //
+    // Mere connection presence is not evidence of polling: every node migrates every tenant database
+    // at startup, and Npgsql parks those connections in the pool long afterward. query_start advancing
+    // past the window's start is what separates an ongoing poller from a parked leftover. Timestamps
+    // all come from the server's own clock, so the test host's clock never enters into it.
+    private async Task<List<string>> FindActiveNodesSinceAsync(string databaseName, DateTime windowStart)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+select distinct application_name
+from pg_stat_activity
+where datname = @db
+  and application_name like 'node-%'
+  and query_start > @windowStart
+order by application_name";
+        cmd.Parameters.AddWithValue("@db", databaseName);
+        cmd.Parameters.AddWithValue("@windowStart", windowStart);
+
+        var names = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            names.Add(await reader.GetFieldValueAsync<string>(0));
+        }
+
+        return names;
+    }
+}

--- a/src/Persistence/PostgresqlTests/MultiTenancy/multi_node_tenant_database_connections.cs
+++ b/src/Persistence/PostgresqlTests/MultiTenancy/multi_node_tenant_database_connections.cs
@@ -150,23 +150,28 @@ public class multi_node_tenant_database_connections : PostgresqlContext, IAsyncL
             }
         }
 
-        // Open a measurement window and let the scheduled-job pollers (1s cadence) turn over
-        // several times inside it.
-        var windowStart = await ServerNowAsync();
-        await Task.Delay(6.Seconds());
+        // Sample two consecutive windows and only count a node that polled in BOTH. The bug is
+        // *sustained* polling - every node hitting every tenant database on a fixed cadence forever.
+        // A single window can't tell that apart from a one-off touch, and a tenant's agent legitimately
+        // migrating between nodes mid-test leaves exactly such a touch. Requiring a node to show up in
+        // both windows keeps the assertion pointed at pollers.
+        var windowOne = await PollersDuringWindowAsync(4.Seconds());
+        var windowTwo = await PollersDuringWindowAsync(4.Seconds());
 
         var offenders = new List<string>();
 
         foreach (var tenant in theTenants)
         {
             var databaseName = TenantDatabase(tenant);
-            var nodes = await FindActiveNodesSinceAsync(databaseName, windowStart);
+            var sustained = windowOne[databaseName].Intersect(windowTwo[databaseName]).OrderBy(x => x).ToList();
 
-            _output.WriteLine($"{databaseName}: queried by [{nodes.Join(", ")}]");
+            _output.WriteLine(
+                $"{databaseName}: window1=[{windowOne[databaseName].Join(", ")}] " +
+                $"window2=[{windowTwo[databaseName].Join(", ")}] sustained=[{sustained.Join(", ")}]");
 
-            if (nodes.Count > 1)
+            if (sustained.Count > 1)
             {
-                offenders.Add($"{databaseName} was queried by {nodes.Count} nodes: {nodes.Join(", ")}");
+                offenders.Add($"{databaseName} is polled by {sustained.Count} nodes: {sustained.Join(", ")}");
             }
         }
 
@@ -210,6 +215,22 @@ public class multi_node_tenant_database_connections : PostgresqlContext, IAsyncL
         }
 
         return condition();
+    }
+
+    // Which nodes queried each tenant database during a window of the given length?
+    private async Task<Dictionary<string, List<string>>> PollersDuringWindowAsync(TimeSpan length)
+    {
+        var windowStart = await ServerNowAsync();
+        await Task.Delay(length);
+
+        var results = new Dictionary<string, List<string>>();
+        foreach (var tenant in theTenants)
+        {
+            var databaseName = TenantDatabase(tenant);
+            results[databaseName] = await FindActiveNodesSinceAsync(databaseName, windowStart);
+        }
+
+        return results;
     }
 
     private async Task<DateTime> ServerNowAsync()

--- a/src/Persistence/PostgresqlTests/MultiTenancy/scheduled_jobs_without_durability_agents.cs
+++ b/src/Persistence/PostgresqlTests/MultiTenancy/scheduled_jobs_without_durability_agents.cs
@@ -1,0 +1,112 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Wolverine;
+using Wolverine.Postgresql;
+using Xunit.Abstractions;
+
+namespace PostgresqlTests.MultiTenancy;
+
+// GH-3376: scheduled job polling moved onto the distributed durability agent, and the node-wide
+// fan-out stopped starting pollers of its own. Hosts running with DurabilityAgentEnabled = false
+// have no NodeAgentController and therefore never build a durability agent, so for them the
+// fan-out is still the only scheduled message pump and must keep working. Without this test, the
+// #3376 fix could silently strand scheduled messages for mediator-style hosts.
+public class scheduled_jobs_without_durability_agents : PostgresqlContext, IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string theSuffix = Guid.NewGuid().ToString("N")[..8];
+    private readonly TenantMessageTracker theTracker = new();
+    private IHost theHost = null!;
+
+    private string MainSchema => $"noagent_{theSuffix}";
+    private string TenantDatabase => $"w3376_noagent_{theSuffix}";
+
+    public scheduled_jobs_without_durability_agents(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        if (!await conn.DatabaseExists(TenantDatabase))
+        {
+            await new DatabaseSpecification().BuildDatabase(conn, TenantDatabase);
+        }
+
+        await conn.CloseAsync();
+
+        var tenantConnectionString = new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString)
+        {
+            Database = TenantDatabase
+        }.ConnectionString;
+
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                // The path under test: no durability agents, so no agent-hosted scheduled polling.
+                opts.Durability.DurabilityAgentEnabled = false;
+
+                opts.Durability.ScheduledJobPollingTime = 1.Seconds();
+                opts.Durability.ScheduledJobFirstExecution = 500.Milliseconds();
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, MainSchema)
+                    .RegisterStaticTenants(tenants => tenants.Register("red", tenantConnectionString));
+
+                opts.Services.AddResourceSetupOnStartup();
+                opts.Services.AddSingleton(theTracker);
+
+                opts.Policies.UseDurableLocalQueues();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<TenantScheduledMessageHandler>();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task scheduled_tenant_message_still_runs_from_the_node_wide_fan_out()
+    {
+        var messageId = Guid.NewGuid();
+
+        await theHost.MessageBus().ScheduleAsync(new TenantScheduledMessage(messageId), 1.Seconds(),
+            new DeliveryOptions { TenantId = "red" });
+
+        var handled = await Poll(30.Seconds(), () => theTracker.Received.Any(r => r.Id == messageId));
+
+        handled.ShouldBeTrue(
+            $"Scheduled message {messageId} was never handled - the node-wide scheduled job fan-out is " +
+            "the only pump for hosts without durability agents");
+
+        theTracker.Received.First(r => r.Id == messageId).TenantId.ShouldBe("red");
+        _output.WriteLine($"Message {messageId} handled without any durability agent");
+    }
+
+    private static async Task<bool> Poll(TimeSpan timeout, Func<bool> condition)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        while (!cts.IsCancellationRequested)
+        {
+            if (condition()) return true;
+            await Task.Delay(250.Milliseconds());
+        }
+
+        return condition();
+    }
+}

--- a/src/Persistence/PostgresqlTests/MultiTenancy/scheduled_messages_across_durability_modes.cs
+++ b/src/Persistence/PostgresqlTests/MultiTenancy/scheduled_messages_across_durability_modes.cs
@@ -1,0 +1,150 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Wolverine;
+using Wolverine.Postgresql;
+using Xunit.Abstractions;
+
+namespace PostgresqlTests.MultiTenancy;
+
+// GH-3376: scheduled job polling for TENANT databases moved onto the distributed durability agent, while
+// main / ancillary stores kept polling from the node-wide fan-out. That split has to hold in every
+// durability mode, for both the main store and a tenant database.
+//
+// These deliberately run with the DEFAULT durability timings. An earlier cut of the #3376 fix moved main
+// store polling onto the agent too, which meant polling no longer started until leader election and agent
+// assignment finished - scheduled messages went from prompt to ~13s late on every startup. Every test
+// that tightened HealthCheckPollingTime / CheckAssignmentPeriod / ScheduledJobPollingTime sailed straight
+// past it; only a default-timings test caught it. Do not "speed these up".
+public class scheduled_messages_across_durability_modes : PostgresqlContext, IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private readonly List<IHost> _hosts = [];
+    private readonly TenantMessageTracker theTracker = new();
+    private readonly string theSuffix = Guid.NewGuid().ToString("N")[..8];
+
+    private string MainSchema => $"modes_{theSuffix}";
+    private string TenantDatabase => $"w3376_modes_{theSuffix}";
+
+    public scheduled_messages_across_durability_modes(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        if (!await conn.DatabaseExists(TenantDatabase))
+        {
+            await new DatabaseSpecification().BuildDatabase(conn, TenantDatabase);
+        }
+
+        await conn.CloseAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        foreach (var host in _hosts)
+        {
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    private async Task<IHost> StartHostAsync(DurabilityMode mode)
+    {
+        var tenantConnectionString = new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString)
+        {
+            Database = TenantDatabase
+        }.ConnectionString;
+
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = mode;
+
+                // Default durability timings on purpose - see the class comment.
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, MainSchema)
+                    .RegisterStaticTenants(tenants => tenants.Register("red", tenantConnectionString));
+
+                opts.Services.AddResourceSetupOnStartup();
+                opts.Services.AddSingleton(theTracker);
+
+                opts.Policies.UseDurableLocalQueues();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<TenantScheduledMessageHandler>();
+            }).StartAsync();
+
+        _hosts.Add(host);
+        return host;
+    }
+
+    [Theory]
+    [InlineData(DurabilityMode.Solo)]
+    [InlineData(DurabilityMode.Balanced)]
+    public async Task scheduled_message_against_the_main_store_executes(DurabilityMode mode)
+    {
+        var host = await StartHostAsync(mode);
+
+        var messageId = Guid.NewGuid();
+        await host.MessageBus().ScheduleAsync(new TenantScheduledMessage(messageId), 1.Seconds());
+
+        // The main store polls from the node-wide fan-out, which starts at boot, so this must not have
+        // to wait on leader election or agent assignment.
+        var elapsed = await TimeUntilHandledAsync(messageId, 20.Seconds());
+
+        elapsed.ShouldNotBeNull(
+            $"Scheduled main-store message was never executed in {mode} mode. The main store polls from " +
+            "the node-wide fan-out - if that stopped, or now waits on agent assignment, this is where it shows.");
+
+        _output.WriteLine($"{mode}/main: executed after {elapsed.Value.TotalSeconds:N1}s");
+    }
+
+    [Theory]
+    [InlineData(DurabilityMode.Solo)]
+    [InlineData(DurabilityMode.Balanced)]
+    public async Task scheduled_message_against_a_tenant_database_executes(DurabilityMode mode)
+    {
+        var host = await StartHostAsync(mode);
+
+        var messageId = Guid.NewGuid();
+        await host.MessageBus().ScheduleAsync(new TenantScheduledMessage(messageId), 1.Seconds(),
+            new DeliveryOptions { TenantId = "red" });
+
+        // A tenant database is polled by its durability agent, so in Balanced mode this legitimately
+        // waits for leader election and assignment first - hence the roomier budget.
+        var elapsed = await TimeUntilHandledAsync(messageId, 60.Seconds());
+
+        elapsed.ShouldNotBeNull(
+            $"Scheduled tenant message was never executed in {mode} mode. Tenant polling rides the " +
+            "distributed durability agent - if it never started, this is where it shows.");
+
+        theTracker.Received.First(r => r.Id == messageId).TenantId.ShouldBe("red");
+        _output.WriteLine($"{mode}/tenant: executed after {elapsed.Value.TotalSeconds:N1}s");
+    }
+
+    private async Task<TimeSpan?> TimeUntilHandledAsync(Guid messageId, TimeSpan timeout)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        using var cts = new CancellationTokenSource(timeout);
+
+        while (!cts.IsCancellationRequested)
+        {
+            if (theTracker.Received.Any(r => r.Id == messageId)) return stopwatch.Elapsed;
+            await Task.Delay(100);
+        }
+
+        return theTracker.Received.Any(r => r.Id == messageId) ? stopwatch.Elapsed : null;
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
@@ -119,7 +119,12 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
 
     public IAgent BuildAgent(IWolverineRuntime runtime)
     {
-        return new DurabilityAgent(runtime, this);
+        return new DurabilityAgent(runtime, this)
+        {
+            // GH-3376: scheduled job polling belongs to this agent, which managed distribution
+            // assigns to exactly one node per database. See StartScheduledJobs() below.
+            AutoStartScheduledJobPolling = true
+        };
     }
 
     public Uri Uri { get; protected set; } = new Uri("null://null");
@@ -308,7 +313,21 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
     public IAgent StartScheduledJobs(IWolverineRuntime runtime)
     {
         var agent = new DurabilityAgent(runtime, this);
-        agent.StartScheduledJobPolling();
+
+        // GH-3376: this node-wide fan-out runs on every node for every known database, outside the
+        // agent distribution machinery. Starting a poller here meant every node polled every tenant
+        // database every ScheduledJobPollingTime; the per-database advisory lock deduped the work but
+        // not the connection, so each losing node still opened a connection, began a transaction, and
+        // rolled back - parking `databases x nodes` connections. Polling now rides the distributed
+        // durability agent (BuildAgent above), which owns exactly one node per database. This mirrors
+        // what the RavenDb and CosmosDb stores already do for the same reason (#2623).
+        //
+        // The exception: hosts with durability agents turned off have no NodeAgentController and so
+        // never build a durability agent. For them this fan-out remains the only scheduled message pump.
+        if (!runtime.Options.Durability.DurabilityAgentEnabled)
+        {
+            agent.StartScheduledJobPolling();
+        }
 
         return agent;
     }

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
@@ -121,9 +121,10 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
     {
         return new DurabilityAgent(runtime, this)
         {
-            // GH-3376: scheduled job polling belongs to this agent, which managed distribution
-            // assigns to exactly one node per database. See StartScheduledJobs() below.
-            AutoStartScheduledJobPolling = true
+            // GH-3376: a tenant database's scheduled job polling belongs to this agent, which managed
+            // distribution assigns to exactly one node. Main / ancillary stores keep polling from the
+            // node-wide fan-out instead - see StartScheduledJobs() below.
+            AutoStartScheduledJobPolling = Role == MessageStoreRole.Tenant
         };
     }
 
@@ -315,16 +316,23 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
         var agent = new DurabilityAgent(runtime, this);
 
         // GH-3376: this node-wide fan-out runs on every node for every known database, outside the
-        // agent distribution machinery. Starting a poller here meant every node polled every tenant
+        // agent distribution machinery. Starting a poller here meant every node polled every TENANT
         // database every ScheduledJobPollingTime; the per-database advisory lock deduped the work but
         // not the connection, so each losing node still opened a connection, began a transaction, and
-        // rolled back - parking `databases x nodes` connections. Polling now rides the distributed
-        // durability agent (BuildAgent above), which owns exactly one node per database. This mirrors
-        // what the RavenDb and CosmosDb stores already do for the same reason (#2623).
+        // rolled back - parking `tenants x nodes` connections, and each added node multiplied the
+        // polling load instead of dividing it. Tenant polling now rides the distributed durability
+        // agent (BuildAgent above), which managed distribution assigns to exactly one node. That
+        // mirrors what the RavenDb and CosmosDb stores already do for the same reason (#2623).
         //
-        // The exception: hosts with durability agents turned off have no NodeAgentController and so
-        // never build a durability agent. For them this fan-out remains the only scheduled message pump.
-        if (!runtime.Options.Durability.DurabilityAgentEnabled)
+        // Main and ancillary stores deliberately keep polling here, on every node:
+        //  - There are a handful of them, and every node already holds connections to them anyway for
+        //    heartbeats, leader election, and the control queues, so scoping them saves nothing.
+        //  - Polling from here starts immediately at boot. Waiting for leader election and agent
+        //    assignment instead would delay scheduled messages by >10s on every startup.
+        //
+        // Hosts with durability agents turned off have no NodeAgentController and so never build a
+        // durability agent. For them this fan-out is the only scheduled message pump, whatever the role.
+        if (!runtime.Options.Durability.DurabilityAgentEnabled || Role != MessageStoreRole.Tenant)
         {
             agent.StartScheduledJobPolling();
         }


### PR DESCRIPTION
Fixes the `nodes × databases` connection footprint reported in #3376.

## The mechanism

Under multi-tenancy, Wolverine started a scheduled-job poller for **every tenant database on every node**, completely outside the agent-distribution machinery. Every `ScheduledJobPollingTime` (default 5s), per database, per node: open a pooled connection, `BEGIN`, try the per-database advisory lock, `SELECT` for due messages, then `ROLLBACK` (quiet) or `COMMIT` (work found).

The advisory lock deduped the *work* across nodes but not the *connection* — the losing node still opened, lock-failed, and rolled back. That reproduces the reporter's fingerprint exactly: `COMMIT`/`ROLLBACK` last-statements, every database connected from every node, backends younger than idle-lifetime pruning, and each added node contributing another ~512 parked connections while "idle".

## Why it was only the fan-out

`MessageStoreCollection.StartScheduledJobProcessing` builds an agent per known store on every node. That agent is **never started** — `WolverineRuntime` only ever calls `StopAsync` on `DurableScheduledJobs` (`WolverineRuntime.Disposal.cs:22`). So the eagerly-started poll timer inside `StartScheduledJobs` was its *entire* runtime contribution.

**This is #2623, unfixed for relational stores.** RavenDb and CosmosDb already return a non-started agent from `StartScheduledJobs` with an explicit comment — *"NodeAgentController owns the durability agent lifecycle ... do not start a second instance here"*. The RDBMS and Oracle stores were never brought along.

## The fix

**Tenant** scheduled polling moves onto the per-database durability agent that managed distribution already assigns to exactly one node. Adding a node now *divides* the tenant polling load instead of multiplying it.

**Main and ancillary stores deliberately keep polling from the fan-out, on every node.** There are only a handful of them, and every node already holds connections to them anyway for heartbeats, leader election, and the control queues — so scoping them saves nothing, while costing real latency (polling wouldn't start until leader election and agent assignment finished). `MessageStoreRole.Tenant` is the discriminator.

Hosts with `DurabilityAgentEnabled = false` have no `NodeAgentController` and never build a durability agent, so for them the fan-out remains the only scheduled-message pump, for every role. Pinned by its own test, verified to fail without the gate.

## Note for reviewers: the second commit is CI correcting me

The first commit scoped *every* store to the agent. `CISqlite` caught it — `scheduled_local_message_survives_host_restart` went from prompt to timing out. The message wasn't lost, it was **13.5s late**, because polling now waited on leader election and assignment. Every test that tightens the durability timings sails straight past that, **including my own new two-node test**, which is why the second commit adds mode coverage at the **default** timings. Observed:

| | main store | tenant DB |
|---|---|---|
| **Solo** | 2.6s | 3.5s |
| **Balanced** | 4.5s | **18.1s** |

That 18.1s is the inherent cost of waiting for agent assignment — and precisely why the main store must not pay it.

## Verification

`multi_node_tenant_database_connections` runs two Balanced nodes against 3 tenant DBs. `pg_stat_activity` can't tell two Wolverine nodes apart, so each host stamps a distinct `ApplicationName` into its connection strings.

Two measurement subtleties, both learned the hard way:

- **Presence ≠ polling.** Every node migrates every tenant DB at startup and Npgsql parks those connections in the pool for minutes, so a presence-based assertion goes red on `main` for the *wrong reason*. It measures `query_start` advancing, off the server's own clock.
- **One query ≠ polling.** A tenant agent legitimately migrating between nodes leaves a one-off touch; that produced a false positive in the full-suite run. The bug is *sustained* polling, so it samples two consecutive windows and only counts a node present in **both**.

Verified against **true `origin/main`**: all 3 databases, both windows, both nodes. Green here: one node each.

Full `wolverine.slnx` builds clean. PostgresqlTests (437), SqliteTests (147), CoreTests (1963), Marten distribution (39) pass. (`Bug_GH3166_dlq_null_received_at` fails on repeat *local* runs — its Marten clean doesn't drop Wolverine's dead-letter table, so rows accumulate; it fails identically on unmodified `main` and passes on a fresh database. Unrelated, but someone may want it.)

## Release note

After a node dies, a **tenant** database's scheduled poll pauses until its durability agent is reassigned. Today's redundant pollers masked that — same semantics recovery already has, but it's a real change. Main/ancillary are unaffected. Dynamic tenants now get polling automatically via agent assignment, where the old fan-out only covered databases present at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)