### PR TITLE
fix(agents): re-upsert assignment row for already-running agents (D4, WO-3)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/startagent_reupserts_assignment.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/startagent_reupserts_assignment.cs
@@ -1,0 +1,161 @@
+using JasperFx;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Regression coverage for the D4 half of the projection-agent churn livelock (GH-3604). When a peer
+/// wipes a live node's node_assignments rows out from under it (an ejection/resurrection under churn),
+/// the leader keeps re-emitting AssignAgent for the same (uri, node) pair. NodeAgentController.StartAgentAsync
+/// used to short-circuit an already-running agent with a bare early return, so the assignment row was never
+/// re-persisted and the grid could never re-learn what was actually running. The early return must now
+/// still upsert the assignment row -- without a needless stop/start and without a second AgentStarted record.
+/// </summary>
+public class startagent_reupserts_assignment
+{
+    private readonly WolverineOptions _options;
+    private readonly IWolverineRuntime _runtime;
+    private readonly IWolverineObserver _observer = Substitute.For<IWolverineObserver>();
+    private readonly INodeAgentPersistence _persistence = Substitute.For<INodeAgentPersistence>();
+    private readonly CancellationTokenSource _cancellation = new();
+
+    public startagent_reupserts_assignment()
+    {
+        _options = new WolverineOptions
+        {
+            ApplicationAssembly = GetType().Assembly
+        };
+        _options.Durability.Mode = DurabilityMode.Solo;
+        _options.Durability.DurabilityAgentEnabled = false; // skip MessageStoreCollection wiring
+        _options.Durability.CheckAssignmentPeriod = 1.Hours(); // keep the recurring loop out of the way
+
+        _runtime = Substitute.For<IWolverineRuntime>();
+        _runtime.Options.Returns(_options);
+        _runtime.DurabilitySettings.Returns(_options.Durability);
+        _runtime.Observer.Returns(_observer);
+    }
+
+    private NodeAgentController controllerFor(params FakeAgent[] agents)
+    {
+        var family = new FakeAgentFamily("test-family");
+        foreach (var agent in agents)
+        {
+            family.Add(agent);
+        }
+
+        return new NodeAgentController(
+            _runtime,
+            _persistence,
+            [family],
+            NullLogger<NodeAgentController>.Instance,
+            _cancellation.Token);
+    }
+
+    [Fact]
+    public async Task re_upserts_assignment_for_an_already_running_agent_without_restarting_it()
+    {
+        var uri = new Uri("test-family://runner");
+        var agent = new FakeAgent(uri);
+        var controller = controllerFor(agent);
+
+        await controller.StartAgentAsync(uri);
+        agent.StartCount.ShouldBe(1);
+        await _persistence.Received(1).AddAssignmentAsync(_options.UniqueNodeId, uri, Arg.Any<CancellationToken>());
+        await _observer.Received(1).AgentStarted(uri);
+
+        // Simulate a peer wiping this live node's assignment rows: the agent is still running here, but the
+        // node_assignments row is gone in persistence. The re-assign that follows must put it back.
+        _persistence.ClearReceivedCalls();
+
+        await controller.StartAgentAsync(uri);
+
+        // The already-running agent is NOT stopped/started again -- no churn, no duplicate AgentStarted...
+        agent.StartCount.ShouldBe(1);
+        agent.StopCount.ShouldBe(0);
+        await _observer.Received(1).AgentStarted(uri);
+
+        // ...but the assignment row IS re-upserted so the grid can re-learn what is running here.
+        await _persistence.Received(1).AddAssignmentAsync(_options.UniqueNodeId, uri, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task re_upserts_assignment_for_a_paused_agent_without_resuming_it()
+    {
+        var uri = new Uri("test-family://paused");
+        var agent = new FakeAgent(uri);
+        var controller = controllerFor(agent);
+
+        await controller.StartAgentAsync(uri);
+
+        // Paused is a deliberate error-backoff / blue-green state; the agent owns its own resume schedule.
+        agent.SimulatePaused();
+        _persistence.ClearReceivedCalls();
+
+        await controller.StartAgentAsync(uri);
+
+        agent.StartCount.ShouldBe(1);
+        agent.StopCount.ShouldBe(0);
+        agent.Status.ShouldBe(AgentStatus.Paused);
+
+        // The node still owns this (paused) agent, so its assignment must survive a re-assign wave.
+        await _persistence.Received(1).AddAssignmentAsync(_options.UniqueNodeId, uri, Arg.Any<CancellationToken>());
+    }
+
+    private class FakeAgentFamily : IAgentFamily
+    {
+        private readonly Dictionary<Uri, FakeAgent> _agents = new();
+
+        public FakeAgentFamily(string scheme)
+        {
+            Scheme = scheme;
+        }
+
+        public void Add(FakeAgent agent) => _agents[agent.Uri] = agent;
+
+        public string Scheme { get; }
+
+        public ValueTask<IReadOnlyList<Uri>> AllKnownAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>(_agents.Keys.ToList());
+
+        public ValueTask<IAgent> BuildAgentAsync(Uri uri, IWolverineRuntime wolverineRuntime)
+            => ValueTask.FromResult<IAgent>(_agents[uri]);
+
+        public ValueTask<IReadOnlyList<Uri>> SupportedAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>(_agents.Keys.ToList());
+
+        public ValueTask EvaluateAssignmentsAsync(AssignmentGrid assignments) => ValueTask.CompletedTask;
+    }
+
+    private class FakeAgent : IAgent
+    {
+        public FakeAgent(Uri uri) => Uri = uri;
+
+        public int StartCount { get; private set; }
+        public int StopCount { get; private set; }
+
+        public Uri Uri { get; }
+        public AgentStatus Status { get; private set; } = AgentStatus.Stopped;
+
+        public void SimulatePaused() => Status = AgentStatus.Paused;
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            StartCount++;
+            Status = AgentStatus.Running;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            StopCount++;
+            Status = AgentStatus.Stopped;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.cs
@@ -178,6 +178,13 @@ public partial class NodeAgentController
             // be fought here.
             if (existing.Status != AgentStatus.Stopped)
             {
+                // GH-3604 (D4): even though the agent is already running here, still re-upsert the
+                // assignment row. If a peer wiped this live node's node_assignments rows out from under it
+                // (e.g. an ejection/resurrection under churn), the leader keeps re-emitting AssignAgent for
+                // the same (uri, node) pair forever because the grid never re-learns what is actually
+                // running -- this early return was the exact no-op that made the loss permanent. The upsert
+                // makes the grid self-healing after any assignment-row loss without a needless stop/start.
+                await upsertAssignmentAsync(agentUri);
                 return;
             }
 
@@ -219,9 +226,18 @@ public partial class NodeAgentController
 
         Agents[agentUri] = agent;
 
+        await upsertAssignmentAsync(agentUri);
+    }
+
+    // Persist that this node owns agentUri. AddAssignmentAsync is an upsert, so this is safe to call for a
+    // freshly started agent or an already-running one whose assignment row may have been lost. The
+    // MarkHealthCheckAsync first side-steps FK problems and timing issues (the assignment row references the
+    // node row) and, via GH-3604 (D2), re-inserts this node's row with its real identity if a peer ejected
+    // it while it was still alive.
+    private async Task upsertAssignmentAsync(Uri agentUri)
+    {
         try
         {
-            // Side step FK problems and timing issues
             await _persistence.MarkHealthCheckAsync(WolverineNode.For(_runtime.Options), _cancellation.Token);
             await _persistence.AddAssignmentAsync(_runtime.Options.UniqueNodeId, agentUri, _cancellation.Token);
         }


### PR DESCRIPTION
## Summary

First of three PRs (WO-3 → WO-1 → WO-2) that break the projection/subscription **agent-assignment churn livelock** analyzed in a customer incident (a 16-hour projection rebuild; database-per-tenant Marten with ~4,450 distributable agents). See the analysis for the full picture; this PR is the smallest, independent half.

**Defect D4:** `NodeAgentController.StartAgentAsync` short-circuited an already-running (or deliberately `Paused`) agent with a bare early return that never re-persisted the assignment. When a peer wipes a *live* node's `node_assignments` rows out from under it — an ejection/resurrection under heavy churn — the leader keeps re-emitting `AssignAgent` for the same `(uri, node)` pair forever, because this no-op meant the grid could never re-learn what is actually running on that node. In the incident CSV this is the flat 172 `wolverinedb://` re-assignments per cycle.

## Change

- The already-running/paused early return now still calls `AddAssignmentAsync` (an idempotent upsert) via a new shared `upsertAssignmentAsync` helper — **no** needless stop/start and **no** second `AgentStarted` observer record — so the grid self-heals after any assignment-row loss.
- The freshly-started path is refactored to reuse the same helper (behavior unchanged: `MarkHealthCheckAsync` then `AddAssignmentAsync`, in the existing try/catch-log).

## Tests

`CoreTests/Runtime/Agents/startagent_reupserts_assignment.cs` — asserts the assignment row is re-upserted for both a running and a paused agent without restarting it and without a duplicate `AgentStarted`. **Red-verified** against `origin/main` (both cases fail without the fix). All 153 `Runtime.Agents` tests pass; full `wolverine.slnx` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1wnxZSPHtSQqrRhDNPHYD