### PR TITLE
fix(oracle): use registered wolverinedb agent scheme for message store Uri (#3589)

### DIFF
--- a/src/Persistence/Oracle/OracleTests/message_store_uri_scheme.cs
+++ b/src/Persistence/Oracle/OracleTests/message_store_uri_scheme.cs
@@ -1,0 +1,67 @@
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.Oracle;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace OracleTests;
+
+// GH-3589: the durability agent family (MessageStoreCollection) registers under the
+// "wolverinedb" scheme, and a message store's Uri IS its agent Uri. If OracleMessageStore
+// hands out a "wolverine://messages/main" or "messagedb://..." Uri, the NodeAgentController
+// cannot resolve a family and throws "Unrecognized agent scheme", so the Oracle durability
+// agent never starts. These tests pin the Uri to the registered agent scheme for every role.
+public class message_store_uri_scheme
+{
+    private static IWolverineRuntime buildRuntime()
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Options.Returns(new WolverineOptions());
+        runtime.LoggerFactory.Returns(NullLoggerFactory.Instance);
+        runtime.DurabilitySettings.Returns(new DurabilitySettings());
+        runtime.Services.Returns(new ServiceCollection().BuildServiceProvider());
+
+        return runtime;
+    }
+
+    private static IMessageStore buildStore(MessageStoreRole role)
+    {
+        var options = new WolverineOptions();
+        var persistence = (OracleBackedPersistence)options.PersistMessagesWithOracle(
+            Servers.OracleConnectionString, "wolverine", role);
+
+        return persistence.BuildMessageStore(buildRuntime());
+    }
+
+    [Fact]
+    public void main_store_uses_the_registered_agent_scheme()
+    {
+        var store = buildStore(MessageStoreRole.Main);
+
+        store.Uri.Scheme.ShouldBe(PersistenceConstants.AgentScheme);
+    }
+
+    [Fact]
+    public void ancillary_store_uses_the_registered_agent_scheme()
+    {
+        var store = buildStore(MessageStoreRole.Ancillary);
+
+        store.Uri.Scheme.ShouldBe(PersistenceConstants.AgentScheme);
+    }
+
+    [Fact]
+    public void main_store_keeps_its_diagnostic_subject_uri()
+    {
+        var store = buildStore(MessageStoreRole.Main);
+
+        // The old "wolverine://messages/main" value lives on as the diagnostic identity only,
+        // never as the agent Uri.
+        store.Describe().SubjectUri.ShouldBe(new Uri("wolverine://messages/main"));
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
@@ -111,12 +111,18 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
 
         if (Role == MessageStoreRole.Main)
         {
-            Uri = new Uri("wolverine://messages/main");
+            // Diagnostic identity only — the agent Uri below always carries the registered
+            // wolverinedb scheme so the NodeAgentController can dispatch the durability agent.
+            SubjectUri = new Uri("wolverine://messages/main");
         }
-        else
-        {
-            Uri = new Uri($"messagedb://{parts.Join("/")}");
-        }
+
+        // GH-3589: the durability agent family (MessageStoreCollection) registers under the
+        // "wolverinedb" scheme (PersistenceConstants.AgentScheme), and a message store's Uri IS
+        // its agent Uri. A "wolverine://messages/main" or "messagedb://..." scheme leaves the
+        // NodeAgentController unable to resolve a family ("Unrecognized agent scheme 'wolverine'"),
+        // so the Oracle durability agent never starts. Mirror MessageDatabase / RavenDb / CosmosDb
+        // and always build the Uri from the registered scheme regardless of role.
+        Uri = new Uri($"{PersistenceConstants.AgentScheme}://{parts.Where(x => x.IsNotEmpty()).Join("/")}");
 
         Name = Uri.ToString();
     }
@@ -128,6 +134,12 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
     public MessageStoreRole Role { get; set; }
     public List<string> TenantIds { get; } = new();
     public Uri Uri { get; internal set; }
+
+    /// <summary>
+    /// Stable diagnostic identity for this store (e.g. "wolverine://messages/main"), kept
+    /// separate from <see cref="Uri"/>, which must carry the registered agent scheme. See GH-3589.
+    /// </summary>
+    public Uri SubjectUri { get; set; } = new Uri("wolverine://messages");
     public bool HasDisposed => _hasDisposed;
     public IMessageInbox Inbox => this;
     public IMessageOutbox Outbox => this;
@@ -211,7 +223,7 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
             ServerName = builder.DataSource ?? string.Empty,
             DatabaseName = _schemaName,
             Subject = GetType().FullNameInCode(),
-            SubjectUri = Uri
+            SubjectUri = SubjectUri
         };
 
         descriptor.TenantIds.AddRange(TenantIds);
@@ -227,7 +239,9 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
     public void PromoteToMain(IWolverineRuntime runtime)
     {
         Role = MessageStoreRole.Main;
-        Uri = new Uri("wolverine://messages/main");
+        // Only the diagnostic identity changes on promotion — Uri keeps its registered
+        // wolverinedb agent scheme so the durability agent stays dispatchable. See GH-3589.
+        SubjectUri = new Uri("wolverine://messages/main");
         _nodes ??= new OracleNodePersistence(_settings, this, _dataSource);
     }
 

--- a/src/Wolverine/Persistence/Durability/IMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/IMessageStore.cs
@@ -81,7 +81,10 @@ public interface IMessageStore : IAsyncDisposable
 
     /// <summary>
     ///     Unique identifier for a message store in case of systems that use multiple message
-    ///     store databases. Must use the "messagedb" scheme, and reflect the database connection
+    ///     store databases. This value doubles as the store's durability agent Uri, so it MUST
+    ///     use the registered agent scheme (<see cref="Wolverine.Persistence.PersistenceConstants.AgentScheme"/>,
+    ///     "wolverinedb") and reflect the database connection — otherwise the NodeAgentController
+    ///     cannot resolve an agent family and the durability agent fails to start (see GH-3589).
     /// </summary>
     Uri Uri { get; }
 


### PR DESCRIPTION
Closes #3589

## Problem

With `WolverineFx.Oracle`, `OracleMessageStore` handed out the wrong URI as its `Uri`:

- **Main store** → `wolverine://messages/main`
- **Ancillary / tenant** → `messagedb://...`

But a message store's `Uri` **is** its durability-agent URI, and the agent family (`MessageStoreCollection`) registers under the `wolverinedb` scheme (`PersistenceConstants.AgentScheme`). `NodeAgentController.findAgentAsync` keys `_agentFamilies` by `uri.Scheme`, so neither `wolverine` nor `messagedb` resolved to a family — it threw `Unrecognized agent scheme 'wolverine'` in a loop and the Oracle durability agent never started. (Reported in Solo mode, but the bug is mode-agnostic.)

## Fix

Mirror the pattern every working store already uses — `MessageDatabase` (RDBMS), `RavenDbMessageStore` (`wolverinedb://ravendb/durability`), `CosmosDbMessageStore` (`wolverinedb://cosmosdb/durability`):

- `Uri` is now always `wolverinedb://oracle/{server}/{database}/{schema}`, regardless of role.
- Added a `SubjectUri` property (default `wolverine://messages`, set to `wolverine://messages/main` for Main) that holds the **diagnostic** identity, kept separate from the agent `Uri`. `Describe()` now emits `SubjectUri = SubjectUri` (was `= Uri`), and `PromoteToMain` sets `SubjectUri` instead of overwriting `Uri`.
- Corrected the stale doc comment on `IMessageStore.Uri` that claimed the `messagedb` scheme was required — the very guidance that led to this bug. It now points to `PersistenceConstants.AgentScheme`.

This is the same class of bug previously resolved for RavenDB and CosmosDB.

## Tests

Adds `message_store_uri_scheme.cs` — a DB-free regression test (the store constructor only parses the connection string via `OracleConnectionStringBuilder`, following the existing `message_store_role_registration.cs` pattern) asserting:

- Main store `Uri.Scheme == "wolverinedb"`
- Ancillary store `Uri.Scheme == "wolverinedb"`
- Main store `Describe().SubjectUri == wolverine://messages/main`

These fail against the pre-fix code, so they are genuine red→green regressions. `Wolverine.Oracle` and `OracleTests` build clean (0 warnings); the new tests plus the existing role-registration tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)