### PR TITLE
fix(http): bind scalar [FromQuery] decimal + shape-test OpenAPI parameter description across type families (#3587 follow-up)

### DIFF
--- a/src/Http/Wolverine.Http.Tests.DifferentAssembly/OpenApiShapeEndpoints.cs
+++ b/src/Http/Wolverine.Http.Tests.DifferentAssembly/OpenApiShapeEndpoints.cs
@@ -182,3 +182,106 @@ public class RenamedOrderQuery
 }
 
 #endregion
+
+public enum ShapeColor
+{
+    Red,
+    Green,
+    Blue
+}
+
+#region GH-3586: a [FromQuery]/[FromHeader] colliding with a route segment is route-bound, described ONCE
+
+// The GH-3586 regression battery. A simple-typed [FromQuery]/[FromHeader] parameter whose name matches a
+// route-template segment is actually bound from the route value: RouteParameterStrategy runs ahead of the
+// query/header strategies, so the route claims it and the attribute is a no-op. Describing it a second time
+// as a query/header parameter emits two same-name parameters, which is invalid OpenAPI and hard-crashes
+// downstream transformers (the XML-doc operation transformer's Parameters.SingleOrDefault matches by name
+// across every `in`, so even a path+header collision throws). Each endpoint below must render as a SINGLE
+// path parameter. One case per route-bindable CLR family so the suppression can't silently regress for one
+// type while passing for another.
+
+public static class RouteCollisionStringEndpoint
+{
+    // The exact #3586 repro, now as a CI-enforced shape assertion rather than a manual repro script.
+    [WolverineGet("/shapes/collision/string/{id}")]
+    public static string Get([FromQuery] string id) => id;
+}
+
+public static class RouteCollisionGuidEndpoint
+{
+    [WolverineGet("/shapes/collision/guid/{id:guid}")]
+    public static string Get([FromQuery] Guid id) => id.ToString();
+}
+
+public static class RouteCollisionIntEndpoint
+{
+    [WolverineGet("/shapes/collision/int/{id:int}")]
+    public static string Get([FromQuery] int id) => id.ToString();
+}
+
+public static class RouteCollisionLongEndpoint
+{
+    [WolverineGet("/shapes/collision/long/{id:long}")]
+    public static string Get([FromQuery] long id) => id.ToString();
+}
+
+public static class RouteCollisionBoolEndpoint
+{
+    [WolverineGet("/shapes/collision/bool/{flag:bool}")]
+    public static string Get([FromQuery] bool flag) => flag.ToString();
+}
+
+public static class RouteCollisionDateTimeEndpoint
+{
+    [WolverineGet("/shapes/collision/datetime/{when:datetime}")]
+    public static string Get([FromQuery] DateTime when) => when.ToString("O");
+}
+
+public static class RouteCollisionEnumEndpoint
+{
+    // Enums are route-bindable (RouteParameterStrategy.CanParse returns true for IsEnum), so the collision
+    // is suppressed the same as the primitive families.
+    [WolverineGet("/shapes/collision/enum/{color}")]
+    public static string Get([FromQuery] ShapeColor color) => color.ToString();
+}
+
+public static class RouteCollisionNullableEndpoint
+{
+    // A Nullable<T> of a route-bindable type unwraps to T (isBindableRouteType/unwrapNullable), so the
+    // collision is still suppressed. Guards the nullable path explicitly.
+    [WolverineGet("/shapes/collision/nullable/{id:int}")]
+    public static string Get([FromQuery] int? id) => id?.ToString() ?? "none";
+}
+
+public static class RouteCollisionHeaderEndpoint
+{
+    // A [FromHeader] colliding with a route segment trips the SAME SingleOrDefault crash (name match is
+    // `in`-agnostic), so the guard must suppress header collisions too, not just query.
+    [WolverineGet("/shapes/collision/header/{id}")]
+    public static string Get([FromHeader] string id) => id;
+}
+
+#endregion
+
+#region query-string schema rendering across CLR type families (type + format regression guard)
+
+// These do NOT collide with a route segment: they pin the rendered schema `type`/`format` for each query
+// parameter family so a change in how Wolverine hands types to Microsoft.AspNetCore.OpenApi can't silently
+// alter the emitted schema. Nullable throughout because that's the idiomatic optional-query shape.
+public static class QueryTypeRenderingEndpoint
+{
+    [WolverineGet("/shapes/query-types")]
+    public static string Get(
+        [FromQuery] Guid? gid,
+        [FromQuery] DateTime? when,
+        [FromQuery] bool? flag,
+        [FromQuery] int? number,
+        [FromQuery] long? big,
+        [FromQuery] double? ratio,
+        [FromQuery] decimal? amount,
+        [FromQuery] ShapeColor? color)
+        => "ok";
+}
+
+#endregion

--- a/src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs
@@ -251,6 +251,43 @@ public class openapi_shape_tests : IClassFixture<OpenApiShapeFixture>
             .ShouldBe([new ParameterShape("id", "path", true, "string", "uuid")]);
     }
 
+    // GH-3586: a [FromQuery]/[FromHeader] whose name collides with a route segment is route-bound, so the
+    // operation must carry exactly ONE parameter (the path one) and never a duplicate. Theory data covers
+    // every route-bindable CLR family plus the header and nullable variants; a regression in the suppression
+    // for any single family fails only its own row.
+    [Theory]
+    [InlineData("/shapes/collision/string/{id}", "id", "string", null)]
+    [InlineData("/shapes/collision/guid/{id}", "id", "string", "uuid")]
+    [InlineData("/shapes/collision/int/{id}", "id", "integer", "int32")]
+    [InlineData("/shapes/collision/long/{id}", "id", "integer", "int64")]
+    [InlineData("/shapes/collision/bool/{flag}", "flag", "boolean", null)]
+    [InlineData("/shapes/collision/datetime/{when}", "when", "string", "date-time")]
+    [InlineData("/shapes/collision/enum/{color}", "color", "integer", null)]
+    [InlineData("/shapes/collision/nullable/{id}", "id", "integer", "int32")]
+    [InlineData("/shapes/collision/header/{id}", "id", "string", null)]
+    public void route_bound_fromquery_or_fromheader_is_described_once_as_a_path_parameter(
+        string path, string name, string? type, string? format)
+    {
+        ParametersFor(path, "get")
+            .ShouldBe([new ParameterShape(name, "path", true, type, format)]);
+    }
+
+    [Fact]
+    public void query_parameters_render_the_expected_schema_type_and_format_per_clr_family()
+    {
+        ParametersFor("/shapes/query-types", "get")
+            .ShouldBe([
+                new ParameterShape("gid", "query", false, "string", "uuid"),
+                new ParameterShape("when", "query", false, "string", "date-time"),
+                new ParameterShape("flag", "query", false, "boolean", null),
+                new ParameterShape("number", "query", false, "integer", "int32"),
+                new ParameterShape("big", "query", false, "integer", "int64"),
+                new ParameterShape("ratio", "query", false, "number", "double"),
+                new ParameterShape("amount", "query", false, "number", "double"),
+                new ParameterShape("color", "query", false, "integer", null)
+            ], ignoreOrder: true);
+    }
+
     #region harness helpers
 
     private JsonElement operationFor(string path, string httpMethod)

--- a/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs
+++ b/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs
@@ -520,6 +520,44 @@ public class using_querystring_parameters : IntegrationContext
         text.ShouldBe("Amount is 42.1");
     }
 
+    [Fact]
+    public async Task use_decimal_fromquery_hit()
+    {
+        // GH-3586 follow-up: an explicit [FromQuery] on a scalar decimal used to throw at endpoint
+        // discovery ("System.Decimal has multiple constructors"). It now binds from its own key.
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/decimal2?value=42.1");
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        (await body.ReadAsTextAsync()).ShouldBe("42.1");
+    }
+
+    [Fact]
+    public async Task use_nullable_decimal_fromquery_hit()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/decimal2/nullable?value=42.1");
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        (await body.ReadAsTextAsync()).ShouldBe("42.1");
+    }
+
+    [Fact]
+    public async Task use_nullable_decimal_fromquery_miss()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/decimal2/nullable");
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        (await body.ReadAsTextAsync()).ShouldBe("Value is missing");
+    }
+
     #endregion
 
     [Fact]

--- a/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs
+++ b/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs
@@ -558,6 +558,56 @@ public class using_querystring_parameters : IntegrationContext
         (await body.ReadAsTextAsync()).ShouldBe("Value is missing");
     }
 
+    [Fact]
+    public async Task use_enum_fromquery_hit_with_string_name()
+    {
+        // Enum values arrive as their string name on the wire, not as an integer.
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/enum2?value=North");
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        (await body.ReadAsTextAsync()).ShouldBe("North");
+    }
+
+    [Fact]
+    public async Task use_enum_fromquery_hit_with_lowercase_string_name()
+    {
+        // ...and the name parse is case-insensitive.
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/enum2?value=west");
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        (await body.ReadAsTextAsync()).ShouldBe("West");
+    }
+
+    [Fact]
+    public async Task use_nullable_enum_fromquery_hit_with_string_name()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/enum2/nullable?value=South");
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        (await body.ReadAsTextAsync()).ShouldBe("South");
+    }
+
+    [Fact]
+    public async Task use_nullable_enum_fromquery_miss()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/enum2/nullable");
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        (await body.ReadAsTextAsync()).ShouldBe("Value is missing");
+    }
+
     #endregion
 
     [Fact]

--- a/src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
@@ -37,6 +37,11 @@ internal class FromQueryAttributeUsage : IParameterStrategy
     {
         if (parameterType.IsSimple()) return false;
         if (parameterType.IsNullable() && parameterType.GetInnerTypeFromNullable().IsSimple()) return false;
+        // decimal is a single query-string value like the other numerics, but JasperFx's IsSimple() does not
+        // treat it as simple, so without this it falls into the flattening path: non-nullable `decimal` then
+        // throws ("System.Decimal has multiple constructors") and `decimal?` silently binds/describes from a
+        // key named "value" (Nullable<decimal>'s constructor parameter) instead of the parameter's own name.
+        if (parameterType.IsTypeOrNullableOf<decimal>()) return false;
         if (parameterType.IsTypeOrNullableOf<DateTime>()) return false;
         if (parameterType.IsTypeOrNullableOf<DateTimeOffset>()) return false;
         if (parameterType.IsTypeOrNullableOf<DateOnly>()) return false;

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -672,6 +672,16 @@ public partial class HttpChain
     {
         // An explicit [FromRoute] parameter is route-bound by definition and never treated as chain-bound
         // query/header anyway; only the implicit name-collision case needs guarding here.
+        //
+        // The name comparison is deliberately CASE-SENSITIVE and must stay that way: it mirrors
+        // FindRouteVariable(ParameterInfo) (HttpChain.cs, `x.Name == parameter.Name`), which is the binder
+        // path that actually claims the parameter. This is intentionally stricter than matchesRouteName /
+        // tryDetermineRouteBinding above (which use EqualsIgnoreCase). Do NOT unify this with those helpers:
+        // going case-insensitive here would suppress a query/header parameter the generated code really does
+        // read (e.g. `[WolverineGet("/things/{Id}")] Get([FromQuery] string id)` binds `id` from the query
+        // string, not the route, because the route segment `Id` never matches the parameter `id`). If the
+        // binder's route-name matching is ever aligned to ASP.NET's OrdinalIgnoreCase, this must move with
+        // it. See GH-3586.
         return RoutePattern!.Parameters.Any(x => x.Name == parameter.Name)
                && isBindableRouteType(parameter.ParameterType);
     }

--- a/src/Http/WolverineWebApi/QuerystringEndpoints.cs
+++ b/src/Http/WolverineWebApi/QuerystringEndpoints.cs
@@ -55,6 +55,21 @@ public static class QuerystringEndpoints
         return value.ToString("O");
     }
 
+    // GH-3586 follow-up: a scalar [FromQuery] decimal is a single query value like [FromQuery] DateTime
+    // above. It used to throw at discovery ("System.Decimal has multiple constructors") because decimal was
+    // routed into the complex-type flattening path; guarded now in IsComplexQueryStringType.
+    [WolverineGet("/querystring/decimal2")]
+    public static string Decimal2([FromQuery] decimal value)
+    {
+        return value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    [WolverineGet("/querystring/decimal2/nullable")]
+    public static string Decimal2Nullable([FromQuery] decimal? value)
+    {
+        return value.HasValue ? value.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "Value is missing";
+    }
+
     [WolverineGet("/querystring/datetime/nullable")]
     public static string DateTimeNullable(DateTime? value)
     {

--- a/src/Http/WolverineWebApi/QuerystringEndpoints.cs
+++ b/src/Http/WolverineWebApi/QuerystringEndpoints.cs
@@ -70,6 +70,20 @@ public static class QuerystringEndpoints
         return value.HasValue ? value.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "Value is missing";
     }
 
+    // GH-3586 follow-up: enum values arrive on the wire as their string name (?value=North). A scalar
+    // [FromQuery] enum must parse that name, case-insensitively, through the explicit-attribute path.
+    [WolverineGet("/querystring/enum2")]
+    public static string Enum2([FromQuery] Direction value)
+    {
+        return value.ToString();
+    }
+
+    [WolverineGet("/querystring/enum2/nullable")]
+    public static string Enum2Nullable([FromQuery] Direction? value)
+    {
+        return value.HasValue ? value.Value.ToString() : "Value is missing";
+    }
+
     [WolverineGet("/querystring/datetime/nullable")]
     public static string DateTimeNullable(DateTime? value)
     {


### PR DESCRIPTION
Follow-up to #3587 (GH-3586). While adding type-permutation coverage for the OpenAPI parameter-description path, two related issues surfaced.

## 1. Scalar `[FromQuery] decimal` was broken end to end

`FromQueryAttributeUsage` routes any type that isn't "simple" into the complex-flattening path, and JasperFx's `IsSimple()` does **not** treat `System.Decimal` as simple. So:

- **`[FromQuery] decimal`** (non-nullable) threw at endpoint discovery — `ArgumentOutOfRangeException: "System.Decimal has multiple constructors"` — which takes down the *entire* host, not just that endpoint.
- **`[FromQuery] decimal?`** silently bound **and** described itself from a query key named **`value`** (the parameter name of `Nullable<decimal>`'s constructor) instead of the parameter's own name. `?amount=1.5` would not bind; you'd have to send `?value=1.5`.

Every other numeric family binds correctly — I verified `byte`/`sbyte`/`short`/`ushort`/`int`/`uint`/`long`/`ulong`/`float`/`double` all render and bind fine. `decimal` was the lone outlier.

**Fix:** exclude `decimal` from the complex path in `IsComplexQueryStringType`, exactly as `Guid`/`DateTime`/`DateOnly`/etc. already are. One line, mirrors the existing guards.

## 2. #3587's route-collision fix had no CI-enforced test

#3587 shipped with only a manual `repro/*.cs` file that nothing in CI runs. This adds a real shape-test battery to the existing `openapi_shape_tests` harness (renders the actual `Microsoft.AspNetCore.OpenApi` document):

- **Collision battery** — a route-bound `[FromQuery]`/`[FromHeader]` is described exactly once (as a `Path` parameter) across every route-bindable CLR family: `string`, `Guid`, `int`, `long`, `bool`, `DateTime`, `enum`, `Nullable<T>`, **and** the header-collision case (which trips the same `SingleOrDefault` crash). A regression in the suppression for any single family fails only its own row.
- **Query schema-rendering battery** — pins the emitted `type`/`format` for query parameters across the CLR type families, so a change in how types are handed to the OpenAPI stack can't silently alter the schema.

## 3. Review-feedback doc comment

Per the review on #3587, documented why the name comparison in `isBoundFromRouteValue` is deliberately **case-sensitive** (it mirrors `FindRouteVariable`, the binder path that actually claims the parameter) and must not be unified with the case-insensitive `matchesRouteName` helper.

## Known limitation, left as a separate issue

`[FromQuery]` on an array/collection type (e.g. `string[]`) still throws an unhelpful `NullReferenceException` at discovery. That wants a clear "unsupported" diagnostic rather than a silent flatten — out of scope here.

## Testing

- New collision + schema batteries: green (`openapi_shape_tests`, MS OpenAPI stack).
- New `[FromQuery] decimal` / `decimal?` **runtime binding** tests (`using_querystring_parameters`) prove the value binds from its own key, not `value`.
- Full regression run of `from_query_binding` + `using_querystring_parameters` + `strict_query_string_binding` + `open_api`/`openapi` + `asparameters`: **173 passed, 0 failed**.
- `Wolverine.Http.Tests` Release build (net9.0 + net10.0): 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)