### PR TITLE
feat(pubsub): named-broker support for sharded/partitioned topics

### DIFF
--- a/docs/guide/messaging/transports/gcp-pubsub/index.md
+++ b/docs/guide/messaging/transports/gcp-pubsub/index.md
@@ -226,6 +226,12 @@ using var host = await Host.CreateDefaultBuilder()
 
 This creates Pub/Sub topics named `orders1` through `orders4` with companion local queues `global-orders1` through `global-orders4`. Messages are routed to the correct shard based on their group id, and Wolverine handles the coordination between nodes automatically.
 
+Both `PublishToShardedPubsubTopics()` and `UseShardedPubsubTopics()` have `...OnNamedBroker()` equivalents to shard across a [named broker](#multiple-named-brokers) instead of the default one:
+
+```csharp
+topology.UseShardedPubsubTopicsOnNamedBroker(new BrokerName("americas"), "orders", 4);
+```
+
 ## URI reference
 
 The `GcpPubsubEndpointUri` helper class builds canonical endpoint URIs:

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/ShardedTopicsNamedBrokerTests.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/ShardedTopicsNamedBrokerTests.cs
@@ -1,0 +1,83 @@
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Pubsub.Internal;
+using Wolverine.Runtime.Partitioning;
+using Xunit;
+
+namespace Wolverine.Pubsub.Tests;
+
+// GH-3632: PublishToShardedPubsubTopics / UseShardedPubsubTopics had no named-broker equivalent, because
+// PartitionedMessageTopologyWithTopics always resolved the default/unnamed PubsubTransport.
+public class ShardedTopicsNamedBrokerTests
+{
+    private static readonly BrokerName TheName = new("americas");
+
+    [Fact]
+    public void sharded_topology_without_a_broker_name_uses_the_default_transport()
+    {
+        var options = new WolverineOptions();
+        options.UsePubsub("wolverine");
+
+        var topology = new PartitionedMessageTopologyWithTopics(options, PartitionSlots.Five, "orders", 4);
+
+        topology.Slots.Count.ShouldBe(4);
+        topology.Slots.ShouldAllBe(x => x.Uri.Scheme == PubsubTransport.ProtocolName);
+    }
+
+    [Fact]
+    public void sharded_topology_with_a_broker_name_targets_the_named_transport()
+    {
+        var options = new WolverineOptions();
+        options.UsePubsub("wolverine");
+        options.AddNamedPubsubBroker(TheName, "wolverine2");
+
+        var topology = new PartitionedMessageTopologyWithTopics(options, PartitionSlots.Five, "orders", 4, TheName);
+
+        topology.Slots.Count.ShouldBe(4);
+        topology.Slots.ShouldAllBe(x => x.Uri.Scheme == TheName.Name);
+        topology.Slots.Select(x => x.Uri).ShouldBe(new[]
+        {
+            new Uri("americas://wolverine2/orders1"),
+            new Uri("americas://wolverine2/orders2"),
+            new Uri("americas://wolverine2/orders3"),
+            new Uri("americas://wolverine2/orders4")
+        });
+    }
+
+    [Fact]
+    public void publish_to_sharded_pubsub_topics_on_named_broker_targets_the_named_transport()
+    {
+        var options = new WolverineOptions();
+        options.UsePubsub("wolverine");
+        options.AddNamedPubsubBroker(TheName, "wolverine2");
+
+        options.MessagePartitioning.ByMessage<OrderPlaced>(x => x.OrderId.ToString());
+        options.MessagePartitioning.PublishToShardedPubsubTopicsOnNamedBroker(TheName, "orders", 4,
+            topology => topology.Message<OrderPlaced>());
+
+        var named = options.Transports.OfType<PubsubTransport>().Single(x => x.Protocol == TheName.Name);
+        named.Topics.Select(x => x.EndpointName).OrderBy(x => x)
+            .ShouldBe(["orders1", "orders2", "orders3", "orders4"]);
+    }
+
+    [Fact]
+    public void use_sharded_pubsub_topics_on_named_broker_targets_the_named_transport()
+    {
+        var options = new WolverineOptions();
+        options.UsePubsub("wolverine");
+        options.AddNamedPubsubBroker(TheName, "wolverine2");
+
+        options.MessagePartitioning.ByMessage<OrderPlaced>(x => x.OrderId.ToString());
+        options.MessagePartitioning.GlobalPartitioned(topology =>
+        {
+            topology.UseShardedPubsubTopicsOnNamedBroker(TheName, "orders", 4);
+            topology.MessagesImplementing<OrderPlaced>();
+        });
+
+        var named = options.Transports.OfType<PubsubTransport>().Single(x => x.Protocol == TheName.Name);
+        named.Topics.Select(x => x.EndpointName).OrderBy(x => x)
+            .ShouldBe(["orders1", "orders2", "orders3", "orders4"]);
+    }
+}
+
+public record OrderPlaced(Guid OrderId);

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/PartitionedMessageTopologyWithTopics.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/PartitionedMessageTopologyWithTopics.cs
@@ -5,24 +5,28 @@ namespace Wolverine.Pubsub.Internal;
 
 public class PartitionedMessageTopologyWithTopics : PartitionedMessageTopology<PubsubTopicListenerConfiguration, PubsubTopicSubscriberConfiguration>
 {
-    public PartitionedMessageTopologyWithTopics(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints) : base(options, listeningSlots, baseName, numberOfEndpoints)
+    public PartitionedMessageTopologyWithTopics(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints, BrokerName? brokerName = null) : base(options, listeningSlots, baseName, numberOfEndpoints, brokerName)
     {
         MaxDegreeOfParallelism = PartitionSlots.Five;
     }
 
     protected override Endpoint buildEndpoint(WolverineOptions options, string name)
     {
-        var transport = options.PubsubTransport();
+        var transport = options.PubsubTransport(BrokerName);
         return transport.Topics[transport.MaybeCorrectName(name)];
     }
 
     protected override PubsubTopicListenerConfiguration buildListener(WolverineOptions options, string name)
     {
-        return options.ListenToPubsubTopic(name);
+        return BrokerName is null
+            ? options.ListenToPubsubTopic(name)
+            : options.ListenToPubsubTopicOnNamedBroker(BrokerName, name);
     }
 
     protected override PubsubTopicSubscriberConfiguration buildSubscriber(IPublishToExpression expression, string name)
     {
-        return expression.ToPubsubTopic(name);
+        return BrokerName is null
+            ? expression.ToPubsubTopic(name)
+            : expression.ToPubsubTopicOnNamedBroker(BrokerName, name);
     }
 }

--- a/src/Transports/GCP/Wolverine.Pubsub/PubsubTransportExtensions.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/PubsubTransportExtensions.cs
@@ -259,4 +259,53 @@ public static class PubsubTransportExtensions
         }, baseName);
         return topology;
     }
+
+    /// <summary>
+    /// Create a sharded message topology with Google Cloud Pub/Sub topics named
+    /// baseName1, baseName2, etc. on a named broker registered via <see cref="AddNamedPubsubBroker" />.
+    /// </summary>
+    /// <param name="rules"></param>
+    /// <param name="name">The name of the additional broker registered via <see cref="AddNamedPubsubBroker" />.</param>
+    /// <param name="baseName"></param>
+    /// <param name="numberOfEndpoints"></param>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public static MessagePartitioningRules PublishToShardedPubsubTopicsOnNamedBroker(this MessagePartitioningRules rules,
+        BrokerName name, string baseName, int numberOfEndpoints, Action<PartitionedMessageTopologyWithTopics> configure)
+    {
+        rules.AddPublishingTopology((opts, _) =>
+        {
+            var topology = new PartitionedMessageTopologyWithTopics(opts, PartitionSlots.Five, baseName, numberOfEndpoints, name);
+            topology.ConfigureListening(x => {});
+            configure(topology);
+            topology.AssertValidity();
+
+            return topology;
+        });
+
+        return rules;
+    }
+
+    /// <summary>
+    /// Use sharded Google Cloud Pub/Sub topics on a named broker registered via <see cref="AddNamedPubsubBroker" />
+    /// for global partitioned message processing. Topics will be named baseName1, baseName2, etc.
+    /// </summary>
+    /// <param name="topology"></param>
+    /// <param name="name">The name of the additional broker registered via <see cref="AddNamedPubsubBroker" />.</param>
+    /// <param name="baseName"></param>
+    /// <param name="numberOfEndpoints"></param>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public static GlobalPartitionedMessageTopology UseShardedPubsubTopicsOnNamedBroker(
+        this GlobalPartitionedMessageTopology topology, BrokerName name, string baseName, int numberOfEndpoints,
+        Action<PartitionedMessageTopologyWithTopics>? configure = null)
+    {
+        topology.SetExternalTopology(opts =>
+        {
+            var t = new PartitionedMessageTopologyWithTopics(opts, PartitionSlots.Five, baseName, numberOfEndpoints, name);
+            configure?.Invoke(t);
+            return t;
+        }, baseName);
+        return topology;
+    }
 }

--- a/src/Wolverine/Runtime/Partitioning/PartitionedMessageTopology.cs
+++ b/src/Wolverine/Runtime/Partitioning/PartitionedMessageTopology.cs
@@ -9,8 +9,8 @@ public abstract class PartitionedMessageTopology<TListener, TSubscriber> : Parti
     where TSubscriber : ISubscriberConfiguration<TSubscriber>
 {
     private PartitionSlots _listeningSlots;
-    
-    public PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints) : base(options, listeningSlots, baseName, numberOfEndpoints)
+
+    public PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints, BrokerName? brokerName = null) : base(options, listeningSlots, baseName, numberOfEndpoints, brokerName)
     {
         if (listeningSlots.HasValue)
         {
@@ -59,15 +59,22 @@ public abstract class PartitionedMessageTopology<TListener, TSubscriber> : Parti
 public abstract class PartitionedMessageTopology
 {
     protected readonly WolverineOptions _options;
-    
-    protected PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints)
+
+    /// <summary>
+    /// The named broker this topology's endpoints should be built against, or null for the
+    /// default/unnamed transport. Set before <see cref="buildEndpoint" /> is first called.
+    /// </summary>
+    protected readonly BrokerName? BrokerName;
+
+    protected PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints, BrokerName? brokerName = null)
     {
         if (numberOfEndpoints <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(numberOfEndpoints), "Must be a positive number");
         }
-        
+
         _options = options;
+        BrokerName = brokerName;
         _names = new string[numberOfEndpoints];
 
         for (int i = 0; i < numberOfEndpoints; i++)


### PR DESCRIPTION
## Summary

Closes #3632.

`PublishToShardedPubsubTopics` / `UseShardedPubsubTopics` had no named-broker equivalent, because `Internal/PartitionedMessageTopologyWithTopics.cs` always resolved the default/unnamed `PubsubTransport` in its `buildEndpoint`/`buildListener`/`buildSubscriber` overrides.

- Threaded an optional `BrokerName?` through the transport-agnostic `PartitionedMessageTopology` base class (`src/Wolverine/Runtime/Partitioning/PartitionedMessageTopology.cs`), set **before** the endpoint-building loop runs in the base constructor. This matters because `buildEndpoint` is invoked from the base constructor, which runs before any derived class's own constructor body (and thus before a field set there would be assigned) — so the broker name has to be known to the base class itself, not just captured in a `PartitionedMessageTopologyWithTopics` field.
- `PartitionedMessageTopologyWithTopics` now resolves `options.PubsubTransport(BrokerName)` / `ListenToPubsubTopicOnNamedBroker` / `ToPubsubTopicOnNamedBroker` when a broker name is present, falling back to the existing default-transport behavior otherwise.
- Added `PublishToShardedPubsubTopicsOnNamedBroker` / `UseShardedPubsubTopicsOnNamedBroker`, mirroring the existing non-named methods plus a `BrokerName` parameter.
- The base class change is additive and optional (defaults to `null`), so RabbitMQ/SQS/Kafka/Pulsar/Redis/Azure Service Bus sharded topologies are unaffected.

## Test plan

- [x] `dotnet build wolverine.slnx -c Release` — full solution builds clean
- [x] New unit tests in `src/Transports/GCP/Wolverine.Pubsub.Tests/ShardedTopicsNamedBrokerTests.cs` covering: default (unnamed) sharded topology still targets the default transport, a named-broker sharded topology targets the named transport's URIs, and both `PublishToShardedPubsubTopicsOnNamedBroker`/`UseShardedPubsubTopicsOnNamedBroker` register topics on the named transport
- [x] Existing `NamedBrokerComplianceTests` still pass
- [x] Terse doc addition cross-referencing named brokers from the existing Global Partitioning section