### PR TITLE
feat(sqlite): clear transport queue tables on message-store reset (#3553)

### DIFF
--- a/docs/guide/durability/managing.md
+++ b/docs/guide/durability/managing.md
@@ -65,13 +65,12 @@ public static async Task testing_setup_or_teardown(IHost host)
 <!-- endSnippet -->
 
 ::: tip
-When you use the [PostgreSQL database-backed queue transport](/guide/messaging/transports/postgresql), both `RebuildAsync()` and
+When you use the PostgreSQL or SQLite database-backed queue transport, both `RebuildAsync()` and
 `ClearAllAsync()` also truncate the queue transport's own tables (the per-queue message table and its scheduled-message
 table) inside the same reset transaction. This keeps integration tests over the database queue transport from carrying
-rows between runs. Other database-backed queue transports do not clear their queue tables on reset yet — follow-up work is
-tracked in [#3551 (MySQL)](https://github.com/JasperFx/wolverine/issues/3551),
-[#3552 (Oracle)](https://github.com/JasperFx/wolverine/issues/3552),
-[#3553 (SQLite)](https://github.com/JasperFx/wolverine/issues/3553), and
+rows between runs. The remaining database-backed queue transports do not clear their queue tables on reset yet — follow-up
+work is tracked in [#3551 (MySQL)](https://github.com/JasperFx/wolverine/issues/3551),
+[#3552 (Oracle)](https://github.com/JasperFx/wolverine/issues/3552), and
 [#3554 (SQL Server)](https://github.com/JasperFx/wolverine/issues/3554).
 :::
 

--- a/src/Persistence/SqliteTests/Transport/reset_clears_transport_queue_tables.cs
+++ b/src/Persistence/SqliteTests/Transport/reset_clears_transport_queue_tables.cs
@@ -1,0 +1,74 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Sqlite;
+using Wolverine.Sqlite.Transport;
+using Wolverine.Tracking;
+
+namespace SqliteTests.Transport;
+
+public class reset_clears_transport_queue_tables : SqliteContext, IAsyncLifetime
+{
+    private readonly SqliteTestDatabase _database;
+    private IHost theHost = null!;
+    private SqliteQueue theQueue = null!;
+    private IMessageStore theMessageStore = null!;
+
+    public reset_clears_transport_queue_tables()
+    {
+        _database = Servers.CreateDatabase(nameof(reset_clears_transport_queue_tables));
+    }
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseSqlitePersistenceAndTransport(_database.ConnectionString);
+
+                // No listener is attached to the queue, so nothing drains it out from
+                // under the test before the reset runs.
+                opts.PublishAllMessages().ToSqliteQueue("resetone");
+            }).StartAsync();
+
+        var transport = theHost.GetRuntime().Options.Transports.GetOrCreate<SqliteTransport>();
+        theQueue = transport.Queues["resetone"];
+        theMessageStore = theHost.GetRuntime().Storage;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+        _database.Dispose();
+    }
+
+    [Fact]
+    public async Task clear_all_async_empties_the_transport_queue_tables()
+    {
+        // Row in the queue table
+        var immediate = ObjectMother.Envelope();
+        immediate.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(immediate);
+
+        // Row in the scheduled-message table
+        var scheduled = ObjectMother.Envelope();
+        scheduled.ScheduleDelay = 1.Hours();
+        scheduled.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(scheduled);
+
+        (await theQueue.CountAsync()).ShouldBe(1);
+        (await theQueue.ScheduledCountAsync()).ShouldBe(1);
+
+        // The message-store reset must also clear the registered transport queue tables,
+        // otherwise integration tests over the SQLite queue transport carry rows between runs.
+        await theMessageStore.Admin.ClearAllAsync();
+
+        (await theQueue.CountAsync()).ShouldBe(0);
+        (await theQueue.ScheduledCountAsync()).ShouldBe(0);
+    }
+}

--- a/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
@@ -556,6 +556,27 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         _otherTables.Add(table);
     }
 
+    /// <summary>
+    /// Also clear the SQLite queue transport's own tables (the per-queue message table and its
+    /// scheduled-message table) as part of a store reset. A reset truncates the envelope tables; the
+    /// queue transport keeps its own tables, so without this override a reset leaves queue rows behind
+    /// and integration tests over the SQLite queue transport carry rows between runs. Scoped to the
+    /// transport's own table types on purpose — <c>AddTable</c> is a general registration path, so we
+    /// clear only what the transport itself registered rather than every entry in <c>_otherTables</c>.
+    /// Runs inside the reset transaction (see the base <c>truncateEnvelopeDataAsync</c>) so the reset
+    /// stays atomic.
+    /// </summary>
+    protected override async Task truncateAdditionalTablesAsync(DbTransaction tx, CancellationToken token)
+    {
+        foreach (var table in _otherTables)
+        {
+            if (table is Transport.QueueTable or Transport.ScheduledMessageTable)
+            {
+                await tx.CreateCommand($"delete from {table.Identifier}").ExecuteNonQueryAsync(token);
+            }
+        }
+    }
+
     public override DatabaseSagaSchema<T, TId> SagaSchemaFor<T, TId>()
     {
         if (_sagaStorage.TryFind(typeof(T), out var raw))


### PR DESCRIPTION
Closes #3553.

Direct port of #3529 (PostgreSQL) to the **SQLite** database-backed queue transport.

## What

`SqliteMessageStore` now overrides `truncateAdditionalTablesAsync` (the per-provider hook added in #3529) to `delete from` the queue transport's own registered `QueueTable` / `ScheduledMessageTable` entries as part of a store reset. The override runs inside the same reset transaction started by the base `truncateEnvelopeDataAsync`, so `ClearAllAsync()` / `RebuildAsync()` stay atomic.

Scoped to the transport's own table types on purpose — `AddTable` is a general registration path, so only what the transport itself registered is cleared, not every entry in `_otherTables`.

Without this, integration tests over the SQLite queue transport carry queue rows between runs.

## Tests

- Ported `reset_clears_transport_queue_tables` to the SQLite suite: seeds one immediate row + one scheduled row, asserts counts, runs `ClearAllAsync()`, asserts both tables are empty. Passes.

## Docs

- `docs/guide/durability/managing.md`: moved SQLite from the "not yet" list to the supported set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)