### PR TITLE
fix(kafka): handle topic already exists error codes

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/create_topics_exception_handling.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/create_topics_exception_handling.cs
@@ -1,0 +1,132 @@
+using Confluent.Kafka;
+using Confluent.Kafka.Admin;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Kafka.Internals;
+
+namespace Wolverine.Kafka.Tests;
+
+public class create_topics_exception_handling
+{
+    [Fact]
+    public async Task single_topic_tolerates_redpanda_topic_already_exists_reason()
+    {
+        await SetupSingleTopic(ExistingTopic("The topic has already been created"));
+    }
+
+    [Fact]
+    public async Task single_topic_tolerates_multiple_topic_already_exists_results()
+    {
+        await SetupSingleTopic(ExceptionFor(
+            ("one", ErrorCode.TopicAlreadyExists, "first"),
+            ("two", ErrorCode.TopicAlreadyExists, "second")));
+    }
+
+    [Fact]
+    public async Task single_topic_propagates_empty_results()
+    {
+        await ShouldPropagateFromSingleTopic(new CreateTopicsException([]));
+    }
+
+    [Fact]
+    public async Task single_topic_propagates_mixed_results()
+    {
+        await ShouldPropagateFromSingleTopic(ExceptionFor(
+            ("one", ErrorCode.TopicAlreadyExists, "exists"),
+            ("two", ErrorCode.TopicAuthorizationFailed, "denied")));
+    }
+
+    [Fact]
+    public async Task single_topic_propagates_unrelated_error()
+    {
+        await ShouldPropagateFromSingleTopic(ExceptionFor(
+            ("topic", ErrorCode.TopicException, "invalid")));
+    }
+
+    [Fact]
+    public async Task single_topic_propagates_unrelated_error_with_misleading_text()
+    {
+        var expected = ExceptionFor(
+            ("topic", ErrorCode.TopicAuthorizationFailed, "already exists."));
+
+        await ShouldPropagateFromSingleTopic(expected);
+    }
+
+    [Fact]
+    public async Task topic_group_continues_after_topic_already_exists()
+    {
+        var visited = new List<string>();
+        var group = new KafkaTopicGroup(
+            new KafkaTransport(), ["one", "two"], EndpointRole.Application)
+        {
+            CreateTopicFunc = (_, topic) =>
+            {
+                visited.Add(topic);
+                return topic == "one"
+                    ? Task.FromException(ExistingTopic(
+                        "The topic has already been created"))
+                    : Task.CompletedTask;
+            }
+        };
+
+        await group.SetupOnAsync(
+            Substitute.For<IAdminClient>(), NullLogger.Instance);
+
+        visited.ShouldBe(["one", "two"]);
+    }
+
+    [Fact]
+    public async Task topic_group_propagates_mixed_results()
+    {
+        var expected = ExceptionFor(
+            ("one", ErrorCode.TopicAlreadyExists, "exists"),
+            ("two", ErrorCode.TopicAuthorizationFailed, "denied"));
+        var group = new KafkaTopicGroup(
+            new KafkaTransport(), ["one", "two"], EndpointRole.Application)
+        {
+            CreateTopicFunc = (_, _) => Task.FromException(expected)
+        };
+
+        var thrown = await Should.ThrowAsync<CreateTopicsException>(
+            () => group.SetupOnAsync(
+                Substitute.For<IAdminClient>(), NullLogger.Instance).AsTask());
+
+        thrown.ShouldBeSameAs(expected);
+    }
+
+    private static Task SetupSingleTopic(CreateTopicsException exception)
+    {
+        var topic = new KafkaTopic(new KafkaTransport(), "topic", EndpointRole.Application)
+        {
+            CreateTopicFunc = (_, _) => Task.FromException(exception)
+        };
+
+        return topic.SetupOnAsync(
+            Substitute.For<IAdminClient>(), NullLogger.Instance).AsTask();
+    }
+
+    private static async Task ShouldPropagateFromSingleTopic(CreateTopicsException expected)
+    {
+        var thrown = await Should.ThrowAsync<CreateTopicsException>(
+            () => SetupSingleTopic(expected));
+
+        thrown.ShouldBeSameAs(expected);
+    }
+
+    private static CreateTopicsException ExistingTopic(string reason)
+    {
+        return ExceptionFor(("topic", ErrorCode.TopicAlreadyExists, reason));
+    }
+
+    private static CreateTopicsException ExceptionFor(
+        params (string Topic, ErrorCode Code, string Reason)[] results)
+    {
+        return new CreateTopicsException(results.Select(x => new CreateTopicReport
+        {
+            Topic = x.Topic,
+            Error = new Error(x.Code, x.Reason)
+        }).ToList());
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -415,7 +415,7 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
         }
         catch (CreateTopicsException e)
         {
-            if (e.Message.Contains("already exists.")) return;
+            if (e.Results.Count > 0 && e.Results.All(x => x.Error.Code == ErrorCode.TopicAlreadyExists)) return;
             throw;
         }
     }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroup.cs
@@ -181,7 +181,7 @@ public class KafkaTopicGroup : KafkaTopic, IBrokerEndpoint
             }
             catch (CreateTopicsException e)
             {
-                if (e.Message.Contains("already exists.")) continue;
+                if (e.Results.Count > 0 && e.Results.All(x => x.Error.Code == ErrorCode.TopicAlreadyExists)) continue;
                 throw;
             }
         }


### PR DESCRIPTION
 Use structured Kafka error codes when handling topic auto-provisioning failures.

  The previous implementation inspected the exception message for `"already exists."`. This was broker-dependent and could also suppress a mixed failure when one result contained that text.

  The new condition ignores the exception only when:

  - At least one result is present.
  - Every result has `ErrorCode.TopicAlreadyExists`.

  This applies to both single-topic and topic-group provisioning.

  ### Tests

  Added regression coverage for:

  - Multiple `TopicAlreadyExists` results.
  - Redpanda-specific error messages.  
  - Empty result collections.
  - Mixed result codes.
  - Unrelated errors containing misleading `"already exists."` text.
  - Topic-group provisioning continuing after an existing topic.