### PR TITLE
feat(claim-check): NATS JetStream Object Store backend (#3506)

### DIFF
--- a/docs/guide/durability/claim-checks.md
+++ b/docs/guide/durability/claim-checks.md
@@ -75,7 +75,7 @@ When `UseClaimCheck(...)` runs without an explicit `Store`, the pipeline falls b
 
 ## Backends
 
-Wolverine ships two production-grade storage backends as separate NuGet packages.
+Wolverine ships several production-grade storage backends as separate NuGet packages.
 
 ### Azure Blob Storage
 
@@ -126,6 +126,28 @@ opts.UseClaimCheck(cc => cc.UseAmazonS3(myS3Client, bucketName: "wolverine-claim
 ```
 
 Token id maps to the object key. The supplied content type is set as `PutObjectRequest.ContentType`, which preserves the MIME type for downloads and S3 lifecycle policies. `DeleteAsync` is naturally idempotent — S3 returns success even when the key is absent.
+
+### NATS JetStream Object Store
+
+For applications already using NATS — especially the [Wolverine NATS transport](/guide/messaging/transports/nats) — the NATS [JetStream Object Store](https://docs.nats.io/nats-concepts/jetstream/obj_store) backend lets you off-load large payloads without standing up a separate blob or object store. This backend is unique to Wolverine in the .NET messaging space.
+
+```sh
+dotnet add package WolverineFx.ClaimCheck.Nats
+```
+
+```csharp
+using Wolverine.ClaimCheck.Nats;
+
+// Reuse the application's existing, already-connected NATS connection
+INatsConnection connection = /* your connected NatsConnection */;
+
+builder.Host.UseWolverine(opts =>
+{
+    opts.UseClaimCheck(cc => cc.UseNatsObjectStore(connection, bucketName: "wolverine-claim-checks"));
+});
+```
+
+The server must have JetStream enabled. The object-store bucket is created on first use if it does not already exist. Token id maps to the object name; the content type travels with the token. `DeleteAsync` is idempotent — a missing object is treated as already deleted. An overload accepting an existing `INatsObjContext` is also available if you manage the object-store context yourself.
 
 ### File system (built in)
 

--- a/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/NatsFact.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/NatsFact.cs
@@ -1,0 +1,53 @@
+using System.Net.Sockets;
+
+namespace Wolverine.ClaimCheck.Nats.Tests;
+
+/// <summary>
+/// Probe NATS once per process and cache the result. Any TCP connect failure on
+/// <c>localhost:4222</c> is treated as "not running" so tests skip cleanly. Mirrors
+/// the <c>LocalStackFact</c> pattern used by the Amazon S3 backend tests.
+/// </summary>
+internal static class NatsServer
+{
+    public const string Host = "localhost";
+    public const int Port = 4222;
+    public const string Url = "nats://localhost:4222";
+
+    private static readonly Lazy<bool> _isRunning = new(Probe);
+
+    public static bool IsRunning => _isRunning.Value;
+
+    public const string SkipReason =
+        "NATS is not running on localhost:4222. " +
+        "Start it with `docker compose up -d nats` from the repo root to enable these tests.";
+
+    private static bool Probe()
+    {
+        try
+        {
+            using var client = new TcpClient();
+            var connect = client.ConnectAsync(Host, Port);
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+            return connect.Wait(TimeSpan.FromSeconds(2)) && client.Connected;
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}
+
+/// <summary>
+/// xUnit <see cref="FactAttribute"/> that skips when NATS is not reachable on its default port.
+/// </summary>
+public sealed class NatsFactAttribute : FactAttribute
+{
+    public NatsFactAttribute()
+    {
+        if (!NatsServer.IsRunning)
+        {
+            Skip = NatsServer.SkipReason;
+        }
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/NatsObjectStoreClaimCheckStoreTests.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/NatsObjectStoreClaimCheckStoreTests.cs
@@ -1,0 +1,111 @@
+using System.Text;
+using NATS.Client.Core;
+using NATS.Client.ObjectStore;
+using NATS.Net;
+using Shouldly;
+using Wolverine.Persistence;
+
+namespace Wolverine.ClaimCheck.Nats.Tests;
+
+public class NatsObjectStoreClaimCheckStoreTests : IAsyncLifetime
+{
+    // Each test class gets its own bucket so parallel classes / re-runs never collide on
+    // object names, mirroring the Amazon S3 backend tests.
+    private readonly string _bucketName = "claimcheck" + Guid.NewGuid().ToString("N");
+    private NatsConnection _connection = null!;
+    private NatsObjectStoreClaimCheckStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        if (!NatsServer.IsRunning)
+        {
+            return;
+        }
+
+        _connection = new NatsConnection(new NatsOpts { Url = NatsServer.Url });
+        await _connection.ConnectAsync();
+
+        _store = new NatsObjectStoreClaimCheckStore(_connection, _bucketName);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_connection is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var context = new NatsObjContext(_connection.CreateJetStreamContext());
+            await context.DeleteObjectStore(_bucketName, CancellationToken.None);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+        finally
+        {
+            await _connection.DisposeAsync();
+        }
+    }
+
+    [NatsFact]
+    public async Task round_trip_store_load_delete()
+    {
+        var payload = Encoding.UTF8.GetBytes("hello, claim check world");
+
+        var token = await _store.StoreAsync(payload, "text/plain");
+
+        token.Id.ShouldNotBeNullOrWhiteSpace();
+        token.ContentType.ShouldBe("text/plain");
+        token.Length.ShouldBe(payload.Length);
+
+        var loaded = await _store.LoadAsync(token);
+        loaded.ToArray().ShouldBe(payload);
+
+        await _store.DeleteAsync(token);
+
+        // After delete, loading the object should fail with a not-found error.
+        await Should.ThrowAsync<NatsObjNotFoundException>(async () => await _store.LoadAsync(token));
+    }
+
+    [NatsFact]
+    public async Task delete_is_idempotent_for_missing_object()
+    {
+        var token = new ClaimCheckToken("doesnotexist" + Guid.NewGuid().ToString("N"), "text/plain", 0);
+
+        // Should not throw even though the object was never created.
+        await _store.DeleteAsync(token);
+    }
+
+    [NatsFact]
+    public async Task load_returns_exact_payload_bytes()
+    {
+        // Binary payload with zero bytes and high bits set to catch any encoding-related
+        // corruption in the round-trip.
+        var payload = new byte[256];
+        for (var i = 0; i < payload.Length; i++)
+        {
+            payload[i] = (byte)i;
+        }
+
+        var token = await _store.StoreAsync(payload, "application/octet-stream");
+        var loaded = await _store.LoadAsync(token);
+
+        loaded.Length.ShouldBe(payload.Length);
+        loaded.ToArray().ShouldBe(payload);
+    }
+
+    [NatsFact]
+    public async Task second_store_reuses_the_bucket()
+    {
+        // Two stores against the same bucket exercise the create-or-get resolution path
+        // (first call creates the bucket, subsequent calls fetch it).
+        var first = await _store.StoreAsync(Encoding.UTF8.GetBytes("one"), "text/plain");
+        var second = await _store.StoreAsync(Encoding.UTF8.GetBytes("two"), "text/plain");
+
+        (await _store.LoadAsync(first)).ToArray().ShouldBe(Encoding.UTF8.GetBytes("one"));
+        (await _store.LoadAsync(second)).ToArray().ShouldBe(Encoding.UTF8.GetBytes("two"));
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/Wolverine.ClaimCheck.Nats.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/Wolverine.ClaimCheck.Nats.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Wolverine.ClaimCheck.Nats\Wolverine.ClaimCheck.Nats.csproj" />
+    </ItemGroup>
+
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Persistence/Wolverine.ClaimCheck.Nats/NatsObjectStoreClaimCheckExtensions.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats/NatsObjectStoreClaimCheckExtensions.cs
@@ -1,0 +1,55 @@
+using NATS.Client.Core;
+using NATS.Client.ObjectStore;
+using Wolverine.Persistence;
+
+namespace Wolverine.ClaimCheck.Nats;
+
+/// <summary>
+/// Extension methods for configuring a NATS JetStream Object Store backed
+/// <see cref="IClaimCheckStore"/> from a Wolverine <see cref="ClaimCheckConfiguration"/>.
+/// </summary>
+public static class NatsObjectStoreClaimCheckExtensions
+{
+    /// <summary>
+    /// Use an explicit, already-connected <see cref="INatsConnection"/> and the given object-store
+    /// bucket name as the backing store for Wolverine claim checks.
+    /// </summary>
+    /// <param name="config">The claim check configuration to attach to.</param>
+    /// <param name="connection">An already-connected <see cref="INatsConnection"/>.</param>
+    /// <param name="bucketName">Name of the object-store bucket used to hold payloads. Created on first use if it does not exist.</param>
+    public static ClaimCheckConfiguration UseNatsObjectStore(
+        this ClaimCheckConfiguration config,
+        INatsConnection connection,
+        string bucketName)
+    {
+        if (config is null) throw new ArgumentNullException(nameof(config));
+        if (connection is null) throw new ArgumentNullException(nameof(connection));
+        if (string.IsNullOrWhiteSpace(bucketName))
+        {
+            throw new ArgumentException("Bucket name must be provided", nameof(bucketName));
+        }
+
+        config.Store = new NatsObjectStoreClaimCheckStore(connection, bucketName);
+        return config;
+    }
+
+    /// <summary>
+    /// Use an explicit, already-constructed <see cref="INatsObjContext"/> and the given object-store
+    /// bucket name as the backing store for Wolverine claim checks.
+    /// </summary>
+    public static ClaimCheckConfiguration UseNatsObjectStore(
+        this ClaimCheckConfiguration config,
+        INatsObjContext context,
+        string bucketName)
+    {
+        if (config is null) throw new ArgumentNullException(nameof(config));
+        if (context is null) throw new ArgumentNullException(nameof(context));
+        if (string.IsNullOrWhiteSpace(bucketName))
+        {
+            throw new ArgumentException("Bucket name must be provided", nameof(bucketName));
+        }
+
+        config.Store = new NatsObjectStoreClaimCheckStore(context, bucketName);
+        return config;
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.Nats/NatsObjectStoreClaimCheckStore.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats/NatsObjectStoreClaimCheckStore.cs
@@ -1,0 +1,149 @@
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using NATS.Client.ObjectStore;
+using NATS.Net;
+using Wolverine.Persistence;
+
+namespace Wolverine.ClaimCheck.Nats;
+
+/// <summary>
+/// NATS JetStream Object Store backed <see cref="IClaimCheckStore"/>. Each claim check
+/// payload is stored as a single object in the configured object-store bucket. The
+/// <see cref="ClaimCheckToken.Id"/> maps directly to the object name; the content type
+/// travels with the token, so it does not need to be persisted alongside the bytes.
+/// </summary>
+public class NatsObjectStoreClaimCheckStore : IClaimCheckStore
+{
+    private readonly INatsObjContext _context;
+    private readonly string _bucketName;
+
+    // The bucket is resolved (created-or-fetched) lazily on first use and cached. Guarded by a
+    // gate so concurrent StoreAsync/LoadAsync calls don't race on the create-or-get.
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private INatsObjStore? _store;
+
+    /// <summary>
+    /// Create a new claim check store backed by a NATS JetStream Object Store bucket, reusing
+    /// an existing NATS connection.
+    /// </summary>
+    /// <param name="connection">A connected <see cref="INatsConnection"/> (JetStream must be enabled on the server).</param>
+    /// <param name="bucketName">Name of the object-store bucket used to hold claim check payloads. Created on first use if it does not exist.</param>
+    public NatsObjectStoreClaimCheckStore(INatsConnection connection, string bucketName)
+        : this(new NatsObjContext(connection.CreateJetStreamContext()), bucketName)
+    {
+    }
+
+    /// <summary>
+    /// Create a new claim check store backed by a NATS JetStream Object Store bucket, using an
+    /// already-constructed object-store context.
+    /// </summary>
+    public NatsObjectStoreClaimCheckStore(INatsObjContext context, string bucketName)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        if (string.IsNullOrWhiteSpace(bucketName))
+        {
+            throw new ArgumentException("Bucket name must be provided", nameof(bucketName));
+        }
+
+        _bucketName = bucketName;
+    }
+
+    /// <summary>The configured object-store bucket name.</summary>
+    public string BucketName => _bucketName;
+
+    public async Task<ClaimCheckToken> StoreAsync(
+        ReadOnlyMemory<byte> payload,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(contentType))
+        {
+            throw new ArgumentException("contentType must be provided", nameof(contentType));
+        }
+
+        var id = Guid.NewGuid().ToString("N");
+        var store = await resolveStoreAsync(cancellationToken).ConfigureAwait(false);
+
+        // The convenience PutAsync overload takes a byte[]; ReadOnlyMemory<byte> may be backed by
+        // memory that doesn't expose an array, so materialize a stable copy.
+        await store.PutAsync(id, payload.ToArray(), cancellationToken).ConfigureAwait(false);
+
+        return new ClaimCheckToken(id, contentType, payload.Length);
+    }
+
+    public async Task<ReadOnlyMemory<byte>> LoadAsync(
+        ClaimCheckToken token,
+        CancellationToken cancellationToken = default)
+    {
+        if (token is null)
+        {
+            throw new ArgumentNullException(nameof(token));
+        }
+
+        var store = await resolveStoreAsync(cancellationToken).ConfigureAwait(false);
+        var bytes = await store.GetBytesAsync(token.Id, cancellationToken).ConfigureAwait(false);
+        return bytes;
+    }
+
+    public async Task DeleteAsync(ClaimCheckToken token, CancellationToken cancellationToken = default)
+    {
+        if (token is null)
+        {
+            throw new ArgumentNullException(nameof(token));
+        }
+
+        var store = await resolveStoreAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await store.DeleteAsync(token.Id, cancellationToken).ConfigureAwait(false);
+        }
+        catch (NatsObjNotFoundException)
+        {
+            // Best-effort delete — a missing object is not an error.
+        }
+    }
+
+    private async ValueTask<INatsObjStore> resolveStoreAsync(CancellationToken cancellationToken)
+    {
+        if (_store is not null)
+        {
+            return _store;
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_store is not null)
+            {
+                return _store;
+            }
+
+            try
+            {
+                _store = await _context.GetObjectStoreAsync(_bucketName, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is NatsObjNotFoundException or NatsJSApiException)
+            {
+                // The bucket doesn't exist yet (a missing object-store bucket surfaces as a JetStream
+                // "stream not found" error). Create it; if another caller won the race, fall back to get.
+                try
+                {
+                    _store = await _context
+                        .CreateObjectStoreAsync(new NatsObjConfig(_bucketName), cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (NatsJSApiException)
+                {
+                    _store = await _context.GetObjectStoreAsync(_bucketName, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            return _store;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.Nats/Wolverine.ClaimCheck.Nats.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats/Wolverine.ClaimCheck.Nats.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>NATS JetStream Object Store backend for the Wolverine Claim Check pattern</Description>
+        <PackageId>WolverineFx.ClaimCheck.Nats</PackageId>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <IsAotCompatible>true</IsAotCompatible>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\Wolverine\Wolverine.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="NATS.Net" />
+    </ItemGroup>
+
+</Project>

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -75,6 +75,8 @@
     <Project Path="src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj" />
     <Project Path="src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage/Wolverine.ClaimCheck.AzureBlobStorage.csproj" />
     <Project Path="src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj" />
+    <Project Path="src/Persistence/Wolverine.ClaimCheck.Nats/Wolverine.ClaimCheck.Nats.csproj" />
+    <Project Path="src/Persistence/Wolverine.ClaimCheck.Nats.Tests/Wolverine.ClaimCheck.Nats.Tests.csproj" />
   </Folder>
   <Folder Name="/Persistence/CosmosDb/">
     <Project Path="src/Persistence/CosmosDbTests/CosmosDbTests.csproj" />


### PR DESCRIPTION
Closes #3506. Part of the claim-check follow-up epic #3511.

Ships a new **`WolverineFx.ClaimCheck.Nats`** package — an `IClaimCheckStore` backed by the NATS [JetStream Object Store](https://docs.nats.io/nats-concepts/jetstream/obj_store). NATS-transport users can off-load large `[Blob]` payloads without standing up a separate blob/object store. This backend is unique in the .NET messaging space (MassTransit/NServiceBus/Brighter don't offer it).

## What

- `NatsObjectStoreClaimCheckStore : IClaimCheckStore` — `StoreAsync` puts one object per payload keyed by `ClaimCheckToken.Id`; `LoadAsync` reads it back; `DeleteAsync` is idempotent (a missing object / `NatsObjNotFoundException` is treated as already-deleted).
  - The object-store bucket is resolved lazily (create-or-get) on first use and cached, guarded against a create/get race. A missing bucket surfaces as a JetStream "stream not found" (`NatsJSApiException`), which is handled.
  - Content type travels with the token, matching how the abstraction works (`LoadAsync` returns bytes; the content type comes from the token), so it isn't redundantly persisted.
- `UseNatsObjectStore(...)` config extensions on `ClaimCheckConfiguration`: one taking an existing `INatsConnection` (reuses the app's connection, per the issue), one taking an `INatsObjContext`.

### On the `...FromServices` overload

The S3/Azure packages expose a `...FromServices` variant, but the current core `UseClaimCheck` captures the store at configuration time and `RemoveAll<IClaimCheckStore>()`s the container — there is no startup re-resolution of a DI-registered store, so a `FromServices`-style registration does not actually route through the claim-check serializer. Rather than ship a convenience that looks wired-up but isn't, this package provides only the explicit-connection overloads (which fully satisfy the issue's "reuse the existing NATS connection" requirement). Making DI-deferred store resolution work is a small core change better tracked on the epic.

## Tests

`NatsObjectStoreClaimCheckStoreTests` (4 tests) — round-trip store/load/delete, idempotent delete of a missing object, exact-bytes round-trip of a 256-byte binary payload, and bucket reuse across two stores. Guarded by `[NatsFact]`, which skips cleanly when NATS isn't reachable on `localhost:4222` (mirrors the S3 `LocalStackFact` pattern). All pass against the docker-compose NATS (`docker compose up -d nats`, JetStream enabled).

Both new projects added to `wolverine.slnx`; Release build clean on net9.0/net10.0 (`IsAotCompatible`). Docs updated (`docs/guide/durability/claim-checks.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)