### PR TITLE
GH-3474: standardized diagnostic headers on dead-letter and retry moves — remaining gaps + docs

### DIFF
--- a/docs/guide/messaging/transports/azureservicebus/deadletterqueues.md
+++ b/docs/guide/messaging/transports/azureservicebus/deadletterqueues.md
@@ -1,5 +1,12 @@
 # Dead Letter Queues
 
+When Wolverine dead letters a message natively, it sets the broker's `DeadLetterReason` property to the
+exception type and `DeadLetterErrorDescription` to the exception message, and additionally copies the standard
+Wolverine diagnostic headers (`exception-type`, `exception-message`, `exception-stack`, `failed-at`,
+`original-destination`) onto the dead lettered message's application properties. See
+[diagnostic headers on dead letter messages](/tutorials/dead-letter-queues#diagnostic-headers-on-dead-letter-messages)
+for the full cross-transport header structure.
+
 The behavior of Wolverine.AzureServiceBus dead letter queuing depends on the endpoint mode:
 
 ### Inline Endpoints

--- a/docs/guide/messaging/transports/gcp-pubsub/deadlettering.md
+++ b/docs/guide/messaging/transports/gcp-pubsub/deadlettering.md
@@ -2,6 +2,12 @@
 
 By default, Wolverine dead lettering is disabled for GCP Pub/Sub transport and Wolverine uses any persistent envelope storage for dead lettering. You can opt in to Wolverine dead lettering through GCP Pub/Sub globally as shown below.
 
+When a message is moved to the dead letter topic, Wolverine stamps the standard diagnostic headers
+(`exception-type`, `exception-message`, `exception-stack`, `failed-at`, `original-destination`) as Pub/Sub
+message attributes, with the delivery attempt count on the standard `attempts` header. See
+[diagnostic headers on dead letter messages](/tutorials/dead-letter-queues#diagnostic-headers-on-dead-letter-messages)
+for the full cross-transport header structure.
+
 <!-- snippet: sample_enable_wolverine_dead_lettering_for_pubsub -->
 <a id='snippet-sample_enable_wolverine_dead_lettering_for_pubsub'></a>
 ```cs

--- a/docs/guide/messaging/transports/kafka.md
+++ b/docs/guide/messaging/transports/kafka.md
@@ -997,6 +997,14 @@ extra topics. Retry topics are for pure-Kafka shops, or orgs whose tooling/obser
 
 Wolverine supports routing failed Kafka messages to a designated dead letter queue (DLQ) Kafka topic instead of relying on database-backed dead letter storage. This is opt-in on a per-listener basis.
 
+Messages produced to the DLQ topic — and to the [non-blocking retry topics](#non-blocking-retry-topics) —
+carry the standard Wolverine diagnostic headers as Kafka headers: `exception-type`, `exception-message`,
+`exception-stack` (truncated to 8,192 characters), `failed-at`, `original-destination`, plus
+`original-partition` and `original-offset` recording exactly where the failed message came from. The delivery
+attempt count is on the standard `attempts` header. See
+[diagnostic headers on dead letter messages](/tutorials/dead-letter-queues#diagnostic-headers-on-dead-letter-messages)
+for the full cross-transport header structure.
+
 ### Enabling the Dead Letter Queue
 
 To enable the native DLQ for a Kafka listener, use the `EnableNativeDeadLetterQueue()` method:

--- a/docs/guide/messaging/transports/nats.md
+++ b/docs/guide/messaging/transports/nats.md
@@ -617,7 +617,10 @@ The response endpoint always uses Core NATS for low-latency replies, even when t
   configured dead-letter subject (so a terminate failure can't lose it), then terminated on the consumer via
   `AckTerminateAsync(reason)` so the server stops redelivering and records why. If **no** dead-letter subject
   is configured, Wolverine logs a warning and the message is terminated without being retained — configure a
-  dead-letter subject to keep poison messages.
+  dead-letter subject to keep poison messages. Messages forwarded to the dead-letter subject carry the
+  standard Wolverine diagnostic headers (`exception-type`, `exception-message`, `exception-stack`,
+  `failed-at`, `original-destination`), with the delivery attempt count on the standard `attempts` header —
+  see [diagnostic headers on dead letter messages](/tutorials/dead-letter-queues#diagnostic-headers-on-dead-letter-messages).
 
 ### Core NATS
 

--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -264,6 +264,12 @@ After the last tier is exhausted the message lands in the dead-letter topic. The
 onto every Pulsar listener at startup (provisioning the retry-letter producer/consumer and the DLQ),
 so you don't also need an explicit `RetryLetterQueueing(...)` call.
 
+Messages moved to the retry-letter or dead-letter topic carry the standard Wolverine diagnostic headers
+(`exception-type`, `exception-message`, `exception-stack`, `failed-at`, `original-destination`) as message
+properties, with the delivery attempt count on the standard `attempts` header. See
+[diagnostic headers on dead letter messages](/tutorials/dead-letter-queues#diagnostic-headers-on-dead-letter-messages)
+for the full cross-transport header structure.
+
 ::: warning Requires a Shared or Key_Shared subscription
 Pulsar message delaying only works on `Shared` / `KeyShared` subscriptions. Applying
 `MoveToPulsarRetryTopic` to an `Exclusive` / `Failover` listener emits a startup warning and the

--- a/docs/guide/messaging/transports/rabbitmq/deadletterqueues.md
+++ b/docs/guide/messaging/transports/rabbitmq/deadletterqueues.md
@@ -79,8 +79,13 @@ With `EnableEnhancedDeadLettering()`, Wolverine will instead publish failed mess
 |--------|-------------|
 | `exception-type` | Full type name of the exception |
 | `exception-message` | The exception message |
-| `exception-stack` | The exception stack trace |
+| `exception-stack` | The exception stack trace, truncated to 8,192 characters |
 | `failed-at` | Unix timestamp (milliseconds) when the failure occurred |
+| `original-destination` | The Wolverine endpoint Uri the message was originally received from |
+
+The delivery attempt count is carried by the standard `attempts` envelope header. See
+[diagnostic headers on dead letter messages](/tutorials/dead-letter-queues#diagnostic-headers-on-dead-letter-messages)
+for the full cross-transport header structure.
 
 ```cs
 using var host = await Host.CreateDefaultBuilder()

--- a/docs/guide/messaging/transports/redis.md
+++ b/docs/guide/messaging/transports/redis.md
@@ -368,7 +368,14 @@ necessary to utilize that.
 ## Dead Letter Queue Messages <Badge type="tip" text="5.10" />
 
 For `Buffered` or `Inline` endpoints, you can use native Redis streams for "dead letter queue" messages using
-the name "{StreamKey}:dead-letter":
+the name "{StreamKey}:dead-letter". Each dead letter stream entry contains the serialized envelope plus the
+standard Wolverine diagnostic headers as top-level entry fields — `exception-type`, `exception-message`,
+`exception-stack`, `failed-at`, `original-destination` — alongside `message-type`, `envelope-id`, and
+`attempts` fields so tooling can inspect failures without deserializing the envelope. See
+[diagnostic headers on dead letter messages](/tutorials/dead-letter-queues#diagnostic-headers-on-dead-letter-messages)
+for the full cross-transport header structure.
+
+Enable the native dead letter queue like this:
 
 <!-- snippet: sample_using_dead_letter_queue_for_redis -->
 <a id='snippet-sample_using_dead_letter_queue_for_redis'></a>

--- a/docs/guide/messaging/transports/sqs/deadletterqueues.md
+++ b/docs/guide/messaging/transports/sqs/deadletterqueues.md
@@ -2,6 +2,12 @@
 
 By default, Wolverine will try to move dead letter messages in SQS to a single, global queue named "wolverine-dead-letter-queue."
 
+When Wolverine moves a failed message to the dead letter queue, it stamps the standard diagnostic headers
+(`exception-type`, `exception-message`, `exception-stack`, `failed-at`, `original-destination`) as SQS message
+attributes, with the delivery attempt count on the standard `attempts` header. See
+[diagnostic headers on dead letter messages](/tutorials/dead-letter-queues#diagnostic-headers-on-dead-letter-messages)
+for the full cross-transport header structure.
+
 ## Customizing the Default Dead Letter Queue Name <Badge type="tip" text="5.39" />
 
 The built-in default name `wolverine-dead-letter-queue` is fine for a single deployment, but multi-environment AWS accounts that share a region collide on it across environments. Override the default for the entire SQS transport in one call:

--- a/docs/tutorials/dead-letter-queues.md
+++ b/docs/tutorials/dead-letter-queues.md
@@ -296,6 +296,37 @@ Wolverine uses the message's `DeliverBy` value as the expiration if it has one; 
 `DeadLetterQueueExpiration` to the current time. Expired rows are deleted by background processes, so cleanup is
 not quite real time.
 
+## Diagnostic headers on dead letter messages <Badge type="tip" text="6.21" />
+
+Whenever Wolverine moves a failed message to a *native* dead letter destination — a RabbitMQ dead letter
+queue, a Kafka DLQ topic (or tiered retry topic), the Azure Service Bus `$DeadLetterQueue`, an SQS dead letter
+queue, a Pulsar DLQ or retry-letter topic, a Redis dead letter stream, a GCP Pub/Sub dead letter topic, or a
+NATS dead-letter subject — it stamps one standard set of diagnostic headers on the moved message:
+
+| Header | Description |
+|--------|-------------|
+| `exception-type` | Full type name of the exception that caused the failure |
+| `exception-message` | The exception message |
+| `exception-stack` | The exception stack trace, truncated to 8,192 characters |
+| `failed-at` | Unix timestamp (milliseconds) when the failure occurred |
+| `original-destination` | The Wolverine endpoint Uri the message was originally received from |
+| `original-partition` | The broker partition the message was received from (partitioned brokers such as Kafka only) |
+| `original-offset` | The broker offset of the original message (offset-tracking brokers such as Kafka only) |
+
+The delivery attempt count travels on the standard `attempts` envelope header that Wolverine already maps on
+every transport, so tooling can read attempts, exception type, and origin without deserializing the message
+body. The header names intentionally align with the `exception_type` and `exception_message` columns of the
+[database dead letter storage](/guide/durability/dead-letter-storage), so failed messages can be grouped the
+same way whether they landed in a broker DLQ or the database table.
+
+Two transport-specific notes:
+
+- **Azure Service Bus** also sets the broker-native `DeadLetterReason` (exception type) and
+  `DeadLetterErrorDescription` (exception message) properties, and copies the headers above onto the dead
+  lettered message's application properties.
+- **Redis** writes the headers as top-level fields on the dead letter stream entry alongside the serialized
+  envelope, plus `message-type`, `envelope-id`, and `attempts` fields.
+
 ## Where to go next
 
 - [Error Handling](/guide/handlers/error-handling) -- the full set of retry, requeue, discard, and pause policies that decide *when* a message is dead lettered, plus exception filtering and the circuit breaker.

--- a/src/Testing/CoreTests/Transports/DeadLetterQueueConstantsTests.cs
+++ b/src/Testing/CoreTests/Transports/DeadLetterQueueConstantsTests.cs
@@ -72,4 +72,64 @@ public class DeadLetterQueueConstantsTests
         envelope.Headers[DeadLetterQueueConstants.ExceptionMessageHeader]
             .ShouldBe("second");
     }
+
+    [Fact]
+    public void stamp_failure_metadata_records_the_original_destination()
+    {
+        var envelope = new Envelope
+        {
+            Destination = new Uri("kafka://topic/incoming")
+        };
+
+        DeadLetterQueueConstants.StampFailureMetadata(envelope, new Exception("boom"));
+
+        envelope.Headers[DeadLetterQueueConstants.OriginalDestinationHeader]
+            .ShouldBe("kafka://topic/incoming");
+    }
+
+    [Fact]
+    public void stamp_failure_metadata_omits_destination_and_partition_headers_when_unknown()
+    {
+        var envelope = new Envelope();
+
+        DeadLetterQueueConstants.StampFailureMetadata(envelope, new Exception("boom"));
+
+        envelope.Headers.ContainsKey(DeadLetterQueueConstants.OriginalDestinationHeader).ShouldBeFalse();
+        envelope.Headers.ContainsKey(DeadLetterQueueConstants.OriginalPartitionHeader).ShouldBeFalse();
+        envelope.Headers.ContainsKey(DeadLetterQueueConstants.OriginalOffsetHeader).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void stamp_failure_metadata_records_partition_and_offset_when_present()
+    {
+        var envelope = new Envelope
+        {
+            PartitionId = 3,
+            Offset = 1234L
+        };
+
+        DeadLetterQueueConstants.StampFailureMetadata(envelope, new Exception("boom"));
+
+        envelope.Headers[DeadLetterQueueConstants.OriginalPartitionHeader].ShouldBe("3");
+        envelope.Headers[DeadLetterQueueConstants.OriginalOffsetHeader].ShouldBe("1234");
+    }
+
+    [Fact]
+    public void stamp_failure_metadata_truncates_very_long_stack_traces()
+    {
+        var longStack = new string('x', DeadLetterQueueConstants.MaxStackTraceLength + 500);
+
+        var truncated = DeadLetterQueueConstants.TruncateStackTrace(longStack);
+
+        truncated.Length.ShouldBe(DeadLetterQueueConstants.MaxStackTraceLength
+                                  + DeadLetterQueueConstants.TruncationMarker.Length);
+        truncated.ShouldEndWith(DeadLetterQueueConstants.TruncationMarker);
+    }
+
+    [Fact]
+    public void truncate_stack_trace_leaves_short_stacks_alone()
+    {
+        DeadLetterQueueConstants.TruncateStackTrace("short stack").ShouldBe("short stack");
+        DeadLetterQueueConstants.TruncateStackTrace(null).ShouldBe("");
+    }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelope.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelope.cs
@@ -1,5 +1,6 @@
 using Azure.Messaging.ServiceBus;
 using JasperFx.Core;
+using Wolverine.Transports;
 
 namespace Wolverine.AzureServiceBus.Internal;
 
@@ -67,16 +68,36 @@ public class AzureServiceBusEnvelope : Envelope
 
     public Task DeadLetterAsync(CancellationToken token, string? deadLetterReason = null, string? deadLetterErrorDescription = null)
     {
+        // Copy the standard failure metadata headers stamped on this envelope onto the
+        // dead lettered message's application properties so the diagnostics survive the
+        // native move to the $DeadLetterQueue. GH-3474
+        var propertiesToModify = buildDiagnosticProperties();
+
         if (Args != null)
-            return Args.DeadLetterMessageAsync(AzureMessage, cancellationToken: token, deadLetterReason: deadLetterReason, deadLetterErrorDescription: deadLetterErrorDescription);
+            return Args.DeadLetterMessageAsync(AzureMessage, propertiesToModify, deadLetterReason, deadLetterErrorDescription, token);
 
         if (ServiceBusReceiver != null)
-            return ServiceBusReceiver.DeadLetterMessageAsync(AzureMessage, cancellationToken: token, deadLetterReason: deadLetterReason, deadLetterErrorDescription: deadLetterErrorDescription);
+            return ServiceBusReceiver.DeadLetterMessageAsync(AzureMessage, propertiesToModify, deadLetterReason, deadLetterErrorDescription, token);
 
         if (SessionReceiver != null)
-            return SessionReceiver.DeadLetterMessageAsync(AzureMessage, cancellationToken: token, deadLetterReason: deadLetterReason, deadLetterErrorDescription: deadLetterErrorDescription);
+            return SessionReceiver.DeadLetterMessageAsync(AzureMessage, propertiesToModify, deadLetterReason, deadLetterErrorDescription, token);
 
         return Task.CompletedTask;
+    }
+
+    private Dictionary<string, object>? buildDiagnosticProperties()
+    {
+        Dictionary<string, object>? properties = null;
+        foreach (var key in DeadLetterQueueConstants.DiagnosticHeaders)
+        {
+            if (Headers.TryGetValue(key, out var value) && value != null)
+            {
+                properties ??= new Dictionary<string, object>();
+                properties[key] = value;
+            }
+        }
+
+        return properties;
     }
 
     private ProcessMessageEventArgs? Args { get; set; }

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Confluent.Kafka;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
@@ -277,13 +276,10 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue, IR
 
         try
         {
+            // Stamp the standard failure metadata (exception info + original
+            // destination/partition/offset) so the mapper carries it as Kafka headers. GH-3474
+            DeadLetterQueueConstants.StampFailureMetadata(envelope, exception);
             var message = await _endpoint.EnvelopeMapper!.CreateMessage(envelope);
-
-            message.Headers ??= new Headers();
-            message.Headers.Add(DeadLetterQueueConstants.ExceptionTypeHeader, Encoding.UTF8.GetBytes(exception.GetType().FullName ?? "Unknown"));
-            message.Headers.Add(DeadLetterQueueConstants.ExceptionMessageHeader, Encoding.UTF8.GetBytes(exception.Message));
-            message.Headers.Add(DeadLetterQueueConstants.ExceptionStackHeader, Encoding.UTF8.GetBytes(exception.StackTrace ?? ""));
-            message.Headers.Add(DeadLetterQueueConstants.FailedAtHeader, Encoding.UTF8.GetBytes(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()));
 
             using var producer = transport.CreateProducer(producerConfig);
             await producer.ProduceAsync(dlqTopicName, message);

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Confluent.Kafka;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
@@ -177,13 +176,10 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
 
         try
         {
+            // Stamp the standard failure metadata (exception info + original
+            // destination/partition/offset) so the mapper carries it as Kafka headers. GH-3474
+            DeadLetterQueueConstants.StampFailureMetadata(envelope, exception);
             var message = await _endpoint.EnvelopeMapper!.CreateMessage(envelope);
-
-            message.Headers ??= new Headers();
-            message.Headers.Add(DeadLetterQueueConstants.ExceptionTypeHeader, Encoding.UTF8.GetBytes(exception.GetType().FullName ?? "Unknown"));
-            message.Headers.Add(DeadLetterQueueConstants.ExceptionMessageHeader, Encoding.UTF8.GetBytes(exception.Message));
-            message.Headers.Add(DeadLetterQueueConstants.ExceptionStackHeader, Encoding.UTF8.GetBytes(exception.StackTrace ?? ""));
-            message.Headers.Add(DeadLetterQueueConstants.FailedAtHeader, Encoding.UTF8.GetBytes(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()));
 
             using var producer = transport.CreateProducer(transport.ProducerConfig);
             await producer.ProduceAsync(dlqTopicName, message);

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/MoveToKafkaRetryTopicContinuation.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/MoveToKafkaRetryTopicContinuation.cs
@@ -5,6 +5,7 @@ using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 using Wolverine.ErrorHandling;
 using Wolverine.Runtime;
+using Wolverine.Transports;
 
 namespace Wolverine.Kafka.Internals;
 
@@ -77,6 +78,11 @@ internal sealed class MoveToKafkaRetryTopicContinuation : UserDefinedContinuatio
         var retryTopicName = KafkaRetryNaming.RetryTopicName(sourceTopic, _delays[nextTier]);
         var retryTopic = transport.Topics[retryTopicName];
         retryTopic.EnsureEnvelopeMapper(runtime);
+
+        // Stamp the standard failure metadata (exception info + original
+        // destination/partition/offset, GH-3474) so retry-topic moves carry the same
+        // diagnostic headers as dead letter moves; the mapper writes them as Kafka headers
+        DeadLetterQueueConstants.StampFailureMetadata(envelope, exception);
 
         var message = await retryTopic.EnvelopeMapper!.CreateMessage(envelope);
         message.Headers ??= new Headers();

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -444,6 +444,14 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
     {
         var messageMetadata = new MessageMetadata();
 
+        // Stamp the standard failure metadata (exception info + original destination) BEFORE
+        // copying the headers into the outgoing metadata so it actually reaches the DLQ or
+        // retry-letter message on the wire. GH-3474
+        if (exception != null)
+        {
+            DeadLetterQueueConstants.StampFailureMetadata(envelope, exception);
+        }
+
         foreach (var property in e.Headers)
         {
             messageMetadata[property.Key] = property.Value;
@@ -480,8 +488,6 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
             messageMetadata.DeliverAtTimeAsDateTimeOffset = DateTimeOffset.UtcNow;
             if (exception != null)
             {
-                DeadLetterQueueConstants.StampFailureMetadata(envelope, exception);
-
                 var exceptionText = exception.ToString();
                 messageMetadata[PulsarEnvelopeConstants.Exception] = exceptionText;
                 e.Headers[PulsarEnvelopeConstants.Exception] = exceptionText;

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
@@ -81,21 +81,28 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
         {
             var database = getDatabase();
             
-            // Serialize the envelope
+            // Stamp the standard failure metadata (GH-3474) so the serialized envelope
+            // round-trips it, then serialize
+            DeadLetterQueueConstants.StampFailureMetadata(envelope, exception);
             var serializedEnvelope = EnvelopeSerializer.Serialize(envelope);
-            
+
             // Build the dead letter entry with error information
             var fields = new List<NameValueEntry>
             {
                 new("envelope", serializedEnvelope),
                 new(DeadLetterQueueConstants.ExceptionTypeHeader, exception.GetType().FullName ?? "Unknown"),
                 new(DeadLetterQueueConstants.ExceptionMessageHeader, exception.Message ?? ""),
-                new(DeadLetterQueueConstants.ExceptionStackHeader, exception.StackTrace ?? ""),
+                new(DeadLetterQueueConstants.ExceptionStackHeader, DeadLetterQueueConstants.TruncateStackTrace(exception.StackTrace)),
                 new(DeadLetterQueueConstants.FailedAtHeader, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()),
                 new("message-type", envelope.MessageType ?? "Unknown"),
                 new("envelope-id", envelope.Id.ToString()),
                 new("attempts", envelope.Attempts.ToString())
             };
+
+            if (envelope.Destination != null)
+            {
+                fields.Add(new(DeadLetterQueueConstants.OriginalDestinationHeader, envelope.Destination.ToString()));
+            }
             
             // Add the dead letter entry to the dead letter stream
             var deadLetterMessageId = await database.StreamAddAsync(_endpoint.DeadLetterQueueKey, fields.ToArray());

--- a/src/Wolverine/Transports/DeadLetterQueueConstants.cs
+++ b/src/Wolverine/Transports/DeadLetterQueueConstants.cs
@@ -1,17 +1,75 @@
+using System.Globalization;
+
 namespace Wolverine.Transports;
 
 public static class DeadLetterQueueConstants
 {
     /// <summary>
-    /// Stamps the envelope headers with standard failure metadata from the given exception.
+    /// Stamps the envelope headers with standard failure metadata from the given exception:
+    /// exception type, message, truncated stack trace, the time of the failure, and the
+    /// original destination (plus partition/offset for partitioned brokers like Kafka)
+    /// the message was received from. See GH-3474.
     /// </summary>
     public static void StampFailureMetadata(Envelope envelope, Exception exception)
     {
         envelope.Headers[ExceptionTypeHeader] = exception.GetType().FullName ?? "Unknown";
         envelope.Headers[ExceptionMessageHeader] = exception.Message;
-        envelope.Headers[ExceptionStackHeader] = exception.StackTrace ?? "";
-        envelope.Headers[FailedAtHeader] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+        envelope.Headers[ExceptionStackHeader] = TruncateStackTrace(exception.StackTrace);
+        envelope.Headers[FailedAtHeader] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            .ToString(CultureInfo.InvariantCulture);
+
+        if (envelope.Destination != null)
+        {
+            envelope.Headers[OriginalDestinationHeader] = envelope.Destination.ToString();
+        }
+
+        if (envelope.PartitionId.HasValue)
+        {
+            envelope.Headers[OriginalPartitionHeader] =
+                envelope.PartitionId.Value.ToString(CultureInfo.InvariantCulture);
+            envelope.Headers[OriginalOffsetHeader] = envelope.Offset.ToString(CultureInfo.InvariantCulture);
+        }
     }
+
+    /// <summary>
+    /// Caps the stamped stack trace so the header stays within broker header/attribute
+    /// size limits
+    /// </summary>
+    public static string TruncateStackTrace(string? stackTrace)
+    {
+        if (stackTrace == null) return string.Empty;
+        if (stackTrace.Length <= MaxStackTraceLength) return stackTrace;
+
+        return stackTrace[..MaxStackTraceLength] + TruncationMarker;
+    }
+
+    /// <summary>
+    /// Maximum number of characters of the exception stack trace that will be stamped
+    /// into the exception-stack header
+    /// </summary>
+    public const int MaxStackTraceLength = 8192;
+
+    /// <summary>
+    /// Appended to the exception-stack header value when the stack trace was cut off
+    /// at MaxStackTraceLength characters
+    /// </summary>
+    public const string TruncationMarker = "... (truncated)";
+
+    /// <summary>
+    /// All header keys stamped by StampFailureMetadata, for transports that need to copy
+    /// the diagnostic headers onto a broker-native dead letter operation (e.g. Azure
+    /// Service Bus propertiesToModify)
+    /// </summary>
+    public static readonly string[] DiagnosticHeaders =
+    [
+        ExceptionTypeHeader,
+        ExceptionMessageHeader,
+        ExceptionStackHeader,
+        FailedAtHeader,
+        OriginalDestinationHeader,
+        OriginalPartitionHeader,
+        OriginalOffsetHeader
+    ];
 
     /// <summary>
     /// The default queue/topic name used for dead letter queues across all transports.
@@ -29,7 +87,7 @@ public static class DeadLetterQueueConstants
     public const string ExceptionMessageHeader = "exception-message";
 
     /// <summary>
-    /// Header key for the exception stack trace.
+    /// Header key for the exception stack trace, truncated to MaxStackTraceLength characters.
     /// </summary>
     public const string ExceptionStackHeader = "exception-stack";
 
@@ -37,4 +95,22 @@ public static class DeadLetterQueueConstants
     /// Header key for the Unix timestamp in milliseconds when the failure occurred.
     /// </summary>
     public const string FailedAtHeader = "failed-at";
+
+    /// <summary>
+    /// Header key for the Wolverine endpoint Uri the message was originally received from
+    /// before it was moved to a dead letter or retry destination.
+    /// </summary>
+    public const string OriginalDestinationHeader = "original-destination";
+
+    /// <summary>
+    /// Header key for the broker partition the message was originally received from, when
+    /// the transport is partitioned (e.g. Kafka).
+    /// </summary>
+    public const string OriginalPartitionHeader = "original-partition";
+
+    /// <summary>
+    /// Header key for the broker offset of the originally received message, when the
+    /// transport tracks offsets (e.g. Kafka).
+    /// </summary>
+    public const string OriginalOffsetHeader = "original-offset";
 }


### PR DESCRIPTION
Closes #3474

The core header set (`exception-type`, `exception-message`, `exception-stack`, `failed-at` via `DeadLetterQueueConstants.StampFailureMetadata`) already landed in fb8d98c9e across most native DLQ paths. This PR completes the issue's remaining task-list items.

## Header set extensions

- `original-destination` — the Wolverine endpoint Uri the message was received from
- `original-partition` / `original-offset` — stamped when the broker is partitioned/offset-tracking (Kafka)
- Stack traces are now **truncated at 8,192 chars** (`TruncateStackTrace`) so the header stays inside broker header/attribute limits
- Attempt count intentionally rides the existing standard `attempts` envelope header rather than a duplicate key
- New `DiagnosticHeaders` array for transports that must copy the set onto broker-native operations

## Per-transport gap fixes

- **Kafka**: both DLQ listeners now stamp the envelope and let the mapper write the headers (identical wire contract, plus the new origin headers — existing `DeadLetterQueueTests` header assertions pass unchanged against a live broker). The tiered **retry-topic continuation** now stamps the standard set alongside its `wolverine-kafka-retry-*` bookkeeping headers.
- **Pulsar**: fixed an ordering bug — `StampFailureMetadata` ran *after* envelope headers were copied into the outgoing `MessageMetadata`, so the standard headers never actually reached the DLQ message on the wire. The stamp now happens before the copy, and **retry-letter moves** stamp too.
- **Azure Service Bus**: the diagnostic headers are copied onto the dead lettered message's **application properties** via the `DeadLetterMessageAsync(message, propertiesToModify, reason, description)` overload — previously only the native `DeadLetterReason`/`DeadLetterErrorDescription` survived the move.
- **Redis**: dead letter stream entries gain an `original-destination` field, the envelope is stamped before serialization so the metadata round-trips, and the stack field uses the shared truncation.

## Admin/query surface (issue task 3)

Already in place — `DeadLetterEnvelopeQuery.ExceptionType`/`ExceptionMessage` filtering and `DeadLetterQueueCount` grouping by exception type, with names aligned to the DB store's `exception_type`/`exception_message` columns. No changes needed; noted here for the checklist.

## Docs

- New canonical **"Diagnostic headers on dead letter messages"** section in `docs/tutorials/dead-letter-queues.md` (full table + ASB/Redis specifics)
- Header-structure notes added to every transport page with a native DLQ path: RabbitMQ (table extended), SQS, Azure Service Bus, GCP Pub/Sub, Kafka (DLQ + retry topics), Pulsar (DLQ + retry-letter), Redis, NATS

## Testing

- `DeadLetterQueueConstantsTests` extended: origin headers present/absent, partition/offset stamping, truncation boundary + marker (9/9 passing)
- Kafka `DeadLetterQueueTests` against a live broker: 6/6 passing
- Full `wolverine.slnx` Release build: 0 warnings, 0 errors

The read-side round-trip (mapping broker-native death metadata like `x-death`/`DeadLetterReason`/`ApproximateReceiveCount` back into these fields on DLQ import) stays with the #3476 epic as scoped in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)