### PR TITLE
GH-3683: make conjoined tenant partition bucketing actually work

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -127,13 +127,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.19.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.19.0" />
-    <PackageVersion Include="Weasel.MySql" Version="9.19.0" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.19.0" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.19.0" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.19.0" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.19.0" />
+    <PackageVersion Include="Weasel.Core" Version="9.20.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.20.0" />
+    <PackageVersion Include="Weasel.MySql" Version="9.20.0" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.20.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.20.0" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.20.0" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.20.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assemblyfixture" Version="2.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/docs/guide/durability/efcore/multi-tenancy.md
+++ b/docs/guide/durability/efcore/multi-tenancy.md
@@ -572,7 +572,12 @@ opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedTenancy.
 
     // Weasel-managed physical partitioning: one partition (or shared
     // bucket) per tenant on every non-saga ITenanted entity table
-    tenancy => tenancy.PartitionPerTenant());
+    tenancy => tenancy.PartitionPerTenant(partitioning =>
+    {
+        // Opt in before registering two tenants against one suffix.
+        // Without this a shared suffix is rejected outright
+        partitioning.AllowPartitionSharing = true;
+    }));
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L257-L265' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenancy_with_partitioning' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -582,7 +587,7 @@ With partitioning enabled:
 * On PostgreSQL, every non-saga `ITenanted` entity table becomes `PARTITION BY LIST (tenant_id)` with one partition per tenant, managed through a `wolverine_tenant_partitions` control table in the durability schema
 * On SQL Server (which can only range-partition over a compact value), entities gain an `int tenant_ordinal` column stamped automatically by Wolverine, and tables are `RANGE RIGHT` partitioned over the ordinal with a registry table mapping tenant ids to ordinals
 * The composite `(tenant, id)` primary key exists **only in the database** — your EF model keeps its own single key, so `FindAsync()`, `Attach()`, and saga loads keep exactly the same call shapes
-* Multiple small tenants can share one physical partition ("bucketing") by registering them with the same partition suffix — the answer to SQL Server's partition count ceiling and to "small tenants don't deserve their own partition"
+* Multiple small tenants can share one physical partition ("bucketing") by registering them with the same partition suffix — the answer to SQL Server's partition count ceiling and to "small tenants don't deserve their own partition". See [Tenant Bucketing](#tenant-bucketing) below
 * Partitioned conjoined contexts require `UseEntityFrameworkCoreWolverineManagedMigrations()` — EF migrations cannot express the partition DDL
 
 Manage tenants through `IConjoinedTenantPartitions<TDbContext>`:
@@ -596,8 +601,10 @@ var partitions = host.Services
 // Each tenant gets its own physical partition
 await partitions.AddTenantAsync("tenant1");
 
-// Or share one partition between small tenants ("bucketing") --
-// requires AllowPartitionSharing on the partitioning options
+// Or share one partition between small tenants ("bucketing") by registering
+// them against the same suffix -- requires AllowPartitionSharing above.
+// Members can be added one at a time as tenants onboard; the bucket is
+// resolved from storage, so they land in the same physical partition
 await partitions.AddTenantAsync("small-tenant-a", "shared_bucket");
 await partitions.AddTenantAsync("small-tenant-b", "shared_bucket");
 
@@ -610,6 +617,47 @@ await partitions.DropTenantAsync("tenant1", deleteData: true);
 Note that with partitioning enabled, a tenant's partition must exist before rows can be written for that tenant.
 Sagas are deliberately **not** partitioned in this release — they keep the conjoined query filtering and tenant
 stamping, but stay in unpartitioned tables so saga identity is untouched.
+
+### Tenant Bucketing <Badge type="tip" text="6.24" />
+
+Giving every tenant its own physical partition stops scaling somewhere — SQL Server caps a table at 15,000
+partitions, and long before that a few thousand nearly-empty partitions cost more in planning time than they
+save in scans. *Bucketing* is the escape hatch: register several small tenants against the same partition
+suffix and they share one physical partition, while large tenants keep theirs to themselves.
+
+Bucketing is opt-in. Set `AllowPartitionSharing` on the partitioning options, then pass the same suffix for
+every member of a bucket:
+
+```cs
+tenancy => tenancy.PartitionPerTenant(p => p.AllowPartitionSharing = true);
+
+// ...
+
+// big tenants keep a partition each
+await partitions.AddTenantAsync("enterprise-customer");
+
+// small ones share -- registered together, or one at a time as they sign up
+await partitions.AddTenantAsync("small-tenant-a", "shared_bucket");
+await partitions.AddTenantAsync("small-tenant-b", "shared_bucket");
+```
+
+Members can be registered together or in completely separate calls; the bucket is resolved from storage, so
+a tenant onboarding a release later still lands in the partition its bucket already owns.
+
+Dropping one member of a bucket removes only that tenant's rows — the remaining members keep the partition and
+their data. The partition itself is released only when its last member is dropped.
+
+::: warning
+`AllowPartitionSharing` is off by default, and passing a shared suffix without it fails fast rather than
+quietly giving each tenant its own partition. Leave it off unless you actually want tenants sharing storage:
+a shared partition means partition pruning no longer isolates those tenants from each other, and a
+partition-level operation touches every member.
+:::
+
+::: tip
+Bucketing required Weasel 9.20.0 (`JasperFx/weasel#391`). On earlier versions a shared suffix did not
+actually produce a shared partition on either engine — see [GH-3683](https://github.com/JasperFx/wolverine/issues/3683).
+:::
 
 ### Partition Status Reporting <Badge type="tip" text="6.24" />
 

--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedPartitioningCompliance.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedPartitioningCompliance.cs
@@ -114,7 +114,9 @@ public abstract class ConjoinedPartitioningCompliance : IAsyncLifetime
                     opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<PartitionedItemsDbContext>(
                         (builder, connectionString) => builder.UseNpgsql(connectionString.Value),
                         AutoCreate.CreateOrUpdate,
-                        tenancy => tenancy.PartitionPerTenant());
+                        // Bucketing is opt-in; enabling it here does not change the behavior of the
+                        // non-bucketed tests, which still register tenants with no suffix
+                        tenancy => tenancy.PartitionPerTenant(p => p.AllowPartitionSharing = true));
                 }
                 else
                 {
@@ -122,7 +124,7 @@ public abstract class ConjoinedPartitioningCompliance : IAsyncLifetime
                     opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<PartitionedItemsDbContext>(
                         (builder, connectionString) => builder.UseSqlServer(connectionString.Value),
                         AutoCreate.CreateOrUpdate,
-                        tenancy => tenancy.PartitionPerTenant());
+                        tenancy => tenancy.PartitionPerTenant(p => p.AllowPartitionSharing = true));
                 }
 
                 opts.UseEntityFrameworkCoreTransactions();
@@ -280,6 +282,118 @@ IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = 'pf_partitioned_it
 
         var green = await theBuilder.BuildAsync("green", CancellationToken.None);
         (await green.Items.ToListAsync()).Single().Id.ShouldBe(id);
+    }
+
+    [Fact]
+    public async Task bucketed_tenants_registered_separately_share_one_partition()
+    {
+        // GH-3683 / weasel#391: registering bucket members ONE AT A TIME is the documented shape and the
+        // natural tenant-onboarding shape, and it silently did not work on either engine. PostgreSQL's
+        // second member was swallowed by CREATE TABLE IF NOT EXISTS so its first write failed with 23514;
+        // SQL Server's registry had no bucket key, so each call quietly allocated a separate ordinal and
+        // the tenants never actually shared the partition that bucketing exists to give them.
+        await thePartitions.AddTenantAsync("smalla", "shared_bucket");
+        await thePartitions.AddTenantAsync("smallb", "shared_bucket");
+
+        // Both members read and write...
+        var aId = Guid.NewGuid();
+        var bId = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c =>
+            c.InvokeForTenantAsync("smalla", new CreatePartitionedItem(aId, "a")));
+        await theHost.ExecuteAndWaitAsync(c =>
+            c.InvokeForTenantAsync("smallb", new CreatePartitionedItem(bId, "b")));
+
+        var a = await theBuilder.BuildAsync("smalla", CancellationToken.None);
+        (await a.Items.ToListAsync()).Single().Id.ShouldBe(aId);
+
+        var b = await theBuilder.BuildAsync("smallb", CancellationToken.None);
+        (await b.Items.ToListAsync()).Single().Id.ShouldBe(bId);
+
+        // ...and they genuinely share ONE physical partition, which is the entire point
+        (await distinctPartitionCountAsync(["smalla", "smallb"])).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task bucketed_tenants_registered_together_share_one_partition()
+    {
+        await thePartitions.AddTenantsAsync(new Dictionary<string, string?>
+        {
+            ["smalla"] = "shared_bucket",
+            ["smallb"] = "shared_bucket"
+        });
+
+        (await distinctPartitionCountAsync(["smalla", "smallb"])).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task dropping_one_bucket_member_leaves_the_others_working()
+    {
+        // The co-tenant data-loss defect found alongside GH-3683: on PostgreSQL the by-value drop resolved
+        // the tenant to its suffix and dropped BY SUFFIX, taking every co-tenant's rows with it.
+        await thePartitions.AddTenantAsync("smalla", "shared_bucket");
+        await thePartitions.AddTenantAsync("smallb", "shared_bucket");
+
+        var survivorId = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c =>
+            c.InvokeForTenantAsync("smalla", new CreatePartitionedItem(Guid.NewGuid(), "doomed")));
+        await theHost.ExecuteAndWaitAsync(c =>
+            c.InvokeForTenantAsync("smallb", new CreatePartitionedItem(survivorId, "survivor")));
+
+        await thePartitions.DropTenantAsync("smalla", deleteData: true);
+
+        // The survivor keeps its rows...
+        var b = await theBuilder.BuildAsync("smallb", CancellationToken.None);
+        (await b.Items.ToListAsync()).Single().Id.ShouldBe(survivorId);
+
+        // ...and can still write
+        var moreId = Guid.NewGuid();
+        await theHost.ExecuteAndWaitAsync(c =>
+            c.InvokeForTenantAsync("smallb", new CreatePartitionedItem(moreId, "more")));
+
+        b = await theBuilder.BuildAsync("smallb", CancellationToken.None);
+        (await b.Items.ToListAsync()).Select(x => x.Id).OrderBy(x => x)
+            .ShouldBe(new[] { survivorId, moreId }.OrderBy(x => x));
+    }
+
+    /// <summary>
+    ///     How many distinct physical partitions the given tenants occupy. PostgreSQL partitions by list on
+    ///     the tenant id, so the partition is the child table the row lands in; SQL Server partitions over a
+    ///     compact ordinal, so it is the registered ordinal
+    /// </summary>
+    private async Task<int> distinctPartitionCountAsync(string[] tenantIds)
+    {
+        if (_engine == DatabaseEngine.PostgreSQL)
+        {
+            await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+select count(distinct c.relname)
+from pg_class c
+join pg_inherits i on i.inhrelid = c.oid
+join pg_class parent on i.inhparent = parent.oid
+join pg_namespace ns on parent.relnamespace = ns.oid
+where ns.nspname = 'conjoined_part' and parent.relname = 'partitioned_items'
+  and pg_get_expr(c.relpartbound, c.oid) like any (@patterns)";
+            var parameter = cmd.CreateParameter();
+            parameter.ParameterName = "patterns";
+            parameter.Value = tenantIds.Select(x => $"%'{x}'%").ToArray();
+            cmd.Parameters.Add(parameter);
+            return (int)(long)(await cmd.ExecuteScalarAsync())!;
+        }
+
+        await using var sqlConn = new SqlConnection(Servers.SqlServerConnectionString);
+        await sqlConn.OpenAsync();
+        await using var sqlCmd = sqlConn.CreateCommand();
+        var names = tenantIds.Select((_, i) => $"@t{i}").ToArray();
+        for (var i = 0; i < tenantIds.Length; i++)
+        {
+            sqlCmd.Parameters.AddWithValue($"@t{i}", tenantIds[i]);
+        }
+
+        sqlCmd.CommandText =
+            $"SELECT COUNT(DISTINCT ordinal) FROM conjoined_part_wolverine.wolverine_tenant_partitions WHERE tenant_id IN ({string.Join(", ", names)})";
+        return (int)(await sqlCmd.ExecuteScalarAsync())!;
     }
 
     [Fact]

--- a/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs
@@ -261,7 +261,12 @@ public class ConjoinedTenancyDocumentationSamples
 
                 // Weasel-managed physical partitioning: one partition (or shared
                 // bucket) per tenant on every non-saga ITenanted entity table
-                tenancy => tenancy.PartitionPerTenant());
+                tenancy => tenancy.PartitionPerTenant(partitioning =>
+                {
+                    // Opt in before registering two tenants against one suffix.
+                    // Without this a shared suffix is rejected outright
+                    partitioning.AllowPartitionSharing = true;
+                }));
             #endregion
         });
     }
@@ -275,8 +280,10 @@ public class ConjoinedTenancyDocumentationSamples
         // Each tenant gets its own physical partition
         await partitions.AddTenantAsync("tenant1");
 
-        // Or share one partition between small tenants ("bucketing") --
-        // requires AllowPartitionSharing on the partitioning options
+        // Or share one partition between small tenants ("bucketing") by registering
+        // them against the same suffix -- requires AllowPartitionSharing above.
+        // Members can be added one at a time as tenants onboard; the bucket is
+        // resolved from storage, so they land in the same physical partition
         await partitions.AddTenantAsync("small-tenant-a", "shared_bucket");
         await partitions.AddTenantAsync("small-tenant-b", "shared_bucket");
 

--- a/src/Persistence/Wolverine.SqlServer/MultiTenancy/SqlServerTenantPartitioning.cs
+++ b/src/Persistence/Wolverine.SqlServer/MultiTenancy/SqlServerTenantPartitioning.cs
@@ -79,69 +79,42 @@ internal class SqlServerTenantPartitioning : ITenantPartitioning
         var db = (IDatabase<SqlConnection>)database;
         await _partitions.InitializeAsync(db, token);
 
-        var ordinals = new Dictionary<string, int>();
-        var tables = new List<TenantPartitionTableStatus>();
-
-        // Tenants without a suffix each get their own auto-allocated ordinal.
-        // Tenants sharing a suffix share one ordinal (a shared physical partition),
-        // mirroring the PostgreSQL suffix bucketing
-        var standalone = tenantIdToSuffix.Where(x => x.Value == null).Select(x => x.Key).ToArray();
-        if (standalone.Any())
+        if (!_options.AllowPartitionSharing)
         {
-            accumulate(await _partitions.AddPartitionsToAllTables(logger, db, standalone, token));
+            assertNoSharing(tenantIdToSuffix);
         }
 
+        // Weasel resolves each named bucket to its ordinal through the registry's bucket column, so
+        // members of one bucket land in the same physical partition whether they were registered
+        // together or one release apart. Wolverine used to resolve the ordinal itself from the
+        // tenant -> ordinal map, which could not see the bucket at all: a brand new tenant matched
+        // nothing and silently got a fresh partition (GH-3683 / weasel#391)
+        var result = await _partitions.AddPartitionsToAllTables(logger, db, tenantIdToSuffix, token);
+
+        return new TenantPartitionResult(
+            result.Ordinals.ToDictionary(x => x.Key, x => x.Value),
+            result.Tables.Select(toStatus).ToList());
+    }
+
+    /// <summary>
+    ///     The bucket -> ordinal map is persisted, so this check spans calls just like the PostgreSQL
+    ///     one: two tenants land in the same bucket whether they were registered together or one
+    ///     release apart
+    /// </summary>
+    private void assertNoSharing(IReadOnlyDictionary<string, string?> tenantIdToSuffix)
+    {
         foreach (var bucket in tenantIdToSuffix.Where(x => x.Value != null).GroupBy(x => x.Value!))
         {
-            if (!_options.AllowPartitionSharing && bucket.Count() > 1)
+            var alreadyRegistered = _partitions.Buckets.TryGetValue(bucket.Key, out var ordinal)
+                ? _partitions.Ordinals.Where(x => x.Value == ordinal).Select(x => x.Key)
+                : [];
+
+            var members = bucket.Select(x => x.Key).Concat(alreadyRegistered).Distinct().ToArray();
+
+            if (members.Length > 1)
             {
                 throw new InvalidOperationException(
-                    $"Tenants {bucket.Select(x => x.Key).Join(", ")} share partition suffix '{bucket.Key}', but partition sharing is not enabled. Enable AllowPartitionSharing on the tenant partitioning options.");
-            }
-
-            // The bucket's ordinal is whichever member is already registered, or
-            // the next free ordinal for a brand new bucket
-            var members = bucket.Select(x => x.Key).ToArray();
-            var existing = members.Where(m => _partitions.Ordinals.ContainsKey(m))
-                .Select(m => _partitions.Ordinals[m]).Distinct().ToArray();
-
-            if (existing.Length > 1)
-            {
-                throw new InvalidOperationException(
-                    $"Tenants {members.Join(", ")} for suffix '{bucket.Key}' are already mapped to different partitions ({string.Join(", ", existing)})");
-            }
-
-            var ordinal = existing.Length == 1
-                ? existing[0]
-                : (_partitions.Ordinals.Values.DefaultIfEmpty(0).Max() + 1);
-
-            var mapping = members.ToDictionary(m => m, _ => ordinal);
-            accumulate(await _partitions.AddPartitionsToAllTables(logger, db, mapping, token));
-        }
-
-        return new TenantPartitionResult(ordinals, tables);
-
-        void accumulate(TenantPartitionAddResult result)
-        {
-            foreach (var pair in result.Ordinals)
-            {
-                ordinals[pair.Key] = pair.Value;
-            }
-
-            // A table can appear once per bucket; the worst status wins so a single
-            // failed batch isn't masked by a later successful one
-            foreach (var status in result.Tables)
-            {
-                var mapped = toStatus(status);
-                var index = tables.FindIndex(x => x.TableName == mapped.TableName);
-                if (index < 0)
-                {
-                    tables.Add(mapped);
-                }
-                else if (tables[index].Status == TenantPartitionStatus.Complete)
-                {
-                    tables[index] = mapped;
-                }
+                    $"Tenants {members.Join(", ")} share partition suffix '{bucket.Key}', but partition sharing is not enabled. Enable AllowPartitionSharing on the tenant partitioning options.");
             }
         }
     }


### PR DESCRIPTION
Closes #3683. Also closes #3686 (the co-tenant data loss found alongside it).

> [!IMPORTANT]
> **Draft — blocked on Weasel 9.20.0 reaching nuget.org.** The root cause is in Weasel, fixed by
> JasperFx/weasel#392. CI will fail restore until that version is published. Everything here was
> verified locally against a packed 9.20.0 build.

## The problem

Tenant *bucketing* — registering several small tenants against one partition suffix so they share a physical
partition — is documented on the EF Core multi-tenancy page and exposed through
`PartitionPerTenant(p => p.AllowPartitionSharing = true)`. It did not work on either engine. It had **no test
coverage**, which is why it went unnoticed; the doc sample demonstrating it is compile-only and never executed.

Both defects were reproduced against real PostgreSQL and SQL Server:

* **PostgreSQL** emitted one single-value `ListPartition` per tenant, so the second member of a bucket was
  swallowed by `CREATE TABLE IF NOT EXISTS` and its first write failed with `23514 no partition of relation
  found for row`.
* **SQL Server** worked inside a single batch but silently not across calls — the natural tenant-onboarding
  shape, and the one the docs showed. The registry stored only `tenant_id -> ordinal`, so a brand-new tenant
  could not discover which ordinal its bucket already owned and quietly got its own partition. The
  15,000-partition ceiling that bucketing exists to dodge was not mitigated at all.

Neither was fixable inside Wolverine, hence JasperFx/weasel#392.

### Plus a data-loss defect found along the way (#3686)

Dropping **one** member of a bucket destroyed **every co-tenant's rows**: the by-value drop resolved the tenant
to its suffix and then dropped by *suffix*, deleting the whole bucket's registry rows and `DROP`ping the shared
partition table. Also fixed in weasel#392, and covered here.

## Changes

`PostgresqlTenantPartitioning` needs **no change** — it hands Weasel the tenant → suffix map, and the fixed
Weasel does the right thing.

`SqlServerTenantPartitioning` was resolving the bucket's ordinal itself out of the tenant → ordinal map, which
is blind to buckets: for a brand-new tenant the lookup matched nothing and it allocated a fresh ordinal. It now
delegates to Weasel's bucket-aware overload, and its `AllowPartitionSharing` guard spans calls via the
persisted bucket map — matching what PostgreSQL already did.

**Compliance coverage on both engines** for #3683's acceptance criteria: members registered together and
separately land in one physical partition, and dropping one member leaves the others reading, writing, and
holding their data.

**Docs.** The bucketing sample showed the sequential pattern *without* enabling `AllowPartitionSharing`, so as
written it would have thrown. The config sample now enables it, and a new **Tenant Bucketing** section covers
when to reach for it, the drop semantics, the isolation trade-off, and the 9.20.0 requirement.

## Verification

Real databases throughout.

| Suite | Result |
|---|---|
| `EfCoreTests.MultiTenancy` | 193/193 |
| `SqlServerTests` | 388/390 (2 skipped, pre-existing) |
| `PostgresqlTests` | 466/467 (1 skipped, pre-existing) |
| `wolverine.slnx` Release build | clean, 0 warnings |

Upstream weasel#392 carries 5 new PostgreSQL tests (**all 5 red on 9.19.1**) and 5 new SQL Server tests, with
both full Weasel suites green.

## Merge order

1. JasperFx/weasel#392
2. Publish Weasel 9.20.0
3. Mark this ready — the `Directory.Packages.props` bump to 9.20.0 is already in this branch