### PR TITLE
GH-3538: Never infer a DbContext parameter as the HTTP request body

### DIFF
--- a/src/Http/Wolverine.Http.Tests.EfCoreOnly/ConjoinedTenancyEndpoints.cs
+++ b/src/Http/Wolverine.Http.Tests.EfCoreOnly/ConjoinedTenancyEndpoints.cs
@@ -44,4 +44,13 @@ public static class ConjoinedNotesEndpoint
     {
         return db.Notes.OrderBy(x => x.Text).ToArrayAsync();
     }
+
+    // GH-3538: a POST endpoint whose ONLY complex parameter is a DbContext. Before the fix the
+    // body-inference decided the DbContext was the JSON request body, so posting with no body
+    // 400'd with "Invalid JSON format". The DbContext must resolve as a service instead.
+    [WolverinePost("/conjoined/notes/quick-add")]
+    public static void QuickAdd(ConjoinedNotesDbContext db)
+    {
+        db.Notes.Add(new TenantedNote { Id = Guid.NewGuid(), Text = "quick-add" });
+    }
 }

--- a/src/Http/Wolverine.Http.Tests/MultiTenancy/conjoined_tenancy_http_detection.cs
+++ b/src/Http/Wolverine.Http.Tests/MultiTenancy/conjoined_tenancy_http_detection.cs
@@ -101,4 +101,23 @@ public class conjoined_tenancy_http_detection : IAsyncLifetime
         blueResult.ShouldNotBeNull();
         blueResult.Single().Id.ShouldBe(blueNote.Id);
     }
+
+    [Fact]
+    public async Task post_endpoint_with_only_a_dbcontext_parameter_does_not_infer_it_as_the_body()
+    {
+        // GH-3538: posting with no request body must NOT 400 — the DbContext is a service
+        // parameter, not the inferred JSON request body. Before the fix this returned 400
+        // "Invalid JSON format"; the empty POST would fail body deserialization.
+        await theHost.Scenario(x =>
+        {
+            x.Post.Url("/conjoined/notes/quick-add");
+            x.WithRequestHeader("tenant", "green");
+            x.StatusCodeShouldBe(204);
+        });
+
+        // The write actually landed for the tenant, proving the DbContext resolved as a service
+        var notes = await theHost.GetAsJson<TenantedNote[]>("/conjoined/notes?tenant=green");
+        notes.ShouldNotBeNull();
+        notes!.ShouldContain(n => n.Text == "quick-add");
+    }
 }

--- a/src/Http/Wolverine.Http/CodeGen/JsonHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/JsonHandling.cs
@@ -90,6 +90,18 @@ internal class JsonBodyParameterStrategy : IParameterStrategy
             return false;
         }
 
+        // GH-3538: an injected EF Core DbContext (e.g. a Wolverine-managed / conjoined
+        // tenant DbContext) is a concrete type, so when it is the only complex parameter on
+        // a POST/PUT endpoint the body inference below would otherwise decide it *is* the
+        // JSON request body and 400 with "Invalid JSON format". A DbContext is always a
+        // service/builder-provided parameter, never the request body — leave it for the
+        // service-resolution path. Checked by base-type name so Wolverine.Http need not
+        // reference Microsoft.EntityFrameworkCore.
+        if (IsDbContext(parameter.ParameterType))
+        {
+            return false;
+        }
+
         if (chain.RequestType == null && parameter.ParameterType.IsConcrete())
         {
             // It *could* be used twice, so let's watch out for this!
@@ -102,6 +114,24 @@ internal class JsonBodyParameterStrategy : IParameterStrategy
             // Oh, this does NOT make me feel good!
             chain.RequestType = parameter.ParameterType;
             return true;
+        }
+
+        return false;
+    }
+
+    // Walks the base-type chain looking for Microsoft.EntityFrameworkCore.DbContext by full
+    // name, so the core Wolverine.Http assembly doesn't take a dependency on EF Core. GH-3538.
+    internal static bool IsDbContext(Type type)
+    {
+        var current = type;
+        while (current != null && current != typeof(object))
+        {
+            if (current.FullName == "Microsoft.EntityFrameworkCore.DbContext")
+            {
+                return true;
+            }
+
+            current = current.BaseType;
         }
 
         return false;


### PR DESCRIPTION
Closes #3538

Spun off from the conjoined EF Core multi-tenancy epic (#3465) — API-friction finding from building the `ConjoinedMultiTenantedEfCore` sample.

## Problem

When an injected `DbContext` (e.g. a Wolverine-managed / conjoined tenant `DbContext`) is the **only** complex parameter on a `[WolverinePost]` / `[WolverinePut]` endpoint, Wolverine.Http's body inference decided the `DbContext` *was* the JSON request body and tried to deserialize the request into it — the endpoint 400'd with "Invalid JSON format". The sample had to reshape endpoint signatures to dodge the inference.

## Fix

`JsonBodyParameterStrategy` (the last-resort strategy that claims any concrete unmatched parameter as the body) now skips `DbContext`-derived parameter types, leaving them for the normal service-resolution path. The check walks the base-type chain by full name (`Microsoft.EntityFrameworkCore.DbContext`) so the core `Wolverine.Http` assembly keeps **no dependency on EF Core**.

## Test

`conjoined_tenancy_http_detection.post_endpoint_with_only_a_dbcontext_parameter_does_not_infer_it_as_the_body` — a `[WolverinePost]` whose only complex parameter is a `ConjoinedNotesDbContext` now succeeds on an empty-body POST (204) and the write lands for the detected tenant. Before the fix this path 400'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKAxzuZ36VP6UPcTQf3MUs