### PR TITLE
docs: database queue transport tables cleared on reset (follow-up to #3529)

### DIFF
--- a/docs/guide/durability/managing.md
+++ b/docs/guide/durability/managing.md
@@ -64,6 +64,16 @@ public static async Task testing_setup_or_teardown(IHost host)
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DocumentationSamples.cs#L21-L48' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_programmatic_management_of_message_storage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+::: tip
+When you use the [PostgreSQL database-backed queue transport](/guide/messaging/transports/postgresql), both `RebuildAsync()` and
+`ClearAllAsync()` also truncate the queue transport's own tables (the per-queue message table and its scheduled-message
+table) inside the same reset transaction. This keeps integration tests over the database queue transport from carrying
+rows between runs. Other database-backed queue transports do not clear their queue tables on reset yet — follow-up work is
+tracked in [#3551 (MySQL)](https://github.com/JasperFx/wolverine/issues/3551),
+[#3552 (Oracle)](https://github.com/JasperFx/wolverine/issues/3552),
+[#3553 (SQLite)](https://github.com/JasperFx/wolverine/issues/3553), and
+[#3554 (SQL Server)](https://github.com/JasperFx/wolverine/issues/3554).
+:::
 
 ## Building Storage on Startup
 


### PR DESCRIPTION
Documents the behavior added in #3529: the PostgreSQL database-backed queue transport now has its own tables (per-queue + scheduled-message) truncated as part of a message-store reset (`RebuildAsync()` / `ClearAllAsync()`), inside the same reset transaction.

Adds a tip to `docs/guide/durability/managing.md` next to the programmatic-management sample, and links the follow-up issues that track porting the same behavior to the other database-backed queue transports:

- #3551 — MySQL
- #3552 — Oracle
- #3553 — SQLite
- #3554 — SQL Server (different registration path via `SqlServerTransportDatabase`; needs investigation)

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)