### PR TITLE
feat(oracle): clear transport queue tables on message-store reset (#3552)

### DIFF
--- a/docs/guide/durability/managing.md
+++ b/docs/guide/durability/managing.md
@@ -65,12 +65,11 @@ public static async Task testing_setup_or_teardown(IHost host)
 <!-- endSnippet -->
 
 ::: tip
-When you use the [PostgreSQL database-backed queue transport](/guide/messaging/transports/postgresql), both `RebuildAsync()` and
+When you use the PostgreSQL or Oracle database-backed queue transport, both `RebuildAsync()` and
 `ClearAllAsync()` also truncate the queue transport's own tables (the per-queue message table and its scheduled-message
-table) inside the same reset transaction. This keeps integration tests over the database queue transport from carrying
-rows between runs. Other database-backed queue transports do not clear their queue tables on reset yet — follow-up work is
-tracked in [#3551 (MySQL)](https://github.com/JasperFx/wolverine/issues/3551),
-[#3552 (Oracle)](https://github.com/JasperFx/wolverine/issues/3552),
+table) as part of a store reset. This keeps integration tests over the database queue transport from carrying
+rows between runs. The remaining database-backed queue transports do not clear their queue tables on reset yet — follow-up
+work is tracked in [#3551 (MySQL)](https://github.com/JasperFx/wolverine/issues/3551),
 [#3553 (SQLite)](https://github.com/JasperFx/wolverine/issues/3553), and
 [#3554 (SQL Server)](https://github.com/JasperFx/wolverine/issues/3554).
 :::

--- a/src/Persistence/Oracle/OracleTests/Transport/reset_clears_transport_queue_tables.cs
+++ b/src/Persistence/Oracle/OracleTests/Transport/reset_clears_transport_queue_tables.cs
@@ -1,0 +1,91 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Weasel.Oracle;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Oracle;
+using Wolverine.Oracle.Transport;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+
+namespace OracleTests.Transport;
+
+[Collection("oracle")]
+public class reset_clears_transport_queue_tables : IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private OracleQueue theQueue = null!;
+    private IMessageStore theMessageStore = null!;
+
+    public async Task InitializeAsync()
+    {
+        // Clean any queue tables left behind by a prior run
+        var dataSource = new OracleDataSource(Servers.OracleConnectionString);
+        await using (var conn = await dataSource.OpenConnectionAsync())
+        {
+            foreach (var table in new[] { "WOLVERINE_QUEUE_RESETONE", "WOLVERINE_QUEUE_RESETONE_SCHEDULED" })
+            {
+                try
+                {
+                    await using var cmd = conn.CreateCommand($"DROP TABLE WOLVERINE.{table} CASCADE CONSTRAINTS");
+                    await cmd.ExecuteNonQueryAsync();
+                }
+                catch (OracleException) { /* table doesn't exist */ }
+            }
+
+            await conn.CloseAsync();
+        }
+
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithOracle(Servers.OracleConnectionString, "WOLVERINE")
+                    .EnableMessageTransport();
+
+                // Neutralize the host's auto-started listener so it cannot drain the queue
+                // mid-test before the reset runs (mirrors the basic_functionality fixture).
+                opts.ListenToOracleQueue("resetone").PollingInterval(1.Hours());
+                opts.Durability.Mode = DurabilityMode.Solo;
+            }).StartAsync();
+
+        var transport = theHost.GetRuntime().Options.Transports.GetOrCreate<OracleTransport>();
+        theQueue = transport.Queues["resetone"];
+        theMessageStore = theHost.GetRuntime().Storage;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task clear_all_async_empties_the_transport_queue_tables()
+    {
+        // Row in the queue table
+        var immediate = ObjectMother.Envelope();
+        immediate.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(immediate);
+
+        // Row in the scheduled-message table
+        var scheduled = ObjectMother.Envelope();
+        scheduled.ScheduleDelay = 1.Hours();
+        scheduled.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(scheduled);
+
+        (await theQueue.CountAsync()).ShouldBe(1);
+        (await theQueue.ScheduledCountAsync()).ShouldBe(1);
+
+        // The message-store reset must also clear the registered transport queue tables,
+        // otherwise integration tests over the Oracle queue transport carry rows between runs.
+        await theMessageStore.Admin.ClearAllAsync();
+
+        (await theQueue.CountAsync()).ShouldBe(0);
+        (await theQueue.ScheduledCountAsync()).ShouldBe(0);
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Admin.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Admin.cs
@@ -44,6 +44,28 @@ internal partial class OracleMessageStore
             }
         }
 
+        // Also clear the Oracle queue transport's own tables (the per-queue message table and its
+        // scheduled-message table) so a reset leaves nothing behind and integration tests over the
+        // Oracle queue transport don't carry rows between runs. Scoped to the transport's own table
+        // types on purpose — AddTable is a general registration path, so we clear only what the
+        // transport itself registered rather than every entry in _otherTables. (RebuildAsync already
+        // drops and recreates these tables, so it needs no equivalent addition.)
+        foreach (var table in _otherTables)
+        {
+            if (table is Transport.QueueTable or Transport.ScheduledMessageTable)
+            {
+                try
+                {
+                    await using var cmd = conn.CreateCommand($"DELETE FROM {table.Identifier.QualifiedName}");
+                    await cmd.ExecuteNonQueryAsync(_cancellation);
+                }
+                catch (OracleException e) when (e.Number == 942)
+                {
+                    // Table doesn't exist yet, ignore
+                }
+            }
+        }
+
         await conn.CloseAsync();
     }
 


### PR DESCRIPTION
Closes #3552.

Follow-up to #3529 (PostgreSQL) for the **Oracle** database-backed queue transport.

## What

Unlike PostgreSQL/MySQL/SQLite, `OracleMessageStore` is a bespoke store rather than a `MessageDatabase<T>` subclass, so there is no `truncateAdditionalTablesAsync` hook to override. Instead:

- **`ClearAllAsync()`** now, after clearing the envelope tables, also `DELETE`s from the queue transport's own registered `QueueTable` / `ScheduledMessageTable` entries. Scoped to the transport's own table types so other `AddTable` registrations are preserved. Missing tables (ORA-00942) are ignored, matching the existing per-table deletes.
- **`RebuildAsync()`** already drops and recreates every `_otherTables` entry (queue tables included) via `AllObjects()`, so it needs no equivalent change.

Without this, integration tests over the Oracle queue transport carry queue rows between runs.

## Tests

- Ported `reset_clears_transport_queue_tables` to the Oracle suite: seeds one immediate row + one scheduled row (listener neutralized via `PollingInterval(1.Hours())`, Solo durability), asserts counts, runs `ClearAllAsync()`, asserts both tables are empty. Passes against the docker-compose Oracle.

## Docs

- `docs/guide/durability/managing.md`: moved Oracle from the "not yet" list to the supported set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)