### PR TITLE
Conjoined EF Core multi-tenancy epic: ITenanted core, tenant partitioning, tenant registry, HTTP detection (GH-3465)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -124,13 +124,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.18.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.18.0" />
-    <PackageVersion Include="Weasel.MySql" Version="9.18.0" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.18.0" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.18.0" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.18.0" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.18.0" />
+    <PackageVersion Include="Weasel.Core" Version="9.18.1" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.18.1" />
+    <PackageVersion Include="Weasel.MySql" Version="9.18.1" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.18.1" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.18.1" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.18.1" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.18.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,20 +35,20 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.29.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.29.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.29.0" />
+    <PackageVersion Include="JasperFx" Version="2.30.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.30.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.30.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.29.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.30.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
-    <PackageVersion Include="Marten" Version="9.16.0" />
+    <PackageVersion Include="Marten" Version="9.16.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="[5.2.0,6.0.0)" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.16.0" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.16.0" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.16.1" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.16.1" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />
@@ -124,13 +124,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.17.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.17.0" />
-    <PackageVersion Include="Weasel.MySql" Version="9.17.0" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.17.0" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.17.0" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.17.0" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.17.0" />
+    <PackageVersion Include="Weasel.Core" Version="9.18.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.18.0" />
+    <PackageVersion Include="Weasel.MySql" Version="9.18.0" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.18.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.18.0" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.18.0" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.18.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/docs/guide/durability/efcore/multi-tenancy.md
+++ b/docs/guide/durability/efcore/multi-tenancy.md
@@ -47,7 +47,7 @@ builder.UseWolverine(opts =>
     }, AutoCreate.CreateOrUpdate);
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L24-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_static_tenant_registry_with_postgresql' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L25-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_static_tenant_registry_with_postgresql' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And instead with [multi-tenanted SQL Server](/guide/durability/sqlserver.html#multi-tenancy) storage:
@@ -87,7 +87,7 @@ builder.UseWolverine(opts =>
     }, AutoCreate.CreateOrUpdate);
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L55-L88' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_static_tenant_registry_with_sqlserver' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L56-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_static_tenant_registry_with_sqlserver' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note in both samples how I'm registering the `DbContext` types. There's a fluent interface first to register the multi-tenanted
@@ -172,7 +172,7 @@ builder.UseWolverine(opts =>
     }, AutoCreate.CreateOrUpdate);
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L55-L88' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_static_tenant_registry_with_sqlserver' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L56-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_static_tenant_registry_with_sqlserver' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Then you can _still_ use those EF Core `DbContext` services with Wolverine messaging including the Wolverine outbox like 
@@ -209,7 +209,7 @@ public class MyMessageHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L184-L213' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_idbcontextoutboxfactory' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L185-L214' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_idbcontextoutboxfactory' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The important thing to note above is just that this pattern and service will work with any .NET code and not just within Wolverine
@@ -245,7 +245,7 @@ public class TenantedItem : ITenanted
     public string? TenantId { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L247-L262' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenanted_entity' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L304-L319' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenanted_entity' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 and registering the `DbContext` with conjoined tenancy:
@@ -275,7 +275,7 @@ builder.UseWolverine(opts =>
         }, AutoCreate.CreateOrUpdate);
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L221-L244' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenancy_with_postgresql' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L222-L245' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenancy_with_postgresql' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 With that registration, Wolverine takes over all the mechanical multi-tenancy chores you would otherwise hand-roll
@@ -296,3 +296,85 @@ Note that a `DbContext` type registered with conjoined tenancy is pinned to the 
 at the time it's created. If you need to query across tenants for administrative functions, use `IgnoreQueryFilters()`
 in your LINQ queries — but remember that the write-side guards will still stop you from modifying another tenant's data
 through a tenant-pinned `DbContext`.
+
+### Tenant Partitioning <Badge type="tip" text="6.21" />
+
+Opt into Weasel-managed **partition-per-tenant** physical partitioning with `PartitionPerTenant()`:
+
+<!-- snippet: sample_conjoined_tenancy_with_partitioning -->
+<a id='snippet-sample_conjoined_tenancy_with_partitioning'></a>
+```cs
+opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedTenancy.ConjoinedItemsDbContext>(
+    (builder, connectionString) => builder.UseNpgsql(connectionString.Value),
+    AutoCreate.CreateOrUpdate,
+
+    // Weasel-managed physical partitioning: one partition (or shared
+    // bucket) per tenant on every non-saga ITenanted entity table
+    tenancy => tenancy.PartitionPerTenant());
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L257-L265' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenancy_with_partitioning' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+With partitioning enabled:
+
+* On PostgreSQL, every non-saga `ITenanted` entity table becomes `PARTITION BY LIST (tenant_id)` with one partition per tenant, managed through a `wolverine_tenant_partitions` control table in the durability schema
+* On SQL Server (which can only range-partition over a compact value), entities gain an `int tenant_ordinal` column stamped automatically by Wolverine, and tables are `RANGE RIGHT` partitioned over the ordinal with a registry table mapping tenant ids to ordinals
+* The composite `(tenant, id)` primary key exists **only in the database** — your EF model keeps its own single key, so `FindAsync()`, `Attach()`, and saga loads keep exactly the same call shapes
+* Multiple small tenants can share one physical partition ("bucketing") by registering them with the same partition suffix — the answer to SQL Server's partition count ceiling and to "small tenants don't deserve their own partition"
+* Partitioned conjoined contexts require `UseEntityFrameworkCoreWolverineManagedMigrations()` — EF migrations cannot express the partition DDL
+
+Manage tenants through `IConjoinedTenantPartitions<TDbContext>`:
+
+<!-- snippet: sample_conjoined_partitioning_tenant_management -->
+<a id='snippet-sample_conjoined_partitioning_tenant_management'></a>
+```cs
+var partitions = host.Services
+    .GetRequiredService<IConjoinedTenantPartitions<ConjoinedTenancy.ConjoinedItemsDbContext>>();
+
+// Each tenant gets its own physical partition
+await partitions.AddTenantAsync("tenant1");
+
+// Or share one partition between small tenants ("bucketing") --
+// requires AllowPartitionSharing on the partitioning options
+await partitions.AddTenantAsync("small-tenant-a", "shared_bucket");
+await partitions.AddTenantAsync("small-tenant-b", "shared_bucket");
+
+// Dropping a tenant's partition removes its rows
+await partitions.DropTenantAsync("tenant1", deleteData: true);
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L271-L285' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_partitioning_tenant_management' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Note that with partitioning enabled, a tenant's partition must exist before rows can be written for that tenant.
+Sagas are deliberately **not** partitioned in this release — they keep the conjoined query filtering and tenant
+stamping, but stay in unpartitioned tables so saga identity is untouched.
+
+### The Tenant Registry <Badge type="tip" text="6.21" />
+
+Conjoined registrations keep an authoritative tenant list in the `wolverine_tenants` table in the durability schema —
+the same table Wolverine's master-table tenancy uses, with an empty connection string marking a shared-database tenant.
+The registry is exposed through JasperFx's `IDynamicTenantSource<string>`, which is also what lights up tenant
+management from [CritterWatch](https://critterwatch.io):
+
+<!-- snippet: sample_conjoined_tenant_registry -->
+<a id='snippet-sample_conjoined_tenant_registry'></a>
+```cs
+var tenants = host.Services.GetRequiredService<IDynamicTenantSource<string>>();
+
+// Registers the tenant in wolverine_tenants (and creates its
+// partitions when partitioning is enabled)
+await tenants.AddTenantAsync("tenant1", CancellationToken.None);
+
+// Soft delete: the tenant's data stays, but writes are rejected
+await tenants.DisableTenantAsync("tenant1");
+await tenants.EnableTenantAsync("tenant1");
+
+// Hard delete: registry record removed; with partitioning enabled the
+// tenant's partition is dropped along with its rows
+await tenants.RemoveTenantAsync("tenant1");
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L287-L301' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenant_registry' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Disabled tenants are rejected at `SaveChanges` time with `UnknownTenantIdException`. Removing a tenant deletes its
+registry record, and — when partitioning is enabled — drops the tenant's partition *including its rows*.

--- a/docs/guide/durability/efcore/multi-tenancy.md
+++ b/docs/guide/durability/efcore/multi-tenancy.md
@@ -215,3 +215,84 @@ public class MyMessageHandler
 The important thing to note above is just that this pattern and service will work with any .NET code and not just within Wolverine
 handlers or HTTP endpoints. This is your primary mechanism most likely to start transforming an existing AspNetCore system that isn't
 using Wolverine.HTTP. 
+
+## Conjoined Multi-Tenancy <Badge type="tip" text="6.21" />
+
+::: tip
+Conjoined tenancy is the same model Marten calls ["conjoined" multi-tenancy](https://martendb.io/documents/multi-tenancy.html) —
+one shared database and schema, with each row tagged and filtered by a `tenant_id` column. The `ITenanted` marker interface is
+shared across the whole Critter Stack from `JasperFx.MultiTenancy`, so the exact same marker drives conjoined behavior in
+Marten, Polecat, and Wolverine's EF Core integration.
+:::
+
+The database-per-tenant model above isn't the right fit for every system. If you want all tenants in a **single, shared
+database** — one connection string, one set of tables, a `tenant_id` discriminator column — use Wolverine's *conjoined*
+multi-tenancy for EF Core. Marking an entity with `JasperFx.MultiTenancy.ITenanted` is all it takes:
+
+<!-- snippet: sample_conjoined_tenanted_entity -->
+<a id='snippet-sample_conjoined_tenanted_entity'></a>
+```cs
+// Implementing the JasperFx.MultiTenancy.ITenanted interface --
+// the same marker interface Marten uses for conjoined tenancy --
+// opts this entity into Wolverine's conjoined multi-tenancy
+public class TenantedItem : ITenanted
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+
+    // Wolverine maps, stamps, and hydrates this for you. Treat the
+    // value as framework-managed
+    public string? TenantId { get; set; }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L247-L262' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenanted_entity' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+and registering the `DbContext` with conjoined tenancy:
+
+<!-- snippet: sample_conjoined_tenancy_with_postgresql -->
+<a id='snippet-sample_conjoined_tenancy_with_postgresql'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+
+var configuration = builder.Configuration;
+
+builder.UseWolverine(opts =>
+{
+    // One single database for messaging persistence *and*
+    // all tenanted application data
+    opts.PersistMessagesWithPostgresql(configuration.GetConnectionString("main")!);
+
+    // Conjoined multi-tenancy: every entity implementing
+    // JasperFx.MultiTenancy.ITenanted is mapped with a tenant_id column,
+    // filtered by the current tenant on every query, stamped with the
+    // ambient tenant id on inserts, and guarded against cross-tenant
+    // updates and deletes
+    opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedTenancy.ConjoinedItemsDbContext>(
+        (builder, connectionString) =>
+        {
+            builder.UseNpgsql(connectionString.Value);
+        }, AutoCreate.CreateOrUpdate);
+});
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L221-L244' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenancy_with_postgresql' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+With that registration, Wolverine takes over all the mechanical multi-tenancy chores you would otherwise hand-roll
+with EF Core query filters:
+
+* Every `ITenanted` entity is mapped with a `tenant_id` column (defaulted to Wolverine's `*DEFAULT*` tenant sentinel) and an index on that column
+* A global query filter binds every query to the tenant of the current message or HTTP request — there are no named filters for your team to remember, and no "one forgotten `IgnoreQueryFilters()`" data leakage from ad hoc LINQ
+* On `SaveChanges`, inserted entities are stamped with the ambient tenant id (after any `TenantIdStyle` correction)
+* Updates or deletes against an entity belonging to a *different* tenant throw `CrossTenantWriteException` instead of quietly crossing tenant boundaries
+* Sagas implementing `ITenanted` get tenant-scoped loads — the same saga id in two different tenants are two different sagas as far as loading is concerned
+* All of Wolverine's existing tenant id detection (message `TenantId`, [HTTP tenant detection](/guide/http/multi-tenancy.html#tenant-id-detection), `InvokeForTenantAsync()`) flows through unchanged
+
+Because conjoined tenancy is a single database, the messaging storage is just the plain, non-tenanted message store —
+there's no per-tenant inbox/outbox to manage, and the transactional middleware and outbox work exactly as they do in
+a single-tenant application.
+
+Note that a `DbContext` type registered with conjoined tenancy is pinned to the tenant id of the message being handled
+at the time it's created. If you need to query across tenants for administrative functions, use `IgnoreQueryFilters()`
+in your LINQ queries — but remember that the write-side guards will still stop you from modifying another tenant's data
+through a tenant-pinned `DbContext`.

--- a/src/Http/Wolverine.Http.Tests.EfCoreOnly/ConjoinedTenancyEndpoints.cs
+++ b/src/Http/Wolverine.Http.Tests.EfCoreOnly/ConjoinedTenancyEndpoints.cs
@@ -1,0 +1,47 @@
+using JasperFx.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Wolverine.Http;
+
+namespace Wolverine.Http.Tests.EfCoreOnly;
+
+public class TenantedNote : ITenanted
+{
+    public Guid Id { get; set; }
+    public string Text { get; set; } = null!;
+    public string? TenantId { get; set; }
+}
+
+public class ConjoinedNotesDbContext : DbContext
+{
+    public ConjoinedNotesDbContext(DbContextOptions<ConjoinedNotesDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<TenantedNote> Notes { get; set; } = null!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TenantedNote>(map =>
+        {
+            map.ToTable("tenanted_notes", "conjoined_http");
+            map.HasKey(x => x.Id);
+        });
+    }
+}
+
+public record CreateNote(Guid Id, string Text);
+
+public static class ConjoinedNotesEndpoint
+{
+    [WolverinePost("/conjoined/notes/create")]
+    public static void Post(CreateNote command, ConjoinedNotesDbContext db)
+    {
+        db.Notes.Add(new TenantedNote { Id = command.Id, Text = command.Text });
+    }
+
+    [WolverineGet("/conjoined/notes")]
+    public static Task<TenantedNote[]> Get(ConjoinedNotesDbContext db)
+    {
+        return db.Notes.OrderBy(x => x.Text).ToArrayAsync();
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/MultiTenancy/conjoined_tenancy_http_detection.cs
+++ b/src/Http/Wolverine.Http.Tests/MultiTenancy/conjoined_tenancy_http_detection.cs
@@ -1,0 +1,104 @@
+using Alba;
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Resources;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Shouldly;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Http.Tests.EfCoreOnly;
+using Wolverine.Postgresql;
+using Xunit;
+
+namespace Wolverine.Http.Tests.MultiTenancy;
+
+// GH-3462/GH-3465 Phase 4: HTTP tenant detection flowing into conjoined EF Core
+// multi-tenancy -- the detected tenant pins the DbContext, stamps writes, and
+// scopes reads, with zero tenant-awareness in the endpoint code
+public class conjoined_tenancy_http_detection : IAsyncLifetime
+{
+    private IAlbaHost theHost = null!;
+
+    public async Task InitializeAsync()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "DROP SCHEMA IF EXISTS conjoined_http CASCADE";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var builder = WebApplication.CreateBuilder();
+
+        builder.Services.AddWolverineHttp();
+
+        // The sibling endpoints in the EfCoreOnly assembly need their own DbContext
+        // registered for chain building
+        builder.Services.AddDbContextWithWolverineIntegration<Bug3353DbContext>(x =>
+            x.UseNpgsql(Servers.PostgresConnectionString));
+
+        builder.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedNotesDbContext>(
+            (options, connectionString) => options.UseNpgsql(connectionString.Value),
+            AutoCreate.CreateOrUpdate);
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.ApplicationAssembly = typeof(ConjoinedNotesEndpoint).Assembly;
+            opts.Durability.Mode = DurabilityMode.Solo;
+            opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "conjoined_http_wolverine");
+            opts.UseEntityFrameworkCoreTransactions();
+            opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+            opts.Policies.AutoApplyTransactions();
+            opts.Services.AddResourceSetupOnStartup();
+            opts.Discovery.DisableConventionalDiscovery();
+        });
+
+        theHost = await AlbaHost.For(builder, app =>
+        {
+            app.MapWolverineEndpoints(x =>
+            {
+                x.TenantId.IsQueryStringValue("tenant");
+                x.TenantId.IsRequestHeaderValue("tenant");
+            });
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task detected_tenant_stamps_writes_and_scopes_reads()
+    {
+        var greenNote = new CreateNote(Guid.NewGuid(), "green thoughts");
+        var blueNote = new CreateNote(Guid.NewGuid(), "blue thoughts");
+
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(greenNote).ToUrl("/conjoined/notes/create");
+            x.WithRequestHeader("tenant", "green");
+            x.StatusCodeShouldBe(204);
+        });
+
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(blueNote).ToUrl("/conjoined/notes/create");
+            x.WithRequestHeader("tenant", "blue");
+            x.StatusCodeShouldBe(204);
+        });
+
+        var greenResult = await theHost.GetAsJson<TenantedNote[]>("/conjoined/notes?tenant=green");
+        greenResult.ShouldNotBeNull();
+        greenResult.Single().Id.ShouldBe(greenNote.Id);
+        greenResult.Single().TenantId.ShouldBe("green");
+
+        var blueResult = await theHost.GetAsJson<TenantedNote[]>("/conjoined/notes?tenant=blue");
+        blueResult.ShouldNotBeNull();
+        blueResult.Single().Id.ShouldBe(blueNote.Id);
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/MultiTenancy/multi_tenancy_detection_and_integration.cs
+++ b/src/Http/Wolverine.Http.Tests/MultiTenancy/multi_tenancy_detection_and_integration.cs
@@ -524,7 +524,7 @@ public class MauveTenantDetection : ITenantDetection
 
 public record CreateTodo(string Id, string Description);
 
-public class TenantTodo : ITenanted
+public class TenantTodo : global::Marten.Metadata.ITenanted
 {
     public string Id { get; set; } = null!;
     public string Description { get; set; } = null!;

--- a/src/Persistence/EfCoreTests.MultiTenancy/Bug_3497_model_cache_key_includes_wolverine_schema.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/Bug_3497_model_cache_key_includes_wolverine_schema.cs
@@ -1,0 +1,62 @@
+using IntegrationTests;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using SharedPersistenceModels.Items;
+using Wolverine;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Postgresql;
+using Xunit;
+
+namespace EfCoreTests.MultiTenancy;
+
+// GH-3497: EF caches the built model per context type by default, so two hosts in one
+// process sharing a DbContext type but using different Wolverine durability schemas
+// silently shared whichever envelope-table mapping was built first -- the second host
+// wrote envelopes into the first host's schema (surfaced as ordering-dependent
+// failures in this very test assembly, where Bug_2739's unprovisioned bug2739_master
+// schema leaked into the SQL Server multi-tenancy suites)
+[Collection("multi-tenancy")]
+public class Bug_3497_model_cache_key_includes_wolverine_schema
+{
+    [Fact]
+    public async Task two_hosts_with_different_wolverine_schemas_get_distinct_envelope_mappings()
+    {
+        using var hostA = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "bug3497_a");
+                opts.Services.AddDbContextWithWolverineIntegration<ItemsDbContext>(
+                    x => x.UseNpgsql(Servers.PostgresConnectionString));
+            }).StartAsync();
+
+        using var hostB = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "bug3497_b");
+                opts.Services.AddDbContextWithWolverineIntegration<ItemsDbContext>(
+                    x => x.UseNpgsql(Servers.PostgresConnectionString));
+            }).StartAsync();
+
+        using var scopeA = hostA.Services.CreateScope();
+        using var scopeB = hostB.Services.CreateScope();
+
+        var schemaA = envelopeSchemaOf(scopeA.ServiceProvider.GetRequiredService<ItemsDbContext>());
+        var schemaB = envelopeSchemaOf(scopeB.ServiceProvider.GetRequiredService<ItemsDbContext>());
+
+        schemaA.ShouldBe("bug3497_a");
+        schemaB.ShouldBe("bug3497_b");
+    }
+
+    private static string? envelopeSchemaOf(DbContext context)
+    {
+        var incoming = context.Model.GetEntityTypes()
+            .Single(x => x.ClrType.Name == "IncomingMessage");
+        return incoming.GetSchema();
+    }
+}

--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedPartitioningCompliance.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedPartitioningCompliance.cs
@@ -1,0 +1,274 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.MultiTenancy;
+using JasperFx.Resources;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore.Internals;
+using Wolverine.Postgresql;
+using Wolverine.SqlServer;
+using Wolverine.Tracking;
+using ConjoinedTenancyRuntime = Wolverine.EntityFrameworkCore.Internals.ConjoinedTenancy;
+
+namespace EfCoreTests.MultiTenancy.ConjoinedTenancy;
+
+public class PartitionedItem : ITenanted
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string? TenantId { get; set; }
+}
+
+// Sagas are excluded from physical partitioning in this release; this type
+// proves the exclusion leaves the saga's identity alone
+[WolverineIgnore]
+public class PartitionedCounterSaga : Saga, ITenanted
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+    public string? TenantId { get; set; }
+
+    public static PartitionedCounterSaga Start(StartCounter command)
+    {
+        return new PartitionedCounterSaga { Id = command.Id };
+    }
+
+    public void Handle(IncrementCounter command)
+    {
+        Count++;
+    }
+}
+
+public record CreatePartitionedItem(Guid Id, string Name);
+
+[WolverineIgnore]
+public class PartitionedItemHandler
+{
+    public static void Handle(CreatePartitionedItem command, PartitionedItemsDbContext db)
+    {
+        db.Items.Add(new PartitionedItem { Id = command.Id, Name = command.Name });
+    }
+}
+
+public class PartitionedItemsDbContext : DbContext
+{
+    public PartitionedItemsDbContext(DbContextOptions<PartitionedItemsDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<PartitionedItem> Items { get; set; } = null!;
+    public DbSet<PartitionedCounterSaga> Counters { get; set; } = null!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<PartitionedItem>(map =>
+        {
+            map.ToTable("partitioned_items", "conjoined_part");
+            map.HasKey(x => x.Id);
+        });
+
+        modelBuilder.Entity<PartitionedCounterSaga>(map =>
+        {
+            map.ToTable("partitioned_counters", "conjoined_part");
+            map.HasKey(x => x.Id);
+        });
+    }
+}
+
+[Collection("multi-tenancy")]
+public abstract class ConjoinedPartitioningCompliance : IAsyncLifetime
+{
+    private readonly DatabaseEngine _engine;
+    protected IConjoinedTenantPartitions<PartitionedItemsDbContext> thePartitions = null!;
+    protected IDbContextBuilder<PartitionedItemsDbContext> theBuilder = null!;
+    protected IHost theHost = null!;
+
+    protected ConjoinedPartitioningCompliance(DatabaseEngine engine)
+    {
+        _engine = engine;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await dropPartitionedObjectsAsync();
+
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<PartitionedItemHandler>()
+                    .IncludeType<PartitionedCounterSaga>();
+
+                if (_engine == DatabaseEngine.PostgreSQL)
+                {
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "conjoined_part_wolverine");
+                    opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<PartitionedItemsDbContext>(
+                        (builder, connectionString) => builder.UseNpgsql(connectionString.Value),
+                        AutoCreate.CreateOrUpdate,
+                        tenancy => tenancy.PartitionPerTenant());
+                }
+                else
+                {
+                    opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "conjoined_part_wolverine");
+                    opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<PartitionedItemsDbContext>(
+                        (builder, connectionString) => builder.UseSqlServer(connectionString.Value),
+                        AutoCreate.CreateOrUpdate,
+                        tenancy => tenancy.PartitionPerTenant());
+                }
+
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+                opts.Policies.AutoApplyTransactions();
+                opts.Services.AddResourceSetupOnStartup();
+                opts.PublishAllMessages().Locally();
+            }).StartAsync();
+
+        theBuilder = theHost.Services.GetRequiredService<IDbContextBuilder<PartitionedItemsDbContext>>();
+        thePartitions = theHost.Services
+            .GetRequiredService<IConjoinedTenantPartitions<PartitionedItemsDbContext>>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private async Task dropPartitionedObjectsAsync()
+    {
+        if (_engine == DatabaseEngine.PostgreSQL)
+        {
+            await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "DROP SCHEMA IF EXISTS conjoined_part CASCADE; DROP SCHEMA IF EXISTS conjoined_part_wolverine CASCADE;";
+            await cmd.ExecuteNonQueryAsync();
+        }
+        else
+        {
+            await using var conn = new SqlConnection(Servers.SqlServerConnectionString);
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+IF OBJECT_ID('conjoined_part.partitioned_items') IS NOT NULL DROP TABLE conjoined_part.partitioned_items;
+IF OBJECT_ID('conjoined_part.partitioned_counters') IS NOT NULL DROP TABLE conjoined_part.partitioned_counters;
+IF OBJECT_ID('conjoined_part_wolverine.wolverine_tenant_partitions') IS NOT NULL DROP TABLE conjoined_part_wolverine.wolverine_tenant_partitions;
+IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = 'ps_partitioned_items_tenant_ordinal') DROP PARTITION SCHEME ps_partitioned_items_tenant_ordinal;
+IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = 'pf_partitioned_items_tenant_ordinal') DROP PARTITION FUNCTION pf_partitioned_items_tenant_ordinal;";
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ef_model_keys_stay_single_and_sqlserver_maps_the_ordinal_column()
+    {
+        var context = await theBuilder.BuildAsync(CancellationToken.None);
+
+        // The composite (tenant, id) key lives only in the DATABASE; the EF model
+        // keeps the user's own key so FindAsync/Attach and saga loads are unchanged
+        var itemType = context.Model.FindEntityType(typeof(PartitionedItem))!;
+        itemType.FindPrimaryKey()!.Properties.Select(x => x.Name).ShouldBe([nameof(PartitionedItem.Id)]);
+
+        if (_engine == DatabaseEngine.SqlServer)
+        {
+            var ordinal = itemType.FindProperty(ConjoinedTenancyRuntime.TenantOrdinalPropertyName);
+            ordinal.ShouldNotBeNull();
+            ordinal.IsPrimaryKey().ShouldBeFalse();
+        }
+
+        // Saga identity is untouched by partitioning
+        var sagaType = context.Model.FindEntityType(typeof(PartitionedCounterSaga))!;
+        sagaType.FindPrimaryKey()!.Properties.Select(x => x.Name)
+            .ShouldBe([nameof(PartitionedCounterSaga.Id)]);
+    }
+
+    [Fact]
+    public async Task add_tenants_then_write_and_read_per_tenant()
+    {
+        await thePartitions.AddTenantAsync("green");
+        await thePartitions.AddTenantAsync("blue");
+
+        var greenId = Guid.NewGuid();
+        var blueId = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync("green", new CreatePartitionedItem(greenId, "g")));
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync("blue", new CreatePartitionedItem(blueId, "b")));
+
+        var green = await theBuilder.BuildAsync("green", CancellationToken.None);
+        (await green.Items.ToListAsync()).Single().Id.ShouldBe(greenId);
+
+        var blue = await theBuilder.BuildAsync("blue", CancellationToken.None);
+        (await blue.Items.ToListAsync()).Single().Id.ShouldBe(blueId);
+    }
+
+    [Fact]
+    public async Task adding_the_same_tenant_twice_is_idempotent()
+    {
+        await thePartitions.AddTenantAsync("green");
+        await thePartitions.AddTenantAsync("green");
+    }
+
+    [Fact]
+    public async Task writes_for_an_unregistered_tenant_fail()
+    {
+        var id = Guid.NewGuid();
+
+        await Should.ThrowAsync<Exception>(async () =>
+        {
+            await theHost.TrackActivity().DoNotAssertOnExceptionsDetected()
+                .ExecuteAndWaitAsync(c =>
+                    c.InvokeForTenantAsync("nobody-registered-this", new CreatePartitionedItem(id, "x")));
+        });
+    }
+
+    [Fact]
+    public async Task physical_partition_exists_per_tenant()
+    {
+        await thePartitions.AddTenantAsync("green");
+
+        if (_engine == DatabaseEngine.PostgreSQL)
+        {
+            await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+select count(*) from pg_inherits
+join pg_class parent on pg_inherits.inhparent = parent.oid
+join pg_namespace ns on parent.relnamespace = ns.oid
+where ns.nspname = 'conjoined_part' and parent.relname = 'partitioned_items'";
+            var partitionCount = (long)(await cmd.ExecuteScalarAsync())!;
+            partitionCount.ShouldBeGreaterThanOrEqualTo(1);
+        }
+        else
+        {
+            await using var conn = new SqlConnection(Servers.SqlServerConnectionString);
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                "SELECT COUNT(*) FROM conjoined_part_wolverine.wolverine_tenant_partitions WHERE tenant_id = 'green'";
+            ((int)(await cmd.ExecuteScalarAsync())!).ShouldBe(1);
+        }
+    }
+}
+
+public class conjoined_partitioning_with_postgresql : ConjoinedPartitioningCompliance
+{
+    public conjoined_partitioning_with_postgresql() : base(DatabaseEngine.PostgreSQL)
+    {
+    }
+}
+
+public class conjoined_partitioning_with_sqlserver : ConjoinedPartitioningCompliance
+{
+    public conjoined_partitioning_with_sqlserver() : base(DatabaseEngine.SqlServer)
+    {
+    }
+}

--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedTenancyCompliance.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedTenancyCompliance.cs
@@ -1,0 +1,237 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore.Internals;
+using Wolverine.Persistence.Sagas;
+using Wolverine.Postgresql;
+using Wolverine.SqlServer;
+using Wolverine.Tracking;
+
+namespace EfCoreTests.MultiTenancy.ConjoinedTenancy;
+
+/// <summary>
+///     Compliance battery for conjoined EF Core multi-tenancy (GH-3462). The assertions
+///     mirror Marten's conjoined tenancy semantics: default tenant sentinel, stamp on
+///     insert, tenant-bound query filtering, tenant-scoped saga loads, and cross-tenant
+///     write rejection
+/// </summary>
+[Collection("multi-tenancy")]
+public abstract class ConjoinedTenancyCompliance : IAsyncLifetime
+{
+    private readonly DatabaseEngine _engine;
+    protected IDbContextBuilder<ConjoinedItemsDbContext> theBuilder = null!;
+    protected IHost theHost = null!;
+
+    protected ConjoinedTenancyCompliance(DatabaseEngine engine)
+    {
+        _engine = engine;
+    }
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<ConjoinedItemHandler>()
+                    .IncludeType<ConjoinedCounterSaga>();
+
+                if (_engine == DatabaseEngine.PostgreSQL)
+                {
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "conjoined_wolverine");
+                    opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedItemsDbContext>(
+                        (builder, connectionString) => builder.UseNpgsql(connectionString.Value),
+                        AutoCreate.CreateOrUpdate);
+                }
+                else
+                {
+                    opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "conjoined_wolverine");
+                    opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedItemsDbContext>(
+                        (builder, connectionString) => builder.UseSqlServer(connectionString.Value),
+                        AutoCreate.CreateOrUpdate);
+                }
+
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Services.AddResourceSetupOnStartup();
+
+                opts.PublishAllMessages().Locally();
+            }).StartAsync();
+
+        theBuilder = theHost.Services.GetRequiredService<IDbContextBuilder<ConjoinedItemsDbContext>>();
+
+        // Start from clean tables every run
+        var context = await theBuilder.BuildAsync(CancellationToken.None);
+        await context.Items.IgnoreQueryFilters().ExecuteDeleteAsync();
+        await context.Counters.IgnoreQueryFilters().ExecuteDeleteAsync();
+        await context.GlobalThings.ExecuteDeleteAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task tenanted_entities_are_mapped_with_tenant_id_column_filter_and_index()
+    {
+        var context = await theBuilder.BuildAsync(CancellationToken.None);
+
+        var entityType = context.Model.FindEntityType(typeof(ConjoinedItem))!;
+        var property = entityType.FindProperty(nameof(ConjoinedItem.TenantId))!;
+
+        property.GetColumnName().ShouldBe(StorageConstants.TenantIdColumn);
+        property.GetDefaultValue().ShouldBe(StorageConstants.DefaultTenantId);
+        entityType.GetIndexes().ShouldContain(x => x.Properties.Any(p => p.Name == nameof(ConjoinedItem.TenantId)));
+        entityType.GetQueryFilter().ShouldNotBeNull();
+
+        // And an unmarked entity is left completely alone
+        var globalType = context.Model.FindEntityType(typeof(GlobalThing))!;
+        globalType.FindProperty(nameof(ConjoinedItem.TenantId)).ShouldBeNull();
+        globalType.GetQueryFilter().ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task handler_insert_stamps_the_ambient_tenant_id()
+    {
+        var id = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync("green", new CreateConjoinedItem(id, "one")));
+
+        var context = await theBuilder.BuildAsync("green", CancellationToken.None);
+        var item = await context.Items.FindAsync(id);
+
+        item.ShouldNotBeNull();
+        item.TenantId.ShouldBe("green");
+    }
+
+    [Fact]
+    public async Task insert_without_a_tenant_gets_the_default_tenant_sentinel()
+    {
+        var id = Guid.NewGuid();
+        await theHost.InvokeMessageAndWaitAsync(new CreateConjoinedItem(id, "plain"));
+
+        var context = await theBuilder.BuildAsync(CancellationToken.None);
+        var item = await context.Items.FindAsync(id);
+
+        item.ShouldNotBeNull();
+        item.TenantId.ShouldBe(StorageConstants.DefaultTenantId);
+    }
+
+    [Fact]
+    public async Task queries_are_bound_to_the_tenant_of_each_context_instance()
+    {
+        var greenId = Guid.NewGuid();
+        var blueId = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync("green", new CreateConjoinedItem(greenId, "same")));
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync("blue", new CreateConjoinedItem(blueId, "same")));
+
+        // Alternating tenants on separate context instances proves the filter follows
+        // the executing context instance, not a value captured when the model was cached
+        var green = await theBuilder.BuildAsync("green", CancellationToken.None);
+        var blue = await theBuilder.BuildAsync("blue", CancellationToken.None);
+        var greenAgain = await theBuilder.BuildAsync("green", CancellationToken.None);
+
+        (await green.Items.Where(x => x.Name == "same").ToListAsync()).Single().Id.ShouldBe(greenId);
+        (await blue.Items.Where(x => x.Name == "same").ToListAsync()).Single().Id.ShouldBe(blueId);
+        (await greenAgain.Items.Where(x => x.Name == "same").ToListAsync()).Single().Id.ShouldBe(greenId);
+    }
+
+    [Fact]
+    public async Task find_async_respects_the_tenant_filter()
+    {
+        // Saga loads are generated as FindAsync, so tenant-scoped saga correctness
+        // depends on this behavior
+        var greenId = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync("green", new CreateConjoinedItem(greenId, "mine")));
+
+        var blue = await theBuilder.BuildAsync("blue", CancellationToken.None);
+        (await blue.Items.FindAsync(greenId)).ShouldBeNull();
+
+        var green = await theBuilder.BuildAsync("green", CancellationToken.None);
+        (await green.Items.FindAsync(greenId)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task cross_tenant_update_is_rejected()
+    {
+        var id = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync("green", new CreateConjoinedItem(id, "guarded")));
+
+        var blue = await theBuilder.BuildAsync("blue", CancellationToken.None);
+        var smuggled = await blue.Items.IgnoreQueryFilters().SingleAsync(x => x.Id == id);
+        smuggled.Name = "hijacked";
+
+        var ex = await Should.ThrowAsync<CrossTenantWriteException>(() => blue.SaveChangesAsync());
+        ex.EntityTenantId.ShouldBe("green");
+        ex.ContextTenantId.ShouldBe("blue");
+    }
+
+    [Fact]
+    public async Task cross_tenant_delete_is_rejected()
+    {
+        var id = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync("green", new CreateConjoinedItem(id, "keeper")));
+
+        var blue = await theBuilder.BuildAsync("blue", CancellationToken.None);
+        var smuggled = await blue.Items.IgnoreQueryFilters().SingleAsync(x => x.Id == id);
+        blue.Items.Remove(smuggled);
+
+        await Should.ThrowAsync<CrossTenantWriteException>(() => blue.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task explicitly_stamped_foreign_tenant_id_on_insert_is_rejected()
+    {
+        var green = await theBuilder.BuildAsync("green", CancellationToken.None);
+        green.Items.Add(new ConjoinedItem { Id = Guid.NewGuid(), Name = "smuggle", TenantId = "blue" });
+
+        await Should.ThrowAsync<CrossTenantWriteException>(() => green.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task sagas_are_tenant_scoped()
+    {
+        var id = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync("green", new StartCounter(id)));
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync("green", new IncrementCounter(id)));
+
+        // The same saga id from another tenant must not load green's saga
+        await Should.ThrowAsync<UnknownSagaException>(() => theHost.TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .ExecuteAndWaitAsync(c => c.InvokeForTenantAsync("blue", new IncrementCounter(id))));
+
+        var green = await theBuilder.BuildAsync("green", CancellationToken.None);
+        var saga = await green.Counters.SingleAsync(x => x.Id == id);
+        saga.Count.ShouldBe(1);
+        saga.TenantId.ShouldBe("green");
+
+        var blue = await theBuilder.BuildAsync("blue", CancellationToken.None);
+        (await blue.Counters.FindAsync(id)).ShouldBeNull();
+    }
+}
+
+public class conjoined_tenancy_with_postgresql : ConjoinedTenancyCompliance
+{
+    public conjoined_tenancy_with_postgresql() : base(DatabaseEngine.PostgreSQL)
+    {
+    }
+}
+
+public class conjoined_tenancy_with_sqlserver : ConjoinedTenancyCompliance
+{
+    public conjoined_tenancy_with_sqlserver() : base(DatabaseEngine.SqlServer)
+    {
+    }
+}

--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedTenancyModel.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedTenancyModel.cs
@@ -1,0 +1,85 @@
+using JasperFx.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Wolverine;
+using Wolverine.Attributes;
+
+namespace EfCoreTests.MultiTenancy.ConjoinedTenancy;
+
+public class ConjoinedItem : ITenanted
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string? TenantId { get; set; }
+}
+
+// Deliberately NOT ITenanted -- proves the conventions only apply to marked entities
+public class GlobalThing
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+}
+
+public record CreateConjoinedItem(Guid Id, string Name);
+
+public record IncrementCounter(Guid Id);
+
+public record StartCounter(Guid Id);
+
+[WolverineIgnore]
+public class ConjoinedItemHandler
+{
+    public static void Handle(CreateConjoinedItem command, ConjoinedItemsDbContext db)
+    {
+        db.Items.Add(new ConjoinedItem { Id = command.Id, Name = command.Name });
+    }
+}
+
+[WolverineIgnore]
+public class ConjoinedCounterSaga : Saga, ITenanted
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+    public string? TenantId { get; set; }
+
+    public static ConjoinedCounterSaga Start(StartCounter command)
+    {
+        return new ConjoinedCounterSaga { Id = command.Id };
+    }
+
+    public void Handle(IncrementCounter command)
+    {
+        Count++;
+    }
+}
+
+public class ConjoinedItemsDbContext : DbContext
+{
+    public ConjoinedItemsDbContext(DbContextOptions<ConjoinedItemsDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<ConjoinedItem> Items { get; set; } = null!;
+    public DbSet<GlobalThing> GlobalThings { get; set; } = null!;
+    public DbSet<ConjoinedCounterSaga> Counters { get; set; } = null!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ConjoinedItem>(map =>
+        {
+            map.ToTable("conjoined_items", "conjoined");
+            map.HasKey(x => x.Id);
+        });
+
+        modelBuilder.Entity<GlobalThing>(map =>
+        {
+            map.ToTable("conjoined_global_things", "conjoined");
+            map.HasKey(x => x.Id);
+        });
+
+        modelBuilder.Entity<ConjoinedCounterSaga>(map =>
+        {
+            map.ToTable("conjoined_counters", "conjoined");
+            map.HasKey(x => x.Id);
+        });
+    }
+}

--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedTenantRegistryCompliance.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedTenantRegistryCompliance.cs
@@ -1,0 +1,157 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.MultiTenancy;
+using JasperFx.Resources;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Wolverine;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Postgresql;
+using Wolverine.SqlServer;
+using Wolverine.Tracking;
+
+namespace EfCoreTests.MultiTenancy.ConjoinedTenancy;
+
+/// <summary>
+///     Phase 3 battery (GH-3464): the wolverine_tenants registry as the
+///     authoritative tenant list for conjoined tenancy, exposed through
+///     IDynamicTenantSource for CritterWatch tenant management
+/// </summary>
+[Collection("multi-tenancy")]
+public abstract class ConjoinedTenantRegistryCompliance : IAsyncLifetime
+{
+    private readonly DatabaseEngine _engine;
+    protected IHost theHost = null!;
+    protected IDynamicTenantSource<string> theSource = null!;
+
+    protected ConjoinedTenantRegistryCompliance(DatabaseEngine engine)
+    {
+        _engine = engine;
+    }
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<ConjoinedItemHandler>();
+
+                if (_engine == DatabaseEngine.PostgreSQL)
+                {
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "conjoined_registry");
+                    opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedItemsDbContext>(
+                        (builder, connectionString) => builder.UseNpgsql(connectionString.Value),
+                        AutoCreate.CreateOrUpdate);
+                }
+                else
+                {
+                    opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "conjoined_registry");
+                    opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedItemsDbContext>(
+                        (builder, connectionString) => builder.UseSqlServer(connectionString.Value),
+                        AutoCreate.CreateOrUpdate);
+                }
+
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+                opts.Policies.AutoApplyTransactions();
+                opts.Services.AddResourceSetupOnStartup();
+                opts.PublishAllMessages().Locally();
+            }).StartAsync();
+
+        theSource = theHost.Services.GetRequiredService<IDynamicTenantSource<string>>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private async Task<int> countRegistryRowsAsync(string tenantId)
+    {
+        var sql =
+            $"SELECT COUNT(*) FROM conjoined_registry.wolverine_tenants WHERE tenant_id = '{tenantId}'";
+        if (_engine == DatabaseEngine.PostgreSQL)
+        {
+            await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+        }
+
+        await using var sqlConn = new SqlConnection(Servers.SqlServerConnectionString);
+        await sqlConn.OpenAsync();
+        await using var sqlCmd = sqlConn.CreateCommand();
+        sqlCmd.CommandText = sql;
+        return Convert.ToInt32(await sqlCmd.ExecuteScalarAsync());
+    }
+
+    [Fact]
+    public async Task registry_add_disable_enable_remove_round_trip()
+    {
+        var tenant = "registry_" + Guid.NewGuid().ToString("N").Substring(0, 8);
+
+        await theSource.AddTenantAsync(tenant, CancellationToken.None);
+        (await countRegistryRowsAsync(tenant)).ShouldBe(1);
+
+        // A registered, enabled tenant can write
+        var id = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync(tenant, new CreateConjoinedItem(id, "ok")));
+
+        // Disabling stops writes with UnknownTenantIdException
+        await theSource.DisableTenantAsync(tenant);
+        (await theSource.AllDisabledAsync()).ShouldContain(tenant);
+        await Should.ThrowAsync<UnknownTenantIdException>(() => theHost.TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .ExecuteAndWaitAsync(c => c.InvokeForTenantAsync(tenant, new CreateConjoinedItem(Guid.NewGuid(), "no"))));
+
+        // Re-enabling restores writes
+        await theSource.EnableTenantAsync(tenant);
+        await theHost.ExecuteAndWaitAsync(c =>
+            c.InvokeForTenantAsync(tenant, new CreateConjoinedItem(Guid.NewGuid(), "again")));
+
+        await theSource.RemoveTenantAsync(tenant);
+        (await countRegistryRowsAsync(tenant)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task explicit_connection_string_registration_is_rejected()
+    {
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            theSource.AddTenantAsync("whatever", "Host=elsewhere;Database=other"));
+    }
+
+    [Fact]
+    public async Task refresh_and_enumerate_active_tenants()
+    {
+        var tenant = "active_" + Guid.NewGuid().ToString("N").Substring(0, 8);
+        await theSource.AddTenantAsync(tenant, CancellationToken.None);
+
+        await theSource.RefreshAsync();
+        theSource.AllActiveByTenant().Select(x => x.TenantId).ShouldContain(tenant);
+
+        await theSource.RemoveTenantAsync(tenant);
+    }
+}
+
+public class conjoined_tenant_registry_with_postgresql : ConjoinedTenantRegistryCompliance
+{
+    public conjoined_tenant_registry_with_postgresql() : base(DatabaseEngine.PostgreSQL)
+    {
+    }
+}
+
+public class conjoined_tenant_registry_with_sqlserver : ConjoinedTenantRegistryCompliance
+{
+    public conjoined_tenant_registry_with_sqlserver() : base(DatabaseEngine.SqlServer)
+    {
+    }
+}

--- a/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs
@@ -214,3 +214,51 @@ public class MyMessageHandler
 
 public record CreateItem(string Name);
 
+public class ConjoinedTenancyDocumentationSamples
+{
+    public async Task conjoined_postgresql()
+    {
+        #region sample_conjoined_tenancy_with_postgresql
+        var builder = Host.CreateApplicationBuilder();
+
+        var configuration = builder.Configuration;
+
+        builder.UseWolverine(opts =>
+        {
+            // One single database for messaging persistence *and*
+            // all tenanted application data
+            opts.PersistMessagesWithPostgresql(configuration.GetConnectionString("main")!);
+
+            // Conjoined multi-tenancy: every entity implementing
+            // JasperFx.MultiTenancy.ITenanted is mapped with a tenant_id column,
+            // filtered by the current tenant on every query, stamped with the
+            // ambient tenant id on inserts, and guarded against cross-tenant
+            // updates and deletes
+            opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedTenancy.ConjoinedItemsDbContext>(
+                (builder, connectionString) =>
+                {
+                    builder.UseNpgsql(connectionString.Value);
+                }, AutoCreate.CreateOrUpdate);
+        });
+
+        #endregion
+    }
+
+    #region sample_conjoined_tenanted_entity
+
+    // Implementing the JasperFx.MultiTenancy.ITenanted interface --
+    // the same marker interface Marten uses for conjoined tenancy --
+    // opts this entity into Wolverine's conjoined multi-tenancy
+    public class TenantedItem : ITenanted
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = null!;
+
+        // Wolverine maps, stamps, and hydrates this for you. Treat the
+        // value as framework-managed
+        public string? TenantId { get; set; }
+    }
+
+    #endregion
+}
+

--- a/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs
@@ -12,6 +12,7 @@ using Wolverine;
 using Wolverine.ComplianceTests;
 using Wolverine.ComplianceTests.Scheduling;
 using Wolverine.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore.Internals;
 using Wolverine.Postgresql;
 using Wolverine.SqlServer;
 
@@ -241,6 +242,62 @@ public class ConjoinedTenancyDocumentationSamples
                 }, AutoCreate.CreateOrUpdate);
         });
 
+        #endregion
+    }
+
+    public async Task conjoined_partitioned_postgresql()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        var configuration = builder.Configuration;
+
+        builder.UseWolverine(opts =>
+        {
+            opts.PersistMessagesWithPostgresql(configuration.GetConnectionString("main")!);
+
+            #region sample_conjoined_tenancy_with_partitioning
+            opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedTenancy.ConjoinedItemsDbContext>(
+                (builder, connectionString) => builder.UseNpgsql(connectionString.Value),
+                AutoCreate.CreateOrUpdate,
+
+                // Weasel-managed physical partitioning: one partition (or shared
+                // bucket) per tenant on every non-saga ITenanted entity table
+                tenancy => tenancy.PartitionPerTenant());
+            #endregion
+        });
+    }
+
+    public static async Task conjoined_tenant_management(IHost host)
+    {
+        #region sample_conjoined_partitioning_tenant_management
+        var partitions = host.Services
+            .GetRequiredService<IConjoinedTenantPartitions<ConjoinedTenancy.ConjoinedItemsDbContext>>();
+
+        // Each tenant gets its own physical partition
+        await partitions.AddTenantAsync("tenant1");
+
+        // Or share one partition between small tenants ("bucketing") --
+        // requires AllowPartitionSharing on the partitioning options
+        await partitions.AddTenantAsync("small-tenant-a", "shared_bucket");
+        await partitions.AddTenantAsync("small-tenant-b", "shared_bucket");
+
+        // Dropping a tenant's partition removes its rows
+        await partitions.DropTenantAsync("tenant1", deleteData: true);
+        #endregion
+
+        #region sample_conjoined_tenant_registry
+        var tenants = host.Services.GetRequiredService<IDynamicTenantSource<string>>();
+
+        // Registers the tenant in wolverine_tenants (and creates its
+        // partitions when partitioning is enabled)
+        await tenants.AddTenantAsync("tenant1", CancellationToken.None);
+
+        // Soft delete: the tenant's data stays, but writes are rejected
+        await tenants.DisableTenantAsync("tenant1");
+        await tenants.EnableTenantAsync("tenant1");
+
+        // Hard delete: registry record removed; with partitioning enabled the
+        // tenant's partition is dropped along with its rows
+        await tenants.RemoveTenantAsync("tenant1");
         #endregion
     }
 

--- a/src/Persistence/EfCoreTests/Migrations/with_one_sqlserver_context.cs
+++ b/src/Persistence/EfCoreTests/Migrations/with_one_sqlserver_context.cs
@@ -105,7 +105,11 @@ public class with_one_sqlserver_context : IAsyncLifetime
 
 public class Blog
 {
+    // The did_apply test assigns the id explicitly; without this, EF's convention
+    // makes the int key an identity column and Weasel >= 9.18's faithful
+    // translation creates the table that way (weasel#382), rejecting explicit ids
     [Column("id")]
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public int BlogId { get; set; }
     
     [Column("url")]

--- a/src/Persistence/Wolverine.EntityFrameworkCore/ConjoinedTenancyOptions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/ConjoinedTenancyOptions.cs
@@ -1,0 +1,32 @@
+using Wolverine.RDBMS.MultiTenancy;
+
+namespace Wolverine.EntityFrameworkCore;
+
+/// <summary>
+///     Options for Wolverine's conjoined EF Core multi-tenancy
+/// </summary>
+public class ConjoinedTenancyOptions
+{
+    internal TenantPartitioningOptions? Partitioning { get; private set; }
+
+    public bool PartitioningEnabled => Partitioning != null;
+
+    /// <summary>
+    ///     Name of the Weasel partition control/registry table created in the
+    ///     Wolverine durability schema. Default is wolverine_tenant_partitions
+    /// </summary>
+    public string PartitionControlTableName { get; set; } = "wolverine_tenant_partitions";
+
+    /// <summary>
+    ///     Opt into Weasel-managed physical partitioning: every non-saga ITenanted
+    ///     entity table is partitioned per tenant (PostgreSQL LIST partitions on
+    ///     tenant_id; SQL Server RANGE partitions over a tenant ordinal column).
+    ///     Requires UseEntityFrameworkCoreWolverineManagedMigrations() -- EF
+    ///     migrations cannot express the partition DDL
+    /// </summary>
+    public void PartitionPerTenant(Action<TenantPartitioningOptions>? configure = null)
+    {
+        Partitioning = new TenantPartitioningOptions();
+        configure?.Invoke(Partitioning);
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/CrossTenantWriteException.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/CrossTenantWriteException.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolverine.EntityFrameworkCore;
+
+/// <summary>
+///     Thrown when a conjoined-multi-tenant DbContext tries to insert, update, or delete
+///     an ITenanted entity that belongs to a different tenant than the tenant the
+///     DbContext is scoped to. This is the write-side counterpart of the tenant global
+///     query filter and matches Marten's conjoined tenancy session semantics -- a session
+///     only ever writes its own tenant's data
+/// </summary>
+public class CrossTenantWriteException : InvalidOperationException
+{
+    public CrossTenantWriteException(Type entityType, string? entityTenantId, string contextTenantId,
+        EntityState state) : base(
+        $"Cannot {state.ToString().ToLowerInvariant()} entity of type {entityType.FullName} belonging to tenant '{entityTenantId}' through a DbContext scoped to tenant '{contextTenantId}'. A conjoined multi-tenanted DbContext can only write data for its own tenant.")
+    {
+        EntityType = entityType;
+        EntityTenantId = entityTenantId;
+        ContextTenantId = contextTenantId;
+        State = state;
+    }
+
+    public Type EntityType { get; }
+    public string? EntityTenantId { get; }
+    public string ContextTenantId { get; }
+    public EntityState State { get; }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedDbContextBuilder.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedDbContextBuilder.cs
@@ -1,0 +1,141 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using FastExpressionCompiler;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using JasperFx.Descriptors;
+using JasperFx.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Weasel.Core;
+using Weasel.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore.Internals.Migrations;
+using Wolverine.RDBMS;
+using Wolverine.Runtime;
+
+namespace Wolverine.EntityFrameworkCore.Internals;
+
+// AOT note (#2746): same ctor lookup + expression-compiled factory pattern as the
+// tenanted builders; AOT consumers register the DbContext factory explicitly
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "FastExpressionCompiler.CompileFast at registration; AOT consumers register an explicit factory. See AOT guide / #2755.")]
+[UnconditionalSuppressMessage("Trimming", "IL2090",
+    Justification = "DbContext T parameter accessed for ctor lookup; T is statically rooted by AddWolverineEFCore<T>(). See AOT guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "FastExpressionCompiler emits IL at registration time; AOT consumers register an explicit factory. See AOT guide / #2755.")]
+public class ConjoinedDbContextBuilder<T> : IDbContextBuilder<T> where T : DbContext
+{
+    private readonly Action<DbContextOptionsBuilder<T>, ConnectionString> _configuration;
+    private readonly Func<DbContextOptions<T>, T> _constructor;
+    private readonly IMessageDatabase _database;
+    private readonly IDomainEventScraper[] _domainScrapers;
+    private readonly Lazy<DbContextOptions<T>> _options;
+    private readonly IServiceProvider _serviceProvider;
+
+    public ConjoinedDbContextBuilder(IServiceProvider serviceProvider, IMessageDatabase database,
+        Action<DbContextOptionsBuilder<T>, ConnectionString> configuration,
+        IEnumerable<IDomainEventScraper> domainScrapers)
+    {
+        _serviceProvider = serviceProvider;
+        _database = database;
+        _configuration = configuration;
+        _domainScrapers = domainScrapers.ToArray();
+
+        var optionsType = typeof(DbContextOptions<T>);
+        var ctor = typeof(T).GetConstructors().FirstOrDefault(x =>
+            x.GetParameters().Length == 1 && x.GetParameters()[0].ParameterType == optionsType);
+
+        if (ctor == null)
+        {
+            throw new InvalidOperationException(
+                $"DbContext type {typeof(T).FullNameInCode()} must have a public constructor that accepts {optionsType.FullNameInCode()} as its only argument");
+        }
+
+        var options = Expression.Parameter(optionsType);
+        var callCtor = Expression.New(ctor, options);
+        _constructor = Expression.Lambda<Func<DbContextOptions<T>, T>>(callCtor, options).CompileFast();
+
+        // Conjoined tenancy is one shared database, so every context is built from
+        // identical options
+        _options = new Lazy<DbContextOptions<T>>(buildOptions);
+    }
+
+    public async ValueTask<T> BuildAndEnrollAsync(MessageContext messaging, CancellationToken cancellationToken)
+    {
+        var dbContext = build(messaging.TenantId);
+
+        var transaction = new EfCoreEnvelopeTransaction(dbContext, messaging, _domainScrapers);
+        await messaging.EnlistInOutboxAsync(transaction);
+
+        return dbContext;
+    }
+
+    public ValueTask<T> BuildAsync(string tenantId, CancellationToken cancellationToken)
+    {
+        return new ValueTask<T>(build(tenantId));
+    }
+
+    public ValueTask<T> BuildAsync(CancellationToken cancellationToken)
+    {
+        return BuildAsync(StorageConstants.DefaultTenantId, cancellationToken);
+    }
+
+    public DbContext BuildForMain()
+    {
+        return build(StorageConstants.DefaultTenantId);
+    }
+
+    public DbContextOptions<T> BuildOptionsForMain()
+    {
+        return _options.Value;
+    }
+
+    public Type DbContextType => typeof(T);
+
+    public async Task ApplyAllChangesToDatabasesAsync()
+    {
+        var context = build(StorageConstants.DefaultTenantId);
+        await _serviceProvider.EnsureDatabaseExistsAsync(context);
+        await using var migration = await _serviceProvider.CreateMigrationAsync(context, CancellationToken.None);
+        await migration.ExecuteAsync(AutoCreate.CreateOrUpdate, CancellationToken.None);
+    }
+
+    public async Task EnsureAllDatabasesAreCreatedAsync()
+    {
+        var context = build(StorageConstants.DefaultTenantId);
+        await _serviceProvider.EnsureDatabaseExistsAsync(context);
+    }
+
+    public Task<IReadOnlyList<DbContext>> FindAllAsync()
+    {
+        return Task.FromResult<IReadOnlyList<DbContext>>([BuildForMain()]);
+    }
+
+    public DatabaseCardinality Cardinality => DatabaseCardinality.Single;
+
+    private T build(string? tenantId)
+    {
+        var dbContext = _constructor(_options.Value);
+        ConjoinedTenancy.Pin(dbContext, tenantId);
+        return dbContext;
+    }
+
+    private DbContextOptions<T> buildOptions()
+    {
+        var connectionString = _database.Settings.ConnectionString ?? _database.Settings.DataSource?.ConnectionString;
+        if (connectionString.IsEmpty())
+        {
+            throw new InvalidOperationException(
+                $"Unable to determine the database connection string for the conjoined multi-tenanted DbContext {typeof(T).FullNameInCode()}");
+        }
+
+        var builder = new DbContextOptionsBuilder<T>();
+        builder.UseApplicationServiceProvider(_serviceProvider);
+        builder.ReplaceService<IModelCustomizer, ConjoinedTenancyModelCustomizer>();
+        builder.AddInterceptors(TenantStampingInterceptor.Instance);
+        _configuration(builder, new ConnectionString(connectionString!));
+
+        return builder.Options;
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedDbContextBuilder.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedDbContextBuilder.cs
@@ -8,6 +8,7 @@ using JasperFx.Descriptors;
 using JasperFx.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 using Weasel.Core;
 using Weasel.EntityFrameworkCore;
 using Wolverine.EntityFrameworkCore.Internals.Migrations;
@@ -97,6 +98,20 @@ public class ConjoinedDbContextBuilder<T> : IDbContextBuilder<T> where T : DbCon
     {
         var context = build(StorageConstants.DefaultTenantId);
         await _serviceProvider.EnsureDatabaseExistsAsync(context);
+
+        var options = ConjoinedTenancy.OptionsFor(typeof(T));
+        if (options.PartitioningEnabled)
+        {
+            // Partitioned conjoined tables migrate through a Weasel database object so
+            // the partition manager's initializer hydrates the tenant map before deltas
+            // are computed, and the partition control table migrates with the entity tables
+            var partitions = (ConjoinedTenantPartitions<T>)_serviceProvider
+                .GetRequiredService<IConjoinedTenantPartitions<T>>();
+            var database = await partitions.BuildWeaselDatabaseAsync(CancellationToken.None);
+            await database.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.CreateOrUpdate);
+            return;
+        }
+
         await using var migration = await _serviceProvider.CreateMigrationAsync(context, CancellationToken.None);
         await migration.ExecuteAsync(AutoCreate.CreateOrUpdate, CancellationToken.None);
     }

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedDbContextBuilder.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedDbContextBuilder.cs
@@ -148,6 +148,8 @@ public class ConjoinedDbContextBuilder<T> : IDbContextBuilder<T> where T : DbCon
         var builder = new DbContextOptionsBuilder<T>();
         builder.UseApplicationServiceProvider(_serviceProvider);
         builder.ReplaceService<IModelCustomizer, ConjoinedTenancyModelCustomizer>();
+        // Cache models per (context type, wolverine schema) -- GH-3497
+        builder.ReplaceService<IModelCacheKeyFactory, WolverineModelCacheKeyFactory>();
         builder.AddInterceptors(TenantStampingInterceptor.Instance);
         _configuration(builder, new ConnectionString(connectionString!));
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenancy.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenancy.cs
@@ -1,7 +1,10 @@
 using System.Runtime.CompilerServices;
+using ImTools;
 using JasperFx;
+using JasperFx.Core.Reflection;
 using JasperFx.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
+using Wolverine.RDBMS.MultiTenancy;
 
 namespace Wolverine.EntityFrameworkCore.Internals;
 
@@ -21,7 +24,52 @@ public static class ConjoinedTenancy
     /// </summary>
     public const string QueryFilterName = "wolverine_conjoined_tenancy";
 
+    /// <summary>
+    ///     Name of the shadow property mapped for the SQL Server tenant ordinal
+    ///     column on partitioned entities
+    /// </summary>
+    public const string TenantOrdinalPropertyName = "TenantOrdinal";
+
     private static readonly ConditionalWeakTable<DbContext, string> _tenants = new();
+
+    private static ImHashMap<Type, ConjoinedTenancyOptions> _optionsByContextType =
+        ImHashMap<Type, ConjoinedTenancyOptions>.Empty;
+
+    private static ImHashMap<Type, ITenantPartitioning> _partitioningByContextType =
+        ImHashMap<Type, ITenantPartitioning>.Empty;
+
+    internal static void SetOptions(Type contextType, ConjoinedTenancyOptions options)
+    {
+        _optionsByContextType = _optionsByContextType.AddOrUpdate(contextType, options);
+    }
+
+    /// <summary>
+    ///     The conjoined tenancy options this DbContext type was registered with
+    /// </summary>
+    public static ConjoinedTenancyOptions OptionsFor(Type contextType)
+    {
+        return _optionsByContextType.TryFind(contextType, out var options) ? options : new ConjoinedTenancyOptions();
+    }
+
+    internal static void RegisterPartitioning(Type contextType, ITenantPartitioning partitioning)
+    {
+        _partitioningByContextType = _partitioningByContextType.AddOrUpdate(contextType, partitioning);
+    }
+
+    internal static ITenantPartitioning? PartitioningFor(Type contextType)
+    {
+        return _partitioningByContextType.TryFind(contextType, out var partitioning) ? partitioning : null;
+    }
+
+    internal static bool IsPartitionedEntity(Microsoft.EntityFrameworkCore.Metadata.IReadOnlyEntityType entityType)
+    {
+        // Sagas stay unpartitioned in this release -- the composite primary key
+        // that partitioning requires would change the generated saga load frames
+        return entityType.ClrType.CanBeCastTo<ITenanted>()
+               && !entityType.ClrType.CanBeCastTo<Saga>()
+               && !entityType.IsOwned()
+               && entityType.BaseType == null;
+    }
 
     internal static void Pin(DbContext context, string? tenantId)
     {

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenancy.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenancy.cs
@@ -1,0 +1,40 @@
+using System.Runtime.CompilerServices;
+using JasperFx;
+using JasperFx.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolverine.EntityFrameworkCore.Internals;
+
+/// <summary>
+///     Tracks the tenant id that a conjoined-multi-tenant DbContext instance is pinned
+///     to. The <see cref="ConjoinedDbContextBuilder{T}" /> pins every context it builds,
+///     and both the tenant global query filter and the
+///     <see cref="TenantStampingInterceptor" /> read the pinned value back through
+///     <see cref="TenantIdOf" />.
+/// </summary>
+public static class ConjoinedTenancy
+{
+    /// <summary>
+    ///     Name of the global query filter that Wolverine attaches to every
+    ///     ITenanted entity of a conjoined-multi-tenant DbContext (named filters
+    ///     require EF Core 10+)
+    /// </summary>
+    public const string QueryFilterName = "wolverine_conjoined_tenancy";
+
+    private static readonly ConditionalWeakTable<DbContext, string> _tenants = new();
+
+    internal static void Pin(DbContext context, string? tenantId)
+    {
+        _tenants.AddOrUpdate(context, tenantId.IsDefaultTenant() ? StorageConstants.DefaultTenantId : tenantId!);
+    }
+
+    /// <summary>
+    ///     The tenant id this DbContext instance is pinned to, or
+    ///     StorageConstants.DefaultTenantId when the context was not built through
+    ///     Wolverine's conjoined tenancy (e.g. contexts resolved for EF Core migrations)
+    /// </summary>
+    public static string TenantIdOf(DbContext context)
+    {
+        return _tenants.TryGetValue(context, out var tenantId) ? tenantId : StorageConstants.DefaultTenantId;
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenancy.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenancy.cs
@@ -43,6 +43,11 @@ public static class ConjoinedTenancy
         _optionsByContextType = _optionsByContextType.AddOrUpdate(contextType, options);
     }
 
+    internal static bool IsConjoined(Type contextType)
+    {
+        return _optionsByContextType.TryFind(contextType, out _);
+    }
+
     /// <summary>
     ///     The conjoined tenancy options this DbContext type was registered with
     /// </summary>
@@ -59,6 +64,34 @@ public static class ConjoinedTenancy
     internal static ITenantPartitioning? PartitioningFor(Type contextType)
     {
         return _partitioningByContextType.TryFind(contextType, out var partitioning) ? partitioning : null;
+    }
+
+    private static ImHashMap<Type, ImHashMap<string, bool>> _disabledTenantsByContextType =
+        ImHashMap<Type, ImHashMap<string, bool>>.Empty;
+
+    internal static void SetDisabledTenants(Type contextType, IEnumerable<string> disabledTenantIds)
+    {
+        var map = ImHashMap<string, bool>.Empty;
+        foreach (var tenantId in disabledTenantIds)
+        {
+            map = map.AddOrUpdate(tenantId, true);
+        }
+
+        _disabledTenantsByContextType = _disabledTenantsByContextType.AddOrUpdate(contextType, map);
+    }
+
+    internal static void SetTenantDisabled(Type contextType, string tenantId, bool disabled)
+    {
+        _disabledTenantsByContextType.TryFind(contextType, out var map);
+        map ??= ImHashMap<string, bool>.Empty;
+        map = disabled ? map.AddOrUpdate(tenantId, true) : map.Remove(tenantId);
+        _disabledTenantsByContextType = _disabledTenantsByContextType.AddOrUpdate(contextType, map);
+    }
+
+    internal static bool IsTenantDisabled(Type contextType, string tenantId)
+    {
+        return _disabledTenantsByContextType.TryFind(contextType, out var map)
+               && map.TryFind(tenantId, out var disabled) && disabled;
     }
 
     internal static bool IsPartitionedEntity(Microsoft.EntityFrameworkCore.Metadata.IReadOnlyEntityType entityType)

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenancyModelCustomizer.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenancyModelCustomizer.cs
@@ -1,0 +1,75 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using JasperFx;
+using JasperFx.Core.Reflection;
+using JasperFx.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Wolverine.EntityFrameworkCore.Internals;
+
+/// <summary>
+///     Model customizer for conjoined multi-tenancy. In addition to the Wolverine
+///     envelope storage mapping, every entity implementing
+///     JasperFx.MultiTenancy.ITenanted is mapped with a tenant_id column, an index on
+///     that column, and a global query filter binding queries to the tenant the
+///     DbContext instance is pinned to
+/// </summary>
+// AOT note (#2746): the tenant query filter is built with expression trees over entity
+// types that are statically rooted by the EF model itself; same pattern as the tenanted
+// DbContext builders
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Entity CLR types and their TenantId property are rooted by the EF Core model. See AOT guide / #2755.")]
+[UnconditionalSuppressMessage("Trimming", "IL2072",
+    Justification = "Entity CLR types come from the EF Core model and are rooted by it. See AOT guide / #2755.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "LambdaExpression is only built for EF query filters, never compiled to a delegate here. See AOT guide / #2755.")]
+public class ConjoinedTenancyModelCustomizer : WolverineModelCustomizer
+{
+    private static readonly System.Reflection.MethodInfo _tenantIdOf =
+        typeof(ConjoinedTenancy).GetMethod(nameof(ConjoinedTenancy.TenantIdOf))!;
+
+    public ConjoinedTenancyModelCustomizer(ModelCustomizerDependencies dependencies) : base(dependencies)
+    {
+    }
+
+    public override void Customize(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.Customize(modelBuilder, context);
+
+        var tenantedTypes = modelBuilder.Model.GetEntityTypes()
+            .Where(x => x.ClrType.CanBeCastTo<ITenanted>() && !x.IsOwned() && x.BaseType == null)
+            .Select(x => x.ClrType)
+            .ToArray();
+
+        foreach (var entityType in tenantedTypes)
+        {
+            var entity = modelBuilder.Entity(entityType);
+
+            entity.Property(nameof(IHasTenantId.TenantId))
+                .HasColumnName(StorageConstants.TenantIdColumn)
+                .HasDefaultValue(StorageConstants.DefaultTenantId);
+
+            entity.HasIndex(nameof(IHasTenantId.TenantId));
+
+            // The captured DbContext reference below is re-rooted by EF to the context
+            // instance executing each query, so the filter always evaluates against the
+            // tenant that specific context is pinned to even though the model is cached
+            var filter = buildTenantFilter(entityType, context);
+#if NET10_0_OR_GREATER
+            entity.HasQueryFilter(ConjoinedTenancy.QueryFilterName, filter);
+#else
+            entity.HasQueryFilter(filter);
+#endif
+        }
+    }
+
+    private static LambdaExpression buildTenantFilter(Type entityType, DbContext context)
+    {
+        var parameter = Expression.Parameter(entityType, "e");
+        var tenantId = Expression.Property(parameter, nameof(IHasTenantId.TenantId));
+        var contextTenantId = Expression.Call(_tenantIdOf, Expression.Constant(context, typeof(DbContext)));
+
+        return Expression.Lambda(Expression.Equal(tenantId, contextTenantId), parameter);
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenancyModelCustomizer.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenancyModelCustomizer.cs
@@ -62,6 +62,42 @@ public class ConjoinedTenancyModelCustomizer : WolverineModelCustomizer
             entity.HasQueryFilter(filter);
 #endif
         }
+
+        applyTenantPartitioning(modelBuilder, context);
+    }
+
+    // With PartitionPerTenant(), the DATABASE primary key of every partitioned
+    // entity becomes composite -- the partition column joins it inside the Weasel
+    // table customization (ITenantPartitioning.ApplyToTable) -- but the EF model
+    // keeps the user's own single key so FindAsync/Attach call shapes and saga
+    // loads are unchanged. Here the model only gains what must exist as a mapped
+    // column: SQL Server's int tenant ordinal, stamped by the tenant interceptor
+    private static void applyTenantPartitioning(ModelBuilder modelBuilder, DbContext context)
+    {
+        var options = ConjoinedTenancy.OptionsFor(context.GetType());
+        if (!options.PartitioningEnabled)
+        {
+            return;
+        }
+
+        var usesOrdinal = context.Database.ProviderName?.Contains("SqlServer", StringComparison.OrdinalIgnoreCase)
+                          ?? false;
+        if (!usesOrdinal)
+        {
+            return;
+        }
+
+        var partitioned = modelBuilder.Model.GetEntityTypes()
+            .Where(ConjoinedTenancy.IsPartitionedEntity)
+            .ToArray();
+
+        foreach (var entityType in partitioned)
+        {
+            modelBuilder.Entity(entityType.ClrType)
+                .Property<int>(ConjoinedTenancy.TenantOrdinalPropertyName)
+                .HasColumnName(options.Partitioning!.TenantOrdinalColumn)
+                .ValueGeneratedNever();
+        }
     }
 
     private static LambdaExpression buildTenantFilter(Type entityType, DbContext context)

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenantPartitions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenantPartitions.cs
@@ -1,0 +1,218 @@
+using JasperFx.Core.Reflection;
+using JasperFx.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Weasel.EntityFrameworkCore;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.MultiTenancy;
+
+namespace Wolverine.EntityFrameworkCore.Internals;
+
+/// <summary>
+///     Management API for the Weasel-managed tenant partitions behind a
+///     conjoined multi-tenant DbContext registered with PartitionPerTenant()
+/// </summary>
+// ReSharper disable once UnusedTypeParameter -- T scopes the service to its DbContext registration
+public interface IConjoinedTenantPartitions<T> where T : DbContext
+{
+    /// <summary>
+    ///     Create the partition for a new tenant across every partitioned table
+    /// </summary>
+    Task AddTenantAsync(string tenantId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Create or join a partition for a tenant. Tenants registered with the same
+    ///     partition suffix share one physical partition ("bucketing") when
+    ///     AllowPartitionSharing is enabled on the partitioning options
+    /// </summary>
+    Task AddTenantAsync(string tenantId, string partitionSuffix, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Batch registration of tenants; the dictionary value is the optional
+    ///     partition suffix (null = own partition per tenant)
+    /// </summary>
+    Task AddTenantsAsync(IReadOnlyDictionary<string, string?> tenantIdToSuffix,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Remove a tenant from the partition set. On PostgreSQL this detaches and
+    ///     drops the tenant's partition (deleteData must be true); on SQL Server
+    ///     deleteData: false retains the rows
+    /// </summary>
+    Task DropTenantAsync(string tenantId, bool deleteData = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Hydrate the in-memory tenant partition map from the control table
+    /// </summary>
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+}
+
+internal class ConjoinedTenantPartitions<T> : IConjoinedTenantPartitions<T> where T : DbContext
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<ConjoinedTenantPartitions<T>> _logger;
+    private readonly object _locker = new();
+    private ITenantPartitioning? _partitioning;
+    private IDatabaseWithTables? _database;
+
+    public ConjoinedTenantPartitions(IServiceProvider serviceProvider,
+        ILogger<ConjoinedTenantPartitions<T>> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    internal ITenantPartitioning Partitioning
+    {
+        get
+        {
+            if (_partitioning != null)
+            {
+                return _partitioning;
+            }
+
+            lock (_locker)
+            {
+                if (_partitioning != null)
+                {
+                    return _partitioning;
+                }
+
+                var options = ConjoinedTenancy.OptionsFor(typeof(T));
+                if (!options.PartitioningEnabled)
+                {
+                    throw new InvalidOperationException(
+                        $"DbContext type {typeof(T).FullNameInCode()} is not registered with PartitionPerTenant()");
+                }
+
+                var builder = _serviceProvider.GetRequiredService<IDbContextBuilder<T>>();
+                using var context = builder.BuildForMain();
+                var providerName = context.Database.ProviderName ?? string.Empty;
+
+                var factory = _serviceProvider.GetServices<ITenantPartitioningProviderFactory>()
+                    .FirstOrDefault(x => x.MatchesEfCoreProvider(providerName));
+
+                if (factory == null)
+                {
+                    throw new InvalidOperationException(
+                        $"No tenant partitioning support is registered for EF Core provider '{providerName}'. Wolverine supplies partitioning for PostgreSQL and SQL Server through their message persistence packages.");
+                }
+
+                var settings = _serviceProvider.GetRequiredService<DatabaseSettings>();
+                var controlTable = new DbObjectName(settings.SchemaName ?? "public",
+                    options.PartitionControlTableName);
+
+                _partitioning = factory.Create(controlTable, options.Partitioning!);
+                ConjoinedTenancy.RegisterPartitioning(typeof(T), _partitioning);
+                return _partitioning;
+            }
+        }
+    }
+
+    internal EfSchemaMappingCustomization BuildCustomization()
+    {
+        var partitioning = Partitioning;
+        return new EfSchemaMappingCustomization
+        {
+            AdditionalObjects = partitioning.AdditionalSchemaObjects,
+            CustomizeTable = (entityType, table) =>
+            {
+                if (ConjoinedTenancy.IsPartitionedEntity(entityType))
+                {
+                    partitioning.ApplyToTable(table);
+                }
+            }
+        };
+    }
+
+    internal async ValueTask<IDatabaseWithTables> BuildWeaselDatabaseAsync(CancellationToken cancellationToken)
+    {
+        if (_database != null)
+        {
+            return _database;
+        }
+
+        var builder = _serviceProvider.GetRequiredService<IDbContextBuilder<T>>();
+        await using var context = await builder.BuildAsync(cancellationToken);
+        var database = _serviceProvider.CreateDatabase(context, BuildCustomization(),
+            "conjoined:" + typeof(T).FullNameInCode());
+        Partitioning.AttachInitializer(database);
+        _database = database;
+        return database;
+    }
+
+    public async Task AddTenantAsync(string tenantId, CancellationToken cancellationToken = default)
+    {
+        await AddTenantsAsync(new Dictionary<string, string?> { [tenantId] = null }, cancellationToken);
+    }
+
+    public Task AddTenantAsync(string tenantId, string partitionSuffix,
+        CancellationToken cancellationToken = default)
+    {
+        return AddTenantsAsync(new Dictionary<string, string?> { [tenantId] = partitionSuffix }, cancellationToken);
+    }
+
+    public async Task AddTenantsAsync(IReadOnlyDictionary<string, string?> tenantIdToSuffix,
+        CancellationToken cancellationToken = default)
+    {
+        var database = await BuildWeaselDatabaseAsync(cancellationToken);
+        await Partitioning.AddTenantsAsync(_logger, database, tenantIdToSuffix, cancellationToken);
+    }
+
+    public async Task DropTenantAsync(string tenantId, bool deleteData = false,
+        CancellationToken cancellationToken = default)
+    {
+        var database = await BuildWeaselDatabaseAsync(cancellationToken);
+        await Partitioning.DropTenantsAsync(_logger, database, [tenantId], deleteData, cancellationToken);
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        var database = await BuildWeaselDatabaseAsync(cancellationToken);
+        await Partitioning.InitializeAsync(database, cancellationToken);
+    }
+}
+
+/// <summary>
+///     Hydrates the tenant partition map at host startup so the tenant ordinal
+///     interceptor has a synchronous, pre-populated lookup before the first message
+/// </summary>
+internal class ConjoinedPartitionsActivator<T> : IHostedService where T : DbContext
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<ConjoinedTenantPartitions<T>> _logger;
+
+    public ConjoinedPartitionsActivator(IServiceProvider serviceProvider,
+        ILogger<ConjoinedTenantPartitions<T>> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _serviceProvider.GetRequiredService<IConjoinedTenantPartitions<T>>()
+                .InitializeAsync(cancellationToken);
+        }
+        catch (Exception e)
+        {
+            // The control table may not exist yet on a brand new database when
+            // resource setup runs later in the startup sequence; add-tenant and
+            // migration paths re-initialize
+            _logger.LogDebug(e,
+                "Unable to pre-hydrate conjoined tenant partitions for {DbContextType}; the map hydrates on first use",
+                typeof(T).Name);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenantSource.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenantSource.cs
@@ -1,0 +1,176 @@
+using ImTools;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using JasperFx.Descriptors;
+using JasperFx.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.MultiTenancy;
+using Wolverine.Runtime;
+
+namespace Wolverine.EntityFrameworkCore.Internals;
+
+/// <summary>
+///     The authoritative tenant list for a conjoined multi-tenant DbContext, backed
+///     by the message store's wolverine_tenants registry table. Registering this as
+///     IDynamicTenantSource&lt;string&gt; lights up CritterWatch's tenant management --
+///     add/disable/enable/remove fan out here. The "connection value" for every
+///     tenant is the shared application database
+/// </summary>
+internal class ConjoinedTenantSource<T> : IDynamicTenantSource<string> where T : DbContext
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<ConjoinedTenantSource<T>> _logger;
+    private readonly object _locker = new();
+    private ITenantDatabaseRegistry? _registry;
+    private ImHashMap<string, string> _active = ImHashMap<string, string>.Empty;
+
+    public ConjoinedTenantSource(IServiceProvider serviceProvider, ILogger<ConjoinedTenantSource<T>> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    public DatabaseCardinality Cardinality => DatabaseCardinality.Single;
+
+    private WolverineOptions options => _serviceProvider.GetRequiredService<IWolverineRuntime>().Options;
+
+    private ITenantDatabaseRegistry registry
+    {
+        get
+        {
+            if (_registry != null)
+            {
+                return _registry;
+            }
+
+            lock (_locker)
+            {
+                if (_registry != null)
+                {
+                    return _registry;
+                }
+
+                var store = _serviceProvider.GetRequiredService<IMessageStore>();
+                if (store is not ITenantDatabaseRegistry tenantRegistry)
+                {
+                    throw new InvalidOperationException(
+                        $"Conjoined tenancy for {typeof(T).FullNameInCode()} requires relational database message storage with the wolverine_tenants registry table");
+                }
+
+                _registry = tenantRegistry;
+                return _registry;
+            }
+        }
+    }
+
+    private string sharedConnectionString
+    {
+        get
+        {
+            var database = (IMessageDatabase)_serviceProvider.GetRequiredService<IMessageStore>();
+            return database.Settings.ConnectionString ?? database.Settings.DataSource?.ConnectionString ?? string.Empty;
+        }
+    }
+
+    private IConjoinedTenantPartitions<T>? partitions => _serviceProvider.GetService<IConjoinedTenantPartitions<T>>();
+
+    public ValueTask<string> FindAsync(string tenantId)
+    {
+        tenantId = options.Durability.TenantIdStyle.MaybeCorrectTenantId(tenantId);
+        if (ConjoinedTenancy.IsTenantDisabled(typeof(T), tenantId))
+        {
+            throw new UnknownTenantIdException(tenantId);
+        }
+
+        // Every conjoined tenant shares the application database
+        return new ValueTask<string>(sharedConnectionString);
+    }
+
+    public async Task RefreshAsync()
+    {
+        var assignments = await registry.LoadAllTenantConnectionStrings();
+        var active = ImHashMap<string, string>.Empty;
+        foreach (var assignment in assignments)
+        {
+            active = active.AddOrUpdate(assignment.TenantId, sharedConnectionString);
+        }
+
+        _active = active;
+
+        var disabled = await registry.LoadDisabledTenantIdsAsync();
+        ConjoinedTenancy.SetDisabledTenants(typeof(T), disabled);
+    }
+
+    public IReadOnlyList<string> AllActive()
+    {
+        return _active.Enumerate().Select(x => x.Value).Distinct().ToList();
+    }
+
+    public IReadOnlyList<Assignment<string>> AllActiveByTenant()
+    {
+        return _active.Enumerate().Select(x => new Assignment<string>(x.Key, x.Value)).ToList();
+    }
+
+    public Task AddTenantAsync(string tenantId, string connectionValue)
+    {
+        throw new InvalidOperationException(
+            "Conjoined multi-tenancy uses a single, shared application database -- tenants cannot be assigned their own connection string. Use AddTenantAsync(tenantId) instead.");
+    }
+
+    public async Task<string> AddTenantAsync(string tenantId, CancellationToken token = default)
+    {
+        tenantId = options.Durability.TenantIdStyle.MaybeCorrectTenantId(tenantId);
+
+        // Empty connection string marks a conjoined (shared database) tenant record
+        await registry.AddTenantRecordAsync(tenantId, string.Empty);
+        _active = _active.AddOrUpdate(tenantId, sharedConnectionString);
+        ConjoinedTenancy.SetTenantDisabled(typeof(T), tenantId, false);
+
+        if (partitions != null)
+        {
+            await partitions.AddTenantAsync(tenantId, token);
+        }
+
+        _logger.LogInformation("Added conjoined tenant {TenantId} for {DbContextType}", tenantId, typeof(T).Name);
+        return tenantId.ToLowerInvariant();
+    }
+
+    public async Task DisableTenantAsync(string tenantId)
+    {
+        tenantId = options.Durability.TenantIdStyle.MaybeCorrectTenantId(tenantId);
+        await registry.SetTenantDisabledAsync(tenantId, true);
+        ConjoinedTenancy.SetTenantDisabled(typeof(T), tenantId, true);
+    }
+
+    public async Task EnableTenantAsync(string tenantId)
+    {
+        tenantId = options.Durability.TenantIdStyle.MaybeCorrectTenantId(tenantId);
+        await registry.SetTenantDisabledAsync(tenantId, false);
+        ConjoinedTenancy.SetTenantDisabled(typeof(T), tenantId, false);
+    }
+
+    public async Task RemoveTenantAsync(string tenantId)
+    {
+        tenantId = options.Durability.TenantIdStyle.MaybeCorrectTenantId(tenantId);
+        await registry.DeleteTenantRecordAsync(tenantId);
+        _active = _active.Remove(tenantId);
+        ConjoinedTenancy.SetTenantDisabled(typeof(T), tenantId, false);
+
+        if (partitions != null)
+        {
+            // Hard delete for a partitioned conjoined tenant is the partition drop
+            await partitions.DropTenantAsync(tenantId, deleteData: true);
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> AllDisabledAsync()
+    {
+        var disabled = await registry.LoadDisabledTenantIdsAsync();
+        ConjoinedTenancy.SetDisabledTenants(typeof(T), disabled);
+        return disabled;
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EntityFrameworkCoreBackedPersistence.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EntityFrameworkCoreBackedPersistence.cs
@@ -48,6 +48,13 @@ internal class EntityFrameworkCoreBackedPersistence<T> : IWolverineExtension whe
         options.CodeGeneration.InsertFirstPersistenceStrategy<EFCorePersistenceFrameProvider>();
         options.CodeGeneration.Sources.Add(new TenantedDbContextSource<T>());
 
+        if (ConjoinedTenancy.IsConjoined(typeof(T)))
+        {
+            // Conjoined tenancy keeps its authoritative tenant list in the message
+            // store's wolverine_tenants registry table
+            options.Durability.TenantRegistryRequired = true;
+        }
+
         options.CodeGeneration.MethodPreCompilation.Add(new EFCoreQuerySpecificationPolicy());
         options.CodeGeneration.MethodPreCompilation.Add(new EFCoreBatchingPolicy());
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantStampingInterceptor.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantStampingInterceptor.cs
@@ -59,8 +59,36 @@ public class TenantStampingInterceptor : SaveChangesInterceptor
                             contextTenantId, entry.State);
                     }
 
+                    stampTenantOrdinal(context, entry, tenanted);
+
                     break;
             }
         }
+    }
+
+    // With PartitionPerTenant() on SQL Server, partitioned rows carry the compact
+    // tenant ordinal in a shadow column; the ordinal comes from the pre-hydrated
+    // Weasel partition registry
+    private static void stampTenantOrdinal(DbContext context,
+        Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry, ITenanted tenanted)
+    {
+        var partitioning = ConjoinedTenancy.PartitioningFor(context.GetType());
+        if (partitioning is not { RequiresTenantOrdinalColumn: true })
+        {
+            return;
+        }
+
+        if (entry.Metadata.FindProperty(ConjoinedTenancy.TenantOrdinalPropertyName) == null)
+        {
+            return;
+        }
+
+        if (!partitioning.TryGetOrdinal(tenanted.TenantId!, out var ordinal))
+        {
+            throw new InvalidOperationException(
+                $"No tenant partition is registered for tenant '{tenanted.TenantId}'. Add the tenant first through IConjoinedTenantPartitions<{context.GetType().Name}>.AddTenantAsync()");
+        }
+
+        entry.Property(ConjoinedTenancy.TenantOrdinalPropertyName).CurrentValue = ordinal;
     }
 }

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantStampingInterceptor.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantStampingInterceptor.cs
@@ -36,6 +36,11 @@ public class TenantStampingInterceptor : SaveChangesInterceptor
 
         var contextTenantId = ConjoinedTenancy.TenantIdOf(context);
 
+        if (ConjoinedTenancy.IsTenantDisabled(context.GetType(), contextTenantId))
+        {
+            throw new UnknownTenantIdException(contextTenantId);
+        }
+
         foreach (var entry in context.ChangeTracker.Entries())
         {
             if (entry.Entity is not ITenanted tenanted)

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantStampingInterceptor.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantStampingInterceptor.cs
@@ -1,0 +1,66 @@
+using JasperFx.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Wolverine.EntityFrameworkCore.Internals;
+
+/// <summary>
+///     SaveChanges interceptor installed by Wolverine's conjoined multi-tenancy that
+///     stamps the ambient tenant id onto inserted ITenanted entities and rejects any
+///     write against an entity belonging to a different tenant than the one the
+///     DbContext is pinned to
+/// </summary>
+public class TenantStampingInterceptor : SaveChangesInterceptor
+{
+    public static readonly TenantStampingInterceptor Instance = new();
+
+    public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
+    {
+        applyTenancyRules(eventData.Context);
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData,
+        InterceptionResult<int> result, CancellationToken cancellationToken = default)
+    {
+        applyTenancyRules(eventData.Context);
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    private static void applyTenancyRules(DbContext? context)
+    {
+        if (context == null)
+        {
+            return;
+        }
+
+        var contextTenantId = ConjoinedTenancy.TenantIdOf(context);
+
+        foreach (var entry in context.ChangeTracker.Entries())
+        {
+            if (entry.Entity is not ITenanted tenanted)
+            {
+                continue;
+            }
+
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                case EntityState.Modified:
+                case EntityState.Deleted:
+                    if (tenanted.TenantId.IsDefaultTenant())
+                    {
+                        // Unset (or explicitly default) tenant id -- stamp the ambient tenant
+                        tenanted.TenantId = contextTenantId;
+                    }
+                    else if (tenanted.TenantId != contextTenantId)
+                    {
+                        throw new CrossTenantWriteException(entry.Metadata.ClrType, tenanted.TenantId,
+                            contextTenantId, entry.State);
+                    }
+
+                    break;
+            }
+        }
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantedDbContextBuilderByConnectionString.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantedDbContextBuilderByConnectionString.cs
@@ -78,6 +78,8 @@ public class TenantedDbContextBuilderByConnectionString<T> : IDbContextBuilder<T
         builder.UseApplicationServiceProvider(_serviceProvider);
         
         builder.ReplaceService<IModelCustomizer, WolverineModelCustomizer>();
+        // Cache models per (context type, wolverine schema) -- GH-3497
+        builder.ReplaceService<IModelCacheKeyFactory, WolverineModelCacheKeyFactory>();
         _configuration(builder, new ConnectionString(connectionString), new TenantId(messaging.TenantId!));
         var dbContext = _constructor(builder.Options);
 
@@ -167,6 +169,8 @@ public class TenantedDbContextBuilderByConnectionString<T> : IDbContextBuilder<T
         var builder = new DbContextOptionsBuilder<T>();
         builder.UseApplicationServiceProvider(_serviceProvider);
         builder.ReplaceService<IModelCustomizer, WolverineModelCustomizer>();
+        // Cache models per (context type, wolverine schema) -- GH-3497
+        builder.ReplaceService<IModelCacheKeyFactory, WolverineModelCacheKeyFactory>();
         
         _configuration(builder, new ConnectionString(connectionString), new TenantId(tenantId));
         var dbContext = _constructor(builder.Options);
@@ -210,6 +214,8 @@ public class TenantedDbContextBuilderByConnectionString<T> : IDbContextBuilder<T
         var builder = new DbContextOptionsBuilder<T>();
         builder.UseApplicationServiceProvider(_serviceProvider);
         builder.ReplaceService<IModelCustomizer, WolverineModelCustomizer>();
+        // Cache models per (context type, wolverine schema) -- GH-3497
+        builder.ReplaceService<IModelCacheKeyFactory, WolverineModelCacheKeyFactory>();
         _configuration(builder, new ConnectionString(connectionString!), new TenantId(StorageConstants.DefaultTenantId));
         return builder.Options;
     }

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantedDbContextBuilderByDbDataSource.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/TenantedDbContextBuilderByDbDataSource.cs
@@ -76,6 +76,8 @@ public class TenantedDbContextBuilderByDbDataSource<T> : IDbContextBuilder<T> wh
 
         builder.UseApplicationServiceProvider(_serviceProvider);
         builder.ReplaceService<IModelCustomizer, WolverineModelCustomizer>();
+        // Cache models per (context type, wolverine schema) -- GH-3497
+        builder.ReplaceService<IModelCacheKeyFactory, WolverineModelCacheKeyFactory>();
         _configuration(builder, dataSource, new TenantId(messaging.TenantId!));
         
         var dbContext = _constructor(builder.Options);
@@ -173,6 +175,8 @@ public class TenantedDbContextBuilderByDbDataSource<T> : IDbContextBuilder<T> wh
         var builder = new DbContextOptionsBuilder<T>();
         builder.UseApplicationServiceProvider(_serviceProvider);
         builder.ReplaceService<IModelCustomizer, WolverineModelCustomizer>();
+        // Cache models per (context type, wolverine schema) -- GH-3497
+        builder.ReplaceService<IModelCacheKeyFactory, WolverineModelCacheKeyFactory>();
         
         _configuration(builder, connectionString, new TenantId(tenantId));
         var dbContext = _constructor(builder.Options);
@@ -192,6 +196,8 @@ public class TenantedDbContextBuilderByDbDataSource<T> : IDbContextBuilder<T> wh
         var builder = new DbContextOptionsBuilder<T>();
         builder.UseApplicationServiceProvider(_serviceProvider);
         builder.ReplaceService<IModelCustomizer, WolverineModelCustomizer>();
+        // Cache models per (context type, wolverine schema) -- GH-3497
+        builder.ReplaceService<IModelCacheKeyFactory, WolverineModelCacheKeyFactory>();
         _configuration(builder, dataSource!, new TenantId(StorageConstants.DefaultTenantId));
         return builder.Options;
     }

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/WolverineModelCacheKeyFactory.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/WolverineModelCacheKeyFactory.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Wolverine.RDBMS;
+
+namespace Wolverine.EntityFrameworkCore.Internals;
+
+/// <summary>
+///     Model cache key factory for Wolverine-integrated DbContexts. EF caches the
+///     built model per context type by default, but Wolverine maps its envelope
+///     tables into the model using the host's durability schema -- so two hosts in
+///     one process using the same DbContext type with different Wolverine schemas
+///     must not share a cached model, or the second host silently writes envelopes
+///     into the first host's schema (GH-3497)
+/// </summary>
+public class WolverineModelCacheKeyFactory : IModelCacheKeyFactory
+{
+    public object Create(DbContext context, bool designTime)
+    {
+        string? schemaName = null;
+        try
+        {
+            schemaName = context.Database.GetService<DatabaseSettings>()?.SchemaName;
+        }
+        catch (InvalidOperationException)
+        {
+            // No Wolverine database settings in play -- fall back to type-only caching
+        }
+
+        return (context.GetType(), schemaName, designTime);
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/WolverineModelCacheKeyFactory.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/WolverineModelCacheKeyFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 using Wolverine.RDBMS;
 
 namespace Wolverine.EntityFrameworkCore.Internals;
@@ -16,15 +17,8 @@ public class WolverineModelCacheKeyFactory : IModelCacheKeyFactory
 {
     public object Create(DbContext context, bool designTime)
     {
-        string? schemaName = null;
-        try
-        {
-            schemaName = context.Database.GetService<DatabaseSettings>()?.SchemaName;
-        }
-        catch (InvalidOperationException)
-        {
-            // No Wolverine database settings in play -- fall back to type-only caching
-        }
+        // No Wolverine database settings (no message store) -- type-only caching
+        var schemaName = WolverineModelCustomizer.TryResolveDatabaseSettings(context)?.SchemaName;
 
         return (context.GetType(), schemaName, designTime);
     }

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/WolverineModelCustomizer.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/WolverineModelCustomizer.cs
@@ -1,6 +1,7 @@
 using JasperFx.Core.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Wolverine.RDBMS;
 
@@ -16,11 +17,29 @@ public class WolverineModelCustomizer : RelationalModelCustomizer
     {
         base.Customize(modelBuilder, context);
 
-        var settings = context.Database.GetService<DatabaseSettings>();
-
-        modelBuilder.MapWolverineEnvelopeStorage(settings.SchemaName);
+        // An EF Core application without database-backed message persistence has no
+        // envelope tables to map. Before GH-3497 gave each Wolverine schema its own
+        // model cache entry, hosts like that accidentally borrowed a model built by
+        // a message-persistence host in the same process, so the hard dependency on
+        // DatabaseSettings here never surfaced
+        var settings = TryResolveDatabaseSettings(context);
+        if (settings != null)
+        {
+            modelBuilder.MapWolverineEnvelopeStorage(settings.SchemaName);
+        }
 
         markSagaIdentifiersAsApplicationAssigned(modelBuilder);
+    }
+
+    // Resolves through the application service provider (like EF's own throwing
+    // GetService fallback) but returns null instead of throwing when the host has
+    // no Wolverine database settings
+    internal static DatabaseSettings? TryResolveDatabaseSettings(DbContext context)
+    {
+        return context.GetService<IDbContextOptions>()
+            .FindExtension<CoreOptionsExtension>()?
+            .ApplicationServiceProvider?
+            .GetService<DatabaseSettings>();
     }
 
     // Wolverine assigns saga identities application-side (the id travels on the

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/WolverineModelCustomizer.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/WolverineModelCustomizer.cs
@@ -1,5 +1,7 @@
+using JasperFx.Core.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Wolverine.RDBMS;
 
 namespace Wolverine.EntityFrameworkCore.Internals;
@@ -17,6 +19,41 @@ public class WolverineModelCustomizer : RelationalModelCustomizer
         var settings = context.Database.GetService<DatabaseSettings>();
 
         modelBuilder.MapWolverineEnvelopeStorage(settings.SchemaName);
+
+        markSagaIdentifiersAsApplicationAssigned(modelBuilder);
+    }
+
+    // Wolverine assigns saga identities application-side (the id travels on the
+    // incoming message), so a saga key must never be a database-generated identity
+    // column. EF's convention makes int/long keys ValueGenerated.OnAdd (identity),
+    // which breaks saga inserts as soon as the table DDL honors the model (EF-managed
+    // migrations, or Weasel >= 9.18's EF-model translation — weasel#382). Only
+    // convention-sourced value generation is overridden; an explicit
+    // ValueGeneratedOnAdd() by the user is left alone
+    private static void markSagaIdentifiersAsApplicationAssigned(ModelBuilder modelBuilder)
+    {
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            if (!entityType.ClrType.CanBeCastTo<Saga>())
+            {
+                continue;
+            }
+
+            var primaryKey = entityType.FindPrimaryKey();
+            if (primaryKey == null)
+            {
+                continue;
+            }
+
+            foreach (var property in primaryKey.Properties)
+            {
+                if (((IConventionProperty)property).GetValueGeneratedConfigurationSource() !=
+                    ConfigurationSource.Explicit)
+                {
+                    property.ValueGenerated = ValueGenerated.Never;
+                }
+            }
+        }
     }
 }
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
@@ -259,6 +259,8 @@ public static class WolverineEntityCoreExtensions
         {
             configure(s, b);
             b.ReplaceService<IModelCustomizer, WolverineModelCustomizer>();
+        // Cache models per (context type, wolverine schema) -- GH-3497
+        b.ReplaceService<IModelCacheKeyFactory, WolverineModelCacheKeyFactory>();
         }, ServiceLifetime.Scoped, ServiceLifetime.Singleton);
 
         // TryAddEnumerable, NOT TryAddSingleton: TryAddSingleton gates on the service type alone,

--- a/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
@@ -136,6 +136,12 @@ public static class WolverineEntityCoreExtensions
             services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService, ConjoinedPartitionsActivator<T>>();
         }
 
+        // Authoritative tenant registry (wolverine_tenants) + dynamic tenant source.
+        // Registering IDynamicTenantSource<string> is what lights up CritterWatch's
+        // tenant management for this application
+        services.AddSingleton<ConjoinedTenantSource<T>>();
+        services.AddSingleton<IDynamicTenantSource<string>>(s => s.GetRequiredService<ConjoinedTenantSource<T>>());
+
         services.TryAddSingleton<IDbContextOutboxFactory, DbContextOutboxFactory>();
         registerEFCoreSagaStoreDiagnostics(services);
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
@@ -110,6 +110,72 @@ public static class WolverineEntityCoreExtensions
     }
 
     /// <summary>
+    /// Register a DbContext type that should use Wolverine managed conjoined multi-tenancy -- a single,
+    /// shared database (the application's Wolverine message store database) where every entity implementing
+    /// JasperFx.MultiTenancy.ITenanted is mapped with a tenant_id column, filtered by the current tenant
+    /// through a global query filter, stamped with the ambient tenant id on insert, and guarded against
+    /// cross-tenant updates and deletes
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="dbContextConfiguration"></param>
+    /// <param name="autoCreate">Should this application try to create the database and apply missing migrations at application startup? Default is None, all other options will create the database.</param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public static IServiceCollection AddDbContextWithWolverineManagedConjoinedTenancy<T>(this IServiceCollection services,
+        Action<DbContextOptionsBuilder<T>, ConnectionString> dbContextConfiguration, AutoCreate autoCreate = AutoCreate.None) where T : DbContext
+    {
+        services.TryAddSingleton<IDbContextOutboxFactory, DbContextOutboxFactory>();
+        registerEFCoreSagaStoreDiagnostics(services);
+
+        // For code generation
+        services.AddSingleton<IWolverineExtension, EntityFrameworkCoreBackedPersistence<T>>();
+
+        // STRICTLY FOR EF CORE MIGRATIONS!!!!
+        services.AddScoped<T>(s =>
+        {
+            return (T)s.GetRequiredService<IDbContextBuilder<T>>().BuildForMain();
+        });
+
+        services.AddSingleton<DbContextOptions<T>>(s =>
+        {
+            var builder = s.GetRequiredService<IDbContextBuilder<T>>();
+            return builder.BuildOptionsForMain();
+        });
+
+        services.AddSingleton<IDbContextBuilder<T>>(s =>
+        {
+            var store = s.GetRequiredService<IMessageStore>();
+            if (store is MultiTenantedMessageStore)
+            {
+                throw new InvalidOperationException(
+                    $"Conjoined multi-tenancy for {typeof(T).FullNameInCode()} uses a single, shared database, but Wolverine is configured with multi-tenanted (separate database per tenant) message storage. Use AddDbContextWithWolverineManagedMultiTenancy() for database per tenant multi-tenancy instead.");
+            }
+
+            if (store is not IMessageDatabase database)
+            {
+                throw new InvalidOperationException(
+                    $"Conjoined multi-tenancy for {typeof(T).FullNameInCode()} requires Wolverine to be configured with relational database message storage");
+            }
+
+            return new ConjoinedDbContextBuilder<T>(s, database, dbContextConfiguration, s.GetServices<IDomainEventScraper>());
+        });
+
+        services.AddSingleton<IDbContextBuilder>(s => s.GetRequiredService<IDbContextBuilder<T>>());
+
+        // CritterWatch (#102): single-database snapshot, same masked descriptor
+        // shape as the tenanted variants
+        services.AddSingleton<IDbContextUsageSource, TenantedDbContextUsageSource<T>>();
+
+        if (autoCreate != AutoCreate.None)
+        {
+            services.AddSingleton<IResourceCreator, TenantedDbContextInitializer<T>>();
+        }
+
+        return services;
+    }
+
+    /// <summary>
     /// Register a DbContext type that should use the separately configured Wolverine managed multi-tenancy
     /// for separate databases per tenant using DbDataSource. This option is necessary when using EF Core *with*
     /// Marten managed Multi-Tenancy

--- a/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
@@ -123,8 +123,19 @@ public static class WolverineEntityCoreExtensions
     /// <returns></returns>
     /// <exception cref="InvalidOperationException"></exception>
     public static IServiceCollection AddDbContextWithWolverineManagedConjoinedTenancy<T>(this IServiceCollection services,
-        Action<DbContextOptionsBuilder<T>, ConnectionString> dbContextConfiguration, AutoCreate autoCreate = AutoCreate.None) where T : DbContext
+        Action<DbContextOptionsBuilder<T>, ConnectionString> dbContextConfiguration, AutoCreate autoCreate = AutoCreate.None,
+        Action<ConjoinedTenancyOptions>? tenancy = null) where T : DbContext
     {
+        var conjoinedOptions = new ConjoinedTenancyOptions();
+        tenancy?.Invoke(conjoinedOptions);
+        ConjoinedTenancy.SetOptions(typeof(T), conjoinedOptions);
+
+        if (conjoinedOptions.PartitioningEnabled)
+        {
+            services.AddSingleton<IConjoinedTenantPartitions<T>, ConjoinedTenantPartitions<T>>();
+            services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService, ConjoinedPartitionsActivator<T>>();
+        }
+
         services.TryAddSingleton<IDbContextOutboxFactory, DbContextOutboxFactory>();
         registerEFCoreSagaStoreDiagnostics(services);
 

--- a/src/Persistence/Wolverine.Postgresql/MultiTenancy/PostgresqlTenantPartitioning.cs
+++ b/src/Persistence/Wolverine.Postgresql/MultiTenancy/PostgresqlTenantPartitioning.cs
@@ -1,0 +1,112 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Tables.Partitioning;
+using Wolverine.RDBMS.MultiTenancy;
+
+namespace Wolverine.Postgresql.MultiTenancy;
+
+public class PostgresqlTenantPartitioningProviderFactory : ITenantPartitioningProviderFactory
+{
+    public bool MatchesEfCoreProvider(string efCoreProviderName)
+    {
+        return efCoreProviderName.Contains("Npgsql", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public ITenantPartitioning Create(DbObjectName controlTableName, TenantPartitioningOptions options)
+    {
+        return new PostgresqlTenantPartitioning(controlTableName, options);
+    }
+}
+
+/// <summary>
+///     PostgreSQL partition-per-tenant: LIST partitioning on the tenant id column,
+///     managed through Weasel's ManagedListPartitions control table
+/// </summary>
+internal class PostgresqlTenantPartitioning : ITenantPartitioning
+{
+    private readonly ManagedListPartitions _partitions;
+    private readonly TenantPartitioningOptions _options;
+
+    public PostgresqlTenantPartitioning(DbObjectName controlTableName, TenantPartitioningOptions options)
+    {
+        _options = options;
+        _partitions = new ManagedListPartitions(controlTableName.Name, controlTableName);
+    }
+
+    public bool RequiresTenantOrdinalColumn => false;
+
+    public IReadOnlyList<ISchemaObject> AdditionalSchemaObjects => _partitions.Objects;
+
+    public void ApplyToTable(ITable table)
+    {
+        var pgTable = (Table)table;
+        pgTable.PartitionByList(_options.TenantIdColumn).UsePartitionManager(_partitions);
+
+        // PostgreSQL requires the partition column in every unique constraint, so
+        // the DATABASE primary key becomes (id..., tenant_id). The EF model keeps
+        // the user's own single key -- ids remain globally unique through Wolverine's
+        // tenant stamping, and keyed loads keep their shape
+        pgTable.ModifyColumn(_options.TenantIdColumn).AsPrimaryKey();
+
+        // The managed partition set is reconciled additively at add-tenant time;
+        // routine migration deltas must not try to rebuild the table around the
+        // live partition list
+        pgTable.IgnorePartitionsInMigration = true;
+    }
+
+    public void AttachInitializer(IDatabaseWithTables database)
+    {
+        ((PostgresqlDatabase)database).AddInitializer(_partitions);
+    }
+
+    public Task InitializeAsync(IDatabaseWithTables database, CancellationToken token)
+    {
+        return _partitions.InitializeAsync((PostgresqlDatabase)database, token);
+    }
+
+    public bool TryGetOrdinal(string tenantId, out int ordinal)
+    {
+        ordinal = default;
+        return false;
+    }
+
+    public async Task AddTenantsAsync(ILogger logger, IDatabaseWithTables database,
+        IReadOnlyDictionary<string, string?> tenantIdToSuffix, CancellationToken token)
+    {
+        var values = tenantIdToSuffix.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value ?? pair.Key.ToLowerInvariant());
+
+        var statuses =
+            await _partitions.AddPartitionToAllTables(logger, (PostgresqlDatabase)database, values, token);
+
+        var failures = statuses.Where(x => x.Status != PartitionMigrationStatus.Complete).ToArray();
+        if (failures.Any())
+        {
+            throw new InvalidOperationException(
+                $"Adding tenant partitions failed for table(s) {failures.Select(x => x.Identifier.QualifiedName).Join(", ")}");
+        }
+    }
+
+    public async Task DropTenantsAsync(ILogger logger, IDatabaseWithTables database, IReadOnlyList<string> tenantIds,
+        bool deleteData, CancellationToken token)
+    {
+        // PostgreSQL partition removal is DETACH + DROP -- inherently data-removing.
+        // deleteData == false is not supported on this engine
+        if (!deleteData)
+        {
+            throw new NotSupportedException(
+                "PostgreSQL tenant partition removal detaches and drops the tenant's partition, which removes its rows. Call with deleteData: true to acknowledge.");
+        }
+
+        foreach (var tenantId in tenantIds)
+        {
+            await _partitions.DropPartitionFromAllTablesForValue((PostgresqlDatabase)database, logger, tenantId,
+                token);
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
@@ -286,7 +286,7 @@ internal class PostgresqlBackedPersistence : IPostgresqlBackedPersistence, IWolv
             ScheduledJobLockId = ScheduledJobLockId,
             MigrationLockId = MigrationLockId,
             SchemaName = EnvelopeStorageSchemaName,
-            AddTenantLookupTable = UseMasterTableTenancy,
+            AddTenantLookupTable = UseMasterTableTenancy || _options.Durability.TenantRegistryRequired,
             TenantConnections = TenantConnections,
             // Propagate the AutoCreate override (see #2780). Without this,
             // OverrideAutoCreateResources(autoCreate) mutated the wrapper's

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
@@ -207,6 +207,11 @@ internal class PostgresqlBackedPersistence : IPostgresqlBackedPersistence, IWolv
         options.CodeGeneration.Sources.Add(new DatabaseBackedPersistenceMarker());
         options.CodeGeneration.Sources.Add(new SagaStorageVariableSource());
 
+        // Weasel-managed tenant partitioning support for conjoined EF Core multi-tenancy
+        options.Services.TryAddEnumerable(ServiceDescriptor
+            .Singleton<ITenantPartitioningProviderFactory, Wolverine.Postgresql.MultiTenancy.
+                PostgresqlTenantPartitioningProviderFactory>());
+
         options.Services.AddSingleton<IMessageStore>(s => BuildMessageStore(s.GetRequiredService<IWolverineRuntime>()));
 
         options.Services.AddSingleton<IDatabaseSource, MessageDatabaseDiscovery>();

--- a/src/Persistence/Wolverine.RDBMS/MultiTenancy/ITenantPartitioning.cs
+++ b/src/Persistence/Wolverine.RDBMS/MultiTenancy/ITenantPartitioning.cs
@@ -1,0 +1,110 @@
+using JasperFx;
+using Microsoft.Extensions.Logging;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+
+namespace Wolverine.RDBMS.MultiTenancy;
+
+/// <summary>
+///     Options for Weasel-managed, partition-per-tenant physical partitioning of
+///     conjoined multi-tenant tables
+/// </summary>
+public class TenantPartitioningOptions
+{
+    /// <summary>
+    ///     Name of the tenant id discriminator column. Default is tenant_id
+    /// </summary>
+    public string TenantIdColumn { get; set; } = StorageConstants.TenantIdColumn;
+
+    /// <summary>
+    ///     Name of the integer ordinal column used on database engines that can only
+    ///     partition by range over a compact value (SQL Server). Default is tenant_ordinal
+    /// </summary>
+    public string TenantOrdinalColumn { get; set; } = "tenant_ordinal";
+
+    /// <summary>
+    ///     Allow multiple tenants to share a single physical partition ("bucketing"),
+    ///     via the partition suffix on PostgreSQL or a shared ordinal on SQL Server.
+    ///     The answer to "small tenants don't deserve their own partition" and SQL
+    ///     Server's partition count ceiling
+    /// </summary>
+    public bool AllowPartitionSharing { get; set; }
+}
+
+/// <summary>
+///     Contributed by each database provider package (Wolverine.Postgresql,
+///     Wolverine.SqlServer) to supply the Weasel-managed tenant partitioning
+///     implementation for that database engine
+/// </summary>
+public interface ITenantPartitioningProviderFactory
+{
+    /// <summary>
+    ///     Does this factory serve the given EF Core provider (e.g.
+    ///     "Npgsql.EntityFrameworkCore.PostgreSQL", "Microsoft.EntityFrameworkCore.SqlServer")?
+    /// </summary>
+    bool MatchesEfCoreProvider(string efCoreProviderName);
+
+    ITenantPartitioning Create(DbObjectName controlTableName, TenantPartitioningOptions options);
+}
+
+/// <summary>
+///     Engine-specific Weasel-managed tenant partitioning applied to conjoined
+///     multi-tenant tables: one physical partition per tenant (or per shared
+///     bucket), driven from a control/registry table in the durability schema
+/// </summary>
+public interface ITenantPartitioning
+{
+    /// <summary>
+    ///     True when this engine partitions over a compact integer ordinal (SQL
+    ///     Server) and therefore needs the tenant ordinal column mapped and
+    ///     stamped on every partitioned entity
+    /// </summary>
+    bool RequiresTenantOrdinalColumn { get; }
+
+    /// <summary>
+    ///     Schema objects beyond the entity tables that must be part of the
+    ///     migration -- the partition control/registry table
+    /// </summary>
+    IReadOnlyList<ISchemaObject> AdditionalSchemaObjects { get; }
+
+    /// <summary>
+    ///     Attach the partition strategy to a Weasel table mapped from an EF
+    ///     entity type
+    /// </summary>
+    void ApplyToTable(ITable table);
+
+    /// <summary>
+    ///     Register this partitioning's database initializer with the Weasel
+    ///     database so migrations hydrate the tenant map before computing deltas
+    /// </summary>
+    void AttachInitializer(IDatabaseWithTables database);
+
+    /// <summary>
+    ///     Hydrate (or re-hydrate) the in-memory tenant map from the control table
+    /// </summary>
+    Task InitializeAsync(IDatabaseWithTables database, CancellationToken token);
+
+    /// <summary>
+    ///     Resolve the ordinal for a tenant id on engines where
+    ///     RequiresTenantOrdinalColumn is true. Returns false when the tenant has
+    ///     no partition yet (or the engine has no ordinal concept)
+    /// </summary>
+    bool TryGetOrdinal(string tenantId, out int ordinal);
+
+    /// <summary>
+    ///     Add partitions for the given tenants across all partitioned tables.
+    ///     The dictionary value is the optional partition suffix -- tenants
+    ///     sharing a suffix share a physical partition when AllowPartitionSharing
+    ///     is enabled; null values give each tenant its own partition
+    /// </summary>
+    Task AddTenantsAsync(ILogger logger, IDatabaseWithTables database,
+        IReadOnlyDictionary<string, string?> tenantIdToSuffix, CancellationToken token);
+
+    /// <summary>
+    ///     Remove the given tenants from the partition set. deleteData controls
+    ///     whether the tenants' rows are removed where the engine supports
+    ///     retaining them
+    /// </summary>
+    Task DropTenantsAsync(ILogger logger, IDatabaseWithTables database, IReadOnlyList<string> tenantIds,
+        bool deleteData, CancellationToken token);
+}

--- a/src/Persistence/Wolverine.SqlServer/MultiTenancy/SqlServerTenantPartitioning.cs
+++ b/src/Persistence/Wolverine.SqlServer/MultiTenancy/SqlServerTenantPartitioning.cs
@@ -1,0 +1,133 @@
+using JasperFx.Core;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Weasel.SqlServer.Tables;
+using Weasel.SqlServer.Tables.Partitioning;
+using Wolverine.RDBMS.MultiTenancy;
+
+namespace Wolverine.SqlServer.MultiTenancy;
+
+public class SqlServerTenantPartitioningProviderFactory : ITenantPartitioningProviderFactory
+{
+    public bool MatchesEfCoreProvider(string efCoreProviderName)
+    {
+        return efCoreProviderName.Contains("SqlServer", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public ITenantPartitioning Create(DbObjectName controlTableName, TenantPartitioningOptions options)
+    {
+        return new SqlServerTenantPartitioning(controlTableName, options);
+    }
+}
+
+/// <summary>
+///     SQL Server partition-per-tenant: RANGE RIGHT partitioning over a compact
+///     tenant ordinal column, managed through Weasel's ManagedTenantPartitions
+///     ordinal registry. Application rows carry the ordinal in a column stamped by
+///     Wolverine's tenant interceptor
+/// </summary>
+internal class SqlServerTenantPartitioning : ITenantPartitioning
+{
+    private readonly TenantPartitioningOptions _options;
+    private readonly ManagedTenantPartitions _partitions;
+
+    public SqlServerTenantPartitioning(DbObjectName controlTableName, TenantPartitioningOptions options)
+    {
+        _options = options;
+        _partitions = new ManagedTenantPartitions(controlTableName.Name, controlTableName,
+            options.TenantOrdinalColumn)
+        {
+            AllowOrdinalSharing = options.AllowPartitionSharing
+        };
+    }
+
+    public bool RequiresTenantOrdinalColumn => true;
+
+    public IReadOnlyList<ISchemaObject> AdditionalSchemaObjects => _partitions.Objects;
+
+    public void ApplyToTable(ITable table)
+    {
+        var sqlTable = (Table)table;
+        sqlTable.PartitionByManagedTenants(_partitions);
+
+        // The clustered primary key must be aligned with the partition scheme,
+        // which requires the partition (ordinal) column as a key member. The EF
+        // model keeps the user's own single key
+        sqlTable.ModifyColumn(_options.TenantOrdinalColumn).AsPrimaryKey();
+    }
+
+    public void AttachInitializer(IDatabaseWithTables database)
+    {
+        ((DatabaseBase<SqlConnection>)database).AddInitializer(_partitions);
+    }
+
+    public Task InitializeAsync(IDatabaseWithTables database, CancellationToken token)
+    {
+        return _partitions.InitializeAsync((IDatabase<SqlConnection>)database, token);
+    }
+
+    public bool TryGetOrdinal(string tenantId, out int ordinal)
+    {
+        return _partitions.Ordinals.TryGetValue(tenantId, out ordinal);
+    }
+
+    public async Task AddTenantsAsync(ILogger logger, IDatabaseWithTables database,
+        IReadOnlyDictionary<string, string?> tenantIdToSuffix, CancellationToken token)
+    {
+        var db = (IDatabase<SqlConnection>)database;
+        await _partitions.InitializeAsync(db, token);
+
+        // Tenants without a suffix each get their own auto-allocated ordinal.
+        // Tenants sharing a suffix share one ordinal (a shared physical partition),
+        // mirroring the PostgreSQL suffix bucketing
+        var standalone = tenantIdToSuffix.Where(x => x.Value == null).Select(x => x.Key).ToArray();
+        if (standalone.Any())
+        {
+            await _partitions.AddPartitionToAllTables(logger, db, standalone, token);
+        }
+
+        foreach (var bucket in tenantIdToSuffix.Where(x => x.Value != null).GroupBy(x => x.Value!))
+        {
+            if (!_options.AllowPartitionSharing && bucket.Count() > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Tenants {bucket.Select(x => x.Key).Join(", ")} share partition suffix '{bucket.Key}', but partition sharing is not enabled. Enable AllowPartitionSharing on the tenant partitioning options.");
+            }
+
+            // The bucket's ordinal is whichever member is already registered, or
+            // the next free ordinal for a brand new bucket
+            var members = bucket.Select(x => x.Key).ToArray();
+            var existing = members.Where(m => _partitions.Ordinals.ContainsKey(m))
+                .Select(m => _partitions.Ordinals[m]).Distinct().ToArray();
+
+            if (existing.Length > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Tenants {members.Join(", ")} for suffix '{bucket.Key}' are already mapped to different partitions ({string.Join(", ", existing)})");
+            }
+
+            var ordinal = existing.Length == 1
+                ? existing[0]
+                : (_partitions.Ordinals.Values.DefaultIfEmpty(0).Max() + 1);
+
+            var mapping = members.ToDictionary(m => m, _ => ordinal);
+            var result = await _partitions.AddPartitionsToAllTables(logger, db, mapping, token);
+
+            var failures = result.Tables.Where(x => x.Status != PartitionMigrationStatus.Complete).ToArray();
+            if (failures.Any())
+            {
+                throw new InvalidOperationException(
+                    $"Adding tenant partitions failed for table(s) {failures.Select(x => x.Identifier.QualifiedName).Join(", ")}");
+            }
+        }
+    }
+
+    public Task DropTenantsAsync(ILogger logger, IDatabaseWithTables database, IReadOnlyList<string> tenantIds,
+        bool deleteData, CancellationToken token)
+    {
+        return _partitions.DropPartitionFromAllTables(logger, (IDatabase<SqlConnection>)database, tenantIds,
+            deleteData ? TenantDropBehavior.DeleteData : TenantDropBehavior.RetainData, token);
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/SqlServerBackedPersistence.cs
+++ b/src/Persistence/Wolverine.SqlServer/SqlServerBackedPersistence.cs
@@ -6,6 +6,7 @@ using JasperFx.Core.Reflection;
 using JasperFx.MultiTenancy;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Weasel.Core;
 using Weasel.Core.Migrations;
@@ -175,6 +176,11 @@ internal class SqlServerBackedPersistence : IWolverineExtension, ISqlServerBacke
         options.CodeGeneration.AddPersistenceStrategy<LightweightSagaPersistenceFrameProvider>();
         options.CodeGeneration.Sources.Add(new DatabaseBackedPersistenceMarker());
         options.CodeGeneration.Sources.Add(new SagaStorageVariableSource());
+
+        // Weasel-managed tenant partitioning support for conjoined EF Core multi-tenancy
+        options.Services.TryAddEnumerable(ServiceDescriptor
+            .Singleton<ITenantPartitioningProviderFactory, Wolverine.SqlServer.MultiTenancy.
+                SqlServerTenantPartitioningProviderFactory>());
 
         options.Services.AddSingleton<Migrator, SqlServerMigrator>();
         

--- a/src/Persistence/Wolverine.SqlServer/SqlServerBackedPersistence.cs
+++ b/src/Persistence/Wolverine.SqlServer/SqlServerBackedPersistence.cs
@@ -268,7 +268,7 @@ internal class SqlServerBackedPersistence : IWolverineExtension, ISqlServerBacke
             ConnectionString = ConnectionString,
             ScheduledJobLockId = ScheduledJobLockId,
             SchemaName = EnvelopeStorageSchemaName,
-            AddTenantLookupTable = UseMasterTableTenancy,
+            AddTenantLookupTable = UseMasterTableTenancy || _options.Durability.TenantRegistryRequired,
             TenantConnections = TenantConnections,
             // Propagate the AutoCreate override (see #2780).
             AutoCreate = AutoCreate

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -77,6 +77,13 @@ public class DurabilitySettings : IDescribeMyself
     internal bool TenantIdStyleHasChanged { get; set; }
 
     /// <summary>
+    ///     Set by tenancy integrations (e.g. Wolverine's conjoined EF Core multi-tenancy)
+    ///     that need the message store to provision its wolverine_tenants registry table
+    ///     even without database-per-tenant master table tenancy
+    /// </summary>
+    public bool TenantRegistryRequired { get; set; }
+
+    /// <summary>
     /// If set, this establishes a default database schema name for all registered message
     /// storage databases. Use this with a modular monolith approach where all modules target the same physical database. The default is null.
     /// </summary>


### PR DESCRIPTION
Closes #3462, closes #3463, closes #3464, closes #3497. Completes the Wolverine side of the conjoined tenancy epic #3465 in one PR (per review-bandwidth preference: the phases were validated locally suite-by-suite rather than through per-phase CI round-trips).

Upstream: JasperFx **2.30.0** (shared `ITenanted`, jasperfx#531), Weasel **9.18.1** (weasel#383: EF schema-mapping customization hook + index case-quoting fix), Marten **9.16.1**.

## Phase 1 (#3462) — conjoined core

`ITenanted` on an EF entity makes it conjoined-multi-tenant: `tenant_id` column + sentinel default + index, a tenant-bound global query filter (named filter on EF 10), stamp-on-insert, and `CrossTenantWriteException` guards on cross-tenant writes — via `AddDbContextWithWolverineManagedConjoinedTenancy<T>()`. The filter closes over the model-time `DbContext` and is re-rooted by EF's funcletizer to the executing context instance, so per-context tenant binding works with EF's cached model and **no user base class**. `ConjoinedDbContextBuilder<T>` keeps the `IDbContextBuilder<T>` shape, so codegen frames, the outbox factory, and saga persistence work unchanged; `FindAsync` respects the filter, making saga loads tenant-scoped for free.

## Phase 2 (#3463) — opt-in Weasel-managed tenant partitioning

`tenancy => tenancy.PartitionPerTenant()`:

- PostgreSQL: `PARTITION BY LIST (tenant_id)` per non-saga `ITenanted` table via `ManagedListPartitions` + `wolverine_tenant_partitions` control table, with Marten-style suffix bucketing.
- SQL Server: `RANGE RIGHT` over an `int tenant_ordinal` shadow column via `ManagedTenantPartitions` (weasel#362), ordinal stamped by the tenant interceptor from the pre-hydrated registry; `AllowPartitionSharing` for bucketed ordinals.
- **The composite `(tenant, id)` PK exists only in the database** (attached during Weasel table mapping); the EF model keeps the user's single key, so `FindAsync`/`Attach` call shapes and saga loads are untouched. EF-side composite keys are unworkable regardless — key members must be non-null at `Add()` time, before any interceptor can stamp them, and EF value-generates key members (a GUID string for `TenantId`) if you try.
- Provider abstraction `ITenantPartitioning(+Factory)` lives in `Wolverine.RDBMS`; implementations contributed by `Wolverine.Postgresql` / `Wolverine.SqlServer`.
- Management via `IConjoinedTenantPartitions<T>` (add tenant / shared-suffix bucket / drop).
- Sagas are deliberately **not** partitioned in v1 (composite keys would change saga load frames — flagged as an open question on #3465).

## Phase 3 (#3464) — tenant registry + dynamic tenant source

The message store provisions `wolverine_tenants` for conjoined registrations (`DurabilitySettings.TenantRegistryRequired`). `ConjoinedTenantSource<T> : IDynamicTenantSource<string>` — auto-assign add (registry insert + partition creation), explicit-connection add rejected with a descriptive error, disable/enable enforced at `SaveChanges` with `UnknownTenantIdException`, remove = registry delete + partition drop with data. Registering `IDynamicTenantSource<string>` is what lights up CritterWatch tenant management (CritterWatch#720 continues there).

## Phase 4 — tests + docs

- Compliance batteries (PG + SQL Server): conjoined core (9×2), partitioning (5×2), registry (3×2), all ported from Marten's conjoined semantics.
- HTTP tenant-detection integration test: header/query-string detection pins the context, stamps writes, scopes reads with zero endpoint tenant-awareness.
- Docs: conjoined tenancy + partitioning + registry sections with extracted samples on the EF Core multi-tenancy page.

## Also in this PR

- **#3497 fix**: `WolverineModelCacheKeyFactory` keys EF's model cache on (context type, wolverine schema, designTime) — two hosts sharing a DbContext type with different durability schemas no longer share an envelope-table mapping. The previously ordering-dependent `EfCoreTests.MultiTenancy` SQL Server failures are gone: full suite 176/176 locally.
- **Saga keys are `ValueGeneratedNever` by convention** (unless explicitly configured): saga ids are app-assigned, and Weasel 9.18's faithful EF-model translation turned conventionally-mapped int/long saga keys into IDENTITY columns (weasel#382 analysis).
- The NServiceBus interop regression under Weasel 9.18.0 is fixed upstream in 9.18.1 (index case-quoting, weasel#383).

## Validation (local)

Full `wolverine.slnx` Release build (0 warnings), `EfCoreTests.MultiTenancy` 176/176, `EfCoreTests` saga batteries, PostgreSQL transport + NServiceBus interop, HTTP detection — all green against Weasel 9.18.1.

## Open naming questions (per #3465)

1. `AddDbContextWithWolverineManagedConjoinedTenancy<T>` — happy to rename before 6.21.
2. `CrossTenantWriteException` naming.
3. Sample app + announcement blog post are deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKamPNecC62LWBUh23yuPe
