### PR TITLE
Poll for the outcome in the two flaky Redis tests instead of sleeping (GH-3707)

### DIFF
--- a/src/Transports/Redis/Wolverine.Redis.Tests/DeadLetterQueueTests.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/DeadLetterQueueTests.cs
@@ -14,10 +14,12 @@ namespace Wolverine.Redis.Tests;
 public class DeadLetterQueueTests
 {
     private readonly ITestOutputHelper _output;
+    private readonly ConditionPoller _poller;
 
     public DeadLetterQueueTests(ITestOutputHelper output)
     {
         _output = output;
+        _poller = new ConditionPoller(output, maxRetries: 40, retryDelay: 250.Milliseconds());
     }
 
     private async Task<(IHost host, string streamKey)> CreateHostAsync(bool enableDeadLetterQueue = true)
@@ -128,9 +130,13 @@ public class DeadLetterQueueTests
         var bus = host.MessageBus();
         var command = new FailingCommand(Guid.NewGuid().ToString(), "Test error message");
         await bus.PublishAsync(command);
-        
-        await Task.Delay(2000);
-        
+
+        // GH-3707: dead-lettering only happens once the retry policy is exhausted, so a fixed sleep is a
+        // bet on how loaded the machine is. Poll for the entry instead -- a busy CI agent then costs the
+        // test time rather than a failure.
+        await _poller.WaitForAsync($"dead letter entry at {deadLetterKey}",
+            async () => (await database.StreamReadAsync(deadLetterKey, "0-0", count: 1)).Length > 0);
+
         // Read dead letter entry
         var deadLetterEntries = await database.StreamReadAsync(deadLetterKey, "0-0", count: 1);
         deadLetterEntries.Length.ShouldBeGreaterThan(0);

--- a/src/Transports/Redis/Wolverine.Redis.Tests/ScheduledMessageTests.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/ScheduledMessageTests.cs
@@ -10,8 +10,12 @@ using Xunit;
 namespace Wolverine.Redis.Tests;
 
 [Collection("ScheduledMessageTests")]
-public class ScheduledMessageTests
+public class ScheduledMessageTests(ITestOutputHelper output)
 {
+    // GH-3707: a fixed sleep is a bet on how loaded the machine is. Poll for the outcome instead so a
+    // busy CI agent costs the test time rather than a failure.
+    private readonly ConditionPoller _poller = new(output, maxRetries: 40, retryDelay: 250.Milliseconds());
+
     private async Task<IHost> CreateHostAsync()
     {
         var streamKey = $"scheduled-test-{Guid.NewGuid():N}";
@@ -45,10 +49,10 @@ public class ScheduledMessageTests
         
         // Schedule for 1 second ago (should execute immediately)
         await bus.ScheduleAsync(command, DateTimeOffset.UtcNow.AddSeconds(-1));
-        
-        // Wait for message to be processed
-        await Task.Delay(2000);
-        
+
+        await _poller.WaitForAsync($"scheduled message {command.Id} to be received",
+            () => tracker.ReceivedMessages.Contains(command.Id));
+
         tracker.ReceivedMessages.ShouldContain(command.Id);
     }
 


### PR DESCRIPTION
Addresses the Redis half of #3707. The HTTP half is #3716.

## What was wrong

`DeadLetterQueueTests.dead_letter_queue_should_contain_exception_details` and `ScheduledMessageTests.should_send_scheduled_message_immediately_when_schedule_time_is_past` each published a message and then slept exactly `Task.Delay(2000)` before asserting.

They are **not** order-dependent — both pass alone and in their class on `main`. The issue suspected a genuine timing component on top of the isolation problem, and that is what this is, with no isolation problem underneath it.

Instrumenting both against a local Redis on an idle machine puts the numbers on it — the condition first becomes true at roughly **1500–1750 ms** against the 2000 ms budget:

```
Waiting for condition: dead letter entry at dlq-test-...:dead-letter (total 1500ms)
Waiting for condition: scheduled message bec3ef2a-... to be received (total 1500ms)
```

A 250–500 ms margin is enough on a quiet machine and not enough on a loaded CI agent. Dead-lettering in particular only happens once the retry policy is exhausted, so the wait is a function of machine speed rather than a fixed protocol step — exactly the shape that survives locally and fails under CI parallelism.

Worth noting for anyone reading the CI history: the flaky-retry harness re-runs a failed test **alone**, so a test that fails its retry is not necessarily really broken. Here it is the opposite of the HTTP pair — running alone is the *easiest* condition for these two, which is why the retry sometimes cleared them.

## The fix

Both use the `ConditionPoller` already in this project (10 s ceiling, 250 ms interval), so a busy agent costs the test time rather than a failure. Typical local cost is unchanged — the poll exits as soon as the condition holds, usually earlier than the old fixed sleep.

Scope kept to the two tests named in the issue. Other tests in these files use fixed sleeps too (`should_delay_execution_of_scheduled_message`, `should_handle_multiple_scheduled_messages_at_different_times`, `failed_message_should_move_to_dead_letter_queue`), and several of those budgets are more generous; converting them is a reasonable follow-up but is not what was failing.

## Verification

- Full Redis suite: **144 passed / 0 failed** — the same all-144 figure the issue cites from a clean run.
- The two classes: 10/10 on three consecutive runs.
- Each fixed test alone: passes.
- `dotnet build wolverine.slnx -c Release`: succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMNKwGVHnyaBjiheC5k8KX