### PR TITLE
Tolerate empty agent URI lists in agent command serialization (GH-3460)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/agent_command_serialization.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/agent_command_serialization.cs
@@ -22,4 +22,68 @@ public class agent_command_serialization
 
         other.AgentUris.ShouldBe(command.AgentUris);
     }
+
+    [Fact]
+    public void StartAgents_with_no_agents()
+    {
+        var other = roundTrip(new StartAgents([]));
+
+        other.AgentUris.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void AgentsStarted()
+    {
+        var command = new AgentsStarted([new Uri("fake://one"), new Uri("fake://two"), new Uri("fake://three")]);
+
+        var other = roundTrip(command);
+
+        other.AgentUris.ShouldBe(command.AgentUris);
+    }
+
+    [Fact]
+    public void AgentsStarted_with_no_agents()
+    {
+        // GH-3460 -- StartAgents can legitimately report zero successfully
+        // started agents during node churn
+        var other = roundTrip(new AgentsStarted([]));
+
+        other.AgentUris.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void StopAgents()
+    {
+        var command = new StopAgents([new Uri("fake://one"), new Uri("fake://two"), new Uri("fake://three")]);
+
+        var other = roundTrip(command);
+
+        other.AgentUris.ShouldBe(command.AgentUris);
+    }
+
+    [Fact]
+    public void StopAgents_with_no_agents()
+    {
+        var other = roundTrip(new StopAgents([]));
+
+        other.AgentUris.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void AgentsStopped()
+    {
+        var command = new AgentsStopped([new Uri("fake://one"), new Uri("fake://two"), new Uri("fake://three")]);
+
+        var other = roundTrip(command);
+
+        other.AgentUris.ShouldBe(command.AgentUris);
+    }
+
+    [Fact]
+    public void AgentsStopped_with_no_agents()
+    {
+        var other = roundTrip(new AgentsStopped([]));
+
+        other.AgentUris.ShouldBeEmpty();
+    }
 }

--- a/src/Wolverine/Runtime/Agents/StartAgents.cs
+++ b/src/Wolverine/Runtime/Agents/StartAgents.cs
@@ -19,7 +19,8 @@ internal record AgentsStarted(Uri[] AgentUris) : IAgentCommand, ISerializable
 
     public static object Read(byte[] bytes)
     {
-        var uris = Encoding.UTF8.GetString(bytes).Split(',').Select(x => new Uri(x)).ToArray();
+        var uris = Encoding.UTF8.GetString(bytes).Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => new Uri(x)).ToArray();
         return new AgentsStarted(uris);
     }
 }
@@ -110,7 +111,7 @@ internal record StartAgents(Uri[] AgentUris) : IAgentCommand, ISerializable
 
     public static object Read(byte[] bytes)
     {
-        var agents = Encoding.UTF8.GetString(bytes).Split(',')
+        var agents = Encoding.UTF8.GetString(bytes).Split(',', StringSplitOptions.RemoveEmptyEntries)
             .Select(x => new Uri(x)).ToArray();
         return new StartAgents(agents);
     }
@@ -130,7 +131,8 @@ internal record AgentsStopped(Uri[] AgentUris) : IAgentCommand, ISerializable
 
     public static object Read(byte[] bytes)
     {
-        var uris = Encoding.UTF8.GetString(bytes).Split(',').Select(x => new Uri(x)).ToArray();
+        var uris = Encoding.UTF8.GetString(bytes).Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => new Uri(x)).ToArray();
         return new AgentsStopped(uris);
     }
 }
@@ -189,7 +191,7 @@ internal record StopAgents(Uri[] AgentUris) : IAgentCommand, ISerializable
 
     public static object Read(byte[] bytes)
     {
-        var agents = Encoding.UTF8.GetString(bytes).Split(',')
+        var agents = Encoding.UTF8.GetString(bytes).Split(',', StringSplitOptions.RemoveEmptyEntries)
             .Select(x => new Uri(x)).ToArray();
         return new StopAgents(agents);
     }


### PR DESCRIPTION
## What this fixes

`AgentsStarted`, `StartAgents`, `AgentsStopped`, and `StopAgents` all implement `ISerializable` by joining their URI arrays with commas. For an empty array, `Write()` produces an empty payload, and `Read()` then split the empty string into a single empty element and threw `System.UriFormatException: Invalid URI: The URI is empty.`

This is reachable in normal operation: `StartAgents.ExecuteAsync()` (and its `StopAgents` counterpart) legitimately return `AgentsStarted` / `AgentsStopped` with zero successful agents during agent/node churn. With a durable database control queue, those internal messages became non-replayable dead letters and kept accumulating.

## The fix

`Read()` now splits with `StringSplitOptions.RemoveEmptyEntries` in all four commands, so an empty payload round-trips back to an empty URI array. While the issue reports `AgentsStarted` specifically, all four sibling commands in `StartAgents.cs` shared the identical Write/Read pattern and are fixed together.

## Tests

Extended `CoreTests.Runtime.Agents.agent_command_serialization` with empty-array round-trips for all four commands plus non-empty round-trips for the three commands that previously had no coverage. All 8 pass; full `wolverine.slnx` Release build is clean.

Closes #3460

🤖 Generated with [Claude Code](https://claude.com/claude-code)