### PR TITLE
Reset listener agent status to Running on restart (GH-3604)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/listener_agent_status_resets_on_restart.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/listener_agent_status_resets_on_restart.cs
@@ -1,0 +1,91 @@
+using JasperFx;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+// GH-3604: ExclusiveListenerFamily / LeaderPinnedListenerFamily build their agent set once in the
+// constructor and hand the SAME instance back from BuildAgentAsync for the life of the runtime. So a
+// listener that fails over away from a node and later returns to it is restarted on the very object
+// the earlier StopAsync() marked Stopped. StartAsync() has to put the status back, or that node runs
+// the listener while reporting it as not running: it never reappears in AllRunningAgentUris(), and
+// CheckHealthAsync() reports Unhealthy forever.
+//
+// The observable symptom was multi_node_exclusive_listener_failover.listener_fails_over_when_the_
+// leader_running_it_crashes timing out after 90s with "it kept flapping" -- misleading, since the
+// failover itself worked and only the reporting was stuck.
+public class listener_agent_status_resets_on_restart
+{
+    private static Endpoint EndpointFor(string scheme)
+        => new SchemeEndpoint(new Uri($"{scheme}://queue/incoming")) { EndpointName = "incoming" };
+
+    private static IWolverineRuntime RuntimeThatStartsAndStopsListeners()
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Endpoints.Returns(Substitute.For<IEndpointCollection>());
+
+        return runtime;
+    }
+
+    [Fact]
+    public async Task exclusive_listener_reports_running_again_after_a_restart()
+    {
+        var agent = new ExclusiveListenerAgent(EndpointFor("rabbitmq"), RuntimeThatStartsAndStopsListeners());
+
+        await agent.StopAsync(TestContext.Current.CancellationToken);
+        agent.Status.ShouldBe(AgentStatus.Stopped);
+
+        await agent.StartAsync(TestContext.Current.CancellationToken);
+        agent.Status.ShouldBe(AgentStatus.Running);
+    }
+
+    [Fact]
+    public async Task leader_pinned_listener_reports_running_again_after_a_restart()
+    {
+        // This one moves on every leader election, so a stuck status is guaranteed to bite the second
+        // time the role comes back to a node.
+        var agent = new LeaderPinnedListenerAgent(EndpointFor("rabbitmq"), RuntimeThatStartsAndStopsListeners());
+
+        await agent.StopAsync(TestContext.Current.CancellationToken);
+        agent.Status.ShouldBe(AgentStatus.Stopped);
+
+        await agent.StartAsync(TestContext.Current.CancellationToken);
+        agent.Status.ShouldBe(AgentStatus.Running);
+    }
+
+    [Fact]
+    public async Task a_restarted_exclusive_listener_is_healthy_again()
+    {
+        // CheckHealthAsync short-circuits to Unhealthy on any non-Running status before it ever looks at
+        // the real listening agent, so a stuck status is what monitoring sees.
+        var agent = new ExclusiveListenerAgent(EndpointFor("rabbitmq"), RuntimeThatStartsAndStopsListeners());
+
+        await agent.StopAsync(TestContext.Current.CancellationToken);
+        (await agent.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Unhealthy);
+
+        await agent.StartAsync(TestContext.Current.CancellationToken);
+        (await agent.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken)).Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    // Minimal concrete Endpoint whose Uri scheme is controllable — the only thing the listener agent
+    // ctors read besides EndpointName.
+    private sealed class SchemeEndpoint : Endpoint
+    {
+        public SchemeEndpoint(Uri uri) : base(uri, EndpointRole.Application)
+        {
+        }
+
+        public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+            => throw new NotSupportedException();
+
+        protected override ISender CreateSender(IWolverineRuntime runtime)
+            => throw new NotSupportedException();
+    }
+}

--- a/src/Wolverine/Runtime/Agents/ExclusiveListenerFamily.cs
+++ b/src/Wolverine/Runtime/Agents/ExclusiveListenerFamily.cs
@@ -22,9 +22,16 @@ internal class ExclusiveListenerAgent : IAgent
         Uri = new Uri($"{ExclusiveListenerFamily.SchemeName}://{_endpoint.Uri.Scheme}/{_endpoint.EndpointName}");
     }
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
-        return _runtime.Endpoints.StartListenerAsync(_endpoint, cancellationToken);
+        await _runtime.Endpoints.StartListenerAsync(_endpoint, cancellationToken);
+
+        // GH-3604: the family hands out ONE cached agent instance per endpoint for the life of the runtime,
+        // so a restart lands on the very object a previous StopAsync() marked Stopped. Without resetting the
+        // status here, a node that has ever given this listener up runs it but reports it as not running --
+        // it never appears in AllRunningAgentUris() again, and CheckHealthAsync() below reports Unhealthy
+        // forever.
+        Status = AgentStatus.Running;
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)

--- a/src/Wolverine/Runtime/Agents/LeaderPinnedAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/LeaderPinnedAgentFamily.cs
@@ -22,9 +22,14 @@ internal class LeaderPinnedListenerAgent : IAgent
         Uri = new Uri($"{LeaderPinnedListenerFamily.SchemeName}://{_endpoint.Uri.Scheme}/{_endpoint.EndpointName}");
     }
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
-        return _runtime.Endpoints.StartListenerAsync(_endpoint, cancellationToken);
+        await _runtime.Endpoints.StartListenerAsync(_endpoint, cancellationToken);
+
+        // GH-3604: same cached-instance hazard as ExclusiveListenerAgent -- a leader-pinned listener is
+        // stopped on the old leader and started on the new one, so every election after the first would
+        // otherwise restart this listener while still reporting it Stopped.
+        Status = AgentStatus.Running;
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes [#3604](https://github.com/JasperFx/wolverine/issues/3604). Found while working the handoff in #3727 on the three `Wolverine.RabbitMQ.Tests` tests that fail round one on essentially every CI run.

## The defect

`ExclusiveListenerFamily` and `LeaderPinnedListenerFamily` build their agent set **once**, in the constructor, and hand the *same instance* back from `BuildAgentAsync` for the life of the runtime:

```csharp
_agents = _runtime.Endpoints.ExclusiveListeners().Select(e => new ExclusiveListenerAgent(e, runtime))
    .ToDictionary(e => e.Uri);
```

`StopAsync()` marks that instance `Stopped`. `StartAsync()` never put the status back:

```csharp
public Task StartAsync(CancellationToken cancellationToken)
{
    return _runtime.Endpoints.StartListenerAsync(_endpoint, cancellationToken);   // <-- status untouched
}

public async Task StopAsync(CancellationToken cancellationToken)
{
    await _runtime.Endpoints.StopListenerAsync(_endpoint, cancellationToken);
    Status = AgentStatus.Stopped;
}
```

So a listener that fails over away from a node and later comes **back** to it is restarted on an object still reporting `Stopped`. That node then runs the listener while reporting it as not running:

- it never reappears in `AllRunningAgentUris()` — which filters on `Status != AgentStatus.Stopped`;
- `CheckHealthAsync()` short-circuits to `Unhealthy` on any non-`Running` status *before* it ever looks at the real listening agent, so health reporting is wrong **permanently**, not just transiently. That is what monitoring reads.

`LeaderPinnedListenerAgent` has the identical defect and moves on *every* leader election, so the second time the role returns to a node it is permanently misreported.

## Why the GH-3604 assertion message was misleading

`multi_node_exclusive_listener_failover.listener_fails_over_when_the_leader_running_it_crashes` fails with:

```
System.TimeoutException : The exclusive listener agent never settled on a single surviving node
                          -- it kept flapping.
```

It does not flap. Instrumenting `waitForStableListenerAsync` shows zero holders on **every** poll for 90 consecutive seconds:

```
DIAG @0.0s  first=none count=0 holders=[]
...  (180 consecutive polls)
DIAG @89.7s first=none count=0 holders=[]
```

while the logs over the same window show failover working exactly as designed — new leader elected, listener started on a survivor, Rabbit channel opened, `0 messages in queue multinode-exclusive-failover at listening start up time`. The failover was always fine; only the reporting was stuck. GH-3604 was parked with #3610 as *test-only* partly because the flap could not be pinned down — the flap was never the symptom.

This also explains why only **one** of the three tests in that class failed: it is the only one that *pins* the listener before the crash, and the pin is what stops the listener on a survivor first, poisoning that survivor's cached agent instance.

## Verification

Reproduced locally in isolation before the fix — deterministic, not order-dependent, not a flake: **95.06s / 95.00s / 95.01s** across three runs, matching the CI timings in #3727 to the tenth of a second.

- `multi_node_exclusive_listener_failover`, all 3 tests: **22.2s total, green** (was a deterministic 95s timeout on the one test alone).
- `CoreTests`: **2104 passed, 0 failed** — no blast radius from the status change.
- New `listener_agent_status_resets_on_restart`: **3/3 fail without the fix, 3/3 pass with it**, covering both agent types plus the health-check consequence.
- `dotnet build wolverine.slnx -c Release`: clean, 0 warnings.

## Not in scope

Two other findings from the #3727 handoff are filed separately and are **not** addressed here:

- `multi_node_exclusive_listener_recovery.rows_released_after_the_listener_is_already_running_are_still_recovered` is a genuine pre-existing flake at roughly 40% — 2 failures in 4 runs on unmodified `main`, 1 in 3 with this fix applied, so it is unrelated to this change.
- `Bug_1594_ReplayDeadLetterQueue` passes locally on all three modes once SQL Server is actually running; its CI round-one failure is still unexplained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)