### PR TITLE
Add Durability.MessagingEnabled for event-subscription-only nodes (GH-3746)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/messaging_disabled_node.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/messaging_disabled_node.cs
@@ -1,0 +1,83 @@
+using JasperFx;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// GH-3746. A node with <see cref="DurabilitySettings.MessagingEnabled" /> set to false exists to run
+/// event subscription (projection) agents and nothing else — the case is warming a bumped projection
+/// version off to one side before it serves traffic. It must therefore advertise no agent family that
+/// would make the leader hand it message-handling work, while still advertising the event
+/// subscription agents it was stood up for.
+/// </summary>
+public class messaging_disabled_node
+{
+    private static NodeAgentController ControllerFor(bool messagingEnabled, params IAgentFamily[] families)
+    {
+        var options = new WolverineOptions { ApplicationAssembly = typeof(messaging_disabled_node).Assembly };
+        options.Durability.Mode = DurabilityMode.Balanced;
+        options.Durability.MessagingEnabled = messagingEnabled;
+        options.Durability.DurabilityAgentEnabled = false; // skip MessageStoreCollection wiring
+        // Keep the recurring loop out of the way; the assertions are on construction alone.
+        options.Durability.CheckAssignmentPeriod = 1.Hours();
+
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Options.Returns(options);
+        runtime.DurabilitySettings.Returns(options.Durability);
+        runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+
+        return new NodeAgentController(
+            runtime,
+            Substitute.For<INodeAgentPersistence>(),
+            families,
+            NullLogger<NodeAgentController>.Instance,
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public void the_listener_families_are_not_registered()
+    {
+        // Without this the leader can pin an exclusive listener here, and a node whose read models
+        // are still being built would start handling real messages.
+        var controller = ControllerFor(messagingEnabled: false);
+
+        controller.HasFamily(ExclusiveListenerFamily.SchemeName).ShouldBeFalse();
+        controller.HasFamily(LeaderPinnedListenerFamily.SchemeName).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void the_listener_families_are_still_registered_by_default()
+    {
+        var controller = ControllerFor(messagingEnabled: true);
+
+        controller.HasFamily(ExclusiveListenerFamily.SchemeName).ShouldBeTrue();
+        controller.HasFamily(LeaderPinnedListenerFamily.SchemeName).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void event_subscription_families_are_still_registered()
+    {
+        // The whole point of the node: it is a full cluster member for projections. Turning messaging
+        // off must not make it inert.
+        var controller = ControllerFor(messagingEnabled: false, new StubFamily("event-subscriptions"));
+
+        controller.HasFamily("event-subscriptions").ShouldBeTrue();
+    }
+
+    /// <summary>Stands in for the event subscription family a Marten/Polecat host injects.</summary>
+    private sealed class StubFamily(string scheme) : IAgentFamily
+    {
+        public string Scheme { get; } = scheme;
+        public ValueTask<IReadOnlyList<Uri>> AllKnownAgentsAsync() => new([]);
+        public ValueTask<IAgent> BuildAgentAsync(Uri uri, IWolverineRuntime wolverineRuntime)
+            => throw new NotSupportedException();
+        public ValueTask<IReadOnlyList<Uri>> SupportedAgentsAsync() => new([]);
+        public ValueTask EvaluateAssignmentsAsync(AssignmentGrid assignments) => new();
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -141,6 +141,25 @@ public class DurabilitySettings : IDescribeMyself
     public bool DurabilityAgentEnabled { get; set; } = true;
 
     /// <summary>
+    ///     When false, this node takes no part in message handling at all: it starts no listeners,
+    ///     runs no in-memory scheduled jobs, and advertises neither durability agents nor any
+    ///     transport-owned agents, so the leader never assigns it any. It stays a full member of the
+    ///     cluster otherwise - it registers, takes part in leader election, uses the control queue,
+    ///     and still advertises and runs event subscription (projection) agents.
+    ///
+    ///     The use case is warming a read model before it serves traffic. When a projection version
+    ///     is bumped its tables start empty and are rebuilt from the beginning of the event store,
+    ///     and until that finishes a node running the new version would serve incomplete read
+    ///     models. Standing up a separate set of nodes with MessagingEnabled = false lets them build
+    ///     the new version off to one side while the existing nodes keep serving, without those
+    ///     warming nodes also picking up messages and running handlers against half-built state.
+    ///
+    ///     A strictly stronger statement than <see cref="DurabilityAgentEnabled" />, which only
+    ///     covers the durability agents. The default is true.
+    /// </summary>
+    public bool MessagingEnabled { get; set; } = true;
+
+    /// <summary>
     /// When true, scheduled-for-later messages destined for non-durable
     /// <see cref="Transports.Local.BufferedLocalQueue"/> instances route to
     /// <c>IMessageStore.Inbox</c> instead of the in-process
@@ -473,6 +492,7 @@ public class DurabilitySettings : IDescribeMyself
         desc.AddValue(nameof(Mode), Mode);
         desc.AddValue(nameof(MessageIdentity), MessageIdentity);
         desc.AddValue(nameof(DurabilityAgentEnabled), DurabilityAgentEnabled);
+        desc.AddValue(nameof(MessagingEnabled), MessagingEnabled);
         desc.AddValue(nameof(RecoveryBatchSize), RecoveryBatchSize);
         desc.AddValue(nameof(KeepAfterMessageHandling), KeepAfterMessageHandling);
         desc.AddValue(nameof(NodeReassignmentPollingTime), NodeReassignmentPollingTime);

--- a/src/Wolverine/HostBuilderExtensions.cs
+++ b/src/Wolverine/HostBuilderExtensions.cs
@@ -467,6 +467,37 @@ public static class HostBuilderExtensions
         return services;
     }
 
+    /// <summary>
+    /// Turn off everything in Wolverine except event subscription (projection) distribution. This node
+    /// still registers in the cluster, takes part in leader election and uses the control queue, and it
+    /// still advertises and runs event subscription agents — but it starts no listeners, runs no
+    /// in-memory scheduled jobs, and advertises neither durability agents nor any transport-owned
+    /// agents, so the leader never gives it message-handling work.
+    ///
+    /// Built for warming a read model before it serves traffic: when a projection version is bumped its
+    /// tables start empty and are rebuilt from the beginning of the event store, and a node running the
+    /// new version would serve incomplete read models until that finishes. Standing up a separate set
+    /// of nodes like this lets them build the new version off to one side while the existing nodes keep
+    /// serving, without the warming nodes also picking up messages and running handlers against
+    /// half-built state.
+    ///
+    /// Equivalent to setting <see cref="DurabilitySettings.MessagingEnabled" /> to false.
+    /// </summary>
+    public static IServiceCollection RunWolverineForEventSubscriptionDistributionOnly(
+        this IServiceCollection services)
+    {
+        services.AddSingleton<IWolverineExtension, DisableMessaging>();
+        return services;
+    }
+
+    internal class DisableMessaging : IWolverineExtension
+    {
+        public void Configure(WolverineOptions options)
+        {
+            options.Durability.MessagingEnabled = false;
+        }
+    }
+
     #region sample_disableexternaltransports
     internal class DisableExternalTransports : IWolverineExtension
     {

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.cs
@@ -83,7 +83,9 @@ public partial class NodeAgentController
             _agentFamilies[agentController.Scheme] = agentController;
         }
 
-        if (runtime.Options.Durability.Mode == DurabilityMode.Balanced)
+        // A node with messaging disabled runs event subscription agents and nothing else, so it
+        // advertises no listener agents. See DurabilitySettings.MessagingEnabled.
+        if (runtime.Options.Durability.Mode == DurabilityMode.Balanced && runtime.Options.Durability.MessagingEnabled)
         {
             _agentFamilies[ExclusiveListenerFamily.SchemeName] = new ExclusiveListenerFamily(runtime);
             _agentFamilies[LeaderPinnedListenerFamily.SchemeName] = new LeaderPinnedListenerFamily(runtime);
@@ -98,19 +100,28 @@ public partial class NodeAgentController
             }
         }
 
-        if (runtime.Options.Durability.DurabilityAgentEnabled)
+        if (runtime.Options.Durability.DurabilityAgentEnabled && runtime.Options.Durability.MessagingEnabled)
         {
             _agentFamilies[_runtime.Stores.Scheme] = _runtime.Stores;
         }
 
-        foreach (var family in runtime.Options.Transports.OfType<IAgentFamilySource>().SelectMany(x => x.BuildAgentFamilySources(runtime)))
+        if (runtime.Options.Durability.MessagingEnabled)
         {
-            _agentFamilies[family.Scheme] = family;
+            foreach (var family in runtime.Options.Transports.OfType<IAgentFamilySource>().SelectMany(x => x.BuildAgentFamilySources(runtime)))
+            {
+                _agentFamilies[family.Scheme] = family;
+            }
         }
 
         _cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
         _logger = logger;
     }
+
+    /// <summary>
+    ///     Whether this node registered an agent family for <paramref name="scheme" />, and therefore
+    ///     advertises its agents. Test hook for the family wiring in the constructor.
+    /// </summary>
+    internal bool HasFamily(string scheme) => _agentFamilies.ContainsKey(scheme);
 
     public ConcurrentDictionary<Uri, IAgent> Agents { get; } = new();
 

--- a/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
@@ -240,13 +240,13 @@ public partial class WolverineRuntime : IAgentRuntime
         switch (Options.Durability.Mode)
         {
             case DurabilityMode.Balanced:
-                await startDurableScheduledJobs();
+                if (Options.Durability.MessagingEnabled) await startDurableScheduledJobs();
                 startNodeAgentController();
                 break;
 
 
             case DurabilityMode.Solo:
-                await startDurableScheduledJobs();
+                if (Options.Durability.MessagingEnabled) await startDurableScheduledJobs();
                 startNodeAgentController();
                 await NodeController!.StartSoloModeAsync();
                 break;

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -164,13 +164,13 @@ public partial class WolverineRuntime
                 case DurabilityMode.Balanced:
                     await loadAgentRestrictionsAsync();
                     await startMessagingTransportsAsync();
-                    startInMemoryScheduledJobs();
+                    if (Options.Durability.MessagingEnabled) startInMemoryScheduledJobs();
                     await startNodeAgentWorkflowAsync();
                     _idleAgentCleanupLoop = Task.Run(executeIdleSendingAgentCleanup, Cancellation);
                     break;
                 case DurabilityMode.Solo:
                     await startMessagingTransportsAsync();
-                    startInMemoryScheduledJobs();
+                    if (Options.Durability.MessagingEnabled) startInMemoryScheduledJobs();
                     _idleAgentCleanupLoop = Task.Run(executeIdleSendingAgentCleanup, Cancellation);
                     break;
 
@@ -542,7 +542,14 @@ public partial class WolverineRuntime
             }
         }
 
-        if (!Options.ExternalTransportsAreStubbed)
+        if (!Options.Durability.MessagingEnabled)
+        {
+            // This node exists to run event subscription agents only. See
+            // DurabilitySettings.MessagingEnabled.
+            Logger.LogInformation(
+                "All external endpoint listeners are disabled because Durability.MessagingEnabled is false. Local queues still run: agent commands ride on them.");
+        }
+        else if (!Options.ExternalTransportsAreStubbed)
         {
             await Endpoints.StartListenersAsync();
         }

--- a/src/Wolverine/Runtime/WolverineRuntime.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.cs
@@ -266,8 +266,16 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IWolverineRunt
     public void ScheduleLocalExecutionInMemory(DateTimeOffset executionTime, Envelope envelope)
     {
         if (ScheduledJobs == null)
+        {
+            if (!Options.Durability.MessagingEnabled)
+            {
+                throw new InvalidOperationException(
+                    $"This action is invalid when {nameof(WolverineOptions)}.{nameof(WolverineOptions.Durability)}.{nameof(DurabilitySettings.MessagingEnabled)} is false");
+            }
+
             throw new InvalidOperationException(
                 $"This action is invalid when {nameof(WolverineOptions)}.{nameof(WolverineOptions.Durability)}.{nameof(DurabilitySettings.Mode)} = {Options.Durability.Mode}");
+        }
 
         Logger.LogDebug("Scheduling envelope {EnvelopeId} ({MessageType}) for in-memory execution at {ExecutionTime}", envelope.Id, envelope.MessageType, executionTime);
         MessageTracking.Sent(envelope);


### PR DESCRIPTION
Implements the ask in #3746. Happy to reshape any of it — the naming, the surface, or the placement — this is a first cut to make the discussion concrete rather than a take-it-or-leave-it.

## The problem

There is no supported way to run a node that takes part in event subscription (projection) agent assignment while doing **no message handling at all**.

The use case is warming a read model before it serves traffic. When a projection version is bumped, its tables start empty and are rebuilt from the beginning of the event store; until that finishes, a node running the new version serves incomplete read models. Standing up a separate set of nodes to build the new version off to one side is the natural fix — and it works, because the projection version is part of the agent identity, so old and new nodes advertise disjoint projection agents.

But those warming nodes must be full Wolverine nodes to be assigned the new version's projection agents, and that also hands them message handling. Listeners we can stop via `IEndpointCollection.StartListenerAsync/StopListenerAsync`. Durability agents we cannot: they are assigned per message store, are version-independent, and a durability agent is not a listener, so it recovers and executes persisted envelopes on a node whose read models are half-built. `NodeAgentController.DisableAgentsAsync` is documented "STRICTLY FOR TESTING", and `Solo`/`Serverless`/`MediatorOnly` are not usable — `Balanced` is what enables the leader election and control queue the distribution needs.

For scale context: our deployment is 512 shard databases and ~854 tenants, so about 5 100 projection agents plus 512 durability agents.

## What this adds

`DurabilitySettings.MessagingEnabled` (default `true`), plus a fluent `services.RunWolverineForEventSubscriptionDistributionOnly()` alongside the existing `DisableAllWolverineMessagePersistence` / `UseWolverineSoloMode`.

When false, the node:

- registers no listener agent families, so the leader cannot pin an exclusive or leader-pinned listener there;
- registers no durability agent family;
- registers no transport-owned agent families;
- starts no listeners;
- runs no in-memory scheduled jobs.

It stays a full cluster member otherwise — registers, takes part in leader election, uses the control queue, and still advertises and runs the event subscription agents it was stood up for.

The gating follows the pattern `DurabilityAgentEnabled` already uses in the `NodeAgentController` constructor, so the mechanism should look familiar.

## One thing worth your eye

A node that registers no durability family also cannot **assign** those agents while it is the leader, because `EvaluateAssignmentsAsync` iterates the registered families. That is pre-existing behaviour of `DurabilityAgentEnabled` which this flag inherits rather than introduces — but it does suggest such a node should not be leader-eligible.

I deliberately did not touch leader election in the same PR. If you would rather this flag also made the node ineligible, or rather the families stayed registered with `SupportedAgentsAsync()` returning empty (so a leader could still assign them to others while never taking them itself), say which and I will rework it. The second shape looks cleaner to me but is a bigger behavioural change and I would rather not guess.

## Testing

Three unit tests in `CoreTests.Runtime.Agents.messaging_disabled_node` covering the listener families being absent when off, present by default, and the injected event subscription family still being registered when off. The neighbouring agent tests still pass.

Default is `true`, so nothing changes for existing hosts.
