### PR TITLE
feat(claim-check): PostgreSQL database-LOB backend (#3507)

### DIFF
--- a/docs/guide/durability/claim-checks.md
+++ b/docs/guide/durability/claim-checks.md
@@ -75,7 +75,7 @@ When `UseClaimCheck(...)` runs without an explicit `Store`, the pipeline falls b
 
 ## Backends
 
-Wolverine ships two production-grade storage backends as separate NuGet packages.
+Wolverine ships several production-grade storage backends as separate NuGet packages.
 
 ### Azure Blob Storage
 
@@ -126,6 +126,34 @@ opts.UseClaimCheck(cc => cc.UseAmazonS3(myS3Client, bucketName: "wolverine-claim
 ```
 
 Token id maps to the object key. The supplied content type is set as `PutObjectRequest.ContentType`, which preserves the MIME type for downloads and S3 lifecycle policies. `DeleteAsync` is naturally idempotent — S3 returns success even when the key is absent.
+
+### PostgreSQL (database LOB)
+
+The zero-new-infrastructure option for critter-stack users: off-loaded payloads are stored as `bytea` rows in your existing PostgreSQL database — no S3 / Azure / GCS account required.
+
+```sh
+dotnet add package WolverineFx.ClaimCheck.Postgresql
+```
+
+```csharp
+using Wolverine.ClaimCheck.Postgresql;
+
+builder.Host.UseWolverine(opts =>
+{
+    opts.UseClaimCheck(cc => cc.UsePostgresqlClaimCheck(
+        connectionString: builder.Configuration.GetConnectionString("Postgres")!,
+        schemaName: "public",
+        tableName: "wolverine_claim_check"));
+});
+```
+
+An overload accepting an existing `NpgsqlDataSource` is also available if you want to reuse the data source your application already configures:
+
+```csharp
+opts.UseClaimCheck(cc => cc.UsePostgresqlClaimCheck(myDataSource));
+```
+
+The claim check table is created on first use (`create schema/table if not exists`). Token id maps to the row's primary key; the content type and length are stored alongside the `bytea` body. `DeleteAsync` is naturally idempotent — deleting a missing row is a no-op. Because the payloads live in a table you own, database-native cleanup (a scheduled `delete ... where created < ...`) is straightforward.
 
 ### File system (built in)
 

--- a/src/Persistence/Wolverine.ClaimCheck.Postgresql.Tests/PostgresqlClaimCheckStoreTests.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Postgresql.Tests/PostgresqlClaimCheckStoreTests.cs
@@ -1,0 +1,111 @@
+using System.Text;
+using IntegrationTests;
+using Npgsql;
+using Shouldly;
+using Wolverine.Persistence;
+
+namespace Wolverine.ClaimCheck.Postgresql.Tests;
+
+public class PostgresqlClaimCheckStoreTests : IAsyncLifetime
+{
+    // Each test class gets its own schema so parallel classes / re-runs never collide,
+    // mirroring the Amazon S3 backend's per-class bucket.
+    private readonly string _schema = "claim_check_" + Guid.NewGuid().ToString("N")[..12];
+    private NpgsqlDataSource _dataSource = null!;
+    private PostgresqlClaimCheckStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        _dataSource = NpgsqlDataSource.Create(Servers.PostgresConnectionString);
+        _store = new PostgresqlClaimCheckStore(_dataSource, _schema);
+
+        // touch the store so the schema/table is provisioned before assertions
+        await _store.DeleteAsync(new ClaimCheckToken("warmup", "text/plain", 0));
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"drop schema if exists \"{_schema}\" cascade";
+            await cmd.ExecuteNonQueryAsync();
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+        finally
+        {
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task round_trip_store_load_delete()
+    {
+        var payload = Encoding.UTF8.GetBytes("hello, claim check world");
+
+        var token = await _store.StoreAsync(payload, "text/plain");
+
+        token.Id.ShouldNotBeNullOrWhiteSpace();
+        token.ContentType.ShouldBe("text/plain");
+        token.Length.ShouldBe(payload.Length);
+
+        var loaded = await _store.LoadAsync(token);
+        loaded.ToArray().ShouldBe(payload);
+
+        await _store.DeleteAsync(token);
+
+        // After delete, loading should fail with a not-found error.
+        await Should.ThrowAsync<KeyNotFoundException>(async () => await _store.LoadAsync(token));
+    }
+
+    [Fact]
+    public async Task delete_is_idempotent_for_missing_row()
+    {
+        var token = new ClaimCheckToken("does_not_exist_" + Guid.NewGuid().ToString("N"), "text/plain", 0);
+
+        // Should not throw even though the row was never created.
+        await _store.DeleteAsync(token);
+    }
+
+    [Fact]
+    public async Task load_returns_exact_payload_bytes()
+    {
+        // Binary payload with zero bytes and high bits set to catch any encoding-related
+        // corruption in the bytea round-trip.
+        var payload = new byte[256];
+        for (var i = 0; i < payload.Length; i++)
+        {
+            payload[i] = (byte)i;
+        }
+
+        var token = await _store.StoreAsync(payload, "application/octet-stream");
+        var loaded = await _store.LoadAsync(token);
+
+        loaded.Length.ShouldBe(payload.Length);
+        loaded.ToArray().ShouldBe(payload);
+    }
+
+    [Fact]
+    public async Task provisioning_is_idempotent_across_stores()
+    {
+        // A second store over the same schema/table must not fail re-running the
+        // create-if-not-exists DDL, and must see the first store's row.
+        var token = await _store.StoreAsync(Encoding.UTF8.GetBytes("shared"), "text/plain");
+
+        var second = new PostgresqlClaimCheckStore(_dataSource, _schema);
+        var loaded = await second.LoadAsync(token);
+
+        loaded.ToArray().ShouldBe(Encoding.UTF8.GetBytes("shared"));
+    }
+
+    [Fact]
+    public void rejects_non_identifier_schema_names()
+    {
+        Should.Throw<ArgumentException>(() =>
+            new PostgresqlClaimCheckStore(_dataSource, "bad name; drop table x"));
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.Postgresql.Tests/Wolverine.ClaimCheck.Postgresql.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.Postgresql.Tests/Wolverine.ClaimCheck.Postgresql.Tests.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Include="..\..\Servers.cs">
+            <Link>Servers.cs</Link>
+        </Compile>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Wolverine.ClaimCheck.Postgresql\Wolverine.ClaimCheck.Postgresql.csproj" />
+    </ItemGroup>
+
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Persistence/Wolverine.ClaimCheck.Postgresql/PostgresqlClaimCheckExtensions.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Postgresql/PostgresqlClaimCheckExtensions.cs
@@ -1,0 +1,58 @@
+using Npgsql;
+using Wolverine.Persistence;
+
+namespace Wolverine.ClaimCheck.Postgresql;
+
+/// <summary>
+/// Extension methods for configuring a PostgreSQL database-LOB backed
+/// <see cref="IClaimCheckStore"/> from a Wolverine <see cref="ClaimCheckConfiguration"/>.
+/// </summary>
+public static class PostgresqlClaimCheckExtensions
+{
+    /// <summary>
+    /// Use a PostgreSQL <c>bytea</c> table in the database reached by <paramref name="dataSource"/>
+    /// as the backing store for Wolverine claim checks. The table is created on first use.
+    /// </summary>
+    /// <param name="config">The claim check configuration to attach to.</param>
+    /// <param name="dataSource">Data source for the target PostgreSQL database.</param>
+    /// <param name="schemaName">Schema that owns the claim check table.</param>
+    /// <param name="tableName">Name of the claim check table.</param>
+    public static ClaimCheckConfiguration UsePostgresqlClaimCheck(
+        this ClaimCheckConfiguration config,
+        NpgsqlDataSource dataSource,
+        string schemaName = PostgresqlClaimCheckStore.DefaultSchemaName,
+        string tableName = PostgresqlClaimCheckStore.DefaultTableName)
+    {
+        if (config is null) throw new ArgumentNullException(nameof(config));
+        if (dataSource is null) throw new ArgumentNullException(nameof(dataSource));
+
+        config.Store = new PostgresqlClaimCheckStore(dataSource, schemaName, tableName);
+        return config;
+    }
+
+    /// <summary>
+    /// Use a PostgreSQL <c>bytea</c> table in the database reached by <paramref name="connectionString"/>
+    /// as the backing store for Wolverine claim checks. A dedicated <see cref="NpgsqlDataSource"/> is
+    /// built from the connection string. The table is created on first use.
+    /// </summary>
+    /// <param name="config">The claim check configuration to attach to.</param>
+    /// <param name="connectionString">Connection string for the target PostgreSQL database.</param>
+    /// <param name="schemaName">Schema that owns the claim check table.</param>
+    /// <param name="tableName">Name of the claim check table.</param>
+    public static ClaimCheckConfiguration UsePostgresqlClaimCheck(
+        this ClaimCheckConfiguration config,
+        string connectionString,
+        string schemaName = PostgresqlClaimCheckStore.DefaultSchemaName,
+        string tableName = PostgresqlClaimCheckStore.DefaultTableName)
+    {
+        if (config is null) throw new ArgumentNullException(nameof(config));
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new ArgumentException("Connection string must be provided", nameof(connectionString));
+        }
+
+        var dataSource = NpgsqlDataSource.Create(connectionString);
+        config.Store = new PostgresqlClaimCheckStore(dataSource, schemaName, tableName);
+        return config;
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.Postgresql/PostgresqlClaimCheckStore.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Postgresql/PostgresqlClaimCheckStore.cs
@@ -1,0 +1,179 @@
+using System.Text.RegularExpressions;
+using Npgsql;
+using NpgsqlTypes;
+using Wolverine.Persistence;
+
+namespace Wolverine.ClaimCheck.Postgresql;
+
+/// <summary>
+/// PostgreSQL database-LOB backed <see cref="IClaimCheckStore"/>. Each claim check payload is
+/// stored as a single <c>bytea</c> row in a Wolverine-managed table in the application's own
+/// PostgreSQL database — the zero-new-infrastructure option for critter-stack users, requiring no
+/// S3 / Azure / GCS account. The <see cref="ClaimCheckToken.Id"/> maps to the row's primary key.
+/// </summary>
+public class PostgresqlClaimCheckStore : IClaimCheckStore
+{
+    // Postgres identifiers we build DDL/DML for are validated against this so the schema/table
+    // names (which come from configuration) can be safely embedded in quoted identifiers.
+    private static readonly Regex _identifier = new("^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.Compiled);
+
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly string _schemaName;
+    private readonly string _tableName;
+    private readonly string _qualifiedTable;
+
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private bool _provisioned;
+
+    /// <summary>The default schema used when none is supplied.</summary>
+    public const string DefaultSchemaName = "public";
+
+    /// <summary>The default table name used when none is supplied.</summary>
+    public const string DefaultTableName = "wolverine_claim_check";
+
+    /// <summary>
+    /// Create a new claim check store backed by a PostgreSQL <c>bytea</c> table.
+    /// </summary>
+    /// <param name="dataSource">Data source for the target PostgreSQL database.</param>
+    /// <param name="schemaName">Schema that owns the claim check table. Created on first use if missing.</param>
+    /// <param name="tableName">Name of the claim check table. Created on first use if missing.</param>
+    public PostgresqlClaimCheckStore(
+        NpgsqlDataSource dataSource,
+        string schemaName = DefaultSchemaName,
+        string tableName = DefaultTableName)
+    {
+        _dataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
+
+        if (string.IsNullOrWhiteSpace(schemaName) || !_identifier.IsMatch(schemaName))
+        {
+            throw new ArgumentException(
+                "Schema name must be a simple PostgreSQL identifier (letters, digits, underscores; not starting with a digit)",
+                nameof(schemaName));
+        }
+
+        if (string.IsNullOrWhiteSpace(tableName) || !_identifier.IsMatch(tableName))
+        {
+            throw new ArgumentException(
+                "Table name must be a simple PostgreSQL identifier (letters, digits, underscores; not starting with a digit)",
+                nameof(tableName));
+        }
+
+        _schemaName = schemaName;
+        _tableName = tableName;
+        _qualifiedTable = $"\"{schemaName}\".\"{tableName}\"";
+    }
+
+    /// <summary>The schema that owns the claim check table.</summary>
+    public string SchemaName => _schemaName;
+
+    /// <summary>The claim check table name.</summary>
+    public string TableName => _tableName;
+
+    public async Task<ClaimCheckToken> StoreAsync(
+        ReadOnlyMemory<byte> payload,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(contentType))
+        {
+            throw new ArgumentException("contentType must be provided", nameof(contentType));
+        }
+
+        await ensureProvisionedAsync(cancellationToken).ConfigureAwait(false);
+
+        var id = Guid.NewGuid().ToString("N");
+
+        await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            $"insert into {_qualifiedTable} (id, content_type, body, length) values (@id, @ct, @body, @len)";
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("ct", contentType);
+        cmd.Parameters.Add(new NpgsqlParameter("body", NpgsqlDbType.Bytea) { Value = payload.ToArray() });
+        cmd.Parameters.AddWithValue("len", (long)payload.Length);
+
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+        return new ClaimCheckToken(id, contentType, payload.Length);
+    }
+
+    public async Task<ReadOnlyMemory<byte>> LoadAsync(
+        ClaimCheckToken token,
+        CancellationToken cancellationToken = default)
+    {
+        if (token is null)
+        {
+            throw new ArgumentNullException(nameof(token));
+        }
+
+        await ensureProvisionedAsync(cancellationToken).ConfigureAwait(false);
+
+        await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"select body from {_qualifiedTable} where id = @id";
+        cmd.Parameters.AddWithValue("id", token.Id);
+
+        var result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        if (result is null || result is DBNull)
+        {
+            throw new KeyNotFoundException(
+                $"No claim check payload found in {_qualifiedTable} for token id '{token.Id}'.");
+        }
+
+        return (byte[])result;
+    }
+
+    public async Task DeleteAsync(ClaimCheckToken token, CancellationToken cancellationToken = default)
+    {
+        if (token is null)
+        {
+            throw new ArgumentNullException(nameof(token));
+        }
+
+        await ensureProvisionedAsync(cancellationToken).ConfigureAwait(false);
+
+        await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var cmd = conn.CreateCommand();
+        // Deleting a missing row is a no-op, so DeleteAsync is naturally idempotent.
+        cmd.CommandText = $"delete from {_qualifiedTable} where id = @id";
+        cmd.Parameters.AddWithValue("id", token.Id);
+
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ensureProvisionedAsync(CancellationToken cancellationToken)
+    {
+        if (_provisioned)
+        {
+            return;
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_provisioned)
+            {
+                return;
+            }
+
+            await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                $"create schema if not exists \"{_schemaName}\";" +
+                $"create table if not exists {_qualifiedTable} (" +
+                "id text primary key, " +
+                "content_type text not null, " +
+                "body bytea not null, " +
+                "length bigint not null, " +
+                "created timestamptz not null default (now() at time zone 'utc'));";
+
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+            _provisioned = true;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.Postgresql/Wolverine.ClaimCheck.Postgresql.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.Postgresql/Wolverine.ClaimCheck.Postgresql.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>PostgreSQL database LOB backend for the Wolverine Claim Check pattern</Description>
+        <PackageId>WolverineFx.ClaimCheck.Postgresql</PackageId>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <IsAotCompatible>true</IsAotCompatible>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\Wolverine\Wolverine.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Npgsql" />
+    </ItemGroup>
+
+</Project>

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -75,6 +75,8 @@
     <Project Path="src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj" />
     <Project Path="src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage/Wolverine.ClaimCheck.AzureBlobStorage.csproj" />
     <Project Path="src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj" />
+    <Project Path="src/Persistence/Wolverine.ClaimCheck.Postgresql/Wolverine.ClaimCheck.Postgresql.csproj" />
+    <Project Path="src/Persistence/Wolverine.ClaimCheck.Postgresql.Tests/Wolverine.ClaimCheck.Postgresql.Tests.csproj" />
   </Folder>
   <Folder Name="/Persistence/CosmosDb/">
     <Project Path="src/Persistence/CosmosDbTests/CosmosDbTests.csproj" />


### PR DESCRIPTION
Closes #3507. Part of the claim-check follow-up epic #3511.

Ships a new **`WolverineFx.ClaimCheck.Postgresql`** package — an `IClaimCheckStore` that persists off-loaded `[Blob]` payloads as `bytea` rows in the application's own PostgreSQL database. This is the **zero-new-infrastructure** option for critter-stack users: no S3 / Azure / GCS account required, just the database you already run.

This is the first concrete database-LOB backend under #3507; SQL Server and a Marten-document variant are natural siblings to follow (kept out of this PR to stay focused — and SQL Server is currently out of scope for this batch).

## What

- `PostgresqlClaimCheckStore : IClaimCheckStore`
  - `StoreAsync` inserts one row `(id, content_type, body bytea, length, created)` keyed by a fresh `ClaimCheckToken.Id`.
  - `LoadAsync` selects the `bytea` body back; throws `KeyNotFoundException` if the token is unknown.
  - `DeleteAsync` is naturally idempotent — deleting a missing row is a no-op.
  - The schema + table are provisioned on first use via `create schema/table if not exists`, guarded once behind a gate. Schema/table names (from config) are validated against a simple-identifier regex before being embedded in quoted identifiers; all payload/id values are passed as parameters.
- `UsePostgresqlClaimCheck(...)` config extensions on `ClaimCheckConfiguration`: one taking an existing `NpgsqlDataSource` (reuse the app's data source), one taking a connection string. Both default to `public.wolverine_claim_check`.

Because payloads live in a table you own, database-native GC (a scheduled `delete ... where created < ...`) is straightforward — relevant to the TTL/GC follow-up #3509.

## Tests

`PostgresqlClaimCheckStoreTests` (5 tests, per-class schema for isolation): round-trip store/load/delete, idempotent delete of a missing row, exact-bytes round-trip of a 256-byte binary payload, idempotent provisioning across two stores over the same table, and rejection of non-identifier schema names. All pass against the docker-compose Postgres (port 5433).

Both new projects added to `wolverine.slnx`; Release build clean on net9.0/net10.0 (`IsAotCompatible`). Docs updated (`docs/guide/durability/claim-checks.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)