### PR TITLE
fix(agents): confirm a pending assignment on delivery, not on continued assignment (#3663)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/pending_assignment_ledger.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/pending_assignment_ledger.cs
@@ -106,4 +106,40 @@ public class pending_assignment_ledger
         _self.ActiveAgents.Clear();
         assignedAgentCount(await evaluateAsync()).ShouldBe(FakeAgentFamily.Names.Length);
     }
+
+    /// <summary>
+    /// GH-3663: an operator pause can be the FIRST evaluation to observe a delivered assignment — and that
+    /// same evaluation detaches the paused agent, so a confirmation that requires the agent to still be
+    /// assigned to its node never fires. The delivered-but-unconfirmed ledger entry then suppressed the
+    /// post-restart AssignAgent for a full TTL (2 x CheckAssignmentPeriod = 60s by default), which is why a
+    /// paused projection agent appeared to never resume after RestartAgent. Delivery alone must confirm.
+    /// </summary>
+    [Fact]
+    public async Task pause_then_restart_within_the_ttl_re_emits_the_assignment()
+    {
+        // Initial assignment arms a ledger entry for every agent.
+        assignedAgentCount(await evaluateAsync()).ShouldBe(FakeAgentFamily.Names.Length);
+
+        // The node starts them all and persists the assignment rows...
+        _self.ActiveAgents.AddRange(_family.AllAgentUris());
+
+        // ...but before any unrestricted evaluation sees that, an operator pauses one agent. This
+        // evaluation both observes the delivery (OriginalNode == this node) and detaches the agent, so it
+        // must emit the stop AND still clear the delivered ledger entry.
+        var paused = _family.AllAgentUris().First();
+        var pauseRestrictions = new AgentRestrictions();
+        pauseRestrictions.PauseAgent(paused);
+        var pauseCommands = await _controller.EvaluateAssignmentsAsync([_self], pauseRestrictions);
+        pauseCommands.OfType<StopRemoteAgent>().ShouldContain(x => x.AgentUri == paused);
+        assignedAgentCount(pauseCommands).ShouldBe(0);
+
+        // The stop lands on the node.
+        _self.ActiveAgents.Remove(paused);
+
+        // Restart (the restriction is lifted) well inside the TTL: the reassignment must be emitted
+        // immediately, not swallowed until the stale pre-pause ledger entry expires.
+        var restartCommands = await evaluateAsync();
+        assignedAgentCount(restartCommands).ShouldBe(1);
+        restartCommands.OfType<AssignAgent>().Single().AgentUri.ShouldBe(paused);
+    }
 }

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.EvaluateAssignments.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.EvaluateAssignments.cs
@@ -133,12 +133,18 @@ public partial class NodeAgentController
         // genuinely stuck start is retried once the entry expires.
         var ttl = _runtime.Options.Durability.CheckAssignmentPeriod * 2;
 
-        // Confirmation: an agent now running on the very node we assigned it to is no longer pending. The
-        // grid sets Agent.OriginalNode from each node's persisted ActiveAgents, so OriginalNode == AssignedNode
-        // means the destination started it and persisted the assignment row since we last emitted.
+        // Confirmation: an agent observed running on the very node we assigned it to is no longer pending.
+        // The grid sets Agent.OriginalNode from each node's persisted ActiveAgents, so a matching
+        // OriginalNode means the destination started it and persisted the assignment row since we last
+        // emitted — the only question this ledger asks. Deliberately independent of what THIS evaluation
+        // decides to do with the agent: GH-3663 hit the gap where the confirming evaluation was also the
+        // one detaching the agent for an operator pause (AssignedNode == null), so the delivered entry was
+        // never cleared and kept suppressing the post-restart AssignAgent for a full TTL.
         foreach (var agent in grid.AllAgents)
         {
-            if (agent.OriginalNode != null && ReferenceEquals(agent.AssignedNode, agent.OriginalNode))
+            if (agent.OriginalNode != null
+                && _pendingAssignments.TryGetValue(agent.Uri, out var delivered)
+                && delivered.NodeId == agent.OriginalNode.NodeId)
             {
                 _pendingAssignments.Remove(agent.Uri);
             }


### PR DESCRIPTION
Closes #3663.

## The regression

In 6.23.0, a paused projection/subscription agent under `UseWolverineManagedEventSubscriptionDistribution` did not come back after `RestartAgent` — the restart was accepted, the restriction flipped to `None`, and the agent stayed unassigned. It *did* eventually resume, but only after the pending-assignment ledger's TTL (2 × `CheckAssignmentPeriod` = 60s by default), which any 30s operator/test window reads as "never".

Bisected to the D3/D6 pending-assignment ledger (#3622), confirmed empirically: extending the CritterWatch repro's final wait from 30s to 120s made the agent resume at ~62s — exactly the TTL.

## Mechanism

The ledger's confirmation required the agent to be running **and still assigned to the same node**:

```csharp
if (agent.OriginalNode != null && ReferenceEquals(agent.AssignedNode, agent.OriginalNode))
```

An operator pause breaks that in a systematic way: the first evaluation that could observe the delivered assignment (the assignment row in `ActiveAgents` → `OriginalNode`) is the very evaluation that applies the pause restriction and detaches the agent, so `AssignedNode == null` and the entry is never confirmed. Nothing on the stop path clears the ledger either. The post-restart `AssignAgent` then targets the same `(agent → node)` pair and is suppressed as "still in flight" until the entry ages out.

## The fix

Confirmation now asks only the question the ledger exists to answer — *did the destination act on the `AssignAgent`?* — independent of what the current evaluation decides to do with the agent:

```csharp
if (agent.OriginalNode != null
    && _pendingAssignments.TryGetValue(agent.Uri, out var delivered)
    && delivered.NodeId == agent.OriginalNode.NodeId)
```

The ledger's designed behaviors are preserved: a start that genuinely never took (no assignment row ever appears) still waits out the TTL before being re-driven, re-targets to a different node were already exempt, and duplicate-flood suppression for slow starts is untouched.

## Verification

- New regression test `pending_assignment_ledger.pause_then_restart_within_the_ttl_re_emits_the_assignment` — red without the fix, green with it.
- End-to-end against the issue's repro (`EventStoreCoordinationTests.TenantPartitionedCoordinationTests` in CritterWatch) via a local `6.23.1-gh3663.1` package overlay: all three tests fail on 6.23.0 (3/3, 30s timeouts) and pass with the fix in 8s; the full 42-test `EventStoreCoordinationTests` suite is green against the patched packages.
- CoreTests: 2102 passed on net9.0.
- Full `wolverine.slnx` Release build: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)