### PR TITLE
HttpEndpoint 404 with GrpcServices: query-only [AsParameters] endpoints advertised a form body (#3630)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/asparameters_accepts_metadata_3630.cs
+++ b/src/Http/Wolverine.Http.Tests/asparameters_accepts_metadata_3630.cs
@@ -1,0 +1,81 @@
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace Wolverine.Http.Tests;
+
+/// <summary>
+///     GH-3630 (continuation of GH-3591). Every <c>[AsParameters]</c> chain was marked
+///     <c>IsFormData = true</c> the moment the parameter was matched — before any of its members had been
+///     walked — and only a <c>[FromBody]</c> member ever undid that. So an <c>[AsParameters]</c> type bound
+///     purely from the query string got <c>Accepts("application/x-www-form-urlencoded", "multipart/form-data")</c>
+///     stamped onto its endpoint, on a GET.
+///
+///     <para>ASP.NET Core does not treat that as merely cosmetic: <c>AcceptsMatcherPolicy</c> is a node-builder
+///     policy that turns <c>IAcceptsMetadata</c> into content-type edges in the route matcher. Once anything
+///     else in the app contributed a route pattern of the same shape — <c>MapGrpcService</c>'s
+///     <c>{unimplementedService}/{unimplementedMethod}</c> catch-all in the reported case — a plain GET
+///     carrying no Content-Type stopped being a candidate for its own route and returned <b>404</b>, not 415.
+///     Hence "HttpEndpoint gives 404 with GrpcServices": the gRPC mapping only exposed metadata that was
+///     already wrong.</para>
+/// </summary>
+public class asparameters_accepts_metadata_3630 : IntegrationContext
+{
+    public asparameters_accepts_metadata_3630(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    private IAcceptsMetadata? acceptsFor(string route)
+    {
+        var endpoint = Host.Services.GetServices<EndpointDataSource>()
+            .SelectMany(x => x.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Single(x => x.RoutePattern.RawText == route);
+
+        return endpoint.Metadata.OfType<IAcceptsMetadata>().FirstOrDefault();
+    }
+
+    [Fact]
+    public void a_query_only_asparameters_get_declares_no_request_body()
+    {
+        // /api/asparameters/aliased-array is GET with [AsParameters] AliasedArrayQuery, whose only member
+        // is [FromQuery]. It reads no body, so it must advertise none.
+        acceptsFor("/api/asparameters/aliased-array").ShouldBeNull(
+            "a GET bound entirely from the query string must not advertise that it accepts a request body");
+    }
+
+    [Fact]
+    public void a_query_only_asparameters_get_does_not_advertise_form_content_types()
+    {
+        // The specific stamped value from the bug, spelled out so a regression is unambiguous.
+        var accepts = acceptsFor("/api/asparameters/aliased-int-array");
+
+        (accepts?.ContentTypes ?? []).ShouldNotContain("application/x-www-form-urlencoded");
+        (accepts?.ContentTypes ?? []).ShouldNotContain("multipart/form-data");
+    }
+
+    [Fact]
+    public void an_asparameters_type_with_form_members_still_declares_form_content_types()
+    {
+        // The guard against over-correcting: /api/asparameters1 is a POST whose [AsParameters] type does
+        // have [FromForm] members, so its form Accepts metadata is correct and must survive.
+        var accepts = acceptsFor("/api/asparameters1");
+
+        accepts.ShouldNotBeNull();
+        accepts!.ContentTypes.ShouldContain("application/x-www-form-urlencoded");
+        accepts.ContentTypes.ShouldContain("multipart/form-data");
+    }
+
+    [Fact]
+    public async Task a_query_only_asparameters_get_still_binds_and_responds()
+    {
+        // End to end, with no Content-Type on the request at all.
+        var result = await Host.Scenario(x => x
+            .Get
+            .Url("/api/asparameters/aliased-array?v=red&v=blue"));
+
+        var query = await result.ReadAsJsonAsync<WolverineWebApi.AliasedArrayQuery>();
+        query!.Values.ShouldBe(["red", "blue"]);
+    }
+}

--- a/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
+++ b/src/Http/Wolverine.Http/CodeGen/AsParametersBindingFrame.cs
@@ -45,7 +45,15 @@ internal class AsParamatersAttributeUsage : IParameterStrategy
         {
             chain.RequestType = parameter.ParameterType;
             chain.AsParametersType = parameter.ParameterType;
-            chain.IsFormData = true;
+
+            // Decide form-vs-body-vs-neither HERE rather than inside the binding frame below. The frame is
+            // only built when the chain is compiled, and HttpChain.applyMetadata() — which turns IsFormData
+            // into Accepts metadata — can run BEFORE that, depending on the route warm-up mode. Waiting for
+            // the frame meant the metadata was stamped from the optimistic default. See GH-3630.
+            DescribeAsParametersBinding(parameter.ParameterType, out var hasForm, out var hasBody);
+            chain.IsFormData = hasForm;
+            chain.ReadsRequestBody = hasForm || hasBody;
+
             var bindingFrame = new AsParametersBindingFrame(parameter.ParameterType, chain, container);
             chain.AsParametersVariable = bindingFrame.Variable;
             variable = bindingFrame.Variable;
@@ -53,6 +61,55 @@ internal class AsParamatersAttributeUsage : IParameterStrategy
         }
 
         return false;
+    }
+
+    /// <summary>
+    ///     Does this <c>[AsParameters]</c> type read anything out of the request body? Mirrors the member walk
+    ///     <see cref="AsParametersBindingFrame" /> performs (single public constructor's parameters, then
+    ///     writable public properties), but only far enough to answer the two questions
+    ///     <see cref="HttpChain.applyMetadata" /> needs: is it a form, and is there a body at all.
+    ///
+    ///     <para>A type whose members are all <c>[FromQuery]</c> / <c>[FromRoute]</c> / <c>[FromHeader]</c>
+    ///     answers "no" to both — it reads no body, and an endpoint that advertises one it never reads gets
+    ///     dropped from route matching by ASP.NET Core's <c>AcceptsMatcherPolicy</c>. See GH-3630.</para>
+    /// </summary>
+    internal static void DescribeAsParametersBinding(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors |
+                                    DynamicallyAccessedMemberTypes.PublicProperties)]
+        Type type, out bool hasForm, out bool hasBody)
+    {
+        hasForm = false;
+        hasBody = false;
+
+        // A type with more than one public constructor is rejected by the binding frame below with a clear
+        // message; don't pre-empt that here, just describe what can be described.
+        var constructors = type.GetConstructors();
+        if (constructors.Length == 1)
+        {
+            foreach (var parameter in constructors[0].GetParameters())
+            {
+                if (parameter.HasAttribute<FromFormAttribute>())
+                {
+                    hasForm = true;
+                }
+                else if (parameter.HasAttribute<FromBodyAttribute>())
+                {
+                    hasBody = true;
+                }
+            }
+        }
+
+        foreach (var property in type.GetProperties().Where(x => x is { CanWrite: true, IsSpecialName: false }))
+        {
+            if (property.HasAttribute<FromFormAttribute>())
+            {
+                hasForm = true;
+            }
+            else if (property.HasAttribute<FromBodyAttribute>())
+            {
+                hasBody = true;
+            }
+        }
     }
 
     // TODO -- move this to an extension method in JasperFx. Could be useful in other places
@@ -160,6 +217,18 @@ internal class AsParametersBindingFrame : SyncFrame
             throw new InvalidOperationException(
                 $"{queryType.FullNameInCode()} cannot be decorated with [AsParameters] because it has more than one [FromBody] member. Only a single request body is supported");
         }
+
+        // TryMatch has to mark the chain as form data optimistically, before any member is known, so that
+        // form binding works at all. Correct it now that the members HAVE been walked: the two flags above
+        // are the real answer, and they are mutually exclusive (the guard above rejects both at once).
+        //
+        // A type bound purely from the query string, route, or headers reads no request body whatsoever.
+        // Leaving IsFormData true made applyMetadata() stamp Accepts("application/x-www-form-urlencoded",
+        // "multipart/form-data") onto it — and ASP.NET Core turns that into content-type edges in the route
+        // matcher, so a plain GET carrying no Content-Type stopped being a candidate for its own route and
+        // 404'd. See GH-3630.
+        chain.IsFormData = _hasForms;
+        chain.ReadsRequestBody = _hasForms || _hasJsonBody;
     }
     
     /// <summary>

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -377,7 +377,10 @@ public partial class HttpChain
 
     private void fillRequestType(ApiDescription apiDescription)
     {
-        if (HasRequestType && !IsFormData && apiDescription.HttpMethod != "GET")
+        // ReadsRequestBody keeps a non-GET endpoint whose [AsParameters] type binds only query/route/header
+        // values from being described as taking a body. Before GH-3630 such a chain was excluded here by
+        // IsFormData being (wrongly) true; now that IsFormData reflects reality, this is the guard.
+        if (HasRequestType && ReadsRequestBody && !IsFormData && apiDescription.HttpMethod != "GET")
         {
             var parameterDescription = new ApiParameterDescription
             {

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -516,7 +516,7 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
             .WithMetadata(new HttpMethodMetadata(_httpMethods));
             //.WithMetadata(Method.Method);
 
-        if (HasRequestType)
+        if (HasRequestType && ReadsRequestBody)
         {
             if (IsFormData)
             {
@@ -902,6 +902,17 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
     public bool HasRequestType => RequestType != null && RequestType != typeof(void);
 
     public bool IsFormData { get; internal set; }
+
+    /// <summary>
+    ///     True when this chain actually reads a request body — a JSON body, a form, or uploaded files.
+    ///     An <c>[AsParameters]</c> type whose members all bind from the query string, route, or headers
+    ///     reads no body at all, so the chain must not advertise <c>Accepts</c> metadata for one: ASP.NET
+    ///     Core's <c>AcceptsMatcherPolicy</c> builds content-type edges into the route matcher from that
+    ///     metadata, and a request that carries no matching Content-Type is then dropped from candidate
+    ///     selection entirely — a 404, not a 415. See GH-3630.
+    /// </summary>
+    internal bool ReadsRequestBody { get; set; } = true;
+
     public Type? ComplexQueryStringType { get; set; }
 
     /// <summary>

--- a/src/Wolverine.Grpc.Tests/grpc_and_http_coexistence_3630.cs
+++ b/src/Wolverine.Grpc.Tests/grpc_and_http_coexistence_3630.cs
@@ -1,0 +1,107 @@
+using GreeterProtoFirstGrpc.Server;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Http;
+using Wolverine.Http.FluentValidation;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests;
+
+// GH-3630, the continuation of GH-3591: HTTP routes 404 when Wolverine gRPC services are also mapped.
+// grpc_and_http_coexistence_3591 could not reproduce it, and this fixture is the issue's attached repro
+// narrowed down. It differs from the 3591 fixture on the axes the reporter's Program.cs actually differs on:
+//
+//   * NO explicit app.UseRouting() -- WebApplication's implicit routing is used instead
+//   * a PROTO-FIRST abstract [WolverineGrpcService] stub over stock Grpc.AspNetCore, not code-first
+//     ProtoBuf.Grpc via AddCodeFirstGrpc()
+//   * no pinned opts.ApplicationAssembly
+public class grpc_and_http_coexistence_3630 : IAsyncLifetime
+{
+    private WebApplication _app = null!;
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+        builder.WebHost.UseTestServer();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.Discovery.IncludeAssembly(typeof(GreeterGrpcService).Assembly);
+            opts.Discovery.IncludeAssembly(typeof(grpc_and_http_coexistence_3630).Assembly);
+        });
+
+        // The issue's registration order, verbatim: stock gRPC + Wolverine gRPC + Wolverine HTTP.
+        builder.Services.AddGrpc();
+        builder.Services.AddWolverineGrpc();
+        builder.Services.AddWolverineHttp();
+
+        _app = builder.Build();
+
+        // Deliberately NO _app.UseRouting() -- that is what the reporter's Program.cs does.
+        _app.MapWolverineGrpcServices();
+        _app.MapWolverineEndpoints(o => o.UseFluentValidationProblemDetailMiddleware());
+
+        await _app.StartAsync();
+
+        _client = _app.GetTestServer().CreateClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task http_get_still_responds_when_grpc_services_are_mapped()
+    {
+        var response = await _client.GetAsync("/gh3630/check");
+
+        response.StatusCode.ShouldNotBe(System.Net.HttpStatusCode.NotFound);
+        response.EnsureSuccessStatusCode();
+
+        (await response.Content.ReadAsStringAsync()).ShouldContain("ok");
+    }
+
+    [Fact]
+    public async Task http_get_with_asparameters_and_invoke_still_responds_when_grpc_is_mapped()
+    {
+        // The issue's exact endpoint shape: an [AsParameters] request forwarded through the message bus.
+        var response = await _client.GetAsync("/gh3630/invoke?Name=bob&Pin=1111");
+
+        response.StatusCode.ShouldNotBe(System.Net.HttpStatusCode.NotFound);
+        response.EnsureSuccessStatusCode();
+
+        (await response.Content.ReadAsStringAsync()).ShouldContain("bob");
+    }
+}
+
+public static class Coexistence3630HttpEndpoint
+{
+    [WolverineGet("/gh3630/check")]
+    public static string GetCheck() => "ok";
+
+    [WolverineGet("/gh3630/invoke")]
+    public static Task<Coexist3630CheckResponse> GetInvoke([AsParameters] Coexist3630CheckRequest req,
+        IMessageBus bus)
+        => bus.InvokeAsync<Coexist3630CheckResponse>(req);
+}
+
+// The repro's exact shape: a POSITIONAL RECORD whose constructor parameters carry [FromQuery],
+// not a class with settable properties.
+public record Coexist3630CheckRequest([FromQuery] string? Name, [FromQuery] string? Pin);
+
+public record Coexist3630CheckResponse(string Message);
+
+public static class Coexist3630CheckHandler
+{
+    public static Coexist3630CheckResponse Handle(Coexist3630CheckRequest req) => new($"hello {req.Name}");
+}
+


### PR DESCRIPTION
Closes #3630. Also explains #3591, which was closed as "works on my box" — the fixture committed there missed the trigger by one route segment.

## What actually happens

The gRPC mapping doesn't break anything. It **exposes metadata that was already wrong.**

`AsParamatersAttributeUsage.TryMatch` set `chain.IsFormData = true` for every `[AsParameters]` type the moment the parameter matched — before a single member had been looked at — and only a `[FromBody]` member ever undid it. So a type built entirely from `[FromQuery]` members got

```
Accepts ContentTypes: application/x-www-form-urlencoded,multipart/form-data,
        RequestType: Web.VS.Booking.Check.CheckRequest, IsOptional: True
```

stamped onto its endpoint — **on a GET**.

ASP.NET Core does not treat that as cosmetic. `AcceptsMatcherPolicy` is an `INodeBuilderPolicy`: it turns `IAcceptsMetadata` into **content-type edges in the route matcher**. On its own that stayed latent. But `MapGrpcService` registers a catch-all — `{unimplementedService}/{unimplementedMethod:grpcunimplemented}` — and once the matcher had a parameterized node of that shape, the content-type edges started being applied. A plain GET carrying no `Content-Type` then stopped being a **candidate** for its own route.

The routing log is unambiguous:

```
DfaMatcher[1001] 1 candidate(s) found for the request path '/api/check'
DfaMatcher[1003] Endpoint 'gRPC - Unimplemented service' ... was rejected by constraint 'unimplementedMethod' ...
EndpointRoutingMiddleware[2] Request did not match any endpoints
```

One candidate — gRPC's catch-all, which its own constraint then rejects. Wolverine's `/api/check` endpoint is present in the `EndpointDataSource` with the right pattern, right order, right HTTP method, and no `SuppressMatching`. It just isn't in the matcher. Not a 415, not an ambiguous match: a plain 404.

That is also why **`/api/plain` worked and `/api/check` didn't** in the same app — identical two-segment literal patterns, and the only difference was the `Accepts` metadata.

## Why #3591 couldn't be reproduced

The fixture committed with #3591 was one segment off. `{unimplementedService}/{unimplementedMethod}` matches **exactly two** segments; `/api/coexist/invoke` is three, so the endpoint never shared a node with the catch-all. Changing the test route to two segments reproduces it instantly. The reporter's `/api/check` is two.

## The fix

Decide form-vs-body-vs-neither from the type's members instead of optimistically. `DescribeAsParametersBinding` walks the single public constructor's parameters and the writable public properties — mirroring `AsParametersBindingFrame` — and reports whether anything is `[FromForm]` or `[FromBody]`.

This has to happen in `TryMatch`, **not** in the frame's constructor: `applyMetadata()` runs during endpoint build, which can precede chain compilation depending on the route warm-up mode. (I had it in the frame first; it fixed the test host and did nothing for the reporter's app, which is how the ordering surfaced.)

A new `HttpChain.ReadsRequestBody` then suppresses `Accepts` metadata entirely for a chain that reads no body, and guards `fillRequestType` so a **non-GET** endpoint with a query-only `[AsParameters]` type isn't newly described as taking a JSON body now that `IsFormData` reports the truth. `[FromForm]` types keep their form metadata; `[FromBody]` members keep the JSON path.

Beyond the 404, this also corrects the OpenAPI shape — a GET bound from the query string was being documented as consuming a form body.

## Verification

**Against the reporter's attached repro app**, built against this branch, gRPC mapped, their exact URL:

| | `/api/check?invitationid=...&pin=1111` |
|---|---|
| before | `404 Not Found` |
| after | `200 OK` `{"res":0}` |

and the endpoint carries no `Accepts` metadata at all.

**Tests**

- `asparameters_accepts_metadata_3630` (Wolverine.Http.Tests) — the defect with **no gRPC involved**: a query-only `[AsParameters]` GET declares no request body, does not advertise form content types, still binds end to end, and a `[FromForm]` `[AsParameters]` type keeps its form metadata. **2 of 4 fail on unmodified `main`.**
- `grpc_and_http_coexistence_3630` (Wolverine.Grpc.Tests) — the issue as reported, on the axes the reporter's `Program.cs` actually differs from the #3591 fixture: no explicit `UseRouting()`, a proto-first `[WolverineGrpcService]` stub, and a two-segment route. **1 of 2 fails on unmodified `main`.**

Full `Wolverine.Http.Tests` (906) and `Wolverine.Grpc.Tests` (298) green. `dotnet build wolverine.slnx -c Release` clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkMdiGxiwpnkpKK2VUPqVf