### PR TITLE
feat(pubsub): named-broker support for sharded/partitioned topics (#3632)

### DIFF
--- a/docs/guide/messaging/transports/gcp-pubsub/index.md
+++ b/docs/guide/messaging/transports/gcp-pubsub/index.md
@@ -244,6 +244,12 @@ using var host = await Host.CreateDefaultBuilder()
 
 This creates Pub/Sub topics named `orders1` through `orders4` with companion local queues `global-orders1` through `global-orders4`. Messages are routed to the correct shard based on their group id, and Wolverine handles the coordination between nodes automatically.
 
+Both `PublishToShardedPubsubTopics()` and `UseShardedPubsubTopics()` have `...OnNamedBroker()` equivalents to shard across a [named broker](#multiple-named-brokers) instead of the default one:
+
+```csharp
+topology.UseShardedPubsubTopicsOnNamedBroker(new BrokerName("americas"), "orders", 4);
+```
+
 ## URI reference
 
 The `GcpPubsubEndpointUri` helper class builds canonical endpoint URIs:

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/ShardedTopicsNamedBrokerTests.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/ShardedTopicsNamedBrokerTests.cs
@@ -1,0 +1,83 @@
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Pubsub.Internal;
+using Wolverine.Runtime.Partitioning;
+using Xunit;
+
+namespace Wolverine.Pubsub.Tests;
+
+// GH-3632: PublishToShardedPubsubTopics / UseShardedPubsubTopics had no named-broker equivalent, because
+// PartitionedMessageTopologyWithTopics always resolved the default/unnamed PubsubTransport.
+public class ShardedTopicsNamedBrokerTests
+{
+    private static readonly BrokerName TheName = new("americas");
+
+    [Fact]
+    public void sharded_topology_without_a_broker_name_uses_the_default_transport()
+    {
+        var options = new WolverineOptions();
+        options.UsePubsub("wolverine");
+
+        var topology = new PartitionedMessageTopologyWithTopics(options, PartitionSlots.Five, "orders", 4);
+
+        topology.Slots.Count.ShouldBe(4);
+        topology.Slots.ShouldAllBe(x => x.Uri.Scheme == PubsubTransport.ProtocolName);
+    }
+
+    [Fact]
+    public void sharded_topology_with_a_broker_name_targets_the_named_transport()
+    {
+        var options = new WolverineOptions();
+        options.UsePubsub("wolverine");
+        options.AddNamedPubsubBroker(TheName, "wolverine2");
+
+        var topology = new PartitionedMessageTopologyWithTopics(options, PartitionSlots.Five, "orders", 4, TheName);
+
+        topology.Slots.Count.ShouldBe(4);
+        topology.Slots.ShouldAllBe(x => x.Uri.Scheme == TheName.Name);
+        topology.Slots.Select(x => x.Uri).ShouldBe(new[]
+        {
+            new Uri("americas://wolverine2/orders1"),
+            new Uri("americas://wolverine2/orders2"),
+            new Uri("americas://wolverine2/orders3"),
+            new Uri("americas://wolverine2/orders4")
+        });
+    }
+
+    [Fact]
+    public void publish_to_sharded_pubsub_topics_on_named_broker_targets_the_named_transport()
+    {
+        var options = new WolverineOptions();
+        options.UsePubsub("wolverine");
+        options.AddNamedPubsubBroker(TheName, "wolverine2");
+
+        options.MessagePartitioning.ByMessage<OrderPlaced>(x => x.OrderId.ToString());
+        options.MessagePartitioning.PublishToShardedPubsubTopicsOnNamedBroker(TheName, "orders", 4,
+            topology => topology.Message<OrderPlaced>());
+
+        var named = options.Transports.OfType<PubsubTransport>().Single(x => x.Protocol == TheName.Name);
+        named.Topics.Select(x => x.EndpointName).OrderBy(x => x)
+            .ShouldBe(["orders1", "orders2", "orders3", "orders4"]);
+    }
+
+    [Fact]
+    public void use_sharded_pubsub_topics_on_named_broker_targets_the_named_transport()
+    {
+        var options = new WolverineOptions();
+        options.UsePubsub("wolverine");
+        options.AddNamedPubsubBroker(TheName, "wolverine2");
+
+        options.MessagePartitioning.ByMessage<OrderPlaced>(x => x.OrderId.ToString());
+        options.MessagePartitioning.GlobalPartitioned(topology =>
+        {
+            topology.UseShardedPubsubTopicsOnNamedBroker(TheName, "orders", 4);
+            topology.MessagesImplementing<OrderPlaced>();
+        });
+
+        var named = options.Transports.OfType<PubsubTransport>().Single(x => x.Protocol == TheName.Name);
+        named.Topics.Select(x => x.EndpointName).OrderBy(x => x)
+            .ShouldBe(["orders1", "orders2", "orders3", "orders4"]);
+    }
+}
+
+public record OrderPlaced(Guid OrderId);

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/PartitionedMessageTopologyWithTopics.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/PartitionedMessageTopologyWithTopics.cs
@@ -5,24 +5,28 @@ namespace Wolverine.Pubsub.Internal;
 
 public class PartitionedMessageTopologyWithTopics : PartitionedMessageTopology<PubsubTopicListenerConfiguration, PubsubTopicSubscriberConfiguration>
 {
-    public PartitionedMessageTopologyWithTopics(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints) : base(options, listeningSlots, baseName, numberOfEndpoints)
+    public PartitionedMessageTopologyWithTopics(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints, BrokerName? brokerName = null) : base(options, listeningSlots, baseName, numberOfEndpoints, brokerName)
     {
         MaxDegreeOfParallelism = PartitionSlots.Five;
     }
 
     protected override Endpoint buildEndpoint(WolverineOptions options, string name)
     {
-        var transport = options.PubsubTransport();
+        var transport = options.PubsubTransport(BrokerName);
         return transport.Topics[transport.MaybeCorrectName(name)];
     }
 
     protected override PubsubTopicListenerConfiguration buildListener(WolverineOptions options, string name)
     {
-        return options.ListenToPubsubTopic(name);
+        return BrokerName is null
+            ? options.ListenToPubsubTopic(name)
+            : options.ListenToPubsubTopicOnNamedBroker(BrokerName, name);
     }
 
     protected override PubsubTopicSubscriberConfiguration buildSubscriber(IPublishToExpression expression, string name)
     {
-        return expression.ToPubsubTopic(name);
+        return BrokerName is null
+            ? expression.ToPubsubTopic(name)
+            : expression.ToPubsubTopicOnNamedBroker(BrokerName, name);
     }
 }

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/PartitionedMessageTopologyWithTopics.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/PartitionedMessageTopologyWithTopics.cs
@@ -5,28 +5,37 @@ namespace Wolverine.Pubsub.Internal;
 
 public class PartitionedMessageTopologyWithTopics : PartitionedMessageTopology<PubsubTopicListenerConfiguration, PubsubTopicSubscriberConfiguration>
 {
-    public PartitionedMessageTopologyWithTopics(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints, BrokerName? brokerName = null) : base(options, listeningSlots, baseName, numberOfEndpoints, brokerName)
+    public PartitionedMessageTopologyWithTopics(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints) : base(options, listeningSlots, baseName, numberOfEndpoints)
+    {
+        MaxDegreeOfParallelism = PartitionSlots.Five;
+    }
+
+    /// <summary>
+    /// Build the sharded topics against a named broker registered through
+    /// <c>AddNamedPubsubBroker()</c> rather than the default, unnamed transport.
+    /// </summary>
+    public PartitionedMessageTopologyWithTopics(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints, BrokerName? brokerName) : base(options, listeningSlots, baseName, numberOfEndpoints, brokerName)
     {
         MaxDegreeOfParallelism = PartitionSlots.Five;
     }
 
     protected override Endpoint buildEndpoint(WolverineOptions options, string name)
     {
-        var transport = options.PubsubTransport(BrokerName);
+        var transport = options.PubsubTransport(_brokerName);
         return transport.Topics[transport.MaybeCorrectName(name)];
     }
 
     protected override PubsubTopicListenerConfiguration buildListener(WolverineOptions options, string name)
     {
-        return BrokerName is null
+        return _brokerName is null
             ? options.ListenToPubsubTopic(name)
-            : options.ListenToPubsubTopicOnNamedBroker(BrokerName, name);
+            : options.ListenToPubsubTopicOnNamedBroker(_brokerName, name);
     }
 
     protected override PubsubTopicSubscriberConfiguration buildSubscriber(IPublishToExpression expression, string name)
     {
-        return BrokerName is null
+        return _brokerName is null
             ? expression.ToPubsubTopic(name)
-            : expression.ToPubsubTopicOnNamedBroker(BrokerName, name);
+            : expression.ToPubsubTopicOnNamedBroker(_brokerName, name);
     }
 }

--- a/src/Transports/GCP/Wolverine.Pubsub/PubsubTransportExtensions.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/PubsubTransportExtensions.cs
@@ -288,4 +288,53 @@ public static class PubsubTransportExtensions
         }, baseName);
         return topology;
     }
+
+    /// <summary>
+    /// Create a sharded message topology with Google Cloud Pub/Sub topics named
+    /// baseName1, baseName2, etc. on a named broker registered via <see cref="AddNamedPubsubBroker" />.
+    /// </summary>
+    /// <param name="rules"></param>
+    /// <param name="name">The name of the additional broker registered via <see cref="AddNamedPubsubBroker" />.</param>
+    /// <param name="baseName"></param>
+    /// <param name="numberOfEndpoints"></param>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public static MessagePartitioningRules PublishToShardedPubsubTopicsOnNamedBroker(this MessagePartitioningRules rules,
+        BrokerName name, string baseName, int numberOfEndpoints, Action<PartitionedMessageTopologyWithTopics> configure)
+    {
+        rules.AddPublishingTopology((opts, _) =>
+        {
+            var topology = new PartitionedMessageTopologyWithTopics(opts, PartitionSlots.Five, baseName, numberOfEndpoints, name);
+            topology.ConfigureListening(x => {});
+            configure(topology);
+            topology.AssertValidity();
+
+            return topology;
+        });
+
+        return rules;
+    }
+
+    /// <summary>
+    /// Use sharded Google Cloud Pub/Sub topics on a named broker registered via <see cref="AddNamedPubsubBroker" />
+    /// for global partitioned message processing. Topics will be named baseName1, baseName2, etc.
+    /// </summary>
+    /// <param name="topology"></param>
+    /// <param name="name">The name of the additional broker registered via <see cref="AddNamedPubsubBroker" />.</param>
+    /// <param name="baseName"></param>
+    /// <param name="numberOfEndpoints"></param>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public static GlobalPartitionedMessageTopology UseShardedPubsubTopicsOnNamedBroker(
+        this GlobalPartitionedMessageTopology topology, BrokerName name, string baseName, int numberOfEndpoints,
+        Action<PartitionedMessageTopologyWithTopics>? configure = null)
+    {
+        topology.SetExternalTopology(opts =>
+        {
+            var t = new PartitionedMessageTopologyWithTopics(opts, PartitionSlots.Five, baseName, numberOfEndpoints, name);
+            configure?.Invoke(t);
+            return t;
+        }, baseName);
+        return topology;
+    }
 }

--- a/src/Wolverine/Runtime/Partitioning/PartitionedMessageTopology.cs
+++ b/src/Wolverine/Runtime/Partitioning/PartitionedMessageTopology.cs
@@ -10,7 +10,19 @@ public abstract class PartitionedMessageTopology<TListener, TSubscriber> : Parti
 {
     private PartitionSlots _listeningSlots;
 
-    public PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints, BrokerName? brokerName = null) : base(options, listeningSlots, baseName, numberOfEndpoints, brokerName)
+    public PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints) : base(options, listeningSlots, baseName, numberOfEndpoints)
+    {
+        if (listeningSlots.HasValue)
+        {
+            MaxDegreeOfParallelism = listeningSlots.Value;
+        }
+    }
+
+    /// <summary>
+    /// Build this topology's endpoints against a named broker rather than the default,
+    /// unnamed transport.
+    /// </summary>
+    public PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints, BrokerName? brokerName) : base(options, listeningSlots, baseName, numberOfEndpoints, brokerName)
     {
         if (listeningSlots.HasValue)
         {
@@ -62,11 +74,22 @@ public abstract class PartitionedMessageTopology
 
     /// <summary>
     /// The named broker this topology's endpoints should be built against, or null for the
-    /// default/unnamed transport. Set before <see cref="buildEndpoint" /> is first called.
+    /// default/unnamed transport. Assigned before <see cref="buildEndpoint" /> is first called,
+    /// which matters because buildEndpoint runs from this constructor -- ahead of any derived
+    /// class's own constructor body.
     /// </summary>
-    protected readonly BrokerName? BrokerName;
+    protected readonly BrokerName? _brokerName;
 
-    protected PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints, BrokerName? brokerName = null)
+    protected PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints)
+        : this(options, listeningSlots, baseName, numberOfEndpoints, null)
+    {
+    }
+
+    /// <summary>
+    /// Build this topology's endpoints against a named broker rather than the default,
+    /// unnamed transport.
+    /// </summary>
+    protected PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints, BrokerName? brokerName)
     {
         if (numberOfEndpoints <= 0)
         {
@@ -74,7 +97,7 @@ public abstract class PartitionedMessageTopology
         }
 
         _options = options;
-        BrokerName = brokerName;
+        _brokerName = brokerName;
         _names = new string[numberOfEndpoints];
 
         for (int i = 0; i < numberOfEndpoints; i++)

--- a/src/Wolverine/Runtime/Partitioning/PartitionedMessageTopology.cs
+++ b/src/Wolverine/Runtime/Partitioning/PartitionedMessageTopology.cs
@@ -9,8 +9,8 @@ public abstract class PartitionedMessageTopology<TListener, TSubscriber> : Parti
     where TSubscriber : ISubscriberConfiguration<TSubscriber>
 {
     private PartitionSlots _listeningSlots;
-    
-    public PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints) : base(options, listeningSlots, baseName, numberOfEndpoints)
+
+    public PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints, BrokerName? brokerName = null) : base(options, listeningSlots, baseName, numberOfEndpoints, brokerName)
     {
         if (listeningSlots.HasValue)
         {
@@ -59,15 +59,22 @@ public abstract class PartitionedMessageTopology<TListener, TSubscriber> : Parti
 public abstract class PartitionedMessageTopology
 {
     protected readonly WolverineOptions _options;
-    
-    protected PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints)
+
+    /// <summary>
+    /// The named broker this topology's endpoints should be built against, or null for the
+    /// default/unnamed transport. Set before <see cref="buildEndpoint" /> is first called.
+    /// </summary>
+    protected readonly BrokerName? BrokerName;
+
+    protected PartitionedMessageTopology(WolverineOptions options, PartitionSlots? listeningSlots, string baseName, int numberOfEndpoints, BrokerName? brokerName = null)
     {
         if (numberOfEndpoints <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(numberOfEndpoints), "Must be a positive number");
         }
-        
+
         _options = options;
+        BrokerName = brokerName;
         _names = new string[numberOfEndpoints];
 
         for (int i = 0; i < numberOfEndpoints; i++)


### PR DESCRIPTION
Supersedes #3635. Closes #3632.

The feature is @bittercoder's work, carried over unchanged and preserved as his commit. This PR adds two adjustments that came out of review.

## The feature

`PublishToShardedPubsubTopics` / `UseShardedPubsubTopics` had no named-broker equivalent, because `PartitionedMessageTopologyWithTopics` always resolved the default/unnamed `PubsubTransport` in its `buildEndpoint` / `buildListener` / `buildSubscriber` overrides.

The broker name is threaded through the transport-agnostic `PartitionedMessageTopology` base class and assigned *before* the endpoint-building loop runs in the base constructor. That ordering is the non-obvious part and it's the only thing that works here: `buildEndpoint` is invoked from the base constructor, which runs ahead of any derived class's own constructor body, so a field assigned in `PartitionedMessageTopologyWithTopics` would still be null at that point. Nice catch by @bittercoder.

Adds `PublishToShardedPubsubTopicsOnNamedBroker` / `UseShardedPubsubTopicsOnNamedBroker` mirroring the existing non-named methods. Side effect worth noting: `Uri` becomes `shard://{brokerName}/{baseName}`, so a default and a named sharded topology sharing a `baseName` get distinct topology URIs rather than colliding.

## What's different from #3635

**1. Constructor overloads instead of an optional parameter.** #3635 added an optional `BrokerName?` parameter to three existing *public* constructors (`PartitionedMessageTopology`, `PartitionedMessageTopology<TListener,TSubscriber>`, `PartitionedMessageTopologyWithTopics`). That is source-compatible but binary-breaking — anything precompiled against the four-argument signature would fail with `MissingMethodException`. The broker name now arrives through a separate overload and the original signatures are untouched.

**2. `BrokerName` field renamed to `_brokerName`.** The field was named identically to its own type. Beyond the private/protected field convention, the shadowing is a live hazard: in a derived class the field wins simple-name resolution, so a static member access like `BrokerName.Something` wouldn't compile.

## Notes

This is Pub/Sub-only, matching the issue. The base-class plumbing is transport-agnostic and there are eight sharded topologies deriving from it (RabbitMQ, SQS, Azure Service Bus, Kafka, NATS, Pulsar, Redis, Pub/Sub), so the same support is now a small addition away for each of the others if we want parity later.

## Verification

- All 4 tests in `ShardedTopicsNamedBrokerTests` pass after the refactor.
- `dotnet build wolverine.slnx -c Release` — clean, which also confirms the seven other transports' sharded topologies still bind to the unchanged four-argument constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
