### PR TITLE
fix(postgresql): advisory-lock session hygiene for Marten's gap-liveness gate (#3664)

### DIFF
--- a/docs/guide/durability/postgresql.md
+++ b/docs/guide/durability/postgresql.md
@@ -546,3 +546,35 @@ builder.Host.UseWolverine(opts =>
 ```
 
 
+
+### Advisory locks and Marten's async-daemon gap detection
+
+Marten's async daemon (9.16.1+) will not skip a stale event-sequence gap while any Postgres session
+that *might* have reserved those sequence numbers is still alive — concretely, any session whose open
+transaction predates the gap ([marten#4953](https://github.com/JasperFx/marten/issues/4953)). A
+session that parks inside an open transaction for the life of the process therefore looks like a
+permanent "possible reserver" and can hold the high-water mark — and every async projection — behind a
+genuinely dead gap indefinitely.
+
+Wolverine's long-held locks are deliberately shaped to stay out of that candidate set:
+
+- **Leader election and node coordination** hold *session-scoped* advisory locks on a dedicated,
+  transaction-free connection. In `pg_stat_activity` those sessions read `state = 'idle'` with a NULL
+  `xact_start`, so Marten's liveness probe never counts them.
+- Those sessions are tagged `application_name = 'wolverine-advisory-lock:<database>'` so a
+  `pg_stat_activity` scan attributes them at a glance.
+- The *transaction-scoped* advisory lock used by the scheduled-message poll lives only for the few
+  statements of each poll cycle and commits promptly.
+
+Two rules for combined Marten + Wolverine deployments:
+
+1. **Don't rely on `idle_in_transaction_session_timeout` as a dead-gap backstop.** Older guidance
+   suggested it; if you have any component holding a transaction-scoped lock in a long-lived open
+   transaction, that setting kills the session (and the lock with it). Prefer upgrading Marten to
+   9.16.1+ and, where needed, its `SkipStaleGapsDespiteLiveTransactionsAfter` setting.
+2. **Never add keepalive queries inside a long-lived open transaction** in your own code. A periodic
+   `select 1` bumps `pg_stat_activity.state_change`, which makes the session look active to Marten's
+   liveness fence and re-promotes it to candidate reserver — permanently defeating the mitigation. If a
+   session must hold an open transaction, it should stay completely silent; better yet, hold long-lived
+   exclusivity as a session-scoped lock on a connection with no transaction at all, the way Wolverine's
+   `AdvisoryLock` does.

--- a/src/Persistence/PostgresqlTests/advisory_lock_session_hygiene.cs
+++ b/src/Persistence/PostgresqlTests/advisory_lock_session_hygiene.cs
@@ -1,0 +1,120 @@
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Shouldly;
+using Xunit;
+using AdvisoryLock = Wolverine.Postgresql.AdvisoryLock;
+
+namespace PostgresqlTests;
+
+/// <summary>
+/// GH-3664 — long-held exclusivity must stay invisible to Marten's async-daemon gap-liveness gate
+/// (marten#4953/#5057), which counts any session with an open transaction older than an event-sequence
+/// gap as a possible reserver of that gap and holds the high-water mark for it. Wolverine's dedicated
+/// advisory-lock sessions live for the process lifetime, so they must always read as
+/// <c>state='idle'</c> with a NULL <c>xact_start</c> in pg_stat_activity — and they carry an
+/// <c>application_name</c> tag so an operator scanning pg_stat_activity can tell what is holding them.
+/// </summary>
+public class advisory_lock_session_hygiene : PostgresqlContext
+{
+    [Fact]
+    public async Task lock_session_is_tagged_and_invisible_to_martens_gap_liveness_gate()
+    {
+        const int lockId = unchecked((int)0x3664A001);
+
+        var dataSource = NpgsqlDataSource.Create(Servers.PostgresConnectionString);
+        try
+        {
+            var holder = new AdvisoryLock(dataSource, NullLogger.Instance, "hygiene-test");
+            try
+            {
+                (await holder.TryAttainLockAsync(lockId, CancellationToken.None)).ShouldBeTrue();
+
+                // Let the backend settle back to idle after the lock command.
+                await Task.Delay(250);
+
+                var session = await findLockHolderSessionAsync(lockId);
+                session.ShouldNotBeNull("the advisory lock must be held by a live backend");
+
+                session!.ApplicationName.ShouldBe("wolverine-advisory-lock:hygiene-test");
+
+                // The two properties that keep this session out of Marten's candidate-reserver set:
+                // no open transaction, and plain idle state.
+                session.XactStart.ShouldBeNull(
+                    "the advisory-lock session must never hold an open transaction — an open transaction " +
+                    "makes it a candidate event-sequence reserver and freezes async-daemon progress");
+                session.State.ShouldBe("idle");
+            }
+            finally
+            {
+                await holder.DisposeAsync();
+            }
+        }
+        finally
+        {
+            await dataSource.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task application_name_is_truncated_to_postgres_limit_for_long_database_identifiers()
+    {
+        const int lockId = unchecked((int)0x3664A002);
+
+        // application_name is capped at NAMEDATALEN-1 (63); Postgres truncates louder builds with a
+        // warning, so AdvisoryLock truncates quietly instead.
+        var longIdentifier = new string('x', 100);
+
+        var dataSource = NpgsqlDataSource.Create(Servers.PostgresConnectionString);
+        try
+        {
+            var holder = new AdvisoryLock(dataSource, NullLogger.Instance, longIdentifier);
+            try
+            {
+                (await holder.TryAttainLockAsync(lockId, CancellationToken.None)).ShouldBeTrue();
+                await Task.Delay(250);
+
+                var session = await findLockHolderSessionAsync(lockId);
+                session.ShouldNotBeNull();
+                session!.ApplicationName.ShouldBe($"wolverine-advisory-lock:{longIdentifier}"[..63]);
+            }
+            finally
+            {
+                await holder.DisposeAsync();
+            }
+        }
+        finally
+        {
+            await dataSource.DisposeAsync();
+        }
+    }
+
+    private sealed record LockHolderSession(string ApplicationName, string State, DateTime? XactStart);
+
+    private static async Task<LockHolderSession?> findLockHolderSessionAsync(int lockId)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            select a.application_name, a.state, a.xact_start
+            from pg_locks l
+            join pg_stat_activity a on a.pid = l.pid
+            where l.locktype = 'advisory'
+              and l.granted = true
+              and ((l.classid::bigint << 32) | (l.objid::bigint & x'FFFFFFFF'::bigint)) = @lockId
+            limit 1";
+        cmd.Parameters.AddWithValue("@lockId", (long)lockId);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            return null;
+        }
+
+        return new LockHolderSession(
+            reader.GetString(0),
+            reader.GetString(1),
+            await reader.IsDBNullAsync(2) ? null : reader.GetDateTime(2));
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -476,6 +476,14 @@ join pg_catalog.pg_namespace n on n.oid = c.relnamespace and n.nspname = '{Schem
         await using var conn = await NpgsqlDataSource.OpenConnectionAsync(cancellationToken);
         try
         {
+            // GH-3664: this is a transaction-scoped advisory lock, and Marten's async-daemon gap-liveness
+            // gate (marten#4953/#5057) treats ANY session with an open transaction older than an
+            // event-sequence gap as a possible reserver of that gap. This transaction must therefore stay
+            // short — do the poll's work and commit/rollback promptly, never await anything that isn't a
+            // command on this connection while it is open, and never add keepalive queries inside it
+            // (bumping state_change re-promotes the session to candidate reserver and freezes projections
+            // behind dead gaps). Long-held exclusivity belongs on a session-scoped lock on a
+            // transaction-free dedicated connection instead — see AdvisoryLock in PostgresqlNodePersistence.
             var tx = await conn.BeginTransactionAsync(cancellationToken);
             if (await tx.TryGetGlobalTxLock(Settings.ScheduledJobLockId, cancellationToken) == AttainLockResult.Success)
             {

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlNodePersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlNodePersistence.cs
@@ -425,6 +425,16 @@ internal class AdvisoryLock : IAdvisoryLock
         // we actually try to use it, so without this ping HasLock keeps
         // claiming the lock long after another session has acquired it,
         // and two nodes both believe they're the leader. See GH-2602.
+        //
+        // GH-3664: this ping is only safe because the connection never has
+        // an open transaction — the session reads state='idle' with
+        // xact_start NULL in pg_stat_activity, so Marten's event-gap
+        // liveness gate (marten#4953/#5057) never counts it as a possible
+        // sequence reserver. Do NOT copy this keepalive pattern into any
+        // code path that holds an open transaction: bumping state_change
+        // inside a transaction makes the session look active and
+        // legitimately re-promotes it to candidate reserver, freezing
+        // async-daemon progress behind dead gaps.
         try
         {
             using var cmd = _conn.CreateCommand();
@@ -453,6 +463,38 @@ internal class AdvisoryLock : IAdvisoryLock
         }
     }
 
+    /// <summary>
+    /// GH-3664: stamp the dedicated lock connection's <c>application_name</c> so an operator scanning
+    /// pg_stat_activity can tell at a glance what is holding the session — these connections live for the
+    /// process lifetime and otherwise look like anonymous idle sessions. Deliberately session-scoped SQL
+    /// (set_config) rather than a connection-string edit: the NpgsqlDataSource may carry auth plumbing
+    /// (e.g. Azure token callbacks) that a rebuilt connection string would lose. Best-effort — a tagging
+    /// failure must never cost us the lock connection.
+    /// </summary>
+    private async Task tagSessionAsync(NpgsqlConnection conn, CancellationToken token)
+    {
+        try
+        {
+            // application_name is capped at NAMEDATALEN-1 (63) chars; Postgres would truncate with a
+            // warning, so truncate quietly here instead.
+            var name = $"wolverine-advisory-lock:{_databaseName}";
+            if (name.Length > 63)
+            {
+                name = name[..63];
+            }
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "select set_config('application_name', @name, false)";
+            cmd.Parameters.AddWithValue("name", name);
+            await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "Unable to tag the advisory-lock session for database {Database}",
+                _databaseName);
+        }
+    }
+
     public async Task<bool> TryAttainLockAsync(int lockId, CancellationToken token)
     {
         // Idempotent against repeated calls on the same session. Postgres
@@ -475,6 +517,7 @@ internal class AdvisoryLock : IAdvisoryLock
         {
             _conn = _source.CreateConnection();
             await _conn.OpenAsync(token).ConfigureAwait(false);
+            await tagSessionAsync(_conn, token).ConfigureAwait(false);
         }
 
         if (_conn.State == ConnectionState.Closed)

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -415,6 +415,10 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>, IConnection
         await conn.OpenAsync(cancellationToken);
         try
         {
+            // GH-3664: transaction-scoped lock — keep this transaction short and never await anything
+            // that isn't a command on this connection while it is open. See the fuller discussion on the
+            // Postgres twin (PostgresqlMessageStore.PollForScheduledMessagesAsync); the same hygiene
+            // applies here even though Marten's gap-liveness gate is Postgres-only.
             var tx = (SqlTransaction)await conn.BeginTransactionAsync(cancellationToken);
             if (await tx.TryGetGlobalTxLock(_scheduledLockId, cancellationToken))
             {


### PR DESCRIPTION
Closes #3664. Follow-up from the marten#4953 / marten#5057 field report: any Postgres session parking an open transaction for the life of the process reads as a permanent "possible sequence reserver" to Marten's async-daemon gap-liveness gate (9.16.1+), holding the high-water mark — and every async projection — behind genuinely dead gaps.

## Audit result (suggestion 1 & 2)

Wolverine 6.x (and the 5.0 branch) has **no process-lifetime transaction-scoped locks**. The only `pg_advisory_xact_lock` sites are the scheduled-message polls (`PostgresqlMessageStore.PollForScheduledMessagesAsync` and its SqlServer twin), whose transactions span a few back-to-back statements and commit/rollback promptly — the envelope enqueue happens after commit, and the lock-miss branch closes the connection immediately. Long-held exclusivity (leader election / node coordination) already lives on **session-scoped** locks on a dedicated transaction-free connection, which `pg_stat_activity` reports as `state='idle'` with NULL `xact_start` — invisible to the gate.

## Changes

- **Tag the dedicated advisory-lock session** (suggestion 4) with `application_name = 'wolverine-advisory-lock:<database>'`, applied via session-scoped `set_config` rather than connection-string surgery so NpgsqlDataSource auth plumbing (e.g. Azure token callbacks) is untouched. Truncated to Postgres's 63-char cap, best-effort so a tagging failure can never cost the lock connection.
- **Pin the constraints in comments** at both `TryGetGlobalTxLock` poll sites and on `AdvisoryLock`'s liveness ping (suggestion 3): keep xact-lock transactions short, and never add keepalive queries inside an open transaction — bumping `state_change` re-promotes the session to candidate reserver and defeats Marten's fence. The ping on the lock connection is safe precisely because that session never has an open transaction.
- **New tests** (`PostgresqlTests.advisory_lock_session_hygiene`) pinning the load-bearing invariants: the lock session is tagged, `state='idle'`, `xact_start IS NULL`; 100-char identifiers truncate to 63.
- **Docs** (suggestion 5): new *"Advisory locks and Marten's async-daemon gap detection"* section in the Postgres durability guide, replacing the old `idle_in_transaction_session_timeout` backstop advice with Marten 9.16.1+ / `SkipStaleGapsDespiteLiveTransactionsAfter` guidance and the no-keepalive rule.

Out of scope: SqlServer `Application Name` tagging (connection-string-only in SqlClient, and the Marten gate is Postgres-only) — the SqlServer poll site gets the same short-transaction comment.

## Verification

- `PostgresqlTests`: 462/462 (the single first-pass failure was `Bug_1942_replay_dlq_to_buffered_or_inline` with the RabbitMQ container down; passes with the broker up).
- Full `wolverine.slnx` Release build: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)