### PR TITLE
Kafka KIP-848 consumer rebalance protocol support (GH-3473)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,10 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
 
   kafka:
-    image: confluentinc/confluent-local:7.7.1
+    # Kafka 4.0 broker (Confluent Platform 8.0.x) — required for the KIP-848 next-generation
+    # consumer rebalance protocol (group.protocol=consumer), which is GA and enabled by default
+    # on 4.0+ brokers. See GH-3473.
+    image: confluentinc/confluent-local:8.0.6
     ports:
       - "8082:8082"
       - "9092:9092"

--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -348,6 +348,10 @@ opts.UseKafka(connectionString)
 Both are also available per-listener on `ListenToKafkaTopic(...)` (`UseCooperativeStickyAssignment()` /
 `UseStaticMembership(...)`).
 
+On a **Kafka 4.x cluster**, prefer the [next-generation rebalance protocol](#next-generation-rebalance-protocol-kip-848)
+below over cooperative-sticky — broker-driven incremental rebalancing subsumes what the client-side
+cooperative assignor provides. Static membership pairs with either protocol.
+
 ::: warning group.instance.id must be unique per node and stable across restarts
 Static membership only works when each node uses a **distinct** `group.instance.id` that **stays the same**
 across restarts of that node. Two nodes sharing one id makes Kafka treat them as a single member and fence
@@ -367,6 +371,56 @@ Don't flip an existing, running group straight from the default (eager) assignor
 group must not mix eager and cooperative members. Do a two-step deploy: first roll out a build that lists
 **both** strategies (`[CooperativeSticky, Range]`) so every member supports cooperative, then a second
 deploy that drops the eager strategy.
+:::
+
+### Next-Generation Rebalance Protocol (KIP-848) <Badge type="tip" text="6.21" />
+
+Kafka 4.0 brokers ship the **next-generation consumer rebalance protocol**
+([KIP-848](https://cwiki.apache.org/confluence/display/KAFKA/KIP-848%3A+The+Next+Generation+of+the+Consumer+Rebalance+Protocol))
+as GA and enabled by default. Rebalances become **broker-driven and incremental**: the group coordinator
+computes assignments server side and reconciles members one partition at a time over the heartbeat, so there
+is no stop-the-world JoinGroup/SyncGroup barrier and rebalance pauses drop dramatically. On a Kafka 4.x
+cluster this is the recommended way to run Wolverine's Kafka consumers:
+
+```csharp
+opts.UseKafka(connectionString)
+    // KIP-848: group.protocol = consumer. Requires a Kafka 4.0+ broker.
+    .UseNextGenerationRebalanceProtocol();
+```
+
+Also available per-listener as `ListenToKafkaTopic(...).UseNextGenerationRebalanceProtocol()` (remember that
+`ConfigureConsumer(...)` replaces the whole per-topic consumer config, so call this after it). Unlike most
+settings, the transport-level `group.protocol` *is* inherited by per-topic `ConfigureConsumer(...)` overrides
+that don't set their own — those overrides also inherit the transport's consumer group id, and a group must
+not run members of both rebalance protocols outside of an active migration. Set
+`GroupProtocol = GroupProtocol.Classic` explicitly on a per-topic config to opt a topic back out.
+
+What changes under KIP-848:
+
+- **Kafka 4.0+ broker required.** Against an older broker the consumer cannot join its group. The protocol
+  is GA on 4.0+ brokers and enabled by default (`group.coordinator.rebalance.protocols=classic,consumer`).
+- **Client-side assignors no longer apply.** Partition assignment is computed on the broker — the
+  server-side assignor is chosen with the broker/group config `group.remote.assignor` (`uniform` by
+  default, or `range`). `UseCooperativeStickyAssignment()` / `partition.assignment.strategy` is a
+  classic-protocol setting; incremental, cooperative-style rebalancing is inherent to KIP-848 anyway.
+- **Session timeout and heartbeat interval are broker-controlled**
+  (`group.consumer.session.timeout.ms` / `group.consumer.heartbeat.interval.ms` on the broker). The
+  client-side `session.timeout.ms` and `heartbeat.interval.ms` settings don't apply.
+- **Static membership still works.** `UseStaticMembership(...)` / `group.instance.id` is fully supported
+  under KIP-848 and remains the right tool for churn-free rolling restarts.
+
+librdkafka outright *rejects* a consumer configured with `group.protocol=consumer` plus any of the
+inapplicable classic-protocol settings (`partition.assignment.strategy`, `session.timeout.ms`,
+`heartbeat.interval.ms`, `group.protocol.type`) — which would otherwise fail every listener at startup. When
+the next-generation protocol is enabled, Wolverine clears any of those conflicting settings during
+bootstrap and logs a warning for each one, so e.g. an existing `UseCooperativeStickyAssignment()` call can
+coexist with `UseNextGenerationRebalanceProtocol()` while you migrate configuration.
+
+::: tip Migrating an existing consumer group
+A consumer group is upgraded from the classic to the consumer protocol by rolling its members — the broker
+supports both member kinds in one group *during* the migration and converts the group when the last classic
+member leaves (and can downgrade the same way). Roll all nodes of a service rather than running mixed
+protocols indefinitely, and don't combine this migration with other consumer-group changes in one deploy.
 :::
 
 ### By-Key Concurrency Within a Partition <Badge type="tip" text="6.8" />

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/next_generation_rebalance_protocol.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/next_generation_rebalance_protocol.cs
@@ -1,0 +1,279 @@
+using Confluent.Kafka;
+using Confluent.Kafka.Admin;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Kafka.Internals;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+
+namespace Wolverine.Kafka.Tests;
+
+// GH-3473: the KIP-848 next-generation consumer rebalance protocol (group.protocol=consumer).
+// The config-surface and guard tests need no broker. The end-to-end tests require the docker-compose
+// Kafka broker, which is a Kafka 4.0+ image (confluentinc/confluent-local:8.0.x) where the consumer
+// protocol is GA and enabled by default — `docker compose up -d kafka`.
+public class next_generation_rebalance_protocol
+{
+    // ---- configuration surface ----
+
+    [Fact]
+    public void transport_expression_sets_group_protocol_consumer()
+    {
+        var transport = new KafkaTransport();
+        new KafkaTransportExpression(transport, new WolverineOptions()).UseNextGenerationRebalanceProtocol();
+
+        transport.ConsumerConfig.GroupProtocol.ShouldBe(GroupProtocol.Consumer);
+    }
+
+    [Fact]
+    public void listener_expression_sets_group_protocol_consumer()
+    {
+        var transport = new KafkaTransport();
+        var topic = transport.Topics["orders"];
+        var config = new KafkaListenerConfiguration(topic);
+        config.UseNextGenerationRebalanceProtocol();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        topic.ConsumerConfig.ShouldNotBeNull();
+        topic.ConsumerConfig!.GroupProtocol.ShouldBe(GroupProtocol.Consumer);
+    }
+
+    // ---- bootstrap guard: librdkafka rejects the classic-protocol client-side settings outright when
+    // group.protocol=consumer, so Wolverine clears them with a logged warning instead of letting every
+    // listener fail at consumer creation ----
+
+    [Fact]
+    public void guard_clears_conflicting_client_side_settings_and_warns()
+    {
+        var logger = new RecordingLogger();
+        var config = new ConsumerConfig
+        {
+            GroupProtocol = GroupProtocol.Consumer,
+            PartitionAssignmentStrategy = PartitionAssignmentStrategy.CooperativeSticky,
+            SessionTimeoutMs = 30000,
+            HeartbeatIntervalMs = 3000,
+            GroupProtocolType = "consumer"
+        };
+
+        KafkaGroupProtocolGuard.Sanitize(config, "transport", logger);
+
+        config.PartitionAssignmentStrategy.ShouldBeNull();
+        config.SessionTimeoutMs.ShouldBeNull();
+        config.HeartbeatIntervalMs.ShouldBeNull();
+        config.GroupProtocolType.ShouldBeNull();
+
+        logger.Warnings.Count.ShouldBe(4);
+        logger.Warnings.ShouldContain(w => w.Contains("partition.assignment.strategy"));
+        logger.Warnings.ShouldContain(w => w.Contains("session.timeout.ms"));
+        logger.Warnings.ShouldContain(w => w.Contains("heartbeat.interval.ms"));
+        logger.Warnings.ShouldContain(w => w.Contains("group.protocol.type"));
+    }
+
+    [Fact]
+    public void guard_leaves_static_membership_alone()
+    {
+        // group.instance.id IS supported under KIP-848 — never strip it
+        var logger = new RecordingLogger();
+        var config = new ConsumerConfig
+        {
+            GroupProtocol = GroupProtocol.Consumer,
+            GroupInstanceId = "node-1"
+        };
+
+        KafkaGroupProtocolGuard.Sanitize(config, "transport", logger);
+
+        config.GroupInstanceId.ShouldBe("node-1");
+        logger.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void guard_is_a_no_op_for_the_classic_protocol()
+    {
+        var logger = new RecordingLogger();
+        var config = new ConsumerConfig
+        {
+            PartitionAssignmentStrategy = PartitionAssignmentStrategy.CooperativeSticky,
+            SessionTimeoutMs = 30000
+        };
+
+        KafkaGroupProtocolGuard.Sanitize(config, "transport", logger);
+
+        config.PartitionAssignmentStrategy.ShouldBe(PartitionAssignmentStrategy.CooperativeSticky);
+        config.SessionTimeoutMs.ShouldBe(30000);
+        logger.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void guard_leaves_unrelated_settings_alone()
+    {
+        var logger = new RecordingLogger();
+        var config = new ConsumerConfig
+        {
+            GroupProtocol = GroupProtocol.Consumer,
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = true
+        };
+
+        KafkaGroupProtocolGuard.Sanitize(config, "transport", logger);
+
+        config.AutoOffsetReset.ShouldBe(AutoOffsetReset.Earliest);
+        config.EnableAutoCommit.ShouldBe(true);
+        logger.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void sanitized_config_passes_librdkafka_validation()
+    {
+        // The empirical anchor for the guard: this exact combination throws InvalidOperationException
+        // from ConsumerBuilder.Build() ("`partition.assignment.strategy` is not supported for
+        // `group.protocol=consumer`") before sanitizing. No broker connection is required —
+        // librdkafka validates configuration at client creation.
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = KafkaContainerFixture.ConnectionString,
+            GroupId = "kip848-validation",
+            GroupProtocol = GroupProtocol.Consumer,
+            PartitionAssignmentStrategy = PartitionAssignmentStrategy.CooperativeSticky,
+            SessionTimeoutMs = 30000,
+            HeartbeatIntervalMs = 3000
+        };
+
+        Should.Throw<InvalidOperationException>(() => new ConsumerBuilder<string, byte[]>(config).Build());
+
+        KafkaGroupProtocolGuard.Sanitize(config, "test", new RecordingLogger());
+
+        using var consumer = new ConsumerBuilder<string, byte[]>(config).Build();
+        consumer.ShouldNotBeNull();
+    }
+
+    // ---- end to end against the docker-compose Kafka 4.x broker ----
+
+    [Fact]
+    public async Task end_to_end_round_trip_under_the_next_generation_protocol()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "kip848-e2e";
+                opts.UseKafka(KafkaContainerFixture.ConnectionString)
+                    .UseNextGenerationRebalanceProtocol()
+                    .AutoProvision();
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.Discovery.IncludeAssembly(GetType().Assembly);
+                opts.Services.AddResourceSetupOnStartup();
+
+                opts.PublishMessage<Kip848Message>().ToKafkaTopic("kip848");
+                // BeginAtEarliest so a record produced before the group finishes joining is still consumed
+                opts.ListenToKafkaTopic("kip848").BeginAtEarliest();
+            }).StartAsync();
+
+        await host.TrackActivity().IncludeExternalTransports().Timeout(60.Seconds())
+            .WaitForMessageToBeReceivedAt<Kip848Message>(host)
+            .SendMessageAndWaitAsync(new Kip848Message());
+
+        // Prove the group really joined through KIP-848: the broker reports the group's type
+        using var admin = new AdminClientBuilder(new AdminClientConfig
+        {
+            BootstrapServers = KafkaContainerFixture.ConnectionString
+        }).Build();
+        var description = await admin.DescribeConsumerGroupsAsync(["kip848-e2e"]);
+        description.ConsumerGroupDescriptions.Single().GroupType.ShouldBe(ConsumerGroupType.Consumer);
+
+        // GH-3454 parity: the degrade-only connection-state heuristic behaves identically under the new
+        // protocol — a healthy listener rests at Unknown and never synthesizes Connected
+        var snapshot = host.GetRuntime().Endpoints.CollectEndpointHealth()
+            .Single(s => s.Direction == EndpointDirection.Listening && s.Uri.Scheme == "kafka");
+        snapshot.ConnectionState.ShouldBe(TransportConnectionState.Unknown);
+    }
+
+    [Fact]
+    public async Task conflicting_client_side_settings_are_cleared_at_bootstrap_and_the_listener_still_works()
+    {
+        // Without the bootstrap guard this host would die at listener creation with librdkafka's
+        // "`partition.assignment.strategy` is not supported for `group.protocol=consumer`"
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "kip848-guarded";
+                opts.UseKafka(KafkaContainerFixture.ConnectionString)
+                    .UseCooperativeStickyAssignment()
+                    .ConfigureConsumers(c =>
+                    {
+                        c.SessionTimeoutMs = 20000;
+                        c.HeartbeatIntervalMs = 2000;
+                    })
+                    .UseNextGenerationRebalanceProtocol()
+                    // Static membership must survive the guard — it IS supported under KIP-848
+                    .UseStaticMembership("kip848-node-1")
+                    .AutoProvision();
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.Discovery.IncludeAssembly(GetType().Assembly);
+                opts.Services.AddResourceSetupOnStartup();
+
+                opts.PublishMessage<Kip848GuardedMessage>().ToKafkaTopic("kip848-guarded");
+                opts.ListenToKafkaTopic("kip848-guarded").BeginAtEarliest();
+
+                // A per-topic ConfigureConsumer replaces the consumer config wholesale but inherits the
+                // transport's GroupId — so the transport's group.protocol must flow down with it (and be
+                // sanitized), or this topic would join the same group over the classic protocol
+                opts.ListenToKafkaTopic("kip848-override")
+                    .ConfigureConsumer(c => c.SessionTimeoutMs = 15000)
+                    .BeginAtEarliest();
+            }).StartAsync();
+
+        await host.TrackActivity().IncludeExternalTransports().Timeout(60.Seconds())
+            .WaitForMessageToBeReceivedAt<Kip848GuardedMessage>(host)
+            .SendMessageAndWaitAsync(new Kip848GuardedMessage());
+
+        var transport = host.GetRuntime().Options.Transports.GetOrCreate<KafkaTransport>();
+        transport.ConsumerConfig.GroupProtocol.ShouldBe(GroupProtocol.Consumer);
+        transport.ConsumerConfig.PartitionAssignmentStrategy.ShouldBeNull();
+        transport.ConsumerConfig.SessionTimeoutMs.ShouldBeNull();
+        transport.ConsumerConfig.HeartbeatIntervalMs.ShouldBeNull();
+        transport.ConsumerConfig.GroupInstanceId.ShouldBe("kip848-node-1");
+
+        // The per-topic override inherited the transport's group.protocol and was sanitized in turn —
+        // the fact the host started at all proves librdkafka accepted the cleaned config
+        var overrideTopic = transport.Topics["kip848-override"];
+        overrideTopic.ConsumerConfig.ShouldNotBeNull();
+        overrideTopic.ConsumerConfig!.GroupProtocol.ShouldBe(GroupProtocol.Consumer);
+        overrideTopic.ConsumerConfig.SessionTimeoutMs.ShouldBeNull();
+    }
+
+    private class RecordingLogger : ILogger
+    {
+        public List<string> Warnings { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Warnings.Add(formatter(state, exception));
+            }
+        }
+    }
+}
+
+public record Kip848Message;
+
+public record Kip848GuardedMessage;
+
+public static class Kip848MessageHandler
+{
+    public static void Handle(Kip848Message message)
+    {
+    }
+
+    public static void Handle(Kip848GuardedMessage message)
+    {
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaGroupProtocolGuard.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaGroupProtocolGuard.cs
@@ -1,0 +1,61 @@
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.Kafka.Internals;
+
+/// <summary>
+/// GH-3473: when the KIP-848 next-generation consumer rebalance protocol is enabled
+/// (<c>group.protocol=consumer</c>), librdkafka *rejects* the classic-protocol client-side settings at
+/// consumer creation time ("`partition.assignment.strategy` is not supported for `group.protocol=consumer`",
+/// same for <c>session.timeout.ms</c>, <c>heartbeat.interval.ms</c>, and <c>group.protocol.type</c> — the
+/// first is replaced by the broker-side <c>group.remote.assignor</c>, the timings are defined broker side).
+/// Rather than letting every listener blow up mid-startup, Wolverine clears the conflicting settings during
+/// transport bootstrap and logs a warning per cleared setting. Static membership (<c>group.instance.id</c>)
+/// IS supported under KIP-848 and is deliberately left alone.
+/// </summary>
+internal static class KafkaGroupProtocolGuard
+{
+    public static void Sanitize(ConsumerConfig config, string scope, ILogger logger)
+    {
+        if (config.GroupProtocol != GroupProtocol.Consumer)
+        {
+            return;
+        }
+
+        if (config.PartitionAssignmentStrategy != null)
+        {
+            // Assigning null removes the key from the underlying config dictionary
+            config.PartitionAssignmentStrategy = null;
+            warn(logger, scope, "partition.assignment.strategy",
+                "partition assignment is broker-driven under KIP-848 (see the broker-side group.remote.assignor setting), and cooperative incremental rebalancing is inherent to the protocol");
+        }
+
+        if (config.SessionTimeoutMs != null)
+        {
+            config.SessionTimeoutMs = null;
+            warn(logger, scope, "session.timeout.ms",
+                "the session timeout is defined broker side under KIP-848 (group.consumer.session.timeout.ms)");
+        }
+
+        if (config.HeartbeatIntervalMs != null)
+        {
+            config.HeartbeatIntervalMs = null;
+            warn(logger, scope, "heartbeat.interval.ms",
+                "the heartbeat interval is defined broker side under KIP-848 (group.consumer.heartbeat.interval.ms)");
+        }
+
+        if (config.GroupProtocolType != null)
+        {
+            config.GroupProtocolType = null;
+            warn(logger, scope, "group.protocol.type",
+                "the classic-protocol type name does not apply under KIP-848");
+        }
+    }
+
+    private static void warn(ILogger logger, string scope, string setting, string reason)
+    {
+        logger.LogWarning(
+            "Kafka consumer configuration ({Scope}) sets '{Setting}', which librdkafka rejects when the KIP-848 next-generation rebalance protocol (group.protocol=consumer) is enabled. Wolverine cleared the setting so the consumer can start: {Reason}.",
+            scope, setting, reason);
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -159,6 +159,7 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
             dlqTopic.Compile(runtime);
         }
 
+        sanitizeGroupProtocolConflicts(runtime);
         warnOnStaticMembership(runtime);
         registerRetryTopicListeners(runtime);
 
@@ -262,7 +263,11 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
                 tierTopic.ConsumerConfig = new ConsumerConfig
                 {
                     GroupId = $"{runtime.Options.ServiceName}-retry",
-                    AutoOffsetReset = AutoOffsetReset.Earliest
+                    AutoOffsetReset = AutoOffsetReset.Earliest,
+                    // Follow the transport's rebalance protocol choice (GH-3473). The transport-level
+                    // config was already sanitized, and this fresh config carries no conflicting
+                    // classic-protocol settings. Assigning null is a no-op.
+                    GroupProtocol = ConsumerConfig.GroupProtocol
                 };
                 tierTopic.Compile(runtime);
 
@@ -270,6 +275,42 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
                     tierTopic.TopicName, delay);
             }
         }
+    }
+
+    // GH-3473: with the KIP-848 next-generation rebalance protocol enabled, librdkafka rejects the
+    // classic-protocol client-side settings at consumer creation — which would otherwise fail every
+    // listener mid-startup. Clear them here (with a logged warning apiece) before any consumer is built.
+    // Runs before the tenant transports are compiled so broker-per-tenant clones inherit the sanitized
+    // config, and covers per-topic ConsumerConfig overrides, which replace the transport-level config
+    // wholesale and are therefore sanitized individually.
+    private void sanitizeGroupProtocolConflicts(IWolverineRuntime runtime)
+    {
+        var logger = runtime.LoggerFactory.CreateLogger<KafkaTransport>();
+
+        KafkaGroupProtocolGuard.Sanitize(ConsumerConfig, "transport", logger);
+
+        foreach (var topic in Topics.Where(x => x.ConsumerConfig != null))
+        {
+            inheritGroupProtocol(topic.ConsumerConfig!);
+            KafkaGroupProtocolGuard.Sanitize(topic.ConsumerConfig!, $"topic '{topic.TopicName}'", logger);
+        }
+
+        foreach (var group in TopicGroups.Where(x => x.ConsumerConfig != null))
+        {
+            inheritGroupProtocol(group.ConsumerConfig!);
+            KafkaGroupProtocolGuard.Sanitize(group.ConsumerConfig!, $"topic group '{group.EndpointName}'", logger);
+        }
+    }
+
+    // A per-topic ConsumerConfig replaces the transport-level config wholesale, but it also inherits the
+    // transport's GroupId when it doesn't set one — so if group.protocol did NOT flow down with it, a topic
+    // override would silently join the *same* consumer group over the classic protocol while the other
+    // listeners join it via KIP-848, leaving the group permanently stuck mid-migration with mixed member
+    // kinds. Inherit the transport's group.protocol exactly like GroupId/SASL unless the topic config sets
+    // its own value explicitly.
+    private void inheritGroupProtocol(ConsumerConfig config)
+    {
+        config.GroupProtocol ??= ConsumerConfig.GroupProtocol;
     }
 
     // GH-3139: surface the resolved group.instance.id so operators can verify per-node uniqueness, and

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -90,6 +90,26 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
     }
 
     /// <summary>
+    /// Opt this listener's consumer into the KIP-848 next-generation consumer rebalance protocol
+    /// (<c>group.protocol = consumer</c>): broker-driven, incremental rebalances with no stop-the-world
+    /// JoinGroup/SyncGroup barrier. Requires a Kafka 4.0+ broker. Client-side assignors and group timings
+    /// don't apply under KIP-848 — Wolverine clears any conflicting <c>partition.assignment.strategy</c>,
+    /// <c>session.timeout.ms</c>, <c>heartbeat.interval.ms</c>, or <c>group.protocol.type</c> settings at
+    /// bootstrap with a logged warning. Static membership is still supported. Call after
+    /// <see cref="ConfigureConsumer"/> if you also use that (it replaces the whole consumer config).
+    /// See GH-3473.
+    /// </summary>
+    public KafkaListenerConfiguration UseNextGenerationRebalanceProtocol()
+    {
+        add(topic =>
+        {
+            topic.ConsumerConfig ??= new ConsumerConfig();
+            topic.ConsumerConfig.GroupProtocol = GroupProtocol.Consumer;
+        });
+        return this;
+    }
+
+    /// <summary>
     /// Enable Kafka static group membership (<c>group.instance.id</c>) for this listener so rolling
     /// restarts of the same node don't churn partitions. The id is resolved from
     /// <paramref name="instanceId"/> if supplied, otherwise from <c>POD_NAME</c>, then <c>HOSTNAME</c>,

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTransportExpression.cs
@@ -88,6 +88,25 @@ public class KafkaTransportExpression : BrokerExpression<KafkaTransport, KafkaTo
     }
 
     /// <summary>
+    /// Opt every Kafka consumer on this node into the KIP-848 next-generation consumer rebalance protocol
+    /// (<c>group.protocol = consumer</c>): broker-driven, incremental rebalances with no stop-the-world
+    /// JoinGroup/SyncGroup barrier. Requires a Kafka 4.0+ broker (where the protocol is GA and enabled by
+    /// default). Under KIP-848 the client-side assignors and group timings no longer apply — partition
+    /// assignment is broker-driven (<c>group.remote.assignor</c>) and session/heartbeat are defined broker
+    /// side — so Wolverine clears any conflicting <c>partition.assignment.strategy</c>,
+    /// <c>session.timeout.ms</c>, <c>heartbeat.interval.ms</c>, or <c>group.protocol.type</c> settings at
+    /// bootstrap with a logged warning (librdkafka would otherwise reject the consumer outright). Static
+    /// membership (<see cref="UseStaticMembership(string)"/>) is still fully supported and unaffected.
+    /// Opt-in: don't flip an existing, running consumer group during a live rolling upgrade — the classic
+    /// and consumer protocols can only coexist in one group during a broker-managed migration. See GH-3473.
+    /// </summary>
+    public KafkaTransportExpression UseNextGenerationRebalanceProtocol()
+    {
+        _transport.ConsumerConfig.GroupProtocol = GroupProtocol.Consumer;
+        return this;
+    }
+
+    /// <summary>
     /// Enable Kafka static group membership (<c>group.instance.id</c>) so rolling restarts/deploys of the
     /// same node don't trigger partition churn. The id is resolved from <paramref name="instanceId"/> if
     /// supplied, otherwise from <c>POD_NAME</c>, then <c>HOSTNAME</c>, then the machine name. The id MUST


### PR DESCRIPTION
Makes the KIP-848 next-generation consumer rebalance protocol (`group.protocol=consumer` — broker-driven, incremental rebalances with no stop-the-world JoinGroup/SyncGroup barrier) a supported, documented Wolverine capability.

## API

- `UseKafka(...).UseNextGenerationRebalanceProtocol()` on the transport expression, and the same method per-listener on `ListenToKafkaTopic(...)` — sets `GroupProtocol = GroupProtocol.Consumer`.

## Config guarding decisions

Verified empirically against Confluent.Kafka 2.14 (already the transitively pinned client — ≥ 2.12, no package bump needed): librdkafka **rejects the consumer at `ConsumerBuilder.Build()`** when `group.protocol=consumer` is combined with `partition.assignment.strategy`, `session.timeout.ms`, `heartbeat.interval.ms`, or `group.protocol.type` (e.g. ``"`partition.assignment.strategy` is not supported for `group.protocol=consumer`"``). Left alone, that would fail every listener mid-startup, so Wolverine takes the friendlier path:

- **Clear + warn, not throw**: a new bootstrap guard (`KafkaGroupProtocolGuard`, wired into `KafkaTransport.ConnectAsync` before any consumer is built and before broker-per-tenant clones are compiled) clears each conflicting setting with a logged warning naming the setting and the broker-side replacement (`group.remote.assignor`, `group.consumer.session.timeout.ms`, …). An existing `UseCooperativeStickyAssignment()` can therefore coexist with `UseNextGenerationRebalanceProtocol()` during config migration.
- **Static membership is untouched**: `group.instance.id` (GH-3139) is fully supported under KIP-848 — verified by building a consumer with both, and exercised end-to-end.
- **Per-topic `ConfigureConsumer` overrides inherit the transport's `group.protocol`** (exactly like GroupId/SASL already inherit) unless they set their own. Rationale: those overrides also inherit the transport's consumer *group id*, so without inheritance a topic override would silently join the same group over the classic protocol and leave the group permanently stuck mid-migration with mixed member kinds. `GroupProtocol = GroupProtocol.Classic` on the per-topic config opts back out. Wolverine-generated retry-tier listener configs (GH-3148) follow the transport's protocol choice too.

## Broker / image versions

- **docker-compose Kafka image bumped: `confluentinc/confluent-local:7.7.1` (Kafka 3.7) → `confluentinc/confluent-local:8.0.6` (Kafka 4.0.x)** — KIP-848 needs a 4.0+ broker, where the protocol is GA and enabled by default. This affects all local Kafka tests **and the CIKafka job**, which starts this same compose service; the full Kafka suite was run against the new image to prove it safe (below).
- Confluent.Kafka client stays at 2.14.0 (transitive via the SchemaRegistry Serdes 2.14.0 pins) — `GroupProtocol.Consumer` and the Admin `GroupType` API are already present.

## GH-3454 connection-state parity

The degrade-only consumer error-callback heuristic (#3456) is protocol-agnostic; the end-to-end test asserts a healthy KIP-848 listener still rests at `Unknown` and never synthesizes `Connected`.

## Tests

`Wolverine.Kafka.Tests`, net9.0, against the new compose image:

- Full suite: **Failed 1, Passed 290, Skipped 2, Total 293** (11m31s). The single failure is `batch_processing_with_kafka.end_to_end` — pre-existing/environmental on this dev machine: it fails identically on unmodified `main` (reproduced in a baseline run against the same image, and was already documented as a local environmental failure before this change). CI is the signal for it.
- New `next_generation_rebalance_protocol` class: **9/9 passed**, including two broker-backed end-to-end tests — one proving the group joins as `ConsumerGroupType.Consumer` via Admin `DescribeConsumerGroups`, one proving a host configured with conflicting classic-protocol settings (cooperative-sticky + session/heartbeat overrides + a per-topic `ConfigureConsumer` override) starts cleanly, round-trips messages, and keeps `group.instance.id`.
- `dotnet build wolverine.slnx -c Release`: 0 warnings, 0 errors.

## Docs

New "Next-Generation Rebalance Protocol (KIP-848)" section in `docs/guide/messaging/transports/kafka.md`: 4.0+ broker requirement, what moves broker-side (assignors, session/heartbeat), static-membership interaction, the clear-and-warn guarding, and consumer-group migration guidance; plus a cross-reference from the cooperative-sticky section recommending KIP-848 on Kafka 4.x clusters.

Closes #3473

🤖 Generated with [Claude Code](https://claude.com/claude-code)