### PR TITLE
GH-3676: filter auto-provisioned JetStream durable consumers to their own subject

### DIFF
--- a/src/Transports/NATS/Wolverine.Nats.Tests/NatsJetStreamConsumerFilterTests.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/NatsJetStreamConsumerFilterTests.cs
@@ -1,0 +1,191 @@
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using NATS.Net;
+using Shouldly;
+using Wolverine.Attributes;
+using Wolverine.Nats.Internal;
+using Wolverine.Runtime;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Wolverine.Nats.Tests;
+
+/// <summary>
+/// Regression coverage for GH-3676: a durable JetStream consumer auto-provisioned by the listener
+/// was created with no <c>FilterSubject</c>, so several durable consumers sharing one stream each
+/// received every message published to that stream instead of only their own subject's.
+///
+/// The subject filter was only ever applied to *ephemeral* consumers, while the resource-provisioning
+/// path in <c>NatsEndpoint</c> always set it for named consumers — these tests pin both the consumer
+/// configuration the server ends up with and the delivery behavior that depends on it.
+/// </summary>
+[Collection("NATS Integration")]
+[Trait("Category", "Integration")]
+public class NatsJetStreamConsumerFilterTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public NatsJetStreamConsumerFilterTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task auto_provisioned_durable_consumers_are_filtered_to_their_own_subject()
+    {
+        var natsUrl = NatsTestHelpers.ResolveUrl();
+        if (!await NatsTestHelpers.IsNatsAvailable(natsUrl)) return;
+
+        var id = Guid.NewGuid().ToString("N");
+        var stream = $"FILTER_{id}";
+        var root = $"filter.{id}";
+        var subjectA = $"{root}.type-a";
+        var subjectB = $"{root}.type-b";
+
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureLogging(l => l.AddXunitLogging(_output))
+            .UseWolverine(opts =>
+            {
+                opts.UseNats(natsUrl)
+                    .AutoProvision()
+                    .DefineStream(stream, s => s.WithSubjects($"{root}.>"));
+
+                opts.Policies.DisableConventionalLocalRouting();
+
+                opts.ListenToNatsSubject(subjectA).UseJetStream(stream, $"consumer-a-{id}");
+                opts.ListenToNatsSubject(subjectB).UseJetStream(stream, $"consumer-b-{id}");
+            })
+            .StartAsync();
+
+        await using var connection = new NatsConnection(new NatsOpts { Url = natsUrl });
+        await connection.ConnectAsync();
+        var js = connection.CreateJetStreamContext();
+
+        // Each durable consumer must be scoped to the subject its listener was bound to.
+        // Before the fix both came back with a null FilterSubject
+        var consumerA = await js.GetConsumerAsync(stream, $"consumer-a-{id}");
+        consumerA.Info.Config.FilterSubject.ShouldBe(subjectA);
+
+        var consumerB = await js.GetConsumerAsync(stream, $"consumer-b-{id}");
+        consumerB.Info.Config.FilterSubject.ShouldBe(subjectB);
+    }
+
+    [Fact]
+    public async Task a_scheduling_enabled_consumer_also_owns_its_schedule_subject()
+    {
+        var natsUrl = NatsTestHelpers.ResolveUrl();
+        if (!await NatsTestHelpers.IsNatsAvailable(natsUrl)) return;
+
+        var id = Guid.NewGuid().ToString("N");
+        var stream = $"FILTERSCHED_{id}";
+        var root = $"filtersched.{id}";
+        var subject = $"{root}.receiver";
+
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureLogging(l => l.AddXunitLogging(_output))
+            .UseWolverine(opts =>
+            {
+                opts.UseNats(natsUrl)
+                    .AutoProvision()
+                    .DefineWorkQueueStream(stream, s => s.EnableScheduledDelivery(), $"{root}.>");
+
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.ListenToNatsSubject(subject).UseJetStream(stream, $"sched-consumer-{id}");
+            })
+            .StartAsync();
+
+        var transport = host.Services.GetRequiredService<IWolverineRuntime>()
+            .Options.Transports.GetOrCreate<NatsTransport>();
+        if (!transport.ServerSupportsScheduledSend) return;
+
+        await using var connection = new NatsConnection(new NatsOpts { Url = natsUrl });
+        await connection.ConnectAsync();
+        var js = connection.CreateJetStreamContext();
+
+        // Native scheduling publishes its control message to "{subject}.scheduled". No single NATS
+        // filter covers both that and "{subject}", and on a work queue stream a control message no
+        // consumer covers is discarded, so the scheduled send silently never arrives. The consumer
+        // therefore has to carry both subjects
+        var consumer = await js.GetConsumerAsync(stream, $"sched-consumer-{id}");
+        consumer.Info.Config.FilterSubjects.ShouldBe([subject, $"{subject}.scheduled"]);
+    }
+
+    [Fact]
+    public async Task a_message_only_reaches_the_consumer_whose_subject_matches()
+    {
+        var natsUrl = NatsTestHelpers.ResolveUrl();
+        if (!await NatsTestHelpers.IsNatsAvailable(natsUrl)) return;
+
+        var id = Guid.NewGuid().ToString("N");
+        var stream = $"FILTERDELIVERY_{id}";
+        var root = $"filterdelivery.{id}";
+        var subjectA = $"{root}.type-a";
+        var subjectB = $"{root}.type-b";
+
+        FilteredMessageHandler.Reset();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureLogging(l => l.AddXunitLogging(_output))
+            .UseWolverine(opts =>
+            {
+                // A plain limits stream, not a work queue: work-queue retention deletes a message
+                // on the first ack, which would mask a second consumer pulling the same message
+                opts.UseNats(natsUrl)
+                    .AutoProvision()
+                    .DefineStream(stream, s => s.WithSubjects($"{root}.>"));
+
+                opts.Policies.DisableConventionalLocalRouting();
+
+                opts.ListenToNatsSubject(subjectA).UseJetStream(stream, $"delivery-a-{id}");
+                opts.ListenToNatsSubject(subjectB).UseJetStream(stream, $"delivery-b-{id}");
+
+                opts.PublishMessage<FilteredMessage>().ToNatsSubject(subjectA).UseJetStream(stream)
+                    .SendInline();
+            })
+            .StartAsync();
+
+        await host.MessageBus().SendAsync(new FilteredMessage(id));
+
+        // Only the type-a consumer is subscribed to this subject. With an unfiltered
+        // consumer-b the same message was delivered a second time (GH-3676)
+        await FilteredMessageHandler.WaitForFirstAsync();
+        (await FilteredMessageHandler.SettledCountAsync()).ShouldBe(1);
+    }
+}
+
+public record FilteredMessage(string Id);
+
+[WolverineHandler]
+public static class FilteredMessageHandler
+{
+    private static int _count;
+    private static TaskCompletionSource _first = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static void Reset()
+    {
+        Interlocked.Exchange(ref _count, 0);
+        _first = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public static void Handle(FilteredMessage message)
+    {
+        Interlocked.Increment(ref _count);
+        _first.TrySetResult();
+    }
+
+    public static Task WaitForFirstAsync()
+    {
+        return _first.Task.WaitAsync(30.Seconds());
+    }
+
+    /// <summary>
+    /// Give a duplicate delivery from a second, wrongly-unfiltered consumer time to land before
+    /// counting — a bare count immediately after the first handler run would pass either way
+    /// </summary>
+    public static async Task<int> SettledCountAsync()
+    {
+        await Task.Delay(3.Seconds());
+        return Volatile.Read(ref _count);
+    }
+}

--- a/src/Transports/NATS/Wolverine.Nats/Internal/JetStreamSubscriber.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/JetStreamSubscriber.cs
@@ -70,9 +70,29 @@ internal class JetStreamSubscriber : INatsSubscriber
             config.DeliverPolicy = deliverPolicy;
         }
 
-        if (string.IsNullOrEmpty(_endpoint.ConsumerName))
+        // Scope the consumer to this listener's subject. This used to be applied only to
+        // ephemeral consumers, so a durable consumer created through the fallback below
+        // was provisioned with no filter at all -- and every durable consumer sharing a
+        // stream then received every message published to that stream (GH-3676). The
+        // AutoProvision path in NatsEndpoint has always set it for named consumers; this
+        // is the runtime create-on-missing path catching up. Consumers that already exist
+        // are unaffected: GetConsumerAsync succeeding means this config is never sent
+        if (!string.IsNullOrEmpty(_subscriptionPattern))
         {
-            config.FilterSubject = _subscriptionPattern;
+            // Native scheduling publishes its control message to {subject}{suffix} and no single
+            // NATS filter covers both that and {subject} -- '{subject}.>' excludes {subject}
+            // itself. On a work queue stream a control message no consumer covers is discarded
+            // outright, so the schedule is never registered and the send silently never arrives;
+            // a multi-filter consumer keeps the schedule subject owned by this endpoint
+            var scheduleSubject = _subscriptionPattern + _endpoint.ScheduleSubjectSuffix;
+            if (_endpoint.UsesNativeScheduledSend && !string.IsNullOrEmpty(_endpoint.ScheduleSubjectSuffix))
+            {
+                config.FilterSubjects = [_subscriptionPattern, scheduleSubject];
+            }
+            else
+            {
+                config.FilterSubject = _subscriptionPattern;
+            }
         }
 
         if (!string.IsNullOrEmpty(_endpoint.ConsumerName))

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsEndpoint.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsEndpoint.cs
@@ -105,6 +105,21 @@ public class NatsEndpoint : Endpoint, IBrokerEndpoint
     public string ScheduleSubjectSuffix { get; set; } = ".scheduled";
 
     /// <summary>
+    /// True when native JetStream scheduling is actually in play for this endpoint's stream, which
+    /// means <c>{subject}{ScheduleSubjectSuffix}</c> carries the schedule control messages and must
+    /// stay covered by this endpoint's consumer. Mirrors the predicate CreateSender uses to decide
+    /// whether a sender supports native scheduled send
+    /// </summary>
+    [IgnoreDescription]
+    internal bool UsesNativeScheduledSend =>
+        UseJetStream
+        && _transport.Configuration.EnableJetStream
+        && _transport.ServerSupportsScheduledSend
+        && StreamName != null
+        && _transport.Configuration.Streams.TryGetValue(StreamName, out var scheduleStreamConfig)
+        && scheduleStreamConfig.AllowMsgSchedules;
+
+    /// <summary>
     /// Per-endpoint override for the JetStream consumer's <c>DeliverPolicy</c>.
     /// When non-null this wins over
     /// <see cref="Configuration.JetStreamDefaults.DeliverPolicy"/>; when null the


### PR DESCRIPTION
Closes #3676. Thanks to the reporter for a genuinely excellent bug report — the root-cause analysis
in the issue was correct as written.

## The bug

`JetStreamSubscriber.StartAsync` only assigned `FilterSubject` when `ConsumerName` was **empty**:

```csharp
if (string.IsNullOrEmpty(_endpoint.ConsumerName))
{
    config.FilterSubject = _subscriptionPattern;
}
```

For a named (durable) consumer that does not yet exist, `GetConsumerAsync` throws and Wolverine
provisions it with `CreateOrUpdateConsumerAsync(config)` — at which point `config` is authoritative
and carries no filter. Every durable consumer sharing a stream then received every message published
to that stream.

This was an inconsistency between Wolverine's two provisioning paths rather than a deliberate choice:
the `AutoProvision` path in `NatsEndpoint` has always set `FilterSubject` for named consumers.

Existing consumers are unaffected — `GetConsumerAsync` succeeding means the locally built
`ConsumerConfig` is never sent to the server.

## The part the issue didn't cover: native scheduled delivery

Filtering on the listener subject alone **regressed** `schedule_send_over_native_jetstream_scheduling`,
which is how this surfaced. Native scheduling publishes its control message to
`{subject}{ScheduleSubjectSuffix}` (default `{subject}.scheduled`) with `Nats-Schedule-Target` set to
`{subject}`, and no single NATS filter covers both — `{subject}.>` excludes `{subject}` itself.

On a work queue stream, a control message that no consumer's filter covers is discarded outright, so
the schedule was never registered and the scheduled send silently never arrived. Confirmed against a
live server: with no consumer covering the schedule subject the stream went straight back to
`messages=0` and nothing was ever materialized.

Endpoints where native scheduling is actually in play therefore get a **multi-filter** consumer over
both subjects, keeping the schedule subject owned by the endpoint that scheduled it.
`NatsEndpoint.UsesNativeScheduledSend` mirrors the predicate `CreateSender` already uses, so the
multi-filter form (2.10+) is confined to a feature that already requires 2.12+.

## Tests

New `NatsJetStreamConsumerFilterTests`:

* `auto_provisioned_durable_consumers_are_filtered_to_their_own_subject` — two durable consumers on one
  stream come back with their own `FilterSubject`, asserted against the server's consumer config (the
  same thing the reporter inspected via `/jsz`).
* `a_scheduling_enabled_consumer_also_owns_its_schedule_subject` — pins the multi-filter behavior above.
* `a_message_only_reaches_the_consumer_whose_subject_matches` — behavioral: publish once, assert the
  handler runs exactly once rather than once per consumer on the stream.

Red baseline verified by reverting the fix: the first fails with a null `FilterSubject`, the third
fails on a duplicate delivery. Full NATS suite 149/149 green; full `wolverine.slnx` Release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsRJRc4w5j16raViu4y5Rr
