### PR TITLE
GH-3520: EventSubscriptionAgent restores continuous execution after Rebuild/Rewind

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,13 +35,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.30.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.30.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.30.1" />
+    <PackageVersion Include="JasperFx" Version="2.30.2" />
+    <PackageVersion Include="JasperFx.Events" Version="2.30.2" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.30.2" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.30.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.30.2" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.16.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/src/Testing/CoreTests/Runtime/Agents/event_subscription_agent_rebuild_rewind_resume.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/event_subscription_agent_rebuild_rewind_resume.cs
@@ -1,0 +1,55 @@
+using JasperFx;
+using JasperFx.Events.Projections;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Runtime.Agents;
+using Xunit;
+using IProjectionDaemon = JasperFx.Events.Daemon.IProjectionDaemon;
+using JasperFxSubscriptionAgent = JasperFx.Events.Daemon.ISubscriptionAgent;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Regression coverage for GH-3520. Under Wolverine-managed event-subscription distribution there is no
+/// store coordinator to resurrect a shard the daemon stopped. RebuildProjectionAsync stops the continuous
+/// agent and never restarts it; RewindSubscriptionAsync restarts it daemon-side but the wrapper still
+/// pointed at the stopped pre-rewind agent and reported Running. Either way the shard froze at
+/// RegisteredIdle while its high-water climbed. EventSubscriptionAgent.RebuildAsync/RewindAsync must now
+/// restore continuous execution themselves through the registered daemon start path and refresh their view.
+/// </summary>
+public class event_subscription_agent_rebuild_rewind_resume
+{
+    private readonly IProjectionDaemon _daemon = Substitute.For<IProjectionDaemon>();
+
+    // Store-global shard ("Incident:All", TenantId null) - the shape in the GH-3519/3520 report.
+    private readonly ShardName _shardName = new("Incident");
+    private readonly JasperFxSubscriptionAgent _restarted = Substitute.For<JasperFxSubscriptionAgent>();
+    private readonly EventSubscriptionAgent _agent;
+
+    public event_subscription_agent_rebuild_rewind_resume()
+    {
+        _daemon.StartAgentAsync(Arg.Any<ShardName>(), Arg.Any<CancellationToken>()).Returns(_restarted);
+        _agent = new EventSubscriptionAgent(
+            new Uri("event-subscriptions://marten/incident/all"), _shardName, _daemon);
+    }
+
+    [Fact]
+    public async Task rebuild_restores_continuous_execution_through_the_registered_start_path()
+    {
+        await _agent.RebuildAsync(CancellationToken.None);
+
+        // Before the fix RebuildAsync returned without restarting anything: no start call, and the
+        // wrapper kept its stale status. Now it resumes through the registered daemon start path.
+        await _daemon.Received(1).StartAgentAsync(Arg.Any<ShardName>(), Arg.Any<CancellationToken>());
+        _agent.Status.ShouldBe(AgentStatus.Running);
+    }
+
+    [Fact]
+    public async Task rewind_restores_continuous_execution_through_the_registered_start_path()
+    {
+        await _agent.RewindAsync(0, null, CancellationToken.None);
+
+        await _daemon.Received(1).StartAgentAsync(Arg.Any<ShardName>(), Arg.Any<CancellationToken>());
+        _agent.Status.ShouldBe(AgentStatus.Running);
+    }
+}

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgent.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgent.cs
@@ -59,14 +59,24 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        _innerAgent = await _daemon.StartAgentAsync(_shardName, cancellationToken);
-        Status = AgentStatus.Running;
+        await resumeContinuousAsync(cancellationToken);
 
         // Only count an agent that actually started - a throw above leaves the count untouched
         if (OnStarted != null)
         {
             await OnStarted();
         }
+    }
+
+    // Start (or re-adopt) the continuous inner agent through the registered daemon path and refresh the
+    // wrapper's view of it. Deliberately does NOT invoke OnStarted: the running-agent bookkeeping in
+    // EventStoreAgents counts one logical agent per node for the observer-subscription lifecycle, and a
+    // rebuild/rewind is transparent to that count (the wrapper never observed a matching stop), so
+    // re-counting here would leak the database's tracker subscriptions. See GH-3520.
+    private async Task resumeContinuousAsync(CancellationToken cancellationToken)
+    {
+        _innerAgent = await _daemon.StartAgentAsync(_shardName, cancellationToken);
+        Status = AgentStatus.Running;
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
@@ -86,6 +96,13 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
         // single-database per-tenant partitioning. _shardName.TenantId is null for store-global /
         // database-per-tenant shards, where the tenant-less behavior is correct.
         await _daemon.RebuildProjectionAsync(_shardName.Name, _shardName.TenantId, cancellationToken);
+
+        // GH-3520: the daemon-level rebuild stops the continuous agent and never restarts it. Under
+        // Wolverine-managed distribution there is no store coordinator to resurrect it, and this wrapper
+        // would otherwise keep reporting Running against the now-stopped agent, so NodeAgentController
+        // sees nothing to fix and the shard freezes at RegisteredIdle while its high-water climbs.
+        // Restore continuous execution ourselves through the registered daemon start path.
+        await resumeContinuousAsync(cancellationToken);
     }
 
     public async Task RewindAsync(long? sequenceFloor, DateTimeOffset? timestamp, CancellationToken cancellationToken)
@@ -95,6 +112,14 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
         // CritterWatch needs because DaemonForDatabase() throws under Wolverine-managed distribution.
         await _daemon.RewindSubscriptionAsync(_shardName.Name, _shardName.TenantId, cancellationToken,
             sequenceFloor, timestamp);
+
+        // GH-3520: same freeze as RebuildAsync. RewindSubscriptionAsync restarts continuous agents
+        // daemon-side, but the wrapper's _innerAgent still points at the stopped pre-rewind agent and
+        // Status still reads Running. Re-adopt the live agent through the registered start path so the
+        // wrapper reflects reality. This requires JasperFx#536 (rewind registers its restarted agent) so
+        // the registered start resolves to that same running agent idempotently rather than spinning up a
+        // duplicate on the same progression row - this ships in lockstep with that JasperFx bump.
+        await resumeContinuousAsync(cancellationToken);
     }
 
     public Uri Uri { get; }


### PR DESCRIPTION
Fixes #3520. Wolverine-side half of a coordinated fix with **JasperFx/jasperfx#536**.

## The bug

Under Wolverine-managed event-subscription distribution there is no store coordinator (`AddAsyncDaemon`) to resurrect a shard the daemon stopped:

- `EventSubscriptionAgent.RebuildAsync` → `_daemon.RebuildProjectionAsync(...)` stops the continuous agent and **never restarts it**. The wrapper still reports `Running` against the now-stopped agent, so `NodeAgentController` sees nothing to fix.
- `EventSubscriptionAgent.RewindAsync` → `_daemon.RewindSubscriptionAsync(...)` restarts the agent daemon-side, but the wrapper's `_innerAgent` still points at the stopped pre-rewind agent and `Status` still reads `Running`.

Either way the shard re-registers `RegisteredIdle` daemon-side and freezes forever while the high-water mark climbs (JasperFx/CritterWatch#747). An operator "Restart" routed to an agent Wolverine believes is already running no-ops.

## The fix

`RebuildAsync`/`RewindAsync` now restore continuous execution themselves through the registered daemon start path (`resumeContinuousAsync`) and refresh `_innerAgent`/`Status`:

```csharp
private async Task resumeContinuousAsync(CancellationToken cancellationToken)
{
    _innerAgent = await _daemon.StartAgentAsync(_shardName, cancellationToken);
    Status = AgentStatus.Running;
}
```

`resumeContinuousAsync` deliberately does **not** re-invoke `OnStarted`: a rebuild/rewind is transparent to `EventStoreAgents`' per-node running-agent count (the wrapper never observed a matching stop), so re-counting would leak the database's tracker observer subscriptions at the 1→0 transition.

## Coordination / merge order

- **Rebuild half is independently correct.** `RebuildProjectionAsync` leaves the shard stopped-but-registered, so `_daemon.StartAgentAsync(_shardName)` cleanly starts and re-registers a fresh continuous agent.
- **Rewind half depends on JasperFx#536.** Before that fix, `RewindSubscriptionAsync` leaves an *unregistered* running agent, so re-calling `StartAgentAsync` would start a **second** agent on the same progression row. JasperFx#536 registers the rewind's restarted agent, making the wrapper's start resolve to that same running agent idempotently. **Merge in lockstep with the JasperFx.Events bump that includes #536.**

## Tests

`event_subscription_agent_rebuild_rewind_resume` (CoreTests) drives `RebuildAsync`/`RewindAsync` over a substituted `IProjectionDaemon` and asserts each resumes through the registered start path (`StartAgentAsync` received once) and reports `Running`. Both verified red before the fix, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LDiv9GqbQkkAuU1nf4H6S

---

**Related issues**
- Fixes #3520
- Coordinated with (depends on) JasperFx/jasperfx#536, which closes JasperFx/jasperfx#534 and JasperFx/jasperfx#535
- Companion Wolverine issue: #3519