### PR TITLE
GH-3521: warn loudly when a host's application assembly is pinned by an earlier host

### DIFF
--- a/docs/guide/handlers/discovery.md
+++ b/docs/guide/handlers/discovery.md
@@ -57,6 +57,23 @@ We highly recommend you use [WebApplicationFactory](https://learn.microsoft.com/
 to bootstrap your application in integration tests to avoid any problems around Wolverine's application assembly determination.
 :::
 
+::: warning The application assembly is pinned process-wide (test harnesses)
+The resolved application assembly is cached in a **process-wide static** the first time any host in the process
+falls through to the automatic call-stack determination. In a normal application that runs a single host this is
+harmless. But in a **test process that stands up multiple Wolverine hosts** (xUnit/vstest), whichever test class
+runs *first* pins the scanned assembly for every later host that doesn't set one explicitly — so if an earlier host
+resolved to a referenced assembly (a shared `Tests.Common`, the app-under-test, …), conventional handlers defined in
+a *different* assembly silently disappear for the whole run.
+
+The symptom is quiet and downstream — `No routes can be determined for Envelope … (SomeMessage)` at info level, or
+null scatter/gather results — and it is **order-dependent**: the suite passes in isolation, fails in a full run, and
+can flip between builds as recompilation reshuffles test order.
+
+Wolverine now logs a **warning at startup** when a host adopts an application assembly that differs from where it was
+actually registered, naming both assemblies. If you see that warning (or the routing symptom above), set the
+application assembly explicitly on the affected host, or add the missing assembly to discovery — see just below.
+:::
+
 In testing scenarios, if you're bootstrapping the application independently somehow of the application's "official" configuration, you may have to help
 Wolverine out a little bit and explicitly tell it what the application assembly is:
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -8,6 +8,14 @@ See Jeremy's blog post [How Wolverine allows for easier testing](https://jeremyd
 
 Also see [Wolverine Best Practices](/introduction/best-practices) for other helpful tips.
 
+::: warning Standing up multiple Wolverine hosts in one test process
+Wolverine resolves the *application assembly* it scans for handlers once per process and caches it in a static, so
+whichever host runs first can pin handler discovery for every later host that doesn't set one explicitly. If handlers
+seem to vanish only in full-suite runs (order-dependent `No routes can be determined` errors), see
+[the application-assembly warning under Assembly Discovery](/guide/handlers/discovery.html#assembly-discovery) — set
+`opts.ApplicationAssembly` or `opts.Discovery.IncludeAssembly(...)` explicitly on the affected hosts.
+:::
+
 And this:
 
 @[youtube](ODSAGAllsxw)

--- a/src/Testing/CoreTests/Configuration/remembered_application_assembly_reuse_warning.cs
+++ b/src/Testing/CoreTests/Configuration/remembered_application_assembly_reuse_warning.cs
@@ -1,0 +1,87 @@
+using System.Reflection;
+using JasperFx;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+/// <summary>
+/// GH-3521: the application assembly used for handler discovery is a process-wide value pinned by whichever
+/// Wolverine host started FIRST in the process (JasperFxOptions.ApplicationAssembly / the RememberedApplicationAssembly
+/// static). In a test process that stands up multiple hosts across different assemblies, a later host silently
+/// inherits the first host's assembly, so its conventional handlers vanish with only a downstream "No routes can
+/// be determined" as a symptom. These tests pin the loud warning that now surfaces that divergence.
+/// </summary>
+public class remembered_application_assembly_reuse_warning
+{
+    private static readonly Assembly WolverineAssembly = typeof(WolverineOptions).Assembly;
+    private static readonly Assembly ThisTestAssembly = typeof(remembered_application_assembly_reuse_warning).Assembly;
+
+    private static JasperFxOptions JasperFxWithApplicationAssembly(Assembly assembly)
+    {
+        return new JasperFxOptions { ApplicationAssembly = assembly };
+    }
+
+    [Fact]
+    public async Task a_normal_single_assembly_host_does_not_warn()
+    {
+        // Sanity + false-positive guard: a normal host registered from this test assembly resolves the same
+        // application assembly it adopts, so it must NOT warn. Also pins that the constructor captured the
+        // caller's assembly (this test assembly), not "Wolverine".
+        using var host = await Host.CreateDefaultBuilder().UseWolverine().StartAsync();
+        var options = host.Services.GetRequiredService<WolverineOptions>();
+
+        options.RegistrationCallingAssembly!.GetName().Name.ShouldBe(ThisTestAssembly.GetName().Name);
+        options.ApplicationAssemblyReuseWarning.ShouldBeNull();
+    }
+
+    [Fact]
+    public void warns_when_the_adopted_assembly_diverges_from_where_the_host_registered()
+    {
+        var options = new WolverineOptions();
+        var registered = options.RegistrationCallingAssembly;
+        registered.ShouldNotBeNull();
+
+        // Simulate the process-pinned jasperfx assembly being a DIFFERENT one than where this host registered.
+        var pinnedElsewhere = registered!.GetName().Name == WolverineAssembly.GetName().Name
+            ? ThisTestAssembly
+            : WolverineAssembly;
+
+        options.ReadJasperFxOptions(JasperFxWithApplicationAssembly(pinnedElsewhere));
+
+        // The pinned value is still adopted...
+        options.ApplicationAssembly!.GetName().Name.ShouldBe(pinnedElsewhere.GetName().Name);
+
+        // ...but the divergence is now loud, naming both the adopted and the skipped assembly.
+        options.ApplicationAssemblyReuseWarning.ShouldNotBeNull();
+        options.ApplicationAssemblyReuseWarning.ShouldContain(registered.GetName().Name!);
+        options.ApplicationAssemblyReuseWarning.ShouldContain(pinnedElsewhere.GetName().Name!);
+    }
+
+    [Fact]
+    public void does_not_warn_when_the_adopted_assembly_matches_where_the_host_registered()
+    {
+        var options = new WolverineOptions();
+        var registered = options.RegistrationCallingAssembly;
+        registered.ShouldNotBeNull();
+
+        options.ReadJasperFxOptions(JasperFxWithApplicationAssembly(registered!));
+
+        options.ApplicationAssemblyReuseWarning.ShouldBeNull();
+    }
+
+    [Fact]
+    public void does_not_warn_when_the_user_set_the_application_assembly_explicitly()
+    {
+        var options = new WolverineOptions();
+
+        // An explicit choice is always honored silently, regardless of what the process pinned.
+        options.ApplicationAssembly = WolverineAssembly;
+        options.ReadJasperFxOptions(JasperFxWithApplicationAssembly(ThisTestAssembly));
+
+        options.ApplicationAssemblyReuseWarning.ShouldBeNull();
+    }
+}

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -60,6 +60,14 @@ public partial class WolverineRuntime
             Logger.LogInformation("Starting Wolverine messaging for application assembly {Assembly}",
                 Options.ApplicationAssembly!.GetName());
 
+            // GH-3521: surface the RememberedApplicationAssembly first-host-wins pin loudly. Buffered during
+            // options configuration (no logger existed yet) and emitted here so a silently-inherited scanned
+            // assembly in a multi-host test process is observable instead of a downstream "No routes" mystery.
+            if (Options.ApplicationAssemblyReuseWarning is { } assemblyWarning)
+            {
+                Logger.LogWarning(assemblyWarning);
+            }
+
             logCodeGenerationConfiguration();
 
             await ApplyAsyncExtensions();

--- a/src/Wolverine/WolverineOptions.Assemblies.cs
+++ b/src/Wolverine/WolverineOptions.Assemblies.cs
@@ -16,6 +16,10 @@ public sealed partial class WolverineOptions
     /// </summary>
     public static Assembly? RememberedApplicationAssembly;
 
+    // GH-3521: a warning buffered during options configuration (before any logger exists) and emitted at
+    // WolverineRuntime startup when an implicit host silently inherited a different host's scanned assembly.
+    internal string? ApplicationAssemblyReuseWarning { get; private set; }
+
     private Assembly? _applicationAssembly;
 
     /// <summary>
@@ -126,6 +130,43 @@ public sealed partial class WolverineOptions
         }
 
         HandlerGraph.Discovery.Assemblies.Fill(ApplicationAssembly);
+    }
+
+    // GH-3521: the assembly this host's *own* registration call stack resolves to, captured in the
+    // constructor while the caller's frame is still present (determineCallingAssembly is meaningless from
+    // the lazy ReadJasperFxOptions path). Compared later against the assembly actually adopted for handler
+    // discovery — which, for an implicit host, is the process-pinned jasperfx.ApplicationAssembly — so a
+    // first-host-wins mismatch in a multi-host test process becomes a loud warning instead of a silent
+    // "No routes can be determined". Null when a caller assembly could not be resolved.
+    internal Assembly? RegistrationCallingAssembly { get; private set; }
+
+    internal void CaptureRegistrationCallingAssembly()
+    {
+        RegistrationCallingAssembly = determineCallingAssembly();
+    }
+
+    // GH-3521: record a warning (buffered until a logger exists at runtime startup) when the application
+    // assembly adopted for handler discovery differs from where this host was registered. Only meaningful
+    // for an implicit host (the user set neither ApplicationAssembly nor an assemblyName) — an explicit
+    // choice is always honored silently.
+    internal void CheckForDivergentApplicationAssembly(Assembly adopted)
+    {
+        var registered = RegistrationCallingAssembly;
+        if (registered == null)
+        {
+            return;
+        }
+
+        if (string.Equals(registered.GetName().Name, adopted.GetName().Name, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        ApplicationAssemblyReuseWarning =
+            $"Wolverine adopted application assembly '{adopted.GetName().Name}' for handler discovery, but this host was registered from '{registered.GetName().Name}'. " +
+            $"The application assembly is a process-wide value pinned by whichever host started FIRST in this process (GH-3521), so handler discovery will NOT scan '{registered.GetName().Name}'. " +
+            $"This typically only bites a test harness that stands up multiple Wolverine hosts across different assemblies. If handlers defined in '{registered.GetName().Name}' appear to be missing " +
+            $"(e.g. \"No routes can be determined\"), set opts.ApplicationAssembly = typeof(SomeHandler).Assembly or opts.Discovery.IncludeAssembly(...) explicitly on this host.";
     }
 
     internal void IncludeExtensionAssemblies(Assembly[] assemblies)

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -250,7 +250,15 @@ public sealed partial class WolverineOptions
         {
             establishApplicationAssembly(assemblyName);
         }
-        
+        else
+        {
+            // GH-3521: capture the caller's assembly now, while its frame is still on the stack. The
+            // application assembly is finalized later in ReadJasperFxOptions from a lazy DI factory where
+            // the caller's frame is long gone, so this is the only reliable point to learn where THIS host
+            // was actually registered — needed to detect the first-host-wins pin.
+            CaptureRegistrationCallingAssembly();
+        }
+
         if (ApplicationAssembly != null)
         {
             CodeGeneration.Assemblies.Add(ApplicationAssembly);
@@ -697,6 +705,13 @@ public sealed partial class WolverineOptions
             if (ApplicationAssembly == null)
             {
                 establishApplicationAssembly(null);
+            }
+            else
+            {
+                // GH-3521: jasperfx.ApplicationAssembly is a process-wide value pinned by whichever host
+                // started first. If it differs from where this host was actually registered, handler
+                // discovery will silently scan the wrong assembly — warn loudly.
+                CheckForDivergentApplicationAssembly(ApplicationAssembly);
             }
         }
         


### PR DESCRIPTION
Addresses #3521 (asks 1 & 2 — loud warning + docs). Ask 3 (changing the caching semantics) is intentionally left out per discussion; the warning + docs cover the trap without changing how the assembly is resolved.

## The trap

The application assembly Wolverine scans for handlers is cached in a **process-wide static** (`WolverineOptions.RememberedApplicationAssembly`, and the dominant one in practice, `JasperFxOptions.ApplicationAssembly`) by whichever host starts **first** in the process. In a normal single-host app that's harmless. In a **test process that stands up multiple Wolverine hosts across different assemblies**, a later implicit host silently inherits the first host's assembly — so conventional handlers defined in a *different* assembly vanish for the whole run, with only a downstream `No routes can be determined for Envelope … (SomeMessage)` at info level. It's **order-dependent**: passes in isolation, fails in full-suite runs, flips between builds as recompilation reshuffles test order. Cost CritterWatch a full debugging session (JasperFx/CritterWatch@b365a48e).

## The fix (diagnosability only)

The hard part is *where* to detect it. The application assembly is finalized in `ReadJasperFxOptions`, which runs **lazily from a DI factory** — the caller's frame is long gone there, so `determineCallingAssembly()` is meaningless at that point. So:

1. **Capture the caller's assembly in the `WolverineOptions` constructor**, while its frame is still on the stack (`RegistrationCallingAssembly`). This is where the host is actually registered from.
2. In `ReadJasperFxOptions`, when an **implicit** host adopts the process-pinned `jasperfx.ApplicationAssembly` and it **differs** from where the host registered, buffer a warning (`ApplicationAssemblyReuseWarning`).
3. Emit it at `WolverineRuntime` startup (no logger exists during options config), naming both assemblies and the remedy (`opts.ApplicationAssembly` / `opts.Discovery.IncludeAssembly(...)`).

An **explicit** choice (`opts.ApplicationAssembly` / an `assemblyName`) is honored **silently**, and a normal single-host app never diverges — so it never warns. This is why the fix compares against *where the host registered* rather than blindly warning on any inherited value.

## Docs (ask 2)

- `docs/guide/handlers/discovery.md` — a warning block under **Assembly Discovery** explaining the process-wide pin, the order-dependent symptom, and the new startup warning.
- `docs/guide/testing.md` — a cross-referencing note for multi-host test processes.

## Tests

`remembered_application_assembly_reuse_warning` (CoreTests):
- `a_normal_single_assembly_host_does_not_warn` — a real host; **false-positive guard** that also pins that the ctor captured the caller assembly (this test assembly), not `Wolverine`.
- `warns_when_the_adopted_assembly_diverges_from_where_the_host_registered` — verified red without the divergence check, green with it.
- `does_not_warn_when_the_adopted_assembly_matches…` and `…when_the_user_set_the_application_assembly_explicitly`.

## Not addressed

The **JasperFx `JasperFxOptions` twin** carries the same static and is actually the dominant source of the pinned value; a matching warning there would make the diagnostic fire even for non-Wolverine JasperFx hosts. Flagging as a natural follow-up rather than folding a JasperFx change in here.

---

**Related issues**
- Addresses #3521 (asks 1 & 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LDiv9GqbQkkAuU1nf4H6S