### PR TITLE
Resource discovery no longer eager-connects broker transports

### DIFF
--- a/src/Persistence/PostgresqlTests/Transport/resource_setup_against_a_missing_database.cs
+++ b/src/Persistence/PostgresqlTests/Transport/resource_setup_against_a_missing_database.cs
@@ -1,0 +1,139 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.RDBMS;
+
+namespace PostgresqlTests.Transport;
+
+public class resource_setup_against_a_missing_database : PostgresqlContext, IAsyncLifetime
+{
+    private const string DatabaseName = "wolverine_fresh_provisioning";
+    private string _connectionString = null!;
+
+    public async Task InitializeAsync()
+    {
+        _connectionString = new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString)
+        {
+            Database = DatabaseName
+        }.ConnectionString;
+
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await using var drop = new NpgsqlCommand($"DROP DATABASE IF EXISTS {DatabaseName} WITH (FORCE)", conn);
+        await drop.ExecuteNonQueryAsync();
+        await conn.CloseAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task setup_resources_provisions_the_transport_onto_a_database_created_by_a_resource_creator()
+    {
+        using var host = Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.UsePostgresqlPersistenceAndTransport(_connectionString, schema: "fresh",
+                    transportSchema: "fresh_queues");
+                opts.ListenToPostgresqlQueue("incoming");
+
+                // Stand-in for any database-building registration (EF Core's tenanted DbContext
+                // initializer, or an application-owned creator). IResourceCreator services are
+                // executed before any IStatefulResource.Setup(), so this is the documented way to
+                // make the target database exist before the transport or message store touch it.
+                opts.Services.AddSingleton<IResourceCreator>(new DatabaseCreator(DatabaseName));
+            })
+            .Build();
+
+        // The whole point: resource discovery + setup must succeed while the target database
+        // does not exist yet. Before the discovery seam, FindResources() threw
+        // BrokerInitializationException out of PostgresqlTransport's eager connectivity probe
+        // before DatabaseCreator ever ran.
+        await host.SetupResources();
+
+        (await tableExistsAsync("fresh_queues", "wolverine_queue_incoming")).ShouldBeTrue();
+        (await tableExistsAsync("fresh", DatabaseConstants.IncomingTable)).ShouldBeTrue();
+
+        await host.StartAsync();
+        await host.StopAsync();
+    }
+
+    private async Task<bool> tableExistsAsync(string schema, string table)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+
+        var tables = await conn.ExistingTablesAsync(schemas: [schema]);
+        await conn.CloseAsync();
+
+        return tables.Any(x => x.Name == table);
+    }
+
+    private class DatabaseCreator : IResourceCreator
+    {
+        private readonly string _databaseName;
+
+        public DatabaseCreator(string databaseName)
+        {
+            _databaseName = databaseName;
+        }
+
+        public async Task EnsureCreatedAsync(CancellationToken cancellationToken)
+        {
+            await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+            await conn.OpenAsync(cancellationToken);
+
+            await using var exists =
+                new NpgsqlCommand("select 1 from pg_database where datname = @name", conn);
+            exists.Parameters.AddWithValue("name", _databaseName);
+            if (await exists.ExecuteScalarAsync(cancellationToken) is null)
+            {
+                await using var create = new NpgsqlCommand($"CREATE DATABASE {_databaseName}", conn);
+                await create.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await conn.CloseAsync();
+        }
+
+        public Task Check(CancellationToken token)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task ClearState(CancellationToken token)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task Teardown(CancellationToken token)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task Setup(CancellationToken token)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<IRenderable> DetermineStatus(CancellationToken token)
+        {
+            return Task.FromResult<IRenderable>(new Markup("Database creator"));
+        }
+
+        public string Type => "database";
+        public string Name => _databaseName;
+        public Uri SubjectUri => new("wolverine://database-creator");
+        public Uri ResourceUri => new($"postgresql://localhost/{_databaseName}");
+    }
+}

--- a/src/Wolverine/Transports/BrokerTransport.cs
+++ b/src/Wolverine/Transports/BrokerTransport.cs
@@ -84,12 +84,7 @@ public abstract class BrokerTransport<TEndpoint> : TransportBase<TEndpoint>, IBr
     {
         runtime.Logger.LogInformation("Initializing the Wolverine {TransportName}", GetType().Name);
 
-        foreach (var endpoint in explicitEndpoints())
-        {
-            endpoint.Compile(runtime);
-        }
-
-        tryBuildSystemEndpoints(runtime);
+        await InitializeEndpointsAsync(runtime);
 
         #pragma warning disable CS0219
         var attempts = 1;
@@ -115,6 +110,21 @@ public abstract class BrokerTransport<TEndpoint> : TransportBase<TEndpoint>, IBr
 
         throw new BrokerInitializationException(this);
 
+    }
+
+    // Nothing here may touch the broker or database: resource discovery runs this against targets
+    // that may not exist yet. BrokerResource re-runs ConnectAsync at the start of every operation,
+    // so deferring the connection loses nothing.
+    public ValueTask InitializeEndpointsAsync(IWolverineRuntime runtime)
+    {
+        foreach (var endpoint in explicitEndpoints())
+        {
+            endpoint.Compile(runtime);
+        }
+
+        tryBuildSystemEndpoints(runtime);
+
+        return ValueTask.CompletedTask;
     }
 
     private async ValueTask startupAsync(IWolverineRuntime runtime)

--- a/src/Wolverine/Transports/ITransport.cs
+++ b/src/Wolverine/Transports/ITransport.cs
@@ -59,6 +59,16 @@ public interface ITransport
 
     ValueTask InitializeAsync(IWolverineRuntime runtime);
 
+    /// <summary>
+    /// Build out this transport's endpoint topology (compile configured endpoints, derive system
+    /// endpoints such as dead letter, response, and retry queues) without connecting to the
+    /// underlying broker or database. Resource discovery uses this instead of InitializeAsync so
+    /// that "resources setup" can enumerate a transport's stateful resource for a target that an
+    /// IResourceCreator in the same pass is about to create. Defaults to the full InitializeAsync
+    /// for transports that make no distinction.
+    /// </summary>
+    ValueTask InitializeEndpointsAsync(IWolverineRuntime runtime) => InitializeAsync(runtime);
+
     bool TryBuildStatefulResource(IWolverineRuntime runtime, out IStatefulResource? resource);
 
     bool TryBuildBrokerUsage(out BrokerDescription description);

--- a/src/Wolverine/Transports/MessageRoutingConvention.cs
+++ b/src/Wolverine/Transports/MessageRoutingConvention.cs
@@ -204,6 +204,16 @@ public abstract class MessageRoutingConvention<[DynamicallyAccessedMembers(Dynam
             yield break;
         }
 
+        // Description passes (FindResources / describe) run before any broker connection
+        // exists, and routes built there tolerate a null Sender and are never cached
+        // (GH-2897) — so don't force the agent here, where it would open a broker
+        // connection during resource discovery or throw (e.g. RabbitMQ's SendingConnection).
+        if (WolverineSystemPart.WithinDescription)
+        {
+            yield return endpoint;
+            yield break;
+        }
+
         // This will start up the sending agent. Only safe to call once the broker
         // transport has been initialized (i.e. the sending connection is open).
         var sendingAgent = runtime.Endpoints.GetOrBuildSendingAgent(endpoint.Uri);

--- a/src/Wolverine/WolverineSystemPart.cs
+++ b/src/Wolverine/WolverineSystemPart.cs
@@ -238,7 +238,11 @@ internal class WolverineSystemPart : SystemPartBase
                 {
                     if (transport.TryBuildStatefulResource(_runtime, out var resource))
                     {
-                        await transport.InitializeAsync(_runtime);
+                        // Not the full InitializeAsync: that connects to the broker/database during
+                        // discovery, before any resource's Setup() — defeating the database-building
+                        // IResourceCreators deliberately added first. Each resource reconnects per
+                        // operation, by which time the creators have run.
+                        await transport.InitializeEndpointsAsync(_runtime);
                         list.Add(resource!);
                     }
                 }


### PR DESCRIPTION
Small PR that Closes #3616.

## Problem

`WolverineSystemPart.FindResources()` calls `await transport.InitializeAsync(_runtime)` for every transport that can build a stateful resource — during resource **discovery**, before any resource's `Setup()` runs. `BrokerTransport.InitializeAsync` ends in `startupAsync` → `ConnectAsync` inside a 20×5s retry loop, and for the database-backed transports `ConnectAsync` ends with a connectivity probe.

When the target database is meant to be created by the resource-setup pass itself — the `IResourceCreator` services that `FindResources` deliberately adds *first* ("These have to run first… building multi-tenanted databases") — discovery burns ~100 seconds retrying against a database that cannot yet exist, then throws `BrokerInitializationException` out of `ResourceExecutor.FindResources`, where nothing catches it. Wolverine's own EF Core multi-tenancy (`TenantedDbContextInitializer.EnsureCreatedAsync`) plus a Postgres/SqlServer queue transport pointing at a to-be-created database hits the same wall.

## Change

Discovery now shapes endpoint topology without connecting:

- `ITransport` gains a default interface member `InitializeEndpointsAsync(runtime) => InitializeAsync(runtime)` (non-breaking; same pattern as the existing `Describe()`/`DescribeEndpoint()` defaults).
- `BrokerTransport` implements it as the connection-free half of `InitializeAsync` — compile `explicitEndpoints()` + `tryBuildSystemEndpoints` — and `InitializeAsync` now starts by calling it, so host startup (`WolverineRuntime.HostService.startMessagingTransportsAsync`) is behaviourally unchanged.
- `WolverineSystemPart.FindResources` calls `InitializeEndpointsAsync` instead of `InitializeAsync`.

`BrokerResource` already re-runs `_transport.ConnectAsync` as the first line of every operation (`Check`/`Setup`/`Teardown`/`ClearState`/`DetermineStatus`), which for the DB transports also re-binds `Store`/`Databases` — so each resource connects at operation time, after the `IResourceCreator` pass has created the target.

## Proof test

`PostgresqlTests/Transport/resource_setup_against_a_missing_database.cs`: `UsePostgresqlPersistenceAndTransport` pointed at a database that does not exist, plus a test-local `IResourceCreator` that creates it. Asserts `IHost.SetupResources()` provisions database → transport queue tables → envelope storage, then the host boots.

- On clean `V6.22.0`: fails in 1 m 35 s with `BrokerInitializationException` at `BrokerTransport.InitializeAsync → WolverineSystemPart.FindResources → ResourceExecutor.FindResources`.
- With this change: passes in ~0.5 s.

## Transport audit (why this is safe)

Every `BrokerTransport`-derived transport was audited for resource ops depending on state that only per-endpoint `InitializeAsync(logger)` or `Endpoint.Compile` establishes (the two things discovery no longer runs for non-explicit endpoints):

- **No gaps found.** All resource ops self-resolve their identifiers (e.g. `AmazonSqsQueue.CheckAsync` calls `GetQueueUrlAsync(QueueName)` directly; RabbitMQ ops run inside `WithAdminChannelAsync`; the five DB-transport queues resolve through `Parent.Store` set by the op-level `ConnectAsync`; ASB ops run inside `WithManagementClientAsync`; NATS/Redis/Kafka/GCP ops use transport-level clients from `ConnectAsync`).
- `Endpoint.Compile` guards with `_hasCompiled` — idempotent, and no resource op reads compile-derived state (serializers/Mode are consumed on the sender/listener paths only).
- Only `BrokerTransport` returns `true` from `TryBuildStatefulResource` (sealed); SignalR and the four `DatabaseControlTransport` variants return `false`, MQTT/Pulsar inherit `false` — so the default fallback is never exercised on the resources path and non-broker transports are untouched.
- `describe`/`StartLightweightAsync` stubs external transports and never connected; unchanged.

**Known behavioural nuance (disclosed, not fixed here):** GCP Pub/Sub `CompetingConsumers` listeners get their per-node subscription suffix applied inside `SetupAsync`. Pre-change, a discovery-time `AutoProvision` init applied it before any op; now a *standalone* `resources check`/`statistics` with no prior `setup` in the same process probes the un-suffixed name. Normal `resources setup` and host-startup flows are unaffected.

## Gates (exit-code-gated, net10.0)

- Proof test red on V6.22.0 → green here
- CoreTests 2032/2032; PostgresqlTests full suite 458/458 (1 pre-existing perf skip); SqliteTests 157/157 (1 pre-existing skip)
- Full `wolverine.slnx` Release build: 0 warnings / 0 errors
- Not run locally: SqlServer/RabbitMQ/cloud-broker suites (no containers); net9.0 test leg (runtime not installed on this machine; aborts identically on clean V6.22.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
