### PR TITLE
Treat the lightweight saga provider as a catch-all so Marten and EF Core win (GH-3443)

### DIFF
--- a/src/Testing/CoreTests/Persistence/persistence_provider_precedence.cs
+++ b/src/Testing/CoreTests/Persistence/persistence_provider_precedence.cs
@@ -99,6 +99,50 @@ public class persistence_provider_precedence
         provider.ShouldBeSameAs(catchAll);
     }
 
+    // GH-3443: the real lightweight saga provider claims every saga, so it must be treated as a
+    // catch-all like Marten - otherwise it sorts ahead of Marten and steals sagas Marten should own.
+    [Fact]
+    public void the_lightweight_saga_provider_is_a_catch_all()
+    {
+        // Cast to the interface deliberately: IsCatchAll is a default interface member, so reading it off
+        // the concrete type would only compile when the override is present. Through the interface it
+        // reads the default (false) when the override is missing, which is the real regression.
+        ((IPersistenceFrameProvider)new LightweightSagaPersistenceFrameProvider()).IsCatchAll.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void marten_sorts_ahead_of_the_lightweight_saga_provider()
+    {
+        // A relational message store registers the lightweight provider (appended); Marten registers
+        // via InsertFirstPersistenceStrategy, landing at index 0. This is that raw order.
+        var martenLike = new CatchAllProvider();
+        var lightweight = new LightweightSagaPersistenceFrameProvider();
+
+        var rules = rulesWith(martenLike, lightweight);
+
+        var ordered = rules.OrderedPersistenceProviders();
+
+        // Both are catch-alls, so the stable sort preserves the raw order: Marten first, lightweight
+        // last. Before the fix, lightweight (mis-reported as non-catch-all) sorted FIRST and won every
+        // saga, silently moving Marten-owned sagas onto the lightweight tables.
+        ordered[0].ShouldBeSameAs(martenLike);
+        ordered[^1].ShouldBeSameAs(lightweight);
+    }
+
+    [Fact]
+    public void an_ef_core_like_selective_provider_still_outranks_marten_and_lightweight()
+    {
+        // The GH-3359 rule must survive the fix: a selective provider (EF Core, keyed on a DbContext
+        // mapping) is consulted before either catch-all.
+        var efCoreLike = new SelectiveProvider(typeof(MappedEntity));
+        var martenLike = new CatchAllProvider();
+        var lightweight = new LightweightSagaPersistenceFrameProvider();
+
+        var rules = rulesWith(martenLike, lightweight, efCoreLike);
+
+        rules.OrderedPersistenceProviders()[0].ShouldBeSameAs(efCoreLike);
+    }
+
     public class MappedEntity;
 
     public class UnmappedDocument;

--- a/src/Wolverine/Persistence/Sagas/LightweightSagaPersistenceFrameProvider.cs
+++ b/src/Wolverine/Persistence/Sagas/LightweightSagaPersistenceFrameProvider.cs
@@ -10,6 +10,12 @@ namespace Wolverine.Persistence.Sagas;
 
 public class LightweightSagaPersistenceFrameProvider : IPersistenceFrameProvider
 {
+    // GH-3443: this provider claims EVERY saga (CanApply is true for any SagaChain, CanPersist for any
+    // Saga type), so it is a catch-all exactly like the Marten / RavenDb / Polecat / CosmosDb / in-memory
+    // providers - all of which set this. It was the one that missed the override, which left it sorting
+    // AHEAD of Marten in OrderedPersistenceProviders and silently stealing sagas Marten should own.
+    public bool IsCatchAll => true;
+
     // ApplyTransactionSupport closes EnrollAndFetchSagaStorageFrame<,> over
     // (idType, sagaType) at codegen time; CanPersist closes ISagaStorage<,>
     // over the same. AOT-clean apps in TypeLoadMode.Static run pre-generated


### PR DESCRIPTION
Fixes #3443.

## The bug

`LightweightSagaPersistenceFrameProvider` claims **every** saga — `CanApply` is true for any `SagaChain`, `CanPersist` for any `Saga` type — but it was the one saga persistence provider that never set `IsCatchAll`. Marten, RavenDb, Polecat, CosmosDb, and the in-memory provider all set it; this one defaulted to `false`.

`OrderedPersistenceProviders` sorts non-catch-all providers first (`OrderBy(x => x.IsCatchAll ? 1 : 0)`), so a `false` value sorted the lightweight provider **ahead** of Marten. In a host wiring a relational message store (which registers the lightweight provider) alongside `AddMarten().IntegrateWithWolverine()` — the modular-monolith shape — the lightweight provider then claimed every saga, silently persisting to the lightweight tables the sagas Marten was documented to own. After an upgrade those sagas read as "not found."

## The fix

`IsCatchAll => true` on the lightweight provider — it genuinely is a catch-all, exactly like its five siblings. This restores the documented precedence:

- **EF Core wins over lightweight.** EF Core is a *selective* (non-catch-all) provider keyed on a `DbContext` mapping, so it sorts ahead of both catch-alls.
- **Marten wins over lightweight.** Among the catch-alls the stable sort preserves registration order, and Marten registers via `InsertFirstPersistenceStrategy` (index 0), so it precedes the appended lightweight provider.
- **A relational store with no document store still uses lightweight** — it's the only catch-all present.

## Tests

Three new tests in `persistence_provider_precedence`, each verified to fail without the override:

- `the_lightweight_saga_provider_is_a_catch_all` (cast through the interface, so it reads the default `false` when the override is missing rather than failing to compile)
- `marten_sorts_ahead_of_the_lightweight_saga_provider`
- `an_ef_core_like_selective_provider_still_outranks_marten_and_lightweight`

One-line production change; no other behavior touched. The `sagas.md:629` line that documents this precedence is now accurate again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)