### PR TITLE
Document all eight global partitioning transports (GH-3466)

### DIFF
--- a/docs/guide/messaging/partitioning.md
+++ b/docs/guide/messaging/partitioning.md
@@ -379,8 +379,22 @@ application cluster while guaranteeing that messages within a group id are proce
 parallelism between message groups.
 :::
 
-At this point Wolverine has direct support for partitioned routing to Rabbit MQ or Amazon SQS. Note that in both
-of the following examples, Wolverine is both setting up publishing rules out to these queues, and also configuring
+Wolverine has direct support for partitioned routing to all eight of the transports that support the
+[global partitioning](#global-partitioning) topology through a `PublishToSharded*()` companion to each
+`UseSharded*()` extension method:
+
+| Transport | Extension Method |
+|-----------|-----------------|
+| RabbitMQ | `PublishToShardedRabbitQueues()` |
+| Kafka | `PublishToShardedKafkaTopics()` |
+| Amazon SQS | `PublishToShardedAmazonSqsQueues()` |
+| Pulsar | `PublishToShardedPulsarTopics()` |
+| Azure Service Bus | `PublishToShardedAzureServiceBusQueues()` |
+| GCP Pub/Sub | `PublishToShardedPubsubTopics()` |
+| NATS | `PublishToShardedNatsSubjects()` |
+| Redis Streams | `PublishToShardedRedisStreams()` |
+
+Note that in both of the following examples, Wolverine is both setting up publishing rules out to these queues, and also configuring
 listeners for the queues. Beyond that, Wolverine is making each queue be "exclusive," meaning that only one node
 within a cluster is actively listening and processing messages from each partitioned queue at any one time.
 
@@ -504,6 +518,15 @@ Each supported transport has its own extension method for configuring the extern
 | Kafka | `UseShardedKafkaTopics()` | [Kafka Global Partitioning](/guide/messaging/transports/kafka#global-partitioning) |
 | Amazon SQS | `UseShardedAmazonSqsQueues()` | [SQS Global Partitioning](/guide/messaging/transports/sqs/#global-partitioning) |
 | Pulsar | `UseShardedPulsarTopics()` | [Pulsar Global Partitioning](/guide/messaging/transports/pulsar#global-partitioning) |
+| Azure Service Bus | `UseShardedAzureServiceBusQueues()` | [Azure Service Bus Global Partitioning](/guide/messaging/transports/azureservicebus/#global-partitioning) |
+| GCP Pub/Sub | `UseShardedPubsubTopics()` | [GCP Pub/Sub Global Partitioning](/guide/messaging/transports/gcp-pubsub/#global-partitioning) |
+| NATS | `UseShardedNatsSubjects()` | [NATS Global Partitioning](/guide/messaging/transports/nats#global-partitioning) |
+| Redis Streams | `UseShardedRedisStreams()` | [Redis Global Partitioning](/guide/messaging/transports/redis#global-partitioning) |
+
+A couple of transport-specific notes:
+
+* **Kafka** -- all nodes listening to the sharded topics share a single Kafka consumer group named after the base name so that Kafka assigns each topic's partitions exclusively to one consumer at a time. Wolverine stamps that consumer group id onto the `GroupId` of incoming envelopes by default, which you can turn off per listener with `DisableConsumerGroupIdStamping()` when the consumer group name is not meaningful as envelope metadata (e.g. when combined with `PropagateGroupIdToPartitionKey()`).
+* **Azure Service Bus** -- the broker's native [session identifiers](/guide/messaging/transports/azureservicebus/session-identifiers) provide strictly ordered, per-session processing with a single queue and may be a simpler alternative if you are exclusively on Azure Service Bus. Global partitioning is the transport-agnostic option that behaves the same way across every broker in the table above.
 
 ### Example with RabbitMQ
 

--- a/docs/guide/messaging/transports/azureservicebus/index.md
+++ b/docs/guide/messaging/transports/azureservicebus/index.md
@@ -213,6 +213,36 @@ builder.UseWolverine(opts =>
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end_with_named_broker.cs#L26-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_named_azure_service_bus_broker' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Global Partitioning
+
+Azure Service Bus queues can be used as the external transport for [global partitioned messaging](/guide/messaging/partitioning#global-partitioning). This creates a set of sharded Azure Service Bus queues with companion local queues for sequential processing across a multi-node cluster.
+
+Use `UseShardedAzureServiceBusQueues()` within a `GlobalPartitioned()` configuration:
+
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseAzureServiceBus(azureServiceBusConnectionString).AutoProvision();
+
+        opts.MessagePartitioning.ByMessage<IMyMessage>(x => x.GroupId);
+
+        opts.MessagePartitioning.GlobalPartitioned(topology =>
+        {
+            // Creates 4 sharded Azure Service Bus queues named "orders1" through "orders4"
+            // with matching companion local queues for sequential processing
+            topology.UseShardedAzureServiceBusQueues("orders", 4);
+            topology.MessagesImplementing<IMyMessage>();
+        });
+    }).StartAsync();
+```
+
+This creates Azure Service Bus queues named `orders1` through `orders4` with companion local queues `global-orders1` through `global-orders4`. Messages are routed to the correct shard based on their group id, and Wolverine handles the coordination between nodes automatically.
+
+::: tip
+Azure Service Bus also has a native, broker-side alternative to this feature. [Session identifiers](/guide/messaging/transports/azureservicebus/session-identifiers) provide strictly ordered processing per session id with a single queue and no sharded topology. Consider sessions first if you are exclusively on Azure Service Bus; global partitioning is the transport-agnostic option that behaves identically across every supported broker.
+:::
+
 ## URI reference
 
 The `AzureServiceBusEndpointUri` helper class builds canonical endpoint URIs:

--- a/docs/guide/messaging/transports/gcp-pubsub/index.md
+++ b/docs/guide/messaging/transports/gcp-pubsub/index.md
@@ -28,7 +28,7 @@ var host = await Host.CreateDefaultBuilder()
             .AutoPurgeOnStartup();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L15-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_basic_setup_to_pubsub' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L18-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_basic_setup_to_pubsub' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you'd like to connect to a GCP Pub/Sub emulator running on your development box,
@@ -48,7 +48,7 @@ var host = await Host.CreateDefaultBuilder()
             .UseEmulatorDetection();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L34-L46' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_connect_to_pubsub_emulator' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L37-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_connect_to_pubsub_emulator' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Authentication / Credentials
@@ -89,7 +89,7 @@ var host = await Host.CreateDefaultBuilder()
         opts.ListenToPubsubTopicOnNamedBroker(new BrokerName("americas"), "colors");
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L67-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_named_pubsub_broker' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L67-L86' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_named_pubsub_broker' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note that the `Uri` scheme within Wolverine for any endpoint on a *named* GCP Pub/Sub broker is the broker name you supply, not `pubsub`. So in the example above you would see `Uri` values like `americas://americas-project-id/colors`.
@@ -135,7 +135,7 @@ var host = await Host.CreateDefaultBuilder()
         opts.ListenToPubsubTopic("colors");
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L91-L122' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pubsub_broker_per_tenant' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L91-L124' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pubsub_broker_per_tenant' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To route a specific message to a tenant's project, stamp the tenant id on the send:
@@ -168,7 +168,7 @@ var host = await Host.CreateDefaultBuilder()
             .EnableSystemEndpoints();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L51-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enable_system_endpoints_in_pubsub' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enable_system_endpoints_in_pubsub' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Identifier Prefixing for Shared Environments
@@ -199,6 +199,32 @@ opts.UsePubsub("your-project-id")
 ```
 
 The default delimiter between the prefix and the original name is `.` for GCP Pub/Sub (e.g., `dev-john.orders`).
+
+## Global Partitioning
+
+GCP Pub/Sub topics can be used as the external transport for [global partitioned messaging](/guide/messaging/partitioning#global-partitioning). This creates a set of sharded Pub/Sub topics with companion local queues for sequential processing across a multi-node cluster.
+
+Use `UseShardedPubsubTopics()` within a `GlobalPartitioned()` configuration:
+
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UsePubsub("your-project-id").AutoProvision();
+
+        opts.MessagePartitioning.ByMessage<IMyMessage>(x => x.GroupId);
+
+        opts.MessagePartitioning.GlobalPartitioned(topology =>
+        {
+            // Creates 4 sharded Pub/Sub topics named "orders1" through "orders4"
+            // with matching companion local queues for sequential processing
+            topology.UseShardedPubsubTopics("orders", 4);
+            topology.MessagesImplementing<IMyMessage>();
+        });
+    }).StartAsync();
+```
+
+This creates Pub/Sub topics named `orders1` through `orders4` with companion local queues `global-orders1` through `global-orders4`. Messages are routed to the correct shard based on their group id, and Wolverine handles the coordination between nodes automatically.
 
 ## URI reference
 

--- a/docs/guide/messaging/transports/nats.md
+++ b/docs/guide/messaging/transports/nats.md
@@ -703,6 +703,32 @@ docker run -d --name nats -p 4222:4222 -p 8222:8222 nats:latest --jetstream -m 8
 docker run -d --name nats -p 4222:4222 -p 8222:8222 nats:2.12-alpine --jetstream -m 8222
 ```
 
+## Global Partitioning
+
+NATS subjects can be used as the external transport for [global partitioned messaging](/guide/messaging/partitioning#global-partitioning). This creates a set of sharded NATS subjects with companion local queues for sequential processing across a multi-node cluster.
+
+Use `UseShardedNatsSubjects()` within a `GlobalPartitioned()` configuration:
+
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseNats("nats://localhost:4222").AutoProvision();
+
+        opts.MessagePartitioning.ByMessage<IMyMessage>(x => x.GroupId);
+
+        opts.MessagePartitioning.GlobalPartitioned(topology =>
+        {
+            // Creates 4 sharded NATS subjects named "orders1" through "orders4"
+            // with matching companion local queues for sequential processing
+            topology.UseShardedNatsSubjects("orders", 4);
+            topology.MessagesImplementing<IMyMessage>();
+        });
+    }).StartAsync();
+```
+
+This creates NATS subjects named `orders1` through `orders4` with companion local queues `global-orders1` through `global-orders4`. Messages are routed to the correct shard based on their group id, and Wolverine handles the coordination between nodes automatically.
+
 ## URI reference
 
 The `NatsEndpointUri` helper class builds canonical endpoint URIs:

--- a/docs/guide/messaging/transports/redis.md
+++ b/docs/guide/messaging/transports/redis.md
@@ -403,6 +403,32 @@ using var host = await builder.UseWolverine(opts =>
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/Samples/RedisTransportWithScheduling.cs#L8-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_dead_letter_queue_for_redis' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Global Partitioning
+
+Redis streams can be used as the external transport for [global partitioned messaging](/guide/messaging/partitioning#global-partitioning). This creates a set of sharded Redis streams with companion local queues for sequential processing across a multi-node cluster.
+
+Use `UseShardedRedisStreams()` within a `GlobalPartitioned()` configuration:
+
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseRedisTransport("localhost:6379").AutoProvision();
+
+        opts.MessagePartitioning.ByMessage<IMyMessage>(x => x.GroupId);
+
+        opts.MessagePartitioning.GlobalPartitioned(topology =>
+        {
+            // Creates 4 sharded Redis streams named "orders1" through "orders4"
+            // with matching companion local queues for sequential processing
+            topology.UseShardedRedisStreams("orders", 4);
+            topology.MessagesImplementing<IMyMessage>();
+        });
+    }).StartAsync();
+```
+
+This creates Redis streams named `orders1` through `orders4` with companion local queues `global-orders1` through `global-orders4`. Messages are routed to the correct shard based on their group id, and Wolverine handles the coordination between nodes automatically.
+
 ## URI reference
 
 The `RedisEndpointUri` helper class builds canonical endpoint URIs:


### PR DESCRIPTION
## What this does

The transports table in `docs/guide/messaging/partitioning.md` only advertised **RabbitMQ, Kafka, Amazon SQS, and Pulsar** as supporting the global partitioned messaging topology, while the code ships `UseSharded*` extensions for **eight** transports. Half the support surface was invisible to users.

Per the issue's task list:

- **Transport table** now lists all eight transports: added Azure Service Bus (`UseShardedAzureServiceBusQueues`), GCP Pub/Sub (`UseShardedPubsubTopics`), NATS (`UseShardedNatsSubjects`), and Redis Streams (`UseShardedRedisStreams`), each linking to a new **Global Partitioning** section with a configuration sample on the transport's own docs page (mirroring the existing Kafka/SQS sections).
- **Per-transport notes** under the table: the Kafka sharded topics share a single consumer group named after the base name, with a pointer to `DisableConsumerGroupIdStamping()`; Azure Service Bus users are pointed at native [session identifiers](https://wolverinefx.net/guide/messaging/transports/azureservicebus/session-identifiers) as the broker-native alternative (echoed as a tip in the ASB section).
- **`PublishToSharded*` cross-check**: the "Partitioned Publishing to External Transports" section claimed direct support for "Rabbit MQ or Amazon SQS" only — it now tables all eight `PublishToSharded*` variants.

Also picks up a few mdsnippets line-number refreshes in `gcp-pubsub/index.md` source links that regenerated during the docs build.

`npm run docs:build` passes (Vitepress build fails on dead links, so the new anchors are verified).

Closes #3466

🤖 Generated with [Claude Code](https://claude.com/claude-code)