### PR TITLE
Invalidate the message-name cache when naming strategies change (GH-3703)

### DIFF
--- a/src/Testing/CoreTests/Util/WolverineMessageNamingTests.cs
+++ b/src/Testing/CoreTests/Util/WolverineMessageNamingTests.cs
@@ -44,6 +44,10 @@ public class WolverineMessageNamingTests
     [Fact]
     public void use_interface_from_interop_message_naming()
     {
+        // GH-3703: this used to fail whenever any earlier test in the assembly had already booted a host
+        // that named ConcreteMessage -- WolverineMessageNaming memoizes into a static map, and registering
+        // the interop assembly did not invalidate what was already in it. AddMessageInterfaceAssembly now
+        // clears the cache, so the registration below takes effect regardless of what ran first.
         WolverineMessageNaming.AddMessageInterfaceAssembly(typeof(IInterfaceMessage).Assembly);
 
         typeof(ConcreteMessage).ToMessageTypeName().ShouldBe(typeof(IInterfaceMessage).ToMessageTypeName());

--- a/src/Wolverine/Util/WolverineMessageNaming.cs
+++ b/src/Wolverine/Util/WolverineMessageNaming.cs
@@ -153,6 +153,8 @@ public static class WolverineMessageNaming
     {
         if (_namingStrategies[0] is T) return;
         _namingStrategies.Insert(0, new T());
+
+        clearCache();
     }
 
     /// <summary>
@@ -163,7 +165,22 @@ public static class WolverineMessageNaming
     public static void AddMessageInterfaceAssembly(Assembly assembly)
     {
         var naming = _namingStrategies.OfType<InteropAssemblyInterfaces>().Single();
+        if (naming.Assemblies.Contains(assembly)) return;
+
         naming.Assemblies.Fill(assembly);
+
+        clearCache();
+    }
+
+    /// <summary>
+    /// Discard every memoized message type name. Changing the naming strategies invalidates any name
+    /// already resolved by the previous set -- a type cached under its full name by an earlier
+    /// <see cref="ToMessageTypeName(Type)"/> call (or by <see cref="PrepopulateCache"/> during a host
+    /// start) would otherwise keep that name forever and silently ignore the new strategy. See GH-3703.
+    /// </summary>
+    private static void clearCache()
+    {
+        _typeNames = ImHashMap<Type, string>.Empty;
     }
 
     public static string GetPrettyName(this Type t)


### PR DESCRIPTION
Closes #3703.

## What was wrong

`WolverineMessageNaming.ToMessageTypeName` memoizes into a static `ImHashMap<Type, string>` (`src/Wolverine/Util/WolverineMessageNaming.cs:140`), and `WolverineRuntime.HostService.StartAsync` pre-populates it from `Handlers.AllMessageTypes()` on every host start. Registering an interop assembly afterwards mutated the `InteropAssemblyInterfaces` strategy but left every already-resolved name in the map, so a type named before the registration kept its old name forever and silently ignored the new strategy.

`CoreTests` boots hundreds of hosts, so by the time `WolverineMessageNamingTests.use_interface_from_interop_message_naming` ran, `CoreTests.Util.ConcreteMessage` had already been cached under its plain full name — and the test's `AddMessageInterfaceAssembly` could not displace it. It failed deterministically in the full suite while passing alone.

This is a real (if narrow) product bug, not just a test artifact: `IPolicies.RegisterInteropMessageAssembly` is documented as the way to make Wolverine forward message names to NServiceBus/MassTransit interfaces, and it silently did nothing for any type already named in that process.

## The fix

`AddMessageInterfaceAssembly` and `InsertFirst<T>` clear the memo. Both are configuration-time calls — the only product caller is `IPolicies.RegisterInteropMessageAssembly` — and both now no-op when the registration would not change anything, so the hundreds of host starts in a test run do not thrash the cache. The map is a pure memo, so discarding it only costs a recompute.

## Verification

- `CoreTests`: **2104 total / 2102 passed / 0 failed / 2 skipped**, up from the documented `2101 passed / 1 failed` baseline on `main` — exactly the expected one-test delta, no other movement.
- `WolverineMessageNamingTests` alone: 8/8.
- `dotnet build wolverine.slnx -c Release`: succeeded.

No new test was added. A second test exercising the same global static would itself have been order-dependent on whichever test registered the assembly first; the existing test is the regression guard and is now deterministic in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMNKwGVHnyaBjiheC5k8KX