### PR TITLE
Fix PublishRawJson mapper registration and keep pings recognizable on raw-JSON topics

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -651,6 +651,26 @@ _sender = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Kafka/Wolverine.Kafka.Tests/publish_and_receive_raw_json.cs#L21-L61' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_raw_json_sending_and_receiving_with_kafka' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+::: warning
+Wolverine versions from 5.0 up to and including 6.19 had a bug where `ReceiveRawJson()` and `PublishRawJson()`
+silently ran the *default* Kafka envelope mapper instead of the raw-JSON mapper. If you are upgrading, be aware
+of these behavioral corrections:
+
+* **Incoming records no longer promote Wolverine's reserved header names.** Previously, a record header named
+  `tenant-id`, `saga-id`, `id`, `correlation-id`, etc. was mapped straight onto the matching `Envelope` property —
+  meaning any external producer could set the tenant id or saga identity of your messages. These reserved names
+  are now deliberately ignored on raw-JSON listeners. All *other* record headers are copied into
+  `Envelope.Headers`, and `Envelope.SentAt` is read from the Kafka record timestamp.
+* **Outgoing records are now genuinely raw.** `PublishRawJson()` previously stamped the full set of Wolverine
+  protocol headers (`message-type`, `correlation-id`, and friends) onto every record. Those headers are no longer
+  written. The body bytes are unchanged — messages are still serialized by the endpoint's JSON serializer
+  (camel-cased property names by default), so downstream consumers parsing the JSON are unaffected.
+
+If you have a *trusted* upstream producer that intentionally sets `tenant-id` (or another reserved header) and you
+depend on that promotion, register a custom mapper with `UseInterop((runtime, endpoint) => ...)` in place of
+`ReceiveRawJson()` to keep that behavior as an explicit opt-in.
+:::
+
 ## Confluent Schema Registry Serializers <Badge type="tip" text="5.27" />
 
 When you need to interoperate with other Kafka clients that use the [Confluent Schema Registry](https://docs.confluent.io/platform/current/schema-registry/index.html)

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperOutgoingTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperOutgoingTests.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using System.Text.Json;
+using Confluent.Kafka;
+using Shouldly;
+using Wolverine.Kafka.Internals;
+
+namespace Wolverine.Kafka.Tests;
+
+public class JsonOnlyMapperOutgoingTests
+{
+    [Fact]
+    public void outgoing_message_carries_no_wolverine_headers()
+    {
+        // In the runtime sending path, Envelope.Data is already serialized by the endpoint's
+        // serializer before the mapper runs, so the mapper's only job is the body + key —
+        // no Wolverine protocol headers may leak onto the record.
+        var envelope = new Envelope
+        {
+            Data = JsonSerializer.SerializeToUtf8Bytes(new ColorMessage("blue")),
+            GroupId = "group-1",
+            TenantId = "tenant-1",
+            CorrelationId = "correlation-1"
+        };
+        var outgoing = new Message<string, byte[]>();
+
+        buildMapper().MapEnvelopeToOutgoing(envelope, outgoing);
+
+        (outgoing.Headers?.Any() ?? false).ShouldBeFalse();
+        JsonSerializer.Deserialize<ColorMessage>(outgoing.Value)!.Color.ShouldBe("blue");
+        outgoing.Key.ShouldBe("group-1");
+    }
+
+    [Fact]
+    public void outgoing_ping_round_trips_through_raw_json_mappers()
+    {
+        // Sender liveness pings have to survive a raw-JSON topic where both ends use
+        // JsonOnlyMapper. The receiving side recognizes pings only by the message-type
+        // header (GH-2838), so the outgoing side must write that one header.
+        var mapper = buildMapper();
+        var ping = Envelope.ForPing(new Uri("kafka://localhost/pings"));
+        var outgoing = new Message<string, byte[]>();
+
+        mapper.MapEnvelopeToOutgoing(ping, outgoing);
+
+        var received = new Envelope();
+        mapper.MapIncomingToEnvelope(received, outgoing);
+
+        received.MessageType.ShouldBe(Envelope.PingMessageType);
+    }
+
+    [Fact]
+    public void outgoing_ping_writes_only_the_message_type_header()
+    {
+        var mapper = buildMapper();
+        var ping = Envelope.ForPing(new Uri("kafka://localhost/pings"));
+        var outgoing = new Message<string, byte[]>();
+
+        mapper.MapEnvelopeToOutgoing(ping, outgoing);
+
+        outgoing.Headers.Select(x => x.Key).Single().ShouldBe(EnvelopeConstants.MessageTypeKey);
+        outgoing.Value.ShouldBe(ping.Data);
+    }
+
+    private static JsonOnlyMapper buildMapper()
+    {
+        var topic = new KafkaTopic(
+            new KafkaTransport(),
+            "outgoing-mapping",
+            Configuration.EndpointRole.Application)
+        {
+            MessageType = typeof(ColorMessage)
+        };
+
+        return new JsonOnlyMapper(topic, new JsonSerializerOptions());
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/publish_raw_json_wire_format.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/publish_raw_json_wire_format.cs
@@ -1,0 +1,106 @@
+using System.Text;
+using System.Text.Json;
+using Confluent.Kafka;
+using Microsoft.Extensions.Hosting;
+using JasperFx.Resources;
+using Shouldly;
+using Wolverine.Kafka.Internals;
+using Wolverine.Tracking;
+
+namespace Wolverine.Kafka.Tests;
+
+public class publish_raw_json_wire_format
+{
+    [Fact]
+    public async Task raw_json_endpoints_actually_register_the_json_only_mapper()
+    {
+        // Regression for GH-3407: with the lambda parameters in the (endpoint, mapper) order,
+        // UseInterop bound to the Action customization overload, the JsonOnlyMapper was
+        // discarded, and both ReceiveRawJson and PublishRawJson silently ran the default
+        // KafkaEnvelopeMapper instead.
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka(KafkaContainerFixture.ConnectionString).AutoProvision();
+                opts.Discovery.IncludeAssembly(GetType().Assembly);
+                opts.Policies.DisableConventionalLocalRouting();
+
+                opts.ListenToKafkaTopic("mapper-registration-in").ReceiveRawJson<ColorMessage>();
+                opts.PublishAllMessages().ToKafkaTopic("mapper-registration-out").PublishRawJson();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        var runtime = host.GetRuntime();
+        var transport = runtime.Options.Transports.GetOrCreate<KafkaTransport>();
+
+        transport.Topics["mapper-registration-in"].BuildMapper(runtime).ShouldBeOfType<JsonOnlyMapper>();
+        transport.Topics["mapper-registration-out"].BuildMapper(runtime).ShouldBeOfType<JsonOnlyMapper>();
+
+        await host.StopAsync();
+    }
+
+    [Fact]
+    public async Task published_records_carry_no_wolverine_headers_on_the_wire()
+    {
+        // PublishRawJson promises "pure JSON and no other Wolverine metadata". Read the
+        // record back with a plain Confluent consumer to prove nothing leaks to an
+        // external, non-Wolverine subscriber.
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka(KafkaContainerFixture.ConnectionString).AutoProvision();
+                opts.Policies.DisableConventionalLocalRouting();
+
+                opts.PublishAllMessages().ToKafkaTopic("clean-json").PublishRawJson();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        // The topic may hold records from prior runs, so tag this run's message with a
+        // unique color and scan for exactly that record.
+        var color = Guid.NewGuid().ToString();
+
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = KafkaContainerFixture.ConnectionString,
+            GroupId = Guid.NewGuid().ToString(),
+            AutoOffsetReset = AutoOffsetReset.Earliest
+        };
+
+        using var consumer = new ConsumerBuilder<string, byte[]>(config).Build();
+        consumer.Subscribe("clean-json");
+
+        await host.MessageBus().PublishAsync(new ColorMessage(color));
+
+        ConsumeResult<string, byte[]>? match = null;
+        var deadline = DateTime.UtcNow.AddSeconds(30);
+        while (match == null && DateTime.UtcNow < deadline)
+        {
+            var result = consumer.Consume(TimeSpan.FromSeconds(1));
+            if (result?.Message.Value == null)
+            {
+                continue;
+            }
+
+            if (Encoding.UTF8.GetString(result.Message.Value).Contains(color))
+            {
+                match = result;
+            }
+        }
+
+        match.ShouldNotBeNull();
+        (match.Message.Headers?.Any() ?? false).ShouldBeFalse();
+
+        // The body is written by Wolverine's default serializer, which camel-cases
+        // property names — the raw-JSON mapper changes what headers ride on the record,
+        // never the body bytes themselves.
+        JsonSerializer.Deserialize<ColorMessage>(
+                match.Message.Value,
+                new JsonSerializerOptions(JsonSerializerDefaults.Web))!
+            .Color.ShouldBe(color);
+
+        consumer.Close();
+        await host.StopAsync();
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
@@ -28,6 +28,18 @@ internal class JsonOnlyMapper : IKafkaEnvelopeMapper
     {
         outgoing.Key = envelope.GroupId!;
 
+        // Sender liveness pings must stay recognizable on the receiving side. A raw-JSON
+        // listener identifies pings solely by the message-type header (see the guard in
+        // MapIncomingToEnvelope / GH-2838), so that one header still has to ride along even
+        // though this mapper strips all other Wolverine metadata off the record.
+        if (envelope.MessageType == Envelope.PingMessageType)
+        {
+            outgoing.Headers ??= new Headers();
+            outgoing.Headers.Add(EnvelopeConstants.MessageTypeKey, Encoding.UTF8.GetBytes(Envelope.PingMessageType));
+            outgoing.Value = envelope.Data ?? [];
+            return;
+        }
+
         if (envelope.Data != null && envelope.Data.Any())
         {
             outgoing.Value = envelope.Data;

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -273,6 +273,10 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
     public KafkaListenerConfiguration ReceiveRawJson(Type messageType, JsonSerializerOptions? options = null)
     {
         DefaultIncomingMessage(messageType);
+
+        // The parameter order matters here! (e, _) would bind to the Action<TEndpoint, TConcreteMapper>
+        // customization overload of UseInterop, silently discarding the JsonOnlyMapper and leaving the
+        // default KafkaEnvelopeMapper in effect. See GH-3407.
         return UseInterop((_, e) => new JsonOnlyMapper(e, options ?? new()));
     }
     

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaSubscriberConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaSubscriberConfiguration.cs
@@ -56,7 +56,10 @@ public class KafkaSubscriberConfiguration : InteroperableSubscriberConfiguration
     /// <returns></returns>
     public KafkaSubscriberConfiguration PublishRawJson(JsonSerializerOptions? options = null)
     {
-        return UseInterop((e, _) => new JsonOnlyMapper(e, options ?? new JsonSerializerOptions()));
+        // The parameter order matters here! (e, _) would bind to the Action<TEndpoint, TConcreteMapper>
+        // customization overload of UseInterop, silently discarding the JsonOnlyMapper and leaving the
+        // default KafkaEnvelopeMapper (and all of its Wolverine protocol headers) in effect. See GH-3407.
+        return UseInterop((_, e) => new JsonOnlyMapper(e, options ?? new JsonSerializerOptions()));
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #3407, closing out the loose ends from that review.

### `PublishRawJson()` had the same `UseInterop` overload-resolution bug

Credit to @jakub-petrylak-onerail for spotting the pattern on the listener side in #3407. The subscriber side had the identical problem: with the lambda written as `(e, _)`, only the `Action<TEndpoint, TConcreteMapper>` customization overload of `UseInterop` type-checks, so the `JsonOnlyMapper` was constructed, discarded, and the endpoint kept the default `KafkaEnvelopeMapper`. Since the interop registration refactor (`7dd509729`, first shipped in 5.0.0), `PublishRawJson()` has actually been:

- stamping the full set of Wolverine protocol headers (`message-type`, `correlation-id`, etc.) onto every "raw JSON" record, and
- silently ignoring the `JsonSerializerOptions` argument.

The header stamping is corrected by binding the factory overload with `(_, e)`. Warning comments now sit at both call sites; an audit found no other `UseInterop` lambda misuse in product code.

The body bytes are deliberately **unchanged**: `Envelope.Data` is serialized by the endpoint's serializer before the mapper ever runs, so the record body stays exactly what today's (broken) path produces — only the headers disappear. That also means the `JsonSerializerOptions` argument on both `PublishRawJson()` and `ReceiveRawJson()` remains vestigial (the mapper branch that uses it is unreachable in the runtime path). I left that alone rather than change body formats under existing users — flagging it here as a candidate for a later API cleanup/obsoletion decision.

### Keeping sender pings recognizable (GH-2838)

Fixing the registration would, by itself, have reintroduced GH-2838 in a new form: `InlineKafkaSender.PingAsync` routes liveness pings through the endpoint mapper, and `JsonOnlyMapper.MapEnvelopeToOutgoing` wrote no headers at all — so a raw-JSON *sender's* ping would arrive at a raw-JSON *listener* as an unrecognizable 4-byte record and land in the DLQ as garbage. `MapEnvelopeToOutgoing` now writes exactly one header (`message-type: wolverine-ping`) for ping envelopes, symmetric with the incoming guard added for GH-2838.

### Tests

- Unit: outgoing records carry no Wolverine headers, pings round-trip through a raw-JSON mapper pair, and ping records carry only the `message-type` header.
- Bootstrap regression guard: both `ReceiveRawJson` and `PublishRawJson` endpoints resolve a `JsonOnlyMapper` from `BuildMapper()` — this is the test that would have caught the original overload bug on either side.
- Wire-format integration: a plain Confluent consumer reads a `PublishRawJson` record back and asserts zero headers and a clean JSON body.

### Docs

Added an upgrade warning to the Kafka interoperability page covering both behavior corrections (reserved incoming headers no longer promoted; outgoing records now genuinely raw) and the `UseInterop` escape hatch for anyone who intentionally relied on trusted-producer `tenant-id` promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
