### PR TITLE
SagaConcurrencyException inherits JasperFx.ConcurrencyException (GH-3444)

### DIFF
--- a/src/Testing/CoreTests/Persistence/Sagas/saga_concurrency_exception_tests.cs
+++ b/src/Testing/CoreTests/Persistence/Sagas/saga_concurrency_exception_tests.cs
@@ -1,0 +1,41 @@
+using System;
+using JasperFx;
+using Shouldly;
+using Wolverine;
+using Xunit;
+
+namespace CoreTests.Persistence.Sagas;
+
+// GH-3444: SagaConcurrencyException inherits JasperFx.ConcurrencyException so a single
+// OnException<ConcurrencyException>() policy catches saga concurrency failures across every storage
+// provider. Marten already surfaces JasperFx's type; the EF Core / lightweight / CosmosDb saga paths
+// throw SagaConcurrencyException. The docs (durability/sagas.md) tell users to write exactly that policy.
+public class saga_concurrency_exception_tests
+{
+    [Fact]
+    public void is_a_jasperfx_concurrency_exception()
+    {
+        new SagaConcurrencyException("stale").ShouldBeAssignableTo<ConcurrencyException>();
+    }
+
+    [Fact]
+    public void a_registered_concurrency_exception_policy_would_match_it()
+    {
+        // The catch a user's OnException<ConcurrencyException>() compiles to
+        Exception thrown = new SagaConcurrencyException("stale");
+        (thrown is ConcurrencyException).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void preserves_the_inner_store_exception()
+    {
+        // The CosmosDb saga path attaches the 412 Precondition Failed as the inner exception; inheriting
+        // ConcurrencyException must not lose it (JasperFx 2.28.0 added the (string, Exception) base ctor
+        // that makes this possible — before it, InnerException could not be set at all).
+        var inner = new InvalidOperationException("412 Precondition Failed");
+        var ex = new SagaConcurrencyException("Saga was modified concurrently", inner);
+
+        ex.InnerException.ShouldBeSameAs(inner);
+        ex.Message.ShouldBe("Saga was modified concurrently");
+    }
+}

--- a/src/Wolverine/Saga.cs
+++ b/src/Wolverine/Saga.cs
@@ -42,9 +42,13 @@ public abstract class Saga
 #endregion
 
 /// <summary>
-/// Optimistic concurrency exception from Wolverine saga operations
+/// Optimistic concurrency exception from Wolverine saga operations. Inherits
+/// <see cref="JasperFx.ConcurrencyException"/> (GH-3444) so that a single
+/// <c>OnException&lt;ConcurrencyException&gt;()</c> policy catches saga concurrency failures across every
+/// storage provider — Marten already surfaces JasperFx's type, and the EF Core / lightweight / CosmosDb
+/// saga paths throw this one.
 /// </summary>
-public class SagaConcurrencyException : Exception
+public class SagaConcurrencyException : JasperFx.ConcurrencyException
 {
     public SagaConcurrencyException(string message) : base(message)
     {


### PR DESCRIPTION
Fixes #3444. Depends on the JasperFx 2.28.0 bump (#3448, merged).

## The problem

`docs/guide/durability/sagas.md` tells users to catch saga optimistic-concurrency failures with `OnException<ConcurrencyException>()`. That policy never fired for an **EF Core, lightweight, or CosmosDb** saga: those paths throw `SagaConcurrencyException`, which derived from `System.Exception` rather than `JasperFx.ConcurrencyException`. Marten sagas surface JasperFx's type, so the hierarchies were split and the documented advice silently did nothing for the non-Marten stores.

## The fix

`SagaConcurrencyException` now inherits `JasperFx.ConcurrencyException`. Both ctors chain to the base; the `(string, Exception)` overload relies on the base ctor **added in JasperFx 2.28.0** (jasperfx#521), so the CosmosDb 412 Precondition Failed still round-trips as `InnerException`.

## Behavior change (release note)

A user's existing `OnException<ConcurrencyException>()` policy will now **also** catch saga concurrency failures, not just document-store ones. That is the intent — it makes the documented advice true across every saga provider. There is no built-in `ConcurrencyException` policy in Wolverine core, so nothing internal changes.

## Tests

`saga_concurrency_exception_tests` (CoreTests): assignable to `ConcurrencyException`, a `catch (ConcurrencyException)` matches it, and the inner store exception round-trips. `CosmosDbTests/saga_optimistic_concurrency.cs` already pins the `OnException<SagaConcurrencyException>()` path and keeps passing (the narrower type still matches).

Full `wolverine.slnx` builds clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)