### PR TITLE
Degrade-only connection state for Azure Service Bus and GCP Pub/Sub listeners (GH-3237)

### DIFF
--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/connection_state_3237.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/connection_state_3237.cs
@@ -1,0 +1,97 @@
+using Azure.Messaging.ServiceBus;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Wolverine.Configuration;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+// GH-3237: the Azure Service Bus SDK exposes no queryable connection state, so the listeners derive a
+// degrade-only state from real error callbacks. The resting state for a healthy listener is Unknown —
+// a heuristic may move the state toward trouble, but must never synthesize Connected.
+public class connection_state_3237
+{
+    [Theory]
+    [InlineData(ServiceBusFailureReason.ServiceCommunicationProblem, TransportConnectionState.Reconnecting)]
+    [InlineData(ServiceBusFailureReason.ServiceTimeout, TransportConnectionState.Reconnecting)]
+    [InlineData(ServiceBusFailureReason.ServiceBusy, TransportConnectionState.Reconnecting)]
+    [InlineData(ServiceBusFailureReason.MessagingEntityNotFound, TransportConnectionState.Disconnected)]
+    [InlineData(ServiceBusFailureReason.MessagingEntityDisabled, TransportConnectionState.Disconnected)]
+    public void maps_connection_level_service_bus_failures(ServiceBusFailureReason reason,
+        TransportConnectionState expected)
+    {
+        AzureServiceBusConnectionStateMapper.StateForError(new ServiceBusException("boom", reason))
+            .ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(ServiceBusFailureReason.MessageLockLost)]
+    [InlineData(ServiceBusFailureReason.SessionLockLost)]
+    [InlineData(ServiceBusFailureReason.MessageSizeExceeded)]
+    [InlineData(ServiceBusFailureReason.QuotaExceeded)]
+    [InlineData(ServiceBusFailureReason.GeneralError)]
+    public void message_level_failures_say_nothing_about_the_connection(ServiceBusFailureReason reason)
+    {
+        AzureServiceBusConnectionStateMapper.StateForError(new ServiceBusException("boom", reason))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public void unauthorized_access_means_disconnected()
+    {
+        AzureServiceBusConnectionStateMapper.StateForError(new UnauthorizedAccessException("expired"))
+            .ShouldBe(TransportConnectionState.Disconnected);
+    }
+
+    [Fact]
+    public void unrecognized_exceptions_leave_the_state_alone()
+    {
+        AzureServiceBusConnectionStateMapper.StateForError(new InvalidOperationException("unrelated"))
+            .ShouldBeNull();
+        AzureServiceBusConnectionStateMapper.StateForError(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task healthy_listeners_rest_at_unknown_and_never_report_connected()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAzureServiceBusTesting().AutoProvision().AutoPurgeOnStartup();
+
+                // One batched (default) and one inline listener so both listener types are covered
+                opts.ListenToAzureServiceBusQueue("connstate-batched");
+                opts.PublishMessage<ConnStateMessage>().ToAzureServiceBusQueue("connstate-batched");
+
+                opts.ListenToAzureServiceBusQueue("connstate-inline").ProcessInline();
+            }).StartAsync();
+
+        // Prove the pipe actually works...
+        await host.TrackActivity().IncludeExternalTransports().Timeout(30.Seconds())
+            .SendMessageAndWaitAsync(new ConnStateMessage());
+
+        // ...and that a working listener still reports Unknown, never a synthesized Connected
+        var snapshots = host.GetRuntime().Endpoints.CollectEndpointHealth()
+            .Where(s => s.Direction == EndpointDirection.Listening && s.Uri.Scheme == "asb")
+            .ToArray();
+
+        snapshots.ShouldNotBeEmpty();
+        foreach (var snapshot in snapshots)
+        {
+            snapshot.ConnectionState.ShouldBe(TransportConnectionState.Unknown);
+        }
+    }
+}
+
+public record ConnStateMessage;
+
+public static class ConnStateMessageHandler
+{
+    public static void Handle(ConnStateMessage message)
+    {
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusConnectionStateMapper.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusConnectionStateMapper.cs
@@ -1,0 +1,48 @@
+using Azure.Messaging.ServiceBus;
+using Wolverine.Transports;
+
+namespace Wolverine.AzureServiceBus.Internal;
+
+/// <summary>
+/// GH-3237: maps a real Azure Service Bus SDK failure to a degraded <see cref="TransportConnectionState"/>.
+/// The ASB SDK exposes no queryable connection state, so the only honest signals are error callbacks — this
+/// mapper may only ever move state toward trouble (Reconnecting/Disconnected), never synthesize Connected.
+/// Message-level failures (lock lost, size exceeded, ...) say nothing about the connection and map to null.
+/// </summary>
+internal static class AzureServiceBusConnectionStateMapper
+{
+    /// <summary>
+    /// Returns the degraded connection state implied by the given receive-side failure, or null when the
+    /// failure carries no connection-level information and the current state should be left alone.
+    /// </summary>
+    internal static TransportConnectionState? StateForError(Exception? exception)
+    {
+        switch (exception)
+        {
+            // Auth revoked/expired — the listener cannot consume until credentials are fixed
+            case UnauthorizedAccessException:
+                return TransportConnectionState.Disconnected;
+
+            case ServiceBusException sbe:
+                switch (sbe.Reason)
+                {
+                    // Transient comms trouble; the SDK is retrying the AMQP link under the covers
+                    case ServiceBusFailureReason.ServiceCommunicationProblem:
+                    case ServiceBusFailureReason.ServiceTimeout:
+                    case ServiceBusFailureReason.ServiceBusy:
+                        return TransportConnectionState.Reconnecting;
+
+                    // The entity is gone or disabled — retrying will not bring consumption back
+                    case ServiceBusFailureReason.MessagingEntityNotFound:
+                    case ServiceBusFailureReason.MessagingEntityDisabled:
+                        return TransportConnectionState.Disconnected;
+
+                    default:
+                        return null;
+                }
+
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
@@ -10,9 +10,13 @@ using Wolverine.Transports.Sending;
 
 namespace Wolverine.AzureServiceBus.Internal;
 
-public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue
+public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue, IReportConnectionState
 {
     private readonly CancellationTokenSource _cancellation = new();
+
+    // GH-3237: derived only from real receive-loop failures (degrade-only). A successful receive clears back
+    // to Unknown — never Connected, because the SDK cannot prove the AMQP link is up without traffic.
+    private volatile TransportConnectionState _connectionState = TransportConnectionState.Unknown;
     private readonly RetryBlock<AzureServiceBusEnvelope> _complete;
     private readonly RetryBlock<AzureServiceBusEnvelope> _deadLetter;
     private readonly RetryBlock<Envelope> _defer;
@@ -51,6 +55,8 @@ public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue
     }
 
     public IHandlerPipeline? Pipeline => _wolverineReceiver.Pipeline;
+
+    public TransportConnectionState ConnectionState => _connectionState;
 
     public ValueTask CompleteAsync(Envelope envelope)
     {
@@ -123,6 +129,12 @@ public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue
 
                 failedCount = 0;
 
+                if (_connectionState != TransportConnectionState.Unknown)
+                {
+                    // The receive succeeded, so any previously derived trouble state is stale
+                    _connectionState = TransportConnectionState.Unknown;
+                }
+
                 if (messages.Any())
                 {
                     var envelopes = new List<Envelope>(messages.Count);
@@ -160,6 +172,11 @@ public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue
                 {
                     break;
                 }
+
+                // The receive attempt genuinely failed and this loop is about to back off and retry, so
+                // Reconnecting is the honest floor even for exception types the mapper doesn't recognize
+                _connectionState = AzureServiceBusConnectionStateMapper.StateForError(e)
+                                   ?? TransportConnectionState.Reconnecting;
 
                 failedCount++;
                 var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusListener.cs
@@ -9,9 +9,14 @@ using Wolverine.Transports.Sending;
 
 namespace Wolverine.AzureServiceBus.Internal;
 
-public class InlineAzureServiceBusListener : IListener, ISupportDeadLetterQueue, ISupportNativeScheduling
+public class InlineAzureServiceBusListener : IListener, ISupportDeadLetterQueue, ISupportNativeScheduling,
+    IReportConnectionState
 {
     private readonly CancellationTokenSource _cancellation = new();
+
+    // GH-3237: derived only from ProcessErrorAsync (degrade-only). A successful delivery clears back to
+    // Unknown — never Connected, because the SDK cannot prove the AMQP link is up without traffic.
+    private volatile TransportConnectionState _connectionState = TransportConnectionState.Unknown;
     private readonly RetryBlock<AzureServiceBusEnvelope> _complete;
     private readonly RetryBlock<AzureServiceBusEnvelope> _deadLetter;
     private readonly RetryBlock<AzureServiceBusEnvelope> _defer;
@@ -60,6 +65,8 @@ public class InlineAzureServiceBusListener : IListener, ISupportDeadLetterQueue,
     }
 
     public IHandlerPipeline? Pipeline => _receiver.Pipeline;
+
+    public TransportConnectionState ConnectionState => _connectionState;
 
     public ValueTask CompleteAsync(Envelope envelope)
     {
@@ -136,12 +143,24 @@ public class InlineAzureServiceBusListener : IListener, ISupportDeadLetterQueue,
 
     private Task processErrorAsync(ProcessErrorEventArgs arg)
     {
+        var degraded = AzureServiceBusConnectionStateMapper.StateForError(arg.Exception);
+        if (degraded.HasValue)
+        {
+            _connectionState = degraded.Value;
+        }
+
         _logger.LogError(arg.Exception, "Error trying to receive Azure Service Bus message at {Uri}", _endpoint.Uri);
         return Task.CompletedTask;
     }
 
     private async Task processMessageAsync(ProcessMessageEventArgs arg)
     {
+        if (_connectionState != TransportConnectionState.Unknown)
+        {
+            // Messages are flowing again, so any previously derived trouble state is stale
+            _connectionState = TransportConnectionState.Unknown;
+        }
+
         try
         {
             var envelope = new AzureServiceBusEnvelope(arg);

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/connection_state_3237.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/connection_state_3237.cs
@@ -1,0 +1,84 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Configuration;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.Pubsub.Tests;
+
+// GH-3237: the Pub/Sub SDK hides the streaming-pull connection, so PubsubListener derives a degrade-only
+// state from its own retry loop. The resting state for a healthy listener is Unknown — the heuristic may
+// move the state toward trouble (Reconnecting/Disconnected), but must never synthesize Connected.
+public class connection_state_3237
+{
+    [Fact]
+    public async Task healthy_listener_rests_at_unknown_and_never_reports_connected()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UsePubsubTesting().AutoProvision().AutoPurgeOnStartup();
+
+                opts.PublishMessage<ConnStateMessage>().ToPubsubTopic("connstate");
+                opts.ListenToPubsubTopic("connstate");
+            }).StartAsync();
+
+        // Prove the pipe actually works...
+        await host.TrackActivity().IncludeExternalTransports().Timeout(30.Seconds())
+            .SendMessageAndWaitAsync(new ConnStateMessage());
+
+        // ...and that a working listener still reports Unknown, never a synthesized Connected
+        var snapshot = host.GetRuntime().Endpoints.CollectEndpointHealth()
+            .Single(s => s.Direction == EndpointDirection.Listening && s.Uri.Scheme == PubsubTransport.ProtocolName);
+
+        snapshot.ConnectionState.ShouldBe(TransportConnectionState.Unknown);
+    }
+
+    [Fact]
+    public async Task unreachable_broker_degrades_to_disconnected_after_retries_are_exhausted()
+    {
+        var original = Environment.GetEnvironmentVariable("PUBSUB_EMULATOR_HOST");
+
+        // Point this host at a port nothing listens on so the streaming pull genuinely fails,
+        // driving the retry loop: Reconnecting during backoff, Disconnected once retries run out
+        Environment.SetEnvironmentVariable("PUBSUB_EMULATOR_HOST", "localhost:18085");
+
+        try
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    // No AutoProvision here — provisioning against the dead endpoint would fail startup
+                    opts.UsePubsubTesting();
+
+                    opts.ListenToPubsubTopic("connstate-dead")
+                        .ConfigureListener(c =>
+                        {
+                            c.RetryPolicy.MaxRetryCount = 2;
+                            c.RetryPolicy.RetryDelay = 50;
+                        });
+                }).StartAsync();
+
+            var state = await ConnectionStateTestHelpers.WaitForListenerConnectionStateAsync(
+                host, PubsubTransport.ProtocolName, TransportConnectionState.Disconnected);
+
+            state.ShouldBe(TransportConnectionState.Disconnected);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PUBSUB_EMULATOR_HOST", original);
+        }
+    }
+}
+
+public record ConnStateMessage;
+
+public static class ConnStateMessageHandler
+{
+    public static void Handle(ConnStateMessage message)
+    {
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/PubsubListener.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/PubsubListener.cs
@@ -10,7 +10,7 @@ using Wolverine.Transports;
 
 namespace Wolverine.Pubsub.Internal;
 
-public abstract class PubsubListener : IListener, ISupportDeadLetterQueue
+public abstract class PubsubListener : IListener, ISupportDeadLetterQueue, IReportConnectionState
 {
     protected readonly CancellationTokenSource _cancellation = new();
     protected readonly RetryBlock<Envelope> _deadLetter;
@@ -23,6 +23,13 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue
     protected readonly PubsubTransport _transport;
 
     protected Task _task;
+
+    // GH-3237: the Pub/Sub SDK hides the streaming-pull connection, so this state is derived only from the
+    // retry loop below and may only ever degrade (Reconnecting/Disconnected). Never Connected — the resting
+    // state for a healthy listener is Unknown; use LastQueueActivityAt/loop-health for liveness.
+    private volatile TransportConnectionState _connectionState = TransportConnectionState.Unknown;
+
+    public TransportConnectionState ConnectionState => _connectionState;
 
     /// <summary>
     /// The connection (default or per-tenant) this listener consumes and, for requeue/dead-letter, re-publishes over.
@@ -134,6 +141,9 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue
         {
             try
             {
+                // Back to the resting state for each fresh attempt; only a real failure below may degrade it
+                _connectionState = TransportConnectionState.Unknown;
+
                 await listenAsync();
             }
             catch (TaskCanceledException) when (_cancellation.IsCancellationRequested)
@@ -147,6 +157,8 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue
             // https://stackoverflow.com/questions/60012138/google-cloud-function-pulling-from-pub-sub-subscription-throws-exception-deadl
             catch (RpcException ex) when (ex.StatusCode == StatusCode.DeadlineExceeded)
             {
+                _connectionState = TransportConnectionState.Reconnecting;
+
                 _logger.LogError(ex,
                     "{Uri}: Google Cloud Platform Pub/Sub returned \"DEADLINE_EXCEEDED\", attempting to restart listener.",
                     _endpoint.Uri);
@@ -168,11 +180,15 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue
 
                 if (retryCount > _endpoint.Client.RetryPolicy.MaxRetryCount)
                 {
+                    _connectionState = TransportConnectionState.Disconnected;
+
                     _logger.LogError(ex, "{Uri}: Max retry attempts reached, unable to restart listener.",
                         _endpoint.Uri);
 
                     throw;
                 }
+
+                _connectionState = TransportConnectionState.Reconnecting;
 
                 _logger.LogError(
                     ex,


### PR DESCRIPTION
Closes the implementation half of #3237 for Azure Service Bus and GCP Pub/Sub (Kafka is split into its own follow-up issue).

## What this does

Both SDKs manage their broker connection internally with no queryable state, so these listeners now derive a **degrade-only** `ConnectionState` strictly from real failure signals, per the decision on #3237:

> A heuristic may only ever move state toward trouble, never toward health. `Connected` comes only from a queryable SDK property — which these SDKs don't have — so their resting state is `Unknown`, and liveness stays with loop-health + `LastQueueActivityAt` (#3236).

### Azure Service Bus
- New `AzureServiceBusConnectionStateMapper` shared by both listeners:
  - `ServiceCommunicationProblem` / `ServiceTimeout` / `ServiceBusy` → `Reconnecting`
  - `MessagingEntityNotFound` / `MessagingEntityDisabled` / `UnauthorizedAccessException` → `Disconnected`
  - Message-level failures (lock lost, size exceeded, quota, …) → no state change
- `InlineAzureServiceBusListener`: mapping applied in `ProcessErrorAsync`; a successful delivery clears back to `Unknown`
- `BatchedAzureServiceBusListener`: mapping applied in the receive-loop catch; an unrecognized receive failure floors at `Reconnecting` (the loop is literally in its retry/backoff); a successful receive clears back to `Unknown`

### GCP Pub/Sub
- `PubsubListener` reports from its existing retry seam in `listenForMessagesAsync`: `Reconnecting` during the backoff window (and the DEADLINE_EXCEEDED restart), `Disconnected` once `MaxRetryCount` is exhausted, `Unknown` on each fresh attempt

Neither transport ever reports `Connected`, and no per-message overhead is added (state writes are guarded or on failure paths only).

## Tests
- ASB: mapper theories for every mapped/ignored `ServiceBusFailureReason`, plus an emulator test proving a *working* batched + inline listener rests at `Unknown` (never a synthesized `Connected`)
- GCP: emulator test for the same resting-state invariant, plus a real dead-broker test that points a listener at an unreachable port and observes the genuine `Reconnecting` → `Disconnected` degradation

Full `wolverine.slnx` builds clean in Release; full ASB and Pub/Sub suites pass locally against the docker emulators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
