### PR TITLE
Seed the departed node's inbox rows already owned (GH-3729)

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_node_exclusive_listener_recovery.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_node_exclusive_listener_recovery.cs
@@ -200,7 +200,12 @@ public class multi_node_exclusive_listener_recovery : IAsyncLifetime
     }
 
 
-    private static async Task<Envelope[]> seedDormantMessagesAsync(IHost host, int count)
+    /// <summary>
+    /// Seeds inbox rows directly. <paramref name="ownerId" /> is the owner they are persisted WITH, which
+    /// matters: staging rows as claimable and reassigning them afterwards leaves a window in which the
+    /// listener's recovery loop can legitimately claim them. See GH-3729.
+    /// </summary>
+    private static async Task<Envelope[]> seedDormantMessagesAsync(IHost host, int count, int ownerId)
     {
         var runtime = host.GetRuntime();
         var store = host.Services.GetRequiredService<IMessageStore>();
@@ -215,9 +220,7 @@ public class multi_node_exclusive_listener_recovery : IAsyncLifetime
                 Destination = queueUri(),
                 Status = EnvelopeStatus.Incoming,
 
-                // Exactly how an ungraceful shutdown leaves them, and how the durability agent releases
-                // the rows a dead node owned.
-                OwnerId = TransportConstants.AnyNode,
+                OwnerId = ownerId,
                 ContentType = serializer.ContentType,
                 MessageType = typeof(NodeTrackedMessage).ToMessageTypeName(),
                 SentAt = DateTimeOffset.UtcNow
@@ -268,7 +271,9 @@ public class multi_node_exclusive_listener_recovery : IAsyncLifetime
         // these two agents are on different nodes.
         listenerNode.ShouldNotBe(agentNode);
 
-        var seeded = await seedDormantMessagesAsync(listener, 5);
+        // Dormant and claimable from the outset -- exactly how an ungraceful shutdown leaves them once the
+        // durability agent has released the rows a dead node owned.
+        var seeded = await seedDormantMessagesAsync(listener, 5, TransportConstants.AnyNode);
         var expected = seeded.Select(x => x.Id).ToArray();
 
         var recovered = await waitForAsync(() => expected.All(tracking.Contains), 60.Seconds());
@@ -315,12 +320,17 @@ public class multi_node_exclusive_listener_recovery : IAsyncLifetime
         var listenerNode = nodeNumberOf(listener);
 
         var store = listener.Services.GetRequiredService<IMessageStore>();
-        var seeded = await seedDormantMessagesAsync(listener, 5);
 
         // Owned by a node that is not part of this cluster -- the state a dead node's in-flight batch is in
         // before the durability agent gets around to releasing it.
+        //
+        // GH-3729: these have to be seeded owned by the departed node, not stored as claimable and reassigned
+        // a round-trip later. The listener's recovery loop polls every ScheduledJobPollingTime (250ms here), so
+        // a sweep landing in that window claimed the rows perfectly correctly -- and then the assertion below,
+        // which exists to prove the listener leaves other nodes' rows alone, failed on the test's own setup
+        // rather than on any product behaviour. That was roughly 40% of runs.
         const int departedNode = 987654;
-        await store.ReassignIncomingAsync(departedNode, seeded);
+        var seeded = await seedDormantMessagesAsync(listener, 5, departedNode);
 
         (await store.LoadPageOfGloballyOwnedIncomingAsync(queueUri(), 100))
             .ShouldBeEmpty("Nothing should be dormant yet -- the rows are still owned by the departed node");


### PR DESCRIPTION
Fixes #3729. `multi_node_exclusive_listener_recovery.rows_released_after_the_listener_is_already_running_are_still_recovered` failed roughly **40%** of the time, and the flake was entirely in its own setup. **The ownership check was never at fault** — worth saying plainly, because #3729 raised the possibility that this was a real ownership race.

## The window

The rows were stored **claimable** and only reassigned to the out-of-cluster node a database round-trip later:

```csharp
var seeded = await seedDormantMessagesAsync(listener, 5);   // OwnerId = TransportConstants.AnyNode
await store.ReassignIncomingAsync(departedNode, seeded);    // ...only now owned by 987654
```

The listener's recovery loop polls every `ScheduledJobPollingTime`, which this test deliberately sets to **250ms**. A sweep landing between those two statements claimed the rows — entirely correct, they were owned by `AnyNode` at that instant. But the next assertion exists to prove the opposite:

```csharp
tracking.Count.ShouldBe(0,
    "The listener must not touch inbox rows that are still owned by another node");
```

So the test failed on rows it had itself published as claimable.

## The fix

`seedDormantMessagesAsync` now takes the owner to persist the rows **with**. `StoreIncomingAsync` writes `envelope.OwnerId` straight through (`DatabasePersistence.cs:78`), so the rows belong to the departed node from the moment they exist and there is no window at all.

The parameter is required rather than defaulted because `TransportConstants.AnyNode` is a `static readonly` field, not a constant, so it cannot be a default parameter value (CS1736). Both call sites now state which owner they mean, which reads better here anyway — the two tests want opposite things.

## Verification

**12 consecutive green runs** of the class, ~12s each. At the previous ~40% failure rate that is p ≈ 0.002.

Worth recording how nearly this went wrong: my first attempt didn't compile (the CS1736 above), and the 10 runs I did against the stale binary came back 4/10 failed — which looks exactly like "the fix didn't work" rather than "the fix was never built." Always confirm `Build succeeded` before believing a test result.

`dotnet build wolverine.slnx -c Release`: clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)