### PR TITLE
Upgrade Polecat to 5.2.0 (+ JasperFx 2.29.0)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,7 @@
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.15.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="[5.1.0,6.0.0)" />
+    <PackageVersion Include="Polecat" Version="[5.2.0,6.0.0)" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageVersion Include="Marten.AspNetCore" Version="9.15.1" />
     <PackageVersion Include="Marten.Newtonsoft" Version="9.15.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,13 +35,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.28.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.28.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.28.0" />
+    <PackageVersion Include="JasperFx" Version="2.29.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.29.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.29.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.28.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.29.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.15.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />


### PR DESCRIPTION
Bumps the **Polecat** pin floor `[5.1.0,6.0.0)` → `[5.2.0,6.0.0)`, plus the coordinated **JasperFx family 2.28.0 → 2.29.0** that Polecat 5.2.0 requires.

### Why the JasperFx bump is needed
Polecat 5.2.0 drops the runtime projection-dispatch fallback and depends on **JasperFx / JasperFx.Events 2.29.0**. With the pin at 2.28.0, PolecatTests kept the explicitly-referenced 2.28.0 `JasperFx.Events.SourceGenerator` (its `DropDuplicate` target strips Polecat's bundled 2.29.0 copy), and the 2.28.0 generator doesn't recognize Polecat 5.2.0's projection model — it emitted no dispatchers, so every projection/aggregate test failed at runtime with `InvalidProjectionException: No source-generated dispatcher found` (71 failures in the first CI run).

Bumping `JasperFx`, `JasperFx.Events`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator` → 2.29.0 (RuntimeCompiler stays on its 5.x line) fixes it. This is the coordinated critter-stack move — **Marten 9.16.0 (#3457, merged) also declares JasperFx 2.29.0**, so this aligns it too. Weasel 9.17.0 needs only `>= 2.24.1`.

### Verification
- Full `wolverine.slnx` builds clean in Release (0/0).
- `PolecatTests`: **243/247 pass, 0 failures** (4 skipped) — was 71 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)