### PR TITLE
Re-scope buffered circuit-breaker tests to the non-durable contract (GH-3137)

### DIFF
--- a/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakerIntegrationContext.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakerIntegrationContext.cs
@@ -118,10 +118,34 @@ public abstract class CircuitBreakerIntegrationContext(ITestOutputHelper output)
         return Task.WhenAll(_tasks);
     }
 
+    // GH-3137: how long we allow the listener to churn through the published messages (with requeues,
+    // and, in the trip test, a 10s circuit pause eating into the window). These assertions are about
+    // circuit-breaker *behavior*, not throughput — on a slow/contended CI runner the old 1-minute
+    // budget was itself the thing that failed. Kept generous so processing time is never under test.
+    protected static readonly TimeSpan ProcessingBudget = 3.Minutes();
+
+    // GH-3137: how many of the 1200 published messages must be processed for the trip test to pass.
+    // Buffered variants override this below 1200 — buffered mode acks each message to the broker the
+    // moment it lands in the in-memory buffer, so the handful caught in the listener teardown when the
+    // breaker trips are lost (already acked, never persisted). That is buffered mode's documented
+    // non-durable tradeoff; durable persists and inline has no buffer, so both still require all 1200.
+    // The trip/restart *behavior* is still asserted for every variant.
+    protected virtual int RequiredProcessedCountOnTrip => 1200;
+
+    // GH-3137: the circuit's Accepting transition after a trip is emitted by the Restarter, PauseTime
+    // (10s) after the trip and fully decoupled from message completion — the backlog can drain (and the
+    // waiter resolve) while the listener is still paused. Synchronize to the listener's real lifecycle
+    // instead of snapshotting RecordedStates at the instant messages happen to finish. Returns
+    // immediately if the listener is already Accepting.
+    protected Task waitForListenerToResumeAsync(TimeSpan timeout)
+    {
+        return _runtime.Tracker.WaitForListenerStatusAsync(_queueName, ListeningStatus.Accepting, timeout);
+    }
+
     [Fact]
     public async Task everything_is_wonderful_even_though_there_are_some_failures_so_do_not_ever_trip()
     {
-        var messageWaiter = _recorder.WaitForMessagesToBeProcessed(1200, 1.Minutes());
+        var messageWaiter = _recorder.WaitForMessagesToBeProcessed(1200, ProcessingBudget);
 
         publishHundredMessagesNow(5);
         publishHundredMessagesNow(5);
@@ -146,7 +170,7 @@ public abstract class CircuitBreakerIntegrationContext(ITestOutputHelper output)
     [Fact]
     public async Task the_circuit_breaker_should_trip_and_restart()
     {
-        var messageWaiter = _recorder.WaitForMessagesToBeProcessed(1200, 1.Minutes());
+        var messageWaiter = _recorder.WaitForMessagesToBeProcessed(RequiredProcessedCountOnTrip, ProcessingBudget);
 
         publishHundredMessagesNow(10);
         publishHundredMessagesNow(80);
@@ -172,8 +196,13 @@ public abstract class CircuitBreakerIntegrationContext(ITestOutputHelper output)
 
         await messageWaiter;
 
+        // It tripped at least once...
         _observer.RecordedStates.ShouldContain(ListeningStatus.Stopped);
-        _observer.RecordedStates.Last().ShouldBe(ListeningStatus.Accepting);
+
+        // ...and it recovers. Wait for the actual restart rather than asserting RecordedStates.Last()
+        // at the instant messages finish — that snapshot races the Restarter's post-pause Accepting
+        // (see waitForListenerToResumeAsync / GH-3137).
+        await waitForListenerToResumeAsync(1.Minutes());
     }
 }
 

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/buffered_and_parallel.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/buffered_and_parallel.cs
@@ -9,6 +9,12 @@ namespace CircuitBreakingTests.RabbitMq;
 public class buffered_and_parallel(ITestOutputHelper output)
     : CircuitBreakerIntegrationContext(output)
 {
+    // GH-3137: buffered mode acks each message to the broker on receipt and holds it in memory, so the
+    // few messages in flight when the breaker tears the listener down on a trip are lost (already acked,
+    // never persisted). Require the bulk rather than exact delivery — the trip/restart behavior is still
+    // asserted. Durable/inline keep the full-1200 requirement from the base class.
+    protected override int RequiredProcessedCountOnTrip => 1150;
+
     protected override void configureListener(WolverineOptions opts)
     {
         // Requeue failed messages.

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/buffered_not_parallelized.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/buffered_not_parallelized.cs
@@ -9,6 +9,12 @@ namespace CircuitBreakingTests.RabbitMq;
 public class buffered_not_parallelized(ITestOutputHelper output)
     : CircuitBreakerIntegrationContext(output)
 {
+    // GH-3137: buffered mode acks each message to the broker on receipt and holds it in memory, so the
+    // few messages in flight when the breaker tears the listener down on a trip are lost (already acked,
+    // never persisted). Require the bulk rather than exact delivery — the trip/restart behavior is still
+    // asserted. Durable/inline keep the full-1200 requirement from the base class.
+    protected override int RequiredProcessedCountOnTrip => 1150;
+
     protected override void configureListener(WolverineOptions opts)
     {
         // Requeue failed messages.


### PR DESCRIPTION
Addresses #3137.

## The "flake" is real message loss, not timing noise

I reproduced both quarantined flakes and root-caused them. `buffered_and_parallel` and `buffered_not_parallelized` fail on `the_circuit_breaker_should_trip_and_restart` because **buffered-mode listeners lose in-flight messages when the breaker trips**:

| Variant | `everything_is_wonderful` (no trip) | `..._trip_and_restart` |
|---|---|---|
| **buffered** (parallel / not) | ✅ | ❌ **lost 4 / 8 of 1200** |
| durable (parallel / not) | ✅ | ✅ |
| inline (parallel / not) | ✅ | ✅ |

In a full-suite run (22/24), the **only** two failures are exactly the two buffered *trip* tests — the two the issue names.

**Mechanism:** buffered mode acks each message to the broker the moment it lands in the in-memory buffer. When the breaker trips, `PauseWithDrainAsync` tears the listener down and drains best-effort; messages still in flight at teardown are already acked to the broker and never persisted, so they vanish. Durable persists first (no loss); inline has no buffer (no loss). That's why *only* buffered flakes, and why it's probabilistic (surfaces under the wider teardown race on a loaded CI runner). The old assertion required all-1200 delivery — durability buffered mode explicitly does not promise.

## The fix — assert behavior, not a guarantee the transport doesn't make

Per maintainer direction, re-scope rather than change transport semantics:

- `the_circuit_breaker_should_trip_and_restart` now requires `RequiredProcessedCountOnTrip` messages (a `virtual`, default **1200**). The two buffered variants override it to **1150** — still proving the breaker tripped, recovered, and processed the bulk (~96%+), while tolerating the small in-flight loss. **Durable/inline keep the strict all-1200 requirement.**
- Replace the racy `RecordedStates.Last().ShouldBe(Accepting)` snapshot with `WaitForListenerStatusAsync(Accepting)` — the final Accepting is emitted by the `Restarter` 10s after the trip, decoupled from message completion, so the snapshot raced the restart. (Idiom already used by sibling tests in this project.)
- Widen the processing budget 1m → 3m (a generous ceiling; these tests are about breaker behavior, not throughput) to remove the separate slow-runner timeout flake.

No production code changes.

## Verification

- Full `CircuitBreakingTests` suite: **24/24 green** (was 22/24).
- The two buffered trip tests: **5/5 repeats green** (~30s each; previously timed out at 3m after losing messages).

## Note on the workflow

`circuit-breaking.yml` stays as-is (informational) in this PR. Once this proves stable across a handful of CI runs, it's a candidate to rejoin the required set — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)