### PR TITLE
Fix double execution of compiled queries returned as Wolverine.Http resources (GH-3625)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Marten/compiled_query_writer.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/compiled_query_writer.cs
@@ -10,6 +10,90 @@ public class compiled_query_writer : IntegrationContext
     {
     }
 
+    // Warm the endpoint through the real request pipeline so the chain's handler is
+    // compiled by the same path production uses, then hand back the generated source.
+    // Calling ICodeFile.InitializeSynchronously here instead would pre-empt the
+    // route's own lazy buildHandler() and leave the shared AppFixture chain unable
+    // to serve requests in later tests.
+    private async Task<string> sourceCodeFor(string url, int expectedStatusCode = 200)
+    {
+        await Host.Scenario(x =>
+        {
+            x.Get.Url(url);
+            x.StatusCodeShouldBe(expectedStatusCode);
+        });
+
+        var chain = HttpChains.ChainFor("GET", url);
+        chain.ShouldNotBeNull();
+
+        var source = chain.SourceCode;
+        source.ShouldNotBeNull("Failed to generate the source code");
+        return source;
+    }
+
+    // GH-3625: QuerySpecificationPolicy saw the compiled query variable created by
+    // the endpoint method and injected a redundant QueryAsync() fetch whose result
+    // was discarded, so every request executed the query twice — once for the
+    // discarded fetch, once for CompiledQueryWriterPolicy's streaming call.
+
+    [Fact]
+    public async Task compiled_list_query_resource_is_streamed_without_a_redundant_fetch()
+    {
+        var source = await sourceCodeFor("/invoices/approved");
+
+        source.ShouldContain("WriteArray");
+        source.ShouldNotContain("QueryAsync",
+            customMessage: $"The chain's resource is streamed by WriteArray(); a QueryAsync() call means the query also ran a second, discarded time. Source code follows:\n{source}");
+    }
+
+    [Fact]
+    public async Task compiled_single_query_resource_is_streamed_without_a_redundant_fetch()
+    {
+        var chain = HttpChains.ChainFor("GET", "/invoices/compiled/{id}");
+        chain.ShouldNotBeNull();
+
+        // 404 is the WriteOne path for an unknown id — still compiles and runs the chain
+        await Host.Scenario(x =>
+        {
+            x.Get.Url($"/invoices/compiled/{Guid.NewGuid()}");
+            x.StatusCodeShouldBe(404);
+        });
+
+        var source = chain.SourceCode;
+        source.ShouldNotBeNull("Failed to generate the source code");
+
+        source.ShouldContain("WriteOne");
+        source.ShouldNotContain("QueryAsync",
+            customMessage: $"The chain's resource is streamed by WriteOne(); a QueryAsync() call means the query also ran a second, discarded time. Source code follows:\n{source}");
+    }
+
+    [Fact]
+    public async Task compiled_primitive_query_resource_is_executed_exactly_once()
+    {
+        var source = await sourceCodeFor("/invoices/compiled/count");
+
+        // Match the call site rather than the bare name, which also appears in the
+        // result variable's name
+        var count = source.Split(".QueryAsync<").Length - 1;
+        count.ShouldBe(1,
+            $"Expected exactly one QueryAsync() call in the generated source, found {count}. Source code follows:\n{source}");
+    }
+
+    [Fact]
+    public async Task load_returned_compiled_query_dependency_keeps_its_fetch()
+    {
+        var source = await sourceCodeFor("/invoices/approved/count");
+
+        // Here the compiled query is a data dependency produced by Load(), not the
+        // chain's resource, so the FetchSpecificationFrame must still execute it.
+        source.ShouldContain("QueryAsync",
+            customMessage: $"The Load-returned compiled query must still be fetched for the endpoint method. Source code follows:\n{source}");
+
+        // And the fetch result actually feeds the endpoint method at runtime
+        var text = await Host.GetAsText("/invoices/approved/count");
+        int.TryParse(text, out _).ShouldBeTrue($"Expected an integer count in the response, got '{text}'");
+    }
+
     [Fact]
     public async Task endpoint_returning_compiled_list_query_should_return_query_result()
     {

--- a/src/Http/WolverineWebApi/Marten/Documents.cs
+++ b/src/Http/WolverineWebApi/Marten/Documents.cs
@@ -94,6 +94,17 @@ public class InvoicesEndpoint
     }
 }
 
+// GH-3625 guard: here the compiled query is a Load-returned data dependency, NOT
+// the endpoint's resource, so QuerySpecificationPolicy must still inject the
+// FetchSpecificationFrame that materializes it for the endpoint method.
+public static class ApprovedInvoiceCountEndpoint
+{
+    public static ApprovedInvoicedCompiledQuery Load() => new();
+
+    [WolverineGet("/invoices/approved/count")]
+    public static string Get(IEnumerable<Invoice> invoices) => invoices.Count().ToString();
+}
+
 public class Invoice : ISoftDeleted
 {
     public Guid Id { get; set; }

--- a/src/Persistence/Wolverine.Marten/Codegen/QuerySpecificationPolicy.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/QuerySpecificationPolicy.cs
@@ -64,10 +64,32 @@ internal class QuerySpecificationPolicy : IMethodPreCompilationPolicy
             var baseIndex = method.Frames.IndexOf(frame);
             foreach (var specVar in specVars)
             {
+                // GH-3625: a spec that another frame already consumes directly — a
+                // pre-bound MethodCall argument — is not a Load-style data dependency,
+                // so injecting a fetch would only execute the query again and discard
+                // the result. The concrete case: Wolverine.Http.Marten's
+                // CompiledQueryWriterPolicy claims a compiled query that is the HTTP
+                // endpoint's resource and executes it itself (WriteArray/WriteOne
+                // streaming, or QueryAsync for primitive results).
+                if (IsConsumedDirectly(specVar, frames, frame)) continue;
+
                 var fetchFrame = new FetchSpecificationFrame(specVar);
                 method.Frames.Insert(baseIndex + 1, fetchFrame);
             }
         }
+    }
+
+    /// <summary>
+    /// Returns true if some other frame in the method consumes the specification
+    /// variable itself as an explicitly pre-bound MethodCall argument. Arguments are
+    /// only pre-bound at chain-building time (resource writer policies, cascading
+    /// message capture); ordinary dependencies resolve later during FindVariables,
+    /// so a Load-returned spec whose *result* feeds Handle never matches.
+    /// </summary>
+    private static bool IsConsumedDirectly(Variable specVar, List<Frame> frames, Frame creator)
+    {
+        return frames.OfType<MethodCall>()
+            .Any(call => !ReferenceEquals(call, creator) && call.Arguments.Contains(specVar));
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3625.

## Problem

When a Wolverine.Http endpoint returns a Marten `ICompiledQuery` / `ICompiledListQuery` as its resource (the `UseMartenCompiledQueryResultPolicy()` pattern), the query is executed **twice** per request. `QuerySpecificationPolicy` sees the compiled-query variable created by the endpoint method and injects a `FetchSpecificationFrame` (the Load-returned-specification ergonomic), even though `CompiledQueryWriterPolicy` is about to execute the same query itself.

Generated code before (for the existing `GET /invoices/approved` sample endpoint):

```csharp
var approvedInvoicedCompiledQuery = WolverineWebApi.Marten.InvoicesEndpoint.GetApproved();

// materialized AND discarded
var approvedInvoicedCompiledQuery_result = await ((Marten.IQuerySession)documentSession).QueryAsync<WolverineWebApi.Marten.Invoice, System.Collections.Generic.IEnumerable<WolverineWebApi.Marten.Invoice>>(approvedInvoicedCompiledQuery, httpContext.RequestAborted).ConfigureAwait(false);

// second execution
await Marten.AspNetCore.QueryableExtensions.WriteArray<WolverineWebApi.Marten.Invoice, System.Collections.Generic.IEnumerable<WolverineWebApi.Marten.Invoice>>(((Marten.IQuerySession)documentSession), approvedInvoicedCompiledQuery, httpContext, "application/json", 200).ConfigureAwait(false);
```

After:

```csharp
var approvedInvoicedCompiledQuery = WolverineWebApi.Marten.InvoicesEndpoint.GetApproved();
await Marten.AspNetCore.QueryableExtensions.WriteArray<WolverineWebApi.Marten.Invoice, System.Collections.Generic.IEnumerable<WolverineWebApi.Marten.Invoice>>(((Marten.IQuerySession)documentSession), approvedInvoicedCompiledQuery, httpContext, "application/json", 200).ConfigureAwait(false);
```

The primitive-result path (`GET /invoices/compiled/count`) had the same double execution — a discarded fetch ahead of `CompiledQueryWriterPolicy`'s own `QueryAsync`; it now runs exactly once.

## Fix

`QuerySpecificationPolicy` now skips a specification variable that some other frame in the method already consumes **directly** as a pre-bound `MethodCall` argument — which is exactly how `CompiledQueryWriterPolicy` binds the chain's resource into its `WriteArray` / `WriteOne` / `QueryAsync` calls. Arguments are only pre-bound at chain-building time; ordinary data dependencies resolve later during `FindVariables`, so a Load-returned spec whose *result* feeds the handler never matches and keeps its `FetchSpecificationFrame`. The check is structural, so `Wolverine.Marten` needs no reference to `Wolverine.Http.Marten`.

## Tests

New codegen-assertion tests in `Wolverine.Http.Tests/Marten/compiled_query_writer.cs` (alongside the existing behavioral tests, which still pass):

- `compiled_list_query_resource_is_streamed_without_a_redundant_fetch` — `GET /invoices/approved` generates `WriteArray` and no `QueryAsync`
- `compiled_single_query_resource_is_streamed_without_a_redundant_fetch` — `GET /invoices/compiled/{id}` generates `WriteOne` and no `QueryAsync`
- `compiled_primitive_query_resource_is_executed_exactly_once` — `GET /invoices/compiled/count` generates exactly one `.QueryAsync<` call site
- `load_returned_compiled_query_dependency_keeps_its_fetch` — guards the legit case: a new `WolverineWebApi` endpoint whose `Load()` returns a compiled query as a data dependency (not the resource) still gets its fetch, and the fetch result feeds the endpoint at runtime

All three redundant-fetch tests fail on `main` and pass with the fix. Also verified green: the full `Wolverine.Http.Tests` suite (906 passed) and `MartenTests` `fetch_specifications_tests` / batching tests (message-handler Load-returned specs, tuple batching, `[FromQuerySpecification]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
