### PR TITLE
fix(grpc): codegen write emitted empty files for every gRPC chain (GH-3692)

### DIFF
--- a/src/Wolverine.Grpc.Tests/codegen_write_after_mapping_3692.cs
+++ b/src/Wolverine.Grpc.Tests/codegen_write_after_mapping_3692.cs
@@ -1,0 +1,124 @@
+using GreeterProtoFirstGrpc.Server;
+using JasperFx.CodeGeneration;
+using JasperFx.Core;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using ProtoBuf.Grpc.Server;
+using Shouldly;
+using Wolverine.Grpc.Tests.GrpcMiddlewareScoping;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Wolverine.Grpc.Tests;
+
+/// <summary>
+///     GH-3692: <c>dotnet run -- codegen write</c> wrote an empty file (a bare namespace, no type)
+///     for every gRPC chain.
+///     <para>
+///     <c>MapWolverineGrpcServices()</c> eagerly initializes each chain at app-build time — it needs
+///     the concrete runtime type to hand to <c>MapGrpcService&lt;T&gt;()</c> — and in a normal
+///     <c>Program.cs</c> that runs <i>before</i> <c>RunJasperFxCommands(args)</c> dispatches the
+///     codegen command. Every chain's <c>AssembleTypes</c> then short-circuited on a non-null
+///     <c>_generatedType</c> left over from that eager pass, even though the codegen command hands it
+///     a brand-new <see cref="GeneratedAssembly"/>. Nothing was added, and the written file held
+///     nothing but a namespace declaration.
+///     </para>
+///     <para>
+///     Downstream this broke production boots: with <c>TypeLoadMode.Static</c> the missing type
+///     surfaced as an <c>ExpectedTypeMissingException</c> at startup, and <c>codegen test</c> was
+///     falsely green because it was compiling an empty assembly.
+///     </para>
+/// </summary>
+[Collection(GrpcSerialTestsCollection.Name)]
+public class codegen_write_after_mapping_3692
+{
+    private readonly ITestOutputHelper _output;
+
+    public codegen_write_after_mapping_3692(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task proto_first_chain_still_renders_source_after_mapping()
+    {
+        await assertEveryFileRendersRealSource(builder =>
+        {
+            builder.Host.UseWolverine(opts => opts.ApplicationAssembly = typeof(GreeterGrpcService).Assembly);
+
+            // Proto-first uses the stock ASP.NET Core gRPC host, not the code-first one.
+            builder.Services.AddGrpc();
+            builder.Services.AddWolverineGrpc();
+        }, "GreeterGrpcHandler");
+    }
+
+    [Fact]
+    public async Task code_first_and_hand_written_chains_still_render_source_after_mapping()
+    {
+        await assertEveryFileRendersRealSource(builder =>
+        {
+            builder.Host.UseWolverine(opts =>
+                opts.ApplicationAssembly = typeof(codegen_write_after_mapping_3692).Assembly);
+
+            builder.Services.AddSingleton(new MiddlewareInvocationSink());
+            builder.Services.AddCodeFirstGrpc();
+            builder.Services.AddWolverineGrpc();
+        }, "CodeFirstTestServiceGrpcHandler", "HandWrittenTestGrpcHandler");
+    }
+
+    /// <summary>
+    ///     Boots a host the way a real application does — mapping the gRPC services (which eagerly
+    ///     compiles every chain) before any codegen runs — then replays exactly what
+    ///     <c>DynamicCodeBuilder.WriteGeneratedCode</c> does: a fresh <see cref="GeneratedAssembly"/>
+    ///     per file, then <c>AssembleTypes</c> and render.
+    /// </summary>
+    private async Task assertEveryFileRendersRealSource(Action<WebApplicationBuilder> configure,
+        params string[] expectedFileNames)
+    {
+        var builder = WebApplication.CreateBuilder([]);
+        builder.WebHost.UseTestServer();
+        configure(builder);
+
+        var app = builder.Build();
+        app.UseRouting();
+        app.MapWolverineGrpcServices();
+
+        await app.StartAsync();
+
+        try
+        {
+            var graph = app.Services.GetRequiredService<GrpcGraph>();
+            var serviceSource = app.Services.GetService<IServiceVariableSource>();
+
+            var rendered = new Dictionary<string, string>();
+            foreach (var file in graph.BuildFiles())
+            {
+                var generatedAssembly = graph.StartAssembly(graph.Rules);
+                file.AssembleTypes(generatedAssembly);
+                rendered[file.FileName] = generatedAssembly.GenerateCode(serviceSource);
+            }
+
+            _output.WriteLine("Generated files: " + rendered.Keys.Join(", "));
+
+            foreach (var expected in expectedFileNames)
+            {
+                rendered.ContainsKey(expected)
+                    .ShouldBeTrue($"expected a generated file named '{expected}'");
+            }
+
+            // Not just the named ones — an empty render from *any* chain is the bug.
+            foreach (var pair in rendered)
+            {
+                _output.WriteLine($"===== {pair.Key} =====");
+                _output.WriteLine(pair.Value);
+
+                pair.Value.ShouldContain($"class {pair.Key}",
+                    customMessage: $"the generated source for '{pair.Key}' declared no type");
+            }
+        }
+        finally
+        {
+            await app.StopAsync();
+            await app.DisposeAsync();
+        }
+    }
+}

--- a/src/Wolverine.Grpc/CodeFirstGrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/CodeFirstGrpcServiceChain.cs
@@ -166,7 +166,10 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
 
     void ICodeFile.AssembleTypes(GeneratedAssembly assembly)
     {
-        if (_generatedType != null) return;
+        // GH-3692: see the note on GrpcServiceChain.AssembleTypes — only short-circuit when this
+        // chain has already been assembled into *this* assembly, or the `codegen write` command
+        // (which always starts a fresh GeneratedAssembly) writes an empty file.
+        if (_generatedType != null && ReferenceEquals(_generatedType.ParentAssembly, assembly)) return;
 
         assembly.ReferenceAssembly(ServiceContractType.Assembly);
         assembly.ReferenceAssembly(typeof(IMessageBus).Assembly);

--- a/src/Wolverine.Grpc/GrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/GrpcServiceChain.cs
@@ -222,7 +222,13 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
 
     void ICodeFile.AssembleTypes(GeneratedAssembly assembly)
     {
-        if (_generatedType != null) return;
+        // GH-3692: only short-circuit when this chain has already been assembled into *this*
+        // assembly. `MapWolverineGrpcServices()` eagerly initializes every chain at app-build
+        // time (it needs the concrete runtime type to hand to MapGrpcService<T>()), so by the
+        // time `codegen write` runs, _generatedType is already populated — but it belongs to a
+        // different GeneratedAssembly. A blanket early return left the codegen command's fresh
+        // assembly empty, and the written file contained nothing but a namespace declaration.
+        if (_generatedType != null && ReferenceEquals(_generatedType.ParentAssembly, assembly)) return;
 
         assembly.ReferenceAssembly(StubType.Assembly);
         assembly.ReferenceAssembly(ProtoServiceBase.Assembly);

--- a/src/Wolverine.Grpc/HandWrittenGrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/HandWrittenGrpcServiceChain.cs
@@ -137,7 +137,10 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
 
     void ICodeFile.AssembleTypes(GeneratedAssembly assembly)
     {
-        if (_generatedType != null) return;
+        // GH-3692: see the note on GrpcServiceChain.AssembleTypes — only short-circuit when this
+        // chain has already been assembled into *this* assembly, or the `codegen write` command
+        // (which always starts a fresh GeneratedAssembly) writes an empty file.
+        if (_generatedType != null && ReferenceEquals(_generatedType.ParentAssembly, assembly)) return;
 
         assembly.ReferenceAssembly(ServiceClassType.Assembly);
         assembly.ReferenceAssembly(ServiceContractType.Assembly);


### PR DESCRIPTION
Fixes #3692.

## The bug

`dotnet run -- codegen write` wrote an **empty file** — a bare namespace, no type — for every gRPC chain:

```csharp
// <auto-generated/>
#pragma warning disable

namespace Internal.Generated.WolverineHandlers
{
}
```

`MapWolverineGrpcServices()` eagerly initializes every gRPC chain at app-build time — it has to, because it needs the concrete runtime type to hand to `MapGrpcService<T>()`. In a normal `Program.cs` that call runs *before* `RunJasperFxCommands(args)` dispatches the codegen command, so by the time `codegen write` executes, each chain's `_generatedType` is already populated — but it belongs to a **different** `GeneratedAssembly`.

`DynamicCodeBuilder.WriteGeneratedCode` starts a fresh `GeneratedAssembly` per file. The blanket guard in `AssembleTypes`

```csharp
if (_generatedType != null) return;
```

tripped, nothing was added to that new assembly, and the rendered file held nothing but a namespace declaration.

This is unique to gRPC among the chain types. `HttpChain` carries the same guard but is never eagerly initialized — it generates lazily on first request — which is why the HTTP endpoints in the reporter's app generated fine while the gRPC handler did not.

## Severity is higher than "empty file"

The reporter's `Program.cs` sets `TypeLoadMode.Static` outside Development. With the empty file, the app **fails to boot in production**:

```
JasperFx.CodeGeneration.ExpectedTypeMissingException: Could not load expected pre-built types
for code file GreeterGrpcHandler (Wolverine.Grpc.GrpcServiceChain) from assembly
GreeterProtoFirstGrpc.Server, Version=6.23.1.0, Culture=neutral, PublicKeyToken=null.
```

`codegen test` was also falsely green for the same root cause — it was compiling an empty assembly, so the one command meant to catch this class of bug could not see it.

## The fix

Scope the guard to the assembly actually being assembled, in all three chain types:

```csharp
if (_generatedType != null && ReferenceEquals(_generatedType.ParentAssembly, assembly)) return;
```

- `GrpcServiceChain` (proto-first)
- `CodeFirstGrpcServiceChain`
- `HandWrittenGrpcServiceChain`

All three were confirmed broken independently — code-first and hand-written stayed red after the proto-first fix alone. The eager-init path still short-circuits correctly, because it re-enters with the same assembly.

## Verification

| Check | Result |
|---|---|
| New regression test, on unmodified `main` | **red** — bare namespace |
| Same test, with fix | green (proto-first + code-first + hand-written) |
| Real `dotnet run -- codegen write` on `GreeterProtoFirstGrpc/Server`, no fix | **red** — empty file |
| Same, with fix | full `GreeterGrpcHandler` source |
| Sample booted with `TypeLoadMode.Static` + empty file | **`ExpectedTypeMissingException`** |
| Same, with fix | boots clean, `describe` lists Proto-First Services |
| `Wolverine.Grpc.Tests` | **300/300 pass** |
| `dotnet build wolverine.slnx -c Release` | clean |

## Test coverage note

The existing `codegen_preview_grpc_tests` never initialized a chain before generating, which is precisely why the suite missed this. The new `codegen_write_after_mapping_3692` boots a host the way a real application does — `MapWolverineGrpcServices()` first — then replays exactly what `DynamicCodeBuilder.WriteGeneratedCode` does, and asserts every rendered file declares a type (not just the named ones).

## Follow-up, not in this PR

The reporter also noted that `guide/grpc/contracts.html` and the `GreeterProtoFirstGrpc` sample only demonstrate runtime compilation — neither shows the `TypeLoadMode.Static` workflow for gRPC, which is the path he was trying to follow. Worth a docs pass separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
