### PR TITLE
Configurable MQTT v5 authentication method name (#3588)

### DIFF
--- a/docs/guide/messaging/transports/mqtt.md
+++ b/docs/guide/messaging/transports/mqtt.md
@@ -426,8 +426,9 @@ public static ClearMqttTopic Handle(TriggerZero message)
 
 Wolverine supports MQTT v5 OAuth2/JWT authentication by supplying a token callback and refresh interval when you configure
 the transport. The callback returns raw token bytes (use UTF-8 encoding if your token is a string). When configured,
-Wolverine sets the MQTT authentication method to `OAUTH2-JWT`, sends the initial token with the connect packet, and
-re-authenticates on the configured refresh period while the client is connected.
+Wolverine sets the MQTT authentication method to `OAUTH2-JWT` by default, sends the initial token with the connect
+packet, and re-authenticates on the configured refresh period while the client is connected. Brokers that expect a
+different method name are covered [below](#custom-authentication-methods).
 
 ::: info
 You don't need to configure `AuthenticationMethod` and `AuthenticationData` by yourself. These are overriden when the `MqttJwtAuthenticationOptions` parameter is set.
@@ -445,6 +446,50 @@ builder.UseWolverine(opts =>
             async () => Encoding.UTF8.GetBytes(await GetJwtTokenAsync()),
             30.Minutes()));
 });
+```
+
+### Custom Authentication Methods <Badge type="tip" text="6.24" />
+
+Brokers do not agree on the *name* of the authentication method for what is otherwise the same bearer token
+exchange. Wolverine defaults to `OAUTH2-JWT`, but you can advertise any name the broker expects by passing it as a
+third argument to `MqttJwtAuthenticationOptions`. [Azure Event Grid's custom JWT
+authentication](https://learn.microsoft.com/en-us/azure/event-grid/mqtt-client-custom-jwt), for example, requires
+`CUSTOM-JWT`:
+
+```cs
+var builder = Host.CreateApplicationBuilder();
+
+builder.UseWolverine(opts =>
+{
+    opts.UseMqtt(
+        mqtt => mqtt.WithClientOptions(client =>
+            client.WithTcpServer("your-namespace.westus2-1.ts.eventgrid.azure.net", 8883)
+                .WithTlsOptions(tls => tls.UseTls())),
+
+        new MqttJwtAuthenticationOptions(
+            async () => Encoding.UTF8.GetBytes(await GetJwtTokenAsync()),
+            30.Minutes(),
+
+            // Anything the broker expects. MqttJwtAuthenticationOptions.OAuth2Jwt ("OAUTH2-JWT")
+            // is the default, and there is a constant for Event Grid's custom JWT method.
+            MqttJwtAuthenticationOptions.CustomJwt));
+});
+```
+
+The authentication method applies to both the initial CONNECT packet and every subsequent re-authentication, so
+you keep Wolverine's token refresh loop instead of having to hand-roll `WithAuthentication()` on the raw MQTTnet
+client options. It works the same way on
+[named brokers](#connecting-to-multiple-mqtt-brokers) and on
+[per-tenant connections](#broker-per-tenant), each of which takes its own `MqttJwtAuthenticationOptions`:
+
+```cs
+opts.UseMqtt(mqtt => mqtt.WithClientOptions(client => client.WithTcpServer("shared-broker")))
+    .AddTenant("tenant-west",
+        mqtt => mqtt.WithClientOptions(client => client.WithTcpServer("west-broker")),
+        new MqttJwtAuthenticationOptions(
+            async () => Encoding.UTF8.GetBytes(await GetWestTokenAsync()),
+            30.Minutes(),
+            MqttJwtAuthenticationOptions.CustomJwt));
 ```
 
 ## Broker per Tenant

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/MqttJwtAuthenticationMethodTests.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/MqttJwtAuthenticationMethodTests.cs
@@ -1,0 +1,146 @@
+using System.Text;
+using JasperFx.Core;
+using MQTTnet.Client;
+using Shouldly;
+using Wolverine.MQTT.Internals;
+
+namespace Wolverine.MQTT.Tests;
+
+// GH-3588: brokers disagree on the *name* of the authentication method used for the very same OAuth2 bearer token
+// exchange. Azure Event Grid wants "CUSTOM-JWT" where the default is "OAUTH2-JWT", so the name is configurable.
+public class MqttJwtAuthenticationMethodTests
+{
+    private static Func<Task<byte[]>> TokenIs(string token) => () => Task.FromResult(Encoding.UTF8.GetBytes(token));
+
+    [Fact]
+    public void authentication_method_defaults_to_oauth2_jwt()
+    {
+        var options = new MqttJwtAuthenticationOptions(TokenIs("token"), 30.Minutes());
+
+        options.AuthenticationMethod.ShouldBe("OAUTH2-JWT");
+        options.AuthenticationMethod.ShouldBe(MqttJwtAuthenticationOptions.OAuth2Jwt);
+    }
+
+    [Fact]
+    public void can_override_the_authentication_method()
+    {
+        var options = new MqttJwtAuthenticationOptions(TokenIs("token"), 30.Minutes(),
+            MqttJwtAuthenticationOptions.CustomJwt);
+
+        options.AuthenticationMethod.ShouldBe("CUSTOM-JWT");
+    }
+
+    [Fact]
+    public void can_use_an_arbitrary_broker_specific_authentication_method()
+    {
+        var options = new MqttJwtAuthenticationOptions(TokenIs("token"), 30.Minutes(), "K8S-SAT");
+
+        options.AuthenticationMethod.ShouldBe("K8S-SAT");
+    }
+
+    [Fact]
+    public void the_two_argument_constructor_is_preserved_for_binary_compatibility()
+    {
+        // GH-3588: the authentication method arrived as a constructor *overload* rather than a third defaulted
+        // parameter, so that assemblies compiled against earlier Wolverine versions keep binding to the
+        // two argument constructor that already shipped.
+        typeof(MqttJwtAuthenticationOptions)
+            .GetConstructor([typeof(Func<Task<byte[]>>), typeof(TimeSpan)])
+            .ShouldNotBeNull();
+
+        typeof(MqttJwtAuthenticationOptions)
+            .GetConstructor([typeof(Func<Task<byte[]>>), typeof(TimeSpan), typeof(string)])
+            .ShouldNotBeNull();
+
+        // The positional deconstruction that shipped is unchanged as well
+        typeof(MqttJwtAuthenticationOptions).GetMethod("Deconstruct")!
+            .GetParameters().Length.ShouldBe(2);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void empty_authentication_method_is_rejected(string? method)
+    {
+        Should.Throw<ArgumentException>(() =>
+            new MqttJwtAuthenticationOptions(TokenIs("token"), 30.Minutes(), method!));
+    }
+
+    [Fact]
+    public void with_expression_carries_and_validates_the_authentication_method()
+    {
+        var options = new MqttJwtAuthenticationOptions(TokenIs("token"), 30.Minutes());
+
+        var custom = options with { AuthenticationMethod = MqttJwtAuthenticationOptions.CustomJwt };
+        custom.AuthenticationMethod.ShouldBe("CUSTOM-JWT");
+
+        // the original is untouched
+        options.AuthenticationMethod.ShouldBe("OAUTH2-JWT");
+
+        Should.Throw<ArgumentException>(() => options with { AuthenticationMethod = "" });
+    }
+
+    [Fact]
+    public async Task applies_the_default_authentication_method_and_token_to_the_client_options()
+    {
+        var clientOptions = new MqttClientOptions();
+        var jwt = new MqttJwtAuthenticationOptions(TokenIs("first-token"), 30.Minutes());
+
+        await MqttTransport.ApplyJwtAuthenticationAsync(clientOptions, jwt);
+
+        clientOptions.AuthenticationMethod.ShouldBe("OAUTH2-JWT");
+        Encoding.UTF8.GetString(clientOptions.AuthenticationData).ShouldBe("first-token");
+    }
+
+    [Fact]
+    public async Task applies_a_custom_authentication_method_to_the_client_options()
+    {
+        var clientOptions = new MqttClientOptions();
+        var jwt = new MqttJwtAuthenticationOptions(TokenIs("first-token"), 30.Minutes(),
+            MqttJwtAuthenticationOptions.CustomJwt);
+
+        await MqttTransport.ApplyJwtAuthenticationAsync(clientOptions, jwt);
+
+        clientOptions.AuthenticationMethod.ShouldBe("CUSTOM-JWT");
+        Encoding.UTF8.GetString(clientOptions.AuthenticationData).ShouldBe("first-token");
+    }
+
+    [Fact]
+    public async Task overwrites_an_authentication_method_that_was_set_directly_on_the_client_options()
+    {
+        // If you hand-rolled WithAuthentication() *and* passed MqttJwtAuthenticationOptions, the Wolverine
+        // options win - they are the ones driving the re-authentication loop.
+        var clientOptions = new MqttClientOptions
+        {
+            AuthenticationMethod = "SOMETHING-ELSE",
+            AuthenticationData = Encoding.UTF8.GetBytes("stale-token")
+        };
+
+        var jwt = new MqttJwtAuthenticationOptions(TokenIs("fresh-token"), 30.Minutes(),
+            MqttJwtAuthenticationOptions.CustomJwt);
+
+        await MqttTransport.ApplyJwtAuthenticationAsync(clientOptions, jwt);
+
+        clientOptions.AuthenticationMethod.ShouldBe("CUSTOM-JWT");
+        Encoding.UTF8.GetString(clientOptions.AuthenticationData).ShouldBe("fresh-token");
+    }
+
+    [Fact]
+    public async Task the_token_callback_is_invoked_on_every_application()
+    {
+        var count = 0;
+        var jwt = new MqttJwtAuthenticationOptions(() => Task.FromResult(Encoding.UTF8.GetBytes($"token-{++count}")),
+            30.Minutes(), MqttJwtAuthenticationOptions.CustomJwt);
+
+        var first = new MqttClientOptions();
+        var second = new MqttClientOptions();
+
+        await MqttTransport.ApplyJwtAuthenticationAsync(first, jwt);
+        await MqttTransport.ApplyJwtAuthenticationAsync(second, jwt);
+
+        // Each connection - the default one and every tenant connection - gets its own freshly fetched token
+        Encoding.UTF8.GetString(first.AuthenticationData).ShouldBe("token-1");
+        Encoding.UTF8.GetString(second.AuthenticationData).ShouldBe("token-2");
+    }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTransport.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/Internals/MqttTransport.cs
@@ -131,8 +131,7 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
         Options.ClientOptions.ProtocolVersion = MqttProtocolVersion.V500;
         if (JwtAuthenticationOptions is not null)
         {
-            Options.ClientOptions.AuthenticationMethod = "OAUTH2-JWT";
-            Options.ClientOptions.AuthenticationData = await JwtAuthenticationOptions.GetTokenCallBack();
+            await ApplyJwtAuthenticationAsync(Options.ClientOptions, JwtAuthenticationOptions);
         }
 
         Client.ConnectedAsync += onClientConnected;
@@ -171,14 +170,23 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
 
         if (tenant.Jwt is not null)
         {
-            options.ClientOptions.AuthenticationMethod = "OAUTH2-JWT";
-            options.ClientOptions.AuthenticationData = await tenant.Jwt.GetTokenCallBack();
+            await ApplyJwtAuthenticationAsync(options.ClientOptions, tenant.Jwt);
             client.ConnectedAsync += buildTenantJwtRefreshHandler(client, tenant.Jwt);
         }
 
         await client.StartAsync(options);
 
         return client;
+    }
+
+    // GH-3588: the authentication method name is broker specific. It defaults to "OAUTH2-JWT", but brokers like
+    // Azure Event Grid expect their own name ("CUSTOM-JWT") for the very same token exchange, so it is configurable
+    // on MqttJwtAuthenticationOptions. Applied identically to the default connection and to each tenant connection.
+    internal static async Task ApplyJwtAuthenticationAsync(MqttClientOptions clientOptions,
+        MqttJwtAuthenticationOptions jwt)
+    {
+        clientOptions.AuthenticationMethod = jwt.AuthenticationMethod;
+        clientOptions.AuthenticationData = await jwt.GetTokenCallBack();
     }
 
     // Broker-per-tenant JWT re-authentication loop, scoped to a single tenant client. Mirrors the default

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttJwtAuthenticationOptions.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttJwtAuthenticationOptions.cs
@@ -1,3 +1,64 @@
 namespace Wolverine.MQTT;
 
-public record MqttJwtAuthenticationOptions(Func<Task<byte[]>> GetTokenCallBack, TimeSpan RefreshPeriod);
+/// <summary>
+/// Configures MQTT v5 enhanced authentication with a bearer token. Wolverine sends the token from
+/// <paramref name="GetTokenCallBack"/> as the <c>AuthenticationData</c> of the CONNECT packet, then re-authenticates
+/// with a freshly fetched token every <paramref name="RefreshPeriod"/> while the client is connected.
+/// </summary>
+/// <param name="GetTokenCallBack">Returns the raw token bytes. Use UTF-8 encoding if your token is a string.</param>
+/// <param name="RefreshPeriod">How often a new token is fetched and sent to the broker as a re-authentication.</param>
+public record MqttJwtAuthenticationOptions(Func<Task<byte[]>> GetTokenCallBack, TimeSpan RefreshPeriod)
+{
+    /// <summary>
+    /// The default MQTT v5 authentication method name for OAuth2 bearer tokens.
+    /// </summary>
+    public const string OAuth2Jwt = "OAUTH2-JWT";
+
+    /// <summary>
+    /// The authentication method name required by Azure Event Grid when authenticating an MQTT client with a
+    /// custom JWT. See https://learn.microsoft.com/en-us/azure/event-grid/mqtt-client-custom-jwt
+    /// </summary>
+    public const string CustomJwt = "CUSTOM-JWT";
+
+    // GH-3588: this is an overload rather than a third defaulted parameter on the primary constructor so that the
+    // existing two argument constructor keeps its exact signature and assemblies compiled against earlier
+    // Wolverine versions keep binding to it.
+    /// <summary>
+    /// Configures MQTT v5 enhanced authentication with a bearer token and a broker specific authentication method
+    /// name, for brokers that do not use the default <see cref="OAuth2Jwt"/>.
+    /// </summary>
+    /// <param name="GetTokenCallBack">Returns the raw token bytes. Use UTF-8 encoding if your token is a string.</param>
+    /// <param name="RefreshPeriod">How often a new token is fetched and sent to the broker as a re-authentication.</param>
+    /// <param name="AuthenticationMethod">
+    /// The MQTT v5 authentication method name advertised to the broker. Azure Event Grid's custom JWT
+    /// authentication, for example, requires <see cref="CustomJwt"/>.
+    /// </param>
+    public MqttJwtAuthenticationOptions(Func<Task<byte[]>> GetTokenCallBack, TimeSpan RefreshPeriod,
+        string AuthenticationMethod) : this(GetTokenCallBack, RefreshPeriod)
+    {
+        this.AuthenticationMethod = AuthenticationMethod;
+    }
+
+    private readonly string _authenticationMethod = OAuth2Jwt;
+
+    /// <summary>
+    /// The MQTT v5 authentication method name advertised to the broker. Defaults to <see cref="OAuth2Jwt"/>.
+    /// </summary>
+    public string AuthenticationMethod
+    {
+        get => _authenticationMethod;
+        init => _authenticationMethod = validated(value);
+    }
+
+    private static string validated(string method)
+    {
+        if (string.IsNullOrWhiteSpace(method))
+        {
+            throw new ArgumentException(
+                $"The MQTT authentication method is required. Use {nameof(MqttJwtAuthenticationOptions)}.{nameof(OAuth2Jwt)} unless your broker requires something else.",
+                nameof(AuthenticationMethod));
+        }
+
+        return method;
+    }
+}

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttTransportExpression.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttTransportExpression.cs
@@ -100,7 +100,8 @@ public class MqttTransportExpression
     /// </summary>
     /// <param name="tenantId"></param>
     /// <param name="configure">Configuration for the tenant's own broker connection</param>
-    /// <param name="jwt">Optional OAUTH2-JWT authentication for the tenant's own connection.</param>
+    /// <param name="jwt">Optional bearer token authentication for the tenant's own connection. The authentication method
+    /// defaults to OAUTH2-JWT and is overridable via <see cref="MqttJwtAuthenticationOptions.AuthenticationMethod"/>.</param>
     /// <returns></returns>
     public MqttTransportExpression AddTenant(string tenantId, Action<ManagedMqttClientOptionsBuilder> configure,
         MqttJwtAuthenticationOptions? jwt = null)
@@ -128,7 +129,8 @@ public class MqttTransportExpression
     /// </summary>
     /// <param name="tenantId"></param>
     /// <param name="mqttOptions">The connection options for the tenant's own broker</param>
-    /// <param name="jwt">Optional OAUTH2-JWT authentication for the tenant's own connection.</param>
+    /// <param name="jwt">Optional bearer token authentication for the tenant's own connection. The authentication method
+    /// defaults to OAUTH2-JWT and is overridable via <see cref="MqttJwtAuthenticationOptions.AuthenticationMethod"/>.</param>
     /// <returns></returns>
     public MqttTransportExpression AddTenant(string tenantId, ManagedMqttClientOptions mqttOptions,
         MqttJwtAuthenticationOptions? jwt = null)

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttTransportExtensions.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttTransportExtensions.cs
@@ -26,7 +26,8 @@ public static class MqttTransportExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="configure"></param>
-    /// <param name="jwtAuthenticationOptions">Sets AuthenticationMethod to OAUTH-JWT and uses the callback to fetch a token.
+    /// <param name="jwtAuthenticationOptions">Sets AuthenticationMethod to OAUTH2-JWT -- or whatever
+    /// <see cref="MqttJwtAuthenticationOptions.AuthenticationMethod"/> is set to -- and uses the callback to fetch a token.
     /// When the configured period elapses, a new token is fetched and a ExtendedAuthenticationExchangeData with ReasonCode ReAuth is sent with the new token.
     /// <returns></returns>
     public static MqttTransportExpression UseMqtt(this WolverineOptions options,
@@ -48,7 +49,8 @@ public static class MqttTransportExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="mqttOptions"></param>
-    /// <param name="jwtAuthenticationOptions">Sets AuthenticationMethod to OAUTH-JWT and uses the callback to fetch a token.
+    /// <param name="jwtAuthenticationOptions">Sets AuthenticationMethod to OAUTH2-JWT -- or whatever
+    /// <see cref="MqttJwtAuthenticationOptions.AuthenticationMethod"/> is set to -- and uses the callback to fetch a token.
     /// When the configured period elapses, a new token is fetched and a ExtendedAuthenticationExchangeData with ReasonCode ReAuth is sent with the new token.
     /// <returns></returns>
     public static MqttTransportExpression UseMqtt(this WolverineOptions options, ManagedMqttClientOptions mqttOptions,
@@ -86,7 +88,8 @@ public static class MqttTransportExtensions
     /// <param name="options"></param>
     /// <param name="name">Identity of the additional MQTT broker</param>
     /// <param name="configure">Configuration for the additional broker's connection</param>
-    /// <param name="jwtAuthenticationOptions">Optional OAUTH2-JWT authentication for the additional broker.</param>
+    /// <param name="jwtAuthenticationOptions">Optional bearer token authentication for the additional broker. The
+    /// authentication method defaults to OAUTH2-JWT and is overridable via <see cref="MqttJwtAuthenticationOptions.AuthenticationMethod"/>.</param>
     public static MqttTransportExpression AddNamedMqttBroker(this WolverineOptions options,
         BrokerName name,
         Action<ManagedMqttClientOptionsBuilder> configure,
@@ -109,7 +112,8 @@ public static class MqttTransportExtensions
     /// <param name="options"></param>
     /// <param name="name">Identity of the additional MQTT broker</param>
     /// <param name="mqttOptions">The connection options for the additional broker</param>
-    /// <param name="jwtAuthenticationOptions">Optional OAUTH2-JWT authentication for the additional broker.</param>
+    /// <param name="jwtAuthenticationOptions">Optional bearer token authentication for the additional broker. The
+    /// authentication method defaults to OAUTH2-JWT and is overridable via <see cref="MqttJwtAuthenticationOptions.AuthenticationMethod"/>.</param>
     public static MqttTransportExpression AddNamedMqttBroker(this WolverineOptions options,
         BrokerName name,
         ManagedMqttClientOptions mqttOptions,

--- a/src/Transports/MQTT/Wolverine.Mqtt5.Tests/MqttJwtAuthenticationMethodTests.cs
+++ b/src/Transports/MQTT/Wolverine.Mqtt5.Tests/MqttJwtAuthenticationMethodTests.cs
@@ -1,0 +1,146 @@
+using System.Text;
+using JasperFx.Core;
+using MQTTnet;
+using Shouldly;
+using Wolverine.MQTT.Internals;
+
+namespace Wolverine.MQTT.Tests;
+
+// GH-3588: brokers disagree on the *name* of the authentication method used for the very same OAuth2 bearer token
+// exchange. Azure Event Grid wants "CUSTOM-JWT" where the default is "OAUTH2-JWT", so the name is configurable.
+public class MqttJwtAuthenticationMethodTests
+{
+    private static Func<Task<byte[]>> TokenIs(string token) => () => Task.FromResult(Encoding.UTF8.GetBytes(token));
+
+    [Fact]
+    public void authentication_method_defaults_to_oauth2_jwt()
+    {
+        var options = new MqttJwtAuthenticationOptions(TokenIs("token"), 30.Minutes());
+
+        options.AuthenticationMethod.ShouldBe("OAUTH2-JWT");
+        options.AuthenticationMethod.ShouldBe(MqttJwtAuthenticationOptions.OAuth2Jwt);
+    }
+
+    [Fact]
+    public void can_override_the_authentication_method()
+    {
+        var options = new MqttJwtAuthenticationOptions(TokenIs("token"), 30.Minutes(),
+            MqttJwtAuthenticationOptions.CustomJwt);
+
+        options.AuthenticationMethod.ShouldBe("CUSTOM-JWT");
+    }
+
+    [Fact]
+    public void can_use_an_arbitrary_broker_specific_authentication_method()
+    {
+        var options = new MqttJwtAuthenticationOptions(TokenIs("token"), 30.Minutes(), "K8S-SAT");
+
+        options.AuthenticationMethod.ShouldBe("K8S-SAT");
+    }
+
+    [Fact]
+    public void the_two_argument_constructor_is_preserved_for_binary_compatibility()
+    {
+        // GH-3588: the authentication method arrived as a constructor *overload* rather than a third defaulted
+        // parameter, so that assemblies compiled against earlier Wolverine versions keep binding to the
+        // two argument constructor that already shipped.
+        typeof(MqttJwtAuthenticationOptions)
+            .GetConstructor([typeof(Func<Task<byte[]>>), typeof(TimeSpan)])
+            .ShouldNotBeNull();
+
+        typeof(MqttJwtAuthenticationOptions)
+            .GetConstructor([typeof(Func<Task<byte[]>>), typeof(TimeSpan), typeof(string)])
+            .ShouldNotBeNull();
+
+        // The positional deconstruction that shipped is unchanged as well
+        typeof(MqttJwtAuthenticationOptions).GetMethod("Deconstruct")!
+            .GetParameters().Length.ShouldBe(2);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void empty_authentication_method_is_rejected(string? method)
+    {
+        Should.Throw<ArgumentException>(() =>
+            new MqttJwtAuthenticationOptions(TokenIs("token"), 30.Minutes(), method!));
+    }
+
+    [Fact]
+    public void with_expression_carries_and_validates_the_authentication_method()
+    {
+        var options = new MqttJwtAuthenticationOptions(TokenIs("token"), 30.Minutes());
+
+        var custom = options with { AuthenticationMethod = MqttJwtAuthenticationOptions.CustomJwt };
+        custom.AuthenticationMethod.ShouldBe("CUSTOM-JWT");
+
+        // the original is untouched
+        options.AuthenticationMethod.ShouldBe("OAUTH2-JWT");
+
+        Should.Throw<ArgumentException>(() => options with { AuthenticationMethod = "" });
+    }
+
+    [Fact]
+    public async Task applies_the_default_authentication_method_and_token_to_the_client_options()
+    {
+        var clientOptions = new MqttClientOptions();
+        var jwt = new MqttJwtAuthenticationOptions(TokenIs("first-token"), 30.Minutes());
+
+        await MqttTransport.ApplyJwtAuthenticationAsync(clientOptions, jwt);
+
+        clientOptions.AuthenticationMethod.ShouldBe("OAUTH2-JWT");
+        Encoding.UTF8.GetString(clientOptions.AuthenticationData).ShouldBe("first-token");
+    }
+
+    [Fact]
+    public async Task applies_a_custom_authentication_method_to_the_client_options()
+    {
+        var clientOptions = new MqttClientOptions();
+        var jwt = new MqttJwtAuthenticationOptions(TokenIs("first-token"), 30.Minutes(),
+            MqttJwtAuthenticationOptions.CustomJwt);
+
+        await MqttTransport.ApplyJwtAuthenticationAsync(clientOptions, jwt);
+
+        clientOptions.AuthenticationMethod.ShouldBe("CUSTOM-JWT");
+        Encoding.UTF8.GetString(clientOptions.AuthenticationData).ShouldBe("first-token");
+    }
+
+    [Fact]
+    public async Task overwrites_an_authentication_method_that_was_set_directly_on_the_client_options()
+    {
+        // If you hand-rolled WithAuthentication() *and* passed MqttJwtAuthenticationOptions, the Wolverine
+        // options win - they are the ones driving the re-authentication loop.
+        var clientOptions = new MqttClientOptions
+        {
+            AuthenticationMethod = "SOMETHING-ELSE",
+            AuthenticationData = Encoding.UTF8.GetBytes("stale-token")
+        };
+
+        var jwt = new MqttJwtAuthenticationOptions(TokenIs("fresh-token"), 30.Minutes(),
+            MqttJwtAuthenticationOptions.CustomJwt);
+
+        await MqttTransport.ApplyJwtAuthenticationAsync(clientOptions, jwt);
+
+        clientOptions.AuthenticationMethod.ShouldBe("CUSTOM-JWT");
+        Encoding.UTF8.GetString(clientOptions.AuthenticationData).ShouldBe("fresh-token");
+    }
+
+    [Fact]
+    public async Task the_token_callback_is_invoked_on_every_application()
+    {
+        var count = 0;
+        var jwt = new MqttJwtAuthenticationOptions(() => Task.FromResult(Encoding.UTF8.GetBytes($"token-{++count}")),
+            30.Minutes(), MqttJwtAuthenticationOptions.CustomJwt);
+
+        var first = new MqttClientOptions();
+        var second = new MqttClientOptions();
+
+        await MqttTransport.ApplyJwtAuthenticationAsync(first, jwt);
+        await MqttTransport.ApplyJwtAuthenticationAsync(second, jwt);
+
+        // Each connection - the default one and every tenant connection - gets its own freshly fetched token
+        Encoding.UTF8.GetString(first.AuthenticationData).ShouldBe("token-1");
+        Encoding.UTF8.GetString(second.AuthenticationData).ShouldBe("token-2");
+    }
+}

--- a/src/Transports/MQTT/Wolverine.Mqtt5/Internals/MqttTransport.cs
+++ b/src/Transports/MQTT/Wolverine.Mqtt5/Internals/MqttTransport.cs
@@ -131,8 +131,7 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
         Options.ClientOptions.ProtocolVersion = MqttProtocolVersion.V500;
         if (JwtAuthenticationOptions is not null)
         {
-            Options.ClientOptions.AuthenticationMethod = "OAUTH2-JWT";
-            Options.ClientOptions.AuthenticationData = await JwtAuthenticationOptions.GetTokenCallBack();
+            await ApplyJwtAuthenticationAsync(Options.ClientOptions, JwtAuthenticationOptions);
         }
 
         Client.ConnectedAsync += onClientConnected;
@@ -171,14 +170,23 @@ public class MqttTransport : TransportBase<MqttTopic>, IAsyncDisposable
 
         if (tenant.Jwt is not null)
         {
-            options.ClientOptions.AuthenticationMethod = "OAUTH2-JWT";
-            options.ClientOptions.AuthenticationData = await tenant.Jwt.GetTokenCallBack();
+            await ApplyJwtAuthenticationAsync(options.ClientOptions, tenant.Jwt);
             client.ConnectedAsync += buildTenantJwtRefreshHandler(client, tenant.Jwt);
         }
 
         await client.StartAsync(options);
 
         return client;
+    }
+
+    // GH-3588: the authentication method name is broker specific. It defaults to "OAUTH2-JWT", but brokers like
+    // Azure Event Grid expect their own name ("CUSTOM-JWT") for the very same token exchange, so it is configurable
+    // on MqttJwtAuthenticationOptions. Applied identically to the default connection and to each tenant connection.
+    internal static async Task ApplyJwtAuthenticationAsync(MqttClientOptions clientOptions,
+        MqttJwtAuthenticationOptions jwt)
+    {
+        clientOptions.AuthenticationMethod = jwt.AuthenticationMethod;
+        clientOptions.AuthenticationData = await jwt.GetTokenCallBack();
     }
 
     // Broker-per-tenant JWT re-authentication loop, scoped to a single tenant client. Mirrors the default


### PR DESCRIPTION
Closes #3588.

## The problem

Whenever `MqttJwtAuthenticationOptions` was supplied, Wolverine hardcoded the MQTT v5 authentication method to `"OAUTH2-JWT"`:

```csharp
Options.ClientOptions.AuthenticationMethod = "OAUTH2-JWT";
```

Brokers do not agree on the *name* of what is otherwise the same bearer token exchange. [Azure Event Grid's custom JWT authentication](https://learn.microsoft.com/en-us/azure/event-grid/mqtt-client-custom-jwt) requires `CUSTOM-JWT`, so those brokers could not be reached through Wolverine's authentication support at all.

As @radcki noted on the issue, you *can* set the method by hand via `MqttClientOptionsBuilder.WithAuthentication()` inside `WithClientOptions()` — but that path gives up Wolverine's token refresh loop, which is the whole reason to use `MqttJwtAuthenticationOptions` in the first place. You had to choose between the right method name and re-authentication.

## The change

The method name now rides on `MqttJwtAuthenticationOptions` and defaults to `OAUTH2-JWT`, so existing configuration behaves exactly as before:

```csharp
opts.UseMqtt(
    mqtt => mqtt.WithClientOptions(client =>
        client.WithTcpServer("your-namespace.westus2-1.ts.eventgrid.azure.net", 8883)
            .WithTlsOptions(tls => tls.UseTls())),

    new MqttJwtAuthenticationOptions(
        async () => Encoding.UTF8.GetBytes(await GetJwtTokenAsync()),
        30.Minutes(),
        MqttJwtAuthenticationOptions.CustomJwt));
```

Constants are provided for both known names (`OAuth2Jwt`, `CustomJwt`), but any broker-specific string is accepted. An empty or whitespace method is rejected up front rather than being silently sent to the broker.

Because the method name is negotiated once in the CONNECT packet and persists for the session, the existing re-authentication loop needed no changes — it keeps sending `ExtendedAuthenticationExchangeData` against the method that was negotiated. **You keep token refresh and get the right method name.**

Applied identically to the default connection, named brokers, and each broker-per-tenant connection, via a single shared `ApplyJwtAuthenticationAsync` helper that replaces the four duplicated hardcoded assignments.

### Binary compatibility

The new parameter is a constructor **overload** rather than a third defaulted parameter on the record's primary constructor, so the two-argument constructor and the positional `Deconstruct` that already shipped keep their exact signatures. There is a test pinning this.

## Both MQTT packages

`MqttJwtAuthenticationOptions.cs` is already a linked source file shared by `WolverineFx.MQTT` (MQTTnet 4) and `WolverineFx.Mqtt5`, so the options change lands in both automatically. The two `Internals/MqttTransport.cs` files are genuinely separate (v4/v5 client API differences) and were each updated.

## Testing

New `MqttJwtAuthenticationMethodTests` in both test projects — 12 tests each, 24 total, all green — covering the default, the two named constants, an arbitrary broker string, `with`-expression propagation, empty/whitespace/null rejection, the binary-compatibility pin, and that each connection fetches its own fresh token.

Full MQTT suites: **128/128 and 130/130 passing.**

One pre-existing failure, `Bug_mapper_exception_routes_to_dlq`, was verified to fail identically on `origin/main` — a local SQL Server pre-login handshake timeout, unrelated to this change.

`dotnet build wolverine.slnx -c Release` is clean, 0 warnings / 0 errors.

## Docs

New "Custom Authentication Methods" section in the MQTT guide covering the default connection, named brokers, and per-tenant connections; the existing OAuth2 section now says `OAUTH2-JWT` is the *default* and links onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VFmFxuB9TcySq1yCBiwx6