### PR TITLE
fix(agents): scale-safe chunked, bounded-parallel agent batch starts (D3, WO-4)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/scale_safe_batch_starts.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/scale_safe_batch_starts.cs
@@ -1,0 +1,117 @@
+using CoreTests.Transports;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Regression coverage for D3 of the projection-agent churn livelock (GH-3604). Assignments to a node used
+/// to go out as one mega-batch (~2,100 URIs) answered by a fixed 30s reply window, and the receiving node
+/// started them SERIALLY -- hours of work the reply could never wait out, so the leader re-sent the whole
+/// batch every cycle. WO-4 chunks a destination's assignments into AgentStartBatchSize-sized batches, starts
+/// each batch with bounded parallelism (MaxAgentStartParallelism) on the receiving node, and scales the
+/// reply timeout with chunk size.
+/// </summary>
+public class scale_safe_batch_starts
+{
+    private readonly WolverineOptions _options;
+    private readonly IWolverineRuntime _runtime;
+
+    public scale_safe_batch_starts()
+    {
+        _options = new WolverineOptions { ApplicationAssembly = GetType().Assembly };
+        _options.Transports.NodeControlEndpoint = new FakeEndpoint("fake://self".ToUri(), EndpointRole.System);
+        _options.Durability.DurabilityAgentEnabled = false;
+
+        _runtime = Substitute.For<IWolverineRuntime>();
+        _runtime.Options.Returns(_options);
+        _runtime.DurabilitySettings.Returns(_options.Durability);
+        _runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+    }
+
+    [Fact]
+    public async Task chunks_a_destinations_assignments_into_configured_batch_sizes()
+    {
+        _options.Durability.AgentStartBatchSize = 5;
+
+        var family = new FakeAgentFamily("fake"); // 12 known agents
+        var controller = new NodeAgentController(
+            _runtime, Substitute.For<INodeAgentPersistence>(), [family],
+            NullLogger<NodeAgentController>.Instance, CancellationToken.None);
+
+        var self = new WolverineNode
+        {
+            NodeId = _options.UniqueNodeId,
+            AssignedNodeNumber = 1,
+            ControlUri = _options.Transports.NodeControlEndpoint!.Uri
+        };
+        self.Capabilities.AddRange(family.AllAgentUris());
+
+        var commands = await controller.EvaluateAssignmentsAsync([self], new AgentRestrictions());
+
+        // 12 agents, batch size 5 -> 3 chunks of at most 5, covering all 12 exactly once.
+        var batches = commands.OfType<AssignAgents>().ToArray();
+        batches.Length.ShouldBe(3);
+        batches.All(x => x.AgentIds.Length <= 5).ShouldBeTrue();
+        batches.SelectMany(x => x.AgentIds).Distinct().Count().ShouldBe(FakeAgentFamily.Names.Length);
+    }
+
+    [Fact]
+    public async Task starts_a_batch_with_bounded_parallelism()
+    {
+        const int dop = 4;
+        const int total = 8;
+        _options.Durability.MaxAgentStartParallelism = dop;
+
+        var gate = new object();
+        var concurrent = 0;
+        var maxConcurrent = 0;
+        var reachedCap = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var agents = Substitute.For<IAgentRuntime>();
+        agents.StartLocallyAsync(Arg.Any<Uri>()).Returns(async _ =>
+        {
+            int now;
+            lock (gate)
+            {
+                concurrent++;
+                now = concurrent;
+                if (concurrent > maxConcurrent) maxConcurrent = concurrent;
+            }
+
+            if (now >= dop) reachedCap.TrySetResult();
+
+            await release.Task;
+
+            lock (gate) { concurrent--; }
+        });
+        _runtime.Agents.Returns(agents);
+        _runtime.Logger.Returns(NullLogger.Instance);
+
+        var uris = Enumerable.Range(0, total).Select(i => new Uri($"fake://{i}")).ToArray();
+        var exec = new StartAgents(uris).ExecuteAsync(_runtime, CancellationToken.None);
+
+        // Exactly `dop` starts run concurrently; the rest queue behind them (Parallel.ForEachAsync bound).
+        await reachedCap.Task.WaitAsync(5.Seconds());
+        lock (gate)
+        {
+            concurrent.ShouldBe(dop);
+            maxConcurrent.ShouldBe(dop);
+        }
+
+        release.SetResult();
+        var result = await exec.WaitAsync(5.Seconds());
+
+        // Every agent eventually started, and parallelism never exceeded the cap.
+        result.OfType<AgentsStarted>().Single().AgentUris.Length.ShouldBe(total);
+        maxConcurrent.ShouldBe(dop);
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -244,6 +244,23 @@ public class DurabilitySettings : IDescribeMyself
     public TimeSpan CheckAssignmentPeriod { get; set; } = 30.Seconds();
 
     /// <summary>
+    ///     GH-3604 / D3: the maximum number of agent assignments the leader packs into a single
+    ///     <c>StartAgents</c> control message to a node. A node running a very large agent universe
+    ///     (e.g. database-per-tenant Marten with thousands of subscription shards) cannot start
+    ///     thousands of daemon agents inside one request/reply window, so assignments to a destination
+    ///     are chunked into batches of this size and sent one chunk at a time. Default 50.
+    /// </summary>
+    public int AgentStartBatchSize { get; set; } = 50;
+
+    /// <summary>
+    ///     GH-3604 / D3: the maximum number of agents a receiving node starts concurrently when it
+    ///     handles a <c>StartAgents</c> batch. Daemon-agent starts are I/O bound (database round-trips),
+    ///     so starting them with bounded parallelism instead of serially lets a batch complete well
+    ///     inside the reply window. Default 10.
+    /// </summary>
+    public int MaxAgentStartParallelism { get; set; } = 10;
+
+    /// <summary>
     /// Opt-in switch for the dynamic listener registry: persisted listener URIs that
     /// are activated at runtime in addition to the listeners declared statically
     /// through <see cref="WolverineOptions"/>. When <c>true</c>, <c>IMessageStore.Listeners</c>

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.EvaluateAssignments.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.EvaluateAssignments.cs
@@ -105,15 +105,21 @@ public partial class NodeAgentController
         return commands;
     }
 
-    private static void batchCommands(List<IAgentCommand> commands)
+    private void batchCommands(List<IAgentCommand> commands)
     {
+        // GH-3604 / D3: chunk a destination's assignments into batches of at most AgentStartBatchSize rather
+        // than one mega-batch. A node cannot start thousands of daemon agents inside one reply window; with
+        // WO-5's pending-assignment ledger, one chunk in flight per destination at a time is enough.
+        var batchSize = Math.Max(1, _runtime.Options.Durability.AgentStartBatchSize);
+
         foreach (var group in commands.OfType<AssignAgent>().GroupBy(x => x.Destination).Where(x => x.Count() > 1).ToArray())
         {
-            var assignAgents = new AssignAgents(group.Key, group.Select(x => x.AgentUri).ToArray());
-
             foreach (var message in group) commands.Remove(message);
 
-            commands.Add(assignAgents);
+            foreach (var chunk in group.Select(x => x.AgentUri).Chunk(batchSize))
+            {
+                commands.Add(new AssignAgents(group.Key, chunk));
+            }
         }
 
         foreach (var group in commands.OfType<StopRemoteAgent>().GroupBy(x => x.Destination).Where(x => x.Count() > 1)

--- a/src/Wolverine/Runtime/Agents/StartAgents.cs
+++ b/src/Wolverine/Runtime/Agents/StartAgents.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
@@ -31,7 +30,12 @@ internal record AssignAgents(NodeDestination Destination, Uri[] AgentIds) : IAge
         CancellationToken cancellationToken)
     {
         var startAgents = new StartAgents(AgentIds);
-        var response = await runtime.Agents.InvokeAsync<AgentsStarted>(Destination, startAgents);
+
+        // GH-3604 / D3: scale the reply timeout with the chunk size as a backstop. The receiving node starts
+        // the batch with bounded parallelism, so the reply normally arrives quickly, but a large chunk of
+        // slow daemon-agent starts must not be cut off by the default fixed request/reply window.
+        var timeout = 30.Seconds() + AgentIds.Length.Seconds();
+        var response = await runtime.Agents.InvokeAsync<AgentsStarted>(Destination, startAgents, timeout);
 
         if (response == null)
         {
@@ -60,26 +64,31 @@ internal record StartAgents(Uri[] AgentUris) : IAgentCommand, ISerializable
 {
     public async Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
     {
-        var successful = new List<Uri>(AgentUris.Length);
-        foreach (var agentUri in AgentUris)
+        // GH-3604 / D3: start the batch with bounded parallelism instead of serially. Daemon-agent starts are
+        // I/O bound (database round-trips per shard), so a 50-agent chunk started one-at-a-time was seconds of
+        // dead wall-clock that blew the reply window; a bounded fan-out lets the whole chunk converge quickly
+        // without swamping the node.
+        var successful = new System.Collections.Concurrent.ConcurrentBag<Uri>();
+
+        var dop = Math.Max(1, runtime.Options.Durability.MaxAgentStartParallelism);
+        var options = new ParallelOptions
+        {
+            MaxDegreeOfParallelism = dop,
+            CancellationToken = cancellationToken
+        };
+
+        await Parallel.ForEachAsync(AgentUris, options, async (agentUri, token) =>
         {
             try
             {
-                var stopwatch = new Stopwatch();
-                stopwatch.Start();
-
                 await runtime.Agents.StartLocallyAsync(agentUri);
-
-                Debug.WriteLine($"STARTED {agentUri} in {stopwatch.ElapsedMilliseconds} MILLISECONDS");
-                stopwatch.Stop();
-
                 successful.Add(agentUri);
             }
             catch (Exception e)
             {
                 runtime.Logger.LogError(e, "Failed to start requested agent {AgentUri}", agentUri);
             }
-        }
+        });
 
         return [new AgentsStarted(successful.ToArray())];
     }

--- a/src/Wolverine/Runtime/IAgentRuntime.cs
+++ b/src/Wolverine/Runtime/IAgentRuntime.cs
@@ -10,7 +10,7 @@ public interface IAgentRuntime
 
     Task InvokeAsync(NodeDestination destination, IAgentCommand command);
 
-    Task<T> InvokeAsync<T>(NodeDestination destination, IAgentCommand command) where T : class;
+    Task<T> InvokeAsync<T>(NodeDestination destination, IAgentCommand command, TimeSpan? timeout = null) where T : class;
     Uri[] AllRunningAgentUris();
 
     /// <summary>

--- a/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
@@ -65,13 +65,17 @@ public partial class WolverineRuntime : IAgentRuntime
         }
     }
 
-    public async Task<T> InvokeAsync<T>(NodeDestination destination, IAgentCommand command) where T : class
+    public async Task<T> InvokeAsync<T>(NodeDestination destination, IAgentCommand command, TimeSpan? timeout = null) where T : class
     {
         var messageBus = new MessageBus(this);
 
+        // GH-3604 / D3: callers that dispatch large agent batches (AssignAgents) pass a timeout scaled to the
+        // batch size so a big, slow chunk isn't cut off by the fixed default reply window.
+        var replyTimeout = timeout ?? 30.Seconds();
+
         if (Options.UniqueNodeId == destination.NodeId)
         {
-            return await messageBus.InvokeAsync<T>(command, _agentCancellation.Token, 30.Seconds());
+            return await messageBus.InvokeAsync<T>(command, _agentCancellation.Token, replyTimeout);
         }
 
         // GH-2949: remote-node InvokeAsync<T> used to wait only 10s for the typed reply while
@@ -84,7 +88,7 @@ public partial class WolverineRuntime : IAgentRuntime
         // Wolverine.Runtime.Agents.AgentsStarted ... configured timeout of 10000 milliseconds'.
         return await messageBus
             .EndpointFor(destination.ControlUri)
-            .InvokeAsync<T>(command, _agentCancellation.Token, 30.Seconds());
+            .InvokeAsync<T>(command, _agentCancellation.Token, replyTimeout);
     }
 
     public Uri[] AllRunningAgentUris()


### PR DESCRIPTION
## Summary

Next in the projection/subscription **agent-assignment churn livelock** fix (WO-4), pairing with #3622 (WO-5). Addresses the batch-start scale cliff (D3) that made a large cold start / rebuild unable to complete.

**Defect D3:** assignments to a node went out as a single mega-batch (~2,100 URIs in the incident), answered by a fixed 30s reply window, and the receiving node started them **serially**. Each Marten subscription-agent start is a daemon-shard spin-up with database round-trips (seconds each under rebuild load), so a 2,100-agent batch is *hours* of serial work answered by a 30-second timeout — the reply can never arrive, the leader records nothing, and the next cycle re-sends the whole ~300KB `StartAgents` batch onto the polled `dbcontrol` queue.

## Change

- **Chunk** a destination's assignments into `DurabilitySettings.AgentStartBatchSize` (default 50) batches in `NodeAgentController.batchCommands`, instead of one mega-batch. Chunks are **not** parallelized on the sender — with #3622's pending-assignment ledger, one chunk in flight per destination at a time is enough (and `executeAgentCommandsAsync` already drains sequentially).
- **Bounded-parallel starts** on the receiving node: `StartAgents.ExecuteAsync` uses `Parallel.ForEachAsync` at `DurabilitySettings.MaxAgentStartParallelism` (default 10) instead of a serial loop. Daemon starts are I/O bound, so a bounded fan-out converges a chunk quickly without swamping the node.
- **Scaled reply timeout** as a backstop: `IAgentRuntime.InvokeAsync<T>` gains an optional `timeout`; `AssignAgents` passes `30s + 1s/agent` so a large slow chunk isn't cut off by the fixed default.

Two new tunable knobs on `DurabilitySettings` (`AgentStartBatchSize`, `MaxAgentStartParallelism`) — useful for the database-per-tenant scale guidance (WO-12).

## Tests

`CoreTests/Runtime/Agents/scale_safe_batch_starts.cs`:
- `batchCommands` chunks 12 agents into 3 batches of ≤5 (teeth: a single batch without chunking).
- `StartAgents` runs **exactly** `MaxAgentStartParallelism` concurrently and no more — TCS-gated, so it would time out if starts were still serial.

All 168 `Runtime.Agents`/`Heartbeat` tests pass; full `wolverine.slnx` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1wnxZSPHtSQqrRhDNPHYD