### PR TITLE
Dead-letter scheduled entries that repeatedly fail to deserialize (#3644)

### DIFF
--- a/src/Transports/Redis/Wolverine.Redis.Tests/unreadable_scheduled_entries_are_dead_lettered_3644.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/unreadable_scheduled_entries_are_dead_lettered_3644.cs
@@ -1,0 +1,205 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using StackExchange.Redis;
+using Wolverine.Redis.Internal;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+/// <summary>
+///     GH-3644, the residual of GH-3613. That fix stopped the scheduled sweeps deleting entries they could not
+///     deserialize, because doing so was silently destroying scheduled retries. The cost was that a genuinely
+///     unreadable payload then stayed in <c>{stream}:scheduled</c> forever and re-warned on every sweep.
+///
+///     <para>Now the sweep counts consecutive read failures per entry and, once
+///     <see cref="RedisTransport.MaxScheduledReadAttempts" /> is reached, moves the raw bytes to the dead letter
+///     stream. The entry is never simply dropped, and never removed from the sorted set until it is safely in
+///     the dead letter stream.</para>
+/// </summary>
+[Collection("UnreadableScheduled3644")]
+public class unreadable_scheduled_entries_are_dead_lettered_3644 : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private RedisStreamListener _listener = null!;
+    private RedisTransport _transport = null!;
+    private IDatabase _database = null!;
+    private RedisStreamEndpoint _endpoint = null!;
+
+    // Not a valid serialized Envelope, so EnvelopeSerializer.Deserialize throws on it every time.
+    private static readonly RedisValue UnreadablePayload = new byte[] { 0xFF, 0x00, 0x13, 0x37, 0x42 };
+
+    public async Task InitializeAsync()
+    {
+        var streamKey = $"unreadable-3644-{Guid.NewGuid():N}";
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "Unreadable3644";
+                opts.UseRedisTransport(RedisContainerFixture.ConnectionString).AutoProvision();
+                opts.ListenToRedisStream(streamKey, "unreadable-3644-group")
+                    .StartFromBeginning()
+                    .EnableNativeDeadLetterQueue();
+            }).StartAsync();
+
+        var runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
+        _transport = runtime.Options.Transports.GetOrCreate<RedisTransport>();
+        _endpoint = _transport.StreamEndpoint(streamKey);
+        _database = _transport.GetDatabase(database: 0);
+
+        _listener = new RedisStreamListener(_transport, _endpoint, runtime, Substitute.For<IReceiver>());
+
+        await resetAsync();
+    }
+
+    private async Task resetAsync()
+    {
+        await _database.KeyDeleteAsync(_endpoint.ScheduledMessagesKey);
+        await _database.KeyDeleteAsync(_endpoint.UnreadableScheduledMessagesKey);
+        await _database.KeyDeleteAsync(_endpoint.DeadLetterQueueKey);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await resetAsync();
+        await _listener.DisposeAsync();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private Task planAsync() => _database.SortedSetAddAsync(_endpoint.ScheduledMessagesKey, UnreadablePayload,
+        DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeMilliseconds());
+
+    private Task<long> scheduledCountAsync() => _database.SortedSetLengthAsync(_endpoint.ScheduledMessagesKey);
+
+    private Task<long> deadLetterCountAsync() => _database.StreamLengthAsync(_endpoint.DeadLetterQueueKey);
+
+    [Fact]
+    public async Task an_unreadable_entry_survives_the_attempts_before_the_limit()
+    {
+        _transport.MaxScheduledReadAttempts = 3;
+        await planAsync();
+
+        await _listener.DeleteExpiredAsync(CancellationToken.None);
+        (await scheduledCountAsync()).ShouldBe(1, "still under the limit");
+
+        await _listener.DeleteExpiredAsync(CancellationToken.None);
+        (await scheduledCountAsync()).ShouldBe(1, "still under the limit");
+
+        (await deadLetterCountAsync()).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task an_unreadable_entry_is_dead_lettered_once_the_limit_is_reached()
+    {
+        _transport.MaxScheduledReadAttempts = 3;
+        await planAsync();
+
+        for (var i = 0; i < 3; i++)
+        {
+            await _listener.DeleteExpiredAsync(CancellationToken.None);
+        }
+
+        (await scheduledCountAsync()).ShouldBe(0, "the entry should have left the scheduled set");
+        (await deadLetterCountAsync()).ShouldBe(1, "...by way of the dead letter queue, not by being dropped");
+    }
+
+    [Fact]
+    public async Task the_dead_lettered_entry_carries_the_original_bytes_and_diagnostics()
+    {
+        _transport.MaxScheduledReadAttempts = 1;
+        await planAsync();
+
+        await _listener.DeleteExpiredAsync(CancellationToken.None);
+
+        var entries = await _database.StreamRangeAsync(_endpoint.DeadLetterQueueKey);
+        entries.Length.ShouldBe(1);
+
+        var fields = entries[0].Values.ToDictionary(x => x.Name.ToString(), x => x.Value);
+
+        // The raw payload has to survive verbatim -- it is the only way an operator can recover it.
+        ((byte[])fields["envelope"]!).ShouldBe((byte[])UnreadablePayload!);
+        fields["unreadable-scheduled-message"].ToString().ShouldBe("true");
+        fields[DeadLetterQueueConstants.ExceptionTypeHeader].ToString().ShouldNotBeNullOrEmpty();
+        fields[DeadLetterQueueConstants.OriginalDestinationHeader].ToString().ShouldBe(_endpoint.Uri.ToString());
+    }
+
+    [Fact]
+    public async Task the_failure_counter_is_cleaned_up_after_dead_lettering()
+    {
+        _transport.MaxScheduledReadAttempts = 1;
+        await planAsync();
+
+        await _listener.DeleteExpiredAsync(CancellationToken.None);
+
+        (await _database.HashLengthAsync(_endpoint.UnreadableScheduledMessagesKey)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task setting_the_limit_to_zero_keeps_the_GH_3613_behaviour()
+    {
+        // The escape hatch: never dead-letter, keep the entry indefinitely.
+        _transport.MaxScheduledReadAttempts = 0;
+        await planAsync();
+
+        for (var i = 0; i < 5; i++)
+        {
+            await _listener.DeleteExpiredAsync(CancellationToken.None);
+        }
+
+        (await scheduledCountAsync()).ShouldBe(1);
+        (await deadLetterCountAsync()).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task an_endpoint_without_a_native_dead_letter_queue_keeps_the_entry()
+    {
+        // Nowhere safe to put it, so it stays put rather than being destroyed.
+        _transport.MaxScheduledReadAttempts = 1;
+        _endpoint.NativeDeadLetterQueueEnabled = false;
+        try
+        {
+            await planAsync();
+
+            await _listener.DeleteExpiredAsync(CancellationToken.None);
+
+            (await scheduledCountAsync()).ShouldBe(1);
+        }
+        finally
+        {
+            _endpoint.NativeDeadLetterQueueEnabled = true;
+        }
+    }
+
+    [Fact]
+    public async Task a_readable_expired_message_is_still_evicted_normally()
+    {
+        // Guard against the counting path swallowing the sweep's actual job.
+        _transport.MaxScheduledReadAttempts = 3;
+
+        var envelope = new Envelope
+        {
+            Id = Guid.NewGuid(),
+            MessageType = "retention-message",
+            ContentType = EnvelopeConstants.JsonContentType,
+            Data = [1, 2, 3],
+            DeliverBy = DateTimeOffset.UtcNow.AddMinutes(-1)
+        };
+
+        await _database.SortedSetAddAsync(_endpoint.ScheduledMessagesKey,
+            Runtime.Serialization.EnvelopeSerializer.Serialize(envelope),
+            DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeMilliseconds());
+
+        await _listener.DeleteExpiredAsync(CancellationToken.None);
+
+        (await scheduledCountAsync()).ShouldBe(0);
+        (await deadLetterCountAsync()).ShouldBe(0, "an expired message is evicted, not dead-lettered");
+    }
+}
+
+[CollectionDefinition("UnreadableScheduled3644", DisableParallelization = true)]
+public class UnreadableScheduled3644Collection;

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamEndpoint.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamEndpoint.cs
@@ -46,6 +46,12 @@ public class RedisStreamEndpoint : Endpoint<IRedisEnvelopeMapper, RedisEnvelopeM
     /// The Redis Sorted Set key for scheduled messages
     /// </summary>
     public string ScheduledMessagesKey => $"{StreamKey}:scheduled";
+
+    /// <summary>
+    /// Hash of consecutive read failures per scheduled entry, keyed by the entry's own payload. Bounds how
+    /// long an unreadable scheduled message can sit in the sorted set before being dead-lettered. See GH-3644.
+    /// </summary>
+    public string UnreadableScheduledMessagesKey => $"{StreamKey}:scheduled:unreadable";
     
     /// <summary>
     /// The Redis Stream key for dead letter messages

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
@@ -594,6 +594,94 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
         }
     }
 
+
+    /// <summary>
+    ///     A scheduled entry that cannot be deserialized. Counts consecutive read failures per entry in a
+    ///     side hash and, once <see cref="RedisTransport.MaxScheduledReadAttempts" /> is reached, moves the
+    ///     raw bytes to the dead letter stream and clears them from the scheduled set.
+    ///
+    ///     <para>The entry is never simply dropped: with dead-lettering disabled (either
+    ///     <c>MaxScheduledReadAttempts = 0</c> or an endpoint whose native DLQ is off) it stays in the sorted
+    ///     set exactly as GH-3613 left it. See GH-3644.</para>
+    /// </summary>
+    private async Task handleUnreadableScheduledEntryAsync(IDatabase database, string scheduledKey,
+        RedisValue serializedEnvelope, Exception failure)
+    {
+        var limit = _transport.MaxScheduledReadAttempts;
+
+        if (limit <= 0 || !_endpoint.NativeDeadLetterQueueEnabled)
+        {
+            _logger.LogWarning(failure,
+                "Unable to read a scheduled message in {ScheduledKey} while checking expiration; leaving it in place",
+                scheduledKey);
+            return;
+        }
+
+        var failureKey = _endpoint.UnreadableScheduledMessagesKey;
+
+        long attempts;
+        try
+        {
+            // The payload IS the sorted-set member, so it doubles as a stable hash field. The hash is given
+            // the same lifetime bound as a long-lived scheduled entry so a transient blip cannot leak keys.
+            attempts = await database.HashIncrementAsync(failureKey, serializedEnvelope);
+            await database.KeyExpireAsync(failureKey, TimeSpan.FromDays(7));
+        }
+        catch (Exception counterFailure)
+        {
+            // Failing to count must not escalate into losing the message.
+            _logger.LogWarning(counterFailure,
+                "Unable to record a read failure for a scheduled message in {ScheduledKey}; leaving it in place",
+                scheduledKey);
+            return;
+        }
+
+        if (attempts < limit)
+        {
+            _logger.LogWarning(failure,
+                "Unable to read a scheduled message in {ScheduledKey} while checking expiration (attempt {Attempts} of {Limit}); leaving it in place",
+                scheduledKey, attempts, limit);
+            return;
+        }
+
+        // No Envelope was ever produced, so the usual DeadLetterQueueConstants.StampFailureMetadata path is
+        // unavailable. Write the raw payload plus what diagnostics we do have, so an operator can recover
+        // the bytes by hand.
+        var fields = new List<NameValueEntry>
+        {
+            new("envelope", serializedEnvelope),
+            new(DeadLetterQueueConstants.ExceptionTypeHeader, failure.GetType().FullName ?? "Unknown"),
+            new(DeadLetterQueueConstants.ExceptionMessageHeader, failure.Message ?? ""),
+            new(DeadLetterQueueConstants.ExceptionStackHeader,
+                DeadLetterQueueConstants.TruncateStackTrace(failure.StackTrace)),
+            new(DeadLetterQueueConstants.FailedAtHeader,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()),
+            new(DeadLetterQueueConstants.OriginalDestinationHeader, _endpoint.Uri.ToString()),
+            new("message-type", "Unknown"),
+            new("unreadable-scheduled-message", "true"),
+            new("read-attempts", attempts.ToString())
+        };
+
+        try
+        {
+            var messageId = await database.StreamAddAsync(_endpoint.DeadLetterQueueKey, fields.ToArray());
+
+            // Only stop tracking it once it is safely in the dead letter stream.
+            await database.SortedSetRemoveAsync(scheduledKey, serializedEnvelope);
+            await database.HashDeleteAsync(failureKey, serializedEnvelope);
+
+            _logger.LogError(failure,
+                "A scheduled message in {ScheduledKey} could not be read after {Attempts} attempts and was moved to the dead letter queue {DeadLetterKey} with message ID {MessageId}",
+                scheduledKey, attempts, _endpoint.DeadLetterQueueKey, messageId);
+        }
+        catch (Exception deadLetterFailure)
+        {
+            _logger.LogError(deadLetterFailure,
+                "Unable to move an unreadable scheduled message from {ScheduledKey} to the dead letter queue {DeadLetterKey}; leaving it in place",
+                scheduledKey, _endpoint.DeadLetterQueueKey);
+        }
+    }
+
     public async Task DeleteExpiredAsync(CancellationToken cancellationToken)
     {
         try
@@ -630,13 +718,13 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
                 }
                 catch (Exception ex)
                 {
-                    // Do NOT remove the entry. This sweep only exists to evict messages that are
-                    // genuinely past their DeliverBy; a message we cannot read is not known to be
-                    // expired, and deleting it here silently destroyed scheduled retries that never
-                    // got a chance to redeliver or to reach the dead letter queue (GH-3613).
-                    _logger.LogWarning(ex,
-                        "Unable to read a scheduled message in {ScheduledKey} while checking expiration; leaving it in place",
-                        scheduledKey);
+                    // Never delete outright. This sweep only exists to evict messages that are genuinely
+                    // past their DeliverBy; a message we cannot read is not known to be expired, and
+                    // deleting it here silently destroyed scheduled retries that never got a chance to
+                    // redeliver or to reach the dead letter queue (GH-3613). But leaving it forever means it
+                    // re-warns on every sweep and can never be cleared, so an entry that fails to read
+                    // repeatedly is dead-lettered instead (GH-3644).
+                    await handleUnreadableScheduledEntryAsync(database, scheduledKey, serializedEnvelope, ex);
                 }
             }
 

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisTransport.cs
@@ -55,6 +55,21 @@ public class RedisTransport : BrokerTransport<RedisStreamEndpoint>, IAsyncDispos
     public int ReplyDatabaseId { get; set; } = 0;
 
     /// <summary>
+    /// How many times the scheduled-message sweep will fail to deserialize an entry in
+    /// <c>{stream}:scheduled</c> before moving its raw bytes to the dead letter queue. Defaults to 3.
+    ///
+    /// <para>GH-3613 stopped the sweep from deleting entries it could not read, because that was silently
+    /// destroying scheduled retries. The cost was that a genuinely unreadable payload — a truncated write, a
+    /// serializer change, a hand-edited key — then stayed in the sorted set forever and re-warned on every
+    /// sweep. This bounds that: unreadable is not the same as expired, but it is not permanent either. Set to
+    /// 0 to disable and keep such entries indefinitely. See GH-3644.</para>
+    ///
+    /// <para>Entries are only ever dead-lettered, never dropped, and only when the listening endpoint has its
+    /// native dead letter queue enabled. With it disabled the entry is left in place regardless.</para>
+    /// </summary>
+    public int MaxScheduledReadAttempts { get; set; } = 3;
+
+    /// <summary>
     /// Customizable selector to build a stable consumer name for listeners when an endpoint-level ConsumerName is not set.
     /// Defaults to ServiceName-NodeNumber-MachineName (lowercased and sanitized).
     /// </summary>


### PR DESCRIPTION
Closes #3644. Residual of #3613.

## The trade being rebalanced

#3613 stopped both `{stream}:scheduled` sweeps from deleting entries they could not deserialize, because "can't read it, so drop it" was silently destroying scheduled retries — they never redelivered and never reached the dead letter queue either.

The cost was the other extreme. A genuinely unreadable payload — a truncated write, a serializer change, a hand-edited key — then stayed in the sorted set **forever**: re-warning on every sweep at the durability polling cadence, and showing up as a floor in the scheduled backlog that an operator could not clear.

Unreadable is not the same as expired. But it is not permanent either.

## The change

The sweep now counts consecutive read failures per entry and, once `RedisTransport.MaxScheduledReadAttempts` is reached (default **3**), moves the raw bytes to the dead letter stream and clears them from the scheduled set.

Counts live in `{stream}:scheduled:unreadable`, a hash keyed by the entry's own payload. Redis hash fields are binary-safe, so no digest is needed — and it means the counter is inherently tied to the exact bytes, so a rewritten entry starts fresh rather than inheriting a stale count. A 7-day expiry on the hash keeps a transient blip from leaking keys.

**The entry is never simply dropped.** Every path was written so that the failure mode is "it stays", not "it's gone":

- it leaves the sorted set only **after** the dead letter write succeeds
- `MaxScheduledReadAttempts = 0` disables the whole thing and keeps #3613's behaviour exactly
- an endpoint with its native dead letter queue disabled has nowhere safe to put it, so the entry stays regardless
- a failure to even record the counter leaves the entry alone rather than escalating into a loss

No `Envelope` was ever produced, so `DeadLetterQueueConstants.StampFailureMetadata` is unavailable. The dead letter entry carries the raw payload verbatim under `envelope`, plus exception type/message/stack, failure timestamp, the originating endpoint URI, an `unreadable-scheduled-message` marker, and the attempt count — enough to recover the bytes by hand.

`expiredCount` is deliberately **not** incremented on this path, so the "Deleted N expired scheduled messages" log stays truthful: an unreadable entry was never established to be expired.

## The alternative I didn't take

The issue also floated **log-throttling** — keep leaving the entry, but warn once per entry instead of once per sweep — and I noted at the time it might be the better trade because it keeps the never-destroy guarantee absolute.

I went with dead-lettering because throttling quiets the symptom without ever letting the entry leave, and the operational complaint in the issue is as much "I can't clear this" as "it's noisy". But it is genuinely a judgement call: if you'd rather have the throttle, `MaxScheduledReadAttempts = 0` plus a one-line change to warn once per entry gets there from here, and the config knob is already in place.

## Tests

`unreadable_scheduled_entries_are_dead_lettered_3644`: survival below the limit, dead-lettering at the limit, payload and diagnostics surviving verbatim, counter cleanup afterwards, the zero-disables escape hatch, the no-DLQ-endpoint case, and — the guard that matters — that a readable expired message is still evicted normally rather than dead-lettered.

Full `Wolverine.Redis.Tests` green (**143**), which covers the #3613 sweeps this change sits inside. `dotnet build wolverine.slnx -c Release` clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkMdiGxiwpnkpKK2VUPqVf