### PR TITLE
Split the NServiceBus EnclosedMessageTypes header before resolving it (#3628)

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlEnvelopeMapper.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlEnvelopeMapper.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using Wolverine.Transports;
 using Wolverine.Util;
 using Endpoint = Wolverine.Configuration.Endpoint;
 
@@ -35,7 +36,7 @@ internal class NServiceBusPostgresqlEnvelopeMapper
     public const string MessageIntentHeader = "NServiceBus.MessageIntent";
     public const string ContentTypeHeader = "NServiceBus.ContentType";
     public const string TimeSentHeader = "NServiceBus.TimeSent";
-    public const string EnclosedMessageTypesHeader = "NServiceBus.EnclosedMessageTypes";
+    public const string EnclosedMessageTypesHeader = NServiceBusInterop.EnclosedMessageTypesHeader;
 
     // NServiceBus formats NServiceBus.TimeSent with this exact pattern.
     private const string TimeSentFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
@@ -142,9 +143,10 @@ internal class NServiceBusPostgresqlEnvelopeMapper
             envelope.SentAt = sentAt;
         }
 
-        if (headers.TryGetValue(EnclosedMessageTypesHeader, out var enclosed) && enclosed.IsNotEmpty())
+        if (headers.TryGetValue(EnclosedMessageTypesHeader, out var enclosed)
+            && NServiceBusInterop.ResolveMessageType(enclosed) is string messageType)
         {
-            envelope.MessageType = resolveMessageType(enclosed);
+            envelope.MessageType = messageType;
         }
 
         envelope.Serializer = _endpoint.TryFindSerializer(envelope.ContentType) ?? _endpoint.DefaultSerializer;
@@ -190,31 +192,6 @@ internal class NServiceBusPostgresqlEnvelopeMapper
         return string.Join(";", names);
 
         static string format(Type t) => $"{t.FullName}, {t.Assembly.GetName().Name}";
-    }
-
-    [UnconditionalSuppressMessage("Trimming", "IL2057",
-        Justification =
-            "The enclosed message type name comes from a foreign NServiceBus endpoint at runtime; a failed resolution falls back to the bare type name which Wolverine binds via RegisterInteropMessageAssembly.")]
-    private static string resolveMessageType(string enclosed)
-    {
-        // NServiceBus lists several types separated by ';' (concrete + interfaces),
-        // most-derived first. Use the first entry that resolves to a type loadable in this
-        // process; that is the one Wolverine can map to a handler (directly or via the
-        // RegisterInteropMessageAssembly interface->concrete binding).
-        var entries = enclosed.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-        foreach (var entry in entries)
-        {
-            var type = Type.GetType(entry);
-            if (type != null)
-            {
-                return type.ToMessageTypeName();
-            }
-        }
-
-        // Fall back to the bare type name; Wolverine's interop assembly registration
-        // can still bind it to a concrete handler.
-        return entries.First().Split(',', StringSplitOptions.TrimEntries).First();
     }
 
     private static byte[] stripUtf8Bom(byte[] body)

--- a/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerEnvelopeMapper.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/NServiceBus/NServiceBusSqlServerEnvelopeMapper.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using JasperFx;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using Wolverine.Transports;
 using Wolverine.Util;
 using Endpoint = Wolverine.Configuration.Endpoint;
 
@@ -36,7 +37,7 @@ internal class NServiceBusSqlServerEnvelopeMapper
     public const string MessageIntentHeader = "NServiceBus.MessageIntent";
     public const string ContentTypeHeader = "NServiceBus.ContentType";
     public const string TimeSentHeader = "NServiceBus.TimeSent";
-    public const string EnclosedMessageTypesHeader = "NServiceBus.EnclosedMessageTypes";
+    public const string EnclosedMessageTypesHeader = NServiceBusInterop.EnclosedMessageTypesHeader;
 
     // NServiceBus formats NServiceBus.TimeSent with this exact pattern.
     private const string TimeSentFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
@@ -154,9 +155,10 @@ internal class NServiceBusSqlServerEnvelopeMapper
             envelope.SentAt = sentAt;
         }
 
-        if (headers.TryGetValue(EnclosedMessageTypesHeader, out var enclosed) && enclosed.IsNotEmpty())
+        if (headers.TryGetValue(EnclosedMessageTypesHeader, out var enclosed)
+            && NServiceBusInterop.ResolveMessageType(enclosed) is string messageType)
         {
-            envelope.MessageType = resolveMessageType(enclosed);
+            envelope.MessageType = messageType;
         }
 
         // NServiceBus multi-tenancy: surface the tenant id NServiceBus stamped on the message as
@@ -194,31 +196,6 @@ internal class NServiceBusSqlServerEnvelopeMapper
         return string.Join(";", names);
 
         static string format(Type t) => $"{t.FullName}, {t.Assembly.GetName().Name}";
-    }
-
-    [UnconditionalSuppressMessage("Trimming", "IL2057",
-        Justification =
-            "The enclosed message type name comes from a foreign NServiceBus endpoint at runtime; a failed resolution falls back to the bare type name which Wolverine binds via RegisterInteropMessageAssembly.")]
-    private static string resolveMessageType(string enclosed)
-    {
-        // NServiceBus lists several types separated by ';' (concrete + interfaces),
-        // most-derived first. Use the first entry that resolves to a type loadable in this
-        // process; that is the one Wolverine can map to a handler (directly or via the
-        // RegisterInteropMessageAssembly interface->concrete binding).
-        var entries = enclosed.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-        foreach (var entry in entries)
-        {
-            var type = Type.GetType(entry);
-            if (type != null)
-            {
-                return type.ToMessageTypeName();
-            }
-        }
-
-        // Fall back to the bare type name; Wolverine's interop assembly registration
-        // can still bind it to a concrete handler.
-        return entries.First().Split(',', StringSplitOptions.TrimEntries).First();
     }
 
     private static byte[] stripUtf8Bom(byte[] body)

--- a/src/Testing/CoreTests/Transports/nservicebus_enclosed_message_types_3628.cs
+++ b/src/Testing/CoreTests/Transports/nservicebus_enclosed_message_types_3628.cs
@@ -1,0 +1,105 @@
+using Shouldly;
+using Wolverine.Transports;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Transports;
+
+/// <summary>
+///     GH-3628. NServiceBus writes <c>NServiceBus.EnclosedMessageTypes</c> as a ';'-delimited,
+///     most-derived-first list of every type the published message satisfies — the concrete type, then any
+///     parent type or interface the receiving conventions also class as a message type. The Azure Service Bus
+///     and AWS interop mappers passed that whole string to <see cref="Type.GetType(string)" />, which accepts a
+///     single assembly-qualified name; everything after the first comma is read as assembly metadata, so the
+///     listener threw <c>FileLoadException: The given assembly name was invalid.</c> and the message was never
+///     dispatched. A contract implementing no qualifying interface produces a one-entry header, which is why
+///     the simplest possible message shape did not reproduce it.
+/// </summary>
+public class nservicebus_enclosed_message_types_3628
+{
+    // The exact header shape from the report: MyEvent : IMyEvent under
+    // conventions.DefiningEventsAs(t => t.IsAssignableTo(typeof(IMyEvent))). Neither assembly exists here,
+    // standing in for a foreign NServiceBus endpoint's contracts.
+    private const string ForeignHierarchyHeader =
+        "MyApp.Messages.MyEvent, MyApp.Messages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null;" +
+        "MyApp.Abstractions.IMyEvent, MyApp.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
+
+    [Fact]
+    public void the_unsplit_header_is_what_broke_the_listener()
+    {
+        // Pins the mechanism rather than the fix: Type.GetType does not politely return null for the joined
+        // list, it throws. That is why splitting is required and why a null-check alone was never enough.
+        Should.Throw<Exception>(() => Type.GetType(ForeignHierarchyHeader));
+    }
+
+    [Fact]
+    public void a_multi_type_header_no_longer_takes_the_listener_down()
+    {
+        var resolved = Should.NotThrow(() => NServiceBusInterop.ResolveMessageType(ForeignHierarchyHeader));
+
+        // Nothing in the list is loadable here, so we fall back to the bare name of the most-derived entry.
+        // Wolverine binds that to a concrete handler via RegisterInteropMessageAssembly.
+        resolved.ShouldBe("MyApp.Messages.MyEvent");
+    }
+
+    [Fact]
+    public void the_most_derived_loadable_entry_wins()
+    {
+        // Concrete type first, as NServiceBus orders it. It resolves, so the interface entry is never reached.
+        var header = $"{qualify(typeof(NsbInteropEvent))};{qualify(typeof(INsbInteropEvent))}";
+
+        NServiceBusInterop.ResolveMessageType(header)
+            .ShouldBe(typeof(NsbInteropEvent).ToMessageTypeName());
+    }
+
+    [Fact]
+    public void an_unloadable_leading_entry_falls_through_to_the_next()
+    {
+        // The real cross-assembly interop case: the publisher's concrete type is not deployed here, but the
+        // shared interface is. That entry is the one Wolverine can actually map to a handler.
+        var header =
+            "MyApp.Messages.NotDeployedHere, MyApp.Messages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null;" +
+            qualify(typeof(INsbInteropEvent));
+
+        NServiceBusInterop.ResolveMessageType(header)
+            .ShouldBe(typeof(INsbInteropEvent).ToMessageTypeName());
+    }
+
+    [Fact]
+    public void a_single_unresolvable_entry_yields_its_bare_name_and_not_a_null_reference()
+    {
+        // The old ASB code did messageType!.ToMessageTypeName() on the result of Type.GetType, so a
+        // syntactically valid but unresolvable single type name produced a NullReferenceException.
+        NServiceBusInterop
+            .ResolveMessageType("MyApp.Messages.Gone, MyApp.Messages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null")
+            .ShouldBe("MyApp.Messages.Gone");
+    }
+
+    [Fact]
+    public void a_malformed_header_does_not_throw()
+    {
+        // A junk header must dead-end at this message, not kill the listening loop.
+        Should.NotThrow(() => NServiceBusInterop.ResolveMessageType("!!! not a type name at all"));
+        Should.NotThrow(() => NServiceBusInterop.ResolveMessageType(", , ,"));
+        Should.NotThrow(() => NServiceBusInterop.ResolveMessageType(";;;"));
+    }
+
+    [Fact]
+    public void empty_and_whitespace_padding_are_tolerated()
+    {
+        // Returning null lets callers leave Envelope.MessageType alone rather than overwrite it with a guess.
+        NServiceBusInterop.ResolveMessageType(null).ShouldBeNull();
+        NServiceBusInterop.ResolveMessageType("").ShouldBeNull();
+        NServiceBusInterop.ResolveMessageType(";;;").ShouldBeNull();
+
+        // Padding and empty entries around a good name must not defeat resolution.
+        NServiceBusInterop.ResolveMessageType($" ; {qualify(typeof(NsbInteropEvent))} ; ")
+            .ShouldBe(typeof(NsbInteropEvent).ToMessageTypeName());
+    }
+
+    private static string qualify(Type type) => $"{type.FullName}, {type.Assembly.GetName().Name}";
+
+    public interface INsbInteropEvent;
+
+    public record NsbInteropEvent(string Name) : INsbInteropEvent;
+}

--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/NServiceBusEnvelopeMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/NServiceBusEnvelopeMapper.cs
@@ -4,6 +4,7 @@ using Amazon.SimpleNotificationService.Model;
 using JasperFx.Core;
 using Newtonsoft.Json;
 using Wolverine.Newtonsoft;
+using Wolverine.Transports;
 using Wolverine.Util;
 using Endpoint = Wolverine.Configuration.Endpoint;
 
@@ -88,17 +89,10 @@ internal class NServiceBusEnvelopeMapper : ISnsEnvelopeMapper
             }
         }
 
-        if (sqs.Headers.TryGetValue("NServiceBus.EnclosedMessageTypes", out var messageTypeName))
+        if (sqs.Headers.TryGetValue(NServiceBusInterop.EnclosedMessageTypesHeader, out var enclosed)
+            && NServiceBusInterop.ResolveMessageType(enclosed) is string messageType)
         {
-            Type? messageType = Type.GetType(messageTypeName);
-            if (messageType != null)
-            {
-                envelope.MessageType = messageType.ToMessageTypeName();
-            }
-            else
-            {
-                envelope.MessageType = messageTypeName;
-            }
+            envelope.MessageType = messageType;
         }
     }
     

--- a/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
@@ -13,6 +13,7 @@ using Wolverine.Runtime.Interop;
 using Wolverine.Runtime.Interop.MassTransit;
 using Wolverine.Newtonsoft;
 using Wolverine.Runtime.Serialization;
+using Wolverine.Transports;
 using Wolverine.Util;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
@@ -260,17 +261,10 @@ internal class NServiceBusEnvelopeMapper : ISqsEnvelopeMapper
             }
         }
 
-        if (sqs.Headers.TryGetValue("NServiceBus.EnclosedMessageTypes", out var messageTypeName))
+        if (sqs.Headers.TryGetValue(NServiceBusInterop.EnclosedMessageTypesHeader, out var enclosed)
+            && NServiceBusInterop.ResolveMessageType(enclosed) is string messageType)
         {
-            Type? messageType = Type.GetType(messageTypeName);
-            if (messageType != null)
-            {
-                envelope.MessageType = messageType.ToMessageTypeName();
-            }
-            else
-            {
-                envelope.MessageType = messageTypeName;
-            }
+            envelope.MessageType = messageType;
         }
     }
     

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/nservicebus_interop_multi_type_header_3628.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/nservicebus_interop_multi_type_header_3628.cs
@@ -1,0 +1,103 @@
+using Azure.Messaging.ServiceBus;
+using NSubstitute;
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Wolverine.Runtime;
+using Wolverine.Util;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+/// <summary>
+///     GH-3628. A Wolverine listener with <c>UseNServiceBusInterop()</c> never received an event whose type
+///     implemented any interface the publisher's NServiceBus conventions also class as a message type: the
+///     <c>NServiceBus.EnclosedMessageTypes</c> header is a ';'-delimited list in that case, the mapper handed the
+///     whole thing to <see cref="Type.GetType(string)" />, and mapping threw
+///     <c>FileLoadException: The given assembly name was invalid.</c>
+///
+///     <para>These run against the real mapper each of the three ASB endpoint types builds, with no broker
+///     involved, because the bug lived in the mapping and not in the transport.</para>
+/// </summary>
+public class nservicebus_interop_multi_type_header_3628
+{
+    // MyEvent : IMyEvent as NServiceBus serializes it — concrete type first, then the qualifying interface.
+    // Neither assembly exists here, which is exactly the position a Wolverine subscriber is in when the
+    // publisher's contracts are not deployed on its side.
+    private const string MultiTypeHeader =
+        "MyApp.Messages.MyEvent, MyApp.Messages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null;" +
+        "MyApp.Abstractions.IMyEvent, MyApp.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
+
+    public static IEnumerable<object[]> Endpoints()
+    {
+        yield return ["queue", new Uri("asb://queue/orders")];
+        yield return ["topic", new Uri("asb://topic/events")];
+        yield return ["subscription", new Uri("asb://topic/events/audit")];
+    }
+
+    [Theory]
+    [MemberData(nameof(Endpoints))]
+    public void a_multi_type_header_maps_without_throwing(string _, Uri uri)
+    {
+        mapIncoming(uri, MultiTypeHeader)
+            .MessageType.ShouldBe("MyApp.Messages.MyEvent");
+    }
+
+    [Theory]
+    [MemberData(nameof(Endpoints))]
+    public void a_single_type_header_still_maps_as_before(string _, Uri uri)
+    {
+        // The one-entry shape is what worked all along, and must keep working: a type that IS loadable here
+        // resolves through to Wolverine's message type name rather than the raw header text.
+        var header = $"{typeof(NsbInteropOrder).FullName}, {typeof(NsbInteropOrder).Assembly.GetName().Name}";
+
+        mapIncoming(uri, header)
+            .MessageType.ShouldBe(typeof(NsbInteropOrder).ToMessageTypeName());
+    }
+
+    [Theory]
+    [MemberData(nameof(Endpoints))]
+    public void a_malformed_header_does_not_take_the_listener_down(string _, Uri uri)
+    {
+        // Previously any header Type.GetType could not parse threw out of the mapping and killed the receive
+        // loop. Now it maps to an unroutable message type, which Wolverine dead-letters.
+        Should.NotThrow(() => mapIncoming(uri, "!!! definitely not a type name"));
+    }
+
+    private static Envelope mapIncoming(Uri uri, string enclosedMessageTypes)
+    {
+        var transport = new AzureServiceBusTransport();
+        var endpoint = (AzureServiceBusEndpoint)transport.GetOrCreateEndpoint(uri);
+
+        switch (endpoint)
+        {
+            case AzureServiceBusQueue queue:
+                queue.UseNServiceBusInterop();
+                break;
+            case AzureServiceBusTopic topic:
+                topic.UseNServiceBusInterop();
+                break;
+            case AzureServiceBusSubscription subscription:
+                subscription.UseNServiceBusInterop();
+                break;
+            default:
+                throw new InvalidOperationException($"Unexpected endpoint type {endpoint.GetType().Name}");
+        }
+
+        var mapper = endpoint.BuildMapper(Substitute.For<IWolverineRuntime>());
+
+        var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: new BinaryData("{}"),
+            messageId: Guid.NewGuid().ToString(),
+            properties: new Dictionary<string, object>
+            {
+                ["NServiceBus.EnclosedMessageTypes"] = enclosedMessageTypes
+            });
+
+        var envelope = new Envelope();
+        mapper.MapIncomingToEnvelope(envelope, message);
+
+        return envelope;
+    }
+
+    public record NsbInteropOrder(string Id);
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
@@ -229,12 +228,12 @@ public class AzureServiceBusQueue : AzureServiceBusEndpoint, IBrokerQueue, IMass
         : DeadLetterStorageMode.Durable;
     
     // NServiceBus interop: NSB writes the .NET assembly-qualified type name
-    // to the message header; we resolve it via Type.GetType(string). Type
-    // resolution from a runtime string is fundamentally not AOT-clean — the
-    // trimmer can't know which types may appear. AOT-clean apps using NSB
-    // interop preserve their NSB-side message types via TrimmerRootDescriptor.
-    [UnconditionalSuppressMessage("Trimming", "IL2057",
-        Justification = "Type.GetType(typeName) on NServiceBus wire type names; AOT consumers preserve NSB message types via TrimmerRootDescriptor. See AOT guide.")]
+    // to the message header; NServiceBusInterop.ResolveMessageType turns that
+    // into a Wolverine message type name. Type resolution from a runtime string
+    // is fundamentally not AOT-clean — the trimmer can't know which types may
+    // appear — so the reflection and its IL2057 suppression live there, next to
+    // the call. AOT-clean apps using NSB interop preserve their NSB-side message
+    // types via TrimmerRootDescriptor.
     internal void UseNServiceBusInterop()
     {
         // NServiceBus.EnclosedMessageTypes
@@ -272,20 +271,19 @@ public class AzureServiceBusQueue : AzureServiceBusEndpoint, IBrokerQueue, IMass
             m.MapProperty(x => x.MessageType!, (e, m) =>
             {
                 // Incoming
-                if (m.ApplicationProperties.TryGetValue("NServiceBus.EnclosedMessageTypes", out var raw))
+                if (m.ApplicationProperties.TryGetValue(NServiceBusInterop.EnclosedMessageTypesHeader, out var raw))
                 {
-                    var typeName = (raw is byte[] b ? Encoding.UTF8.GetString(b) : raw.ToString())!;
-                    if (typeName.IsNotEmpty())
+                    var header = raw is byte[] b ? Encoding.UTF8.GetString(b) : raw?.ToString();
+                    if (NServiceBusInterop.ResolveMessageType(header) is string messageType)
                     {
-                        var messageType = Type.GetType(typeName);
-                        e.MessageType = messageType!.ToMessageTypeName();
+                        e.MessageType = messageType;
                     }
                 }
             },
                 (e, m) =>
             {
                 // Outgoing, use the interop strategy here
-                m.ApplicationProperties["NServiceBus.EnclosedMessageTypes"] = e.Message!.GetType().ToMessageTypeName();
+                m.ApplicationProperties[NServiceBusInterop.EnclosedMessageTypesHeader] = e.Message!.GetType().ToMessageTypeName();
             });
         });
     }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
@@ -239,8 +238,8 @@ public class AzureServiceBusSubscription : AzureServiceBusEndpoint, IBrokerQueue
         }
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2057",
-        Justification = "Type.GetType(typeName) on NServiceBus wire type names; AOT consumers preserve NSB message types via TrimmerRootDescriptor. See AOT guide.")]
+    // Type resolution from the NServiceBus.EnclosedMessageTypes header is not AOT-clean; the reflection and
+    // its IL2057 suppression live in NServiceBusInterop.ResolveMessageType, next to the call.
     internal void UseNServiceBusInterop()
     {
         DefaultSerializer = new NewtonsoftSerializer(new JsonSerializerSettings());
@@ -275,19 +274,18 @@ public class AzureServiceBusSubscription : AzureServiceBusEndpoint, IBrokerQueue
 
             m.MapProperty(x => x.MessageType!, (e, msg) =>
             {
-                if (msg.ApplicationProperties.TryGetValue("NServiceBus.EnclosedMessageTypes", out var raw))
+                if (msg.ApplicationProperties.TryGetValue(NServiceBusInterop.EnclosedMessageTypesHeader, out var raw))
                 {
-                    var typeName = (raw is byte[] b ? Encoding.UTF8.GetString(b) : raw.ToString())!;
-                    if (typeName.IsNotEmpty())
+                    var header = raw is byte[] b ? Encoding.UTF8.GetString(b) : raw?.ToString();
+                    if (NServiceBusInterop.ResolveMessageType(header) is string messageType)
                     {
-                        var messageType = Type.GetType(typeName);
-                        e.MessageType = messageType!.ToMessageTypeName();
+                        e.MessageType = messageType;
                     }
                 }
             },
                 (e, msg) =>
             {
-                msg.ApplicationProperties["NServiceBus.EnclosedMessageTypes"] = e.Message!.GetType().ToMessageTypeName();
+                msg.ApplicationProperties[NServiceBusInterop.EnclosedMessageTypesHeader] = e.Message!.GetType().ToMessageTypeName();
             });
         });
     }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusTopic.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
@@ -135,8 +134,8 @@ public class AzureServiceBusTopic : AzureServiceBusEndpoint, IMassTransitInterop
 
     public override bool IsPartitioned { get => Options.EnablePartitioning; }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2057",
-        Justification = "Type.GetType(typeName) on NServiceBus wire type names; AOT consumers preserve NSB message types via TrimmerRootDescriptor. See AOT guide.")]
+    // Type resolution from the NServiceBus.EnclosedMessageTypes header is not AOT-clean; the reflection and
+    // its IL2057 suppression live in NServiceBusInterop.ResolveMessageType, next to the call.
     internal void UseNServiceBusInterop()
     {
         DefaultSerializer = new NewtonsoftSerializer(new JsonSerializerSettings());
@@ -171,19 +170,18 @@ public class AzureServiceBusTopic : AzureServiceBusEndpoint, IMassTransitInterop
 
             m.MapProperty(x => x.MessageType!, (e, msg) =>
             {
-                if (msg.ApplicationProperties.TryGetValue("NServiceBus.EnclosedMessageTypes", out var raw))
+                if (msg.ApplicationProperties.TryGetValue(NServiceBusInterop.EnclosedMessageTypesHeader, out var raw))
                 {
-                    var typeName = (raw is byte[] b ? Encoding.UTF8.GetString(b) : raw.ToString())!;
-                    if (typeName.IsNotEmpty())
+                    var header = raw is byte[] b ? Encoding.UTF8.GetString(b) : raw?.ToString();
+                    if (NServiceBusInterop.ResolveMessageType(header) is string messageType)
                     {
-                        var messageType = Type.GetType(typeName);
-                        e.MessageType = messageType!.ToMessageTypeName();
+                        e.MessageType = messageType;
                     }
                 }
             },
                 (e, msg) =>
             {
-                msg.ApplicationProperties["NServiceBus.EnclosedMessageTypes"] = e.Message!.GetType().ToMessageTypeName();
+                msg.ApplicationProperties[NServiceBusInterop.EnclosedMessageTypesHeader] = e.Message!.GetType().ToMessageTypeName();
             });
         });
     }

--- a/src/Wolverine/Transports/NServiceBusInterop.cs
+++ b/src/Wolverine/Transports/NServiceBusInterop.cs
@@ -1,0 +1,85 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.Core;
+using Wolverine.Util;
+
+namespace Wolverine.Transports;
+
+/// <summary>
+/// Shared handling for the NServiceBus headers that every Wolverine NServiceBus interop mapper has to read,
+/// regardless of transport.
+/// </summary>
+/// <remarks>
+/// GH-3628. Each transport grew its own copy of this logic and they drifted: the database transports split the
+/// <c>NServiceBus.EnclosedMessageTypes</c> list correctly, while Azure Service Bus and the AWS transports passed
+/// the whole raw header to <see cref="Type.GetType(string)" />. That works only for the simplest possible
+/// contract — a message type implementing no interface the NServiceBus conventions also treat as a message type —
+/// and throws for anything else, taking the listener down. Sharing one implementation is the point: a transport
+/// cannot silently fall behind a fix made for another.
+/// </remarks>
+internal static class NServiceBusInterop
+{
+    public const string EnclosedMessageTypesHeader = "NServiceBus.EnclosedMessageTypes";
+
+    /// <summary>
+    /// Resolve the Wolverine message type name from an <c>NServiceBus.EnclosedMessageTypes</c> header value.
+    /// Returns null when the header carries nothing usable, so callers can leave <c>Envelope.MessageType</c>
+    /// alone rather than overwriting it with a guess.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2057",
+        Justification =
+            "The enclosed message type name comes from a foreign NServiceBus endpoint at runtime; a failed resolution falls back to the bare type name which Wolverine binds via RegisterInteropMessageAssembly.")]
+    public static string? ResolveMessageType(string? enclosed)
+    {
+        if (enclosed.IsEmpty())
+        {
+            return null;
+        }
+
+        // NServiceBus writes this as a ';'-delimited, most-derived-first list of every type the message
+        // satisfies -- the concrete type followed by any parent types or interfaces that the receiving
+        // endpoint's conventions also class as message types (MessageMetadata.SerializeMessageHierarchy is a
+        // string.Join(";", ...)). Only one entry at a time is a valid assembly-qualified name.
+        var entries = enclosed!.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (var entry in entries)
+        {
+            // Use the first entry that resolves to a type loadable in this process; that is the one Wolverine
+            // can map to a handler, either directly or via the RegisterInteropMessageAssembly
+            // interface->concrete binding.
+            if (tryLoad(entry) is Type type)
+            {
+                return type.ToMessageTypeName();
+            }
+        }
+
+        if (entries.Length == 0)
+        {
+            return null;
+        }
+
+        // Nothing resolved. Fall back to the bare type name of the most-derived entry; Wolverine's interop
+        // assembly registration can still bind that to a concrete handler. A header carrying no usable name at
+        // all yields null rather than an empty MessageType -- an unroutable message belongs in the dead letter
+        // queue, not stamped with a blank type.
+        var bare = entries[0].Split(',', StringSplitOptions.TrimEntries)[0];
+        return bare.IsNotEmpty() ? bare : null;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2057",
+        Justification = "See ResolveMessageType; the name is foreign runtime data and failure is handled.")]
+    private static Type? tryLoad(string typeName)
+    {
+        try
+        {
+            return Type.GetType(typeName);
+        }
+        catch (Exception)
+        {
+            // Type.GetType does NOT merely return null for a name it cannot make sense of -- a malformed
+            // assembly-qualified name throws (FileLoadException "The given assembly name was invalid." is the
+            // one GH-3628 was reported against). A junk header must not be able to kill a listener, so treat an
+            // unloadable entry exactly like an unresolved one and move on to the next.
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Closes #3628. Thanks to the reporter for a diagnosis that named the mechanism, the three call sites, and the correct in-repo precedent — this PR is essentially their suggested fix, widened by two sites.

## The bug

NServiceBus writes `NServiceBus.EnclosedMessageTypes` as a `;`-delimited, most-derived-first list of every type the published message satisfies — the concrete type, then any parent type or interface the conventions also class as a message type (`MessageMetadata.SerializeMessageHierarchy` is a `string.Join(";", ...)`). For `MyEvent : IMyEvent` under `conventions.DefiningEventsAs(...)` that is two entries.

The Azure Service Bus and AWS interop mappers handed that whole string to `Type.GetType`, which takes a *single* assembly-qualified name and reads everything after the first comma as assembly metadata. Result: `FileLoadException: The given assembly name was invalid.` out of envelope mapping, and the message never reached a handler.

A contract implementing no qualifying interface produces a one-entry header, which is why the simplest possible message shape never reproduced it.

## The fix

The database transports (#3198/#3201) already split this correctly. Rather than copy that helper a third time, it moves to `Wolverine.Transports.NServiceBusInterop` in core and every mapper points at it — so a transport cannot silently fall behind a fix made for another, which is the drift the issue asked to close.

Sites corrected. The report named the three ASB endpoints; **SNS and SQS carry the identical bug** and are fixed here too:

- `Wolverine.AzureServiceBus`: `AzureServiceBusQueue`, `AzureServiceBusTopic`, `AzureServiceBusSubscription`
- `Wolverine.AmazonSns/Internal/NServiceBusEnvelopeMapper`
- `Wolverine.AmazonSqs/AmazonSqsListenerConfiguration`

SNS and SQS *looked* safer — they null-checked the result and fell back to the raw header — but that fallback was unreachable, because `Type.GetType` throws on the joined string rather than returning null.

`Wolverine.Postgresql` and `Wolverine.SqlServer` drop their private copies and share the header constant. RabbitMQ's NSB interop was checked and does not map the message type from this header at all, so there is no sixth site.

## The two adjacent defects the issue called out

Both fixed:

- **`messageType!.ToMessageTypeName()`** meant a syntactically valid but unresolvable single type name was a `NullReferenceException` rather than a clear failure. Resolution now falls back to the bare type name, which Wolverine can still bind via `RegisterInteropMessageAssembly`.
- **No path was guarded**, so a malformed header took the listener down instead of dead-lettering the message. Each entry is tried inside a `try`/`catch`, because `Type.GetType` does *not* politely return null for a name it cannot parse. A header carrying no usable name yields null and leaves `Envelope.MessageType` alone rather than stamping it blank.

## Scope note

Outgoing hierarchy emission stays transport-specific and unchanged — the database mappers emit the concrete type plus its interfaces, the broker transports emit just the message type name. Changing that is a wire-format change nobody asked for.

The three ASB `IL2057` suppressions are removed: the reflection they documented now lives in `NServiceBusInterop`, and its suppression sits next to the call. ASB builds clean on both TFMs under `IsAotCompatible` + `TreatWarningsAsErrors`.

## Coverage

16 new tests:

- **7 in `CoreTests`** over `ResolveMessageType` — the reported multi-type header, an unloadable leading entry falling through to a shared interface that *is* deployed, the single-unresolvable-entry NRE case, malformed input, and padding. One of them pins that `Type.GetType` **throws** on the joined header, so the reason splitting is required cannot be refactored away by someone who assumes a null check suffices.
- **9 in `Wolverine.AzureServiceBus.Tests`** driving the real mapper each of the three endpoint types builds, across all three header shapes. No broker required — the bug was in the mapping, so the test does not need one.

The database NSB mappers have no test coverage in-repo either before or after this change; their edit is a straight substitution of identical logic, now covered indirectly by the `CoreTests` battery.

`wolverine.slnx` builds clean in Release, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Li3ySPL3WLEJhuVJvAzFTp
