### PR TITLE
Make the JsonSerializerOptions on Kafka raw-JSON endpoints actually work

### DIFF
--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -663,8 +663,15 @@ of these behavioral corrections:
   `Envelope.Headers`, and `Envelope.SentAt` is read from the Kafka record timestamp.
 * **Outgoing records are now genuinely raw.** `PublishRawJson()` previously stamped the full set of Wolverine
   protocol headers (`message-type`, `correlation-id`, and friends) onto every record. Those headers are no longer
-  written. The body bytes are unchanged — messages are still serialized by the endpoint's JSON serializer
-  (camel-cased property names by default), so downstream consumers parsing the JSON are unaffected.
+  written. When no `JsonSerializerOptions` are passed, the body bytes are unchanged — messages are still serialized
+  by the endpoint's JSON serializer (camel-cased property names by default), so downstream consumers parsing the
+  JSON are unaffected.
+* **The `JsonSerializerOptions` argument now works.** Previously the options passed to either method were silently
+  ignored on every code path. Supplying options now sets that endpoint's default JSON serialization — driving
+  deserialization of incoming bodies on `ReceiveRawJson()` (e.g. snake_cased payloads via
+  `PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower`) and serialization of outgoing bodies on
+  `PublishRawJson()`. Omitting the argument keeps Wolverine's defaults (camel-cased, case-insensitive reads),
+  so existing callers see no change.
 
 If you have a *trusted* upstream producer that intentionally sets `tenant-id` (or another reserved header) and you
 depend on that promotion, register a custom mapper with `UseInterop((runtime, endpoint) => ...)` in place of

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/Bugs/Bug_2838_receive_raw_json_honors_wolverine_ping.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/Bugs/Bug_2838_receive_raw_json_honors_wolverine_ping.cs
@@ -23,7 +23,7 @@ public class Bug_2838_receive_raw_json_honors_wolverine_ping
             MessageType = typeof(Msg2838)
         };
 
-        var mapper = new JsonOnlyMapper(topic, new System.Text.Json.JsonSerializerOptions());
+        var mapper = new JsonOnlyMapper(topic);
 
         var incoming = new Message<string, byte[]>
         {
@@ -52,7 +52,7 @@ public class Bug_2838_receive_raw_json_honors_wolverine_ping
             MessageType = typeof(Msg2838)
         };
 
-        var mapper = new JsonOnlyMapper(topic, new System.Text.Json.JsonSerializerOptions());
+        var mapper = new JsonOnlyMapper(topic);
 
         var payload = Encoding.UTF8.GetBytes("{\"name\":\"hi\"}");
         var incoming = new Message<string, byte[]>

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperOutgoingTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperOutgoingTests.cs
@@ -71,6 +71,6 @@ public class JsonOnlyMapperOutgoingTests
             MessageType = typeof(ColorMessage)
         };
 
-        return new JsonOnlyMapper(topic, new JsonSerializerOptions());
+        return new JsonOnlyMapper(topic);
     }
 }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperTimestampTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/JsonOnlyMapperTimestampTests.cs
@@ -203,6 +203,6 @@ public class JsonOnlyMapperTimestampTests
             MessageType = messageType
         };
 
-        return new JsonOnlyMapper(topic, new JsonSerializerOptions());
+        return new JsonOnlyMapper(topic);
     }
 }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/raw_json_serializer_options.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/raw_json_serializer_options.cs
@@ -1,0 +1,134 @@
+using System.Text;
+using System.Text.Json;
+using Confluent.Kafka;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using JasperFx.Resources;
+using Shouldly;
+using Wolverine.Kafka.Internals;
+using Wolverine.Tracking;
+
+namespace Wolverine.Kafka.Tests;
+
+public class raw_json_serializer_options
+{
+    [Fact]
+    public async Task receive_raw_json_honors_the_supplied_options_for_deserialization()
+    {
+        // Wolverine's default serializer is camel-cased + case-insensitive, which cannot
+        // match snake_cased JSON — so this only passes if the options supplied to
+        // ReceiveRawJson actually drive deserialization.
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+        // Unique per run so records left behind by prior runs can't satisfy (or confuse)
+        // the tracked wait condition below
+        var topic = "snake-json-" + Guid.NewGuid().ToString("N")[..8];
+
+        using var receiver = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka(KafkaContainerFixture.ConnectionString).AutoProvision()
+                    // The consumer group has no committed offsets on this freshly provisioned
+                    // topic, and the librdkafka default of Latest would race the producer below
+                    .ConfigureConsumers(c => c.AutoOffsetReset = AutoOffsetReset.Earliest);
+                opts.Discovery.IncludeAssembly(GetType().Assembly);
+
+                opts.ListenToKafkaTopic(topic).ReceiveRawJson<WireMessage>(options);
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        var transport = receiver.GetRuntime().Options.Transports.GetOrCreate<KafkaTransport>();
+        var colorName = Guid.NewGuid().ToString();
+
+        var session = await receiver.TrackActivity()
+            .WaitForMessageToBeReceivedAt<WireMessage>(receiver)
+            // The default 5s tracked-session timeout is not enough for a consumer group
+            // join on a freshly auto-provisioned topic
+            .Timeout(60.Seconds())
+            .ExecuteAndWaitAsync((Func<IMessageContext, Task>)(async _ =>
+            {
+                using var producer = new ProducerBuilder<string, byte[]>(transport.ProducerConfig).Build();
+                await producer.ProduceAsync(topic, new Message<string, byte[]>
+                {
+                    Value = Encoding.UTF8.GetBytes($"{{\"color_name\":\"{colorName}\"}}")
+                });
+                producer.Flush();
+            }));
+
+        session.Received.SingleMessage<WireMessage>()
+            .ColorName.ShouldBe(colorName);
+
+        await receiver.StopAsync();
+    }
+
+    [Fact]
+    public async Task publish_raw_json_honors_the_supplied_options_for_serialization()
+    {
+        // Plain JsonSerializerOptions serialize Pascal-cased, unlike Wolverine's camel-cased
+        // default — so a Pascal-cased body on the wire proves the supplied options were used.
+        var topic = "pascal-json-" + Guid.NewGuid().ToString("N")[..8];
+
+        using var sender = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka(KafkaContainerFixture.ConnectionString).AutoProvision();
+                opts.Policies.DisableConventionalLocalRouting();
+
+                opts.PublishAllMessages().ToKafkaTopic(topic)
+                    .PublishRawJson(new JsonSerializerOptions());
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        var colorName = Guid.NewGuid().ToString();
+
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = KafkaContainerFixture.ConnectionString,
+            GroupId = Guid.NewGuid().ToString(),
+            AutoOffsetReset = AutoOffsetReset.Earliest
+        };
+
+        using var consumer = new ConsumerBuilder<string, byte[]>(config).Build();
+        consumer.Subscribe(topic);
+
+        await sender.MessageBus().PublishAsync(new WireMessage { ColorName = colorName });
+
+        string? body = null;
+        var deadline = DateTime.UtcNow.AddSeconds(30);
+        while (body == null && DateTime.UtcNow < deadline)
+        {
+            var result = consumer.Consume(TimeSpan.FromSeconds(1));
+            if (result?.Message.Value == null)
+            {
+                continue;
+            }
+
+            var json = Encoding.UTF8.GetString(result.Message.Value);
+            if (json.Contains(colorName))
+            {
+                body = json;
+            }
+        }
+
+        body.ShouldNotBeNull();
+        body.ShouldContain($"\"ColorName\":\"{colorName}\"");
+
+        consumer.Close();
+        await sender.StopAsync();
+    }
+}
+
+public class WireMessage
+{
+    public string ColorName { get; set; } = null!;
+}
+
+public static class WireMessageHandler
+{
+    public static void Handle(WireMessage message)
+    {
+        // nothing to do — reception is asserted through the tracked session
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/IKafkaEnvelopeMapper.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json;
 using Confluent.Kafka;
 using Wolverine.Runtime.Serialization;
 using Wolverine.Transports;
@@ -14,13 +13,12 @@ public interface IKafkaEnvelopeMapper : IEnvelopeMapper<Message<string, byte[]>,
 /// </summary>
 internal class JsonOnlyMapper : IKafkaEnvelopeMapper
 {
-    private readonly JsonSerializerOptions _options;
+    private readonly KafkaTopic _topic;
     private readonly string? _messageTypeName;
 
-    public JsonOnlyMapper(KafkaTopic topic, JsonSerializerOptions options)
+    public JsonOnlyMapper(KafkaTopic topic)
     {
-        _options = options;
-
+        _topic = topic;
         _messageTypeName = topic.MessageType?.ToMessageTypeName();
     }
 
@@ -40,13 +38,11 @@ internal class JsonOnlyMapper : IKafkaEnvelopeMapper
             return;
         }
 
+        // Envelope.Data lazily serializes the message through the endpoint's serializer,
+        // so this covers both pre-serialized (durable/forwarded) and live-message sends.
         if (envelope.Data != null && envelope.Data.Any())
         {
             outgoing.Value = envelope.Data;
-        }
-        else if (envelope.Message != null)
-        {
-            outgoing.Value = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(envelope.Message, _options));
         }
         else
         {
@@ -73,6 +69,18 @@ internal class JsonOnlyMapper : IKafkaEnvelopeMapper
 
         envelope.Data = incoming.Value;
         envelope.MessageType = _messageTypeName;
+
+        // Raw records carry no content-type, which routes deserialization to the *global*
+        // default serializer (HandlerPipeline.serializerFor) — stamping the endpoint's own
+        // serializer here is what lets ReceiveRawJson's JsonSerializerOptions take effect.
+        // ContentType is stamped too so a durable-inbox recovery replay, which loses the
+        // transient Serializer reference, still resolves this endpoint's serializer through
+        // the content-type lookup.
+        if (_topic.DefaultSerializer != null)
+        {
+            envelope.Serializer = _topic.DefaultSerializer;
+            envelope.ContentType = _topic.DefaultSerializer.ContentType;
+        }
 
         if (incoming.Timestamp.Type is TimestampType.CreateTime or TimestampType.LogAppendTime)
         {

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -4,6 +4,7 @@ using Confluent.Kafka.Admin;
 using Wolverine.Configuration;
 using Wolverine.ErrorHandling;
 using Wolverine.Kafka.Internals;
+using Wolverine.Runtime.Serialization;
 
 namespace Wolverine.Kafka;
 
@@ -254,12 +255,16 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
     /// JSON message bodies. This option maybe be necessary to receive
     /// messages from non-Wolverine applications
     /// </summary>
-    /// <param name="options"></param>
+    /// <param name="options">
+    /// When supplied, becomes this endpoint's default JSON serialization settings for both
+    /// deserializing incoming bodies and serializing outgoing ones. When omitted, Wolverine's
+    /// default System.Text.Json settings (camel-cased, case-insensitive reads) apply.
+    /// </param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     public KafkaListenerConfiguration ReceiveRawJson<T>(JsonSerializerOptions? options = null)
     {
-        return ReceiveRawJson(typeof(T));
+        return ReceiveRawJson(typeof(T), options);
     }
 
     /// <summary>
@@ -268,16 +273,29 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
     /// messages from non-Wolverine applications
     /// </summary>
     /// <param name="messageType"></param>
-    /// <param name="options"></param>
+    /// <param name="options">
+    /// When supplied, becomes this endpoint's default JSON serialization settings for both
+    /// deserializing incoming bodies and serializing outgoing ones. When omitted, Wolverine's
+    /// default System.Text.Json settings (camel-cased, case-insensitive reads) apply.
+    /// </param>
     /// <returns></returns>
     public KafkaListenerConfiguration ReceiveRawJson(Type messageType, JsonSerializerOptions? options = null)
     {
         DefaultIncomingMessage(messageType);
 
+        if (options != null)
+        {
+            // The mapper leaves deserialization to the endpoint's serializer (see
+            // HandlerPipeline.serializerFor), and Envelope.Data serializes outgoing message
+            // bodies through the same serializer — so the endpoint's default serializer is
+            // the one true place these options can take effect.
+            add(e => e.DefaultSerializer = new SystemTextJsonSerializer(options));
+        }
+
         // The parameter order matters here! (e, _) would bind to the Action<TEndpoint, TConcreteMapper>
         // customization overload of UseInterop, silently discarding the JsonOnlyMapper and leaving the
         // default KafkaEnvelopeMapper in effect. See GH-3407.
-        return UseInterop((_, e) => new JsonOnlyMapper(e, options ?? new()));
+        return UseInterop((_, e) => new JsonOnlyMapper(e));
     }
     
     /// <summary>

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaSubscriberConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaSubscriberConfiguration.cs
@@ -3,6 +3,7 @@ using Confluent.Kafka;
 using Confluent.Kafka.Admin;
 using Wolverine.Configuration;
 using Wolverine.Kafka.Internals;
+using Wolverine.Runtime.Serialization;
 
 namespace Wolverine.Kafka;
 
@@ -52,14 +53,26 @@ public class KafkaSubscriberConfiguration : InteroperableSubscriberConfiguration
     /// Publish only the raw, serialized JSON representation of messages to the downstream
     /// Kafka subscribers
     /// </summary>
-    /// <param name="options"></param>
+    /// <param name="options">
+    /// When supplied, becomes this endpoint's default JSON serialization settings for outgoing
+    /// message bodies. When omitted, Wolverine's default System.Text.Json settings
+    /// (camel-cased property names) apply.
+    /// </param>
     /// <returns></returns>
     public KafkaSubscriberConfiguration PublishRawJson(JsonSerializerOptions? options = null)
     {
+        if (options != null)
+        {
+            // Envelope.Data serializes outgoing message bodies through the endpoint's
+            // serializer before the mapper runs, so the endpoint's default serializer is
+            // the one true place these options can take effect.
+            add(e => e.DefaultSerializer = new SystemTextJsonSerializer(options));
+        }
+
         // The parameter order matters here! (e, _) would bind to the Action<TEndpoint, TConcreteMapper>
         // customization overload of UseInterop, silently discarding the JsonOnlyMapper and leaving the
         // default KafkaEnvelopeMapper (and all of its Wolverine protocol headers) in effect. See GH-3407.
-        return UseInterop((_, e) => new JsonOnlyMapper(e, options ?? new JsonSerializerOptions()));
+        return UseInterop((_, e) => new JsonOnlyMapper(e));
     }
 
     /// <summary>


### PR DESCRIPTION
Final follow-up in the raw-JSON series (#3407, #3442): the `JsonSerializerOptions` argument on `ReceiveRawJson()` and `PublishRawJson()` has never had any effect on any code path. This makes it real.

### Why it was dead

- **Outgoing**: `Envelope.Data` lazily serializes the message through the *endpoint's* serializer before the mapper runs, so `JsonOnlyMapper`'s `Message`-fallback branch — the only consumer of the stored options — was unreachable. Deleted, along with the now-parameterless options plumbing in the mapper.
- **Incoming**: the mapper never looked at the options at all, and raw records carry no content-type, so `HandlerPipeline.serializerFor` fell through to the **global** default serializer.
- **Bonus**: the generic `ReceiveRawJson<T>(options)` overload dropped the argument entirely when delegating to the `Type` overload.

### The fix

Supplying options now sets the endpoint's `DefaultSerializer` to a `SystemTextJsonSerializer` wrapping them — one mechanism that covers both directions coherently ("this endpoint speaks JSON in this dialect"):

- Outgoing bodies serialize through `Envelope.Data` → endpoint serializer → the supplied options.
- Incoming: `JsonOnlyMapper` now stamps `envelope.Serializer` (and `ContentType`) from the endpoint, mirroring what the base `EnvelopeMapper` does — without this, the null content-type on raw records routes deserialization to the global serializer regardless of endpoint configuration. Stamping `ContentType` also keeps the endpoint's serializer resolvable on a durable-inbox recovery replay, where the transient `Serializer` reference is lost.

**Compatibility**: gated on `options != null`. Bare `ReceiveRawJson<T>()` / `PublishRawJson()` callers see zero change — Wolverine's defaults (camel-cased, case-insensitive reads) still apply, and body bytes are byte-identical to before. Only callers who explicitly passed options see a change, and it's the behavior the parameter has always advertised.

### Tests

- Snake-cased external JSON (`{"color_name": ...}`) round-trips through `ReceiveRawJson<T>(SnakeCaseLower options)` — impossible with the default case-insensitive camelCase serializer, so it proves the options drive deserialization.
- A plain Confluent consumer reads a `PublishRawJson(new JsonSerializerOptions())` record and asserts a Pascal-cased body — distinct from Wolverine's camel-cased default, proving the options drive serialization.

(Test-infra note: both tests use per-run unique topics and `AutoOffsetReset.Earliest`; the librdkafka `Latest` default silently discards records produced while a consumer group is still joining a freshly provisioned topic.)

### Docs

The Kafka interop upgrade warning gains a bullet stating the options now work and what they control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
