### PR TITLE
fix(pulsar): don't claim native scheduling without a retry-letter topic (#3491)

### DIFF
--- a/src/Testing/CoreTests/Runtime/MessageContextTests.cs
+++ b/src/Testing/CoreTests/Runtime/MessageContextTests.cs
@@ -289,6 +289,7 @@ public class MessageContextTests
     public async Task reschedule_with_native_scheduling()
     {
         var callback = Substitute.For<IChannelCallback, ISupportNativeScheduling>();
+        callback.As<ISupportNativeScheduling>().NativeSchedulingEnabled.Returns(true);
         var scheduledTime = DateTime.Today.AddHours(8);
 
         theContext.ReadEnvelope(theEnvelope, callback);
@@ -300,6 +301,27 @@ public class MessageContextTests
         await theContext.Storage.Inbox.DidNotReceive().RescheduleExistingEnvelopeForRetryAsync(theEnvelope);
         await callback.As<ISupportNativeScheduling>().Received()
             .MoveToScheduledUntilAsync(theEnvelope, scheduledTime);
+    }
+
+    [Fact]
+    public async Task reschedule_falls_back_to_durable_inbox_when_native_scheduling_disabled()
+    {
+        // A listener that implements ISupportNativeScheduling but reports NativeSchedulingEnabled == false
+        // (e.g. Pulsar without a retry-letter topic) must NOT be treated as able to reschedule natively;
+        // the runtime should fall back to the durable inbox rather than silently no-op. GH-3491.
+        var callback = Substitute.For<IChannelCallback, ISupportNativeScheduling>();
+        callback.As<ISupportNativeScheduling>().NativeSchedulingEnabled.Returns(false);
+        var scheduledTime = DateTime.Today.AddHours(8);
+
+        theContext.ReadEnvelope(theEnvelope, callback);
+
+        await theContext.ReScheduleAsync(scheduledTime);
+
+        theEnvelope.ScheduledTime.ShouldBe(scheduledTime);
+
+        await callback.As<ISupportNativeScheduling>().DidNotReceive()
+            .MoveToScheduledUntilAsync(Arg.Any<Envelope>(), Arg.Any<DateTimeOffset>());
+        await theContext.Storage.Inbox.Received().RescheduleExistingEnvelopeForRetryAsync(theEnvelope);
     }
 
     [Fact]

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -376,19 +376,26 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
 
     public bool NativeRetryLetterQueueEnabled { get; }
 
+    // Only claim the native-scheduling capability when the retry-letter queue is actually configured;
+    // otherwise MoveToScheduledUntilAsync has no producer to move the message to and the runtime should
+    // fall back to the durable/buffered rescheduler rather than believe a native reschedule succeeded.
+    public bool NativeSchedulingEnabled => NativeRetryLetterQueueEnabled;
+
     public async Task MoveToScheduledUntilAsync(Envelope envelope, DateTimeOffset time)
     {
         if (NativeRetryLetterQueueEnabled && envelope is PulsarEnvelope)
         {
-            await moveToQueueAsync(envelope, envelope.Failure, false);
+            // Honor the caller's requested delivery time rather than the retry-letter tier schedule.
+            await moveToQueueAsync(envelope, envelope.Failure, false, time);
         }
     }
 
-    private async Task moveToQueueAsync(Envelope envelope, Exception? exception, bool isDeadLettered = false)
+    private async Task moveToQueueAsync(Envelope envelope, Exception? exception, bool isDeadLettered = false,
+        DateTimeOffset? scheduledTime = null)
     {
         if (envelope is PulsarEnvelope e)
         {
-            var messageMetadata = BuildMessageMetadata(envelope, e, exception, isDeadLettered);
+            var messageMetadata = BuildMessageMetadata(envelope, e, exception, isDeadLettered, scheduledTime);
 
             IConsumer<ReadOnlySequence<byte>>? sourceConsumer;
             IProducer<ReadOnlySequence<byte>> targetProducer;
@@ -440,7 +447,7 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
     }
 
     private MessageMetadata BuildMessageMetadata(Envelope envelope, PulsarEnvelope e, Exception? exception,
-        bool isDeadLettered)
+        bool isDeadLettered, DateTimeOffset? scheduledTime = null)
     {
         var messageMetadata = new MessageMetadata();
 
@@ -481,7 +488,9 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
             var delayTime = _endpoint.RetryLetterTopic!.Retry[envelope.Attempts - 1];
             messageMetadata[PulsarEnvelopeConstants.DelayTimeMetadataKey] =
                 delayTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
-            messageMetadata.DeliverAtTimeAsDateTimeOffset = DateTimeOffset.UtcNow.Add(delayTime);
+            // A caller-supplied reschedule time (ReScheduleAsync / scheduled-retry policy) wins over the
+            // retry-letter tier delay so "retry at T" is actually honored; fall back to the tier schedule.
+            messageMetadata.DeliverAtTimeAsDateTimeOffset = scheduledTime ?? DateTimeOffset.UtcNow.Add(delayTime);
         }
         else
         {

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -357,12 +357,15 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
     private ISupportNativeScheduling? tryGetRescheduler(IChannelCallback? channel, Envelope e)
     {
         // TODO: is that ok, or should we modify Task ISupportNativeScheduling.MoveToScheduledUntilAsync(Envelope envelope, DateTimeOffset time) in DurableReceiver and BufferedReceiver?
-        if (e.Listener is ISupportNativeScheduling c2)
+        // Gate on NativeSchedulingEnabled so a listener whose native scheduling is conditional (e.g.
+        // Pulsar without a retry-letter topic) is skipped and the durable/buffered channel below is
+        // used instead of silently no-op'ing. Mirrors the NativeDeadLetterQueueEnabled gating below.
+        if (e.Listener is ISupportNativeScheduling { NativeSchedulingEnabled: true } c2)
         {
             return c2;
         }
 
-        if (channel is ISupportNativeScheduling c)
+        if (channel is ISupportNativeScheduling { NativeSchedulingEnabled: true } c)
         {
             return c;
         }

--- a/src/Wolverine/Transports/IChannelCallback.cs
+++ b/src/Wolverine/Transports/IChannelCallback.cs
@@ -25,6 +25,15 @@ public interface ISupportNativeScheduling
     /// <param name="time"></param>
     /// <returns></returns>
     Task MoveToScheduledUntilAsync(Envelope envelope, DateTimeOffset time);
+
+    /// <summary>
+    ///     Whether this implementation can actually honor a native reschedule for the current
+    ///     configuration. Defaults to true. Implementations whose native scheduling is conditional
+    ///     (e.g. the Pulsar listener, which only reschedules when a retry-letter topic is configured)
+    ///     override this so the runtime falls back to the durable/buffered rescheduler instead of
+    ///     silently no-op'ing. Mirrors <see cref="ISupportDeadLetterQueue.NativeDeadLetterQueueEnabled" />.
+    /// </summary>
+    bool NativeSchedulingEnabled => true;
 }
 
 /// <summary>


### PR DESCRIPTION
Closes #3491.

## Problem

`PulsarListener` implemented `ISupportNativeScheduling` **unconditionally**, so `ReScheduleAsync()` / scheduled-retry error policies always preferred it over the durable/buffered rescheduler (`tryGetRescheduler` returns the listener before ever considering the channel). But its `MoveToScheduledUntilAsync` only acts when a retry-letter topic is configured:

1. **Silent no-op** — with no `RetryLetterTopic`, a scheduled retry did *nothing*: no reschedule, no requeue, no log. The runtime logged "Rescheduling … via native scheduling" and believed it succeeded; the durable-inbox fallback was never reached.
2. **Requested `time` ignored** — even on the happy path it forwarded to the tiered retry-letter delays, not the caller's requested `DateTimeOffset`.

## Fix

Mirrors the existing dead-letter gating (`ISupportDeadLetterQueue { NativeDeadLetterQueueEnabled: true }`):

- Added a **default-implemented** `bool NativeSchedulingEnabled => true;` to `ISupportNativeScheduling`. No existing implementer needs changes — `DurableReceiver`, `BufferedReceiver`, Redis, and Azure listeners all keep the default `true`.
- `MessageContext.tryGetRescheduler` now gates both candidate checks on `{ NativeSchedulingEnabled: true }`, so a listener that can't honor a native reschedule is skipped and the durable/buffered channel (which *is* the correct fallback — both receivers implement the interface) is used instead.
- `PulsarListener` overrides `NativeSchedulingEnabled => NativeRetryLetterQueueEnabled`.
- `MoveToScheduledUntilAsync` now threads the caller's requested time through `moveToQueueAsync` → `BuildMessageMetadata`, so the retry producer's `DeliverAtTime` honors "retry at T" (falling back to the tier delay when no explicit time is given).

## Tests

- **Core (no Docker):** `MessageContextTests.reschedule_falls_back_to_durable_inbox_when_native_scheduling_disabled` — a listener implementing `ISupportNativeScheduling` but reporting `NativeSchedulingEnabled == false` falls back to the durable inbox and does **not** call `MoveToScheduledUntilAsync`. Updated `reschedule_with_native_scheduling` to opt the mock into the capability. All 3 reschedule tests pass.
- **Pulsar integration (Docker):** ran `PulsarNativeReliabilityTests` (4 tests, retry-letter path) — all green, confirming the metadata-threading change doesn't regress the tier-delay path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)