### PR TITLE
feat(pubsub): add ListenToPubsubSubscriptionOnNamedBroker

### DIFF
--- a/docs/guide/messaging/transports/gcp-pubsub/index.md
+++ b/docs/guide/messaging/transports/gcp-pubsub/index.md
@@ -94,6 +94,24 @@ var host = await Host.CreateDefaultBuilder()
 
 Note that the `Uri` scheme within Wolverine for any endpoint on a *named* GCP Pub/Sub broker is the broker name you supply, not `pubsub`. So in the example above you would see `Uri` values like `americas://americas-project-id/colors`.
 
+Attaching to an existing, already-provisioned subscription (`ListenToPubsubSubscription`) also has a named-broker counterpart, `ListenToPubsubSubscriptionOnNamedBroker`:
+
+<!-- snippet: sample_listen_to_pubsub_subscription_on_named_broker -->
+<a id='snippet-sample_listen_to_pubsub_subscription_on_named_broker'></a>
+```cs
+var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.AddNamedPubsubBroker(new BrokerName("americas"), "americas-project-id");
+
+        // Attach to an existing, already-provisioned subscription on the named broker.
+        // No AutoProvision() needed if this app has no provisioning rights on that project.
+        opts.ListenToPubsubSubscriptionOnNamedBroker(new BrokerName("americas"), "existing-subscription-name");
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L91-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_listen_to_pubsub_subscription_on_named_broker' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
 ## Multi-Tenancy with a Broker Per Tenant
 
 Named brokers (above) are a *static* topology: you pin specific endpoints to a specific broker at configuration time. **Broker-per-tenant** is different — it is *runtime* routing. You declare one shared topic topology, and each tenant is served by its **own dedicated GCP project**. Which project a message goes to (and which project an inbound message came from) is decided at runtime by the message's [tenant id](/guide/handlers/multi-tenancy), typically set through `DeliveryOptions.TenantId`.

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs
@@ -86,6 +86,22 @@ public class DocumentationSamples
         #endregion
     }
 
+    public async Task listen_to_existing_subscription_on_named_broker()
+    {
+        #region sample_listen_to_pubsub_subscription_on_named_broker
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.AddNamedPubsubBroker(new BrokerName("americas"), "americas-project-id");
+
+                // Attach to an existing, already-provisioned subscription on the named broker.
+                // No AutoProvision() needed if this app has no provisioning rights on that project.
+                opts.ListenToPubsubSubscriptionOnNamedBroker(new BrokerName("americas"), "existing-subscription-name");
+            }).StartAsync();
+
+        #endregion
+    }
+
     public async Task broker_per_tenant()
     {
         #region sample_pubsub_broker_per_tenant

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/NamedBrokerComplianceTests.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/NamedBrokerComplianceTests.cs
@@ -45,6 +45,22 @@ public class NamedBrokerComplianceTests
         endpoint.Uri.ShouldBe(new Uri("americas://wolverine2/colors"));
         named.ResourceUri.ShouldBe(new Uri("americas://wolverine2"));
     }
+
+    [Fact]
+    public void named_broker_can_listen_to_an_existing_subscription()
+    {
+        var options = new WolverineOptions();
+
+        options.AddNamedPubsubBroker(new BrokerName("americas"), "wolverine2");
+        options.ListenToPubsubSubscriptionOnNamedBroker(new BrokerName("americas"), "existing-sub");
+
+        var named = options.Transports.OfType<PubsubTransport>().Single(x => x.Protocol == "americas");
+        var endpoint = named.Topics["existing-sub"];
+
+        endpoint.IsListener.ShouldBeTrue();
+        endpoint.IsExistingSubscription.ShouldBeTrue();
+        endpoint.Uri.Scheme.ShouldBe("americas");
+    }
 }
 
 // Integration: round-trip a message over a second project on the same emulator, addressed exclusively through the

--- a/src/Transports/GCP/Wolverine.Pubsub/PubsubTransportExtensions.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/PubsubTransportExtensions.cs
@@ -186,6 +186,35 @@ public static class PubsubTransportExtensions
     }
 
     /// <summary>
+    ///     Listen for incoming messages on an existing Google Cloud Platform Pub/Sub subscription on a named broker.
+    ///     Since an existing subscription is used, IdentifierPrefix is not applied to the subscription name.
+    /// </summary>
+    /// <param name="endpoints"></param>
+    /// <param name="name">The name of the additional broker registered via <see cref="AddNamedPubsubBroker" />.</param>
+    /// <param name="subscriptionName">The name of the Google Cloud Platform Pub/Sub subscription</param>
+    /// <param name="configure">
+    ///     Optional configuration for this Google Cloud Platform Pub/Sub endpoint.
+    /// </param>
+    /// <returns></returns>
+    public static PubsubTopicListenerConfiguration ListenToPubsubSubscriptionOnNamedBroker(
+        this WolverineOptions endpoints,
+        BrokerName name,
+        string subscriptionName,
+        Action<PubsubEndpoint>? configure = null
+    )
+    {
+        var transport = endpoints.PubsubTransport(name);
+        var topic = transport.Topics[subscriptionName];
+
+        topic.IsListener = true;
+        topic.IsExistingSubscription = true;
+
+        configure?.Invoke(topic);
+
+        return new PubsubTopicListenerConfiguration(topic);
+    }
+
+    /// <summary>
     ///     Publish the designated messages to a Google Cloud Platform Pub/Sub topic.
     /// </summary>
     /// <param name="publishing"></param>


### PR DESCRIPTION
## Summary

Closes #3631.

Named-broker support for `Wolverine.Pubsub` (#3318) added `OnNamedBroker` overloads for topic-based publishing and listening, but not for attaching to an existing subscription. `ListenToPubsubSubscription` only worked against the default/unnamed transport, with no public way to reach a named transport's `Topics` cache from application code.

- Adds `ListenToPubsubSubscriptionOnNamedBroker(BrokerName, string, Action<PubsubEndpoint>?)` to `PubsubTransportExtensions`, mirroring `ListenToPubsubSubscription`'s semantics with the same `BrokerName` plumbing used by `ListenToPubsubTopicOnNamedBroker`.
- No other production code changes needed — `PubsubEndpoint`/`PubsubListener`/`SetupAsync` already branch on `IsExistingSubscription` per-endpoint regardless of which transport instance the endpoint came from.

## Test plan

- [x] New unit test `named_broker_can_listen_to_an_existing_subscription` in `NamedBrokerComplianceTests.cs`, asserting the new method wires `IsExistingSubscription`/`IsListener` on the named transport.
- [x] `dotnet test` on `Wolverine.Pubsub.Tests` (net9.0 + net10.0) — all passing.
- [x] Added a short "Multiple / Named Brokers" doc snippet (`sample_listen_to_pubsub_subscription_on_named_broker`) showing the new overload.