### PR TITLE
GH-3490: JasperFx 2.30.1 batching max-age fix + batched durable inbox for Kafka (measured)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,13 +35,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.30.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.30.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.30.0" />
+    <PackageVersion Include="JasperFx" Version="2.30.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.30.1" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.30.1" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.30.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.30.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.16.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -1282,11 +1282,15 @@ transport, and the factors behind them.
   as a message is buffered, *before* it is handled — an ungraceful process crash can lose
   buffered messages (effectively at-most-once). Use it when throughput matters and your
   handlers are idempotent or losses on crash are tolerable.
-- **Durable** (`UseDurableInbox()`) writes each incoming message to the database inbox before
-  the offset advances. The inbox write happens on the consume loop, so your database's write
-  latency directly gates consumption throughput on that listener. Plan for the inbox database
-  to be close (latency-wise) and lightly contended, and scale with `ListenerCount` when a
-  single listener's insert rate becomes the ceiling.
+- **Durable** (`UseDurableInbox()`) writes incoming messages to the database inbox before
+  the offset advances. The consume loop drains up to `MaximumMessagesToReceive` (default 100)
+  already-fetched records at a time and persists them with a single batched insert, so under
+  load the inbox cost is paid per batch rather than per record — measured locally this took a
+  2,000 msg/s stream from unbounded backlog to a steady ~32ms delivery p50 (GH-3490). Your
+  database's write latency still gates the ceiling; plan for the inbox database to be close
+  (latency-wise) and lightly contended, set `MaximumMessagesToReceive(1)` if you need strict
+  record-at-a-time consumption, and scale with `ListenerCount` when a single listener's insert
+  rate becomes the ceiling.
 - **Inline** (`ProcessInline()`) processes one message at a time per consumer, end to end, and
   only then stores the offset. Strongest per-partition guarantees, lowest throughput per
   listener — scale with `ListenerCount` (bounded by the topic's partition count).

--- a/src/Testing/KafkaPerfRig/KafkaPerfRig.csproj
+++ b/src/Testing/KafkaPerfRig/KafkaPerfRig.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\Transports\Kafka\Wolverine.Kafka\Wolverine.Kafka.csproj" />
+        <ProjectReference Include="..\..\Transports\RabbitMQ\Wolverine.RabbitMQ\Wolverine.RabbitMQ.csproj" />
         <ProjectReference Include="..\..\Persistence\Wolverine.Postgresql\Wolverine.Postgresql.csproj" />
         <ProjectReference Include="..\..\Wolverine.RuntimeCompilation\Wolverine.RuntimeCompilation.csproj" />
     </ItemGroup>

--- a/src/Testing/KafkaPerfRig/NativeRabbitTwin.cs
+++ b/src/Testing/KafkaPerfRig/NativeRabbitTwin.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+using System.Text.Json;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace KafkaPerfRig;
+
+/// <summary>
+/// Raw RabbitMQ.Client 7 twin for GH-3492: fire-and-forget publishes (no publisher confirms —
+/// the fastest-native anchor, the confirm cliff is its own experiment cell), one
+/// AsyncEventingBasicConsumer with manual per-message acks and the same prefetch as a default
+/// Wolverine Inline listener. Same corpus, rate loops, and stage clock as every other twin.
+/// </summary>
+public static class NativeRabbitTwin
+{
+    public static async Task RunPublisherAsync(RigConfig cfg)
+    {
+        var factory = new ConnectionFactory { Uri = new Uri(cfg.RabbitUri) };
+        await using var connection = await factory.CreateConnectionAsync();
+        await using var channel = await connection.CreateChannelAsync();
+        await declareQueuesAsync(channel, cfg);
+
+        Console.WriteLine($"[rig] native rabbit publisher up: {cfg.Describe()}");
+
+        async Task publish<T>(string queue, T message)
+        {
+            var bytes = JsonSerializer.SerializeToUtf8Bytes(message);
+            await channel.BasicPublishAsync("", queue, false, new BasicProperties(), bytes);
+        }
+
+        var counters = await PublishLoops.RunAsync(cfg,
+            (gameId, seq, t0, warmup) => publish(cfg.SmallQueue,
+                new SmallEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Small }),
+            (gameId, seq, t0, warmup) => publish(cfg.LargeQueue,
+                new LargeEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Large }));
+
+        Console.WriteLine($"[rig] native rabbit publisher done: {counters.small} small, {counters.large} large");
+    }
+
+    public static async Task RunConsumerAsync(RigConfig cfg, CancellationToken token)
+    {
+        var factory = new ConnectionFactory { Uri = new Uri(cfg.RabbitUri) };
+        await using var connection = await factory.CreateConnectionAsync();
+        await using var channel = await connection.CreateChannelAsync();
+        await declareQueuesAsync(channel, cfg);
+        await channel.BasicQosAsync(0, cfg.RabbitPrefetch, false);
+
+        var consumer = new AsyncEventingBasicConsumer(channel);
+        consumer.ReceivedAsync += async (_, ea) =>
+        {
+            var t2 = Stopwatch.GetTimestamp();
+
+            string kind;
+            long t0;
+            bool warmup;
+            if (ea.RoutingKey == cfg.LargeQueue)
+            {
+                var message = JsonSerializer.Deserialize<LargeEvent>(ea.Body.Span)!;
+                (kind, t0, warmup) = ("large", message.T0, message.Warmup);
+            }
+            else
+            {
+                var message = JsonSerializer.Deserialize<SmallEvent>(ea.Body.Span)!;
+                (kind, t0, warmup) = ("small", message.T0, message.Warmup);
+            }
+
+            var t3 = Stopwatch.GetTimestamp();
+            if (RigHandlerSettings.HandlerMs > 0)
+            {
+                await Task.Delay(RigHandlerSettings.HandlerMs);
+            }
+
+            StageRecorder.Record(new StageSample(kind, warmup, t0, t2, t3, Stopwatch.GetTimestamp()));
+            await channel.BasicAckAsync(ea.DeliveryTag, false);
+        };
+
+        await channel.BasicConsumeAsync(cfg.SmallQueue, false, consumer);
+        await channel.BasicConsumeAsync(cfg.LargeQueue, false, consumer);
+        Console.WriteLine($"[rig] native rabbit consumer up: {cfg.Describe()}");
+
+        try
+        {
+            await Task.Delay(Timeout.Infinite, token);
+        }
+        catch (OperationCanceledException)
+        {
+            // shutdown
+        }
+
+        StageRecorder.Dump(cfg.OutDir, "native-rabbit-consumer", new
+        {
+            harness = "native-rabbit",
+            handlerMs = cfg.HandlerMs,
+            prefetch = cfg.RabbitPrefetch
+        });
+    }
+
+    private static async Task declareQueuesAsync(IChannel channel, RigConfig cfg)
+    {
+        foreach (var queue in new[] { cfg.SmallQueue, cfg.LargeQueue })
+        {
+            await channel.QueueDeclareAsync(queue, true, false, false);
+        }
+    }
+}

--- a/src/Testing/KafkaPerfRig/NativeTwin.cs
+++ b/src/Testing/KafkaPerfRig/NativeTwin.cs
@@ -32,8 +32,21 @@ public static class NativeTwin
         Task publish<T>(string topic, T message, string gameId)
         {
             var bytes = JsonSerializer.SerializeToUtf8Bytes(message);
-            producer.Produce(topic, new Message<string, byte[]> { Key = gameId, Value = bytes }, handleReport);
-            return Task.CompletedTask;
+            var record = new Message<string, byte[]> { Key = gameId, Value = bytes };
+            while (true)
+            {
+                try
+                {
+                    producer.Produce(topic, record, handleReport);
+                    return Task.CompletedTask;
+                }
+                catch (ProduceException<string, byte[]> e) when (e.Error.Code == ErrorCode.Local_QueueFull)
+                {
+                    // max-throughput mode outruns librdkafka's local queue; give the
+                    // background poller a beat to drain and retry
+                    producer.Poll(TimeSpan.FromMilliseconds(10));
+                }
+            }
         }
 
         Console.WriteLine($"[rig] native publisher up: {cfg.Describe()}");

--- a/src/Testing/KafkaPerfRig/Program.cs
+++ b/src/Testing/KafkaPerfRig/Program.cs
@@ -37,8 +37,39 @@ switch (role)
         await NativeTwin.RunPublisherAsync(cfg);
         break;
 
+    case "rabbit-consumer":
+        await WolverineRabbit.RunConsumerAsync(cfg);
+        break;
+
+    case "rabbit-publisher":
+        await WolverineRabbit.RunPublisherAsync(cfg);
+        break;
+
+    case "native-rabbit-consumer":
+    {
+        RigHandlerSettings.HandlerMs = cfg.HandlerMs;
+        using var cancellation = new CancellationTokenSource();
+        using var sigterm = PosixSignalRegistration.Create(PosixSignal.SIGTERM, ctx =>
+        {
+            ctx.Cancel = true;
+            cancellation.Cancel();
+        });
+        using var sigint = PosixSignalRegistration.Create(PosixSignal.SIGINT, ctx =>
+        {
+            ctx.Cancel = true;
+            cancellation.Cancel();
+        });
+        await NativeRabbitTwin.RunConsumerAsync(cfg, cancellation.Token);
+        break;
+    }
+
+    case "native-rabbit-publisher":
+        await NativeRabbitTwin.RunPublisherAsync(cfg);
+        break;
+
     default:
-        Console.WriteLine("usage: KafkaPerfRig <wolverine-consumer|wolverine-publisher|native-consumer|native-publisher>");
+        Console.WriteLine(
+            "usage: KafkaPerfRig <wolverine|native|rabbit|native-rabbit>-<consumer|publisher>");
         Console.WriteLine("Configuration via RIG_* environment variables; see RigConfig.cs and rig.sh.");
         return 1;
 }

--- a/src/Testing/KafkaPerfRig/RigConfig.cs
+++ b/src/Testing/KafkaPerfRig/RigConfig.cs
@@ -46,6 +46,17 @@ public class RigConfig
 
     public string PostgresSchema { get; } = env("RIG_PG_SCHEMA", "kafka_rig");
 
+    // 0 = leave the endpoint's default listener count
+    public int ListenerCount { get; } = envInt("RIG_LISTENER_COUNT", 0);
+
+    // --- RabbitMQ (GH-3492) ---
+    public string RabbitUri { get; } = env("RIG_RABBIT_URI", "amqp://guest:guest@localhost:5672");
+    public string SmallQueue => $"rig-small-{RunId}";
+    public string LargeQueue => $"rig-large-{RunId}";
+
+    // native Rabbit twin prefetch; match Wolverine's listener PreFetchCount default of 100
+    public ushort RabbitPrefetch { get; } = (ushort)envInt("RIG_RABBIT_PREFETCH", 100);
+
     private static string env(string key, string fallback)
     {
         return Environment.GetEnvironmentVariable(key) is { Length: > 0 } value ? value : fallback;

--- a/src/Testing/KafkaPerfRig/StageRecorder.cs
+++ b/src/Testing/KafkaPerfRig/StageRecorder.cs
@@ -44,33 +44,65 @@ public static class StageRecorder
         Directory.CreateDirectory(outDir);
         var samples = _samples.ToArray();
 
-        var csv = new StringBuilder("kind,warmup,transit_ms,dwell_ms,handler_ms,total_ms\n");
-        foreach (var s in samples)
-        {
-            csv.Append(
-                $"{s.Kind},{s.Warmup},{toMs(s.T0, s.T2):F3},{toMs(s.T2, s.T3):F3},{toMs(s.T3, s.T4):F3},{toMs(s.T0, s.T4):F3}\n");
-        }
-
         var csvPath = Path.Combine(outDir, $"{label}-stages.csv");
-        File.WriteAllText(csvPath, csv.ToString());
+        if (samples.Length <= 1_000_000)
+        {
+            var csv = new StringBuilder("kind,warmup,transit_ms,dwell_ms,handler_ms,total_ms\n");
+            foreach (var s in samples)
+            {
+                csv.Append(
+                    $"{s.Kind},{s.Warmup},{toMs(s.T0, s.T2):F3},{toMs(s.T2, s.T3):F3},{toMs(s.T3, s.T4):F3},{toMs(s.T0, s.T4):F3}\n");
+            }
+
+            File.WriteAllText(csvPath, csv.ToString());
+        }
+        else
+        {
+            // max-throughput runs collect millions of samples; the summary percentiles are
+            // what matters there and a multi-GB CSV helps no one
+            File.WriteAllText(csvPath, $"suppressed: {samples.Length} samples, see summary json\n");
+        }
 
         var summary = new Dictionary<string, object> { ["scenario"] = scenario, ["samples"] = samples.Length };
         foreach (var kind in new[] { "small", "large" })
         {
-            var measured = samples.Where(s => s.Kind == kind && !s.Warmup).ToArray();
-            if (measured.Length == 0)
+            var ofKind = samples.Where(s => s.Kind == kind).ToArray();
+            if (ofKind.Length == 0)
             {
                 continue;
             }
 
-            summary[kind] = new Dictionary<string, object>
+            var entry = new Dictionary<string, object> { ["count"] = ofKind.Length };
+            summary[kind] = entry;
+
+            // Sustained consumption rate over the trimmed middle of the RECEIVE window (drop the
+            // first/last 10% of samples by handler-exit time). Deliberately independent of the
+            // publish-time warmup flag: in max-throughput mode the publisher outruns the
+            // consumer, so the consumer can spend the whole run inside the "warmup" segment of
+            // the backlog — the receive-side steady-state rate is the honest metric.
+            if (ofKind.Length >= 100)
             {
-                ["count"] = measured.Length,
-                ["transit_ms"] = percentiles(measured.Select(s => toMs(s.T0, s.T2))),
-                ["dwell_ms"] = percentiles(measured.Select(s => toMs(s.T2, s.T3))),
-                ["handler_ms"] = percentiles(measured.Select(s => toMs(s.T3, s.T4))),
-                ["total_ms"] = percentiles(measured.Select(s => toMs(s.T0, s.T4)))
-            };
+                var byExit = ofKind.OrderBy(s => s.T4).ToArray();
+                var trim = byExit.Length / 10;
+                var mid = byExit[trim..^trim];
+                var windowSeconds = (mid[^1].T4 - mid[0].T4) / (double)Stopwatch.Frequency;
+                if (windowSeconds > 0)
+                {
+                    entry["consumed_per_sec"] = Math.Round(mid.Length / windowSeconds, 1);
+                }
+            }
+
+            // Latency percentiles only make sense for rate-controlled runs, and only over
+            // post-warmup samples.
+            var measured = ofKind.Where(s => !s.Warmup).ToArray();
+            if (measured.Length > 0)
+            {
+                entry["measured_count"] = measured.Length;
+                entry["transit_ms"] = percentiles(measured.Select(s => toMs(s.T0, s.T2)));
+                entry["dwell_ms"] = percentiles(measured.Select(s => toMs(s.T2, s.T3)));
+                entry["handler_ms"] = percentiles(measured.Select(s => toMs(s.T3, s.T4)));
+                entry["total_ms"] = percentiles(measured.Select(s => toMs(s.T0, s.T4)));
+            }
         }
 
         var json = JsonSerializer.Serialize(summary, new JsonSerializerOptions { WriteIndented = true });

--- a/src/Testing/KafkaPerfRig/StampingRabbitMapper.cs
+++ b/src/Testing/KafkaPerfRig/StampingRabbitMapper.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics;
+using RabbitMQ.Client;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Runtime;
+
+namespace KafkaPerfRig;
+
+/// <summary>
+/// RabbitMQ twin of <see cref="StampingKafkaMapper"/>: the default mapper plus the monotonic
+/// consume-callback timestamp (the rig's t2 stage) stamped as an incoming header.
+/// </summary>
+public class StampingRabbitMapper : RabbitMqEnvelopeMapper
+{
+    public StampingRabbitMapper(Endpoint endpoint, IWolverineRuntime runtime) : base(endpoint, runtime)
+    {
+    }
+
+    protected override void writeIncomingHeaders(IReadOnlyBasicProperties incoming, Envelope envelope)
+    {
+        base.writeIncomingHeaders(incoming, envelope);
+        envelope.Headers[StampingKafkaMapper.ConsumeTimestampHeader] = Stopwatch.GetTimestamp().ToString();
+    }
+}

--- a/src/Testing/KafkaPerfRig/WolverinePublisher.cs
+++ b/src/Testing/KafkaPerfRig/WolverinePublisher.cs
@@ -79,9 +79,36 @@ public static class PublishLoops
 
         async Task<int> loopAsync(double rate, Func<string, int, long, bool, Task> publish)
         {
-            if (rate <= 0)
+            if (rate == 0)
             {
                 return 0;
+            }
+
+            // rate < 0 = max-throughput mode: publish as fast as the publisher can sustain.
+            // The consumer-side sustained receive rate is the measurement.
+            if (rate < 0)
+            {
+                var sent = 0;
+                while (!cancellation.IsCancellationRequested)
+                {
+                    var gameId = games[sent % games.Length];
+                    try
+                    {
+                        await publish(gameId, sent, Stopwatch.GetTimestamp(), inWarmup());
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+
+                    sent++;
+                    if (sent % 50_000 == 0)
+                    {
+                        Console.WriteLine($"[rig] published {sent}");
+                    }
+                }
+
+                return sent;
             }
 
             var count = 0;

--- a/src/Testing/KafkaPerfRig/WolverineRabbit.cs
+++ b/src/Testing/KafkaPerfRig/WolverineRabbit.cs
@@ -1,0 +1,139 @@
+using IntegrationTests;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.RabbitMQ;
+
+namespace KafkaPerfRig;
+
+/// <summary>
+/// RabbitMQ twins of WolverineConsumer/WolverinePublisher for GH-3492, sharing the corpus,
+/// rate loops, stage clock, and recorder with the Kafka rig.
+/// </summary>
+public static class WolverineRabbit
+{
+    public static async Task RunConsumerAsync(RigConfig cfg)
+    {
+        RigHandlerSettings.HandlerMs = cfg.HandlerMs;
+        RigHandlerSettings.SequenceByGame = cfg.Sequencing == "semaphore";
+
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning))
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ApplicationAssembly = typeof(RigHandlers).Assembly;
+                opts.Discovery.IncludeType<RigHandlers>();
+
+                opts.UseRabbitMq(new Uri(cfg.RabbitUri)).AutoProvision();
+
+                if (cfg.ConsumerMode == "durable")
+                {
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, cfg.PostgresSchema);
+                }
+
+                configureListener(opts.ListenToRabbitQueue(cfg.SmallQueue), cfg);
+                configureListener(opts.ListenToRabbitQueue(cfg.LargeQueue), cfg);
+            });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+        Console.WriteLine($"[rig] wolverine rabbit consumer up: {cfg.Describe()}");
+
+        await host.WaitForShutdownAsync();
+
+        StageRecorder.Dump(cfg.OutDir, "rabbit-consumer", new
+        {
+            harness = "wolverine-rabbit",
+            mode = cfg.ConsumerMode,
+            send = cfg.SendMode,
+            batchSize = cfg.BatchSize,
+            batchTimeoutMs = cfg.BatchTimeoutMs,
+            sequencing = cfg.Sequencing,
+            handlerMs = cfg.HandlerMs,
+            maxParallel = cfg.MaxParallel,
+            listenerCount = cfg.ListenerCount
+        });
+    }
+
+    private static void configureListener(RabbitMqListenerConfiguration listener, RigConfig cfg)
+    {
+        listener.UseInterop((runtime, queue) => new StampingRabbitMapper(queue, runtime));
+
+        // "default" leaves Wolverine's out-of-the-box RabbitMQ endpoint mode (Inline) untouched —
+        // that IS the R1 experiment.
+        switch (cfg.ConsumerMode)
+        {
+            case "durable":
+                listener.UseDurableInbox();
+                break;
+            case "inline":
+                listener.ProcessInline();
+                break;
+            case "buffered":
+                listener.BufferedInMemory();
+                break;
+        }
+
+        if (cfg.MaxParallel > 0)
+        {
+            listener.MaximumParallelMessages(cfg.MaxParallel);
+        }
+
+        if (cfg.ListenerCount > 0)
+        {
+            listener.ListenerCount(cfg.ListenerCount);
+        }
+    }
+
+    public static async Task RunPublisherAsync(RigConfig cfg)
+    {
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning))
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ApplicationAssembly = typeof(RigHandlers).Assembly;
+
+                opts.UseRabbitMq(new Uri(cfg.RabbitUri)).AutoProvision();
+
+                configureSubscriber(opts.PublishMessage<SmallEvent>().ToRabbitQueue(cfg.SmallQueue), cfg);
+                configureSubscriber(opts.PublishMessage<LargeEvent>().ToRabbitQueue(cfg.LargeQueue), cfg);
+            });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+        Console.WriteLine($"[rig] wolverine rabbit publisher up: {cfg.Describe()}");
+
+        var bus = host.MessageBus();
+
+        var counters = await PublishLoops.RunAsync(cfg,
+            (gameId, seq, t0, warmup) => bus.PublishAsync(
+                new SmallEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Small },
+                new DeliveryOptions { GroupId = gameId }).AsTask(),
+            (gameId, seq, t0, warmup) => bus.PublishAsync(
+                new LargeEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Large },
+                new DeliveryOptions { GroupId = gameId }).AsTask());
+
+        Console.WriteLine($"[rig] rabbit publisher done: {counters.small} small, {counters.large} large. Draining...");
+
+        await Task.Delay(3000);
+        await host.StopAsync();
+    }
+
+    private static void configureSubscriber(RabbitMqSubscriberConfiguration subscriber, RigConfig cfg)
+    {
+        if (cfg.SendMode == "inline")
+        {
+            subscriber.SendInline();
+        }
+        else if (cfg.SendMode == "batched")
+        {
+            subscriber
+                .MessageBatchSize(cfg.BatchSize)
+                .MessageBatchTimeout(TimeSpan.FromMilliseconds(cfg.BatchTimeoutMs));
+        }
+        // "default": leave Wolverine's out-of-the-box sending mode + batching untouched
+    }
+}

--- a/src/Testing/KafkaPerfRig/cells-rabbit.sh
+++ b/src/Testing/KafkaPerfRig/cells-rabbit.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# GH-3492 RabbitMQ experiment sweep — same shape as cells.sh, rabbit/native-rabbit harnesses.
+# Requires: docker compose up -d rabbitmq postgresql
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+WARMUP="${CELL_WARMUP:-20}"
+DURATION="${CELL_DURATION:-120}"
+
+run_cell() {
+  local name="$1" harness="$2"
+  shift 2
+  if [[ "${SELECTED:-0}" == "1" ]] && ! printf '%s\n' "${CELLS[@]}" | grep -qx "$name"; then
+    return 0
+  fi
+  echo ""
+  echo "=================== CELL: $name ==================="
+  RIG_WARMUP_S="$WARMUP" RIG_DURATION_S="$DURATION" ./rig.sh "$harness" "$name" "$@" || echo "[cells] $name FAILED"
+}
+
+if [[ $# -gt 0 ]]; then
+  SELECTED=1
+  CELLS=("$@")
+else
+  SELECTED=0
+  CELLS=()
+fi
+
+# --- client-shaped latency cells (1Kb @8/s + 100Kb @0.6/s, 9ms handler) ---
+
+# Wolverine RabbitMQ out-of-the-box: Inline listeners, default sender batching (R1 shape)
+run_cell r-default        rabbit        RIG_MODE=default RIG_SEND_MODE=default RIG_SEQ=none
+
+# native anchor
+run_cell r-native         native-rabbit RIG_SEQ=none
+
+# batching latency: Wolverine defaults (100,250ms debounce pre-fix) vs effectively-off
+run_cell r-batch-default  rabbit        RIG_MODE=default RIG_SEND_MODE=batched RIG_BATCH_SIZE=100 RIG_BATCH_TIMEOUT_MS=250 RIG_SEQ=none
+run_cell r-batch-1-1      rabbit        RIG_MODE=default RIG_SEND_MODE=batched RIG_BATCH_SIZE=1 RIG_BATCH_TIMEOUT_MS=1 RIG_SEQ=none
+
+# --- R1 throughput: inline single-file vs parallelism levers (2000/s, 5ms handler) ---
+
+RTHRU="RIG_SMALL_RATE=2000 RIG_LARGE_RATE=0 RIG_HANDLER_MS=5 RIG_SEQ=none RIG_SEND_MODE=default"
+
+run_cell r-thru-inline-1   rabbit        $RTHRU RIG_MODE=default
+run_cell r-thru-inline-4   rabbit        $RTHRU RIG_MODE=default RIG_LISTENER_COUNT=4
+run_cell r-thru-buffered   rabbit        $RTHRU RIG_MODE=buffered
+run_cell r-thru-durable    rabbit        $RTHRU RIG_MODE=durable
+run_cell r-thru-native     native-rabbit $RTHRU
+
+# --- max-throughput cells (uncapped publisher, no handler work) ---
+
+RMAX="RIG_SMALL_RATE=-1 RIG_LARGE_RATE=0 RIG_HANDLER_MS=0 RIG_SEQ=none RIG_SEND_MODE=default RIG_WARMUP_S=15 RIG_DURATION_S=45"
+
+run_cell r-max-inline      rabbit        $RMAX RIG_MODE=default
+run_cell r-max-buffered    rabbit        $RMAX RIG_MODE=buffered
+run_cell r-max-durable     rabbit        $RMAX RIG_MODE=durable
+run_cell r-max-native      native-rabbit $RMAX
+
+echo ""
+echo "[cells-rabbit] sweep complete."

--- a/src/Testing/KafkaPerfRig/cells.sh
+++ b/src/Testing/KafkaPerfRig/cells.sh
@@ -65,6 +65,14 @@ run_cell thru-native        native    $THRU
 run_cell thru-durable       wolverine $THRU RIG_MODE=durable
 run_cell thru-inline        wolverine $THRU RIG_MODE=inline
 
+# --- max-throughput cells (uncapped publisher; consumed_per_sec is the metric) ---
+
+MAX="RIG_SMALL_RATE=-1 RIG_LARGE_RATE=0 RIG_HANDLER_MS=0 RIG_SEQ=none RIG_BATCH_SIZE=100 RIG_BATCH_TIMEOUT_MS=250 RIG_WARMUP_S=15 RIG_DURATION_S=45"
+
+run_cell max-buffered       wolverine $MAX
+run_cell max-native         native    $MAX
+run_cell max-durable        wolverine $MAX RIG_MODE=durable
+
 echo ""
 echo "[cells] sweep complete. Summaries:"
 for f in rig-results/*/*-summary.json; do

--- a/src/Testing/KafkaPerfRig/rig.sh
+++ b/src/Testing/KafkaPerfRig/rig.sh
@@ -55,6 +55,19 @@ kill -TERM "$CONSUMER_PID"
 wait "$CONSUMER_PID" || true
 trap - EXIT
 
+# Best-effort per-run broker cleanup: max-throughput cells write millions of messages per run,
+# and letting them accumulate across runs eventually fills the Docker VM disk and takes every
+# container down (learned the hard way on 2026-07-19).
+if [[ "$HARNESS" == *rabbit* ]]; then
+  docker exec wolverine-rabbitmq-1 rabbitmqctl delete_queue "rig-small-${RIG_RUN_ID}" >/dev/null 2>&1 || true
+  docker exec wolverine-rabbitmq-1 rabbitmqctl delete_queue "rig-large-${RIG_RUN_ID}" >/dev/null 2>&1 || true
+else
+  docker exec wolverine-kafka-1 kafka-topics --bootstrap-server localhost:9092 --delete \
+    --topic "rig.small.${RIG_RUN_ID}" >/dev/null 2>&1 || true
+  docker exec wolverine-kafka-1 kafka-topics --bootstrap-server localhost:9092 --delete \
+    --topic "rig.large.${RIG_RUN_ID}" >/dev/null 2>&1 || true
+fi
+
 echo "[rig.sh] done. results:"
 ls -l "$RIG_OUT"
 grep -A 100 '"scenario"' "$RIG_OUT/consumer.log" | tail -60 || true

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Confluent.Kafka;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Transports;
 using Wolverine.Util;
@@ -69,6 +70,12 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue, IR
     // OperationCanceledException ends the loop; any other Consume error flows to BackgroundReceiveLoop's
     // log -> backoff -> continue (previously this hot-looped on every error). A processing error AFTER a
     // successful consume is a poison pill — advance past its offset and continue, exactly as before.
+    //
+    // GH-3490: durable endpoints additionally drain whatever records librdkafka has already
+    // fetched (up to MaximumMessagesToReceive) and hand them to the receiver as one array, so
+    // the durable inbox persists them with a single batched insert instead of gating the
+    // consume loop on one INSERT round trip per record. Measured locally, the per-record path
+    // capped a durable listener around ~1-2k msg/s while the broker backlog grew unbounded.
     private async Task<bool> consumeOnceAsync(CancellationToken token)
     {
         var result = _consumer.Consume(token);
@@ -77,41 +84,18 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue, IR
 
         try
         {
-            var message = result.Message;
-
-            // Seed the offset watermark in consume (in-order) order so out-of-order handler completion can never
-            // commit past this still-in-flight offset (GH-3161).
-            _committer.Track(result.Topic, result.Partition.Value, result.Offset.Value);
-
-            // Non-blocking retry-tier topic (GH-3148): wait out the fixed delay relative to when the record was
-            // produced before reprocessing. Records in a tier are time-ordered, so the head record gates the rest.
-            if (_endpoint.RetryTierDelay is { } retryDelay)
+            // Retry-tier topics gate on per-record produce timestamps and durable batching only
+            // helps inbox-backed endpoints, so everything else keeps strict one-at-a-time consumption.
+            if (_endpoint.Mode == EndpointMode.Durable
+                && _endpoint.MaximumMessagesToReceive > 1
+                && _endpoint.RetryTierDelay == null)
             {
-                var due = message.Timestamp.UtcDateTime + retryDelay;
-                var wait = due - DateTime.UtcNow;
-                if (wait > TimeSpan.Zero)
-                {
-                    await Task.Delay(wait, token);
-                }
+                await consumeManyAsync(result);
             }
-
-            var envelope = _endpoint.EnvelopeMapper!.CreateEnvelope(result.Topic, message);
-            envelope.TopicName = result.Topic;
-            envelope.Offset = result.Offset.Value;
-            envelope.PartitionId = result.Partition.Value;
-            envelope.MessageType ??= _messageTypeName;
-
-            if (_endpoint.GroupByMessageKey)
+            else
             {
-                // GH-3140: shard by-key processing on the Kafka message key.
-                envelope.GroupId = message.Key;
+                await consumeSingleAsync(result, token);
             }
-            else if (_endpoint.StampConsumerGroupIdOnEnvelope)
-            {
-                envelope.GroupId = Config.GroupId;
-            }
-
-            await _receiver.ReceivedAsync(this, envelope);
         }
         catch (OperationCanceledException)
         {
@@ -126,6 +110,102 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue, IR
         }
 
         return true;
+    }
+
+    private async Task consumeSingleAsync(ConsumeResult<string, byte[]> result, CancellationToken token)
+    {
+        var message = result.Message;
+
+        // Seed the offset watermark in consume (in-order) order so out-of-order handler completion can never
+        // commit past this still-in-flight offset (GH-3161).
+        _committer.Track(result.Topic, result.Partition.Value, result.Offset.Value);
+
+        // Non-blocking retry-tier topic (GH-3148): wait out the fixed delay relative to when the record was
+        // produced before reprocessing. Records in a tier are time-ordered, so the head record gates the rest.
+        if (_endpoint.RetryTierDelay is { } retryDelay)
+        {
+            var due = message.Timestamp.UtcDateTime + retryDelay;
+            var wait = due - DateTime.UtcNow;
+            if (wait > TimeSpan.Zero)
+            {
+                await Task.Delay(wait, token);
+            }
+        }
+
+        var envelope = buildEnvelope(result);
+        await _receiver.ReceivedAsync(this, envelope);
+    }
+
+    private async Task consumeManyAsync(ConsumeResult<string, byte[]> first)
+    {
+        var envelopes = new List<Envelope>(Math.Min(_endpoint.MaximumMessagesToReceive, 32));
+        var current = first;
+
+        while (true)
+        {
+            // Track in consume order BEFORE dispatch so the watermark can never commit past an
+            // in-flight record (GH-3161), poison pills included.
+            _committer.Track(current.Topic, current.Partition.Value, current.Offset.Value);
+
+            try
+            {
+                envelopes.Add(buildEnvelope(current));
+            }
+            catch (Exception e)
+            {
+                // Poison pill mid-batch: advance past its offset, keep the rest of the batch.
+                _committer.Complete(current.Topic, current.Partition.Value, current.Offset.Value);
+                _logger.LogError(e, "Error trying to map Kafka message to a Wolverine envelope");
+            }
+
+            if (envelopes.Count >= _endpoint.MaximumMessagesToReceive)
+            {
+                break;
+            }
+
+            // Zero-timeout poll: only drains records librdkafka already holds locally — never
+            // waits on the broker, so a quiet topic still processes each record immediately.
+            var next = _consumer.Consume(TimeSpan.Zero);
+            if (next == null)
+            {
+                break;
+            }
+
+            current = next;
+        }
+
+        switch (envelopes.Count)
+        {
+            case 0:
+                return;
+            case 1:
+                await _receiver.ReceivedAsync(this, envelopes[0]);
+                return;
+            default:
+                await _receiver.ReceivedAsync(this, envelopes.ToArray());
+                return;
+        }
+    }
+
+    private Envelope buildEnvelope(ConsumeResult<string, byte[]> result)
+    {
+        var envelope = _endpoint.EnvelopeMapper!.CreateEnvelope(result.Topic, result.Message);
+        envelope.TopicName = result.Topic;
+        envelope.Offset = result.Offset.Value;
+        envelope.PartitionId = result.Partition.Value;
+        envelope.MessageType ??= _messageTypeName;
+
+        if (_endpoint.GroupByMessageKey)
+        {
+            // GH-3140: shard by-key processing on the Kafka message key.
+            envelope.GroupId = result.Message.Key;
+        }
+        else if (_endpoint.StampConsumerGroupIdOnEnvelope)
+        {
+            envelope.GroupId = Config.GroupId;
+        }
+
+        return envelope;
     }
 
     public ConsumerConfig Config { get; }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaListenerConfiguration.cs
@@ -36,6 +36,23 @@ public class KafkaListenerConfiguration : InteroperableListenerConfiguration<Kaf
     }
 
     /// <summary>
+    /// For durable (inbox-backed) listeners, the maximum number of already-fetched records the
+    /// consume loop drains in one pass so the inbox persists them with one batched insert
+    /// instead of one insert per record. 1 reverts to strict record-at-a-time consumption.
+    /// Ignored for Buffered/Inline endpoints and retry-tier topics. Default 100. See GH-3490.
+    /// </summary>
+    public KafkaListenerConfiguration MaximumMessagesToReceive(int maximum)
+    {
+        if (maximum < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximum), "Must be at least 1");
+        }
+
+        add(topic => topic.MaximumMessagesToReceive = maximum);
+        return this;
+    }
+
+    /// <summary>
     /// Choose how this listener commits consumer offsets back to Kafka. Defaults to
     /// <see cref="CommitMode.StoreThenAutoFlush"/> (non-blocking, idiomatic high throughput). See GH-3150.
     /// </summary>

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -64,6 +64,14 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
     public CommitMode CommitMode { get; set; } = CommitMode.StoreThenAutoFlush;
 
     /// <summary>
+    /// For durable (inbox-backed) listeners, the maximum number of already-fetched records the
+    /// consume loop will drain in one pass so the inbox can persist them with one batched
+    /// insert instead of one insert per record. 1 reverts to strict record-at-a-time consumption.
+    /// Ignored for Buffered/Inline endpoints and retry-tier topics. Default 100. See GH-3490.
+    /// </summary>
+    public int MaximumMessagesToReceive { get; set; } = 100;
+
+    /// <summary>
     /// Number of completed messages between commits when <see cref="CommitMode"/> is
     /// <see cref="Kafka.CommitMode.BatchCount"/>. Default 100.
     /// </summary>


### PR DESCRIPTION
Second Kafka wave for #3490: the pin bump that delivers jasperfx#533 to users, the O1 durable-inbox batching, and the rig's throughput mode + RabbitMQ roles for the #3492 wave.

## Before/after (local rig, fresh broker, pre-registered predictions all confirmed)

| cell | BEFORE (6.20/jfx 2.30.0 era) | AFTER (this PR) |
|---|---|---|
| batch-default (100,250ms) 1Kb @8/s — transit p50 | **5,767 ms** | **136 ms** (p99 262 ms, timeout-bounded) |
| lone messages (100Kb @0.6/s) | 263 ms | 264 ms (always paid the full timeout; tune the timeout down for these routes) |
| client-shaped batch (10,10ms) | 19.9 ms | 20.0 ms (unchanged, as predicted) |
| **durable** @2,000 msg/s — transit p50 | **14,127 ms, unbounded backlog** | **31.5 ms, keeps up** |
| **durable** max sustained | 1,460 msg/s | **2,671 msg/s (+83%)** |
| buffered max sustained | 10,726 msg/s | 10,872 msg/s (unchanged as predicted) |
| native Confluent anchor | 107,669 msg/s | 106,296 msg/s (stable) |

## Changes

- **JasperFx pins → 2.30.1** (JasperFx/jasperfx#533: sender-batch timeout is a max-age, not a debounce). Full jasperfx.sln test suite green on net9.0+net10.0 before publishing. Applies to every transport using the batched sender.
- **O1 — batched durable inbox for Kafka**: durable listeners drain up to `MaximumMessagesToReceive` (default 100, new listener knob mirroring the ASB name) already-fetched records per consume pass → one multi-VALUES inbox insert via the existing `DurableReceiver.ProcessReceivedMessagesAsync` path (which already handles duplicate-fallback per envelope). Offsets are tracked in consume order before dispatch (GH-3161 invariant); poison pills advance individually; retry-tier topics and Buffered/Inline endpoints keep strict record-at-a-time consumption. Remaining durable ceiling is the per-message mark-handled UPDATE — follow-up (O1b).
- **Rig**: max-throughput mode + sustained-rate measurement, RabbitMQ + native RabbitMQ.Client twin roles and `cells-rabbit.sh` (ready for the #3492 wave), per-run broker cleanup after the max cells filled the Docker VM disk and crashed every container.
- Docs: durable-mode section updated with the new knob + measured numbers.

## Validation

- `wolverine.slnx` full Release build clean
- Wolverine.Kafka.Tests 290/293 — sole failure is the pre-existing `[Flaky]`-tagged `batch_processing_with_kafka` local-environment failure (fails identically on unmodified main; CI green on #3501)
- CoreTests 1994/1996 green
- Release-notes draft with these numbers is in the ledger (KAFKA-PERF-DEEP-DIVE-PLAN.md §9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4XSARYV567q5Y3fW6iwiu