### PR TITLE
Source DatabaseServerId from DatabaseDescriptor.Port instead of re-parsing (jasperfx#514)

### DIFF
--- a/src/Persistence/PostgresqlTests/database_server_id_matches_descriptor.cs
+++ b/src/Persistence/PostgresqlTests/database_server_id_matches_descriptor.cs
@@ -1,0 +1,40 @@
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Shouldly;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.RDBMS;
+using Xunit;
+
+namespace PostgresqlTests;
+
+// Consolidation check (jasperfx#514 / connection-budget follow-up): the PostgreSQL store's ServerId is
+// now sourced from Describe(), so the connection-budget key and the diagnostic descriptor agree on the
+// host and port. Wolverine's docker-compose PostgreSQL runs on 5433, which is exactly the collision case
+// the port is in the key for.
+public class database_server_id_matches_descriptor : PostgresqlContext
+{
+    [Fact]
+    public void server_id_carries_the_port_and_matches_the_descriptor()
+    {
+        var settings = new DatabaseSettings { ConnectionString = Servers.PostgresConnectionString };
+        var store = new PostgresqlMessageStore(settings, new DurabilitySettings(),
+            NpgsqlDataSource.Create(Servers.PostgresConnectionString),
+            NullLogger<PostgresqlMessageStore>.Instance);
+
+        var expectedPort = new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString).Port;
+
+        var descriptor = store.Describe();
+        descriptor.Port.ShouldBe(expectedPort);
+
+        var serverId = store.ServerId;
+        serverId.Engine.ShouldBe("PostgreSQL");
+        serverId.Port.ShouldBe(expectedPort);
+        serverId.ServerName.ShouldBe(descriptor.ServerName);
+
+        // The whole point of the consolidation: one source of truth.
+        serverId.Port.ShouldBe(descriptor.Port);
+        serverId.ServerName.ShouldBe(descriptor.ServerName);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -565,8 +565,9 @@ join pg_catalog.pg_namespace n on n.oid = c.relnamespace and n.nspname = '{Schem
                 return _serverId.Value;
             }
 
-            var builder = new NpgsqlConnectionStringBuilder(DataSource?.ConnectionString ?? Settings.ConnectionString);
-            _serverId = new DatabaseServerId("PostgreSQL", builder.Host ?? string.Empty, builder.Port);
+            // Sourced from Describe() so the server id and the diagnostic descriptor can't disagree
+            // about the host/port. Cached, so the descriptor is only built once.
+            _serverId = DatabaseServerId.For(Describe());
 
             return _serverId.Value;
         }
@@ -600,6 +601,9 @@ join pg_catalog.pg_namespace n on n.oid = c.relnamespace and n.nspname = '{Schem
         {
             Engine = "PostgreSQL",
             ServerName = builder.Host ?? string.Empty,
+            // PostgreSQL carries the port separately from the host, and it matters for connection
+            // budgeting: two clusters co-hosted on one box would otherwise collide onto one budget.
+            Port = builder.Port,
             DatabaseName = builder.Database ?? string.Empty,
             Subject = GetType().FullNameInCode(),
             SubjectUri = SubjectUri,

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -475,8 +475,9 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>, IConnection
                 return _serverId.Value;
             }
 
-            var builder = new SqlConnectionStringBuilder(_settings.ConnectionString);
-            _serverId = new DatabaseServerId("SqlServer", builder.DataSource ?? string.Empty, null);
+            // Sourced from Describe() so the server id and the diagnostic descriptor can't disagree
+            // about the host. Cached, so the descriptor is only built once.
+            _serverId = DatabaseServerId.For(Describe());
 
             return _serverId.Value;
         }
@@ -515,6 +516,9 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>, IConnection
         {
             Engine = "SqlServer",
             ServerName = builder.DataSource ?? string.Empty,
+            // Deliberately null: SqlServer's Data Source already carries the port (host,1433) or a
+            // named instance (host\SQLEXPRESS), so splitting it back out would only invent ambiguity.
+            Port = null,
             DatabaseName = builder.InitialCatalog ?? string.Empty,
             Subject = GetType().FullNameInCode(),
             SchemaOrNamespace = _settings.SchemaName!,

--- a/src/Testing/CoreTests/Persistence/database_server_id_factory_tests.cs
+++ b/src/Testing/CoreTests/Persistence/database_server_id_factory_tests.cs
@@ -1,0 +1,43 @@
+using JasperFx.Descriptors;
+using Shouldly;
+using Wolverine.Persistence;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+// DatabaseServerId is now built from a DatabaseDescriptor (jasperfx#514 added Port to the descriptor),
+// so a provider populates Engine / ServerName / Port once in Describe() and the connection-budget key
+// and the diagnostic descriptor can't disagree.
+public class database_server_id_factory_tests
+{
+    [Fact]
+    public void maps_engine_server_and_port_from_the_descriptor()
+    {
+        var descriptor = new DatabaseDescriptor
+        {
+            Engine = "PostgreSQL",
+            ServerName = "shard-a",
+            Port = 5433
+        };
+
+        var id = DatabaseServerId.For(descriptor);
+
+        id.Engine.ShouldBe("PostgreSQL");
+        id.ServerName.ShouldBe("shard-a");
+        id.Port.ShouldBe(5433);
+    }
+
+    [Fact]
+    public void carries_a_null_port_when_the_descriptor_leaves_it_null()
+    {
+        // SqlServer folds the port into the server name, so its descriptor leaves Port null.
+        var descriptor = new DatabaseDescriptor
+        {
+            Engine = "SqlServer",
+            ServerName = @"localhost,1433",
+            Port = null
+        };
+
+        DatabaseServerId.For(descriptor).Port.ShouldBeNull();
+    }
+}

--- a/src/Wolverine/Persistence/DatabaseServerId.cs
+++ b/src/Wolverine/Persistence/DatabaseServerId.cs
@@ -1,3 +1,5 @@
+using JasperFx.Descriptors;
+
 namespace Wolverine.Persistence;
 
 /// <summary>
@@ -17,6 +19,19 @@ namespace Wolverine.Persistence;
 /// </param>
 public readonly record struct DatabaseServerId(string Engine, string ServerName, int? Port)
 {
+    /// <summary>
+    /// Build the server id from a <see cref="DatabaseDescriptor"/>. The descriptor is the single source
+    /// of the server's <see cref="DatabaseDescriptor.Engine"/> / <see cref="DatabaseDescriptor.ServerName"/>
+    /// / <see cref="DatabaseDescriptor.Port"/> (jasperfx#514), so a provider populates those once in its
+    /// <c>Describe()</c> and both the connection-budget key and the diagnostic descriptor agree — rather
+    /// than each re-parsing the connection string. Port carries the engine's own convention: PostgreSQL
+    /// sets it, SqlServer leaves it null because the port is already folded into the server name.
+    /// </summary>
+    public static DatabaseServerId For(DatabaseDescriptor descriptor)
+    {
+        return new DatabaseServerId(descriptor.Engine, descriptor.ServerName, descriptor.Port);
+    }
+
     /// <summary>
     /// The value used as the <c>server</c> metric tag and in diagnostic output. The engine is
     /// deliberately left out — a host:port pair is already unique, and operators recognize it.


### PR DESCRIPTION
Deferred cleanup from the connection-budget work (#3397), unblocked by the JasperFx 2.28.0 bump (#3448, merged).

## What changed

JasperFx 2.28.0 adds a strongly-typed `Port` to `DatabaseDescriptor` (jasperfx#514). The PostgreSQL and SQL Server stores each parsed the connection string **twice** — once in `Describe()` for the diagnostic descriptor, once in `ServerId` for the connection-budget key — and `Describe()` never populated the new `Port` at all.

Now:
- `Describe()` sets `Port` — PostgreSQL from the connection-string builder, SQL Server **explicitly null** because its `Data Source` already carries `host,1433` or a named instance.
- `ServerId` is built from `Describe()` via a new `DatabaseServerId.For(descriptor)` factory.

One source of truth for the server's engine/host/port, so the budget key and the diagnostic descriptor can't drift apart.

## Behavior preserved

Observable `ServerId` values are **unchanged** — both providers already sourced from the same connection string, so PostgreSQL still keys on `host:port` and SQL Server still on the `Data Source` with a null port. The change is that `DatabaseDescriptor.Port` is now populated (a bonus for diagnostics / CritterWatch) and there's a single mapping.

## Tests

- `database_server_id_factory_tests` (CoreTests): the factory maps engine/host/port, including the null-port case.
- `database_server_id_matches_descriptor` (PostgresqlTests): a real PostgreSQL store's `ServerId.Port == Describe().Port ==` the configured port (5433 on the compose database) — the end-to-end consolidation, and the co-hosted-cluster collision case the port exists to prevent.

The existing `connection_budget_sweeper_tests` (which key on `DatabaseServerId`) keep passing. Full `wolverine.slnx` builds clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)