### PR TITLE
fix(http): bind [FromQuery] on arrays/collections instead of misrouting to complex-flattening (#3602)

### DIFF
--- a/src/Http/Wolverine.Http.Tests.DifferentAssembly/OpenApiShapeEndpoints.cs
+++ b/src/Http/Wolverine.Http.Tests.DifferentAssembly/OpenApiShapeEndpoints.cs
@@ -284,4 +284,13 @@ public static class QueryTypeRenderingEndpoint
         => "ok";
 }
 
+// GH-3602: an explicit [FromQuery] on an array/collection is a single repeated-value query parameter
+// (schema type `array`), NOT a flattened complex object. It must render as one array-typed query
+// parameter apiece and never drag the element/container type into components/schemas.
+public static class QueryArrayRenderingEndpoint
+{
+    [WolverineGet("/shapes/query-array")]
+    public static string Get([FromQuery] string[]? tags, [FromQuery] int[]? ids) => "ok";
+}
+
 #endregion

--- a/src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs
+++ b/src/Http/Wolverine.Http.Tests/openapi_shape_tests.cs
@@ -288,6 +288,19 @@ public class openapi_shape_tests : IClassFixture<OpenApiShapeFixture>
             ], ignoreOrder: true);
     }
 
+    // GH-3602: an explicit [FromQuery] array/collection binds from repeated query values, so it must render
+    // as exactly ONE array-typed query parameter apiece — not a flattened complex object, and never pulled
+    // into components/schemas the way a genuine complex [FromQuery] container is.
+    [Fact]
+    public void array_fromquery_renders_as_array_typed_query_parameters()
+    {
+        ParametersFor("/shapes/query-array", "get")
+            .ShouldBe([
+                new ParameterShape("tags", "query", false, "array", null),
+                new ParameterShape("ids", "query", false, "array", null)
+            ], ignoreOrder: true);
+    }
+
     #region harness helpers
 
     private JsonElement operationFor(string path, string httpMethod)

--- a/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs
+++ b/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs
@@ -283,6 +283,84 @@ public class using_querystring_parameters : IntegrationContext
         text.ShouldBe("none");
     }
 
+    // GH-3602: [FromQuery] on an array/collection must bind from repeated query values just like the
+    // attribute-less form above, instead of being misrouted into complex member-flattening (which threw
+    // at discovery). Covers string[], int[] and List<int>.
+    [Fact]
+    public async Task using_fromquery_string_array_completely_hit()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get
+                .Url("/querystring/stringarray2")
+                .QueryString("values", "foo")
+                .QueryString("values", "bar")
+                .QueryString("values", "baz");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        (await body.ReadAsTextAsync()).ShouldBe("foo,bar,baz");
+    }
+
+    [Fact]
+    public async Task using_fromquery_string_array_completely_miss()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/stringarray2");
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        (await body.ReadAsTextAsync()).ShouldBe("none");
+    }
+
+    [Fact]
+    public async Task using_fromquery_int_array_completely_hit()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get
+                .Url("/querystring/intarray2")
+                .QueryString("values", "4")
+                .QueryString("values", "2")
+                .QueryString("values", "1");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        (await body.ReadAsTextAsync()).ShouldBe("1,2,4");
+    }
+
+    [Fact]
+    public async Task using_fromquery_int_list_completely_hit()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get
+                .Url("/querystring/intlist2")
+                .QueryString("values", "4")
+                .QueryString("values", "2")
+                .QueryString("values", "1");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        (await body.ReadAsTextAsync()).ShouldBe("1,2,4");
+    }
+
+    [Fact]
+    public async Task using_fromquery_int_list_completely_miss()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/querystring/intlist2");
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        (await body.ReadAsTextAsync()).ShouldBe("none");
+    }
+
     [Fact]
     public async Task using_datetime_with_default_value()
     {

--- a/src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/QueryStringBindingFrame.cs
@@ -49,7 +49,32 @@ internal class FromQueryAttributeUsage : IParameterStrategy
         if (parameterType.IsTypeOrNullableOf<TimeSpan>()) return false;
         if (parameterType.IsTypeOrNullableOf<Guid>()) return false;
 
+        // GH-3602: an array or supported collection of a bindable simple element (string[], int[],
+        // List<Guid>, IReadOnlyList<int>, ...) binds from *repeated* query values through the same path
+        // as the attribute-less form, not by member-flattening. Arrays in particular expose no public
+        // constructor, so routing one into QueryStringBindingFrame throws at discovery. Declining here
+        // lets these fall through to QueryStringParameterStrategy / TryFindOrCreateQuerystringValue, whose
+        // ParsedArrayQueryStringValue / ParsedCollectionQueryStringValue frames already handle them.
+        if (IsBindableQueryStringCollection(parameterType)) return false;
+
         return true;
+    }
+
+    /// <summary>
+    /// Is this an array or supported generic collection whose element type the query-string binder can read
+    /// directly (string or any <see cref="RouteParameterStrategy.CanParse"/> type)? Mirrors the collection
+    /// branches of <see cref="HttpChain.TryFindOrCreateQuerystringValue(Type, string, string?)"/> so the
+    /// attribute-decorated and attribute-less forms bind identically. See GH-3602.
+    /// </summary>
+    internal static bool IsBindableQueryStringCollection(Type parameterType)
+    {
+        if (parameterType.IsArray)
+        {
+            var elementType = parameterType.GetElementType()!;
+            return elementType == typeof(string) || RouteParameterStrategy.CanParse(elementType);
+        }
+
+        return ParsedCollectionQueryStringValue.CanParse(parameterType);
     }
 }
 

--- a/src/Http/WolverineWebApi/QuerystringEndpoints.cs
+++ b/src/Http/WolverineWebApi/QuerystringEndpoints.cs
@@ -43,6 +43,33 @@ public static class QuerystringEndpoints
         return values.OrderBy(x => x).Select(x => x.ToString()).Join(",");
     }
 
+    // GH-3602: an explicit [FromQuery] on an array/collection of a simple element must bind from repeated
+    // query values exactly like the attribute-less StringArray/IntArray above, not get misrouted into the
+    // complex-type member-flattening path (which threw at discovery because arrays have no ctor).
+    [WolverineGet("/querystring/stringarray2")]
+    public static string StringArray2([FromQuery] string[]? values)
+    {
+        if (values == null || values.IsEmpty()) return "none";
+
+        return values.Join(",");
+    }
+
+    [WolverineGet("/querystring/intarray2")]
+    public static string IntArray2([FromQuery] int[]? values)
+    {
+        if (values == null || values.IsEmpty()) return "none";
+
+        return values.OrderBy(x => x).Select(x => x.ToString()).Join(",");
+    }
+
+    [WolverineGet("/querystring/intlist2")]
+    public static string IntList2([FromQuery] List<int>? values)
+    {
+        if (values == null || values.IsEmpty()) return "none";
+
+        return values.OrderBy(x => x).Select(x => x.ToString()).Join(",");
+    }
+
     [WolverineGet("/querystring/datetime")]
     public static string DateTime(DateTime value)
     {


### PR DESCRIPTION
Fixes #3602.

## Problem

An explicit `[FromQuery]` on an **array/collection of a simple type** was misrouted into the complex-type member-flattening path and threw at chain discovery:

```csharp
[WolverineGet("/things")]
public static string Get([FromQuery] string[] tags) => string.Join(",", tags);   // threw at discovery
```

`FromQueryAttributeUsage.IsComplexQueryStringType(string[])` returned `true` (an array is not `IsSimple()`, not a nullable-simple, and not one of the explicitly-excluded scalar types). So the parameter was handed to `QueryStringBindingFrame`, whose constructor calls `queryType.GetConstructors().Single()` — arrays expose **no** public constructor, so this threw `InvalidOperationException` ("Sequence contains no elements") before the endpoint could bind.

The attribute-less form already worked, binding as repeated query values:

```csharp
public static string Get(string[]? tags) => ...;   // fine — /querystring/stringarray
```

This is the same failure family as the scalar `decimal` case fixed in #3594.

## Fix

`IsComplexQueryStringType` now declines arrays and supported generic collections (`List<T>`/`IList<T>`/`IReadOnlyList<T>`/`IEnumerable<T>`) of a bindable simple element, so `[FromQuery] T[]` falls through to `QueryStringParameterStrategy` and binds through the **same** `ParsedArrayQueryStringValue` / `ParsedCollectionQueryStringValue` frames as the attribute-less form. The new `IsBindableQueryStringCollection` helper mirrors the collection branches of `HttpChain.TryFindOrCreateQuerystringValue` so the two forms stay in lockstep.

Runtime binding for existing shapes is unchanged; only the previously-throwing array/collection shapes are affected.

## Tests

- **Binding** (`using_querystring_parameters`): `[FromQuery] string[]`, `[FromQuery] int[]`, and `[FromQuery] List<int>` bind from repeated query values (hit + miss), matching the attribute-less endpoints.
- **OpenAPI shape** (`openapi_shape_tests`): `[FromQuery]` arrays render as exactly one `array`-typed query parameter apiece — never a phantom flattened object, and never dragged into `components/schemas`.

Verified red baseline: reverting the `IsComplexQueryStringType` hunk makes the new endpoints fail host bootstrap (discovery throws). `Wolverine.Http.Tests` FromQuery/AsParameters/OpenAPI/querystring areas (112 tests) are green, and the affected projects build clean in Release across net9.0/net10.0.

Found while adding the type-permutation coverage in #3594 (follow-up to #3586 / #3587).

🤖 Generated with [Claude Code](https://claude.com/claude-code)