### PR TITLE
fix(agents): pending-assignment ledger suppresses duplicate AssignAgent floods (D3/D6, WO-5)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/pending_assignment_ledger.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/pending_assignment_ledger.cs
@@ -1,0 +1,109 @@
+using CoreTests.Transports;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Regression coverage for the D3/D6 half of the projection-agent churn livelock (GH-3604). A first-time
+/// assignment (grid Agent.OriginalNode == null) is emitted as AssignAgent, but a heavily loaded node can
+/// take many assignment cycles to actually start each agent and persist its assignment row. Without a
+/// pending-assignment ledger the leader re-emits the SAME (agent -> node) AssignAgent every cycle, piling
+/// duplicate mega-batches onto the polled control queue and writing ~one AssignmentChanged telemetry row
+/// per agent per cycle into the database the rebuild is already saturating. The ledger suppresses those
+/// re-emissions until the assignment is confirmed running or the TTL expires.
+/// </summary>
+public class pending_assignment_ledger
+{
+    private readonly WolverineOptions _options;
+    private readonly IWolverineRuntime _runtime;
+    private readonly INodeAgentPersistence _persistence = Substitute.For<INodeAgentPersistence>();
+    private readonly FakeAgentFamily _family = new("fake");
+    private readonly NodeAgentController _controller;
+    private readonly WolverineNode _self;
+
+    public pending_assignment_ledger()
+    {
+        _options = new WolverineOptions { ApplicationAssembly = GetType().Assembly };
+        _options.Transports.NodeControlEndpoint = new FakeEndpoint("fake://self".ToUri(), EndpointRole.System);
+        _options.Durability.DurabilityAgentEnabled = false;
+
+        _runtime = Substitute.For<IWolverineRuntime>();
+        _runtime.Options.Returns(_options);
+        _runtime.DurabilitySettings.Returns(_options.Durability);
+        _runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+
+        _controller = new NodeAgentController(
+            _runtime, _persistence, [_family], NullLogger<NodeAgentController>.Instance, CancellationToken.None);
+
+        _self = new WolverineNode
+        {
+            NodeId = _options.UniqueNodeId,
+            AssignedNodeNumber = 1,
+            ControlUri = _options.Transports.NodeControlEndpoint!.Uri
+        };
+        _self.Capabilities.AddRange(_family.AllAgentUris());
+    }
+
+    private Task<AgentCommands> evaluateAsync()
+        => _controller.EvaluateAssignmentsAsync([_self], new AgentRestrictions());
+
+    private static int assignedAgentCount(AgentCommands commands)
+        => commands.OfType<AssignAgents>().Sum(x => x.AgentIds.Length)
+           + commands.OfType<AssignAgent>().Count();
+
+    [Fact]
+    public async Task suppresses_re_emission_of_the_same_assignment_within_the_ttl()
+    {
+        // First evaluation: nothing is running anywhere, so every fake agent is assigned to the one node.
+        var first = await evaluateAsync();
+        assignedAgentCount(first).ShouldBe(FakeAgentFamily.Names.Length);
+
+        // Second evaluation with the SAME still-unconfirmed state: the node hasn't persisted any assignment
+        // row yet (ActiveAgents still empty), so pre-fix the leader would re-emit the whole batch. The ledger
+        // must now suppress every one of them.
+        var second = await evaluateAsync();
+        assignedAgentCount(second).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task re_emits_after_the_ttl_expires_without_confirmation()
+    {
+        // Short TTL so the expiry backstop can be exercised with a real delay: 2 x CheckAssignmentPeriod.
+        // (Suppression-within-TTL is covered separately with the default 30s period, where no expiry can
+        // race the assertions.)
+        _options.Durability.CheckAssignmentPeriod = 10.Milliseconds();
+
+        assignedAgentCount(await evaluateAsync()).ShouldBe(FakeAgentFamily.Names.Length);
+
+        await Task.Delay(100.Milliseconds()); // comfortably past the 20ms TTL
+
+        // A start that never took must eventually be re-driven.
+        assignedAgentCount(await evaluateAsync()).ShouldBe(FakeAgentFamily.Names.Length);
+    }
+
+    [Fact]
+    public async Task confirmation_clears_the_ledger_so_a_later_loss_re_emits()
+    {
+        assignedAgentCount(await evaluateAsync()).ShouldBe(FakeAgentFamily.Names.Length);
+
+        // The node actually started the agents and persisted the assignment rows: they now show up in its
+        // ActiveAgents, so the next grid has OriginalNode == AssignedNode == this node. That confirms the
+        // pending assignments and clears the ledger (and emits nothing, since they're already where we want).
+        _self.ActiveAgents.AddRange(_family.AllAgentUris());
+        assignedAgentCount(await evaluateAsync()).ShouldBe(0);
+
+        // Now the node loses them (e.g. a restart): ActiveAgents empty again. Because confirmation cleared
+        // the ledger — rather than the entries merely being suppressed — the reassignment is re-emitted
+        // immediately instead of waiting out a TTL.
+        _self.ActiveAgents.Clear();
+        assignedAgentCount(await evaluateAsync()).ShouldBe(FakeAgentFamily.Names.Length);
+    }
+}

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.EvaluateAssignments.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.EvaluateAssignments.cs
@@ -6,6 +6,19 @@ public partial class NodeAgentController
 {
     public AssignmentGrid? LastAssignments { get; internal set; }
 
+    // GH-3604 / D3+D6: leader-side, in-memory record of AssignAgent commands emitted but not yet confirmed
+    // running on their destination. A first-time assignment (grid Agent.OriginalNode == null) is emitted as
+    // AssignAgent, but a heavily loaded node — e.g. one starting thousands of Marten subscription agents —
+    // can take many assignment cycles to actually start each agent and persist its assignment row. Until the
+    // next LoadNodeAgentState reflects it as running, the leader would re-emit the SAME (agent -> node)
+    // AssignAgent every ~CheckAssignmentPeriod, piling duplicate mega-batches onto the polled control queue
+    // and writing ~one AssignmentChanged telemetry row per agent per cycle into the same database the
+    // rebuild is already saturating. This ledger suppresses those re-emissions for a TTL. It is leader-only
+    // and in-memory: a new leader starts empty and safely re-emits.
+    private readonly Dictionary<Uri, PendingAssignment> _pendingAssignments = new();
+
+    private readonly record struct PendingAssignment(Guid NodeId, DateTimeOffset SentAt);
+
     // Tested w/ integration tests all the way
     public async Task<AgentCommands> EvaluateAssignmentsAsync(
         IReadOnlyList<WolverineNode> nodes,
@@ -92,6 +105,11 @@ public partial class NodeAgentController
             commands.Add(new StopRemoteAgent(report.AgentUri, report.ExistingNode.ToDestination()));
         }
 
+        // GH-3604 / D3+D6: drop AssignAgent commands still in flight from a recent wave BEFORE the observer
+        // logs them, so a slow start isn't punished with a duplicate control-queue flood and a matching
+        // burst of AssignmentChanged telemetry rows.
+        suppressPendingAssignments(grid, commands);
+
         await _observer.AssignmentsChanged(grid, commands);
 
         LastAssignments = grid;
@@ -103,6 +121,71 @@ public partial class NodeAgentController
         }
 
         return commands;
+    }
+
+    // Confirm-and-suppress the pending-assignment ledger for this evaluation. See _pendingAssignments.
+    private void suppressPendingAssignments(AssignmentGrid grid, AgentCommands commands)
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        // TTL must exceed the worst-case time for a destination to actually start an assigned agent and have
+        // it show up in a later LoadNodeAgentState. 2x CheckAssignmentPeriod is the conservative default; a
+        // genuinely stuck start is retried once the entry expires.
+        var ttl = _runtime.Options.Durability.CheckAssignmentPeriod * 2;
+
+        // Confirmation: an agent now running on the very node we assigned it to is no longer pending. The
+        // grid sets Agent.OriginalNode from each node's persisted ActiveAgents, so OriginalNode == AssignedNode
+        // means the destination started it and persisted the assignment row since we last emitted.
+        foreach (var agent in grid.AllAgents)
+        {
+            if (agent.OriginalNode != null && ReferenceEquals(agent.AssignedNode, agent.OriginalNode))
+            {
+                _pendingAssignments.Remove(agent.Uri);
+            }
+        }
+
+        // Expire stale entries so a start that never took is eventually re-driven.
+        if (_pendingAssignments.Count > 0)
+        {
+            var expired = _pendingAssignments
+                .Where(kv => now - kv.Value.SentAt >= ttl)
+                .Select(kv => kv.Key)
+                .ToArray();
+            foreach (var uri in expired)
+            {
+                _pendingAssignments.Remove(uri);
+            }
+        }
+
+        var suppressed = 0;
+        for (var i = commands.Count - 1; i >= 0; i--)
+        {
+            if (commands[i] is not AssignAgent assign)
+            {
+                continue;
+            }
+
+            if (_pendingAssignments.TryGetValue(assign.AgentUri, out var pending)
+                && pending.NodeId == assign.Destination.NodeId)
+            {
+                // Same (agent -> node) assignment still in flight from a recent wave: don't re-emit it.
+                commands.RemoveAt(i);
+                suppressed++;
+            }
+            else
+            {
+                // New assignment, a re-target to a different node, or a TTL-expired retry: emit it and (re)arm
+                // the ledger entry.
+                _pendingAssignments[assign.AgentUri] = new PendingAssignment(assign.Destination.NodeId, now);
+            }
+        }
+
+        if (suppressed > 0)
+        {
+            _logger.LogDebug(
+                "Suppressed {Count} AssignAgent command(s) still in flight from a recent assignment wave",
+                suppressed);
+        }
     }
 
     private static void batchCommands(List<IAgentCommand> commands)


### PR DESCRIPTION
## Summary

Next phase of the projection/subscription **agent-assignment churn livelock** fix (WO-5), after the merged trio #3619/#3620/#3621 broke the livelock. This addresses the **flood amplification** (D3/D6) that made the incident so violent on the polled `dbcontrol` control transport.

**Defect D3/D6:** a first-time assignment (grid `Agent.OriginalNode == null`) is emitted as `AssignAgent`. A heavily loaded node — one starting thousands of Marten subscription agents — takes many assignment cycles to actually start each agent and persist its assignment row. Until the next `LoadNodeAgentState` reflects it as running, the leader re-emitted the *same* `(agent → node)` `AssignAgent` **every `CheckAssignmentPeriod`**:
- duplicate ~300KB `StartAgents` mega-batches pile onto the polled `dbcontrol` queue (D3);
- `AssignmentsChanged` writes **one `NodeRecord` per command** (before batching) — ~one telemetry row per agent per cycle into the very database the rebuild is saturating (D6; ~96K inserts/hour in the incident).

## Change

`EvaluateAssignmentsAsync` now keeps a **leader-side, in-memory pending-assignment ledger**. Before the observer logs the commands, `suppressPendingAssignments`:
- **confirms + clears** entries whose agent is now running on the node it was assigned to (grid `OriginalNode == AssignedNode`);
- **expires** entries older than `2 × CheckAssignmentPeriod`, so a start that never took is eventually re-driven;
- **suppresses** any `AssignAgent` still in flight to the same node from a recent wave, and arms the ledger for genuinely new / re-targeted / TTL-expired ones.

Suppressing *before* `_observer.AssignmentsChanged` also removes the matching telemetry-write flood. The ledger is in-memory and leader-only — a new leader starts empty and safely re-emits.

Pairs with **WO-4** (scale-safe chunked/bounded-parallel batch starts, coming next): "one chunk in flight per destination is enough with WO-5."

## Tests

`CoreTests/Runtime/Agents/pending_assignment_ledger.cs` drives the **real** `EvaluateAssignmentsAsync` via `FakeAgentFamily`: suppression within the TTL (**teeth-verified** — fails if suppression is removed), re-emit after TTL expiry, and confirmation clearing the ledger so a later loss re-emits immediately. All 169 `Runtime.Agents`/`Heartbeat` tests pass; full `wolverine.slnx` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1wnxZSPHtSQqrRhDNPHYD