### PR TITLE
Pulsar native scheduled delivery via DeliverAt (GH-3470)

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -170,6 +170,60 @@ When a pattern is configured it takes precedence, and the topic the listener was
 used only as the Wolverine endpoint identity. Pattern subscriptions match topics that exist at
 subscription time and pick up newly created matching topics as Pulsar discovers them.
 
+## Scheduled Delivery <Badge type="tip" text="6.21" />
+
+The Pulsar transport supports [scheduled message delivery](/guide/messaging/message-bus.html#scheduling-message-delivery-or-execution)
+natively at the broker. When you schedule or delay a message:
+
+```csharp
+// Send in 10 minutes
+await bus.ScheduleAsync(new OrderReminder(orderId), 10.Minutes());
+
+// Or at a specific time
+await bus.ScheduleAsync(new OrderReminder(orderId), DateTimeOffset.UtcNow.AddHours(4));
+
+// Or with delivery options on a plain send
+await bus.SendAsync(new OrderReminder(orderId), new DeliveryOptions { ScheduleDelay = 10.Minutes() });
+```
+
+Wolverine stamps the envelope's scheduled time onto the outgoing Pulsar message as
+[deliver-at metadata](https://pulsar.apache.org/docs/next/concepts-messaging/#delayed-message-delivery)
+(`DeliverAt` / `DeliverAfter`), so the **broker itself** holds the message until it is due. Nothing extra
+needs to be configured — this also works for storage-less applications with no message persistence, and the
+pending message survives application restarts because it is parked on the broker, not in the sending or
+receiving process. Delayed message delivery has been available (and enabled by default) on Pulsar brokers
+since Pulsar 2.4.
+
+::: warning The broker only honors delayed delivery for Shared / Key_Shared subscriptions
+Pulsar dispatches delayed messages only on `Shared` / `KeyShared` subscriptions — the same constraint as the
+retry-letter topics. An `Exclusive` or `Failover` consumer (and Wolverine's Pulsar listeners default to
+`Exclusive`) receives the message **immediately**. Wolverine listeners handle that gracefully: the scheduled
+time also round-trips as an envelope header, so a Wolverine listener that receives a not-yet-due message
+holds it locally and executes it at the right time (durable listeners park it in the durable inbox;
+buffered listeners hold it in memory). But if you want the message parked **on the broker** — or the
+consumer is a non-Wolverine application that knows nothing about Wolverine's envelope headers — configure the
+listening subscription as `Shared` or `KeyShared`:
+
+```csharp
+opts.ListenToPulsarTopic("persistent://public/default/reminders")
+    .SubscriptionType(SubscriptionType.Shared);
+```
+:::
+
+If your broker is configured with delayed delivery disabled (`delayedDeliveryEnabled=false`), opt out of the
+native path and let Wolverine fall back to its own durable message scheduling:
+
+```csharp
+opts.UsePulsar(c => c.ServiceUrl(pulsarUri))
+    // Scheduled sends to Pulsar endpoints now go through Wolverine's
+    // durable scheduled message storage instead of broker deliver-at
+    .DisableNativeScheduledSend();
+```
+
+Scheduled delivery is independent of the [tiered retry-letter machinery](#tiered-retry-letter-policy) —
+retry-letter redelivery delays are stamped by the listener on its own retry-topic producer and are unaffected
+by this setting.
+
 ## Per-Message Redelivery
 
 By default, when a message fails and is requeued, the Pulsar listener acknowledges it and

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/native_scheduled_delivery.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/native_scheduled_delivery.cs
@@ -1,0 +1,277 @@
+using System.Collections.Concurrent;
+using DotPulsar;
+using DotPulsar.Extensions;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+// GH-3470: broker-native delayed delivery for scheduled messages via Pulsar's DeliverAt metadata.
+
+// ---- metadata stamping unit tests (no broker) ----
+
+public class native_scheduled_delivery_metadata
+{
+    [Fact]
+    public void stamps_deliver_at_from_the_envelope_scheduled_time()
+    {
+        var scheduledTime = DateTimeOffset.UtcNow.AddMinutes(5);
+        var envelope = new Envelope { ScheduledTime = scheduledTime };
+        var outgoing = new MessageMetadata();
+
+        PulsarSender.ApplyScheduledDelivery(envelope, outgoing);
+
+        outgoing.DeliverAtTime.ShouldBe(scheduledTime.ToUnixTimeMilliseconds());
+    }
+
+    [Fact]
+    public void converts_local_scheduled_times_to_universal_time()
+    {
+        var localTime = new DateTimeOffset(2030, 1, 1, 12, 0, 0, TimeSpan.FromHours(5));
+        var envelope = new Envelope { ScheduledTime = localTime };
+        var outgoing = new MessageMetadata();
+
+        PulsarSender.ApplyScheduledDelivery(envelope, outgoing);
+
+        outgoing.DeliverAtTimeAsDateTimeOffset.ShouldBe(localTime.ToUniversalTime());
+    }
+
+    [Fact]
+    public void leaves_the_metadata_untouched_without_a_scheduled_time()
+    {
+        var envelope = new Envelope();
+        var outgoing = new MessageMetadata();
+
+        PulsarSender.ApplyScheduledDelivery(envelope, outgoing);
+
+        outgoing.DeliverAtTime.ShouldBe(0);
+    }
+
+    [Fact]
+    public void respects_deliver_at_stamped_by_a_custom_interop_mapper()
+    {
+        var mapperStamped = DateTimeOffset.UtcNow.AddHours(1);
+        var envelope = new Envelope { ScheduledTime = DateTimeOffset.UtcNow.AddMinutes(5) };
+        var outgoing = new MessageMetadata { DeliverAtTimeAsDateTimeOffset = mapperStamped };
+
+        PulsarSender.ApplyScheduledDelivery(envelope, outgoing);
+
+        outgoing.DeliverAtTime.ShouldBe(mapperStamped.ToUnixTimeMilliseconds());
+    }
+}
+
+// ---- configuration unit tests (no broker) ----
+
+public class native_scheduled_delivery_configuration
+{
+    [Fact]
+    public void native_scheduled_send_is_enabled_by_default()
+    {
+        new PulsarTransport().NativeScheduledSendEnabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void disable_native_scheduled_send_flips_the_transport_flag()
+    {
+        var options = new WolverineOptions();
+        var configuration = options.UsePulsar().DisableNativeScheduledSend();
+
+        configuration.Transport.NativeScheduledSendEnabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void broker_per_tenant_transports_inherit_the_flag()
+    {
+        var options = new WolverineOptions();
+        var configuration = options.UsePulsar()
+            .DisableNativeScheduledSend()
+            .AddTenant("tenant-a", new Uri("pulsar://tenant-a:6650"));
+
+        var transport = configuration.Transport;
+        var tenant = transport.Tenants["tenant-a"];
+        tenant.Compile(transport);
+
+        tenant.Transport.NativeScheduledSendEnabled.ShouldBeFalse();
+    }
+}
+
+// ---- broker-native hold proof (Pulsar docker) ----
+
+public class native_scheduled_delivery_broker_hold
+{
+    // Proves the broker itself holds a scheduled message until its deliver-at time by consuming with
+    // a RAW DotPulsar Shared consumer — no Wolverine listener, so Wolverine's receiver-side
+    // scheduled-time fallback cannot mask a missing DeliverAt stamp.
+    [Fact]
+    public async Task broker_holds_the_scheduled_message_until_deliver_at()
+    {
+        var topic = $"persistent://public/default/native-schedule-{Guid.NewGuid():N}";
+
+        using var publisher = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.PublishAllMessages().ToPulsarTopic(topic).SendInline();
+            opts.Discovery.DisableConventionalDiscovery();
+        });
+
+        await using var client = PulsarClient.Builder()
+            .ServiceUrl(PulsarContainerFixture.ServiceUrl)
+            .Build();
+
+        await using var consumer = client.NewConsumer()
+            .Topic(topic)
+            .SubscriptionName("raw-native-schedule")
+            .SubscriptionType(SubscriptionType.Shared)
+            .Create();
+
+        // Make sure the Shared subscription exists before publishing
+        using (var connecting = new CancellationTokenSource(30.Seconds()))
+        {
+            await consumer.StateChangedTo(ConsumerState.Active, connecting.Token);
+        }
+
+        var delay = 6.Seconds();
+        var sentAt = DateTimeOffset.UtcNow;
+        await publisher.MessageBus().ScheduleAsync(new NativeScheduledPing(Guid.NewGuid()), delay);
+
+        // The message must NOT be visible in the early window — the broker is holding it
+        var receivedEarly = false;
+        using (var early = new CancellationTokenSource(3.Seconds()))
+        {
+            try
+            {
+                await consumer.Receive(early.Token);
+                receivedEarly = true;
+            }
+            catch (OperationCanceledException)
+            {
+                // expected — nothing deliverable yet
+            }
+        }
+
+        receivedEarly.ShouldBeFalse();
+
+        // And it MUST arrive once the deliver-at time has passed
+        using var late = new CancellationTokenSource(30.Seconds());
+        var message = await consumer.Receive(late.Token);
+        await consumer.Acknowledge(message, late.Token);
+
+        var receivedAt = DateTimeOffset.UtcNow;
+
+        // One second of tolerance for clock skew between the broker container and the test process
+        (receivedAt - sentAt).ShouldBeGreaterThanOrEqualTo(delay - 1.Seconds());
+    }
+}
+
+// ---- end to end over Wolverine hosts (Pulsar docker) ----
+
+public class native_scheduled_delivery_end_to_end : IAsyncLifetime
+{
+    private readonly string _topic = $"persistent://public/default/native-schedule-e2e-{Guid.NewGuid():N}";
+    private IHost? _sender;
+    private IHost? _receiver;
+
+    public async Task InitializeAsync()
+    {
+        _sender = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.PublishMessage<NativeScheduledPing>().ToPulsarTopic(_topic).SendInline();
+            opts.Discovery.DisableConventionalDiscovery();
+        });
+
+        _receiver = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+
+            // Native delayed delivery is only honored by the broker for Shared / KeyShared subscriptions
+            opts.ListenToPulsarTopic(_topic)
+                .SubscriptionName("native-scheduled-e2e")
+                .SubscriptionType(SubscriptionType.Shared);
+
+            opts.Services.AddSingleton<NativeScheduledSink>();
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<NativeScheduledPingHandler>();
+        });
+
+        // Give the durable subscription a moment to attach before anything is published
+        await Task.Delay(2.Seconds());
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_sender != null)
+        {
+            await _sender.StopAsync();
+            _sender.Dispose();
+        }
+
+        if (_receiver != null)
+        {
+            await _receiver.StopAsync();
+            _receiver.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task scheduled_message_is_handled_after_its_deliver_at_time_and_plain_sends_are_unaffected()
+    {
+        // Guard: the native path must be engaged, not the durable-scheduling fallback
+        var runtime = _sender!.Services.GetRequiredService<IWolverineRuntime>();
+        var agent = runtime.Endpoints.GetOrBuildSendingAgent(PulsarEndpointUri.Topic(_topic));
+        agent.SupportsNativeScheduledSend.ShouldBeTrue();
+
+        var sink = _receiver!.Services.GetRequiredService<NativeScheduledSink>();
+
+        // 1) A scheduled message is not handled before its deliver-at time
+        var delay = 5.Seconds();
+        var scheduled = new NativeScheduledPing(Guid.NewGuid());
+        var sentAt = DateTimeOffset.UtcNow;
+
+        await _sender
+            .TrackActivity()
+            .AlsoTrack(_receiver)
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<NativeScheduledPing>(_receiver!)
+            .ExecuteAndWaitAsync(c => c.ScheduleAsync(scheduled, delay));
+
+        var handledAt = sink.HandledAt[scheduled.Id];
+
+        // One second of tolerance for clock skew between the broker container and the test process
+        (handledAt - sentAt).ShouldBeGreaterThanOrEqualTo(delay - 1.Seconds());
+
+        // 2) A plain send on the same endpoint is delivered promptly
+        var plain = new NativeScheduledPing(Guid.NewGuid());
+        var plainSentAt = DateTimeOffset.UtcNow;
+
+        await _sender
+            .TrackActivity()
+            .AlsoTrack(_receiver)
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<NativeScheduledPing>(_receiver!)
+            .ExecuteAndWaitAsync(c => c.SendAsync(plain).AsTask());
+
+        var plainHandledAt = sink.HandledAt[plain.Id];
+        (plainHandledAt - plainSentAt).ShouldBeLessThan(10.Seconds());
+    }
+}
+
+public record NativeScheduledPing(Guid Id);
+
+public class NativeScheduledSink
+{
+    public ConcurrentDictionary<Guid, DateTimeOffset> HandledAt { get; } = new();
+}
+
+public class NativeScheduledPingHandler
+{
+    public static void Handle(NativeScheduledPing message, NativeScheduledSink sink)
+    {
+        sink.HandledAt[message.Id] = DateTimeOffset.UtcNow;
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/Internal/PulsarTenant.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/Internal/PulsarTenant.cs
@@ -49,6 +49,7 @@ internal class PulsarTenant
     {
         Transport.DeadLetterTopic = parent.DeadLetterTopic;
         Transport.RetryLetterTopic = parent.RetryLetterTopic;
+        Transport.NativeScheduledSendEnabled = parent.NativeScheduledSendEnabled;
 
         Configure(Transport.Builder);
     }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarConfiguration.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarConfiguration.cs
@@ -45,6 +45,21 @@ public class PulsarConfiguration
     }
 
     /// <summary>
+    /// GH-3470: opt out of Pulsar broker-native delayed delivery for scheduled/delayed sends on this
+    /// transport. By default Wolverine stamps DotPulsar's deliver-at message metadata from
+    /// <see cref="Envelope.ScheduledTime"/> so the broker itself holds the message until it is due
+    /// (Pulsar delayed message delivery, enabled by default on brokers since Pulsar 2.4). Call this
+    /// when the target broker is configured with <c>delayedDeliveryEnabled=false</c> — Wolverine then
+    /// falls back to its own durable scheduled-message scheduler for this transport's endpoints,
+    /// exactly as for transports without native scheduling support.
+    /// </summary>
+    public PulsarConfiguration DisableNativeScheduledSend()
+    {
+        _transport.NativeScheduledSendEnabled = false;
+        return this;
+    }
+
+    /// <summary>
     /// Register a Wolverine tenant that is served by its own dedicated Pulsar <b>cluster</b> (GH-3308), while
     /// sharing the topic topology declared on this transport. Outbound messages whose
     /// <see cref="Envelope.TenantId"/> matches <paramref name="tenantId"/> are routed to that cluster; inbound

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarSender.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarSender.cs
@@ -14,6 +14,7 @@ public class PulsarSender : ISender, IAsyncDisposable
     private readonly IPulsarEnvelopeMapper _mapper;
     private readonly IProducer<ReadOnlySequence<byte>> _producer;
     private readonly Schemas.IPulsarMessageCodec? _codec;
+    private readonly bool _nativeScheduledSendEnabled;
 
     // GH-3185: producer deduplication state.
     private const int SequenceCacheLimit = 100_000;
@@ -27,6 +28,7 @@ public class PulsarSender : ISender, IAsyncDisposable
         var endpoint1 = endpoint;
         _cancellation = cancellation;
         _codec = endpoint.MessageCodec;
+        _nativeScheduledSendEnabled = transport.NativeScheduledSendEnabled;
 
         // GH-3183: when an endpoint schema is configured, create the producer with it so the broker
         // registers the schema for the topic. The schema is a pass-through over Wolverine's bytes, so the
@@ -63,7 +65,11 @@ public class PulsarSender : ISender, IAsyncDisposable
         return _producer.DisposeAsync();
     }
 
-    public bool SupportsNativeScheduledSend => true;
+    // GH-3470: scheduled/delayed sends are honored natively by stamping Pulsar's deliver-at
+    // metadata in SendAsync. Can be turned off transport-wide (e.g. a broker with
+    // delayedDeliveryEnabled=false) via DisableNativeScheduledSend(), which makes Wolverine
+    // fall back to its own durable scheduled-message storage instead.
+    public bool SupportsNativeScheduledSend => _nativeScheduledSendEnabled;
     public Uri Destination { get; }
 
     public async Task<bool> PingAsync()
@@ -87,6 +93,11 @@ public class PulsarSender : ISender, IAsyncDisposable
 
         _mapper.MapEnvelopeToOutgoing(envelope, message);
 
+        if (_nativeScheduledSendEnabled)
+        {
+            ApplyScheduledDelivery(envelope, message);
+        }
+
         if (_deduplicationEnabled && _sequenceIds != null)
         {
             // Reuse the same sequence id for repeat sends of the same envelope (e.g. outbox resends) so
@@ -109,5 +120,30 @@ public class PulsarSender : ISender, IAsyncDisposable
         }
 
         await _producer.Send(message, new ReadOnlySequence<byte>(envelope.Data!), _cancellation);
+    }
+
+    /// <summary>
+    ///     GH-3470: map <see cref="Envelope.ScheduledTime"/> onto Pulsar's broker-native delayed
+    ///     delivery metadata (DeliverAt) so the broker itself holds the message until it is due,
+    ///     instead of publishing immediately and relying on the receiving node to delay execution.
+    ///     Runs after the envelope mapper so a custom <see cref="IPulsarEnvelopeMapper"/> that has
+    ///     already stamped its own deliver-at metadata is left alone. Note that the Pulsar broker
+    ///     only honors deliver-at for Shared / KeyShared subscriptions on the consuming side —
+    ///     Exclusive / Failover consumers see the message immediately, in which case Wolverine
+    ///     listeners still fall back to holding the envelope locally until its scheduled time via
+    ///     the round-tripped scheduled-time header.
+    /// </summary>
+    internal static void ApplyScheduledDelivery(Envelope envelope, MessageMetadata outgoing)
+    {
+        // Respect deliver-at metadata a custom interop mapper may have stamped itself
+        if (outgoing.DeliverAtTime != 0)
+        {
+            return;
+        }
+
+        if (envelope.ScheduledTime.HasValue)
+        {
+            outgoing.DeliverAtTimeAsDateTimeOffset = envelope.ScheduledTime.Value.ToUniversalTime();
+        }
     }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransport.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransport.cs
@@ -77,6 +77,21 @@ public class PulsarTransport : TransportBase<PulsarEndpoint>, IAsyncDisposable
     /// </summary>
     public RetryLetterTopic? RetryLetterTopic { get; internal set; }
 
+    /// <summary>
+    /// GH-3470: when true (the default), scheduled/delayed sends are honored by the Pulsar broker itself —
+    /// Wolverine stamps DotPulsar's deliver-at message metadata from <see cref="Envelope.ScheduledTime"/>,
+    /// so the broker holds the message until it is due (Pulsar delayed message delivery, available and
+    /// enabled by default since Pulsar 2.4). Set to false via
+    /// <see cref="PulsarConfiguration.DisableNativeScheduledSend"/> for brokers configured with
+    /// <c>delayedDeliveryEnabled=false</c>; Wolverine then falls back to its durable scheduled-message
+    /// scheduler for this transport's endpoints.
+    ///
+    /// Note the broker only honors deliver-at for Shared / KeyShared subscriptions on the consuming side;
+    /// Exclusive / Failover consumers receive delayed messages immediately, and Wolverine listeners then
+    /// fall back to holding the envelope locally until its scheduled time.
+    /// </summary>
+    public bool NativeScheduledSendEnabled { get; internal set; } = true;
+
 
     //private IEnumerable<DeadLetterTopic> enabledDeadLetterTopics()
     //{


### PR DESCRIPTION
## What this does

Pulsar has true broker-native, arbitrary-timestamp delayed delivery (`DeliverAt` / `DeliverAfter`), but Wolverine's Pulsar sender never stamped it: the sender *claimed* `SupportsNativeScheduledSend => true`, yet scheduled/delayed sends were published immediately and only worked because the scheduled time round-trips as an envelope header and the **receiving** Wolverine node held the message locally (in memory for buffered listeners — lost on restart, and useless for non-Wolverine consumers).

This PR makes Pulsar a first-class native scheduling transport:

- **`PulsarSender.SendAsync` now maps `Envelope.ScheduledTime` onto DotPulsar's `DeliverAtTime` message metadata**, so the broker itself parks the message until it is due. The stamp is applied *after* the envelope mapper runs, so it uniformly covers the default mapper, CloudEvents, and custom interop mappers — and a custom mapper that stamps its own deliver-at metadata is respected (never overwritten).
- **Capability gating** (the same shape as the NATS transport's server-version gate): Pulsar brokers have shipped delayed delivery enabled by default since 2.4, so it is on by default, but `UsePulsar(...).DisableNativeScheduledSend()` opts out for brokers running `delayedDeliveryEnabled=false`. The sender then reports `SupportsNativeScheduledSend => false` and Wolverine falls back to its durable scheduled-message scheduler. Broker-per-tenant child transports inherit the flag (`PulsarTenant.Compile`).

## Subscription-type caveat

Pulsar only dispatches delayed messages on **Shared / KeyShared** subscriptions — `Exclusive` / `Failover` consumers (Wolverine's Pulsar listener default) receive them immediately. That is handled gracefully and documented:

- Wolverine-to-Wolverine stays correct under any subscription type: the scheduled time still round-trips as a header, so a listener that receives a not-yet-due envelope holds it locally until it is due (durable inbox for durable listeners, in-memory for buffered) — the pre-existing fallback, unchanged.
- To have the message parked **on the broker** (or consumed by non-Wolverine apps), the listening subscription must be `Shared`/`KeyShared`. The new *Scheduled Delivery* section in `docs/guide/messaging/transports/pulsar.md` spells this out, mirroring the identical constraint already documented for the retry-letter topics.

## Retry-letter interaction

None: `MoveToPulsarRetryTopic` / retry-letter redelivery builds its own `MessageMetadata` (including its own tiered `DeliverAtTimeAsDateTimeOffset`) on a separate producer inside `PulsarListener` and never flows through `PulsarSender`, so delays are not double-applied. Verified by reading the path and by the retry/redelivery test suites.

## Test coverage

New `native_scheduled_delivery.cs` in `Wolverine.Pulsar.Tests` — **9 tests, all passing**:

- Unit: deliver-at stamped from `ScheduledTime` (incl. UTC conversion), metadata untouched without a scheduled time, custom-mapper deliver-at respected, config flag default/`DisableNativeScheduledSend()`/tenant inheritance.
- Integration (Testcontainers Pulsar): a **raw DotPulsar `Shared` consumer** proves the *broker* holds a scheduled message — nothing receivable in the early window, delivered only after deliver-at (this consumer knows nothing about Wolverine headers, so the receiver-side fallback cannot mask a missing stamp).
- Integration end-to-end over two Wolverine hosts on a `Shared` subscription: a message scheduled 5s out is handled no earlier than its deliver-at time; a plain send on the same endpoint is delivered promptly.

Also: `dotnet build wolverine.slnx -c Release` succeeds with 0 warnings/0 errors, and the compliance `schedule_send` tests pass.

**Local environmental note:** on the (heavily loaded, multi-suite) dev box, the three pre-existing `can_schedule_retry` compliance variants failed with tracked-session timeouts — they fail **identically on an unmodified main checkout** on the same machine (baselined via `git stash` + rebuild), so they are environmental, not caused by this diff. CI is the real signal for those.

Closes #3470

🤖 Generated with [Claude Code](https://claude.com/claude-code)