### PR TITLE
Store-scoped FindAgentUriAsync overload (#3647)

### DIFF
--- a/src/Persistence/MartenTests/Distribution/store_scoped_find_agent_uri_3647.cs
+++ b/src/Persistence/MartenTests/Distribution/store_scoped_find_agent_uri_3647.cs
@@ -1,0 +1,171 @@
+using IntegrationTests;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using MartenTests.Distribution.TripDomain;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace MartenTests.Distribution;
+
+// GH-3647: FindAgentUriAsync had the same store-blindness GH-3618 fixed for the transient-rebuild path.
+// It concatenates every store's agents and matches on the trailing shard path alone (MatchesShard compares
+// AbsolutePath.EndsWith), so a projection name registered in more than one store resolved to whichever store
+// was enumerated first. This URI is what tooling routes restart / pause / resume / rebuild through, so
+// guessing wrong acts on another store's LIVE agent.
+//
+// Unlike store_scoped_transient_rebuild_3618, the projection is registered ASYNC in both stores here --
+// that is what makes both of them resolve an agent URI at all, which is the precondition for the ambiguity.
+public class store_scoped_find_agent_uri_3647 : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private IDocumentStore _main = null!;
+    private IGh3647AncillaryStore _ancillary = null!;
+
+    public async Task InitializeAsync()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync("gh3647_main");
+            await conn.DropSchemaAsync("gh3647_anc");
+            await conn.CloseAsync();
+        }
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddMarten(m =>
+                    {
+                        m.DisableNpgsqlLogging = true;
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "gh3647_main";
+                        m.Projections.Add<TripProjection>(ProjectionLifecycle.Async);
+                    })
+                    .IntegrateWithWolverine(x => x.UseWolverineManagedEventSubscriptionDistribution = true);
+
+                opts.Services.AddMartenStore<IGh3647AncillaryStore>(m =>
+                    {
+                        m.DisableNpgsqlLogging = true;
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "gh3647_anc";
+                        m.Projections.Add<TripProjection>(ProjectionLifecycle.Async);
+                    })
+                    .IntegrateWithWolverine(x => x.UseWolverineManagedEventSubscriptionDistribution = true);
+
+                opts.Discovery.DisableConventionalDiscovery();
+            }).StartAsync();
+
+        _main = _host.Services.GetRequiredService<IDocumentStore>();
+        _ancillary = _host.Services.GetRequiredService<IGh3647AncillaryStore>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _host.GetRuntime().Agents.DisableHealthChecks();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private EventSubscriptionAgentFamily theFamily =>
+        _host.Services.GetServices<IEventSubscriptionAgentFamily>()
+            .OfType<EventSubscriptionAgentFamily>().Single();
+
+    private static string identityOf(IDocumentStore store) => ((IEventStore)store).Identity.ToString();
+
+    [Fact]
+    public async Task both_stores_resolve_an_agent_uri_for_the_shared_projection_name()
+    {
+        // The precondition for the ambiguity: two stores, one projection name, both distributed as agents.
+        var agents = await theFamily.SupportedAgentsAsync();
+
+        agents.Count(x => x.AbsolutePath.TrimEnd('/').EndsWith("/Trip/All", StringComparison.OrdinalIgnoreCase))
+            .ShouldBe(2, "both stores should contribute an agent for Trip:All");
+    }
+
+    [Fact]
+    public async Task scoping_to_the_main_store_resolves_that_store_s_agent_uri()
+    {
+        var uri = await theFamily.FindAgentUriAsync(identityOf(_main), "Trip:All", null);
+
+        uri.ShouldNotBeNull();
+        EventSubscriptionAgentFamily.StoreIdentityOf(uri!)
+            .ShouldBe(identityOf(_main).ToLowerInvariant());
+    }
+
+    [Fact]
+    public async Task scoping_to_the_ancillary_store_resolves_that_store_s_agent_uri()
+    {
+        // The mirror image. Asserting both directions is what proves the overload narrows by store rather
+        // than merely agreeing with the family's enumeration order.
+        var uri = await theFamily.FindAgentUriAsync(identityOf(_ancillary), "Trip:All", null);
+
+        uri.ShouldNotBeNull();
+        EventSubscriptionAgentFamily.StoreIdentityOf(uri!)
+            .ShouldBe(identityOf(_ancillary).ToLowerInvariant());
+    }
+
+    [Fact]
+    public async Task the_two_store_scoped_lookups_return_different_uris()
+    {
+        // The single assertion that would have caught the bug: same shard identity, two stores, two answers.
+        var main = await theFamily.FindAgentUriAsync(identityOf(_main), "Trip:All", null);
+        var ancillary = await theFamily.FindAgentUriAsync(identityOf(_ancillary), "Trip:All", null);
+
+        main.ShouldNotBeNull();
+        ancillary.ShouldNotBeNull();
+        main.ShouldNotBe(ancillary!);
+    }
+
+    /// <summary>
+    ///     Documents the gap being closed. The store-blind overload still resolves a URI and is unchanged, but
+    ///     it can only ever return one of the two, and the caller has no say in which.
+    /// </summary>
+    [Fact]
+    public async Task the_store_blind_overload_still_resolves_but_cannot_be_steered()
+    {
+        var blind = await theFamily.FindAgentUriAsync("Trip:All", null);
+        blind.ShouldNotBeNull();
+
+        var main = await theFamily.FindAgentUriAsync(identityOf(_main), "Trip:All", null);
+        var ancillary = await theFamily.FindAgentUriAsync(identityOf(_ancillary), "Trip:All", null);
+
+        new[] { main, ancillary }.ShouldContain(blind);
+    }
+
+    [Fact]
+    public async Task a_store_outside_this_family_resolves_nothing()
+    {
+        (await theFamily.FindAgentUriAsync("someone-else:Marten", "Trip:All", null)).ShouldBeNull(
+            "so a caller looping over families can try the next one");
+    }
+
+    [Fact]
+    public async Task an_unregistered_shard_in_a_known_store_resolves_nothing()
+    {
+        (await theFamily.FindAgentUriAsync(identityOf(_main), "DoesNotExist:All", null)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task the_store_identity_match_is_case_insensitive()
+    {
+        // System.Uri lowercases the authority while EventStoreIdentity preserves casing (GH-3168), so the
+        // lookup has to normalize the same way the family keys its stores.
+        var uri = await theFamily.FindAgentUriAsync(identityOf(_main).ToUpperInvariant(), "Trip:All", null);
+
+        uri.ShouldNotBeNull();
+        EventSubscriptionAgentFamily.StoreIdentityOf(uri!).ShouldBe(identityOf(_main).ToLowerInvariant());
+    }
+}
+
+public interface IGh3647AncillaryStore : IDocumentStore;

--- a/src/Testing/CoreTests/Runtime/Agents/event_subscription_family_store_identity_of.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/event_subscription_family_store_identity_of.cs
@@ -84,4 +84,23 @@ public class event_subscription_family_store_identity_of
         (await family.TryRebuildRegisteredProjectionAsync("", "Trip:All", null, CancellationToken.None))
             .ShouldBeFalse();
     }
+
+    [Fact]
+    public async Task find_agent_uri_for_a_store_this_family_does_not_manage_reports_nothing()
+    {
+        // GH-3647: the store-scoped FindAgentUriAsync overload must return null rather than falling back to a
+        // store-blind search, so a caller looping over every registered family moves on to the next one.
+        var family = new EventSubscriptionAgentFamily([], []);
+
+        (await family.FindAgentUriAsync("nobody:marten", "Trip:All", null, CancellationToken.None))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task find_agent_uri_with_an_empty_store_identity_reports_nothing()
+    {
+        var family = new EventSubscriptionAgentFamily([], []);
+
+        (await family.FindAgentUriAsync("", "Trip:All", null, CancellationToken.None)).ShouldBeNull();
+    }
 }

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
@@ -42,15 +42,43 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
     /// latter, a non-null <paramref name="tenantId" /> is resolved to its <c>DatabaseId</c> via the
     /// store's tenant→database mapping and matched by the database segment of the agent URI (GH-3128).</para>
     /// </summary>
-    public async ValueTask<Uri?> FindAgentUriAsync(string shardIdentity, string? tenantId,
+    public ValueTask<Uri?> FindAgentUriAsync(string shardIdentity, string? tenantId,
         CancellationToken token = default)
+    {
+        return findAgentUriAsync(_stores.Enumerate().Select(x => x.Value).ToArray(), shardIdentity, tenantId, token);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<Uri?> FindAgentUriAsync(string storeIdentity, string shardIdentity, string? tenantId,
+        CancellationToken token = default)
+    {
+        if (string.IsNullOrEmpty(storeIdentity) || !_stores.TryFind(StoreKey(storeIdentity), out var agents))
+        {
+            return new ValueTask<Uri?>((Uri?)null);
+        }
+
+        return findAgentUriAsync([agents], shardIdentity, tenantId, token);
+    }
+
+    /// <summary>
+    /// The shared resolution both <c>FindAgentUriAsync</c> overloads run, differing only in which stores are
+    /// in scope. <see cref="MatchesShard" /> compares the trailing shard path alone, so restricting
+    /// <paramref name="stores" /> to one store is what makes a projection name that appears in several stores
+    /// resolve unambiguously. See GH-3647.
+    /// </summary>
+    private async ValueTask<Uri?> findAgentUriAsync(EventStoreAgents[] stores, string shardIdentity,
+        string? tenantId, CancellationToken token)
     {
         if (!ShardName.TryParse(shardIdentity, out var baseName) || baseName is null)
         {
             return null;
         }
 
-        var known = await SupportedAgentsAsync().ConfigureAwait(false);
+        var known = new List<Uri>();
+        foreach (var store in stores)
+        {
+            known.AddRange(await store.SupportedAgentsAsync(_cancellation.Token).ConfigureAwait(false));
+        }
 
         if (string.IsNullOrEmpty(tenantId))
         {
@@ -67,9 +95,8 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
 
         // Database-per-tenant (sharded databases): the shard RelativeUrl is identical across tenant
         // databases, so resolve the tenant's database and match the base-shard agent URI in it. See GH-3128.
-        foreach (var entry in _stores.Enumerate())
+        foreach (var agents in stores)
         {
-            var agents = entry.Value;
             var databaseId = await agents.TryResolveTenantDatabaseIdAsync(tenantId, token).ConfigureAwait(false);
             if (databaseId == null)
             {
@@ -121,7 +148,7 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
     /// <summary>
     /// The identity of the event store that owns an <c>event-subscriptions://</c> agent
     /// <paramref name="uri" />, in the form <see cref="TryRebuildRegisteredProjectionAsync(string,string,string?,CancellationToken)" />
-    /// expects. Lets a caller holding a URI from <see cref="FindAgentUriAsync" /> scope a rebuild to that
+    /// expects. Lets a caller holding a URI from <see cref="FindAgentUriAsync(string,string?,CancellationToken)" /> scope a rebuild to that
     /// store without decomposing the URI grammar itself — the grammar (see <see cref="UriFor" />) stays in
     /// here. Returns <c>null</c> for any URI that is not an agent URI of this scheme or that carries no
     /// store-name segment. See GH-3618.

--- a/src/Wolverine/Runtime/Agents/IEventSubscriptionAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/IEventSubscriptionAgentFamily.cs
@@ -21,6 +21,29 @@ public interface IEventSubscriptionAgentFamily
     ValueTask<Uri?> FindAgentUriAsync(string shardIdentity, string? tenantId, CancellationToken token = default);
 
     /// <summary>
+    /// Same as <see cref="FindAgentUriAsync(string,string?,CancellationToken)" />, but scoped to a single event
+    /// store rather than searching every store this family manages. <paramref name="storeIdentity" /> is the
+    /// store's <c>EventStoreIdentity.ToString()</c> value (matched case-insensitively), which
+    /// <see cref="EventSubscriptionAgentFamily.StoreIdentityOf" /> derives from an agent URI.
+    ///
+    /// <para>The store-blind overload concatenates the agents of every store and matches on the trailing shard
+    /// path alone, so when the SAME projection name is registered in more than one store it returns whichever
+    /// store happens to be enumerated first. Since this URI is what tooling uses to route restart / pause /
+    /// resume / rebuild at a <em>live</em> agent, guessing wrong acts on another store's running agent. See
+    /// GH-3647, and GH-3618 for the same gap on the transient-rebuild path.</para>
+    ///
+    /// <para>Returns <c>null</c> when this family does not manage <paramref name="storeIdentity" />, or when that
+    /// store has no matching registered shard, so a caller looping over families can try the next one.</para>
+    ///
+    /// <para>The default implementation ignores <paramref name="storeIdentity" /> and delegates to the store-blind
+    /// overload, preserving the behavior of any pre-existing implementation of this interface. Implementations
+    /// that manage more than one store should override it.</para>
+    /// </summary>
+    ValueTask<Uri?> FindAgentUriAsync(string storeIdentity, string shardIdentity, string? tenantId,
+        CancellationToken token = default)
+        => FindAgentUriAsync(shardIdentity, tenantId, token);
+
+    /// <summary>
     /// Rebuild a REGISTERED projection addressed by its <paramref name="shardIdentity" /> (the JasperFx
     /// <c>ShardName.Identity</c>, e.g. <c>"Trip:All"</c>) regardless of its lifecycle (Inline / Live /
     /// Async) or whether it is currently distributed as a continuous agent. This is the path for rebuilding
@@ -40,7 +63,7 @@ public interface IEventSubscriptionAgentFamily
     /// single event store rather than searching every store this family manages. <paramref name="storeIdentity" /> is
     /// the store's <c>EventStoreIdentity.ToString()</c> value (matched case-insensitively);
     /// <see cref="EventSubscriptionAgentFamily.StoreIdentityOf" /> derives it from an agent URI that
-    /// <see cref="FindAgentUriAsync" /> already resolved, so a caller never has to decompose the URI itself.
+    /// <see cref="FindAgentUriAsync(string,string?,CancellationToken)" /> already resolved, so a caller never has to decompose the URI itself.
     ///
     /// <para>This exists because the store-blind overload cannot tell two stores apart when the SAME projection
     /// name is registered in more than one of them (a primary plus an ancillary store, say) and NEITHER has a live


### PR DESCRIPTION
Closes #3647. Mirror of #3642 (merged), which fixed the same store-blindness on the transient-rebuild path.

## The gap

`FindAgentUriAsync(shardIdentity, tenantId)` concatenates the agents of **every** store the family manages, then matches on the trailing shard path alone:

```csharp
private static bool MatchesShard(Uri agentUri, string relativeUrl)
    => agentUri.AbsolutePath.TrimEnd('/').EndsWith("/" + relativeUrl, StringComparison.OrdinalIgnoreCase);
```

The store segments of the URI are never consulted. So with `Trip:All` registered as an async projection in both a primary and an ancillary store, the call returns whichever store's agent URI happens to be enumerated first, and the caller has no way to say which it meant.

This matters more than #3618 did. That one was explicitly the *no*-live-agent fallback; **this** URI is what tooling routes restart / pause / resume / rebuild through, so a wrong answer acts on another store's **running** agent.

(The database-per-tenant branch further down was already store-aware — it iterates `_stores` and resolves each store's tenant → `DatabaseId`. The store-global and single-database-per-tenant branches were not.)

## The change

```csharp
ValueTask<Uri?> FindAgentUriAsync(string storeIdentity, string shardIdentity, string? tenantId,
    CancellationToken token = default);
```

Keyed on the store's `EventStoreIdentity.ToString()` value, matched case-insensitively the same way the family keys its own stores (the GH-3168 normalization). Returns `null` — rather than falling back to a store-blind search — when this family doesn't manage the named store, so a caller looping over families moves on to the next. Default interface method delegating to the store-blind overload, so existing implementations keep compiling and behaving as before.

Both overloads now run one shared `findAgentUriAsync` differing only in which stores are in scope, so the store-global, single-database-per-tenant, and database-per-tenant (GH-3128) branches stay in one place rather than being duplicated. The store-blind path passes every store and is behaviourally unchanged.

`EventSubscriptionAgentFamily.StoreIdentityOf(Uri)` (added in #3642) already gives callers the key format, so no new seam was needed.

## Tests

`store_scoped_find_agent_uri_3647` (MartenTests) registers `TripProjection` **Async** in both a primary and an ancillary Marten store. Async rather than Inline is the point — that's what makes both stores actually resolve an agent URI, which is the precondition for the ambiguity, and it's the one thing that differs from the #3642 fixture:

- `both_stores_resolve_an_agent_uri_for_the_shared_projection_name` — 2 agents share the `Trip/All` path, establishing the ambiguity exists
- scoping to main → main's URI; scoping to ancillary → ancillary's URI (asserted via `StoreIdentityOf`, both directions, so this proves narrowing rather than agreement with enumeration order)
- `the_two_store_scoped_lookups_return_different_uris` — the single assertion that would have caught the bug
- the store-blind overload still resolves, but can only ever return one of the two
- unknown store → null, unregistered shard → null, identity match is case-insensitive

Plus DB-free null cases in `event_subscription_family_store_identity_of` (CoreTests).

8 Marten + 9 CoreTests green; full `MartenTests.Distribution` suite green; `dotnet build wolverine.slnx -c Release` clean, 0 warnings.

## Note on the baseline

The new tests fail to **compile** against `main` rather than failing an assertion, since the overload doesn't exist there. That turned out to be useful evidence rather than a gap: `FindAgentUriAsync(identity, "Trip:All", null)` could plausibly have bound to the pre-existing `(shardIdentity, tenantId, token)` overload and silently asserted nothing. The `cannot convert from '<null>' to 'CancellationToken'` errors on `main` prove it can't, and on this branch `the_two_store_scoped_lookups_return_different_uris` passing proves the store scoping is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkMdiGxiwpnkpKK2VUPqVf