### PR TITLE
test(grpc): gRPC + Wolverine HTTP coexistence regression tests (#3591)

### DIFF
--- a/src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj
+++ b/src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj
@@ -8,6 +8,9 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
         <ProjectReference Include="..\Wolverine.Grpc\Wolverine.Grpc.csproj"/>
+        <!-- GH-3591: coexistence of gRPC services and Wolverine HTTP endpoints in one host. -->
+        <ProjectReference Include="..\Http\Wolverine.Http\Wolverine.Http.csproj"/>
+        <ProjectReference Include="..\Http\Wolverine.Http.FluentValidation\Wolverine.Http.FluentValidation.csproj"/>
         <ProjectReference Include="..\Testing\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj"/>
         <ProjectReference Include="..\Extensions\Wolverine.FluentValidation\Wolverine.FluentValidation.csproj"/>
         <ProjectReference Include="..\Extensions\Wolverine.FluentValidation.Grpc\Wolverine.FluentValidation.Grpc.csproj"/>

--- a/src/Wolverine.Grpc.Tests/grpc_and_http_coexistence_3591.cs
+++ b/src/Wolverine.Grpc.Tests/grpc_and_http_coexistence_3591.cs
@@ -1,0 +1,111 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using PingPongWithGrpc.Ponger;
+using ProtoBuf.Grpc.Server;
+using Shouldly;
+using Wolverine.Http;
+using Wolverine.Http.FluentValidation;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests;
+
+// GH-3591: mapping Wolverine gRPC services in the same host as Wolverine HTTP endpoints made every
+// HTTP route 404. Commenting out MapWolverineGrpcServices() brought HTTP back, so the two mappings
+// were not coexisting. These tests stand up one host with both — in the exact registration and
+// mapping order from the issue — and assert the HTTP route responds.
+public class grpc_and_http_coexistence_3591 : IAsyncLifetime
+{
+    private WebApplication _app = null!;
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+        builder.WebHost.UseTestServer();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.ApplicationAssembly = typeof(PingGrpcService).Assembly;
+            opts.Discovery.IncludeAssembly(typeof(grpc_and_http_coexistence_3591).Assembly);
+        });
+
+        // The issue's registration order, verbatim.
+        builder.Services.AddGrpc();
+        builder.Services.AddCodeFirstGrpc();
+        builder.Services.AddWolverineGrpc(_ => { });
+        builder.Services.AddWolverineHttp();
+        builder.Services.AddSingleton<PingTracker>();
+
+        _app = builder.Build();
+
+        _app.UseRouting();
+
+        // The issue's mapping order: gRPC services before Wolverine HTTP endpoints, with the
+        // FluentValidation ProblemDetails middleware configured.
+        _app.MapWolverineGrpcServices();
+        _app.MapWolverineEndpoints(o => o.UseFluentValidationProblemDetailMiddleware());
+
+        await _app.StartAsync();
+
+        _client = _app.GetTestServer().CreateClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task http_get_still_responds_when_grpc_services_are_mapped()
+    {
+        var response = await _client.GetAsync("/api/coexist/check");
+
+        response.StatusCode.ShouldNotBe(System.Net.HttpStatusCode.NotFound);
+        response.EnsureSuccessStatusCode();
+
+        (await response.Content.ReadAsStringAsync()).ShouldContain("ok");
+    }
+
+    [Fact]
+    public async Task http_get_with_asparameters_and_invoke_still_responds_when_grpc_is_mapped()
+    {
+        // The issue's exact endpoint shape: [AsParameters] request forwarded through the message bus.
+        var response = await _client.GetAsync("/api/coexist/invoke?Name=bob");
+
+        response.StatusCode.ShouldNotBe(System.Net.HttpStatusCode.NotFound);
+        response.EnsureSuccessStatusCode();
+
+        (await response.Content.ReadAsStringAsync()).ShouldContain("bob");
+    }
+}
+
+public static class CoexistenceHttpEndpoint
+{
+    [WolverineGet("/api/coexist/check")]
+    public static string GetCheck() => "ok";
+
+    [WolverineGet("/api/coexist/invoke")]
+    public static Task<CoexistCheckResponse> GetCheck([AsParameters] CoexistCheckRequest req, IMessageBus bus)
+        => bus.InvokeAsync<CoexistCheckResponse>(req);
+}
+
+// A bindable [AsParameters] type: parameterless ctor + a [FromQuery] settable property, so the
+// HTTP chain compiles and the querystring binds. (Properties with no source attribute are not bound.)
+public class CoexistCheckRequest
+{
+    [FromQuery]
+    public string Name { get; set; } = string.Empty;
+}
+
+public record CoexistCheckResponse(string Message);
+
+public static class CoexistCheckHandler
+{
+    public static CoexistCheckResponse Handle(CoexistCheckRequest req) => new($"hello {req.Name}");
+}


### PR DESCRIPTION
Regression tests for #3591. **The reported bug does not reproduce on `main`** — this PR adds coverage that locks in gRPC + Wolverine HTTP coexistence rather than a fix.

## What #3591 reported

On 6.18.0, mapping Wolverine gRPC services made every Wolverine HTTP route return 404; commenting out `app.MapWolverineGrpcServices()` brought HTTP back.

## What I found

I could not reproduce the 404 on current `main`. I built the issue's setup faithfully — same service registration (`AddGrpc()` + `AddCodeFirstGrpc()` + `AddWolverineGrpc()` + `AddWolverineHttp()`), same mapping order (`MapWolverineGrpcServices()` **before** `MapWolverineEndpoints()`), the `UseFluentValidationProblemDetailMiddleware()` from the issue, and the exact endpoint shape (`[AsParameters]` request forwarded through `IMessageBus.InvokeAsync`). HTTP responds 200 and binds correctly with gRPC services mapped.

(Two red herrings along the way, both my test-authoring rather than product bugs: an `[AsParameters]` record with a required positional constructor fails codegen with `new T()`, and `[AsParameters]` only binds properties that carry a source attribute like `[FromQuery]` — a bare property stays default. Neither is gRPC-related.)

## What this PR adds

Two tests in `Wolverine.Grpc.Tests/grpc_and_http_coexistence_3591.cs`, standing up one TestServer host with both mappings:

- `http_get_still_responds_when_grpc_services_are_mapped` — a plain `[WolverineGet]` route returns 200, not 404.
- `http_get_with_asparameters_and_invoke_still_responds_when_grpc_is_mapped` — the issue's exact `[AsParameters]` + `InvokeAsync` endpoint returns 200 and binds the querystring.

Both green. This guards the coexistence guarantee so it can't silently regress.

Adds `ProjectReference`s to `Wolverine.Http` and `Wolverine.Http.FluentValidation` from the gRPC test project (previously it referenced neither, which is why no test caught coexistence before).

## Recommendation

Since the reported 404 doesn't reproduce here, I'd suggest asking @ziaxdk to retest against a current build before closing #3591 — it looks fixed sometime after 6.18.0. Full gRPC suite 296 green; `dotnet build wolverine.slnx -c Release` clean with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXcbLZ2Bm4uunW2CYa6qvx
