### PR TITLE
Upgrade Marten to 9.16.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,12 +43,12 @@
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
     <PackageVersion Include="JasperFx.SourceGenerator" Version="2.28.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
-    <PackageVersion Include="Marten" Version="9.15.1" />
+    <PackageVersion Include="Marten" Version="9.16.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="[5.1.0,6.0.0)" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.15.1" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.15.1" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.16.0" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.16.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />


### PR DESCRIPTION
Bumps **Marten**, **Marten.AspNetCore**, and **Marten.Newtonsoft** from `9.15.1` → `9.16.0`.

- Clean `dotnet restore wolverine.slnx` — no downgrade/conflict warnings against the current **JasperFx 2.28.0** and **Weasel 9.17.0** pins.
- Full `wolverine.slnx` builds clean in Release (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)