### PR TITLE
Release daemon tracker subscriptions when a database's last agent stops (GH-3376)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/event_store_agents_observer_subscriptions.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/event_store_agents_observer_subscriptions.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// GH-3376 hygiene: EventStoreAgents used to subscribe every observer to a database daemon's Tracker and
+/// never unsubscribe (the standing "do we need to care about un-subscribing?" TODO), so a node kept
+/// observing databases it no longer owned until the whole store was disposed. The subscriptions are now
+/// released when the last of a database's agents stops on this node, and re-established if the database is
+/// reassigned back. The daemon itself stays cached and undisposed - it is shared with IProjectionCoordinator
+/// callers (via AllDaemonsAsync) and in-flight rebuilds, so tearing it down here would be a use-after-dispose.
+///
+/// These assert on what the observer actually hears, against a real ShardStateTracker, rather than on the
+/// subscription bookkeeping - the leak only matters if a released observer keeps getting fed.
+/// </summary>
+public class event_store_agents_observer_subscriptions
+{
+    private readonly DatabaseId theDatabaseId = new("localhost", "claims1");
+    private readonly IProjectionDaemon theDaemon = Substitute.For<IProjectionDaemon>();
+    private readonly ShardStateTracker theTracker = new(NullLogger.Instance);
+    private readonly RecordingObserver theObserver = new();
+    private readonly EventStoreAgents theAgents;
+
+    public event_store_agents_observer_subscriptions()
+    {
+        theDaemon.Tracker.Returns(theTracker);
+
+        var usage = new EventStoreUsage
+        {
+            Database = new DatabaseUsage
+            {
+                Databases =
+                {
+                    new DatabaseDescriptor { ServerName = "localhost", DatabaseName = "claims1" }
+                }
+            },
+            Subscriptions =
+            {
+                new SubscriptionDescriptor(SubscriptionType.SingleStreamProjection)
+                {
+                    Lifecycle = ProjectionLifecycle.Async,
+                    ShardNames = new[] { ShardName.Compose("provided-cares"), ShardName.Compose("other-shard") }
+                }
+            }
+        };
+
+        var store = Substitute.For<IEventStore>();
+        store.Identity.Returns(new EventStoreIdentity("main", "marten"));
+        store.TryCreateUsage(Arg.Any<CancellationToken>()).Returns(Task.FromResult<EventStoreUsage?>(usage));
+        store.BuildProjectionDaemonAsync(Arg.Any<DatabaseId>())
+            .Returns(new ValueTask<IProjectionDaemon>(theDaemon));
+
+        theAgents = new EventStoreAgents(store, [theObserver]);
+    }
+
+    // The shard cache is keyed by ShardName.RelativeUrl, so ask ShardName for the path rather than
+    // hand-writing the format.
+    private static string PathFor(string projectionName) => ShardName.Compose(projectionName).RelativeUrl;
+
+    private async Task<EventSubscriptionAgent> startAgentAsync(string projectionName)
+    {
+        var shardPath = PathFor(projectionName);
+        var uri = new Uri($"event://marten/main/localhost/claims1/{shardPath}");
+        var agent = await theAgents.BuildAgentAsync(uri, theDatabaseId, shardPath);
+        await agent.StartAsync(CancellationToken.None);
+        return agent;
+    }
+
+    // The tracker publishes to observers through a block, so give it a beat to drain.
+    private async Task<bool> observerHearsAsync(long highWaterMark)
+    {
+        var before = theObserver.Count;
+        await theTracker.MarkHighWaterAsync(highWaterMark);
+
+        using var cts = new CancellationTokenSource(2.Seconds());
+        while (!cts.IsCancellationRequested)
+        {
+            if (theObserver.Count > before) return true;
+            await Task.Delay(25);
+        }
+
+        return theObserver.Count > before;
+    }
+
+    [Fact]
+    public async Task stops_feeding_the_observer_once_the_last_agent_for_a_database_stops()
+    {
+        var agent = await startAgentAsync("provided-cares");
+        (await observerHearsAsync(5)).ShouldBeTrue("a running agent's database should feed its observers");
+
+        await agent.StopAsync(CancellationToken.None);
+
+        (await observerHearsAsync(10)).ShouldBeFalse(
+            "the node stopped the database's last agent, so it must no longer observe that database");
+    }
+
+    [Fact]
+    public async Task keeps_feeding_the_observer_while_another_agent_for_the_database_runs()
+    {
+        var first = await startAgentAsync("provided-cares");
+        var second = await startAgentAsync("other-shard");
+
+        await first.StopAsync(CancellationToken.None);
+
+        (await observerHearsAsync(5)).ShouldBeTrue("a second agent for this database is still running");
+
+        await second.StopAsync(CancellationToken.None);
+
+        (await observerHearsAsync(10)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task re_subscribes_when_a_released_database_is_reassigned_to_this_node()
+    {
+        var agent = await startAgentAsync("provided-cares");
+        await agent.StopAsync(CancellationToken.None);
+        (await observerHearsAsync(5)).ShouldBeFalse();
+
+        // Reassigned back. The daemon is served from cache, so without re-subscribing the observers
+        // would stay deaf for the rest of the process lifetime.
+        await startAgentAsync("provided-cares");
+
+        (await observerHearsAsync(10)).ShouldBeTrue("a reassigned database must feed its observers again");
+    }
+
+    [Fact]
+    public async Task does_not_tear_down_the_shared_daemon_when_the_last_agent_stops()
+    {
+        var agent = await startAgentAsync("provided-cares");
+        await agent.StopAsync(CancellationToken.None);
+
+        // The daemon is handed out to IProjectionCoordinator callers and held across rebuilds, so
+        // releasing this node's interest in the database must not stop or dispose it underneath them.
+        await theDaemon.DidNotReceive().StopAllAsync();
+        (await theAgents.FindDaemonAsync(theDatabaseId)).ShouldBeSameAs(theDaemon);
+    }
+
+    private class RecordingObserver : IObserver<ShardState>
+    {
+        private readonly ConcurrentBag<ShardState> _states = [];
+
+        public int Count => _states.Count;
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(ShardState value) => _states.Add(value);
+    }
+}

--- a/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
+++ b/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
@@ -15,6 +15,16 @@ public class EventStoreAgents : IAsyncDisposable
     private readonly SemaphoreSlim _daemonLock = new(1);
     private ImHashMap<DatabaseId, IProjectionDaemon> _daemons = ImHashMap<DatabaseId, IProjectionDaemon>.Empty;
 
+    // The observer subscriptions taken out against each database's daemon Tracker, so they can be
+    // disposed when this node stops owning that database instead of living until the whole store is
+    // disposed. Absence of an entry means "not currently subscribed" - FindDaemonAsync re-subscribes a
+    // cached daemon on reuse, so a database revoked and later reassigned still feeds its observers.
+    private ImHashMap<DatabaseId, IDisposable[]> _observerSubscriptions = ImHashMap<DatabaseId, IDisposable[]>.Empty;
+
+    // How many of each database's subscription agents are running on this node right now, so the 1->0
+    // transition is detectable. Only mutated under _daemonLock.
+    private ImHashMap<DatabaseId, int> _runningAgentCounts = ImHashMap<DatabaseId, int>.Empty;
+
     // Keyed by ShardName.RelativeUrl. Populated as a side effect of SupportedAgentsAsync, but also resolved
     // on demand by BuildAgentAsync (a node assigned an agent may never have enumerated its own shards). An
     // ImHashMap so the enumeration writes and the BuildAgentAsync reads are lock-free across threads. See
@@ -42,6 +52,16 @@ public class EventStoreAgents : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        foreach (var entry in _observerSubscriptions.Enumerate())
+        {
+            foreach (var subscription in entry.Value)
+            {
+                subscription.SafeDispose();
+            }
+        }
+
+        _observerSubscriptions = ImHashMap<DatabaseId, IDisposable[]>.Empty;
+
         foreach (var entry in _daemons.Enumerate())
         {
             try
@@ -60,7 +80,10 @@ public class EventStoreAgents : IAsyncDisposable
 
     public async ValueTask<IProjectionDaemon> FindDaemonAsync(DatabaseId databaseId)
     {
-        if (_daemons.TryFind(databaseId, out var daemon))
+        // Fast path only when the daemon is cached AND currently subscribed - a daemon whose
+        // subscriptions were released at the 1->0 transition has to go through the lock to be
+        // re-subscribed before it's handed back out.
+        if (_daemons.TryFind(databaseId, out var daemon) && _observerSubscriptions.TryFind(databaseId, out _))
         {
             return daemon;
         }
@@ -69,19 +92,13 @@ public class EventStoreAgents : IAsyncDisposable
         try
         {
             // Gotta do the double lock thing
-            if (_daemons.TryFind(databaseId, out daemon))
+            if (!_daemons.TryFind(databaseId, out daemon))
             {
-                return daemon;
+                daemon = await _store.BuildProjectionDaemonAsync(databaseId);
+                _daemons = _daemons.AddOrUpdate(databaseId, daemon);
             }
 
-            daemon = await _store.BuildProjectionDaemonAsync(databaseId);
-            foreach (var observer in _observers)
-            {
-                // TODO -- do we need to care about un-subscribing?
-                daemon.Tracker.Subscribe(observer);
-            }
-            
-            _daemons = _daemons.AddOrUpdate(databaseId, daemon);
+            subscribeObservers(databaseId, daemon);
         }
         finally
         {
@@ -89,6 +106,66 @@ public class EventStoreAgents : IAsyncDisposable
         }
 
         return daemon;
+    }
+
+    // Callers must hold _daemonLock.
+    private void subscribeObservers(DatabaseId databaseId, IProjectionDaemon daemon)
+    {
+        if (_observerSubscriptions.TryFind(databaseId, out _)) return;
+
+        var subscriptions = _observers.Select(x => daemon.Tracker.Subscribe(x)).ToArray();
+        _observerSubscriptions = _observerSubscriptions.AddOrUpdate(databaseId, subscriptions);
+    }
+
+    private async ValueTask agentStartedAsync(DatabaseId databaseId)
+    {
+        await _daemonLock.WaitAsync();
+        try
+        {
+            _runningAgentCounts.TryFind(databaseId, out var count);
+            _runningAgentCounts = _runningAgentCounts.AddOrUpdate(databaseId, count + 1);
+        }
+        finally
+        {
+            _daemonLock.Release();
+        }
+    }
+
+    // The 1->0 transition: this node just stopped the last of a database's subscription agents, so it
+    // has no further interest in that database's tracker. Drop the observer subscriptions rather than
+    // holding them until the store is disposed (the standing TODO in FindDaemonAsync).
+    //
+    // The daemon itself is deliberately left cached and undisposed. It is shared - AllDaemonsAsync()
+    // hands it to Polecat's IProjectionCoordinator, and TryRebuildRegisteredProjectionAsync holds it
+    // across a rebuild - so disposing it here would be a use-after-dispose for anyone mid-borrow, and
+    // removing it from _daemons would strand it from the disposal sweep in DisposeAsync. Fully
+    // releasing the daemon needs a quiesce hook on the JasperFx side; see GH-3376.
+    private async ValueTask agentStoppedAsync(DatabaseId databaseId)
+    {
+        await _daemonLock.WaitAsync();
+        try
+        {
+            _runningAgentCounts.TryFind(databaseId, out var count);
+
+            // Clamp: a stop without a matching successful start must not drive this negative
+            var remaining = Math.Max(0, count - 1);
+            _runningAgentCounts = _runningAgentCounts.AddOrUpdate(databaseId, remaining);
+
+            if (remaining > 0) return;
+
+            if (_observerSubscriptions.TryFind(databaseId, out var subscriptions))
+            {
+                _observerSubscriptions = _observerSubscriptions.Remove(databaseId);
+                foreach (var subscription in subscriptions)
+                {
+                    subscription.SafeDispose();
+                }
+            }
+        }
+        finally
+        {
+            _daemonLock.Release();
+        }
     }
 
     public async ValueTask<IReadOnlyList<Uri>> SupportedAgentsAsync(CancellationToken cancellation)
@@ -191,7 +268,11 @@ public class EventStoreAgents : IAsyncDisposable
 
         var daemon = await FindDaemonAsync(databaseId);
 
-        return new EventSubscriptionAgent(uri, shardName, daemon);
+        return new EventSubscriptionAgent(uri, shardName, daemon)
+        {
+            OnStarted = () => agentStartedAsync(databaseId),
+            OnStopped = () => agentStoppedAsync(databaseId)
+        };
     }
 
     /// <summary>

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgent.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgent.cs
@@ -35,6 +35,15 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
     /// </summary>
     public Action<string, string, DateTimeOffset>? OnRestarted { get; set; }
 
+    /// <summary>
+    /// Set by <see cref="EventStoreAgents.BuildAgentAsync"/> so the owning store can count how many of a
+    /// database's agents are running on this node, and let go of that database's tracker subscriptions
+    /// when the last one stops.
+    /// </summary>
+    internal Func<ValueTask>? OnStarted { get; set; }
+
+    internal Func<ValueTask>? OnStopped { get; set; }
+
     public EventSubscriptionAgent(Uri uri, ShardName shardName, IProjectionDaemon daemon, ILogger logger)
     {
         _shardName = shardName;
@@ -52,12 +61,23 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
     {
         _innerAgent = await _daemon.StartAgentAsync(_shardName, cancellationToken);
         Status = AgentStatus.Running;
+
+        // Only count an agent that actually started - a throw above leaves the count untouched
+        if (OnStarted != null)
+        {
+            await OnStarted();
+        }
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         await _daemon.StopAgentAsync(_shardName);
         Status = AgentStatus.Stopped;
+
+        if (OnStopped != null)
+        {
+            await OnStopped();
+        }
     }
 
     public async Task RebuildAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Leak hygiene found while diagnosing #3376. Independent of the connection fix in #3439 — that one is the connection story, this one is not.

## The leak

`EventStoreAgents.FindDaemonAsync` subscribed every observer to a database daemon's `Tracker` and never unsubscribed, carrying a standing TODO:

```csharp
foreach (var observer in _observers)
{
    // TODO -- do we need to care about un-subscribing?
    daemon.Tracker.Subscribe(observer);
}
```

So a node kept observing databases it no longer owned, until the whole store was disposed.

## The fix

Subscriptions are released on the 1→0 agent transition for a database, and **re-established if that database is reassigned back**. The re-subscribe is not optional: the daemon is served from cache, so without it a reassigned database would leave its observers deaf for the rest of the process lifetime.

## What this deliberately does *not* do

The plan called for disposing the daemon on 1→0. It can't safely: the daemon is **shared**. `AllDaemonsAsync()` hands it to Polecat's `IProjectionCoordinator` (`WolverineProjectionCoordinator.cs:50`), and `TryRebuildRegisteredProjectionAsync` holds it across a long rebuild. Disposing here is a use-after-dispose for anyone mid-borrow — and driving catch-up through `IProjectionCoordinator` is the supported path now.

Removing it from `_daemons` without disposing is also wrong: `DisposeAsync` sweeps that map at shutdown, so the daemon would never be stopped or disposed at all.

A full release wants a quiesce hook on the JasperFx side (`StopAllAsync` + the tenant high-water timer + the dead-letter block), which is tracked separately. The retained daemons are bounded by the number of databases this node has owned, and are already quiesced at 1→0.

## Tests

`event_store_agents_observer_subscriptions` asserts on **what the observer actually hears** from a real `ShardStateTracker`, rather than on subscription bookkeeping — the leak only matters if a released observer keeps getting fed. Covers: release on last stop, no release while a sibling agent runs, re-subscribe on reassignment, and that the shared daemon is not torn down.

3 of the 4 fail without the change (the fourth asserts non-disposal, so it correctly passes either way). `EventStoreAgents` previously had no direct test coverage, which is part of why the TODO survived.

Full `wolverine.slnx` builds clean; CoreTests (1963) and the Marten distribution suite (39) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)