### PR TITLE
fix(http): parse enum array query and form values case-insensitively

### DIFF
--- a/src/Http/Wolverine.Http.Tests/strict_query_string_binding.cs
+++ b/src/Http/Wolverine.Http.Tests/strict_query_string_binding.cs
@@ -345,6 +345,22 @@ public class strict_query_string_binding : IClassFixture<StrictQueryBindingFixtu
         response.Pages.ShouldBe([3]);
     }
 
+    // An enum array element used to parse case-sensitively while the scalar binder passed
+    // ignoreCase, so a camelCased value -- the default System.Text.Json spelling clients see in
+    // responses -- fell through to the rejection block and turned a valid request into a 400.
+    [Fact]
+    public async Task differently_cased_enum_array_elements_bind_in_strict_mode()
+    {
+        var result = await _fixture.StrictHost.Scenario(x =>
+        {
+            x.Get.Url("/strict/collections?Colours=red&Colours=GREEN&Colours=bLuE");
+            x.StatusCodeShouldBe(200);
+        });
+
+        var response = await result.ReadAsJsonAsync<StrictCollectionQueryModel>();
+        response.Colours.ShouldBe([StrictColour.Red, StrictColour.Green, StrictColour.Blue]);
+    }
+
     [Fact]
     public async Task omitted_collections_keep_initializers_in_strict_mode()
     {

--- a/src/Http/Wolverine.Http.Tests/using_form_parameters.cs
+++ b/src/Http/Wolverine.Http.Tests/using_form_parameters.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using JasperFx;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.Core;
@@ -214,6 +215,41 @@ public class using_form_parameters : IntegrationContext
 
         var text = await body.ReadAsTextAsync();
         text.ShouldBe($"{guid1},{guid2},{guid3}");
+    }
+
+    // The Alba-based form collection tests below are skipped because Alba cannot post form collections,
+    // but a raw client can, so the [FromForm] TEnum[] binder is exercised end to end here. Its elements
+    // used to parse case-sensitively while the scalar and List<TEnum> form binders passed ignoreCase.
+    [Fact]
+    public async Task use_parsed_enum_array_from_form()
+    {
+        var text = await postEnumArrayForm("North", "East", "South");
+        text.ShouldBe("North,East,South");
+    }
+
+    [Fact]
+    public async Task use_parsed_enum_array_from_form_is_case_insensitive()
+    {
+        var text = await postEnumArrayForm("north", "eAsT", "SOUTH");
+        text.ShouldBe("North,East,South");
+    }
+
+    [Fact]
+    public async Task use_parsed_enum_array_from_form_still_ignores_unparseable_values()
+    {
+        var text = await postEnumArrayForm("north", "nonsense");
+        text.ShouldBe("North");
+    }
+
+    private async Task<string> postEnumArrayForm(params string[] values)
+    {
+        var content = new FormUrlEncodedContent(
+            values.Select(x => new KeyValuePair<string, string>("collection", x)));
+
+        var response = await Host.Server.CreateClient().PostAsync("/form/array/enum", content);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadAsStringAsync();
     }
 
     [Fact(Skip = "Seems alba doesn't support collections in form data in any way")]

--- a/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs
+++ b/src/Http/Wolverine.Http.Tests/using_querystring_parameters.cs
@@ -218,6 +218,62 @@ public class using_querystring_parameters : IntegrationContext
     }
 
     [Fact]
+    public async Task use_parsed_enum_array()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get
+                .Url("/querystring/enumarray")
+                .QueryString("values", "North")
+                .QueryString("values", "East")
+                .QueryString("values", "South");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        var text = await body.ReadAsTextAsync();
+        text.ShouldBe("North,East,South");
+    }
+
+    // An enum array element used to be parsed case-sensitively while the scalar and List<TEnum> binders
+    // parsed case-insensitively, so a camelCased value -- the default System.Text.Json spelling clients
+    // see in responses -- was silently dropped from the array.
+    [Fact]
+    public async Task use_parsed_enum_array_is_case_insensitive()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get
+                .Url("/querystring/enumarray")
+                .QueryString("values", "north")
+                .QueryString("values", "eAsT")
+                .QueryString("values", "SOUTH");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        var text = await body.ReadAsTextAsync();
+        text.ShouldBe("North,East,South");
+    }
+
+    [Fact]
+    public async Task use_parsed_enum_array_still_ignores_unparseable_values()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Get
+                .Url("/querystring/enumarray")
+                .QueryString("values", "north")
+                .QueryString("values", "nonsense");
+
+            x.Header("content-type").SingleValueShouldEqual("text/plain");
+        });
+
+        var text = await body.ReadAsTextAsync();
+        text.ShouldBe("North");
+    }
+
+    [Fact]
     public async Task using_string_array_completely_hit()
     {
         var body = await Scenario(x =>

--- a/src/Http/Wolverine.Http/CodeGen/FormHandling.cs
+++ b/src/Http/Wolverine.Http/CodeGen/FormHandling.cs
@@ -146,7 +146,9 @@ internal class ParsedArrayFormValue : SyncFrame, IReadHttpFrame
 
             if (elementType!.IsEnum)
             {
-                writer.Write($"BLOCK:if ({elementAlias}.TryParse<{elementAlias}>({Variable.Usage}Value, out var {Variable.Usage}ValueParsed))");
+                // Case-insensitive for the same reason as ParsedArrayQueryStringValue -- the scalar
+                // and List<TEnum> form binders already pass ignoreCase.
+                writer.Write($"BLOCK:if ({elementAlias}.TryParse<{elementAlias}>({Variable.Usage}Value, true, out var {Variable.Usage}ValueParsed))");
             }
             else if (elementType.IsBoolean())
             {

--- a/src/Http/Wolverine.Http/CodeGen/ParsedArrayQueryStringValue.cs
+++ b/src/Http/Wolverine.Http/CodeGen/ParsedArrayQueryStringValue.cs
@@ -59,7 +59,10 @@ internal class ParsedArrayQueryStringValue : SyncFrame, IReadHttpFrame
 
             if (elementType!.IsEnum)
             {
-                writer.Write($"BLOCK:if ({elementAlias}.TryParse<{elementAlias}>({Variable.Usage}Value, out var {Variable.Usage}ValueParsed))");
+                // Enum names arrive on the wire as strings and must parse case-insensitively, matching the
+                // scalar binder and the List<TEnum> binder. Without ignoreCase a camelCased element (the
+                // default System.Text.Json spelling clients see in responses) is dropped from the array.
+                writer.Write($"BLOCK:if ({elementAlias}.TryParse<{elementAlias}>({Variable.Usage}Value, true, out var {Variable.Usage}ValueParsed))");
             }
             else if (elementType.IsBoolean())
             {

--- a/src/Http/WolverineWebApi/QuerystringEndpoints.cs
+++ b/src/Http/WolverineWebApi/QuerystringEndpoints.cs
@@ -43,6 +43,14 @@ public static class QuerystringEndpoints
         return values.OrderBy(x => x).Select(x => x.ToString()).Join(",");
     }
 
+    [WolverineGet("/querystring/enumarray")]
+    public static string EnumArray(Direction[]? values)
+    {
+        if (values == null || values.IsEmpty()) return "none";
+
+        return values.Select(x => x.ToString()).Join(",");
+    }
+
     // GH-3602: an explicit [FromQuery] on an array/collection of a simple element must bind from repeated
     // query values exactly like the attribute-less StringArray/IntArray above, not get misrouted into the
     // complex-type member-flattening path (which threw at discovery because arrays have no ctor).

--- a/src/Http/WolverineWebApi/TestEndpoints.cs
+++ b/src/Http/WolverineWebApi/TestEndpoints.cs
@@ -199,6 +199,12 @@ public static class FormCollectionEndpoints
     {
         return string.Join(",", collection);
     }
+
+    [WolverinePost("/form/array/enum")]
+    public static string UsingEnumArray([FromForm]Direction[] collection)
+    {
+        return string.Join(",", collection);
+    }
     
     
 }


### PR DESCRIPTION
An enum element bound into an array parsed case-sensitively, while the scalar binder and the List<TEnum> binder both passed ignoreCase to Enum.TryParse. A camelCased value -- the default System.Text.Json spelling clients see in responses -- was therefore dropped from the array while binding fine on a scalar parameter of the same enum type.

With WolverineHttpOptions.RejectUnparseableQueryValues enabled the dropped element turns the request into a 400; before that option existed it silently produced an unfiltered result set, which is the more dangerous failure.

Two emission sites were affected, both on the array path:

  - ParsedArrayQueryStringValue for TEnum[] bound from the query string
  - ParsedArrayFormValue for [FromForm] TEnum[]

Unparseable values are still rejected -- only the case comparison changes, so a genuinely bad value keeps its 400 under strict binding.

The form collection tests are skipped because Alba cannot post form collections, so the form binder is covered end to end with a raw client, matching the approach already used in from_form_file_binding.