### PR TITLE
SQS: inspect SendMessageBatch partial failures instead of silently dropping rejected entries (GH-3493)

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/SqsSenderProtocolTests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/SqsSenderProtocolTests.cs
@@ -1,0 +1,160 @@
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.AmazonSqs.Tests.Internal;
+
+public class SqsSenderProtocolTests
+{
+    private readonly ISenderCallback _callback = Substitute.For<ISenderCallback>();
+    private readonly SqsSenderProtocol _protocol;
+    private readonly AmazonSqsQueue _queue;
+    private readonly IAmazonSQS _sqs = Substitute.For<IAmazonSQS>();
+
+    public SqsSenderProtocolTests()
+    {
+        var transport = new AmazonSqsTransport { Client = _sqs };
+        _queue = new AmazonSqsQueue("foo", transport)
+        {
+            Mapper = new DefaultSqsEnvelopeMapper()
+        };
+
+        _sqs.GetQueueUrlAsync("foo", Arg.Any<CancellationToken>())
+            .Returns(new GetQueueUrlResponse { QueueUrl = "https://sqs.local/foo" });
+
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.LoggerFactory.Returns(NullLoggerFactory.Instance);
+
+        _protocol = new SqsSenderProtocol(runtime, _queue, _sqs);
+    }
+
+    private static Envelope buildEnvelope()
+    {
+        return new Envelope
+        {
+            Data = [1, 2, 3],
+            MessageType = "foo.bar"
+        };
+    }
+
+    private OutgoingMessageBatch batchFor(params Envelope[] envelopes)
+    {
+        return new OutgoingMessageBatch(_queue.Uri, envelopes);
+    }
+
+    [Fact]
+    public async Task marks_the_entire_batch_successful_when_no_entries_fail()
+    {
+        var batch = batchFor(buildEnvelope(), buildEnvelope(), buildEnvelope());
+
+        _sqs.SendMessageBatchAsync(Arg.Any<SendMessageBatchRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new SendMessageBatchResponse());
+
+        await _protocol.SendBatchAsync(_callback, batch);
+
+        await _callback.Received(1).MarkSuccessfulAsync(batch);
+        await _callback.DidNotReceive().MarkProcessingFailureAsync(Arg.Any<OutgoingMessageBatch>());
+        await _callback.DidNotReceive()
+            .MarkProcessingFailureAsync(Arg.Any<OutgoingMessageBatch>(), Arg.Any<Exception>());
+    }
+
+    [Fact]
+    public async Task partial_failure_reports_only_the_failed_envelopes_as_processing_failures()
+    {
+        var success1 = buildEnvelope();
+        var failed = buildEnvelope();
+        var success2 = buildEnvelope();
+
+        var batch = batchFor(success1, failed, success2);
+
+        _sqs.SendMessageBatchAsync(Arg.Any<SendMessageBatchRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new SendMessageBatchResponse
+            {
+                Failed =
+                [
+                    new BatchResultErrorEntry
+                    {
+                        Id = failed.Id.ToString(),
+                        Code = "ThrottlingException",
+                        Message = "Rate exceeded",
+                        SenderFault = false
+                    }
+                ]
+            });
+
+        await _protocol.SendBatchAsync(_callback, batch);
+
+        // The two accepted envelopes are still marked successful
+        await _callback.Received(1).MarkSuccessfulAsync(Arg.Is<OutgoingMessageBatch>(b =>
+            b.Messages.Count == 2 && b.Messages.Contains(success1) && b.Messages.Contains(success2)));
+
+        // Only the rejected envelope goes down the failure path for retry
+        await _callback.Received(1).MarkProcessingFailureAsync(Arg.Is<OutgoingMessageBatch>(b =>
+            b.Messages.Count == 1 && b.Messages.Contains(failed)));
+
+        // And the whole original batch was definitely not marked successful
+        await _callback.DidNotReceive().MarkSuccessfulAsync(batch);
+    }
+
+    [Fact]
+    public async Task failed_entry_with_unrecognized_id_is_ignored()
+    {
+        var batch = batchFor(buildEnvelope(), buildEnvelope());
+
+        _sqs.SendMessageBatchAsync(Arg.Any<SendMessageBatchRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new SendMessageBatchResponse
+            {
+                Failed =
+                [
+                    new BatchResultErrorEntry
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        Code = "InternalError",
+                        Message = "Unknown entry"
+                    }
+                ]
+            });
+
+        await _protocol.SendBatchAsync(_callback, batch);
+
+        // Nothing in the batch matches the failed entry id, so nothing should be retried
+        await _callback.Received(1).MarkSuccessfulAsync(batch);
+        await _callback.DidNotReceive().MarkProcessingFailureAsync(Arg.Any<OutgoingMessageBatch>());
+        await _callback.DidNotReceive()
+            .MarkProcessingFailureAsync(Arg.Any<OutgoingMessageBatch>(), Arg.Any<Exception>());
+    }
+
+    [Fact]
+    public async Task exception_on_a_later_chunk_only_fails_the_unsent_envelopes()
+    {
+        // 12 envelopes = 2 chunks against the SQS batch limit of 10
+        var envelopes = Enumerable.Range(0, 12).Select(_ => buildEnvelope()).ToArray();
+        var batch = batchFor(envelopes);
+
+        var exception = new InvalidOperationException("SQS is down");
+
+        _sqs.SendMessageBatchAsync(Arg.Any<SendMessageBatchRequest>(), Arg.Any<CancellationToken>())
+            .Returns(
+                _ => new SendMessageBatchResponse(),
+                _ => throw exception);
+
+        await _protocol.SendBatchAsync(_callback, batch);
+
+        // The first chunk of 10 was accepted by SQS and must not be resent
+        await _callback.Received(1).MarkSuccessfulAsync(Arg.Is<OutgoingMessageBatch>(b =>
+            b.Messages.Count == 10 && envelopes.Take(10).All(e => b.Messages.Contains(e))));
+
+        // Only the two envelopes in the failed chunk are routed to the failure path
+        await _callback.Received(1).MarkProcessingFailureAsync(Arg.Is<OutgoingMessageBatch>(b =>
+            b.Messages.Count == 2 && b.Messages.Contains(envelopes[10]) && b.Messages.Contains(envelopes[11])),
+            exception);
+
+        await _callback.DidNotReceive().MarkSuccessfulAsync(batch);
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSenderProtocol.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSenderProtocol.cs
@@ -35,21 +35,94 @@ internal class SqsSenderProtocol : ISenderProtocolWithNativeScheduling, IConditi
         await _queue.InitializeAsync(_logger);
 
         // SQS has a hard limit of 10 messages per batch request
-        var chunks = batch.Messages.Chunk(10);
+        var chunks = batch.Messages.Chunk(10).ToArray();
 
-        try
+        var successes = new List<Envelope>();
+        var failures = new List<Envelope>();
+
+        for (var i = 0; i < chunks.Length; i++)
         {
-            foreach (var chunk in chunks)
-            {
-                var sqsBatch = new OutgoingSqsBatch(_queue, _logger, chunk);
-                await _sqs.SendMessageBatchAsync(sqsBatch.Request);
-            }
+            var chunk = chunks[i];
+            var sqsBatch = new OutgoingSqsBatch(_queue, _logger, chunk);
 
+            try
+            {
+                var response = await _sqs.SendMessageBatchAsync(sqsBatch.Request);
+                sortChunkResults(sqsBatch, chunk, response, successes, failures);
+            }
+            catch (Exception e)
+            {
+                // This chunk (and any chunk after it) never made it to SQS, but earlier
+                // chunks may already have been accepted, so only fail what actually failed
+                var unsent = chunks.Skip(i).SelectMany(x => x);
+
+                if (successes.Count != 0)
+                {
+                    await callback.MarkSuccessfulAsync(new OutgoingMessageBatch(batch.Destination, successes));
+                }
+
+                await callback.MarkProcessingFailureAsync(
+                    new OutgoingMessageBatch(batch.Destination, failures.Concat(unsent).ToList()), e);
+
+                return;
+            }
+        }
+
+        if (failures.Count == 0)
+        {
             await callback.MarkSuccessfulAsync(batch);
         }
-        catch (Exception e)
+        else
         {
-            await callback.MarkProcessingFailureAsync(batch, e);
+            if (successes.Count != 0)
+            {
+                await callback.MarkSuccessfulAsync(new OutgoingMessageBatch(batch.Destination, successes));
+            }
+
+            await callback.MarkProcessingFailureAsync(new OutgoingMessageBatch(batch.Destination, failures));
+        }
+    }
+
+    // SendMessageBatchAsync is not transactional -- SQS can accept some entries and reject
+    // others (throttling, oversized message, etc.) in the very same 200 response, so every
+    // entry in response.Failed has to be routed back through the sender callback for retry
+    private void sortChunkResults(OutgoingSqsBatch sqsBatch, Envelope[] chunk, SendMessageBatchResponse response,
+        List<Envelope> successes, List<Envelope> failures)
+    {
+        if (response.Failed == null || response.Failed.Count == 0)
+        {
+            successes.AddRange(chunk);
+            return;
+        }
+
+        var failed = new HashSet<Envelope>();
+        foreach (var entry in response.Failed)
+        {
+            if (sqsBatch.TryGetEnvelope(entry.Id, out var envelope))
+            {
+                _logger.LogError(
+                    "SQS batch send to {Uri} failed for message {Id}: {Code} - {Message} (SenderFault: {SenderFault}). The message will be retried",
+                    _queue.Uri, entry.Id, entry.Code, entry.Message, entry.SenderFault);
+                failed.Add(envelope);
+            }
+            else
+            {
+                _logger.LogError(
+                    "SQS batch send to {Uri} reported a failed entry with unrecognized Id {Id}: {Code} - {Message}",
+                    _queue.Uri, entry.Id, entry.Code, entry.Message);
+            }
+        }
+
+        foreach (var envelope in chunk)
+        {
+            if (failed.Contains(envelope))
+            {
+                failures.Add(envelope);
+            }
+            else
+            {
+                successes.Add(envelope);
+            }
         }
     }
 }


### PR DESCRIPTION
The SQS sender protocol chunked envelopes through `SendMessageBatchAsync` but never inspected `SendMessageBatchResponse.Failed`: per-entry rejections (throttling, oversize) were marked successful and the messages silently lost. This is the do-first correctness item from the GH-3493 plan — landing it standalone since the rest of that perf wave is descoped for this release.

- Failed entries resolve back to their envelopes via `OutgoingSqsBatch.TryGetEnvelope` (previously dead code) and route to `MarkProcessingFailureAsync` as a sub-batch, feeding Wolverine's retry machinery; accepted entries stay successful. Same partial-failure idiom as the SNS sender protocol.
- A `Failed` Id that doesn't match the batch is logged and skipped.
- Bonus fix on the exception path: a throw on chunk N of M no longer re-fails chunks SQS already accepted (previously the whole batch was retried → duplicates); only the current + unsent chunks fail.
- 4 new unit tests (NSubstitute'd IAmazonSQS + ISenderCallback, no LocalStack needed): whole-batch success, partial-failure routing, unrecognized id, later-chunk exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4XSARYV567q5Y3fW6iwiu