### PR TITLE
GH-3496: EF Core tenant partition back-fill and per-table status reporting

### DIFF
--- a/docs/guide/durability/efcore/multi-tenancy.md
+++ b/docs/guide/durability/efcore/multi-tenancy.md
@@ -611,6 +611,34 @@ Note that with partitioning enabled, a tenant's partition must exist before rows
 Sagas are deliberately **not** partitioned in this release — they keep the conjoined query filtering and tenant
 stamping, but stay in unpartitioned tables so saga identity is untouched.
 
+### Partition Status Reporting <Badge type="tip" text="6.24" />
+
+Partition DDL is applied one table at a time with failures isolated, so a batch registration can partially
+succeed — one table's DDL failing does not roll back the tables that already reconciled. Every add returns a
+`TenantPartitionResult` reporting the outcome per table, so callers can surface partial failures instead of
+inferring success from the absence of an exception:
+
+snippet: sample_conjoined_partitioning_status_reporting
+
+On SQL Server the result also carries the `tenant_id -> ordinal` map that was assigned. On PostgreSQL, which
+partitions by list on the tenant id itself, `Ordinals` is empty.
+
+Tenant onboarding through `IDynamicTenantSource<string>` has nowhere to hand back per-table statuses, so a
+partial failure there throws `TenantPartitionException` — carrying the same `Failures` collection — rather than
+registering a tenant whose partitions were never created and letting it fail at its first write.
+
+### Back-filling a Table That Joins Late <Badge type="tip" text="6.24" />
+
+Routine migration deltas deliberately leave Weasel-managed partitions alone, so a table that joins an existing
+managed set — a newly deployed service, or a newly mapped `ITenanted` entity — has **no partition for any tenant
+registered before that table existed**. `MigrateTenantPartitionsAsync()` reconciles every partitioned table
+against the full registered tenant set:
+
+snippet: sample_conjoined_partitioning_back_fill
+
+The back-fill is a reconcile rather than a one-shot, so it is safe to run on every deploy. It also repairs a
+partitioned table that is missing a partition for an already-registered tenant.
+
 ### The Tenant Registry <Badge type="tip" text="6.21" />
 
 Conjoined registrations keep an authoritative tenant list in the `wolverine_tenants` table in the durability schema —

--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedPartitioningCompliance.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedPartitioningCompliance.cs
@@ -230,6 +230,59 @@ IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = 'pf_partitioned_it
     }
 
     [Fact]
+    public async Task add_tenants_reports_the_outcome_for_every_managed_table()
+    {
+        var result = await thePartitions.AddTenantsAsync(new Dictionary<string, string?>
+        {
+            ["green"] = null,
+            ["blue"] = null
+        });
+
+        result.Succeeded.ShouldBeTrue();
+        result.Failures.ShouldBeEmpty();
+
+        // The partitioned entity table is reported; the saga table is excluded from
+        // physical partitioning, so it is not part of the managed set
+        result.Tables.ShouldContain(x => x.TableName.Contains("partitioned_items"));
+        result.Tables.ShouldNotContain(x => x.TableName.Contains("partitioned_counters"));
+
+        if (_engine == DatabaseEngine.SqlServer)
+        {
+            // SQL Server partitions over a compact ordinal, so the assigned map comes back
+            result.Ordinals.Keys.OrderBy(x => x).ShouldBe(["blue", "green"]);
+            result.Ordinals["green"].ShouldNotBe(result.Ordinals["blue"]);
+        }
+        else
+        {
+            // PostgreSQL partitions by list on the tenant id itself -- no ordinals
+            result.Ordinals.ShouldBeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task back_fill_reconciles_every_managed_table_and_is_idempotent()
+    {
+        await thePartitions.AddTenantAsync("green");
+        await thePartitions.AddTenantAsync("blue");
+
+        var first = await thePartitions.MigrateTenantPartitionsAsync();
+        first.Succeeded.ShouldBeTrue();
+        first.Tables.ShouldContain(x => x.TableName.Contains("partitioned_items"));
+
+        // Back-fill is a reconcile, not a one-shot -- re-running it changes nothing
+        var second = await thePartitions.MigrateTenantPartitionsAsync();
+        second.Succeeded.ShouldBeTrue();
+
+        // and the tenants registered before the back-fill still write and read
+        var id = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c =>
+            c.InvokeForTenantAsync("green", new CreatePartitionedItem(id, "g")));
+
+        var green = await theBuilder.BuildAsync("green", CancellationToken.None);
+        (await green.Items.ToListAsync()).Single().Id.ShouldBe(id);
+    }
+
+    [Fact]
     public async Task physical_partition_exists_per_tenant()
     {
         await thePartitions.AddTenantAsync("green");
@@ -263,6 +316,45 @@ public class conjoined_partitioning_with_postgresql : ConjoinedPartitioningCompl
 {
     public conjoined_partitioning_with_postgresql() : base(DatabaseEngine.PostgreSQL)
     {
+    }
+
+    /// <summary>
+    ///     The back-fill's reason to exist, in the shape it can actually be forced on
+    ///     PostgreSQL: a partitioned table that is missing a partition for an already
+    ///     registered tenant. A table that joins the managed set late is the same
+    ///     situation -- routine migration deltas leave managed partitions alone, so
+    ///     nothing else recreates it
+    /// </summary>
+    [Fact]
+    public async Task back_fill_recreates_a_partition_missing_for_a_registered_tenant()
+    {
+        await thePartitions.AddTenantAsync("green");
+
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var drop = conn.CreateCommand();
+            drop.CommandText = "DROP TABLE conjoined_part.partitioned_items_green;";
+            await drop.ExecuteNonQueryAsync();
+        }
+
+        // Without its partition, the tenant's writes have nowhere to land
+        await Should.ThrowAsync<Exception>(async () =>
+        {
+            await theHost.TrackActivity().DoNotAssertOnExceptionsDetected()
+                .ExecuteAndWaitAsync(c =>
+                    c.InvokeForTenantAsync("green", new CreatePartitionedItem(Guid.NewGuid(), "before")));
+        });
+
+        var result = await thePartitions.MigrateTenantPartitionsAsync();
+        result.Succeeded.ShouldBeTrue();
+
+        var id = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c =>
+            c.InvokeForTenantAsync("green", new CreatePartitionedItem(id, "after")));
+
+        var green = await theBuilder.BuildAsync("green", CancellationToken.None);
+        (await green.Items.ToListAsync()).Single().Id.ShouldBe(id);
     }
 }
 

--- a/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs
@@ -284,6 +284,35 @@ public class ConjoinedTenancyDocumentationSamples
         await partitions.DropTenantAsync("tenant1", deleteData: true);
         #endregion
 
+        #region sample_conjoined_partitioning_status_reporting
+        // Partition DDL is applied per table with failures isolated, so a batch
+        // can partially succeed -- check the result rather than relying on the
+        // absence of an exception
+        var result = await partitions.AddTenantsAsync(new Dictionary<string, string?>
+        {
+            ["tenant2"] = null,
+            ["tenant3"] = null
+        });
+
+        if (!result.Succeeded)
+        {
+            foreach (var table in result.Failures)
+            {
+                Console.WriteLine($"{table.TableName} => {table.Status}");
+            }
+        }
+        #endregion
+
+        #region sample_conjoined_partitioning_back_fill
+        // Back-fill: reconcile every partitioned table against the full registered
+        // tenant set. Needed when a table joins an existing managed set -- a newly
+        // deployed service, or a newly mapped ITenanted entity -- because routine
+        // migrations deliberately leave managed partitions alone, so the new table
+        // would have no partition for any tenant registered before it existed
+        var backFill = await partitions.MigrateTenantPartitionsAsync();
+        Console.WriteLine($"Back-fill reconciled {backFill.Tables.Count} table(s)");
+        #endregion
+
         #region sample_conjoined_tenant_registry
         var tenants = host.Services.GetRequiredService<IDynamicTenantSource<string>>();
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenantPartitions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenantPartitions.cs
@@ -20,23 +20,36 @@ namespace Wolverine.EntityFrameworkCore.Internals;
 public interface IConjoinedTenantPartitions<T> where T : DbContext
 {
     /// <summary>
-    ///     Create the partition for a new tenant across every partitioned table
+    ///     Create the partition for a new tenant across every partitioned table.
+    ///     The returned result reports the outcome per table -- partition DDL is
+    ///     applied with failures isolated, so check Succeeded rather than assuming
+    ///     an exception-free call reached every table
     /// </summary>
-    Task AddTenantAsync(string tenantId, CancellationToken cancellationToken = default);
+    Task<TenantPartitionResult> AddTenantAsync(string tenantId, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Create or join a partition for a tenant. Tenants registered with the same
     ///     partition suffix share one physical partition ("bucketing") when
     ///     AllowPartitionSharing is enabled on the partitioning options
     /// </summary>
-    Task AddTenantAsync(string tenantId, string partitionSuffix, CancellationToken cancellationToken = default);
+    Task<TenantPartitionResult> AddTenantAsync(string tenantId, string partitionSuffix,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Batch registration of tenants; the dictionary value is the optional
     ///     partition suffix (null = own partition per tenant)
     /// </summary>
-    Task AddTenantsAsync(IReadOnlyDictionary<string, string?> tenantIdToSuffix,
+    Task<TenantPartitionResult> AddTenantsAsync(IReadOnlyDictionary<string, string?> tenantIdToSuffix,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Back-fill: reconcile every partitioned table against the full registered
+    ///     tenant set. Call this when a table joins an existing managed set -- a
+    ///     newly deployed service, or a newly mapped ITenanted entity -- because
+    ///     routine migrations deliberately leave managed partitions alone and the
+    ///     new table would otherwise have no partition for any existing tenant
+    /// </summary>
+    Task<TenantPartitionResult> MigrateTenantPartitionsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Remove a tenant from the partition set. On PostgreSQL this detaches and
@@ -145,22 +158,29 @@ internal class ConjoinedTenantPartitions<T> : IConjoinedTenantPartitions<T> wher
         return database;
     }
 
-    public async Task AddTenantAsync(string tenantId, CancellationToken cancellationToken = default)
+    public Task<TenantPartitionResult> AddTenantAsync(string tenantId, CancellationToken cancellationToken = default)
     {
-        await AddTenantsAsync(new Dictionary<string, string?> { [tenantId] = null }, cancellationToken);
+        return AddTenantsAsync(new Dictionary<string, string?> { [tenantId] = null }, cancellationToken);
     }
 
-    public Task AddTenantAsync(string tenantId, string partitionSuffix,
+    public Task<TenantPartitionResult> AddTenantAsync(string tenantId, string partitionSuffix,
         CancellationToken cancellationToken = default)
     {
         return AddTenantsAsync(new Dictionary<string, string?> { [tenantId] = partitionSuffix }, cancellationToken);
     }
 
-    public async Task AddTenantsAsync(IReadOnlyDictionary<string, string?> tenantIdToSuffix,
+    public async Task<TenantPartitionResult> AddTenantsAsync(IReadOnlyDictionary<string, string?> tenantIdToSuffix,
         CancellationToken cancellationToken = default)
     {
         var database = await BuildWeaselDatabaseAsync(cancellationToken);
-        await Partitioning.AddTenantsAsync(_logger, database, tenantIdToSuffix, cancellationToken);
+        return await Partitioning.AddTenantsAsync(_logger, database, tenantIdToSuffix, cancellationToken);
+    }
+
+    public async Task<TenantPartitionResult> MigrateTenantPartitionsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var database = await BuildWeaselDatabaseAsync(cancellationToken);
+        return await Partitioning.MigrateAllTablesAsync(_logger, database, cancellationToken);
     }
 
     public async Task DropTenantAsync(string tenantId, bool deleteData = false,

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenantSource.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedTenantSource.cs
@@ -132,7 +132,19 @@ internal class ConjoinedTenantSource<T> : IDynamicTenantSource<string> where T :
 
         if (partitions != null)
         {
-            await partitions.AddTenantAsync(tenantId, token);
+            var result = await partitions.AddTenantAsync(tenantId, token);
+            if (!result.Succeeded)
+            {
+                // IDynamicTenantSource has nowhere to hand back the per-table
+                // statuses, and a tenant registered without its partitions would
+                // fail at its first write instead of here
+                _logger.LogError(
+                    "Registered conjoined tenant {TenantId} for {DbContextType}, but partition DDL failed for {Tables}",
+                    tenantId, typeof(T).Name,
+                    result.Failures.Select(x => x.TableName).Join(", "));
+
+                throw new TenantPartitionException(result.Failures);
+            }
         }
 
         _logger.LogInformation("Added conjoined tenant {TenantId} for {DbContextType}", tenantId, typeof(T).Name);

--- a/src/Persistence/Wolverine.Postgresql/MultiTenancy/PostgresqlTenantPartitioning.cs
+++ b/src/Persistence/Wolverine.Postgresql/MultiTenancy/PostgresqlTenantPartitioning.cs
@@ -74,22 +74,80 @@ internal class PostgresqlTenantPartitioning : ITenantPartitioning
         return false;
     }
 
-    public async Task AddTenantsAsync(ILogger logger, IDatabaseWithTables database,
+    public async Task<TenantPartitionResult> AddTenantsAsync(ILogger logger, IDatabaseWithTables database,
         IReadOnlyDictionary<string, string?> tenantIdToSuffix, CancellationToken token)
     {
         var values = tenantIdToSuffix.ToDictionary(
             pair => pair.Key,
             pair => pair.Value ?? pair.Key.ToLowerInvariant());
 
+        if (!_options.AllowPartitionSharing)
+        {
+            await _partitions.InitializeAsync((PostgresqlDatabase)database, token);
+            assertNoSharing(values);
+        }
+
         var statuses =
             await _partitions.AddPartitionToAllTables(logger, (PostgresqlDatabase)database, values, token);
 
-        var failures = statuses.Where(x => x.Status != PartitionMigrationStatus.Complete).ToArray();
-        if (failures.Any())
+        return toResult(statuses);
+    }
+
+    public async Task<TenantPartitionResult> MigrateAllTablesAsync(ILogger logger, IDatabaseWithTables database,
+        CancellationToken token)
+    {
+        var db = (PostgresqlDatabase)database;
+        await _partitions.InitializeAsync(db, token);
+
+        // ManagedListPartitions has no dedicated back-fill entry point, but its add
+        // is purely additive and idempotent -- every partition is written as
+        // CREATE TABLE IF NOT EXISTS -- so replaying the full registered value ->
+        // suffix map reconciles any table that joined the managed set late
+        var registered = _partitions.Partitions.ToDictionary(pair => pair.Key, pair => pair.Value);
+        if (!registered.Any())
         {
-            throw new InvalidOperationException(
-                $"Adding tenant partitions failed for table(s) {failures.Select(x => x.Identifier.QualifiedName).Join(", ")}");
+            return TenantPartitionResult.Empty;
         }
+
+        var statuses = await _partitions.AddPartitionToAllTables(logger, db, registered, token);
+
+        return toResult(statuses);
+    }
+
+    /// <summary>
+    ///     PostgreSQL persists the tenant -> suffix map in the control table, so the
+    ///     check spans calls: two tenants land in the same bucket whether they were
+    ///     registered together or one release apart
+    /// </summary>
+    private void assertNoSharing(IReadOnlyDictionary<string, string> values)
+    {
+        foreach (var bucket in values.GroupBy(x => x.Value))
+        {
+            var members = bucket.Select(x => x.Key)
+                .Concat(_partitions.Partitions.Where(x => x.Value == bucket.Key).Select(x => x.Key))
+                .Distinct()
+                .ToArray();
+
+            if (members.Length > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Tenants {members.Join(", ")} share partition suffix '{bucket.Key}', but partition sharing is not enabled. Enable AllowPartitionSharing on the tenant partitioning options.");
+            }
+        }
+    }
+
+    private static TenantPartitionResult toResult(IEnumerable<TablePartitionStatus> statuses)
+    {
+        var tables = statuses.Select(x => new TenantPartitionTableStatus(x.Identifier.QualifiedName,
+            x.Status switch
+            {
+                PartitionMigrationStatus.Complete => TenantPartitionStatus.Complete,
+                PartitionMigrationStatus.RequiresTableRebuild => TenantPartitionStatus.RequiresTableRebuild,
+                _ => TenantPartitionStatus.Failed
+            })).ToList();
+
+        // PostgreSQL partitions by list on the tenant id itself, so there are no ordinals
+        return new TenantPartitionResult(new Dictionary<string, int>(), tables);
     }
 
     public async Task DropTenantsAsync(ILogger logger, IDatabaseWithTables database, IReadOnlyList<string> tenantIds,

--- a/src/Persistence/Wolverine.RDBMS/MultiTenancy/ITenantPartitioning.cs
+++ b/src/Persistence/Wolverine.RDBMS/MultiTenancy/ITenantPartitioning.cs
@@ -95,10 +95,22 @@ public interface ITenantPartitioning
     ///     Add partitions for the given tenants across all partitioned tables.
     ///     The dictionary value is the optional partition suffix -- tenants
     ///     sharing a suffix share a physical partition when AllowPartitionSharing
-    ///     is enabled; null values give each tenant its own partition
+    ///     is enabled; null values give each tenant its own partition.
+    ///     Partition DDL is applied per table with failures isolated, so the
+    ///     returned result can report a partial success
     /// </summary>
-    Task AddTenantsAsync(ILogger logger, IDatabaseWithTables database,
+    Task<TenantPartitionResult> AddTenantsAsync(ILogger logger, IDatabaseWithTables database,
         IReadOnlyDictionary<string, string?> tenantIdToSuffix, CancellationToken token);
+
+    /// <summary>
+    ///     Reconcile every partitioned table against the full registered tenant set.
+    ///     Routine migration deltas deliberately leave managed partitions alone, so a
+    ///     table that joins an existing managed set -- a newly deployed service, or a
+    ///     newly mapped entity -- has no partitions for the tenants registered before
+    ///     it existed until this back-fill runs
+    /// </summary>
+    Task<TenantPartitionResult> MigrateAllTablesAsync(ILogger logger, IDatabaseWithTables database,
+        CancellationToken token);
 
     /// <summary>
     ///     Remove the given tenants from the partition set. deleteData controls

--- a/src/Persistence/Wolverine.RDBMS/MultiTenancy/TenantPartitionResult.cs
+++ b/src/Persistence/Wolverine.RDBMS/MultiTenancy/TenantPartitionResult.cs
@@ -1,0 +1,88 @@
+namespace Wolverine.RDBMS.MultiTenancy;
+
+/// <summary>
+///     Per-table outcome of a tenant partition add or back-fill operation.
+///     Weasel.Postgresql and Weasel.SqlServer each declare their own engine-specific
+///     status enum; this is the engine-neutral projection Wolverine hands to callers
+/// </summary>
+public enum TenantPartitionStatus
+{
+    /// <summary>
+    ///     The table's partitions are in sync with the registered tenant set
+    /// </summary>
+    Complete,
+
+    /// <summary>
+    ///     The partition DDL failed for this table. The operation is failure-isolated
+    ///     per table, so other tables in the same batch may well have succeeded
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    ///     The table cannot be reconciled additively and needs a full rebuild --
+    ///     typically an existing non-partitioned table, or one whose live partition
+    ///     set has drifted from the registry
+    /// </summary>
+    RequiresTableRebuild
+}
+
+/// <summary>
+///     The outcome of a tenant partition operation for one physical table
+/// </summary>
+/// <param name="TableName">Qualified name of the partitioned table</param>
+/// <param name="Status">What happened to this table</param>
+public record TenantPartitionTableStatus(string TableName, TenantPartitionStatus Status);
+
+/// <summary>
+///     The result of adding tenants to -- or back-filling -- the Weasel-managed
+///     partition set. Partition DDL is applied per table with failures isolated, so
+///     a batch can partially succeed; inspect <see cref="Failures" /> rather than
+///     assuming an exception-free call touched every table
+/// </summary>
+/// <param name="Ordinals">
+///     Tenant id to partition ordinal, for engines that partition over a compact
+///     integer ordinal (SQL Server). Empty on PostgreSQL, which partitions by list
+///     on the tenant id itself
+/// </param>
+/// <param name="Tables">Per-table outcome, one entry per partitioned table</param>
+public record TenantPartitionResult(
+    IReadOnlyDictionary<string, int> Ordinals,
+    IReadOnlyList<TenantPartitionTableStatus> Tables)
+{
+    public static TenantPartitionResult Empty { get; } =
+        new(new Dictionary<string, int>(), []);
+
+    /// <summary>
+    ///     Every partitioned table was reconciled successfully
+    /// </summary>
+    public bool Succeeded => Tables.All(x => x.Status == TenantPartitionStatus.Complete);
+
+    /// <summary>
+    ///     The tables that did not reconcile. Re-running the add, or
+    ///     MigrateTenantPartitionsAsync, retries them
+    /// </summary>
+    public IReadOnlyList<TenantPartitionTableStatus> Failures =>
+        Tables.Where(x => x.Status != TenantPartitionStatus.Complete).ToList();
+}
+
+/// <summary>
+///     Thrown when tenant partition DDL failed for at least one table on a code path
+///     that cannot hand the caller a <see cref="TenantPartitionResult" /> -- most
+///     notably tenant onboarding through IDynamicTenantSource, where silently
+///     registering a tenant whose partitions were never created would fail later at
+///     the tenant's first write
+/// </summary>
+public class TenantPartitionException : Exception
+{
+    public TenantPartitionException(IReadOnlyList<TenantPartitionTableStatus> failures)
+        : base(
+            $"Tenant partition DDL failed for table(s) {string.Join(", ", failures.Select(x => $"{x.TableName} ({x.Status})"))}")
+    {
+        Failures = failures;
+    }
+
+    /// <summary>
+    ///     The tables that did not reconcile
+    /// </summary>
+    public IReadOnlyList<TenantPartitionTableStatus> Failures { get; }
+}

--- a/src/Persistence/Wolverine.SqlServer/MultiTenancy/SqlServerTenantPartitioning.cs
+++ b/src/Persistence/Wolverine.SqlServer/MultiTenancy/SqlServerTenantPartitioning.cs
@@ -73,11 +73,14 @@ internal class SqlServerTenantPartitioning : ITenantPartitioning
         return _partitions.Ordinals.TryGetValue(tenantId, out ordinal);
     }
 
-    public async Task AddTenantsAsync(ILogger logger, IDatabaseWithTables database,
+    public async Task<TenantPartitionResult> AddTenantsAsync(ILogger logger, IDatabaseWithTables database,
         IReadOnlyDictionary<string, string?> tenantIdToSuffix, CancellationToken token)
     {
         var db = (IDatabase<SqlConnection>)database;
         await _partitions.InitializeAsync(db, token);
+
+        var ordinals = new Dictionary<string, int>();
+        var tables = new List<TenantPartitionTableStatus>();
 
         // Tenants without a suffix each get their own auto-allocated ordinal.
         // Tenants sharing a suffix share one ordinal (a shared physical partition),
@@ -85,7 +88,7 @@ internal class SqlServerTenantPartitioning : ITenantPartitioning
         var standalone = tenantIdToSuffix.Where(x => x.Value == null).Select(x => x.Key).ToArray();
         if (standalone.Any())
         {
-            await _partitions.AddPartitionToAllTables(logger, db, standalone, token);
+            accumulate(await _partitions.AddPartitionsToAllTables(logger, db, standalone, token));
         }
 
         foreach (var bucket in tenantIdToSuffix.Where(x => x.Value != null).GroupBy(x => x.Value!))
@@ -113,15 +116,55 @@ internal class SqlServerTenantPartitioning : ITenantPartitioning
                 : (_partitions.Ordinals.Values.DefaultIfEmpty(0).Max() + 1);
 
             var mapping = members.ToDictionary(m => m, _ => ordinal);
-            var result = await _partitions.AddPartitionsToAllTables(logger, db, mapping, token);
+            accumulate(await _partitions.AddPartitionsToAllTables(logger, db, mapping, token));
+        }
 
-            var failures = result.Tables.Where(x => x.Status != PartitionMigrationStatus.Complete).ToArray();
-            if (failures.Any())
+        return new TenantPartitionResult(ordinals, tables);
+
+        void accumulate(TenantPartitionAddResult result)
+        {
+            foreach (var pair in result.Ordinals)
             {
-                throw new InvalidOperationException(
-                    $"Adding tenant partitions failed for table(s) {failures.Select(x => x.Identifier.QualifiedName).Join(", ")}");
+                ordinals[pair.Key] = pair.Value;
+            }
+
+            // A table can appear once per bucket; the worst status wins so a single
+            // failed batch isn't masked by a later successful one
+            foreach (var status in result.Tables)
+            {
+                var mapped = toStatus(status);
+                var index = tables.FindIndex(x => x.TableName == mapped.TableName);
+                if (index < 0)
+                {
+                    tables.Add(mapped);
+                }
+                else if (tables[index].Status == TenantPartitionStatus.Complete)
+                {
+                    tables[index] = mapped;
+                }
             }
         }
+    }
+
+    public async Task<TenantPartitionResult> MigrateAllTablesAsync(ILogger logger, IDatabaseWithTables database,
+        CancellationToken token)
+    {
+        var db = (IDatabase<SqlConnection>)database;
+        var statuses = await _partitions.MigrateAllTablesAsync(logger, db, token);
+
+        return new TenantPartitionResult(
+            _partitions.Ordinals.ToDictionary(x => x.Key, x => x.Value),
+            statuses.Select(toStatus).ToList());
+    }
+
+    private static TenantPartitionTableStatus toStatus(TablePartitionStatus status)
+    {
+        return new TenantPartitionTableStatus(status.Identifier.QualifiedName, status.Status switch
+        {
+            PartitionMigrationStatus.Complete => TenantPartitionStatus.Complete,
+            PartitionMigrationStatus.RequiresTableRebuild => TenantPartitionStatus.RequiresTableRebuild,
+            _ => TenantPartitionStatus.Failed
+        });
     }
 
     public Task DropTenantsAsync(ILogger logger, IDatabaseWithTables database, IReadOnlyList<string> tenantIds,


### PR DESCRIPTION
Closes #3496.

Wolverine already pins Weasel 9.19.0, and the first two bullets of #3496 had landed with the
original conjoined-tenancy work: `TenantDropBehavior.DeleteData` is wired into the SQL Server
drop path, and `AllowOrdinalSharing` + the explicit-ordinal `AddPartitionsToAllTables` overloads
back the `AllowPartitionSharing` option. This PR finishes the remaining two.

## New-table back-fill

Routine migration deltas deliberately leave Weasel-managed partitions alone, so a table that joins
an existing managed set — a newly deployed service, or a newly mapped `ITenanted` entity — has no
partition for any tenant registered before that table existed. `MigrateAllTablesAsync` reconciles
every partitioned table against the full registered tenant set, exposed as
`IConjoinedTenantPartitions<T>.MigrateTenantPartitionsAsync()`.

* SQL Server delegates to `ManagedTenantPartitions.MigrateAllTablesAsync`.
* PostgreSQL's `ManagedListPartitions` has no dedicated back-fill entry point, but its add is
  purely additive and idempotent (`CREATE TABLE IF NOT EXISTS` per partition), so replaying the
  full registered value → suffix map reconciles a late-joining table.

## Per-table status reporting

Partition DDL is applied per table with failures isolated, so a batch can partially succeed. The
providers were throwing that detail away — collapsing the statuses into an `InvalidOperationException`
listing table names. `AddTenantsAsync` now returns a `TenantPartitionResult` carrying the assigned
ordinals plus per-table statuses.

Weasel.Postgresql and Weasel.SqlServer each declare their *own* `TablePartitionStatus` /
`PartitionMigrationStatus`, and `Wolverine.RDBMS` references neither, so the result types are
engine-neutral Wolverine types that both providers project into.

Tenant onboarding through `IDynamicTenantSource<string>` has nowhere to hand back per-table
statuses, so a partial failure there now throws `TenantPartitionException` — carrying the same
`Failures` collection — instead of registering a tenant whose partitions were never created and
letting it fail at its first write.

## Also

PostgreSQL was not enforcing `AllowPartitionSharing` at all (SQL Server has always thrown). The
check is now applied on both engines, and on PostgreSQL it spans calls — the tenant → suffix map is
persisted in the control table, so two tenants land in the same bucket whether they were registered
together or one release apart.

## Tests

`ConjoinedPartitioningCompliance` gains coverage on both PostgreSQL and SQL Server for per-table
status reporting and for back-fill (reconcile + idempotence). PostgreSQL adds a test that forces
the back-fill's reason to exist: drop a registered tenant's partition, watch its writes fail, then
back-fill and watch them succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsRJRc4w5j16raViu4y5Rr

