### PR TITLE
fix: make `resources setup` provision message storage even when AutoCreate is None

### DIFF
--- a/src/Persistence/PostgresqlTests/explicit_resource_setup_with_auto_create_none.cs
+++ b/src/Persistence/PostgresqlTests/explicit_resource_setup_with_auto_create_none.cs
@@ -1,0 +1,106 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.RDBMS;
+
+namespace PostgresqlTests;
+
+public class explicit_resource_setup_with_auto_create_none : PostgresqlContext, IAsyncLifetime
+{
+    private const string SchemaName = "autocreate_none";
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync(SchemaName);
+        await conn.CloseAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    private static IHostBuilder configureHost()
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.AutoBuildMessageStorageOnStartup = AutoCreate.None;
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, SchemaName)
+                    .OverrideAutoCreateResources(AutoCreate.None);
+            });
+    }
+
+    private static async Task<bool> envelopeTablesExist()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        var tables = await conn.ExistingTablesAsync(schemas: [SchemaName]);
+        await conn.CloseAsync();
+
+        return tables.Any(x => x.Name == DatabaseConstants.IncomingTable);
+    }
+
+    [Fact]
+    public async Task setup_resources_builds_the_message_storage_even_when_auto_create_is_none()
+    {
+        using var host = configureHost().Build();
+
+        await host.SetupResources();
+
+        (await envelopeTablesExist()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task passive_migration_still_honors_auto_create_none()
+    {
+        using var host = configureHost().Build();
+
+        var store = host.Services.GetRequiredService<IMessageStore>();
+        await store.Admin.MigrateAsync();
+
+        (await envelopeTablesExist()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task migration_with_an_auto_create_override_builds_the_message_storage()
+    {
+        using var host = configureHost().Build();
+
+        var store = host.Services.GetRequiredService<IMessageStore>();
+        await store.Admin.MigrateAsync(AutoCreate.CreateOrUpdate);
+
+        (await envelopeTablesExist()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task host_startup_with_auto_build_none_does_not_create_the_message_storage()
+    {
+        using var host = configureHost().Build();
+
+        try
+        {
+            await host.StartAsync();
+            await host.StopAsync();
+        }
+        catch (Exception)
+        {
+            // The host may well fail during startup because the message storage was
+            // never provisioned. This test only cares that startup did not create it
+        }
+
+        (await envelopeTablesExist()).ShouldBeFalse();
+    }
+}

--- a/src/Persistence/Wolverine.Marten/MartenMessageDatabaseSource.cs
+++ b/src/Persistence/Wolverine.Marten/MartenMessageDatabaseSource.cs
@@ -106,6 +106,12 @@ internal class MartenMessageDatabaseSource : ITenantedMessageSource
         {
             await store.Admin.MigrateAsync();
         }
+        else
+        {
+            _runtime.LoggerFactory.CreateLogger<MartenMessageDatabaseSource>().LogInformation(
+                "Skipping message storage migration for tenant message database {Database} because AutoCreate is None",
+                database.Identifier);
+        }
 
         return store;
     }

--- a/src/Persistence/Wolverine.Polecat/PolecatMessageDatabaseSource.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatMessageDatabaseSource.cs
@@ -108,6 +108,12 @@ internal class PolecatMessageDatabaseSource : ITenantedMessageSource
         {
             await store.Admin.MigrateAsync();
         }
+        else
+        {
+            _runtime.LoggerFactory.CreateLogger<PolecatMessageDatabaseSource>().LogInformation(
+                "Skipping message storage migration for tenant message database {Database} because AutoCreate is None",
+                identifier);
+        }
 
         return store;
     }

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
@@ -1,6 +1,8 @@
 using System.Data.Common;
+using JasperFx;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using Microsoft.Extensions.Logging;
 using Weasel.Core;
 using Wolverine.Logging;
 using Wolverine.Persistence.Durability;
@@ -49,8 +51,15 @@ public abstract partial class MessageDatabase<T>
         }
     }
 
-    public async Task MigrateAsync()
+    public Task MigrateAsync()
     {
+        return MigrateAsync(null);
+    }
+
+    public async Task MigrateAsync(AutoCreate? overrideAutoCreate)
+    {
+        var autoCreate = overrideAutoCreate ?? _settings.AutoCreate;
+
         Func<Task> tryMigrate = async () =>
         {
             await using var conn = await DataSource.OpenConnectionAsync(_cancellation);
@@ -66,7 +75,7 @@ public abstract partial class MessageDatabase<T>
                 // (or equivalents on other engines). See GH-2518.
                 lockAcquired = await acquireMigrationLockAsync(lockId, typedConn, _cancellation);
 
-                await migrateAsync(conn);
+                await migrateAsync(conn, autoCreate);
             }
             finally
             {
@@ -202,13 +211,26 @@ public abstract partial class MessageDatabase<T>
         }
     }
 
-    private async Task migrateAsync(DbConnection conn)
+    private Task migrateAsync(DbConnection conn)
+    {
+        return migrateAsync(conn, _settings.AutoCreate);
+    }
+
+    private async Task migrateAsync(DbConnection conn, AutoCreate autoCreate)
     {
         var migration = await SchemaMigration.DetermineAsync(conn, _cancellation, Objects);
 
         if (migration.Difference != SchemaPatchDifference.None)
         {
-            await Migrator.ApplyAllAsync(conn, migration, _settings.AutoCreate, new MigrationLogger(Logger), ct: _cancellation);
+            if (autoCreate == AutoCreate.None)
+            {
+                Logger.LogWarning(
+                    "Message storage in database {Database} is out of date ({Difference}) but AutoCreate is None — no migration applied. Run 'resources setup' to provision it",
+                    Name, migration.Difference);
+                return;
+            }
+
+            await Migrator.ApplyAllAsync(conn, migration, autoCreate, new MigrationLogger(Logger), ct: _cancellation);
         }
     }
 

--- a/src/Wolverine/Persistence/Durability/IMessageStoreAdmin.cs
+++ b/src/Wolverine/Persistence/Durability/IMessageStoreAdmin.cs
@@ -1,4 +1,5 @@
-﻿using Wolverine.Logging;
+﻿using JasperFx;
+using Wolverine.Logging;
 
 namespace Wolverine.Persistence.Durability;
 
@@ -73,4 +74,16 @@ public interface IMessageStoreAdmin
     /// </summary>
     /// <returns></returns>
     Task MigrateAsync();
+
+    /// <summary>
+    ///     Apply any necessary database migrations to bring the underlying envelope storage to the
+    ///     configured requirements of the Wolverine system, overriding the store's configured
+    ///     AutoCreate rules. This is the path used by explicit setup operations like
+    ///     "resources setup" or IHost.SetupResources() where a configured AutoCreate of None
+    ///     should not suppress the storage provisioning. The default implementation ignores the
+    ///     override and delegates to <see cref="MigrateAsync()"/> for stores whose migrations
+    ///     are not gated by AutoCreate rules.
+    /// </summary>
+    /// <param name="overrideAutoCreate">When not null, use this AutoCreate rule in place of the store's configured value</param>
+    Task MigrateAsync(AutoCreate? overrideAutoCreate) => MigrateAsync();
 }

--- a/src/Wolverine/Persistence/Durability/MessageStoreResource.cs
+++ b/src/Wolverine/Persistence/Durability/MessageStoreResource.cs
@@ -1,3 +1,4 @@
+using JasperFx;
 using JasperFx.Resources;
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -39,7 +40,11 @@ internal class MessageStoreResource : IStatefulResource
 
     public Task Setup(CancellationToken token)
     {
-        return _persistence.Admin.MigrateAsync();
+        // An explicit setup call ("resources setup" / IHost.SetupResources()) is itself the
+        // intent to provision the storage, so Setup always migrates with CreateOrUpdate
+        // regardless of the configured AutoCreate. Mirrors Weasel's DatabaseResource.Setup,
+        // where ApplyAllConfiguredChangesToDatabaseAsync promotes None to CreateOrUpdate
+        return _persistence.Admin.MigrateAsync(AutoCreate.CreateOrUpdate);
     }
 
     public async Task<IRenderable> DetermineStatus(CancellationToken token)

--- a/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
@@ -479,14 +479,24 @@ public partial class MultiTenantedMessageStore : IMessageStore, IMessageInbox, I
         return executeOnAllAsync(d => d.Admin.AssertStorageExistsAsync(token));
     }
 
-    async Task IMessageStoreAdmin.MigrateAsync()
+    Task IMessageStoreAdmin.MigrateAsync()
+    {
+        return migrateAsync(null);
+    }
+
+    Task IMessageStoreAdmin.MigrateAsync(AutoCreate? overrideAutoCreate)
+    {
+        return migrateAsync(overrideAutoCreate);
+    }
+
+    private async Task migrateAsync(AutoCreate? overrideAutoCreate)
     {
         if (!_initialized)
         {
             await InitializeAsync(_runtime);
         }
 
-        await Main.Admin.MigrateAsync();
+        await Main.Admin.MigrateAsync(overrideAutoCreate);
 
         var exceptions = new List<Exception>();
 
@@ -494,7 +504,7 @@ public partial class MultiTenantedMessageStore : IMessageStore, IMessageInbox, I
         {
             try
             {
-                await assignment.Value.Admin.MigrateAsync();
+                await assignment.Value.Admin.MigrateAsync(overrideAutoCreate);
                 _byTenant = _byTenant.AddOrUpdate(assignment.TenantId, assignment.Value);
             }
             catch (Exception e)

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -274,6 +274,11 @@ public partial class WolverineRuntime
                     "Failed to migrate Wolverine message storage on startup. Continuing startup anyway because ResourceMigrationFailureMode is ContinueOnFailures.");
             }
         }
+        else if (Storage is not NullMessageStore)
+        {
+            Logger.LogInformation(
+                "Skipping automatic message storage migration on startup because AutoBuildMessageStorageOnStartup is None. The message storage must have been provisioned ahead of time, e.g. with 'resources setup' / IHost.SetupResources()");
+        }
 
         _hasMigratedStorage = true;
     }


### PR DESCRIPTION
Fixes #3573.

## Problem

As described in the linked issue: the documented production recipe (`ResourceAutoCreate = AutoCreate.None` + explicit `resources setup` / `IHost.SetupResources()`) silently skips the message-store migration, because `MessageStoreResource.Setup` passes the store's configured `AutoCreate` — inherited as `None` via Marten/Polecat and the production profile — straight into Weasel's migrator. Weasel's own `DatabaseResource.Setup` deliberately promotes `None` → `CreateOrUpdate` for exactly this reason; the message-store resource never adopted the promotion, so the same deployment recipe provisions all of the Marten schema and none of `wolverine.*`.

## The fix

Mirror Weasel's semantics, scoped to the explicit setup path only:

- **`IMessageStoreAdmin`** gains a default-interface overload:
  ```csharp
  Task MigrateAsync(AutoCreate? overrideAutoCreate) => MigrateAsync();
  ```
  The default keeps source/binary compatibility for external implementations and is the correct behavior for stores whose migrations are not gated by `AutoCreate` at all (RavenDB, CosmosDB, Oracle, `NullMessageStore`) — this follows the existing DIM precedent of `AssertStorageExistsAsync` on the same interface.
- **`MessageStoreResource.Setup`** now calls `Admin.MigrateAsync(AutoCreate.CreateOrUpdate)` instead of the parameterless method.
- **`MessageDatabase<T>`** (Postgres, SqlServer, MySql, Sqlite) implements the overload: `overrideAutoCreate ?? _settings.AutoCreate`, threaded through the existing advisory-lock migration path. The parameterless `MigrateAsync()` is unchanged in behavior.
- **`MultiTenantedMessageStore`** propagates the override to the Main store and every active tenant store.

Why this shape and not a promotion inside `MigrateAsync()` itself: host startup (`tryMigrateStorage`, tenant-store discovery, `MessageStoreCollection.MigrateAsync`) funnels into the same parameterless `MigrateAsync()`. A blanket promotion there would make startup provision schema that `AutoBuildMessageStorageOnStartup = None` / per-store `AutoCreate.None` explicitly forbids. The override parameter keeps the two intents separate: passive paths keep honoring `None`; only the explicit resource-setup call promotes.

The previously *silent* skips also now log:

- `MessageDatabase<T>`: **warning** when a schema difference is detected but `AutoCreate` is `None` ("Message storage in database … is out of date … but AutoCreate is None — no migration applied. Run 'resources setup' to provision it"). Fires at most once per store per startup.
- `WolverineRuntime.tryMigrateStorage`: **information** when startup migration is skipped because `AutoBuildMessageStorageOnStartup` is `None`.
- `MartenMessageDatabaseSource` / `PolecatMessageDatabaseSource` (the `// TODO -- add some resiliency here` site): **information** when a newly discovered tenant store skips migration because `AutoCreate` is `None`.

## Provider coverage

`MessageStoreResource` is shared by all stores, so the Setup-side change is uniform. Store-side:

| Store | Overload | Notes |
| --- | --- | --- |
| `MessageDatabase<T>` — Postgres, SqlServer, MySql, Sqlite (incl. Marten/Polecat-built stores) | implemented | the stores that had the bug |
| `MultiTenantedMessageStore` (wraps every `ITenantedMessageSource`: Postgres/SqlServer/MySql/Oracle/Sqlite tenanted stores, Marten, Polecat) | implemented | propagates override to Main + all active tenants |
| `OracleMessageStore` | DIM default | its `MigrateAsync` already always applies `CreateOrUpdate`; never had the bug |
| `RavenDbMessageStore` | DIM default | `MigrateAsync` is a no-op (schemaless) |
| `CosmosDbMessageStore` | DIM default | `MigrateAsync` creates the container unconditionally |
| `NullMessageStore` | DIM default | no-op |

EF Core resource setup goes through `EntityFrameworkCoreSystemPart` / `IResourceCreator`, not `MessageStoreResource`, and is out of scope here.

## Behavior change table

| Path | Per-store AutoCreate | Before | After |
| --- | --- | --- | --- |
| `resources setup` / `SetupResources()` | `None` | silent no-op; `wolverine.*` never created | **storage provisioned** (applied as `CreateOrUpdate`) |
| `resources setup` / `SetupResources()` | `CreateOrUpdate` | applied as `CreateOrUpdate` | unchanged |
| `resources setup` / `SetupResources()` | `CreateOnly` | applied as `CreateOnly` | applied as `CreateOrUpdate` (see note) |
| Host startup, `AutoBuildMessageStorageOnStartup != None` | `None` | silent no-op | no-op + **warning** when schema is out of date |
| Host startup, `AutoBuildMessageStorageOnStartup = None` | any (except `NullMessageStore`, which stays silent) | skipped silently | skipped + **information** log |
| Tenant store discovery (Marten/Polecat) | `None` | skipped silently | skipped + **information** log |
| `Admin.MigrateAsync()` (parameterless) | any | honors configured value | unchanged (plus the warning above when `None` with pending diff) |
| `Admin.RebuildAsync()` | any | honors configured value | unchanged |

Note on the `CreateOnly` row: the explicit setup path now always applies `CreateOrUpdate`. Weasel's own promotion only rewrites `None`, so this is marginally more aggressive for stores configured `CreateOnly`; `CreateOrUpdate` never drops data (that is `CreateOrDrop`/`All`), and "make the resources match configuration" is what `resources setup` advertises. Happy to narrow it to `None`-only if preferred — it would need the configured value surfaced through `IMessageStoreAdmin`, which is why the simpler override won here.

## Tests

`src/Persistence/PostgresqlTests/explicit_resource_setup_with_auto_create_none.cs` (per-store `AutoCreate.None` via `OverrideAutoCreateResources` + `AutoBuildMessageStorageOnStartup = None`):

- `setup_resources_builds_the_message_storage_even_when_auto_create_is_none` — the fixed behavior
- `passive_migration_still_honors_auto_create_none` — parameterless `MigrateAsync()` still creates nothing
- `migration_with_an_auto_create_override_builds_the_message_storage`
- `host_startup_with_auto_build_none_does_not_create_the_message_storage` — startup semantics unchanged

All four pass locally against Postgres, alongside the existing `message_store_initialization_and_configuration` and Sqlite message-store tests.

## Transports are already consistent

The broker transports do not have this gap: `BrokerResource.Setup` provisions endpoints
unconditionally — `AutoProvision` only gates the passive startup path, never an explicit
`resources setup`. Weasel databases and broker transports both treat an explicit Setup as
intent; the message store was the lone outlier this PR aligns.

## Related

- JasperFx/wolverine#2780 / JasperFx/wolverine#2804 — prior work making per-store `OverrideAutoCreateResources` behave (this PR is the same knob's remaining blind spot on the explicit-setup path)
- JasperFx/polecat#267 / JasperFx/polecat#268 — same issue-first pattern for the sibling stack
- JasperFx/wolverine#1602 — same missing-`wolverine_nodes` symptom via the generated-migration (db-patch) path; different mechanism.


