### PR TITLE
test(cosmosdb): cover exclusive listener inbox recovery (#3596)

### DIFF
--- a/src/Persistence/CosmosDbTests/exclusive_listener_recovery_compliance.cs
+++ b/src/Persistence/CosmosDbTests/exclusive_listener_recovery_compliance.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Wolverine;
+using Wolverine.ComplianceTests.ExclusiveListeners;
+using Wolverine.CosmosDb;
+
+namespace CosmosDbTests;
+
+/// <summary>
+/// GH-3590/GH-3596 -- see <see cref="ExclusiveListenerRecoveryCompliance"/>. The last scenario is what pins
+/// the <c>CosmosDbDurabilityAgent</c> skipping any destination whose <c>ListenerScope</c> is not
+/// <c>CompetingConsumers</c>, and every scenario exercises the null guard around
+/// <c>FindListenerCircuit()</c> that landed alongside it.
+/// </summary>
+[Collection("cosmosdb")]
+public class exclusive_listener_recovery_compliance : ExclusiveListenerRecoveryCompliance
+{
+    private readonly AppFixture _fixture;
+
+    public exclusive_listener_recovery_compliance(AppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    protected override void ConfigureStorage(WolverineOptions options)
+    {
+        options.UseCosmosDbPersistence(AppFixture.DatabaseName);
+
+        // Every test in the "cosmosdb" collection shares the one emulator client, so it is registered as
+        // an instance and not a factory -- the host's container must not dispose it on shutdown
+        options.Services.AddSingleton(_fixture.Client);
+    }
+}

--- a/src/Persistence/CosmosDbTests/saga_storage_compliance.cs
+++ b/src/Persistence/CosmosDbTests/saga_storage_compliance.cs
@@ -70,6 +70,10 @@ public class CosmosDbSagaHost : ISagaHost
     }
 }
 
+// CosmosDbSagaHost stands up real Wolverine hosts against the one shared emulator database, so this suite
+// has to be serialized with the rest of the CosmosDb tests. Left outside the collection it ran in parallel
+// and its node/durability churn intermittently released inbox ownership out from under other suites.
+[Collection("cosmosdb")]
 public class saga_storage_compliance : StringIdentifiedSagaComplianceSpecs<CosmosDbSagaHost>
 {
     public saga_storage_compliance()


### PR DESCRIPTION
Closes #3596.

## What

Adds `CosmosDbTests/exclusive_listener_recovery_compliance.cs` — the CosmosDb subclass of the shared `ExclusiveListenerRecoveryCompliance` fixture from #3590.

That fixture's five scenarios now run against CosmosDb:

1. `recover_dormant_messages_for_a_single_node_listener`
2. `a_latched_circuit_recovers_nothing`
3. `exclusive_listener_recovers_its_own_dormant_inbox_end_to_end`
4. `leader_pinned_listener_recovers_its_own_dormant_inbox_end_to_end`
5. `durability_agent_leaves_dormant_rows_for_a_single_node_listener_alone`

(5) pins the #3590 change to `CosmosDbDurabilityAgent.Incoming` that skips any destination whose `ListenerScope` is not `CompetingConsumers`, and every scenario exercises the `FindListenerCircuit()` null guard that landed on the line below it. Neither had a test until now.

## Also: `saga_storage_compliance` moved into the `cosmosdb` collection

Writing the new suite surfaced a real pre-existing flake, so this PR fixes it too.

`CosmosDbSagaHost` stands up real Wolverine hosts (Solo durability, node persistence, durability agent) against the one shared emulator database — but `saga_storage_compliance` carried no `[Collection("cosmosdb")]`, so it ran *in parallel* with every suite that does. Its node and durability churn intermittently released inbox ownership out from under the others.

The new compliance suite is what caught it: scenario (1) recovers 5 dormant rows, claims them, and asserts a second sweep finds nothing — and that second sweep occasionally found a row it had already claimed, because a parallel host had reset its owner back to 0.

`saga_storage_compliance` is the only class outside the collection that touches the shared database. `document_serialization`, `DocumentationSamples` and `saga_serialization_validation` deliberately never connect to the emulator, so they are left alone.

## Notes

- The issue assumed this could not be run locally for want of a docker service. It can: `CosmosDbTests` already starts the emulator via Testcontainers (`AppFixture`), and the fixture's listening endpoint is the broker-free `SingleNodeListenerTransport`.
- The `CosmosClient` is registered as an *instance* rather than a factory, matching the other CosmosDb suites, so the host's container does not dispose the shared client on shutdown.
- The fixture's default `ResetStateAsync` (`host.ResetResourceState()` → `CosmosDbMessageStore.Admin.ClearAllAsync()`) was sufficient; no override needed.

## Verification

Run locally on `net9.0` against the emulator:

- new suite alone: 5/5 passed, 5 consecutive runs
- full `CosmosDbTests`: 97/97 passed, 3 consecutive runs after the collection fix. Before it, the full suite failed 1 run in 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)