### PR TITLE
Kafka retry-tier listeners inherit native DLQ enablement; DLQ tests get isolated topics

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/DeadLetterQueueTests.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/DeadLetterQueueTests.cs
@@ -23,7 +23,14 @@ public class DeadLetterQueueTests : IAsyncLifetime
     {
         _output = output;
         _topicName = $"dlq-test-{Guid.NewGuid():N}";
-        _dlqTopicName = "wolverine-dead-letter-queue";
+
+        // A per-test DLQ topic, NOT the shared "wolverine-dead-letter-queue" default. Several suites in
+        // this assembly dead-letter onto the default topic (the DLQ compliance fixture, the retry-topic
+        // tests), and these tests consume the FIRST message a fresh earliest-offset consumer finds — so
+        // reading the shared topic returns whichever suite happened to dead-letter first, and the
+        // exception-header assertions fail deterministically against another test's residue. Same
+        // pattern BufferedDeadLetterQueueTests always used.
+        _dlqTopicName = $"dlq-test-verify-{Guid.NewGuid():N}";
     }
 
     public async ValueTask InitializeAsync()
@@ -33,6 +40,7 @@ public class DeadLetterQueueTests : IAsyncLifetime
             {
                 opts.UseKafka(KafkaContainerFixture.ConnectionString)
                     .AutoProvision()
+                    .DeadLetterQueueTopicName(_dlqTopicName)
                     .ConfigureConsumers(c => c.AutoOffsetReset = AutoOffsetReset.Earliest);
 
                 opts.ListenToKafkaTopic(_topicName)

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/dlq_compliance.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/dlq_compliance.cs
@@ -20,7 +20,12 @@ public class BufferedComplianceWithDlqFixture : TransportComplianceFixture, IAsy
 
         await ReceiverIs(opts =>
         {
-            opts.UseKafka(KafkaContainerFixture.ConnectionString).AutoProvision();
+            // Dead-letter onto this fixture's own topic rather than the shared default: suites like
+            // DeadLetterQueueTests and kafka_retry_topics read the first message off their DLQ topic,
+            // and this fixture's compliance failures landing on the shared default poisoned them.
+            opts.UseKafka(KafkaContainerFixture.ConnectionString)
+                .AutoProvision()
+                .DeadLetterQueueTopicName("buffered.dlq.dead-letter");
 
             opts.ListenToKafkaTopic(receiverTopic)
                 .Named("receiver")

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/kafka_retry_topics.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/kafka_retry_topics.cs
@@ -13,16 +13,23 @@ public class kafka_retry_topics : IAsyncLifetime
 {
     private IHost _host = null!;
     private string _topic = null!;
+    private string _dlqTopic = null!;
 
     public async ValueTask InitializeAsync()
     {
         RetryState.Reset();
         _topic = $"retry-{Guid.NewGuid():N}";
 
+        // Per-test DLQ topic: the shared default topic collects dead letters from other suites in this
+        // assembly, and the assertion below reads the FIRST message it finds. See DeadLetterQueueTests.
+        _dlqTopic = $"retry-dlq-{Guid.NewGuid():N}";
+
         _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.UseKafka(KafkaContainerFixture.ConnectionString).AutoProvision();
+                opts.UseKafka(KafkaContainerFixture.ConnectionString)
+                    .AutoProvision()
+                    .DeadLetterQueueTopicName(_dlqTopic);
                 opts.PublishAllMessages().ToKafkaTopic(_topic).SendInline();
                 opts.ListenToKafkaTopic(_topic)
                     .ProcessInline()
@@ -78,7 +85,7 @@ public class kafka_retry_topics : IAsyncLifetime
             GroupId = Guid.NewGuid().ToString(),
             AutoOffsetReset = AutoOffsetReset.Earliest
         }).Build();
-        consumer.Subscribe("wolverine-dead-letter-queue");
+        consumer.Subscribe(_dlqTopic);
 
         var deadline = DateTime.UtcNow.AddSeconds(15);
         ConsumeResult<string, byte[]>? dlq = null;

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTransport.cs
@@ -258,6 +258,15 @@ public class KafkaTransport : BrokerTransport<KafkaTopic>
                 tierTopic.IsListener = true;
                 tierTopic.RetryTierDelay = delay;
                 tierTopic.Mode = EndpointMode.Inline;
+
+                // The LAST tier's exhaustion path is MoveToDeadLetterQueueAsync, and that decision is made
+                // against the TIER listener's endpoint — not the source topic the message originally
+                // arrived on. Without inheriting the source's native-DLQ enablement, an exhausted message
+                // never reached the Kafka dead letter topic at all: on a durable host it fell back to the
+                // database DLQ, and on a storeless host it was simply dropped. The test covering this
+                // passed vacuously for months by consuming another suite's residue off the shared default
+                // DLQ topic.
+                tierTopic.NativeDeadLetterQueueEnabled = Topics[source].NativeDeadLetterQueueEnabled;
                 // Stable group + earliest so a tier consumer never misses a just-produced retry record
                 // (a Latest consumer races the producer). Reads + commits its own retry-topic offsets.
                 tierTopic.ConsumerConfig = new ConsumerConfig


### PR DESCRIPTION
Fixes the pre-existing CIKafka red that #3758 surfaced honestly (`dead_letter_message_has_exception_headers` under the supervised runner's ordering; `kafka_retry_topics.permanent_failure_walks_all_tiers_then_dead_letters` under the old harness's — same root cause, different victim by run order).

## The product bug

Retry-tier topics created by `MoveToKafkaRetryTopic` were configured as listeners but **never inherited `NativeDeadLetterQueueEnabled` from their source topic**. The last tier's exhaustion path decides the DLQ move against the *tier* endpoint, so an exhausted message never reached the Kafka dead letter topic — on a durable host it fell back to the database DLQ, and on a storeless host it was **dropped outright**. `KafkaTransport`'s tier setup now copies the source topic's enablement.

## The test bug that hid it

Four suites shared the default `wolverine-dead-letter-queue` topic, and both `DeadLetterQueueTests` and `kafka_retry_topics` assert on the **first** message a fresh earliest-offset consumer finds there. `permanent_failure_walks_all_tiers_then_dead_letters` passed **vacuously** off other suites' residue whenever it ran after them — which is exactly why the product bug above went unseen — and whichever reader ran before the polluters failed instead. Every suite now dead-letters onto its own per-test topic (the pattern `BufferedDeadLetterQueueTests` always used). Isolating the topics is what exposed the product bug: with no residue to read, the exhausted message genuinely wasn't there.

## Verification

Full local Kafka suite: 298 passed, 2 skipped, and the only failure is `batch_processing_with_kafka.end_to_end` — already tagged `Category=Flaky` and excluded from every CI run (unrelated to this change; fails identically without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eR4GL278688VhyhrGcttJ