### PR TITLE
fix(durability): stop orphaning inbox rows when a circuit breaker latches the receiver (GH-3680)

### DIFF
--- a/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/durable_and_not_parallel.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/RabbitMq/durable_and_not_parallel.cs
@@ -41,7 +41,7 @@ public class durable_and_not_parallel(ITestOutputHelper output)
     // this test can be a genuine message-loss bug -- so it is skipped rather than tuned away until
     // the missing messages are actually accounted for. Every sibling variant, and the
     // "do not ever trip" assertion in this class, still run.
-    [Fact(Skip = "Unreliable on CI, see https://github.com/JasperFx/wolverine/issues/3680")]
+    [Fact]
     public override Task the_circuit_breaker_should_trip_and_restart()
     {
         return base.the_circuit_breaker_should_trip_and_restart();

--- a/src/Wolverine/Persistence/Durability/ListenerInboxRecovery.cs
+++ b/src/Wolverine/Persistence/Durability/ListenerInboxRecovery.cs
@@ -111,7 +111,34 @@ public class ListenerInboxRecovery
             }
 
             await store.ReassignIncomingAsync(_runtime.DurabilitySettings.AssignedNodeNumber, envelopes);
-            await _circuit.EnqueueDirectlyAsync(envelopes);
+
+            // GH-3680. See the matching comment in RecoverIncomingMessagesCommand: once these rows are
+            // owned by this live node, only this node can ever give them back. A failed hand-off into the
+            // listener (e.g. the circuit tripped between the status check above and here) would otherwise
+            // strand them permanently.
+            try
+            {
+                await _circuit.EnqueueDirectlyAsync(envelopes);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e,
+                    "Error trying to enqueue {Count} recovered messages into single node listener {Listener}. Releasing them back to any node so that they are recovered on a later sweep",
+                    envelopes.Count, destination);
+
+                try
+                {
+                    await store.ReassignIncomingAsync(TransportConstants.AnyNode, envelopes);
+                }
+                catch (Exception releaseFailure)
+                {
+                    _logger.LogError(releaseFailure,
+                        "Error trying to release {Count} un-enqueued messages for {Listener} back to any node",
+                        envelopes.Count, destination);
+                }
+
+                break;
+            }
 
             _logger.RecoveredIncoming(envelopes);
             _logger.LogInformation(

--- a/src/Wolverine/Persistence/Durability/RecoverIncomingMessagesCommand.cs
+++ b/src/Wolverine/Persistence/Durability/RecoverIncomingMessagesCommand.cs
@@ -51,7 +51,26 @@ public class RecoverIncomingMessagesCommand : IAgentCommand
 
         await _store.ReassignIncomingAsync(_settings.AssignedNodeNumber, envelopes);
 
-        await _circuit.EnqueueDirectlyAsync(envelopes);
+        // GH-3680. The rows above are now owned by *this* node, and orphan recovery only ever releases
+        // rows owned by a node it has proven to be dead. If the hand-off into the listener fails -- and it
+        // absolutely can, because a circuit breaker trip between DeterminePageSize() and here nulls out the
+        // agent's receiver -- then nothing on any node will ever release them again and the messages are
+        // lost for the life of the process. Hand ownership back so the next sweep can retry.
+        try
+        {
+            await _circuit.EnqueueDirectlyAsync(envelopes);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e,
+                "Error trying to enqueue {Count} recovered messages into the listener for {Destination}. Releasing them back to any node so that they are recovered on a later sweep",
+                envelopes.Count, _count.Destination);
+
+            await releaseAsync(envelopes);
+
+            return AgentCommands.Empty;
+        }
+
         _logger.RecoveredIncoming(envelopes);
 
         _logger.LogInformation("Successfully recovered {Count} messages from the inbox for listener {Listener}",
@@ -65,6 +84,20 @@ public class RecoverIncomingMessagesCommand : IAgentCommand
         }
 
         return AgentCommands.Empty;
+    }
+
+    private async Task releaseAsync(IReadOnlyList<Envelope> envelopes)
+    {
+        try
+        {
+            await _store.ReassignIncomingAsync(TransportConstants.AnyNode, envelopes);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e,
+                "Error trying to release {Count} un-enqueued messages for {Destination} back to any node",
+                envelopes.Count, _count.Destination);
+        }
     }
 
     public virtual int DeterminePageSize(IListenerCircuit listener, IncomingCount count,

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -422,6 +422,17 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
                 await executeWithRetriesAsync(async () =>
                 {
                     envelope.OwnerId = TransportConstants.AnyNode;
+
+                    // GH-3680 defense in depth. Never write an inbox row that no recovery sweep can see.
+                    // Status defaults to 'Outgoing' and received_at to null on an envelope that never went
+                    // through MarkReceived, and both are filter columns for inbox recovery.
+                    if (envelope.Status == EnvelopeStatus.Outgoing)
+                    {
+                        envelope.Status = EnvelopeStatus.Incoming;
+                    }
+
+                    envelope.Destination ??= Uri;
+
                     assignAncillaryStoreIfNeeded(envelope);
                     try
                     {
@@ -612,6 +623,17 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
             throw new OperationCanceledException();
         }
 
+        // GH-3680. MarkReceived has to happen BEFORE the latch check, not after it. It is what stamps
+        // Status = Incoming, Destination (persisted as received_at) and Listener onto the envelope. The
+        // latched branch below persists the envelope to the inbox as a safety net, so skipping MarkReceived
+        // wrote rows with the default Status of 'Outgoing' and a null received_at -- invisible to
+        // CheckRecoverableIncomingMessagesOperation (which filters on Status = 'Incoming') and to
+        // LoadPageOfGloballyOwnedIncomingAsync (which filters on received_at), i.e. permanently orphaned.
+        // A null Listener also meant the latched branch silently skipped the defer back to the broker, so
+        // nothing else was going to redeliver them either. That is real message loss under a *durable*
+        // inbox whenever a circuit breaker trip latches the receiver mid-flight.
+        foreach (var envelope in envelopes) envelope.MarkReceived(listener, now, _settings, _endpoint.WireTap);
+
         // A latched receiver must apply the full single-envelope semantics (persist as
         // owner 0 + defer back to the listener), so route through the one-at-a-time path
         // which already implements them (GH-3492).
@@ -620,8 +642,6 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
             foreach (var envelope in envelopes) await _receivingOne.PostAsync(envelope).ConfigureAwait(false);
             return;
         }
-
-        foreach (var envelope in envelopes) envelope.MarkReceived(listener, now, _settings, _endpoint.WireTap);
 
         // Per-envelope guards that the single-envelope path (receiveOneAsync) has always
         // applied but this batch path historically skipped (GH-3492): serializer unwrap


### PR DESCRIPTION
Closes #3680.

## The "flake" was real durable message loss

`DurableReceiver.ProcessReceivedMessagesAsync` checked `_latched` **before** calling `Envelope.MarkReceived`. The latched branch then persists each envelope to the durable inbox as a safety net — but on an envelope that never went through `MarkReceived`, `Status` is still the enum default (`Outgoing`, the first member of `EnvelopeStatus`) and `Destination` is null.

Both are filter columns for inbox recovery:

- `CheckRecoverableIncomingMessagesOperation` selects `where status = 'Incoming'`
- `LoadPageOfGloballyOwnedIncomingAsync` selects on `received_at` (= `Destination`)

so the rows were written in a state **no recovery sweep on any node can ever see**. A null `Listener` also made the latched branch skip its `Listener.DeferAsync` nack, so the broker copy was not requeued either — and when the listener restarted, the broker's redelivery hit `DuplicateIncomingEnvelopeException`, which acks and drops.

Net result: genuine message loss under a *durable* inbox any time a circuit breaker trip latches the receiver mid-flight.

## Evidence

Log reading dead-ended (zero `[Error]` lines; zero "Issuing a command to recover" lines across 358 durability sweeps — the rows were invisible to the query). What settled it was gating `TeardownResources()` behind an env var and querying the leftover schema directly:

```
before:  1191 rows Handled + 9 rows status='Outgoing', received_at=NULL   test times out at 3m
after:   1200 rows Handled, 0 orphans                                     test passes in 16.5s
```

Reproduced 3/3 runs locally on `durable_and_not_parallel.the_circuit_breaker_should_trip_and_restart`. Note that #3680's premise that this only fails on CI was wrong — it fails locally on the first run.

## Changes

- **Move the `MarkReceived` loop above the `_latched` check** in `ProcessReceivedMessagesAsync`, so the safety-net row is written as a recoverable `Incoming` row addressed to the listener. This is the fix.
- Defense in depth in `receiveOneAsync`'s latched branch: never persist an inbox row with a default `Outgoing` status or a null `Destination`.
- `RecoverIncomingMessagesCommand` / `ListenerInboxRecovery` both reassign rows to this node and *then* hand them to the listener. A failed hand-off (the agent nulls its receiver on a circuit trip) left the rows owned by a live node, which only orphan-release-for-a-dead-node would ever undo. Release them back to any node so a later sweep retries. **This one is a hazard found by inspection in the same code path, not the observed root cause above.**
- Un-skips the test that #3680 disabled.

## Verification

Full `CircuitBreakingTests` suite (the `CICircuitBreaking` CI job): **24/24 passed, 0 skipped**, 3.5 min, net9.0.

This is the second time a "flake" in this test has turned out to be genuine message loss (after #3137) — which is a good argument for never tuning its timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VFmFxuB9TcySq1yCBiwx6