### PR TITLE
Fix Oracle durability operation batch execution

### DIFF
--- a/src/Persistence/Oracle/OracleTests/oracle_durability_command_translation.cs
+++ b/src/Persistence/Oracle/OracleTests/oracle_durability_command_translation.cs
@@ -1,0 +1,46 @@
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Wolverine.Oracle;
+
+namespace OracleTests;
+
+public class oracle_durability_command_translation
+{
+    [Fact]
+    public void rewrites_generic_parameter_markers_for_oracle()
+    {
+        OracleMessageStore.normalizeParameterMarkers(
+                "delete from messages where replayable = @replayable and keep_until <= @p0")
+            .ShouldBe(
+                "delete from messages where replayable = :replayable and keep_until <= :p0");
+    }
+
+    [Fact]
+    public void separates_generic_database_batches_into_oracle_statements()
+    {
+        OracleMessageStore.splitStatements(
+                "select destination from outgoing; delete from incoming;")
+            .ShouldBe(
+            [
+                "select destination from outgoing",
+                "delete from incoming"
+            ]);
+    }
+
+    [Fact]
+    public void converts_boolean_parameters_to_oracle_number()
+    {
+        using var command = new OracleCommand();
+        command.Parameters.Add(new OracleParameter
+        {
+            ParameterName = "replayable",
+            Value = true
+        });
+
+        OracleMessageStore.normalizeParameters(command);
+
+        var parameter = (OracleParameter)command.Parameters["replayable"];
+        parameter.OracleDbType.ShouldBe(OracleDbType.Int16);
+        parameter.Value.ShouldBe(1);
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Durability.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Durability.cs
@@ -1,0 +1,133 @@
+using System.Text.RegularExpressions;
+using Oracle.ManagedDataAccess.Client;
+using Weasel.Core;
+using Wolverine.RDBMS.Polling;
+
+namespace Wolverine.Oracle;
+
+internal partial class OracleMessageStore
+{
+    async Task IDatabaseOperationBatchExecutor.ExecuteDatabaseOperationBatchAsync(
+        IDatabaseOperation[] operations,
+        CancellationToken cancellationToken)
+    {
+        await using var connection =
+            (OracleConnection)await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var transaction =
+            (OracleTransaction)await connection.BeginTransactionAsync(cancellationToken);
+
+        try
+        {
+            foreach (var operation in operations)
+            {
+                await executeOperationAsync(
+                    connection,
+                    transaction,
+                    operation,
+                    operations,
+                    cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            try
+            {
+                await transaction.RollbackAsync(cancellationToken);
+            }
+            catch
+            {
+                // Preserve the database operation failure that triggered the rollback.
+            }
+
+            throw;
+        }
+    }
+
+    private static async Task executeOperationAsync(
+        OracleConnection connection,
+        OracleTransaction transaction,
+        IDatabaseOperation operation,
+        IDatabaseOperation[] operations,
+        CancellationToken cancellationToken)
+    {
+        var builder = new DbCommandBuilder(connection);
+        operation.ConfigureCommand(builder);
+
+        await using var command = (OracleCommand)builder.Compile();
+        command.BindByName = true;
+        command.Transaction = transaction;
+
+        normalizeParameters(command);
+
+        var statements = splitStatements(command.CommandText);
+
+        if (statements.Length == 0) return;
+
+        try
+        {
+            if (operation is IDoNotReturnData)
+            {
+                foreach (var statement in statements)
+                {
+                    command.CommandText = normalizeParameterMarkers(statement);
+                    await command.ExecuteNonQueryAsync(cancellationToken);
+                }
+
+                return;
+            }
+
+            if (statements.Length != 1)
+            {
+                throw new InvalidOperationException(
+                    $"Oracle database operation '{operation}' returns data and must contain exactly one SQL statement.");
+            }
+
+            command.CommandText = normalizeParameterMarkers(statements[0]);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            var exceptions = new List<Exception>();
+            await operation.ReadResultsAsync(reader, exceptions, cancellationToken);
+            await reader.CloseAsync();
+        }
+        catch (ObjectDisposedException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            throw new DatabaseBatchCommandException(command, operations, e);
+        }
+    }
+
+    internal static string normalizeParameterMarkers(string sql)
+    {
+        return Regex.Replace(sql, @"@(?=[A-Za-z_])", ":");
+    }
+
+    internal static string[] splitStatements(string sql)
+    {
+        return sql.Split(
+            ';',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    internal static void normalizeParameters(OracleCommand command)
+    {
+        foreach (OracleParameter parameter in command.Parameters)
+        {
+            switch (parameter.Value)
+            {
+                case bool boolean:
+                    parameter.OracleDbType = OracleDbType.Int16;
+                    parameter.Value = boolean ? 1 : 0;
+                    break;
+
+                case Guid guid:
+                    parameter.OracleDbType = OracleDbType.Raw;
+                    parameter.Value = guid.ToByteArray();
+                    break;
+            }
+        }
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
@@ -36,7 +36,7 @@ using Table = Weasel.Oracle.Tables.Table;
 
 namespace Wolverine.Oracle;
 
-internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMessageOutbox, IMessageStoreAdmin, IDeadLetters, IScheduledMessages, ISagaSupport
+internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMessageOutbox, IMessageStoreAdmin, IDeadLetters, IScheduledMessages, ISagaSupport, IDatabaseOperationBatchExecutor
 {
     private readonly OracleDataSource _dataSource;
     private readonly DatabaseSettings _settings;

--- a/src/Persistence/Wolverine.RDBMS/Polling/DatabaseOperationBatch.cs
+++ b/src/Persistence/Wolverine.RDBMS/Polling/DatabaseOperationBatch.cs
@@ -47,6 +47,21 @@ internal class DatabaseOperationBatch : IAgentCommand
     {
         if (_operations.Length == 0) return AgentCommands.Empty;
 
+        if (_database is IDatabaseOperationBatchExecutor executor)
+        {
+            try
+            {
+                await executor.ExecuteDatabaseOperationBatchAsync(_operations, cancellationToken);
+            }
+            catch (ObjectDisposedException)
+            {
+                // The system is shutting down, let this go.
+                return AgentCommands.Empty;
+            }
+
+            return postProcessingCommands();
+        }
+
         var builder = _database.ToCommandBuilder();
         foreach (var operation in _operations) operation.ConfigureCommand(builder);
 
@@ -79,12 +94,7 @@ internal class DatabaseOperationBatch : IAgentCommand
 
         try
         {
-            var commands = new AgentCommands();
-            foreach (var operation in _operations)
-            {
-                commands.AddRange(operation.PostProcessingCommands());
-            }
-            return commands;
+            return postProcessingCommands();
         }
         finally
         {
@@ -97,6 +107,17 @@ internal class DatabaseOperationBatch : IAgentCommand
                 // Don't let an exception get out of there. 
             }
         }
+    }
+
+    private AgentCommands postProcessingCommands()
+    {
+        var commands = new AgentCommands();
+        foreach (var operation in _operations)
+        {
+            commands.AddRange(operation.PostProcessingCommands());
+        }
+
+        return commands;
     }
 
     public static async Task ApplyCallbacksAsync(IReadOnlyList<IDatabaseOperation> operations, DbDataReader reader,

--- a/src/Persistence/Wolverine.RDBMS/Polling/IDatabaseOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Polling/IDatabaseOperation.cs
@@ -15,3 +15,10 @@ public interface IDatabaseOperation
 
     IEnumerable<IAgentCommand> PostProcessingCommands();
 }
+
+internal interface IDatabaseOperationBatchExecutor
+{
+    Task ExecuteDatabaseOperationBatchAsync(
+        IDatabaseOperation[] operations,
+        CancellationToken cancellationToken);
+}


### PR DESCRIPTION
## Summary

- allow message database providers to opt into provider-specific durability batch execution
- execute Oracle durability operations as individual commands in a single transaction
- translate generic `@name` bind markers to Oracle `:name` markers and normalize boolean and `Guid` parameter values
- add focused coverage for Oracle command translation

## Background

#3589 corrected the Oracle message store agent URI, which allows the durability agent to start. Once running, the agent exposed a second Oracle-specific failure: generic RDBMS durability batches concatenate multiple SQL statements into one command and use `@` bind markers. ODP.NET rejects those commands with `ORA-00933` and `ORA-00936`, so persisted inbox/outbox messages are not recovered.

## Root cause and fix

The shared `DatabaseOperationBatch` implementation assumes that a provider can execute several result sets from one multi-statement command. Oracle does not support that command shape through ODP.NET.

This change adds an internal provider hook without changing Wolverine's public API. `OracleMessageStore` uses that hook to configure each existing `IDatabaseOperation` independently, execute the statements in order within one Oracle transaction, invoke its result callback, and then keep the existing post-processing behavior.

The Oracle executor also:

- enables bind-by-name
- translates generic `@` markers to `:`
- maps booleans to `NUMBER(1)`-compatible values
- maps `Guid` values to Oracle `RAW`

Other database providers continue through the existing batching path.

Fixes #3614.

## Validation

- `dotnet test src/Persistence/Oracle/OracleTests/OracleTests.csproj --no-restore --filter "FullyQualifiedName~oracle_durability_command_translation"`  
  Passed 3 tests on `net9.0` and 3 tests on `net10.0`.
- External downstream recovery scenario against Oracle XE and RabbitMQ: persisted a durable outgoing message while RabbitMQ was unavailable, restarted the application, then verified that the durability agent recovered the outbox row and delivered the message.

This is opened as a draft to allow discussion of the provider-specific execution hook and test coverage.
