### PR TITLE
Bump to 6.23.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.23.0</Version>
+        <Version>6.23.1</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Patch release bump for the three fixes already merged on top of 6.23.0.

| Issue | PR | Fix |
|---|---|---|
| #3663 | #3665 | A paused projection/subscription agent did not resume after `RestartAgent` until the pending-assignment ledger's TTL expired (2 × `CheckAssignmentPeriod`, 60s by default). Delivery alone now confirms a ledger entry. |
| #3664 | #3667 | Advisory-lock session hygiene for Marten's async-daemon gap-liveness gate — `application_name` tagging, pinned constraints at the transaction-scoped lock sites, and combined-deployment docs. |
| #3666 | #3668 | `ApplyRestrictionsAsync` merges and persists the restriction change *before* kickstarting health detection, so the kickstarted evaluation can no longer act against the operator's intent (it could briefly start the agent being paused). |

`6.23.1` is not yet on NuGet, so the publish workflow's `--skip-duplicate` won't silently no-op this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)