### PR TITLE
fix(claim-check): honor a DI-registered IClaimCheckStore (#3564)

### DIFF
--- a/src/Testing/CoreTests/Persistence/ClaimCheck/RecordingInMemoryClaimCheckStore.cs
+++ b/src/Testing/CoreTests/Persistence/ClaimCheck/RecordingInMemoryClaimCheckStore.cs
@@ -1,0 +1,46 @@
+using System.Collections.Concurrent;
+using Wolverine.Persistence;
+
+namespace CoreTests.Persistence.ClaimCheck;
+
+/// <summary>
+/// A trivial in-memory <see cref="IClaimCheckStore"/> that records how many times it was
+/// exercised. Used to prove that a DI-registered store is actually used by the claim-check
+/// pipeline (rather than the file-system fallback) — see GH-3564.
+/// </summary>
+public sealed class RecordingInMemoryClaimCheckStore : IClaimCheckStore
+{
+    private readonly ConcurrentDictionary<string, byte[]> _payloads = new();
+
+    public int StoreCount;
+    public int LoadCount;
+    public int DeleteCount;
+
+    public Task<ClaimCheckToken> StoreAsync(ReadOnlyMemory<byte> payload, string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref StoreCount);
+        var id = Guid.NewGuid().ToString("N");
+        _payloads[id] = payload.ToArray();
+        return Task.FromResult(new ClaimCheckToken(id, contentType, payload.Length));
+    }
+
+    public Task<ReadOnlyMemory<byte>> LoadAsync(ClaimCheckToken token,
+        CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref LoadCount);
+        if (!_payloads.TryGetValue(token.Id, out var bytes))
+        {
+            throw new KeyNotFoundException($"No claim-check payload stored under '{token.Id}'.");
+        }
+
+        return Task.FromResult<ReadOnlyMemory<byte>>(bytes);
+    }
+
+    public Task DeleteAsync(ClaimCheckToken token, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref DeleteCount);
+        _payloads.TryRemove(token.Id, out _);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Testing/CoreTests/Persistence/ClaimCheck/from_services_store_resolution.cs
+++ b/src/Testing/CoreTests/Persistence/ClaimCheck/from_services_store_resolution.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Persistence;
+using Wolverine.Tracking;
+using Wolverine.Transports.Tcp;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Persistence.ClaimCheck;
+
+/// <summary>
+/// Regression coverage for GH-3564: when the claim-check store is registered in the container
+/// (the pattern used by every <c>...FromServices</c> overload) rather than assigned explicitly
+/// during the UseClaimCheck callback, the pipeline must actually use that store instead of
+/// silently falling back to the file system.
+/// </summary>
+public class from_services_store_resolution : IAsyncLifetime
+{
+    // A single shared store stands in for a real external backend that both nodes point at.
+    private readonly RecordingInMemoryClaimCheckStore _store = new();
+    private IHost _publisher = null!;
+    private IHost _receiver = null!;
+
+    public async Task InitializeAsync()
+    {
+        CapturedMessages.Reset();
+
+        var port = PortFinder.GetAvailablePort();
+
+        _publisher = await Host.CreateDefaultBuilder().UseWolverine(opts =>
+        {
+            opts.ApplicationAssembly = typeof(from_services_store_resolution).Assembly;
+
+            // Mimic a ...FromServices overload: register the store in DI, but never assign
+            // configuration.Store. Pre-fix, UseClaimCheck ignored this registration and built the
+            // serializer around the file-system fallback.
+            opts.UseClaimCheck(c => c.Options.Services.AddSingleton<IClaimCheckStore>(_store));
+
+            opts.PublishMessage<BlobByteArrayMessage>().ToPort(port);
+        }).StartAsync();
+
+        _receiver = await Host.CreateDefaultBuilder().UseWolverine(opts =>
+        {
+            opts.ApplicationAssembly = typeof(from_services_store_resolution).Assembly;
+
+            opts.UseClaimCheck(c => c.Options.Services.AddSingleton<IClaimCheckStore>(_store));
+            opts.ListenAtPort(port);
+        }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _receiver.StopAsync();
+        await _publisher.StopAsync();
+        _receiver.Dispose();
+        _publisher.Dispose();
+    }
+
+    [Fact]
+    public void di_registered_store_survives_UseClaimCheck()
+    {
+        // RemoveAll<IClaimCheckStore>() previously wiped the FromServices registration.
+        _publisher.Services.GetRequiredService<IClaimCheckStore>().ShouldBeSameAs(_store);
+        _receiver.Services.GetRequiredService<IClaimCheckStore>().ShouldBeSameAs(_store);
+    }
+
+    [Fact]
+    public async Task blob_payload_is_off_loaded_to_the_di_registered_store()
+    {
+        var bytes = new byte[2048];
+        Random.Shared.NextBytes(bytes);
+
+        var session = await _publisher.TrackActivity()
+            .AlsoTrack(_receiver)
+            .SendMessageAndWaitAsync(new BlobByteArrayMessage("doc.pdf", bytes));
+
+        // The round trip must succeed through the DI-registered backend...
+        var received = session.Received.SingleMessage<BlobByteArrayMessage>();
+        received.ShouldNotBeNull();
+        received.Name.ShouldBe("doc.pdf");
+        received.Payload!.ShouldBe(bytes);
+
+        // ...and, decisively, the recording store must have seen the traffic. Pre-fix these were
+        // zero because the payload went to the file-system fallback instead.
+        _store.StoreCount.ShouldBeGreaterThan(0);
+        _store.LoadCount.ShouldBeGreaterThan(0);
+    }
+}

--- a/src/Wolverine/Persistence/ClaimCheck/Internal/DeferredClaimCheckStore.cs
+++ b/src/Wolverine/Persistence/ClaimCheck/Internal/DeferredClaimCheckStore.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Wolverine.Persistence.ClaimCheck.Internal;
+
+/// <summary>
+/// An <see cref="IClaimCheckStore"/> proxy used when the real store is registered in the
+/// application's DI container (e.g. via the <c>...FromServices</c> overloads) and therefore
+/// cannot be resolved at Wolverine configuration time. The Wolverine runtime calls
+/// <see cref="AttachProvider"/> once the container has been built; the first
+/// store / load / delete call then resolves and caches the concrete
+/// <see cref="IClaimCheckStore"/> out of the container. See GH-3564.
+/// </summary>
+internal sealed class DeferredClaimCheckStore : IClaimCheckStore
+{
+    private readonly object _lock = new();
+    private IServiceProvider? _provider;
+    private volatile IClaimCheckStore? _resolved;
+
+    /// <summary>
+    /// Hand the built application service provider to this store. Called once by the
+    /// Wolverine runtime during startup, before any message is serialized.
+    /// </summary>
+    public void AttachProvider(IServiceProvider provider)
+    {
+        _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+    }
+
+    private IClaimCheckStore resolve()
+    {
+        var resolved = _resolved;
+        if (resolved is not null)
+        {
+            return resolved;
+        }
+
+        lock (_lock)
+        {
+            if (_resolved is not null)
+            {
+                return _resolved;
+            }
+
+            if (_provider is null)
+            {
+                throw new InvalidOperationException(
+                    "The claim-check store has not been bound to the application service provider yet. " +
+                    "UseClaimCheck deferred to a DI-registered IClaimCheckStore, but the Wolverine runtime " +
+                    "has not finished starting. Off-loading a [Blob] payload before the host is started is not supported.");
+            }
+
+            var store = _provider.GetService<IClaimCheckStore>();
+            if (store is null || ReferenceEquals(store, this))
+            {
+                throw new InvalidOperationException(
+                    "UseClaimCheck was configured to resolve an IClaimCheckStore from the service container " +
+                    "(for example via a ...FromServices overload), but no concrete IClaimCheckStore is registered. " +
+                    "Register one in the service collection, or assign a store explicitly inside the UseClaimCheck callback.");
+            }
+
+            _resolved = store;
+            return store;
+        }
+    }
+
+    public Task<ClaimCheckToken> StoreAsync(ReadOnlyMemory<byte> payload, string contentType,
+        CancellationToken cancellationToken = default)
+        => resolve().StoreAsync(payload, contentType, cancellationToken);
+
+    public Task<ReadOnlyMemory<byte>> LoadAsync(ClaimCheckToken token,
+        CancellationToken cancellationToken = default)
+        => resolve().LoadAsync(token, cancellationToken);
+
+    public Task DeleteAsync(ClaimCheckToken token, CancellationToken cancellationToken = default)
+        => resolve().DeleteAsync(token, cancellationToken);
+}

--- a/src/Wolverine/Persistence/ClaimCheck/WolverineOptionsClaimCheckExtensions.cs
+++ b/src/Wolverine/Persistence/ClaimCheck/WolverineOptionsClaimCheckExtensions.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Wolverine.Persistence.ClaimCheck.Internal;
@@ -30,7 +31,36 @@ public static class WolverineOptionsClaimCheckExtensions
         var configuration = new ClaimCheckConfiguration(options);
         configure?.Invoke(configuration);
 
-        var store = configuration.Store ?? new FileSystemClaimCheckStore(ClaimCheckConfiguration.DefaultFileSystemDirectory());
+        IClaimCheckStore store;
+        if (configuration.Store is not null)
+        {
+            // An explicit store was assigned during configuration (e.g. UseFileSystem, or
+            // UseAmazonS3 with an already-built client). It wins outright: capture it directly
+            // in the serializer and expose it in DI for ad-hoc resolution.
+            store = configuration.Store;
+            options.Services.RemoveAll<IClaimCheckStore>();
+            options.Services.AddSingleton(store);
+            options.DeferredClaimCheckStore = null;
+        }
+        else if (options.Services.Any(d => d.ServiceType == typeof(IClaimCheckStore)))
+        {
+            // No explicit store, but one is already registered in the container — this is the
+            // ...FromServices path (GH-3564). The concrete store depends on services that do not
+            // exist until the container is built, so defer resolution: the serializer captures a
+            // proxy that the runtime binds to the built provider at startup. The DI registration
+            // is left intact so both the serializer and user code (GetRequiredService
+            // <IClaimCheckStore>()) resolve the real backend rather than the file-system fallback.
+            store = options.DeferredClaimCheckStore ??= new DeferredClaimCheckStore();
+        }
+        else
+        {
+            // Nothing configured: fall back to a local file-system store rooted under the temp
+            // folder, and expose it in DI so user code can resolve it for ad-hoc operations.
+            store = new FileSystemClaimCheckStore(ClaimCheckConfiguration.DefaultFileSystemDirectory());
+            options.Services.RemoveAll<IClaimCheckStore>();
+            options.Services.AddSingleton(store);
+            options.DeferredClaimCheckStore = null;
+        }
 
         // If UseClaimCheck has already been applied to this options instance,
         // unwrap and re-wrap so the operation is idempotent (new store wins).
@@ -43,11 +73,6 @@ public static class WolverineOptionsClaimCheckExtensions
         {
             options.DefaultSerializer = new ClaimCheckMessageSerializer(current, store);
         }
-
-        // Replace any DI-registered IMessageSerializer with the decorator and expose
-        // the IClaimCheckStore so user code can resolve it for ad-hoc operations.
-        options.Services.RemoveAll<IClaimCheckStore>();
-        options.Services.AddSingleton(store);
 
         return options;
     }

--- a/src/Wolverine/Runtime/WolverineRuntime.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.cs
@@ -94,6 +94,11 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IWolverineRunt
 
         _container = container;
 
+        // GH-3564: when UseClaimCheck deferred to a DI-registered IClaimCheckStore (the
+        // ...FromServices overloads), hand it the built service provider now so the claim-check
+        // serializer resolves the real backend instead of silently falling back to the file system.
+        options.DeferredClaimCheckStore?.AttachProvider(container.Services);
+
         Cancellation = DurabilitySettings.Cancellation;
         _agentCancellation = CancellationTokenSource.CreateLinkedTokenSource(Cancellation);
 

--- a/src/Wolverine/WolverineOptions.ClaimCheck.cs
+++ b/src/Wolverine/WolverineOptions.ClaimCheck.cs
@@ -1,0 +1,16 @@
+using Wolverine.Persistence.ClaimCheck.Internal;
+
+namespace Wolverine;
+
+public sealed partial class WolverineOptions
+{
+    /// <summary>
+    /// Set when <see cref="Wolverine.Persistence.WolverineOptionsClaimCheckExtensions.UseClaimCheck"/>
+    /// defers to a DI-registered <see cref="Wolverine.Persistence.IClaimCheckStore"/> (the
+    /// <c>...FromServices</c> overloads). The claim-check serializer captures this proxy at
+    /// configuration time; the runtime binds it to the built service provider at startup so the
+    /// real backend is used instead of the file-system fallback. Null when a store was assigned
+    /// explicitly or the file-system fallback is in use. See GH-3564.
+    /// </summary>
+    internal DeferredClaimCheckStore? DeferredClaimCheckStore { get; set; }
+}


### PR DESCRIPTION
Closes #3564.

## Problem

The `...FromServices` claim-check overloads (`UseAmazonS3FromServices`, `UseGoogleCloudStorageFromServices`) register the store as a DI factory but leave `ClaimCheckConfiguration.Store` null. `UseClaimCheck` then resolved the store **at configuration time**, fell back to a `FileSystemClaimCheckStore`, and called `RemoveAll<IClaimCheckStore>()` — silently discarding the intended backend.

Result: a `...FromServices`-configured app off-loads `[Blob]` payloads to a local temp folder the receiving node can't read. Single-node dev/test still "works" (both wind up on the file system), so it goes unnoticed until production.

## Fix

`UseClaimCheck` now distinguishes three cases:

- **Explicit `Store`** (e.g. `UseFileSystem`, `UseAmazonS3` with a built client) → used directly (unchanged).
- **A container-registered `IClaimCheckStore` with no explicit store** (the `...FromServices` path) → the serializer captures a `DeferredClaimCheckStore` proxy and the DI registration is left intact. The runtime binds the proxy to the built service provider at startup, so the first off-load resolves the real backend.
- **Nothing configured** → file-system fallback (unchanged).

This fixes all `...FromServices` backends at once (S3, Azure Blob, GCS).

## Tests

New `from_services_store_resolution` coverage using an in-memory store registered exactly like the `...FromServices` overloads do — asserts the DI registration survives `UseClaimCheck` and that a full publish→receive round trip actually flows through that store (not the file system). No external infrastructure required; 13/13 claim-check CoreTests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELDdVFYo78uj8GDa3NHu7i