### PR TITLE
Bump Marten to 9.22.2 and Weasel to 9.23.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,12 +44,12 @@
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
     <PackageVersion Include="JasperFx.SourceGenerator" Version="2.37.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
-    <PackageVersion Include="Marten" Version="9.20.0" />
+    <PackageVersion Include="Marten" Version="9.22.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="[5.7.0,6.0.0)" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.20.0" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.20.0" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.22.2" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.22.2" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />
@@ -127,13 +127,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.20.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.20.0" />
-    <PackageVersion Include="Weasel.MySql" Version="9.20.0" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.20.0" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.20.0" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.20.0" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.20.0" />
+    <PackageVersion Include="Weasel.Core" Version="9.23.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.23.0" />
+    <PackageVersion Include="Weasel.MySql" Version="9.23.0" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.23.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.23.0" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.23.0" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.23.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- xUnit v3. Test projects use xunit.v3 and must set <OutputType>Exe</OutputType>.


### PR DESCRIPTION
Routine stack pin bump ahead of the 6.24.3 release.

- Marten / Marten.AspNetCore / Marten.Newtonsoft: 9.20.0 → 9.22.2
- Weasel.* (all 7 packages): 9.20.0 → 9.23.0
- Polecat deliberately left on its floating range `[5.7.0,6.0.0)`, which already resolves to 5.9.1
- JasperFx already at 2.37.0

Full `wolverine.slnx` builds clean in Release with the new pins (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eR4GL278688VhyhrGcttJ