### PR TITLE
GH-3519: Isolate agent start failures so one wedged agent doesn't skip its siblings

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/agent_start_isolation.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/agent_start_isolation.cs
@@ -1,0 +1,127 @@
+using JasperFx;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Regression coverage for GH-3519. When a single agent cannot start during a Solo-mode
+/// assignment reevaluation (e.g. an event-subscription shard that loses a first-assignment
+/// startup race with high-water detection), that one failure must not skip the remaining,
+/// healthy sibling agents in the same family. Before the fix the family loop bailed on the
+/// first throw, so every agent after the wedged one stayed unstarted — reproduced in the wild
+/// as "two of three projection shards dead on that boot; only one ran."
+/// </summary>
+public class agent_start_isolation
+{
+    private readonly WolverineOptions _options;
+    private readonly IWolverineRuntime _runtime;
+    private readonly CancellationTokenSource _cancellation = new();
+
+    public agent_start_isolation()
+    {
+        _options = new WolverineOptions
+        {
+            ApplicationAssembly = GetType().Assembly
+        };
+        _options.Durability.Mode = DurabilityMode.Solo;
+        _options.Durability.DurabilityAgentEnabled = false; // skip MessageStoreCollection wiring
+        // Keep the recurring loop out of the way; the assertion is on the single startup pass.
+        _options.Durability.CheckAssignmentPeriod = 1.Hours();
+
+        _runtime = Substitute.For<IWolverineRuntime>();
+        _runtime.Options.Returns(_options);
+        _runtime.DurabilitySettings.Returns(_options.Durability);
+        _runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+    }
+
+    [Fact]
+    public async Task one_failing_agent_does_not_prevent_its_siblings_from_starting()
+    {
+        var healthyBefore = new Uri("test-family://a");
+        var wedged = new Uri("test-family://b");
+        var healthyAfter = new Uri("test-family://c");
+
+        var family = new FakeAgentFamily("test-family");
+        family.Add(new FakeAgent(healthyBefore));
+        family.Add(new FakeAgent(wedged) { ThrowOnStart = true });
+        family.Add(new FakeAgent(healthyAfter));
+
+        var controller = new NodeAgentController(
+            _runtime,
+            Substitute.For<INodeAgentPersistence>(),
+            [family],
+            NullLogger<NodeAgentController>.Instance,
+            _cancellation.Token);
+
+        await controller.StartSoloModeAsync();
+        await _cancellation.CancelAsync();
+
+        // The agent listed before the wedged one starts (it always did), but critically the
+        // sibling listed AFTER the wedged one must also be started now.
+        controller.Agents.ContainsKey(healthyBefore).ShouldBeTrue();
+        controller.Agents.ContainsKey(healthyAfter).ShouldBeTrue(
+            "a sibling agent after the failing one must still be started (GH-3519)");
+
+        // The agent that could not start is not recorded as running, so it is retried next tick.
+        controller.Agents.ContainsKey(wedged).ShouldBeFalse();
+    }
+
+    private class FakeAgentFamily : IAgentFamily
+    {
+        private readonly Dictionary<Uri, FakeAgent> _agents = new();
+
+        public FakeAgentFamily(string scheme)
+        {
+            Scheme = scheme;
+        }
+
+        public void Add(FakeAgent agent) => _agents[agent.Uri] = agent;
+
+        public string Scheme { get; }
+
+        public ValueTask<IReadOnlyList<Uri>> AllKnownAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>(_agents.Keys.ToList());
+
+        public ValueTask<IAgent> BuildAgentAsync(Uri uri, IWolverineRuntime wolverineRuntime)
+            => ValueTask.FromResult<IAgent>(_agents[uri]);
+
+        public ValueTask<IReadOnlyList<Uri>> SupportedAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>(_agents.Keys.ToList());
+
+        public ValueTask EvaluateAssignmentsAsync(AssignmentGrid assignments) => ValueTask.CompletedTask;
+    }
+
+    private class FakeAgent : IAgent
+    {
+        public FakeAgent(Uri uri) => Uri = uri;
+
+        public bool ThrowOnStart { get; init; }
+
+        public Uri Uri { get; }
+        public AgentStatus Status { get; private set; } = AgentStatus.Stopped;
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (ThrowOnStart)
+            {
+                throw new Exception("Unable to start a subscription agent for " + Uri);
+            }
+
+            Status = AgentStatus.Running;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            Status = AgentStatus.Stopped;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.StartLocally.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.StartLocally.cs
@@ -70,19 +70,35 @@ public partial class NodeAgentController
     {
         foreach (var controller in _agentFamilies.Values)
         {
+            IReadOnlyList<Uri> allAgents;
             try
             {
-                var allAgents = await controller.AllKnownAgentsAsync();
-                foreach (var uri in allAgents)
-                {
-                    // This is idempotent, so call away!
-                    await StartAgentAsync(uri);
-                }
+                allAgents = await controller.AllKnownAgentsAsync();
             }
             catch (Exception e)
             {
                 _logger.LogError(e, "Error trying to reevaluate agent assignments for '{Scheme}' agents",
                     controller.Scheme);
+                continue;
+            }
+
+            foreach (var uri in allAgents)
+            {
+                try
+                {
+                    // This is idempotent, so call away!
+                    await StartAgentAsync(uri);
+                }
+                catch (Exception e)
+                {
+                    // GH-3519: isolate each agent's start so a single agent that cannot start --
+                    // e.g. an event-subscription shard that loses a first-assignment startup race
+                    // with high-water detection -- does not skip the remaining, healthy sibling
+                    // agents in the same family for this reevaluation tick. The wedged agent is
+                    // still retried on the next tick; it just no longer takes its siblings down
+                    // with it.
+                    _logger.LogError(e, "Error trying to start agent {AgentUri}", uri);
+                }
             }
         }
     }


### PR DESCRIPTION
Contributes to #3519

## Scope

This PR **contains the blast radius** of the event-subscription startup race described in #3519. It does **not** claim to fix the underlying race (see "What this does not fix" below).

## The bug

In `DurabilityMode.Solo`, `NodeAgentController.startAllAgentsAsync` iterated each agent family's agents and awaited `StartAgentAsync` per agent inside a **single per-family `try/catch`**:

```csharp
foreach (var controller in _agentFamilies.Values)
{
    try
    {
        var allAgents = await controller.AllKnownAgentsAsync();
        foreach (var uri in allAgents)
        {
            await StartAgentAsync(uri);   // one throw here...
        }
    }
    catch (Exception e) { /* ...aborts the whole family loop */ }
}
```

When one agent's start throws — e.g. an event-subscription shard that loses a first-assignment startup race with high-water detection, surfacing as `AgentStartingException` → `System.Exception: Unable to start a subscription agent for Identity: …` — the throw breaks out of the family loop. **Every sibling agent listed after the wedged one is never started that tick**, and because the 30s reevaluation re-runs the same ordering, those siblings stay dead for the life of the process.

This matches the field report in #3519: "two of three shards dead on that boot; only one ran … its progression frozen while its store's high-water climbed thousands of events."

## The fix

Isolate each agent's start in its own `try/catch` (log + continue) so a single failing agent only blocks itself:

- `AllKnownAgentsAsync()` failure still logs and skips to the next family (unchanged semantics).
- Each `StartAgentAsync(uri)` now catches independently — a wedged agent is logged and skipped, and its healthy siblings in the same family still start.
- The wedged agent is still retried on the next reevaluation tick exactly as before; it just no longer takes its siblings down with it.

## Test

`CoreTests/Runtime/Agents/agent_start_isolation.cs` builds a Solo-mode `NodeAgentController` with a fake family of three agents where the middle one throws on start, and asserts the sibling listed **after** the failing one still lands in `Agents`. Verified red before the change (fails on exactly that assertion) and green after.

## What this does not fix

The reason the wedged shard fails to start in the first place is a startup race inside the JasperFx projection daemon (high-water detection not yet primed for a `SubscribeFromPresent` shard during the first assignment evaluation). That is tracked separately and still requires the CritterWatch multi-store repro to validate a root-cause fix. This PR is the defensive, independently-valuable half: the race can no longer wedge unrelated sibling agents on the node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKAxzuZ36VP6UPcTQf3MUs