### PR TITLE
Add runtime.AllLocallyOwnedDatabasesAsync(store) — first-class node-local database filter (#3584)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/all_locally_owned_databases.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/all_locally_owned_databases.cs
@@ -1,0 +1,186 @@
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Descriptors;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Coverage for <see cref="EventStoreOwnershipExtensions.AllLocallyOwnedDatabasesAsync" /> — the
+/// first-class "which databases does THIS node own" filter over <see cref="IEventStore.AllDatabases" />.
+/// Recurring per-node work against a multi-database store (progress queries, telemetry polls, readiness
+/// gates) must scope to the databases whose event-subscription agents run locally instead of fanning a
+/// connection pool out to every shard database from every node (GH-3340, CritterWatch#791).
+/// </summary>
+public class all_locally_owned_databases
+{
+    private static readonly EventStoreIdentity TheIdentity = new("main", "marten");
+    private static readonly EventStoreIdentity OtherIdentity = new("other", "marten");
+
+    private readonly IWolverineRuntime _runtime = Substitute.For<IWolverineRuntime>();
+    private readonly IAgentRuntime _agents = Substitute.For<IAgentRuntime>();
+    private readonly IEventStore _store = Substitute.For<IEventStore>();
+    private readonly WolverineOptions _options = new();
+
+    public all_locally_owned_databases()
+    {
+        _options.Durability.Mode = DurabilityMode.Balanced;
+        _runtime.Options.Returns(_options);
+        _runtime.Agents.Returns(_agents);
+        _store.Identity.Returns(TheIdentity);
+
+        withFamilyRegistered(true);
+    }
+
+    private void withFamilyRegistered(bool registered)
+    {
+        var services = new ServiceCollection();
+        if (registered)
+        {
+            services.AddSingleton(Substitute.For<IEventSubscriptionAgentFamily>());
+        }
+
+        _runtime.Services.Returns(services.BuildServiceProvider());
+    }
+
+    private static IEventDatabase database(string identifier)
+    {
+        var db = Substitute.For<IEventDatabase>();
+        db.Identifier.Returns(identifier);
+        return db;
+    }
+
+    private void storeHasDatabases(params IEventDatabase[] databases)
+    {
+        _store.AllDatabases().Returns(new ValueTask<IReadOnlyList<IEventDatabase>>(databases));
+    }
+
+    private void storeUsageDescribes(params (string Server, string Database, string Identifier)[] descriptors)
+    {
+        var usage = new EventStoreUsage(new Uri("eventstore://main"), _store)
+        {
+            Database = new DatabaseUsage
+            {
+                Cardinality = DatabaseCardinality.StaticMultiple,
+                Databases = descriptors.Select(d => new DatabaseDescriptor
+                {
+                    ServerName = d.Server, DatabaseName = d.Database, Identifier = d.Identifier
+                }).ToList()
+            }
+        };
+
+        _store.TryCreateUsage(Arg.Any<CancellationToken>()).Returns(usage);
+    }
+
+    private void nodeRunsAgentsFor(EventStoreIdentity identity, params (string Server, string Database)[] ids)
+    {
+        var uris = ids
+            .Select(id => EventSubscriptionAgentFamily.UriFor(
+                identity, new DatabaseId(id.Server, id.Database), new ShardName("Trip")))
+            .ToArray();
+
+        _agents.AllRunningAgentUris().Returns(uris);
+    }
+
+    [Fact]
+    public async Task a_single_database_store_is_returned_as_is()
+    {
+        var only = database("main");
+        storeHasDatabases(only);
+
+        var owned = await _runtime.AllLocallyOwnedDatabasesAsync(_store);
+
+        owned.ShouldBe([only]);
+    }
+
+    [Fact]
+    public async Task solo_mode_owns_every_database()
+    {
+        // Solo runs the daemon in-process rather than as managed agents, so the running-agent set
+        // carries no ownership signal — and the one node owns everything anyway
+        _options.Durability.Mode = DurabilityMode.Solo;
+        storeHasDatabases(database("shard1"), database("shard2"));
+
+        var owned = await _runtime.AllLocallyOwnedDatabasesAsync(_store);
+
+        owned.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task without_managed_distribution_every_database_is_returned()
+    {
+        // No IEventSubscriptionAgentFamily registered: ownership does not exist as a concept
+        withFamilyRegistered(false);
+        storeHasDatabases(database("shard1"), database("shard2"));
+
+        var owned = await _runtime.AllLocallyOwnedDatabasesAsync(_store);
+
+        owned.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task filters_to_the_databases_whose_agents_run_on_this_node()
+    {
+        var shard1 = database("shard1");
+        var shard2 = database("shard2");
+        var shard3 = database("shard3");
+        storeHasDatabases(shard1, shard2, shard3);
+        storeUsageDescribes(
+            ("pg1", "db_shard1", "shard1"),
+            ("pg1", "db_shard2", "shard2"),
+            ("pg2", "db_shard3", "shard3"));
+
+        nodeRunsAgentsFor(TheIdentity, ("pg1", "db_shard1"), ("pg2", "db_shard3"));
+
+        var owned = await _runtime.AllLocallyOwnedDatabasesAsync(_store);
+
+        owned.ShouldBe([shard1, shard3]);
+    }
+
+    [Fact]
+    public async Task agents_of_another_store_do_not_count_as_ownership()
+    {
+        storeHasDatabases(database("shard1"), database("shard2"));
+        storeUsageDescribes(("pg1", "db_shard1", "shard1"), ("pg1", "db_shard2", "shard2"));
+
+        // This node runs agents for the same databases, but registered under a DIFFERENT store
+        nodeRunsAgentsFor(OtherIdentity, ("pg1", "db_shard1"), ("pg1", "db_shard2"));
+
+        var owned = await _runtime.AllLocallyOwnedDatabasesAsync(_store);
+
+        owned.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_node_that_owns_nothing_yet_gets_an_empty_list()
+    {
+        // Distribution is on but this node has no assignments (startup, or a rebalance in flight):
+        // empty is the honest answer, so a readiness gate can wait instead of latching early
+        storeHasDatabases(database("shard1"), database("shard2"));
+        _agents.AllRunningAgentUris().Returns([]);
+
+        var owned = await _runtime.AllLocallyOwnedDatabasesAsync(_store);
+
+        owned.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task fails_open_when_the_store_yields_no_usage_descriptor()
+    {
+        storeHasDatabases(database("shard1"), database("shard2"));
+        nodeRunsAgentsFor(TheIdentity, ("pg1", "db_shard1"));
+        _store.TryCreateUsage(Arg.Any<CancellationToken>()).Returns(Task.FromResult<EventStoreUsage?>(null));
+
+        // Owned ids exist but cannot be mapped to databases: better every database than silently none
+        var owned = await _runtime.AllLocallyOwnedDatabasesAsync(_store);
+
+        owned.Count.ShouldBe(2);
+    }
+}

--- a/src/Wolverine/Runtime/Agents/EventStoreOwnershipExtensions.cs
+++ b/src/Wolverine/Runtime/Agents/EventStoreOwnershipExtensions.cs
@@ -1,0 +1,110 @@
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Wolverine.Runtime.Agents;
+
+public static class EventStoreOwnershipExtensions
+{
+    /// <summary>
+    /// The subset of <see cref="IEventStore.AllDatabases" /> whose event-subscription / projection agents
+    /// are currently assigned to and running on THIS node under Wolverine-managed event subscription
+    /// distribution (<c>UseWolverineManagedEventSubscriptionDistribution = true</c>).
+    ///
+    /// <para>
+    /// Use this instead of <see cref="IEventStore.AllDatabases" /> for any recurring per-node work against a
+    /// multi-database store — progress queries, telemetry polls, readiness gates, sweeps. Under database-affine
+    /// agent assignment a node already holds open connection pools for exactly the databases it owns; scoping
+    /// per-node work to those databases reuses them, while fanning out to every database opens a fresh pool per
+    /// database per node (512 shard databases × N pods was enough to drive a shared database server to its
+    /// connection ceiling — GH-3340, CritterWatch#791).
+    /// </para>
+    ///
+    /// <para>Semantics:</para>
+    /// <list type="bullet">
+    /// <item>A store backed by zero or one database is returned as-is — there is nothing to scope.</item>
+    /// <item>Under <see cref="DurabilityMode.Solo" /> every database is local: the one node owns everything,
+    /// and the daemon runs in-process rather than as managed agents, so the running-agent set carries no
+    /// ownership signal to read.</item>
+    /// <item>When no <see cref="IEventSubscriptionAgentFamily" /> is registered — Wolverine-managed event
+    /// subscription distribution is not in play — ownership does not exist as a concept and every database is
+    /// returned, preserving the unscoped behavior.</item>
+    /// <item>Otherwise the running managed-agent set is authoritative: each database's agents run on exactly
+    /// one node, so the union of this method's results across all nodes covers every database exactly once.
+    /// A node that currently owns no agents for the store gets an EMPTY list — that is the honest answer
+    /// during startup or after a rebalance, so callers gating readiness can wait instead of latching early.
+    /// Callers that must never go dark (monitoring sweeps) should treat empty as "fall back to all databases"
+    /// themselves. Ownership shifts as Wolverine rebalances agents, so never cache the result.</item>
+    /// </list>
+    /// </summary>
+    public static async ValueTask<IReadOnlyList<IEventDatabase>> AllLocallyOwnedDatabasesAsync(
+        this IWolverineRuntime runtime, IEventStore store, CancellationToken token = default)
+    {
+        var all = await store.AllDatabases().ConfigureAwait(false);
+        if (all.Count <= 1)
+        {
+            return all;
+        }
+
+        if (runtime.Options.Durability.Mode == DurabilityMode.Solo)
+        {
+            return all;
+        }
+
+        if (!runtime.Services.GetServices<IEventSubscriptionAgentFamily>().Any())
+        {
+            return all;
+        }
+
+        var ownedIds = runtime.Agents.AllRunningAgentUris()
+            .Where(uri => BelongsToStore(uri, store.Identity))
+            .Select(EventSubscriptionAgentFamily.DatabaseIdOf)
+            .Where(id => id != null)
+            .Select(id => id!)
+            .ToHashSet();
+
+        if (ownedIds.Count == 0)
+        {
+            return Array.Empty<IEventDatabase>();
+        }
+
+        // Map the owned DatabaseIds back to database identifiers through the store's usage descriptors —
+        // the exact source EventStoreAgents built the agent URIs from, so the round trip cannot drift.
+        var usage = await store.TryCreateUsage(token).ConfigureAwait(false);
+        if (usage?.Database == null)
+        {
+            // No usage descriptor to map through: fail open rather than silently dropping databases.
+            return all;
+        }
+
+        var ownedIdentifiers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var descriptor in usage.Database.Databases)
+        {
+            if (ownedIds.Contains(new DatabaseId(descriptor.ServerName, descriptor.DatabaseName)))
+            {
+                ownedIdentifiers.Add(descriptor.Identifier);
+            }
+        }
+
+        if (usage.Database.MainDatabase is { } main &&
+            ownedIds.Contains(new DatabaseId(main.ServerName, main.DatabaseName)))
+        {
+            ownedIdentifiers.Add(main.Identifier);
+        }
+
+        return all.Where(db => ownedIdentifiers.Contains(db.Identifier)).ToList();
+    }
+
+    // Agent URIs are event-subscriptions://{storeType}/{storeName}/{databaseId}/{shard...}
+    // (EventSubscriptionAgentFamily.UriFor); the (type, name) prefix identifies the owning store.
+    private static bool BelongsToStore(Uri uri, EventStoreIdentity identity)
+    {
+        if (uri.Scheme != EventSubscriptionAgentFamily.SchemeName || uri.Segments.Length < 3)
+        {
+            return false;
+        }
+
+        return uri.Host.Equals(identity.Type, StringComparison.OrdinalIgnoreCase)
+               && uri.Segments[1].Trim('/').Equals(identity.Name, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
Closes #3584.

Adds `runtime.AllLocallyOwnedDatabasesAsync(store)` to Wolverine core — the canonical, store-scoped filter over `IEventStore.AllDatabases()` returning only the databases whose event-subscription agents run on THIS node under Wolverine-managed distribution.

Semantics (documented on the method):

- zero/one database → returned as-is;
- `DurabilityMode.Solo` → all databases (one node owns everything; Solo runs the daemon in-process, so there are no managed agent URIs to read ownership from);
- no `IEventSubscriptionAgentFamily` registered → all databases (ownership doesn't exist as a concept; unscoped behavior preserved);
- otherwise: running managed-agent URIs filtered to this store's `(type, name)` prefix → `DatabaseId`s → mapped back to `IEventDatabase.Identifier` through the store's usage descriptors (`TryCreateUsage`), the same source `EventStoreAgents` builds the agent URIs from, so the round trip cannot drift;
- a node that owns nothing gets an **empty** list — honest during startup or a rebalance (readiness gates want to wait; monitoring sweeps that must never go dark can fall back to all databases themselves);
- fail-open when the store yields no usage descriptor (better every database than silently none);
- results must never be cached — assignments move as Wolverine rebalances.

Seven unit tests in `CoreTests.Runtime.Agents.all_locally_owned_databases` cover each branch, including the store-scoping (agents of another store never count as ownership — `AllLocallyOwnedDatabaseIds()` mixes stores, this helper doesn't).

First consumer PRs after this lands: CritterWatch's `EventProgressionPoller` (its dead-letter sweep already hand-rolls this filter with a string-`Contains` since #791; its progression/orphan/per-tenant-high-water passes are unscoped entirely) and application-level readiness gates.
