### PR TITLE
Stamp the assigned node onto owned event-store daemons (running_on_node, marten#5001)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,9 +44,9 @@
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
     <PackageVersion Include="JasperFx.SourceGenerator" Version="2.33.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
-    <PackageVersion Include="Marten" Version="9.16.1" />
+    <PackageVersion Include="Marten" Version="9.17.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="[5.2.0,6.0.0)" />
+    <PackageVersion Include="Polecat" Version="[5.4.0,6.0.0)" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageVersion Include="Marten.AspNetCore" Version="9.16.1" />
     <PackageVersion Include="Marten.Newtonsoft" Version="9.16.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,13 +36,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.31.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.31.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.31.0" />
+    <PackageVersion Include="JasperFx" Version="2.33.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.33.1" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.33.1" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.31.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.33.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.16.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/src/Testing/CoreTests/Runtime/Agents/event_store_agents_observer_subscriptions.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/event_store_agents_observer_subscriptions.cs
@@ -150,6 +150,27 @@ public class event_store_agents_observer_subscriptions
         (await theAgents.FindDaemonAsync(theDatabaseId)).ShouldBeSameAs(theDaemon);
     }
 
+    [Fact]
+    public async Task stamps_the_assigned_node_number_onto_the_owned_daemon_tracker()
+    {
+        // marten#5001: when this node owns a database's daemon, its assigned node number must ride onto the
+        // tracker so it stamps every published ShardState into the running_on_node telemetry column.
+        theAgents.AssignedNodeNumber = 7;
+
+        await theAgents.FindDaemonAsync(theDatabaseId);
+
+        theTracker.AssignedNodeNumber.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task leaves_the_tracker_node_unset_when_this_node_has_no_assignment()
+    {
+        // Default AssignedNodeNumber == 0 (e.g. before any agent assignment) leaves the tracker alone.
+        await theAgents.FindDaemonAsync(theDatabaseId);
+
+        theTracker.AssignedNodeNumber.ShouldBe(0);
+    }
+
     private class RecordingObserver : IObserver<ShardState>
     {
         private readonly ConcurrentBag<ShardState> _states = [];

--- a/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
+++ b/src/Wolverine/Runtime/Agents/EventStoreAgents.cs
@@ -41,6 +41,16 @@ public class EventStoreAgents : IAsyncDisposable
     public EventStoreIdentity Identity { get; }
 
     /// <summary>
+    /// The node number this Wolverine node runs on (<see cref="DurabilitySettings.AssignedNodeNumber"/>),
+    /// set by <see cref="EventSubscriptionAgentFamily.BuildAgentAsync"/> when this node is assigned an
+    /// agent. Stamped onto each owned daemon's <see cref="ShardStateTracker.AssignedNodeNumber"/> so the
+    /// extended-progression writer can persist <c>running_on_node</c> — this node's daemon only runs the
+    /// agents assigned to this node, so the local node number is the assigned node for every state it
+    /// publishes. Zero (the default) means unset. See marten#5001 / jasperfx#550.
+    /// </summary>
+    public int AssignedNodeNumber { get; set; }
+
+    /// <summary>
     /// How many databases back this event store. The distribution in
     /// <see cref="EventSubscriptionAgentFamily.EvaluateAssignmentsAsync"/> keys off this: a store backed by
     /// multiple databases (static or dynamic) gets database-affine assignment — all of a database's agents
@@ -85,6 +95,7 @@ public class EventStoreAgents : IAsyncDisposable
         // re-subscribed before it's handed back out.
         if (_daemons.TryFind(databaseId, out var daemon) && _observerSubscriptions.TryFind(databaseId, out _))
         {
+            stampAssignedNode(daemon);
             return daemon;
         }
 
@@ -98,6 +109,7 @@ public class EventStoreAgents : IAsyncDisposable
                 _daemons = _daemons.AddOrUpdate(databaseId, daemon);
             }
 
+            stampAssignedNode(daemon);
             subscribeObservers(databaseId, daemon);
         }
         finally
@@ -106,6 +118,17 @@ public class EventStoreAgents : IAsyncDisposable
         }
 
         return daemon;
+    }
+
+    // marten#5001: stamp this node's number onto the daemon's tracker so it rides every published
+    // ShardState into the extended-progression running_on_node column. Idempotent; no-op until this node
+    // has been assigned an agent (AssignedNodeNumber left 0).
+    private void stampAssignedNode(IProjectionDaemon daemon)
+    {
+        if (AssignedNodeNumber != 0)
+        {
+            daemon.Tracker.AssignedNodeNumber = AssignedNodeNumber;
+        }
     }
 
     // Callers must hold _daemonLock.

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
@@ -135,6 +135,10 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
             var databaseId = DatabaseId.Parse(uri.Segments[2].Trim('/'));
             var shardPath = uri.Segments.Skip(3).Join("");
 
+            // marten#5001: this node is being assigned an agent, so tell the store agents which node they
+            // run on; the daemon stamps it onto every published ShardState (running_on_node telemetry).
+            store.AssignedNodeNumber = wolverineRuntime.Options.Durability.AssignedNodeNumber;
+
             return await store.BuildAgentAsync(uri, databaseId, shardPath);
         }
 


### PR DESCRIPTION
The Wolverine-managed-distribution half of [JasperFx/marten#5001](https://github.com/JasperFx/marten/issues/5001) — `running_on_node` stays NULL under managed distribution.

## What

`EventStoreAgents` carries the local `AssignedNodeNumber` and stamps it onto each daemon's `ShardStateTracker` when this node owns the daemon. `EventSubscriptionAgentFamily.BuildAgentAsync` (which has the `IWolverineRuntime`) sets it from `Options.Durability.AssignedNodeNumber` when this node is assigned an agent.

## Why

JasperFx's `ExtendedProgressionWriter` carries `ShardState.AssignedNodeNumber` into the persisted `running_on_node`, but nothing supplied that value on the runtime publish path — Wolverine owns the node assignment. A node's daemon only runs the agents assigned to *it*, so the local node number is the assigned node for every `ShardState` that daemon publishes. JasperFx **2.33.1** ([jasperfx#550](https://github.com/JasperFx/jasperfx/issues/550) / jasperfx#551) added the `ShardStateTracker.AssignedNodeNumber` stamp point this drives; the pin is bumped `2.31.0 → 2.33.1`.

This works for both the Marten and Polecat integrations (the change is in core `EventStoreAgents`, shared by both).

## Tests

`event_store_agents_observer_subscriptions`: stamps the assigned node onto the owned daemon's tracker; leaves it unset (0) when this node has no assignment. Existing subscription-lifecycle tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)