### PR TITLE
GH-3499: SignalR cascading responses survive an already-flushed MessageContext

### DIFF
--- a/src/Transports/SignalR/Wolverine.SignalR.Tests/respond_after_context_has_flushed.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR.Tests/respond_after_context_has_flushed.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using Shouldly;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+
+namespace Wolverine.SignalR.Tests;
+
+public class respond_after_context_has_flushed : WebSocketTestContext
+{
+    // GH-3499 -- a handler whose MessageContext has already flushed (e.g. an
+    // explicit SaveChangesAsync() on an outboxed session drains the context)
+    // was silently dropping the ResponseToCallingWebSocket cascading response
+    [Fact]
+    public async Task response_is_still_delivered_when_the_context_already_flushed()
+    {
+        var green = await StartClientHost("green");
+        var red = await StartClientHost("red");
+
+        var tracked = await red.TrackActivity()
+            .IncludeExternalTransports()
+            .AlsoTrack(theWebApp)
+            .SendMessageAndWaitAsync(new RequiresResponseAfterFlush("Josh Allen"));
+
+        var record = tracked.Executed.SingleRecord<ResponseAfterFlush>();
+
+        // Verify that the response still went to the original calling client
+        record.ServiceName.ShouldBe("red");
+        record.Message.ShouldBeOfType<ResponseAfterFlush>().Name.ShouldBe("Josh Allen");
+    }
+}
+
+public record RequiresResponseAfterFlush(string Name) : WebSocketMessage;
+public record ResponseAfterFlush(string Name) : WebSocketMessage;
+
+public static class ResponseAfterFlushHandler
+{
+    public static async Task<ResponseToCallingWebSocket<ResponseAfterFlush>> Handle(
+        RequiresResponseAfterFlush msg, IMessageContext context)
+    {
+        // Simulate what an explicit SaveChangesAsync() on an outboxed session
+        // does to the context: enqueue an outgoing message, then drain the
+        // context so its OnlyOnce flush guard latches before the cascading
+        // response is applied
+        await context.PublishAsync(new FromFirst(msg.Name));
+        await ((MessageContext)context).FlushOutgoingMessagesAsync();
+
+        return new ResponseAfterFlush(msg.Name).RespondToCallingWebSocket();
+    }
+
+    public static void Handle(ResponseAfterFlush msg) => Debug.WriteLine(msg);
+}

--- a/src/Transports/SignalR/Wolverine.SignalR/ResponseToCallingWebSocket.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/ResponseToCallingWebSocket.cs
@@ -1,3 +1,4 @@
+using Wolverine.Runtime;
 using Wolverine.SignalR.Internals;
 
 namespace Wolverine.SignalR;
@@ -10,14 +11,33 @@ namespace Wolverine.SignalR;
 /// <typeparam name="T"></typeparam>
 public record ResponseToCallingWebSocket<T>(T Message) : ISendMyself
 {
-    ValueTask ISendMyself.ApplyAsync(IMessageContext context)
+    async ValueTask ISendMyself.ApplyAsync(IMessageContext context)
     {
         if (context.Envelope is SignalREnvelope se)
         {
+            var options = new DeliveryOptions
+                { RoutingInformation = new WebSocketRouting.Connection(se.ConnectionId) };
+
+            // GH-3499 -- if the handler's context has already flushed its outgoing
+            // messages (e.g. an explicit SaveChangesAsync() on an outboxed session
+            // drained it), enqueueing here would be silently dropped by the
+            // MultiFlushMode.OnlyOnce guard. Send through a fresh context instead
+            if (context is MessageContext { HasFlushed: true } flushed)
+            {
+                var fresh = new MessageContext(flushed.Runtime)
+                {
+                    TenantId = flushed.TenantId,
+                    CorrelationId = flushed.CorrelationId
+                };
+
+                await fresh.EndpointFor(se.Destination!).SendAsync(Message, options);
+                await fresh.FlushOutgoingMessagesAsync();
+                return;
+            }
+
             // This gets us back to the same SignalR Hub
-            return context
-                .EndpointFor(se.Destination!)
-                .SendAsync(Message, new DeliveryOptions { RoutingInformation = new WebSocketRouting.Connection(se.ConnectionId) });
+            await context.EndpointFor(se.Destination!).SendAsync(Message, options);
+            return;
         }
 
         throw new InvalidWolverineSignalROperationException("The current message was not received from SignalR");

--- a/src/Transports/SignalR/Wolverine.SignalR/SignalRMessage.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/SignalRMessage.cs
@@ -1,3 +1,4 @@
+using Wolverine.Runtime;
 using Wolverine.SignalR.Internals;
 
 namespace Wolverine.SignalR;
@@ -11,9 +12,27 @@ namespace Wolverine.SignalR;
 /// <typeparam name="T"></typeparam>
 public record SignalRMessage<T>(T Message, WebSocketRouting.ILocator Locator) : ISendMyself
 {
-    ValueTask ISendMyself.ApplyAsync(IMessageContext context)
+    async ValueTask ISendMyself.ApplyAsync(IMessageContext context)
     {
-        return context.PublishAsync(Message,
-            new DeliveryOptions() { SagaId = Locator.ToString(), RoutingInformation = Locator });
+        var options = new DeliveryOptions { SagaId = Locator.ToString(), RoutingInformation = Locator };
+
+        // GH-3499 -- if the handler's context has already flushed its outgoing
+        // messages (e.g. an explicit SaveChangesAsync() on an outboxed session
+        // drained it), enqueueing here would be silently dropped by the
+        // MultiFlushMode.OnlyOnce guard. Send through a fresh context instead
+        if (context is MessageContext { HasFlushed: true } flushed)
+        {
+            var fresh = new MessageContext(flushed.Runtime)
+            {
+                TenantId = flushed.TenantId,
+                CorrelationId = flushed.CorrelationId
+            };
+
+            await fresh.PublishAsync(Message, options);
+            await fresh.FlushOutgoingMessagesAsync();
+            return;
+        }
+
+        await context.PublishAsync(Message, options);
     }
 }

--- a/src/Wolverine/AssemblyAttributes.cs
+++ b/src/Wolverine/AssemblyAttributes.cs
@@ -52,6 +52,7 @@ using Wolverine.Attributes;
 [assembly: InternalsVisibleTo("Wolverine.Nats")]
 [assembly: InternalsVisibleTo("Wolverine.MQTT")]
 [assembly: InternalsVisibleTo("Wolverine.Redis")]
+[assembly: InternalsVisibleTo("Wolverine.SignalR")]
 [assembly: InternalsVisibleTo("Wolverine.Pubsub")]
 [assembly: InternalsVisibleTo("MetricsTests")]
 [assembly: InternalsVisibleTo("Wolverine.MySql")]

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -43,6 +43,15 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
     private bool _hasFlushed;
     private object? _sagaId;
 
+    /// <summary>
+    /// Has this context already flushed its outgoing messages? When true, any
+    /// envelope enqueued afterward will be dropped by the default
+    /// MultiFlushMode.OnlyOnce guard in FlushOutgoingMessagesAsync(). Cascading
+    /// wrappers that must deliver regardless (e.g. SignalR responses, GH-3499)
+    /// check this to reroute through a fresh context
+    /// </summary>
+    internal bool HasFlushed => _hasFlushed;
+
     public MessageContext(IWolverineRuntime runtime) : base(runtime)
     {
     }
@@ -142,6 +151,18 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
             switch (MultiFlushMode)
             {
                 case MultiFlushMode.OnlyOnce:
+                    lock (_outstandingLock)
+                    {
+                        if (_outstanding.Count > 0)
+                        {
+                            // GH-3499 -- a silent drop of enqueued envelopes is the worst outcome,
+                            // so at least make the loss visible
+                            Runtime.Logger.LogWarning(
+                                "MessageContext for {MessageType} has already flushed its outgoing messages, so {Count} envelope(s) enqueued after that flush will not be sent. This can happen when messages are enqueued after an explicit transaction commit (e.g. SaveChangesAsync()) has already drained the context. Consider MultiFlushMode.AllowMultiples if multiple flushes are expected",
+                                Envelope?.MessageType, _outstanding.Count);
+                        }
+                    }
+
                     return;
 
                 case MultiFlushMode.AllowMultiples:


### PR DESCRIPTION
Closes #3499

## The bug

A handler that receives a message over the SignalR transport and returns `msg.RespondToCallingWebSocket()` loses the response silently whenever the handler also writes through an outboxed session and calls `SaveChangesAsync()` explicitly before returning. The explicit save drains the `MessageContext` and latches the `MultiFlushMode.OnlyOnce` guard, so the cascading response lands in `_outstanding` after the flush and the pipeline's post-handler `FlushOutgoingMessagesAsync()` returns without sending it — no send, no log, no error.

## The fix

Both suggestions from the issue, plus the same treatment for `SignalRMessage<T>` which had the identical flaw:

- **`ResponseToCallingWebSocket<T>` / `SignalRMessage<T>`**: when the handler's context has already flushed (`MessageContext.HasFlushed`, newly exposed internally with `InternalsVisibleTo("Wolverine.SignalR")`), the wrapper sends + flushes through a **fresh `MessageContext`** (propagating tenant id and correlation id). When the context has *not* flushed — the normal flow — behavior is unchanged, so outbox ordering with middleware-managed transactions is preserved.
- **Core**: `FlushOutgoingMessagesAsync()` under `MultiFlushMode.OnlyOnce` now logs a **warning** when the early return is about to drop outstanding envelopes, instead of failing silently. No behavior change otherwise — the GH-215 double-flush guard semantics are untouched (existing `MessageContextTests` for all three `MultiFlushMode`s still pass).

## Testing

- New regression test `respond_after_context_has_flushed` reproduces the drop by draining the context inside the handler before returning the cascading response; verified it **fails without the fix** (response never delivered, exactly the reported symptom) and passes with it.
- Full `Wolverine.SignalR.Tests` suite: 28/28 passing.
- `CoreTests` `MessageContextTests`: 64/64 passing.
- Full `wolverine.slnx` Release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)