### PR TITLE
Reassignments run in the source node's lane and batch by AgentStartBatchSize (GH-3749, GH-3748)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/pending_assignment_grid_state.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/pending_assignment_grid_state.cs
@@ -128,11 +128,10 @@ public class pending_assignment_grid_state
 
         var commands = await _controller.EvaluateAssignmentsAsync([_node1, _node2], restrictions);
 
-        // A reassignment normally runs in the lane of the node TAKING the agent. That is wrong here: the
+        // A reassignment runs in the lane of its SOURCE node (GH-3749). That matters doubly here: the
         // start it has to cancel is still sitting in node 1's queue, so a stop dispatched anywhere else
         // finds nothing to stop and node 1 brings the agent up moments later anyway.
         var reassign = commands.OfType<ReassignAgent>().ShouldHaveSingleItem();
-        reassign.StopInSourceLane.ShouldBeTrue();
         reassign.DestinationNodeId.ShouldBe(_node1.NodeId);
     }
 

--- a/src/Testing/CoreTests/Runtime/Agents/reassign_agents_batching.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/reassign_agents_batching.cs
@@ -1,0 +1,218 @@
+using CoreTests.Transports;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// GH-3749. Reassignment was the one agent command that broke both halves of the dispatcher's contract: it
+/// ran in the DESTINATION node's lane while doing its blocking stop round trip against the SOURCE — so a
+/// source that was merely busy froze every batched start queued for a healthy destination — and it was the
+/// one command type batchCommands never chunked, so a rebalance emitted thousands of serial single-agent
+/// round trips that AgentStartBatchSize had no effect on. In the field: a stable five-node cluster frozen
+/// for seven minutes, one node holding 799 agents and four holding zero, because 22 stops aimed at a busy
+/// source sat at the head of an idle destination's lane.
+/// </summary>
+public class reassign_agents_batching
+{
+    private static NodeDestination destination(string name) => new(Guid.NewGuid(), new Uri($"fake://{name}"));
+
+    private static Uri[] agents(params string[] names) => names.Select(x => new Uri($"fake://{x}")).ToArray();
+
+    /*** LANE KEYING ***/
+
+    [Fact]
+    public void single_reassignment_runs_in_the_source_nodes_lane()
+    {
+        var source = destination("source");
+        var target = destination("target");
+
+        // THE GH-3749 defect: this used to be ActiveNode.NodeId, putting a blocking round trip against the
+        // source into the destination's lane, where it wedged the batched starts behind it.
+        new ReassignAgent(new Uri("fake://one"), source, target)
+            .DestinationNodeId.ShouldBe(source.NodeId);
+    }
+
+    [Fact]
+    public void batched_reassignment_runs_in_the_source_nodes_lane()
+    {
+        var source = destination("source");
+        var target = destination("target");
+
+        new ReassignAgents(source, target, agents("one", "two"))
+            .DestinationNodeId.ShouldBe(source.NodeId);
+    }
+
+    /*** EXECUTION ***/
+
+    private readonly MockWolverineRuntime theRuntime = new();
+    private readonly NodeDestination theSource = destination("source");
+    private readonly NodeDestination theTarget = destination("target");
+
+    private void sourceConfirmsStopping(params string[] names)
+    {
+        theRuntime.Agents
+            .InvokeAsync<AgentsStopped>(theSource, Arg.Any<IAgentCommand>(), Arg.Any<TimeSpan?>())
+            .Returns(new AgentsStopped(agents(names)));
+    }
+
+    [Fact]
+    public async Task stops_the_batch_on_the_source_with_a_reply_window_scaled_to_the_batch_size()
+    {
+        sourceConfirmsStopping("one", "two", "three");
+
+        var command = new ReassignAgents(theSource, theTarget, agents("one", "two", "three"));
+        await command.ExecuteAsync(theRuntime, CancellationToken.None);
+
+        await theRuntime.Agents.Received().InvokeAsync<AgentsStopped>(
+            theSource,
+            new StopAgents(agents("one", "two", "three")),
+            AgentBatchTimeouts.ReplyWindowFor(3));
+    }
+
+    [Fact]
+    public async Task cascades_one_batched_start_into_the_destinations_lane_when_every_stop_is_confirmed()
+    {
+        sourceConfirmsStopping("one", "two", "three");
+
+        var command = new ReassignAgents(theSource, theTarget, agents("one", "two", "three"));
+        var cascaded = await command.ExecuteAsync(theRuntime, CancellationToken.None);
+
+        cascaded.ShouldHaveSingleItem()
+            .ShouldBe(new AssignAgents(theTarget, agents("one", "two", "three")));
+    }
+
+    [Fact]
+    public async Task only_confirmed_stops_are_followed_by_starts()
+    {
+        // The source let go of two of three inside the reply window. Starting "three" anywhere else while
+        // its old copy may still be running is the two-copies bug, so it stays put for the next evaluation.
+        sourceConfirmsStopping("one", "two");
+
+        var command = new ReassignAgents(theSource, theTarget, agents("one", "two", "three"));
+        var cascaded = await command.ExecuteAsync(theRuntime, CancellationToken.None);
+
+        cascaded.ShouldHaveSingleItem()
+            .ShouldBe(new AssignAgents(theTarget, agents("one", "two")));
+    }
+
+    [Fact]
+    public async Task no_starts_at_all_when_nothing_was_confirmed_stopped()
+    {
+        sourceConfirmsStopping();
+
+        var command = new ReassignAgents(theSource, theTarget, agents("one", "two"));
+        var cascaded = await command.ExecuteAsync(theRuntime, CancellationToken.None);
+
+        cascaded.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task no_starts_when_the_reply_never_came()
+    {
+        // The NSubstitute default — no reply within the window resolves to null rather than throwing here.
+        var command = new ReassignAgents(theSource, theTarget, agents("one", "two"));
+        var cascaded = await command.ExecuteAsync(theRuntime, CancellationToken.None);
+
+        cascaded.ShouldBeEmpty();
+    }
+
+    /*** VALUE EQUALITY — lets the dispatcher recognise re-emitted work; see AgentUriSet ***/
+
+    [Fact]
+    public void equality_is_order_independent_over_the_agents()
+    {
+        var one = new ReassignAgents(theSource, theTarget, agents("a", "b", "c"));
+
+        one.ShouldBe(new ReassignAgents(theSource, theTarget, agents("c", "a", "b")));
+        one.GetHashCode().ShouldBe(new ReassignAgents(theSource, theTarget, agents("c", "a", "b")).GetHashCode());
+    }
+
+    [Fact]
+    public void different_nodes_or_agents_are_different_commands()
+    {
+        var one = new ReassignAgents(theSource, theTarget, agents("a", "b"));
+
+        one.ShouldNotBe(new ReassignAgents(theSource, theTarget, agents("a", "c")));
+        one.ShouldNotBe(new ReassignAgents(destination("other"), theTarget, agents("a", "b")));
+        one.ShouldNotBe(new ReassignAgents(theSource, destination("other"), agents("a", "b")));
+    }
+
+    /*** BATCHING IN THE LEADER'S EVALUATION ***/
+
+    [Fact]
+    public async Task a_rebalance_chunks_reassignments_by_agent_start_batch_size()
+    {
+        var options = new WolverineOptions { ApplicationAssembly = GetType().Assembly };
+        options.Transports.NodeControlEndpoint = new FakeEndpoint("fake://self".ToUri(), EndpointRole.System);
+        options.Durability.DurabilityAgentEnabled = false;
+        options.Durability.AgentStartBatchSize = 2;
+
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Options.Returns(options);
+        runtime.DurabilitySettings.Returns(options.Durability);
+        runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+
+        var family = new FakeAgentFamily("fake"); // 12 known agents
+        var controller = new NodeAgentController(
+            runtime, Substitute.For<INodeAgentPersistence>(), [family],
+            NullLogger<NodeAgentController>.Instance, CancellationToken.None);
+
+        // Node 1 is running everything; node 2 joins empty. DistributeEvenly moves half across — the
+        // rebalance-after-a-deploy shape from GH-3753.
+        var node1 = new WolverineNode
+        {
+            NodeId = options.UniqueNodeId, AssignedNodeNumber = 1, ControlUri = new Uri("fake://self")
+        };
+        node1.Capabilities.AddRange(family.AllAgentUris());
+        node1.ActiveAgents.AddRange(family.AllAgentUris());
+
+        var node2 = new WolverineNode
+        {
+            NodeId = Guid.NewGuid(), AssignedNodeNumber = 2, ControlUri = new Uri("fake://two")
+        };
+        node2.Capabilities.AddRange(family.AllAgentUris());
+
+        var commands = await controller.EvaluateAssignmentsAsync([node1, node2], new AgentRestrictions());
+
+        // Every moved agent travels as a chunked ReassignAgents — never as a pile of individual commands
+        // AgentStartBatchSize cannot touch.
+        commands.OfType<ReassignAgent>().ShouldBeEmpty();
+
+        var batches = commands.OfType<ReassignAgents>().ToArray();
+        batches.ShouldNotBeEmpty();
+        batches.All(x => x.AgentUris.Length <= 2).ShouldBeTrue();
+        batches.All(x => x.OriginalNode.NodeId == node1.NodeId && x.ActiveNode.NodeId == node2.NodeId)
+            .ShouldBeTrue();
+
+        // Half of twelve agents move, each exactly once.
+        var moved = batches.SelectMany(x => x.AgentUris).ToArray();
+        moved.Length.ShouldBe(6);
+        moved.Distinct().Count().ShouldBe(6);
+    }
+
+    /*** THE GH-3748 REPLY WINDOW ***/
+
+    [Fact]
+    public void small_batches_keep_the_second_per_agent_window()
+    {
+        AgentBatchTimeouts.ReplyWindowFor(1).ShouldBe(31.Seconds());
+        AgentBatchTimeouts.ReplyWindowFor(20).ShouldBe(50.Seconds());
+    }
+
+    [Fact]
+    public void batches_past_the_threshold_get_thirty_seconds_per_agent()
+    {
+        // GH-3748: a projection shard behind a version bump was measured at 27s p50 / 215s max per start,
+        // so the old 30s + N window could never be satisfied at any batch size.
+        AgentBatchTimeouts.ReplyWindowFor(21).ShouldBe(660.Seconds());
+        AgentBatchTimeouts.ReplyWindowFor(100).ShouldBe(3030.Seconds());
+    }
+}

--- a/src/Testing/SlowTests/Agents/SlowStartingAgents.cs
+++ b/src/Testing/SlowTests/Agents/SlowStartingAgents.cs
@@ -19,15 +19,41 @@ public class AgentStartTelemetry
     private readonly ConcurrentDictionary<int, int> _startsPerNode = new();
     private int _inFlight;
     private int _peakInFlight;
+    private int _agentCount;
 
     public AgentStartTelemetry(int agentCount, TimeSpan startDelay)
     {
-        AgentCount = agentCount;
+        _agentCount = agentCount;
         StartDelay = startDelay;
     }
 
-    public int AgentCount { get; }
+    public int AgentCount => Volatile.Read(ref _agentCount);
     public TimeSpan StartDelay { get; }
+
+    /// <summary>
+    /// GH-3753: how long an agent takes to let go when stopped. Zero by default. A projection version
+    /// bump puts a stopping shard behind the same side-effect gate as a starting one, and #3749's lane
+    /// wedge only appears when the SOURCE of a reassignment answers its stops slowly — a fast-stopping
+    /// source drains thousands of reassignments without ever blocking anything. Mutable so a test can
+    /// turn slow stops on for its rebalance phase and back off for teardown.
+    /// </summary>
+    public TimeSpan StopDelay { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// GH-3753: expands the known agent universe mid-test. Stands in for the arrival of a new
+    /// generation of agents — the projection-version-bump deploy shape, where freshly-placeable agents
+    /// and reassignments of the old ones are in flight at the same time. Every node's family shares
+    /// this one telemetry instance, so the whole cluster sees the new universe on its next evaluation.
+    /// </summary>
+    public void GrowUniverseTo(int agentCount)
+    {
+        if (agentCount < AgentCount)
+        {
+            throw new ArgumentOutOfRangeException(nameof(agentCount), "The universe only grows");
+        }
+
+        Volatile.Write(ref _agentCount, agentCount);
+    }
 
     /// <summary>
     /// The high-water mark of concurrent <see cref="SlowStartAgent.StartAsync" /> calls anywhere in the
@@ -76,8 +102,16 @@ public class AgentStartTelemetry
         _startsPerNode.AddOrUpdate(nodeNumber, 1, (_, count) => count + 1);
     }
 
-    internal void RecordStop(Uri uri)
+    internal async Task RecordStopAsync(Uri uri, CancellationToken token)
     {
+        var delay = StopDelay;
+        if (delay > TimeSpan.Zero)
+        {
+            // Stand-in for a stopping daemon shard that has to finish letting go of its work — slow for
+            // the same reason its start is slow during a version-bump deploy.
+            await Task.Delay(delay, token);
+        }
+
         _startedOn.TryRemove(uri, out _);
     }
 }
@@ -104,11 +138,10 @@ public class SlowStartAgent : IAgent
         Status = AgentStatus.Running;
     }
 
-    public Task StopAsync(CancellationToken cancellationToken)
+    public async Task StopAsync(CancellationToken cancellationToken)
     {
+        await _telemetry.RecordStopAsync(Uri, cancellationToken);
         Status = AgentStatus.Stopped;
-        _telemetry.RecordStop(Uri);
-        return Task.CompletedTask;
     }
 }
 

--- a/src/Testing/SlowTests/Agents/agent_reassignment_at_scale.cs
+++ b/src/Testing/SlowTests/Agents/agent_reassignment_at_scale.cs
@@ -1,0 +1,260 @@
+using System.Diagnostics;
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace SlowTests.Agents;
+
+/// <summary>
+/// Reproduction harness for GH-3753 / GH-3749: "node assignment is very slow, or never completes, when a
+/// release contains a projection version bump".
+///
+/// <para>The production shape (512 tenant databases, ~6,500 agents, five nodes): a deploy with no version
+/// bump converges in minutes; a deploy WITH one leaves one node holding everything, its peers frozen at
+/// zero, and the total placed count marching BACKWARDS. The mechanism (GH-3749) is that a reassignment
+/// used to run in the DESTINATION node's dispatcher lane while doing a blocking stop round trip against
+/// the SOURCE — and a version bump is exactly what makes the source slow to answer a stop, so a couple of
+/// dozen reassignments at the head of a healthy destination's lane starved the batched fresh starts queued
+/// behind them. Reassignments were also the one command never chunked by AgentStartBatchSize.</para>
+///
+/// <para>This test builds the deploy in miniature: one node running the whole old generation with SLOW
+/// STOPS enabled (the source is busy replaying), then two fresh nodes join at the same moment a new
+/// generation of agents arrives — so reassignments of the old agents and first-time placements of the new
+/// ones are in flight together, which is the combination that separated the broken deploys from the
+/// healthy control.</para>
+/// </summary>
+[Collection("agent_scale")]
+public class agent_reassignment_at_scale : IAsyncLifetime
+{
+    private const string SchemaName = "agent_rescale";
+
+    private const int NodeCount = 3;
+    private const int OldGeneration = 240; // running on node 1 before the "deploy"
+    private const int FullUniverse = 480;  // old + the new generation arriving with the deploy
+
+    private static readonly TimeSpan StartDelay = 250.Milliseconds();
+    private static readonly TimeSpan StopDelay = 2.Seconds();
+
+    private readonly ITestOutputHelper _output;
+    private readonly List<IHost> _hosts = new();
+    private readonly AgentStartTelemetry _telemetry = new(OldGeneration, StartDelay);
+
+    public agent_reassignment_at_scale(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync(SchemaName);
+        await conn.CloseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // The slow stop stands in for a busy source during the test; teardown should not pay it for
+        // hundreds of agents.
+        _telemetry.StopDelay = TimeSpan.Zero;
+
+        foreach (var host in _hosts)
+        {
+            host.GetRuntime().Agents.DisableHealthChecks();
+        }
+
+        _hosts.Reverse();
+        foreach (var host in _hosts)
+        {
+            try
+            {
+                await host.StopAsync();
+                host.Dispose();
+            }
+            catch (Exception e)
+            {
+                _output.WriteLine("Error shutting a host down: " + e);
+            }
+        }
+    }
+
+    private Task<IHost> startHostAsync()
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Balanced;
+
+                opts.Durability.FirstHealthCheckExecution = 5.Seconds();
+                opts.Durability.HealthCheckPollingTime = 2.Seconds();
+                opts.Durability.CheckAssignmentPeriod = 5.Seconds();
+
+                // The shipped defaults, deliberately — the reported cluster's knobs.
+                opts.Durability.AgentStartBatchSize = 50;
+                opts.Durability.MaxAgentStartParallelism = 10;
+
+                opts.Services.AddSingleton<IAgentFamily>(new SlowStartAgentFamily(_telemetry, opts));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, SchemaName);
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task a_version_bump_deploy_converges_and_never_marches_backwards()
+    {
+        // ── Phase 1: the world before the deploy — one node owns the whole old generation. ──
+        _hosts.Add(await startHostAsync());
+
+        var stopwatch = Stopwatch.StartNew();
+        while (true)
+        {
+            var placed = await takeSampleAsync(stopwatch.Elapsed);
+            if (placed.TotalAssigned >= OldGeneration) break;
+
+            stopwatch.Elapsed.ShouldBeLessThan(2.Minutes(),
+                $"node 1 never took the old generation; got to {placed.TotalAssigned} of {OldGeneration}");
+            await Task.Delay(1.Seconds(), TestContext.Current.CancellationToken);
+        }
+
+        _output.WriteLine($"Phase 1: node 1 owns all {OldGeneration} old-generation agents at {stopwatch.Elapsed.TotalSeconds:0}s");
+
+        // ── The deploy: stops become slow (every shard is behind the side-effect gate), a new
+        // generation of agents arrives, and two fresh nodes join. ──
+        _telemetry.StopDelay = StopDelay;
+        _telemetry.GrowUniverseTo(FullUniverse);
+
+        var deployStarted = stopwatch.Elapsed;
+        _hosts.AddRange(await Task.WhenAll(startHostAsync(), startHostAsync()));
+
+        var samples = new List<Sample>();
+        var hardTimeout = deployStarted + 6.Minutes();
+
+        var runningMax = 0;
+        var worstBackslide = 0;
+        TimeSpan? freshNodesCarrying = null;
+        TimeSpan? convergedAt = null;
+
+        while (stopwatch.Elapsed < hardTimeout)
+        {
+            await Task.Delay(1.Seconds(), TestContext.Current.CancellationToken);
+
+            var sample = await takeSampleAsync(stopwatch.Elapsed - deployStarted);
+            samples.Add(sample);
+
+            // The field failure marched backwards: 2,401 → 1,885 over four minutes, because stops kept
+            // landing while the starts that should follow them never ran. A final-count assertion alone
+            // would pass right through that, so track the worst dip below the running maximum.
+            runningMax = Math.Max(runningMax, sample.TotalAssigned);
+            worstBackslide = Math.Max(worstBackslide, runningMax - sample.TotalAssigned);
+
+            // The sharpest #3749 symptom: nodes handed hundreds of fresh placements landed ZERO because
+            // reassignment stops against the busy source sat at the head of their lanes.
+            if (freshNodesCarrying == null && sample.AssignedPerNode.Count(x => x.Key != 1 && x.Value >= 20) >= 2)
+            {
+                freshNodesCarrying = sample.Elapsed;
+            }
+
+            if (sample.TotalAssigned >= FullUniverse)
+            {
+                convergedAt = sample.Elapsed;
+                break;
+            }
+        }
+
+        writeReport(samples, convergedAt, freshNodesCarrying, worstBackslide);
+
+        // The healthy nodes must start receiving and starting their FRESH agents while the busy source is
+        // still slowly answering reassignment stops — not after every reassignment has drained. Pre-fix,
+        // ~40 unbatched reassignments at ~2s+ a stop sat ahead of each fresh node's first chunk, so this
+        // took well over 100 seconds; batched into the source's own lane it takes a handful.
+        freshNodesCarrying.ShouldNotBeNull("the two fresh nodes never carried 20 agents each");
+        freshNodesCarrying.Value.ShouldBeLessThan(60.Seconds());
+
+        // erdtsieck's acceptance criterion for GH-3753, scaled down: after a deploy, every agent assigned
+        // across every node, within minutes. The stop work itself is ~80 moves x 2s serial on the source,
+        // so the floor is ~160s of honest work; pre-fix the same shape does not converge inside the hard
+        // timeout.
+        convergedAt.ShouldNotBeNull($"never converged to {FullUniverse}; hard timeout after 6 minutes");
+        convergedAt.Value.ShouldBeLessThan(4.Minutes());
+
+        // Never worse than one reassignment chunk in flight: a stop may land before its paired start, but
+        // only within the batch being moved. The field failure lost hundreds net.
+        worstBackslide.ShouldBeLessThanOrEqualTo(70);
+
+        // And the end state is an actual spread, not one node holding everything.
+        var final = samples.Last();
+        final.AssignedPerNode.Count.ShouldBe(NodeCount);
+        foreach (var pair in final.AssignedPerNode)
+        {
+            pair.Value.ShouldBeGreaterThan(100);
+        }
+    }
+
+    private record Sample(TimeSpan Elapsed, Dictionary<int, int> AssignedPerNode)
+    {
+        public int TotalAssigned => AssignedPerNode.Values.Sum();
+    }
+
+    private async Task<Sample> takeSampleAsync(TimeSpan elapsed)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        var perNode = new Dictionary<int, int>();
+
+        await using (var cmd = conn.CreateCommand($@"
+select n.node_number, count(a.id)
+from {SchemaName}.wolverine_nodes n
+left join {SchemaName}.wolverine_node_assignments a
+    on a.node_id = n.id and a.id like '{SlowStartAgentFamily.SchemeName}://%'
+group by n.node_number
+order by n.node_number"))
+        {
+            await using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                perNode[reader.GetInt32(0)] = (int)reader.GetInt64(1);
+            }
+        }
+
+        await conn.CloseAsync();
+
+        return new Sample(elapsed, perNode);
+    }
+
+    private void writeReport(List<Sample> samples, TimeSpan? convergedAt, TimeSpan? freshNodesCarrying,
+        int worstBackslide)
+    {
+        _output.WriteLine(
+            $"{OldGeneration} old agents on node 1, universe grown to {FullUniverse} at deploy, {NodeCount} nodes, {StartDelay.TotalMilliseconds}ms per start, {StopDelay.TotalSeconds}s per stop");
+        _output.WriteLine("");
+        _output.WriteLine("elapsed | assigned per node             | total");
+        _output.WriteLine("--------+-------------------------------+------");
+
+        foreach (var sample in samples)
+        {
+            var per = sample.AssignedPerNode.OrderBy(x => x.Key)
+                .Select(x => $"{x.Key}:{x.Value,4}").Join("  ");
+            _output.WriteLine($"{sample.Elapsed.TotalSeconds,6:0}s | {per,-29} | {sample.TotalAssigned,5}");
+        }
+
+        _output.WriteLine("");
+        _output.WriteLine($"Fresh nodes carrying ≥20 each: {(freshNodesCarrying.HasValue ? $"{freshNodesCarrying.Value.TotalSeconds:0.0}s" : "NEVER")}");
+        _output.WriteLine($"Converged at:                  {(convergedAt.HasValue ? $"{convergedAt.Value.TotalSeconds:0.0}s" : "NEVER")}");
+        _output.WriteLine($"Worst backslide:               {worstBackslide} agents below the running max");
+        _output.WriteLine($"Peak concurrent agent starts:  {_telemetry.PeakInFlight}");
+        _output.WriteLine($"Agent starts per node:         {_telemetry.StartsPerNode.OrderBy(x => x.Key).Select(x => $"{x.Key}:{x.Value}").Join("  ")}");
+    }
+}

--- a/src/Wolverine/Runtime/Agents/AgentCommandDispatcher.cs
+++ b/src/Wolverine/Runtime/Agents/AgentCommandDispatcher.cs
@@ -132,8 +132,9 @@ internal class AgentCommandDispatcher : IAsyncDisposable
 
     /// <summary>
     ///     The agents a command would START somewhere. Deliberately only the first-time placements: a
-    ///     <see cref="ReassignAgent" /> also stops the agent on its previous node, so suppressing one because
-    ///     a start is already pending would drop that stop, and the stop commands are not starts at all.
+    ///     <see cref="ReassignAgent" /> or <see cref="ReassignAgents" /> also stops the agents on their
+    ///     previous node, so suppressing one because a start is already pending would drop that stop, and
+    ///     the stop commands are not starts at all.
     /// </summary>
     internal static Uri[] StartedAgentsOf(IAgentCommand command) => command switch
     {
@@ -190,8 +191,8 @@ internal class AgentCommandDispatcher : IAsyncDisposable
                 if (cascaded != null)
                 {
                     // Route a cascade back through Enqueue rather than executing it here, so it lands in the
-                    // lane of the node it actually targets -- e.g. ReassignAgent runs in the new node's lane
-                    // and cascades an AssignAgent for that same node.
+                    // lane of the node it actually targets -- e.g. ReassignAgent runs in the source node's
+                    // lane (GH-3749) and cascades an AssignAgent that belongs in the destination's lane.
                     foreach (var next in cascaded) Enqueue(next);
                 }
             }

--- a/src/Wolverine/Runtime/Agents/AgentCommandDrain.cs
+++ b/src/Wolverine/Runtime/Agents/AgentCommandDrain.cs
@@ -46,8 +46,8 @@ internal class AgentCommandDrain
             // Cascaded commands are deferred to the next round rather than appended to the lane that
             // produced them. That keeps the "a cascade runs after its producer" ordering the serial drain
             // had, and re-partitions them against the destinations of the round they actually belong to --
-            // e.g. ReassignAgent runs in the new node's lane and cascades an AssignAgent that is then
-            // re-keyed onto that same lane next round.
+            // e.g. ReassignAgent runs in the source node's lane (GH-3749) and cascades an AssignAgent that
+            // is keyed onto the destination's lane next round.
             var round = commands.ToArray();
             commands.Clear();
 

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.Agent.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.Agent.cs
@@ -120,10 +120,9 @@ public partial class AssignmentGrid
 
                     // Being moved before the first start was confirmed. Stop-then-start, sequenced through
                     // the pending node's lane, so whichever of the two nodes ends up with it, only one does.
-                    command = new ReassignAgent(Uri, PendingNode.ToDestination(), AssignedNode.ToDestination())
-                    {
-                        StopInSourceLane = true
-                    };
+                    // ReassignAgent always runs in its source's lane (GH-3749), which is exactly the ordering
+                    // this case needs: the stop queues behind the start it is cancelling.
+                    command = new ReassignAgent(Uri, PendingNode.ToDestination(), AssignedNode.ToDestination());
                     return true;
                 }
 

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.EvaluateAssignments.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.EvaluateAssignments.cs
@@ -332,5 +332,23 @@ public partial class NodeAgentController
 
             commands.Add(stopAgents);
         }
+
+        // GH-3749: reassignment was the one command type never batched, so a rebalance moving thousands of
+        // agents emitted thousands of individual ReassignAgent commands -- each a serial StopAgent round
+        // trip against the source inside one lane, with AgentStartBatchSize having no effect on any of them.
+        // Chunked like the starts: one chunk's stops per round trip, and the confirmed remainder cascades as
+        // a single AssignAgents into the destination's lane.
+        foreach (var group in commands.OfType<ReassignAgent>()
+                     .GroupBy(x => (x.OriginalNode, x.ActiveNode))
+                     .Where(x => x.Count() > 1)
+                     .ToArray())
+        {
+            foreach (var message in group) commands.Remove(message);
+
+            foreach (var chunk in group.Select(x => x.AgentUri).Chunk(batchSize))
+            {
+                commands.Add(new ReassignAgents(group.Key.OriginalNode, group.Key.ActiveNode, chunk));
+            }
+        }
     }
 }

--- a/src/Wolverine/Runtime/Agents/ReassignAgent.cs
+++ b/src/Wolverine/Runtime/Agents/ReassignAgent.cs
@@ -1,25 +1,19 @@
-using System.Text;
+using JasperFx.Core;
 using Microsoft.Extensions.Logging;
 
 namespace Wolverine.Runtime.Agents;
 
 internal record ReassignAgent(Uri AgentUri, NodeDestination OriginalNode, NodeDestination ActiveNode) : IAgentCommand
 {
-    /// <summary>
-    ///     GH-3698. Run the stop half in <see cref="OriginalNode" />'s lane rather than
-    ///     <see cref="ActiveNode" />'s. Set when the agent is being taken off a node that may not have
-    ///     <i>started</i> it yet — a dispatch the leader has sent but not seen confirmed. The stop then queues
-    ///     behind that still-pending start instead of racing ahead of it and finding nothing to stop, which
-    ///     would leave the agent coming up on both nodes.
-    /// </summary>
-    internal bool StopInSourceLane { get; init; }
-
-    // Two nodes are involved, but only the stop half runs inline here -- the start is cascaded back to the
-    // drain as a separate AssignAgent, which lands in ActiveNode's lane on the next round. Keying the whole
-    // command to ActiveNode keeps a reassignment behind any other work already queued for the node that is
-    // about to take the agent; keying it to OriginalNode instead orders it behind that node's own queue,
-    // which is what matters when the agent might still be starting there.
-    public Guid? DestinationNodeId => StopInSourceLane ? OriginalNode.NodeId : ActiveNode.NodeId;
+    // GH-3749: keyed to the SOURCE node. The only blocking work this command does inline is the stop round
+    // trip against OriginalNode, and the lanes exist precisely so that a node slow (or dead) on the wire
+    // wedges nothing but its own queue -- keyed to ActiveNode, a source mid-replay froze every batched
+    // AssignAgents chunk queued behind it for a perfectly healthy destination. The start half is cascaded
+    // as an AssignAgent, which the dispatcher routes into ActiveNode's own lane, so it still queues behind
+    // whatever work the destination already has. That ordering also covers the GH-3698 re-target of a
+    // dispatched-but-unconfirmed start: the stop runs in the lane where that start may still be queued,
+    // behind it, instead of racing ahead and finding nothing to stop.
+    public Guid? DestinationNodeId => OriginalNode.NodeId;
 
     public async Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
     {
@@ -40,5 +34,88 @@ internal record ReassignAgent(Uri AgentUri, NodeDestination OriginalNode, NodeDe
 
         // Do this in separate steps
         return [new AssignAgent(AgentUri, ActiveNode)];
+    }
+}
+
+/// <summary>
+///     GH-3749: the batched form of <see cref="ReassignAgent" />, produced by
+///     <c>NodeAgentController.batchCommands</c> for a group of agents all moving between the same two nodes,
+///     chunked by <c>AgentStartBatchSize</c>. Reassignment was the one command type never batched: a
+///     rebalance emitted one <see cref="ReassignAgent" /> per moved agent, each costing its own serial
+///     <see cref="StopAgent" /> round trip against the source inside one lane, and
+///     <c>AgentStartBatchSize</c> had no effect on any of them.
+/// </summary>
+internal record ReassignAgents(NodeDestination OriginalNode, NodeDestination ActiveNode, Uri[] AgentUris)
+    : IAgentCommand
+{
+    // Source lane, for the same reason as ReassignAgent: the inline round trip is the stop against
+    // OriginalNode, and the cascaded starts land in ActiveNode's lane on their own.
+    public Guid? DestinationNodeId => OriginalNode.NodeId;
+
+    public async Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
+    {
+        var timeout = AgentBatchTimeouts.ReplyWindowFor(AgentUris.Length);
+        var response =
+            await runtime.Agents.InvokeAsync<AgentsStopped>(OriginalNode, new StopAgents(AgentUris), timeout);
+
+        if (response == null)
+        {
+            return AgentCommands.Empty;
+        }
+
+        var confirmed = response.AgentUris ?? [];
+        var unconfirmed = AgentUriSet.Missing(AgentUris, confirmed);
+
+        if (unconfirmed.Length > 0)
+        {
+            // Only a CONFIRMED stop may be followed by a start elsewhere -- starting an agent whose old
+            // copy may still be running is the two-copies bug the GH-3698 wave stamped out. The stragglers
+            // stay where they are and the leader re-decides them on a later evaluation.
+            runtime.Logger.LogWarning(
+                "Node {OriginalNode} confirmed stopping {ConfirmedCount} of {RequestedCount} agents being reassigned to node {ActiveNode}; {UnconfirmedCount} remain unconfirmed and will be re-evaluated: {UnconfirmedAgents}",
+                OriginalNode.NodeId, confirmed.Length, AgentUris.Length, ActiveNode.NodeId, unconfirmed.Length,
+                unconfirmed);
+        }
+
+        if (confirmed.Length == 0)
+        {
+            return AgentCommands.Empty;
+        }
+
+        return [new AssignAgents(ActiveNode, confirmed)];
+    }
+
+    // See AgentUriSet: value equality over the agents, independent of their order, so the dispatcher can
+    // recognise the same reassignment work re-emitted by a later evaluation.
+    public virtual bool Equals(ReassignAgents? other)
+        => other is not null && OriginalNode == other.OriginalNode && ActiveNode == other.ActiveNode
+                             && AgentUriSet.AreEquivalent(AgentUris, other.AgentUris);
+
+    public override int GetHashCode() => HashCode.Combine(OriginalNode, ActiveNode, AgentUriSet.HashOf(AgentUris));
+}
+
+/// <summary>
+///     GH-3748: the request/reply window for every batched agent command, scaled to the batch size.
+///
+///     <para>The old shape gave a chunk <c>30s + 1s per agent</c> (starts) or a flat default (stops), which
+///     assumes an agent starts or stops in about a second. A Marten projection shard behind a version bump
+///     replays synchronously inside its start (jasperfx#480's side-effect gate) and was measured at 27s p50 /
+///     82s p95 / 215s max per shard — so no achievable batch size satisfied the window and every chunk timed
+///     out (15 of 17 at <c>AgentStartBatchSize = 100</c>). Past <see cref="SlowWorkThreshold" /> agents the
+///     per-agent allowance is 30 seconds instead.</para>
+///
+///     <para>The window is a backstop, not a pace-setter: the reply arrives as soon as the batch has actually
+///     been worked through, and a partial confirmation (GH-3750) reports whatever made it. All the window
+///     decides is when to give up and let the leader re-decide, so a generous window costs little and a tight
+///     one is a cluster that can never converge.</para>
+/// </summary>
+internal static class AgentBatchTimeouts
+{
+    internal const int SlowWorkThreshold = 20;
+
+    public static TimeSpan ReplyWindowFor(int agentCount)
+    {
+        var perAgentSeconds = agentCount > SlowWorkThreshold ? 30 : 1;
+        return 30.Seconds() + (agentCount * perAgentSeconds).Seconds();
     }
 }

--- a/src/Wolverine/Runtime/Agents/StartAgents.cs
+++ b/src/Wolverine/Runtime/Agents/StartAgents.cs
@@ -182,10 +182,11 @@ internal record AssignAgents(NodeDestination Destination, Uri[] AgentIds) : IAge
     {
         var startAgents = new StartAgents(AgentIds);
 
-        // GH-3604 / D3: scale the reply timeout with the chunk size as a backstop. The receiving node starts
-        // the batch with bounded parallelism, so the reply normally arrives quickly, but a large chunk of
-        // slow daemon-agent starts must not be cut off by the default fixed request/reply window.
-        var timeout = 30.Seconds() + AgentIds.Length.Seconds();
+        // GH-3604 / D3, rescaled by GH-3748: scale the reply timeout with the chunk size as a backstop. The
+        // receiving node starts the batch with bounded parallelism, so the reply normally arrives quickly,
+        // but a large chunk of slow daemon-agent starts must not be cut off by the reply window. See
+        // AgentBatchTimeouts for why big chunks get a much larger per-agent allowance.
+        var timeout = AgentBatchTimeouts.ReplyWindowFor(AgentIds.Length);
         var response = await runtime.Agents.InvokeAsync<AgentsStarted>(Destination, startAgents, timeout);
 
         if (response == null)
@@ -233,7 +234,12 @@ internal record StopRemoteAgents(NodeDestination Destination, Uri[] AgentIds) : 
         CancellationToken cancellationToken)
     {
         var startAgents = new StopAgents(AgentIds);
-        await runtime.Agents.InvokeAsync<AgentsStopped>(Destination, startAgents);
+
+        // GH-3748: this used to ride the flat default reply window no matter how many agents were in the
+        // batch, and a stop can be as slow as a start (a projection shard mid-replay has to let go of its
+        // work). Same scaled backstop as AssignAgents.
+        var timeout = AgentBatchTimeouts.ReplyWindowFor(AgentIds.Length);
+        await runtime.Agents.InvokeAsync<AgentsStopped>(Destination, startAgents, timeout);
 
         return AgentCommands.Empty;
     }


### PR DESCRIPTION
Closes #3749. Mitigates #3748 (root ack-decoupling stays open — see below). Part of the #3753 campaign.

## What changed

**GH-3749 defect 1 — wrong lane.** `ReassignAgent` ran in the **destination** node's dispatcher lane while doing its blocking `StopAgent` round trip against the **source**. Lanes are strictly serial, so a source that was merely busy (every stop slow behind the projection-version-bump side-effect gate) froze every batched `AssignAgents` chunk queued for a perfectly healthy destination — the field measurement was 22 reassignments starving 1,290 placements on an idle node. `ReassignAgent.DestinationNodeId` is now `OriginalNode.NodeId`, so a slow or dead source wedges nothing but its own lane, restoring the invariant `AgentCommandDispatcher`'s doc comment claims. The start half already cascades through `Enqueue` into the destination's own lane, so it still orders behind that node's queued work — which also covers the GH-3698 pending re-target case, so the narrow `StopInSourceLane` flag is gone.

**GH-3749 defect 2 — never batched.** Reassignment was the one command type `batchCommands` never chunked; a rebalance emitted thousands of individual stop round trips and `AgentStartBatchSize` had no effect on any of them (reporter verified at 50, 100, 400, 1500). New `ReassignAgents` batches all agents moving between the same two nodes, chunked by `AgentStartBatchSize`: one `StopAgents` round trip, then one `AssignAgents` cascade for exactly the **confirmed-stopped** subset — an unconfirmed stop is never followed by a start elsewhere, preserving the GH-3698 single-copy invariant. Unconfirmed stragglers are re-decided by a later evaluation.

**GH-3748 mitigation — per Jeremy: every batched reply window, 30s/agent past 20 agents.** Shared `AgentBatchTimeouts.ReplyWindowFor(n)` (`30s + n×1s` up to 20 agents, `30s + n×30s` beyond) now backs `AssignAgents`, `StopRemoteAgents` (previously a flat 30s default at any batch size), and `ReassignAgents`. The old 1s-per-agent assumption is off by 1–2 orders of magnitude for a Marten shard behind a version bump (27s p50 / 215s max measured), so no batch size could ever satisfy the old window. **Not the root fix**: acknowledgements still wait for the work itself, and the single-agent 60s ack window (`WolverineRuntime.Agents.cs`) is untouched because the >20-agents condition can't apply to it — so #3748 should stay open for ack/work decoupling.

## Evidence — new SlowTests harness (`agent_reassignment_at_scale`)

Miniature of the reported deploy: one node owning 240 old-generation agents with **2s stops** (busy source), then a version-bump deploy — universe grows to 480 and two fresh nodes join, so reassignments and first-time placements are in flight together. Same knobs as the reported cluster (batch 50, parallelism 10).

| metric | main @ 4d05fbd8a (unfixed) | this branch |
|---|---|---|
| both fresh nodes carrying agents | 163.1s — **one node at 0 for ~2.5 min** while peers sat full | **2.7s** |
| full convergence (480 agents / 3 nodes) | 246.3s | **102.9s** |
| worst backwards march of placed count | **76** agents (323→321 visible in samples) | **3** |
| peak concurrent starts, cluster-wide | **10** — pinned at ONE node's `MaxAgentStartParallelism` | 20 |

The unfixed run reproduces every headline symptom of #3753: a node handed hundreds of placements holding zero, the total marching backwards, and cluster-wide start concurrency capped at a single node. The test **fails on main and passes here** (verified both ways), and the pre-existing GH-3698 `agent_assignment_at_scale` harness still passes.

⚠️ Note: **SlowTests is compiled by `wolverine.slnx` but not run by any CI workflow or Nuke target** — both scale harnesses are locally-run. The 261 CoreTests agent tests (11 new: lane keying, confirmed-subset cascade, value equality, chunking through `EvaluateAssignmentsAsync`, reply-window arithmetic) do run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eR4GL278688VhyhrGcttJ