### PR TITLE
EnvelopeMapper reads both timestamp header formats (#3645, step 1 of 2)

### DIFF
--- a/src/Testing/CoreTests/Transports/envelope_mapper_reads_both_timestamp_formats_3645.cs
+++ b/src/Testing/CoreTests/Transports/envelope_mapper_reads_both_timestamp_formats_3645.cs
@@ -1,0 +1,105 @@
+using Shouldly;
+using Wolverine.Runtime.Serialization;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Transports;
+
+/// <summary>
+///     GH-3645, step ONE. Wolverine has two writers for the same timestamp header keys:
+///     <see cref="EnvelopeMapper{TIncoming,TOutgoing}" /> emits
+///     <see cref="EnvelopeConstants.TransportHeaderDateTimeFormat" /> (<c>"yyyy-MM-dd HH:mm:ss:ffffff Z"</c>),
+///     while <see cref="EnvelopeSerializer" /> emits round-trippable <c>"o"</c>. The mapper's reader only ever
+///     accepted its own format, so an <c>"o"</c> value — from the serializer, from a non-Wolverine producer, or
+///     from a future Wolverine that has flipped its writers — bound as <c>default</c>/<c>null</c> silently.
+///     That silent-null is precisely the failure mode of GH-1716 and GH-3613.
+///
+///     <para>The reader now accepts both. The <b>writer is deliberately unchanged</b> and pinned below: readers
+///     have to tolerate both formats in a shipped release before the writers can flip, or a newer sender talking
+///     to an older receiver reintroduces the silent null.</para>
+/// </summary>
+public class envelope_mapper_reads_both_timestamp_formats_3645
+{
+    private static readonly DateTimeOffset TheTimestamp =
+        new DateTimeOffset(2026, 7, 30, 18, 25, 40, TimeSpan.Zero).AddTicks(4828020);
+
+    private static Envelope readBack(string headerValue, string key)
+    {
+        var incoming = new StubTransportMessage();
+        incoming.Headers[key] = headerValue;
+
+        var envelope = new Envelope();
+        new StubEnvelopeMapper(new StubEndpoint()).MapIncomingToEnvelope(envelope, incoming);
+        return envelope;
+    }
+
+    [Fact]
+    public void reads_the_legacy_transport_header_format()
+    {
+        // Unchanged behaviour: this is still what the mapper writes.
+        var value = TheTimestamp.ToString(EnvelopeConstants.TransportHeaderDateTimeFormat);
+
+        readBack(value, EnvelopeConstants.ExecutionTimeKey)
+            .ScheduledTime!.Value.ToUniversalTime().ShouldBe(TheTimestamp);
+    }
+
+    [Fact]
+    public void reads_the_round_trippable_format()
+    {
+        // New: an "o" value used to bind null.
+        readBack(TheTimestamp.ToString("o"), EnvelopeConstants.ExecutionTimeKey)
+            .ScheduledTime!.Value.ToUniversalTime().ShouldBe(TheTimestamp);
+    }
+
+    [Fact]
+    public void reads_a_deliver_by_in_the_round_trippable_format()
+    {
+        readBack(TheTimestamp.ToString("o"), EnvelopeConstants.DeliverByKey)
+            .DeliverBy!.Value.ToUniversalTime().ShouldBe(TheTimestamp);
+    }
+
+    [Fact]
+    public void an_unreadable_timestamp_still_binds_nothing_rather_than_throwing()
+    {
+        readBack("not a timestamp at all", EnvelopeConstants.ExecutionTimeKey)
+            .ScheduledTime.ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     The point of the whole exercise: a value written by Wolverine's OTHER writer must be readable by the
+    ///     mapper. Before this change the two sides could not read each other.
+    /// </summary>
+    [Fact]
+    public void a_value_written_by_the_envelope_serializer_is_readable_by_the_mapper()
+    {
+        var outgoing = new Envelope
+        {
+            ScheduledTime = TheTimestamp,
+            MessageType = "some-message",
+            Data = [1, 2, 3]
+        };
+
+        var roundTripped = EnvelopeSerializer.Deserialize(EnvelopeSerializer.Serialize(outgoing));
+
+        // Take what the binary format put on the wire for this key and feed it to the mapper's reader.
+        readBack(roundTripped.ScheduledTime!.Value.ToString("o"), EnvelopeConstants.ExecutionTimeKey)
+            .ScheduledTime!.Value.ToUniversalTime().ShouldBe(TheTimestamp);
+    }
+
+    /// <summary>
+    ///     Pins step ONE as step one. The writer must still emit the legacy format until a later release, so
+    ///     that a newer sender cannot hand an older receiver something it cannot parse. When GH-3645 step two
+    ///     lands, this assertion flips to <c>"o"</c> — deliberately, not by accident.
+    /// </summary>
+    [Fact]
+    public void the_writer_still_emits_the_legacy_format()
+    {
+        var outgoing = new Envelope { ScheduledTime = TheTimestamp };
+        var written = new StubTransportMessage();
+
+        new StubEnvelopeMapper(new StubEndpoint()).MapEnvelopeToOutgoing(outgoing, written);
+
+        written.Headers[EnvelopeConstants.ExecutionTimeKey]
+            .ShouldBe(TheTimestamp.ToString(EnvelopeConstants.TransportHeaderDateTimeFormat));
+    }
+}

--- a/src/Wolverine/Transports/EnvelopeMapper.cs
+++ b/src/Wolverine/Transports/EnvelopeMapper.cs
@@ -70,6 +70,30 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
     // Shared with EnvelopeSerializer.tryReadTimestamp so that the reader always understands what this
     // writer emits — the two drifting apart is GH-3613.
     private const string DateTimeOffsetFormat = EnvelopeConstants.TransportHeaderDateTimeFormat;
+
+    /// <summary>
+    ///     Read a timestamp header written in EITHER of the two shapes Wolverine puts on the wire: this
+    ///     mapper's own <see cref="EnvelopeConstants.TransportHeaderDateTimeFormat" />, or the round-trippable
+    ///     <c>"o"</c> that <see cref="Wolverine.Runtime.Serialization.EnvelopeSerializer" /> writes and that any
+    ///     non-Wolverine producer would use.
+    ///
+    ///     <para>This is step ONE of GH-3645. The writers still emit the legacy format; teaching every reader to
+    ///     accept both has to ship first, or a mixed-version fleet would silently bind <c>null</c> for
+    ///     <c>ScheduledTime</c> / <c>DeliverBy</c> when a newer sender met an older receiver — which is exactly
+    ///     the failure GH-1716 and GH-3613 were. Flipping the writers is a separate, later change.</para>
+    /// </summary>
+    internal static bool TryParseTimestamp(string? raw, out DateTimeOffset value)
+    {
+        // Tried first: it is still what this mapper writes, so it is the common case on the wire today.
+        if (DateTimeOffset.TryParseExact(raw, DateTimeOffsetFormat, null, DateTimeStyles.AssumeUniversal,
+                out value))
+        {
+            return true;
+        }
+
+        return DateTimeOffset.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal,
+            out value);
+    }
     private readonly Endpoint _endpoint;
 
     private readonly Dictionary<PropertyInfo, string> _envelopeToHeader = new();
@@ -345,8 +369,7 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         {
             var typed = (Action<Envelope, DateTimeOffset>)setter.CreateDelegate(typeof(Action<Envelope, DateTimeOffset>));
             return (env, inc) => typed(env,
-                read(env, inc, headerKey, out var raw) && DateTimeOffset.TryParseExact(raw, DateTimeOffsetFormat,
-                    null, DateTimeStyles.AssumeUniversal, out var time)
+                read(env, inc, headerKey, out var raw) && TryParseTimestamp(raw, out var time)
                     ? time
                     : default);
         }
@@ -354,8 +377,7 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         {
             var typed = (Action<Envelope, DateTimeOffset?>)setter.CreateDelegate(typeof(Action<Envelope, DateTimeOffset?>));
             return (env, inc) => typed(env,
-                read(env, inc, headerKey, out var raw) && DateTimeOffset.TryParseExact(raw, DateTimeOffsetFormat,
-                    null, DateTimeStyles.AssumeUniversal, out var time)
+                read(env, inc, headerKey, out var raw) && TryParseTimestamp(raw, out var time)
                     ? time
                     : null);
         }
@@ -594,7 +616,7 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
     {
         if (tryReadIncomingHeader(incoming, key, out var raw))
         {
-            if (DateTimeOffset.TryParseExact(raw, DateTimeOffsetFormat, null, DateTimeStyles.AssumeUniversal,  out var flag))
+            if (TryParseTimestamp(raw, out var flag))
             {
                 return flag;
             }
@@ -607,8 +629,7 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
     {
         if (tryReadIncomingHeader(incoming, key, out var raw))
         {
-            if (DateTimeOffset.TryParseExact(raw, DateTimeOffsetFormat, null, DateTimeStyles.AssumeUniversal,
-                    out var flag))
+            if (TryParseTimestamp(raw, out var flag))
             {
                 return flag;
             }


### PR DESCRIPTION
Addresses #3645. **Step one of two — deliberately does not close it.**

## The problem

Wolverine has two writers for the same timestamp header keys (`time-to-send`, `deliver-by`):

| writer | format |
|---|---|
| `EnvelopeMapper<,>` | `EnvelopeConstants.TransportHeaderDateTimeFormat` — `"yyyy-MM-dd HH:mm:ss:ffffff Z"` |
| `EnvelopeSerializer` | round-trippable `"o"` |

The mapper's reader only ever accepted its own format. All four parse sites were `TryParseExact(raw, DateTimeOffsetFormat, …)`, and a failed parse falls through to `default`/`null` rather than throwing — so an `"o"` value bound as **null, silently**. That is precisely the failure mode of #1716 and #3613, sitting in the other reader the whole time.

An `"o"` value reaches this reader from `EnvelopeSerializer`, from any non-Wolverine producer, and — critically — from a future Wolverine that has flipped its writers.

## The change

All four sites (the two compiled-delegate readers and the two `protected readDateTimeOffset` helpers) now go through one `TryParseTimestamp`, which tries the legacy format first — it's still what we write, so it's the common case on the wire — then falls back to a standard parse.

## Why the writers are untouched

**This is the ordering the issue calls for, and getting it backwards reintroduces the bug we just fixed.** If writers flipped to `"o"` first, a newer sender talking to an older receiver would hand it a value that receiver's `TryParseExact` cannot read, and `ScheduledTime`/`DeliverBy` would silently bind null across a mixed-version fleet.

So: readers tolerate both in a shipped release, **then** writers flip in a later one. There's a test (`the_writer_still_emits_the_legacy_format`) pinning the writer so step two is a deliberate flip rather than an accident, and #3645 stays open to hold it.

## Tests

`envelope_mapper_reads_both_timestamp_formats_3645`:

- legacy format still reads (unchanged behaviour)
- `"o"` reads, for both `time-to-send` and `deliver-by`
- an unreadable value still binds nothing rather than throwing
- **the cross-writer case that is the whole point**: a value produced by `EnvelopeSerializer` is readable by the mapper
- the writer still emits the legacy format

**3 of 6 fail on unmodified `main`.** Full `CoreTests` green (2075). `dotnet build wolverine.slnx -c Release` clean, 0 warnings.

## Still to decide (step two)

Flipping `writeDateTimeOffset` / `writeNullableDateTimeOffset` to `"o"`. Worth confirming before then whether any persisted artifact captured the legacy shape and is replayed later — DLQ rows, inbox headers. The reader tolerance covers it either way, but it should be a deliberate check rather than an assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkMdiGxiwpnkpKK2VUPqVf