### PR TITLE
perf(sqs): batch message deletions, and chunk outgoing batches on the request size limit (GH-3493)

### DIFF
--- a/SQS-PERF-DEEP-DIVE-PLAN.md
+++ b/SQS-PERF-DEEP-DIVE-PLAN.md
@@ -143,7 +143,14 @@ latency. Log negative results below the table.
 
 | Optimization | PR | Scenario (QE-cell) | Metric | Before | After | Release-note one-liner |
 |---|---|---|---|---|---|---|
-| _(SO1 delete batching, SO2 batch-failure handling, SO4 send parallelism, ... — rows added as measured)_ | | | | | | |
+| SO2 batch-send failure handling | #3503 | — | correctness | silent loss | routed to retry | Per-entry SendMessageBatch failures are no longer silently marked successful |
+| SO1 delete batching | this wave | QE2 | API calls / 10 msgs | 10 DeleteMessage | 1 DeleteMessageBatch | SQS listeners delete completed messages in batches: 10x fewer round trips and 10x lower SQS API spend on the receive side |
+| SO3 size-aware chunking | this wave | — | correctness | whole request bounces | chunked under 256KB | Outgoing SQS batches now respect the 256KB per-request limit, not just the 10-message limit |
+
+**Not measured on real SQS.** SO1's ratio is structural (10 deletes become 1 request) and is
+covered by unit tests plus the LocalStack suites, but the latency/throughput numbers this plan
+asks for still need a real-SQS run per §8 — LocalStack RTTs are not publishable. The ledger rows
+above quote API-call counts, which are exact, rather than timings, which are not.
 
 ## 7. Sequencing & exit criteria
 

--- a/docs/guide/messaging/transports/sqs/performance.md
+++ b/docs/guide/messaging/transports/sqs/performance.md
@@ -11,9 +11,10 @@ Durable endpoints benefit doubly: the whole received batch is written to the dat
 a **single** batched insert, so durable SQS endpoints are considerably cheaper per message than
 push-based transports.
 
-Message *completion*, however, is currently one `DeleteMessage` API call per message — ten
-deletes per receive at full batches. At high throughput, delete round trips (not receives) are
-usually the ceiling for a single listener. The practical levers:
+Message *completion* is batched too. Completed messages accumulate for up to 50 milliseconds and
+are deleted with a single `DeleteMessageBatch` call of up to 10 — so a full 10-message receive is
+settled with one round trip instead of ten. Since SQS bills per API call, this is a cost lever as
+much as a latency one. The practical levers:
 
 ```cs
 opts.ListenToSqsQueue("orders")
@@ -26,8 +27,18 @@ opts.ListenToSqsQueue("orders")
     // faster listener shutdown.
     .ConfigureListener(l => l.WaitTimeSeconds = 20)
 
+    // Delete batching. Defaults to 10 (the SQS maximum) with a 50ms window.
+    // Pass 1 to go back to one DeleteMessage call per message.
+    .DeleteMessageBatchSize(10, 50.Milliseconds())
+
     .MaximumParallelMessages(10);
 ```
+
+::: tip
+The delete window is a *maximum batch age*, not a quiet period, so a single message never waits
+longer than the window. Batches are also flushed when a listener stops, so a paused listener
+does not leave settled messages to reappear at their visibility timeout.
+:::
 
 ## Visibility timeout: size it against your processing window
 
@@ -72,6 +83,11 @@ The default envelope mapper embeds the serialized Wolverine envelope in the mess
 Base64, which inflates the wire size by roughly a third — budget against the 256 KB SQS message
 limit accordingly. For large or high-volume payloads where you control both ends, the raw JSON
 mapper (or a custom `ISqsEnvelopeMapper`) avoids the Base64 wrapping.
+
+SQS also caps an entire `SendMessageBatch` *request* at 256 KB, not just each message in it, so
+ten individually legal 30 KB messages would bounce the whole request. Wolverine chunks outgoing
+batches on both limits — ten entries and the request payload budget — so large messages simply
+produce smaller batches.
 
 ## FIFO queues
 

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/sqs_batch_chunking_3493.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/sqs_batch_chunking_3493.cs
@@ -1,0 +1,115 @@
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+
+namespace Wolverine.AmazonSqs.Tests.Internal;
+
+/// <summary>
+/// GH-3493 (SO3). SQS caps a whole SendMessageBatch request at 256KB, not just each message, so
+/// chunking on the ten-entry limit alone let ten individually legal messages bounce the request.
+/// </summary>
+public class sqs_batch_chunking_3493
+{
+    private static Envelope envelopeOfSize(int bytes)
+    {
+        return new Envelope
+        {
+            Id = Guid.NewGuid(),
+            Data = new byte[bytes]
+        };
+    }
+
+    [Fact]
+    public void chunks_small_messages_at_the_ten_entry_limit()
+    {
+        var envelopes = Enumerable.Range(0, 25).Select(_ => envelopeOfSize(100)).ToArray();
+
+        var chunks = SqsSenderProtocol.ChunkMessages(envelopes);
+
+        chunks.Length.ShouldBe(3);
+        chunks[0].Length.ShouldBe(10);
+        chunks[1].Length.ShouldBe(10);
+        chunks[2].Length.ShouldBe(5);
+    }
+
+    [Fact]
+    public void chunks_large_messages_on_the_request_payload_limit()
+    {
+        // Ten of these are each legal on their own but together blow past 256KB.
+        var envelopes = Enumerable.Range(0, 10).Select(_ => envelopeOfSize(60 * 1024)).ToArray();
+
+        var chunks = SqsSenderProtocol.ChunkMessages(envelopes);
+
+        chunks.Length.ShouldBeGreaterThan(1);
+        chunks.ShouldAllBe(chunk =>
+            chunk.Sum(x => SqsSenderProtocol.EstimateEntrySize(x)) <= SqsSenderProtocol.MaximumBatchPayloadBytes
+            || chunk.Length == 1);
+        chunks.SelectMany(x => x).Count().ShouldBe(10);
+    }
+
+    [Fact]
+    public void an_oversized_single_message_still_gets_its_own_chunk()
+    {
+        var envelopes = new[] { envelopeOfSize(400 * 1024), envelopeOfSize(100) };
+
+        var chunks = SqsSenderProtocol.ChunkMessages(envelopes);
+
+        chunks.Length.ShouldBe(2);
+        chunks[0].Length.ShouldBe(1);
+        chunks[1].Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public void no_messages_are_dropped_or_duplicated()
+    {
+        var envelopes = Enumerable.Range(0, 37).Select(i => envelopeOfSize(i * 2000)).ToArray();
+
+        var chunks = SqsSenderProtocol.ChunkMessages(envelopes);
+
+        chunks.SelectMany(x => x).ShouldBe(envelopes);
+    }
+
+    [Fact]
+    public void empty_batch_yields_no_chunks()
+    {
+        SqsSenderProtocol.ChunkMessages([]).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void estimate_accounts_for_base64_inflation()
+    {
+        // 3 raw bytes become 4 base64 characters, so the estimate must exceed the raw length.
+        SqsSenderProtocol.EstimateEntrySize(envelopeOfSize(30_000))
+            .ShouldBeGreaterThan(30_000 + SqsSenderProtocol.EntryOverheadBytes);
+    }
+}
+
+/// <summary>
+/// GH-3493 (SO1). Guard rails on the delete batching knob.
+/// </summary>
+public class sqs_delete_batch_configuration_3493
+{
+    [Fact]
+    public void defaults_to_the_sqs_maximum()
+    {
+        var queue = new AmazonSqsQueue("foo", new AmazonSqsTransport());
+        queue.DeleteMessageBatchSize.ShouldBe(AmazonSqsQueue.MaximumDeleteBatchSize);
+        queue.DeleteMessageBatchTimeout.ShouldBe(TimeSpan.FromMilliseconds(50));
+    }
+
+    [Fact]
+    public void one_is_allowed_as_the_opt_out()
+    {
+        var queue = new AmazonSqsQueue("foo", new AmazonSqsTransport()) { DeleteMessageBatchSize = 1 };
+        queue.DeleteMessageBatchSize.ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(11)]
+    public void rejects_sizes_outside_the_sqs_limits(int size)
+    {
+        var queue = new AmazonSqsQueue("foo", new AmazonSqsTransport());
+        Should.Throw<ArgumentOutOfRangeException>(() => queue.DeleteMessageBatchSize = size);
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
@@ -79,6 +79,29 @@ public class AmazonSqsListenerConfiguration : ListenerConfiguration<AmazonSqsLis
     }
 
     /// <summary>
+    ///     How many completed messages this listener coalesces into a single SQS
+    ///     <c>DeleteMessageBatch</c> call, and how long a completion waits for that batch to fill.
+    ///     Deleting per message costs one HTTP round trip -- and one billable API call -- each,
+    ///     which is 10 deletes for every 10 message receive. Valid sizes are 1 through 10; pass 1
+    ///     to go back to a delete per message. Defaults are 10 and 50 milliseconds. See GH-3493.
+    /// </summary>
+    /// <param name="size">Messages per delete request, 1 to 10</param>
+    /// <param name="timeout">Maximum age of a pending delete batch. Defaults to 50 milliseconds</param>
+    public AmazonSqsListenerConfiguration DeleteMessageBatchSize(int size, TimeSpan? timeout = null)
+    {
+        add(e =>
+        {
+            e.DeleteMessageBatchSize = size;
+            if (timeout.HasValue)
+            {
+                e.DeleteMessageBatchTimeout = timeout.Value;
+            }
+        });
+
+        return this;
+    }
+
+    /// <summary>
     ///     Configure how the queue should be created within SQS
     /// </summary>
     /// <param name="configure"></param>

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -107,6 +107,43 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
     public int MaxNumberOfMessages { get; set; } = 10;
 
     /// <summary>
+    ///     Hard Amazon SQS limit on the number of entries in a single <c>DeleteMessageBatch</c>
+    ///     request.
+    /// </summary>
+    public const int MaximumDeleteBatchSize = 10;
+
+    private int _deleteMessageBatchSize = MaximumDeleteBatchSize;
+
+    /// <summary>
+    ///     How many message deletions this listener coalesces into a single
+    ///     <c>DeleteMessageBatch</c> call. Completion is otherwise one HTTP round trip -- and one
+    ///     billable API call -- per message, so a 10 message receive is paid for with 10 sequential
+    ///     deletes. Valid values are 1 through 10; 1 reverts to a delete per message. Default 10.
+    ///     See GH-3493.
+    /// </summary>
+    public int DeleteMessageBatchSize
+    {
+        get => _deleteMessageBatchSize;
+        set
+        {
+            if (value < 1 || value > MaximumDeleteBatchSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(DeleteMessageBatchSize),
+                    $"Must be between 1 and {MaximumDeleteBatchSize}");
+            }
+
+            _deleteMessageBatchSize = value;
+        }
+    }
+
+    /// <summary>
+    ///     The longest a completed message waits for its delete batch to fill before the batch is
+    ///     sent anyway. This is a maximum batch age, not a quiet period. Default 50 milliseconds --
+    ///     far inside any usable visibility timeout. See GH-3493.
+    /// </summary>
+    public TimeSpan DeleteMessageBatchTimeout { get; set; } = TimeSpan.FromMilliseconds(50);
+
+    /// <summary>
     ///     Additional configuration for how an SQS queue should be created
     /// </summary>
     [ChildDescription]

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -20,6 +20,14 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
     private readonly TimeSpan _drainTimeout;
     private readonly ILogger _logger;
 
+    // GH-3493 (SO1): completion used to be one DeleteMessage HTTP round trip per message, so a
+    // single 10-message receive was paid for with 10 sequential deletes. These coalesce into
+    // DeleteMessageBatch calls of up to 10 -- 10x fewer round trips and 10x fewer billable API
+    // calls. Null when the endpoint opts out with DeleteMessageBatchSize = 1.
+    private readonly BatchingChannel<Message>? _deleteBatching;
+    private readonly Block<Message[]>? _deleteBlock;
+    private readonly RetryBlock<Message> _singleDeleteBlock;
+
     public SqsListener(IWolverineRuntime runtime, AmazonSqsQueue queue, AmazonSqsTransport transport,
         IReceiver receiver)
     {
@@ -57,6 +65,17 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
         _deadLetterBlock =
             new RetryBlock<Envelope>(async (e, _) => { await _deadLetterQueue!.SendMessageAsync(e, logger); }, logger,
                 runtime.Cancellation);
+
+        _singleDeleteBlock = new RetryBlock<Message>(
+            (message, token) => _transport.Client!.DeleteMessageAsync(_queue.QueueUrl, message.ReceiptHandle, token),
+            logger, runtime.Cancellation);
+
+        if (_queue.DeleteMessageBatchSize > 1)
+        {
+            _deleteBlock = new Block<Message[]>((batch, _) => deleteBatchAsync(batch));
+            _deleteBatching = new BatchingChannel<Message>(_queue.DeleteMessageBatchTimeout, _deleteBlock,
+                _queue.DeleteMessageBatchSize);
+        }
 
         // GH-3236: the receive loop is now a shared BackgroundReceiveLoop — it owns the task, the
         // catch -> log -> exponential-backoff -> continue policy, the idle delay when a poll returns nothing, the
@@ -144,8 +163,43 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
     public async ValueTask DisposeAsync()
     {
         await _loop.DisposeAsync();
+        await flushPendingDeletesAsync();
         _requeueBlock.Dispose();
         _deadLetterBlock?.Dispose();
+        _singleDeleteBlock.Dispose();
+
+        if (_deleteBatching != null)
+        {
+            await _deleteBatching.DisposeAsync();
+        }
+
+        if (_deleteBlock != null)
+        {
+            await _deleteBlock.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Push any accumulated-but-unsent deletes at SQS. Anything still in flight simply reappears
+    /// after its visibility timeout.
+    /// </summary>
+    private async Task flushPendingDeletesAsync()
+    {
+        if (_deleteBatching == null)
+        {
+            return;
+        }
+
+        try
+        {
+            _deleteBatching.TriggerBatch();
+            _deleteBatching.Complete();
+            await _deleteBatching.WaitForCompletionAsync().WaitAsync(_drainTimeout);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "Error flushing pending SQS deletes for {Uri}", _queue.Uri);
+        }
     }
 
     public Uri Address => _queue.Uri;
@@ -153,6 +207,10 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
     public async ValueTask StopAsync()
     {
         await _loop.StopAsync(_drainTimeout);
+
+        // Don't leave completed messages sitting in the batch window while this listener is paused
+        // -- they'd reappear at the visibility timeout and be handled twice.
+        _deleteBatching?.TriggerBatch();
     }
 
     public async Task<bool> TryRequeueAsync(Envelope envelope)
@@ -190,6 +248,70 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
 
     public Task CompleteAsync(Message sqsMessage)
     {
-        return _transport.Client!.DeleteMessageAsync(_queue.QueueUrl, sqsMessage.ReceiptHandle);
+        if (_deleteBatching == null)
+        {
+            return _transport.Client!.DeleteMessageAsync(_queue.QueueUrl, sqsMessage.ReceiptHandle);
+        }
+
+        return _deleteBatching.PostAsync(sqsMessage).AsTask();
+    }
+
+    /// <summary>
+    /// Delete up to <c>DeleteMessageBatchSize</c> messages in one request. DeleteMessageBatch is
+    /// not transactional -- SQS can reject individual entries inside an otherwise successful
+    /// response -- so each failed entry falls back to a retried single delete. A delete that never
+    /// lands only means the message reappears after its visibility timeout, which the durable inbox
+    /// deduplicates.
+    /// </summary>
+    private async Task deleteBatchAsync(Message[] batch)
+    {
+        var entries = new List<DeleteMessageBatchRequestEntry>(batch.Length);
+        for (var i = 0; i < batch.Length; i++)
+        {
+            entries.Add(new DeleteMessageBatchRequestEntry(i.ToString(), batch[i].ReceiptHandle));
+        }
+
+        DeleteMessageBatchResponse response;
+        try
+        {
+            response = await _transport.Client!.DeleteMessageBatchAsync(
+                new DeleteMessageBatchRequest(_queue.QueueUrl, entries));
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e,
+                "Error deleting a batch of {Count} messages from {Uri}; falling back to individual deletes",
+                batch.Length, _queue.Uri);
+
+            foreach (var message in batch)
+            {
+                await _singleDeleteBlock.PostAsync(message);
+            }
+
+            return;
+        }
+
+        if (response.Failed == null || response.Failed.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var entry in response.Failed)
+        {
+            if (int.TryParse(entry.Id, out var index) && index >= 0 && index < batch.Length)
+            {
+                _logger.LogWarning(
+                    "SQS batch delete from {Uri} failed for entry {Id}: {Code} - {Message} (SenderFault: {SenderFault}). Retrying as a single delete",
+                    _queue.Uri, entry.Id, entry.Code, entry.Message, entry.SenderFault);
+
+                await _singleDeleteBlock.PostAsync(batch[index]);
+            }
+            else
+            {
+                _logger.LogError(
+                    "SQS batch delete from {Uri} reported a failed entry with unrecognized Id {Id}: {Code} - {Message}",
+                    _queue.Uri, entry.Id, entry.Code, entry.Message);
+            }
+        }
     }
 }

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSenderProtocol.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSenderProtocol.cs
@@ -30,12 +30,25 @@ internal class SqsSenderProtocol : ISenderProtocolWithNativeScheduling, IConditi
         return _queue.CanScheduleNatively(envelope, utcNow);
     }
 
+    /// <summary>
+    ///     Amazon SQS caps an entire <c>SendMessageBatch</c> request at 256KB, not just the
+    ///     individual messages. Chunk below that with room to spare, since the entry size here is
+    ///     an estimate (GH-3493).
+    /// </summary>
+    internal const int MaximumBatchPayloadBytes = 240 * 1024;
+
+    /// <summary>
+    ///     Fixed allowance per entry for the serialized envelope's headers and the SQS entry
+    ///     scaffolding, added before the base64 inflation. Over-estimating costs an extra request;
+    ///     under-estimating bounces a whole batch.
+    /// </summary>
+    internal const int EntryOverheadBytes = 1024;
+
     public async Task SendBatchAsync(ISenderCallback callback, OutgoingMessageBatch batch)
     {
         await _queue.InitializeAsync(_logger);
 
-        // SQS has a hard limit of 10 messages per batch request
-        var chunks = batch.Messages.Chunk(10).ToArray();
+        var chunks = ChunkMessages(batch.Messages);
 
         var successes = new List<Envelope>();
         var failures = new List<Envelope>();
@@ -81,6 +94,51 @@ internal class SqsSenderProtocol : ISenderProtocolWithNativeScheduling, IConditi
 
             await callback.MarkProcessingFailureAsync(new OutgoingMessageBatch(batch.Destination, failures));
         }
+    }
+
+    /// <summary>
+    ///     Split an outgoing batch on BOTH of SQS's limits: at most 10 entries per request, and at
+    ///     most 256KB across the whole request. Chunking on the count alone let ten individually
+    ///     legal 30KB messages bounce the entire request (GH-3493). A single message that is over
+    ///     the limit on its own still gets its own request and fails there, exactly as before.
+    /// </summary>
+    internal static Envelope[][] ChunkMessages(IEnumerable<Envelope> envelopes)
+    {
+        var chunks = new List<Envelope[]>();
+        var current = new List<Envelope>(10);
+        var currentSize = 0;
+
+        foreach (var envelope in envelopes)
+        {
+            var size = EstimateEntrySize(envelope);
+
+            if (current.Count > 0 && (current.Count == 10 || currentSize + size > MaximumBatchPayloadBytes))
+            {
+                chunks.Add(current.ToArray());
+                current.Clear();
+                currentSize = 0;
+            }
+
+            current.Add(envelope);
+            currentSize += size;
+        }
+
+        if (current.Count > 0)
+        {
+            chunks.Add(current.ToArray());
+        }
+
+        return chunks.ToArray();
+    }
+
+    /// <summary>
+    ///     Estimated wire size of one batch entry. The default mapper serializes the whole envelope
+    ///     -- headers included -- and base64 encodes it, which inflates by 4/3.
+    /// </summary>
+    internal static int EstimateEntrySize(Envelope envelope)
+    {
+        var raw = (envelope.Data?.Length ?? 0) + EntryOverheadBytes;
+        return (raw + 2) / 3 * 4;
     }
 
     // SendMessageBatchAsync is not transactional -- SQS can accept some entries and reject


### PR DESCRIPTION
The Amazon SQS performance deep dive (GH-3493). SO2 (batch-send partial failures) already landed
in #3503; this is SO1 and SO3.

## SO1 — `DeleteMessageBatch` instead of a delete per message

SQS is a good citizen on receive — one `ReceiveMessage` returns up to 10 messages and durable
endpoints persist the whole array with one batched inbox insert — but completion was one
`DeleteMessage` HTTP round trip per message, flowing through a concurrency-1 retry block. Ten
delete round trips for every one receive round trip. `DeleteMessageBatch` was never used anywhere
in the repo.

Completed messages now accumulate for up to 50ms and are deleted with a single
`DeleteMessageBatch` of up to 10 entries:

- **10x fewer round trips** on the receive side, and since SQS bills per API call, **10x lower
  SQS spend** for message completion.
- `DeleteMessageBatch` is not transactional, so any per-entry failure falls back to a retried
  single delete. A delete that never lands only means the message reappears at its visibility
  timeout, which the durable inbox deduplicates — the same failure mode as before.
- The window is a *maximum batch age*, not a quiet period, so a single message never waits longer
  than 50ms. Batches are flushed on `StopAsync` and on dispose, so a paused listener does not
  leave settled messages to reappear.

Configurable per endpoint, with 1 restoring the old behavior exactly:

```cs
opts.ListenToSqsQueue("orders").DeleteMessageBatchSize(10, 50.Milliseconds());
```

## SO3 — outgoing batches respect the request payload limit

`SendMessageBatch` was chunked on the 10-entry limit only. SQS also caps the **entire request**
at 256KB, not just each message, so ten individually legal 30KB messages bounced the whole
request. Chunking now cuts on both limits. An oversized single message still gets its own request
and fails there, exactly as before.

## Tests

- 11 new unit tests covering chunking (count limit, payload limit, oversized singletons, no
  dropped or duplicated messages) and the delete-batch configuration guard rails.
- Full `Wolverine.AmazonSqs.Tests` against LocalStack, net9.0: **246 passed, 6 skipped, 1 failed**.
  The one failure, `end_to_end_with_conventional_routing_with_prefix.send_from_one_node_to_another_all_with_conventional_routing`,
  fails identically on a clean `origin/main` worktree against the same LocalStack container.

## Not done here

The plan's §8 is explicit that LocalStack numbers are not publishable — the latency/throughput
cells still need a real-SQS account run. The ledger rows added to `SQS-PERF-DEEP-DIVE-PLAN.md`
quote API-call counts, which are exact, rather than timings, which are not. SO5 (visibility
renewal), SO6 (high-throughput FIFO helper) and the §4 sequencing decision table remain open on
the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)