### PR TITLE
fix(asb): de-quadratic session listeners, surface MaxConcurrentCalls, settle the original on a batched defer (GH-3494)

### DIFF
--- a/AZURESERVICEBUS-PERF-DEEP-DIVE-PLAN.md
+++ b/AZURESERVICEBUS-PERF-DEEP-DIVE-PLAN.md
@@ -160,7 +160,19 @@ feed the #3488/GH-3471 release notes directly** — that's the first ledger entr
 
 | Optimization | PR | Scenario (AE-cell) | Metric | Before | After | Release-note one-liner |
 |---|---|---|---|---|---|---|
-| _(PrefetchCount validation (#3488), AO2 session de-quadratic, AO4 settlement concurrency, ... — rows added as measured)_ | | | | | | |
+| AO2 session de-quadratic (accept-loop listener) | this wave | AE5 | concurrent accept loops at `RequireSessions(5)` | 25 | 5 | `RequireSessions(n)` opens n session accept loops instead of n-squared |
+| AO2 session de-quadratic (`ServiceBusSessionProcessor` path, GH-3533) | this wave | AE5 | concurrent sessions at `RequireSessions(8)` | 64 | 8 | Same n-squared on the session-processor path: `MaxConcurrentSessions` was set per processor while ListeningAgent was already building n of them |
+| AO3 `MaximumConcurrentCalls` | this wave | AE1 | inline handler concurrency | 1 (SDK default, unreachable) | configurable | Inline Azure Service Bus listeners can now process messages concurrently without dropping to the raw `ConfigureProcessor` hook |
+| AO8 batched defer settles the original | this wave | AE8 | duplicates per deferral | 2 deliveries | 1 | Deferring on a buffered/durable Azure Service Bus listener no longer leaves the original message locked to be redelivered |
+
+**Not measured on a real namespace.** AO2's 25→5 is structural and unit-tested; AO3 and AO8 are
+correctness/ergonomics fixes verified by tests. The throughput numbers this plan asks for -- and
+the PrefetchCount validation in AE2 -- still need the real Standard/Premium namespace runs
+described in §2 and §8. The emulator is explicitly not publishable.
+
+**Deferred, needs a JasperFx change:** AO4 (settlement concurrency). `RetryBlock` hard-codes a
+parallel count of 1 (`Block<Item>(1, Unbounded, executeAsync)`), so widening ASB's per-message
+`CompleteMessageAsync` concurrency is not a Wolverine-side change. Track upstream before revisiting.
 
 ## 7. Sequencing & exit criteria
 

--- a/docs/guide/messaging/transports/azureservicebus/performance.md
+++ b/docs/guide/messaging/transports/azureservicebus/performance.md
@@ -36,14 +36,22 @@ means silent redelivery and a rising delivery count.
 ### Inline endpoints process one message at a time by default
 
 Inline ASB endpoints use a `ServiceBusProcessor`, whose `MaxConcurrentCalls` defaults to **1**.
-Wolverine does not change that default, so an inline listener is single-threaded unless you
-raise it:
+Wolverine leaves that default alone, so an inline listener is single-threaded unless you raise it:
 
 ```cs
 opts.ListenToAzureServiceBusQueue("orders")
     .ProcessInline()
-    .ConfigureProcessor(o => o.MaxConcurrentCalls = 10);
+    .MaximumConcurrentCalls(10);
 ```
+
+`MaximumParallelMessages` has no effect on an inline endpoint — that knob sizes Wolverine's own
+in-process worker queue, which inline listeners bypass. The raw
+`ConfigureProcessor(o => o.MaxConcurrentCalls = 10)` hook still works and takes precedence.
+
+On a **session** listener driven by a `ServiceBusSessionProcessor`, `MaximumConcurrentCalls` maps
+to `MaxConcurrentCallsPerSession` instead, which trades away the per-session FIFO ordering that is
+usually the reason for using sessions at all. Leave it alone there unless you mean it — to process
+more sessions at once, use `RequireSessions(n)`.
 
 ## Lock duration vs. processing window
 
@@ -86,6 +94,7 @@ outgoing batches are additionally grouped by session id so each batch shares a p
 Sessions give broker-enforced ordering per `SessionId` (mapped automatically from Wolverine's
 `Envelope.GroupId`) with cluster-wide exclusivity — but session processing is inherently more
 expensive than plain consumption: each session must be accepted, locked, drained, and released.
+`RequireSessions(n)` opens exactly `n` concurrent session accept loops — one per listener.
 Keep `RequireSessions(n)` counts modest, and note that strict per-session *processing* order on
 Buffered/Durable endpoints also needs `PartitionProcessingByGroupId(...)` (or inline
 execution), since the local worker queue otherwise executes a session's batch in parallel —

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/configuring_session_processor_options.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/configuring_session_processor_options.cs
@@ -77,7 +77,7 @@ public class configuring_session_processor_options
     }
 
     [Fact]
-    public void build_session_processor_options_maps_listener_count_to_max_concurrent_sessions()
+    public void build_session_processor_options_accepts_one_session_per_processor()
     {
         var transport = new AzureServiceBusTransport();
         var queue = transport.Queues["incoming"];
@@ -88,10 +88,28 @@ public class configuring_session_processor_options
         ((IDelayedEndpointConfiguration)configuration).Apply();
 
         var options = AzureServiceBusTransport.BuildSessionProcessorOptions(queue);
-        options.MaxConcurrentSessions.ShouldBe(8);
+
+        // GH-3494 (AO2): ListeningAgent builds ListenerCount of these listeners, so mapping
+        // RequireSessions(8) onto each processor's MaxConcurrentSessions gave 8 x 8 = 64
+        // concurrent sessions. One per processor keeps the total at the 8 that was asked for.
+        options.MaxConcurrentSessions.ShouldBe(1);
 
         // FIFO ordering per session is preserved
         options.MaxConcurrentCallsPerSession.ShouldBe(1);
+    }
+
+    [Fact]
+    public void a_user_can_still_override_max_concurrent_sessions()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+
+        var configuration = new AzureServiceBusQueueListenerConfiguration(queue);
+        configuration.RequireSessions(8).ConfigureSessionProcessor(o => o.MaxConcurrentSessions = 3);
+
+        ((IDelayedEndpointConfiguration)configuration).Apply();
+
+        AzureServiceBusTransport.BuildSessionProcessorOptions(queue).MaxConcurrentSessions.ShouldBe(3);
     }
 
     [Fact]

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/maximum_concurrent_calls_3494.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/maximum_concurrent_calls_3494.cs
@@ -1,0 +1,98 @@
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Wolverine.Configuration;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+/// <summary>
+/// GH-3494 (AO3). Wolverine never set MaxConcurrentCalls, so an inline Azure Service Bus listener
+/// ran on the SDK default of 1 -- one message at a time per endpoint -- reachable only through the
+/// raw ConfigureProcessor hook.
+/// </summary>
+public class maximum_concurrent_calls_3494
+{
+    [Fact]
+    public void defaults_to_null_so_the_sdk_default_still_applies()
+    {
+        var transport = new AzureServiceBusTransport();
+        transport.Queues["incoming"].MaximumConcurrentCalls.ShouldBeNull();
+    }
+
+    [Fact]
+    public void must_be_at_least_one()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+
+        Should.Throw<ArgumentOutOfRangeException>(() => queue.MaximumConcurrentCalls = 0);
+    }
+
+    [Fact]
+    public void queue_listener_configuration_sets_it()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+
+        var configuration = new AzureServiceBusQueueListenerConfiguration(queue);
+        configuration.MaximumConcurrentCalls(12);
+        ((IDelayedEndpointConfiguration)configuration).Apply();
+
+        queue.MaximumConcurrentCalls.ShouldBe(12);
+    }
+
+    [Fact]
+    public void subscription_listener_configuration_sets_it()
+    {
+        var transport = new AzureServiceBusTransport();
+        var subscription = transport.Topics["topic1"].FindOrCreateSubscription("sub1");
+
+        var configuration = new AzureServiceBusSubscriptionListenerConfiguration(subscription);
+        configuration.MaximumConcurrentCalls(4);
+        ((IDelayedEndpointConfiguration)configuration).Apply();
+
+        subscription.MaximumConcurrentCalls.ShouldBe(4);
+    }
+
+    [Fact]
+    public void flows_onto_the_processor_options()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+        queue.MaximumConcurrentCalls = 8;
+
+        AzureServiceBusTransport.BuildProcessorOptions(queue).MaxConcurrentCalls.ShouldBe(8);
+    }
+
+    [Fact]
+    public void configure_processor_still_wins_over_the_endpoint_value()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+        queue.MaximumConcurrentCalls = 8;
+        queue.ConfigureProcessor = o => o.MaxConcurrentCalls = 3;
+
+        AzureServiceBusTransport.BuildProcessorOptions(queue).MaxConcurrentCalls.ShouldBe(3);
+    }
+
+    [Fact]
+    public void session_processor_keeps_per_session_fifo_unless_asked_otherwise()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+        queue.ConfigureSessionProcessor = _ => { };
+
+        AzureServiceBusTransport.BuildSessionProcessorOptions(queue).MaxConcurrentCallsPerSession.ShouldBe(1);
+    }
+
+    [Fact]
+    public void session_processor_honors_the_opt_in()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+        queue.MaximumConcurrentCalls = 5;
+        queue.ConfigureSessionProcessor = _ => { };
+
+        AzureServiceBusTransport.BuildSessionProcessorOptions(queue).MaxConcurrentCallsPerSession.ShouldBe(5);
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/session_listener_accept_loops_3494.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/session_listener_accept_loops_3494.cs
@@ -1,0 +1,44 @@
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+/// <summary>
+/// GH-3494 (AO2). ListeningAgent already builds Endpoint.ListenerCount listeners, so the session
+/// listener spawning ListenerCount accept loops of its own made RequireSessions(n) open n-squared
+/// concurrent AcceptNextSessionAsync loops -- 25 of them for RequireSessions(5).
+/// </summary>
+public class session_listener_accept_loops_3494
+{
+    private static AzureServiceBusSessionListener buildListener(int listenerCount)
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+        queue.Options.RequiresSession = true;
+        queue.ListenerCount = listenerCount;
+
+        // The accept loop itself immediately fails against a transport with no live connection and
+        // backs off inside its own catch, which is all this test needs -- it only asserts on how
+        // many loops were started.
+        return new AzureServiceBusSessionListener(transport, queue, Substitute.For<IReceiver>(),
+            Substitute.For<IEnvelopeMapper<ServiceBusReceivedMessage, ServiceBusMessage>>(), NullLogger.Instance,
+            Substitute.For<ISender>());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(10)]
+    public async Task always_runs_exactly_one_accept_loop_per_listener(int listenerCount)
+    {
+        await using var listener = buildListener(listenerCount);
+        listener.AcceptLoopCount.ShouldBe(1);
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusQueueListenerConfiguration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusQueueListenerConfiguration.cs
@@ -171,6 +171,22 @@ public class
     }
 
     /// <summary>
+    ///     How many messages an <c>Inline</c> listener for this queue processes concurrently. This
+    ///     is the Azure Service Bus SDK's <c>MaxConcurrentCalls</c>, which Wolverine left at the SDK
+    ///     default of 1 -- so an inline Azure Service Bus listener consumed strictly one message at
+    ///     a time per endpoint. On a session listener driven by a <c>ServiceBusSessionProcessor</c>
+    ///     this sets <c>MaxConcurrentCallsPerSession</c> instead, which trades away the per-session
+    ///     FIFO ordering, so leave it alone on session endpoints unless you mean it. Has no effect
+    ///     on the default Buffered/Durable batch receive loop. See GH-3494.
+    /// </summary>
+    /// <param name="concurrency">Concurrent handler invocations. Must be at least 1</param>
+    public AzureServiceBusQueueListenerConfiguration MaximumConcurrentCalls(int concurrency)
+    {
+        add(e => e.MaximumConcurrentCalls = concurrency);
+        return this;
+    }
+
+    /// <summary>
     /// Completely disable all SQS dead letter queueing for just this queue
     /// </summary>
     /// <returns></returns>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusSubscriptionListenerConfiguration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusSubscriptionListenerConfiguration.cs
@@ -194,6 +194,21 @@ public class AzureServiceBusSubscriptionListenerConfiguration : InteroperableLis
     }
 
     /// <summary>
+    ///     How many messages an <c>Inline</c> listener for this subscription processes concurrently.
+    ///     This is the Azure Service Bus SDK's <c>MaxConcurrentCalls</c>, which Wolverine left at
+    ///     the SDK default of 1 -- so an inline listener consumed strictly one message at a time per
+    ///     endpoint. On a session listener driven by a <c>ServiceBusSessionProcessor</c> this sets
+    ///     <c>MaxConcurrentCallsPerSession</c> instead, which trades away the per-session FIFO
+    ///     ordering. Has no effect on the default Buffered/Durable batch receive loop. See GH-3494.
+    /// </summary>
+    /// <param name="concurrency">Concurrent handler invocations. Must be at least 1</param>
+    public AzureServiceBusSubscriptionListenerConfiguration MaximumConcurrentCalls(int concurrency)
+    {
+        add(e => e.MaximumConcurrentCalls = concurrency);
+        return this;
+    }
+
+    /// <summary>
     /// Force this subscription listener to require session identifiers. Use this for FIFO semantics
     /// </summary>
     /// <param name="listenerCount">The maximum number of parallel sessions that can be processed at any one time</param>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.Listening.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.Listening.cs
@@ -190,6 +190,14 @@ public partial class AzureServiceBusTransport
             PrefetchCount = endpoint.PrefetchCount
         };
 
+        // GH-3494 (AO3): Wolverine never set MaxConcurrentCalls, so an inline listener ran on the
+        // SDK default of 1 -- single threaded per endpoint, reachable only through the raw
+        // ConfigureProcessor hook. Applied before ConfigureProcessor so that hook still wins.
+        if (endpoint.MaximumConcurrentCalls.HasValue)
+        {
+            options.MaxConcurrentCalls = endpoint.MaximumConcurrentCalls.Value;
+        }
+
         endpoint.ConfigureProcessor?.Invoke(options);
 
         // Reserved by Wolverine: the inline listener relies on the peek-lock model to complete,
@@ -229,13 +237,24 @@ public partial class AzureServiceBusTransport
         {
             PrefetchCount = endpoint.PrefetchCount,
 
-            // Map the existing "parallel sessions" knob (ListenerCount, set via RequireSessions(count))
-            // onto the processor's concurrency. A user may override this in ConfigureSessionProcessor.
-            MaxConcurrentSessions = endpoint.ListenerCount > 0 ? endpoint.ListenerCount : 1,
+            // GH-3494 (AO2): ONE session per processor. ListeningAgent already builds
+            // Endpoint.ListenerCount of these listeners, so mapping RequireSessions(n) onto each
+            // processor's MaxConcurrentSessions meant n listeners x n sessions = n-squared
+            // concurrent sessions -- 64 of them for RequireSessions(8). One per listener keeps the
+            // documented meaning of RequireSessions(n): n parallel sessions in total.
+            // A user may still override this in ConfigureSessionProcessor.
+            MaxConcurrentSessions = 1,
 
             // Preserve the in-session FIFO ordering the hand-rolled loop provided
             MaxConcurrentCallsPerSession = 1
         };
+
+        // GH-3494 (AO3): opt-in concurrency WITHIN a session. Left at 1 unless asked for, because
+        // raising it gives up the per-session FIFO ordering that is the whole point of sessions.
+        if (endpoint.MaximumConcurrentCalls.HasValue)
+        {
+            options.MaxConcurrentCallsPerSession = endpoint.MaximumConcurrentCalls.Value;
+        }
 
         endpoint.ConfigureSessionProcessor?.Invoke(options);
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
@@ -84,6 +84,32 @@ public abstract class AzureServiceBusEndpoint : Endpoint<IAzureServiceBusEnvelop
         }
     }
 
+    private int? _maximumConcurrentCalls;
+
+    /// <summary>
+    ///     How many messages an <c>Inline</c> or session-processor listener for this endpoint hands
+    ///     to the handler pipeline at once. This maps to the Azure Service Bus SDK's
+    ///     <c>MaxConcurrentCalls</c>, which Wolverine never set -- so inline Azure Service Bus
+    ///     listeners ran strictly one message at a time on the SDK default, and the only way to
+    ///     change that was the raw <see cref="ConfigureProcessor" /> hook. Null keeps the SDK
+    ///     default of 1. Does not apply to the default Buffered/Durable batch receive loop, which
+    ///     scales through MaximumParallelMessages instead. See GH-3494.
+    /// </summary>
+    public int? MaximumConcurrentCalls
+    {
+        get => _maximumConcurrentCalls;
+        set
+        {
+            if (value is < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value,
+                    "MaximumConcurrentCalls must be at least 1");
+            }
+
+            _maximumConcurrentCalls = value;
+        }
+    }
+
     /// <summary>
     ///     Optional customization of the Azure Service Bus <see cref="ServiceBusProcessorOptions" /> used
     ///     by inline listeners for this endpoint. Wolverine reserves control of the properties it depends

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
@@ -44,8 +44,20 @@ public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue
         _complete = new RetryBlock<AzureServiceBusEnvelope>((e, _) => { return e.CompleteAsync(_cancellation.Token); },
             _logger, _cancellation.Token);
 
-        _defer = new RetryBlock<Envelope>(async (envelope, _) => { await _requeue.SendAsync(envelope); }, logger,
-            _cancellation.Token);
+        _defer = new RetryBlock<Envelope>(async (envelope, _) =>
+        {
+            // GH-3494 (AO8): settle the original before re-sending the copy, exactly like the
+            // inline listener already does. Leaving it unsettled meant the message stayed locked
+            // until the lock expired and Azure Service Bus redelivered it -- so every deferral
+            // produced a duplicate on top of the copy this block sends.
+            if (envelope is AzureServiceBusEnvelope e && !e.IsCompleted)
+            {
+                await e.CompleteAsync(_cancellation.Token);
+                e.IsCompleted = true;
+            }
+
+            await _requeue.SendAsync(envelope);
+        }, logger, _cancellation.Token);
 
         _deadLetter =
             new RetryBlock<AzureServiceBusEnvelope>(

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/SessionSpecificListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/SessionSpecificListener.cs
@@ -33,18 +33,17 @@ internal class AzureServiceBusSessionListener : IListener
         _logger = logger;
         _requeue = requeue;
 
-        var listenerCount = _endpoint.ListenerCount;
-        if (listenerCount == 0)
-        {
-            listenerCount = 1;
-        }
-
-        for (var i = 0; i < listenerCount; i++)
-        {
-            var task = Task.Run(listenForMessages, _cancellation.Token);
-            _tasks.Add(task);
-        }
+        // GH-3494 (AO2): exactly ONE accept loop per listener instance. ListeningAgent already
+        // builds Endpoint.ListenerCount of these listeners, so spawning ListenerCount loops inside
+        // each one made RequireSessions(n) open n-squared concurrent AcceptNextSessionAsync loops --
+        // 25 for RequireSessions(5) -- all competing for the same sessions.
+        _tasks.Add(Task.Run(listenForMessages, _cancellation.Token));
     }
+
+    /// <summary>
+    /// The number of concurrent AcceptNextSessionAsync loops this listener runs. Exposed for testing.
+    /// </summary>
+    internal int AcceptLoopCount => _tasks.Count;
 
     public IHandlerPipeline? Pipeline => _receiver.Pipeline;
 


### PR DESCRIPTION
The Azure Service Bus deep dive (GH-3494), Wave 0 — the items the plan calls out as landable from
code review and tests, before a real namespace is available. **No emulator timings are quoted**:
§2 and §8 rule the emulator out as a source of publishable numbers, and AE2's PrefetchCount
validation still needs a real Standard/Premium namespace. Everything below is an exact count.

## AO2 — the n² was real, on **both** session paths

`ListeningAgent` builds `Endpoint.ListenerCount` listeners whenever that count exceeds 1
(`ListeningAgent.cs:373-381`). Both session implementations then multiplied by `ListenerCount`
*again*.

**Accept-loop listener** (`AzureServiceBusSessionListener`, the default when
`ConfigureSessionProcessor` is unset) — concurrent `AcceptNextSessionAsync` loops:

| `RequireSessions(n)` | Before | After |
|---|---|---|
| unset / 1 | 1 | 1 |
| 3 | 9 | **3** |
| 5 | **25** | **5** |
| 10 | **100** | **10** |

**`ServiceBusSessionProcessor` path** (opt-in, added in #3533) — I did not expect to find this one.
`BuildSessionProcessorOptions` set `MaxConcurrentSessions = endpoint.ListenerCount` on *each* of the
`ListenerCount` processors:

| `RequireSessions(n)` | Concurrent sessions before | After |
|---|---|---|
| 8 | 8 processors x 8 sessions = **64** | **8** |

Both now yield exactly `n`, which is what `RequireSessions(n)` is documented to mean, and a user
`ConfigureSessionProcessor(o => o.MaxConcurrentSessions = ...)` still overrides.

⚠️ **Reviewer's call:** this changes behavior that `build_session_processor_options_maps_listener_count_to_max_concurrent_sessions`
asserted in #3533, merged four days ago. I rewrote that test to assert the total-concurrency
invariant instead, with the reasoning inline, and added one covering the user override. If #3533
intended 8x8 deliberately, say so and I'll revert this half.

## AO3 — inline concurrency was 1, and unreachable

Wolverine never set `ServiceBusProcessorOptions.MaxConcurrentCalls`, so every inline ASB endpoint ran
at the SDK default of **one** concurrent handler invocation, changeable only through the raw
`ConfigureProcessor` hook (`MaximumParallelMessages` does not apply to inline endpoints — it sizes
Wolverine's in-process worker queue, which inline bypasses).

```cs
opts.ListenToAzureServiceBusQueue("orders").ProcessInline().MaximumConcurrentCalls(10);
```

Applied before `ConfigureProcessor` so that hook still wins. On the session-processor path it maps to
`MaxConcurrentCallsPerSession` and stays at 1 unless explicitly asked for, since raising it discards
the per-session FIFO ordering that is usually the point of sessions.

## AO8 — one deferral produced two deliveries

The batched listener's `_defer` block re-sent a copy but never settled the original, which then sat
locked until the lock expired and Azure Service Bus redelivered it.

| | Before | After |
|---|---|---|
| Deliveries from one deferral | **2** (re-sent copy + redelivered original) | **1** |

`InlineAzureServiceBusListener` already did complete-then-resend; the batched path now matches.

## AO4 — deferred, needs an upstream change

Widening settlement concurrency is not a Wolverine-side change: `RetryBlock` hard-codes
`new Block<Item>(1, Block<Item>.Unbounded, executeAsync)`, so the per-message `CompleteMessageAsync`
calls are serialized by construction. Noted in the plan.

## Tests

12 new unit tests (accept-loop count across `RequireSessions` 0/1/5/10; the `MaximumConcurrentCalls`
surface, its precedence against `ConfigureProcessor`, and the session-processor mapping), plus the
two rewritten session-processor tests.

The emulator suite is noisy on this box, so every failure was baselined against a clean
`origin/main` worktree on the **same** emulator with the **same** filter:

| Run | Build | Result |
|---|---|---|
| Full suite | this branch | 271 passed / 25 failed (1h01m) |
| Failing subset (34 tests) | this branch | 7 passed / 27 failed (1h04m) |
| Same subset | **clean `origin/main`** | 11 passed / 23 failed (59m) |
| 2 session tests, isolated, x3 | this branch | 0 of 6 passed |
| 2 session tests, isolated, x3 | **clean `origin/main`** | **0 of 6 passed** |
| `when_using_handler_type_naming`, isolated | both | 2/2 passed on each |

Two failure modes, both environmental and both reproduced on clean `main`:

1. **ConventionalRouting / conventional-routing `Bugs`** — `BrokerInitializationException: Unable to
   initialize the Broker asb in time`. Emulator broker-init timeouts under the per-class
   `DeleteAllEmulatorObjects` + `AutoProvision` churn. The count moves around with test ordering
   (21 in the full run, 25 in the isolated subset, 23 on main) — it goes *up* when fewer tests run,
   which is the opposite of a code regression. Nothing in this diff touches discovery or provisioning.
2. **Two session ordering assertions** (`["One","Three","Two"]`, `["Dummy 4.2","Dummy 4.1"]`) — these
   passed in main's 34-test subset and failed in the branch's, which looked branch-specific until I
   ran them in isolation: **3/3 failures on branch and 3/3 on clean main.** The earlier main pass was
   test-ordering luck. This matches the plan's own §8 note that sessions misbehave on the emulator.
   Both endpoints use `RequireSessions()` / `RequireSessions(1)`, so AO2 spawns one accept loop
   before and after — that path is unchanged for them.

Operational note for anyone rerunning these: `AzureServiceBusTesting` calls
`DeleteAllEmulatorObjectsAsync()` once per test process, so two ASB test processes against one
emulator wipe each other's entities. These runs have to be serial.

## Still open on GH-3494

AO1 (`ServiceBusSessionProcessor` rewrite of the accept-loop listener), AO4, AO5 (lock renewal on the
batched path), AO6/AE2 (PrefetchCount validation and guidance), and the whole real-namespace matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)