### PR TITLE
Bump to 6.24.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.24.0</Version>
+        <Version>6.24.1</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Version bump for the 6.24.1 patch release.

Contents:
- #3734 — bound `wolverine_node_records` by row count, not just age (GH-3701)
- #3735 — standalone force-catch-up for Marten under Wolverine-managed distribution (GH-3697)
- #3736 — stop shattering agent Uris that contain a comma (GH-3733)
- #3737 — ack only the completed delivery, not every lower tag (GH-3706)
- #3730 — pause + node-loss compliance coverage (GH-3698)
- #3732 — seed the departed node's inbox rows already owned (GH-3729)
- #3731 — remove the stale RabbitMQ handoff doc (GH-3726)

🤖 Generated with [Claude Code](https://claude.com/claude-code)