### PR TITLE
fix(agents): ejection hysteresis + leader protection (hardens D1, WO-6)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/ejection_hysteresis_tests.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/ejection_hysteresis_tests.cs
@@ -1,0 +1,149 @@
+using CoreTests.Transports;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Regression coverage for WO-6 (GH-3604) — ejection hysteresis + leader protection. A single stale
+/// snapshot read (replica lag, a GC pause, an aggressive StaleNodeTimeout, or a leader momentarily busy
+/// before D1 was fixed) used to be enough for a peer to DeleteAsync a very-much-alive node — wiping its
+/// row, its in-flight envelope ownership, and its agent assignments — which fed the eject/resurrect
+/// flapping. The destructive delete now requires N consecutive stale observations, and a follower may
+/// never delete the current leader's row: only a node that actually holds the leadership lock cleans up a
+/// stale leader. Routing to a stale node still stops immediately (grid exclusion, unchanged).
+/// </summary>
+public class ejection_hysteresis_tests
+{
+    private readonly WolverineOptions _options;
+    private readonly INodeAgentPersistence _persistence;
+    private readonly IWolverineRuntime _runtime;
+    private readonly NodeAgentController _controller;
+    private readonly Guid _peerId = Guid.NewGuid();
+
+    public ejection_hysteresis_tests()
+    {
+        _options = new WolverineOptions { ApplicationAssembly = GetType().Assembly };
+        _options.Transports.NodeControlEndpoint = new FakeEndpoint("fake://self".ToUri(), EndpointRole.System);
+        _options.Durability.DurabilityAgentEnabled = false;
+        _options.Durability.StaleNodeTimeout = 30.Seconds();
+
+        _runtime = Substitute.For<IWolverineRuntime>();
+        _runtime.Options.Returns(_options);
+        _runtime.DurabilitySettings.Returns(_options.Durability);
+        _runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+
+        _persistence = Substitute.For<INodeAgentPersistence>();
+        // Keep this node a follower; the ejection path we exercise runs before the leadership attempt.
+        _persistence.TryAttainLeadershipLockAsync(Arg.Any<CancellationToken>()).Returns(false);
+
+        _controller = new NodeAgentController(
+            _runtime, _persistence, Array.Empty<IAgentFamily>(),
+            NullLogger<NodeAgentController>.Instance, CancellationToken.None);
+    }
+
+    private WolverineNode Self() => new()
+    {
+        NodeId = _options.UniqueNodeId,
+        AssignedNodeNumber = 1,
+        ControlUri = _options.Transports.NodeControlEndpoint!.Uri,
+        LastHealthCheck = DateTimeOffset.UtcNow
+    };
+
+    private WolverineNode Peer(bool stale, bool isLeader = false)
+    {
+        var node = new WolverineNode
+        {
+            NodeId = _peerId,
+            AssignedNodeNumber = 99,
+            ControlUri = new Uri("fake://peer"),
+            LastHealthCheck = stale
+                ? DateTimeOffset.UtcNow.Subtract(60.Seconds())
+                : DateTimeOffset.UtcNow
+        };
+        if (isLeader) node.AssignAgents([NodeAgentController.LeaderUri]);
+        return node;
+    }
+
+    private void snapshotIs(params WolverineNode[] nodes)
+        => _persistence.LoadNodeAgentStateAsync(Arg.Any<CancellationToken>())
+            .Returns(new NodeAgentState(nodes, new AgentRestrictions()));
+
+    private Task tickAsync() => _controller.DoHealthChecksAsync();
+
+    private Task assertPeerDeleted(int times)
+        => _persistence.Received(times).DeleteAsync(_peerId, 99);
+
+    [Fact]
+    public async Task does_not_eject_a_stale_peer_on_the_first_observation()
+    {
+        snapshotIs(Self(), Peer(stale: true));
+
+        await tickAsync();
+
+        await _persistence.DidNotReceive().DeleteAsync(_peerId, Arg.Any<int>());
+    }
+
+    [Fact]
+    public async Task ejects_a_stale_peer_after_two_consecutive_observations()
+    {
+        snapshotIs(Self(), Peer(stale: true));
+
+        await tickAsync(); // observation 1 — below threshold
+        await _persistence.DidNotReceive().DeleteAsync(_peerId, Arg.Any<int>());
+
+        await tickAsync(); // observation 2 — threshold reached
+        await assertPeerDeleted(1);
+    }
+
+    [Fact]
+    public async Task resets_the_streak_when_the_peer_recovers_between_observations()
+    {
+        snapshotIs(Self(), Peer(stale: true));
+        await tickAsync(); // observation 1
+
+        snapshotIs(Self(), Peer(stale: false));
+        await tickAsync(); // peer healthy again — streak resets
+
+        snapshotIs(Self(), Peer(stale: true));
+        await tickAsync(); // stale again, but only the first of a NEW streak
+
+        await _persistence.DidNotReceive().DeleteAsync(_peerId, Arg.Any<int>());
+    }
+
+    [Fact]
+    public async Task a_follower_never_deletes_a_stale_leaders_row()
+    {
+        // Isolate leader protection from hysteresis: one observation is enough to reach the threshold.
+        _options.Durability.StaleNodeEjectionThreshold = 1;
+        _persistence.HasLeadershipLock().Returns(false); // this node is a follower
+
+        snapshotIs(Self(), Peer(stale: true, isLeader: true));
+
+        await tickAsync();
+        await tickAsync();
+
+        // The freed advisory lock lets a follower attain leadership through the normal path; it must NOT
+        // destroy the leader's row itself.
+        await _persistence.DidNotReceive().DeleteAsync(_peerId, Arg.Any<int>());
+    }
+
+    [Fact]
+    public async Task the_leadership_lock_holder_may_eject_a_stale_leader()
+    {
+        _options.Durability.StaleNodeEjectionThreshold = 1;
+        _persistence.HasLeadershipLock().Returns(true); // this node has taken over leadership
+
+        snapshotIs(Self(), Peer(stale: true, isLeader: true));
+
+        await tickAsync();
+
+        await assertPeerDeleted(1);
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -237,6 +237,16 @@ public class DurabilitySettings : IDescribeMyself
     public TimeSpan StaleNodeTimeout { get; set; } = 1.Minutes();
 
     /// <summary>
+    ///     GH-3604 / D1: how many consecutive health-check ticks the observing node must see another node
+    ///     as stale before it destructively deletes that node's row (which also releases the node's
+    ///     in-flight envelope ownership and its agent assignments). Routing to a stale node stops
+    ///     immediately regardless — it is dropped from the assignment grid on the first observation — so
+    ///     this only adds hysteresis to the irreversible delete, preventing a single stale snapshot read or
+    ///     transient blip from ejecting a node that is really alive. Minimum (and default) 2.
+    /// </summary>
+    public int StaleNodeEjectionThreshold { get; set; } = 2;
+
+    /// <summary>
     ///     How often should Wolverine do a full check that all assigned agents are
     ///     really running and try to restart (or stop) any differences from the last
     ///     good set of assignments

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
@@ -299,12 +299,48 @@ public partial class NodeAgentController
         return await EvaluateAssignmentsAsync(nodes, restrictions);
     }
 
+    // GH-3604 / D1: consecutive stale-observation counts per node id, used to add hysteresis to the
+    // destructive DeleteAsync. Only the observing node mutates it, from the serialized health-check path.
+    private readonly Dictionary<Guid, int> _staleObservations = new();
+
     private async Task ejectStaleNodes(IReadOnlyList<WolverineNode> staleNodes)
     {
+        // A node that is no longer stale on this tick resets its streak, so only a *sustained* absence ejects.
+        var staleIds = staleNodes.Select(x => x.NodeId).ToHashSet();
+        foreach (var recovered in _staleObservations.Keys.Where(id => !staleIds.Contains(id)).ToArray())
+        {
+            _staleObservations.Remove(recovered);
+        }
+
+        var threshold = Math.Max(1, _runtime.Options.Durability.StaleNodeEjectionThreshold);
+
+        // Leader protection: only a node that currently holds the leadership lock may destroy another node's
+        // row when that node is the current leader. A follower that merely sees the leader as stale must not
+        // wipe it — the freed advisory lock lets a follower attain leadership through the normal election
+        // path, and that confirmed new leader ejects the old row on a later tick. This prevents a transient
+        // blip from destroying a live leader's row, ownership, and assignments.
+        var holdsLeadership = _persistence.HasLeadershipLock();
+
         // As per GH-1116, don't delete yourself!
         foreach (var staleNode in staleNodes.Where(x => x.AssignedNodeNumber != _runtime.DurabilitySettings.AssignedNodeNumber))
         {
+            var count = (_staleObservations.TryGetValue(staleNode.NodeId, out var previous) ? previous : 0) + 1;
+            _staleObservations[staleNode.NodeId] = count;
+
+            // Hysteresis: routing to the node already stopped this tick (it is filtered out of the assignment
+            // grid upstream); wait for N consecutive observations before the irreversible delete.
+            if (count < threshold)
+            {
+                continue;
+            }
+
+            if (staleNode.IsLeader() && !holdsLeadership)
+            {
+                continue;
+            }
+
             await _persistence.DeleteAsync(staleNode.NodeId, staleNode.AssignedNodeNumber);
+            _staleObservations.Remove(staleNode.NodeId);
         }
 
         if (staleNodes.Any())


### PR DESCRIPTION
## Summary

Final work order of the projection/subscription **agent-assignment churn livelock** phase (WO-6), hardening against the eject/resurrect flapping after #3619/#3620/#3621 (merged) and #3622/#3623 (open).

**Defect (hardens D1):** a single stale snapshot read — replica lag, a GC pause between the heartbeat write and the read, an aggressive `StaleNodeTimeout`, or (before #3620 fixed D1) a leader momentarily busy — was enough for a peer to `DeleteAsync` a **very-much-alive** node, wiping its row, its in-flight envelope ownership, and its agent assignments. That over-eager destructive delete is what turned a transient blip into the measured 26-consecutive-`DormantNodeEjected` flapping.

## Change

- **Ejection hysteresis:** the delete now requires `DurabilitySettings.StaleNodeEjectionThreshold` (default **2**) consecutive stale observations of the same node by the observing node. A node seen healthy on any tick resets its streak, so a blip never ejects. Routing to a stale node still stops **immediately** — it's filtered out of the assignment grid on the first observation — so redistribution timing is unchanged; only the irreversible delete is gated. (This cleanly separates "stop routing to node" from "destroy its row", as the analysis suggested.)
- **Leader protection:** a follower may never delete the current leader's row. Only a node that actually holds the leadership lock cleans up a stale leader. The freed advisory lock lets a follower attain leadership through the normal election path, and that confirmed new leader ejects the old row on a later tick — so a transient blip can't destroy a live leader.

## Tests

`CoreTests/Runtime/Agents/ejection_hysteresis_tests.cs` scripts `LoadNodeAgentStateAsync` snapshots: no eject on the first observation, eject after two consecutive, streak reset on recovery, a follower never deletes a stale leader, and the lock holder does. **Teeth-verified** (removing the guards fails 4 of 5).

Because this touches the election path, the DB-backed leadership compliance tests were run locally **one at a time** (the full serial suite buffers output and is slow): `eject_a_stale_node`, `take_over_leader_ship_if_leader_becomes_stale`, `..._with_racing_nodes`, `leader_switchover_between_nodes`, `spin_up_several_nodes_take_away_original_node`, `spin_up_several_nodes_take_away_non_leader_node` — all green. All 171 `Runtime.Agents`/`Heartbeat` unit tests pass; full `wolverine.slnx` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1wnxZSPHtSQqrRhDNPHYD