### PR TITLE
Addtional FSharp frame implementations and more http coverage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,13 +36,13 @@
     <PackageVersion Include="Grpc.StatusProto" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="HtmlTags" Version="9.0.0" />
-    <PackageVersion Include="JasperFx" Version="2.31.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.31.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.31.0" />
+    <PackageVersion Include="JasperFx" Version="2.34.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.34.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.34.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.31.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.34.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.16.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/src/Http/Wolverine.Http/CodeGen/JsonHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/JsonHandling.cs
@@ -57,8 +57,10 @@ internal class ReadJsonBody : AsyncFrame
         // `this` self identifier, jasperfx#393) returning (body, continuation). F# has no early
         // `return`, so the abort guard renders the rest of the chain inside its `else` branch.
         var optionalArg = Optional ? ", true" : "";
+        // ReadJsonAsync returns ValueTask<(T?, HandlerContinuation)> — a struct (value) tuple.
+        // F# requires `let! struct (a, b) =` for struct tuple destructuring.
         writer.Write(
-            $"let! ({Variable.Usage}, jsonContinue) = this.{nameof(HttpHandler.ReadJsonAsync)}<{Variable.VariableType.FSharpName()}>(httpContext{optionalArg})");
+            $"let! struct ({Variable.Usage}, jsonContinue) = this.{nameof(HttpHandler.ReadJsonAsync)}<{Variable.VariableType.FSharpName()}>(httpContext{optionalArg})");
 
         var condition = $"jsonContinue = {typeof(HandlerContinuation).FSharpName()}.{nameof(HandlerContinuation.Stop)}";
         FSharpEmitHelpers.WriteAbortGuard(writer, method, condition, Next);

--- a/src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
@@ -115,9 +115,28 @@ internal class QueryStringBindingFrame : SyncFrame
     public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
     {
         writer.WriteComment("Binding QueryString values to the argument marked with [FromQuery]");
-        var arguments = _parameters.Select(x => x.FSharpUsage).Join(", ");
 
-        writer.Write($"{Variable.FSharpAssignmentUsage} = {Variable.VariableType.FSharpName()}({arguments})");
+        string constructionExpr;
+        if (Variable.VariableType.IsFSharpRecord())
+        {
+            // F# records cannot be constructed with positional constructor syntax from F# code.
+            // Build record expression: { Field1 = val1; Field2 = val2; ... }
+            // Constructor parameter names are camelCase; capitalize first letter for the field name.
+            var ctorParams = _constructor.GetParameters();
+            var fields = ctorParams
+                .Zip(_parameters, (p, v) => $"{char.ToUpperInvariant(p.Name![0])}{p.Name[1..]} = {v.FSharpUsage}")
+                .Join("; ");
+            constructionExpr = $"{{ {fields} }}";
+        }
+        else
+        {
+            var arguments = _parameters.Select(x => x.FSharpUsage).Join(", ");
+            constructionExpr = $"{Variable.VariableType.FSharpName()}({arguments})";
+        }
+
+        // F# record type inference can pick the wrong record when field names are ambiguous across
+        // opened namespaces. Emit an explicit type annotation to disambiguate.
+        writer.Write($"let {Variable.Usage} : {Variable.VariableType.FSharpName()} = {constructionExpr}");
 
         foreach (var frame in _props.OfType<Frame>())
         {

--- a/src/Http/Wolverine.Http/HttpEndpointRegistry.cs
+++ b/src/Http/Wolverine.Http/HttpEndpointRegistry.cs
@@ -147,12 +147,14 @@ internal class WriteEndpointTypesFrame : SyncFrame
     {
         if (_types.Length == 0)
         {
-            writer.Write($"System.Array.Empty<{typeof(Type).FSharpName()}>()");
+            writer.Write($"System.Array.Empty<System.Type>()");
         }
         else
         {
-            var literals = string.Join("; ", _types.Select(t => $"typeof<{t.FSharpName()}>"));
-            writer.Write($"[| {literals} |]");
+            // typeof<> in F# cannot resolve F# module types (only class/record/DU types).
+            // Use Type.GetType with the assembly-qualified name — works for both.
+            var quotedNames = string.Join("; ", _types.Select(t => $"\"{t.AssemblyQualifiedName}\""));
+            writer.Write($"[| {quotedNames} |] |> Array.choose (fun n -> System.Type.GetType(n) |> Option.ofObj)");
         }
 
         Next?.GenerateFSharpCode(method, writer);

--- a/src/Persistence/Wolverine.Marten/Codegen/AncillaryOutboxFactoryFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/AncillaryOutboxFactoryFrame.cs
@@ -49,4 +49,10 @@ internal class AncillaryOutboxFactoryFrame : SyncFrame
         writer.Write($"var {Factory!.Usage} = ({typeof(OutboxedSessionFactory).FullNameInCode()}){_outerFactory.Usage};");
         Next?.GenerateCode(method, writer);
     }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write($"let {Factory!.Usage} = {_outerFactory.Usage} :?> {typeof(OutboxedSessionFactory).FullNameInCode()}");
+        Next?.GenerateFSharpCode(method, writer);
+    }
 }

--- a/src/Persistence/Wolverine.Polecat/Codegen/AncillaryOutboxFactoryFrame.cs
+++ b/src/Persistence/Wolverine.Polecat/Codegen/AncillaryOutboxFactoryFrame.cs
@@ -44,4 +44,10 @@ internal class AncillaryOutboxFactoryFrame : SyncFrame
         writer.Write($"var {Factory!.Usage} = ({typeof(OutboxedSessionFactory).FullNameInCode()}){_outerFactory.Usage};");
         Next?.GenerateCode(method, writer);
     }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write($"let {Factory!.Usage} = {_outerFactory.Usage} :?> {typeof(OutboxedSessionFactory).FullNameInCode()}");
+        Next?.GenerateFSharpCode(method, writer);
+    }
 }

--- a/src/Testing/Wolverine.Behavioural.FSharpApp/Generated.fs
+++ b/src/Testing/Wolverine.Behavioural.FSharpApp/Generated.fs
@@ -10,9 +10,9 @@ open Wolverine.Runtime.Handlers
 
 type BehaviouralPingHandler1244766258() =
     inherit Wolverine.Runtime.Handlers.MessageHandler()
-    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+    override this.HandleAsync(_context: Wolverine.Runtime.MessageContext, _cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
         // The actual message body
-        let behaviouralPing = context.Envelope.Message :?> WolverineBehaviouralFSharpApp.BehaviouralPing
+        let behaviouralPing = _context.Envelope.Message :?> WolverineBehaviouralFSharpApp.BehaviouralPing
 
         if not (isNull System.Diagnostics.Activity.Current) then
             System.Diagnostics.Activity.Current.SetTag("message.handler", "WolverineBehaviouralFSharpApp.BehaviouralPingHandler") |> ignore

--- a/src/Testing/Wolverine.Core.FSharpFixture/Generated.fs
+++ b/src/Testing/Wolverine.Core.FSharpFixture/Generated.fs
@@ -14,7 +14,7 @@ type CheckThingHandler649476295(loggerForMessage: Microsoft.Extensions.Logging.I
     inherit Wolverine.Runtime.Handlers.MessageHandler()
     let _loggerForMessage = loggerForMessage
 
-    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, _cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
         // The actual message body
         let checkThing = context.Envelope.Message :?> Wolverine.Core.FSharpContracts.CheckThing
 
@@ -39,7 +39,7 @@ type CreateNameHandler1923366998(loggerForMessage: Microsoft.Extensions.Logging.
     inherit Wolverine.Runtime.Handlers.MessageHandler()
     let _loggerForMessage = loggerForMessage
 
-    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, _cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
         task {
             // The actual message body
             let createName = context.Envelope.Message :?> Wolverine.Core.FSharpContracts.CreateName
@@ -70,7 +70,7 @@ type CreateNameHandler1923366998(loggerForMessage: Microsoft.Extensions.Logging.
 
 type GateHandler1696712162() =
     inherit Wolverine.Runtime.Handlers.MessageHandler()
-    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, _cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
         // The actual message body
         let gate = context.Envelope.Message :?> Wolverine.Core.FSharpContracts.Gate
 
@@ -95,7 +95,7 @@ type IncrementCountHandler540640831(inMemorySagaPersistor: Wolverine.Persistence
     inherit Wolverine.Runtime.Handlers.MessageHandler()
     let _inMemorySagaPersistor = inMemorySagaPersistor
 
-    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, _cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
         // The actual message body
         let incrementCount = context.Envelope.Message :?> Wolverine.Core.FSharpContracts.IncrementCount
 
@@ -106,7 +106,7 @@ type IncrementCountHandler540640831(inMemorySagaPersistor: Wolverine.Persistence
         if System.String.IsNullOrEmpty(sagaId) then
             raise (Wolverine.Persistence.Sagas.IndeterminateSagaStateIdException(context.Envelope))
         let countingSaga = _inMemorySagaPersistor.Load<Wolverine.Core.FSharpContracts.CountingSaga>(sagaId)
-        if isNull countingSaga then
+        if isNull (box countingSaga) then
             raise (Wolverine.Persistence.Sagas.UnknownSagaException(typeof<Wolverine.Core.FSharpContracts.CountingSaga>, sagaId))
         else
             context.SetSagaId(sagaId)
@@ -129,7 +129,7 @@ type StartCountHandler1561563330(inMemorySagaPersistor: Wolverine.Persistence.Sa
     inherit Wolverine.Runtime.Handlers.MessageHandler()
     let _inMemorySagaPersistor = inMemorySagaPersistor
 
-    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, _cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
         // The actual message body
         let startCount = context.Envelope.Message :?> Wolverine.Core.FSharpContracts.StartCount
 
@@ -151,7 +151,7 @@ type StartCountHandler1561563330(inMemorySagaPersistor: Wolverine.Persistence.Sa
 
 type TickHandler1778389912() =
     inherit Wolverine.Runtime.Handlers.MessageHandler()
-    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
+    override this.HandleAsync(context: Wolverine.Runtime.MessageContext, _cancellation: System.Threading.CancellationToken) : System.Threading.Tasks.Task =
         // The actual message body
         let tick = context.Envelope.Message :?> Wolverine.Core.FSharpContracts.Tick
 

--- a/src/Testing/Wolverine.Cosmos.FSharpFixture/Generated.fs
+++ b/src/Testing/Wolverine.Cosmos.FSharpFixture/Generated.fs
@@ -31,14 +31,11 @@ type ContinueThingHandler603355368(container: Microsoft.Azure.Cosmos.Container) 
 
             // Try to load the existing saga document from CosmosDB
             let mutable thingSaga = Unchecked.defaultof<WolverineCosmosFSharpSample.ThingSaga>
-            // Capture the ETag so the eventual write can be a compare-and-swap against this exact revision
-            let mutable thingSaga_Etag : string = null
             try
                 let! _cosmosResponse = _container.ReadItemAsync<WolverineCosmosFSharpSample.ThingSaga>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, cancellationToken = cancellation)
                 thingSaga <- _cosmosResponse.Resource
-                thingSaga_Etag <- _cosmosResponse.ETag
             with :? Microsoft.Azure.Cosmos.CosmosException as e when e.StatusCode = System.Net.HttpStatusCode.NotFound ->
-                ()
+                thingSaga <- Unchecked.defaultof<WolverineCosmosFSharpSample.ThingSaga>
             if isNull thingSaga then
                 raise (Wolverine.Persistence.Sagas.UnknownSagaException(typeof<WolverineCosmosFSharpSample.ThingSaga>, sagaId))
             else
@@ -52,19 +49,11 @@ type ContinueThingHandler603355368(container: Microsoft.Azure.Cosmos.Container) 
 
                 // Delete the saga if completed, otherwise update it
                 if thingSaga.IsCompleted() then
-                    try
-                        let! _ = _container.DeleteItemAsync<WolverineCosmosFSharpSample.ThingSaga>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None, requestOptions = Microsoft.Azure.Cosmos.ItemRequestOptions(IfMatchEtag = thingSaga_Etag))
-                        ()
-                    with :? Microsoft.Azure.Cosmos.CosmosException as e when e.StatusCode = System.Net.HttpStatusCode.PreconditionFailed ->
-                        // The saga document was changed by another message since it was read
-                        raise (Wolverine.SagaConcurrencyException(sprintf "Saga of type WolverineCosmosFSharpSample.ThingSaga and id %O cannot be updated because of optimistic concurrency violations" sagaId, e))
+                    let! _ = _container.DeleteItemAsync<WolverineCosmosFSharpSample.ThingSaga>(sagaId, Microsoft.Azure.Cosmos.PartitionKey.None)
+                    ()
                 else
-                    try
-                        let! _ = _container.UpsertItemAsync(thingSaga, requestOptions = Microsoft.Azure.Cosmos.ItemRequestOptions(IfMatchEtag = thingSaga_Etag))
-                        ()
-                    with :? Microsoft.Azure.Cosmos.CosmosException as e when e.StatusCode = System.Net.HttpStatusCode.PreconditionFailed ->
-                        // The saga document was changed by another message since it was read
-                        raise (Wolverine.SagaConcurrencyException(sprintf "Saga of type WolverineCosmosFSharpSample.ThingSaga and id %O cannot be updated because of optimistic concurrency violations" sagaId, e))
+                    let! _ = _container.UpsertItemAsync(thingSaga)
+                    ()
                 
                 // Have to flush outgoing messages just in case Marten did nothing because of https://github.com/JasperFx/wolverine/issues/536
                 do! context.FlushOutgoingMessagesAsync()

--- a/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
+++ b/src/Testing/Wolverine.Http.FSharpFixture/Generated.fs
@@ -41,7 +41,7 @@ type POST_fsharp_things(wolverineHttpOptions: Wolverine.Http.WolverineHttpOption
             let! tenantId = this.TryDetectTenantId(httpContext)
             if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
             // Reading the request body via JSON deserialization
-            let! (command, jsonContinue) = this.ReadJsonAsync<Wolverine.Http.FSharpContracts.CreateThing>(httpContext)
+            let! struct (command, jsonContinue) = this.ReadJsonAsync<Wolverine.Http.FSharpContracts.CreateThing>(httpContext)
             if jsonContinue = Wolverine.HandlerContinuation.Stop then
                 ()
             else
@@ -218,7 +218,7 @@ type POST_fsharp_publish(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptio
             messageContext.TenantId <- tenantId
             if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
             // Reading the request body via JSON deserialization
-            let! (command, jsonContinue) = this.ReadJsonAsync<Wolverine.Http.FSharpContracts.CreateThing>(httpContext)
+            let! struct (command, jsonContinue) = this.ReadJsonAsync<Wolverine.Http.FSharpContracts.CreateThing>(httpContext)
             if jsonContinue = Wolverine.HandlerContinuation.Stop then
                 ()
             else
@@ -250,7 +250,7 @@ type GET_fsharp_filter(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions
             let! tenantId = this.TryDetectTenantId(httpContext)
             if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.SetTag("handler.type", "Wolverine.Http.FSharpContracts.ThingEndpoints") |> ignore
             // Binding QueryString values to the argument marked with [FromQuery]
-            let thingFilter = Wolverine.Http.FSharpContracts.ThingFilter(Name, MaxResults)
+            let thingFilter : Wolverine.Http.FSharpContracts.ThingFilter = Wolverine.Http.FSharpContracts.ThingFilter(Name, MaxResults)
             let thingEndpoints = Wolverine.Http.FSharpContracts.ThingEndpoints()
             
             // The actual HTTP request handler execution
@@ -288,5 +288,5 @@ type GET_fsharp_authed(wolverineHttpOptions: Wolverine.Http.WolverineHttpOptions
 type GeneratedHttpEndpointRegistry() =
     inherit Wolverine.Http.HttpEndpointRegistry()
     override this.EndpointTypes() : System.Type[] =
-        [| typeof<Wolverine.Http.FSharpContracts.AuthedEndpoints>; typeof<Wolverine.Http.FSharpContracts.ThingEndpoints> |]
+        [| "Wolverine.Http.FSharpContracts.AuthedEndpoints, Wolverine.Http.FSharpContracts, Version=6.22.0.0, Culture=neutral, PublicKeyToken=null"; "Wolverine.Http.FSharpContracts.ThingEndpoints, Wolverine.Http.FSharpContracts, Version=6.22.0.0, Culture=neutral, PublicKeyToken=null" |] |> Array.choose (fun n -> System.Type.GetType(n) |> Option.ofObj)
 

--- a/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpFrameTests.cs
+++ b/src/Testing/Wolverine.Http.FSharpTests/HttpFSharpFrameTests.cs
@@ -1,0 +1,47 @@
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Http.FSharpTests;
+
+/// <summary>
+///     Unit-level checks on the F# code emitted by specific Wolverine.Http frames,
+///     complementing the compile gate that proves the full output builds. Each test calls
+///     <see cref="HttpFSharpCodegenSample.GenerateCode" /> (cached via a static lazy) and
+///     asserts on the presence or absence of specific F# patterns.
+/// </summary>
+public class HttpFSharpFrameTests
+{
+    private static readonly Lazy<string> _code =
+        new(HttpFSharpCodegenSample.GenerateCode, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private string Code => _code.Value;
+
+    [Fact]
+    public void read_json_body_emits_struct_tuple_destructuring()
+    {
+        // ReadJsonAsync<T> returns ValueTask<(T?, HandlerContinuation)> — a VALUE (struct) tuple.
+        // F# requires `let! struct (a, b) = expr` for struct tuple destructuring; the reference
+        // tuple form `let! (a, b) = expr` causes FS0001 at compile time.
+        Code.ShouldContain("let! struct (");
+        Code.ShouldNotContain("let! (command, jsonContinue)");
+    }
+
+    [Fact]
+    public void write_endpoint_types_uses_runtime_type_resolution()
+    {
+        // typeof<> in F# cannot resolve F# module types (only class/record/DU types).
+        // WriteEndpointTypesFrame.GenerateFSharpCode() uses Type.GetType(assemblyQualifiedName)
+        // so F# module types defined in application assemblies resolve correctly.
+        Code.ShouldContain("Array.choose (fun n -> System.Type.GetType(n)");
+    }
+
+    [Fact]
+    public void query_string_binding_emits_explicit_type_annotation()
+    {
+        // Without a type annotation, F# type inference can pick an unintended record type when
+        // field names are ambiguous across opened namespaces (e.g. Platform.Core.SqlBroadcast vs
+        // an endpoint-local InboxQueryRequest both having Skip/Take fields). QueryStringBindingFrame
+        // now emits `let var : FullType = { ... }` to pin the inferred type unambiguously.
+        Code.ShouldContain("let thingFilter : Wolverine.Http.FSharpContracts.ThingFilter =");
+    }
+}

--- a/src/Wolverine/Runtime/Handlers/HandlerRegistry.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerRegistry.cs
@@ -133,8 +133,11 @@ internal class WriteTypeArrayFrame : SyncFrame
     }
 
     // F# counterpart so `codegen write --language fsharp` can emit the static HandlerRegistry.
-    // typeof<> in F# cannot resolve F# module types (only class/record/DU types), so we use
-    // Type.GetType with the assembly-qualified name which resolves both modules and classes.
+    //
+    // F# modules compile to sealed abstract classes but F# syntax forbids using them as typeof<>
+    // type arguments (SourceConstructFlags.Module = 7).  For those we fall back to the runtime
+    // Type.GetType path.  Plain F# classes / C# types use the compile-time typeof<T> form, which
+    // the CodegenWriteFSharpCli tests assert is present for class-based handlers.
     public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
     {
         if (_types.Length == 0)
@@ -143,10 +146,22 @@ internal class WriteTypeArrayFrame : SyncFrame
         }
         else
         {
-            var quotedNames = string.Join("; ", _types.Select(t => $"\"{t.AssemblyQualifiedName}\""));
-            writer.Write($"[| {quotedNames} |] |> Array.choose (fun n -> System.Type.GetType(n) |> Option.ofObj)");
+            var parts = _types.Select(t => IsFSharpModule(t)
+                ? $"(System.Type.GetType(\"{t.AssemblyQualifiedName}\") |> Option.ofObj)"
+                : $"(Some typeof<{t.FullNameInCode()}>)");
+            writer.Write($"[| {string.Join("; ", parts)} |] |> Array.choose id");
         }
 
         Next?.GenerateFSharpCode(method, writer);
+    }
+
+    private static bool IsFSharpModule(Type t)
+    {
+        // F# modules compile to abstract sealed classes (the .NET "static class" pattern).
+        // F# classes/records are concrete (not abstract+sealed), so this check reliably
+        // separates modules (which cannot appear as typeof<> type arguments in F# syntax)
+        // from classes that can.  C# static classes are also abstract+sealed but handler
+        // types are concrete instances, so there is no false-positive concern in practice.
+        return t.IsAbstract && t.IsSealed;
     }
 }

--- a/src/Wolverine/Runtime/Handlers/HandlerRegistry.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerRegistry.cs
@@ -132,9 +132,9 @@ internal class WriteTypeArrayFrame : SyncFrame
         Next?.GenerateCode(method, writer);
     }
 
-    // F# counterpart so `codegen write --language fsharp` can emit the static HandlerRegistry. F#
-    // method bodies are expressions (no `return`/`;`): an empty array, or an F# array literal of
-    // typeof<...> values.
+    // F# counterpart so `codegen write --language fsharp` can emit the static HandlerRegistry.
+    // typeof<> in F# cannot resolve F# module types (only class/record/DU types), so we use
+    // Type.GetType with the assembly-qualified name which resolves both modules and classes.
     public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
     {
         if (_types.Length == 0)
@@ -143,8 +143,8 @@ internal class WriteTypeArrayFrame : SyncFrame
         }
         else
         {
-            var literals = string.Join("; ", _types.Select(t => $"typeof<{t.FSharpName()}>"));
-            writer.Write($"[| {literals} |]");
+            var quotedNames = string.Join("; ", _types.Select(t => $"\"{t.AssemblyQualifiedName}\""));
+            writer.Write($"[| {quotedNames} |] |> Array.choose (fun n -> System.Type.GetType(n) |> Option.ofObj)");
         }
 
         Next?.GenerateFSharpCode(method, writer);

--- a/src/Wolverine/Runtime/Handlers/MessageFrame.cs
+++ b/src/Wolverine/Runtime/Handlers/MessageFrame.cs
@@ -32,8 +32,23 @@ internal class MessageFrame : Frame
         // downcast (`:?>`): `let message = envelope.Message :?> SomeMessage`.
         writer.WriteComment("The actual message body");
         var binding = _message.IsReferenced ? _message.FSharpAssignmentUsage : $"let _{_message.Usage}";
+
+        // _envelope.Usage may be a derived path like "context.Envelope". When any method argument
+        // that forms the root of this path is unreferenced, WriteFSharpMethod will have prefixed it
+        // with `_` (e.g. "context" → "_context"). Adjust the envelope expression to match so the
+        // emitted body refers to the same identifier as the parameter declaration.
+        var envelopeExpr = _envelope.FSharpUsage;
+        foreach (var arg in method.Arguments)
+        {
+            if (!arg.IsReferenced && envelopeExpr.StartsWith(arg.Usage + "."))
+            {
+                envelopeExpr = "_" + arg.Usage + envelopeExpr.Substring(arg.Usage.Length);
+                break;
+            }
+        }
+
         writer.Write(
-            $"{binding} = {_envelope.Usage}.{nameof(Envelope.Message)} :?> {_message.VariableType.FSharpName()}");
+            $"{binding} = {envelopeExpr}.{nameof(Envelope.Message)} :?> {_message.VariableType.FSharpName()}");
         writer.BlankLine();
         Next?.GenerateFSharpCode(method, writer);
     }

--- a/src/Wolverine/Runtime/Handlers/MessageFrame.cs
+++ b/src/Wolverine/Runtime/Handlers/MessageFrame.cs
@@ -30,8 +30,9 @@ internal class MessageFrame : Frame
         // F#: `envelope.Message` is `obj`, so the cast to the concrete message type is a dynamic
         // downcast (`:?>`): `let message = envelope.Message :?> SomeMessage`.
         writer.WriteComment("The actual message body");
+        var binding = _message.IsReferenced ? _message.FSharpAssignmentUsage : $"let _{_message.Usage}";
         writer.Write(
-            $"{_message.FSharpAssignmentUsage} = {_envelope.Usage}.{nameof(Envelope.Message)} :?> {_message.VariableType.FSharpName()}");
+            $"{binding} = {_envelope.Usage}.{nameof(Envelope.Message)} :?> {_message.VariableType.FSharpName()}");
         writer.BlankLine();
         Next?.GenerateFSharpCode(method, writer);
     }

--- a/src/Wolverine/Runtime/Handlers/MessageFrame.cs
+++ b/src/Wolverine/Runtime/Handlers/MessageFrame.cs
@@ -14,6 +14,7 @@ internal class MessageFrame : Frame
     {
         _message = message;
         _envelope = envelope;
+        uses.Add(envelope);
     }
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)

--- a/src/Wolverine/Runtime/RecordEndpointCausationFrame.cs
+++ b/src/Wolverine/Runtime/RecordEndpointCausationFrame.cs
@@ -37,4 +37,12 @@ public class RecordEndpointCausationFrame : Frame
             $"{_context!.Usage}, {_context!.Usage}.Runtime.Observer, \"{_endpointOrigin}\", \"{_handlerType}\");");
         Next?.GenerateCode(method, writer);
     }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write(
+            $"{typeof(EndpointCausation).FullName}.{nameof(EndpointCausation.RecordEndpointCauseAndEffect)}(" +
+            $"{_context!.Usage}, {_context!.Usage}.Runtime.Observer, \"{_endpointOrigin}\", \"{_handlerType}\") |> ignore");
+        Next?.GenerateFSharpCode(method, writer);
+    }
 }


### PR DESCRIPTION
808d5ed — feat: GenerateFSharpCode overrides for unimplemented frames
src/Wolverine/Runtime/RecordEndpointCausationFrame.cs
src/Persistence/Wolverine.Marten/Codegen/AncillaryOutboxFactoryFrame.cs
src/Persistence/Wolverine.Polecat/Codegen/AncillaryOutboxFactoryFrame.cs
- Missing GenerateFSharpCode() overrides; without these the static codegen path fell through to C# emission
- Marten/Polecat use :?> downcast; RecordEndpointCausation uses |> ignore for unit return

4b371cd — feat: struct-tuple destructuring and type annotation in HTTP frame codegen
src/Http/Wolverine.Http/CodeGen/JsonHandling.cs
src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
- ReadJsonBody: let! struct (a, b) = (value tuple requires struct keyword)
- QueryStringBindingFrame: explicit let var : FullType = annotation to prevent F# from inferring wrong record type when field names are ambiguous across opened namespaces; also handles F# records via record-expression syntax

aa34f1d — feat: use Type.GetType for F# module type resolution in registry frames
src/Http/Wolverine.Http/HttpEndpointRegistry.cs
src/Wolverine/Runtime/Handlers/HandlerRegistry.cs
- typeof<> in F# cannot resolve F# module types; replace with Type.GetType(assemblyQualifiedName) |> Option.ofObj via Array.choose

8033f87 — test: F# codegen assertion tests for Wolverine HTTP frames
src/Testing/Wolverine.Http.FSharpTests/HttpFSharpFrameTests.cs  ← new file
src/Testing/Wolverine.Http.FSharpFixture/Generated.fs           ← regenerated
- 3 tests asserting struct-tuple pattern, runtime type resolution, and explicit type annotation in generated output