### PR TITLE
Make Wolverine.Http.Tests order-independent (GH-3714)

### DIFF
--- a/src/Http/Wolverine.Http.Tests/IntegrationContext.cs
+++ b/src/Http/Wolverine.Http.Tests/IntegrationContext.cs
@@ -118,6 +118,32 @@ public abstract class IntegrationContext : IAsyncLifetime, IOpenApiSource
         return (tracked, result);
     }
 
+    /// <summary>
+    /// Same as <see cref="TrackedHttpCall(Action{Scenario},int)"/>, but lets the test state up front which
+    /// message executions it is waiting on. Necessary whenever the HTTP request only *enqueues* work — the
+    /// Wolverine HTTP transport endpoints (/_wolverine/batch, /_wolverine/invoke with a local queue) return
+    /// as soon as the envelopes are handed to the local queue, so the tracked session can observe zero
+    /// activity and complete before the first envelope reaches the handler pipeline. See GH-3714.
+    /// </summary>
+    protected async Task<(ITrackedSession, IScenarioResult)> TrackedHttpCall(
+        Action<Scenario> configuration,
+        Func<TrackedSessionConfiguration, TrackedSessionConfiguration> configureTracking,
+        int timeoutInMilliseconds = 5000)
+    {
+        IScenarioResult result = null!;
+
+        var session = configureTracking(Host.TrackActivity(TimeSpan.FromMilliseconds(timeoutInMilliseconds)));
+
+        Func<IMessageContext, Task> execution = async _ =>
+        {
+            result = await Host.Scenario(configuration);
+        };
+
+        var tracked = await session.ExecuteAndWaitAsync(execution);
+
+        return (tracked, result);
+    }
+
     protected Endpoint EndpointFor(string routePattern)
     {
         var endpoint = Host.Services.GetRequiredService<EndpointDataSource>()

--- a/src/Http/Wolverine.Http.Tests/OnExceptionTests.cs
+++ b/src/Http/Wolverine.Http.Tests/OnExceptionTests.cs
@@ -85,10 +85,27 @@ public class OnExceptionTests : IntegrationContext
             x.StatusCodeShouldBe(500);
         });
 
+        // GH-3714: the generated endpoint writes the ProblemDetails response from inside the try block, so
+        // Alba can see a complete response while the server-side finally frame has not run yet. Waiting on
+        // the recorded action is the only ordering this test can rely on -- asserting straight after the
+        // scenario made it a race that only the rest of the suite running first happened to win.
+        await waitForRecordedActionAsync("Finally");
+
         // Handler threw, OnException handled it, Finally always runs
         ExceptionWithFinallyEndpoints.Actions.ShouldContain("Handler");
         ExceptionWithFinallyEndpoints.Actions.ShouldContain("OnException");
         ExceptionWithFinallyEndpoints.Actions.ShouldContain("Finally");
+    }
+
+    private static async Task waitForRecordedActionAsync(string action)
+    {
+        // List<T>.Contains scans by index, so it is safe to read while the request thread is still
+        // appending -- unlike an Enumerable.Contains, which would throw on a concurrent modification.
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (!ExceptionWithFinallyEndpoints.Actions.Contains(action) && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(25);
+        }
     }
 
     [Fact]

--- a/src/Http/Wolverine.Http.Tests/Transport/HttpTransportExecutorTests.cs
+++ b/src/Http/Wolverine.Http.Tests/Transport/HttpTransportExecutorTests.cs
@@ -244,13 +244,6 @@ public class HttpTransportExecutorTests : IntegrationContext
         });
     }
 
-    // GH-3707: order-dependent. Posts to /_wolverine/batch/{queue} for a queue that is
-    // configured nowhere, so on its own the message lands somewhere nothing executes it and the
-    // tracking session records no activity. It only passes when earlier tests in the shared
-    // AppFixture have already warmed that path. Fails in isolation on main under xUnit 2 as well,
-    // so this is a pre-existing defect -- xUnit v3 merely orders the suite differently and
-    // stopped hiding it. Excluded from CI until the underlying behaviour is settled.
-    [Trait("Category", "Flaky")]
     [Fact]
     public async Task batch_with_multiple_queues_routes_to_correct_queue()
     {
@@ -262,12 +255,14 @@ public class HttpTransportExecutorTests : IntegrationContext
 
         var data = EnvelopeSerializer.Serialize(envelopes);
 
+        // See GH-3714 -- the batch endpoint hands off to the local queue and returns, so the tracked
+        // session needs an explicit condition rather than relying on activity already being underway.
         var (tracked, result) = await TrackedHttpCall(s =>
         {
             s.Post.ByteArray(data).ToUrl("/_wolverine/batch/custom-queue")
                 .ContentType(HttpTransport.EnvelopeBatchContentType);
             s.StatusCodeShouldBeOk();
-        });
+        }, t => t.WaitForExecutionOf<HttpMessage1>());
 
         tracked.Executed.SingleMessage<HttpMessage1>().Name.ShouldBe("queue-test");
     }

--- a/src/Http/Wolverine.Http.Tests/Transport/http_transport_end_to_end.cs
+++ b/src/Http/Wolverine.Http.Tests/Transport/http_transport_end_to_end.cs
@@ -17,13 +17,6 @@ public class http_transport_end_to_end : IntegrationContext
     {
     }
 
-    // GH-3707: order-dependent. Posts to /_wolverine/batch/{queue} for a queue that is
-    // configured nowhere, so on its own the message lands somewhere nothing executes it and the
-    // tracking session records no activity. It only passes when earlier tests in the shared
-    // AppFixture have already warmed that path. Fails in isolation on main under xUnit 2 as well,
-    // so this is a pre-existing defect -- xUnit v3 merely orders the suite differently and
-    // stopped hiding it. Excluded from CI until the underlying behaviour is settled.
-    [Trait("Category", "Flaky")]
     [Fact]
     public async Task publish_multiple_messages()
     {
@@ -37,10 +30,16 @@ public class http_transport_end_to_end : IntegrationContext
 
         var data = EnvelopeSerializer.Serialize(envelopes);
 
+        // The batch endpoint returns as soon as the envelopes are handed to the local queue, so the
+        // tracked session has to be told what to wait for or it completes with no activity at all
+        // before the handler pipeline has picked anything up. GH-3714.
         var (tracked, result) = await TrackedHttpCall(s =>
         {
             s.Post.ByteArray(data).ToUrl("/_wolverine/batch/one").ContentType(HttpTransport.EnvelopeBatchContentType);
-        });
+        }, t => t
+            .WaitForExecutionOf<HttpMessage1>()
+            .WaitForExecutionOf<HttpMessage2>()
+            .WaitForExecutionOf<HttpMessage3>());
 
         tracked.Executed.SingleMessage<HttpMessage1>().Name.ShouldBe("one");
         tracked.Executed.SingleMessage<HttpMessage2>().Name.ShouldBe("two");


### PR DESCRIPTION
Closes #3714. Also resolves the HTTP half of #3707.

## What was wrong

Three tests in `Wolverine.Http.Tests` passed only because something else in the assembly ran first. `Parallelization.cs` sets `CollectionPerAssembly`, so every test shares one `AppFixture` — one `AlbaHost` over `WolverineWebApi.Program` — which makes order-coupling available by construction. xUnit v3 orders the suite differently from v2 and stopped hiding them. Two were parked behind `[Trait("Category", "Flaky")]`, which every CI target filters out, so they were contributing **no coverage at all**.

## The batch-endpoint diagnosis in #3707 was wrong

The report said posting to `/_wolverine/batch/{queue}` for a queue configured nowhere leaves the message somewhere nothing executes it. That is not what happens:

- `HttpTransportExecutor.ExecuteBatchAsync` calls `AgentForLocalQueue(queueName)`, which builds the local queue on demand. `WolverineWebApi` sets `opts.Policies.UseDurableLocalQueues()`, so it comes back as a `DurableLocalQueue`.
- The envelopes are persisted and executed. The inbox rows are there with `status = Handled`:

```
 08deed93-ec40-8f08-... | Handled | http://localhost/_wolverine/batch/one | WolverineWebApi.HttpMessage1
 08deed93-ec40-916a-... | Handled | http://localhost/_wolverine/batch/one | WolverineWebApi.HttpMessage2
 08deed93-ec40-91b0-... | Handled | http://localhost/_wolverine/batch/one | WolverineWebApi.HttpMessage3
```

What actually fails is the **tracking**. `MessageEventType.Received` is only raised from `HandlerPipeline`, which runs asynchronously off the local queue's block — after the batch endpoint has already returned 200. `TrackedSession.IsCompleted()` returns true the moment execution finishes with no envelope records and no conditions, so `ExecuteAndWaitAsync` returns before anything has run and the test reports `No activity detected!`. When earlier tests have warmed the path the block wins the race; alone it does not.

## The fix

**`publish_multiple_messages`, `batch_with_multiple_queues_routes_to_correct_queue`** — say what the session is waiting for. New `TrackedHttpCall` overload on `IntegrationContext` takes a tracked-session configuration. `WaitForExecutionOf<T>()` keys off `ExecutionFinished`, which is the same event `tracked.Executed` reads, so the record the assertion needs is guaranteed present — and it is a single AND'ed condition, so it does not trip the `_conditions.Any(x => x.IsCompleted())` short-circuit in `IsCompleted()`. Both `Flaky` traits deleted.

**`OnExceptionTests.on_exception_with_finally_both_run`** — found by sweeping every class in the assembly in its own process. The generated endpoint writes the ProblemDetails response from inside the `try` block:

```csharp
catch (CustomHttpException customHttpException) {
    var problemDetails = ExceptionWithFinallyEndpoints.OnException(customHttpException);
    await WriteProblems(problemDetails, httpContext).ConfigureAwait(false);
    return;
}
finally { ExceptionWithFinallyEndpoints.Finally(); }
```

so Alba can observe a complete response while the server-side `finally` frame has not run yet. Shouldly's failure message even shows `Finally` present in the rendered collection — it landed between the failed `Contains` scan and the message being built. The test now waits for the recorded action. The endpoint class is a published doc snippet (`sample_on_exception_with_finally` in `docs/guide/http/exception-handling.md`), so the wait lives in the test rather than as a completion source in the sample.

## Looking for the rest

Every one of the 169 test classes in the assembly was run in its own process — a class that passes in the full suite but fails alone is order-dependent by definition. `OnExceptionTests` was the only hit, reproduced 3/3 unloaded afterwards to rule out a load artifact.

## Verification

- Each fixed test alone: passes, 3/3 runs.
- Full suite: **943 passed / 0 failed / 10 skipped**, with the two formerly-excluded tests back in.
- `dotnet build wolverine.slnx -c Release`: succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMNKwGVHnyaBjiheC5k8KX