### PR TITLE
Fail fast when an endpoint advertises a body its HTTP method cannot carry (#3648)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/bodyless_method_request_body_guard_3648.cs
+++ b/src/Http/Wolverine.Http.Tests/bodyless_method_request_body_guard_3648.cs
@@ -1,0 +1,125 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+using Wolverine.Attributes;
+
+namespace Wolverine.Http.Tests;
+
+// GH-3648: an endpoint that advertises a request body on a method that cannot carry one is unreachable.
+// ASP.NET Core's AcceptsMatcherPolicy compiles IAcceptsMetadata into content-type edges in the route
+// matcher, so the endpoint is dropped from candidate selection and every request returns a bare 404 --
+// not a 415, with nothing logged. That silence is what made GH-3591/GH-3630 so hard to diagnose, so this
+// now fails fast at startup instead.
+//
+// As with the GH-3135 guard above, these intentionally-invalid endpoints carry [WolverineIgnore] so the
+// shared application host never discovers them; ChainFor builds them directly.
+public class bodyless_method_request_body_guard_3648
+{
+    [Fact]
+    public void throws_for_a_get_decorated_with_accepts_content_type()
+    {
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            HttpChain.ChainFor<GetWithAcceptsContentType>(x => x.Get(null!)));
+
+        ex.Message.ShouldContain("GET");
+        ex.Message.ShouldContain("would return 404");
+        ex.Message.ShouldContain("[AcceptsContentType(\"application/json\")]");
+    }
+
+    [Fact]
+    public void throws_for_a_get_whose_asparameters_type_binds_from_a_form()
+    {
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            HttpChain.ChainFor<GetWithFormMembers>(x => x.Get(null!)));
+
+        ex.Message.ShouldContain("bind from a form");
+    }
+
+    [Fact]
+    public void throws_for_a_get_taking_a_file_parameter()
+    {
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            HttpChain.ChainFor<GetWithFileParameter>(x => x.Get(null!)));
+
+        ex.Message.ShouldContain("read from a form");
+    }
+
+    [Fact]
+    public void the_same_shapes_are_fine_on_post()
+    {
+        // The guard is about the HTTP method, not the binding. Every shape above is legitimate on POST.
+        Should.NotThrow(() => HttpChain.ChainFor<PostWithAcceptsContentType>(x => x.Post(null!)));
+        Should.NotThrow(() => HttpChain.ChainFor<PostWithFormMembers>(x => x.Post(null!)));
+    }
+
+    [Fact]
+    public void a_query_only_get_is_still_allowed()
+    {
+        // After GH-3630 a query-only [AsParameters] GET emits no Accepts metadata at all, so it must not
+        // trip this guard -- that combination is the single most common Wolverine HTTP endpoint shape.
+        Should.NotThrow(() => HttpChain.ChainFor<GetWithQueryOnly>(x => x.Get(null!)));
+    }
+
+    [Fact]
+    public void a_delete_with_a_body_is_deliberately_still_allowed()
+    {
+        // DELETE with a request body has no defined semantics but is not forbidden, and some APIs rely on
+        // it. Failing those at startup would be a gratuitous break, so the guard covers GET/HEAD only.
+        Should.NotThrow(() => HttpChain.ChainFor<DeleteWithAcceptsContentType>(x => x.Delete(null!)));
+    }
+}
+
+public record Gh3648Payload(string Name);
+
+public record Gh3648FormCommand([FromForm] string Name);
+
+public record Gh3648QueryCommand([FromQuery] string? Name);
+
+public class GetWithAcceptsContentType
+{
+    [WolverineIgnore]
+    [WolverineGet("/3648/get-accepts"), AcceptsContentType("application/json")]
+    public string Get(Gh3648Payload payload) => "nope";
+}
+
+public class GetWithFormMembers
+{
+    [WolverineIgnore]
+    [WolverineGet("/3648/get-form")]
+    public string Get([AsParameters] Gh3648FormCommand command) => "nope";
+}
+
+public class GetWithFileParameter
+{
+    [WolverineIgnore]
+    [WolverineGet("/3648/get-file")]
+    public string Get(IFormFile file) => "nope";
+}
+
+public class GetWithQueryOnly
+{
+    [WolverineIgnore]
+    [WolverineGet("/3648/get-query")]
+    public string Get([AsParameters] Gh3648QueryCommand command) => "ok";
+}
+
+public class PostWithAcceptsContentType
+{
+    [WolverineIgnore]
+    [WolverinePost("/3648/post-accepts"), AcceptsContentType("application/json")]
+    public string Post(Gh3648Payload payload) => "ok";
+}
+
+public class PostWithFormMembers
+{
+    [WolverineIgnore]
+    [WolverinePost("/3648/post-form")]
+    public string Post([AsParameters] Gh3648FormCommand command) => "ok";
+}
+
+public class DeleteWithAcceptsContentType
+{
+    [WolverineIgnore]
+    [WolverineDelete("/3648/delete-accepts"), AcceptsContentType("application/json")]
+    public string Delete(Gh3648Payload payload) => "ok";
+}

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -516,15 +516,28 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
             .WithMetadata(new HttpMethodMetadata(_httpMethods));
             //.WithMetadata(Method.Method);
 
+        // Checked outside the HasRequestType branch below on purpose. On a GET a complex parameter binds
+        // from the query string rather than the body, so no Accepts metadata is produced -- but the
+        // attribute itself still reaches the endpoint metadata through the GetCustomAttributes() loop at
+        // the end of this method, and ContentTypeEndpointSelectorPolicy filters candidates on the
+        // attribute directly. The endpoint is just as unreachable, via the other policy. See GH-3648.
+        if (Method.Method.TryGetAttribute<AcceptsContentTypeAttribute>(out var declaredAccepts))
+        {
+            assertCanReceiveARequestBody(
+                $"it is decorated with [AcceptsContentType(\"{declaredAccepts.ContentTypes.Join("\", \"")}\")]");
+        }
+
         if (HasRequestType && ReadsRequestBody)
         {
             if (IsFormData)
             {
+                assertCanReceiveARequestBody("its [AsParameters] or [FromForm] members bind from a form");
                 Metadata.Accepts(RequestType, true, "application/x-www-form-urlencoded", "multipart/form-data");
             }
-            else if (Method.Method.TryGetAttribute<AcceptsContentTypeAttribute>(out var acceptsAtt))
+            else if (declaredAccepts != null)
             {
-                Metadata.Accepts(RequestType, false, acceptsAtt.ContentTypes[0], acceptsAtt.ContentTypes[1..]);
+                Metadata.Accepts(RequestType, false, declaredAccepts.ContentTypes[0],
+                    declaredAccepts.ContentTypes[1..]);
             }
             else
             {
@@ -533,6 +546,8 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
         }
         else if (FileParameters.Any())
         {
+            assertCanReceiveARequestBody(
+                $"it takes the file parameter '{FileParameters[0].Name}', which is read from a form");
             Metadata.Accepts(typeof(IFormFile), true, "application/x-www-form-urlencoded", "multipart/form-data");
         }
 
@@ -540,6 +555,34 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
         foreach (var attribute in Method.HandlerType.GetCustomAttributes()) Metadata.WithMetadata(attribute);
         foreach (var attribute in Method.Method.GetCustomAttributes()) Metadata.WithMetadata(attribute);
+    }
+
+    // GET and HEAD only. DELETE is deliberately NOT included: a request body on DELETE has no defined
+    // semantics but is not forbidden, and some APIs do rely on it -- failing those at startup would be a
+    // gratuitous break. See GH-3648.
+    private static readonly string[] BodylessHttpMethods = ["GET", "HEAD"];
+
+    /// <summary>
+    ///     Fail fast when a chain would advertise a request body on an HTTP method that cannot carry one.
+    ///     This is never a configuration anyone wants: ASP.NET Core's <c>AcceptsMatcherPolicy</c> compiles
+    ///     <c>IAcceptsMetadata</c> into content-type edges in the route matcher, so such an endpoint is
+    ///     silently dropped from candidate selection and every request to it returns a bare <b>404</b> --
+    ///     not a 415, not an error, and nothing is logged. That is what made GH-3591/GH-3630 so hard to
+    ///     diagnose, and the endpoint is unreachable either way. See GH-3648.
+    /// </summary>
+    private void assertCanReceiveARequestBody(string why)
+    {
+        if (_httpMethods.Count == 0 || !_httpMethods.All(x => BodylessHttpMethods.Contains(x)))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"HTTP endpoint {Method.HandlerType.FullNameInCode()}.{Method.Method.Name} is mapped to " +
+            $"{_httpMethods.Join("/")} {RoutePattern?.RawText}, but declares a request body because {why}. " +
+            $"A {_httpMethods.Join("/")} request carries no body, so ASP.NET Core would drop this endpoint from " +
+            "route matching entirely and every request to it would return 404. Either map it to a method that " +
+            "takes a body (POST/PUT/PATCH), or bind from the query string, route, or headers instead.");
     }
 
     private void applyAntiforgeryMetadata()


### PR DESCRIPTION
Closes #3648.

An endpoint that declares a request body on **GET or HEAD** is unreachable, and fails in the least diagnosable way available. ASP.NET Core's `AcceptsMatcherPolicy` compiles `IAcceptsMetadata` into content-type edges in the route matcher, so the endpoint is dropped from candidate selection and every request returns a bare **404** — not a 415, not an exception, nothing logged. That silence is why #3591 was closed as unreproducible and why #3630 needed a full repro app to pin down.

It now throws at chain-build time, naming the endpoint, the route, the methods it's mapped to, and which of the three causes applies:

- `[AcceptsContentType(...)]` on the method
- `[AsParameters]` / `[FromForm]` members that bind from a form
- an `IFormFile` parameter

```
HTTP endpoint MyApp.Endpoints.GetCheck is mapped to GET /api/check, but declares a
request body because it is decorated with [AcceptsContentType("application/json")].
A GET request carries no body, so ASP.NET Core would drop this endpoint from route
matching entirely and every request to it would return 404. Either map it to a
method that takes a body (POST/PUT/PATCH), or bind from the query string, route, or
headers instead.
```

## One thing worth reviewing

The `[AcceptsContentType]` check sits **outside** the `HasRequestType` branch on purpose. On a GET a complex parameter binds from the query string rather than the body, so no `Accepts` metadata is produced — but the attribute still reaches the endpoint metadata through the trailing `GetCustomAttributes()` loop, and `ContentTypeEndpointSelectorPolicy` filters candidates on the **attribute** directly (see #3649). The endpoint is equally unreachable, just via the other policy.

My first attempt had the check inside that branch and the test caught it, so this is a case where the two-policy split in #3649 mattered in practice.

## Scope decisions

**DELETE is deliberately excluded.** A request body on DELETE has no defined semantics but is not forbidden, and real APIs rely on it — failing those at startup would be a gratuitous break. The guard covers GET and HEAD only, with a test pinning that DELETE still passes. Say the word if you'd rather it were included.

**This is a behaviour change.** An application with one of these endpoints now fails at startup instead of silently 404ing. That's the intent — the endpoint never worked — but it is a break and worth a release note. The alternative from the issue was to warn and drop the metadata; I went with throw because it matches the existing chain-validation guards (duplicate `[FromBody]`, duplicate form key) and because there is no scenario where the current behaviour is wanted. Easy to soften to a warning if you'd prefer.

## Tests

`bodyless_method_request_body_guard_3648` covers all three causes, that the same shapes are fine on POST, that DELETE is untouched, and — the one that matters most — that a **query-only `[AsParameters]` GET does not trip the guard**. After #3630 that shape emits no `Accepts` metadata, and it's the single most common Wolverine HTTP endpoint; a guard that broke it would be worse than the bug.

Full `Wolverine.Http.Tests` green (924), so nothing in the repo's own endpoint surface trips it. `dotnet build wolverine.slnx -c Release` clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkMdiGxiwpnkpKK2VUPqVf