### PR TITLE
Bound the node record table by row count, not just age (GH-3701)

### DIFF
--- a/src/Persistence/MySql/MySqlTests/Agents/delete_old_node_records.cs
+++ b/src/Persistence/MySql/MySqlTests/Agents/delete_old_node_records.cs
@@ -1,0 +1,117 @@
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using MySqlConnector;
+using Shouldly;
+using Wolverine;
+using Wolverine.MySql;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Sagas;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace MySqlTests.Agents;
+
+/// <summary>
+/// GH-3701: the node record row cap. MySQL inherited the interface's no-op default before this, so
+/// <c>wolverine_node_records</c> was bounded only by age — which is no ceiling at all under assignment churn.
+/// MySQL also rejects a LIMIT inside a subquery over the table being deleted, so the implementation resolves
+/// a floor id first; these tests are what pin that rewrite to the same semantics as the other stores.
+/// </summary>
+[Collection("mysql")]
+public class delete_old_node_records : IAsyncLifetime
+{
+    private const string SchemaName = "node_record_retention";
+    private MySqlMessageStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await using (var conn = new MySqlConnection(Servers.MySqlConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"DROP DATABASE IF EXISTS `{SchemaName}`";
+            await cmd.ExecuteNonQueryAsync();
+            await conn.CloseAsync();
+        }
+
+        var dataSource = MySqlDataSourceFactory.Create(Servers.MySqlConnectionString);
+        var settings = new DatabaseSettings
+        {
+            ConnectionString = Servers.MySqlConnectionString,
+            SchemaName = SchemaName,
+            Role = MessageStoreRole.Main
+        };
+
+        _store = new MySqlMessageStore(settings, new DurabilitySettings(), dataSource,
+            NullLogger<MySqlMessageStore>.Instance, Array.Empty<SagaTableDefinition>());
+
+        await _store.Admin.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+    }
+
+    private async Task insertNodeRecordsAsync(int count)
+    {
+        await using var conn = new MySqlConnection(Servers.MySqlConnectionString);
+        await conn.OpenAsync();
+
+        for (var i = 1; i <= count; i++)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                $"INSERT INTO {SchemaName}.{DatabaseConstants.NodeRecordTableName} (node_number, event_name, description) VALUES (@number, @event, @description)";
+            cmd.Parameters.AddWithValue("number", 1);
+            cmd.Parameters.AddWithValue("event", NodeRecordType.AssignmentChanged.ToString());
+            cmd.Parameters.AddWithValue("description", $"Record {i:00}");
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        await conn.CloseAsync();
+    }
+
+    [Fact]
+    public async Task retains_the_most_recent_records()
+    {
+        await insertNodeRecordsAsync(10);
+        (await _store.Nodes.FetchRecentRecordsAsync(100)).Count.ShouldBe(10);
+
+        await _store.Nodes.DeleteOldNodeRecordsAsync(3);
+
+        var remaining = await _store.Nodes.FetchRecentRecordsAsync(100);
+        remaining.Count.ShouldBe(3);
+        remaining.Select(x => x.Description).OrderBy(x => x)
+            .ShouldBe(["Record 08", "Record 09", "Record 10"]);
+    }
+
+    [Fact]
+    public async Task zero_retain_is_a_noop()
+    {
+        await insertNodeRecordsAsync(3);
+
+        await _store.Nodes.DeleteOldNodeRecordsAsync(0);
+
+        (await _store.Nodes.FetchRecentRecordsAsync(100)).Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task fewer_records_than_the_cap_keeps_all()
+    {
+        await insertNodeRecordsAsync(2);
+
+        await _store.Nodes.DeleteOldNodeRecordsAsync(5);
+
+        (await _store.Nodes.FetchRecentRecordsAsync(100)).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task empty_table_does_not_throw()
+    {
+        await _store.Nodes.DeleteOldNodeRecordsAsync(5);
+
+        (await _store.Nodes.FetchRecentRecordsAsync(100)).Count.ShouldBe(0);
+    }
+}

--- a/src/Persistence/MySql/Wolverine.MySql/MySqlNodePersistence.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlNodePersistence.cs
@@ -378,6 +378,21 @@ internal class MySqlNodePersistence : DatabaseConstants, INodeAgentPersistence
             .FetchListAsync(readRecord);
     }
 
+    // GH-3701: the row cap that bounds the node record table alongside the age sweep. Without this the
+    // store fell through to the interface's no-op default and only the age bound applied. MySQL rejects
+    // a LIMIT inside a subquery of the same table being deleted ("This version of MySQL doesn't yet
+    // support 'LIMIT & IN/ALL/ANY/SOME subquery'"), so the surviving window is resolved to a floor id in
+    // a derived table first and the delete is a plain range scan on the primary key.
+    public async Task DeleteOldNodeRecordsAsync(int retainCount)
+    {
+        if (retainCount <= 0) return;
+
+        await _dataSource.CreateCommand(
+                $"DELETE FROM {_settings.SchemaName}.{NodeRecordTableName} WHERE id < COALESCE((SELECT floor_id FROM (SELECT MIN(id) AS floor_id FROM (SELECT id FROM {_settings.SchemaName}.{NodeRecordTableName} ORDER BY id DESC LIMIT @retain) AS keep) AS floor), 0)")
+            .With("retain", retainCount)
+            .ExecuteNonQueryAsync();
+    }
+
     public bool HasLeadershipLock()
     {
         return _database.AdvisoryLock.HasLock(_lockId);

--- a/src/Persistence/Oracle/OracleTests/Agents/delete_old_node_records.cs
+++ b/src/Persistence/Oracle/OracleTests/Agents/delete_old_node_records.cs
@@ -1,0 +1,108 @@
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Weasel.Oracle;
+using Wolverine;
+using Wolverine.Oracle;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Sagas;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace OracleTests.Agents;
+
+/// <summary>
+/// GH-3701: the node record row cap. Oracle inherited the interface's no-op default before this, so
+/// <c>wolverine_node_records</c> was bounded only by age — which is no ceiling at all under assignment churn.
+/// </summary>
+[Collection("oracle")]
+public class delete_old_node_records : IAsyncLifetime
+{
+    private const string SchemaName = "WOLVERINE";
+    private OracleMessageStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var dataSource = new OracleDataSource(Servers.OracleConnectionString);
+        var settings = new DatabaseSettings
+        {
+            ConnectionString = Servers.OracleConnectionString,
+            SchemaName = SchemaName,
+            Role = MessageStoreRole.Main
+        };
+
+        _store = new OracleMessageStore(settings, new DurabilitySettings(), dataSource,
+            NullLogger<OracleMessageStore>.Instance, Array.Empty<SagaTableDefinition>());
+
+        await _store.Admin.RebuildAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+    }
+
+    private async Task insertNodeRecordsAsync(int count)
+    {
+        await using var conn = new OracleConnection(Servers.OracleConnectionString);
+        await conn.OpenAsync();
+
+        for (var i = 1; i <= count; i++)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.BindByName = true;
+            cmd.CommandText =
+                $"INSERT INTO {SchemaName}.{DatabaseConstants.NodeRecordTableName} (node_number, event_name, description) VALUES (:number, :event_name, :description)";
+            cmd.Parameters.Add("number", 1);
+            cmd.Parameters.Add("event_name", NodeRecordType.AssignmentChanged.ToString());
+            cmd.Parameters.Add("description", $"Record {i:00}");
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        await conn.CloseAsync();
+    }
+
+    [Fact]
+    public async Task retains_the_most_recent_records()
+    {
+        await insertNodeRecordsAsync(10);
+        (await _store.Nodes.FetchRecentRecordsAsync(100)).Count.ShouldBe(10);
+
+        await _store.Nodes.DeleteOldNodeRecordsAsync(3);
+
+        var remaining = await _store.Nodes.FetchRecentRecordsAsync(100);
+        remaining.Count.ShouldBe(3);
+        remaining.Select(x => x.Description).OrderBy(x => x)
+            .ShouldBe(["Record 08", "Record 09", "Record 10"]);
+    }
+
+    [Fact]
+    public async Task zero_retain_is_a_noop()
+    {
+        await insertNodeRecordsAsync(3);
+
+        await _store.Nodes.DeleteOldNodeRecordsAsync(0);
+
+        (await _store.Nodes.FetchRecentRecordsAsync(100)).Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task fewer_records_than_the_cap_keeps_all()
+    {
+        await insertNodeRecordsAsync(2);
+
+        await _store.Nodes.DeleteOldNodeRecordsAsync(5);
+
+        (await _store.Nodes.FetchRecentRecordsAsync(100)).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task empty_table_does_not_throw()
+    {
+        await _store.Nodes.DeleteOldNodeRecordsAsync(5);
+
+        (await _store.Nodes.FetchRecentRecordsAsync(100)).Count.ShouldBe(0);
+    }
+}

--- a/src/Persistence/Oracle/OracleTests/Agents/delete_old_node_records.cs
+++ b/src/Persistence/Oracle/OracleTests/Agents/delete_old_node_records.cs
@@ -36,15 +36,33 @@ public class delete_old_node_records : IAsyncLifetime
         _store = new OracleMessageStore(settings, new DurabilitySettings(), dataSource,
             NullLogger<OracleMessageStore>.Instance, Array.Empty<SagaTableDefinition>());
 
-        await _store.Admin.RebuildAsync();
+        // Deliberately NOT Admin.RebuildAsync(). In Oracle a schema IS a user, so every test in the
+        // "oracle" collection shares WOLVERINE -- rebuilding it drops the tables out from under the
+        // siblings that run after this class. Migrate to make sure the table exists, then clear only the
+        // one table this class actually owns.
+        await _store.Admin.MigrateAsync();
+        await clearNodeRecordsAsync();
     }
 
     public async ValueTask DisposeAsync()
     {
+        await clearNodeRecordsAsync();
         await _store.DisposeAsync();
     }
 
-    private async Task insertNodeRecordsAsync(int count)
+    private static async Task clearNodeRecordsAsync()
+    {
+        await using var conn = new OracleConnection(Servers.OracleConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"DELETE FROM {SchemaName}.{DatabaseConstants.NodeRecordTableName}";
+        await cmd.ExecuteNonQueryAsync();
+
+        await conn.CloseAsync();
+    }
+
+    private static async Task insertNodeRecordsAsync(int count)
     {
         await using var conn = new OracleConnection(Servers.OracleConnectionString);
         await conn.OpenAsync();
@@ -53,11 +71,15 @@ public class delete_old_node_records : IAsyncLifetime
         {
             await using var cmd = conn.CreateCommand();
             cmd.BindByName = true;
+
+            // NOT :number -- NUMBER is an Oracle reserved word and a bind variable named after one is
+            // rejected with ORA-01745: invalid host/bind variable name. Same for :description, which
+            // collides with the DESCRIPTION keyword in some contexts. Prefix them.
             cmd.CommandText =
-                $"INSERT INTO {SchemaName}.{DatabaseConstants.NodeRecordTableName} (node_number, event_name, description) VALUES (:number, :event_name, :description)";
-            cmd.Parameters.Add("number", 1);
-            cmd.Parameters.Add("event_name", NodeRecordType.AssignmentChanged.ToString());
-            cmd.Parameters.Add("description", $"Record {i:00}");
+                $"INSERT INTO {SchemaName}.{DatabaseConstants.NodeRecordTableName} (node_number, event_name, description) VALUES (:p_number, :p_event, :p_description)";
+            cmd.Parameters.Add("p_number", 1);
+            cmd.Parameters.Add("p_event", NodeRecordType.AssignmentChanged.ToString());
+            cmd.Parameters.Add("p_description", $"Record {i:00}");
             await cmd.ExecuteNonQueryAsync();
         }
 

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleNodePersistence.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleNodePersistence.cs
@@ -390,6 +390,22 @@ internal class OracleNodePersistence : DatabaseConstants, INodeAgentPersistence
         return list;
     }
 
+    // GH-3701: the row cap that bounds the node record table alongside the age sweep. Without this the
+    // store fell through to the interface's no-op default and only the age bound applied. Expressed as a
+    // floor id rather than a NOT IN over a FETCH FIRST subquery so the delete stays a primary-key range scan.
+    public async Task DeleteOldNodeRecordsAsync(int retainCount)
+    {
+        if (retainCount <= 0) return;
+
+        await using var conn = await _dataSource.OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand(
+            $"DELETE FROM {_settings.SchemaName}.{NodeRecordTableName} WHERE id < NVL((SELECT MIN(id) FROM (SELECT id FROM {_settings.SchemaName}.{NodeRecordTableName} ORDER BY id DESC FETCH FIRST :retain ROWS ONLY)), 0)");
+        cmd.With("retain", retainCount);
+
+        await cmd.ExecuteNonQueryAsync();
+        await conn.CloseAsync();
+    }
+
     public bool HasLeadershipLock()
     {
         return _database.AdvisoryLock.HasLock(_lockId);

--- a/src/Persistence/PostgresqlTests/Agents/node_record_retention.cs
+++ b/src/Persistence/PostgresqlTests/Agents/node_record_retention.cs
@@ -1,0 +1,112 @@
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.RDBMS;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace PostgresqlTests.Agents;
+
+/// <summary>
+/// GH-3701: <c>wolverine_node_records</c> is append-only diagnostics with no foreign keys and no hot-path
+/// reader, and until now nothing bounded its row count. <c>DeleteOldNodeRecordsAsync</c> was implemented for
+/// every relational store but had no call site outside tests, and the only pruning that did run was the
+/// age sweep against <c>NodeEventRecordExpirationTime</c> (5 days) — which is no ceiling at all on a cluster
+/// writing one <c>AssignmentChanged</c> row per agent per assignment decision. The reporting cluster reached
+/// 36,135,221 rows / 16 GB in five days, every one of those rows inside the age window.
+///
+/// This pins the call site: a running host must trim the table down to
+/// <see cref="DurabilitySettings.NodeRecordRetention"/> on its own, with no test-side invocation of the
+/// persistence method.
+/// </summary>
+[Collection("marten")]
+public class node_record_retention : IAsyncLifetime
+{
+    private readonly string _schemaName = $"node_retention_{Guid.NewGuid().ToString("N")[..8]}";
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync(_schemaName);
+            await conn.CloseAsync();
+        }
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, _schemaName);
+
+                opts.Durability.NodeRecordRetention = 5;
+
+                // The production cadence is hourly. Nothing here depends on the *period* being right, only
+                // on the prune running at all, so shorten it to keep the test's poll window sane.
+                opts.Durability.NodeRecordPruningPeriod = 1.Seconds();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private async Task insertNodeRecordsAsync(int count)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        for (var i = 1; i <= count; i++)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                $"insert into {_schemaName}.{DatabaseConstants.NodeRecordTableName} (node_number, event_name, description) values ($1, $2, $3)";
+            cmd.Parameters.AddWithValue(1);
+            cmd.Parameters.AddWithValue(NodeRecordType.AssignmentChanged.ToString());
+            cmd.Parameters.AddWithValue($"Record {i}");
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        await conn.CloseAsync();
+    }
+
+    private async Task<int> countNodeRecordsAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"select count(*) from {_schemaName}.{DatabaseConstants.NodeRecordTableName}";
+        var count = Convert.ToInt32(await cmd.ExecuteScalarAsync());
+
+        await conn.CloseAsync();
+        return count;
+    }
+
+    [Fact]
+    public async Task a_running_host_prunes_the_node_record_table_down_to_the_retention_cap()
+    {
+        await insertNodeRecordsAsync(50);
+        (await countNodeRecordsAsync()).ShouldBeGreaterThanOrEqualTo(50);
+
+        var count = 0;
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(30);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            count = await countNodeRecordsAsync();
+            if (count <= 5) break;
+            await Task.Delay(500.Milliseconds(), TestContext.Current.CancellationToken);
+        }
+
+        // The host also writes its own NodeStarted/AgentStarted records while this runs, so the cap is the
+        // ceiling, not an exact count. Before the fix this stayed at 50+ forever.
+        count.ShouldBeLessThanOrEqualTo(5);
+    }
+}

--- a/src/Persistence/SqliteTests/Agents/delete_old_node_records.cs
+++ b/src/Persistence/SqliteTests/Agents/delete_old_node_records.cs
@@ -1,0 +1,109 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Weasel.Sqlite;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.Runtime.Agents;
+using Wolverine.Sqlite;
+using Xunit;
+
+namespace SqliteTests.Agents;
+
+/// <summary>
+/// GH-3701: the node record row cap. Sqlite inherited the interface's no-op default before this, so
+/// <c>wolverine_node_records</c> was bounded only by age.
+/// </summary>
+public class delete_old_node_records : IAsyncLifetime
+{
+    private readonly SqliteTestDatabase _database = Servers.CreateDatabase(nameof(delete_old_node_records));
+    private SqliteMessageStore _store = null!;
+    private SqliteDataSource _dataSource = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _dataSource = new SqliteDataSource(_database.ConnectionString);
+
+        var settings = new DatabaseSettings
+        {
+            ConnectionString = _database.ConnectionString,
+            SchemaName = "main",
+            Role = MessageStoreRole.Main
+        };
+
+        _store = new SqliteMessageStore(settings, new DurabilitySettings(), _dataSource,
+            NullLogger<SqliteMessageStore>.Instance);
+
+        await _store.Admin.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        _dataSource.Dispose();
+        _database.Dispose();
+    }
+
+    private async Task insertNodeRecordsAsync(int count)
+    {
+        await using var conn = new SqliteConnection(_database.ConnectionString);
+        await conn.OpenAsync();
+
+        for (var i = 1; i <= count; i++)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                $"insert into {DatabaseConstants.NodeRecordTableName} (node_number, event_name, timestamp, description) values (@number, @event, @time, @description)";
+            cmd.Parameters.AddWithValue("@number", 1);
+            cmd.Parameters.AddWithValue("@event", NodeRecordType.AssignmentChanged.ToString());
+            cmd.Parameters.AddWithValue("@time", DateTimeOffset.UtcNow.ToString("o"));
+            cmd.Parameters.AddWithValue("@description", $"Record {i:00}");
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        await conn.CloseAsync();
+    }
+
+    [Fact]
+    public async Task retains_the_most_recent_records()
+    {
+        await insertNodeRecordsAsync(10);
+        (await _store.Nodes.FetchRecentRecordsAsync(100)).Count.ShouldBe(10);
+
+        await _store.Nodes.DeleteOldNodeRecordsAsync(3);
+
+        var remaining = await _store.Nodes.FetchRecentRecordsAsync(100);
+        remaining.Count.ShouldBe(3);
+        remaining.Select(x => x.Description).OrderBy(x => x)
+            .ShouldBe(["Record 08", "Record 09", "Record 10"]);
+    }
+
+    [Fact]
+    public async Task zero_retain_is_a_noop()
+    {
+        await insertNodeRecordsAsync(3);
+
+        await _store.Nodes.DeleteOldNodeRecordsAsync(0);
+
+        (await _store.Nodes.FetchRecentRecordsAsync(100)).Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task fewer_records_than_the_cap_keeps_all()
+    {
+        await insertNodeRecordsAsync(2);
+
+        await _store.Nodes.DeleteOldNodeRecordsAsync(5);
+
+        (await _store.Nodes.FetchRecentRecordsAsync(100)).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task empty_table_does_not_throw()
+    {
+        await _store.Nodes.DeleteOldNodeRecordsAsync(5);
+
+        (await _store.Nodes.FetchRecentRecordsAsync(100)).Count.ShouldBe(0);
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/Durability/TrimNodeRecordsCommand.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/TrimNodeRecordsCommand.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Logging;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+
+namespace Wolverine.RDBMS.Durability;
+
+/// <summary>
+/// GH-3701: cap the node record table at <see cref="DurabilitySettings.NodeRecordRetention"/> rows.
+///
+/// <see cref="DeleteOldNodeEventRecords"/> bounds the same table by age
+/// (<see cref="DurabilitySettings.NodeEventRecordExpirationTime"/>, 5 days by default), which is no ceiling
+/// at all when the write rate is high: one <c>AssignmentChanged</c> row per agent per assignment decision on
+/// a cluster with thousands of distributed agents is millions of rows a day, and all of them are inside the
+/// age window. The reporting cluster reached 36M rows / 16 GB in five days — 15 GB of heap on a diagnostic
+/// table nothing on the hot path reads, plus the write and WAL load of the inserts, on the main Wolverine
+/// database, while the cluster was already unhealthy for an unrelated reason.
+///
+/// The "keep the newest N by id" delete itself is engine-specific (LIMIT / TOP / FETCH FIRST), so it lives
+/// behind <see cref="INodeAgentPersistence.DeleteOldNodeRecordsAsync"/> on the store rather than being
+/// expressed as an <c>IDatabaseOperation</c> here. Stores that do not implement it inherit the interface's
+/// no-op default and are simply left to the age sweep.
+/// </summary>
+internal class TrimNodeRecordsCommand : IAgentCommand
+{
+    private readonly IMessageDatabase _database;
+    private readonly DurabilitySettings _settings;
+    private readonly ILogger _logger;
+
+    public TrimNodeRecordsCommand(IMessageDatabase database, DurabilitySettings settings, ILogger logger)
+    {
+        _database = database;
+        _settings = settings;
+        _logger = logger;
+    }
+
+    public async Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
+    {
+        var retention = _settings.NodeRecordRetention;
+        if (retention <= 0)
+        {
+            return AgentCommands.Empty;
+        }
+
+        try
+        {
+            await _database.Nodes.DeleteOldNodeRecordsAsync(retention);
+        }
+        catch (Exception e)
+        {
+            // Housekeeping must never be able to take down the durability agent's running block.
+            _logger.LogError(e, "Error trying to trim the node record table in database {Database} to {Retention} rows",
+                _database.Name, retention);
+        }
+
+        return AgentCommands.Empty;
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
+++ b/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
@@ -31,6 +31,7 @@ internal class DurabilityAgent : IAgent
     private Timer? _recoveryTimer;
     private Timer? _scheduledJobTimer;
     private Timer? _handledCleanupTimer;
+    private Timer? _nodeRecordPruningTimer;
 
     private readonly DurabilityHealthSignals _health;
     private DateTime _lastHealthCheck = DateTime.UtcNow;
@@ -134,6 +135,20 @@ internal class DurabilityAgent : IAgent
             _runningBlock.Post(command);
         }, _settings, 5.Seconds(), _settings.HandledMessageCleanupPollingTime);
 
+        // GH-3701: node records only exist on the Main store, and their housekeeping is slow, unbounded-scan
+        // work that has no business riding along on the recovery batch. See PruneNodeRecords.
+        if (_database.Settings.Role == MessageStoreRole.Main)
+        {
+            // Hold the first pass back so it can't pile onto startup, but never past the configured period
+            // itself -- a host that asks for a short period is asking to see pruning promptly.
+            var pruningStart = _settings.NodeRecordPruningPeriod < 1.Minutes()
+                ? _settings.NodeRecordPruningPeriod
+                : 1.Minutes();
+
+            _nodeRecordPruningTimer = new Timer(_ => PruneNodeRecords(), _settings, pruningStart,
+                _settings.NodeRecordPruningPeriod);
+        }
+
         if (AutoStartScheduledJobPolling)
         {
             StartScheduledJobPolling();
@@ -168,6 +183,11 @@ internal class DurabilityAgent : IAgent
             await _handledCleanupTimer.DisposeAsync();
         }
 
+        if (_nodeRecordPruningTimer != null)
+        {
+            await _nodeRecordPruningTimer.DisposeAsync();
+        }
+
         Status = AgentStatus.Stopped;
     }
 
@@ -193,23 +213,31 @@ internal class DurabilityAgent : IAgent
         return new Uri($"{uri}{markerType.Name}");
     }
 
-#pragma warning disable CS0649 // Field is never assigned to
-    private DateTimeOffset? _lastNodeRecordPruneTime;
-#pragma warning restore CS0649
-
-    private bool isTimeToPruneNodeEventRecords()
+    /// <summary>
+    /// GH-3701: everything that keeps the node record table from growing without bound. Two deletes, both
+    /// against the <c>Main</c> store, both on the slow <see cref="DurabilitySettings.NodeRecordPruningPeriod"/>
+    /// timer rather than the five-second recovery batch:
+    ///
+    /// 1. <see cref="DeleteOldNodeEventRecords"/> — the age sweep against
+    ///    <see cref="DurabilitySettings.NodeEventRecordExpirationTime"/> (5 days by default). This one already
+    ///    existed, but it was appended to <see cref="buildOperationBatch"/> behind an
+    ///    <c>isTimeToPruneNodeEventRecords()</c> guard reading a field that was never assigned — the
+    ///    suppression on it (<c>CS0649</c>) said so outright — so the guard always returned true and the whole
+    ///    delete ran on every recovery cycle.
+    /// 2. <see cref="TrimNodeRecordsCommand"/> — the row cap against
+    ///    <see cref="DurabilitySettings.NodeRecordRetention"/>. An age bound alone puts no ceiling on the
+    ///    table: the reporting cluster wrote one <c>AssignmentChanged</c> row per agent per assignment
+    ///    decision, ~12.8M rows/day, reaching 36M rows / 16 GB well inside the 5-day window.
+    /// </summary>
+    internal void PruneNodeRecords()
     {
-        if (_lastNodeRecordPruneTime == null)
-        {
-            return true;
-        }
+        _runningBlock.Post(new DatabaseOperationBatch(_database,
+            [new DeleteOldNodeEventRecords(_database, _settings)]));
 
-        if (DateTimeOffset.UtcNow.Subtract(_lastNodeRecordPruneTime.Value) > 1.Hours())
+        if (_settings.NodeRecordRetention > 0)
         {
-            return true;
+            _runningBlock.Post(new TrimNodeRecordsCommand(_database, _settings, _logger));
         }
-
-        return false;
     }
 
     internal IDatabaseOperation[] buildOperationBatch(IReadOnlyList<int>? activeNodeNumbers = null)
@@ -238,13 +266,8 @@ internal class DurabilityAgent : IAgent
             }
         }
 
-        if (_database.Settings.Role == MessageStoreRole.Main)
-        {
-            if (isTimeToPruneNodeEventRecords())
-            {
-                ops.Add(new DeleteOldNodeEventRecords(_database, _settings));
-            }
-        }
+        // GH-3701: node record pruning used to live here, on the five-second recovery cadence. It now runs
+        // on its own timer -- see PruneNodeRecords.
 
         if (_runtime.Options.Durability.OutboxStaleTime.HasValue)
         {

--- a/src/Persistence/Wolverine.Sqlite/SqliteNodePersistence.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteNodePersistence.cs
@@ -376,6 +376,20 @@ internal class SqliteNodePersistence : DatabaseConstants, INodeAgentPersistence
         return records;
     }
 
+    // GH-3701: the row cap that bounds the node record table alongside the age sweep. Without this the
+    // store fell through to the interface's no-op default and only the age bound applied.
+    public async Task DeleteOldNodeRecordsAsync(int retainCount)
+    {
+        if (retainCount <= 0) return;
+
+        await using var conn = await _dataSource.OpenConnectionAsync(CancellationToken.None).ConfigureAwait(false);
+        await using var cmd = conn.CreateCommand(
+                $"delete from {NodeRecordTableName} where id not in (select id from {NodeRecordTableName} order by id desc limit @retain)")
+            .With("retain", retainCount);
+
+        await cmd.ExecuteNonQueryAsync();
+    }
+
     public bool HasLeadershipLock()
     {
         return _database.AdvisoryLock.HasLock(_lockId);

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -247,6 +247,30 @@ public class DurabilitySettings : IDescribeMyself
     public int StaleNodeEjectionThreshold { get; set; } = 2;
 
     /// <summary>
+    ///     GH-3701: a hard cap on the number of rows retained in the node record table
+    ///     (<c>wolverine_node_records</c>), the append-only diagnostic log written by
+    ///     <c>INodeAgentPersistence.LogRecordsAsync</c> and read back by <c>FetchRecentRecordsAsync</c>.
+    ///     <see cref="NodeEventRecordExpirationTime" /> bounds those rows by *age* only, which puts no ceiling on
+    ///     the table at all: a cluster churning assignments writes one <c>AssignmentChanged</c> row per agent per
+    ///     decision, so millions of rows a day fit comfortably inside the age window and turn an
+    ///     agent-assignment incident into a database capacity problem on top of it. This cap is applied on the
+    ///     same housekeeping pass as the age sweep, every <see cref="NodeRecordPruningPeriod" />, against the
+    ///     <c>Main</c> store only. Raise it on very large agent universes, where one assignment wave is already
+    ///     thousands of rows. Set to zero or a negative number to keep the age sweep as the only bound, which
+    ///     was the behavior before 6.24.1.
+    /// </summary>
+    public int NodeRecordRetention { get; set; } = 10_000;
+
+    /// <summary>
+    ///     GH-3701: how often the node record table is pruned, both by age
+    ///     (<see cref="NodeEventRecordExpirationTime" />) and down to <see cref="NodeRecordRetention" /> rows.
+    ///     Deliberately far slower than <see cref="ScheduledJobPollingTime" /> — this is a housekeeping scan
+    ///     over a table nothing on the hot path reads, and until 6.24.1 it was being appended to every
+    ///     five-second recovery batch instead.
+    /// </summary>
+    public TimeSpan NodeRecordPruningPeriod { get; set; } = 1.Hours();
+
+    /// <summary>
     ///     How often should Wolverine do a full check that all assigned agents are
     ///     really running and try to restart (or stop) any differences from the last
     ///     good set of assignments
@@ -463,6 +487,8 @@ public class DurabilitySettings : IDescribeMyself
         desc.AddValue(nameof(DeadLetterQueueExpirationEnabled), DeadLetterQueueExpirationEnabled);
         desc.AddValue(nameof(DeadLetterQueueExpiration), DeadLetterQueueExpiration);
         desc.AddValue(nameof(NodeEventRecordExpirationTime), NodeEventRecordExpirationTime);
+        desc.AddValue(nameof(NodeRecordRetention), NodeRecordRetention);
+        desc.AddValue(nameof(NodeRecordPruningPeriod), NodeRecordPruningPeriod);
         desc.AddValue(nameof(SendingAgentIdleTimeout), SendingAgentIdleTimeout);
         desc.AddValue(nameof(DrainTimeout), DrainTimeout);
         desc.AddValue(nameof(EnableInboxPartitioning), EnableInboxPartitioning);

--- a/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
@@ -596,6 +596,15 @@ public partial class MultiTenantedMessageStore : IMessageStore, IMessageInbox, I
         return Main.Nodes.FetchRecentRecordsAsync(count);
     }
 
+    // GH-3701: node records are written to, and read back from, the Main store only -- see LogRecordsAsync
+    // and FetchRecentRecordsAsync above -- so the retention cap has to follow them there. Without this
+    // override a multi-tenanted store inherited the interface's no-op default and never trimmed at all,
+    // which is exactly the shape (one main store, hundreds of tenant databases) the 36M-row report came from.
+    Task INodeAgentPersistence.DeleteOldNodeRecordsAsync(int retainCount)
+    {
+        return Main.Nodes.DeleteOldNodeRecordsAsync(retainCount);
+    }
+
     bool INodeAgentPersistence.HasLeadershipLock()
     {
         return Main.Nodes.HasLeadershipLock();


### PR DESCRIPTION
Closes #3701.

## The report

`wolverine_node_records` reached **36,135,221 rows / 16 GB** (15 GB heap + 867 MB index) in five days on a production cluster — a diagnostic table with no foreign keys whose only reader is `FetchRecentRecordsAsync`, and which nothing in Wolverine ever asks for more than ~100 rows from.

## Two defects

**1. The row cap had no call site.** `INodeAgentPersistence.DeleteOldNodeRecordsAsync(int retainCount)` was implemented for the relational stores, tested, and never invoked outside those tests — exactly as reported.

**2. The pruning that *did* run only bounds by age.** `DeleteOldNodeEventRecords` deletes against `NodeEventRecordExpirationTime` (5 days). Age is no ceiling at all when the write rate is high: one `AssignmentChanged` row per agent per assignment decision, on a cluster with thousands of distributed agents, is millions of rows a day — all of them inside the window. Every one of those 36M rows was younger than the cutoff.

## And a third, found on the way in

The age sweep was appended to `buildOperationBatch` behind this guard:

```csharp
#pragma warning disable CS0649 // Field is never assigned to
    private DateTimeOffset? _lastNodeRecordPruneTime;
#pragma warning restore CS0649
```

The suppression says it outright — the field is never assigned, so `isTimeToPruneNodeEventRecords()` always returned `true` and the intended hourly throttle never engaged. The delete went out on **every recovery cycle**, i.e. every 5 seconds by default. On the reporting cluster that is a full scan of a 16 GB table every five seconds, on the main Wolverine database, while it was already unhealthy for an unrelated reason (#3698).

## The fix

- **`Durability.NodeRecordRetention`** — a hard row cap, default 10,000, applied by a new `TrimNodeRecordsCommand`. Zero or negative keeps the old age-only behavior.
- **`Durability.NodeRecordPruningPeriod`** — default hourly. Both deletes now run on a dedicated timer against the `Main` store instead of riding the 5-second recovery batch, which is what the dead throttle was supposed to achieve.
- **`MultiTenantedMessageStore`** now delegates `DeleteOldNodeRecordsAsync` to `Main.Nodes`, matching `LogRecordsAsync` / `FetchRecentRecordsAsync`. It was inheriting the interface's no-op default, so a multi-tenanted store would never have trimmed even once a call site existed — and one main store with hundreds of tenant databases is precisely the reporter's shape.
- **Sqlite, MySQL and Oracle** implement the row cap; they had also been falling through to the no-op default. MySQL rejects a `LIMIT` inside a subquery over the table being deleted, and Oracle pays for a `NOT IN` over a `FETCH FIRST` subquery, so both resolve a floor id first and delete as a primary-key range scan.

## On the write volume itself

The reporter offered to split off the "one `AssignmentChanged` row per agent per decision is very fine-grained" point. That is a fair separate issue and this PR does not touch it — but with a row cap in place, that volume is now a bounded cost rather than an unbounded one.

## Tests

- `PostgresqlTests/Agents/node_record_retention.cs` — seeds 50 rows, starts a **real host**, and asserts the table drains to the cap with no test-side call to `DeleteOldNodeRecordsAsync`. Red baseline verified: 54 rows remain without the fix.
- Store-level retention tests for Sqlite, MySQL and Oracle, mirroring the existing Postgres and SQL Server ones (newest rows retained, zero-retain no-op, under-cap no-op, empty table).
- Full `wolverine.slnx` Release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)