### PR TITLE
fix(agents): decouple node heartbeat from command execution (D1, WO-1)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/heartbeat_decoupled_from_command_execution.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/heartbeat_decoupled_from_command_execution.cs
@@ -1,0 +1,130 @@
+using CoreTests.Transports;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Regression coverage for the D1 trigger of the projection-agent-assignment churn livelock (GH-3604).
+/// The node heartbeat used to be written only as the first step of <see cref="NodeAgentController.DoHealthChecksAsync"/>,
+/// which ran serially in the same loop as the agent-command drain. A leader that spent ~60s burning remote
+/// InvokeAsync&lt;AgentsStarted&gt; reply timeouts while starting thousands of subscription agents therefore
+/// delayed its OWN next heartbeat past StaleNodeTimeout — looking dead to its peers precisely when it was
+/// doing the most work, getting ejected, and resurrecting under a fresh node number. The heartbeat is now
+/// written on an independent loop via <see cref="NodeAgentController.WriteHeartbeatAsync"/>, which must NOT
+/// share the <c>_healthCheckGuard</c> or it would inherit the very starvation this decoupling removes.
+/// </summary>
+public class heartbeat_decoupled_from_command_execution
+{
+    private readonly WolverineOptions _options;
+    private readonly INodeAgentPersistence _persistence;
+    private readonly IWolverineRuntime _runtime;
+    private readonly NodeAgentController _controller;
+
+    public heartbeat_decoupled_from_command_execution()
+    {
+        _options = new WolverineOptions
+        {
+            ApplicationAssembly = GetType().Assembly
+        };
+        _options.Transports.NodeControlEndpoint = new FakeEndpoint("fake://self".ToUri(), EndpointRole.System);
+        _options.Durability.DurabilityAgentEnabled = false; // skip MessageStoreCollection wiring
+        _options.Durability.StaleNodeTimeout = 30.Seconds();
+
+        _runtime = Substitute.For<IWolverineRuntime>();
+        _runtime.Options.Returns(_options);
+        _runtime.DurabilitySettings.Returns(_options.Durability);
+        _runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+
+        _persistence = Substitute.For<INodeAgentPersistence>();
+
+        _controller = new NodeAgentController(
+            _runtime,
+            _persistence,
+            Array.Empty<IAgentFamily>(),
+            NullLogger<NodeAgentController>.Instance,
+            CancellationToken.None);
+    }
+
+    private WolverineNode SelfRow(DateTimeOffset lastHealthCheck) => new()
+    {
+        NodeId = _options.UniqueNodeId,
+        AssignedNodeNumber = _options.Durability.AssignedNodeNumber,
+        ControlUri = _options.Transports.NodeControlEndpoint!.Uri,
+        LastHealthCheck = lastHealthCheck
+    };
+
+    [Fact]
+    public async Task write_heartbeat_marks_the_health_check_for_this_node()
+    {
+        await _controller.WriteHeartbeatAsync();
+
+        await _persistence.Received(1).MarkHealthCheckAsync(
+            Arg.Is<WolverineNode>(n => n.NodeId == _options.UniqueNodeId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task heartbeat_is_written_even_while_a_health_check_evaluation_is_wedged()
+    {
+        // Park a DoHealthChecksAsync deep inside its guarded section, holding _healthCheckGuard and standing
+        // in for a leader wedged draining agent commands. If WriteHeartbeatAsync shared that guard (the old
+        // coupling), every heartbeat below would bounce off it and never write — which is exactly how a busy
+        // leader got itself ejected.
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _persistence.HasLeadershipLock().Returns(false);
+        _persistence.TryAttainLeadershipLockAsync(Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                entered.TrySetResult();
+                await release.Task;
+                return true;
+            });
+        _persistence.LoadNodeAgentStateAsync(Arg.Any<CancellationToken>())
+            .Returns(new NodeAgentState([SelfRow(DateTimeOffset.UtcNow)], new AgentRestrictions()));
+
+        var wedged = _controller.DoHealthChecksAsync();
+        await entered.Task.WaitAsync(5.Seconds());
+
+        // The wedged evaluation is already past its own MarkHealthCheckAsync and is now stuck holding the
+        // guard. Clear those calls, then prove the independent heartbeat path keeps writing regardless.
+        _persistence.ClearReceivedCalls();
+
+        await _controller.WriteHeartbeatAsync();
+        await _controller.WriteHeartbeatAsync();
+        await _controller.WriteHeartbeatAsync();
+
+        await _persistence.Received(3).MarkHealthCheckAsync(
+            Arg.Any<WolverineNode>(), Arg.Any<CancellationToken>());
+
+        release.SetResult();
+        await wedged.WaitAsync(5.Seconds());
+    }
+
+    [Fact]
+    public async Task write_heartbeat_is_a_no_op_once_cancelled()
+    {
+        var cancellation = new CancellationTokenSource();
+        var controller = new NodeAgentController(
+            _runtime,
+            _persistence,
+            Array.Empty<IAgentFamily>(),
+            NullLogger<NodeAgentController>.Instance,
+            cancellation.Token);
+
+        await cancellation.CancelAsync();
+
+        await controller.WriteHeartbeatAsync();
+
+        await _persistence.DidNotReceive().MarkHealthCheckAsync(
+            Arg.Any<WolverineNode>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
@@ -24,6 +24,39 @@ public partial class NodeAgentController
 {
     public bool IsLeader { get; private set; }
 
+    /// <summary>
+    /// Write this node's heartbeat, wholly independent of the assignment/health-check evaluation in
+    /// <see cref="DoHealthChecksAsync"/> and the agent-command drain that follows it. Runs on its own timer
+    /// (<c>WolverineRuntime.writeHeartbeats</c>) so that no amount of slow command work — e.g. a leader
+    /// burning remote <c>InvokeAsync&lt;AgentsStarted&gt;</c> reply timeouts while starting thousands of
+    /// subscription agents — can delay the next heartbeat past <c>StaleNodeTimeout</c> and get a
+    /// very-much-alive node ejected by its peers. That starvation was the D1 trigger of the
+    /// projection-agent-assignment churn livelock (GH-3604): a busy leader looked dead precisely when it
+    /// was doing the most work, was ejected, resurrected under a fresh node number, and the grid never
+    /// recovered. Deliberately does NOT take <c>_healthCheckGuard</c>: the guard exists to serialise
+    /// leadership-lease mutation inside <see cref="DoHealthChecksAsync"/>, and sharing it here would let the
+    /// heartbeat inherit exactly the starvation this decoupling removes.
+    /// </summary>
+    public async Task WriteHeartbeatAsync()
+    {
+        if (_cancellation.IsCancellationRequested)
+            return;
+
+        try
+        {
+            await _persistence.MarkHealthCheckAsync(WolverineNode.For(_runtime.Options), _cancellation.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutting down; nothing to do.
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error writing the heartbeat for node {NodeNumber}",
+                _runtime.Options.Durability.AssignedNodeNumber);
+        }
+    }
+
     public async Task<AgentCommands> DoHealthChecksAsync()
     {
         if (_cancellation.IsCancellationRequested)
@@ -54,7 +87,11 @@ public partial class NodeAgentController
             ? WolverineTracing.ActivitySource.StartActivity("wolverine_node_assignments")
             : null;
 
-        // write health check regardless, and due to GH-1232, pass in the whole node so you can do an upsert
+        // Write the health check regardless, and due to GH-1232, pass in the whole node so you can do an
+        // upsert. This write is now also performed independently by WriteHeartbeatAsync on its own timer
+        // (GH-3604 / D1); keeping it here preserves the GH-2682 "we just wrote our own heartbeat, so never
+        // consider self stale on this tick" invariant for the assignment evaluation below. It is an
+        // idempotent UPDATE, so the two writers never conflict.
         await _persistence.MarkHealthCheckAsync(WolverineNode.For(_runtime.Options), _cancellation.Token);
 
         var (nodes, restrictions) = await _persistence.LoadNodeAgentStateAsync(_cancellation.Token);

--- a/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
@@ -19,6 +19,7 @@ public partial class WolverineRuntime : IAgentRuntime
 {
     private bool _agentsAreDisabled;
     private Task? _healthCheckLoop;
+    private Task? _heartbeatLoop;
 
     private readonly CancellationTokenSource _agentCancellation;
 
@@ -257,7 +258,44 @@ public partial class WolverineRuntime : IAgentRuntime
             }
         }
 
+        // GH-3604 (D1): the heartbeat runs on its OWN loop, independent of executeHealthChecks. See
+        // writeHeartbeats. Start it first so a slow first assignment evaluation can't delay the very
+        // first heartbeat either.
+        _heartbeatLoop = Task.Run(writeHeartbeats, Cancellation);
         _healthCheckLoop = Task.Run(executeHealthChecks, Cancellation);
+    }
+
+    // GH-3604 (D1): keep the node heartbeat wholly independent of DoHealthChecksAsync and the agent-command
+    // drain in executeHealthChecks. Those two run serially in the same loop, so a leader that spends 60s
+    // burning remote InvokeAsync<AgentsStarted> reply timeouts while starting thousands of subscription
+    // agents used to delay its own next heartbeat past StaleNodeTimeout — looking dead to its peers
+    // precisely when it was doing the most work, getting ejected, and resurrecting under a fresh node
+    // number. This loop only ever does the cheap heartbeat write, so no amount of command work can starve
+    // it.
+    private async Task writeHeartbeats()
+    {
+        await Task.Delay(Options.Durability.FirstHealthCheckExecution, Cancellation);
+
+        while (!Cancellation.IsCancellationRequested)
+        {
+            if (NodeController != null)
+            {
+                try
+                {
+                    await NodeController.WriteHeartbeatAsync();
+                }
+                catch (OperationCanceledException)
+                {
+                    // Nothing here
+                }
+                catch (Exception e)
+                {
+                    Logger.LogError(e, "Error trying to write the node heartbeat");
+                }
+            }
+
+            await Task.Delay(Options.Durability.HealthCheckPollingTime, Cancellation);
+        }
     }
 
     private async Task executeHealthChecks()
@@ -291,6 +329,7 @@ public partial class WolverineRuntime : IAgentRuntime
 
     private async Task teardownAgentsAsync()
     {
+        _heartbeatLoop?.SafeDispose();
         _healthCheckLoop?.SafeDispose();
 
         if (NodeController != null)
@@ -307,6 +346,7 @@ public partial class WolverineRuntime : IAgentRuntime
     internal async Task DisableAgentsAsync(DateTimeOffset lastHeartbeatTime)
     {
         _agentsAreDisabled = true;
+        _heartbeatLoop?.SafeDispose();
         _healthCheckLoop?.SafeDispose();
 
         if (NodeController != null)


### PR DESCRIPTION
## Summary

Second of three PRs (WO-3 → WO-1 → WO-2) that break the projection/subscription **agent-assignment churn livelock** analyzed from a customer incident (a 16-hour projection rebuild; database-per-tenant Marten with ~4,450 distributable agents). Independent of #3619.

**Defect D1 (the livelock trigger):** the node heartbeat was written only as the first step of `NodeAgentController.DoHealthChecksAsync`, which runs serially in the same loop (`WolverineRuntime.executeHealthChecks`) as the agent-command drain (`executeAgentCommandsAsync`). A leader that spent ~60s burning two 30s remote `InvokeAsync<AgentsStarted>` reply timeouts (trying to start ~2,100 Marten subscription agents per batch) therefore delayed its *own* next heartbeat past `StaleNodeTimeout` (60s default). Its peers saw the row go stale, ejected it, and it resurrected under a fresh node number — the measured 70s wave cadence and 26 consecutive `DormantNodeEjected` node numbers (273→298) in the incident CSV. A busy leader looked dead precisely when it was doing the most work.

## Change

- New independent loop `WolverineRuntime.writeHeartbeats` (its own `Task`) calls `NodeAgentController.WriteHeartbeatAsync` at `HealthCheckPollingTime`, wholly separate from the health-check/command loop. No amount of slow command work can starve it.
- `WriteHeartbeatAsync` deliberately does **not** take `_healthCheckGuard` — that guard serialises leadership-lease mutation inside `DoHealthChecksAsync`, and sharing it would re-introduce the starvation.
- The in-line `MarkHealthCheckAsync` inside `DoHealthChecksInternalAsync` is kept (idempotent UPDATE) so the GH-2682 "we just wrote our own heartbeat, so never consider self stale on this tick" invariant for assignment evaluation stays intact. The two writers never conflict.
- The new loop is disposed alongside `_healthCheckLoop` in both teardown paths.

## Tests

`CoreTests/Runtime/Agents/heartbeat_decoupled_from_command_execution.cs` — proves the heartbeat is still written while a `DoHealthChecksAsync` evaluation is **wedged holding the guard** (stubbed `INodeAgentPersistence`, mirroring a leader stuck draining commands). Verified to have teeth: injecting a guard-take into `WriteHeartbeatAsync` makes that test fail. All 162 `Runtime.Agents`/`Runtime.Heartbeat` tests pass; full `wolverine.slnx` builds clean.

A DB-backed multi-node integration test with a deliberately slow agent start is a natural follow-up alongside the multi-node failover suite (#3610).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1wnxZSPHtSQqrRhDNPHYD