### PR TITLE
feat(dead-letters): add Replayable filter to DeadLetterEnvelopeQuery (#3567)

### DIFF
--- a/docs/guide/durability/dead-letter-storage.md
+++ b/docs/guide/durability/dead-letter-storage.md
@@ -139,6 +139,7 @@ app.MapDeadLettersEndpoints()
   - `MessageType` (string?): Filter by message type.
   - `ExceptionType` (string?): Filter by exception type.
   - `ExceptionMessage` (string?): Filter by exception message.
+  - `Replayable` (bool?): Filter by the replayable flag. Omit (or `null`) for no filtering; `false` returns only envelopes not yet marked replayable; `true` returns only those already queued for replay. Filtering happens in the database so `TotalCount` and paging stay coherent for the subset.
   - `From` (DateTimeOffset?): Start date for fetching records.
   - `Until` (DateTimeOffset?): End date for fetching records.
   - `TenantId` (string?): Tenant identifier for multi-tenancy support.
@@ -151,6 +152,18 @@ app.MapDeadLettersEndpoints()
 
 ::: tip Pagination
 The pagination model changed from cursor-based (`StartId` / `NextId`) to offset-based (`PageNumber`) in Wolverine 5. Pass `PageNumber` incrementing from `0` to walk through pages; `TotalCount` lets you compute how many pages exist as `ceil(TotalCount / Limit)`.
+:::
+
+::: tip Filtering by replayable state <Badge type="tip" text="6.22" />
+After deploying a fix, operators commonly want to separate the messages that are still stuck (`"Replayable": false`) from the ones already queued for replay (`"Replayable": true`). Because the predicate is applied in the database rather than in memory after paging, `TotalCount` reflects the filtered subset — so a `false`-only view drives a paginated UI or batch redrive correctly.
+
+```json
+{
+  "Limit": 50,
+  "PageNumber": 0,
+  "Replayable": false
+}
+```
 :::
 
 **Request Example**:

--- a/docs/tutorials/dead-letter-queues.md
+++ b/docs/tutorials/dead-letter-queues.md
@@ -268,6 +268,20 @@ await store.DeadLetters.MarkDeadLetterEnvelopesAsReplayableAsync("InvalidPayment
 `IDeadLetters` also exposes `QueryAsync`, `SummarizeAllAsync`, `ReplayAsync`, `DiscardAsync`, and
 `EditAndReplayAsync` (which lets you fix up a message body before replaying it) for more fine-grained control.
 
+`DeadLetterEnvelopeQuery` filters by message type, exception type, exception message, time range, and — as of
+6.22 — the `Replayable` flag. The filter is applied in the database, so `TotalCount` and paging stay coherent
+for the subset (unlike filtering a page in memory after it comes back):
+
+```cs
+// Everything still stuck (not yet queued for replay) after a fix went out
+var stillStuck = await store.DeadLetters.QueryAsync(
+    new DeadLetterEnvelopeQuery(TimeRange.AllTime()) { Replayable = false },
+    CancellationToken.None);
+
+// null (the default) leaves the replayable column unfiltered; true returns only
+// envelopes already marked for replay.
+```
+
 ## Keeping the dead letter table from growing forever
 
 A busy system can accumulate a lot of dead letters, and an oversized table will eventually drag on performance.

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.DeadLetters.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.DeadLetters.cs
@@ -250,6 +250,12 @@ internal partial class OracleMessageStore
             builder.AppendParameter(query.ReceivedAt);
         }
 
+        if (query.Replayable.HasValue)
+        {
+            builder.Append($" AND {DatabaseConstants.Replayable} = ");
+            builder.AppendParameter(query.Replayable.Value ? 1 : 0); // Oracle uses NUMBER(1) for bool
+        }
+
         if (query.MessageIds is { Length: > 0 })
         {
             builder.Append(" AND id IN (");

--- a/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.DeadLetters.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.DeadLetters.cs
@@ -136,6 +136,11 @@ public partial class CosmosDbMessageStore : IDeadLetters
             conditions.Add("c.receivedAt = @receivedAt");
         }
 
+        if (query.Replayable.HasValue)
+        {
+            conditions.Add("c.replayable = @replayable");
+        }
+
         var whereClause = string.Join(" AND ", conditions);
 
         // Count query
@@ -282,6 +287,7 @@ public partial class CosmosDbMessageStore : IDeadLetters
         if (query.ExceptionType.IsNotEmpty()) conditions.Add("c.exceptionType = @exceptionType");
         if (query.MessageType.IsNotEmpty()) conditions.Add("c.messageType = @messageType");
         if (query.ReceivedAt.IsNotEmpty()) conditions.Add("c.receivedAt = @receivedAt");
+        if (query.Replayable.HasValue) conditions.Add("c.replayable = @replayable");
 
         var queryText = $"SELECT * FROM c WHERE {string.Join(" AND ", conditions)}";
         var queryDef = RebuildQueryDef(queryText, query);
@@ -337,6 +343,7 @@ public partial class CosmosDbMessageStore : IDeadLetters
             queryDef = queryDef.WithParameter("@exceptionMessage", query.ExceptionMessage);
         if (query.MessageType.IsNotEmpty()) queryDef = queryDef.WithParameter("@messageType", query.MessageType);
         if (query.ReceivedAt.IsNotEmpty()) queryDef = queryDef.WithParameter("@receivedAt", query.ReceivedAt);
+        if (query.Replayable.HasValue) queryDef = queryDef.WithParameter("@replayable", query.Replayable.Value);
 
         return queryDef;
     }

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.DeadLetterAdminService.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.DeadLetterAdminService.cs
@@ -163,6 +163,12 @@ public abstract partial class MessageDatabase<T>
             builder.AppendParameter(query.ReceivedAt);
         }
 
+        if (query.Replayable.HasValue)
+        {
+            builder.Append($" and {DatabaseConstants.Replayable} = ");
+            builder.AppendParameter(query.Replayable.Value);
+        }
+
         if (query.MessageIds != null && query.MessageIds.Any())
         {
             writeMessageIdArrayQueryList(builder, query.MessageIds);

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.DeadLetters.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.DeadLetters.cs
@@ -114,6 +114,12 @@ public partial class RavenDbMessageStore : IDeadLetters
             queryable = (IRavenQueryable<DeadLetterMessage>)queryable.Where(x => x.ReceivedAt == receivedAtUri);
         }
 
+        if (query.Replayable.HasValue)
+        {
+            var replayable = query.Replayable.Value;
+            queryable = (IRavenQueryable<DeadLetterMessage>)queryable.Where(x => x.Replayable == replayable);
+        }
+
         // Get total count
         var totalCount = await queryable.CountAsync(token);
 
@@ -230,6 +236,11 @@ update
         if (query.ReceivedAt.IsNotEmpty())
         {
             conditions.Add($"m.ReceivedAt = '{query.ReceivedAt}'");
+        }
+
+        if (query.Replayable.HasValue)
+        {
+            conditions.Add($"m.Replayable = {(query.Replayable.Value ? "true" : "false")}");
         }
 
         return conditions.Count > 0 ? "where " + string.Join(" and ", conditions) : "";

--- a/src/Testing/Wolverine.ComplianceTests/DeadLetterAdminCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/DeadLetterAdminCompliance.cs
@@ -528,6 +528,59 @@ public abstract class DeadLetterAdminCompliance : IAsyncLifetime
     }
 
     [Fact]
+    public async Task query_by_replayable_flag()
+    {
+        // Two disjoint partitions by exception type. We mark only the BadImageFormatException
+        // partition replayable, then assert the Replayable filter selects each partition
+        // server-side (including a coherent TotalCount, which in-memory filtering cannot give).
+        withTargetMessage1();
+        theGenerator.ExceptionSource = msg => new BadImageFormatException(msg);
+        await load(9, FiveHoursAgo);
+
+        theGenerator.ExceptionSource = msg => new DivideByZeroException(msg);
+        await load(6, FourHoursAgo);
+
+        var replayableQuery = new DeadLetterEnvelopeQuery(TimeRange.AllTime())
+            { ExceptionType = typeof(BadImageFormatException).FullNameInCode() };
+        await theDeadLetters.ReplayAsync(replayableQuery, CancellationToken.None);
+
+        // Replayable = true → only the 9 marked envelopes
+        var onlyReplayable = await theDeadLetters.QueryAsync(
+            new DeadLetterEnvelopeQuery(TimeRange.AllTime()) { Replayable = true, PageSize = 1000 },
+            CancellationToken.None);
+        onlyReplayable.TotalCount.ShouldBe(9);
+        onlyReplayable.Envelopes.Count.ShouldBe(9);
+        onlyReplayable.Envelopes.ShouldAllBe(e => e.Replayable);
+
+        // Replayable = false → only the 6 that were never marked
+        var onlyStuck = await theDeadLetters.QueryAsync(
+            new DeadLetterEnvelopeQuery(TimeRange.AllTime()) { Replayable = false, PageSize = 1000 },
+            CancellationToken.None);
+        onlyStuck.TotalCount.ShouldBe(6);
+        onlyStuck.Envelopes.Count.ShouldBe(6);
+        onlyStuck.Envelopes.ShouldAllBe(e => !e.Replayable);
+
+        // Replayable = null (default) → no filtering, all 15
+        var all = await theDeadLetters.QueryAsync(
+            new DeadLetterEnvelopeQuery(TimeRange.AllTime()) { PageSize = 1000 },
+            CancellationToken.None);
+        all.TotalCount.ShouldBe(15);
+        all.Envelopes.Count.ShouldBe(15);
+
+        // The replayable predicate composes with the other filters
+        var replayableStuck = await theDeadLetters.QueryAsync(
+            new DeadLetterEnvelopeQuery(TimeRange.AllTime())
+            {
+                Replayable = false,
+                ExceptionType = typeof(BadImageFormatException).FullNameInCode(),
+                PageSize = 1000
+            },
+            CancellationToken.None);
+        replayableStuck.TotalCount.ShouldBe(0);
+        replayableStuck.Envelopes.Count.ShouldBe(0);
+    }
+
+    [Fact]
     public async Task discard_by_message_batch()
     {
         withTargetMessage1();

--- a/src/Wolverine/Persistence/Durability/DeadLetterManagement/DeadLetterEnvelopeQuery.cs
+++ b/src/Wolverine/Persistence/Durability/DeadLetterManagement/DeadLetterEnvelopeQuery.cs
@@ -27,6 +27,14 @@ public class DeadLetterEnvelopeQuery
     
     public string? ExceptionMessage { get; set; }
 
+    /// <summary>
+    /// When set, restricts results to envelopes whose replayable flag matches. <c>null</c>
+    /// (the default) keeps the current behavior of not filtering on the replayable column.
+    /// <c>false</c> returns only envelopes not yet marked replayable; <c>true</c> returns only
+    /// those already marked for replay.
+    /// </summary>
+    public bool? Replayable { get; set; }
+
     public TimeRange Range { get; set; } = TimeRange.AllTime();
 
     /// <summary>

--- a/src/Wolverine/Persistence/Durability/DeadLetterManagement/DeadLetterEnvelopeResults.cs
+++ b/src/Wolverine/Persistence/Durability/DeadLetterManagement/DeadLetterEnvelopeResults.cs
@@ -22,6 +22,15 @@ public class DeadLetterEnvelopeGetRequest
     public string? MessageType { get; set; }
     public string? ExceptionType { get; set; }
     public string? ExceptionMessage { get; set; }
+
+    /// <summary>
+    /// When set, restricts results to envelopes whose replayable flag matches. <c>null</c>
+    /// (the default) keeps the current behavior of not filtering on the replayable state.
+    /// <c>false</c> returns only envelopes not yet marked replayable; <c>true</c> returns only
+    /// those already marked for replay.
+    /// </summary>
+    public bool? Replayable { get; set; }
+
     public DateTimeOffset? From { get; set; }
     public DateTimeOffset? Until { get; set; }
     public string? TenantId { get; set; }

--- a/src/Wolverine/Persistence/MessageStoreCollection.cs
+++ b/src/Wolverine/Persistence/MessageStoreCollection.cs
@@ -467,6 +467,7 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
             MessageType = request.MessageType,
             ExceptionType = request.ExceptionType,
             ExceptionMessage = request.ExceptionMessage,
+            Replayable = request.Replayable,
             Range = new TimeRange(request.From, request.Until)
         };
 


### PR DESCRIPTION
Closes #3567.

## Context

`DeadLetterEnvelopeQuery` could filter by message type, exception type/message, received-at, and time range — but not by the `replayable` flag. Selecting "everything not yet queued for replay" meant paging the whole result set and filtering in memory, which makes `PageSize`/`PageNumber`/`TotalCount` incoherent for the subset.

## Change

Add an optional, nullable `bool? Replayable` to `DeadLetterEnvelopeQuery`, mirrored on the HTTP `DeadLetterEnvelopeGetRequest` (`/dead-letters`):

- `null` (default) → no filtering — fully backwards compatible.
- `false` → only envelopes not yet marked replayable.
- `true` → only envelopes already queued for replay.

The predicate is applied **server-side** across every store, so `TotalCount` and paging stay coherent for the subset, and it composes with `DiscardAsync`/`ReplayAsync` (same query object):

- shared RDBMS where-clause — **Postgres / SqlServer**
- **Oracle** (`NUMBER(1)` 1/0 variant)
- **RavenDb** (LINQ query + RQL where-clause for discard/replay)
- **CosmosDb** (SQL condition + parameter binding)

## Tests

Deterministic `query_by_replayable_flag` compliance test asserting all three states, a coherent `TotalCount`, and composition with the exception-type filter. **Verified against PostgreSQL** (10/10 DLQ compliance tests pass). SqlServer/Oracle/Raven/Cosmos ride the same code paths — worth a CI run across stores before merge.

## Docs

Updated both the programmatic `IDeadLetters` tutorial and the `/dead-letters` REST reference (new field + focused "still stuck" example).

> Note: version badges set to **6.22** — adjust if the target release differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELDdVFYo78uj8GDa3NHu7i