### PR TITLE
feat(postgresql): surface TransportSchemaName in queue endpoint diagnostics

### DIFF
--- a/src/Persistence/PostgresqlTests/Transport/PostgresqlQueueTests.cs
+++ b/src/Persistence/PostgresqlTests/Transport/PostgresqlQueueTests.cs
@@ -57,6 +57,22 @@ public class PostgresqlQueueTests
     }
 
     [Fact]
+    public void describe_properties_includes_the_resolved_transport_schema()
+    {
+        // Two hosts sharing one Postgres database must set an identical TransportSchemaName;
+        // if they diverge, messages strand silently. Surfacing the resolved schema in endpoint
+        // diagnostics (wolverine describe) is what makes such a mismatch observable.
+        theTransport.TransportSchemaName = "custom_queue_schema";
+
+        var queue = new PostgresqlQueue("one", theTransport);
+
+        var properties = queue.DescribeProperties();
+
+        properties.ShouldContainKey(nameof(PostgresqlTransport.TransportSchemaName));
+        properties[nameof(PostgresqlTransport.TransportSchemaName)].ShouldBe("custom_queue_schema");
+    }
+
+    [Fact]
     public void short_queue_name_leaves_identifiers_untouched()
     {
         var queue = new PostgresqlQueue("orders", theTransport);

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueue.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueue.cs
@@ -183,6 +183,19 @@ public class PostgresqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         });
     }
 
+    public override IDictionary<string, object> DescribeProperties()
+    {
+        var dict = base.DescribeProperties();
+
+        // Surface the resolved transport-queue schema so `wolverine describe` / endpoint
+        // diagnostics make it visible. Two hosts sharing one Postgres database must set an
+        // identical TransportSchemaName; if they diverge the queue tables live in different
+        // schemas and messages strand silently. This is visibility only - no assertion here.
+        dict[nameof(PostgresqlTransport.TransportSchemaName)] = Parent.TransportSchemaName;
+
+        return dict;
+    }
+
     public async ValueTask<Dictionary<string, string>> GetAttributesAsync()
     {
         var count = await CountAsync();


### PR DESCRIPTION
## Problem

Two Wolverine apps sharing one PostgreSQL database must set an identical `TransportSchemaName`, or their queue tables live in different schemas and messages strand silently (sender writes schema A, listener polls schema B — no error, no DLQ). First hit running CritterWatch as a second host, and again when splitting a modular monolith into separate deployables. Nothing in `wolverine describe` surfaces the resolved transport schema.

## Change

Override `PostgresqlQueue.DescribeProperties()` to include the resolved `TransportSchemaName`. Visibility only — no behaviour change, no assertion — so a mismatch between two hosts becomes a one-glance diff in `wolverine describe` instead of a silent outage.

Closes #3526
