### PR TITLE
fix(http): don't describe a route-bound [FromQuery]/[FromHeader] parameter twice in OpenAPI (#3586)

### DIFF
--- a/repro/README.md
+++ b/repro/README.md
@@ -16,3 +16,15 @@ single-file apps.
 `[FromRoute(Name = "journey-id")]` on an endpoint method parameter. Against
 `main` the first assertion fails with `0`, because the attribute's name was
 ignored and the argument was bound from the query string instead.
+
+## duplicate-fromquery-route-parameter.cs
+
+`[FromQuery]` on a parameter whose name is also a route-template segment
+(`[WolverineGet("/things/{id}")] Get([FromQuery] string id)`). Against `main`
+the assertion fails with `2`: the parameter is emitted twice in the endpoint's
+`ApiDescription` — once `Source=Path` (from the route template) and once
+`Source=Query` (from `[FromQuery]`). Two same-name parameters are invalid
+OpenAPI and crash `Microsoft.AspNetCore.OpenApi`'s XML-comment operation
+transformer (`operation.Parameters.SingleOrDefault(p => p.Name == comment.Name)`
+→ "Sequence contains more than one matching element"), returning HTTP 500 for
+all of `/openapi/{document}.json`. This regressed between 6.16 and 6.21.

--- a/repro/duplicate-fromquery-route-parameter.cs
+++ b/repro/duplicate-fromquery-route-parameter.cs
@@ -1,0 +1,76 @@
+#:sdk Microsoft.NET.Sdk.Web
+#:project ../src/Http/Wolverine.Http/Wolverine.Http.csproj
+#:project ../src/Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj
+#:property TargetFramework=net10.0
+#:property PublishAot=false
+#:property JsonSerializerIsReflectionEnabledByDefault=true
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.DependencyInjection;
+using Wolverine;
+using Wolverine.Http;
+
+// A route-template parameter (`{id}`) annotated [FromQuery] is emitted TWICE in the endpoint's
+// ApiDescription: once with Source=Path (from the route template) and once with Source=Query (from
+// [FromQuery]). Two parameters with the same name is invalid OpenAPI. It also crashes .NET's OpenAPI
+// XML-documentation transformer, whose per-<param> lookup does
+//     operation.Parameters.SingleOrDefault(p => p.Name == comment.Name)
+// throwing "Sequence contains more than one matching element" and failing ALL of
+// /openapi/{document}.json (HTTP 500). This regressed between 6.16 and 6.21.
+
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseUrls("http://127.0.0.1:5401");
+builder.Host.UseWolverine();
+builder.Services.AddWolverineHttp();
+builder.Services.AddEndpointsApiExplorer();
+
+var app = builder.Build();
+app.MapWolverineEndpoints();
+await app.StartAsync();
+
+var provider = app.Services.GetRequiredService<IApiDescriptionGroupCollectionProvider>();
+var descriptions = provider.ApiDescriptionGroups.Items.SelectMany(g => g.Items).ToList();
+
+var failures = 0;
+
+var getThing = descriptions.FirstOrDefault(d =>
+    string.Equals(d.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase)
+    && (d.RelativePath?.Contains("things/{id}") ?? false));
+
+if (getThing is null)
+{
+    failures++;
+    Console.WriteLine("FAIL  could not find the GET things/{id} ApiDescription");
+}
+else
+{
+    var idParams = getThing.ParameterDescriptions.Where(p => p.Name == "id").ToList();
+    var sources = string.Join(", ", idParams.Select(p => p.Source?.Id ?? "<null>"));
+    expect($"count of 'id' parameters (sources: {sources})", "1", idParams.Count.ToString());
+}
+
+await app.StopAsync();
+return failures;
+
+void expect(string description, string expected, string actual)
+{
+    if (actual == expected)
+    {
+        Console.WriteLine($"PASS  {description} -> \"{actual}\"");
+    }
+    else
+    {
+        failures++;
+        Console.WriteLine($"FAIL  {description} -> expected \"{expected}\", got \"{actual}\"");
+    }
+}
+
+public static class ThingEndpoints
+{
+    /// <summary>Gets a thing by id.</summary>
+    /// <param name="id">The identifier of the thing.</param>
+    [WolverineGet("/things/{id}")]
+    public static string Get([FromQuery] string id) => id;
+}

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -625,6 +625,18 @@ public partial class HttpChain
         {
             foreach (var parameter in call.Method.GetParameters())
             {
+                // A simple [FromQuery]/[FromHeader] parameter whose name matches a route-template segment is
+                // actually bound from the route value, not the query string or a header: FromQueryAttributeUsage
+                // declines simple types and RouteParameterStrategy runs before the query/header strategies, so
+                // the route claims it and the attribute is a no-op. The route-template loop already describes it
+                // as a Path parameter; describing it again here would emit a second same-name parameter, which is
+                // invalid OpenAPI and crashes downstream transformers (e.g. the XML-doc operation transformer's
+                // Parameters.SingleOrDefault). Regressed when GH-3380 began deriving parameters from the chain.
+                if (isBoundFromRouteValue(parameter))
+                {
+                    continue;
+                }
+
                 if (parameter.TryGetAttribute<FromQueryAttribute>(out var fromQuery))
                 {
                     // A complex [FromQuery] type is bound by flattening it into one query string value per
@@ -646,6 +658,22 @@ public partial class HttpChain
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Would this endpoint/chain parameter be bound from a route value rather than the query string or a
+    /// header? RouteParameterStrategy matches by the parameter's own name (case-sensitively, mirroring
+    /// <see cref="FindRouteVariable(ParameterInfo, out Variable?)"/>) and runs before the query/header
+    /// strategies, so a name collision with a route-template segment on a route-bindable type makes any
+    /// [FromQuery]/[FromHeader] attribute a no-op. Such a parameter is already described by the
+    /// route-template loop and must not be described again as chain-bound. See GH-3380.
+    /// </summary>
+    private bool isBoundFromRouteValue(ParameterInfo parameter)
+    {
+        // An explicit [FromRoute] parameter is route-bound by definition and never treated as chain-bound
+        // query/header anyway; only the implicit name-collision case needs guarding here.
+        return RoutePattern!.Parameters.Any(x => x.Name == parameter.Name)
+               && isBindableRouteType(parameter.ParameterType);
     }
 
     private static void addChainBoundParameter(ApiDescription apiDescription, string name, Type parameterType,


### PR DESCRIPTION
## What

A Wolverine HTTP parameter that is **both** a route-template segment and annotated `[FromQuery]` (or `[FromHeader]`) was emitted **twice** in the `ApiDescription` — once `Source=Path` (route template) and once `Source=Query`/`Header`. Two same-name parameters are invalid OpenAPI and crash the .NET XML-doc operation transformer (`operation.Parameters.SingleOrDefault(p => p.Name == comment.Name)` → *"Sequence contains more than one matching element"*), returning HTTP 500 for the whole `/openapi/{document}.json`.

```csharp
[WolverineGet("/things/{id}")]
public static string Get([FromQuery] string id) => id;
```

Closes #3586.

## Root cause

At runtime the `[FromQuery]` here is a no-op: `FromQueryAttributeUsage` declines simple types and `RouteParameterStrategy` runs before the query/header strategies, so the route claims `id` and binds it from the route value. The generated handler proves it — a route-value read, no query access:

```csharp
var id = (string?)httpContext.GetRouteValue("id");
```

The duplicate lived only in the OpenAPI description path: `fillChainBoundParameters` (added in #3418 / GH-3380) walked the endpoint method, saw `[FromQuery]`, and added a second parameter alongside the `Path` one the route-template loop already emits. Regressed between 6.16 and 6.21.

## The fix

Skip a route-bound parameter in `fillChainBoundParameters` (name matches a route segment + route-bindable type, mirroring `RouteParameterStrategy`/`FindRouteVariable`). **Description-only change — runtime binding is unchanged.**

The OpenAPI document now reflects what actually happens: a single `Path` parameter. To be explicit about the behavior this encodes — **the `[FromQuery]` is silently ignored, exactly as it already was at binding time.** This PR only makes the emitted OpenAPI tell that truth; it does not change how the value binds.

## Follow-up worth discussing

That silent precedence is arguably a footgun: a user who writes `[FromQuery]`/`[FromHeader]` on a parameter whose name collides with a route segment gets route binding with no diagnostic. It may be friendlier to **emit an error during codegen** for this conflicting configuration rather than silently accepting it and preferring the route value. That's a separate behavioral change from this description fix, so I've left it out here — happy to open a follow-up if maintainers agree.

## Testing

Self-verifying file-based repro added at `repro/duplicate-fromquery-route-parameter.cs`:

```
dotnet run repro/duplicate-fromquery-route-parameter.cs
```

- Repro passes (`sources: Path`, count 1); the sibling `kebab-cased-route-parameter.cs` still passes.
- Existing `openapi_shape_tests` (16) and all `open_api`/`openapi` tests (60) pass.
- `Wolverine.Http` builds with 0 warnings/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
