### PR TITLE
Update MQTT transport to MQTTnet 5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,7 +70,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64" />
-    <PackageVersion Include="MQTTnet.Extensions.ManagedClient" Version="4.3.7.1207" />
+    <PackageVersion Include="MQTTnet" Version="5.2.0.1603" />
+    <PackageVersion Include="MQTTnet.Server" Version="5.2.0.1603" />
     <PackageVersion Include="MySqlConnector" Version="2.4.0" />
     <PackageVersion Include="NATS.Net" Version="2.8.2" />
     <PackageVersion Include="NewId" Version="4.0.1" />

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/Bugs/Bug_mapper_exception_routes_to_dlq.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/Bugs/Bug_mapper_exception_routes_to_dlq.cs
@@ -2,7 +2,6 @@ using IntegrationTests;
 using JasperFx.Core;
 using Microsoft.Extensions.Hosting;
 using MQTTnet;
-using MQTTnet.Client;
 using Shouldly;
 using Wolverine.Persistence.Durability.DeadLetterManagement;
 using Wolverine.Runtime;
@@ -51,7 +50,7 @@ public class Bug_mapper_exception_routes_to_dlq : IAsyncLifetime
     [Fact]
     public async Task unmappable_message_is_persisted_to_wolverine_dead_letters()
     {
-        var factory = new MqttFactory();
+        var factory = new MqttClientFactory();
         using var client = factory.CreateMqttClient();
 
         var options = new MqttClientOptionsBuilder()

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/MqttTransportJwtRefreshTests.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/MqttTransportJwtRefreshTests.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
-using MQTTnet.Client;
+using MQTTnet;
 using MQTTnet.Extensions.ManagedClient;
 using NSubstitute;
 using Shouldly;

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/Samples.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/Samples.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using JasperFx.Core;
 using Microsoft.Extensions.Hosting;
 using MQTTnet;
@@ -214,7 +215,7 @@ public class MyMqttEnvelopeMapper : IMqttEnvelopeMapper
     {
         // These are the absolute minimums necessary for Wolverine to function
         envelope.MessageType = typeof(PaymentMade).ToMessageTypeName();
-        envelope.Data = incoming.PayloadSegment.Array;
+        envelope.Data = incoming.Payload.ToArray();
 
         // Optional items
         envelope.DeliverWithin = 5.Seconds(); // throw away the message if it

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/broker_connection_summary_3269.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/broker_connection_summary_3269.cs
@@ -1,6 +1,7 @@
 using JasperFx.Descriptors;
-using MQTTnet.Client;
+using MQTTnet;
 using Shouldly;
+using System.Net;
 using Wolverine.Configuration.Capabilities;
 using Wolverine.MQTT.Internals;
 using Xunit;
@@ -16,7 +17,10 @@ public class broker_connection_summary_3269
     public void describe_endpoint_reports_tcp_host_and_port()
     {
         var transport = new MqttTransport();
-        transport.Options.ClientOptions.ChannelOptions = new MqttClientTcpOptions { Server = "mqtt.host", Port = 8883 };
+        transport.Options.ClientOptions.ChannelOptions = new MqttClientTcpOptions
+        {
+            RemoteEndpoint = new DnsEndPoint("mqtt.host", 8883)
+        };
 
         transport.DescribeEndpoint().ShouldBe("mqtt.host:8883");
     }
@@ -25,7 +29,10 @@ public class broker_connection_summary_3269
     public void credentials_never_leak_into_the_description()
     {
         var transport = new MqttTransport();
-        transport.Options.ClientOptions.ChannelOptions = new MqttClientTcpOptions { Server = "mqtt.host", Port = 1883 };
+        transport.Options.ClientOptions.ChannelOptions = new MqttClientTcpOptions
+        {
+            RemoteEndpoint = new DnsEndPoint("mqtt.host", 1883)
+        };
         transport.Options.ClientOptions.Credentials =
             new MqttClientCredentials("user", System.Text.Encoding.UTF8.GetBytes(Secret));
 

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/connectivity.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/connectivity.cs
@@ -5,6 +5,7 @@ using MQTTnet;
 using MQTTnet.Extensions.ManagedClient;
 using MQTTnet.Internal;
 using MQTTnet.Protocol;
+using Shouldly;
 using Wolverine.ComplianceTests;
 using Wolverine.Util;
 using Xunit.Abstractions;
@@ -19,6 +20,49 @@ public class Connectivity
     public Connectivity(ITestOutputHelper output)
     {
         _output = output;
+    }
+
+    [Fact]
+    public async Task managed_client_reconnects_and_restores_subscriptions()
+    {
+        var port = PortFinder.GetAvailablePort();
+        var topic = $"reconnect/{Guid.NewGuid():N}";
+        await using var broker = new LocalMqttBroker(port)
+        {
+            Logger = new XUnitLogger(_output, "MQTT")
+        };
+        await broker.StartAsync();
+
+        using var managedClient = new MqttClientFactory().CreateManagedMqttClient();
+        var received = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        managedClient.ApplicationMessageReceivedAsync += e =>
+        {
+            if (e.ApplicationMessage.Topic == topic)
+            {
+                received.TrySetResult();
+            }
+
+            return CompletedTask.Instance;
+        };
+
+        await managedClient.StartAsync(new ManagedMqttClientOptionsBuilder()
+            .WithAutoReconnectDelay(100.Milliseconds())
+            .WithClientOptions(o => o.WithTcpServer("127.0.0.1", port))
+            .Build());
+
+        await managedClient.SubscribeAsync(topic);
+
+        await broker.StopAsync();
+        await waitUntilAsync(() => !managedClient.IsConnected, 10.Seconds());
+
+        await managedClient.EnqueueAsync(topic, "queued-while-offline");
+
+        await broker.StartAsync();
+        await waitUntilAsync(() => managedClient.IsConnected, 10.Seconds());
+
+        var completed = await Task.WhenAny(received.Task, Task.Delay(10.Seconds()));
+        completed.ShouldBe(received.Task);
     }
 
     [Fact]
@@ -73,5 +117,21 @@ public class Connectivity
         // await transport.DisposeAsync();
 
 
+    }
+
+    private static async Task waitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(50.Milliseconds());
+        }
+
+        condition().ShouldBeTrue();
     }
 }

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/connectivity.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/connectivity.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Text;
 using JasperFx.Core;
 using MQTTnet;
@@ -30,11 +31,11 @@ public class Connectivity
         };
         await broker.StartAsync();
 
-        var managedClient = new MqttFactory().CreateManagedMqttClient();
+        var managedClient = new MqttClientFactory().CreateManagedMqttClient();
 
         managedClient.ApplicationMessageReceivedAsync += e =>
         {
-            _output.WriteLine(">> RECEIVED: " + e.ApplicationMessage.Topic + ", " + Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment));
+            _output.WriteLine(">> RECEIVED: " + e.ApplicationMessage.Topic + ", " + Encoding.UTF8.GetString(e.ApplicationMessage.Payload.ToArray()));
             return CompletedTask.Instance;
         };
 

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/named_broker_tests.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/named_broker_tests.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Text;
 using JasperFx.Core;
 using Microsoft.Extensions.Hosting;
@@ -241,14 +242,14 @@ internal class RawMqttSubscriber : IAsyncDisposable
 
     public static async Task<RawMqttSubscriber> StartAsync(int port, string topic)
     {
-        var client = new MqttFactory().CreateManagedMqttClient();
+        var client = new MqttClientFactory().CreateManagedMqttClient();
         var subscriber = new RawMqttSubscriber(client);
 
         client.ApplicationMessageReceivedAsync += e =>
         {
             lock (subscriber._messages)
             {
-                subscriber._messages.Add(Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment));
+                subscriber._messages.Add(Encoding.UTF8.GetString(e.ApplicationMessage.Payload.ToArray()));
             }
 
             return Task.CompletedTask;

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttEnvelopeMapper.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttEnvelopeMapper.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using JasperFx.Core;
 using MQTTnet;
 using MQTTnet.Packets;
@@ -102,7 +103,7 @@ public class MqttEnvelopeMapper : IMqttEnvelopeMapper
     public void MapIncomingToEnvelope(Envelope envelope, MqttApplicationMessage incoming)
     {
         envelope.ContentType = incoming.ContentType;
-        envelope.Data = incoming.PayloadSegment.ToArray();
+        envelope.Data = incoming.Payload.ToArray();
 
         envelope.MessageType = _topic.MessageTypeName;
         envelope.TopicName = incoming.Topic;

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttListener.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttListener.cs
@@ -2,7 +2,7 @@ using System.Text;
 using JasperFx.Blocks;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
-using MQTTnet.Client;
+using MQTTnet;
 using MQTTnet.Extensions.ManagedClient;
 using Wolverine.Runtime;
 using Wolverine.Transports;

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttNetLogger.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttNetLogger.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
-using MQTTnet.Client;
-using MQTTnet.Diagnostics;
+using MQTTnet;
+using MQTTnet.Diagnostics.Logger;
 
 namespace Wolverine.MQTT.Internals;
 

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTenant.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTenant.cs
@@ -25,7 +25,7 @@ internal class MqttTenant
     /// overridden with the tenant-specific broker configuration.
     /// </summary>
     public ManagedMqttClientOptions Options { get; set; } = new()
-        { ClientOptions = new MQTTnet.Client.MqttClientOptions() };
+        { ClientOptions = new MQTTnet.MqttClientOptions() };
 
     /// <summary>
     /// Optional JWT authentication configuration for the tenant's own connection.

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTransport.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTransport.cs
@@ -3,9 +3,9 @@ using JasperFx.Core;
 using JasperFx.Descriptors;
 using Microsoft.Extensions.Logging;
 using MQTTnet;
-using MQTTnet.Client;
 using MQTTnet.Extensions.ManagedClient;
 using MQTTnet.Formatter;
+using System.Net;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Routing;
@@ -123,7 +123,7 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
 
         _logger = runtime.LoggerFactory.CreateLogger<MqttTransport>();
 
-        var mqttFactory = new MqttFactory();
+        var mqttFactory = new MqttClientFactory();
 
         var logger = new MqttNetLogger(runtime.LoggerFactory.CreateLogger<MqttClient>());
         Client = mqttFactory.CreateManagedMqttClient(logger);
@@ -153,7 +153,7 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
         }
     }
 
-    private async Task<IManagedMqttClient> buildTenantClientAsync(IWolverineRuntime runtime, MqttFactory mqttFactory,
+    private async Task<IManagedMqttClient> buildTenantClientAsync(IWolverineRuntime runtime, MqttClientFactory mqttFactory,
         MqttTenant tenant)
     {
         var logger = new MqttNetLogger(runtime.LoggerFactory.CreateLogger<MqttClient>());
@@ -217,8 +217,8 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
                         if (!client.IsConnected) continue;
 
                         await client.InternalClient
-                            .SendExtendedAuthenticationExchangeDataAsync(
-                                new MqttExtendedAuthenticationExchangeData
+                            .SendEnhancedAuthenticationExchangeDataAsync(
+                                new MqttEnhancedAuthenticationExchangeData
                                 {
                                     AuthenticationData = await jwt.GetTokenCallBack(),
                                     ReasonCode = MQTTnet.Protocol.MqttAuthenticateReasonCode.ReAuthenticate
@@ -288,8 +288,8 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
                     if (!Client.IsConnected) continue;
 
                     await Client.InternalClient
-                        .SendExtendedAuthenticationExchangeDataAsync(
-                            new MqttExtendedAuthenticationExchangeData
+                        .SendEnhancedAuthenticationExchangeDataAsync(
+                            new MqttEnhancedAuthenticationExchangeData
                             {
                                 AuthenticationData = await JwtAuthenticationOptions.GetTokenCallBack(),
                                 ReasonCode = MQTTnet.Protocol.MqttAuthenticateReasonCode.ReAuthenticate
@@ -345,9 +345,10 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
     {
         switch (Options.ClientOptions?.ChannelOptions)
         {
-            case MqttClientTcpOptions tcp:
-                var port = tcp.Port ?? 1883;
-                return $"{tcp.Server}:{port}";
+            case MqttClientTcpOptions { RemoteEndpoint: DnsEndPoint dns }:
+                return $"{dns.Host}:{dns.Port}";
+            case MqttClientTcpOptions { RemoteEndpoint: IPEndPoint ip }:
+                return $"{ip.Address}:{ip.Port}";
             case MqttClientWebSocketOptions ws:
                 // The websocket URI is the endpoint; credentials ride on Credentials, not the URI.
                 return ws.Uri;

--- a/src/Transports/MQTT/Wolverine.MQTT/LocalMqttBroker.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/LocalMqttBroker.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Debug;
 using MQTTnet;
-using MQTTnet.Diagnostics;
+using MQTTnet.Diagnostics.Logger;
 using MQTTnet.Server;
 
 namespace Wolverine.MQTT;
@@ -30,7 +30,7 @@ public class LocalMqttBroker : IAsyncDisposable, IMqttNetLogger
 
     public async Task StartAsync()
     {
-        var mqttFactory = new MqttFactory(this);
+        var mqttFactory = new MqttServerFactory();
 
         _mqttServer = mqttFactory.CreateMqttServer(_mqttServerOptions);
 

--- a/src/Transports/MQTT/Wolverine.MQTT/ManagedMqttClientCompatibility.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/ManagedMqttClientCompatibility.cs
@@ -1,0 +1,162 @@
+using System.Text;
+using MQTTnet.Diagnostics.Logger;
+using MQTTnet.Protocol;
+
+namespace MQTTnet.Extensions.ManagedClient;
+
+public class ManagedMqttClientOptions
+{
+    public MqttClientOptions ClientOptions { get; set; } = new();
+}
+
+public class ManagedMqttClientOptionsBuilder
+{
+    private MqttClientOptions _clientOptions = new();
+
+    public ManagedMqttClientOptionsBuilder WithMaxPendingMessages(int _)
+    {
+        return this;
+    }
+
+    public ManagedMqttClientOptionsBuilder WithClientOptions(Action<MqttClientOptionsBuilder> configure)
+    {
+        var builder = new MqttClientOptionsBuilder();
+        configure(builder);
+        _clientOptions = builder.Build();
+
+        return this;
+    }
+
+    public ManagedMqttClientOptions Build()
+    {
+        return new ManagedMqttClientOptions { ClientOptions = _clientOptions };
+    }
+}
+
+public class ManagedMqttApplicationMessage
+{
+    public MqttApplicationMessage ApplicationMessage { get; set; } = null!;
+    public Guid Id { get; set; }
+}
+
+public interface IManagedMqttClient : IDisposable
+{
+    event Func<MqttApplicationMessageReceivedEventArgs, Task> ApplicationMessageReceivedAsync;
+    event Func<MqttClientConnectedEventArgs, Task> ConnectedAsync;
+    event Func<MqttClientDisconnectedEventArgs, Task> DisconnectedAsync;
+
+    bool IsConnected { get; }
+    IMqttClient InternalClient { get; }
+
+    Task StartAsync(ManagedMqttClientOptions options);
+    Task StopAsync();
+    Task PingAsync(CancellationToken cancellationToken = default);
+    Task EnqueueAsync(ManagedMqttApplicationMessage message);
+    Task EnqueueAsync(string topic, string payload, MqttQualityOfServiceLevel qualityOfServiceLevel = MqttQualityOfServiceLevel.AtLeastOnce, bool retain = false);
+    Task SubscribeAsync(string topic, MqttQualityOfServiceLevel qualityOfServiceLevel = MqttQualityOfServiceLevel.AtLeastOnce);
+}
+
+internal class ManagedMqttClient : IManagedMqttClient
+{
+    private readonly IMqttClient _client;
+    private ManagedMqttClientOptions _options = new();
+
+    public ManagedMqttClient(IMqttClient client)
+    {
+        _client = client;
+    }
+
+    public event Func<MqttApplicationMessageReceivedEventArgs, Task> ApplicationMessageReceivedAsync
+    {
+        add => _client.ApplicationMessageReceivedAsync += value;
+        remove => _client.ApplicationMessageReceivedAsync -= value;
+    }
+
+    public event Func<MqttClientConnectedEventArgs, Task> ConnectedAsync
+    {
+        add => _client.ConnectedAsync += value;
+        remove => _client.ConnectedAsync -= value;
+    }
+
+    public event Func<MqttClientDisconnectedEventArgs, Task> DisconnectedAsync
+    {
+        add => _client.DisconnectedAsync += value;
+        remove => _client.DisconnectedAsync -= value;
+    }
+
+    public bool IsConnected => _client.IsConnected;
+    public IMqttClient InternalClient => _client;
+
+    public async Task StartAsync(ManagedMqttClientOptions options)
+    {
+        _options = options;
+        if (!_client.IsConnected)
+        {
+            await _client.ConnectAsync(_options.ClientOptions, CancellationToken.None);
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        if (_client.IsConnected)
+        {
+            await _client.DisconnectAsync(new MqttClientDisconnectOptions(), CancellationToken.None);
+        }
+    }
+
+    public Task PingAsync(CancellationToken cancellationToken = default)
+    {
+        return _client.PingAsync(cancellationToken);
+    }
+
+    public Task EnqueueAsync(ManagedMqttApplicationMessage message)
+    {
+        return publishAsync(message.ApplicationMessage);
+    }
+
+    public Task EnqueueAsync(string topic, string payload, MqttQualityOfServiceLevel qualityOfServiceLevel = MqttQualityOfServiceLevel.AtLeastOnce, bool retain = false)
+    {
+        var message = new MqttApplicationMessage
+        {
+            Topic = topic,
+            PayloadSegment = Encoding.UTF8.GetBytes(payload),
+            QualityOfServiceLevel = qualityOfServiceLevel,
+            Retain = retain
+        };
+
+        return publishAsync(message);
+    }
+
+    public Task SubscribeAsync(string topic, MqttQualityOfServiceLevel qualityOfServiceLevel = MqttQualityOfServiceLevel.AtLeastOnce)
+    {
+        return _client.SubscribeAsync(topic, qualityOfServiceLevel, CancellationToken.None);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+    }
+
+    private async Task publishAsync(MqttApplicationMessage message)
+    {
+        if (!_client.IsConnected)
+        {
+            await _client.ConnectAsync(_options.ClientOptions, CancellationToken.None);
+        }
+
+        await _client.PublishAsync(message, CancellationToken.None);
+    }
+}
+
+public static class MqttClientFactoryCompatibilityExtensions
+{
+    public static IManagedMqttClient CreateManagedMqttClient(this MqttClientFactory factory)
+    {
+        return new ManagedMqttClient(factory.CreateMqttClient());
+    }
+
+    public static IManagedMqttClient CreateManagedMqttClient(this MqttClientFactory factory, IMqttNetLogger logger)
+    {
+        return new ManagedMqttClient(factory.CreateMqttClient(logger));
+    }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT/ManagedMqttClientCompatibility.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/ManagedMqttClientCompatibility.cs
@@ -7,14 +7,35 @@ namespace MQTTnet.Extensions.ManagedClient;
 public class ManagedMqttClientOptions
 {
     public MqttClientOptions ClientOptions { get; set; } = new();
+    public int MaxPendingMessages { get; set; } = 10000;
+    public TimeSpan AutoReconnectDelay { get; set; } = TimeSpan.FromSeconds(5);
 }
 
 public class ManagedMqttClientOptionsBuilder
 {
     private MqttClientOptions _clientOptions = new();
+    private int _maxPendingMessages = 10000;
+    private TimeSpan _autoReconnectDelay = TimeSpan.FromSeconds(5);
 
-    public ManagedMqttClientOptionsBuilder WithMaxPendingMessages(int _)
+    public ManagedMqttClientOptionsBuilder WithMaxPendingMessages(int maxPendingMessages)
     {
+        if (maxPendingMessages <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxPendingMessages), "Max pending messages must be greater than zero");
+        }
+
+        _maxPendingMessages = maxPendingMessages;
+        return this;
+    }
+
+    public ManagedMqttClientOptionsBuilder WithAutoReconnectDelay(TimeSpan autoReconnectDelay)
+    {
+        if (autoReconnectDelay <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(autoReconnectDelay), "Auto reconnect delay must be greater than zero");
+        }
+
+        _autoReconnectDelay = autoReconnectDelay;
         return this;
     }
 
@@ -29,7 +50,12 @@ public class ManagedMqttClientOptionsBuilder
 
     public ManagedMqttClientOptions Build()
     {
-        return new ManagedMqttClientOptions { ClientOptions = _clientOptions };
+        return new ManagedMqttClientOptions
+        {
+            ClientOptions = _clientOptions,
+            MaxPendingMessages = _maxPendingMessages,
+            AutoReconnectDelay = _autoReconnectDelay
+        };
     }
 }
 
@@ -59,11 +85,22 @@ public interface IManagedMqttClient : IDisposable
 internal class ManagedMqttClient : IManagedMqttClient
 {
     private readonly IMqttClient _client;
+    private readonly SemaphoreSlim _connectionLock = new(1, 1);
+    private readonly object _pendingLock = new();
+    private readonly Queue<MqttApplicationMessage> _pendingMessages = new();
+    private readonly SemaphoreSlim _publishingLock = new(1, 1);
+    private readonly object _reconnectLock = new();
+    private readonly Dictionary<string, MqttQualityOfServiceLevel> _subscriptions = new();
+    private CancellationTokenSource? _lifetime;
     private ManagedMqttClientOptions _options = new();
+    private Task? _reconnectTask;
+    private bool _started;
+    private bool _stopping;
 
     public ManagedMqttClient(IMqttClient client)
     {
         _client = client;
+        _client.DisconnectedAsync += onClientDisconnectedAsync;
     }
 
     public event Func<MqttApplicationMessageReceivedEventArgs, Task> ApplicationMessageReceivedAsync
@@ -90,18 +127,39 @@ internal class ManagedMqttClient : IManagedMqttClient
     public async Task StartAsync(ManagedMqttClientOptions options)
     {
         _options = options;
-        if (!_client.IsConnected)
+        _stopping = false;
+        _started = true;
+        _lifetime = new CancellationTokenSource();
+
+        try
         {
-            await _client.ConnectAsync(_options.ClientOptions, CancellationToken.None);
+            await ensureConnectedAsync(_lifetime.Token);
+            await tryPublishQueuedMessagesAsync(_lifetime.Token);
+        }
+        catch
+        {
+            scheduleReconnect();
         }
     }
 
     public async Task StopAsync()
     {
+        _stopping = true;
+        _started = false;
+
+        var lifetime = _lifetime;
+        if (lifetime is not null)
+        {
+            await lifetime.CancelAsync();
+        }
+
         if (_client.IsConnected)
         {
             await _client.DisconnectAsync(new MqttClientDisconnectOptions(), CancellationToken.None);
         }
+
+        lifetime?.Dispose();
+        _lifetime = null;
     }
 
     public Task PingAsync(CancellationToken cancellationToken = default)
@@ -111,7 +169,8 @@ internal class ManagedMqttClient : IManagedMqttClient
 
     public Task EnqueueAsync(ManagedMqttApplicationMessage message)
     {
-        return publishAsync(message.ApplicationMessage);
+        enqueue(message.ApplicationMessage);
+        return publishQueuedMessagesAsync();
     }
 
     public Task EnqueueAsync(string topic, string payload, MqttQualityOfServiceLevel qualityOfServiceLevel = MqttQualityOfServiceLevel.AtLeastOnce, bool retain = false)
@@ -124,27 +183,222 @@ internal class ManagedMqttClient : IManagedMqttClient
             Retain = retain
         };
 
-        return publishAsync(message);
+        enqueue(message);
+        return publishQueuedMessagesAsync();
     }
 
-    public Task SubscribeAsync(string topic, MqttQualityOfServiceLevel qualityOfServiceLevel = MqttQualityOfServiceLevel.AtLeastOnce)
+    public async Task SubscribeAsync(string topic, MqttQualityOfServiceLevel qualityOfServiceLevel = MqttQualityOfServiceLevel.AtLeastOnce)
     {
-        return _client.SubscribeAsync(topic, qualityOfServiceLevel, CancellationToken.None);
+        lock (_subscriptions)
+        {
+            _subscriptions[topic] = qualityOfServiceLevel;
+        }
+
+        if (!_client.IsConnected)
+        {
+            scheduleReconnect();
+            return;
+        }
+
+        try
+        {
+            await _client.SubscribeAsync(topic, qualityOfServiceLevel, CancellationToken.None);
+        }
+        catch
+        {
+            scheduleReconnect();
+        }
     }
 
     public void Dispose()
     {
+        _stopping = true;
+        _started = false;
+        _lifetime?.Cancel();
+        _lifetime?.Dispose();
+        _client.DisconnectedAsync -= onClientDisconnectedAsync;
         _client.Dispose();
+        _connectionLock.Dispose();
+        _publishingLock.Dispose();
     }
 
-    private async Task publishAsync(MqttApplicationMessage message)
+    private void enqueue(MqttApplicationMessage message)
     {
-        if (!_client.IsConnected)
+        lock (_pendingLock)
         {
-            await _client.ConnectAsync(_options.ClientOptions, CancellationToken.None);
+            if (_pendingMessages.Count >= _options.MaxPendingMessages)
+            {
+                throw new InvalidOperationException($"The managed MQTT client has reached the configured pending message limit of {_options.MaxPendingMessages}");
+            }
+
+            _pendingMessages.Enqueue(message);
+        }
+    }
+
+    private async Task ensureConnectedAsync(CancellationToken cancellationToken)
+    {
+        if (_client.IsConnected)
+        {
+            return;
         }
 
-        await _client.PublishAsync(message, CancellationToken.None);
+        await _connectionLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (!_client.IsConnected)
+            {
+                await _client.ConnectAsync(_options.ClientOptions, cancellationToken);
+            }
+
+            await restoreSubscriptionsAsync(cancellationToken);
+        }
+        finally
+        {
+            _connectionLock.Release();
+        }
+    }
+
+    private async Task publishQueuedMessagesAsync()
+    {
+        await tryPublishQueuedMessagesAsync(CancellationToken.None);
+    }
+
+    private async Task<bool> tryPublishQueuedMessagesAsync(CancellationToken cancellationToken)
+    {
+        if (!_started)
+        {
+            return true;
+        }
+
+        if (!_client.IsConnected)
+        {
+            scheduleReconnect();
+            return false;
+        }
+
+        await _publishingLock.WaitAsync(cancellationToken);
+        try
+        {
+            while (_client.IsConnected)
+            {
+                MqttApplicationMessage? message;
+                lock (_pendingLock)
+                {
+                    if (_pendingMessages.Count == 0)
+                    {
+                        return true;
+                    }
+
+                    message = _pendingMessages.Peek();
+                }
+
+                try
+                {
+                    await _client.PublishAsync(message, cancellationToken);
+
+                    lock (_pendingLock)
+                    {
+                        if (_pendingMessages.Count > 0 && ReferenceEquals(_pendingMessages.Peek(), message))
+                        {
+                            _pendingMessages.Dequeue();
+                        }
+                    }
+                }
+                catch
+                {
+                    scheduleReconnect();
+                    return false;
+                }
+            }
+        }
+        finally
+        {
+            _publishingLock.Release();
+        }
+
+        scheduleReconnect();
+        return false;
+    }
+
+    private async Task restoreSubscriptionsAsync(CancellationToken cancellationToken)
+    {
+        KeyValuePair<string, MqttQualityOfServiceLevel>[] subscriptions;
+        lock (_subscriptions)
+        {
+            subscriptions = _subscriptions.ToArray();
+        }
+
+        foreach (var subscription in subscriptions)
+        {
+            await _client.SubscribeAsync(subscription.Key, subscription.Value, cancellationToken);
+        }
+    }
+
+    private Task onClientDisconnectedAsync(MqttClientDisconnectedEventArgs _)
+    {
+        if (_started && !_stopping)
+        {
+            scheduleReconnect();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void scheduleReconnect()
+    {
+        if (!_started || _stopping)
+        {
+            return;
+        }
+
+        lock (_reconnectLock)
+        {
+            if (_reconnectTask is null || _reconnectTask.IsCompleted)
+            {
+                _reconnectTask = Task.Run(reconnectAsync);
+            }
+        }
+    }
+
+    private async Task reconnectAsync()
+    {
+        var lifetime = _lifetime;
+        if (lifetime is null)
+        {
+            return;
+        }
+
+        while (_started && !_stopping && !lifetime.IsCancellationRequested)
+        {
+            try
+            {
+                await ensureConnectedAsync(lifetime.Token);
+                var published = await tryPublishQueuedMessagesAsync(lifetime.Token);
+
+                if (_client.IsConnected && published)
+                {
+                    return;
+                }
+            }
+            catch (OperationCanceledException) when (lifetime.IsCancellationRequested)
+            {
+                return;
+            }
+            catch
+            {
+                // MQTTnet's managed client used to hide transient broker failures. Keep trying here as long as
+                // the Wolverine transport is still running.
+            }
+
+            try
+            {
+                await Task.Delay(_options.AutoReconnectDelay, lifetime.Token);
+            }
+            catch (OperationCanceledException) when (lifetime.IsCancellationRequested)
+            {
+                return;
+            }
+        }
     }
 }
 

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttEnvelope.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttEnvelope.cs
@@ -1,4 +1,5 @@
-using MQTTnet.Client;
+using System.Buffers;
+using MQTTnet;
 
 namespace Wolverine.MQTT;
 
@@ -12,7 +13,7 @@ public class MqttEnvelope : Envelope
     internal MqttEnvelope(MqttTopic topic, MqttApplicationMessageReceivedEventArgs args)
     {
         Args = args;
-        Data = args.ApplicationMessage.PayloadSegment.Array;
+        Data = args.ApplicationMessage.Payload.ToArray();
         MessageType = topic.MessageTypeName;
         Destination = topic.Uri;
     }

--- a/src/Transports/MQTT/Wolverine.MQTT/Wolverine.MQTT.csproj
+++ b/src/Transports/MQTT/Wolverine.MQTT/Wolverine.MQTT.csproj
@@ -15,7 +15,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MQTTnet.Extensions.ManagedClient" />
+        <PackageReference Include="MQTTnet" />
+        <PackageReference Include="MQTTnet.Server" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Update MQTT transport packages from `MQTTnet.Extensions.ManagedClient` 4.3.7 to MQTTnet 5.2.0 packages.
- Add a thin compatibility layer for the managed-client API surface Wolverine already uses, backed by MQTTnet v5's native `IMqttClient`.
- Adapt MQTT factory, server factory, payload, diagnostic endpoint, and enhanced-auth APIs for MQTTnet 5.

## Testing
- `dotnet build src/Transports/MQTT/Wolverine.MQTT/Wolverine.MQTT.csproj -v minimal`
- `dotnet build src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj -v minimal`
- `dotnet test src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj -f net10.0 --no-build -v minimal --filter "FullyQualifiedName!~Bug_mapper_exception_routes_to_dlq"`
  - Passed: 117, skipped: 1

## Notes
- Full `dotnet test` could not complete locally because this machine has .NET 8 and .NET 10 runtimes installed, but not .NET 9, and the SQL Server-backed dead-letter test needs a reachable local SQL Server.