### PR TITLE
Clear Wolverine storage in the GH-3166 DLQ test so it survives a second run

### DIFF
--- a/src/Persistence/PostgresqlTests/Bugs/Bug_GH3166_dlq_null_received_at.cs
+++ b/src/Persistence/PostgresqlTests/Bugs/Bug_GH3166_dlq_null_received_at.cs
@@ -46,6 +46,12 @@ public class Bug_GH3166_dlq_null_received_at : IAsyncLifetime
         await marten.Advanced.Clean.CompletelyRemoveAllAsync();
 
         _store = _host.Services.GetRequiredService<IWolverineRuntime>().Storage;
+
+        // Marten's clean only removes Marten's own schema objects - Wolverine's envelope tables
+        // survive it with their rows intact. Without this the dead letter written below accumulates
+        // across runs against the same database, and the counts asserted at the end climb with every
+        // run: this test passed on CI (fresh database) while failing on any second local run.
+        await _store.Admin.ClearAllAsync();
     }
 
     public async Task DisposeAsync() => await _host.StopAsync();


### PR DESCRIPTION
Small test-hygiene fix, found while working on #3376.

## The problem

`Bug_GH3166_dlq_null_received_at` asserts an **exact** dead letter count:

```csharp
var summary = await _store.DeadLetters.SummarizeAllAsync("svc", TimeRange.AllTime(), CancellationToken.None);
summary.Sum(x => x.Count).ShouldBe(1);
```

…but its setup only cleans **Marten's** schema objects:

```csharp
var marten = _host.Services.GetRequiredService<IDocumentStore>();
await marten.Advanced.Clean.CompletelyRemoveAllAsync();
```

Marten's clean doesn't touch Wolverine's envelope tables — they survive with their rows intact. So the dead letter the test writes accumulates in `dlq_nullrecv.wolverine_dead_letters` across runs, and the asserted counts climb every time.

**The result: it passes on CI, which always gets a fresh database, and fails on any second local run.** I hit it while chasing an unrelated change and watched the count go `3`, then `7`, before realizing the test was rotting my database rather than my code breaking it. It cost me a detour to rule out; the next person shouldn't pay that.

## The fix

One line — clear Wolverine's storage alongside Marten's, which is what `ClearAllAsync` is for (it truncates the incoming, outgoing, and dead-letter tables).

## Verification

Against `origin/main`, on a freshly dropped schema:

| run | without fix | with fix |
|---|---|---|
| 1 | pass | pass |
| 2 | **fail** | pass |
| 3 | — | pass |

The "with fix" runs additionally start from an already-dirty database and still pass. Full `PostgresqlTests.Bugs` namespace is green (9/9).

No production code touched — the GH-3166 behavior this test guards is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)