### PR TITLE
Re-point the GH-3740 tests at the better guarantee JasperFx 2.37.0 gives us

### DIFF
--- a/src/Testing/CoreTests/Acceptance/service_capabilities_resilience_3740.cs
+++ b/src/Testing/CoreTests/Acceptance/service_capabilities_resilience_3740.cs
@@ -1,3 +1,4 @@
+using JasperFx.Descriptors;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Wolverine;
@@ -14,11 +15,15 @@ namespace CoreTests.Acceptance;
 // configuration, and it is read over and over by monitoring tools like CritterWatch. A single throwing
 // property getter anywhere in the object graph used to abort the entire read, so a monitoring console
 // received *no* capabilities at all -- forever, since every subsequent attempt re-ran the same doomed code.
-// It's now best effort: the offending item is logged and skipped, everything else still gets reported.
+// It's now best effort, at two levels:
+//   * JasperFx 2.37.0 (jasperfx#590) guards the reflective getter walk itself, so a throwing property
+//     costs you that one property -- recorded as OptionsValue.Unreadable -- and nothing more.
+//   * Wolverine still guards each transport individually, for the failures OptionsDescription can't see
+//     (a transport whose TryBuildBrokerUsage throws outright).
 public class service_capabilities_resilience_3740
 {
     [Fact]
-    public async Task one_misbehaving_transport_does_not_lose_the_whole_snapshot()
+    public async Task one_misbehaving_property_getter_costs_only_that_property()
     {
         using var host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
@@ -31,8 +36,38 @@ public class service_capabilities_resilience_3740
         var capabilities =
             await ServiceCapabilities.ReadFrom(host.GetRuntime(), null, TestContext.Current.CancellationToken);
 
-        // The broker that can't describe itself is simply missing...
-        capabilities.Brokers.ShouldNotContain(x => x.ProtocolName == BadlyBehavedTransport.ProtocolName);
+        // The broker whose getter throws is still described...
+        var badlyBehaved =
+            capabilities.Brokers.SingleOrDefault(x => x.ProtocolName == BadlyBehavedTransport.ProtocolName);
+        badlyBehaved.ShouldNotBeNull();
+
+        // ...with just the offending property standing in as unreadable
+        var explosive = badlyBehaved.PropertyFor(nameof(BadlyBehavedTransport.Explosive));
+        explosive.ShouldNotBeNull();
+        explosive.Value.ShouldStartWith(OptionsValue.UnreadablePrefix);
+
+        // ...and every other broker, and the rest of the snapshot, comes through
+        capabilities.Brokers.ShouldContain(x => x.ProtocolName == WellBehavedTransport.ProtocolName);
+        capabilities.PropertyFor("ServiceName").ShouldNotBeNull();
+        capabilities.DurabilitySettings.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task one_undescribable_transport_does_not_lose_the_whole_snapshot()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Transports.Add(new UndescribableTransport());
+                opts.Transports.Add(new WellBehavedTransport());
+            })
+            .StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var capabilities =
+            await ServiceCapabilities.ReadFrom(host.GetRuntime(), null, TestContext.Current.CancellationToken);
+
+        // The broker that can't describe itself at all is simply missing...
+        capabilities.Brokers.ShouldNotContain(x => x.ProtocolName == UndescribableTransport.ProtocolName);
 
         // ...while every other broker, and the rest of the snapshot, comes through
         capabilities.Brokers.ShouldContain(x => x.ProtocolName == WellBehavedTransport.ProtocolName);
@@ -44,7 +79,7 @@ public class service_capabilities_resilience_3740
     public async Task cancellation_is_not_swallowed_as_a_section_failure()
     {
         using var host = await Host.CreateDefaultBuilder()
-            .UseWolverine(opts => opts.Transports.Add(new BadlyBehavedTransport()))
+            .UseWolverine(opts => opts.Transports.Add(new UndescribableTransport()))
             .StartAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         using var cancellation = new CancellationTokenSource();
@@ -82,6 +117,27 @@ internal class BadlyBehavedTransport : TransportBase<Endpoint>
     /// based, and JasperFx's OptionsDescription reads every public property reflectively.
     /// </summary>
     public string Explosive => throw new InvalidOperationException("Simulated bad property getter for GH-3740");
+
+    protected override IEnumerable<Endpoint> endpoints() => [];
+
+    protected override Endpoint findEndpointByUri(Uri uri) => throw new NotSupportedException();
+}
+
+/// <summary>
+/// A transport that fails to describe itself at all, rather than merely owning one bad property getter.
+/// OptionsDescription can't help here -- the throw happens before it ever runs -- so this is what exercises
+/// Wolverine's own per-transport guard.
+/// </summary>
+internal class UndescribableTransport : TransportBase<Endpoint>
+{
+    public const string ProtocolName = "undescribable";
+
+    public UndescribableTransport() : base(ProtocolName, "Undescribable Test Transport", [ProtocolName])
+    {
+    }
+
+    public override bool TryBuildBrokerUsage(out BrokerDescription description) =>
+        throw new InvalidOperationException("Simulated undescribable transport for GH-3740");
 
     protected override IEnumerable<Endpoint> endpoints() => [];
 


### PR DESCRIPTION
`main` is red at `90229b2c5`, and has been since the JasperFx 2.37.0 bump (`134f4cf5b`). Only these two tests fail, on `main` itself and on every PR branched from it:

```
CoreTests.Acceptance.service_capabilities_resilience_3740.cancellation_is_not_swallowed_as_a_section_failure
CoreTests.Acceptance.service_capabilities_resilience_3740.one_misbehaving_transport_does_not_lose_the_whole_snapshot
```

## Why

2.37.0 carries [jasperfx#590](https://github.com/JasperFx/jasperfx/pull/590), which guards `OptionsDescription`'s reflective getter walk directly: a property whose getter throws is recorded as `OptionsValue.Unreadable` instead of taking the whole description down with it.

That is strictly better than what Wolverine's own GH-3740 guard could do on its own — the broker is now *described, minus one property*, rather than dropped entirely. But it means `TryBuildBrokerUsage` no longer throws for `BadlyBehavedTransport`, so both tests were left asserting the old, worse outcome:

- `one_misbehaving_transport_does_not_lose_the_whole_snapshot` asserted the bad broker was **absent**. It is now present, correctly.
- `cancellation_is_not_swallowed_as_a_section_failure` reached the cancellation check only *because* a section threw. With nothing throwing, the check is never reached.

So this is the test suite catching a behaviour improvement, not a product regression. No product code changes here.

## What changed

- **`one_misbehaving_property_getter_costs_only_that_property`** (renamed) asserts the real contract now: the broker **is** in the snapshot and only `Explosive` reads back with the `OptionsValue.UnreadablePrefix` marker.
- **`one_undescribable_transport_does_not_lose_the_whole_snapshot`** is new, and keeps covering *Wolverine's* per-transport guard in `readTransports` — the half `OptionsDescription` cannot help with, because a throw out of `TryBuildBrokerUsage` happens before it ever runs. Backed by a new `UndescribableTransport`.
- **`cancellation_is_not_swallowed_as_a_section_failure`** uses that transport too, since it needs a section that genuinely fails to reach the cancellation check at all.

## Verification

- 11 capabilities tests green on `net9.0` and `net10.0` against a clean `origin/main` + this commit.
- Confirmed **non-vacuous**: deleting the `try`/`catch` in `readTransports` fails `one_undescribable_transport_does_not_lose_the_whole_snapshot`, and the cancellation test still fails without the `ThrowIfCancellationRequested` in `warnAboutFailedSection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)