### PR TITLE
Bump to 6.22.0-alpha.2 + JasperFx 2.31.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.22.0-alpha.1</Version>
+        <Version>6.22.0-alpha.2</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,13 +35,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.30.2" />
-    <PackageVersion Include="JasperFx.Events" Version="2.30.2" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.30.2" />
+    <PackageVersion Include="JasperFx" Version="2.31.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.31.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.31.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.30.2" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.31.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.16.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />


### PR DESCRIPTION
Version + dependency bump for the **6.22.0-alpha.2** NuGet release.

## Changes
- JasperFx family (`JasperFx`, `JasperFx.Events`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator`) **2.30.2 → 2.31.0**
- Wolverine `<Version>` **6.22.0-alpha.1 → 6.22.0-alpha.2**

Marten (9.16.1) and Weasel (9.18.1) are already at their latest; the Polecat range `[5.2.0,6.0.0)` floats to 5.3.0. Full `wolverine.slnx` builds clean in Release locally (0 warnings, 0 errors) — the CI matrix here validates runtime, especially the codegen-sensitive `CIMarten` / `CIPolecat` suites.

## Release contents since 6.22.0-alpha.1
- **GH-3533** — Azure Service Bus session-id pinning (#3534)
- **GH-3519** — agent-start isolation so one wedged agent doesn't skip siblings (#3535)
- **GH-3536** — conjoined EF Core `DbContextUsage` descriptor distinguishes conjoined (#3545)
- **GH-3538** — never infer a `DbContext` parameter as the HTTP request body (#3546)
- **GH-3537 + GH-3539** — conjoined tenancy admin API + docs friction fixes (#3547)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKAxzuZ36VP6UPcTQf3MUs