### PR TITLE
feat(persistence): global partitioning topologies for PostgreSQL and SQL Server queues (GH-3468, GH-3469)

### DIFF
--- a/docs/guide/durability/postgresql.md
+++ b/docs/guide/durability/postgresql.md
@@ -262,6 +262,64 @@ Wolverine has an internal control queue (`dbcontrol`) used for internal operatio
 This queue is hardcoded to poll every second and should not be changed to ensure the stability of the application.
 :::
 
+### Global Partitioning <Badge type="tip" text="6.24" />
+
+PostgreSQL queues can be used as the external transport for
+[global partitioned messaging](/guide/messaging/partitioning#global-partitioning). This gives you
+cluster-wide sequential processing by group id with **no extra infrastructure** — the shards are
+just more tables in the database you already have.
+
+Use `UseShardedPostgresqlQueues()` inside a `GlobalPartitioned()` configuration:
+
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UsePostgresqlPersistenceAndTransport(connectionString)
+            .AutoProvision();
+
+        opts.MessagePartitioning.ByMessage<IOrderMessage>(x => x.OrderId.ToString());
+
+        opts.MessagePartitioning.GlobalPartitioned(topology =>
+        {
+            // Creates PostgreSQL queues named "orders1" through "orders4"
+            // with matching companion local queues for sequential processing
+            topology.UseShardedPostgresqlQueues("orders", 4);
+            topology.MessagesImplementing<IOrderMessage>();
+        });
+    }).StartAsync();
+```
+
+That creates queues named `orders1` through `orders4` — each backed by its own
+`wolverine_queue_orders{n}` / `wolverine_queue_orders{n}_scheduled` table pair — with companion
+local queues `global-orders1` through `global-orders4`. Each shard queue is marked exclusive, so
+only one node in the cluster listens to it at a time.
+
+If you only want the *publishing* half — sharded queues with no companion local queues, so every
+message really does round-trip through the database — use the `MessagePartitioningRules` variant
+instead:
+
+```cs
+opts.MessagePartitioning.PublishToShardedPostgresqlQueues("orders", 4, topology =>
+{
+    topology.MessagesImplementing<IOrderMessage>();
+    topology.MaxDegreeOfParallelism = PartitionSlots.Five;
+});
+```
+
+::: info Long base names
+PostgreSQL truncates identifiers at `NAMEDATALEN` (63 characters by default). Wolverine runs every
+queue table name through Weasel's deterministic shortening helper, so a long sharded base name still
+produces distinct, in-range table names for each shard.
+:::
+
+::: warning Multi-tenancy
+Under [database-per-tenant storage](#multi-tenancy) the shard queue tables are provisioned in
+**every** tenant database and slot routing is unchanged — a group id maps to the same slot number
+regardless of tenant. Listening is then assigned per `(queue, database)` pair by the sticky listener
+agent family rather than per queue.
+:::
+
 ### Resetting in Tests
 
 `RebuildAsync()` / `ClearAllAsync()` on the message store clear envelope storage only — they leave

--- a/docs/guide/durability/sqlserver.md
+++ b/docs/guide/durability/sqlserver.md
@@ -229,6 +229,71 @@ _listener = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/SqlServerTests/Transport/with_multiple_hosts.cs#L21-L56' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sql_server_as_queue_between_two_apps' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### Global Partitioning <Badge type="tip" text="6.24" />
+
+Sql Server queues can be used as the external transport for
+[global partitioned messaging](/guide/messaging/partitioning#global-partitioning). This gives you
+cluster-wide sequential processing by group id with **no extra infrastructure** — the shards are
+just more tables in the database you already have.
+
+Use `UseShardedSqlServerQueues()` inside a `GlobalPartitioned()` configuration:
+
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UseSqlServerPersistenceAndTransport(connectionString)
+            .AutoProvision();
+
+        opts.MessagePartitioning.ByMessage<IOrderMessage>(x => x.OrderId.ToString());
+
+        opts.MessagePartitioning.GlobalPartitioned(topology =>
+        {
+            // Creates Sql Server queues named "orders1" through "orders4"
+            // with matching companion local queues for sequential processing
+            topology.UseShardedSqlServerQueues("orders", 4);
+            topology.MessagesImplementing<IOrderMessage>();
+        });
+    }).StartAsync();
+```
+
+That creates queues named `orders1` through `orders4` — each backed by its own
+`wolverine_queue_orders{n}` / `wolverine_queue_orders{n}_scheduled` table pair — with companion
+local queues `global-orders1` through `global-orders4`. Each shard queue is marked exclusive, so
+only one node in the cluster listens to it at a time.
+
+If you only want the *publishing* half — sharded queues with no companion local queues, so every
+message really does round-trip through the database — use the `MessagePartitioningRules` variant
+instead:
+
+```cs
+opts.MessagePartitioning.PublishToShardedSqlServerQueues("orders", 4, topology =>
+{
+    topology.MessagesImplementing<IOrderMessage>();
+    topology.MaxDegreeOfParallelism = PartitionSlots.Five;
+});
+```
+
+**Sharded queues opt into the [high-throughput table layout](#optimizing-queue-throughput) by
+default**, because ordered per-slot processing is exactly the case the `seq`-clustered layout was
+designed for. That opt-in is per queue, so it does *not* change the layout of any other queue in the
+transport, and it does not flip the transport-wide `OptimizeQueueThroughput()` setting. Turn it off
+for the shard queues if you need them to match the default layout:
+
+```cs
+topology.UseShardedSqlServerQueues("orders", 4, t => t.OptimizeThroughput = false);
+```
+
+An individual non-sharded queue can also opt in or out directly through
+`SqlServerQueue.OptimizeThroughput`, which falls back to the transport-wide setting when it is not
+set explicitly.
+
+::: warning Multi-tenancy
+Under [database-per-tenant storage](#multi-tenancy-1) the shard queue tables are provisioned in
+**every** tenant database and slot routing is unchanged — a group id maps to the same slot number
+regardless of tenant.
+:::
+
 ### Resetting in Tests
 
 `RebuildAsync()` / `ClearAllAsync()` on the message store clear envelope storage only — they leave

--- a/docs/guide/messaging/partitioning.md
+++ b/docs/guide/messaging/partitioning.md
@@ -379,7 +379,7 @@ application cluster while guaranteeing that messages within a group id are proce
 parallelism between message groups.
 :::
 
-Wolverine has direct support for partitioned routing to all eight of the transports that support the
+Wolverine has direct support for partitioned routing to all ten of the transports that support the
 [global partitioning](#global-partitioning) topology through a `PublishToSharded*()` companion to each
 `UseSharded*()` extension method:
 
@@ -393,6 +393,8 @@ Wolverine has direct support for partitioned routing to all eight of the transpo
 | GCP Pub/Sub | `PublishToShardedPubsubTopics()` |
 | NATS | `PublishToShardedNatsSubjects()` |
 | Redis Streams | `PublishToShardedRedisStreams()` |
+| PostgreSQL | `PublishToShardedPostgresqlQueues()` |
+| Sql Server | `PublishToShardedSqlServerQueues()` |
 
 Note that in both of the following examples, Wolverine is both setting up publishing rules out to these queues, and also configuring
 listeners for the queues. Beyond that, Wolverine is making each queue be "exclusive," meaning that only one node
@@ -522,13 +524,16 @@ Each supported transport has its own extension method for configuring the extern
 | GCP Pub/Sub | `UseShardedPubsubTopics()` | [GCP Pub/Sub Global Partitioning](/guide/messaging/transports/gcp-pubsub/#global-partitioning) |
 | NATS | `UseShardedNatsSubjects()` | [NATS Global Partitioning](/guide/messaging/transports/nats#global-partitioning) |
 | Redis Streams | `UseShardedRedisStreams()` | [Redis Global Partitioning](/guide/messaging/transports/redis#global-partitioning) |
+| PostgreSQL | `UseShardedPostgresqlQueues()` | [PostgreSQL Global Partitioning](/guide/durability/postgresql#global-partitioning) |
+| Sql Server | `UseShardedSqlServerQueues()` | [Sql Server Global Partitioning](/guide/durability/sqlserver#global-partitioning) |
 
-All eight extension methods share the same signature, `(string baseName, int numberOfEndpoints)`, and create endpoints named `baseName1`, `baseName2`, and so on, with matching companion local queues. Swap the RabbitMQ call in the example below for any of the others to use a different transport, for example `topology.UseShardedAzureServiceBusQueues("sequenced", 5)` or `topology.UseShardedNatsSubjects("sequenced", 5)`.
+All ten extension methods share the same signature, `(string baseName, int numberOfEndpoints)`, and create endpoints named `baseName1`, `baseName2`, and so on, with matching companion local queues. Swap the RabbitMQ call in the example below for any of the others to use a different transport, for example `topology.UseShardedAzureServiceBusQueues("sequenced", 5)` or `topology.UseShardedNatsSubjects("sequenced", 5)`.
 
 A couple of transport-specific notes:
 
 * **Kafka** -- all nodes listening to the sharded topics share a single Kafka consumer group named after the base name so that Kafka assigns each topic's partitions exclusively to one consumer at a time. Wolverine stamps that consumer group id onto the `GroupId` of incoming envelopes by default, which you can turn off per listener with `DisableConsumerGroupIdStamping()` when the consumer group name is not meaningful as envelope metadata (e.g. when combined with `PropagateGroupIdToPartitionKey()`).
 * **Azure Service Bus** -- the broker's native [session identifiers](/guide/messaging/transports/azureservicebus/session-identifiers) provide strictly ordered, per-session processing with a single queue and may be a simpler alternative if you are exclusively on Azure Service Bus. Global partitioning is the transport-agnostic option that behaves the same way across every broker in the table above.
+* **PostgreSQL / Sql Server** -- the database queues need no extra infrastructure at all; each shard is just another pair of tables in the database you already have. They are inherently durable, which suits global partitioning since the topology forces `EndpointMode.Durable` on every slot anyway. The Sql Server shard queues additionally opt into the [`seq`-clustered high-throughput table layout](/guide/durability/sqlserver#optimizing-queue-throughput) by default.
 
 ### Example with RabbitMQ
 

--- a/src/Persistence/PostgresqlTests/Transport/global_partitioned_sharded_processing.cs
+++ b/src/Persistence/PostgresqlTests/Transport/global_partitioned_sharded_processing.cs
@@ -1,0 +1,216 @@
+using System.Collections.Concurrent;
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Postgresql;
+using Wolverine.Postgresql.Transport;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.Tracking;
+
+namespace PostgresqlTests.Transport;
+
+public class global_partitioned_sharded_processing : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        PgLetterHandler.Received.Clear();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.UsePostgresqlPersistenceAndTransport(Servers.PostgresConnectionString, "gletters_pg",
+                        transportSchema: "gletters_pg_queues")
+                    .AutoProvision()
+                    .AutoPurgeOnStartup();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(PgLetterHandler));
+
+                opts.MessagePartitioning.ByMessage<IPgLetterMessage>(x => x.Id.ToString());
+
+                opts.MessagePartitioning.GlobalPartitioned(topology =>
+                {
+                    topology.UseShardedPostgresqlQueues("gletters", 4);
+                    topology.MessagesImplementing<IPgLetterMessage>();
+                });
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private static async Task pumpOutMessages(IMessageContext bus)
+    {
+        var tasks = new Task[5];
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = Task.Run(async () =>
+            {
+                for (var j = 0; j < 5; j++)
+                {
+                    var id = Guid.NewGuid();
+
+                    await bus.PublishAsync(new PgLogA(id));
+                    await bus.PublishAsync(new PgLogB(id));
+                    await bus.PublishAsync(new PgLogC(id));
+                    await bus.PublishAsync(new PgLogD(id));
+                }
+            });
+        }
+
+        await Task.WhenAll(tasks);
+    }
+
+    [Fact]
+    public void builds_the_expected_shard_queues()
+    {
+        var transport = _host.GetRuntime().Options.Transports.GetOrCreate<PostgresqlTransport>();
+
+        foreach (var name in new[] { "gletters1", "gletters2", "gletters3", "gletters4" })
+        {
+            var queue = transport.Queues[name];
+            queue.UsedInShardedTopology.ShouldBeTrue();
+            queue.IsListener.ShouldBeTrue();
+            queue.ListenerScope.ShouldBe(ListenerScope.Exclusive);
+
+            // Global partitioning forces durable mode on every slot
+            queue.Mode.ShouldBe(EndpointMode.Durable);
+
+            // Each slot is tagged with its companion local queue
+            queue.GlobalPartitionLocalQueueUri.ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task hammer_it_with_lots_of_messages_global_partitioned()
+    {
+        var tracked = await _host
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(120.Seconds())
+            .ExecuteAndWaitAsync(pumpOutMessages);
+
+        var envelopes = tracked.Executed.Envelopes().ToArray();
+
+        // In single-node mode, global partitioning routes directly to companion local queues
+        envelopes.Any(x => x.Destination == new Uri("local://global-gletters1/")).ShouldBeTrue();
+        envelopes.Any(x => x.Destination == new Uri("local://global-gletters2/")).ShouldBeTrue();
+        envelopes.Any(x => x.Destination == new Uri("local://global-gletters3/")).ShouldBeTrue();
+        envelopes.Any(x => x.Destination == new Uri("local://global-gletters4/")).ShouldBeTrue();
+
+        // Every message for one group id lands on exactly one slot
+        foreach (var group in PgLetterHandler.Received.GroupBy(x => x.Id))
+        {
+            group.Select(x => x.Destination).Distinct().Count().ShouldBe(1);
+        }
+    }
+}
+
+/// <summary>
+/// The publishing-only sibling of the topology above. This one has no companion local queue
+/// shortcut, so every message really does round-trip through the sharded PostgreSQL queue tables.
+/// </summary>
+public class sharded_publishing_through_postgresql_queues : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        PgLetterHandler.Received.Clear();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.UsePostgresqlPersistenceAndTransport(Servers.PostgresConnectionString, "pletters_pg",
+                        transportSchema: "pletters_pg_queues")
+                    .AutoProvision()
+                    .AutoPurgeOnStartup();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(PgLetterHandler));
+
+                opts.MessagePartitioning.ByMessage<IPgLetterMessage>(x => x.Id.ToString());
+
+                opts.MessagePartitioning.PublishToShardedPostgresqlQueues("pletters", 4, topology =>
+                {
+                    topology.MessagesImplementing<IPgLetterMessage>();
+                    topology.MaxDegreeOfParallelism = PartitionSlots.Five;
+                });
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private static async Task publishOneRoundOfLetters(IMessageContext bus)
+    {
+        for (var i = 0; i < 25; i++)
+        {
+            var id = Guid.NewGuid();
+            await bus.PublishAsync(new PgLogA(id));
+            await bus.PublishAsync(new PgLogB(id));
+            await bus.PublishAsync(new PgLogC(id));
+            await bus.PublishAsync(new PgLogD(id));
+        }
+    }
+
+    [Fact]
+    public async Task messages_round_trip_through_every_shard_queue()
+    {
+        var tracked = await _host
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(120.Seconds())
+            .ExecuteAndWaitAsync(publishOneRoundOfLetters);
+
+        var envelopes = tracked.Executed.Envelopes().ToArray();
+
+        envelopes.Any(x => x.Destination == new Uri("postgresql://pletters1")).ShouldBeTrue();
+        envelopes.Any(x => x.Destination == new Uri("postgresql://pletters2")).ShouldBeTrue();
+        envelopes.Any(x => x.Destination == new Uri("postgresql://pletters3")).ShouldBeTrue();
+        envelopes.Any(x => x.Destination == new Uri("postgresql://pletters4")).ShouldBeTrue();
+
+        // Every message carrying one group id lands on exactly one shard queue
+        foreach (var group in PgLetterHandler.Received.GroupBy(x => x.Id))
+        {
+            group.Select(x => x.Destination).Distinct().Count().ShouldBe(1);
+        }
+    }
+}
+
+public interface IPgLetterMessage
+{
+    Guid Id { get; }
+}
+
+public record PgLogA(Guid Id) : IPgLetterMessage;
+
+public record PgLogB(Guid Id) : IPgLetterMessage;
+
+public record PgLogC(Guid Id) : IPgLetterMessage;
+
+public record PgLogD(Guid Id) : IPgLetterMessage;
+
+public static class PgLetterHandler
+{
+    public static readonly ConcurrentBag<(Guid Id, Uri? Destination)> Received = new();
+
+    public static void Handle(PgLogA message, Envelope envelope) => Received.Add((message.Id, envelope.Destination));
+    public static void Handle(PgLogB message, Envelope envelope) => Received.Add((message.Id, envelope.Destination));
+    public static void Handle(PgLogC message, Envelope envelope) => Received.Add((message.Id, envelope.Destination));
+    public static void Handle(PgLogD message, Envelope envelope) => Received.Add((message.Id, envelope.Destination));
+}

--- a/src/Persistence/PostgresqlTests/Transport/sharded_queue_table_naming.cs
+++ b/src/Persistence/PostgresqlTests/Transport/sharded_queue_table_naming.cs
@@ -1,0 +1,59 @@
+using JasperFx.Core.Reflection;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Postgresql.Transport;
+using Wolverine.Runtime.Partitioning;
+
+namespace PostgresqlTests.Transport;
+
+/// <summary>
+/// GH-3468. PostgreSQL silently truncates identifiers past NAMEDATALEN (63 chars), so
+/// a long sharded base name has to still produce distinct, in-range queue table names.
+/// </summary>
+public class sharded_queue_table_naming
+{
+    private static PartitionedMessageTopologyWithDatabaseQueues topologyFor(string baseName, int slots)
+    {
+        var options = new WolverineOptions();
+        var transport = options.As<WolverineOptions>().Transports.GetOrCreate<PostgresqlTransport>();
+        transport.TransportSchemaName = "gletters_naming";
+
+        return new PartitionedMessageTopologyWithDatabaseQueues(options, PartitionSlots.Five, baseName, slots);
+    }
+
+    [Fact]
+    public void short_base_name_uses_the_literal_table_names()
+    {
+        var topology = topologyFor("gletters", 4);
+
+        topology.Slots.OfType<PostgresqlQueue>().Select(x => x.QueueTable.Identifier.Name)
+            .ShouldBe(["wolverine_queue_gletters1", "wolverine_queue_gletters2", "wolverine_queue_gletters3",
+                "wolverine_queue_gletters4"
+            ]);
+    }
+
+    [Fact]
+    public void long_base_name_shortens_to_distinct_identifiers()
+    {
+        // "wolverine_queue_" is 16 characters, so this base name blows past NAMEDATALEN
+        var baseName = new string('a', 60);
+        var topology = topologyFor(baseName, 4);
+
+        var queues = topology.Slots.OfType<PostgresqlQueue>().ToArray();
+        queues.Length.ShouldBe(4);
+
+        var queueTableNames = queues.Select(x => x.QueueTable.Identifier.Name).ToArray();
+        var scheduledTableNames = queues.Select(x => x.ScheduledTable.Identifier.Name).ToArray();
+
+        foreach (var name in queueTableNames.Concat(scheduledTableNames))
+        {
+            name.Length.ShouldBeLessThanOrEqualTo(63);
+        }
+
+        // The whole point: shard 1 and shard 2 must not collapse onto the same table
+        queueTableNames.Distinct().Count().ShouldBe(4);
+        scheduledTableNames.Distinct().Count().ShouldBe(4);
+        queueTableNames.Intersect(scheduledTableNames).Any().ShouldBeFalse();
+    }
+}

--- a/src/Persistence/SqlServerTests/Transport/global_partitioned_sharded_processing.cs
+++ b/src/Persistence/SqlServerTests/Transport/global_partitioned_sharded_processing.cs
@@ -1,0 +1,224 @@
+using System.Collections.Concurrent;
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.SqlServer;
+using Wolverine.SqlServer.Transport;
+using Wolverine.Tracking;
+
+namespace SqlServerTests.Transport;
+
+public class global_partitioned_sharded_processing : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        SqlLetterHandler.Received.Clear();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.UseSqlServerPersistenceAndTransport(Servers.SqlServerConnectionString, "gletters_sql",
+                        transportSchema: "gletters_sql_queues")
+                    .AutoProvision()
+                    .AutoPurgeOnStartup();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(SqlLetterHandler));
+
+                opts.MessagePartitioning.ByMessage<ISqlLetterMessage>(x => x.Id.ToString());
+
+                opts.MessagePartitioning.GlobalPartitioned(topology =>
+                {
+                    topology.UseShardedSqlServerQueues("gletters", 4);
+                    topology.MessagesImplementing<ISqlLetterMessage>();
+                });
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private static async Task pumpOutMessages(IMessageContext bus)
+    {
+        var tasks = new Task[5];
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = Task.Run(async () =>
+            {
+                for (var j = 0; j < 5; j++)
+                {
+                    var id = Guid.NewGuid();
+
+                    await bus.PublishAsync(new SqlLogA(id));
+                    await bus.PublishAsync(new SqlLogB(id));
+                    await bus.PublishAsync(new SqlLogC(id));
+                    await bus.PublishAsync(new SqlLogD(id));
+                }
+            });
+        }
+
+        await Task.WhenAll(tasks);
+    }
+
+    [Fact]
+    public void builds_the_expected_shard_queues()
+    {
+        var transport = _host.GetRuntime().Options.Transports.OfType<SqlServerTransport>().Single();
+
+        foreach (var name in new[] { "gletters1", "gletters2", "gletters3", "gletters4" })
+        {
+            var queue = transport.Queues[name];
+            queue.UsedInShardedTopology.ShouldBeTrue();
+            queue.IsListener.ShouldBeTrue();
+            queue.ListenerScope.ShouldBe(ListenerScope.Exclusive);
+
+            // Global partitioning forces durable mode on every slot
+            queue.Mode.ShouldBe(EndpointMode.Durable);
+
+            // Each slot is tagged with its companion local queue
+            queue.GlobalPartitionLocalQueueUri.ShouldNotBeNull();
+
+            // Sharded queues opt into the seq-clustered FIFO layout by default (GH-3469)
+            queue.OptimizeThroughput.ShouldBeTrue();
+            queue.QueueTable.Columns.Any(x => x.Name == "seq").ShouldBeTrue();
+            queue.ScheduledTable.Columns.Any(x => x.Name == "seq").ShouldBeTrue();
+        }
+
+        // ...and the opt-in is per queue, so the transport-wide default is untouched
+        transport.OptimizeQueueThroughput.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task hammer_it_with_lots_of_messages_global_partitioned()
+    {
+        var tracked = await _host
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(120.Seconds())
+            .ExecuteAndWaitAsync(pumpOutMessages);
+
+        var envelopes = tracked.Executed.Envelopes().ToArray();
+
+        // In single-node mode, global partitioning routes directly to companion local queues
+        envelopes.Any(x => x.Destination == new Uri("local://global-gletters1/")).ShouldBeTrue();
+        envelopes.Any(x => x.Destination == new Uri("local://global-gletters2/")).ShouldBeTrue();
+        envelopes.Any(x => x.Destination == new Uri("local://global-gletters3/")).ShouldBeTrue();
+        envelopes.Any(x => x.Destination == new Uri("local://global-gletters4/")).ShouldBeTrue();
+
+        // Every message for one group id lands on exactly one slot
+        foreach (var group in SqlLetterHandler.Received.GroupBy(x => x.Id))
+        {
+            group.Select(x => x.Destination).Distinct().Count().ShouldBe(1);
+        }
+    }
+}
+
+/// <summary>
+/// The publishing-only sibling of the topology above. This one has no companion local queue
+/// shortcut, so every message really does round-trip through the sharded SQL Server queue tables.
+/// </summary>
+public class sharded_publishing_through_sqlserver_queues : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        SqlLetterHandler.Received.Clear();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.UseSqlServerPersistenceAndTransport(Servers.SqlServerConnectionString, "pletters_sql",
+                        transportSchema: "pletters_sql_queues")
+                    .AutoProvision()
+                    .AutoPurgeOnStartup();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(SqlLetterHandler));
+
+                opts.MessagePartitioning.ByMessage<ISqlLetterMessage>(x => x.Id.ToString());
+
+                opts.MessagePartitioning.PublishToShardedSqlServerQueues("pletters", 4, topology =>
+                {
+                    topology.MessagesImplementing<ISqlLetterMessage>();
+                    topology.MaxDegreeOfParallelism = PartitionSlots.Five;
+                });
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private static async Task publishOneRoundOfLetters(IMessageContext bus)
+    {
+        for (var i = 0; i < 25; i++)
+        {
+            var id = Guid.NewGuid();
+            await bus.PublishAsync(new SqlLogA(id));
+            await bus.PublishAsync(new SqlLogB(id));
+            await bus.PublishAsync(new SqlLogC(id));
+            await bus.PublishAsync(new SqlLogD(id));
+        }
+    }
+
+    [Fact]
+    public async Task messages_round_trip_through_every_shard_queue()
+    {
+        var tracked = await _host
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(120.Seconds())
+            .ExecuteAndWaitAsync(publishOneRoundOfLetters);
+
+        var envelopes = tracked.Executed.Envelopes().ToArray();
+
+        envelopes.Any(x => x.Destination == new Uri("sqlserver://pletters1")).ShouldBeTrue();
+        envelopes.Any(x => x.Destination == new Uri("sqlserver://pletters2")).ShouldBeTrue();
+        envelopes.Any(x => x.Destination == new Uri("sqlserver://pletters3")).ShouldBeTrue();
+        envelopes.Any(x => x.Destination == new Uri("sqlserver://pletters4")).ShouldBeTrue();
+
+        // Every message carrying one group id lands on exactly one shard queue
+        foreach (var group in SqlLetterHandler.Received.GroupBy(x => x.Id))
+        {
+            group.Select(x => x.Destination).Distinct().Count().ShouldBe(1);
+        }
+    }
+}
+
+public interface ISqlLetterMessage
+{
+    Guid Id { get; }
+}
+
+public record SqlLogA(Guid Id) : ISqlLetterMessage;
+
+public record SqlLogB(Guid Id) : ISqlLetterMessage;
+
+public record SqlLogC(Guid Id) : ISqlLetterMessage;
+
+public record SqlLogD(Guid Id) : ISqlLetterMessage;
+
+public static class SqlLetterHandler
+{
+    public static readonly ConcurrentBag<(Guid Id, Uri? Destination)> Received = new();
+
+    public static void Handle(SqlLogA message, Envelope envelope) => Received.Add((message.Id, envelope.Destination));
+    public static void Handle(SqlLogB message, Envelope envelope) => Received.Add((message.Id, envelope.Destination));
+    public static void Handle(SqlLogC message, Envelope envelope) => Received.Add((message.Id, envelope.Destination));
+    public static void Handle(SqlLogD message, Envelope envelope) => Received.Add((message.Id, envelope.Destination));
+}

--- a/src/Persistence/SqlServerTests/Transport/sharded_queue_table_layout.cs
+++ b/src/Persistence/SqlServerTests/Transport/sharded_queue_table_layout.cs
@@ -1,0 +1,81 @@
+using JasperFx.Core.Reflection;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.RDBMS;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.SqlServer.Transport;
+
+namespace SqlServerTests.Transport;
+
+/// <summary>
+/// GH-3469. The sharded topology opts its own queues into the seq-clustered high throughput
+/// layout without disturbing anything else in the transport, and shard-suffixed table names
+/// stay well inside SQL Server's 128 character identifier limit.
+/// </summary>
+public class sharded_queue_table_layout
+{
+    private static (SqlServerTransport, PartitionedMessageTopologyWithDatabaseQueues) topologyFor(string baseName,
+        int slots)
+    {
+        var options = new WolverineOptions();
+        var transport = new SqlServerTransport(new DatabaseSettings { SchemaName = "gletters_layout" });
+        options.As<WolverineOptions>().Transports.Add(transport);
+
+        var topology = new PartitionedMessageTopologyWithDatabaseQueues(options, PartitionSlots.Five, baseName, slots);
+        return (transport, topology);
+    }
+
+    [Fact]
+    public void shard_queues_default_to_the_high_throughput_layout()
+    {
+        var (transport, topology) = topologyFor("gletters", 4);
+
+        foreach (var queue in topology.Slots.OfType<SqlServerQueue>())
+        {
+            queue.OptimizeThroughput.ShouldBeTrue();
+            queue.QueueTable.Columns.Any(x => x.Name == "seq").ShouldBeTrue();
+            queue.ScheduledTable.Columns.Any(x => x.Name == "seq").ShouldBeTrue();
+        }
+
+        // Per queue, not transport-wide -- an unrelated queue keeps the default layout
+        transport.OptimizeQueueThroughput.ShouldBeFalse();
+        transport.Queues["unrelated"].OptimizeThroughput.ShouldBeFalse();
+        transport.Queues["unrelated"].QueueTable.Columns.Any(x => x.Name == "seq").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void can_opt_the_shard_queues_back_out()
+    {
+        var (_, topology) = topologyFor("gletters", 4);
+        topology.OptimizeThroughput = false;
+
+        foreach (var queue in topology.Slots.OfType<SqlServerQueue>())
+        {
+            queue.OptimizeThroughput.ShouldBeFalse();
+            queue.QueueTable.Columns.Any(x => x.Name == "seq").ShouldBeFalse();
+        }
+    }
+
+    [Fact]
+    public void shard_table_names_are_distinct_and_within_the_identifier_limit()
+    {
+        // "wolverine_queue_" (16) + base name + shard suffix + "_scheduled" (10)
+        var baseName = new string('a', 90);
+        var (_, topology) = topologyFor(baseName, 4);
+
+        var queues = topology.Slots.OfType<SqlServerQueue>().ToArray();
+        queues.Length.ShouldBe(4);
+
+        var names = queues.Select(x => x.QueueTable.Identifier.Name)
+            .Concat(queues.Select(x => x.ScheduledTable.Identifier.Name))
+            .ToArray();
+
+        foreach (var name in names)
+        {
+            name.Length.ShouldBeLessThanOrEqualTo(128);
+        }
+
+        names.Distinct().Count().ShouldBe(names.Length);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlConfigurationExtensions.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlConfigurationExtensions.cs
@@ -4,6 +4,7 @@ using JasperFx.Core.Reflection;
 using Wolverine.Configuration;
 using Wolverine.Persistence.Durability;
 using Wolverine.Postgresql.Transport;
+using Wolverine.Runtime.Partitioning;
 
 
 namespace Wolverine.Postgresql;
@@ -185,5 +186,58 @@ public static class PostgresqlConfigurationExtensions
         publishing.To(queue.Uri);
 
         return new PostgresqlSubscriberConfiguration(queue);
+    }
+
+    /// <summary>
+    /// Shard message publishing across a set of PostgreSQL queues named baseName1, baseName2, and so on
+    /// using the global message grouping rules. This is the publishing-only variant -- see
+    /// UseShardedPostgresqlQueues() for the full global partitioning topology that also shards the
+    /// message *execution* across companion local queues.
+    /// </summary>
+    /// <param name="rules"></param>
+    /// <param name="baseName"></param>
+    /// <param name="numberOfEndpoints"></param>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public static MessagePartitioningRules PublishToShardedPostgresqlQueues(this MessagePartitioningRules rules,
+        string baseName, int numberOfEndpoints, Action<PartitionedMessageTopologyWithDatabaseQueues> configure)
+    {
+        rules.AddPublishingTopology((opts, _) =>
+        {
+            var topology =
+                new PartitionedMessageTopologyWithDatabaseQueues(opts, PartitionSlots.Five, baseName, numberOfEndpoints);
+            topology.ConfigureListening(x => { });
+            configure(topology);
+            topology.AssertValidity();
+
+            return topology;
+        });
+
+        return rules;
+    }
+
+    /// <summary>
+    /// Use sharded PostgreSQL queues for global partitioned message processing.
+    /// Queues will be named baseName1, baseName2, etc.
+    /// </summary>
+    /// <param name="topology"></param>
+    /// <param name="baseName"></param>
+    /// <param name="numberOfEndpoints"></param>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public static GlobalPartitionedMessageTopology UseShardedPostgresqlQueues(
+        this GlobalPartitionedMessageTopology topology, string baseName, int numberOfEndpoints,
+        Action<PartitionedMessageTopologyWithDatabaseQueues>? configure = null)
+    {
+        topology.SetExternalTopology(opts =>
+        {
+            var t = new PartitionedMessageTopologyWithDatabaseQueues(opts, PartitionSlots.Five, baseName,
+                numberOfEndpoints);
+            t.ConfigureListening(x => { });
+            configure?.Invoke(t);
+            return t;
+        }, baseName);
+
+        return topology;
     }
 }

--- a/src/Persistence/Wolverine.Postgresql/Transport/PartitionedMessageTopologyWithDatabaseQueues.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PartitionedMessageTopologyWithDatabaseQueues.cs
@@ -1,0 +1,34 @@
+using Wolverine.Configuration;
+using Wolverine.Runtime.Partitioning;
+
+namespace Wolverine.Postgresql.Transport;
+
+/// <summary>
+/// Global partitioning topology where each slot is a PostgreSQL queue named
+/// "baseName1", "baseName2", and so on. Each slot queue is backed by its own
+/// wolverine_queue_{name} / wolverine_queue_{name}_scheduled table pair.
+/// </summary>
+public class PartitionedMessageTopologyWithDatabaseQueues : PartitionedMessageTopology<PostgresqlListenerConfiguration, PostgresqlSubscriberConfiguration>
+{
+    public PartitionedMessageTopologyWithDatabaseQueues(WolverineOptions options, PartitionSlots? listeningSlots,
+        string baseName, int numberOfEndpoints) : base(options, listeningSlots, baseName, numberOfEndpoints)
+    {
+        MaxDegreeOfParallelism = PartitionSlots.Five;
+    }
+
+    protected override Endpoint buildEndpoint(WolverineOptions options, string name)
+    {
+        var transport = options.PostgresqlTransport();
+        return transport.Queues[transport.MaybeCorrectName(name)];
+    }
+
+    protected override PostgresqlListenerConfiguration buildListener(WolverineOptions options, string name)
+    {
+        return options.ListenToPostgresqlQueue(name);
+    }
+
+    protected override PostgresqlSubscriberConfiguration buildSubscriber(IPublishToExpression expression, string name)
+    {
+        return expression.ToPostgresqlQueue(name);
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/SqlServerConfigurationExtensions.cs
+++ b/src/Persistence/Wolverine.SqlServer/SqlServerConfigurationExtensions.cs
@@ -9,6 +9,7 @@ using Wolverine.ErrorHandling;
 using Wolverine.Persistence.Durability;
 using Wolverine.RateLimiting;
 using Wolverine.RDBMS;
+using Wolverine.Runtime.Partitioning;
 using Wolverine.SqlServer.RateLimiting;
 using Wolverine.SqlServer.Schema;
 using Wolverine.SqlServer.Transport;
@@ -160,5 +161,58 @@ public static class SqlServerConfigurationExtensions
         publishing.To(queue.Uri);
 
         return new SqlServerSubscriberConfiguration(queue);
+    }
+
+    /// <summary>
+    /// Shard message publishing across a set of SQL Server queues named baseName1, baseName2, and so on
+    /// using the global message grouping rules. This is the publishing-only variant -- see
+    /// UseShardedSqlServerQueues() for the full global partitioning topology that also shards the
+    /// message *execution* across companion local queues.
+    /// </summary>
+    /// <param name="rules"></param>
+    /// <param name="baseName"></param>
+    /// <param name="numberOfEndpoints"></param>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public static MessagePartitioningRules PublishToShardedSqlServerQueues(this MessagePartitioningRules rules,
+        string baseName, int numberOfEndpoints, Action<PartitionedMessageTopologyWithDatabaseQueues> configure)
+    {
+        rules.AddPublishingTopology((opts, _) =>
+        {
+            var topology =
+                new PartitionedMessageTopologyWithDatabaseQueues(opts, PartitionSlots.Five, baseName, numberOfEndpoints);
+            topology.ConfigureListening(x => { });
+            configure(topology);
+            topology.AssertValidity();
+
+            return topology;
+        });
+
+        return rules;
+    }
+
+    /// <summary>
+    /// Use sharded SQL Server queues for global partitioned message processing.
+    /// Queues will be named baseName1, baseName2, etc.
+    /// </summary>
+    /// <param name="topology"></param>
+    /// <param name="baseName"></param>
+    /// <param name="numberOfEndpoints"></param>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public static GlobalPartitionedMessageTopology UseShardedSqlServerQueues(
+        this GlobalPartitionedMessageTopology topology, string baseName, int numberOfEndpoints,
+        Action<PartitionedMessageTopologyWithDatabaseQueues>? configure = null)
+    {
+        topology.SetExternalTopology(opts =>
+        {
+            var t = new PartitionedMessageTopologyWithDatabaseQueues(opts, PartitionSlots.Five, baseName,
+                numberOfEndpoints);
+            t.ConfigureListening(x => { });
+            configure?.Invoke(t);
+            return t;
+        }, baseName);
+
+        return topology;
     }
 }

--- a/src/Persistence/Wolverine.SqlServer/Transport/PartitionedMessageTopologyWithDatabaseQueues.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/PartitionedMessageTopologyWithDatabaseQueues.cs
@@ -1,0 +1,58 @@
+using Wolverine.Configuration;
+using Wolverine.Runtime.Partitioning;
+
+namespace Wolverine.SqlServer.Transport;
+
+/// <summary>
+/// Global partitioning topology where each slot is a SQL Server queue named
+/// "baseName1", "baseName2", and so on. Each slot queue is backed by its own
+/// wolverine_queue_{name} / wolverine_queue_{name}_scheduled table pair.
+/// </summary>
+public class PartitionedMessageTopologyWithDatabaseQueues : PartitionedMessageTopology<SqlServerListenerConfiguration, SqlServerSubscriberConfiguration>
+{
+    private bool _optimizeThroughput;
+
+    public PartitionedMessageTopologyWithDatabaseQueues(WolverineOptions options, PartitionSlots? listeningSlots,
+        string baseName, int numberOfEndpoints) : base(options, listeningSlots, baseName, numberOfEndpoints)
+    {
+        MaxDegreeOfParallelism = PartitionSlots.Five;
+
+        // Partitioned processing is exactly the ordered-throughput case the seq-clustered layout
+        // was built for, so opt the shard queues in by default regardless of the transport-wide
+        // setting. Set this back to false if the shard tables have to match the default layout.
+        OptimizeThroughput = true;
+    }
+
+    /// <summary>
+    ///     Use the higher-throughput, seq-clustered table layout for the shard queues. Defaults to
+    ///     true for a sharded topology -- see <see cref="SqlServerQueue.OptimizeThroughput" />.
+    /// </summary>
+    public bool OptimizeThroughput
+    {
+        get => _optimizeThroughput;
+        set
+        {
+            _optimizeThroughput = value;
+            foreach (var queue in Slots.OfType<SqlServerQueue>())
+            {
+                queue.OptimizeThroughput = value;
+            }
+        }
+    }
+
+    protected override Endpoint buildEndpoint(WolverineOptions options, string name)
+    {
+        var transport = options.SqlServerTransport();
+        return transport.Queues[transport.MaybeCorrectName(name)];
+    }
+
+    protected override SqlServerListenerConfiguration buildListener(WolverineOptions options, string name)
+    {
+        return options.ListenToSqlServerQueue(name);
+    }
+
+    protected override SqlServerSubscriberConfiguration buildSubscriber(IPublishToExpression expression, string name)
+    {
+        return expression.ToSqlServerQueue(name);
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Transport/QueueTable.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/QueueTable.cs
@@ -6,7 +6,7 @@ namespace Wolverine.SqlServer.Transport;
 
 internal class QueueTable : Table
 {
-    public QueueTable(SqlServerTransport transport, string tableName) : base(
+    public QueueTable(SqlServerTransport transport, string tableName, bool optimizeThroughput) : base(
         new DbObjectName(transport.TransportSchemaName, tableName))
     {
         var id = AddColumn<Guid>(DatabaseConstants.Id);
@@ -15,7 +15,7 @@ internal class QueueTable : Table
         AddColumn<DateTimeOffset>(DatabaseConstants.KeepUntil);
         AddColumn<DateTimeOffset>("timestamp").DefaultValueByExpression("SYSDATETIMEOFFSET()");
 
-        if (transport.OptimizeQueueThroughput)
+        if (optimizeThroughput)
         {
             // Opt-in high-throughput layout (see OptimizeQueueThroughput()): cluster on a monotonic
             // identity so the TOP(n) ... ORDER BY seq dequeue is a clustered seek and the matching

--- a/src/Persistence/Wolverine.SqlServer/Transport/ScheduledMessageTable.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/ScheduledMessageTable.cs
@@ -6,7 +6,7 @@ namespace Wolverine.SqlServer.Transport;
 
 internal class ScheduledMessageTable : Table
 {
-    public ScheduledMessageTable(SqlServerTransport transport, string tableName) : base(
+    public ScheduledMessageTable(SqlServerTransport transport, string tableName, bool optimizeThroughput) : base(
         new DbObjectName(transport.TransportSchemaName, tableName))
     {
         var id = AddColumn<Guid>(DatabaseConstants.Id);
@@ -22,7 +22,7 @@ internal class ScheduledMessageTable : Table
             Columns = [DatabaseConstants.ExecutionTime]
         });
 
-        if (transport.OptimizeQueueThroughput)
+        if (optimizeThroughput)
         {
             // Match the high-throughput layout of the ready queue table (see OptimizeQueueThroughput()):
             // cluster on a monotonic identity, keep the id unique and non-clustered for idempotent

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueue.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueue.cs
@@ -44,14 +44,30 @@ public class SqlServerQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         EndpointName = name;
         BrokerRole = "queue";
 
-        // Gotta be lazy so the schema names get set
-        _queueTable = new Lazy<QueueTable>(() => new QueueTable(Parent, _queueTableName));
-        _scheduledTable = new Lazy<ScheduledMessageTable>(() => new ScheduledMessageTable(Parent, _scheduledTableName));
+        // Gotta be lazy so the schema names and OptimizeThroughput get set
+        _queueTable = new Lazy<QueueTable>(() => new QueueTable(Parent, _queueTableName, OptimizeThroughput));
+        _scheduledTable =
+            new Lazy<ScheduledMessageTable>(() => new ScheduledMessageTable(Parent, _scheduledTableName, OptimizeThroughput));
     }
 
     public string Name { get; }
 
     internal SqlServerTransport Parent { get; }
+
+    private bool? _optimizeThroughput;
+
+    /// <summary>
+    ///     Use the higher-throughput queue table storage layout for *this* queue: the queue and
+    ///     scheduled tables are clustered on a monotonic <c>seq</c> identity for FIFO dequeue and
+    ///     contiguous deletes, with a unique non-clustered index on the message id, instead of a
+    ///     clustered primary key on a random Guid. When not set explicitly this falls back to the
+    ///     transport-wide <see cref="SqlServerTransport.OptimizeQueueThroughput" /> setting.
+    /// </summary>
+    public bool OptimizeThroughput
+    {
+        get => _optimizeThroughput ?? Parent.OptimizeQueueThroughput;
+        set => _optimizeThroughput = value;
+    }
 
     internal Table QueueTable => _queueTable.Value;
 
@@ -329,7 +345,7 @@ public class SqlServerQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
 
         // Mirror the dequeue ordering chosen by the listener (see SqlServerQueueListener): "seq" under
         // the high-throughput layout, "timestamp" otherwise.
-        var orderBy = Parent.OptimizeQueueThroughput ? "seq" : "timestamp";
+        var orderBy = OptimizeThroughput ? "seq" : "timestamp";
 
         _writeDirectlyToQueueTableSql =
             $@"insert into {QueueTable.Identifier} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.KeepUntil}) values (@id, @body, @type, @expires)";

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueueListener.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueueListener.cs
@@ -54,7 +54,7 @@ internal class SqlServerQueueListener : IListener, IReportReceiveLoopHealth
 
         // When the high-throughput layout is enabled the tables are clustered on the monotonic
         // "seq" identity, so dequeue ordering must use it; otherwise fall back to "timestamp".
-        var orderBy = queue.Parent.OptimizeQueueThroughput ? "seq" : "timestamp";
+        var orderBy = queue.OptimizeThroughput ? "seq" : "timestamp";
 
         _tryPopMessagesDirectlySql = $@"
 DECLARE @NOCOUNT VARCHAR(3) = 'OFF';

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
@@ -56,6 +56,8 @@ public class SqlServerTransport : BrokerTransport<SqlServerQueue>
     /// clustered on a monotonic <c>seq</c> identity column (for FIFO dequeue and contiguous deletes)
     /// with a unique non-clustered index on the message id, instead of a clustered primary key on a
     /// random Guid. Off by default. Enable via <see cref="SqlServerPersistenceExpression.OptimizeQueueThroughput"/>.
+    /// This is the default for every queue in this transport; an individual queue can opt in or out
+    /// through <see cref="SqlServerQueue.OptimizeThroughput"/> (sharded topology queues opt in).
     /// </summary>
     public bool OptimizeQueueThroughput { get; set; }
 


### PR DESCRIPTION
Closes #3468. Closes #3469.

Part 1 of 3 in the GlobalPartitioning epic (#3482). The database queues were the last two transports missing the [global partitioning](https://wolverinefx.net/guide/messaging/partitioning.html#global-partitioning) topology — and arguably the best candidates for it, since they give you cluster-wide sequential processing by group id with **no extra infrastructure**: each shard is just another pair of tables in the database you already have.

## What's here

**PostgreSQL (#3468)** — `PartitionedMessageTopologyWithDatabaseQueues` plus `UseShardedPostgresqlQueues()` / `PublishToShardedPostgresqlQueues()`, following the same two-piece transport contract as Rabbit/Kafka/SQS. The transport contributes only topology; all slot routing stays central in `Envelope.SlotForSending`.

`PostgresqlQueue` already runs its table names through `PostgresqlIdentifier.Shorten()` (GH-2942), so a long sharded base name stays inside `NAMEDATALEN` and stays distinct per shard — pinned by a new naming test.

**SQL Server (#3469)** — the same, ported: `UseShardedSqlServerQueues()` / `PublishToShardedSqlServerQueues()`.

Sharded queues **opt into the `seq`-clustered high-throughput table layout by default**, since ordered per-slot processing is exactly the case that layout was built for. To make that possible without dragging every other queue along, `OptimizeQueueThroughput` moves from transport-wide-only to a per-queue `SqlServerQueue.OptimizeThroughput` that falls back to the transport setting when unset. `QueueTable` / `ScheduledMessageTable` now take the flag rather than reading it off the transport.

## DB-per-tenant semantics

Documented rather than left implicit: shard queue tables are provisioned in **every** tenant database and slot routing is unchanged — a group id maps to the same slot number regardless of tenant. On PostgreSQL, listening is then assigned per `(queue, database)` pair by the sticky listener agent family.

## Tests

Per transport: a global-partitioned end-to-end scenario, a publishing-only scenario that really does round-trip every message through the shard queue tables (no companion-local-queue shortcut), a shard-queue configuration test, and table-naming/layout tests.

## Verification

- New tests green locally against Postgres and SQL Server.
- Full `SqlServerTests.Transport` suite green — **95 passed, 0 failed, 1 skipped** — so the per-queue `OptimizeThroughput` refactor is clean.
- `dotnet build wolverine.slnx -c Release` — 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)