### PR TITLE
Record exception detail on the deserialize span (#3599)

### DIFF
--- a/src/Testing/CoreTests/Runtime/tracking_diagnostics_opt_in.cs
+++ b/src/Testing/CoreTests/Runtime/tracking_diagnostics_opt_in.cs
@@ -2,9 +2,12 @@ using System.Diagnostics;
 using JasperFx.Core;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
+using Wolverine;
+using Wolverine.ErrorHandling;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Handlers;
 using Wolverine.Tracking;
+using Wolverine.Util;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -338,6 +341,61 @@ public class tracking_diagnostics_opt_in
             await Task.Delay(100.Milliseconds());
 
             captured.Any(a => a.OperationName == WolverineTracing.Deserialize).ShouldBeFalse();
+        }
+        finally
+        {
+            listener.Dispose();
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task deserialize_span_records_exception_detail_on_failure_when_enabled()
+    {
+        var (host, captured, listener) = await startWithTrackingAsync(t =>
+            t.DeserializationSpanEnabled = true);
+
+        try
+        {
+            // TrackingDiagnosticsHandler makes TrackingDiagnosticsMessage a known
+            // message type, so TryDeserializeEnvelope gets past the type lookup and
+            // hands the malformed body to the serializer, which throws. Building the
+            // pipeline directly is the same seam FaultCryptoExceptionGuardTests uses;
+            // the serialized-inbound path can't be synthesized through InvokeMessageAndWait.
+            var runtime = host.GetRuntime();
+            var pipeline = new HandlerPipeline(runtime, runtime);
+
+            var envelope = new Envelope
+            {
+                ContentType = "application/json",
+                MessageType = typeof(TrackingDiagnosticsMessage).ToMessageTypeName(),
+                // Truncated JSON — the System.Text.Json reader throws a JsonException.
+                Data = "{ \"Text\": "u8.ToArray()
+            };
+
+            var continuation = await pipeline.TryDeserializeEnvelope(envelope);
+
+            // Existing error-queue path is preserved.
+            var moveToErrorQueue = continuation.ShouldBeOfType<MoveToErrorQueue>();
+            moveToErrorQueue.Exception.ShouldNotBeNull();
+            envelope.Message.ShouldBeNull();
+
+            var deserializeActivity = captured.Single(a => a.OperationName == WolverineTracing.Deserialize);
+            deserializeActivity.Status.ShouldBe(ActivityStatusCode.Error);
+
+            // AddException emits exactly one "exception" event carrying the standard
+            // OpenTelemetry exception.* attributes, so OTLP exporters can diagnose the
+            // malformed payload instead of only seeing the generic "Serialization Failure".
+            var exceptionEvents = deserializeActivity.Events
+                .Where(e => e.Name == "exception")
+                .ToArray();
+            exceptionEvents.Length.ShouldBe(1);
+
+            var tags = exceptionEvents[0].Tags.ToDictionary(t => t.Key, t => t.Value);
+            tags["exception.type"].ShouldBe(moveToErrorQueue.Exception.GetType().FullName);
+            tags["exception.message"].ShouldBe(moveToErrorQueue.Exception.Message);
+            tags.Keys.ShouldContain("exception.stacktrace");
         }
         finally
         {

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -242,6 +242,15 @@ public class HandlerPipeline : IHandlerPipeline
         catch (Exception? e)
         {
             activity?.SetStatus(ActivityStatusCode.Error, e.GetType().Name);
+
+            // Record the caught exception as an OpenTelemetry "exception" event so
+            // OTLP exporters see exception.type / exception.message / exception.stacktrace
+            // for the malformed or incompatible payload, instead of only the generic
+            // "Serialization Failure" status the parent activity is later stamped with.
+            // AddException is a no-op when activity is null (span not started because
+            // DeserializationSpanEnabled is off), so the opt-in cost stays trivial.
+            activity?.AddException(e);
+
             return new MoveToErrorQueue(e);
         }
         finally


### PR DESCRIPTION
Fixes #3599.

## Problem

When inbound envelope deserialization fails, `HandlerPipeline.TryDeserializeEnvelope()` catches the exception and marks the opt-in `wolverine.deserialize` activity with `ActivityStatusCode.Error`, but never records the exception itself. The parent message-processing activity is then stamped with the generic status description `Serialization Failure`.

As a result, OTLP exporters receive an error span with no `exception.type`, `exception.message`, or `exception.stacktrace` — the exact detail needed to diagnose a malformed or incompatible payload.

## Fix

Call `activity?.AddException(e)` alongside the existing `SetStatus` in the catch block. This emits a standard .NET OpenTelemetry `exception` activity event carrying `exception.type` / `exception.message` / `exception.stacktrace`.

`AddException` is a no-op when `activity` is `null` — which is the case whenever `WolverineOptions.Tracking.DeserializationSpanEnabled` is off or there is no listener — so the existing opt-in behavior and near-zero cost when disabled are preserved. `Activity.AddException` ships in .NET 9, and Wolverine targets net9.0/net10.0.

## Test

Adds a regression to `tracking_diagnostics_opt_in` that:

- enables `DeserializationSpanEnabled`;
- forces a serializer failure (truncated JSON for a known message type);
- asserts the exported `wolverine.deserialize` activity is `ActivityStatusCode.Error`, contains exactly one `exception` event with type/message/stacktrace attributes, and still routes the envelope through the existing `MoveToErrorQueue` path.

The test was verified to fail against the pre-fix code and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)