### PR TITLE
fix(durability): recover exclusive listener inboxes on the listening node (#3590)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ### WolverineFx (core)
 
+- **Fixed: durable exclusive / leader-pinned listeners never recovered their dormant inbox messages when the
+  durability agent ran on another node ([#3590](https://github.com/JasperFx/wolverine/issues/3590)).**
+  Inbox recovery was gated on the *local* listener circuit being `Accepting`, but the `DurabilityAgent` is
+  assigned per message database and distributed independently of the listener agents. Whenever the agent for a
+  database landed on a node that was not hosting that endpoint's exclusive listener, messages sitting at
+  `owner_id = 0` (the state an ungraceful shutdown leaves behind) were never recovered — a permanent deadlock
+  between two independently-assigned agents. Now the per-database durability agents skip every destination whose
+  `ListenerScope` is not `CompetingConsumers` (RDBMS, RavenDb and CosmosDb agents alike), and the node actually
+  hosting the listener recovers them itself through the new `ListenerInboxRecovery`: an initial sweep when the
+  listener reaches `Accepting`, then polling on the `Durability.ScheduledJobPollingTime` cadence for as long as
+  it stays `Accepting`. The sweep covers the main store, every tenant database in a separate-database-per-tenant
+  system, and every ancillary store, and it respects latching and `BufferingLimits` exactly as before. Applies
+  to `ExclusiveNodeWithParallelism()`, `ListenWithStrictOrdering()`, and `ListenOnlyAtLeader()`, in `Solo` mode
+  as well as `Balanced`. Also adds `IEndpointCollection.IsSingleNodeListener(Uri)` (a default interface method,
+  so existing implementors are unaffected) and a reusable `ExclusiveListenerRecoveryCompliance` fixture in
+  `WolverineFx.ComplianceTests`. See the
+  [exclusive node processing guide](https://wolverinefx.net/guide/messaging/exclusive-node-processing.html#inbox-recovery-ownership).
+
 - **New `IMessageBus.StreamAsync<TRequest, TResponse>` primitive for streaming requests.**
   The mirror image of `StreamAsync<T>`: a caller hands one handler invocation an
   `IAsyncEnumerable<TRequest>` stream of messages and awaits a single `TResponse`. The handler

--- a/docs/guide/durability/index.md
+++ b/docs/guide/durability/index.md
@@ -223,6 +223,50 @@ using var host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DocumentationSamples.cs#L82-L97' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_durable_inbox' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### Who Recovers the Inbox <Badge type="tip" text="6.22" />
+
+An incoming envelope in durable storage is either owned by a specific node (its `owner_id` is that node's
+assigned number) or it is *unowned* — `owner_id = 0`, meaning "any node may claim this". Messages become
+unowned when the node that owned them dies ungracefully and another node releases its ownership, and when
+replayed dead letter messages are moved back into the inbox. Getting those unowned messages back into a
+running listener is what "inbox recovery" means.
+
+Which node does that recovery depends on the endpoint's `ListenerScope`:
+
+| Listener | Recovered by | Why |
+| --- | --- | --- |
+| `CompetingConsumers` (the default) | The **durability agent** for that message database | Every node is listening, so whichever node holds the database's durability agent can safely claim the messages and process them locally |
+| `Exclusive` (`ExclusiveNodeWithParallelism()`, `ListenWithStrictOrdering()`) | The **node currently hosting the listener** | Only one node is listening. A different node claiming the messages would strand them again |
+| `PinnedToLeader` (`ListenOnlyAtLeader()`) | The **node currently hosting the listener** | Same reason |
+
+The distinction matters because the durability agent is **assigned per message database**, and those
+assignments are distributed across the cluster completely independently of the listener agents. So the node
+running the durability agent for a database is frequently *not* the node running that database's exclusive
+listener. If the durability agent were in charge of recovery for an exclusive endpoint, the two agents would
+deadlock: the agent would refuse to recover because its local listener isn't accepting, and the listening node
+would never look. (That was [GH-3590](https://github.com/JasperFx/wolverine/issues/3590), fixed in 6.22.)
+
+So for single node listeners, Wolverine inverts the ownership:
+
+* The per-database durability agents **never claim** inbox messages for endpoints whose `ListenerScope` is not
+  `CompetingConsumers`. They keep doing everything else for those endpoints — releasing a dead node's
+  ownership, [bumping stale inbox rows](#bumping-out-stale-inbox-outbox-messages), expiring messages.
+* The node that currently holds the listener recovers them itself, starting the moment the listener reaches
+  `Accepting` and then re-checking on the `Durability.ScheduledJobPollingTime` cadence for as long as it stays
+  `Accepting`. The repeat matters: a dead node's messages are released back to `owner_id = 0` later, by
+  whichever node holds that database's durability agent, and that is usually *after* the exclusive listener has
+  already restarted somewhere else.
+* That sweep covers **every** database that can hold inbox rows for the listener: the main store, every tenant
+  database when you use a separate database per tenant (including tenant databases provisioned at runtime), and
+  any [ancillary stores](/guide/durability/marten/ancillary-stores).
+* A listener that is latched, paused, or already at its `BufferingLimits` recovers nothing, exactly as with the
+  durability agent — circuit breaking behaves the way it always has.
+
+None of this is configurable, and it works the same in `Solo` mode as in `Balanced`. The practical consequence
+worth remembering: **if no node in the cluster is running an exclusive endpoint's listener, that endpoint's
+unowned inbox messages stay put by design.** They are recovered promptly once a listener activates. See
+[Exclusive Node Processing](/guide/messaging/exclusive-node-processing#inbox-recovery-ownership).
+
 ## Local Queues
 
 When you mark a [local queue](/guide/messaging/transports/local) as durable, you're telling Wolverine to ensure that every message published

--- a/docs/guide/messaging/exclusive-node-processing.md
+++ b/docs/guide/messaging/exclusive-node-processing.md
@@ -124,6 +124,38 @@ If the node running an exclusive listener fails:
 3. Processing resumes on the new node
 4. Any in-flight messages are handled according to your durability settings
 
+### Inbox Recovery Ownership <Badge type="tip" text="6.22" />
+
+For an endpoint using the durable inbox, ordinary "competing consumers" listeners have their dormant inbox
+messages recovered by the [durability agent](/guide/durability/). That agent is assigned **per message
+database** and distributed across the cluster independently of your listeners, so on any given node it might
+be running for a database whose exclusive listener lives somewhere else entirely.
+
+That does not work for a single node listener. Recovery has to happen on the one node that actually holds the
+listener, otherwise recovered messages would be handed to a node that is not listening. So for endpoints using
+`ExclusiveNodeWithParallelism()`, `ListenWithStrictOrdering()`, or `ListenOnlyAtLeader()`:
+
+* The per-database **durability agents never claim** those endpoints' inbox messages. They keep doing
+  everything else for them — releasing a dead node's ownership back to the cluster, bumping stale inbox rows,
+  expiring messages — they just stop claiming.
+* The **node currently hosting the listener** recovers them itself, starting as soon as the listener reaches
+  `Accepting` and then polling on the `Durability.ScheduledJobPollingTime` cadence for as long as it stays
+  `Accepting`. The poll matters: a dead node's messages are released back to `owner_id = 0` later, on whichever
+  node holds that database's durability agent, which is usually *after* the exclusive listener has restarted
+  somewhere else.
+* The sweep covers **every database that can hold inbox rows for the listener** — the main store, every tenant
+  database when you use a separate database per tenant (including tenant databases added at runtime), and any
+  ancillary stores.
+* A listener that is latched, paused, or already at its `BufferingLimits` recovers nothing, exactly like the
+  durability agent's own recovery. Circuit breaking still behaves the way it always has.
+
+This all happens automatically; there is nothing to configure. It applies in `Solo` mode as well as `Balanced`.
+
+::: tip
+If you see inbox messages sitting at `owner_id = 0` for an exclusive endpoint, check that the listener is
+actually running (and `Accepting`) somewhere in the cluster. Nothing else will pick them up by design.
+:::
+
 ### Local Queues
 
 Exclusive node processing is not supported for local queues since they are inherently single-node:

--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -208,6 +208,11 @@ This option does a couple things:
 * Sets any local execution of the listener's internal, local queue to be strictly sequential and only process messages with
   a single thread
 
+If the endpoint is also using the durable inbox, the node that currently holds the listener is the *only* node
+that recovers that endpoint's dormant inbox messages — the per-database durability agents deliberately leave
+them alone. See [Inbox Recovery Ownership](/guide/messaging/exclusive-node-processing#inbox-recovery-ownership)
+for the details. The same applies to `ListenOnlyAtLeader()`.
+
 ## Disabling All External Listeners
 
 In some cases, you may want to disable all message processing for messages received from external

--- a/src/Persistence/MartenTests/AncillaryStores/exclusive_listener_recovery_from_ancillary_store.cs
+++ b/src/Persistence/MartenTests/AncillaryStores/exclusive_listener_recovery_from_ancillary_store.cs
@@ -1,0 +1,154 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Wolverine;
+using Wolverine.ComplianceTests.ExclusiveListeners;
+using Wolverine.Configuration;
+using Wolverine.Marten;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Wolverine.Util;
+
+namespace MartenTests.AncillaryStores;
+
+/// <summary>
+/// GH-3590, ancillary-store variant. Inbox rows for a durable exclusive listener can live in an ancillary store
+/// sitting in an entirely different database. The listening node's recovery sweeps those too, and stamps
+/// <c>envelope.Store</c> so the follow-on mark-as-handled write lands in the ancillary database rather than
+/// silently falling back to the main store — the GH-2318 hazard.
+/// </summary>
+public class exclusive_listener_recovery_from_ancillary_store : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private string _ancillaryConnectionString = null!;
+
+    public async Task InitializeAsync()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            _ancillaryConnectionString = await createDatabaseIfNotExistsAsync(conn, "exclusive_ancillary");
+            await conn.CloseAsync();
+        }
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Durability.ScheduledJobPollingTime = 250.Milliseconds();
+                opts.Durability.MessageStorageSchemaName = "exclusive_recovery_main";
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "exclusive_recovery_main";
+                }).IntegrateWithWolverine();
+
+                opts.Services.AddMartenStore<IExclusiveRecoveryStore>(m =>
+                {
+                    m.Connection(_ancillaryConnectionString);
+                    m.DatabaseSchemaName = "exclusive_recovery_ancillary";
+                }).IntegrateWithWolverine();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<RecoveredMessageHandler>();
+
+                opts.ListenToSingleNodeEndpoint(
+                    ExclusiveListenerRecoveryCompliance.ExclusiveEndpointName, ListenerScope.Exclusive);
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private static async Task<string> createDatabaseIfNotExistsAsync(NpgsqlConnection conn, string databaseName)
+    {
+        if (!await conn.DatabaseExists(databaseName))
+        {
+            await new DatabaseSpecification().BuildDatabase(conn, databaseName);
+        }
+
+        return new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString)
+        {
+            Database = databaseName
+        }.ConnectionString;
+    }
+
+    [Fact]
+    public async Task recovers_dormant_messages_out_of_the_ancillary_store()
+    {
+        using var tracking = RecoveredMessages.Track();
+
+        var runtime = _host.GetRuntime();
+        var destination =
+            SingleNodeListenerTransport.ToUri(ExclusiveListenerRecoveryCompliance.ExclusiveEndpointName);
+
+        var ancillary = runtime.Stores.FindAncillaryStore(typeof(IExclusiveRecoveryStore));
+        ancillary.ShouldNotBeNull();
+
+        var serializer = runtime.Options.DefaultSerializer;
+        var envelopes = Enumerable.Range(0, 5).Select(i =>
+        {
+            var id = Guid.NewGuid();
+            var envelope = new Envelope(new RecoveredMessage(id, i))
+            {
+                Id = id,
+                Destination = destination,
+                Status = EnvelopeStatus.Incoming,
+                OwnerId = TransportConstants.AnyNode,
+                ContentType = serializer.ContentType,
+                MessageType = typeof(RecoveredMessage).ToMessageTypeName(),
+                SentAt = DateTimeOffset.UtcNow
+            };
+
+            envelope.Data = serializer.Write(envelope);
+
+            return envelope;
+        }).ToArray();
+
+        await ancillary.Inbox.StoreIncomingAsync(envelopes);
+
+        var expected = envelopes.Select(x => x.Id).ToArray();
+
+        var succeeded = await waitForAsync(() => expected.All(tracking.Contains), 60.Seconds());
+
+        succeeded.ShouldBeTrue(
+            $"Expected all {expected.Length} dormant messages in the ancillary store to be recovered by the " +
+            $"exclusive listener, but only saw {tracking.Count}");
+
+        // And they were completed against the ancillary store rather than leaking into the main one
+        var stillIncoming = await waitForAsync(
+            () => ancillary.LoadPageOfGloballyOwnedIncomingAsync(destination, 100).GetAwaiter().GetResult().Count == 0,
+            10.Seconds());
+
+        stillIncoming.ShouldBeTrue("The ancillary store's inbox rows should no longer be globally owned");
+    }
+
+    private static async Task<bool> waitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (condition()) return true;
+            await Task.Delay(100.Milliseconds());
+        }
+
+        return condition();
+    }
+}
+
+public interface IExclusiveRecoveryStore : IDocumentStore;

--- a/src/Persistence/MartenTests/exclusive_listener_recovery_compliance.cs
+++ b/src/Persistence/MartenTests/exclusive_listener_recovery_compliance.cs
@@ -1,0 +1,23 @@
+using IntegrationTests;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Wolverine;
+using Wolverine.ComplianceTests.ExclusiveListeners;
+using Wolverine.Marten;
+
+namespace MartenTests;
+
+/// <summary>
+/// GH-3590 -- see <see cref="ExclusiveListenerRecoveryCompliance"/>.
+/// </summary>
+public class exclusive_listener_recovery_compliance : ExclusiveListenerRecoveryCompliance
+{
+    protected override void ConfigureStorage(WolverineOptions options)
+    {
+        options.Services.AddMarten(m =>
+        {
+            m.Connection(Servers.PostgresConnectionString);
+            m.DatabaseSchemaName = "exclusive_recovery_marten";
+        }).IntegrateWithWolverine();
+    }
+}

--- a/src/Persistence/MySql/MySqlTests/exclusive_listener_recovery_compliance.cs
+++ b/src/Persistence/MySql/MySqlTests/exclusive_listener_recovery_compliance.cs
@@ -1,0 +1,17 @@
+using IntegrationTests;
+using Wolverine;
+using Wolverine.ComplianceTests.ExclusiveListeners;
+using Wolverine.MySql;
+
+namespace MySqlTests;
+
+/// <summary>
+/// GH-3590 -- see <see cref="ExclusiveListenerRecoveryCompliance"/>.
+/// </summary>
+public class exclusive_listener_recovery_compliance : ExclusiveListenerRecoveryCompliance
+{
+    protected override void ConfigureStorage(WolverineOptions options)
+    {
+        options.PersistMessagesWithMySql(Servers.MySqlConnectionString, "exclusive_recovery");
+    }
+}

--- a/src/Persistence/Oracle/OracleTests/exclusive_listener_recovery_compliance.cs
+++ b/src/Persistence/Oracle/OracleTests/exclusive_listener_recovery_compliance.cs
@@ -1,0 +1,17 @@
+using IntegrationTests;
+using Wolverine;
+using Wolverine.ComplianceTests.ExclusiveListeners;
+using Wolverine.Oracle;
+
+namespace OracleTests;
+
+/// <summary>
+/// GH-3590 -- see <see cref="ExclusiveListenerRecoveryCompliance"/>.
+/// </summary>
+public class exclusive_listener_recovery_compliance : ExclusiveListenerRecoveryCompliance
+{
+    protected override void ConfigureStorage(WolverineOptions options)
+    {
+        options.PersistMessagesWithOracle(Servers.OracleConnectionString, "WOLVERINE");
+    }
+}

--- a/src/Persistence/PersistenceTests/Durability/single_node_listener_recovery_exclusion.cs
+++ b/src/Persistence/PersistenceTests/Durability/single_node_listener_recovery_exclusion.cs
@@ -1,0 +1,147 @@
+using System.Data.Common;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime.Agents;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Durability;
+using Wolverine.Transports;
+using Wolverine.Transports.Local;
+using Xunit;
+
+namespace PersistenceTests.Durability;
+
+/// <summary>
+/// GH-3590. The per-database durability agent is distributed independently of the listener agents, so it will
+/// routinely run on a node that is NOT hosting a given exclusive (or leader-pinned) listener. It must never
+/// claim inbox rows for those endpoints — the listening node recovers them itself through
+/// <see cref="ListenerInboxRecovery"/>.
+/// </summary>
+public class single_node_listener_recovery_exclusion
+{
+    private readonly IEndpointCollection theEndpoints = Substitute.For<IEndpointCollection>();
+    private readonly IMessageDatabase theDatabase = Substitute.For<IMessageDatabase>();
+
+    private readonly DurabilitySettings theSettings = new()
+    {
+        RecoveryBatchSize = 100
+    };
+
+    private readonly Uri theExclusiveUri = new("rabbitmq://queue/exclusive");
+    private readonly Uri theCompetingUri = new("rabbitmq://queue/competing");
+
+    private async Task<IAgentCommand[]> commandsFor(params Uri[] destinations)
+    {
+        var operation =
+            new CheckRecoverableIncomingMessagesOperation(theDatabase, theEndpoints, theSettings,
+                NullLogger.Instance);
+
+        var reader = Substitute.For<DbDataReader>();
+        var index = -1;
+        reader.ReadAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            index++;
+            return index < destinations.Length;
+        });
+        reader.GetFieldValueAsync<string>(0, Arg.Any<CancellationToken>())
+            .Returns(_ => destinations[index].ToString());
+        reader.GetFieldValueAsync<int>(1, Arg.Any<CancellationToken>()).Returns(_ => 5);
+
+        await operation.ReadResultsAsync(reader, new List<Exception>(), CancellationToken.None);
+
+        return operation.PostProcessingCommands().ToArray();
+    }
+
+    private IListenerCircuit acceptingCircuitFor(Uri uri, ListenerScope scope)
+    {
+        var endpoint = new LocalQueue(uri.Segments.Last())
+        {
+            ListenerScope = scope,
+            BufferingLimits = new BufferingLimits(500, 100)
+        };
+
+        var circuit = Substitute.For<IListeningAgent, IListenerCircuit>();
+        circuit.Endpoint.Returns(endpoint);
+        circuit.Status.Returns(ListeningStatus.Accepting);
+        circuit.QueueCount.Returns(0);
+
+        theEndpoints.FindListenerCircuit(uri).Returns(circuit);
+
+        return circuit;
+    }
+
+    [Fact]
+    public async Task does_not_issue_a_recovery_command_for_an_exclusive_listener()
+    {
+        acceptingCircuitFor(theExclusiveUri, ListenerScope.Exclusive);
+        theEndpoints.IsSingleNodeListener(theExclusiveUri).Returns(true);
+
+        var commands = await commandsFor(theExclusiveUri);
+
+        commands.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task never_even_looks_up_a_circuit_for_a_single_node_listener()
+    {
+        // The FindListenerCircuit() fallback resolves an unknown address to the durable local queue, which
+        // would happily swallow another node's messages. The skip has to happen first.
+        theEndpoints.IsSingleNodeListener(theExclusiveUri).Returns(true);
+
+        await commandsFor(theExclusiveUri);
+
+        theEndpoints.DidNotReceive().FindListenerCircuit(theExclusiveUri);
+    }
+
+    [Fact]
+    public async Task still_recovers_for_a_competing_consumers_listener()
+    {
+        acceptingCircuitFor(theCompetingUri, ListenerScope.CompetingConsumers);
+        theEndpoints.IsSingleNodeListener(theCompetingUri).Returns(false);
+
+        var commands = await commandsFor(theCompetingUri);
+
+        commands.Single().ShouldBeOfType<RecoverIncomingMessagesCommand>();
+    }
+
+    [Fact]
+    public async Task skips_only_the_single_node_destination_in_a_mixed_batch()
+    {
+        acceptingCircuitFor(theExclusiveUri, ListenerScope.Exclusive);
+        acceptingCircuitFor(theCompetingUri, ListenerScope.CompetingConsumers);
+
+        theEndpoints.IsSingleNodeListener(theExclusiveUri).Returns(true);
+        theEndpoints.IsSingleNodeListener(theCompetingUri).Returns(false);
+
+        var commands = await commandsFor(theExclusiveUri, theCompetingUri);
+
+        commands.Single().ShouldBeOfType<RecoverIncomingMessagesCommand>();
+    }
+
+    [Theory]
+    [InlineData(ListenerScope.Exclusive)]
+    [InlineData(ListenerScope.PinnedToLeader)]
+    public void determine_page_size_is_zero_for_a_single_node_listener(ListenerScope scope)
+    {
+        var circuit = acceptingCircuitFor(theExclusiveUri, scope);
+
+        var command = new RecoverIncomingMessagesCommand(theDatabase, new IncomingCount(theExclusiveUri, 50),
+            circuit, theSettings, NullLogger.Instance);
+
+        command.DeterminePageSize(circuit, new IncomingCount(theExclusiveUri, 50), theSettings).ShouldBe(0);
+    }
+
+    [Fact]
+    public void determine_page_size_is_unchanged_for_competing_consumers()
+    {
+        var circuit = acceptingCircuitFor(theCompetingUri, ListenerScope.CompetingConsumers);
+
+        var command = new RecoverIncomingMessagesCommand(theDatabase, new IncomingCount(theCompetingUri, 50),
+            circuit, theSettings, NullLogger.Instance);
+
+        command.DeterminePageSize(circuit, new IncomingCount(theCompetingUri, 50), theSettings).ShouldBe(50);
+    }
+}

--- a/src/Persistence/PostgresqlTests/MultiTenancy/exclusive_listener_recovery_across_tenant_databases.cs
+++ b/src/Persistence/PostgresqlTests/MultiTenancy/exclusive_listener_recovery_across_tenant_databases.cs
@@ -1,0 +1,169 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Wolverine;
+using Wolverine.ComplianceTests.ExclusiveListeners;
+using Wolverine.Configuration;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Wolverine.Util;
+using Xunit;
+
+namespace PostgresqlTests.MultiTenancy;
+
+/// <summary>
+/// GH-3590, separate-database-per-tenant variant. A durable exclusive listener owns its own inbox recovery, and
+/// "its own inbox" means <em>every</em> database that can hold rows for it — the main store AND every tenant
+/// database — not just the default one. <see cref="ListenerInboxRecovery"/> goes through
+/// <c>MessageStoreCollection.FindAllAsync()</c> for exactly this reason.
+/// </summary>
+public class exclusive_listener_recovery_across_tenant_databases : PostgresqlContext, IAsyncLifetime
+{
+    private readonly string theSuffix = Guid.NewGuid().ToString("N")[..8];
+    private readonly string[] theTenants = ["red", "blue", "green"];
+
+    private IHost _host = null!;
+
+    private string MainSchema => $"ex3590_{theSuffix}";
+    private string TenantDatabase(string tenant) => $"w3590_{tenant}_{theSuffix}";
+
+    private static string ConnectionStringFor(string database)
+    {
+        return new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString)
+        {
+            Database = database
+        }.ConnectionString;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+
+            foreach (var tenant in theTenants)
+            {
+                var databaseName = TenantDatabase(tenant);
+                if (!await conn.DatabaseExists(databaseName))
+                {
+                    await new DatabaseSpecification().BuildDatabase(conn, databaseName);
+                }
+            }
+
+            await conn.CloseAsync();
+        }
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Durability.ScheduledJobPollingTime = 250.Milliseconds();
+
+                opts.PersistMessagesWithPostgresql(ConnectionStringFor("postgres"), MainSchema)
+                    .RegisterStaticTenants(tenants =>
+                    {
+                        foreach (var tenant in theTenants)
+                        {
+                            tenants.Register(tenant, ConnectionStringFor(TenantDatabase(tenant)));
+                        }
+                    });
+
+                opts.Services.AddResourceSetupOnStartup();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<RecoveredMessageHandler>();
+
+                opts.ListenToSingleNodeEndpoint(
+                    ExclusiveListenerRecoveryCompliance.ExclusiveEndpointName, ListenerScope.Exclusive);
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task drains_dormant_messages_out_of_every_tenant_database()
+    {
+        using var tracking = RecoveredMessages.Track();
+
+        var runtime = _host.GetRuntime();
+        var destination =
+            SingleNodeListenerTransport.ToUri(ExclusiveListenerRecoveryCompliance.ExclusiveEndpointName);
+
+        runtime.Endpoints.FindListeningAgent(destination)
+            .ShouldNotBeNull("The exclusive listener should be running in Solo mode");
+
+        var expected = new List<Guid>();
+
+        // Seed dormant rows in EVERY tenant database, not just the main one
+        foreach (var tenant in theTenants)
+        {
+            var store = await runtime.Stores.Main.As<MultiTenantedMessageStore>().Source.FindAsync(tenant);
+            store.ShouldNotBeNull();
+
+            var seeded = await seedAsync(store!, runtime, destination, tenant, 3);
+            expected.AddRange(seeded);
+        }
+
+        var succeeded = await waitForAsync(() => expected.All(tracking.Contains), 60.Seconds());
+
+        succeeded.ShouldBeTrue(
+            $"Expected all {expected.Count} dormant messages across {theTenants.Length} tenant databases to be " +
+            $"recovered by the exclusive listener, but only saw {tracking.Count}");
+    }
+
+    private static async Task<Guid[]> seedAsync(IMessageStore store, IWolverineRuntime runtime, Uri destination,
+        string tenantId, int count)
+    {
+        var serializer = runtime.Options.DefaultSerializer;
+
+        var envelopes = Enumerable.Range(0, count).Select(i =>
+        {
+            var id = Guid.NewGuid();
+            var envelope = new Envelope(new RecoveredMessage(id, i))
+            {
+                Id = id,
+                Destination = destination,
+                Status = EnvelopeStatus.Incoming,
+                OwnerId = TransportConstants.AnyNode,
+                ContentType = serializer.ContentType,
+                MessageType = typeof(RecoveredMessage).ToMessageTypeName(),
+                TenantId = tenantId,
+                SentAt = DateTimeOffset.UtcNow
+            };
+
+            envelope.Data = serializer.Write(envelope);
+
+            return envelope;
+        }).ToArray();
+
+        await store.Inbox.StoreIncomingAsync(envelopes);
+
+        return envelopes.Select(x => x.Id).ToArray();
+    }
+
+    private static async Task<bool> waitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (condition()) return true;
+            await Task.Delay(100.Milliseconds());
+        }
+
+        return condition();
+    }
+}

--- a/src/Persistence/PostgresqlTests/exclusive_listener_recovery_compliance.cs
+++ b/src/Persistence/PostgresqlTests/exclusive_listener_recovery_compliance.cs
@@ -1,0 +1,17 @@
+using IntegrationTests;
+using Wolverine;
+using Wolverine.ComplianceTests.ExclusiveListeners;
+using Wolverine.Postgresql;
+
+namespace PostgresqlTests;
+
+/// <summary>
+/// GH-3590 -- see <see cref="ExclusiveListenerRecoveryCompliance"/>.
+/// </summary>
+public class exclusive_listener_recovery_compliance : ExclusiveListenerRecoveryCompliance
+{
+    protected override void ConfigureStorage(WolverineOptions options)
+    {
+        options.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "exclusive_recovery");
+    }
+}

--- a/src/Persistence/SqlServerTests/exclusive_listener_recovery_compliance.cs
+++ b/src/Persistence/SqlServerTests/exclusive_listener_recovery_compliance.cs
@@ -1,0 +1,17 @@
+using IntegrationTests;
+using Wolverine;
+using Wolverine.ComplianceTests.ExclusiveListeners;
+using Wolverine.SqlServer;
+
+namespace SqlServerTests;
+
+/// <summary>
+/// GH-3590 -- see <see cref="ExclusiveListenerRecoveryCompliance"/>.
+/// </summary>
+public class exclusive_listener_recovery_compliance : ExclusiveListenerRecoveryCompliance
+{
+    protected override void ConfigureStorage(WolverineOptions options)
+    {
+        options.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "exclusive_recovery");
+    }
+}

--- a/src/Persistence/SqliteTests/exclusive_listener_recovery_compliance.cs
+++ b/src/Persistence/SqliteTests/exclusive_listener_recovery_compliance.cs
@@ -1,0 +1,23 @@
+using Wolverine;
+using Wolverine.ComplianceTests.ExclusiveListeners;
+using Wolverine.Sqlite;
+
+namespace SqliteTests;
+
+/// <summary>
+/// GH-3590 -- see <see cref="ExclusiveListenerRecoveryCompliance"/>.
+/// </summary>
+public class exclusive_listener_recovery_compliance : ExclusiveListenerRecoveryCompliance, IDisposable
+{
+    private readonly SqliteTestDatabase _database = Servers.CreateDatabase("exclusive_recovery");
+
+    protected override void ConfigureStorage(WolverineOptions options)
+    {
+        options.PersistMessagesWithSqlite(_database.ConnectionString);
+    }
+
+    public void Dispose()
+    {
+        _database.Dispose();
+    }
+}

--- a/src/Persistence/Wolverine.CosmosDb/Internals/Durability/CosmosDbDurabilityAgent.Incoming.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/Durability/CosmosDbDurabilityAgent.Incoming.cs
@@ -35,8 +35,18 @@ public partial class CosmosDbDurabilityAgent
             foreach (var listenerStr in listeners)
             {
                 var receivedAt = new Uri(listenerStr);
+
+                // GH-3590: exclusive and leader-pinned listeners run on exactly one node, which is not
+                // necessarily this one. Those endpoints recover their own inbox (ListenerInboxRecovery).
+                // Checked before the circuit lookup because FindListenerCircuit() falls back to the durable
+                // local queue and would otherwise mis-route another node's messages here.
+                if (_runtime.Endpoints.IsSingleNodeListener(receivedAt))
+                {
+                    continue;
+                }
+
                 var circuit = _runtime.Endpoints.FindListenerCircuit(receivedAt);
-                if (circuit!.Status != ListeningStatus.Accepting)
+                if (circuit == null || circuit.Status != ListeningStatus.Accepting)
                 {
                     continue;
                 }

--- a/src/Persistence/Wolverine.RDBMS/Durability/CheckRecoverableIncomingMessagesOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/CheckRecoverableIncomingMessagesOperation.cs
@@ -54,6 +54,16 @@ internal class CheckRecoverableIncomingMessagesOperation : IDatabaseOperation
         
         foreach (var incoming in _incoming)
         {
+            // GH-3590: exclusive and leader-pinned listeners are only active on ONE node, while this durability
+            // agent is assigned per database and may well be running somewhere else. Recovery for those endpoints
+            // is owned by the listening node itself (ListenerInboxRecovery). This check has to happen BEFORE any
+            // circuit lookup, because FindListenerCircuit() falls back to the durable local queue and would
+            // otherwise mis-route another node's messages into this node's local queue.
+            if (_endpoints.IsSingleNodeListener(incoming.Destination))
+            {
+                continue;
+            }
+
             var listener = _endpoints.FindListenerCircuit(incoming.Destination);
             if (listener == null) continue; // This *might* happen during shutdown
 

--- a/src/Persistence/Wolverine.RavenDb/Internals/Durability/RavenDbDurabilityAgent.Incoming.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/Durability/RavenDbDurabilityAgent.Incoming.cs
@@ -22,6 +22,16 @@ public partial class RavenDbDurabilityAgent
             foreach (var listener in listeners.Where(x => x.ReceivedAt != null))
             {
                 var receivedAt = listener.ReceivedAt!;
+
+                // GH-3590: exclusive and leader-pinned listeners run on exactly one node, which is not
+                // necessarily this one. Those endpoints recover their own inbox (ListenerInboxRecovery).
+                // Checked before the circuit lookup because FindListenerCircuit() falls back to the durable
+                // local queue and would otherwise mis-route another node's messages here.
+                if (_runtime.Endpoints.IsSingleNodeListener(receivedAt))
+                {
+                    continue;
+                }
+
                 // circuit can be null when the URI isn't serviced by this node
                 var circuit = _runtime.Endpoints.FindListenerCircuit(receivedAt);
                 if (circuit == null || circuit.Status != ListeningStatus.Accepting)

--- a/src/Testing/CoreTests/Configuration/is_single_node_listener.cs
+++ b/src/Testing/CoreTests/Configuration/is_single_node_listener.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Tracking;
+using Wolverine.Transports.Tcp;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+/// <summary>
+/// GH-3590. The durability agents ask this question on every recovery pass to decide whether a destination's
+/// inbox rows are theirs to claim, so it has to be right for every <see cref="ListenerScope"/> — and safe for
+/// addresses the node has never heard of.
+/// </summary>
+public class is_single_node_listener
+{
+    // Deliberately built inside each test rather than from IAsyncLifetime.InitializeAsync: a Wolverine host
+    // created from xUnit's async-lifetime path resolves its calling assembly to "testhost", which pins the
+    // process-wide RememberedApplicationAssembly and trips remembered_application_assembly_reuse_warning.
+    private static async Task withHostAsync(Action<IHost> assertion)
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ListenAtPort(PortFinder.GetAvailablePort()).ListenWithStrictOrdering("exclusive-one");
+                opts.ListenAtPort(PortFinder.GetAvailablePort()).ListenOnlyAtLeader().Named("leader-one");
+                opts.ListenAtPort(PortFinder.GetAvailablePort()).Named("competing-one");
+
+                opts.Durability.Mode = DurabilityMode.Solo;
+            }).StartAsync();
+
+        assertion(host);
+    }
+
+    private static bool isSingleNodeListener(IHost host, string endpointName)
+    {
+        var endpoints = host.GetRuntime().Endpoints;
+        return endpoints.IsSingleNodeListener(endpoints.EndpointByName(endpointName)!.Uri);
+    }
+
+    [Fact]
+    public Task exclusive_listener_is_a_single_node_listener()
+    {
+        return withHostAsync(host => isSingleNodeListener(host, "exclusive-one").ShouldBeTrue());
+    }
+
+    [Fact]
+    public Task leader_pinned_listener_is_a_single_node_listener()
+    {
+        return withHostAsync(host => isSingleNodeListener(host, "leader-one").ShouldBeTrue());
+    }
+
+    [Fact]
+    public Task competing_consumers_listener_is_not_a_single_node_listener()
+    {
+        return withHostAsync(host => isSingleNodeListener(host, "competing-one").ShouldBeFalse());
+    }
+
+    [Fact]
+    public Task unknown_address_is_not_a_single_node_listener()
+    {
+        return withHostAsync(host =>
+            host.GetRuntime().Endpoints.IsSingleNodeListener(new Uri("tcp://localhost:65001")).ShouldBeFalse());
+    }
+}

--- a/src/Testing/Wolverine.ComplianceTests/ExclusiveListeners/ExclusiveListenerRecoveryCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/ExclusiveListeners/ExclusiveListenerRecoveryCompliance.cs
@@ -1,0 +1,427 @@
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Wolverine.Util;
+using Xunit;
+
+namespace Wolverine.ComplianceTests.ExclusiveListeners;
+
+/// <summary>
+/// GH-3590. Durable listeners that are only ever active on ONE node — <see cref="ListenerScope.Exclusive"/>
+/// and <see cref="ListenerScope.PinnedToLeader"/> — can not depend on the per-database durability agent to
+/// recover dormant (<c>owner_id = 0</c>) inbox rows, because that agent is distributed per database and
+/// routinely lands on a different node than the listener. Recovery is instead owned by the listening node
+/// itself through <see cref="ListenerInboxRecovery"/>.
+///
+/// A provider opts into this suite by supplying nothing more than its storage bootstrapping, so every current
+/// and future <see cref="IMessageStore"/> reuses the same harness. The listening endpoint is a broker-free
+/// durable transport (<see cref="SingleNodeListenerTransport"/>) so no message broker is needed.
+/// </summary>
+public abstract class ExclusiveListenerRecoveryCompliance : IAsyncLifetime
+{
+    /// <summary>
+    /// The listener under test in the end to end scenarios — actually started, so it drives its own recovery.
+    /// </summary>
+    public const string ExclusiveEndpointName = "exclusive-recovery";
+
+    public const string LeaderPinnedEndpointName = "leader-pinned-recovery";
+
+    /// <summary>
+    /// An endpoint that carries <see cref="ListenerScope.Exclusive"/> but is deliberately NOT started, standing
+    /// in for "the exclusive listener lives on some other node". This is how a single-host test can observe what
+    /// the durability agent does — or rather does not do — with dormant rows it must not claim.
+    /// </summary>
+    public const string DormantEndpointName = "dormant-exclusive-recovery";
+
+    private readonly List<IHost> _hosts = new();
+
+    /// <summary>
+    /// The only thing a provider has to supply: attach its message store to the options.
+    /// </summary>
+    protected abstract void ConfigureStorage(WolverineOptions options);
+
+    /// <summary>
+    /// Some providers need extra teardown between runs. The default wipes all Wolverine state through the
+    /// standard resource model.
+    /// </summary>
+    protected virtual Task ResetStateAsync(IHost host)
+    {
+        return host.ResetResourceState();
+    }
+
+    public virtual Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        foreach (var host in _hosts.ToArray())
+        {
+            try
+            {
+                await host.StopAsync();
+                host.Dispose();
+            }
+            catch (Exception)
+            {
+                // Nothing useful to do about a host that won't shut down cleanly during teardown
+            }
+        }
+
+        _hosts.Clear();
+    }
+
+    protected async Task<IHost> startHostAsync(DurabilityMode mode)
+    {
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "ExclusiveListenerRecovery";
+                opts.Durability.Mode = mode;
+
+                // Keep the polling tight so the tests don't have to wait out the 5 second default
+                opts.Durability.ScheduledJobPollingTime = 250.Milliseconds();
+                opts.Durability.NodeReassignmentPollingTime = 1.Seconds();
+                opts.Durability.HealthCheckPollingTime = 1.Seconds();
+
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Discovery.IncludeType<RecoveredMessageHandler>();
+
+                opts.ListenToSingleNodeEndpoint(ExclusiveEndpointName, ListenerScope.Exclusive);
+                opts.ListenToSingleNodeEndpoint(LeaderPinnedEndpointName, ListenerScope.PinnedToLeader);
+
+                // Registered, exclusive, but never listening on this node
+                opts.ListenToSingleNodeEndpoint(DormantEndpointName, ListenerScope.Exclusive).IsListener = false;
+
+                ConfigureStorage(opts);
+            })
+            .StartAsync();
+
+        _hosts.Add(host);
+
+        // Every test method seeds its own dormant rows, so start each one from a clean inbox
+        await ResetStateAsync(host);
+
+        return host;
+    }
+
+    protected static Uri UriFor(string endpointName)
+    {
+        return SingleNodeListenerTransport.ToUri(endpointName);
+    }
+
+    /// <summary>
+    /// Seed dormant inbox rows exactly the way an ungraceful shutdown leaves them: status Incoming, owner_id
+    /// back at <see cref="TransportConstants.AnyNode"/>, received_at pointed at the single node listener.
+    /// </summary>
+    protected static async Task<Envelope[]> seedDormantMessagesAsync(IMessageStore store, IWolverineRuntime runtime,
+        Uri destination, int count)
+    {
+        var serializer = runtime.Options.DefaultSerializer;
+
+        var envelopes = Enumerable.Range(0, count).Select(i =>
+        {
+            // Deliberately the same Guid on both, so the tests can correlate what was seeded in the inbox with
+            // what the handler actually received.
+            var id = Guid.NewGuid();
+            var envelope = new Envelope(new RecoveredMessage(id, i))
+            {
+                Id = id,
+                Destination = destination,
+                Status = EnvelopeStatus.Incoming,
+                OwnerId = TransportConstants.AnyNode,
+                ContentType = serializer.ContentType,
+                MessageType = typeof(RecoveredMessage).ToMessageTypeName(),
+                SentAt = DateTimeOffset.UtcNow
+            };
+
+            envelope.Data = serializer.Write(envelope);
+
+            return envelope;
+        }).ToArray();
+
+        await store.Inbox.StoreIncomingAsync(envelopes);
+
+        return envelopes;
+    }
+
+    protected static async Task<bool> waitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            await Task.Delay(100.Milliseconds());
+        }
+
+        return condition();
+    }
+
+    #region Store primitive compliance
+
+    [Fact]
+    public async Task recover_dormant_messages_for_a_single_node_listener()
+    {
+        var host = await startHostAsync(DurabilityMode.Solo);
+        var runtime = host.GetRuntime();
+        var store = host.Services.GetRequiredService<IMessageStore>();
+        var destination = UriFor(DormantEndpointName);
+
+        var circuit = new RecordingListenerCircuit(runtime.Endpoints.EndpointFor(destination)!);
+        var seeded = await seedDormantMessagesAsync(store, runtime, destination, 5);
+
+        var recovery = new ListenerInboxRecovery(runtime, circuit, NullLogger.Instance);
+        var count = await recovery.RecoverAsync();
+
+        count.ShouldBe(seeded.Length);
+        circuit.Enqueued.Select(x => x.Id).OrderBy(x => x)
+            .ShouldBe(seeded.Select(x => x.Id).OrderBy(x => x));
+
+        // Every recovered envelope knows which store it came from -- GH-2318
+        foreach (var envelope in circuit.Enqueued)
+        {
+            envelope.Store.ShouldNotBeNull();
+        }
+
+        // Reassigned to this node, so a second sweep finds nothing left to claim
+        (await recovery.RecoverAsync()).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_latched_circuit_recovers_nothing()
+    {
+        var host = await startHostAsync(DurabilityMode.Solo);
+        var runtime = host.GetRuntime();
+        var store = host.Services.GetRequiredService<IMessageStore>();
+        var destination = UriFor(DormantEndpointName);
+
+        var circuit = new RecordingListenerCircuit(runtime.Endpoints.EndpointFor(destination)!)
+        {
+            Status = ListeningStatus.Stopped
+        };
+
+        await seedDormantMessagesAsync(store, runtime, destination, 5);
+
+        var recovery = new ListenerInboxRecovery(runtime, circuit, NullLogger.Instance);
+
+        (await recovery.RecoverAsync()).ShouldBe(0);
+        circuit.Enqueued.ShouldBeEmpty();
+
+        // Still dormant, and available to whichever node picks up the listener later
+        (await store.LoadPageOfGloballyOwnedIncomingAsync(destination, 100)).Count.ShouldBe(5);
+    }
+
+    #endregion
+
+    #region End to end
+
+    [Fact]
+    public async Task exclusive_listener_recovers_its_own_dormant_inbox_end_to_end()
+    {
+        await recoversEndToEndAsync(ExclusiveEndpointName);
+    }
+
+    [Fact]
+    public async Task leader_pinned_listener_recovers_its_own_dormant_inbox_end_to_end()
+    {
+        await recoversEndToEndAsync(LeaderPinnedEndpointName);
+    }
+
+    private async Task recoversEndToEndAsync(string endpointName)
+    {
+        using var tracking = RecoveredMessages.Track();
+
+        var host = await startHostAsync(DurabilityMode.Solo);
+        var runtime = host.GetRuntime();
+        var store = host.Services.GetRequiredService<IMessageStore>();
+        var destination = UriFor(endpointName);
+
+        runtime.Endpoints.FindListeningAgent(destination).ShouldNotBeNull(
+            $"Expected the {endpointName} listener to be running in Solo mode");
+
+        var seeded = await seedDormantMessagesAsync(store, runtime, destination, 5);
+        var expected = seeded.Select(x => x.Id).ToArray();
+
+        var succeeded = await waitForAsync(() => expected.All(tracking.Contains), 30.Seconds());
+
+        succeeded.ShouldBeTrue(
+            $"Expected the {endpointName} listener to recover and handle all {seeded.Length} dormant inbox " +
+            $"messages, but only saw {tracking.Count}");
+    }
+
+    #endregion
+
+    #region Durability agent exclusion
+
+    /// <summary>
+    /// With the single node listener deliberately NOT running on this node, the per-database durability agent
+    /// must leave the dormant rows exactly where they are — no claim, no error storm — and they must recover
+    /// promptly once the listener does activate here.
+    /// </summary>
+    [Fact]
+    public async Task durability_agent_leaves_dormant_rows_for_a_single_node_listener_alone()
+    {
+        using var tracking = RecoveredMessages.Track();
+
+        var host = await startHostAsync(DurabilityMode.Solo);
+        var runtime = host.GetRuntime();
+        var store = host.Services.GetRequiredService<IMessageStore>();
+        var destination = UriFor(DormantEndpointName);
+
+        runtime.Endpoints.FindListeningAgent(destination).ShouldBeNull(
+            "This endpoint stands in for an exclusive listener that is active on some other node");
+
+        var seeded = await seedDormantMessagesAsync(store, runtime, destination, 5);
+
+        // Give the durability agent several polling passes to misbehave
+        await Task.Delay(2.Seconds());
+
+        var stillDormant = await store.LoadPageOfGloballyOwnedIncomingAsync(destination, 100);
+        stillDormant.Count.ShouldBe(seeded.Length,
+            "The durability agent must never claim inbox rows for a listener that only runs on one node");
+
+        tracking.Count.ShouldBe(0,
+            "Nothing should have been recovered on a node that is not hosting the exclusive listener");
+
+        // ... and the moment the listener does activate here, they are recovered
+        await runtime.Endpoints.StartListenerAsync(runtime.Endpoints.EndpointFor(destination)!,
+            CancellationToken.None);
+
+        var expected = seeded.Select(x => x.Id).ToArray();
+        var succeeded = await waitForAsync(() => expected.All(tracking.Contains), 30.Seconds());
+
+        succeeded.ShouldBeTrue(
+            $"Expected all {seeded.Length} dormant messages to be recovered once the exclusive listener started " +
+            $"on this node, but only saw {tracking.Count}");
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Captures what a real <see cref="Wolverine.Transports.ListeningAgent"/> would have enqueued, so the store
+/// primitive tests can assert on recovery without standing up a full listener.
+/// </summary>
+public class RecordingListenerCircuit : IListenerCircuit
+{
+    public RecordingListenerCircuit(Endpoint endpoint)
+    {
+        Endpoint = endpoint;
+    }
+
+    public List<Envelope> Enqueued { get; } = new();
+
+    public ListeningStatus Status { get; set; } = ListeningStatus.Accepting;
+
+    public Endpoint Endpoint { get; }
+
+    public int QueueCount => Enqueued.Count;
+
+    public ValueTask PauseAsync(TimeSpan pauseTime) => ValueTask.CompletedTask;
+
+    public ValueTask PauseWithDrainAsync(TimeSpan pauseTime) => ValueTask.CompletedTask;
+
+    public ValueTask StartAsync() => ValueTask.CompletedTask;
+
+    public Task EnqueueDirectlyAsync(IEnumerable<Envelope> envelopes)
+    {
+        Enqueued.AddRange(envelopes);
+        return Task.CompletedTask;
+    }
+}
+
+public record RecoveredMessage(Guid Id, int Sequence);
+
+public class RecoveredMessageHandler
+{
+    public static void Handle(RecoveredMessage message)
+    {
+        RecoveredMessages.Record(message);
+    }
+}
+
+/// <summary>
+/// Static handler state is process wide and these suites run serially per assembly, so the tracking session
+/// is scoped and disposed rather than reset ad hoc.
+/// </summary>
+public static class RecoveredMessages
+{
+    private static readonly object _locker = new();
+    private static RecoveredMessageTracking? _current;
+
+    public static RecoveredMessageTracking Track()
+    {
+        lock (_locker)
+        {
+            _current = new RecoveredMessageTracking();
+            return _current;
+        }
+    }
+
+    internal static void Record(RecoveredMessage message)
+    {
+        lock (_locker)
+        {
+            _current?.Record(message);
+        }
+    }
+
+    internal static void Clear(RecoveredMessageTracking tracking)
+    {
+        lock (_locker)
+        {
+            if (ReferenceEquals(_current, tracking))
+            {
+                _current = null;
+            }
+        }
+    }
+}
+
+public class RecoveredMessageTracking : IDisposable
+{
+    private readonly object _locker = new();
+    private readonly List<RecoveredMessage> _received = new();
+
+    internal void Record(RecoveredMessage message)
+    {
+        lock (_locker)
+        {
+            _received.Add(message);
+        }
+    }
+
+    public int Count
+    {
+        get
+        {
+            lock (_locker)
+            {
+                return _received.Count;
+            }
+        }
+    }
+
+    public bool Contains(Guid id)
+    {
+        lock (_locker)
+        {
+            return _received.Any(x => x.Id == id);
+        }
+    }
+
+    public void Dispose()
+    {
+        RecoveredMessages.Clear(this);
+    }
+}

--- a/src/Testing/Wolverine.ComplianceTests/ExclusiveListeners/SingleNodeListenerTransport.cs
+++ b/src/Testing/Wolverine.ComplianceTests/ExclusiveListeners/SingleNodeListenerTransport.cs
@@ -1,0 +1,136 @@
+using JasperFx.Core;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.ComplianceTests.ExclusiveListeners;
+
+/// <summary>
+/// A deliberately broker-free durable transport used by <see cref="ExclusiveListenerRecoveryCompliance"/>.
+///
+/// Exclusive (and leader-pinned) listeners can not be local queues, so testing GH-3590 across *every* message
+/// store would otherwise require dragging a real message broker into the compliance suite. This transport gives
+/// us a durable, non-local listening endpoint whose messages only ever arrive through the transactional inbox —
+/// which is exactly the recovery path under test — with no ports to bind and nothing to install.
+/// </summary>
+public class SingleNodeListenerTransport : TransportBase<SingleNodeListenerEndpoint>
+{
+    public const string ProtocolName = "single-node-listener";
+
+    public SingleNodeListenerTransport() : base(ProtocolName, "Single Node Listener", [])
+    {
+        Endpoints = new LightweightCache<string, SingleNodeListenerEndpoint>(name =>
+            new SingleNodeListenerEndpoint(name));
+    }
+
+    public new LightweightCache<string, SingleNodeListenerEndpoint> Endpoints { get; }
+
+    public static Uri ToUri(string endpointName)
+    {
+        return new Uri($"{ProtocolName}://{endpointName}");
+    }
+
+    // These endpoints are only ever fed from the transactional inbox, so they must never be picked as the
+    // reply endpoint for the application.
+    public override Endpoint? ReplyEndpoint() => null;
+
+    protected override IEnumerable<SingleNodeListenerEndpoint> endpoints()
+    {
+        return Endpoints;
+    }
+
+    protected override SingleNodeListenerEndpoint findEndpointByUri(Uri uri)
+    {
+        return Endpoints[uri.Host];
+    }
+}
+
+public class SingleNodeListenerEndpoint : Endpoint
+{
+    public SingleNodeListenerEndpoint(string endpointName)
+        : base(SingleNodeListenerTransport.ToUri(endpointName), EndpointRole.Application)
+    {
+        EndpointName = endpointName;
+        Mode = EndpointMode.Durable;
+        IsListener = true;
+        BrokerRole = "single-node-listener";
+    }
+
+    protected override bool supportsMode(EndpointMode mode)
+    {
+        return mode == EndpointMode.Durable;
+    }
+
+    public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+    {
+        return ValueTask.FromResult<IListener>(new SingleNodeListener(Uri));
+    }
+
+    protected override ISender CreateSender(IWolverineRuntime runtime)
+    {
+        return new SingleNodeListenerSender(Uri);
+    }
+}
+
+/// <summary>
+/// There is no wire. Envelopes reach the endpoint's receiver purely through inbox recovery, so the listener
+/// only has to exist and be disposable.
+/// </summary>
+internal class SingleNodeListener : IListener
+{
+    public SingleNodeListener(Uri address)
+    {
+        Address = address;
+    }
+
+    public Uri Address { get; }
+
+    public IHandlerPipeline? Pipeline => null;
+
+    public ValueTask CompleteAsync(Envelope envelope) => ValueTask.CompletedTask;
+
+    public ValueTask DeferAsync(Envelope envelope) => ValueTask.CompletedTask;
+
+    public ValueTask StopAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+/// <summary>
+/// Sending is only here so the endpoint can be routed to; the compliance tests seed the inbox directly.
+/// </summary>
+internal class SingleNodeListenerSender : ISender
+{
+    public SingleNodeListenerSender(Uri destination)
+    {
+        Destination = destination;
+    }
+
+    public bool SupportsNativeScheduledSend => false;
+
+    public Uri Destination { get; }
+
+    public Task<bool> PingAsync() => Task.FromResult(true);
+
+    public ValueTask SendAsync(Envelope envelope) => ValueTask.CompletedTask;
+}
+
+public static class SingleNodeListenerTransportExtensions
+{
+    /// <summary>
+    /// Add a durable, broker-free listening endpoint whose listener is only ever active on a single node —
+    /// either <see cref="ListenerScope.Exclusive"/> or <see cref="ListenerScope.PinnedToLeader"/>.
+    /// </summary>
+    public static SingleNodeListenerEndpoint ListenToSingleNodeEndpoint(this WolverineOptions options,
+        string endpointName, ListenerScope scope)
+    {
+        var transport = options.Transports.GetOrCreate<SingleNodeListenerTransport>();
+        var endpoint = transport.Endpoints[endpointName];
+        endpoint.IsListener = true;
+        endpoint.Mode = EndpointMode.Durable;
+        endpoint.ListenerScope = scope;
+
+        return endpoint;
+    }
+}

--- a/src/Wolverine/Configuration/EndpointCollection.cs
+++ b/src/Wolverine/Configuration/EndpointCollection.cs
@@ -48,6 +48,17 @@ public interface IEndpointCollection : IAsyncDisposable
     Task StopListenerAsync(Endpoint endpoint, CancellationToken cancellationToken);
 
     IListenerCircuit? FindListenerCircuit(Uri address);
+
+    /// <summary>
+    /// Is the listening endpoint at this address scoped to a single node in the cluster -- i.e.
+    /// <see cref="ListenerScope.Exclusive"/> or <see cref="ListenerScope.PinnedToLeader"/> rather than
+    /// <see cref="ListenerScope.CompetingConsumers"/>? Inbox recovery for these endpoints is owned by the
+    /// node hosting the listener itself, *not* by the database's durability agent. See GH-3590.
+    /// </summary>
+    bool IsSingleNodeListener(Uri address)
+    {
+        return EndpointFor(address) is { ListenerScope: not ListenerScope.CompetingConsumers };
+    }
 }
 
 public class EndpointCollection : IEndpointCollection
@@ -357,6 +368,23 @@ public class EndpointCollection : IEndpointCollection
         {
             await agent.StopAndDrainAsync();
         }
+    }
+
+    private ImHashMap<Uri, bool> _singleNodeListeners = ImHashMap<Uri, bool>.Empty;
+
+    public bool IsSingleNodeListener(Uri address)
+    {
+        // Cached because this is asked on every durability agent recovery pass, once per distinct
+        // received_at destination, and EndpointFor() is a linear scan across every transport.
+        if (_singleNodeListeners.TryFind(address, out var isSingleNode))
+        {
+            return isSingleNode;
+        }
+
+        isSingleNode = EndpointFor(address) is { ListenerScope: not ListenerScope.CompetingConsumers };
+        _singleNodeListeners = _singleNodeListeners.AddOrUpdate(address, isSingleNode);
+
+        return isSingleNode;
     }
 
     public IListenerCircuit? FindListenerCircuit(Uri address)

--- a/src/Wolverine/Persistence/Durability/ListenerInboxRecovery.cs
+++ b/src/Wolverine/Persistence/Durability/ListenerInboxRecovery.cs
@@ -1,0 +1,231 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
+using Wolverine.Logging;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace Wolverine.Persistence.Durability;
+
+/// <summary>
+/// Recovers dormant ("globally owned", i.e. <c>owner_id = 0</c>) inbox messages for a *single* listening
+/// endpoint, completely outside of the <c>DurabilityAgent</c>. This exists for endpoints whose listener is
+/// only ever active on one node — <see cref="ListenerScope.Exclusive"/> and
+/// <see cref="ListenerScope.PinnedToLeader"/> — where the per-database durability agent may well be assigned
+/// to a *different* node than the one hosting the listener, and inbox recovery is gated on the *local*
+/// listener circuit being <see cref="ListeningStatus.Accepting"/>. See GH-3590.
+///
+/// This works purely against the <see cref="IMessageStore"/> surface, so every store (RDBMS family, RavenDb,
+/// CosmosDb, and any future store) gets it for free, and it sweeps every database that could hold inbox rows
+/// for the listener: the main store, every tenant database, and every ancillary store.
+/// </summary>
+public class ListenerInboxRecovery
+{
+    private readonly IListenerCircuit _circuit;
+    private readonly ILogger _logger;
+    private readonly IWolverineRuntime _runtime;
+
+    public ListenerInboxRecovery(IWolverineRuntime runtime, IListenerCircuit circuit, ILogger logger)
+    {
+        _runtime = runtime;
+        _circuit = circuit;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Sweep every known message store for dormant incoming envelopes addressed to this listener, reassign
+    /// them to the current node, and enqueue them directly into the listener. Returns the number of envelopes
+    /// that were recovered.
+    /// </summary>
+    public async Task<int> RecoverAsync(CancellationToken token = default)
+    {
+        if (_circuit.Status != ListeningStatus.Accepting)
+        {
+            return 0;
+        }
+
+        IReadOnlyList<IMessageStore> stores;
+        try
+        {
+            // Note that this deliberately goes through MessageStoreCollection instead of the "Main" store so
+            // that separate-database-per-tenant systems hit *every* tenant database, dynamic tenant sources are
+            // refreshed on each sweep, and ancillary stores are covered too.
+            stores = await _runtime.Stores.FindAllAsync();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error trying to determine the message stores for inbox recovery of listener {Uri}",
+                _circuit.Endpoint.Uri);
+            return 0;
+        }
+
+        var total = 0;
+        foreach (var store in stores)
+        {
+            if (token.IsCancellationRequested) break;
+            if (_circuit.Status != ListeningStatus.Accepting) break;
+
+            try
+            {
+                total += await recoverFromStoreAsync(store, token);
+            }
+            catch (Exception e)
+            {
+                // One bad database (a tenant that just got dropped, a transient outage) must not abort the
+                // sweep of the others.
+                _logger.LogError(e,
+                    "Error trying to recover inbox messages for listener {Uri} from message store {Store}",
+                    _circuit.Endpoint.Uri, store.Name);
+            }
+        }
+
+        return total;
+    }
+
+    private async Task<int> recoverFromStoreAsync(IMessageStore store, CancellationToken token)
+    {
+        var destination = _circuit.Endpoint.Uri;
+        var total = 0;
+
+        while (!token.IsCancellationRequested)
+        {
+            var pageSize = DeterminePageSize(_circuit, _runtime.DurabilitySettings);
+            if (pageSize <= 0)
+            {
+                break;
+            }
+
+            var envelopes = await store.LoadPageOfGloballyOwnedIncomingAsync(destination, pageSize);
+            if (envelopes.Count == 0)
+            {
+                break;
+            }
+
+            // Ensure each recovered envelope carries a reference to the store it was loaded from. This is
+            // critical for ancillary stores: without it the envelope's Store property is null and
+            // DelegatingMessageInbox falls back to the main store when marking the envelope as handled --
+            // leaving it stuck as "Incoming" in the ancillary store. See GH-2318.
+            foreach (var envelope in envelopes)
+            {
+                envelope.Store ??= store;
+            }
+
+            await store.ReassignIncomingAsync(_runtime.DurabilitySettings.AssignedNodeNumber, envelopes);
+            await _circuit.EnqueueDirectlyAsync(envelopes);
+
+            _logger.RecoveredIncoming(envelopes);
+            _logger.LogInformation(
+                "Recovered {Count} messages from the inbox of {Store} for single node listener {Listener}",
+                envelopes.Count, store.Name, destination);
+
+            total += envelopes.Count;
+
+            if (envelopes.Count < pageSize)
+            {
+                break;
+            }
+
+            if (_circuit.Status != ListeningStatus.Accepting)
+            {
+                break;
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// Mirrors <see cref="RecoverIncomingMessagesCommand.DeterminePageSize"/> -- a latched or too busy listener
+    /// recovers nothing, and the page never pushes the listener past its buffering limits.
+    /// </summary>
+    internal static int DeterminePageSize(IListenerCircuit listener, DurabilitySettings settings)
+    {
+        if (listener.Status != ListeningStatus.Accepting)
+        {
+            return 0;
+        }
+
+        var pageSize = settings.RecoveryBatchSize;
+
+        if (pageSize + listener.QueueCount > listener.Endpoint.BufferingLimits.Maximum)
+        {
+            pageSize = listener.Endpoint.BufferingLimits.Maximum - listener.QueueCount - 1;
+        }
+
+        return pageSize < 0 ? 0 : pageSize;
+    }
+}
+
+/// <summary>
+/// Background poller that drives <see cref="ListenerInboxRecovery"/> for a durable listening endpoint whose
+/// listener is only active on one node. A single sweep at startup is not sufficient: orphan release for a dead
+/// node (<c>owner_id</c> back to 0) happens later, on whichever node holds that database's durability agent, so
+/// dormant rows can appear *after* the exclusive listener has already restarted on its new node. Polling also
+/// naturally picks up newly provisioned tenant databases.
+/// </summary>
+internal class ListenerInboxRecoveryLoop : IDisposable
+{
+    private readonly CancellationTokenSource _cancellation;
+    private readonly IListenerCircuit _circuit;
+    private readonly ILogger _logger;
+    private readonly ListenerInboxRecovery _recovery;
+    private readonly TimeSpan _pollingTime;
+    private readonly Task _task;
+
+    public ListenerInboxRecoveryLoop(IWolverineRuntime runtime, IListenerCircuit circuit, ILogger logger)
+    {
+        _circuit = circuit;
+        _logger = logger;
+        _recovery = new ListenerInboxRecovery(runtime, circuit, logger);
+        _pollingTime = runtime.DurabilitySettings.ScheduledJobPollingTime;
+        _cancellation = CancellationTokenSource.CreateLinkedTokenSource(runtime.DurabilitySettings.Cancellation);
+
+        _task = Task.Run(() => pollAsync(_cancellation.Token), _cancellation.Token);
+    }
+
+    private async Task pollAsync(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            if (_circuit.Status != ListeningStatus.Accepting)
+            {
+                // The circuit is latched, paused, or stopped. Keep the loop alive so a Restarter-driven
+                // recovery of the *listener* resumes inbox recovery without any extra wiring.
+                if (!await delayAsync(token)) return;
+                continue;
+            }
+
+            try
+            {
+                await _recovery.RecoverAsync(token);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error while recovering inbox messages for single node listener {Uri}",
+                    _circuit.Endpoint.Uri);
+            }
+
+            if (!await delayAsync(token)) return;
+        }
+    }
+
+    private async Task<bool> delayAsync(CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(_pollingTime, token);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    public void Dispose()
+    {
+        _cancellation.Cancel();
+        _cancellation.SafeDispose();
+        _task.SafeDispose();
+    }
+}

--- a/src/Wolverine/Persistence/Durability/RecoverIncomingMessagesCommand.cs
+++ b/src/Wolverine/Persistence/Durability/RecoverIncomingMessagesCommand.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
 using Wolverine.Logging;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Agents;
@@ -70,6 +71,13 @@ public class RecoverIncomingMessagesCommand : IAgentCommand
         DurabilitySettings durabilitySettings)
     {
         if (listener.Status != ListeningStatus.Accepting)
+        {
+            return 0;
+        }
+
+        // GH-3590 defense in depth. Inbox recovery for single node listeners (Exclusive / PinnedToLeader) is
+        // owned by the node that is actually hosting the listener, never by the per-database durability agent.
+        if (listener.Endpoint.ListenerScope != ListenerScope.CompetingConsumers)
         {
             return 0;
         }

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.ErrorHandling;
 using Wolverine.Logging;
+using Wolverine.Persistence.Durability;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Partitioning;
 using Wolverine.Runtime.WorkerQueues;
@@ -65,6 +66,7 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
     private readonly WolverineRuntime _runtime;
     private IReceiver? _receiver;
     private IDisposable? _restarter;
+    private ListenerInboxRecoveryLoop? _inboxRecovery;
     private int _lastObservedQueueCount;
     private DateTimeOffset _lastQueueCountChangeAt = DateTimeOffset.UtcNow;
     private bool _disposed;
@@ -111,6 +113,7 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
 
         _restarter?.SafeDispose();
         _backPressureAgent?.SafeDispose();
+        stopInboxRecovery();
 
         if (Listener != null)
         {
@@ -137,6 +140,7 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
         _receiver?.Dispose();
         _circuitBreaker?.SafeDisposeSynchronously();
         _backPressureAgent?.SafeDispose();
+        stopInboxRecovery();
         _semaphore.Dispose();
     }
 
@@ -242,6 +246,10 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
     /// </summary>
     private async ValueTask StopAndDrainCoreAsync(bool latchBeforeDrain)
     {
+        // GH-3590. Always tear the loop down first -- StartAsync() rebuilds it when this listener becomes
+        // the active one again.
+        stopInboxRecovery();
+
         if (Status == ListeningStatus.Stopped || Status == ListeningStatus.GloballyLatched)
         {
             return;
@@ -383,6 +391,30 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
 
         _logger.LogInformation("Started message listening at {Uri}", Uri);
 
+        startInboxRecoveryIfNecessary();
+    }
+
+    /// <summary>
+    /// GH-3590: a durable listener that is only ever active on a single node (Exclusive or PinnedToLeader) can
+    /// not rely on the per-database durability agent to recover its dormant inbox messages, because that agent
+    /// is assigned per database and routinely lands on a different node. Such a listener owns its own inbox
+    /// recovery for as long as it is the active listener.
+    /// </summary>
+    private void startInboxRecoveryIfNecessary()
+    {
+        if (Endpoint.Mode != EndpointMode.Durable) return;
+        if (Endpoint.ListenerScope == ListenerScope.CompetingConsumers) return;
+        if (!_runtime.Options.Durability.DurabilityAgentEnabled) return;
+        if (_runtime.Storage is NullMessageStore) return;
+
+        _inboxRecovery?.SafeDispose();
+        _inboxRecovery = new ListenerInboxRecoveryLoop(_runtime, this, _logger);
+    }
+
+    private void stopInboxRecovery()
+    {
+        _inboxRecovery?.SafeDispose();
+        _inboxRecovery = null;
     }
 
     public async ValueTask PauseAsync(TimeSpan pauseTime)


### PR DESCRIPTION
Closes #3590.

## Problem

A durable listener scoped to a single node — `ListenerScope.Exclusive` (`ExclusiveNodeWithParallelism()` / `ListenWithStrictOrdering()`) or `ListenerScope.PinnedToLeader` (`ListenOnlyAtLeader()`) — never recovered its dormant `owner_id = 0` inbox messages unless the per-database `DurabilityAgent` happened to land on the same node as the listener.

Inbox recovery was gated on the **local** listener circuit being `Accepting` (`CheckRecoverableIncomingMessagesOperation.PostProcessingCommands()` and `RecoverIncomingMessagesCommand.DeterminePageSize()`, with the RavenDb and CosmosDb agents inlining the same check). But `DurabilityAgent`s are assigned **per message database** and distributed across the cluster completely independently of the listener agents. Whenever the agent for a database ran on a node that was not hosting that endpoint`s exclusive listener, the rows were stranded forever: a permanent deadlock between two independently-assigned agents. The `Accepting` gate was designed for circuit breaking; for exclusive listeners it turned into a trap.

Customer-reported after an ungraceful shutdown.

## Fix

Ownership is inverted for single node listeners.

**Durability agents stop claiming them.** Every agent skips destinations whose `ListenerScope != CompetingConsumers`. The skip happens **before** any `FindListenerCircuit()` lookup, because that lookup falls back to the durable local queue and would otherwise mis-route another node`s messages into this node`s queue — the subtlety flagged on the issue. Applied in `CheckRecoverableIncomingMessagesOperation` (RDBMS), `RavenDbDurabilityAgent.Incoming` and `CosmosDbDurabilityAgent.Incoming`, with defense-in-depth in `RecoverIncomingMessagesCommand.DeterminePageSize`. Everything else the agents do for these endpoints — orphan release, stale-inbox bumping, expiration — is unchanged. (The CosmosDb edit also fixes a latent `circuit!.Status` NRE on the line below; it was the only agent not null-guarding that.)

**The listening node recovers its own inbox.** New `ListenerInboxRecovery` (core), driven by `ListeningAgent`: an initial sweep on reaching `Accepting`, then polling at `DurabilitySettings.ScheduledJobPollingTime` for as long as it stays `Accepting`. Polling rather than one-shot is required — a dead node`s rows are released back to `owner_id = 0` later, by whichever node holds that database`s durability agent, which is usually *after* the exclusive listener has already restarted elsewhere. The loop tears down on stop / pause / latch / dispose and is rebuilt by `StartAsync()`. Runs in `Solo` as well as `Balanced`, since the agent path is removed unconditionally.

`ListenerInboxRecovery` works purely against the existing `IMessageStore` surface (`LoadPageOfGloballyOwnedIncomingAsync` + `ReassignIncomingAsync`), so every current and future store gets it for free with no per-provider implementation. It enumerates through `MessageStoreCollection.FindAllAsync()`, so one sweep covers the main store, every tenant database in a separate-database-per-tenant system (dynamic tenant sources refreshed each pass), and every ancillary store — stamping `envelope.Store ??= store` per GH-2318 so mark-as-handled routes back to the right database. Latching and `BufferingLimits` are respected exactly as before, so circuit breaking is unaffected. A failure against one database is logged and does not abort the sweep of the others.

Adds `IEndpointCollection.IsSingleNodeListener(Uri)` as a **default interface method** — non-breaking for external implementors — memoized with `ImHashMap` in `EndpointCollection` since the durability agents ask it on every recovery pass and `EndpointFor()` is a linear scan.

## Tests

Compliance-test-first, per the issue. Every scenario was **verified red** against the unfixed code paths before being accepted.

The open question on the issue was the fixture transport. Answer: **neither TCP nor a port-bound transport** — a new broker-free `SingleNodeListenerTransport` inside `Wolverine.ComplianceTests`. Exclusive listeners cannot be local queues, and these endpoints are only ever fed from the transactional inbox anyway, so the fixture needs no broker, no ports, and nothing to install.

| Coverage | Location | Result |
| --- | --- | --- |
| `ExclusiveListenerRecoveryCompliance` × 6 providers (PostgreSQL, SQL Server, SQLite, Marten, MySQL, Oracle) | `Wolverine.ComplianceTests` + thin subclasses | 30 green |
| Durability agent exclusion (NSubstitute) | `PersistenceTests/Durability/single_node_listener_recovery_exclusion.cs` | 7 green |
| Separate-database-per-tenant sweep | `PostgresqlTests/MultiTenancy` | green |
| Ancillary store sweep | `MartenTests/AncillaryStores` | green |
| `IsSingleNodeListener` across all three scopes + unknown address | `CoreTests` | 4 green |

A provider opts in with nothing but its storage bootstrapping:

```csharp
public class exclusive_listener_recovery_compliance : ExclusiveListenerRecoveryCompliance
{
    protected override void ConfigureStorage(WolverineOptions options)
    {
        options.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "exclusive_recovery");
    }
}
```

Red-baseline verification:

- disable the `ListeningAgent` recovery loop → the 3 behavioral compliance scenarios fail
- disable the agent exclusions → 5 of the 7 unit tests fail
- swap `Stores.FindAllAsync()` for the main store alone → the tenant and ancillary tests fail

Full suites run locally, all zero failures: CoreTests 2016, PersistenceTests 77, PostgresqlTests 447, SqlServerTests 374, SqliteTests 153, MartenTests 527. `dotnet build wolverine.slnx -c Release` clean with 0 warnings.

## Docs

- New **"Who Recovers the Inbox"** section in the durability / inbox-outbox guide, with a scope → owner table and the reasoning.
- New **"Inbox Recovery Ownership"** section in the exclusive node processing guide.
- Cross-link from the strictly-ordered listeners section of `listeners.md`.
- CHANGELOG entry under 6.22.

## Scope

Per the decisions on the issue: `PinnedToLeader` gets identical semantics with its own dedicated test coverage (there is no shared `Endpoint.IsExclusive` flag to piggyback on, so every check is `ListenerScope != CompetingConsumers`); `ReassignIncomingAsync` is unchanged; **no 5.x backport**.

## Follow ups filed

- #3595 — RavenDb subclass of the compliance fixture (no local service to run it against)
- #3596 — CosmosDb subclass of the compliance fixture (same)
- #3597 — multi-node end to end test, Rabbit MQ + PostgreSQL, exercising real agent distribution putting the durability agent and the exclusive listener on different nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)