### PR TITLE
feat(claim-check): Google Cloud Storage backend (#3505)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Google.Api.CommonProtos" Version="2.16.0" />
     <PackageVersion Include="Google.Cloud.PubSub.V1" Version="3.24.0" />
+    <PackageVersion Include="Google.Cloud.Storage.V1" Version="4.13.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.31.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
     <PackageVersion Include="Grpc.Core" Version="2.46.6" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,14 @@ services:
         "--user-output-enabled",
       ]
 
+  # GCS emulator used by the WolverineFx.ClaimCheck.GoogleCloudStorage backend tests.
+  # Serves plain HTTP on 4443; tests point the client at it via STORAGE_EMULATOR_HOST.
+  fake-gcs-server:
+    image: "fsouza/fake-gcs-server:latest"
+    ports:
+      - "4443:4443"
+    command: ["-scheme", "http", "-host", "0.0.0.0", "-port", "4443", "-public-host", "localhost:4443"]
+
   rabbitmq:
     image: "rabbitmq:4-management"
     ports:

--- a/docs/guide/durability/claim-checks.md
+++ b/docs/guide/durability/claim-checks.md
@@ -75,7 +75,7 @@ When `UseClaimCheck(...)` runs without an explicit `Store`, the pipeline falls b
 
 ## Backends
 
-Wolverine ships two production-grade storage backends as separate NuGet packages.
+Wolverine ships several production-grade storage backends as separate NuGet packages.
 
 ### Azure Blob Storage
 
@@ -126,6 +126,32 @@ opts.UseClaimCheck(cc => cc.UseAmazonS3(myS3Client, bucketName: "wolverine-claim
 ```
 
 Token id maps to the object key. The supplied content type is set as `PutObjectRequest.ContentType`, which preserves the MIME type for downloads and S3 lifecycle policies. `DeleteAsync` is naturally idempotent — S3 returns success even when the key is absent.
+
+### Google Cloud Storage
+
+```sh
+dotnet add package WolverineFx.ClaimCheck.GoogleCloudStorage
+```
+
+```csharp
+using Google.Cloud.Storage.V1;
+using Wolverine.ClaimCheck.GoogleCloudStorage;
+
+builder.Services.AddSingleton(StorageClient.Create());
+
+builder.Host.UseWolverine(opts =>
+{
+    opts.UseClaimCheck(cc => cc.UseGoogleCloudStorageFromServices(bucketName: "wolverine-claim-checks"));
+});
+```
+
+The `UseGoogleCloudStorageFromServices` overload defers `StorageClient` resolution until the container is built, mirroring the S3 pattern. An explicit-client overload is also available for tests and one-off setups:
+
+```csharp
+opts.UseClaimCheck(cc => cc.UseGoogleCloudStorage(myStorageClient, bucketName: "wolverine-claim-checks"));
+```
+
+Token id maps to the object name, and the supplied content type is set on the object so it downloads with the right MIME type and participates in GCS lifecycle rules. `DeleteAsync` is idempotent — a `404 Not Found` on a missing object is swallowed.
 
 ### File system (built in)
 

--- a/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/FakeGcsFact.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/FakeGcsFact.cs
@@ -1,0 +1,53 @@
+using System.Net.Sockets;
+
+namespace Wolverine.ClaimCheck.GoogleCloudStorage.Tests;
+
+/// <summary>
+/// Probe the fake-gcs-server emulator once per process and cache the result. Any TCP connect
+/// failure on <c>localhost:4443</c> is treated as "not running" so tests skip cleanly. Mirrors
+/// the <c>LocalStackFact</c> pattern used by the Amazon S3 backend tests.
+/// </summary>
+internal static class FakeGcs
+{
+    public const string Host = "localhost";
+    public const int Port = 4443;
+    public const string EmulatorHost = "http://localhost:4443";
+
+    private static readonly Lazy<bool> _isRunning = new(Probe);
+
+    public static bool IsRunning => _isRunning.Value;
+
+    public const string SkipReason =
+        "The fake-gcs-server emulator is not running on localhost:4443. " +
+        "Start it with `docker compose up -d fake-gcs-server` from the repo root to enable these tests.";
+
+    private static bool Probe()
+    {
+        try
+        {
+            using var client = new TcpClient();
+            var connect = client.ConnectAsync(Host, Port);
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+            return connect.Wait(TimeSpan.FromSeconds(2)) && client.Connected;
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}
+
+/// <summary>
+/// xUnit <see cref="FactAttribute"/> that skips when the fake-gcs-server emulator is not reachable.
+/// </summary>
+public sealed class FakeGcsFactAttribute : FactAttribute
+{
+    public FakeGcsFactAttribute()
+    {
+        if (!FakeGcs.IsRunning)
+        {
+            Skip = FakeGcs.SkipReason;
+        }
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/GoogleCloudStorageClaimCheckStoreTests.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/GoogleCloudStorageClaimCheckStoreTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Text;
+using Google;
+using Google.Cloud.Storage.V1;
+using Shouldly;
+using Wolverine.Persistence;
+
+namespace Wolverine.ClaimCheck.GoogleCloudStorage.Tests;
+
+public class GoogleCloudStorageClaimCheckStoreTests : IAsyncLifetime
+{
+    private const string ProjectId = "wolverine-test";
+
+    // Each test class gets its own bucket so parallel classes / re-runs never collide on object
+    // names, mirroring the Amazon S3 backend tests.
+    private readonly string _bucketName = "claim-check-tests-" + Guid.NewGuid().ToString("N");
+    private StorageClient _client = null!;
+    private GoogleCloudStorageClaimCheckStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        if (!FakeGcs.IsRunning)
+        {
+            return;
+        }
+
+        // Point the client at the fake-gcs-server emulator. BaseUri is used verbatim (it must
+        // include the /storage/v1/ service path), and UnauthenticatedAccess skips the Google
+        // credential pipeline the emulator doesn't need.
+        _client = new StorageClientBuilder
+        {
+            BaseUri = FakeGcs.EmulatorHost + "/storage/v1/",
+            UnauthenticatedAccess = true
+        }.Build();
+
+        await _client.CreateBucketAsync(ProjectId, _bucketName);
+
+        _store = new GoogleCloudStorageClaimCheckStore(_client, _bucketName);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_client is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await foreach (var obj in _client.ListObjectsAsync(_bucketName))
+            {
+                await _client.DeleteObjectAsync(_bucketName, obj.Name);
+            }
+
+            await _client.DeleteBucketAsync(_bucketName);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+        finally
+        {
+            _client.Dispose();
+        }
+    }
+
+    [FakeGcsFact]
+    public async Task round_trip_store_load_delete()
+    {
+        var payload = Encoding.UTF8.GetBytes("hello, claim check world");
+
+        var token = await _store.StoreAsync(payload, "text/plain");
+
+        token.Id.ShouldNotBeNullOrWhiteSpace();
+        token.ContentType.ShouldBe("text/plain");
+        token.Length.ShouldBe(payload.Length);
+
+        var loaded = await _store.LoadAsync(token);
+        loaded.ToArray().ShouldBe(payload);
+
+        await _store.DeleteAsync(token);
+
+        // After delete, the object should not exist any more.
+        (await ObjectExistsAsync(token.Id)).ShouldBeFalse();
+    }
+
+    [FakeGcsFact]
+    public async Task uploads_use_supplied_content_type()
+    {
+        var payload = new byte[] { 1, 2, 3, 4, 5 };
+        const string contentType = "application/x-wolverine-test";
+
+        var token = await _store.StoreAsync(payload, contentType);
+
+        var metadata = await _client.GetObjectAsync(_bucketName, token.Id);
+        metadata.ContentType.ShouldBe(contentType);
+    }
+
+    [FakeGcsFact]
+    public async Task delete_is_idempotent_for_missing_object()
+    {
+        var token = new ClaimCheckToken("does-not-exist-" + Guid.NewGuid().ToString("N"), "text/plain", 0);
+
+        // Should not throw even though the object was never created.
+        await _store.DeleteAsync(token);
+    }
+
+    [FakeGcsFact]
+    public async Task load_returns_exact_payload_bytes()
+    {
+        // Binary payload with zero bytes and high bits set to catch any encoding-related corruption.
+        var payload = new byte[256];
+        for (var i = 0; i < payload.Length; i++)
+        {
+            payload[i] = (byte)i;
+        }
+
+        var token = await _store.StoreAsync(payload, "application/octet-stream");
+        var loaded = await _store.LoadAsync(token);
+
+        loaded.Length.ShouldBe(payload.Length);
+        loaded.ToArray().ShouldBe(payload);
+    }
+
+    private async Task<bool> ObjectExistsAsync(string objectName)
+    {
+        try
+        {
+            await _client.GetObjectAsync(_bucketName, objectName);
+            return true;
+        }
+        catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/Wolverine.ClaimCheck.GoogleCloudStorage.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/Wolverine.ClaimCheck.GoogleCloudStorage.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Wolverine.ClaimCheck.GoogleCloudStorage\Wolverine.ClaimCheck.GoogleCloudStorage.csproj" />
+    </ItemGroup>
+
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage/GoogleCloudStorageClaimCheckExtensions.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage/GoogleCloudStorageClaimCheckExtensions.cs
@@ -1,0 +1,61 @@
+using Google.Cloud.Storage.V1;
+using Microsoft.Extensions.DependencyInjection;
+using Wolverine.Persistence;
+
+namespace Wolverine.ClaimCheck.GoogleCloudStorage;
+
+/// <summary>
+/// Extension methods for configuring a Google Cloud Storage backed
+/// <see cref="IClaimCheckStore"/> from a Wolverine <see cref="ClaimCheckConfiguration"/>.
+/// </summary>
+public static class GoogleCloudStorageClaimCheckExtensions
+{
+    /// <summary>
+    /// Use an explicit, already-constructed <see cref="StorageClient"/> and the given bucket name
+    /// as the backing store for Wolverine claim checks.
+    /// </summary>
+    /// <param name="config">The claim check configuration to attach to.</param>
+    /// <param name="client">An already-configured <see cref="StorageClient"/> instance.</param>
+    /// <param name="bucketName">Name of the existing GCS bucket used to hold payloads.</param>
+    public static ClaimCheckConfiguration UseGoogleCloudStorage(
+        this ClaimCheckConfiguration config,
+        StorageClient client,
+        string bucketName)
+    {
+        if (config is null) throw new ArgumentNullException(nameof(config));
+        if (client is null) throw new ArgumentNullException(nameof(client));
+        if (string.IsNullOrWhiteSpace(bucketName))
+        {
+            throw new ArgumentException("Bucket name must be provided", nameof(bucketName));
+        }
+
+        config.Store = new GoogleCloudStorageClaimCheckStore(client, bucketName);
+        return config;
+    }
+
+    /// <summary>
+    /// Resolve <see cref="StorageClient"/> from the application service container at runtime and use
+    /// the given bucket name as the backing store for Wolverine claim checks. This is convenient when
+    /// the storage client is registered through standard DI, and mirrors the Amazon S3
+    /// <c>UseAmazonS3FromServices</c> pattern.
+    /// </summary>
+    /// <param name="config">The claim check configuration to attach to.</param>
+    /// <param name="bucketName">Name of the existing GCS bucket used to hold payloads.</param>
+    public static ClaimCheckConfiguration UseGoogleCloudStorageFromServices(
+        this ClaimCheckConfiguration config,
+        string bucketName)
+    {
+        if (config is null) throw new ArgumentNullException(nameof(config));
+        if (string.IsNullOrWhiteSpace(bucketName))
+        {
+            throw new ArgumentException("Bucket name must be provided", nameof(bucketName));
+        }
+
+        // The StorageClient is not necessarily available at configuration time — register the store
+        // as a DI singleton built from the resolved client. Mirrors UseAmazonS3FromServices.
+        config.Options.Services.AddSingleton<IClaimCheckStore>(sp =>
+            new GoogleCloudStorageClaimCheckStore(sp.GetRequiredService<StorageClient>(), bucketName));
+
+        return config;
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage/GoogleCloudStorageClaimCheckStore.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage/GoogleCloudStorageClaimCheckStore.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using Google;
+using Google.Cloud.Storage.V1;
+using Wolverine.Persistence;
+
+namespace Wolverine.ClaimCheck.GoogleCloudStorage;
+
+/// <summary>
+/// Google Cloud Storage backed <see cref="IClaimCheckStore"/>. Each claim check payload is stored
+/// as a single object in the configured bucket. The <see cref="ClaimCheckToken.Id"/> maps directly
+/// to the GCS object name, and the content type from the token is set on the object.
+/// </summary>
+public class GoogleCloudStorageClaimCheckStore : IClaimCheckStore
+{
+    private readonly StorageClient _client;
+    private readonly string _bucketName;
+
+    /// <summary>
+    /// Create a new claim check store backed by an existing GCS bucket.
+    /// </summary>
+    /// <param name="client">Configured Google Cloud Storage client.</param>
+    /// <param name="bucketName">
+    /// Name of the GCS bucket used to hold claim check payloads. The bucket must already exist;
+    /// this store does not create it.
+    /// </param>
+    public GoogleCloudStorageClaimCheckStore(StorageClient client, string bucketName)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        if (string.IsNullOrWhiteSpace(bucketName))
+        {
+            throw new ArgumentException("Bucket name must be provided", nameof(bucketName));
+        }
+
+        _bucketName = bucketName;
+    }
+
+    /// <summary>
+    /// The configured storage client. Useful for tests and for callers that need to perform
+    /// bucket-level lifecycle operations.
+    /// </summary>
+    public StorageClient Client => _client;
+
+    /// <summary>The configured bucket name.</summary>
+    public string BucketName => _bucketName;
+
+    public async Task<ClaimCheckToken> StoreAsync(
+        ReadOnlyMemory<byte> payload,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(contentType))
+        {
+            throw new ArgumentException("contentType must be provided", nameof(contentType));
+        }
+
+        var id = Guid.NewGuid().ToString("N");
+
+        // ReadOnlyMemory<byte> may be backed by memory that doesn't expose an array, so go through
+        // ToArray() to hand the client a stable MemoryStream.
+        var buffer = payload.ToArray();
+        using var stream = new MemoryStream(buffer, writable: false);
+
+        await _client.UploadObjectAsync(_bucketName, id, contentType, stream, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        return new ClaimCheckToken(id, contentType, payload.Length);
+    }
+
+    public async Task<ReadOnlyMemory<byte>> LoadAsync(
+        ClaimCheckToken token,
+        CancellationToken cancellationToken = default)
+    {
+        if (token is null)
+        {
+            throw new ArgumentNullException(nameof(token));
+        }
+
+        // Size the buffer exactly when we know the length so we avoid MemoryStream's doubling growth.
+        using var ms = token.Length > 0 ? new MemoryStream((int)token.Length) : new MemoryStream();
+        await _client.DownloadObjectAsync(_bucketName, token.Id, ms, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        return new ReadOnlyMemory<byte>(ms.GetBuffer(), 0, (int)ms.Length);
+    }
+
+    public async Task DeleteAsync(ClaimCheckToken token, CancellationToken cancellationToken = default)
+    {
+        if (token is null)
+        {
+            throw new ArgumentNullException(nameof(token));
+        }
+
+        try
+        {
+            await _client.DeleteObjectAsync(_bucketName, token.Id, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (GoogleApiException e) when (e.HttpStatusCode == HttpStatusCode.NotFound)
+        {
+            // Best-effort delete — a missing object is not an error.
+        }
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage/Wolverine.ClaimCheck.GoogleCloudStorage.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage/Wolverine.ClaimCheck.GoogleCloudStorage.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Google Cloud Storage backend for the Wolverine Claim Check pattern</Description>
+        <PackageId>WolverineFx.ClaimCheck.GoogleCloudStorage</PackageId>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <IsAotCompatible>true</IsAotCompatible>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\Wolverine\Wolverine.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Google.Cloud.Storage.V1" />
+    </ItemGroup>
+
+</Project>

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -75,6 +75,8 @@
     <Project Path="src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj" />
     <Project Path="src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage/Wolverine.ClaimCheck.AzureBlobStorage.csproj" />
     <Project Path="src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj" />
+    <Project Path="src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage/Wolverine.ClaimCheck.GoogleCloudStorage.csproj" />
+    <Project Path="src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/Wolverine.ClaimCheck.GoogleCloudStorage.Tests.csproj" />
   </Folder>
   <Folder Name="/Persistence/CosmosDb/">
     <Project Path="src/Persistence/CosmosDbTests/CosmosDbTests.csproj" />


### PR DESCRIPTION
Closes #3505. Part of the claim-check follow-up epic #3511.

Ships a new **`WolverineFx.ClaimCheck.GoogleCloudStorage`** package — an `IClaimCheckStore` backed by Google Cloud Storage, mirroring the shipped `WolverineFx.ClaimCheck.AzureBlobStorage` and `WolverineFx.ClaimCheck.AmazonS3` packages.

## What

- `GoogleCloudStorageClaimCheckStore : IClaimCheckStore` — `StoreAsync` uploads one object per payload keyed by a fresh `ClaimCheckToken.Id`, with the token's content type set on the object; `LoadAsync` downloads it back (buffer sized from the token length when known); `DeleteAsync` swallows a `404 Not Found` so it is idempotent.
- `UseGoogleCloudStorage(StorageClient client, string bucketName)` — explicit client.
- `UseGoogleCloudStorageFromServices(string bucketName)` — defers `StorageClient` resolution to DI, matching the S3 `UseAmazonS3FromServices` pattern (as the issue requested).

## Test infrastructure

- Added `Google.Cloud.Storage.V1` to central package management (`Directory.Packages.props`).
- Added a **`fake-gcs-server`** service to `docker-compose.yml` (plain HTTP on `4443`) so the backend can be tested without a real GCP account.

## Tests

`GoogleCloudStorageClaimCheckStoreTests` (4 tests, per-class bucket) — round-trip store/load/delete, content-type preservation, idempotent delete of a missing object, and exact-bytes round-trip of a 256-byte binary payload. Guarded by `[FakeGcsFact]`, which skips cleanly when the emulator isn't reachable on `localhost:4443` (mirrors the S3 `LocalStackFact` pattern). The client targets the emulator via `BaseUri` (`http://localhost:4443/storage/v1/`) + `UnauthenticatedAccess`. All pass against `docker compose up -d fake-gcs-server`.

Both new projects added to `wolverine.slnx`; Release build clean on net9.0/net10.0 (`IsAotCompatible`). Docs updated (`docs/guide/durability/claim-checks.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)