### PR TITLE
SQS native DelaySeconds for short scheduled sends on standard queues (GH-3472)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -211,6 +211,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                                     ]},
                                 {text: 'Amazon SQS', link: '/guide/messaging/transports/sqs/', items:[
                                         {text: 'Publishing', link:'/guide/messaging/transports/sqs/publishing'},
+                                        {text: 'Scheduled Delivery', link:'/guide/messaging/transports/sqs/scheduled'},
                                         {text: 'Listening', link:'/guide/messaging/transports/sqs/listening'},
                                         {text: 'Dead Letter Queues', link:'/guide/messaging/transports/sqs/deadletterqueues'},
                                         {text: 'Configuring Queues', link:'/guide/messaging/transports/sqs/queues'},

--- a/docs/guide/messaging/transports/sqs/fifo-queues.md
+++ b/docs/guide/messaging/transports/sqs/fifo-queues.md
@@ -54,6 +54,13 @@ await messageBus.PublishAsync(new OrderPlaced(orderId), new DeliveryOptions
 
 If you enable `ContentBasedDeduplication` on the queue (as shown above), you can omit the `DeduplicationId` and SQS will generate one based on the message body.
 
+## Scheduled Messages and FIFO Queues
+
+SQS does not allow per-message delays (`DelaySeconds`) on FIFO queues — only a queue-level delay
+that applies to every message. For that reason, Wolverine never uses native SQS delays for
+scheduled sends to a FIFO queue and always falls back to its own message scheduling instead. See
+[Scheduled Delivery](/guide/messaging/transports/sqs/scheduled) for the details.
+
 ## Dead Letter Queues for FIFO
 
 When using dead letter queues with FIFO queues, the dead letter queue must also be a FIFO queue. Make sure to name it with a `.fifo` suffix:

--- a/docs/guide/messaging/transports/sqs/scheduled.md
+++ b/docs/guide/messaging/transports/sqs/scheduled.md
@@ -1,0 +1,41 @@
+# Scheduled Delivery
+
+Amazon SQS supports delaying the delivery of individual messages through the
+[per-message `DelaySeconds` parameter](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-timers.html),
+but only up to a hard limit of **15 minutes**, and only on **standard** (non-FIFO) queues.
+
+Wolverine uses this native capability automatically whenever it can. There is nothing to enable —
+just use Wolverine's normal scheduled sending:
+
+```cs
+// Delivered through SQS native DelaySeconds (standard queue, within 15 minutes)
+await bus.ScheduleAsync(new ValidateOrder(orderId), 5.Minutes());
+
+// Also fine — an absolute time within the next 15 minutes
+await bus.ScheduleAsync(new ValidateOrder(orderId), DateTimeOffset.UtcNow.AddMinutes(10));
+```
+
+The decision between native delay and Wolverine's own message scheduling is made **per message**
+at the time the message is routed:
+
+| Scenario | Behavior |
+|----------|----------|
+| Standard queue, delay ≤ 15 minutes | Sent immediately to SQS with `DelaySeconds` — the broker holds the message and delivers it after the delay |
+| Standard queue, delay > 15 minutes | Falls back to Wolverine's own [message scheduling](/guide/messaging/message-bus.html#scheduling-message-delivery-or-execution) — the message is sent to SQS when its time arrives |
+| FIFO queue, any delay | Always falls back to Wolverine's scheduled message storage — SQS only supports a queue-level delay on FIFO queues, never per-message delays |
+
+A couple of important consequences of the native path:
+
+* **Storage-less applications** (no message store configured) can now use short, retry-style
+  scheduled sends to standard SQS queues reliably — the broker itself holds the message, so no
+  database is needed and the delay survives an application restart.
+* Because the message is handed to SQS immediately, a natively delayed message **cannot be
+  cancelled or rescheduled** once sent.
+
+For delays past the 15 minute limit (and for all FIFO queues), the fallback behavior depends on
+your durability setup:
+
+* With a message store configured, the scheduled message is kept in the durable inbox and
+  published to SQS by Wolverine's scheduling agent when the time comes — this is fully durable.
+* Without a message store, the message is held by the in-process, in-memory scheduler, and will
+  be lost if the application restarts before the scheduled time.

--- a/src/Testing/CoreTests/Transports/Sending/ConditionalNativeSchedulingTests.cs
+++ b/src/Testing/CoreTests/Transports/Sending/ConditionalNativeSchedulingTests.cs
@@ -1,0 +1,128 @@
+using System;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Wolverine.Configuration;
+using Wolverine.Logging;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace CoreTests.Transports.Sending;
+
+public class ConditionalNativeSchedulingTests
+{
+    private readonly DateTimeOffset theCurrentTime = DateTimeOffset.UtcNow;
+
+    private Envelope envelopeScheduledIn(TimeSpan delay)
+    {
+        return new Envelope { ScheduledTime = theCurrentTime.Add(delay) };
+    }
+
+    [Fact]
+    public void agent_without_native_scheduling_is_false_regardless_of_envelope()
+    {
+        var agent = Substitute.For<ISendingAgent>();
+        agent.SupportsNativeScheduledSend.Returns(false);
+
+        agent.SupportsNativeScheduledSendFor(envelopeScheduledIn(5.Seconds()), theCurrentTime)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void agent_with_unconditional_native_scheduling_is_true()
+    {
+        var agent = Substitute.For<ISendingAgent>();
+        agent.SupportsNativeScheduledSend.Returns(true);
+
+        agent.SupportsNativeScheduledSendFor(envelopeScheduledIn(30.Days()), theCurrentTime)
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void inline_agent_consults_the_conditional_sender_per_envelope()
+    {
+        var sender = new ConditionalSender { Limit = 15.Minutes() };
+        var agent = new InlineSendingAgent(NullLogger.Instance, sender, new StubEndpoint(),
+            Substitute.For<IMessageTracker>(), new DurabilitySettings());
+
+        agent.SupportsNativeScheduledSendFor(envelopeScheduledIn(5.Minutes()), theCurrentTime)
+            .ShouldBeTrue();
+
+        agent.SupportsNativeScheduledSendFor(envelopeScheduledIn(20.Minutes()), theCurrentTime)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void conditional_interface_is_not_consulted_when_the_sender_opts_out_entirely()
+    {
+        var sender = new ConditionalSender { Limit = 15.Minutes(), SupportsNativeScheduledSend = false };
+        var agent = new InlineSendingAgent(NullLogger.Instance, sender, new StubEndpoint(),
+            Substitute.For<IMessageTracker>(), new DurabilitySettings());
+
+        agent.SupportsNativeScheduledSendFor(envelopeScheduledIn(5.Minutes()), theCurrentTime)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void tenanted_sender_delegates_the_conditional_decision_to_the_default_sender()
+    {
+        var inner = new ConditionalSender { Limit = 15.Minutes() };
+        var tenanted = new TenantedSender(new Uri("stub://one"), TenantedIdBehavior.FallbackToDefault, inner);
+        var agent = new InlineSendingAgent(NullLogger.Instance, tenanted, new StubEndpoint(),
+            Substitute.For<IMessageTracker>(), new DurabilitySettings());
+
+        agent.SupportsNativeScheduledSendFor(envelopeScheduledIn(5.Minutes()), theCurrentTime)
+            .ShouldBeTrue();
+
+        agent.SupportsNativeScheduledSendFor(envelopeScheduledIn(20.Minutes()), theCurrentTime)
+            .ShouldBeFalse();
+    }
+
+    private class ConditionalSender : ISender, IConditionalNativeScheduling
+    {
+        public TimeSpan Limit { get; set; } = TimeSpan.MaxValue;
+
+        public bool SupportsNativeScheduledSend { get; set; } = true;
+
+        public Uri Destination { get; } = new("stub://one");
+
+        public Task<bool> PingAsync()
+        {
+            return Task.FromResult(true);
+        }
+
+        public ValueTask SendAsync(Envelope envelope)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public bool CanScheduleNatively(Envelope envelope, DateTimeOffset utcNow)
+        {
+            return envelope.ScheduledTime is not { } time || time.Subtract(utcNow) <= Limit;
+        }
+    }
+
+    private class StubEndpoint : Endpoint
+    {
+        public StubEndpoint() : base(new Uri("stub://one"), EndpointRole.Application)
+        {
+        }
+
+        public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override ISender CreateSender(IWolverineRuntime runtime)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override bool supportsMode(EndpointMode mode)
+        {
+            return true;
+        }
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/scheduled_send_native_delay_3472.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/scheduled_send_native_delay_3472.cs
@@ -1,0 +1,341 @@
+using System.Diagnostics;
+using Amazon.SQS;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+public class NativeDelayDecisionTests
+{
+    private readonly AmazonSqsQueue theStandardQueue = new AmazonSqsTransport().Queues["standard"];
+    private readonly AmazonSqsQueue theFifoQueue = new AmazonSqsTransport().Queues["ordered.fifo"];
+    private readonly DateTimeOffset theCurrentTime = DateTimeOffset.UtcNow;
+
+    [Fact]
+    public void standard_queue_can_schedule_natively_with_no_scheduled_time()
+    {
+        theStandardQueue.CanScheduleNatively(new Envelope(), theCurrentTime).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void standard_queue_can_schedule_natively_within_15_minutes()
+    {
+        var envelope = new Envelope { ScheduledTime = theCurrentTime.AddMinutes(5) };
+        theStandardQueue.CanScheduleNatively(envelope, theCurrentTime).ShouldBeTrue();
+
+        envelope.ScheduledTime = theCurrentTime.AddSeconds(AmazonSqsQueue.MaximumSqsDelaySeconds);
+        theStandardQueue.CanScheduleNatively(envelope, theCurrentTime).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void standard_queue_cannot_schedule_natively_beyond_15_minutes()
+    {
+        var envelope = new Envelope { ScheduledTime = theCurrentTime.AddMinutes(16) };
+        theStandardQueue.CanScheduleNatively(envelope, theCurrentTime).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void fifo_queue_can_never_schedule_natively()
+    {
+        theFifoQueue.CanScheduleNatively(new Envelope(), theCurrentTime).ShouldBeFalse();
+
+        var envelope = new Envelope { ScheduledTime = theCurrentTime.AddSeconds(30) };
+        theFifoQueue.CanScheduleNatively(envelope, theCurrentTime).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void delay_seconds_is_zero_with_no_scheduled_time()
+    {
+        theStandardQueue.NativeDelaySecondsFor(new Envelope(), theCurrentTime, NullLogger.Instance)
+            .ShouldBe(0);
+    }
+
+    [Fact]
+    public void delay_seconds_is_zero_for_past_scheduled_time()
+    {
+        var envelope = new Envelope { ScheduledTime = theCurrentTime.AddMinutes(-1) };
+        theStandardQueue.NativeDelaySecondsFor(envelope, theCurrentTime, NullLogger.Instance)
+            .ShouldBe(0);
+    }
+
+    [Fact]
+    public void delay_seconds_rounds_up_to_whole_seconds()
+    {
+        var envelope = new Envelope { ScheduledTime = theCurrentTime.AddMilliseconds(4500) };
+        theStandardQueue.NativeDelaySecondsFor(envelope, theCurrentTime, NullLogger.Instance)
+            .ShouldBe(5);
+    }
+
+    [Fact]
+    public void delay_seconds_is_zero_for_fifo_queues()
+    {
+        var envelope = new Envelope { ScheduledTime = theCurrentTime.AddSeconds(30) };
+        theFifoQueue.NativeDelaySecondsFor(envelope, theCurrentTime, NullLogger.Instance)
+            .ShouldBe(0);
+    }
+
+    [Fact]
+    public void delay_seconds_is_defensively_capped_at_the_sqs_maximum()
+    {
+        // The routing layer falls back to Wolverine scheduling before an envelope like this
+        // can ever reach the sender, so this cap is defense in depth only
+        var envelope = new Envelope { ScheduledTime = theCurrentTime.AddMinutes(30) };
+        theStandardQueue.NativeDelaySecondsFor(envelope, theCurrentTime, NullLogger.Instance)
+            .ShouldBe(AmazonSqsQueue.MaximumSqsDelaySeconds);
+    }
+}
+
+public class scheduled_send_with_native_delay : IAsyncLifetime
+{
+    private const string QueueName = "native-delay-3472";
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        // Deliberately storageless (no message store) so a natively delayed delivery
+        // cannot be confused with Wolverine's own scheduled message polling
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAmazonSqsTransportLocally()
+                    .AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToSqsQueue(QueueName);
+
+                opts.PublishMessage<SqsNativeDelayMessage>().ToSqsQueue(QueueName);
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public void sending_agent_makes_the_native_decision_per_envelope()
+    {
+        var runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+        var agent = runtime.Endpoints.GetOrBuildSendingAgent(new Uri($"sqs://{QueueName}"));
+
+        agent.SupportsNativeScheduledSend.ShouldBeTrue();
+
+        var utcNow = DateTimeOffset.UtcNow;
+
+        var withinWindow = new Envelope { ScheduledTime = utcNow.AddMinutes(5) };
+        agent.SupportsNativeScheduledSendFor(withinWindow, utcNow).ShouldBeTrue();
+
+        var pastWindow = new Envelope { ScheduledTime = utcNow.AddMinutes(20) };
+        agent.SupportsNativeScheduledSendFor(pastWindow, utcNow).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task scheduled_message_within_the_window_is_delivered_natively_after_the_delay()
+    {
+        var message = new SqsNativeDelayMessage("delayed");
+        var stopwatch = Stopwatch.StartNew();
+
+        var session = await _host.TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(2.Minutes())
+            .WaitForMessageToBeReceivedAt<SqsNativeDelayMessage>(_host)
+            .ExecuteAndWaitAsync(c => c.ScheduleAsync(message, 5.Seconds()).AsTask());
+
+        stopwatch.Stop();
+
+        session.Received.SingleMessage<SqsNativeDelayMessage>()
+            .Name.ShouldBe(message.Name);
+
+        // The broker honored the delay
+        stopwatch.Elapsed.ShouldBeGreaterThan(4.Seconds());
+
+        // Proves the native path: the envelope went straight out to SQS instead of being
+        // wrapped for Wolverine's own scheduled message storage at local://durable
+        session.Sent.RecordsInOrder()
+            .Any(x => x.Envelope!.Destination?.Scheme == "sqs")
+            .ShouldBeTrue();
+        session.AllRecordsInOrder()
+            .Any(x => x.Envelope?.Destination == Transports.TransportConstants.DurableLocalUri)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task scheduled_message_beyond_the_window_falls_back_to_wolverine_scheduling()
+    {
+        var session = await _host.TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(30.Seconds())
+            .ExecuteAndWaitAsync(c => c.ScheduleAsync(new SqsNativeDelayMessage("way later"), 20.Minutes()).AsTask());
+
+        // The message was captured by Wolverine's own scheduling (in memory here since
+        // there is no message store) instead of being sent to the broker
+        session.Scheduled.Envelopes()
+            .Any(x => x.Message is SqsNativeDelayMessage)
+            .ShouldBeTrue();
+
+        session.Sent.RecordsInOrder()
+            .Any(x => x.Envelope!.Destination?.Scheme == "sqs")
+            .ShouldBeFalse();
+
+        session.Received.RecordsInOrder().ShouldBeEmpty();
+    }
+}
+
+public class inline_scheduled_send_with_native_delay : IAsyncLifetime
+{
+    private const string QueueName = "native-delay-inline-3472";
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAmazonSqsTransportLocally()
+                    .AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToSqsQueue(QueueName).ProcessInline();
+
+                opts.PublishMessage<SqsInlineNativeDelayMessage>().ToSqsQueue(QueueName).SendInline();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task scheduled_message_is_delivered_natively_after_the_delay()
+    {
+        var message = new SqsInlineNativeDelayMessage("inline delayed");
+        var stopwatch = Stopwatch.StartNew();
+
+        var session = await _host.TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(2.Minutes())
+            .WaitForMessageToBeReceivedAt<SqsInlineNativeDelayMessage>(_host)
+            .ExecuteAndWaitAsync(c => c.ScheduleAsync(message, 5.Seconds()).AsTask());
+
+        stopwatch.Stop();
+
+        session.Received.SingleMessage<SqsInlineNativeDelayMessage>()
+            .Name.ShouldBe(message.Name);
+
+        stopwatch.Elapsed.ShouldBeGreaterThan(4.Seconds());
+
+        session.Sent.RecordsInOrder()
+            .Any(x => x.Envelope!.Destination?.Scheme == "sqs")
+            .ShouldBeTrue();
+        session.AllRecordsInOrder()
+            .Any(x => x.Envelope?.Destination == Transports.TransportConstants.DurableLocalUri)
+            .ShouldBeFalse();
+    }
+}
+
+public class scheduled_send_to_fifo_queue_falls_back : IAsyncLifetime
+{
+    private const string QueueName = "native-delay-3472.fifo";
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAmazonSqsTransportLocally()
+                    .AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToSqsQueue(QueueName)
+                    .ConfigureQueueCreation(request =>
+                    {
+                        request.Attributes ??= new Dictionary<string, string>();
+                        request.Attributes[QueueAttributeName.FifoQueue] = "true";
+                        request.Attributes[QueueAttributeName.ContentBasedDeduplication] = "true";
+                    });
+
+                opts.PublishMessage<SqsFifoDelayMessage>().ToSqsQueue(QueueName)
+                    .ConfigureQueueCreation(request =>
+                    {
+                        request.Attributes ??= new Dictionary<string, string>();
+                        request.Attributes[QueueAttributeName.FifoQueue] = "true";
+                        request.Attributes[QueueAttributeName.ContentBasedDeduplication] = "true";
+                    });
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public void fifo_sending_agent_reports_no_native_scheduled_send_support()
+    {
+        var runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+        var agent = runtime.Endpoints.GetOrBuildSendingAgent(new Uri($"sqs://{QueueName}"));
+
+        agent.SupportsNativeScheduledSend.ShouldBeFalse();
+
+        var utcNow = DateTimeOffset.UtcNow;
+        var withinWindow = new Envelope { ScheduledTime = utcNow.AddSeconds(30) };
+        agent.SupportsNativeScheduledSendFor(withinWindow, utcNow).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task scheduled_message_to_fifo_queue_is_delivered_via_the_fallback()
+    {
+        var message = new SqsFifoDelayMessage("fifo delayed");
+
+        var session = await _host.TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(2.Minutes())
+            .WaitForMessageToBeReceivedAt<SqsFifoDelayMessage>(_host)
+            .ExecuteAndWaitAsync(c => c.PublishAsync(message, new DeliveryOptions
+            {
+                ScheduleDelay = 5.Seconds(),
+                GroupId = "native-delay-tests"
+            }).AsTask());
+
+        session.Received.SingleMessage<SqsFifoDelayMessage>()
+            .Name.ShouldBe(message.Name);
+
+        // The fallback captured the message with Wolverine's own scheduling first
+        session.Scheduled.Envelopes()
+            .Any(x => x.Message is SqsFifoDelayMessage)
+            .ShouldBeTrue();
+    }
+}
+
+public record SqsNativeDelayMessage(string Name);
+
+public record SqsInlineNativeDelayMessage(string Name);
+
+public record SqsFifoDelayMessage(string Name);
+
+public static class NativeDelayMessageHandler
+{
+    public static void Handle(SqsNativeDelayMessage message)
+    {
+        // nothing
+    }
+
+    public static void Handle(SqsInlineNativeDelayMessage message)
+    {
+        // nothing
+    }
+
+    public static void Handle(SqsFifoDelayMessage message)
+    {
+        // nothing
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -14,6 +14,13 @@ namespace Wolverine.AmazonSqs.Internal;
 
 public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoint
 {
+    /// <summary>
+    ///     Hard Amazon SQS limit for the per-message DelaySeconds parameter (15 minutes). Scheduled
+    ///     sends within this window to a standard queue are delayed natively by SQS; anything past it
+    ///     falls back to Wolverine's own message scheduling
+    /// </summary>
+    public const int MaximumSqsDelaySeconds = 900;
+
     private readonly AmazonSqsTransport _parent;
 
     private bool _initialized;
@@ -244,6 +251,58 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
         return new DefaultSqsEnvelopeMapper();
     }
 
+    /// <summary>
+    ///     Can the requested delivery time of this envelope be honored natively by SQS through the
+    ///     per-message DelaySeconds parameter? Standard queues only (FIFO queues support just a
+    ///     queue-level delay), and only within the 15 minute SQS maximum
+    /// </summary>
+    internal bool CanScheduleNatively(Envelope envelope, DateTimeOffset utcNow)
+    {
+        if (IsFifoQueue)
+        {
+            return false;
+        }
+
+        if (envelope.ScheduledTime is not { } scheduledTime)
+        {
+            return true;
+        }
+
+        return scheduledTime.Subtract(utcNow).TotalSeconds <= MaximumSqsDelaySeconds;
+    }
+
+    /// <summary>
+    ///     The DelaySeconds value to stamp on an outgoing SQS message for this envelope, or 0 for
+    ///     "send immediately". Only applies to standard queues; SQS rejects per-message delays on
+    ///     FIFO queues
+    /// </summary>
+    internal int NativeDelaySecondsFor(Envelope envelope, DateTimeOffset utcNow, ILogger logger)
+    {
+        if (IsFifoQueue || envelope.ScheduledTime is not { } scheduledTime)
+        {
+            return 0;
+        }
+
+        var remaining = scheduledTime.Subtract(utcNow);
+        if (remaining <= TimeSpan.Zero)
+        {
+            return 0;
+        }
+
+        var seconds = (int)Math.Ceiling(remaining.TotalSeconds);
+        if (seconds <= MaximumSqsDelaySeconds)
+        {
+            return seconds;
+        }
+
+        // Defensive only. Wolverine's routing falls back to its own message scheduling for
+        // delays past the SQS maximum, so this should be unreachable through normal publishing
+        logger.LogWarning(
+            "Envelope {EnvelopeId} reached the SQS sender for queue {Queue} with a scheduled delay of {Seconds}s, which exceeds the SQS maximum of {MaximumSeconds}s. The message will be delivered after the maximum delay instead",
+            envelope.Id, QueueName, seconds, MaximumSqsDelaySeconds);
+        return MaximumSqsDelaySeconds;
+    }
+
     internal async Task SendMessageAsync(Envelope envelope, ILogger logger)
     {
         if (!_initialized)
@@ -283,6 +342,12 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
         {
             request.MessageAttributes ??= new Dictionary<string, MessageAttributeValue>();
             request.MessageAttributes.Add(attribute.Key, attribute.Value);
+        }
+
+        var delaySeconds = NativeDelaySecondsFor(envelope, DateTimeOffset.UtcNow, logger);
+        if (delaySeconds > 0)
+        {
+            request.DelaySeconds = delaySeconds;
         }
 
         await _parent.Client!.SendMessageAsync(request);
@@ -454,8 +519,17 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
 
         var protocol = new SqsSenderProtocol(runtime, this,
             _parent.Client ?? throw new InvalidOperationException("Parent transport has not been initialized"));
-        return new BatchedSender(this, protocol, runtime.Cancellation,
+        var sender = new BatchedSender(this, protocol, runtime.Cancellation,
             runtime.LoggerFactory.CreateLogger<SqsSenderProtocol>());
+
+        // FIFO queues only support a queue-level delay, never the per-message DelaySeconds, so
+        // scheduled sends to a FIFO queue always fall back to Wolverine's own message scheduling
+        if (IsFifoQueue)
+        {
+            sender.SupportsNativeScheduledSend = false;
+        }
+
+        return sender;
     }
 
     /// <summary>

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/InlineSqsSender.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/InlineSqsSender.cs
@@ -4,7 +4,7 @@ using Wolverine.Transports.Sending;
 
 namespace Wolverine.AmazonSqs.Internal;
 
-internal class InlineSqsSender : ISender
+internal class InlineSqsSender : ISender, IConditionalNativeScheduling
 {
     private readonly ILogger _logger;
     private readonly AmazonSqsQueue _queue;
@@ -15,7 +15,15 @@ internal class InlineSqsSender : ISender
         _logger = runtime.LoggerFactory.CreateLogger<InlineSqsSender>();
     }
 
-    public bool SupportsNativeScheduledSend => false;
+    // Standard queues can delay individual messages natively (DelaySeconds, max 15 minutes);
+    // FIFO queues only support a queue-level delay, so they never schedule natively
+    public bool SupportsNativeScheduledSend => !_queue.IsFifoQueue;
+
+    bool IConditionalNativeScheduling.CanScheduleNatively(Envelope envelope, DateTimeOffset utcNow)
+    {
+        return _queue.CanScheduleNatively(envelope, utcNow);
+    }
+
     public Uri Destination => _queue.Uri;
 
     public async Task<bool> PingAsync()

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSenderProtocol.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSenderProtocol.cs
@@ -8,7 +8,7 @@ using Wolverine.Transports.Sending;
 
 namespace Wolverine.AmazonSqs.Internal;
 
-internal class SqsSenderProtocol :ISenderProtocol
+internal class SqsSenderProtocol : ISenderProtocolWithNativeScheduling, IConditionalNativeScheduling
 {
     private readonly ILogger _logger;
     private readonly AmazonSqsQueue _queue;
@@ -21,6 +21,13 @@ internal class SqsSenderProtocol :ISenderProtocol
         _logger = runtime.LoggerFactory.CreateLogger<SqsSenderProtocol>();
 
         _queue.Mapper ??= _queue.BuildMapper(runtime);
+    }
+
+    // Standard queues can delay individual messages natively (DelaySeconds, max 15 minutes);
+    // FIFO queues only support a queue-level delay, so they never schedule natively
+    bool IConditionalNativeScheduling.CanScheduleNatively(Envelope envelope, DateTimeOffset utcNow)
+    {
+        return _queue.CanScheduleNatively(envelope, utcNow);
     }
 
     public async Task SendBatchAsync(ISenderCallback callback, OutgoingMessageBatch batch)
@@ -86,6 +93,12 @@ internal class OutgoingSqsBatch
                 {
                     entry.MessageAttributes ??= new Dictionary<string, MessageAttributeValue>();
                     entry.MessageAttributes.Add(attribute.Key, attribute.Value);
+                }
+
+                var delaySeconds = queue.NativeDelaySecondsFor(envelope, DateTimeOffset.UtcNow, logger);
+                if (delaySeconds > 0)
+                {
+                    entry.DelaySeconds = delaySeconds;
                 }
 
                 entries.Add(entry);

--- a/src/Wolverine/Runtime/DestinationEndpoint.cs
+++ b/src/Wolverine/Runtime/DestinationEndpoint.cs
@@ -4,6 +4,7 @@ using Wolverine.Configuration;
 using Wolverine.Runtime.RemoteInvocation;
 using Wolverine.Runtime.Scheduled;
 using Wolverine.Transports;
+using Wolverine.Transports.Sending;
 
 namespace Wolverine.Runtime;
 
@@ -47,7 +48,8 @@ internal class DestinationEndpoint : IDestinationEndpoint
         options?.Override(envelope);
 
         // adjust for local, scheduled send
-        if (envelope.IsScheduledForLater(DateTimeOffset.UtcNow) && !_endpoint.Agent!.SupportsNativeScheduledSend)
+        var utcNow = DateTimeOffset.UtcNow;
+        if (envelope.IsScheduledForLater(utcNow) && !_endpoint.Agent!.SupportsNativeScheduledSendFor(envelope, utcNow))
         {
             var localDurableQueue =
                 _parent.Runtime.Endpoints.GetOrBuildSendingAgent(TransportConstants.DurableLocalUri);
@@ -89,7 +91,8 @@ internal class DestinationEndpoint : IDestinationEndpoint
         configure?.Invoke(envelope);
         
         // adjust for local, scheduled send
-        if (envelope.IsScheduledForLater(DateTimeOffset.UtcNow) && !_endpoint.Agent!.SupportsNativeScheduledSend)
+        var utcNow = DateTimeOffset.UtcNow;
+        if (envelope.IsScheduledForLater(utcNow) && !_endpoint.Agent!.SupportsNativeScheduledSendFor(envelope, utcNow))
         {
             var localDurableQueue =
                 _parent.Runtime.Endpoints.GetOrBuildSendingAgent(TransportConstants.DurableLocalUri);

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -12,6 +12,7 @@ using Wolverine.Persistence.Durability;
 using Wolverine.Runtime.Agents;
 using Wolverine.Runtime.RemoteInvocation;
 using Wolverine.Transports;
+using Wolverine.Transports.Sending;
 using Wolverine.Util;
 
 namespace Wolverine.Runtime;
@@ -172,11 +173,12 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
 
             try
             {
-                if (envelope.IsScheduledForLater(DateTimeOffset.UtcNow))
+                var utcNow = DateTimeOffset.UtcNow;
+                if (envelope.IsScheduledForLater(utcNow))
                 {
                     if (!envelope.Sender!.IsDurable)
                     {
-                        if (envelope.Sender!.SupportsNativeScheduledSend)
+                        if (envelope.Sender!.SupportsNativeScheduledSendFor(envelope, utcNow))
                         {
                             Runtime.Logger.LogDebug("Sending scheduled envelope {EnvelopeId} ({MessageType}) via native scheduled send to {Destination}", envelope.Id, envelope.MessageType, envelope.Destination);
                             await sendEnvelopeAsync(envelope).ConfigureAwait(false);

--- a/src/Wolverine/Runtime/Routing/MessageRoute.cs
+++ b/src/Wolverine/Runtime/Routing/MessageRoute.cs
@@ -173,7 +173,8 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
             envelope.TopicName = TopicRouting.DetermineTopicName(envelope);
         }
 
-        if (envelope.IsScheduledForLater(DateTimeOffset.UtcNow))
+        var utcNow = DateTimeOffset.UtcNow;
+        if (envelope.IsScheduledForLater(utcNow))
         {
             if (IsLocal)
             {
@@ -181,9 +182,9 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
                 envelope.OwnerId = TransportConstants.AnyNode;
                 runtime.Logger.LogDebug("Envelope {EnvelopeId} ({MessageType}) marked as Scheduled for local execution at {Destination}", envelope.Id, envelope.MessageType, envelope.Destination);
             }
-            else if (!sender.SupportsNativeScheduledSend)
+            else if (!sender.SupportsNativeScheduledSendFor(envelope, utcNow))
             {
-                runtime.Logger.LogDebug("Envelope {EnvelopeId} ({MessageType}) wrapped for durable scheduled send to {Destination} (transport does not support native scheduling)", envelope.Id, envelope.MessageType, envelope.Destination);
+                runtime.Logger.LogDebug("Envelope {EnvelopeId} ({MessageType}) wrapped for durable scheduled send to {Destination} (transport does not support native scheduling for this envelope)", envelope.Id, envelope.MessageType, envelope.Destination);
                 return envelope.ForScheduledSend(localDurableQueue);
             }
             else

--- a/src/Wolverine/Transports/Sending/BatchedSender.cs
+++ b/src/Wolverine/Transports/Sending/BatchedSender.cs
@@ -6,7 +6,7 @@ using Wolverine.Logging;
 
 namespace Wolverine.Transports.Sending;
 
-public class BatchedSender : ISender, ISenderRequiresCallback
+public class BatchedSender : ISender, ISenderRequiresCallback, IConditionalNativeScheduling
 {
     private readonly CancellationToken _cancellation;
     private readonly ILogger _logger;
@@ -70,6 +70,12 @@ public class BatchedSender : ISender, ISenderRequiresCallback
     }
 
     public bool SupportsNativeScheduledSend { get; set; }
+
+    bool IConditionalNativeScheduling.CanScheduleNatively(Envelope envelope, DateTimeOffset utcNow)
+    {
+        return _protocol is not IConditionalNativeScheduling conditional ||
+               conditional.CanScheduleNatively(envelope, utcNow);
+    }
 
     public ValueTask SendAsync(Envelope message)
     {

--- a/src/Wolverine/Transports/Sending/IConditionalNativeScheduling.cs
+++ b/src/Wolverine/Transports/Sending/IConditionalNativeScheduling.cs
@@ -1,0 +1,52 @@
+namespace Wolverine.Transports.Sending;
+
+/// <summary>
+///     Optional, envelope-aware companion to <see cref="ISender.SupportsNativeScheduledSend" /> (and
+///     <see cref="ISenderProtocolWithNativeScheduling" /> for batched senders) for transports whose
+///     native scheduled delivery only covers some messages. Example: Amazon SQS caps per-message
+///     <c>DelaySeconds</c> at 15 minutes and disallows it entirely on FIFO queues. When an
+///     <see cref="ISender" /> or <see cref="ISenderProtocol" /> implements this interface, Wolverine
+///     asks per envelope at routing time whether the transport can honor the requested delivery time
+///     natively, and falls back to its own message scheduling (the durable message store, or the
+///     in-memory scheduler when there is no message store) for envelopes that cannot be scheduled
+///     natively
+/// </summary>
+public interface IConditionalNativeScheduling
+{
+    /// <summary>
+    ///     Can the requested delivery time of this particular envelope be honored by the
+    ///     transport's native scheduled delivery?
+    /// </summary>
+    bool CanScheduleNatively(Envelope envelope, DateTimeOffset utcNow);
+}
+
+public static class ConditionalNativeSchedulingExtensions
+{
+    /// <summary>
+    ///     Envelope-aware version of <see cref="ISendingAgent.SupportsNativeScheduledSend" />. Answers
+    ///     whether this sending agent can natively schedule delivery of this particular envelope by
+    ///     consulting <see cref="IConditionalNativeScheduling" /> on the underlying sender when the
+    ///     transport's native scheduling support is conditional
+    /// </summary>
+    public static bool SupportsNativeScheduledSendFor(this ISendingAgent agent, Envelope envelope,
+        DateTimeOffset utcNow)
+    {
+        if (!agent.SupportsNativeScheduledSend)
+        {
+            return false;
+        }
+
+        // Unwrap the agent to the actual transport sender where the conditional
+        // capability lives. Local queues and other ISendingAgent implementations
+        // that are not sender wrappers answer for themselves
+        var sender = agent switch
+        {
+            SendingAgent sendingAgent => (object)sendingAgent.Sender,
+            InlineSendingAgent inlineAgent => inlineAgent.Sender,
+            _ => agent
+        };
+
+        return sender is not IConditionalNativeScheduling conditional ||
+               conditional.CanScheduleNatively(envelope, utcNow);
+    }
+}

--- a/src/Wolverine/Transports/Sending/TenantedSender.cs
+++ b/src/Wolverine/Transports/Sending/TenantedSender.cs
@@ -58,7 +58,7 @@ internal class InvalidTenantSender : ISender
 /// which explicitly calls MarkSuccessfulAsync after a successful send.
 /// See https://github.com/JasperFx/wolverine/issues/2361
 /// </summary>
-public class TenantedSender : ISender, IDisposable, IAsyncDisposable
+public class TenantedSender : ISender, IDisposable, IAsyncDisposable, IConditionalNativeScheduling
 {
     public TenantedIdBehavior TenantedIdBehavior { get; }
     private readonly ISender _defaultSender = null!;
@@ -83,6 +83,14 @@ public class TenantedSender : ISender, IDisposable, IAsyncDisposable
     }
 
     public bool SupportsNativeScheduledSend => _defaultSender.SupportsNativeScheduledSend;
+
+    bool IConditionalNativeScheduling.CanScheduleNatively(Envelope envelope, DateTimeOffset utcNow)
+    {
+        // Tenant senders are siblings of the default sender against the same queue/topic
+        // topology, so the default sender's answer holds for every tenant
+        return _defaultSender is not IConditionalNativeScheduling conditional ||
+               conditional.CanScheduleNatively(envelope, utcNow);
+    }
     public Uri Destination { get; }
     public async Task<bool> PingAsync()
     {


### PR DESCRIPTION
Closes #3472

SQS supports per-message delays up to 15 minutes (`DelaySeconds`) on standard queues, but the SQS senders reported `SupportsNativeScheduledSend => false`, so every scheduled/delayed send routed through the database scheduler — including short retry-style delays the broker could handle natively (and that storageless apps couldn't do durably at all).

## The decision mechanism: per-envelope native-vs-fallback routing

`SupportsNativeScheduledSend` is a static per-sender capability, but SQS needs a **per-message** decision (≤ 15 min AND standard queue → native; otherwise fall back). The runtime had no per-envelope escape hatch, so this PR adds a small one to core rather than clamping or losing long delays:

* **New optional capability interface** `IConditionalNativeScheduling` (`src/Wolverine/Transports/Sending/IConditionalNativeScheduling.cs`) with a single `CanScheduleNatively(Envelope, DateTimeOffset utcNow)` method, implementable by an `ISender` or an `ISenderProtocol`.
* **New envelope-aware extension** `ISendingAgent.SupportsNativeScheduledSendFor(envelope, utcNow)`: answers `false` when the agent doesn't support native scheduling at all, and otherwise consults `IConditionalNativeScheduling` on the underlying sender (unwrapping `SendingAgent`/`InlineSendingAgent`, with `BatchedSender` delegating to its protocol and `TenantedSender` to its default sender). Senders that don't implement the interface behave exactly as before.
* All three runtime decision sites now use the envelope-aware check instead of the bare property, with the envelope they already had in hand:
  * `MessageRoute.WriteEnvelope` (routing)
  * `DestinationEndpoint.SendAsync` / `SendRawMessageAsync`
  * `MessageContext.FlushOutgoingMessagesAsync` (outbox flush, non-durable senders)

When the per-envelope answer is "no", the envelope takes the **pre-existing** fallback path (`ForScheduledSend` → `local://durable`): the durable inbox scheduler with a message store, or the in-memory scheduler on storageless apps. Long delays are therefore never clamped and never lost — they simply keep the exact behavior they had before this PR.

## SQS transport changes

* `AmazonSqsQueue.CanScheduleNatively`: standard queue AND (`ScheduledTime - now`) ≤ 900s. FIFO queues always answer `false` (SQS only supports queue-level delay there, never per-message).
* `AmazonSqsQueue.NativeDelaySecondsFor`: computes the `DelaySeconds` to stamp (rounds up to whole seconds, 0 for past/absent times). A > 900s value cannot reach the sender through normal publishing because routing already fell back, but as defense in depth it is capped at 900 **with a warning log** rather than silently.
* `DelaySeconds` is applied on **both send paths**: the inline sender (`AmazonSqsQueue.SendMessageAsync` → `SendMessageRequest.DelaySeconds`) and the batched protocol (`OutgoingSqsBatch` → `SendMessageBatchRequestEntry.DelaySeconds`).
* Capability reporting: `InlineSqsSender.SupportsNativeScheduledSend => !IsFifoQueue`; `SqsSenderProtocol` now implements `ISenderProtocolWithNativeScheduling` (+ the conditional interface), and `CreateSender` forces `SupportsNativeScheduledSend = false` on the batched sender for FIFO queues.

## Behavior matrix

| Scenario | Behavior |
|---|---|
| Standard queue, delay ≤ 15 min | Sent immediately with native `DelaySeconds` (works storageless; durable endpoints store-and-forward as before and delete the outgoing row on successful handoff to SQS) |
| Standard queue, delay > 15 min | Pre-existing fallback: durable inbox scheduling with a message store, in-memory scheduler without |
| FIFO queue, any delay | Always the fallback — never per-message delay |

## Tests (`scheduled_send_native_delay_3472.cs`)

* Unit: `CanScheduleNatively` / `NativeDelaySecondsFor` decision table (standard vs FIFO, window boundary, round-up, past times, defensive cap).
* Integration (LocalStack, **no message store** so native delivery can't be confused with DB polling):
  * Standard queue, batched sender: 5s scheduled send arrives after the delay, straight to `sqs://` with no `local://durable` wrapper record.
  * Standard queue, inline sender: same, over `SendInline()`.
  * Standard queue, 20-minute delay: falls back — captured by Wolverine scheduling, nothing sent to the broker.
  * FIFO queue: agent reports no native support; a 5s scheduled send still delivers via the fallback.
* Per-envelope decision surface: agent reports `SupportsNativeScheduledSendFor` true at +5 min, false at +20 min on a standard queue; always false on FIFO.

## Docs

* New page `docs/guide/messaging/transports/sqs/scheduled.md` (native delay, 15-minute limit, standard-vs-FIFO, fallback semantics incl. storageless caveat) + sidebar entry.
* FIFO queue page cross-links the scheduled-delivery behavior.

Out of scope per the issue: FIFO staging-queue re-loop for unbounded delay; EventBridge Scheduler backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
