### PR TITLE
Dead-letter metric: only MovedToErrorQueue marks a dead letter

### DIFF
--- a/src/Wolverine/Runtime/Metrics/RecordDeadLetter.cs
+++ b/src/Wolverine/Runtime/Metrics/RecordDeadLetter.cs
@@ -2,7 +2,8 @@ namespace Wolverine.Runtime.Metrics;
 
 /// <summary>
 /// Records that a message was moved to the dead-letter queue after exhausting all retry
-/// policies. Posted when <c>MovedToErrorQueue</c> or <c>MessageFailed</c> is called.
+/// policies. Posted only when <c>MovedToErrorQueue</c> is called — a plain
+/// <c>MessageFailed</c> is not a dead letter (CritterWatch GH-721).
 /// Increments the dead-letter count for <see cref="ExceptionType"/> in
 /// <see cref="PerTenantTracking.DeadLetterCounts"/>.
 /// </summary>

--- a/src/Wolverine/Runtime/WolverineRuntime.DirectMetrics.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.DirectMetrics.cs
@@ -104,8 +104,14 @@ public partial class WolverineRuntime
         {
             var time = DateTimeOffset.UtcNow.Subtract(envelope.SentAt.ToUniversalTime()).TotalMilliseconds;
             _sink.Post(new RecordEffectiveTime(time, envelope.TenantId!));
-            _sink.Post(new RecordDeadLetter(ex.GetType().FullNameInCode(), envelope.TenantId!));
-            
+            // Deliberately NOT posting RecordDeadLetter here (CritterWatch GH-721):
+            // MessageFailed fires on failure paths that never write a dead-letter row
+            // (cascading post-processing failures, batch item failures), and the real
+            // DLQ move raises MovedToErrorQueue right after MessageFailed — posting
+            // from both double-counted every genuine dead letter and reported
+            // thousands of phantom dead letters per hour over empty DLQ tables.
+            // Exceptions are already tracked via RecordFailure in LogException.
+
             _runtime.ActiveSession?.Record(MessageEventType.Sent, envelope, _serviceName, _uniqueNodeId, ex);
         }
 

--- a/src/Wolverine/Runtime/WolverineRuntime.HybridMetricsPublishingMessageTracker.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HybridMetricsPublishingMessageTracker.cs
@@ -72,7 +72,9 @@ public partial class WolverineRuntime
         {
             var time = DateTimeOffset.UtcNow.Subtract(envelope.SentAt.ToUniversalTime()).TotalMilliseconds;
             _sink.Post(new RecordEffectiveTime(time, envelope.TenantId!));
-            _sink.Post(new RecordDeadLetter(ex.GetType().FullNameInCode(), envelope.TenantId!));
+            // Deliberately NOT posting RecordDeadLetter here — see the identical
+            // note in WolverineRuntime.DirectMetrics.MessageFailed (CritterWatch
+            // GH-721): only MovedToErrorQueue marks a real dead letter.
 
             _runtime.MessageFailed(envelope, ex);
         }


### PR DESCRIPTION
## The defect

`MessageFailed` posted `RecordDeadLetter` in both the direct and hybrid metrics trackers, corrupting the exported `DeadLetters` count two ways:

1. **Every real dead letter double-counted** — `MoveToErrorQueue.ExecuteAsync` raises `MessageFailed` and `MovedToErrorQueue` back-to-back (`MoveToErrorQueue.cs:63-64`), so each genuine DLQ move posted `RecordDeadLetter` twice.
2. **Phantom dead letters** — `MessageFailed` also fires on failure paths that never write a dead-letter row: cascading post-processing failures (`MessageSucceededContinuation`), batch item failures (`ApplyItemContinuation` / `ProbeIndividuallyContinuation`). Monitored systems reported thousands of dead letters per hour over provably-empty `wolverine_dead_letters` tables.

Field evidence: JasperFx/CritterWatch#721 — four surfaces disagreeing at once (services table 3682 DLQ/hr red + firing MetricsDlqRate alert, vs a zero-row DLQ browser and dashboard, vs `psql` showing empty tables).

## The fix

`RecordDeadLetter` posts only from `MovedToErrorQueue`, matching its own doc contract ("moved to the dead-letter queue after exhausting all retry policies"). Exceptions remain tracked via `RecordFailure` in `LogException`; `MessageFailed` still records effective time + session events. Doc comment on `RecordDeadLetter` updated.

## Tests

CoreTests `--filter Metrics`: 27/27 green on net9.0 + net10.0 (the accumulation tests exercise the record pipeline and are unaffected; no existing test pinned the MessageFailed→RecordDeadLetter posting — which is how this slipped through). CritterWatch will add a fleet-level "no-phantom" E2E (exceptions>0 with empty DLQ table ⇒ DLQ/hr renders 0) as its acceptance gate once the pins pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)