### PR TITLE
test(ravendb): cover exclusive listener inbox recovery (#3595)

### DIFF
--- a/src/Persistence/RavenDbTests/exclusive_listener_recovery_compliance.cs
+++ b/src/Persistence/RavenDbTests/exclusive_listener_recovery_compliance.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.DependencyInjection;
+using Raven.Client.Documents;
+using Wolverine;
+using Wolverine.ComplianceTests.ExclusiveListeners;
+using Wolverine.RavenDb;
+
+namespace RavenDbTests;
+
+/// <summary>
+/// GH-3590/GH-3595 -- see <see cref="ExclusiveListenerRecoveryCompliance"/>. The last scenario is what pins
+/// the <c>RavenDbDurabilityAgent</c> skipping any destination whose <c>ListenerScope</c> is not
+/// <c>CompetingConsumers</c>.
+/// </summary>
+[Collection("raven")]
+public class exclusive_listener_recovery_compliance : ExclusiveListenerRecoveryCompliance
+{
+    private readonly DatabaseFixture _fixture;
+    private IDocumentStore _store = null!;
+
+    public exclusive_listener_recovery_compliance(DatabaseFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public override Task InitializeAsync()
+    {
+        // RavenTestDriver hands back a brand new database on every call and xUnit builds one instance of
+        // this class per test method, so each scenario gets its own isolated inbox.
+        _store = _fixture.StartRavenStore();
+        return Task.CompletedTask;
+    }
+
+    protected override void ConfigureStorage(WolverineOptions options)
+    {
+        options.UseRavenDbPersistence();
+
+        // Registered as an instance rather than a factory so the host's container does not dispose the
+        // store out from under the DatabaseFixture that owns it
+        options.Services.AddSingleton<IDocumentStore>(_store);
+    }
+}


### PR DESCRIPTION
Closes #3595.

## What

Adds `RavenDbTests/exclusive_listener_recovery_compliance.cs` — the RavenDb subclass of the shared `ExclusiveListenerRecoveryCompliance` fixture from #3590.

That fixture's five scenarios now run against RavenDb:

1. `recover_dormant_messages_for_a_single_node_listener`
2. `a_latched_circuit_recovers_nothing`
3. `exclusive_listener_recovers_its_own_dormant_inbox_end_to_end`
4. `leader_pinned_listener_recovers_its_own_dormant_inbox_end_to_end`
5. `durability_agent_leaves_dormant_rows_for_a_single_node_listener_alone`

(5) is the one that pins the #3590 change to `RavenDbDurabilityAgent.Incoming`, which skips any destination whose `ListenerScope` is not `CompetingConsumers` — recovery for those endpoints belongs to the node hosting the listener, not to the per-database durability agent. That change had no test until now.

## Notes

- The issue assumed this could not be run locally for want of a docker service. It can: `RavenDbTests` uses the embedded `RavenTestDriver`, and the fixture's listening endpoint is the broker-free `SingleNodeListenerTransport`, so nothing external is needed.
- `RavenTestDriver.GetDocumentStore()` hands back a brand new database per call and xUnit builds one instance of the test class per test method, so every scenario gets an isolated inbox. The fixture's default `ResetStateAsync` needed no override.
- The `IDocumentStore` is registered as an *instance* rather than a factory so the host's container does not dispose it out from under the `DatabaseFixture` that owns it.

## Verification

Run locally on `net9.0`:

- new suite: 5/5 passed
- full `RavenDbTests`: 207/207 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)