### PR TITLE
415 instead of 404 when no Content-Type reaches an [AcceptsContentType] route (#3649)

### DIFF
--- a/docs/guide/http/conneg.md
+++ b/docs/guide/http/conneg.md
@@ -182,3 +182,9 @@ public static class RequestConnegEndpoints
 ```
 
 This allows the same route and HTTP method to handle different request body formats.
+
+A request whose `Content-Type` none of the endpoints on the route declares gets a `415 Unsupported Media Type`.
+That includes a request that sends **no** `Content-Type` header at all, which returned a `404` before Wolverine
+6.23 — the route exists, so a media-type status is the honest answer. Matching compares only the media type, so
+parameters such as `charset=utf-8` do not defeat it, but it is otherwise exact: `application/json` does **not**
+match a declared `application/vnd.item.v1+json`, and a wildcard in the attribute never matches anything.

--- a/src/Http/Wolverine.Http.Tests/accepts_content_type_negative_cases_3649.cs
+++ b/src/Http/Wolverine.Http.Tests/accepts_content_type_negative_cases_3649.cs
@@ -21,12 +21,13 @@ namespace Wolverine.Http.Tests;
 ///       <item>every <em>mismatched</em> Content-Type is handled by the framework policy alone → 415. Wolverine's
 ///       policy is redundant for these.</item>
 ///       <item>a <em>missing</em> Content-Type is the one case where Wolverine's policy is load-bearing: without
-///       it both same-route endpoints stay valid candidates and routing throws an ambiguous match (500).
-///       With it, all candidates are invalidated → 404.</item>
+///       it both same-route endpoints stay valid candidates and routing throws an ambiguous match (500).</item>
 ///     </list>
 ///
-///     <para>That 404 is the one outcome here that looks wrong — see
-///     <c>a_missing_content_type_currently_404s</c> below. It is pinned rather than asserted-as-correct.</para>
+///     <para>The missing-Content-Type case originally answered a bare <b>404</b> — the policy invalidated every
+///     candidate and supplied nothing in their place. These tests pinned that 404 and left the decision open;
+///     it now answers <b>415</b>, matching what the same endpoints have always returned for a Content-Type
+///     that is present but undeclared. See <c>a_missing_content_type_is_unsupported_media_type</c>.</para>
 /// </summary>
 public class accepts_content_type_negative_cases_3649 : IntegrationContext
 {
@@ -36,9 +37,11 @@ public class accepts_content_type_negative_cases_3649 : IntegrationContext
 
     // Both /content-negotiation/items endpoints declare exactly one vnd media type each, so this exercises
     // content-type dispatch between two endpoints sharing a route.
-    private async Task<HttpStatusCode> statusFor(string? contentType)
+    private Task<HttpStatusCode> statusFor(string? contentType) => statusFor("/content-negotiation/items", contentType);
+
+    private async Task<HttpStatusCode> statusFor(string url, string? contentType)
     {
-        var request = new HttpRequestMessage(HttpMethod.Post, "/content-negotiation/items")
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
         {
             Content = new StringContent("{\"name\":\"Test Item\"}", Encoding.UTF8)
         };
@@ -108,31 +111,58 @@ public class accepts_content_type_negative_cases_3649 : IntegrationContext
     }
 
     /// <summary>
-    ///     PINNING CURRENT BEHAVIOUR, NOT ENDORSING IT. A request with a body but no <c>Content-Type</c> header
-    ///     gets a bare <b>404</b>, while the very same endpoints answer <b>415</b> for a Content-Type that is
-    ///     present but undeclared. 415 is the defensible answer for both.
+    ///     A request with a body but no <c>Content-Type</c> header used to get a bare <b>404</b>, while the very
+    ///     same endpoints answered <b>415</b> for a Content-Type that was present but undeclared. 415 is the
+    ///     defensible answer for both, and is now what both give.
     ///
-    ///     <para>Cause: <see cref="ContentTypeEndpointSelectorPolicy" /> invalidates every candidate
-    ///     (<c>SetValidity(i, false)</c>) with no 415 fallback, so routing finds nothing and falls through.
-    ///     Removing just that <c>string.IsNullOrEmpty</c> branch does NOT fix it — verified — because the
-    ///     framework's node-builder policy then leaves both same-route candidates valid and the request becomes
-    ///     an ambiguous match (500). So fixing this properly means supplying a 415 result rather than deleting
-    ///     the invalidation.</para>
-    ///
-    ///     <para>Change this assertion to <c>UnsupportedMediaType</c> when that fix lands. It is a
-    ///     user-visible behaviour change, which is why it is not bundled here.</para>
+    ///     <para>The original cause was that <see cref="ContentTypeEndpointSelectorPolicy" /> invalidated every
+    ///     candidate (<c>SetValidity(i, false)</c>) and supplied nothing in their place, so routing found no
+    ///     endpoint and fell through. Note that deleting the <c>string.IsNullOrEmpty</c> branch does NOT fix it
+    ///     — verified — because the framework's node-builder policy then leaves both same-route candidates valid
+    ///     and the request becomes an ambiguous match (500). The fix therefore <em>supplies</em> a 415 endpoint
+    ///     when content-type filtering empties the candidate set, rather than skipping the invalidation.</para>
     /// </summary>
     [Fact]
-    public async Task a_missing_content_type_currently_404s()
+    public async Task a_missing_content_type_is_unsupported_media_type()
     {
-        (await statusFor(null)).ShouldBe(HttpStatusCode.NotFound);
+        (await statusFor(null)).ShouldBe(HttpStatusCode.UnsupportedMediaType);
+    }
+
+    [Fact]
+    public async Task a_sole_endpoint_owning_its_route_agrees_on_every_status()
+    {
+        // /content-negotiation/sole has no same-route sibling competing for candidacy, so the framework policy
+        // resolves mismatches on its own and Wolverine's only contributes the missing-header case. The point is
+        // that the answer does not depend on which shape you happen to have.
+        (await statusFor("/content-negotiation/sole", "application/vnd.sole.v1+json")).ShouldBe(HttpStatusCode.OK);
+        (await statusFor("/content-negotiation/sole", "application/json")).ShouldBe(HttpStatusCode.UnsupportedMediaType);
+        (await statusFor("/content-negotiation/sole", null)).ShouldBe(HttpStatusCode.UnsupportedMediaType);
+    }
+
+    [Fact]
+    public async Task a_method_mismatch_is_still_405_not_415()
+    {
+        // GET /content-negotiation/items carries no Content-Type, so the 415 substitution must not swallow the
+        // 405 that HttpMethodMatcherPolicy (Order 0) has already decided on. The policy only records candidates
+        // that were valid when it saw them, which is what keeps these two apart.
+        var response = await Host.Server.CreateClient().GetAsync("/content-negotiation/items");
+        response.StatusCode.ShouldBe(HttpStatusCode.MethodNotAllowed);
+    }
+
+    [Fact]
+    public async Task an_unmatched_route_is_still_404()
+    {
+        // The 415 is scoped to routes that exist and declare content types. Nothing about supplying it should
+        // make a genuinely unknown path look like a media-type problem.
+        (await statusFor("/content-negotiation/no-such-route", "application/vnd.item.v1+json"))
+            .ShouldBe(HttpStatusCode.NotFound);
     }
 
     [Fact]
     public async Task wolverine_s_selector_policy_is_still_registered()
     {
         // The measurements above only hold while both policies are in play. If someone concludes the Wolverine
-        // policy is redundant and removes it, the missing-Content-Type case regresses from 404 to a 500
+        // policy is redundant and removes it, the missing-Content-Type case regresses from its 415 to a 500
         // ambiguous match — so this asserts the policy is present and points at why.
         Host.Services.GetServices<Microsoft.AspNetCore.Routing.MatcherPolicy>()
             .OfType<ContentTypeEndpointSelectorPolicy>()

--- a/src/Http/Wolverine.Http/ContentTypeEndpointSelectorPolicy.cs
+++ b/src/Http/Wolverine.Http/ContentTypeEndpointSelectorPolicy.cs
@@ -9,8 +9,31 @@ namespace Wolverine.Http;
 /// ASP.NET Core MatcherPolicy that filters candidate endpoints by the request's Content-Type
 /// header when endpoints are decorated with <see cref="AcceptsContentTypeAttribute"/>.
 /// </summary>
+/// <remarks>
+/// GH-3649 measured what this policy actually contributes on top of the framework's own
+/// <c>AcceptsMatcherPolicy</c>, which acts on the same <c>IAcceptsMetadata</c>. For every request whose
+/// Content-Type is <em>present but undeclared</em> the framework policy already resolves the mismatch to a
+/// 415 at node-build time, so this policy is redundant there. It is load-bearing for exactly one case: a
+/// request with <em>no Content-Type header at all</em>, where the framework leaves every same-route
+/// candidate valid and routing throws an ambiguous match. Invalidating those candidates is therefore
+/// necessary — but invalidating them and stopping leaves nothing for the router to select, which surfaced
+/// as a bare 404 while the identical endpoints answered 415 for a header that was merely wrong. So when
+/// content-type filtering empties the candidate set, this policy now supplies the same 415 the framework
+/// would have.
+/// </remarks>
 internal class ContentTypeEndpointSelectorPolicy : MatcherPolicy, IEndpointSelectorPolicy
 {
+    // Mirrors the framework's own AcceptsMatcherPolicy, which substitutes an equivalent endpoint when its
+    // content-type edges resolve to no match.
+    private static readonly Endpoint _unsupportedMediaTypeEndpoint = new(
+        context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
+            return Task.CompletedTask;
+        },
+        EndpointMetadataCollection.Empty,
+        "415 HTTP Unsupported Media Type");
+
     // Run after HttpMethodMatcherPolicy (order 0) and other built-in policies
     public override int Order => 100;
 
@@ -31,6 +54,13 @@ internal class ContentTypeEndpointSelectorPolicy : MatcherPolicy, IEndpointSelec
     {
         var requestContentType = httpContext.Request.ContentType;
 
+        // Index of a candidate this policy rejected on content type, kept so we can hand the router a 415 if
+        // it turns out we rejected all of them. Only candidates that were valid coming in are recorded, so a
+        // candidate already invalidated by an earlier policy — a method mismatch, say — never gets its 405
+        // turned into a 415.
+        var rejected = -1;
+        var anyValid = false;
+
         for (var i = 0; i < candidates.Count; i++)
         {
             if (!candidates.IsValidCandidate(i))
@@ -44,6 +74,7 @@ internal class ContentTypeEndpointSelectorPolicy : MatcherPolicy, IEndpointSelec
             if (acceptsAttribute == null)
             {
                 // No attribute — leave this candidate valid as a fallback
+                anyValid = true;
                 continue;
             }
 
@@ -51,13 +82,33 @@ internal class ContentTypeEndpointSelectorPolicy : MatcherPolicy, IEndpointSelec
             {
                 // No Content-Type header but endpoint requires specific content type
                 candidates.SetValidity(i, false);
+                rejected = i;
                 continue;
             }
 
             if (!IsContentTypeMatch(requestContentType, acceptsAttribute.ContentTypes))
             {
                 candidates.SetValidity(i, false);
+                rejected = i;
             }
+            else
+            {
+                anyValid = true;
+            }
+        }
+
+        if (!anyValid && rejected >= 0)
+        {
+            // Every remaining candidate was rejected on content type. Substitute a 415 rather than letting
+            // routing fall through to a 404 — the request reached a route that exists and named a media type
+            // it does not serve.
+            candidates.ReplaceEndpoint(rejected, _unsupportedMediaTypeEndpoint, candidates[rejected].Values);
+
+            // ReplaceEndpoint preserves the candidate's existing score and only ever invalidates (when the
+            // replacement endpoint is null) — it does not re-validate. Without this the substituted endpoint is
+            // installed on a candidate the loop above already marked invalid, and the router still sees nothing
+            // to select.
+            candidates.SetValidity(rejected, true);
         }
 
         return Task.CompletedTask;

--- a/src/Http/WolverineWebApi/ContentNegotiationEndpoints.cs
+++ b/src/Http/WolverineWebApi/ContentNegotiationEndpoints.cs
@@ -21,4 +21,13 @@ public static class ContentNegotiationEndpoints
     {
         return new ContentItemCreated(command.Name, command.Category, "v2");
     }
+
+    // GH-3649. The pair above is the content-negotiation shape — two endpoints sharing one route. This is the
+    // plainer and more common one: a single [AcceptsContentType] endpoint owning its route, where nothing else
+    // is competing for candidacy. Both shapes must agree on the status for an unusable Content-Type.
+    [WolverinePost("/content-negotiation/sole"), AcceptsContentType("application/vnd.sole.v1+json")]
+    public static ContentItemCreated CreateSole(CreateContentItemV1 command)
+    {
+        return new ContentItemCreated(command.Name, null, "sole");
+    }
 }


### PR DESCRIPTION
Closes #3649.

#3651 pinned `[AcceptsContentType]`'s negative cases and left exactly one decision open: a request with **no `Content-Type` header at all** answered a bare **404**, while the very same endpoints answered **415** for a header that was present but undeclared. This settles it as 415.

## What #3651 established

Every case was measured twice — as shipped, and with `ContentTypeEndpointSelectorPolicy` unregistered:

| request `Content-Type` | both policies | framework only |
|---|---|---|
| declared exactly | 200 | 200 |
| declared + `charset=utf-8` | 200 | 200 |
| undeclared | 415 | 415 |
| malformed | 415 | 415 |
| `*/*` | 415 | 415 |
| **absent entirely** | **404** | **500** |

ASP.NET Core's `AcceptsMatcherPolicy` resolves every *mismatch* on its own, so Wolverine's policy is redundant for those. It is load-bearing for exactly one case: with no `Content-Type`, the framework leaves both same-route endpoints valid and routing throws an ambiguous match. Wolverine's policy invalidates them — but invalidated them and supplied nothing, so the router found no endpoint and fell through to a 404.

## The fix

`ContentTypeEndpointSelectorPolicy` now substitutes a 415 endpoint when content-type filtering empties the candidate set, mirroring what the framework policy does when its own content-type edges resolve to no match.

Two things worth recording, because both cost time:

- **Deleting the `string.IsNullOrEmpty` branch does not work.** Re-verified: the framework policy then leaves both same-route candidates valid and you get the 500. A 415 has to be *supplied*, not arrived at by skipping the invalidation. #3651's doc comment already said this; it holds.
- **`CandidateSet.ReplaceEndpoint` does not re-validate.** It preserves the candidate's existing score and only ever *invalidates*, when the replacement endpoint is null. Installing the 415 on a candidate the loop had already marked invalid left the 404 completely unchanged. The explicit `SetValidity(rejected, true)` is what makes it take effect.

Only candidates that were **valid on entry** are recorded as content-type rejections, so a 405 that `HttpMethodMatcherPolicy` (Order 0) already decided on is never rewritten into a 415.

## Coverage

- `a_missing_content_type_currently_404s` → `a_missing_content_type_is_unsupported_media_type`, the assertion flip #3651 anticipated.
- New `/content-negotiation/sole` endpoint — a single `[AcceptsContentType]` endpoint owning its route. The existing pair is the content-negotiation shape; this is the plainer and more common one, and the tests pin that both shapes agree on every status.
- New guards that the 415 substitution stays in its lane: a method mismatch is still **405**, an unmatched route is still **404**.
- `docs/guide/http/conneg.md` now states the status-code behaviour, which it never did.

Full `Wolverine.Http.Tests` green — 939 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Li3ySPL3WLEJhuVJvAzFTp
