### PR TITLE
Bump JasperFx to 2.28.0 and Weasel to 9.16.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,13 +35,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.27.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.27.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.27.0" />
+    <PackageVersion Include="JasperFx" Version="2.28.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.28.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.28.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.27.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.28.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.15.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
@@ -124,13 +124,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.16.2" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.16.2" />
-    <PackageVersion Include="Weasel.MySql" Version="9.16.2" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.16.2" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.16.2" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.16.2" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.16.2" />
+    <PackageVersion Include="Weasel.Core" Version="9.16.4" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.16.4" />
+    <PackageVersion Include="Weasel.MySql" Version="9.16.4" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.16.4" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.16.4" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.16.4" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.16.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />


### PR DESCRIPTION
Routine dependency bump, and the prerequisite for the SagaConcurrencyException work (#3444).

## Changes

- `JasperFx`, `JasperFx.Events`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator`: **2.27.0 → 2.28.0**
- Weasel family (`Core`, `EntityFrameworkCore`, `MySql`, `Oracle`, `Postgresql`, `SqlServer`, `Sqlite`): **9.16.2 → 9.16.4**
- `JasperFx.RuntimeCompiler` unchanged at `5.0.0` (already latest)

## What 2.28.0 brings

jasperfx#521, which this repo needs:
- `ConcurrencyException(string, Exception)` — unblocks `SagaConcurrencyException : ConcurrencyException` (#3444)
- Resizable `MaxConcurrentEventLoadsPerDatabase` / `MaxConcurrentBatchWritesPerDatabase` on the daemon
- Per-tenant high-water timer now re-paces on `SlowPollingTime` changes and idles when the daemon has no agents

## Compatibility

Marten stays at **9.15.1**: it depends on `JasperFx >= 2.27.0` and `Weasel.Postgresql >= 9.16.3`, both satisfied by the higher pins via NuGet min-version resolution — no downgrade, no conflict on restore.

Full `wolverine.slnx` builds clean (**0 warnings, 0 errors**); CoreTests green (1963). CI runs the full Marten / EF Core / provider matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)