### PR TITLE
Settle RabbitMQ deliveries against the channel they arrived on (GH-3687)

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_3687_settling_a_delivery_from_a_dead_channel.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_3687_settling_a_delivery_from_a_dead_channel.cs
@@ -1,0 +1,174 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using RabbitMQ.Client;
+using Shouldly;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests.Bugs;
+
+/// <summary>
+/// Regression coverage for the "NullReferenceException in RabbitMqListener.CompleteAsync" report.
+///
+/// Deploy churn tears channels down constantly. An envelope that was already processed would try to
+/// ACK through the listener's channel, but every rebuild path nulls that channel
+/// (RabbitMqChannelAgent.teardownChannel), so `Channel!.BasicAckAsync(...)` dereferenced null. The
+/// RetryBlock then retried the ACK — pointlessly, because delivery tags are scoped to the channel
+/// they arrived on and can never be settled on any later channel. With no ACK, the broker redelivered,
+/// which showed up as a steady "Duplicate incoming envelope detected" stream from the durable inbox.
+///
+/// The fix binds each delivery to the channel it actually arrived on (RabbitMqEnvelope.DeliveredOn)
+/// and no-ops the settle when that channel is gone or has been replaced.
+///
+/// NOTE the second test below guards something subtler than the NRE: a bare null check would have
+/// been WORSE than the crash. Delivery tags restart at 1 on each new channel, and CompleteAsync acks
+/// with multiple: true, so replaying a stale tag against a rebuilt channel would ack every lower tag
+/// on it — including messages still in the handler pipeline. That is silent message loss.
+/// </summary>
+public class Bug_3687_settling_a_delivery_from_a_dead_channel : IAsyncLifetime
+{
+    private readonly string _queueName = $"bug3687-{Guid.NewGuid():N}";
+    private IHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "Bug3687";
+                opts.UseRabbitMq()
+                    .AutoProvision()
+                    .AutoPurgeOnStartup();
+
+                opts.PublishMessage<Bug3687Message>().ToRabbitQueue(_queueName);
+                opts.ListenToRabbitQueue(_queueName);
+
+                opts.LocalRoutingConventionDisabled = true;
+            }).StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private RabbitMqListener findListener()
+    {
+        var runtime = _host.GetRuntime();
+        var agent = runtime.Endpoints.ActiveListeners()
+            .Single(x => x.Uri == new Uri($"rabbitmq://queue/{_queueName}"));
+        return ((ListeningAgent)agent).Listener.ShouldBeOfType<RabbitMqListener>();
+    }
+
+    private static async Task<bool> waitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(100);
+        }
+
+        return condition();
+    }
+
+    [Fact]
+    public async Task completing_a_delivery_after_the_channel_is_torn_down_does_not_throw()
+    {
+        var listener = findListener();
+        var deliveringChannel = listener.Channel!;
+        deliveringChannel.IsOpen.ShouldBeTrue();
+
+        // A delivery that arrived on the channel the listener is holding right now.
+        var envelope = new RabbitMqEnvelope(listener, 4200UL, deliveringChannel);
+        listener.CanSettle(envelope).ShouldBeTrue("A live delivery on the current channel must be settleable");
+
+        // Tear the listener down the way a pod shutdown does. teardownChannel() nulls Channel, which
+        // is the exact state that produced the reported NullReferenceException.
+        await listener.DisposeAsync();
+        listener.Channel.ShouldBeNull();
+
+        // Pre-fix this threw NullReferenceException out of `Channel!.BasicAckAsync(...)`, and the
+        // RetryBlock then re-ran it three times before discarding.
+        await Should.NotThrowAsync(() => listener.CompleteAsync(envelope));
+
+        listener.CanSettle(envelope).ShouldBeFalse("A delivery cannot be settled once the channel is gone");
+    }
+
+    [Fact]
+    public async Task a_stale_delivery_tag_is_never_settled_against_a_replaced_channel()
+    {
+        // Prove the pipe works before we break the channel.
+        await _host.MessageBus().PublishAsync(new Bug3687Message("before-break"));
+        (await waitForAsync(() => Bug3687MessageHandler.Contains("before-break"), 30.Seconds()))
+            .ShouldBeTrue("Expected the message to be handled before the channel is broken");
+
+        var listener = findListener();
+        var originalChannel = listener.Channel!;
+
+        // A delivery that arrived on the channel we are about to kill.
+        var staleEnvelope = new RabbitMqEnvelope(listener, 4200UL, originalChannel);
+        listener.CanSettle(staleEnvelope).ShouldBeTrue();
+
+        // Force a broker-initiated channel shutdown without dropping the connection: a passive declare
+        // against a queue that does not exist returns 404 NOT_FOUND and takes the channel down.
+        try
+        {
+            await originalChannel.QueueDeclarePassiveAsync($"missing-{Guid.NewGuid():N}");
+        }
+        catch
+        {
+            // Expected — the passive declare fails and takes the channel with it.
+        }
+
+        var rebuilt = await waitForAsync(
+            () => listener.Channel is { IsOpen: true } && !ReferenceEquals(listener.Channel, originalChannel),
+            30.Seconds());
+        rebuilt.ShouldBeTrue("The listener should have rebuilt onto a fresh channel");
+
+        // The heart of it. The listener now holds a healthy, OPEN channel — so a null check would
+        // happily pass here and ack tag 4200 against a channel whose tags restart at 1, sweeping up
+        // every lower tag with multiple: true. The channel-identity check is what prevents that.
+        listener.Channel!.IsOpen.ShouldBeTrue();
+        listener.CanSettle(staleEnvelope)
+            .ShouldBeFalse("A tag from the dead channel must not be settled against the replacement");
+
+        await Should.NotThrowAsync(() => listener.CompleteAsync(staleEnvelope));
+
+        // A delivery on the CURRENT channel is still settleable — the guard is not just latching off.
+        var freshEnvelope = new RabbitMqEnvelope(listener, 1UL, listener.Channel!);
+        listener.CanSettle(freshEnvelope).ShouldBeTrue();
+
+        // And the listener is still genuinely working end to end.
+        await _host.MessageBus().PublishAsync(new Bug3687Message("after-break"));
+        (await waitForAsync(() => Bug3687MessageHandler.Contains("after-break"), 30.Seconds()))
+            .ShouldBeTrue("Expected the listener to keep consuming after the channel rebuild");
+    }
+}
+
+public record Bug3687Message(string Value);
+
+public static class Bug3687MessageHandler
+{
+    private static readonly List<string> Received = new();
+
+    public static bool Contains(string value)
+    {
+        lock (Received)
+        {
+            return Received.Contains(value);
+        }
+    }
+
+    public static void Handle(Bug3687Message message)
+    {
+        lock (Received)
+        {
+            Received.Add(message.Value);
+        }
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelCallback.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelCallback.cs
@@ -10,20 +10,36 @@ internal class RabbitMqChannelCallback : IChannelCallback, IDisposable, ISupport
 {
     private readonly RetryBlock<RabbitMqEnvelope> _deadLetterQueue;
 
+    // Sample broker text:
+    //   Already closed: The AMQP operation was interrupted: AMQP close-reason, initiated by Peer,
+    //   code=406, text='PRECONDITION_FAILED - unknown delivery tag 1', classId=60, methodId=80
+    //
+    // NOTE the tag number sits INSIDE the quotes. Earlier versions of this check looked for
+    // "'PRECONDITION_FAILED - unknown delivery tag'" with a trailing apostrophe, which never matched
+    // any real broker message -- so in moveToErrorQueueAsync the exception was rethrown and retried
+    // three times before being discarded. Match without the closing quote.
+    private const string UnknownDeliveryTag = "PRECONDITION_FAILED - unknown delivery tag";
+
+    private static bool isUnknownDeliveryTag(AlreadyClosedException exception)
+    {
+        return exception.Message.Contains(UnknownDeliveryTag);
+    }
+
     internal RabbitMqChannelCallback(ILogger logger, CancellationToken cancellationToken)
     {
         Logger = logger;
         Complete = new RetryBlock<RabbitMqEnvelope>(async (e, _) =>
         {
-            // AlreadyClosedException: Already closed: The AMQP operation was interrupted: AMQP close-reason, initiated by Peer, code=406, text='PRECONDITION_FAILED - unknown delivery tag 1', classId=60, methodId=80
-
             try
             {
                 await e.CompleteAsync();
             }
             catch (AlreadyClosedException exception)
             {
-                if (exception.Message.Contains("'PRECONDITION_FAILED - unknown delivery tag'"))
+                // An unknown delivery tag is terminal -- the tag's channel is gone and no retry on any
+                // later channel can succeed. Swallowing it here stops the RetryBlock from burning its
+                // budget; the broker will redeliver and the durable inbox will deduplicate.
+                if (isUnknownDeliveryTag(exception))
                 {
                     logger.LogInformation("Encountered an unknown delivery tag, discarding the envelope");
                 }
@@ -97,18 +113,20 @@ internal class RabbitMqChannelCallback : IChannelCallback, IDisposable, ISupport
     {
         try
         {
-            if (envelope.RabbitMqListener.Channel is not null)
+            // A null check is not enough -- the tag has to be nacked on the channel it arrived on, or
+            // it addresses an unrelated delivery on a rebuilt channel. See RabbitMqListener.CanSettle.
+            if (envelope.RabbitMqListener.CanSettle(envelope))
             {
                 // Mark as acknowledged before the NACK so that any subsequent
                 // CompleteAsync() call is a no-op (prevents double ack/nack)
                 envelope.Acknowledged = true;
                 envelope.HasBeenAcked = true;
-                await envelope.RabbitMqListener.Channel.BasicNackAsync(envelope.DeliveryTag, false, false, token);
+                await envelope.DeliveredOn.BasicNackAsync(envelope.DeliveryTag, false, false, token);
             }
         }
         catch (AlreadyClosedException exception)
         {
-            if (exception.Message.Contains("'PRECONDITION_FAILED - unknown delivery tag'"))
+            if (isUnknownDeliveryTag(exception))
             {
                 Logger.LogInformation("Encountered an unknown delivery tag, discarding the envelope");
                 return;

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelope.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelope.cs
@@ -1,12 +1,23 @@
+using RabbitMQ.Client;
+
 namespace Wolverine.RabbitMQ.Internal;
 
 internal class RabbitMqEnvelope : Envelope
 {
-    public RabbitMqEnvelope(RabbitMqListener listener, ulong deliveryTag)
+    public RabbitMqEnvelope(RabbitMqListener listener, ulong deliveryTag, IChannel deliveredOn)
     {
         RabbitMqListener = listener;
         DeliveryTag = deliveryTag;
+        DeliveredOn = deliveredOn;
     }
+
+    /// <summary>
+    /// The channel this delivery actually arrived on. Delivery tags are scoped to a single
+    /// channel and restart at 1 on each new one, so every settle path has to compare against
+    /// this rather than just using whatever channel the listener currently holds. See
+    /// <see cref="RabbitMqListener.CanSettle"/>.
+    /// </summary>
+    internal IChannel DeliveredOn { get; }
 
     /// <summary>
     /// This is only here for chaos testing. Don't use this for any
@@ -27,7 +38,7 @@ internal class RabbitMqEnvelope : Envelope
     {
         if (Acknowledged) return;
 
-        await RabbitMqListener.CompleteAsync(DeliveryTag);
+        await RabbitMqListener.CompleteAsync(this);
         Acknowledged = true;
     }
 
@@ -39,7 +50,7 @@ internal class RabbitMqEnvelope : Envelope
         // and consumes a prefetch slot (blocking PreFetchCount(1) entirely).
         if (!Acknowledged)
         {
-            await RabbitMqListener.CompleteAsync(DeliveryTag);
+            await RabbitMqListener.CompleteAsync(this);
             Acknowledged = true;
         }
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -306,18 +306,54 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
         return $"RabbitMqListener: {Address}";
     }
 
+    /// <summary>
+    /// True only when this delivery can still legitimately be settled -- that is, when the channel it
+    /// arrived on is the channel we currently hold AND that channel is still open.
+    ///
+    /// A bare null check is NOT sufficient here, and using one would silently lose messages. Delivery
+    /// tags are scoped to a single channel and restart at 1 on every new one, so a stale tag replayed
+    /// against a rebuilt channel addresses a completely different delivery -- and because CompleteAsync
+    /// acks with multiple: true, that would ack every LOWER tag on the new channel as well, including
+    /// messages still in the handler pipeline.
+    ///
+    /// When this returns false the correct behavior is to do nothing at all. The broker never saw an
+    /// ack, so it requeues the delivery on channel close and redelivers it; the durable inbox then
+    /// deduplicates it. Retrying the settle instead -- which is what the RetryBlock used to do after
+    /// `Channel!` threw a NullReferenceException mid-reconnect -- can never succeed on any later
+    /// channel, and just burns the retry budget while the same message cycles round again.
+    /// </summary>
+    internal bool CanSettle(RabbitMqEnvelope envelope)
+    {
+        var channel = Channel;
+        if (channel is null || !ReferenceEquals(channel, envelope.DeliveredOn) || !channel.IsOpen)
+        {
+            Logger.LogDebug(
+                "Discarding an unsettleable Rabbit MQ delivery tag {DeliveryTag} at {Uri}; the channel it arrived on was closed or replaced. The broker will redeliver and the durable inbox will deduplicate.",
+                envelope.DeliveryTag, Address);
+
+            return false;
+        }
+
+        return true;
+    }
+
     public async ValueTask RequeueAsync(RabbitMqEnvelope envelope)
     {
-        if (!envelope.Acknowledged)
+        if (!envelope.Acknowledged && CanSettle(envelope))
         {
-            await Channel!.BasicNackAsync(envelope.DeliveryTag, false, false, _cancellation);
+            await envelope.DeliveredOn.BasicNackAsync(envelope.DeliveryTag, false, false, _cancellation);
         }
 
         await _sender.Value.SendAsync(envelope);
     }
 
-    public async Task CompleteAsync(ulong deliveryTag)
+    public Task CompleteAsync(RabbitMqEnvelope envelope)
     {
+        if (!CanSettle(envelope))
+        {
+            return Task.CompletedTask;
+        }
+
         // NOTE: multiple: true also acks every LOWER delivery tag on this channel. That is wrong
         // under a concurrent listener -- it acks messages still in the handler pipeline -- but it
         // is currently load-bearing, because it sweeps up deliveries that some settle paths never
@@ -328,6 +364,6 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
         // basic.ack is a fire-and-forget frame, not an RPC, so batching saves no round trips while
         // the extra channel hops cost ~10% of max inline throughput. See the ledger in
         // RABBITMQ-PERF-DEEP-DIVE-PLAN.md.
-        await Channel!.BasicAckAsync(deliveryTag, true, _cancellation);
+        return envelope.DeliveredOn.BasicAckAsync(envelope.DeliveryTag, true, _cancellation).AsTask();
     }
 }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
@@ -83,11 +83,22 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
     {
         if (_latched || _cancellation.IsCancellationRequested || !_listener.IsConnected)
         {
-            await _listener.Channel!.BasicRejectAsync(deliveryTag, true, _cancellation);
+            // Reject on the DELIVERING channel, not on whatever the listener currently holds. One of the
+            // conditions above is !IsConnected, which is exactly when the listener's channel has been
+            // torn down and nulled -- dereferencing it here threw a NullReferenceException. The tag is
+            // channel-scoped anyway, so the listener's channel would have been the wrong one regardless.
+            if (Channel.IsOpen)
+            {
+                await Channel.BasicRejectAsync(deliveryTag, true, _cancellation);
+            }
+
             return;
         }
 
-        var envelope = new RabbitMqEnvelope(_listener, deliveryTag);
+        // Capture the delivering channel on the envelope. Delivery tags are channel-scoped, so every
+        // later settle path has to check the tag against THIS channel rather than whatever channel the
+        // listener happens to hold by then.
+        var envelope = new RabbitMqEnvelope(_listener, deliveryTag, Channel);
 
         try
         {


### PR DESCRIPTION
Fixes #3687.

## The bug

`RabbitMqListener.CompleteAsync` acked through the listener's *current* channel:

```csharp
await Channel!.BasicAckAsync(deliveryTag, true, _cancellation);
```

`Channel` is `IChannel?`, and every rebuild path nulls it via `RabbitMqChannelAgent.teardownChannel()` — `ReconnectedAsync`, `restartAfterCallbackExceptionAsync`, `EnsureInitiated`'s stale-channel drop, `DisposeAsync`, and the cancellation registration. An ack in flight during any of those windows dereferenced null. The `!` was an assertion the code could not honor.

Because delivery tags are scoped to the channel they arrived on, that ack can never succeed on any later channel either. No ack → the broker redelivers → the durable inbox dedupes → the ack is attempted again. Under continuous channel churn (a cluster mid-deploy) that is self-sustaining, which is what the reporter saw: a steady NRE loop alongside a steady "Duplicate incoming envelope detected" stream.

## Why a null check would have been worse than the crash

Delivery tags restart at 1 on each new channel, and `CompleteAsync` acks with `multiple: true` — deliberately, since it is load-bearing for settle paths that never ack (GH-3492). So `if (Channel is not null)` would replay a stale tag against a rebuilt channel and ack **every lower delivery tag on it**, including messages still in the handler pipeline. Silent message loss, traded for a visible crash.

`RabbitMqChannelCallback.moveToErrorQueueAsync` already had exactly that null-only pattern.

## The fix

`RabbitMqEnvelope` now captures `DeliveredOn`, the channel the delivery actually arrived on. A new `RabbitMqListener.CanSettle` gates every settle path on channel *identity* plus `IsOpen`:

```csharp
var channel = Channel;
if (channel is null || !ReferenceEquals(channel, envelope.DeliveredOn) || !channel.IsOpen)
```

When it returns false the correct behavior is to do nothing: the broker never saw an ack, so it requeues on channel close and redelivers, and the inbox deduplicates. `CompleteAsync`, `RequeueAsync` and `moveToErrorQueueAsync` all now settle against `envelope.DeliveredOn`.

## Two more found along the way

- **`WorkerQueueMessageConsumer.HandleBasicDeliverAsync`** dereferenced `_listener.Channel!` in its latched/reject path — where one of the guard conditions is `!_listener.IsConnected`, i.e. precisely when that channel is null. It now rejects on the delivering channel, which was the correct channel anyway.
- **The "unknown delivery tag" match was dead code.** It tested for `"'PRECONDITION_FAILED - unknown delivery tag'"`, but the broker text is `text='PRECONDITION_FAILED - unknown delivery tag 1'` — the tag number sits *inside* the quotes, so the trailing apostrophe never matched. In `moveToErrorQueueAsync` that made the branch unreachable, so the exception was rethrown and retried three times before being discarded. Extracted to a named constant with the real broker text documented.

## Note on the RetryBlock

The report described the RetryBlock as retrying the ack forever. It does not — `RetryBlock.MaximumAttempts` is 3 with pauses of 50/100/250ms, after which it logs "Discarding message …" and drops. The steady error rate was a steady *arrival* of fresh envelopes through the redeliver→dedupe→re-ack cycle, not one immortal envelope.

The broader gap is real but out of scope here: none of Wolverine's ack/nack RetryBlocks classify exceptions, so terminal failures (lock lost, receipt handle expired, delivery tag's channel gone) burn the full retry budget on every transport. Worth tracking separately — the SDKs already expose the signal (`ServiceBusException.IsTransient`, `AmazonSQSException.Retryable`), and for RabbitMQ specifically acks arguably should not be retried at all, since `basic.ack` is a fire-and-forget frame with no transient state to retry into.

## Tests

`Bug_3687_settling_a_delivery_from_a_dead_channel` adds two regressions:

1. `completing_a_delivery_after_the_channel_is_torn_down_does_not_throw` — the literal reported NRE.
2. `a_stale_delivery_tag_is_never_settled_against_a_replaced_channel` — kills the channel with a passive declare against a missing queue (same trigger as the #3171 tests), waits for the rebuild, and asserts a tag from the dead channel is *not* settled against the healthy replacement. This is the guard for the `multiple: true` data-loss path, which a null check would not have caught. It also asserts a delivery on the current channel is still settleable, so the guard cannot pass by latching off.

**Red baseline verified.** The new API doesn't exist on `main`, so I reproduced the failure directly: in a clean `origin/main` worktree, `listener.CompleteAsync(4200UL)` after `DisposeAsync()` throws `NullReferenceException`. Post-fix the equivalent call is a no-op.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
