### PR TITLE
perf(rabbitmq): per-endpoint consumer dispatch concurrency (GH-3492)

### DIFF
--- a/RABBITMQ-PERF-DEEP-DIVE-PLAN.md
+++ b/RABBITMQ-PERF-DEEP-DIVE-PLAN.md
@@ -163,13 +163,35 @@ transfer); the GH-3490 debounce never applied to Rabbit's sender path (default i
 buffered both unaffected — checked both directions); R5 buffered-below-inline max anomaly
 recorded but unfixed (RO5 follow-up).
 
+### Measured 2026-07-27 (wave 2; local rig, same box, `perf/3492-rabbitmq-wave2` vs `origin/main` @073312262)
+
+| Cell | BEFORE | AFTER | Verdict |
+|---|---|---|---|
+| r-thru-inline @2000/s, 5ms handler, default | 163.7/s | — | R1 reconfirmed on this box |
+| ...same cell + `ConsumerDispatchConcurrency(5)` | 163.7/s | **828/s (5.1x)** | **RO6 headline** |
+| ...same cell + `ConsumerDispatchConcurrency(20)` | 163.7/s | **1,999/s (12.2x)** | RO6 — keeps up with the full offered load |
+| r-max-inline (uncapped, 0ms handler) | 41.0k/41.0-44.2k/s | 42.7k/41.3k/s | ack `multiple:false` fix is throughput-neutral |
+| r-max-native (anchor) | 51.0k/s | — | Wolverine inline ≈ 84% of the native twin at max throughput |
+
+**RO2 ack-watermark coalescing: REJECTED on measurement.** A prototype that batched settlements
+behind a 5ms/prefetch-sized `BatchingChannel` and issued one cumulative `basic.ack` per batch
+measured **37.7-39.5k/s vs a 41.0-44.2k/s baseline — a ~10% regression** across three runs each.
+The premise was wrong: `basic.ack` is a fire-and-forget AMQP frame, not an RPC, so coalescing
+saves no round trips while the extra channel hops cost real throughput. The native twin acks per
+message too, which is why acks were never the inline gap. What survives from RO2 is the
+correctness half — `BasicAckAsync(tag, multiple: true)` on every completion also acked every
+lower delivery tag on the channel, so out-of-order completion under a concurrent listener acked
+messages that were still in the handler pipeline. Now `multiple: false`.
+
 Same rules as #3490 §9: rows only from archived rig runs, exact E-cell + config recorded,
 before/after from the same rig version, one-liner phrased for release notes. Log negative
 results below the table.
 
 | Optimization | PR | Scenario (RE-cell) | Metric | Before | After | Release-note one-liner |
 |---|---|---|---|---|---|---|
-| _(RO1 batched inbox, RO2 ack coalescing, RO3 mapper fixes, ... — rows added as measured)_ | | | | | | |
+| RO1 batched durable inbox | #3512 | r-max-durable | throughput | 1,086/s | 3,101/s | Durable RabbitMQ listeners persist prefetched deliveries in one batched insert: +186% max throughput |
+| RO6 per-endpoint `ConsumerDispatchConcurrency` | this wave | r-thru-inline @2000/s, 5ms handler | throughput | 164/s | 1,999/s | Inline RabbitMQ listeners can now scale consumption per endpoint instead of transport-wide: 12x on a 5ms handler |
+| RO2 ack coalescing | — | r-max-inline | throughput | 41-44k/s | 37.7-39.5k/s | REJECTED — `basic.ack` is not an RPC; batching costs ~10% and saves nothing |
 
 ## 7. Sequencing & exit criteria
 

--- a/RABBITMQ-PERF-DEEP-DIVE-PLAN.md
+++ b/RABBITMQ-PERF-DEEP-DIVE-PLAN.md
@@ -170,7 +170,7 @@ recorded but unfixed (RO5 follow-up).
 | r-thru-inline @2000/s, 5ms handler, default | 163.7/s | — | R1 reconfirmed on this box |
 | ...same cell + `ConsumerDispatchConcurrency(5)` | 163.7/s | **828/s (5.1x)** | **RO6 headline** |
 | ...same cell + `ConsumerDispatchConcurrency(20)` | 163.7/s | **1,999/s (12.2x)** | RO6 — keeps up with the full offered load |
-| r-max-inline (uncapped, 0ms handler) | 41.0k/41.0-44.2k/s | 42.7k/41.3k/s | ack `multiple:false` fix is throughput-neutral |
+| r-max-inline (uncapped, 0ms handler) | 41.0k/41.0-44.2k/s | 42.7k/41.3k/s | ack `multiple:false` is throughput-neutral (change itself deferred, see below) |
 | r-max-native (anchor) | 51.0k/s | — | Wolverine inline ≈ 84% of the native twin at max throughput |
 
 **RO2 ack-watermark coalescing: REJECTED on measurement.** A prototype that batched settlements
@@ -178,10 +178,32 @@ behind a 5ms/prefetch-sized `BatchingChannel` and issued one cumulative `basic.a
 measured **37.7-39.5k/s vs a 41.0-44.2k/s baseline — a ~10% regression** across three runs each.
 The premise was wrong: `basic.ack` is a fire-and-forget AMQP frame, not an RPC, so coalescing
 saves no round trips while the extra channel hops cost real throughput. The native twin acks per
-message too, which is why acks were never the inline gap. What survives from RO2 is the
-correctness half — `BasicAckAsync(tag, multiple: true)` on every completion also acked every
-lower delivery tag on the channel, so out-of-order completion under a concurrent listener acked
-messages that were still in the handler pipeline. Now `multiple: false`.
+message too, which is why acks were never the inline gap.
+
+**RO2 ack semantics (`multiple: true` → `false`): DEFERRED, and here is why it is not a one-liner.**
+`BasicAckAsync(tag, multiple: true)` on every completion also acks every lower delivery tag on the
+channel, so out-of-order completion under a concurrent listener acks messages still in the handler
+pipeline — a real at-least-once hole. But that sweep turns out to be **load-bearing**: it is
+currently the only thing settling deliveries that some paths never acknowledge at all. Flipping it
+to `multiple: false` in isolation makes those deliveries leak.
+
+Measured, after a full `Wolverine.RabbitMQ.Tests` run against a freshly deleted queue:
+
+| Build | quorum1 after the full suite |
+|---|---|
+| `origin/main` | 0 messages |
+| `multiple: false` | **1 message ready (leaked)** |
+
+CI caught it twice on fresh containers: `quorum_queue_compliance.will_requeue_and_increment_attempts`
+fails 2-of-2 attempts on the ack branch and passes on two sibling PRs off the same base that carry
+no RabbitMQ changes. The isolated retry runs fail because the leaked message is still sitting in the
+queue from the full run — locally the same test passes against a clean queue and fails against a
+dirty one, on both branches.
+
+The fix is to find and settle the leaking path (prime suspect:
+`RabbitMqInteropFriendlyCallback.MoveToErrorsAsync` posts a copy to the dead-letter queue and never
+acks or nacks the original, unlike `RabbitMqChannelCallback.moveToErrorQueueAsync` which nacks), NOT
+to keep the sweep. Split onto its own branch so the RO6 win is not held hostage to it.
 
 Same rules as #3490 §9: rows only from archived rig runs, exact E-cell + config recorded,
 before/after from the same rig version, one-liner phrased for release notes. Log negative
@@ -192,6 +214,7 @@ results below the table.
 | RO1 batched durable inbox | #3512 | r-max-durable | throughput | 1,086/s | 3,101/s | Durable RabbitMQ listeners persist prefetched deliveries in one batched insert: +186% max throughput |
 | RO6 per-endpoint `ConsumerDispatchConcurrency` | this wave | r-thru-inline @2000/s, 5ms handler | throughput | 164/s | 1,999/s | Inline RabbitMQ listeners can now scale consumption per endpoint instead of transport-wide: 12x on a 5ms handler |
 | RO2 ack coalescing | — | r-max-inline | throughput | 41-44k/s | 37.7-39.5k/s | REJECTED — `basic.ack` is not an RPC; batching costs ~10% and saves nothing |
+| RO2 ack semantics (`multiple: false`) | deferred | full RabbitMQ suite | messages leaked into quorum1 | 0 | 1 | DEFERRED — the cumulative sweep is load-bearing; fix the unsettled path first |
 
 ## 7. Sequencing & exit criteria
 

--- a/docs/guide/messaging/transports/rabbitmq/performance.md
+++ b/docs/guide/messaging/transports/rabbitmq/performance.md
@@ -26,9 +26,21 @@ opts.ListenToRabbitQueue("orders")
 
     .MaximumParallelMessages(10);
 
-// 3. Raise the client's per-channel dispatch concurrency (applies transport-wide)
+// 3. Raise the client's dispatch concurrency for just this endpoint
+opts.ListenToRabbitQueue("orders").ConsumerDispatchConcurrency(20);
+
+// ...or transport-wide, for every channel in the process
 opts.UseRabbitMq(...).ConfigureChannelCreation(o => o.ConsumerDispatchConcurrency = 4);
 ```
+
+::: tip
+`ConsumerDispatchConcurrency` is usually the cheapest of the three for an Inline listener — it
+costs no extra channels or connections. On the local rig, an Inline listener with a 5ms handler
+under a 2,000 msg/s load went from **164 msg/s** at the default of 1 to **828 msg/s** at 5 and
+**1,999 msg/s** at 20, where it kept up with the full offered load (GH-3492). Raising it gives up
+strict one-at-a-time ordering on that endpoint, which is the whole point — if you need ordering,
+use `PartitionProcessingByGroupId` or sharded queues instead of a single serialized consumer.
+:::
 
 ## Choosing the endpoint mode
 

--- a/src/Testing/KafkaPerfRig/RigConfig.cs
+++ b/src/Testing/KafkaPerfRig/RigConfig.cs
@@ -49,6 +49,9 @@ public class RigConfig
     // 0 = leave the endpoint's default listener count
     public int ListenerCount { get; } = envInt("RIG_LISTENER_COUNT", 0);
 
+    // GH-3492 RO6: per-endpoint consumer dispatch concurrency. 0 leaves the transport-wide default.
+    public int DispatchConcurrency { get; } = envInt("RIG_DISPATCH_CONCURRENCY", 0);
+
     // --- RabbitMQ (GH-3492) ---
     public string RabbitUri { get; } = env("RIG_RABBIT_URI", "amqp://guest:guest@localhost:5672");
     public string SmallQueue => $"rig-small-{RunId}";

--- a/src/Testing/KafkaPerfRig/WolverineRabbit.cs
+++ b/src/Testing/KafkaPerfRig/WolverineRabbit.cs
@@ -85,6 +85,11 @@ public static class WolverineRabbit
         {
             listener.ListenerCount(cfg.ListenerCount);
         }
+
+        if (cfg.DispatchConcurrency > 0)
+        {
+            listener.ConsumerDispatchConcurrency((ushort)cfg.DispatchConcurrency);
+        }
     }
 
     public static async Task RunPublisherAsync(RigConfig cfg)

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Internals/consumer_dispatch_concurrency_3492.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Internals/consumer_dispatch_concurrency_3492.cs
@@ -1,0 +1,49 @@
+using NSubstitute;
+using Shouldly;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests.Internals;
+
+/// <summary>
+/// GH-3492 (RO6). The RabbitMQ client's dispatch concurrency was only settable transport-wide,
+/// which made the single most effective Inline scaling lever an all-or-nothing process setting.
+/// </summary>
+public class consumer_dispatch_concurrency_3492
+{
+    private static IWolverineRuntime runtime()
+    {
+        var wolverineRuntime = Substitute.For<IWolverineRuntime>();
+        wolverineRuntime.Options.Returns(new WolverineOptions());
+        return wolverineRuntime;
+    }
+
+    [Fact]
+    public void defaults_to_null_so_the_transport_wide_value_still_applies()
+    {
+        new RabbitMqQueue("foo", new RabbitMqTransport()).ConsumerDispatchConcurrency.ShouldBeNull();
+    }
+
+    [Fact]
+    public void listener_configuration_sets_it()
+    {
+        var endpoint = new RabbitMqQueue("foo", new RabbitMqTransport());
+        var expression = new RabbitMqListenerConfiguration(endpoint, new RabbitMqTransport());
+
+        expression.ConsumerDispatchConcurrency(20).ShouldBeSameAs(expression);
+
+        endpoint.Compile(runtime());
+
+        endpoint.ConsumerDispatchConcurrency.ShouldBe((ushort)20);
+    }
+
+    [Fact]
+    public void must_be_at_least_one()
+    {
+        var endpoint = new RabbitMqQueue("foo", new RabbitMqTransport());
+        var expression = new RabbitMqListenerConfiguration(endpoint, new RabbitMqTransport());
+
+        Should.Throw<ArgumentOutOfRangeException>(() => expression.ConsumerDispatchConcurrency(0));
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs
@@ -14,7 +14,12 @@ public enum ConnectionRole
 public interface IConnectionMonitor
 {
     Task ConnectAsync();
-    Task<IChannel> CreateChannelAsync();
+    /// <param name="consumerDispatchConcurrency">
+    /// Overrides the transport-wide <see cref="WolverineRabbitMqChannelOptions.ConsumerDispatchConcurrency"/>
+    /// for this one channel. Listeners use it to scale a single endpoint's consumption without
+    /// changing every other channel in the process (GH-3492).
+    /// </param>
+    Task<IChannel> CreateChannelAsync(ushort? consumerDispatchConcurrency = null);
     ConnectionRole Role { get; }
 }
 
@@ -54,15 +59,17 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
     /// Configures the channel using custom RabbitMQ channel creation options if specified.
     /// </summary>
     /// <returns>A task that resolves to an <see cref="IChannel"/> instance for RabbitMQ communication.</returns>
-    public Task<IChannel> CreateChannelAsync()
+    public Task<IChannel> CreateChannelAsync(ushort? consumerDispatchConcurrency = null)
     {
-        var connection = _connection 
+        var connection = _connection
             ?? throw new InvalidOperationException("The connection is not initialized");
 
         var wolverineOptions = new WolverineRabbitMqChannelOptions();
         _transport.ChannelCreationOptions?.Invoke(wolverineOptions);
 
-        var options = new CreateChannelOptions(wolverineOptions.PublisherConfirmationsEnabled, wolverineOptions.PublisherConfirmationTrackingEnabled, consumerDispatchConcurrency: wolverineOptions.ConsumerDispatchConcurrency);
+        var options = new CreateChannelOptions(wolverineOptions.PublisherConfirmationsEnabled,
+            wolverineOptions.PublisherConfirmationTrackingEnabled,
+            consumerDispatchConcurrency: consumerDispatchConcurrency ?? wolverineOptions.ConsumerDispatchConcurrency);
 
         return connection.CreateChannelAsync(options);
     }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelAgent.cs
@@ -97,9 +97,15 @@ internal abstract class RabbitMqChannelAgent : IAsyncDisposable, IReportConnecti
         }
     }
 
+    /// <summary>
+    /// Per-agent override of the transport-wide consumer dispatch concurrency. Only listeners
+    /// consume, so senders leave this null (GH-3492).
+    /// </summary>
+    protected virtual ushort? ConsumerDispatchConcurrency => null;
+
     protected async Task startNewChannel()
     {
-        Channel = await _monitor.CreateChannelAsync();
+        Channel = await _monitor.CreateChannelAsync(ConsumerDispatchConcurrency);
 
         Channel.CallbackExceptionAsync += HandleChannelExceptionAsync;
         Channel.ChannelShutdownAsync += HandleChannelShutdownAsync;

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -96,6 +96,8 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
 
     public RabbitMqQueue Queue { get; }
 
+    protected override ushort? ConsumerDispatchConcurrency => Queue.ConsumerDispatchConcurrency;
+
     public async ValueTask StopAsync()
     {
         var consumer = _consumer;
@@ -316,6 +318,16 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
 
     public async Task CompleteAsync(ulong deliveryTag)
     {
-        await Channel!.BasicAckAsync(deliveryTag, true, _cancellation);
+        // GH-3492 (RO2): ack ONLY this delivery. This used to pass multiple: true, which tells the
+        // broker "and every lower delivery tag on this channel too". Completions finish out of
+        // order under any concurrent listener -- Buffered or Durable with MaxDegreeOfParallelism
+        // above 1 -- so completing tag 10 silently acked tags 1-9 while they were still in the
+        // handler pipeline, and a crash then lost them.
+        //
+        // Coalescing these into cumulative acks behind a batching window was measured and REJECTED:
+        // basic.ack is a fire-and-forget frame, not an RPC, so batching saves no round trips while
+        // the extra channel hops cost ~10% of max inline throughput. See the ledger in
+        // RABBITMQ-PERF-DEEP-DIVE-PLAN.md.
+        await Channel!.BasicAckAsync(deliveryTag, false, _cancellation);
     }
 }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -318,16 +318,16 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
 
     public async Task CompleteAsync(ulong deliveryTag)
     {
-        // GH-3492 (RO2): ack ONLY this delivery. This used to pass multiple: true, which tells the
-        // broker "and every lower delivery tag on this channel too". Completions finish out of
-        // order under any concurrent listener -- Buffered or Durable with MaxDegreeOfParallelism
-        // above 1 -- so completing tag 10 silently acked tags 1-9 while they were still in the
-        // handler pipeline, and a crash then lost them.
+        // NOTE: multiple: true also acks every LOWER delivery tag on this channel. That is wrong
+        // under a concurrent listener -- it acks messages still in the handler pipeline -- but it
+        // is currently load-bearing, because it sweeps up deliveries that some settle paths never
+        // acknowledge at all. Changing it in isolation leaks those deliveries. Tracked separately;
+        // see GH-3492 and the ack-semantics branch.
         //
         // Coalescing these into cumulative acks behind a batching window was measured and REJECTED:
         // basic.ack is a fire-and-forget frame, not an RPC, so batching saves no round trips while
         // the extra channel hops cost ~10% of max inline throughput. See the ledger in
         // RABBITMQ-PERF-DEEP-DIVE-PLAN.md.
-        await Channel!.BasicAckAsync(deliveryTag, false, _cancellation);
+        await Channel!.BasicAckAsync(deliveryTag, true, _cancellation);
     }
 }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -67,6 +67,15 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
     public int MaximumMessagesToReceive { get; set; } = 100;
 
     /// <summary>
+    /// Overrides the transport-wide consumer dispatch concurrency for just this queue's listening
+    /// channels. This is the RabbitMQ client's own limit on how many deliveries it hands to a
+    /// consumer at once, and with the default of 1 an Inline listener consumes strictly one
+    /// message at a time no matter what MaxDegreeOfParallelism says. Null uses the transport-wide
+    /// value set through ConfigureChannelCreation(). See GH-3492.
+    /// </summary>
+    public ushort? ConsumerDispatchConcurrency { get; set; }
+
+    /// <summary>
     ///     The number of unacknowledged messages that can be processed concurrently
     /// </summary>
     public ushort PreFetchCount

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
@@ -113,6 +113,25 @@ public class RabbitMqListenerConfiguration : InteroperableListenerConfiguration<
     }
 
     /// <summary>
+    ///     Override the RabbitMQ client's consumer dispatch concurrency for just this endpoint's
+    ///     listening channels. This governs how many deliveries the client hands to the consumer
+    ///     at once: at the default of 1, an <c>Inline</c> listener runs strictly one message at a
+    ///     time through the handler no matter how MaxDegreeOfParallelism is set. Raising it is the
+    ///     per-endpoint alternative to the transport-wide
+    ///     <c>ConfigureChannelCreation(o =&gt; o.ConsumerDispatchConcurrency = n)</c>. See GH-3492.
+    /// </summary>
+    public RabbitMqListenerConfiguration ConsumerDispatchConcurrency(ushort concurrency)
+    {
+        if (concurrency < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(concurrency), "Must be at least 1");
+        }
+
+        add(e => e.ConsumerDispatchConcurrency = concurrency);
+        return this;
+    }
+
+    /// <summary>
     /// For durable (inbox-backed) listeners, the maximum number of prefetched deliveries the
     /// consumer coalesces into one batched inbox insert (5ms max accumulation age). 1 reverts
     /// to strict message-at-a-time persistence. Ignored for Buffered/Inline endpoints.


### PR DESCRIPTION
Wave 2 of the RabbitMQ performance deep dive (GH-3492). Wave 1 was #3512.

**Scope note:** this PR originally also flipped the acknowledgement semantics. CI caught a real
regression there, so that half has been split onto its own branch — see the bottom of this
description. What remains here is RO6 plus a measured negative result.

## RO6 — `ConsumerDispatchConcurrency` is now per endpoint

The RabbitMQ client's consumer dispatch concurrency was only settable transport-wide, through
`ConfigureChannelCreation`. That made the single most effective lever for RabbitMQ's `Inline`
default an all-or-nothing process setting.

```cs
opts.ListenToRabbitQueue("orders").ConsumerDispatchConcurrency(20);
```

Measured on the in-repo rig (`KafkaPerfRig`, rabbit harness), Inline listener, 1Kb payloads, 5ms
simulated handler, 2,000 msg/s offered load, 10s warmup / 30s measured:

| `ConsumerDispatchConcurrency` | Throughput | Consumed in window | Transit p50 | Total p50 | Handler p50 |
|---|---|---|---|---|---|
| 1 (client default) | 163.7/s | 8,602 | — (nothing from the measured window was consumed before the run ended) | — | — |
| 5 | 828/s | 43,456 | 22,871.9 ms | 22,878.4 ms | 6.311 ms |
| 20 | **1,999.1/s** | 79,980 | **1.486 ms** (p95 2.54, p99 3.22) | **7.275 ms** | 5.573 ms |

The throughput multiples (5.1x, 12.2x) understate it. At 1 and 5 the listener never catches up and
the backlog grows without bound — at 5 the delivery p50 is 22.9 **seconds**. At 20 it matches the
full offered load and delivery p50 collapses to 1.5 ms. Handler time is flat across all three cells,
so this is scheduling, not handler drift. Unlike `ListenerCount`, it costs no extra channels or
connections.

## RO2 ack coalescing — built, measured, rejected

The plan proposed coalescing acks into cumulative ones behind a batching window. I built it
(BatchingChannel + contiguous watermark + cumulative ack, 7 unit tests green) and threw it away on
the numbers, `r-max-inline` (uncapped publisher, 0ms handler):

| Build | Runs |
|---|---|
| `origin/main` baseline | 43,899.8 / 41,024.9 / 44,201.3 msg/s |
| **RO2 ack coalescing** | **39,501 / 37,715 / 37,818.9 msg/s** |
| native `RabbitMQ.Client` twin | 50,965.1 msg/s |

**~10% regression, three runs each, no overlap between the distributions.** The premise was wrong:
`basic.ack` is a fire-and-forget AMQP frame, not an RPC, so coalescing saves zero round trips while
the extra channel hops cost real throughput. The native twin acks per message too and still runs at
51k/s, which is the direct evidence that acks were never the inline gap — Wolverine inline sits at
~84% of the native twin, and whatever the remaining 16% is, it is not acknowledgement.

Recorded in `RABBITMQ-PERF-DEEP-DIVE-PLAN.md` §6 so nobody re-litigates it.

## Split out: the ack semantics change

`BasicAckAsync(tag, multiple: true)` also acks every lower delivery tag on the channel, so
out-of-order completion under a concurrent listener acks messages still in the handler pipeline.
That is a genuine at-least-once hole and I originally fixed it here.

CI proved it is not a one-liner. **The cumulative sweep is load-bearing** — it is currently the only
thing settling deliveries that some paths never acknowledge at all. Measured after a full
`Wolverine.RabbitMQ.Tests` run against a freshly deleted queue:

| Build | `quorum1` after the full suite |
|---|---|
| `origin/main` | 0 messages |
| `multiple: false` | **1 message ready (leaked)** |

That leaked message then fails `quorum_queue_compliance.will_requeue_and_increment_attempts` on the
next run against the same broker, which is exactly what CI hit — twice, on fresh containers, 2-of-2
retry attempts — while #3673 and #3674, branched off the same base with zero RabbitMQ changes, kept
CIRabbitMQ green. Locally the same test passes against a clean queue and fails against a dirty one
on **both** branches, which is why my local baseline missed it.

The fix belongs with the leaking settle path, not with keeping the sweep (prime suspect:
`RabbitMqInteropFriendlyCallback.MoveToErrorsAsync` posts a copy to the dead-letter queue and never
acks or nacks the original, unlike `RabbitMqChannelCallback.moveToErrorQueueAsync` which nacks).
Branch: `fix/3492-rabbitmq-ack-semantics`.

## Tests

New unit coverage for the per-endpoint knob (`consumer_dispatch_concurrency_3492`). Full
`Wolverine.RabbitMQ.Tests` results are on the CI run for this branch.

GH-3492 stays open for the remaining items: the ack semantics fix, RO5 (back-pressure churn), O1b
(batched mark-handled), RO4 (publisher-confirm windowing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)