### PR TITLE
System traffic no longer counts as application message metrics (CritterWatch GH-907)

### DIFF
--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -921,6 +921,15 @@ will be added back to Wolverine in 4.0.
 | wolverine-outbox-count       | Observable Gauge                                                                                          | Current number of persisted outgoing (outbox) messages. Tagged by `source` and `database`                                                                                                                                                                                              |
 | wolverine-scheduled-count    | Observable Gauge                                                                                          | Current number of persisted scheduled messages. Tagged by `source` and `database`                                                                                                                                                                                                      |
 
+::: tip System traffic is not counted <Badge type="tip" text="6.25" />
+Wolverine's own internal traffic — node agent commands on the control queues, acknowledgements, and
+CritterWatch monitoring messages — is excluded from all of the message-level instruments above, as is any
+endpoint marked with the `System` role or with `TelemetryEnabled = false`. An idle application therefore
+reports zero message volume even when Wolverine's node coordination or CritterWatch monitoring is busy
+underneath. Before 6.25 this internal chatter was counted, which could show up as a steady, phantom
+message rate (~150/minute was reported) on an otherwise quiet system.
+:::
+
 ### Standard Metrics Tags
 
 Every Wolverine metric instrument above is tagged with these dimensions so you can slice the series in your

--- a/src/Testing/CoreTests/Runtime/system_traffic_metrics_silencing.cs
+++ b/src/Testing/CoreTests/Runtime/system_traffic_metrics_silencing.cs
@@ -1,0 +1,194 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using CoreTests.Transports;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Wolverine.Runtime.Handlers;
+using Wolverine.Transports.Tcp;
+using Xunit;
+
+namespace CoreTests.Runtime;
+
+/// <summary>
+/// CritterWatch GH-907: a monitoring tool must not measurably inflate the thing it is monitoring. An idle
+/// Wolverine app with CritterWatch applied reported ~150 messages/minute of nothing but its own agent
+/// commands and monitoring traffic, because (a) the meter counters were unconditional, (b) the accumulator
+/// guard was a string match that knew nothing of control endpoints, and (c) only IAgentCommand — not the
+/// full system-message surface — was excluded from the CritterWatch publishing trackers. The fix resolves a
+/// metrics-silent tracker ONCE at each construction site (endpoint agents, pipelines, executors); these
+/// tests pin that selection and the resulting meter silence.
+/// </summary>
+public class system_traffic_metrics_silencing : IAsyncLifetime
+{
+    private const string TheServiceName = "system-traffic-silencing";
+
+    private IHost _host = null!;
+    private WolverineRuntime _runtime = null!;
+    private MeterListener _listener = null!;
+    private readonly ConcurrentDictionary<string, int> _counts = new();
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = TheServiceName;
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<SilencingProbeHandler>();
+            }).StartAsync();
+
+        _runtime = (WolverineRuntime)_host.Services.GetService(typeof(IWolverineRuntime))!;
+
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == "Wolverine:" + TheServiceName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        _listener.SetMeasurementEventCallback<int>((inst, _, _, _) => record(inst));
+        _listener.SetMeasurementEventCallback<long>((inst, _, _, _) => record(inst));
+        _listener.SetMeasurementEventCallback<double>((inst, _, _, _) => record(inst));
+        _listener.Start();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _listener.Dispose();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private void record(Instrument instrument)
+    {
+        _counts.AddOrUpdate(instrument.Name, 1, (_, count) => count + 1);
+    }
+
+    private static Endpoint appEndpoint()
+        => new FakeEndpoint("fake://app".ToUri(), EndpointRole.Application);
+
+    private static Endpoint systemEndpoint()
+        => new FakeEndpoint("fake://control".ToUri(), EndpointRole.System);
+
+    private Envelope envelopeFor(object message) => new()
+    {
+        Message = message,
+        Destination = "fake://somewhere".ToUri(),
+        MessageType = message.GetType().FullName
+    };
+
+    /*** TRACKER SELECTION — decided once at construction, never per envelope ***/
+
+    [Fact]
+    public void system_role_endpoints_get_the_metrics_silent_tracker()
+    {
+        _runtime.MessageTrackingFor(systemEndpoint())
+            .ShouldBeOfType<WolverineRuntime.SystemTrafficMessageTracker>();
+    }
+
+    [Fact]
+    public void telemetry_disabled_endpoints_get_the_metrics_silent_tracker()
+    {
+        var endpoint = appEndpoint();
+        endpoint.TelemetryEnabled = false;
+
+        _runtime.MessageTrackingFor(endpoint)
+            .ShouldBeOfType<WolverineRuntime.SystemTrafficMessageTracker>();
+    }
+
+    [Fact]
+    public void application_endpoints_keep_the_standard_tracker()
+    {
+        _runtime.MessageTrackingFor(appEndpoint()).ShouldBeSameAs(_runtime.MessageTracking);
+    }
+
+    [Fact]
+    public void agent_commands_execute_metrics_silent_even_on_an_application_endpoint()
+    {
+        // The message-type half of the gate: an agent command handled on ANY endpoint is system traffic.
+        var executor = ((IExecutorFactory)_runtime).BuildFor(typeof(CheckAgentHealth), appEndpoint());
+
+        executor.ShouldBeOfType<Executor>().Tracker
+            .ShouldBeOfType<WolverineRuntime.SystemTrafficMessageTracker>();
+    }
+
+    [Fact]
+    public void agent_commands_invoked_through_the_runtime_pipeline_are_metrics_silent()
+    {
+        var executor = ((IExecutorFactory)_runtime).BuildFor(typeof(CheckAgentHealth));
+
+        executor.ShouldBeOfType<Executor>().Tracker
+            .ShouldBeOfType<WolverineRuntime.SystemTrafficMessageTracker>();
+    }
+
+    [Fact]
+    public void application_messages_on_application_endpoints_keep_metrics()
+    {
+        var executor = ((IExecutorFactory)_runtime).BuildFor(typeof(SilencingProbeMessage), appEndpoint());
+
+        executor.ShouldBeOfType<Executor>().Tracker.ShouldBeSameAs(_runtime.MessageTracking);
+    }
+
+    [Fact]
+    public void promoting_an_endpoint_to_node_control_duty_marks_it_as_system()
+    {
+        // UseTcpForControlEndpoint promotes a plain TCP endpoint; before GH-907 it stayed
+        // Application-role and its agent-command traffic was counted as application volume.
+        var options = new WolverineOptions();
+        var endpoint = new TcpEndpoint(577);
+        endpoint.Role.ShouldBe(EndpointRole.Application);
+
+        options.Transports.NodeControlEndpoint = endpoint;
+
+        endpoint.Role.ShouldBe(EndpointRole.System);
+    }
+
+    /*** METER BEHAVIOR — the silent tracker records nothing, the standard one records ***/
+
+    [Fact]
+    public void the_silent_tracker_reaches_no_meter_instrument()
+    {
+        _counts.Clear();
+        var tracker = _runtime.MessageTrackingFor(systemEndpoint());
+        var envelope = envelopeFor(new CheckAgentHealth());
+
+        tracker.Sent(envelope);
+        tracker.Received(envelope);
+        tracker.ExecutionStarted(envelope);
+        tracker.ExecutionFinished(envelope);
+        tracker.MessageSucceeded(envelope);
+        tracker.MessageFailed(envelope, new InvalidOperationException("boom"));
+
+        _listener.RecordObservableInstruments();
+        _counts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void the_standard_tracker_still_records()
+    {
+        _counts.Clear();
+        var envelope = envelopeFor(new SilencingProbeMessage());
+
+        _runtime.MessageTracking.Sent(envelope);
+
+        _counts.ContainsKey(MetricsConstants.MessagesSent).ShouldBeTrue();
+    }
+}
+
+public record SilencingProbeMessage;
+
+public class SilencingProbeHandler
+{
+    public void Handle(SilencingProbeMessage _)
+    {
+    }
+}

--- a/src/Wolverine/Configuration/EndpointCollection.cs
+++ b/src/Wolverine/Configuration/EndpointCollection.cs
@@ -453,17 +453,17 @@ public class EndpointCollection : IEndpointCollection
                     : _runtime.Storage.Outbox;
 
                 return new DurableSendingAgent(sender, _options.Durability,
-                    _runtime.LoggerFactory.CreateLogger<DurableSendingAgent>(), _runtime.MessageTracking,
+                    _runtime.LoggerFactory.CreateLogger<DurableSendingAgent>(), _runtime.MessageTrackingFor(endpoint),
                     outbox, endpoint, _runtime, sendingPolicies);
 
             case EndpointMode.BufferedInMemory:
                 return new BufferedSendingAgent(_runtime.LoggerFactory.CreateLogger<BufferedSendingAgent>(),
-                    _runtime.MessageTracking, sender, _runtime.DurabilitySettings,
+                    _runtime.MessageTrackingFor(endpoint), sender, _runtime.DurabilitySettings,
                     endpoint, _runtime, sendingPolicies);
 
             case EndpointMode.Inline:
                 return new InlineSendingAgent(_runtime.LoggerFactory.CreateLogger<InlineSendingAgent>(), sender,
-                    endpoint, _runtime.MessageTracking,
+                    endpoint, _runtime.MessageTrackingFor(endpoint),
                     _runtime.DurabilitySettings, _runtime, sendingPolicies);
         }
 

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -45,7 +45,9 @@ public class HandlerPipeline : IHandlerPipeline
         _contextPool = runtime.ExecutionPool;
         _cancellation = runtime.Cancellation;
 
-        Logger = runtime.MessageTracking;
+        // CritterWatch GH-907: a system endpoint's received traffic never reaches the meters or the
+        // CritterWatch accumulator. Resolved once here, not per envelope.
+        Logger = runtime.MessageTrackingFor(endpoint);
 
         _executors = new LightweightCache<Type, IExecutor>(type => executorFactory.BuildFor(type, endpoint));
     }

--- a/src/Wolverine/Runtime/Handlers/Executor.cs
+++ b/src/Wolverine/Runtime/Handlers/Executor.cs
@@ -57,6 +57,12 @@ internal class Executor : IExecutor
     private readonly IMessageTracker _tracker;
     private readonly IWolverineRuntime? _runtime;
 
+    /// <summary>
+    ///     The tracker this executor reports to. Exposed for tests asserting which traffic is
+    ///     metrics-silent (CritterWatch GH-907).
+    /// </summary>
+    internal IMessageTracker Tracker => _tracker;
+
     public Executor(ObjectPool<MessageContext> contextPool, IWolverineRuntime runtime, IMessageHandler handler,
         FailureRuleCollection rules, TimeSpan timeout)
         : this(contextPool, runtime.LoggerFactory.CreateLogger(handler.MessageType), handler, runtime.MessageTracking, rules, timeout)

--- a/src/Wolverine/Runtime/Wolverine.ExecutorFactory.cs
+++ b/src/Wolverine/Runtime/Wolverine.ExecutorFactory.cs
@@ -1,5 +1,6 @@
 ﻿using JasperFx.Core.Reflection;
 using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
 using Wolverine.Logging;
 using Wolverine.Runtime.Agents;
 using Wolverine.Runtime.Handlers;
@@ -13,6 +14,18 @@ public partial class WolverineRuntime : IExecutorFactory
 {
     IExecutor IExecutorFactory.BuildFor(Type messageType)
     {
+        // CritterWatch GH-907: system message types (agent commands, acknowledgements, CritterWatch
+        // monitoring traffic) invoked through the runtime-level pipeline must not record execution
+        // metrics. Decided here, once per message type, never per envelope.
+        if (messageType.IsSystemMessageType())
+        {
+            var handler = Handlers.HandlerFor(messageType);
+            if (handler != null)
+            {
+                return Executor.Build(this, ExecutionPool, Handlers, handler, SystemTraffic);
+            }
+        }
+
         var executor = Executor.Build(this, ExecutionPool, Handlers, messageType);
 
         return executor;
@@ -45,23 +58,42 @@ public partial class WolverineRuntime : IExecutorFactory
             }
         }
 
-        IMessageTracker tracker = this;
-        if (!messageType.CanBeCastTo<IAgentCommand>() && Options.Metrics.Mode == WolverineMetricsMode.CritterWatch)
-        {
-            var accumulator = MetricsAccumulator.FindAccumulator(messageType.ToMessageTypeName(), endpoint);
-            tracker = new DirectMetricsPublishingMessageTracker(this, accumulator.EntryPoint);
-        }
-        else if (!messageType.CanBeCastTo<IAgentCommand>() && Options.Metrics.Mode == WolverineMetricsMode.Hybrid)
-        {
-            var accumulator = MetricsAccumulator.FindAccumulator(messageType.ToMessageTypeName(), endpoint);
-            tracker = new HybridMetricsPublishingMessageTracker(this, accumulator.EntryPoint);
-        }
+        var tracker = trackerFor(messageType, endpoint);
 
         var executor = handler == null
             ? new NoHandlerExecutor(messageType, this)
             : Executor.Build(this, ExecutionPool, Handlers, handler, tracker);
 
         return executor;
+    }
+
+    // CritterWatch GH-907: pick each executor's tracker ONCE at construction. System traffic — a system
+    // message type (agent commands, acks, CritterWatch monitoring messages), a system-role endpoint (node
+    // control queues, internal local queues), or an endpoint with telemetry deliberately switched off —
+    // gets the metrics-silent tracker, in EVERY metrics mode. This used to exclude only IAgentCommand and
+    // only from the two CritterWatch-publishing modes, so agent commands still hit the OTel meters in the
+    // default mode and CritterWatch's own monitoring messages were counted (and re-published) as
+    // application volume — the feedback loop behind an idle app reporting hundreds of messages a minute.
+    private IMessageTracker trackerFor(Type messageType, Endpoint endpoint)
+    {
+        if (messageType.IsSystemMessageType() || endpoint.Role == EndpointRole.System || !endpoint.TelemetryEnabled)
+        {
+            return SystemTraffic;
+        }
+
+        if (Options.Metrics.Mode == WolverineMetricsMode.CritterWatch)
+        {
+            var accumulator = MetricsAccumulator.FindAccumulator(messageType.ToMessageTypeName(), endpoint);
+            return new DirectMetricsPublishingMessageTracker(this, accumulator.EntryPoint);
+        }
+
+        if (Options.Metrics.Mode == WolverineMetricsMode.Hybrid)
+        {
+            var accumulator = MetricsAccumulator.FindAccumulator(messageType.ToMessageTypeName(), endpoint);
+            return new HybridMetricsPublishingMessageTracker(this, accumulator.EntryPoint);
+        }
+
+        return this;
     }
 
     /// <summary>

--- a/src/Wolverine/Runtime/WolverineRuntime.SystemTraffic.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.SystemTraffic.cs
@@ -1,0 +1,150 @@
+using Wolverine.Configuration;
+using Wolverine.Logging;
+using Wolverine.Tracking;
+
+namespace Wolverine.Runtime;
+
+public partial class WolverineRuntime
+{
+    /// <summary>
+    ///     The single metrics-silent tracker instance handed to every construction site that carries
+    ///     system traffic. See <see cref="SystemTrafficMessageTracker" />.
+    /// </summary>
+    internal IMessageTracker SystemTraffic => _systemTraffic ??= new SystemTrafficMessageTracker(this);
+
+    private SystemTrafficMessageTracker? _systemTraffic;
+
+    /// <summary>
+    ///     The message tracker a sending agent, local queue, or listening pipeline for this endpoint
+    ///     should use — resolved ONCE at construction, never per envelope. System endpoints (node control
+    ///     queues, reply queues, the internal local queues) and endpoints whose telemetry is deliberately
+    ///     switched off get the metrics-silent tracker, so their traffic never reaches the meters or the
+    ///     CritterWatch accumulator. CritterWatch GH-907: a monitoring tool must not measurably inflate
+    ///     the thing it is monitoring, and an idle app was reporting hundreds of messages a minute of
+    ///     nothing but its own control-queue and monitoring traffic.
+    /// </summary>
+    internal IMessageTracker MessageTrackingFor(Endpoint endpoint)
+    {
+        return endpoint.Role == EndpointRole.System || !endpoint.TelemetryEnabled
+            ? SystemTraffic
+            : MessageTracking;
+    }
+
+    /// <summary>
+    ///     CritterWatch GH-907. An <see cref="IMessageTracker" /> for Wolverine's own internal traffic —
+    ///     agent commands on the node control queues, acknowledgements, CritterWatch monitoring messages —
+    ///     that keeps the debug logging, tracked-session bookkeeping, and wire taps of the standard
+    ///     tracker while emitting <b>no metrics</b>: no meter counters or histograms, and nothing into the
+    ///     CritterWatch accumulator (which would otherwise publish the system's own noise back to the
+    ///     console as apparent application volume — a feedback loop, since those publishes are themselves
+    ///     messages that get counted).
+    ///
+    ///     <para>Deliberately a separate tracker resolved once at construction time (per endpoint, per
+    ///     executor) rather than an if-test inside the counting methods: Wolverine keeps per-envelope
+    ///     branching out of the hot path, the same way <c>InlineSendingAgent</c> picks
+    ///     <c>sendWithTracing</c> vs <c>sendWithOutTracing</c> up front.</para>
+    /// </summary>
+    internal class SystemTrafficMessageTracker : IMessageTracker
+    {
+        private readonly WolverineRuntime _runtime;
+
+        public SystemTrafficMessageTracker(WolverineRuntime runtime)
+        {
+            _runtime = runtime;
+        }
+
+        public void Sent(Envelope envelope)
+        {
+            _runtime.ActiveSession?.MaybeRecord(MessageEventType.Sent, envelope, _runtime._serviceName,
+                _runtime._uniqueNodeId);
+            _sent(_runtime.Logger, envelope.CorrelationId!, envelope.GetMessageTypeName(), envelope.Id,
+                envelope.Destination?.ToString() ?? string.Empty, null);
+
+            _runtime.fireWireTapSuccess(envelope);
+        }
+
+        public void Received(Envelope envelope)
+        {
+            _runtime.ActiveSession?.Record(MessageEventType.Received, envelope, _runtime._serviceName,
+                _runtime._uniqueNodeId);
+            _received(_runtime.Logger, envelope.CorrelationId!, envelope.GetMessageTypeName(), envelope.Id,
+                envelope.Destination?.ToString() ?? string.Empty,
+                envelope.ReplyUri?.ToString() ?? string.Empty, null);
+        }
+
+        public void ExecutionStarted(Envelope envelope)
+        {
+            _runtime.ExecutionStarted(envelope);
+        }
+
+        public void ExecutionFinished(Envelope envelope)
+        {
+            // Still stop the timing so the envelope's state stays symmetric with ExecutionStarted;
+            // the measurement is simply not recorded anywhere.
+            envelope.StopTiming();
+            _runtime.ActiveSession?.Record(MessageEventType.ExecutionFinished, envelope, _runtime._serviceName,
+                _runtime._uniqueNodeId);
+        }
+
+        public void ExecutionFinished(Envelope envelope, Exception exception)
+        {
+            ExecutionFinished(envelope);
+        }
+
+        public void MessageSucceeded(Envelope envelope)
+        {
+            _runtime.ActiveSession?.Record(MessageEventType.MessageSucceeded, envelope, _runtime._serviceName,
+                _runtime._uniqueNodeId);
+
+            _runtime.fireWireTapSuccess(envelope);
+        }
+
+        public void MessageFailed(Envelope envelope, Exception ex)
+        {
+            // The base tracker records this with MessageEventType.Sent as well — see
+            // WolverineRuntime.MessageFailed
+            _runtime.ActiveSession?.Record(MessageEventType.Sent, envelope, _runtime._serviceName,
+                _runtime._uniqueNodeId, ex);
+
+            _runtime.fireWireTapFailure(envelope, ex);
+        }
+
+        public void NoHandlerFor(Envelope envelope)
+        {
+            _runtime.NoHandlerFor(envelope);
+        }
+
+        public void NoRoutesFor(Envelope envelope)
+        {
+            _runtime.NoRoutesFor(envelope);
+        }
+
+        public void MovedToErrorQueue(Envelope envelope, Exception ex)
+        {
+            _runtime.ActiveSession?.Record(MessageEventType.MovedToErrorQueue, envelope, _runtime._serviceName,
+                _runtime._uniqueNodeId);
+            _movedToErrorQueue(_runtime.Logger, envelope, ex);
+        }
+
+        public void DiscardedEnvelope(Envelope envelope)
+        {
+            _runtime.DiscardedEnvelope(envelope);
+        }
+
+        public void Requeued(Envelope envelope)
+        {
+            _runtime.Requeued(envelope);
+        }
+
+        public void LogException(Exception ex, object? correlationId = null,
+            string message = "Exception detected:")
+        {
+            _runtime.LogException(ex, correlationId, message);
+        }
+
+        public void LogStatus(string message)
+        {
+            _runtime.ActiveSession?.LogStatus(message);
+        }
+    }
+}

--- a/src/Wolverine/TransportCollection.cs
+++ b/src/Wolverine/TransportCollection.cs
@@ -33,6 +33,13 @@ public class TransportCollection : IEnumerable<ITransport>, IAsyncDisposable
             if (value != null)
             {
                 value.IsListener = true;
+
+                // CritterWatch GH-907: whatever endpoint carries node control traffic is system
+                // traffic by definition. The database and shared-memory control endpoints are born
+                // with the System role, but a generic endpoint promoted to control duty (e.g.
+                // UseTcpForControlEndpoint) was not — leaving its agent-command traffic visible to
+                // metrics as apparent application volume.
+                value.Role = EndpointRole.System;
             }
 
             _nodeControlEndpoint = value;

--- a/src/Wolverine/Transports/Local/BufferedLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/BufferedLocalQueue.cs
@@ -20,7 +20,7 @@ internal class BufferedLocalQueue : BufferedReceiver, ISendingAgent, IListenerCi
     public BufferedLocalQueue(Endpoint endpoint, IWolverineRuntime runtime) : base(endpoint, runtime,
         new HandlerPipeline((WolverineRuntime)runtime, (IExecutorFactory)runtime, endpoint), Block<Envelope>.Unbounded)
     {
-        _messageTracker = runtime.MessageTracking;
+        _messageTracker = ((WolverineRuntime)runtime).MessageTrackingFor(endpoint);
         _runtime = runtime;
         Destination = endpoint.Uri;
         Endpoint = endpoint;

--- a/src/Wolverine/Transports/Local/DurableLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/DurableLocalQueue.cs
@@ -38,7 +38,7 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
             ? new DelegatingMessageInbox(runtime.Storage.Inbox, runtime.Stores)
             : runtime.Storage.Inbox;
 
-        _messageLogger = runtime.MessageTracking;
+        _messageLogger = runtime.MessageTrackingFor(endpoint);
         _serializer = endpoint.DefaultSerializer ??
                       throw new ArgumentOutOfRangeException(nameof(endpoint),
                           "No default serializer for this Endpoint");


### PR DESCRIPTION
Fixes the Wolverine half of [CritterWatch #907](https://github.com/JasperFx/critterwatch/issues/907): an idle Wolverine app with CritterWatch applied reported **~150 messages/minute** of nothing but its own machinery — agent commands on the control queues, acks, and CritterWatch's monitoring messages, the last of which fed back on itself (accumulator exports are published to CritterWatch as messages that were themselves counted).

## The three gaps

1. **Meter counters were unconditional.** `wolverine-messages-sent` incremented for every send regardless of what the traffic was (the `TelemetryEnabled` flag gated spans, never metrics). Sending agents, local queues, and listening pipelines now resolve their tracker via `MessageTrackingFor(endpoint)` — a **System-role** endpoint or one with **`TelemetryEnabled = false`** gets a new metrics-silent `SystemTrafficMessageTracker` that keeps debug logging, tracked-session bookkeeping, and wire taps, but records nothing.
2. **The executor factory excluded only `IAgentCommand`, and only in the CritterWatch modes.** It now excludes the full system-message surface via the existing `IsSystemMessageType()` predicate (`IInternalMessage`, `IAgentCommand`, `INotToBeRouted` — which covers `ICritterWatchMessage` and acknowledgements — and opted-out assemblies), in **every** metrics mode, and consults the endpoint role too.
3. **`UseTcpForControlEndpoint` never stamped the System role** on the endpoint it promoted, unlike the database/shared-memory control endpoints that are born with it. The `NodeControlEndpoint` setter stamps it now.

## Design constraints honored (from the issue)

- **No per-envelope branching**: every decision is resolved once at construction (per endpoint agent, per executor) — the `sendWithTracing`/`sendWithOutTracing` pattern.
- **`EndpointRole`, not string matching**, is the classification the system relies on; the old `IsSystemEndpoint` string match stays only as defense in depth on the accumulator paths.

## Behavior change to be aware of

`Endpoint.TelemetryEnabled = false` now silences **metrics** as well as traces for that endpoint, and system message types no longer appear in any message-level instrument in any mode. The metrics docs gained a callout.

## Testing

- New `system_traffic_metrics_silencing` suite in CoreTests (9 tests): tracker selection per role/flag/message type, control-endpoint promotion, and MeterListener-verified silence vs. counting.
- Full CoreTests: 2176 passed. MetricsTests: 25 passed — including the pump tests that prove application traffic is **still counted** in CritterWatch/Hybrid modes.

## Companion change

`Wolverine.CritterWatch` will mark its own outbound/inbound endpoints System-role in a CritterWatch-repo PR (`InternalsVisibleTo` already covers it); end-to-end idle-app verification lands there per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eR4GL278688VhyhrGcttJ