### PR TITLE
Skip the flattened container when describing chain-bound [FromQuery] parameters

### DIFF
--- a/src/Http/Wolverine.Http.Tests.DifferentAssembly/OpenApiShapeEndpoints.cs
+++ b/src/Http/Wolverine.Http.Tests.DifferentAssembly/OpenApiShapeEndpoints.cs
@@ -126,7 +126,7 @@ public static class ComplexQueryStringEndpoint
         => $"{search.Filter}:{search.PageNumber}:{search.PageSize}";
 }
 
-// The flattened members and a GH-3380 query value bound only by a compound handler have to coexist.
+// The flattened members and a second query value bound by a compound handler have to coexist.
 public static class ComplexQueryStringWithCompoundHandlerEndpoint
 {
     public static string Load([FromQuery] string? audit) => audit ?? "none";
@@ -134,6 +134,20 @@ public static class ComplexQueryStringWithCompoundHandlerEndpoint
     [WolverineGet("/shapes/complex-query-compound")]
     public static string Get([FromQuery] OrderSearchQuery search, string audit)
         => $"{search.Filter}:{audit}";
+}
+
+// The container is bound ONLY by the compound handler and never appears in the endpoint signature.
+// Compound handler methods are parameter-matched with the endpoint method, so this flattens the same
+// way — and the container must not be described here either.
+public record OrderSearchResult(string Description);
+
+public static class ComplexQueryStringOnCompoundHandlerEndpoint
+{
+    public static OrderSearchResult Load([FromQuery] OrderSearchQuery search)
+        => new(search.Filter ?? "none");
+
+    [WolverineGet("/shapes/complex-query-on-load")]
+    public static string Get(OrderSearchResult result) => result.Description;
 }
 
 #endregion

--- a/src/Http/Wolverine.Http.Tests.DifferentAssembly/OpenApiShapeEndpoints.cs
+++ b/src/Http/Wolverine.Http.Tests.DifferentAssembly/OpenApiShapeEndpoints.cs
@@ -104,6 +104,40 @@ public static class UnboundRouteValueEndpoint
 
 #endregion
 
+#region [FromQuery] complex type shapes
+
+// A [FromQuery] complex type is flattened into one query parameter per member. The container itself has
+// no wire representation, so it must not also be declared as a parameter of its own.
+public class OrderSearchQuery
+{
+    [FromQuery(Name = "filter")]
+    public string? Filter { get; set; }
+
+    [FromQuery(Name = "pageNumber")]
+    public int PageNumber { get; set; } = 1;
+
+    public int PageSize { get; set; } = 50;
+}
+
+public static class ComplexQueryStringEndpoint
+{
+    [WolverineGet("/shapes/complex-query")]
+    public static string Get([FromQuery] OrderSearchQuery search)
+        => $"{search.Filter}:{search.PageNumber}:{search.PageSize}";
+}
+
+// The flattened members and a GH-3380 query value bound only by a compound handler have to coexist.
+public static class ComplexQueryStringWithCompoundHandlerEndpoint
+{
+    public static string Load([FromQuery] string? audit) => audit ?? "none";
+
+    [WolverineGet("/shapes/complex-query-compound")]
+    public static string Get([FromQuery] OrderSearchQuery search, string audit)
+        => $"{search.Filter}:{audit}";
+}
+
+#endregion
+
 #region [AsParameters] shapes
 
 public record OrderLineQuery([FromRoute] long OrderId, [FromQuery] string? Filter);

--- a/src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs
@@ -190,6 +190,19 @@ public class openapi_shape_tests : IClassFixture<OpenApiShapeFixture>
     }
 
     [Fact]
+    public void complex_query_string_type_bound_only_by_a_compound_handler()
+    {
+        ParametersFor("/shapes/complex-query-on-load", "get")
+            .ShouldBe([
+                new ParameterShape("filter", "query", false, "string", null),
+                new ParameterShape("pageNumber", "query", false, "integer", "int32"),
+                new ParameterShape("PageSize", "query", false, "integer", "int32")
+            ]);
+
+        SchemaNames().ShouldNotContain(nameof(OrderSearchQuery));
+    }
+
+    [Fact]
     public void as_parameters_route_and_query_members()
     {
         ParametersFor("/shapes/asparameters/orders/{orderId}", "get")

--- a/src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs
@@ -164,6 +164,32 @@ public class openapi_shape_tests : IClassFixture<OpenApiShapeFixture>
     }
 
     [Fact]
+    public void complex_query_string_type_is_declared_only_through_its_flattened_members()
+    {
+        ParametersFor("/shapes/complex-query", "get")
+            .ShouldBe([
+                new ParameterShape("filter", "query", false, "string", null),
+                new ParameterShape("pageNumber", "query", false, "integer", "int32"),
+                new ParameterShape("PageSize", "query", false, "integer", "int32")
+            ]);
+
+        // The container has no wire representation, so it has no business in components/schemas either
+        SchemaNames().ShouldNotContain(nameof(OrderSearchQuery));
+    }
+
+    [Fact]
+    public void complex_query_string_type_alongside_a_compound_handler_query_value()
+    {
+        ParametersFor("/shapes/complex-query-compound", "get")
+            .ShouldBe([
+                new ParameterShape("filter", "query", false, "string", null),
+                new ParameterShape("pageNumber", "query", false, "integer", "int32"),
+                new ParameterShape("PageSize", "query", false, "integer", "int32"),
+                new ParameterShape("audit", "query", false, "string", null)
+            ]);
+    }
+
+    [Fact]
     public void as_parameters_route_and_query_members()
     {
         ParametersFor("/shapes/asparameters/orders/{orderId}", "get")
@@ -287,6 +313,22 @@ public class openapi_shape_tests : IClassFixture<OpenApiShapeFixture>
         return schema.TryGetProperty("properties", out var properties)
             ? properties.EnumerateObject().Select(x => x.Name).ToList()
             : [];
+    }
+
+    /// <summary>
+    /// Every type name registered under <c>components/schemas</c> in the rendered document.
+    /// </summary>
+    public IReadOnlyList<string> SchemaNames()
+    {
+        var root = _fixture.Document.RootElement;
+
+        if (!root.TryGetProperty("components", out var components) ||
+            !components.TryGetProperty("schemas", out var schemas))
+        {
+            return [];
+        }
+
+        return schemas.EnumerateObject().Select(x => x.Name).ToList();
     }
 
     private JsonElement resolveSchema(JsonElement schema)

--- a/src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
@@ -20,18 +20,30 @@ internal class FromQueryAttributeUsage : IParameterStrategy
             return false;
         }
 
-        if (parameter.ParameterType.IsSimple()) return false;
-        if (parameter.ParameterType.IsNullable() && parameter.ParameterType.GetInnerTypeFromNullable().IsSimple()) return false;
-        if (parameter.ParameterType.IsTypeOrNullableOf<DateTime>()) return false;
-        if (parameter.ParameterType.IsTypeOrNullableOf<DateTimeOffset>()) return false;
-        if (parameter.ParameterType.IsTypeOrNullableOf<DateOnly>()) return false;
-        if (parameter.ParameterType.IsTypeOrNullableOf<TimeOnly>()) return false;
-        if (parameter.ParameterType.IsTypeOrNullableOf<TimeSpan>()) return false;
-        if (parameter.ParameterType.IsTypeOrNullableOf<Guid>()) return false;
+        if (!IsComplexQueryStringType(parameter.ParameterType)) return false;
 
         chain.ComplexQueryStringType = parameter.ParameterType;
 
         variable = new QueryStringBindingFrame(parameter.ParameterType, chain).Variable;
+        return true;
+    }
+
+    /// <summary>
+    /// Is a [FromQuery] parameter of this type bound by flattening it into one query string value per
+    /// member, rather than being read from a single query string key? Simple values (including the date,
+    /// time and Guid types that read as a single value) bind directly.
+    /// </summary>
+    internal static bool IsComplexQueryStringType(Type parameterType)
+    {
+        if (parameterType.IsSimple()) return false;
+        if (parameterType.IsNullable() && parameterType.GetInnerTypeFromNullable().IsSimple()) return false;
+        if (parameterType.IsTypeOrNullableOf<DateTime>()) return false;
+        if (parameterType.IsTypeOrNullableOf<DateTimeOffset>()) return false;
+        if (parameterType.IsTypeOrNullableOf<DateOnly>()) return false;
+        if (parameterType.IsTypeOrNullableOf<TimeOnly>()) return false;
+        if (parameterType.IsTypeOrNullableOf<TimeSpan>()) return false;
+        if (parameterType.IsTypeOrNullableOf<Guid>()) return false;
+
         return true;
     }
 }

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -627,6 +627,15 @@ public partial class HttpChain
             {
                 if (parameter.TryGetAttribute<FromQueryAttribute>(out var fromQuery))
                 {
+                    // A complex [FromQuery] type is bound by flattening it into one query string value per
+                    // member, all of them already declared by fillQuerystringParameters. The container
+                    // itself never appears on the wire, so describing it would add a phantom query
+                    // parameter — and drag the type into components/schemas. See GH-3575.
+                    if (CodeGen.FromQueryAttributeUsage.IsComplexQueryStringType(parameter.ParameterType))
+                    {
+                        continue;
+                    }
+
                     var name = fromQuery.Name.IsNotEmpty() ? fromQuery.Name! : parameter.Name!;
                     addChainBoundParameter(apiDescription, name, parameter.ParameterType, BindingSource.Query);
                 }


### PR DESCRIPTION
Fixes #3575.

## What changed

`fillChainBoundParameters` now skips a `[FromQuery]` parameter whose type Wolverine binds by
flattening into per-member query string values. Those members are already described by
`fillQuerystringParameters`; the container never appears on the wire, so the extra whole-object
parameter was a phantom, and it pulled the container type into `components/schemas`.

`FromQueryAttributeUsage.TryMatch` already owns the simple-vs-complex distinction that decides
whether a `[FromQuery]` type gets flattened — it rejects simple types,
`DateTime`/`DateTimeOffset`/`DateOnly`/`TimeOnly`/`TimeSpan`/`Guid` and their nullable forms. That
predicate moved into `FromQueryAttributeUsage.IsComplexQueryStringType(Type)` so the binding side and
the description side read one definition. `TryMatch` behavior is unchanged.

Scoped to the `[FromQuery]` branch — `[FromHeader]` doesn't have the same gap, since headers are
never flattened and the header variable is named after the header key, so the existing dedupe guard
already matches.

## The postprocessor shape

One shape changes beyond the endpoint-method case in the issue, and it's worth being explicit about.

Compound handler `After` postprocessors are inserted into `Postprocessors` without parameter matching
(`Chain.cs:350-357` — note `OnException` and `Finally` immediately below both call
`ApplyParameterMatching`, and `After` doesn't). So a complex `[FromQuery]` on an `After` is never run
through `FromQueryAttributeUsage`, never gets a `QueryStringBindingFrame`, and is resolved by ordinary
variable resolution instead. It never reads the query string at all.

Today that shape renders *only* the composite. After this change it renders nothing for that
parameter — which is the accurate description, since no query string input is read. It's the same fix
applied to a second shape, not a regression: the composite documented a wire parameter the server
never looks at.

## Alternatives considered

- **`parameter.ParameterType == ComplexQueryStringType`.** Equivalent for the endpoint-method and
  compound-handler shapes, since both are matched in the `HttpChain` constructor and the field is set.
  Passed over because `ComplexQueryStringType` is single-valued (last write wins when a chain binds
  more than one container) and is never set for the postprocessor shape above, leaving that composite
  in place.
- **Excluding `Method` from `allMethodCalls()`.** Closest to #3380's intent, but it only fixes the
  endpoint-method case: a complex `[FromQuery]` on a compound handler's `Load` lives in `Middleware`,
  goes through the same strategy, and would still get the phantom entry.
  `complex_query_string_type_bound_only_by_a_compound_handler` pins exactly that.

## Tests

Three shapes added to the `openapi_shape_tests` harness, which renders the real
Microsoft.AspNetCore.OpenApi document:

- `/shapes/complex-query` — the flattened members only, and no `OrderSearchQuery` in
  `components/schemas`.
- `/shapes/complex-query-compound` — the same alongside a second query value bound by a compound
  handler.
- `/shapes/complex-query-on-load` — the container bound *only* by a compound handler `Load` and absent
  from the endpoint signature.

All three fail without the guard and pass with it (verified by reverting the hunk). Full
`Wolverine.Http.Tests` (873) and `Wolverine.Http.AspVersioning.Tests` (66) are green, and
`wolverine.slnx` builds clean in Release.
