### PR TITLE
Oracle: run the durability agent through the shared batching mechanics

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -127,13 +127,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.18.1" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.18.1" />
-    <PackageVersion Include="Weasel.MySql" Version="9.18.1" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.18.1" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.18.1" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.18.1" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.18.1" />
+    <PackageVersion Include="Weasel.Core" Version="9.19.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.19.0" />
+    <PackageVersion Include="Weasel.MySql" Version="9.19.0" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.19.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.19.0" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.19.0" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.19.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/Persistence/Oracle/OracleTests/oracle_durability_agent_recovery.cs
+++ b/src/Persistence/Oracle/OracleTests/oracle_durability_agent_recovery.cs
@@ -1,0 +1,145 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Oracle;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Polling;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+
+namespace OracleTests;
+
+/// <summary>
+///     GH-3614, end to end. The durability agent batches its whole recovery operation set into one
+///     command builder and executes it. On Oracle that batch used to arrive as a single command full
+///     of semicolon-separated statements bound with <c>@</c> markers, which ODP.NET rejected outright
+///     with ORA-00933 / ORA-00936 -- so the agent threw on every sweep and nothing persisted in the
+///     inbox or outbox was ever recovered.
+///     <para>
+///     This runs the real <see cref="DurabilityAgent.buildOperationBatch" /> set against a real Oracle
+///     database, which is the assertion that actually would have caught the bug.
+///     </para>
+/// </summary>
+[Collection("oracle")]
+public class oracle_durability_agent_recovery : IAsyncLifetime
+{
+    private IHost theHost = null!;
+
+    public async Task InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithOracle(Servers.OracleConnectionString, "WOLVERINE");
+
+                // Balanced rather than Solo -- ReleaseOrphanedMessagesOperation is only part of the
+                // recovery batch outside Solo mode, and it is one of the two-statement operations
+                opts.Durability.Mode = DurabilityMode.Balanced;
+            })
+            .StartAsync();
+
+        await theHost.ResetResourceState();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private (IWolverineRuntime, IMessageDatabase) theRuntimeAndDatabase()
+    {
+        var runtime = theHost.Services.GetRequiredService<IWolverineRuntime>();
+        return (runtime, (IMessageDatabase)runtime.Storage);
+    }
+
+    [Fact]
+    public async Task the_full_recovery_batch_executes_against_oracle()
+    {
+        var (runtime, database) = theRuntimeAndDatabase();
+
+        var operations = new DurabilityAgent(runtime, database).buildOperationBatch();
+        operations.ShouldNotBeEmpty();
+
+        // Before the fix this threw DatabaseBatchCommandException wrapping ORA-00933 / ORA-00936
+        await new DatabaseOperationBatch(database, operations).ExecuteAsync(runtime, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task the_recovery_batch_releases_messages_owned_by_a_dead_node()
+    {
+        var (runtime, database) = theRuntimeAndDatabase();
+
+        // Persist an incoming envelope owned by a node number that does not exist any more --
+        // exactly the state ReleaseOrphanedMessagesOperation is there to clean up
+        var envelope = ObjectMother.Envelope();
+        envelope.Status = EnvelopeStatus.Incoming;
+        envelope.OwnerId = 8888;
+
+        await database.Inbox.StoreIncomingAsync(envelope);
+        (await ownerOf(envelope.Id)).ShouldBe(8888);
+
+        await new DatabaseOperationBatch(database, new DurabilityAgent(runtime, database).buildOperationBatch())
+            .ExecuteAsync(runtime, CancellationToken.None);
+
+        (await ownerOf(envelope.Id)).ShouldBe(TransportConstants.AnyNode);
+    }
+
+    [Fact]
+    public async Task replayable_dead_letters_are_moved_back_to_the_inbox()
+    {
+        var (runtime, database) = theRuntimeAndDatabase();
+
+        var envelope = ObjectMother.Envelope();
+        envelope.Status = EnvelopeStatus.Incoming;
+
+        await database.Inbox.StoreIncomingAsync(envelope);
+        await database.Inbox.MoveToDeadLetterStorageAsync(envelope, new DivideByZeroException("boom"));
+        await database.DeadLetters.MarkDeadLetterEnvelopesAsReplayableAsync([envelope.Id]);
+
+        // This is the operation that writes two statements -- the insert and the delete -- so it is
+        // the one that proves per-statement splitting works, not just per-operation
+        await new DatabaseOperationBatch(database, new DurabilityAgent(runtime, database).buildOperationBatch())
+            .ExecuteAsync(runtime, CancellationToken.None);
+
+        (await countAsync(
+                $"select count(*) from WOLVERINE.{DatabaseConstants.IncomingTable} where id = :id", envelope.Id))
+            .ShouldBe(1);
+        (await countAsync(
+                $"select count(*) from WOLVERINE.{DatabaseConstants.DeadLetterTable} where id = :id", envelope.Id))
+            .ShouldBe(0);
+    }
+
+    private async Task<int> ownerOf(Guid id)
+    {
+        await using var conn = new OracleConnection(Servers.OracleConnectionString);
+        await conn.OpenAsync();
+
+        await using var command = conn.CreateCommand();
+        command.BindByName = true;
+        command.CommandText =
+            $"select owner_id from WOLVERINE.{DatabaseConstants.IncomingTable} where id = :id";
+        command.Parameters.Add(new OracleParameter("id", OracleDbType.Raw) { Value = id.ToByteArray() });
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync());
+    }
+
+    private async Task<int> countAsync(string sql, Guid id)
+    {
+        await using var conn = new OracleConnection(Servers.OracleConnectionString);
+        await conn.OpenAsync();
+
+        await using var command = conn.CreateCommand();
+        command.BindByName = true;
+        command.CommandText = sql;
+        command.Parameters.Add(new OracleParameter("id", OracleDbType.Raw) { Value = id.ToByteArray() });
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync());
+    }
+}

--- a/src/Persistence/Oracle/OracleTests/oracle_durability_command_translation.cs
+++ b/src/Persistence/Oracle/OracleTests/oracle_durability_command_translation.cs
@@ -1,0 +1,159 @@
+using System.Data.Common;
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Weasel.Core;
+using Wolverine;
+using Wolverine.Oracle;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Durability;
+using Wolverine.RDBMS.Polling;
+
+namespace OracleTests;
+
+/// <summary>
+///     GH-3614. The durability agent batches several <see cref="IDatabaseOperation" />s into one
+///     command builder. The generic builder emits <c>@</c> bind markers and concatenates every
+///     statement into a single command, and ODP.NET rejects both -- with ORA-00933 / ORA-00936 --
+///     so no persisted inbox or outbox message was ever recovered on Oracle.
+///     <para>
+///     Oracle now hands back a <c>Weasel.Oracle.OracleDbCommandBuilder</c>, which emits <c>:</c>
+///     markers, types parameters through OracleProvider, and splits at each statement boundary.
+///     These assertions run against the real durability operations, and need no database.
+///     </para>
+/// </summary>
+public class oracle_durability_command_translation
+{
+    private static OracleMessageStore theStore()
+    {
+        return new OracleMessageStore(
+            new DatabaseSettings { SchemaName = "WOLVERINE", Role = MessageStoreRole.Main },
+            new DurabilitySettings(),
+            new OracleDataSource(Servers.OracleConnectionString),
+            NullLogger<OracleMessageStore>.Instance);
+    }
+
+    private static IReadOnlyList<DbCommand> compile(params IDatabaseOperation[] operations)
+    {
+        var builder = theStore().ToCommandBuilder();
+
+        foreach (var operation in operations)
+        {
+            builder.StartNewCommand();
+            operation.ConfigureCommand(builder);
+        }
+
+        return builder.CompileCommands();
+    }
+
+    [Fact]
+    public void the_message_store_hands_back_an_oracle_shaped_builder()
+    {
+        theStore().ToCommandBuilder().ShouldBeOfType<Weasel.Oracle.OracleDbCommandBuilder>();
+    }
+
+    [Fact]
+    public void uses_oracle_bind_markers_rather_than_the_generic_ones()
+    {
+        var commands = compile(
+            new DeleteExpiredEnvelopesOperation(new DbObjectName("WOLVERINE", "wolverine_incoming_envelopes"),
+                DateTimeOffset.UtcNow));
+
+        var sql = commands.Single().CommandText;
+
+        sql.ShouldContain(":p0");
+        sql.ShouldNotContain("@");
+    }
+
+    [Fact]
+    public void separates_batched_operations_into_individual_oracle_statements()
+    {
+        var store = theStore();
+
+        var commands = compile(
+            new DeleteExpiredEnvelopesOperation(new DbObjectName("WOLVERINE", "wolverine_incoming_envelopes"),
+                DateTimeOffset.UtcNow),
+            new MoveReplayableErrorMessagesToIncomingOperation(store),
+            new DeleteOldNodeEventRecords(store, new DurabilitySettings()));
+
+        // One command per *statement*, not per operation -- ODP.NET cannot execute several statements
+        // from one command, and MoveReplayableErrorMessagesToIncomingOperation writes two (the insert
+        // and the delete)
+        commands.Count.ShouldBe(4);
+
+        foreach (var command in commands)
+        {
+            command.ShouldBeOfType<OracleCommand>().BindByName.ShouldBeTrue();
+            command.CommandText.ShouldNotContain(";");
+        }
+    }
+
+    [Fact]
+    public void each_statement_only_carries_its_own_parameters()
+    {
+        var commands = compile(
+            new DeleteExpiredEnvelopesOperation(new DbObjectName("WOLVERINE", "wolverine_incoming_envelopes"),
+                DateTimeOffset.UtcNow),
+            new DeleteExpiredDeadLetterMessagesOperation(theStore(), NullLogger.Instance, DateTimeOffset.UtcNow));
+
+        commands.Count.ShouldBe(2);
+
+        foreach (var command in commands)
+        {
+            foreach (DbParameter parameter in command.Parameters)
+            {
+                command.CommandText.ShouldContain(":" + parameter.ParameterName);
+            }
+        }
+    }
+
+    [Fact]
+    public void converts_boolean_parameters_to_an_oracle_number()
+    {
+        var commands = compile(new MoveReplayableErrorMessagesToIncomingOperation(theStore()));
+
+        // The insert and the delete both bind :replayable, and it is only ever created once, so
+        // both split commands have to carry it
+        commands.Count.ShouldBe(2);
+
+        foreach (var command in commands)
+        {
+            var parameter = command.Parameters
+                .Cast<OracleParameter>()
+                .Single(x => x.ParameterName == "replayable");
+
+            parameter.OracleDbType.ShouldBe(OracleDbType.Int16);
+            parameter.Value.ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public void converts_guid_parameters_to_oracle_raw()
+    {
+        var id = Guid.NewGuid();
+        var builder = theStore().ToCommandBuilder();
+
+        builder.Append("select 1 from dual where id = ");
+        builder.AppendParameter(id);
+
+        var parameter = (OracleParameter)builder.CompileCommands().Single().Parameters[0];
+
+        parameter.OracleDbType.ShouldBe(OracleDbType.Raw);
+        parameter.Value.ShouldBe(id.ToByteArray());
+    }
+
+    [Fact]
+    public void date_time_offsets_keep_their_oracle_type()
+    {
+        var commands = compile(
+            new DeleteExpiredEnvelopesOperation(new DbObjectName("WOLVERINE", "wolverine_incoming_envelopes"),
+                DateTimeOffset.UtcNow));
+
+        commands.Single().Parameters
+            .Cast<OracleParameter>()
+            .Single().OracleDbType.ShouldBe(OracleDbType.TimeStampTZ);
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
@@ -387,10 +387,12 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
     // IMessageDatabase - extra methods
     public Weasel.Core.DbCommandBuilder ToCommandBuilder()
     {
-        // The IMessageDatabase interface requires DbCommandBuilder, but we create an OracleCommandBuilder
-        // internally. Return a DbCommandBuilder that uses Oracle's OracleCommand as the underlying command.
+        // OracleDbCommandBuilder is a DbCommandBuilder, so it satisfies IMessageDatabase, but it emits
+        // Oracle's ':' bind markers instead of the generic '@', types parameters through OracleProvider
+        // (Guid as RAW(16), bool as NUMBER(1)), and -- because ODP.NET cannot execute several statements
+        // from one command -- splits at each StartNewCommand() boundary into one command per statement.
         // Our dead letter methods use ToOracleCommandBuilder() instead.
-        return new Weasel.Core.DbCommandBuilder(CreateConnection());
+        return new Weasel.Oracle.OracleDbCommandBuilder();
     }
 
     internal Weasel.Oracle.CommandBuilder ToOracleCommandBuilder()
@@ -403,7 +405,11 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
 
     public Task EnqueueAsync(IDatabaseOperation operation)
     {
-        // For Oracle, we execute operations directly since we can't batch
+        // NOTE: this silently drops the operation. OracleMessageStore implements IMessageDatabase
+        // directly rather than deriving from MessageDatabase, so it has no DatabaseBatcher to hand
+        // the operation to. The durability agent does not use this path -- it builds its own
+        // DatabaseOperationBatch -- and the one caller that does, OracleNodePersistence.LogRecordsAsync,
+        // works around it by inserting directly. Tracked separately; see the comment there.
         return Task.CompletedTask;
     }
 

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleNodePersistence.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleNodePersistence.cs
@@ -340,9 +340,8 @@ internal class OracleNodePersistence : DatabaseConstants, INodeAgentPersistence
     {
         if (records.Length == 0) return;
 
-        // OracleMessageStore.EnqueueAsync is a no-op (the shared DatabaseBatcher uses
-        // @-prefixed parameter syntax that Oracle rejects), so insert each record
-        // directly using the Oracle command extensions.
+        // OracleMessageStore.EnqueueAsync is a no-op -- it has no DatabaseBatcher to hand the
+        // operation to -- so insert each record directly using the Oracle command extensions.
         await using var conn = await _dataSource.OpenConnectionAsync();
         try
         {

--- a/src/Persistence/Wolverine.RDBMS/Durability/MoveReplayableErrorMessagesToIncomingOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/MoveReplayableErrorMessagesToIncomingOperation.cs
@@ -24,10 +24,15 @@ internal class MoveReplayableErrorMessagesToIncomingOperation : IDatabaseOperati
         builder.Append(
             $"select {DatabaseConstants.Body}, {DatabaseConstants.Id}, '{EnvelopeStatus.Incoming}', 0, null, 0, {DatabaseConstants.MessageType}, {DatabaseConstants.ReceivedAt}, null ");
         builder.Append(
-            $"from {_database.SchemaName}.{DatabaseConstants.DeadLetterTable} where {DatabaseConstants.Replayable} = @replayable;");
+            $"from {_database.SchemaName}.{DatabaseConstants.DeadLetterTable} where {DatabaseConstants.Replayable} = {builder.ParameterPrefix}replayable;");
         builder.AddNamedParameter("replayable", true);
+
+        // This operation writes two statements, so the boundary has to be explicit -- the trailing
+        // semicolon is enough for the providers that concatenate, but Oracle needs a real split
+        builder.StartNewCommand();
+
         builder.Append(
-            $"delete from {_database.SchemaName}.{DatabaseConstants.DeadLetterTable} where {DatabaseConstants.Replayable} = @replayable;");
+            $"delete from {_database.SchemaName}.{DatabaseConstants.DeadLetterTable} where {DatabaseConstants.Replayable} = {builder.ParameterPrefix}replayable;");
     }
 
     public Task ReadResultsAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)

--- a/src/Persistence/Wolverine.RDBMS/Durability/PersistNodeRecord.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/PersistNodeRecord.cs
@@ -23,6 +23,10 @@ public class PersistNodeRecord : IDatabaseOperation, IDoNotReturnData
 
         foreach (var @event in _events)
         {
+            // One insert per event, so each is its own statement for the providers that cannot
+            // execute several from one command
+            builder.StartNewCommand();
+
             builder.Append("insert into ");
 
             // GH-2940: emit the schema identifier unquoted, matching every other durability SQL

--- a/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesForAncillaryOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesForAncillaryOperation.cs
@@ -36,6 +36,11 @@ internal class ReleaseOrphanedMessagesForAncillaryOperation : IDatabaseOperation
 
         builder.Append(
             $"update {incomingTable} set {DatabaseConstants.OwnerId} = 0 where {DatabaseConstants.OwnerId} != 0 and {DatabaseConstants.OwnerId} not in ({nodeList});");
+
+        // Two statements in one operation, so the boundary has to be explicit for the providers
+        // that cannot execute several statements from one command
+        builder.StartNewCommand();
+
         builder.Append(
             $"update {outgoingTable} set {DatabaseConstants.OwnerId} = 0 where {DatabaseConstants.OwnerId} != 0 and {DatabaseConstants.OwnerId} not in ({nodeList});");
     }

--- a/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesOperation.cs
@@ -30,6 +30,11 @@ internal class ReleaseOrphanedMessagesOperation : IDatabaseOperation, IDoNotRetu
 
         builder.Append(
             $"update {incomingTable} set {DatabaseConstants.OwnerId} = 0 where {DatabaseConstants.OwnerId} != 0 and {DatabaseConstants.OwnerId} not in (select {DatabaseConstants.NodeNumber} from {nodesTable});");
+
+        // Two statements in one operation, so the boundary has to be explicit for the providers
+        // that cannot execute several statements from one command
+        builder.StartNewCommand();
+
         builder.Append(
             $"update {outgoingTable} set {DatabaseConstants.OwnerId} = 0 where {DatabaseConstants.OwnerId} != 0 and {DatabaseConstants.OwnerId} not in (select {DatabaseConstants.NodeNumber} from {nodesTable});");
     }

--- a/src/Persistence/Wolverine.RDBMS/Polling/DatabaseOperationBatch.cs
+++ b/src/Persistence/Wolverine.RDBMS/Polling/DatabaseOperationBatch.cs
@@ -48,43 +48,87 @@ internal class DatabaseOperationBatch : IAgentCommand
         if (_operations.Length == 0) return AgentCommands.Empty;
 
         var builder = _database.ToCommandBuilder();
-        foreach (var operation in _operations) operation.ConfigureCommand(builder);
 
-        await using var cmd = builder.Compile();
+        // Mark a statement boundary before each operation and remember which command each one's
+        // results will come back on. On every provider whose driver can execute several statements
+        // from a single command -- which is all of them except Oracle -- StartNewCommand() is a
+        // no-op, CompileCommands() returns one command holding every statement, and all of this
+        // collapses to exactly what it has always done. Oracle's builder splits at each boundary.
+        //
+        // An operation may contribute more than one statement (ReleaseOrphanedMessagesOperation,
+        // MoveReplayableErrorMessagesToIncomingOperation, PersistNodeRecord) or none at all
+        // (ReleaseOrphanedMessagesForAncillaryOperation, when it has no active node numbers). Every
+        // such operation is IDoNotReturnData -- each of the four that *do* return data appends
+        // exactly one statement unconditionally -- so associating an operation with the first command
+        // it produced is enough. Any further commands execute with no callbacks, and a zero-statement
+        // operation clamps into the last group where ApplyCallbacksAsync skips it as IDoNotReturnData.
+        var starts = new int[_operations.Length];
+        for (var i = 0; i < _operations.Length; i++)
+        {
+            builder.StartNewCommand();
+
+            // Nothing is open at this point, so the builder's count is the index the next command
+            // it produces will occupy
+            starts[i] = builder.CommandCount;
+            _operations[i].ConfigureCommand(builder);
+        }
+
+        var commands = builder.CompileCommands();
+        if (commands.Count == 0) return AgentCommands.Empty;
+
+        var groups = new List<IDatabaseOperation>[commands.Count];
+        for (var i = 0; i < commands.Count; i++) groups[i] = [];
+        for (var i = 0; i < _operations.Length; i++)
+        {
+            groups[Math.Min(starts[i], commands.Count - 1)].Add(_operations[i]);
+        }
 
         await using var conn = await _database.DataSource.OpenConnectionAsync(cancellationToken);
 
-        cmd.Connection = conn;
         var tx = await conn.BeginTransactionAsync(cancellationToken);
-        cmd.Transaction = tx;
 
+        DbCommand? current = null;
         try
         {
-            await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
             var exceptions = new List<Exception>();
-            await ApplyCallbacksAsync(_operations, reader, exceptions, cancellationToken);
-            await reader.CloseAsync();
+
+            for (var i = 0; i < commands.Count; i++)
+            {
+                current = commands[i];
+                current.Connection = conn;
+                current.Transaction = tx;
+
+                await using var reader = await current.ExecuteReaderAsync(cancellationToken);
+                if (groups[i].Count != 0)
+                {
+                    await ApplyCallbacksAsync(groups[i], reader, exceptions, cancellationToken);
+                }
+
+                await reader.CloseAsync();
+            }
 
             await tx.CommitAsync(cancellationToken);
         }
         catch (ObjectDisposedException)
         {
-            // The system is shutting down, let this go. 
+            // The system is shutting down, let this go.
         }
         catch (Exception e)
         {
             await conn.CloseAsync();
-            throw new DatabaseBatchCommandException(cmd, _operations, e);
+            throw new DatabaseBatchCommandException(current!, _operations, e);
+        }
+        finally
+        {
+            foreach (var command in commands)
+            {
+                await command.DisposeAsync();
+            }
         }
 
         try
         {
-            var commands = new AgentCommands();
-            foreach (var operation in _operations)
-            {
-                commands.AddRange(operation.PostProcessingCommands());
-            }
-            return commands;
+            return postProcessingCommands();
         }
         finally
         {
@@ -97,6 +141,17 @@ internal class DatabaseOperationBatch : IAgentCommand
                 // Don't let an exception get out of there. 
             }
         }
+    }
+
+    private AgentCommands postProcessingCommands()
+    {
+        var commands = new AgentCommands();
+        foreach (var operation in _operations)
+        {
+            commands.AddRange(operation.PostProcessingCommands());
+        }
+
+        return commands;
     }
 
     public static async Task ApplyCallbacksAsync(IReadOnlyList<IDatabaseOperation> operations, DbDataReader reader,


### PR DESCRIPTION
Supersedes #3615. Fixes #3614.

Builds on @pedroandrade03's diagnosis and carries their test coverage forward — retargeted at this design and extended with end-to-end assertions. Thank you for the careful root-cause work on this one.

## Why not the approach in #3615

#3615 gave Oracle a provider-specific `IDatabaseOperationBatchExecutor` hook, then repaired the already-compiled SQL with `Regex.Replace(sql, "@(?=[A-Za-z_])", ":")` and `sql.Split(';')`. That works, but it leaves Oracle on its own execution path forever and does string surgery on SQL that should never have been generated in the wrong shape to begin with.

Two of the three things it fixed were already solved in Weasel and simply not wired up:

- The `@` markers came from `OracleMessageStore.ToCommandBuilder()` returning `new Weasel.Core.DbCommandBuilder(...)`, whose constructor **hardcodes `'@'`**. `Weasel.Oracle.CommandBuilder` has used `':'` all along — but it's a *sibling* of `DbCommandBuilder`, not a subclass, so it couldn't be returned where `IMessageDatabase` expects one.
- The `Guid` → `RAW(16)` conversion already existed in `Weasel.Oracle.CommandBuilder`.

The third thing is real and unavoidable: **ODP.NET cannot execute several statements from one command**. Verified directly against 23.7.0:

```
CanCreateBatch = False
CreateBatch threw: NotSupportedException
```

## What this does instead

Teaches the *shared* batching mechanics about statement boundaries, and lets each provider decide what a boundary means. Paired with JasperFx/weasel#390 (Weasel 9.19.0).

`DatabaseOperationBatch` now marks a boundary before each operation and executes whatever `CompileCommands()` returns:

- **Every provider except Oracle**: `StartNewCommand()` is a no-op, `CompileCommands()` returns a single command holding every statement, and behaviour is byte-for-byte what it was.
- **Oracle**: returns Weasel's `OracleDbCommandBuilder`, which emits `:` markers, sets `BindByName`, types parameters through `OracleProvider`, and splits into one `OracleCommand` per statement.

**No public API change** — `IMessageDatabase.ToCommandBuilder()` still returns `DbCommandBuilder`; Oracle just returns an Oracle-shaped one.

## Three things per-operation splitting would have missed

1. **Four operations write more than one statement each** — both `ReleaseOrphanedMessages*` variants, `MoveReplayableErrorMessagesToIncomingOperation` (insert + delete), and `PersistNodeRecord` (one insert per event). Splitting per *operation* isn't enough, so those now mark their internal boundaries explicitly.
2. **`:replayable` is bound by two different statements.** `AddNamedParameter` finds-or-adds, so the parameter exists exactly once; any index-range slicing binds it to one command and the other fails at execution. Weasel now also matches parameters by name reference (whole-token, so `:p1` isn't mistaken for `:p11`).
3. **`MoveReplayableErrorMessagesToIncomingOperation` hardcoded `@replayable`** in its SQL text, so the marker abstraction leaked regardless of provider. It reads `builder.ParameterPrefix` now.

## Also documented

`OracleMessageStore.EnqueueAsync` is a no-op that silently drops its operation. The comment claimed it was about `@` parameter syntax; the real reason is that `OracleMessageStore` implements `IMessageDatabase` directly rather than deriving from `MessageDatabase`, so it has no `DatabaseBatcher`. The durability agent doesn't use that path — it builds its own `DatabaseOperationBatch` — and the one caller that does (`OracleNodePersistence.LogRecordsAsync`) works around it with direct inserts. Comment corrected, behaviour unchanged; worth its own issue.

## Validation

Red-baselined: reverting only `ToCommandBuilder()` makes all three new end-to-end recovery tests fail with `ORA-03405`, then pass with the fix.

| Suite | Result |
|---|---|
| `OracleTests` (live Oracle, full suite) | 109/109 |
| `PersistenceTests` | 77/77 |
| `PostgresqlMessageStoreTests` | 49/49 |
| `SqliteMessageStoreTests` | 48/48 |
| `SqlServerTests` (store + durability) | 160/160 |
| `dotnet build wolverine.slnx -c Release` | clean |

New coverage:

- `oracle_durability_command_translation` — Pedro's cases, retargeted at the real durability operations rather than internal string helpers: bind markers, per-statement splitting, per-command parameter ownership, `Guid`/`bool`/`DateTimeOffset` typing.
- `oracle_durability_agent_recovery` — runs the real `DurabilityAgent.buildOperationBatch()` set against a real Oracle database, and asserts orphaned messages are released and replayable dead letters move back to the inbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
