### PR TITLE
feat(http): Marten 9.18 streaming types (StreamPaged, StreamPagedByCursor, ETag) + version bump

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,12 +44,12 @@
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
     <PackageVersion Include="JasperFx.SourceGenerator" Version="2.34.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
-    <PackageVersion Include="Marten" Version="9.17.1" />
+    <PackageVersion Include="Marten" Version="9.18.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="[5.4.0,6.0.0)" />
+    <PackageVersion Include="Polecat" Version="[5.5.0,6.0.0)" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.16.1" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.16.1" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.18.0" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.18.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />

--- a/docs/guide/http/marten.md
+++ b/docs/guide/http/marten.md
@@ -588,6 +588,8 @@ needed**. Just `using Marten.AspNetCore;` in your endpoint file and return one.
 | `StreamOne<T>`         | `IQueryable<T>` — regular Marten document query  | Single `T`     | yes  |
 | `StreamMany<T>`        | `IQueryable<T>` — regular Marten document query  | JSON array `T[]` | no (empty array = 200) |
 | `StreamAggregate<T>`   | `IDocumentSession` + stream id — event-sourced   | Single `T`     | yes  |
+| `StreamPaged<T>`       | `IQueryable<T>` + page number/size                | Paged envelope | no   |
+| `StreamPagedByCursor<T>` | `IQueryable<T>` + cursor/page size              | Cursor envelope | no   |
 
 **Key difference — `StreamOne<T>` vs `StreamAggregate<T>`**:
 
@@ -662,3 +664,74 @@ Reach for these types when:
 
 For small responses where the query result is already going to be materialized
 (to make a decision, for example), a plain `T` return is fine.
+
+## Paged Streaming Responses <Badge type="tip" text="9.18" />
+
+`Marten.AspNetCore` 9.18 adds two more `IResult` types built on the same
+streaming infrastructure, for paginated queries: `StreamPaged<T>` and
+`StreamPagedByCursor<T>`. Like `StreamOne<T>`, `StreamMany<T>`, and
+`StreamAggregate<T>`, both types just work with Wolverine.HTTP — they
+implement `IResult` and `IEndpointMetadataProvider`, so no Wolverine-specific
+code is required.
+
+### `StreamPaged<T>` — offset paging
+
+```csharp
+[WolverineGet("/invoices/paged")]
+public static StreamPaged<Invoice> GetPaged(int pageNumber, int pageSize, IQuerySession session)
+    => new(session.Query<Invoice>().OrderBy(x => x.Id), pageNumber, pageSize);
+```
+
+Returns `200 application/json` with a paged envelope shaped like:
+
+```json
+{
+    "pageNumber": 1,
+    "pageSize": 20,
+    "totalItemCount": 42,
+    "items": [ /* Invoice[] */ ]
+}
+```
+
+Use this for classic "page 1 of N" UIs where you need a total count and
+random access to any page number.
+
+### `StreamPagedByCursor<T>` — keyset (cursor) paging
+
+```csharp
+[WolverineGet("/invoices/by-cursor")]
+public static StreamPagedByCursor<Invoice> GetByCursor(string? cursor, int pageSize, IQuerySession session)
+    => new(session.Query<Invoice>().OrderBy(x => x.Id), cursor, pageSize);
+```
+
+Returns `200 application/json` with the requested page of items plus a
+`nextCursor` value the client passes back on the next request to continue
+from where it left off:
+
+```json
+{
+    "items": [ /* Invoice[] */ ],
+    "nextCursor": "..."
+}
+```
+
+Keyset pagination scales better than offset paging for large or
+frequently-changing result sets, because it doesn't need to compute a total
+count or skip over previously-seen rows on every request.
+
+## ETag Support for `StreamOne<T>` and `StreamAggregate<T>` <Badge type="tip" text="9.18" />
+
+`StreamOne<T>` and `StreamAggregate<T>` compute and emit an `ETag` response
+header by default. If the client sends a matching `If-None-Match` request
+header, Marten short-circuits the response with `304 Not Modified` instead of
+re-serializing and sending the body — useful for caching individual
+documents or aggregates behind a CDN or browser cache.
+
+Set `EmitETag = false` to opt out if you don't want this behavior for a
+particular endpoint:
+
+```csharp
+[WolverineGet("/invoices/{id}")]
+public static StreamOne<Invoice> Get(Guid id, IQuerySession session)
+    => new(session.Query<Invoice>().Where(x => x.Id == id)) { EmitETag = false };
+```

--- a/src/Http/Wolverine.Http.Tests/Marten/streaming_endpoints.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/streaming_endpoints.cs
@@ -103,6 +103,44 @@ public class streaming_endpoints(AppFixture fixture) : IntegrationContext(fixtur
         });
     }
 
+    [Fact]
+    public async Task stream_one_emits_etag_header_by_default()
+    {
+        var invoice = new Invoice { Id = Guid.NewGuid() };
+        await using (var session = Store.LightweightSession())
+        {
+            session.Store(invoice);
+            await session.SaveChangesAsync();
+        }
+
+        var result = await Host.Scenario(x =>
+        {
+            x.Get.Url($"/streaming/invoice/{invoice.Id}");
+            x.StatusCodeShouldBe(200);
+        });
+
+        result.Context.Response.Headers["ETag"].FirstOrDefault().ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task stream_one_omits_etag_header_when_disabled()
+    {
+        var invoice = new Invoice { Id = Guid.NewGuid() };
+        await using (var session = Store.LightweightSession())
+        {
+            session.Store(invoice);
+            await session.SaveChangesAsync();
+        }
+
+        var result = await Host.Scenario(x =>
+        {
+            x.Get.Url($"/streaming/invoice/{invoice.Id}/no-etag");
+            x.StatusCodeShouldBe(200);
+        });
+
+        result.Context.Response.Headers["ETag"].Any().ShouldBeFalse();
+    }
+
     // ───────────────────────── StreamMany<T> ─────────────────────────
 
     [Fact]
@@ -167,6 +205,63 @@ public class streaming_endpoints(AppFixture fixture) : IntegrationContext(fixtur
             x.StatusCodeShouldBe(404);
         });
     }
+
+    // ───────────────────────── StreamPaged<T> ─────────────────────────
+
+    [Fact]
+    public async Task stream_paged_returns_paged_envelope()
+    {
+        var ids = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).OrderBy(x => x).ToArray();
+        await using (var session = Store.LightweightSession())
+        {
+            foreach (var id in ids) session.Store(new Invoice { Id = id });
+            await session.SaveChangesAsync();
+        }
+
+        var result = await Host.Scenario(x =>
+        {
+            x.Get.Url("/streaming/invoices/paged?pageNumber=1&pageSize=2");
+            x.StatusCodeShouldBe(200);
+            x.ContentTypeShouldBe("application/json");
+        });
+
+        var body = await result.ReadAsJsonAsync<PagedEnvelope>();
+
+        body.ShouldNotBeNull();
+        body!.PageNumber.ShouldBe(1);
+        body.PageSize.ShouldBe(2);
+        body.Items.Count.ShouldBe(2);
+    }
+
+    // ───────────────────── StreamPagedByCursor<T> ─────────────────────
+
+    [Fact]
+    public async Task stream_paged_by_cursor_returns_items_and_next_cursor()
+    {
+        var ids = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).OrderBy(x => x).ToArray();
+        await using (var session = Store.LightweightSession())
+        {
+            foreach (var id in ids) session.Store(new Invoice { Id = id });
+            await session.SaveChangesAsync();
+        }
+
+        var result = await Host.Scenario(x =>
+        {
+            x.Get.Url("/streaming/invoices/cursor?pageSize=2");
+            x.StatusCodeShouldBe(200);
+            x.ContentTypeShouldBe("application/json");
+        });
+
+        var body = await result.ReadAsJsonAsync<CursorEnvelope>();
+
+        body.ShouldNotBeNull();
+        body!.Items.Count.ShouldBe(2);
+        body.NextCursor.ShouldNotBeNullOrEmpty();
+    }
+
+    private record PagedEnvelope(int PageNumber, int PageSize, long TotalItemCount, List<Invoice> Items);
+
+    private record CursorEnvelope(List<Invoice> Items, string? NextCursor);
 
     // ───────────────────────── OpenAPI metadata ─────────────────────────
 

--- a/src/Http/WolverineWebApi/Marten/StreamingEndpoints.cs
+++ b/src/Http/WolverineWebApi/Marten/StreamingEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Marten;
 using Marten.AspNetCore;
 using Wolverine.Http;
@@ -6,7 +7,8 @@ namespace WolverineWebApi.Marten;
 
 /// <summary>
 /// Endpoints exercising the <see cref="StreamOne{T}"/>, <see cref="StreamMany{T}"/>,
-/// and <see cref="StreamAggregate{T}"/> helpers from <c>Marten.AspNetCore</c>.
+/// <see cref="StreamAggregate{T}"/>, <see cref="StreamPaged{T}"/>, and
+/// <see cref="StreamPagedByCursor{T}"/> helpers from <c>Marten.AspNetCore</c>.
 /// Used by the streaming_endpoints tests for GH-1562. Wolverine.Http dispatches
 /// these as ordinary <c>IResult</c> return values via the existing
 /// <c>ResultWriterPolicy</c> — no Wolverine-specific code needed.
@@ -17,6 +19,11 @@ public static class StreamingEndpoints
     [WolverineGet("/streaming/invoice/{id}")]
     public static StreamOne<Invoice> GetOne(Guid id, IQuerySession session)
         => new(session.Query<Invoice>().Where(x => x.Id == id));
+
+    // StreamOne with ETag support disabled (opt-out of the default 304 behavior)
+    [WolverineGet("/streaming/invoice/{id}/no-etag")]
+    public static StreamOne<Invoice> GetOneNoETag(Guid id, IQuerySession session)
+        => new(session.Query<Invoice>().Where(x => x.Id == id)) { EmitETag = false };
 
     // StreamOne with custom OnFoundStatus
     [WolverineGet("/streaming/invoice/{id}/custom-status")]
@@ -48,4 +55,14 @@ public static class StreamingEndpoints
     [WolverineGet("/streaming/order/{id}")]
     public static StreamAggregate<Order> GetOrder(Guid id, IDocumentSession session)
         => new(session, id);
+
+    // StreamPaged - paged JSON envelope (pageNumber, pageSize, totalItemCount, items)
+    [WolverineGet("/streaming/invoices/paged")]
+    public static StreamPaged<Invoice> GetPaged(int pageNumber, int pageSize, IQuerySession session)
+        => new(session.Query<Invoice>().OrderBy(x => x.Id), pageNumber, pageSize);
+
+    // StreamPagedByCursor - keyset pagination with a continuation cursor
+    [WolverineGet("/streaming/invoices/cursor")]
+    public static StreamPagedByCursor<Invoice> GetByCursor(string? cursor, int pageSize, IQuerySession session)
+        => new(session.Query<Invoice>().OrderBy(x => x.Id), cursor, pageSize);
 }


### PR DESCRIPTION
Supersedes #3583 (thanks @erdtsieck — carried over verbatim with co-authorship).

The original PR added the docs, example endpoints, and tests for the new
`Marten.AspNetCore` 9.18 streaming types but could not compile or pass CI,
because `main` was pinned to Marten 9.16.1/9.17.1 — the new types don't exist
until 9.18. This PR carries the same content **and** bumps the pins so it builds.

## Changes

Anne's original content, unchanged:
- `src/Http/WolverineWebApi/Marten/StreamingEndpoints.cs` — `GetPaged` (`StreamPaged<Invoice>`), `GetByCursor` (`StreamPagedByCursor<Invoice>`), and `GetOneNoETag` (`StreamOne<Invoice>` with `EmitETag = false`).
- `src/Http/Wolverine.Http.Tests/Marten/streaming_endpoints.cs` — tests for the paged envelope, cursor pagination + `nextCursor`, and ETag header presence/absence.
- `docs/guide/http/marten.md` — the two new paged streaming types, ETag support, extended comparison table.

Version bump to make it real:
- `Marten` / `Marten.AspNetCore` / `Marten.Newtonsoft` → **9.18.0**
- `Polecat` range floor → **5.5.0**
- (`JasperFx` 2.34.0 and `Weasel` 9.18.1 already on `main` satisfy both.)

These types implement `IResult` + `IEndpointMetadataProvider`, so they just work
through the existing `ResultWriterPolicy` — no Wolverine-specific code required,
same as the `StreamOne`/`StreamMany`/`StreamAggregate` support in GH-1562.

## Verification

- `dotnet build src/Http/Wolverine.Http.Tests` (net9.0) — clean, 0 warnings/errors.
- All 16 `streaming_endpoints` tests pass against Postgres, including the new paged/cursor/ETag cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)