### PR TITLE
Register the event-subscription family aliases from the ancillary Marten path (GH-3438)

### DIFF
--- a/src/Persistence/MartenTests/Distribution/ancillary_managed_distribution_family_registration.cs
+++ b/src/Persistence/MartenTests/Distribution/ancillary_managed_distribution_family_registration.cs
@@ -1,0 +1,94 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Marten;
+using Marten.Events.Daemon.Coordination;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Marten.Distribution;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace MartenTests.Distribution;
+
+// GH-3438: the ancillary Marten integration used to register only the concrete EventSubscriptionAgentFamily,
+// never the IAgentFamily / IEventSubscriptionAgentFamily aliases. On a host whose only store wanting managed
+// distribution is ancillary (here the main store deliberately does NOT opt in), nothing resolved the family
+// through those interfaces — so Wolverine's managed distribution and external tooling (CritterWatch's
+// projection admin) got an empty family. The ancillary path now registers the aliases when its own
+// UseWolverineManagedEventSubscriptionDistribution flag is set.
+public class ancillary_managed_distribution_family_registration : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync("gh3438_main");
+            await conn.DropSchemaAsync("gh3438_anc");
+            await conn.CloseAsync();
+        }
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                // Main store provides node/envelope storage but deliberately does NOT opt into managed
+                // distribution, so it registers no family aliases. Any that resolve must come from the
+                // ancillary path.
+                opts.Services.AddMarten(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "gh3438_main";
+                }).IntegrateWithWolverine();
+
+                opts.Services.AddMartenStore<IGh3438Store>(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "gh3438_anc";
+                }).IntegrateWithWolverine(x => x.UseWolverineManagedEventSubscriptionDistribution = true);
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public void the_event_subscription_agent_family_resolves_through_its_interface()
+    {
+        // The exact repro from the issue: empty before the fix.
+        _host.Services.GetServices<IEventSubscriptionAgentFamily>().ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void the_family_is_registered_as_an_agent_family_for_distribution()
+    {
+        _host.Services.GetServices<IAgentFamily>()
+            .OfType<EventSubscriptionAgentFamily>()
+            .ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void the_ancillary_store_gets_the_managed_projection_coordinator()
+    {
+        _host.Services.GetRequiredService<IProjectionCoordinator<IGh3438Store>>()
+            .ShouldBeOfType<WolverineProjectionCoordinator<IGh3438Store>>();
+    }
+}
+
+public interface IGh3438Store : IDocumentStore;

--- a/src/Persistence/Wolverine.Marten/AncillaryWolverineOptionsMartenExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/AncillaryWolverineOptionsMartenExtensions.cs
@@ -58,6 +58,17 @@ public class AncillaryMartenIntegration
     /// </summary>
     public AutoCreate? AutoCreate { get; set; }
 
+    /// <summary>
+    /// Opt into Wolverine-managed distribution of this store's async projections and event
+    /// subscriptions (GH-3438), mirroring the main store's
+    /// <see cref="MartenIntegration.UseWolverineManagedEventSubscriptionDistribution"/>. This is what an
+    /// ancillary-only host — one with no main <c>AddMarten</c> that already enables it — must set to run
+    /// managed distribution and to expose the store to tooling (e.g. CritterWatch's projection admin)
+    /// that resolves the agent family through <c>IEventSubscriptionAgentFamily</c>. When a main store
+    /// already enables it, that registration wins and setting it here is redundant but harmless.
+    /// </summary>
+    public bool UseWolverineManagedEventSubscriptionDistribution { get; set; }
+
     internal void AssertValidity()
     {
         if (SchemaName.IsNotEmpty() && SchemaName != SchemaName.ToLowerInvariant())
@@ -110,16 +121,35 @@ public static class AncillaryWolverineOptionsMartenExtensions
         expression.Services.AddType(typeof(IDatabaseSource), typeof(MessageDatabaseDiscovery),
             ServiceLifetime.Singleton);
 
-        // TODO -- watch the service registrations
+        // The concrete family already takes IEnumerable<IEventStore>, so one instance manages every
+        // registered store including the ancillaries.
         expression.Services.AddSingleton<EventSubscriptionAgentFamily>();
-        
-        
+
+        // GH-3438: the main-store integration aliases the family to IAgentFamily /
+        // IEventSubscriptionAgentFamily, but an ancillary-only host has no main integration to do that,
+        // so managed distribution and any tooling resolving the family through those interfaces get
+        // nothing. Register the aliases from here too when managed distribution is opted in. TryAdd so
+        // that a main store which already aliased them wins and we don't double-register (one family
+        // instance covers all stores either way). Gated on the flag because NodeAgentController
+        // distributes the agents of every registered IAgentFamily — an ancillary host that never asked
+        // for managed distribution must not suddenly start distributing.
+        if (integration.UseWolverineManagedEventSubscriptionDistribution)
+        {
+            expression.Services.TryAddSingleton<IAgentFamily>(s => s.GetRequiredService<EventSubscriptionAgentFamily>());
+            expression.Services.TryAddSingleton<IEventSubscriptionAgentFamily>(s => s.GetRequiredService<EventSubscriptionAgentFamily>());
+        }
+
         expression.Services.AddSingleton<IProjectionCoordinator<T>>(s =>
         {
-            var integration = s.GetService<MartenIntegration>();
+            var mainIntegration = s.GetService<MartenIntegration>();
             var store = s.GetRequiredService<T>();
-            
-            if (integration == null || !integration.UseWolverineManagedEventSubscriptionDistribution)
+
+            // Managed when the main store opted in (main+ancillary), or when this ancillary store did
+            // (ancillary-only) — the captured integration carries the ancillary flag.
+            var managed = integration.UseWolverineManagedEventSubscriptionDistribution
+                          || (mainIntegration?.UseWolverineManagedEventSubscriptionDistribution ?? false);
+
+            if (!managed)
             {
                 return new ProjectionCoordinator<T>(store, s.GetRequiredService<ILogger<ProjectionCoordinator>>());
             }


### PR DESCRIPTION
Fixes #3438.

## The gap

The **main-store** integration aliases `EventSubscriptionAgentFamily` to both `IAgentFamily` and `IEventSubscriptionAgentFamily`. The **ancillary** integration registered only the concrete type, with a standing `// TODO -- watch the service registrations`. So a host whose only store wanting managed distribution is **ancillary** — no main `AddMarten` that opts in — registered **no `IEventSubscriptionAgentFamily`**. Wolverine's managed distribution and external tooling (CritterWatch's projection admin: rebuild/pause/restart) resolve the family through that interface and got an empty result.

## What I found beyond the issue

The issue's repro assumes an `AncillaryMartenIntegration.UseWolverineManagedEventSubscriptionDistribution` flag — **which didn't exist**. And the per-store `IProjectionCoordinator<T>` resolver only consulted the *main* `MartenIntegration`, which is null/absent for an ancillary-only host. So the fix is three coordinated parts, not a one-line alias add:

1. **New flag** `UseWolverineManagedEventSubscriptionDistribution` on `AncillaryMartenIntegration`, mirroring the main store's. This is the opt-in an ancillary-only host previously had no way to express.
2. **Gated alias registration.** When the flag is set, the ancillary path registers the two interface aliases via **`TryAddSingleton`** — `Try` so a main store that already aliased them wins and one family instance (it already takes `IEnumerable<IEventStore>`) covers every store. **Gated on the flag** because `NodeAgentController` distributes the agents of *every* registered `IAgentFamily`; an ancillary host that never opted in must not suddenly start distributing.
3. **Resolver consults the ancillary flag** too, so an ancillary-only host gets the managed `WolverineProjectionCoordinator<T>` instead of silently falling back to the non-managed coordinator.

## Test

`ancillary_managed_distribution_family_registration`: an ancillary store opts in while the main store deliberately does **not**, so any family resolving through the interface must come from the ancillary path. Asserts the family resolves through `IEventSubscriptionAgentFamily`, is present as an `IAgentFamily` for distribution, and that the ancillary store gets the managed coordinator.

Verified red/green: with the flag present but the registration reverted, all three assertions **fail**; with the fix they pass. The existing `with_ancillary_stores` tests (main+ancillary) still pass — no regression on that path. Full `wolverine.slnx` builds clean (0 warnings).

Note: one unrelated multi-node failover test (`tenant_partitioned_distribution_multinode.agents_fail_over...`) flaked under full-suite load and passes in isolation; it uses a main store, not ancillary, so it's untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)