### PR TITLE
ci: run CI workflows for pull requests targeting the 5.0 branch

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -2,9 +2,9 @@ name: aws
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/azure-service-bus.yml
+++ b/.github/workflows/azure-service-bus.yml
@@ -2,9 +2,9 @@ name: azure-service-bus
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/cosmosdb.yml
+++ b/.github/workflows/cosmosdb.yml
@@ -2,9 +2,9 @@ name: cosmosdb
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/efcore.yml
+++ b/.github/workflows/efcore.yml
@@ -2,9 +2,9 @@ name: efcore
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/grpc.yml
+++ b/.github/workflows/grpc.yml
@@ -2,9 +2,9 @@ name: grpc
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/http.yml
+++ b/.github/workflows/http.yml
@@ -2,9 +2,9 @@ name: http
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/kafka.yml
+++ b/.github/workflows/kafka.yml
@@ -2,9 +2,9 @@ name: kafka
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/marten.yml
+++ b/.github/workflows/marten.yml
@@ -2,9 +2,9 @@ name: marten
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/mqtt.yml
+++ b/.github/workflows/mqtt.yml
@@ -2,9 +2,9 @@ name: mqtt
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -2,9 +2,9 @@ name: mysql
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/nats.yml
+++ b/.github/workflows/nats.yml
@@ -2,9 +2,9 @@ name: nats
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -2,9 +2,9 @@ name: oracle
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -2,9 +2,9 @@ name: persistence
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/polecat.yml
+++ b/.github/workflows/polecat.yml
@@ -2,9 +2,9 @@ name: polecat
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/pulsar.yml
+++ b/.github/workflows/pulsar.yml
@@ -2,9 +2,9 @@ name: pulsar
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/rabbitmq.yml
+++ b/.github/workflows/rabbitmq.yml
@@ -2,9 +2,9 @@ name: rabbitmq
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ravendb.yml
+++ b/.github/workflows/ravendb.yml
@@ -2,9 +2,9 @@ name: ravendb
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -2,9 +2,9 @@ name: redis
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -2,9 +2,9 @@ name: sqlite
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/sqlserver.yml
+++ b/.github/workflows/sqlserver.yml
@@ -2,9 +2,9 @@ name: sqlserver
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "5.0" ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
The 5.0 maintenance-branch workflows only triggered on push / pull_request to `main`, so PRs **into** `5.0` (like the 5.40.0 backports) received no CI to green-gate on.

This adds `"5.0"` to the branch filters across all 21 test/build workflows so 5.x PRs run the same matrix as `main` PRs. `docs.yml` and `publish_nugets.yml` are deliberately left as-is (main-push / release-tag triggers).

Bootstrap note: because `pull_request` workflows are defined by the **base** branch, this change only takes effect once merged to `5.0` — it therefore cannot itself be CI-gated (workflow-trigger-only change). Merging this unblocks CI on #3544 (the GH-3533 → 5.40.0 backport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKAxzuZ36VP6UPcTQf3MUs