### PR TITLE
GH-3518: Solo-mode health-check loop no longer leaks an unbounded OTel trace

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/solo_mode_health_check_tracing.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/solo_mode_health_check_tracing.cs
@@ -1,0 +1,139 @@
+using System.Diagnostics;
+using CoreTests.Transports;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Regression coverage for GH-3518. In DurabilityMode.Solo the recurring health-check
+/// loop is launched with a fire-and-forget Task.Run inside StartSoloModeAsync. Before the
+/// fix that Task.Run captured the ambient ExecutionContext — including the AsyncLocal
+/// behind Activity.Current — while the startup "wolverine_node_assignments" activity was
+/// still current. Every subsequent loop iteration (and every DB call underneath it) then
+/// reparented itself to that one stopped-but-still-ambient activity for the entire process
+/// lifetime, producing a single OTel trace that grew without bound.
+///
+/// The fix suppresses ExecutionContext flow when scheduling the loop and starts a fresh,
+/// bounded activity per tick — so each tick is its own root trace, and ShouldTraceHealthCheck()
+/// (hence NodeAssignmentHealthCheckTraceSamplingPeriod) is finally honored in Solo mode.
+/// </summary>
+public class solo_mode_health_check_tracing : IDisposable
+{
+    private readonly WolverineOptions _options;
+    private readonly IWolverineRuntime _runtime;
+    private readonly NodeAgentController _controller;
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly List<Activity> _captured = new();
+    private readonly ActivityListener _listener;
+
+    public solo_mode_health_check_tracing()
+    {
+        _options = new WolverineOptions
+        {
+            ApplicationAssembly = GetType().Assembly
+        };
+        _options.Durability.Mode = DurabilityMode.Solo;
+        _options.Durability.DurabilityAgentEnabled = false; // skip MessageStoreCollection wiring
+        // Fast ticks so the recurring loop fires several times within the test window.
+        _options.Durability.CheckAssignmentPeriod = 25.Milliseconds();
+
+        _runtime = Substitute.For<IWolverineRuntime>();
+        _runtime.Options.Returns(_options);
+        _runtime.DurabilitySettings.Returns(_options.Durability);
+        _runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Wolverine",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity =>
+            {
+                if (activity.OperationName == "wolverine_node_assignments")
+                {
+                    lock (_captured)
+                    {
+                        _captured.Add(activity);
+                    }
+                }
+            }
+        };
+        ActivitySource.AddActivityListener(_listener);
+
+        _controller = new NodeAgentController(
+            _runtime,
+            Substitute.For<INodeAgentPersistence>(),
+            Array.Empty<IAgentFamily>(),
+            NullLogger<NodeAgentController>.Instance,
+            _cancellation.Token);
+    }
+
+    private Activity[] snapshot()
+    {
+        lock (_captured)
+        {
+            return _captured.ToArray();
+        }
+    }
+
+    [Fact]
+    public async Task each_recurring_tick_is_its_own_bounded_root_trace()
+    {
+        await _controller.StartSoloModeAsync();
+
+        // Let the recurring loop fire several times (25ms period).
+        await Task.Delay(400.Milliseconds());
+
+        // Stop the loop before asserting.
+        await _cancellation.CancelAsync();
+
+        var activities = snapshot();
+
+        // The startup activity plus at least a couple of recurring-loop ticks. Before the
+        // fix the loop never started a fresh activity at all, so only the single startup
+        // "wolverine_node_assignments" activity was ever produced.
+        activities.Length.ShouldBeGreaterThan(2,
+            "the recurring Solo-mode health-check loop must start a fresh activity per tick");
+
+        // The core GH-3518 invariant: every tick is its own root trace, never nesting under
+        // a long-lived ambient parent. If the loop reparents to the captured startup context
+        // (the bug), the tick activities would share a TraceId and/or carry a non-null Parent.
+        foreach (var activity in activities)
+        {
+            activity.Parent.ShouldBeNull(
+                "each Solo-mode health-check activity must be a root, not nested under a leaked ambient parent");
+        }
+
+        activities.Select(a => a.TraceId).Distinct().Count()
+            .ShouldBe(activities.Length, "each Solo-mode health-check tick must get its own bounded trace");
+    }
+
+    [Fact]
+    public async Task sampling_period_throttles_solo_mode_recurring_checks()
+    {
+        // NodeAssignmentHealthCheckTraceSamplingPeriod was a no-op in Solo mode before the fix
+        // because ShouldTraceHealthCheck() was only evaluated once, at startup. Now it gates
+        // every tick, so a long sampling period must suppress the per-tick traces.
+        _options.Durability.NodeAssignmentHealthCheckTraceSamplingPeriod = 1.Hours();
+
+        await _controller.StartSoloModeAsync();
+        await Task.Delay(400.Milliseconds());
+        await _cancellation.CancelAsync();
+
+        // Only the startup tick should trace within a 1-hour sampling window.
+        snapshot().Length.ShouldBe(1,
+            "a long sampling period must throttle the recurring Solo-mode health checks");
+    }
+
+    public void Dispose()
+    {
+        _cancellation.Cancel();
+        _listener.Dispose();
+        _cancellation.Dispose();
+    }
+}

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.StartLocally.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.StartLocally.cs
@@ -8,37 +8,62 @@ public partial class NodeAgentController
 
     public async Task StartSoloModeAsync()
     {
-        using var activity = ShouldTraceHealthCheck() 
-            ? WolverineTracing.ActivitySource.StartActivity("wolverine_node_assignments") 
-            : null;
-        
-        await _runtime.Storage.Nodes.ClearAllAsync(_cancellation.Token);
-        await _runtime.Storage.Admin.ReleaseAllOwnershipAsync();
-
-        var current = WolverineNode.For(_runtime.Options);
-
-        _runtime.Options.Durability.AssignedNodeNumber = current.AssignedNodeNumber = 1;
-        await _observer.NodeStarted();
-
-        await startAllAgentsAsync();
-
-        _soloCheckingTask = Task.Run(async () =>
+        // Scope the startup activity to the *initial* assignment work only. Critically,
+        // this using block must close before the recurring loop is scheduled below --
+        // see GH-3518.
+        using (var activity = ShouldTraceHealthCheck()
+                   ? WolverineTracing.ActivitySource.StartActivity("wolverine_node_assignments")
+                   : null)
         {
-            while (!_cancellation.IsCancellationRequested)
-            {
-                try
-                {
-                    await Task.Delay(_runtime.Options.Durability.CheckAssignmentPeriod, _cancellation.Token);
-                    await startAllAgentsAsync();
-                }
-                catch (OperationCanceledException)
-                {
-                    // Just done
-                }
-            }
-        }, _cancellation.Token);
+            await _runtime.Storage.Nodes.ClearAllAsync(_cancellation.Token);
+            await _runtime.Storage.Admin.ReleaseAllOwnershipAsync();
+
+            var current = WolverineNode.For(_runtime.Options);
+
+            _runtime.Options.Durability.AssignedNodeNumber = current.AssignedNodeNumber = 1;
+            await _observer.NodeStarted();
+
+            await startAllAgentsAsync();
+        }
+
+        _soloCheckingTask = startSoloHealthCheckLoop();
 
         HasStartedInSoloMode = true;
+    }
+
+    private Task startSoloHealthCheckLoop()
+    {
+        // Suppress the ambient ExecutionContext flow so the AsyncLocal behind
+        // Activity.Current is NOT captured into the forked background task. Without this,
+        // Task.Run snapshots whatever activity happens to be current at scheduling time
+        // and every loop iteration (plus every DB call underneath it) reparents itself to
+        // that one long-lived activity for the entire process lifetime -- producing a
+        // single unbounded trace. See GH-3518. Each tick starts its own fresh, bounded
+        // activity below, gated by ShouldTraceHealthCheck() so the sampling period is
+        // actually honored in Solo mode.
+        using (ExecutionContext.SuppressFlow())
+        {
+            return Task.Run(async () =>
+            {
+                while (!_cancellation.IsCancellationRequested)
+                {
+                    try
+                    {
+                        await Task.Delay(_runtime.Options.Durability.CheckAssignmentPeriod, _cancellation.Token);
+
+                        using var activity = ShouldTraceHealthCheck()
+                            ? WolverineTracing.ActivitySource.StartActivity("wolverine_node_assignments")
+                            : null;
+
+                        await startAllAgentsAsync();
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Just done
+                    }
+                }
+            }, _cancellation.Token);
+        }
     }
 
     private async Task startAllAgentsAsync()


### PR DESCRIPTION
Fixes #3518.

## The bug

In `DurabilityMode.Solo`, `NodeAgentController.StartSoloModeAsync()` opened the `wolverine_node_assignments` activity and then scheduled the recurring health-check loop as a fire-and-forget `Task.Run(...)` **inside** that activity's `using` block.

`Task.Run` captures the ambient `ExecutionContext` — including the `AsyncLocal<Activity>` behind `Activity.Current` — at the moment it's scheduled, while the startup activity is still current. The `using` block's `Dispose()` only restores `Activity.Current` in the *calling* context; it can't reach into the already-captured context of the forked task.

Net effect: every iteration of the loop — and every DB call `startAllAgentsAsync()` makes underneath it — reparented itself to that one long-lived `wolverine_node_assignments` activity for the entire process lifetime. One OTel trace per process, growing without bound (the reporter measured ~4,700 spans in a 2-node, ~5-minute local dev run).

A secondary symptom: because `ShouldTraceHealthCheck()` was only ever evaluated **once** in Solo mode (at startup), `NodeAssignmentHealthCheckTraceSamplingPeriod` had no effect on the recurring loop.

## The fix

`src/Wolverine/Runtime/Agents/NodeAgentController.StartLocally.cs`:

1. **Scope the startup activity to the initial assignment work only** — the `using` block now closes *before* the loop is scheduled.
2. **Suppress `ExecutionContext` flow** (`ExecutionContext.SuppressFlow()`) when forking the background task, so `Activity.Current` is not captured into it.
3. **Start a fresh, bounded activity per tick** inside the loop, gated by `ShouldTraceHealthCheck()` — so each tick is its own root trace, and `NodeAssignmentHealthCheckTraceSamplingPeriod` is finally honored in Solo mode.

This also addresses the reporter's design concern: each tick is now a small, self-contained root trace rather than a parent/child chain nested under one long-lived activity.

## Tests

New `solo_mode_health_check_tracing` (CoreTests) drives `StartSoloModeAsync()` directly with substitutes and an `ActivityListener`:

- `each_recurring_tick_is_its_own_bounded_root_trace` — asserts the loop produces multiple `wolverine_node_assignments` activities, each a root (`Parent == null`) with a distinct `TraceId`. **Verified red against the unfixed code** (only the single startup activity existed → count check fails), green with the fix.
- `sampling_period_throttles_solo_mode_recurring_checks` — a 1-hour `NodeAssignmentHealthCheckTraceSamplingPeriod` now suppresses the recurring per-tick traces.

All 152 tests across the Heartbeat / Solo / Agents suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LDiv9GqbQkkAuU1nf4H6S

---

**Related issues**
- Fixes #3518