### PR TITLE
GH-3492 RabbitMQ perf wave: durable delivery coalescing + hardened batch arrival + mapper fix (measured)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -194,7 +194,8 @@ const config: UserConfig<DefaultTheme.Config> = {
                                         {text: 'Topics', link:'/guide/messaging/transports/rabbitmq/topics'},
                                         {text: 'Interoperability', link:'/guide/messaging/transports/rabbitmq/interoperability'},
                                         {text: 'Connecting to Multiple Brokers', link: '/guide/messaging/transports/rabbitmq/multiple-brokers'},
-                                        {text: 'Multi-Tenancy', link: '/guide/messaging/transports/rabbitmq/multi-tenancy'}
+                                        {text: 'Multi-Tenancy', link: '/guide/messaging/transports/rabbitmq/multi-tenancy'},
+                                        {text: 'Performance Tuning', link: '/guide/messaging/transports/rabbitmq/performance'}
                                     ]},
                                 {text: 'Azure Service Bus', link: '/guide/messaging/transports/azureservicebus/', items:[
                                         {text: 'Publishing', link:'/guide/messaging/transports/azureservicebus/publishing'},

--- a/docs/guide/messaging/transports/rabbitmq/performance.md
+++ b/docs/guide/messaging/transports/rabbitmq/performance.md
@@ -1,0 +1,107 @@
+# Performance Tuning
+
+This page collects the levers that matter most for throughput and latency with the Rabbit MQ
+transport, and the factors behind them.
+
+## Rabbit MQ listeners default to Inline — and that shapes everything
+
+Unlike most Wolverine transports, Rabbit MQ endpoints default to **`Inline`** mode: each message
+is processed completely — handler, cascading messages, acknowledgement — before the next message
+is dispatched on that channel. Combined with the client's default dispatch concurrency of 1,
+an out-of-the-box Rabbit MQ listener consumes **one message at a time**. This gives strong
+ordering and no-loss semantics, but it means `MaximumParallelMessages` has **no effect** on an
+Inline endpoint. If a listener seems mysteriously slow, check its mode first.
+
+Three ways to scale consumption:
+
+```cs
+opts.ListenToRabbitQueue("orders")
+    // 1. Multiple parallel listeners = N channels + N consumers on the queue.
+    //    Works for every mode, and is the way to scale Inline endpoints.
+    .ListenerCount(5)
+
+    // 2. Switch to buffered (or durable) mode so messages fan out to
+    //    parallel in-process workers (MaximumParallelMessages wide).
+    .BufferedInMemory()
+
+    .MaximumParallelMessages(10);
+
+// 3. Raise the client's per-channel dispatch concurrency (applies transport-wide)
+opts.UseRabbitMq(...).ConfigureChannelCreation(o => o.ConsumerDispatchConcurrency = 4);
+```
+
+## Choosing the endpoint mode
+
+- **Inline** (default): ack after successful handling. Safest, slowest per listener; scale with
+  `ListenerCount`.
+- **Buffered**: messages are acked **as soon as they are buffered in memory**, before handling —
+  an ungraceful shutdown loses whatever was buffered (at-most-once on crash). Fastest mode;
+  use with idempotent handlers or tolerable-loss workloads.
+- **Durable**: each message is written to the database inbox before it is acked, and handled
+  from there. The consumer coalesces prefetched deliveries for up to 5ms into a single batched
+  inbox insert (up to `MaximumMessagesToReceive`, default 100), so under load the write cost is
+  paid per batch rather than per message — measured locally this took a 2,000 msg/s stream from
+  unbounded backlog to sub-millisecond delivery p50, and nearly tripled the maximum sustained
+  durable rate (GH-3492). Set `MaximumMessagesToReceive(1)` for strict message-at-a-time
+  persistence. Database write latency still bounds the ceiling; scale with `ListenerCount` and
+  keep the inbox database close.
+
+## Prefetch
+
+Wolverine sets the channel prefetch (`basic.qos`) automatically: for Buffered/Durable endpoints
+it defaults to `2 × MaximumParallelMessages`, and for Inline endpoints to 100. Override with
+`.PreFetchCount(...)` on the listener. For Inline endpoints prefetch mostly just hides network
+latency between messages; for Buffered/Durable it controls how far the broker can run ahead of
+your workers — higher values smooth throughput at the cost of more unacked messages redelivered
+if the node dies.
+
+## Publisher confirms are off by default
+
+Wolverine publishes with confirms **disabled** by default: publishes are fire-and-forget at the
+AMQP level, which is fast, but a broker-side failure after the publish call can lose the
+message. Enabling confirms (`ConfigureChannelCreation(o => o.PublisherConfirmationsEnabled = true)`)
+makes every publish await the broker's acknowledgement — a per-publish round trip. Pick one
+durability mechanism deliberately: if you are already using Wolverine's durable outbox, the
+outbox provides the delivery guarantee and confirms mostly add latency; if you run without the
+outbox and cannot lose messages, turn confirms on and accept the cost. Also note Wolverine
+publishes with `mandatory: false`, so a message routed to a non-existent queue binding is
+silently dropped by the broker — provision your topology (or use `AutoProvision`) rather than
+relying on publish failures to surface binding mistakes.
+
+## Back pressure closes the channel
+
+When a Buffered/Durable listener exceeds `BufferingLimits.Maximum` (default 1,000 in-memory
+messages), Wolverine stops the listener — which for Rabbit MQ tears down the channel, and the
+broker **redelivers everything unacked** when the listener restarts below the resume threshold
+(default 500). Under sustained overload this becomes a redelivery churn cycle. Size
+`BufferingLimits` so normal bursts fit, or add processing parallelism so the buffer drains
+faster than it fills.
+
+## Queue types
+
+Classic queues are the throughput baseline. Quorum queues add Raft replication — real fsync and
+inter-node traffic per message — so expect materially lower per-queue throughput and benchmark
+with your actual cluster. Also be aware that RabbitMQ 4.x defaults quorum queues to a
+`delivery-limit` of 20: the *broker* will dead-letter or drop a message after 20 deliveries
+regardless of Wolverine's own error policies, so align your retry policies with the queue's
+delivery limit.
+
+## Sequential processing by key
+
+Rabbit MQ has no broker-native partition/session primitive surfaced through Wolverine, so
+ordered-by-key processing is done on the consumer side:
+
+- `PartitionProcessingByGroupId(...)` on a listener keeps messages with the same `GroupId`
+  strictly sequential while different groups process in parallel — prefer this over blocking
+  locks inside handlers/middleware, which tie up worker slots and inflate execution-time
+  metrics.
+- `UseShardedRabbitQueues(...)` inside a global partitioned topology spreads messages across N
+  queues by group hash with exclusive listeners for cluster-wide ordering — note global
+  partitioning forces durable endpoints, so it carries the inbox-write cost per message.
+
+## Interpreting Wolverine's metrics
+
+`wolverine-execution-time` measures the handler *plus all middleware* (including time blocked
+inside middleware); `wolverine-effective-time` is wall-clock from the sender's `SentAt` stamp
+through handling, cascading-message flush, and the final ack, and is sensitive to clock skew
+across machines.

--- a/src/Testing/KafkaPerfRig/WolverineRabbit.cs
+++ b/src/Testing/KafkaPerfRig/WolverineRabbit.cs
@@ -134,6 +134,15 @@ public static class WolverineRabbit
                 .MessageBatchSize(cfg.BatchSize)
                 .MessageBatchTimeout(TimeSpan.FromMilliseconds(cfg.BatchTimeoutMs));
         }
+        else if (cfg.SendMode == "buffered")
+        {
+            // RabbitMQ subscribers default to Inline sending, so the BatchedSender (and the
+            // GH-3490 batching-timeout semantics) only apply when a route opts into buffering
+            subscriber
+                .BufferedInMemory()
+                .MessageBatchSize(cfg.BatchSize)
+                .MessageBatchTimeout(TimeSpan.FromMilliseconds(cfg.BatchTimeoutMs));
+        }
         // "default": leave Wolverine's out-of-the-box sending mode + batching untouched
     }
 }

--- a/src/Testing/KafkaPerfRig/cells-rabbit.sh
+++ b/src/Testing/KafkaPerfRig/cells-rabbit.sh
@@ -35,9 +35,12 @@ run_cell r-default        rabbit        RIG_MODE=default RIG_SEND_MODE=default R
 # native anchor
 run_cell r-native         native-rabbit RIG_SEQ=none
 
-# batching latency: Wolverine defaults (100,250ms debounce pre-fix) vs effectively-off
+# batching latency: Wolverine defaults (100,250ms debounce pre-fix) vs effectively-off.
+# NOTE: Rabbit subscribers default to Inline sending, so batch knobs without BufferedInMemory
+# are inert — r-batch-buffered is the cell that actually exercises the BatchedSender.
 run_cell r-batch-default  rabbit        RIG_MODE=default RIG_SEND_MODE=batched RIG_BATCH_SIZE=100 RIG_BATCH_TIMEOUT_MS=250 RIG_SEQ=none
 run_cell r-batch-1-1      rabbit        RIG_MODE=default RIG_SEND_MODE=batched RIG_BATCH_SIZE=1 RIG_BATCH_TIMEOUT_MS=1 RIG_SEQ=none
+run_cell r-batch-buffered rabbit        RIG_MODE=default RIG_SEND_MODE=buffered RIG_BATCH_SIZE=100 RIG_BATCH_TIMEOUT_MS=250 RIG_SEQ=none
 
 # --- R1 throughput: inline single-file vs parallelism levers (2000/s, 5ms handler) ---
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelopeMapper.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelopeMapper.cs
@@ -65,6 +65,12 @@ public class RabbitMqEnvelopeMapper : EnvelopeMapper<IReadOnlyBasicProperties, I
             (e, props) => props.Type = e.MessageType);
     }
 
+    // writeIncomingHeaders below copies every incoming header with the exact same conversion as
+    // tryReadIncomingHeader (byte[] -> UTF8, else ToString), so the typed reserved-header readers
+    // can reuse those already-decoded values instead of re-reading and re-decoding the raw header
+    // dictionary per property (GH-3492, same seam as Kafka in GH-3490).
+    protected override bool preferCopiedIncomingHeaders => true;
+
     protected override void writeOutgoingHeader(IBasicProperties outgoing, string key, string value)
     {
         outgoing.Headers![key] = value;

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -59,6 +59,14 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
     internal bool HasDeclared { get; private set; }
 
     /// <summary>
+    /// For durable (inbox-backed) listeners, the maximum number of prefetched deliveries the
+    /// consumer will coalesce into one batched inbox insert (with a 5ms max accumulation age).
+    /// 1 reverts to strict message-at-a-time persistence. Ignored for Buffered/Inline
+    /// endpoints. Default 100. See GH-3492.
+    /// </summary>
+    public int MaximumMessagesToReceive { get; set; } = 100;
+
+    /// <summary>
     ///     The number of unacknowledged messages that can be processed concurrently
     /// </summary>
     public ushort PreFetchCount

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
@@ -1,5 +1,7 @@
+using JasperFx.Blocks;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
+using Wolverine.Configuration;
 using Wolverine.Transports;
 
 namespace Wolverine.RabbitMQ.Internal;
@@ -14,6 +16,13 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
     private readonly IReceiver _workerQueue;
     private bool _latched;
 
+    // GH-3492: durable endpoints coalesce prefetched deliveries into Envelope[] batches so the
+    // inbox persists them with one multi-VALUES insert instead of gating on one INSERT round
+    // trip per message. The 5ms window is a max-age (JasperFx >= 2.30.1), so a lone message
+    // pays at most 5ms; a firehose batches at MaximumMessagesToReceive. Null for
+    // Buffered/Inline endpoints, which keep the direct per-delivery path.
+    private readonly BatchingChannel<Envelope>? _batching;
+
     public WorkerQueueMessageConsumer(IChannel channel, IReceiver workerQueue, ILogger logger,
         RabbitMqListener listener,
         IRabbitMqEnvelopeMapper mapper, Uri address, CancellationToken cancellation) : base(channel)
@@ -24,11 +33,47 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
         _mapper = mapper;
         _address = address;
         _cancellation = cancellation;
+
+        if (listener.Queue.Mode == EndpointMode.Durable && listener.Queue.MaximumMessagesToReceive > 1)
+        {
+            var flush = new Block<Envelope[]>((batch, _) => deliverBatchAsync(batch));
+            _batching = new BatchingChannel<Envelope>(TimeSpan.FromMilliseconds(5), flush,
+                listener.Queue.MaximumMessagesToReceive);
+        }
+    }
+
+    private async Task deliverBatchAsync(Envelope[] batch)
+    {
+        try
+        {
+            await _workerQueue.ReceivedAsync(_listener, batch);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e,
+                "Failure receiving a batch of {Count} incoming messages at {Address}, trying to 'Nack' them",
+                batch.Length, _address);
+
+            foreach (var envelope in batch.OfType<RabbitMqEnvelope>())
+            {
+                try
+                {
+                    await Channel.BasicNackAsync(envelope.DeliveryTag, false, true, _cancellation);
+                }
+                catch (Exception nackEx)
+                {
+                    _logger.LogError(nackEx, "Failed to Nack message {Id} at {Address}", envelope.Id, _address);
+                }
+            }
+        }
     }
 
     public void Dispose()
     {
         _latched = true;
+        // Push any accumulated-but-unflushed deliveries onward; anything genuinely in flight
+        // is unacked and will be redelivered by the broker (and deduplicated by the inbox).
+        _batching?.TriggerBatch();
     }
 
     //TODO do something with the token passed in here
@@ -92,6 +137,15 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
         if (envelope.IsPing())
         {
             await Channel.BasicAckAsync(deliveryTag, false, _cancellation);
+            return;
+        }
+
+        if (_batching != null)
+        {
+            // Durable micro-batching (GH-3492): hand off to the batching channel and return so
+            // the dispatch loop can pull the next prefetched delivery; the flush block owns
+            // failure handling + nacks from here.
+            await _batching.PostAsync(envelope);
             return;
         }
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
@@ -113,6 +113,23 @@ public class RabbitMqListenerConfiguration : InteroperableListenerConfiguration<
     }
 
     /// <summary>
+    /// For durable (inbox-backed) listeners, the maximum number of prefetched deliveries the
+    /// consumer coalesces into one batched inbox insert (5ms max accumulation age). 1 reverts
+    /// to strict message-at-a-time persistence. Ignored for Buffered/Inline endpoints.
+    /// Default 100. See GH-3492.
+    /// </summary>
+    public RabbitMqListenerConfiguration MaximumMessagesToReceive(int maximum)
+    {
+        if (maximum < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximum), "Must be at least 1");
+        }
+
+        add(e => e.MaximumMessagesToReceive = maximum);
+        return this;
+    }
+
+    /// <summary>
     /// Mark this queue as owned by an external system. Wolverine will not declare (create) the queue
     /// at startup or delete it during <c>resources teardown</c>, even when <c>AutoProvision()</c> is
     /// enabled, and will not set up or tear down its bindings. Use this when the calling identity lacks

--- a/src/Wolverine/Persistence/Durability/DelegatingMessageInbox.cs
+++ b/src/Wolverine/Persistence/Durability/DelegatingMessageInbox.cs
@@ -40,11 +40,27 @@ internal class DelegatingMessageInbox : IMessageInbox
         return (envelope.Store?.Inbox ?? _inner).StoreIncomingAsync(envelope);
     }
 
-    // This would only be coming from a batch receipt and not from any kind of 
+    // This would only be coming from a batch receipt and not from any kind of
     // local queueing
-    public Task StoreIncomingAsync(IReadOnlyList<Envelope> envelopes)
+    public async Task StoreIncomingAsync(IReadOnlyList<Envelope> envelopes)
     {
-        return _inner.StoreIncomingAsync(envelopes);
+        // Route by ancillary store exactly like the single-envelope overload above —
+        // this overload used to send the whole batch to the main store, which put
+        // ancillary-owned envelopes in the wrong inbox (and mark-as-handled, which DOES
+        // route by store, then updated the other database, leaving the misplaced row
+        // stuck as Incoming). Surfaced by the GH-3492 durable delivery coalescing;
+        // mirrors MarkIncomingEnvelopeAsHandledAsync below (GH-3492).
+        var groups = envelopes.GroupBy(x => x.Store).ToList();
+        if (groups.Count == 1)
+        {
+            await (groups[0].Key?.Inbox ?? _inner).StoreIncomingAsync(envelopes);
+            return;
+        }
+
+        foreach (var group in groups)
+        {
+            await (group.Key?.Inbox ?? _inner).StoreIncomingAsync(group.ToList());
+        }
     }
 
     public Task MarkIncomingEnvelopeAsHandledAsync(Envelope envelope)

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -612,7 +612,82 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
             throw new OperationCanceledException();
         }
 
+        // A latched receiver must apply the full single-envelope semantics (persist as
+        // owner 0 + defer back to the listener), so route through the one-at-a-time path
+        // which already implements them (GH-3492).
+        if (_latched)
+        {
+            foreach (var envelope in envelopes) await _receivingOne.PostAsync(envelope).ConfigureAwait(false);
+            return;
+        }
+
         foreach (var envelope in envelopes) envelope.MarkReceived(listener, now, _settings, _endpoint.WireTap);
+
+        // Per-envelope guards that the single-envelope path (receiveOneAsync) has always
+        // applied but this batch path historically skipped (GH-3492): serializer unwrap
+        // (MassTransit-style interop), missing id/message-type dead-lettering, and expiry.
+        // Envelopes that fail a guard are handled individually and drop out of the batch.
+        var survivors = new List<Envelope>(envelopes.Length);
+        foreach (var envelope in envelopes)
+        {
+            if (ShouldPersistBeforeProcessing && !envelope.IsFromLocalDurableQueue())
+            {
+                try
+                {
+                    envelope.Serializer?.UnwrapEnvelopeIfNecessary(envelope);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogInformation(e,
+                        "Failed to unwrap metadata for Envelope {Id} received at durable {Destination}. Moving to dead letter queue",
+                        envelope.Id, envelope.Destination);
+
+                    if (envelope.Id == Guid.Empty)
+                    {
+                        envelope.Id = Envelope.IdGenerator();
+                    }
+
+                    envelope.MessageType ??= $"unknown/{e.GetType().Name}";
+                    envelope.Failure = e;
+                    await _moveToErrors.PostAsync(envelope).ConfigureAwait(false);
+                    await _completeBlock.PostAsync(envelope).ConfigureAwait(false);
+                    continue;
+                }
+
+                if (envelope.Id == Guid.Empty)
+                {
+                    envelope.Id = Envelope.IdGenerator();
+                }
+
+                if (envelope.MessageType.IsEmpty())
+                {
+                    _logger.LogInformation(
+                        "Empty or missing message type name for Envelope {Id} received at durable {Destination}. Moving to dead letter queue",
+                        envelope.Id, envelope.Destination);
+                    await _moveToErrors.PostAsync(envelope).ConfigureAwait(false);
+                    await _completeBlock.PostAsync(envelope).ConfigureAwait(false);
+                    continue;
+                }
+            }
+
+            if (envelope.IsExpired())
+            {
+                await _completeBlock.PostAsync(envelope).ConfigureAwait(false);
+                continue;
+            }
+
+            survivors.Add(envelope);
+        }
+
+        if (survivors.Count == 0)
+        {
+            return;
+        }
+
+        if (survivors.Count != envelopes.Length)
+        {
+            envelopes = survivors.ToArray();
+        }
 
         var batchSucceeded = false;
         if (ShouldPersistBeforeProcessing)


### PR DESCRIPTION
RabbitMQ wave for #3492 — measured on the shared rig (native RabbitMQ.Client twin as the anchor), before-numbers from a pre-fix worktree. This closes out the messaging-performance work for this release (ASB/SQS perf waves deferred; their plans + the rig scaffolding stay in-repo for later).

## Before/after (local rig)

| cell | BEFORE | AFTER (this PR) |
|---|---|---|
| **durable** @2,000 msg/s — delivery p50 | **14.7 s, falling unboundedly behind** (1,688/s) | **0.8 ms, keeps up** (1,999.9/s) |
| **durable** max sustained | 1,086 msg/s | **3,101 msg/s (+186%)** |
| out-of-box route (1Kb @8/s) transit p50 | 2.39 ms | 2.40 ms (native anchor: 2.1 ms — parity, no regression from the mapper change) |
| buffered-send route with (100, 250ms) batching | 2.0 ms | 1.7 ms — **Rabbit sends never routed through the debounced batching channel; unaffected by the GH-3490 bug in both directions** |
| inline max / buffered max | 29.6k / 16.4k msg/s | 27.8k / 15.3k msg/s (run variance; the buffered-below-inline anomaly is pre-existing → RO5 follow-up) |

Also measured (R1, now in the docs): out-of-box Inline consumption does ~179 msg/s against a 2,000 msg/s load with a 5 ms handler — and the equivalent single-consumer raw-client loop does 166 msg/s, so that's the consumption pattern, not Wolverine overhead. `BufferedInMemory()` holds the same load at 2 ms p50; `ListenerCount(4)` scales inline ~4×.

## Changes

- **RO1 — durable delivery coalescing** (`WorkerQueueMessageConsumer`): durable endpoints post mapped envelopes into a `BatchingChannel` (5 ms max-age — bounded thanks to jasperfx#533 — size cap = new `MaximumMessagesToReceive` knob, default 100, mirroring Kafka/ASB naming) whose flush hands `Envelope[]` to the existing batched inbox path → one multi-VALUES insert per batch. Acks still only after persistence; flush failures nack-requeue the batch; Buffered/Inline endpoints keep the direct per-delivery path; `MaximumMessagesToReceive(1)` opts out.
- **Batch-arrival path hardened to match single-arrival semantics** (`DurableReceiver.ProcessReceivedMessagesAsync`, core): per-envelope serializer unwrap (MassTransit interop), missing-id/message-type dead-lettering, expiry, and drain-time latching — guards the one-at-a-time path has always had but the array path (used by Kafka's #3502 batching and now RabbitMQ) historically skipped.
- **Incoming mapper double-decode eliminated for RabbitMQ** (`preferCopiedIncomingHeaders`, same seam as Kafka in #3501; conversion symmetry between `writeIncomingHeaders` and `tryReadIncomingHeader` verified — both do byte[]→UTF8/ToString on the same dictionary).
- **Docs**: RabbitMQ "Performance Tuning" page (inline-default scaling guidance with the measured numbers, mode trade-offs, prefetch, confirms, back-pressure) + nav entry.
- Rig: buffered-send mode + `r-batch-buffered` cell.

## Validation

- Wolverine.RabbitMQ.Tests green (456+ passed; the only local failures were the SQL-Server-backed DLQ tests before the sqlserver container was restarted — green after)
- Full `wolverine.slnx` Release build + CoreTests + Kafka suite re-run after the core `ProcessReceivedMessagesAsync` change (Kafka exercises the same path via #3502)
- Ledger with all cells including negative results: RABBITMQ-PERF-DEEP-DIVE-PLAN.md §6

## Not addressed (recorded for later)

RO2 ack-watermark coalescing (inline max gap to native), RO5 buffered back-pressure churn (buffered max < inline max), O1b batched mark-handled (shared with Kafka — the remaining durable ceiling both transports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4XSARYV567q5Y3fW6iwiu
