### PR TITLE
Redis scheduled retries no longer vanish on an unreadable timestamp (#3613)

### DIFF
--- a/src/Testing/CoreTests/Serialization/envelope_timestamp_header_formats_3613.cs
+++ b/src/Testing/CoreTests/Serialization/envelope_timestamp_header_formats_3613.cs
@@ -1,0 +1,146 @@
+using CoreTests.Transports;
+using JasperFx.Core;
+using Shouldly;
+using Wolverine.Runtime.Serialization;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Serialization;
+
+/// <summary>
+///     Regression coverage for GH-3613 (and the unfinished half of GH-1716).
+///     Wolverine has two writers for the same timestamp keys. The binary envelope format
+///     (<see cref="EnvelopeSerializer" />) writes round-trippable <c>"o"</c> values, while
+///     <see cref="EnvelopeMapper{TIncoming,TOutgoing}" /> writes transport headers in a custom
+///     <c>"yyyy-MM-dd HH:mm:ss:ffffff Z"</c> format that neither <c>DateTime.Parse</c> nor
+///     <c>DateTimeOffset.TryParse</c> can read back. <see cref="EnvelopeSerializer.ReadDataElement" />
+///     sees values from both sources, and used to blow up on <c>deliver-by</c> (or silently drop
+///     <c>time-to-send</c> / <c>keep-until</c>) when handed a mapper-written value.
+/// </summary>
+public class envelope_timestamp_header_formats_3613
+{
+    // The value from the GH-3613 report, which is exactly what EnvelopeMapper writes.
+    private const string MapperFormattedValue = "2026-07-30 18:25:40:482802 Z";
+
+    // ...which carries six fractional-second digits: 0.482802s == 4,828,020 ticks.
+    private static readonly DateTimeOffset TheExpectedTime =
+        new DateTimeOffset(2026, 7, 30, 18, 25, 40, TimeSpan.Zero).AddTicks(4828020);
+
+    [Fact]
+    public void read_deliver_by_written_in_the_transport_header_format()
+    {
+        var envelope = new Envelope();
+
+        EnvelopeSerializer.ReadDataElement(envelope, EnvelopeConstants.DeliverByKey, MapperFormattedValue);
+
+        envelope.DeliverBy!.Value.ToUniversalTime().ShouldBe(TheExpectedTime);
+    }
+
+    [Fact]
+    public void read_scheduled_time_written_in_the_transport_header_format()
+    {
+        var envelope = new Envelope();
+
+        EnvelopeSerializer.ReadDataElement(envelope, EnvelopeConstants.ExecutionTimeKey, MapperFormattedValue);
+
+        envelope.ScheduledTime!.Value.ToUniversalTime().ShouldBe(TheExpectedTime);
+    }
+
+    [Fact]
+    public void read_keep_until_written_in_the_transport_header_format()
+    {
+        var envelope = new Envelope();
+
+        EnvelopeSerializer.ReadDataElement(envelope, EnvelopeConstants.KeepUntilKey, MapperFormattedValue);
+
+        envelope.KeepUntil!.Value.ToUniversalTime().ShouldBe(TheExpectedTime);
+    }
+
+    /// <summary>
+    ///     The core of the bug: a scheduled retry envelope carrying a mapper-formatted
+    ///     <c>deliver-by</c> has to survive a full trip through the durable/scheduled wire format.
+    ///     Before the fix the read threw, and every caller that treats a deserialization failure as
+    ///     "corrupt, discard" -- the Redis scheduled-set sweeps among them -- destroyed the message.
+    /// </summary>
+    [Fact]
+    public void a_mapper_formatted_deliver_by_header_survives_a_full_round_trip()
+    {
+        var outgoing = new Envelope
+        {
+            Data = [1, 2, 3],
+            Destination = "tcp://localhost:2222/incoming".ToUri(),
+            MessageType = "some-message"
+        };
+
+        // A custom IEnvelopeMapper copying raw broker headers, or interop with another Wolverine
+        // endpoint, lands the mapper's own formatting in Headers under the reserved key.
+        outgoing.Headers[EnvelopeConstants.DeliverByKey] = MapperFormattedValue;
+
+        Should.NotThrow(() => EnvelopeSerializer.Deserialize(EnvelopeSerializer.Serialize(outgoing)));
+    }
+
+    [Fact]
+    public void an_unreadable_timestamp_does_not_fail_the_whole_envelope_read()
+    {
+        var envelope = new Envelope();
+
+        Should.NotThrow(() =>
+            EnvelopeSerializer.ReadDataElement(envelope, EnvelopeConstants.DeliverByKey, "not a timestamp at all"));
+
+        envelope.DeliverBy.ShouldBeNull();
+    }
+
+    [Fact]
+    public void deliver_by_is_not_read_twice()
+    {
+        var envelope = new Envelope { DeliverBy = TheExpectedTime };
+
+        EnvelopeSerializer.ReadDataElement(envelope, EnvelopeConstants.DeliverByKey,
+            "2020-01-01 01:01:01:000000 Z");
+
+        envelope.DeliverBy!.Value.ShouldBe(TheExpectedTime);
+    }
+
+    [Fact]
+    public void the_round_trippable_format_still_reads()
+    {
+        var envelope = new Envelope();
+
+        EnvelopeSerializer.ReadDataElement(envelope, EnvelopeConstants.DeliverByKey,
+            TheExpectedTime.ToString("o"));
+
+        envelope.DeliverBy!.Value.ToUniversalTime().ShouldBe(TheExpectedTime);
+    }
+
+    /// <summary>
+    ///     Locks the writer and the reader together rather than trusting a hand-copied format string:
+    ///     whatever a real <see cref="EnvelopeMapper{TIncoming,TOutgoing}" /> puts on the wire for a
+    ///     timestamp key must be readable by <see cref="EnvelopeSerializer.ReadDataElement" />.
+    /// </summary>
+    [Theory]
+    [InlineData(EnvelopeConstants.DeliverByKey)]
+    [InlineData(EnvelopeConstants.ExecutionTimeKey)]
+    public void what_a_real_envelope_mapper_writes_is_what_the_reader_accepts(string key)
+    {
+        var outgoing = new Envelope
+        {
+            DeliverBy = TheExpectedTime,
+            ScheduledTime = TheExpectedTime,
+            MessageType = "some-message",
+            Data = [1, 2, 3]
+        };
+
+        var written = new StubTransportMessage();
+        new StubEnvelopeMapper(new StubEndpoint()).MapEnvelopeToOutgoing(outgoing, written);
+
+        written.Headers.ContainsKey(key).ShouldBeTrue();
+        var onTheWire = written.Headers[key]!;
+
+        var incoming = new Envelope();
+        EnvelopeSerializer.ReadDataElement(incoming, key, onTheWire);
+
+        var read = key == EnvelopeConstants.DeliverByKey ? incoming.DeliverBy : incoming.ScheduledTime;
+        read.ShouldNotBeNull($"'{key}' was written as '{onTheWire}' but the reader could not read it back");
+        read!.Value.ToUniversalTime().ShouldBe(TheExpectedTime);
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis.Tests/scheduled_entries_are_never_silently_dropped_3613.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/scheduled_entries_are_never_silently_dropped_3613.cs
@@ -1,0 +1,152 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using StackExchange.Redis;
+using Wolverine.Redis.Internal;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Serialization;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+/// <summary>
+///     GH-3613. Both sweeps over the <c>{stream}:scheduled</c> sorted set used to respond to a payload they
+///     could not deserialize by REMOVING it: <c>DeleteExpiredAsync</c> deleted it as "corrupted", and
+///     <c>MoveScheduledToReadyStreamAsync</c> claimed the entry before attempting to read it, so the
+///     entry was already gone when the read threw. Either way a scheduled retry vanished without ever being
+///     redelivered and without reaching <c>MoveToErrorQueue()</c> / the dead letter queue.
+/// </summary>
+[Collection("ScheduledEntryRetention3613")]
+public class scheduled_entries_are_never_silently_dropped_3613 : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private RedisStreamListener _listener = null!;
+    private IDatabase _database = null!;
+    private string _scheduledKey = null!;
+    private string _streamKey = null!;
+
+    public async Task InitializeAsync()
+    {
+        _streamKey = $"retention-3613-{Guid.NewGuid():N}";
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "ScheduledEntryRetention3613";
+                opts.UseRedisTransport(RedisContainerFixture.ConnectionString).AutoProvision();
+                opts.ListenToRedisStream(_streamKey, "retention-3613-group").StartFromBeginning();
+            }).StartAsync();
+
+        var runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+        var transport = runtime.Options.Transports.GetOrCreate<RedisTransport>();
+        var endpoint = transport.StreamEndpoint(_streamKey);
+
+        _database = transport.GetDatabase(database: 0);
+        _scheduledKey = endpoint.ScheduledMessagesKey;
+
+        // Drive the sweeps directly rather than waiting on the polling loop.
+        _listener = new RedisStreamListener(transport, endpoint, runtime, Substitute.For<IReceiver>());
+
+        await _database.KeyDeleteAsync(_scheduledKey);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _database.KeyDeleteAsync(_scheduledKey);
+        await _listener.DisposeAsync();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    // Not a valid serialized Envelope, so EnvelopeSerializer.Deserialize throws on it. Stands in for the
+    // GH-3613 payload, whose 'deliver-by' value made the read blow up.
+    private static readonly RedisValue UnreadablePayload = new byte[] { 0xFF, 0x00, 0x13, 0x37, 0x42 };
+
+    // Pre-serialized Data so the envelope round-trips without needing a registered message type.
+    private static Envelope readableEnvelope()
+    {
+        return new Envelope
+        {
+            Id = Guid.NewGuid(),
+            MessageType = "retention-message",
+            ContentType = EnvelopeConstants.JsonContentType,
+            Data = [1, 2, 3]
+        };
+    }
+
+    [Fact]
+    public async Task delete_expired_leaves_an_entry_it_cannot_deserialize_in_place()
+    {
+        // Due in the past, so the sweep definitely inspects it.
+        await _database.SortedSetAddAsync(_scheduledKey, UnreadablePayload,
+            DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeMilliseconds());
+
+        await _listener.DeleteExpiredAsync(CancellationToken.None);
+
+        (await _database.SortedSetLengthAsync(_scheduledKey)).ShouldBe(1,
+            "an unreadable scheduled entry must not be treated as expired and deleted");
+    }
+
+    [Fact]
+    public async Task delete_expired_still_evicts_a_genuinely_expired_message()
+    {
+        var envelope = readableEnvelope();
+        envelope.DeliverBy = DateTimeOffset.UtcNow.AddMinutes(-1);
+
+        await _database.SortedSetAddAsync(_scheduledKey, EnvelopeSerializer.Serialize(envelope),
+            DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeMilliseconds());
+
+        await _listener.DeleteExpiredAsync(CancellationToken.None);
+
+        (await _database.SortedSetLengthAsync(_scheduledKey)).ShouldBe(0,
+            "a readable message past its DeliverBy is still supposed to be evicted");
+    }
+
+    [Fact]
+    public async Task delete_expired_leaves_a_message_that_is_not_yet_expired()
+    {
+        var envelope = readableEnvelope();
+        envelope.DeliverBy = DateTimeOffset.UtcNow.AddMinutes(10);
+
+        await _database.SortedSetAddAsync(_scheduledKey, EnvelopeSerializer.Serialize(envelope),
+            DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeMilliseconds());
+
+        await _listener.DeleteExpiredAsync(CancellationToken.None);
+
+        (await _database.SortedSetLengthAsync(_scheduledKey)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task moving_due_entries_leaves_one_it_cannot_deserialize_in_place()
+    {
+        await _database.SortedSetAddAsync(_scheduledKey, UnreadablePayload,
+            DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeMilliseconds());
+
+        var moved = await _listener.MoveScheduledToReadyStreamAsync(CancellationToken.None);
+
+        moved.ShouldBe(0);
+        (await _database.SortedSetLengthAsync(_scheduledKey)).ShouldBe(1,
+            "the entry must not be claimed out of the sorted set before it can be read");
+    }
+
+    [Fact]
+    public async Task moving_due_entries_still_promotes_a_readable_message_to_the_stream()
+    {
+        var envelope = readableEnvelope();
+        envelope.ScheduledTime = DateTimeOffset.UtcNow.AddMinutes(-1);
+
+        await _database.SortedSetAddAsync(_scheduledKey, EnvelopeSerializer.Serialize(envelope),
+            DateTimeOffset.UtcNow.AddMinutes(-1).ToUnixTimeMilliseconds());
+
+        var moved = await _listener.MoveScheduledToReadyStreamAsync(CancellationToken.None);
+
+        moved.ShouldBe(1);
+        (await _database.SortedSetLengthAsync(_scheduledKey)).ShouldBe(0);
+        (await _database.StreamLengthAsync(_streamKey)).ShouldBeGreaterThan(0);
+    }
+}
+
+[CollectionDefinition("ScheduledEntryRetention3613", DisableParallelization = true)]
+public class ScheduledEntryRetention3613Collection;

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
@@ -502,7 +502,9 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
             // Query only entries whose score <= now (ready to execute), without
             // removing entries that aren't ready yet. This avoids the race condition
             // where a pop-then-re-add temporarily empties the sorted set.
-            var readyEntries = await database.SortedSetRangeByScoreAsync(
+            // WithScores so that an entry we claim but then fail to hand off to the stream can be
+            // restored at its original due time instead of being dropped (GH-3613).
+            var readyEntries = await database.SortedSetRangeByScoreWithScoresAsync(
                 scheduledKey,
                 double.NegativeInfinity,
                 now,
@@ -521,19 +523,23 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
 
             long count = 0;
 
-            foreach (var serializedEnvelope in readyEntries)
+            foreach (var entry in readyEntries)
             {
                 if (cancellationToken.IsCancellationRequested) break;
 
+                var serializedEnvelope = entry.Element;
+                var claimed = false;
+
                 try
                 {
-                    // Remove from sorted set first; if another consumer already
-                    // removed it we skip.
-                    var removed = await database.SortedSetRemoveAsync(scheduledKey, serializedEnvelope);
-                    if (!removed) continue;
-
-                    // Deserialize the envelope
+                    // Deserialize BEFORE claiming the entry. Claiming first meant that a payload we
+                    // could not read was already gone from the sorted set by the time the catch below
+                    // ran, so the message was lost outright (GH-3613).
                     var envelope = EnvelopeSerializer.Deserialize(serializedEnvelope!);
+
+                    // Claim the entry; if another consumer already removed it we skip.
+                    claimed = await database.SortedSetRemoveAsync(scheduledKey, serializedEnvelope);
+                    if (!claimed) continue;
 
                     // Add it to the stream
                     _endpoint.EnvelopeMapper ??= _endpoint.BuildMapper(_runtime);
@@ -557,10 +563,24 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
                 {
                     _logger.LogError(
                         ex,
-                        "Error processing scheduled message in {ScheduledKey}",
+                        "Error processing scheduled message in {ScheduledKey}, leaving it in place to be retried",
                         scheduledKey);
-                    // Remove the corrupted message from the scheduled set
-                    await database.SortedSetRemoveAsync(scheduledKey, serializedEnvelope);
+
+                    // If we already claimed the entry but failed to hand it to the stream, put it back
+                    // rather than dropping it. An entry we never claimed is left where it is.
+                    if (claimed)
+                    {
+                        try
+                        {
+                            await database.SortedSetAddAsync(scheduledKey, serializedEnvelope, entry.Score);
+                        }
+                        catch (Exception restoreFailure)
+                        {
+                            _logger.LogError(restoreFailure,
+                                "Unable to restore scheduled message to {ScheduledKey} after a failed hand-off to stream {StreamKey}; the message is lost",
+                                scheduledKey, _endpoint.StreamKey);
+                        }
+                    }
                 }
             }
 
@@ -610,10 +630,13 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Error checking expiration for scheduled message in {ScheduledKey}, removing it", scheduledKey);
-                    // Remove corrupted messages
-                    await database.SortedSetRemoveAsync(scheduledKey, serializedEnvelope);
-                    expiredCount++;
+                    // Do NOT remove the entry. This sweep only exists to evict messages that are
+                    // genuinely past their DeliverBy; a message we cannot read is not known to be
+                    // expired, and deleting it here silently destroyed scheduled retries that never
+                    // got a chance to redeliver or to reach the dead letter queue (GH-3613).
+                    _logger.LogWarning(ex,
+                        "Unable to read a scheduled message in {ScheduledKey} while checking expiration; leaving it in place",
+                        scheduledKey);
                 }
             }
 

--- a/src/Wolverine/EnvelopeConstants.cs
+++ b/src/Wolverine/EnvelopeConstants.cs
@@ -28,4 +28,15 @@ public static class EnvelopeConstants
     public const string KeepUntilKey = "keep-until";
     public const string UserNameKey = "user-name";
     public const string CausationIdKey = "causation-id";
+
+    /// <summary>
+    ///     The format <see cref="Wolverine.Transports.EnvelopeMapper{TIncoming,TOutgoing}" /> uses when it writes
+    ///     <see cref="DateTimeOffset" /> envelope properties (<c>time-to-send</c>, <c>deliver-by</c>) into
+    ///     transport headers. It is deliberately NOT round-trippable by <c>DateTime.Parse</c> or
+    ///     <c>DateTimeOffset.TryParse</c> — the ':' before the fractional seconds and the bare trailing 'Z'
+    ///     are not recognized by either. Wolverine's own binary envelope format
+    ///     (<see cref="Wolverine.Runtime.Serialization.EnvelopeSerializer" />) writes <c>"o"</c> instead, so
+    ///     any reader that can see values from both sources has to try this format explicitly. See GH-3613.
+    /// </summary>
+    internal const string TransportHeaderDateTimeFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
 }

--- a/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
@@ -132,33 +132,19 @@ public static class EnvelopeSerializer
                     // Don't read it twice
                     if (env.ScheduledTime.HasValue) return;
 
-                    try
+                    if (tryReadTimestamp(value, out var scheduledTime))
                     {
-                        env.ScheduledTime = XmlConvert.ToDateTime(value, XmlDateTimeSerializationMode.Utc);
-                    }
-                    catch (Exception )
-                    {
-                        if (DateTimeOffset.TryParse(value, out var dt))
-                        {
-                            env.ScheduledTime = dt;
-                        }
+                        env.ScheduledTime = scheduledTime;
                     }
                     break;
-                
+
                 case EnvelopeConstants.KeepUntilKey:
                     // Don't read it twice
                     if (env.KeepUntil.HasValue) return;
 
-                    try
+                    if (tryReadTimestamp(value, out var keepUntil))
                     {
-                        env.KeepUntil = XmlConvert.ToDateTime(value, XmlDateTimeSerializationMode.Utc);
-                    }
-                    catch (Exception )
-                    {
-                        if (DateTimeOffset.TryParse(value, out var dt))
-                        {
-                            env.KeepUntil = dt;
-                        }
+                        env.KeepUntil = keepUntil;
                     }
                     break;
 
@@ -167,7 +153,13 @@ public static class EnvelopeSerializer
                     break;
 
                 case EnvelopeConstants.DeliverByKey:
-                    env.DeliverBy = DateTime.Parse(value);
+                    // Don't read it twice
+                    if (env.DeliverBy.HasValue) return;
+
+                    if (tryReadTimestamp(value, out var deliverBy))
+                    {
+                        env.DeliverBy = deliverBy;
+                    }
                     break;
 
                 case EnvelopeConstants.TenantIdKey:
@@ -195,6 +187,38 @@ public static class EnvelopeSerializer
         {
             throw new InvalidOperationException($"Error trying to read data for {key} = '{value}'", e);
         }
+    }
+
+    /// <summary>
+    ///     Parse a timestamp header that may have been written by either of Wolverine's two writers:
+    ///     the binary envelope format (<c>"o"</c>, see <see cref="BinaryWriterExtensions" />) or a transport
+    ///     <see cref="Wolverine.Transports.EnvelopeMapper{TIncoming,TOutgoing}" /> header
+    ///     (<see cref="EnvelopeConstants.TransportHeaderDateTimeFormat" />). Returns false rather than throwing
+    ///     on an unrecognized value: a malformed timestamp must not be able to fail the whole envelope read,
+    ///     because callers up the stack treat a deserialization failure as "corrupt, discard" and the message
+    ///     is then lost outright instead of being retried or dead-lettered. See GH-1716 and GH-3613.
+    /// </summary>
+    private static bool tryReadTimestamp(string value, out DateTimeOffset parsed)
+    {
+        try
+        {
+            parsed = XmlConvert.ToDateTime(value, XmlDateTimeSerializationMode.Utc);
+            return true;
+        }
+        catch (Exception)
+        {
+            // Not an xsd/round-trip value; fall through to the looser attempts below.
+        }
+
+        if (DateTimeOffset.TryParse(value, out parsed))
+        {
+            return true;
+        }
+
+        // EnvelopeMapper's transport-header format, which neither of the parses above accepts.
+        return DateTimeOffset.TryParseExact(value, EnvelopeConstants.TransportHeaderDateTimeFormat,
+            CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out parsed);
     }
 
     public static Envelope[] ReadMany(byte[] buffer)

--- a/src/Wolverine/Transports/EnvelopeMapper.cs
+++ b/src/Wolverine/Transports/EnvelopeMapper.cs
@@ -67,7 +67,9 @@ public interface IEnvelopeMapper
 /// </remarks>
 public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIncoming, TOutgoing>, IEnvelopeMapper
 {
-    private const string DateTimeOffsetFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
+    // Shared with EnvelopeSerializer.tryReadTimestamp so that the reader always understands what this
+    // writer emits — the two drifting apart is GH-3613.
+    private const string DateTimeOffsetFormat = EnvelopeConstants.TransportHeaderDateTimeFormat;
     private readonly Endpoint _endpoint;
 
     private readonly Dictionary<PropertyInfo, string> _envelopeToHeader = new();


### PR DESCRIPTION
Closes #3613.

A message that failed and was rescheduled via `OnException<Exception>().ScheduleRetry(delays)` could disappear on the Redis transport — never redelivered, and never reaching `MoveToErrorQueue()`/the dead letter queue either. Three separate defects compound into that silent loss.

## 1. Wolverine writes a timestamp format its own reader can't parse

The reported value — `'2026-07-30 18:25:40:482802 Z'` — is not corruption. It is **exactly what Wolverine writes**. `EnvelopeMapper<,>` formats `DateTimeOffset` envelope properties into transport headers with a private

```csharp
private const string DateTimeOffsetFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
```

which round-trips only through the mapper's own matching `TryParseExact`. Meanwhile `EnvelopeSerializer.ReadDataElement` reads those same keys and used `DateTime.Parse` for `deliver-by` — which throws on that format. That answers the "I couldn't point to the exact line that formats the bad value" part of the report.

It also means **#1716 was only half-fixed**. That issue took the same shape for `time-to-send` and was resolved by catching the exception and falling back to `DateTimeOffset.TryParse` — but that parse *also* fails on the mapper's format (the `:` before the fractional seconds and the bare trailing `Z` are recognized by neither). So on current `main`, `ScheduledTime` and `KeepUntil` were silently set to **null** rather than recovered:

| input `'2026-07-30 18:25:40:482802 Z'` | result |
|---|---|
| `DateTime.Parse` | throws `FormatException` |
| `DateTimeOffset.TryParse` | `false` |
| `XmlConvert.ToDateTime` | throws `FormatException` |
| `TryParseExact` w/ mapper format | ✅ round-trips exactly |

`deliver-by`, `time-to-send`, and `keep-until` now all go through one `tryReadTimestamp` helper that tries the round-trippable form, then a loose parse, then the mapper's format explicitly — so the value is **recovered** instead of dropped. `deliver-by` also picks up the read-twice guard the other two already had.

The mapper's format string moves to `EnvelopeConstants.TransportHeaderDateTimeFormat`, shared by writer and reader so the two can't drift apart again. A test pins what a real `EnvelopeMapper` puts on the wire to what `ReadDataElement` accepts, rather than trusting a hand-copied format string.

## 2. `DeleteExpiredAsync` deleted anything it couldn't read

That sweep exists to evict messages past their `DeliverBy`, but its catch-all treated *any* deserialization failure as "corrupted" and removed the entry — the `"...removing it"` warning in the report. A message we cannot read is not known to be expired. It is now left in place.

## 3. `MoveScheduledToReadyStreamAsync` claimed entries before reading them

`SortedSetRemove` ran *before* `Deserialize`, so a payload that failed to read was already gone from the sorted set by the time the catch block ran — lost outright rather than left for a later sweep. It now deserializes first, and if a claimed entry fails hand-off to the stream it is restored at its original due score (the range query switched to `WithScores` for this) rather than dropped.

## Note on the fix in the issue

The reporter's suggested patch stops the throw, but because `DateTimeOffset.TryParse` also fails on this format it leaves `DeliverBy` **null** — the retry then survives and redelivers only as a side effect of no longer looking expired, and the delivery deadline is silently discarded. This version parses the value.

## Tests

- `envelope_timestamp_header_formats_3613` (CoreTests) — the reader for all three timestamp keys, the full round trip, tolerance of a genuinely unreadable value, and the writer/reader agreement guard. **7 of 9 fail on unmodified `main`.**
- `scheduled_entries_are_never_silently_dropped_3613` (Wolverine.Redis.Tests) — both Redis sweeps leave an unreadable entry in place, *and* still evict a genuinely expired message / still promote a due one. **2 of 5 fail on unmodified `main`.**

Full `CoreTests` green (2058 passed). `dotnet build wolverine.slnx -c Release` clean.

## Follow-up worth considering (not in this PR)

An entry that is *genuinely* un-deserializable now stays in the sorted set and re-warns on every sweep, instead of being deleted. That is strictly better than silent data loss, but the right end state is probably to dead-letter it after N failed reads rather than leave it forever. Happy to file that separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkMdiGxiwpnkpKK2VUPqVf