### PR TITLE
GH-3537 + GH-3539: Conjoined tenancy admin convenience API + docs friction fixes

### DIFF
--- a/docs/guide/durability/efcore/multi-tenancy.md
+++ b/docs/guide/durability/efcore/multi-tenancy.md
@@ -225,6 +225,16 @@ shared across the whole Critter Stack from `JasperFx.MultiTenancy`, so the exact
 Marten, Polecat, and Wolverine's EF Core integration.
 :::
 
+::: warning
+Conjoined tenancy builds the per-tenant `DbContext` through Wolverine's runtime code generation, so your application
+**must** reference the `WolverineFx.RuntimeCompilation` package ([GH-2876](https://github.com/JasperFx/wolverine/issues/2876)).
+Without it the host fails fast at startup. Add it up front:
+
+```bash
+dotnet add package WolverineFx.RuntimeCompilation
+```
+:::
+
 The database-per-tenant model above isn't the right fit for every system. If you want all tenants in a **single, shared
 database** — one connection string, one set of tables, a `tenant_id` discriminator column — use Wolverine's *conjoined*
 multi-tenancy for EF Core. Marking an entity with `JasperFx.MultiTenancy.ITenanted` is all it takes:
@@ -296,6 +306,24 @@ Note that a `DbContext` type registered with conjoined tenancy is pinned to the 
 at the time it's created. If you need to query across tenants for administrative functions, use `IgnoreQueryFilters()`
 in your LINQ queries — but remember that the write-side guards will still stop you from modifying another tenant's data
 through a tenant-pinned `DbContext`.
+
+### Managing Tenants <Badge type="tip" text="6.22" />
+
+The list of known tenants lives in the `wolverine_tenants` registry table. You can batch-register or remove tenants for
+a conjoined `DbContext` with the `IHost` convenience API, which mirrors Marten's `AddMartenManagedTenantsAsync` family:
+
+```csharp
+// Register two tenants (creates their partitions when partitioning is enabled).
+// Returns the ids as stored, normalized to the configured TenantIdStyle.
+var added = await host.AddWolverineManagedTenantsAsync<InvoicingDbContext>("acme", "hooli");
+
+// Remove them again (drops the partition + its data when partitioning is enabled)
+await host.RemoveWolverineManagedTenantsAsync<InvoicingDbContext>("acme", "hooli");
+```
+
+For finer-grained control — enabling/disabling a tenant, or per-tenant work from inside a handler or endpoint — resolve
+`IDynamicTenantSource<string>` from the container and call `AddTenantAsync` / `DisableTenantAsync` / `EnableTenantAsync` /
+`RemoveTenantAsync` directly.
 
 ### A Worked Example <Badge type="tip" text="6.21" />
 

--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedManagedTenantsApiCompliance.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedManagedTenantsApiCompliance.cs
@@ -1,0 +1,107 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.MultiTenancy;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Postgresql;
+using Wolverine.SqlServer;
+using Xunit;
+
+namespace EfCoreTests.MultiTenancy.ConjoinedTenancy;
+
+/// <summary>
+///     GH-3537: the batch AddWolverineManagedTenantsAsync / RemoveWolverineManagedTenantsAsync
+///     convenience API mirroring Marten's admin family.
+/// </summary>
+[Collection("multi-tenancy")]
+public abstract class ConjoinedManagedTenantsApiCompliance : IAsyncLifetime
+{
+    private readonly DatabaseEngine _engine;
+    protected IHost theHost = null!;
+
+    protected ConjoinedManagedTenantsApiCompliance(DatabaseEngine engine)
+    {
+        _engine = engine;
+    }
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<ConjoinedItemHandler>();
+
+                if (_engine == DatabaseEngine.PostgreSQL)
+                {
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "conjoined_admin_api");
+                    opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedItemsDbContext>(
+                        (builder, connectionString) => builder.UseNpgsql(connectionString.Value),
+                        AutoCreate.CreateOrUpdate);
+                }
+                else
+                {
+                    opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "conjoined_admin_api");
+                    opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedItemsDbContext>(
+                        (builder, connectionString) => builder.UseSqlServer(connectionString.Value),
+                        AutoCreate.CreateOrUpdate);
+                }
+
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+                opts.Policies.AutoApplyTransactions();
+                opts.Services.AddResourceSetupOnStartup();
+                opts.PublishAllMessages().Locally();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task batch_add_then_remove_round_trips_through_the_registry()
+    {
+        var a = "api_" + Guid.NewGuid().ToString("N").Substring(0, 8);
+        var b = "api_" + Guid.NewGuid().ToString("N").Substring(0, 8);
+
+        var added = await theHost.AddWolverineManagedTenantsAsync<ConjoinedItemsDbContext>(a, b);
+        added.Count.ShouldBe(2);
+
+        var source = theHost.Services.GetRequiredService<IDynamicTenantSource<string>>();
+        await source.RefreshAsync();
+        var active = source.AllActiveByTenant().Select(x => x.TenantId).ToList();
+        active.ShouldContain(a);
+        active.ShouldContain(b);
+
+        await theHost.RemoveWolverineManagedTenantsAsync<ConjoinedItemsDbContext>(a, b);
+
+        await source.RefreshAsync();
+        var afterRemoval = source.AllActiveByTenant().Select(x => x.TenantId).ToList();
+        afterRemoval.ShouldNotContain(a);
+        afterRemoval.ShouldNotContain(b);
+    }
+}
+
+public class conjoined_managed_tenants_api_with_postgresql : ConjoinedManagedTenantsApiCompliance
+{
+    public conjoined_managed_tenants_api_with_postgresql() : base(DatabaseEngine.PostgreSQL)
+    {
+    }
+}
+
+public class conjoined_managed_tenants_api_with_sqlserver : ConjoinedManagedTenantsApiCompliance
+{
+    public conjoined_managed_tenants_api_with_sqlserver() : base(DatabaseEngine.SqlServer)
+    {
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/ConjoinedTenancyHostExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/ConjoinedTenancyHostExtensions.cs
@@ -1,0 +1,63 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.EntityFrameworkCore.Internals;
+
+namespace Wolverine.EntityFrameworkCore;
+
+/// <summary>
+/// Convenience admin API for Wolverine-managed conjoined EF Core multi-tenancy, mirroring Marten's
+/// AddMartenManagedTenantsAsync / RemoveMartenManagedTenantsAsync family (GH-3537). These batch the
+/// per-tenant registry operations that previously had to be done one id at a time through the
+/// resolved IDynamicTenantSource&lt;string&gt;.
+/// </summary>
+public static class ConjoinedTenancyHostExtensions
+{
+    /// <summary>
+    /// Register the given tenant ids for the conjoined <typeparamref name="T"/> DbContext in the
+    /// wolverine_tenants registry (creating the per-tenant partition when partitioning is enabled).
+    /// Returns the registered tenant ids as stored (they are normalized to the configured
+    /// <c>TenantIdStyle</c>).
+    /// </summary>
+    public static Task<IReadOnlyList<string>> AddWolverineManagedTenantsAsync<T>(this IHost host,
+        params string[] tenantIds) where T : DbContext
+    {
+        return host.AddWolverineManagedTenantsAsync<T>(CancellationToken.None, tenantIds);
+    }
+
+    /// <summary>
+    /// Register the given tenant ids for the conjoined <typeparamref name="T"/> DbContext in the
+    /// wolverine_tenants registry (creating the per-tenant partition when partitioning is enabled).
+    /// Returns the registered tenant ids as stored (they are normalized to the configured
+    /// <c>TenantIdStyle</c>).
+    /// </summary>
+    public static async Task<IReadOnlyList<string>> AddWolverineManagedTenantsAsync<T>(this IHost host,
+        CancellationToken token, params string[] tenantIds) where T : DbContext
+    {
+        var source = host.Services.GetRequiredService<ConjoinedTenantSource<T>>();
+
+        var results = new List<string>(tenantIds.Length);
+        foreach (var tenantId in tenantIds)
+        {
+            results.Add(await source.AddTenantAsync(tenantId, token));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Remove the given tenant ids for the conjoined <typeparamref name="T"/> DbContext from the
+    /// wolverine_tenants registry (dropping the per-tenant partition and its data when partitioning
+    /// is enabled).
+    /// </summary>
+    public static async Task RemoveWolverineManagedTenantsAsync<T>(this IHost host,
+        params string[] tenantIds) where T : DbContext
+    {
+        var source = host.Services.GetRequiredService<ConjoinedTenantSource<T>>();
+
+        foreach (var tenantId in tenantIds)
+        {
+            await source.RemoveTenantAsync(tenantId);
+        }
+    }
+}

--- a/src/Samples/ConjoinedMultiTenantedEfCore/README.md
+++ b/src/Samples/ConjoinedMultiTenantedEfCore/README.md
@@ -29,6 +29,17 @@ same conjoined-tenancy semantics Marten has always had.
 | Opt-in per-tenant physical partitioning | commented option in `Program.cs` |
 | `wolverine_tenants` registry | `Tenants/TenantEndpoints.cs` |
 
+## Requirements
+
+Conjoined tenancy builds each per-tenant `DbContext` through Wolverine's runtime code
+generation, so the app references the **`WolverineFx.RuntimeCompilation`** package
+([GH-2876](https://github.com/JasperFx/wolverine/issues/2876)). Without it the host fails
+fast at startup:
+
+```bash
+dotnet add package WolverineFx.RuntimeCompilation
+```
+
 ## Running it
 
 ```bash


### PR DESCRIPTION
Closes #3537
Closes #3539

Two residuals from the conjoined EF Core multi-tenancy epic (#3465, Phase 3), bundled because #3539 and #3537's docs both edit the same page.

## GH-3537 — batch admin API

Adds `IHost` extensions mirroring Marten's `AddMartenManagedTenantsAsync` family:

```csharp
var added = await host.AddWolverineManagedTenantsAsync<InvoicingDbContext>("acme", "hooli");
await host.RemoveWolverineManagedTenantsAsync<InvoicingDbContext>("acme", "hooli");
```

Previously the only path was resolving `IDynamicTenantSource<string>` and calling `AddTenantAsync` / `RemoveTenantAsync` one id at a time (what the sample's `TenantEndpoints` does). The batch methods delegate to the registered `ConjoinedTenantSource<T>` (registry + partition creation/drop) and return the registered ids as stored (normalized to the configured `TenantIdStyle`).

**Deliberately deferred**: the explicit partition-suffix assignment form and the per-table `TablePartitionStatus[]` / `TenantPartitionAddResult` return shape. Those types don't exist yet and the issue calls for coordinating the shape with the batch-status work in #3496 — so this PR ships the clean, non-controversial batch-by-ids ergonomics now and leaves the status-reporting design to #3496. (These are alpha packages, so a later enrichment of the return type is fine.)

Compliance battery (`ConjoinedManagedTenantsApiCompliance`, Postgres + SqlServer) round-trips add → registry → remove.

## GH-3539 — docs friction

Fresh 6.x apps following the conjoined docs hit the GH-2876 `WolverineFx.RuntimeCompilation` startup requirement blind. Both the conjoined tenancy docs section (`docs/guide/durability/efcore/multi-tenancy.md`) and the `ConjoinedMultiTenantedEfCore` sample README now state the requirement up front with the `dotnet add package` snippet, before the reader can hit a fail-fast startup. The docs also gain a "Managing Tenants" subsection for the new admin API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKAxzuZ36VP6UPcTQf3MUs