### PR TITLE
fix(http): explicitly-routed chains describe their request body (#3646)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/chain_request_description_is_complete_before_metadata_3646.cs
+++ b/src/Http/Wolverine.Http.Tests/chain_request_description_is_complete_before_metadata_3646.cs
@@ -1,30 +1,38 @@
+using System.Text.Json;
+using JasperFx;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.CodeGeneration.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Wolverine.Attributes;
+using ServiceContainer = JasperFx.ServiceContainer;
 
 namespace Wolverine.Http.Tests;
 
 /// <summary>
-///     GH-3646, resolved as an INVARIANT rather than a fix.
+///     GH-3646: <c>HttpChain.applyMetadata()</c> turns <c>IsFormData</c> / <c>RequestType</c> /
+///     <c>RequestBodyIsOptional</c> into <c>Accepts</c> metadata and the API description, and it is the LAST
+///     statement of the <see cref="HttpChain" /> constructor. Everything it reads has to be assigned by then.
 ///
-///     <para>The concern was that <c>HttpChain.applyMetadata()</c> — which turns <c>IsFormData</c> /
-///     <c>RequestType</c> / <c>RequestBodyIsOptional</c> into <c>Accepts</c> metadata and the API description —
-///     might observe those values before the codegen frames that assign them had run, making the description a
-///     race whose winner differs between hosts.</para>
+///     <para>The originally suspected cause — codegen — was wrong, and these first tests are what disproved it.
+///     The parameter strategies (including <c>AsParamatersAttributeUsage.TryMatch</c> and the
+///     <c>AsParametersBindingFrame</c> it builds) run during construction, not during compilation, so a chain
+///     from <c>HttpChain.ChainFor</c> — which compiles nothing — is already described correctly.</para>
 ///
-///     <para>It does not. <c>applyMetadata()</c> is the LAST statement of the <see cref="HttpChain" />
-///     constructor, and the endpoint's parameter strategies (including
-///     <c>AsParamatersAttributeUsage.TryMatch</c> and the <c>AsParametersBindingFrame</c> it builds) have
-///     already run by then — during construction, not during compilation. <c>HttpChain.ChainFor</c> compiles
-///     nothing, so the assertions below prove the description is complete with no codegen at all.</para>
+///     <para>What WAS broken is the construction path: the route reaches an attribute-routed chain from inside
+///     the constructor, but <c>HttpGraph.Add</c> used to map it onto the finished chain afterwards. Since
+///     <c>MapToRoute()</c> is what runs the parameter strategies, metadata on those chains was built from a null
+///     <c>RequestType</c> and an empty method list. <c>Add</c> now routes through the constructor.</para>
 ///
-///     <para>That ordering is currently accidental: nothing stated it, and nothing would catch a refactor that
-///     deferred parameter matching to compile time. These tests state it. If someone moves strategy execution
-///     later, the description silently reverts to defaults — a query-only GET would advertise a form body again
-///     (GH-3630) and a <c>[FromBody]</c> member would be described as its containing type (GH-3135) — and these
-///     fail instead.</para>
+///     <para>The ordering was never stated anywhere, which is why the gap survived. These tests state it. If
+///     someone moves strategy execution later, the description silently reverts to defaults — a query-only GET
+///     advertises a form body again (GH-3630), a <c>[FromBody]</c> member is described as its containing type
+///     (GH-3135), a published message advertises no body at all — and these fail instead.</para>
 /// </summary>
 public class chain_request_description_is_complete_before_metadata_3646
 {
@@ -82,6 +90,53 @@ public class chain_request_description_is_complete_before_metadata_3646
             .SelectMany(x => x.ContentTypes)
             .ShouldContain("multipart/form-data");
     }
+
+    /// <summary>
+    ///     The case the tests above did NOT cover, and the one that was actually broken: a chain whose route is
+    ///     supplied explicitly instead of by a <c>[WolverineHttpMethod]</c> attribute. <c>HttpGraph.Add</c> used to
+    ///     construct the chain and only then call <c>MapToRoute()</c> — which is what runs the parameter
+    ///     strategies — so <c>applyMetadata()</c>, the constructor's last statement, had already snapshotted a
+    ///     null <c>RequestType</c> and an empty method list. <c>PublishMessage&lt;T&gt;</c> and
+    ///     <c>SendMessage&lt;T&gt;</c> both build their endpoints this way.
+    /// </summary>
+    [Fact]
+    public void an_explicitly_routed_chain_is_described_the_same_as_an_attribute_routed_one()
+    {
+        var chain = buildGraph().Add(new MethodCall(typeof(Gh3646ExplicitlyRoutedEndpoint),
+            nameof(Gh3646ExplicitlyRoutedEndpoint.Handle)), System.Net.Http.HttpMethod.Post, "/3646/explicit");
+
+        chain.RequestType.ShouldBe(typeof(Gh3646Payload));
+
+        var endpoint = chain.BuildEndpoint(RouteWarmup.Lazy);
+
+        var accepts = endpoint.Metadata.OfType<IAcceptsMetadata>().ShouldHaveSingleItem();
+        accepts.RequestType.ShouldBe(typeof(Gh3646Payload));
+        accepts.ContentTypes.ShouldContain("application/json");
+
+        endpoint.Metadata.OfType<HttpMethodMetadata>()
+            .SelectMany(x => x.HttpMethods)
+            .ShouldContain("POST");
+    }
+
+    // Mirrors what HttpChain.ChainFor() builds internally, since HttpGraph.Add is what is under test here.
+    private static HttpGraph buildGraph()
+    {
+        var registry = new ServiceCollection();
+        registry.AddSingleton<JsonSerializerOptions>();
+        registry.AddTransient<IServiceVariableSource, ServiceCollectionServerVariableSource>();
+        registry.AddSingleton<IServiceContainer, ServiceContainer>();
+        registry.AddSingleton<IServiceCollection>(registry);
+
+        var container = registry.BuildServiceProvider().GetRequiredService<IServiceContainer>();
+
+        return new HttpGraph(new WolverineOptions(), container);
+    }
+}
+
+public class Gh3646ExplicitlyRoutedEndpoint
+{
+    [WolverineIgnore]
+    public string Handle(Gh3646Payload payload) => "ok";
 }
 
 public record Gh3646Payload(string Name);

--- a/src/Http/Wolverine.Http.Tests/publishing_messages_from_http_endpoint.cs
+++ b/src/Http/Wolverine.Http.Tests/publishing_messages_from_http_endpoint.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
 using Shouldly;
 using WolverineWebApi;
 
@@ -33,5 +34,22 @@ public class publishing_messages_from_http_endpoint : IntegrationContext
 
         // And status-code 200 is removed
         endpoint.Metadata.FirstOrDefault(x => x is IProducesResponseTypeMetadata m && m.StatusCode == 200).ShouldBeNull();
+    }
+
+    [Fact]
+    public void endpoint_describes_the_message_it_reads_from_the_body()
+    {
+        // GH-3646: these endpoints are built through HttpGraph.Add rather than from a [WolverinePost]
+        // attribute. The route used to be mapped onto the chain AFTER the constructor had already applied
+        // metadata, so the endpoint advertised no request body at all and carried no HTTP method.
+        var endpoint = EndpointFor("/publish/message1");
+
+        var accepts = endpoint.Metadata.OfType<IAcceptsMetadata>().ShouldHaveSingleItem();
+        accepts.RequestType.ShouldBe(typeof(HttpMessage1));
+        accepts.ContentTypes.ShouldContain("application/json");
+
+        endpoint.Metadata.OfType<HttpMethodMetadata>()
+            .SelectMany(x => x.HttpMethods)
+            .ShouldContain("POST");
     }
 }

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -108,7 +108,21 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
     private string _description;
     private Type? _requestType;
 
-    public HttpChain(MethodCall method, HttpGraph parent)
+    public HttpChain(MethodCall method, HttpGraph parent) : this(method, parent, null, null)
+    {
+    }
+
+    /// <summary>
+    ///     GH-3646: routes supplied explicitly rather than by a <see cref="WolverineHttpMethodAttribute" /> —
+    ///     <see cref="HttpGraph.Add" />, and through it <c>PublishMessage&lt;T&gt;</c> / <c>SendMessage&lt;T&gt;</c> —
+    ///     have to be mapped from INSIDE the constructor, not bolted on after it. <see cref="MapToRoute" /> is what
+    ///     runs the parameter strategies that assign <see cref="RequestType" />, <see cref="IsFormData" /> and the
+    ///     HTTP methods, and <see cref="applyMetadata" /> is the constructor's last statement. Mapping the route
+    ///     afterwards left metadata built from an unassigned request type: the endpoint advertised no
+    ///     <c>IAcceptsMetadata</c> at all and carried an empty <c>HttpMethodMetadata</c>, even though the chain
+    ///     itself knew the request type perfectly well.
+    /// </summary>
+    internal HttpChain(MethodCall method, HttpGraph parent, string? httpMethod, string? url)
     {
         _description = method.ToString();
         _parent = parent ?? throw new ArgumentNullException(nameof(parent));
@@ -159,6 +173,13 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
             {
                 EndpointDescription = att.Description;
             }
+        }
+
+        // Applied after the attribute so an explicit route still wins, exactly as it did when HttpGraph.Add
+        // called MapToRoute() on the constructed chain. See GH-3646.
+        if (httpMethod != null && url != null)
+        {
+            MapToRoute(httpMethod, url);
         }
 
         OperationId ??= $"{Method.HandlerType.FullNameInCode()}.{Method.Method.Name}";

--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -221,8 +221,9 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
 
     public HttpChain Add(MethodCall method, HttpMethod httpMethod, string url)
     {
-        var chain = new HttpChain(method, this);
-        chain.MapToRoute(httpMethod.ToString(), url);
+        // GH-3646: the route goes through the constructor rather than being mapped onto the finished chain,
+        // so the parameter strategies run before applyMetadata() reads what they assign.
+        var chain = new HttpChain(method, this, httpMethod.ToString(), url);
         _chains.Add(chain);
         return chain;
     }

--- a/src/Http/Wolverine.Http/WolverineHttpOptions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpOptions.cs
@@ -467,9 +467,10 @@ public class WolverineHttpOptions
 #pragma warning disable CS4014
         var method = MethodCall.For<PublishingEndpoint<T>>(x => x.PublishAsync(default!, null!, null!));
 #pragma warning restore CS4014
+        // GH-3646: Add() maps the route through the constructor now, so the second MapToRoute() that used to
+        // sit here is gone -- it only re-ran parameter matching after the metadata was already built.
         var chain = Endpoints!.Add(method, httpMethod, url);
 
-        chain.MapToRoute(httpMethod.ToString(), url);
         chain.DisplayName = $"Forward {typeof(T).FullNameInCode()} to Wolverine";
         chain.OperationId = $"Publish:{typeof(T).FullNameInCode()}";
         customize?.Invoke(chain);
@@ -494,9 +495,9 @@ public class WolverineHttpOptions
 #pragma warning disable CS4014
         var method = MethodCall.For<SendingEndpoint<T>>(x => x.SendAsync(default!, null!, null!));
 #pragma warning restore CS4014
+        // GH-3646: see PublishMessage above.
         var chain = Endpoints!.Add(method, httpMethod, url);
 
-        chain.MapToRoute(httpMethod.ToString(), url);
         chain.DisplayName = $"Forward {typeof(T).FullNameInCode()} to Wolverine";
         chain.OperationId = $"Send:{typeof(T).FullNameInCode()}";
         customize?.Invoke(chain);


### PR DESCRIPTION
Closes #3646.

## The residual #3655 missed

`applyMetadata()` — which turns `IsFormData` / `RequestType` / `RequestBodyIsOptional` into `Accepts` metadata and the API description — is the last statement of the `HttpChain` constructor, and `MapToRoute()` is what runs the parameter strategies that assign them. An attribute-routed chain calls `MapToRoute()` from **inside** the constructor (`HttpChain.cs:174`), so the ordering holds — that part of #3655's disproof is correct and stands.

`HttpGraph.Add` inverted it:

```csharp
var chain = new HttpChain(method, this);       // constructor ends with applyMetadata()
chain.MapToRoute(httpMethod.ToString(), url);  // ...and only now do the strategies run
```

`PublishMessage<T>` and `SendMessage<T>` are the endpoints built that way. Measured against `WolverineWebApi` on `main`:

```
PROBE /publish/message1: accepts=0  httpMethods=[]      chainRequestType=HttpMessage1
PROBE /publish/message2: accepts=0  httpMethods=[]      chainRequestType=HttpMessage2
PROBE /send/message5:    accepts=0  httpMethods=[]      chainRequestType=HttpMessage5
PROBE /orders/create3:   accepts=1  httpMethods=[POST]  chainRequestType=StartOrder   <- [WolverinePost]
```

The chain knew its request type in every row. The metadata built from it only knew it where the route had been mapped first. OpenAPI therefore documented these as a body-less POST even though they deserialize the message out of the request body — the same silently-wrong-description class as #3135.

## The change

`Add()` passes the route through an internal `HttpChain` constructor overload that maps it in the same position the attribute branch does — after the attribute, so an explicit route still wins exactly as it did when it was applied last. The redundant second `MapToRoute()` in `PublishMessage`/`SendMessage` goes with it; it only re-ran parameter matching after the metadata was already built.

Nothing changes about which strategy binds what. `JsonBodyParameterStrategy` already reads `chain.HttpMethods`, and `MapToRoute` fills those before it invokes parameter matching, so the strategies see the same state they always did. In particular a GET-routed `PublishMessage<T>` still gets no request type (`JsonHandling.cs:76` bails on GET) and so cannot trip the #3648 fail-fast — no configuration that started before stops starting now.

## On #3646's own proposal

The issue asked for either moving decisions earlier or restructuring so `applyMetadata()` cannot observe pre-assignment state. Neither was needed: the state was already assigned early enough, on every path but one, and that one just needed to map its route where the others do.

## Not addressed

`HttpMethodMetadata` also came out empty on these endpoints, which should mean no HTTP-method constraint reaches the route matcher. It is populated correctly now, but I could not cleanly demonstrate the routing consequence beforehand — a `GET /publish/message1` returned 400 rather than 405, and so did a GET against the attribute-routed contrast endpoint, so something else is absorbing method matching in that host. Whatever that is, it is unrelated to this change and worth its own look.

## Verification

- `Wolverine.Http.Tests` **938 passed / 0 failed / 10 skipped** (net9.0), including 2 new tests
- `Wolverine.Http.AspVersioning.Tests` **66 passed / 0 failed** (net10.0)
- `dotnet build wolverine.slnx -c Release` clean, 0 warnings

New coverage: `an_explicitly_routed_chain_is_described_the_same_as_an_attribute_routed_one` on the `HttpGraph.Add` path, and `endpoint_describes_the_message_it_reads_from_the_body` asserting it on the real `/publish/message1` endpoint. Both fail on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Li3ySPL3WLEJhuVJvAzFTp
