### PR TITLE
fix(agents): bounded-parallel drain of local agents on shutdown (D3/WO-7)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/parallel_drain_on_stop.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/parallel_drain_on_stop.cs
@@ -1,0 +1,149 @@
+using CoreTests.Transports;
+using JasperFx;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Regression coverage for D3/WO-7 of the projection-agent churn livelock (GH-3604). Node shutdown drained
+/// every locally-running agent SERIALLY (the old foreach in stopAllAgentsAsync), which could not finish
+/// thousands of daemon subscription agents inside a typical 30s SIGTERM grace window -- k8s then SIGKILLed
+/// the process mid-drain and abandoned unflushed daemon progression. WO-7 drains with bounded parallelism
+/// (Durability.MaxAgentStopParallelism) so the shutdown window is usable at scale.
+/// </summary>
+public class parallel_drain_on_stop
+{
+    private readonly WolverineOptions _options;
+    private readonly IWolverineRuntime _runtime;
+
+    public parallel_drain_on_stop()
+    {
+        _options = new WolverineOptions { ApplicationAssembly = GetType().Assembly };
+        _options.Transports.NodeControlEndpoint = new FakeEndpoint("fake://self".ToUri(), EndpointRole.System);
+        _options.Durability.DurabilityAgentEnabled = false;
+
+        _runtime = Substitute.For<IWolverineRuntime>();
+        _runtime.Options.Returns(_options);
+        _runtime.DurabilitySettings.Returns(_options.Durability);
+        _runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+    }
+
+    private NodeAgentController buildController()
+    {
+        return new NodeAgentController(
+            _runtime, Substitute.For<INodeAgentPersistence>(),
+            [], NullLogger<NodeAgentController>.Instance, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task drains_running_agents_with_bounded_parallelism()
+    {
+        const int dop = 4;
+        const int total = 12;
+        _options.Durability.MaxAgentStopParallelism = dop;
+
+        var gate = new object();
+        var concurrent = 0;
+        var maxConcurrent = 0;
+        var reachedCap = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var controller = buildController();
+        for (var i = 0; i < total; i++)
+        {
+            var uri = new Uri($"fake://{i}");
+            controller.Agents[uri] = new GatedAgent(uri, async () =>
+            {
+                int now;
+                lock (gate)
+                {
+                    concurrent++;
+                    now = concurrent;
+                    if (concurrent > maxConcurrent) maxConcurrent = concurrent;
+                }
+
+                if (now >= dop) reachedCap.TrySetResult();
+                await release.Task;
+                lock (gate) { concurrent--; }
+            });
+        }
+
+        var stopping = controller.StopAsync(Substitute.For<IMessageBus>());
+
+        // Exactly `dop` drains run concurrently; the rest queue behind them (Parallel.ForEachAsync bound).
+        await reachedCap.Task.WaitAsync(5.Seconds());
+        lock (gate)
+        {
+            concurrent.ShouldBe(dop);
+            maxConcurrent.ShouldBe(dop);
+        }
+
+        release.SetResult();
+        await stopping.WaitAsync(5.Seconds());
+
+        // Every agent was stopped and removed, and parallelism never exceeded the cap.
+        maxConcurrent.ShouldBe(dop);
+        controller.Agents.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_wedged_agent_does_not_abort_the_drain_of_its_peers()
+    {
+        _options.Durability.MaxAgentStopParallelism = 4;
+
+        var controller = buildController();
+
+        var good = new List<GatedAgent>();
+        for (var i = 0; i < 6; i++)
+        {
+            var uri = new Uri($"fake://good/{i}");
+            var agent = new GatedAgent(uri, () => Task.CompletedTask);
+            good.Add(agent);
+            controller.Agents[uri] = agent;
+        }
+
+        var badUri = new Uri("fake://bad");
+        controller.Agents[badUri] = new GatedAgent(badUri, () => throw new InvalidOperationException("wedged"));
+
+        await controller.StopAsync(Substitute.For<IMessageBus>()).WaitAsync(5.Seconds());
+
+        // Every healthy agent still drained and was removed even though a peer threw. The throwing agent is
+        // logged and left in the map (only a clean stop removes the entry), so the failure is contained.
+        good.All(x => x.Status == AgentStatus.Stopped).ShouldBeTrue();
+        good.All(x => !controller.Agents.ContainsKey(x.Uri)).ShouldBeTrue();
+        controller.Agents.Keys.ShouldBe([badUri]);
+    }
+
+    private class GatedAgent : IAgent
+    {
+        private readonly Func<Task> _onStop;
+
+        public GatedAgent(Uri uri, Func<Task> onStop)
+        {
+            Uri = uri;
+            _onStop = onStop;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            Status = AgentStatus.Running;
+            await Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            await _onStop();
+            Status = AgentStatus.Stopped;
+        }
+
+        public AgentStatus Status { get; private set; } = AgentStatus.Running;
+        public Uri Uri { get; }
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -271,6 +271,15 @@ public class DurabilitySettings : IDescribeMyself
     public int MaxAgentStartParallelism { get; set; } = 10;
 
     /// <summary>
+    ///     GH-3604 / D3 (WO-7): the maximum number of agents this node stops concurrently when it is
+    ///     draining every locally-running agent on shutdown. The old sequential drain
+    ///     (<c>stopAllAgentsAsync</c>) could not finish thousands of daemon subscription agents inside a
+    ///     typical 30s SIGTERM grace window, so agents were SIGKILLed mid-stop with unflushed progression.
+    ///     A bounded fan-out makes the shutdown window usable at scale. Default 10.
+    /// </summary>
+    public int MaxAgentStopParallelism { get; set; } = 10;
+
+    /// <summary>
     /// Opt-in switch for the dynamic listener registry: persisted listener URIs that
     /// are activated at runtime in addition to the listeners declared statically
     /// through <see cref="WolverineOptions"/>. When <c>true</c>, <c>IMessageStore.Listeners</c>

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.cs
@@ -151,18 +151,31 @@ public partial class NodeAgentController
 
     private async Task stopAllAgentsAsync()
     {
-        foreach (var entry in Agents)
+        // GH-3604 / D3 (WO-7): drain every locally-running agent with bounded parallelism instead of one at a
+        // time. On a node running a large agent universe (database-per-tenant Marten with thousands of
+        // subscription shards) the old sequential loop could not finish inside a typical 30s SIGTERM grace
+        // window, so k8s SIGKILLed the process mid-drain and abandoned unflushed daemon progression -->
+        // ProgressionOutOfOrderException on the next start. A bounded fan-out makes the shutdown window usable.
+        //
+        // Deliberately NOT threading a cancellation token into StopAsync here (each still gets
+        // CancellationToken.None as before): this is the shutdown path itself, and a cancelled drain would
+        // leave agents half-stopped. Each StopAsync keeps its own try/catch so one wedged agent cannot abort
+        // the drain of its peers.
+        var dop = Math.Max(1, _runtime.Options.Durability.MaxAgentStopParallelism);
+        var options = new ParallelOptions { MaxDegreeOfParallelism = dop };
+
+        await Parallel.ForEachAsync(Agents.ToArray(), options, async (entry, _token) =>
         {
             try
             {
                 await entry.Value.StopAsync(CancellationToken.None);
-                Agents.Remove(entry.Key, out var _);
+                Agents.TryRemove(entry.Key, out _);
             }
             catch (Exception e)
             {
                 _logger.LogError(e, "Error trying to stop agent {AgentUri}", entry.Value.Uri);
             }
-        }
+        });
     }
 
     private ValueTask<IAgent> findAgentAsync(Uri uri)


### PR DESCRIPTION
## What

`NodeAgentController.stopAllAgentsAsync` — the node-shutdown drain — stopped every locally-running agent **serially**. On a node running a large agent universe (database-per-tenant Marten with thousands of subscription shards) that loop could not finish inside a typical 30s SIGTERM grace window, so Kubernetes SIGKILLed the process mid-drain and abandoned unflushed daemon progression → `ProgressionOutOfOrderException` on the next start.

This is the **Wolverine-only, unblocked half of WO-7** from the projection-agent churn analysis (#3604 / GH-3604). The deeper daemon-side *flush-on-stop* piece (making the Marten/Polecat subscription agent's `StopAsync` await in-flight page completion + progression flush) stays blocked on the §4 Marten/Polecat verification and is intentionally **not** in this PR.

## Change

- Drain now fans out with bounded parallelism via `Parallel.ForEachAsync`, capped by a new `Durability.MaxAgentStopParallelism` (default **10**, symmetric with `MaxAgentStartParallelism` introduced by WO-4 / #3623).
- The drain deliberately passes `CancellationToken.None` to each `StopAsync` — it *is* the shutdown path, and a cancelled drain would leave agents half-stopped.
- Per-agent `try/catch` is preserved so one wedged agent cannot abort the drain of its peers; only a clean stop removes the entry from the map.

## Tests — `parallel_drain_on_stop.cs`

- `drains_running_agents_with_bounded_parallelism` — TCS-gated concurrency test, **red-verified** against the old sequential loop (it times out, never reaching the DOP cap); green with the fix. Asserts exactly `dop` drains run concurrently and all agents are removed.
- `a_wedged_agent_does_not_abort_the_drain_of_its_peers` — a throwing `StopAsync` is logged and left in the map while every healthy agent still drains and is removed.

Full `wolverine.slnx` builds clean (Release); all 170 `Runtime.Agents` tests pass.

## Follow-ups (not in this PR)
- WO-7 daemon-half (flush-on-stop) and WO-8 (`ApplyEventException`-stopped shards → `Paused` agent) — both blocked on §4 Marten/Polecat verification; WO-8 likely needs a JasperFx.Events release + pin bump.
- WO-9/WO-10 — CritterWatch churn/`ApplyEventException` alerts — separate repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)