### PR TITLE
build: route every test target through the flaky-retry harness (GH-3705)

### DIFF
--- a/build/build.cs
+++ b/build/build.cs
@@ -64,17 +64,16 @@ partial class Build : NukeBuild
     Target Full => _ => _
         .DependsOn(Test, PersistenceTests, SqliteTests, RabbitmqTests, PulsarTests);
 
+    // Every test target in this file goes through RunTestProject rather than calling DotNetTest
+    // directly, so they all get the flaky-retry harness and the standard Category!=Flaky filter.
+    // CoreTests is the one that matters most: the `CI` target above is what the .NET workflow runs,
+    // so before GH-3705 the largest core suite was the only thing in CI without a second attempt.
     Target CoreTests => _ => _
         .DependsOn(Compile)
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Testing.CoreTests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Testing.CoreTests);
         });
    
     Target PolicyTests => _ => _
@@ -82,12 +81,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Testing.PolicyTests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Testing.PolicyTests);
         });
 
     Target TestExtensions => _ => _
@@ -98,12 +92,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Extensions.Wolverine_FluentValidation_Tests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Extensions.Wolverine_FluentValidation_Tests);
         });
 
     Target DataAnnotationsValidationTests => _ => _
@@ -111,12 +100,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Extensions.Wolverine_DataAnnotationsValidation_Tests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Extensions.Wolverine_DataAnnotationsValidation_Tests);
         });
 
     Target MemoryPackTests => _ => _
@@ -124,12 +108,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Extensions.Wolverine_MemoryPack_Tests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Extensions.Wolverine_MemoryPack_Tests);
         });
     
     Target MessagePackTests => _ => _
@@ -137,12 +116,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Extensions.Wolverine_MessagePack_Tests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Extensions.Wolverine_MessagePack_Tests);
         });
 
     Target HttpTests => _ => _
@@ -153,12 +127,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Http.Wolverine_Http_Tests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Http.Wolverine_Http_Tests);
         });
 
     Target Commands => _ => _
@@ -247,12 +216,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Persistence.Sqlite.SqliteTests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Persistence.Sqlite.SqliteTests);
         });
 
     Target PersistenceTests => _ => _
@@ -260,12 +224,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Persistence.PersistenceTests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Persistence.PersistenceTests);
         });
     
     Target RabbitmqTests => _ => _
@@ -273,12 +232,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Transports.RabbitMQ.Wolverine_RabbitMQ_Tests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Transports.RabbitMQ.Wolverine_RabbitMQ_Tests);
         });
     
     Target PulsarTests => _ => _
@@ -286,12 +240,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Transports.Pulsar.Wolverine_Pulsar_Tests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Transports.Pulsar.Wolverine_Pulsar_Tests);
         });
 
     Target TestSamples => _ => _
@@ -303,12 +252,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Samples.TodoWebService.TodoWebServiceTests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Samples.TodoWebService.TodoWebServiceTests);
         });
    
     Target BankingServiceSampleTests => _ => _
@@ -316,12 +260,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Samples.TestHarness.BankingService_Tests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Samples.TestHarness.BankingService_Tests);
         });
 
     Target AppWithMiddlewareSampleTests => _ => _
@@ -329,12 +268,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Samples.Middleware.AppWithMiddleware_Tests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Samples.Middleware.AppWithMiddleware_Tests);
         });
 
     Target ItemServiceSampleTests => _ => _
@@ -342,12 +276,7 @@ partial class Build : NukeBuild
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            DotNetTest(c => c
-                .SetProjectFile(Solution.Samples.EFCoreSample.ItemService_Tests)
-                .SetConfiguration(Configuration)
-                .EnableNoBuild()
-                .EnableNoRestore()
-                .SetFramework(Framework));
+            RunTestProject(Solution.Samples.EFCoreSample.ItemService_Tests);
         });
 
     Target Pack => _ => _


### PR DESCRIPTION
Closes #3705.

The `CIHttp` half of this issue was already fixed in #3699 (`10b8076a3`). This is the audit the
issue also asked for — "it is worth auditing the other targets for the same inconsistency while
in there" — and it turns up one that matters more than `CIHttp` did.

## `CoreTests` was the last target in CI without a retry

`build/build.cs` had **fifteen** targets calling `DotNetTest` directly instead of going through
`RunTestProject` → `RunWithFlakyRetry`. Fourteen are local-dev conveniences. One is not:

```csharp
Target CI => _ => _.DependsOn(CoreTests, CIMessageRouting);
```

and `.github/workflows/dotnet.yml` runs `./build.sh ci` on every push and PR. So the largest
suite in the repo — **2,104 tests** — ran on every PR with no second attempt, which is exactly
the complaint this issue was filed about. `CIMessageRouting`, the other half of that same target,
already used `RunTestProject`.

All fifteen now go through `RunTestProject`. No bare `DotNetTest` call remains in `build.cs`; the
two in `TestAllPersistence.cs` are the harness itself.

## What they gain besides the retry

- The standard `Category!=Flaky` filter.
- The TRX-parsing report that distinguishes "flaky, passed on retry" from a hard failure — the
  signal the issue notes these targets "lose entirely."

Worth being precise about the filter: `CoreTests` carries no `[Trait("Category", "Flaky")]`
today, so that half is **latent rather than load-bearing**. It mattered because `CoreTests` was
the one CI-executed suite where adding such a trait would have silently excluded nothing.

## Behaviour that is deliberately unchanged

`--no-build`, `--no-restore` and framework selection all survive: `RunTestProject` passes
`frameworkOverride ?? Framework`, and every one of these targets already `.DependsOn(Compile)`.
`ProceedAfterFailure()` still holds — `RunTestProjects` throws `InvalidOperationException` where
the raw call threw Nuke's `ProcessException`, and Nuke treats the two identically.

## Verification

```
./build.sh CoreTests --framework net9.0
=== CoreTests: Running all tests (filter: Category!=Flaky) ===
> dotnet test .../CoreTests.csproj --no-build --no-restore --framework net9.0 \
    --filter Category!=Flaky --logger trx;LogFilePrefix=CoreTests
Passed! - Failed: 0, Passed: 2102, Skipped: 2, Total: 2104
=== CoreTests: All tests passed ===
```

The harness engages, the filter is applied, the TRX logger is attached, and the suite is green.

## One thing this fix explicitly does not buy

Recorded on the issue already, but worth repeating here because it is the trap: **retry does not
rescue order-dependent tests.** The harness re-runs a failed test *alone*, so a test that fails
*because* it is alone reproduces its failure on the retry. Those needed real fixes — #3714 and
#3707, both now closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
