### PR TITLE
Opt-in 409 ProblemDetails for Marten concurrency exceptions in Wolverine.Http

### DIFF
--- a/docs/guide/http/exception-handling.md
+++ b/docs/guide/http/exception-handling.md
@@ -2,7 +2,7 @@
 
 Wolverine supports an `OnException` / `OnExceptionAsync` naming convention for middleware methods that allows you to handle exceptions thrown during endpoint execution. This is the recommended approach for structured exception handling in Wolverine HTTP endpoints.
 
-For mapping Marten concurrency exceptions to a `409 Conflict` with a `ProblemDetails` body across every Marten-backed endpoint at once, see [Concurrency Exceptions](/guide/http/marten.html#concurrency-exceptions).
+For mapping Marten concurrency exceptions to a `409 Conflict` with a `ProblemDetails` body across the endpoints using the Marten aggregate handler workflow or transactional middleware, see [Concurrency Exceptions](/guide/http/marten.html#concurrency-exceptions).
 
 ## Handler-Level Exception Handling
 

--- a/docs/guide/http/exception-handling.md
+++ b/docs/guide/http/exception-handling.md
@@ -2,6 +2,8 @@
 
 Wolverine supports an `OnException` / `OnExceptionAsync` naming convention for middleware methods that allows you to handle exceptions thrown during endpoint execution. This is the recommended approach for structured exception handling in Wolverine HTTP endpoints.
 
+For mapping Marten concurrency exceptions to a `409 Conflict` with a `ProblemDetails` body across every Marten-backed endpoint at once, see [Concurrency Exceptions](/guide/http/marten.html#concurrency-exceptions).
+
 ## Handler-Level Exception Handling
 
 The simplest approach is to add `OnException` methods directly on your endpoint class. The first parameter must be the exception type to catch:
@@ -32,7 +34,7 @@ public static class OnExceptionEndpoints
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L21-L45' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_handler_level' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L22-L46' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_handler_level' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Key behaviors:
@@ -87,7 +89,7 @@ public static class MultipleExceptionEndpoints
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L47-L88' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_specific' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L48-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_specific' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Async Exception Handlers
@@ -120,7 +122,7 @@ public static class AsyncExceptionEndpoints
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L90-L114' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_async' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L91-L115' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_async' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Combining with Finally
@@ -161,7 +163,7 @@ public static class ExceptionWithFinallyEndpoints
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L116-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_with_finally' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L117-L149' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_with_finally' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The execution order is: Handler (throws) -> OnException -> Finally

--- a/docs/guide/http/marten.md
+++ b/docs/guide/http/marten.md
@@ -407,15 +407,25 @@ opts.UseProblemDetailsForConcurrencyExceptions();
 This policy only applies to endpoints that use the aggregate handler workflow (`[AggregateHandler]`,
 `[Aggregate]`, or `[WriteAggregate]`) or that commit a Marten session through Wolverine's transactional
 middleware. On each matching endpoint it catches `JasperFx.ConcurrencyException` — the base type of
-Marten's `EventStreamUnexpectedMaxEventIdException` and `DcbConcurrencyException` — and writes the
-`ProblemDetails` response with the configured status code. The response is also registered in the
-endpoint's OpenAPI metadata.
+Marten's `EventStreamUnexpectedMaxEventIdException` and `DcbConcurrencyException` — writes the
+`ProblemDetails` response with the configured status code, and logs the handled conflict at the
+`Information` level so operators keep a signal where the escaping exception used to leave an error log.
+The response is registered in the endpoint's OpenAPI metadata on aggregate workflow endpoints and on
+routes accepting verbs other than `GET`/`HEAD`, so read-only endpoints that merely commit an empty
+session don't advertise an unreachable conflict response to generated clients.
+
+On endpoints loading their aggregate with `ConcurrencyStyle.Exclusive`, the policy additionally catches
+`Marten.Exceptions.StreamLockedException`, which is thrown on the load path by
+`FetchForExclusiveWriting` and does *not* inherit from `ConcurrencyException`. A locked stream usually
+means another session merely held the lock at that moment, so clients should treat the resulting
+response as retryable.
 
 ::: warning
-The policy also catches `Marten.Exceptions.StreamLockedException`, which is thrown on the load path
-when using exclusive locking (`FetchForExclusiveWriting`) and does *not* inherit from
-`ConcurrencyException`. A locked stream usually means another session merely held the lock at that
-moment, so clients should treat the resulting response as retryable.
+Catch blocks are ordered most-specific-first, so once the policy is active a broader `OnException(Exception)`
+handler will no longer observe these exception types — the policy only steps aside for a user-defined
+handler of the *exact same* exception type. Also note that if the response has already started streaming
+when the exception surfaces, the policy rethrows so the failure still aborts the response rather than
+silently truncating a success status.
 :::
 
 If you need different behavior for a specific endpoint — or prefer to keep the mapping explicit without

--- a/docs/guide/http/marten.md
+++ b/docs/guide/http/marten.md
@@ -391,53 +391,64 @@ Wolverine can't (yet) handle a signature with multiple event streams of the same
 The aggregate handler workflow leans on Marten's optimistic concurrency protections, so any endpoint
 using it can fail at commit time when the underlying stream has advanced past the expected version. By
 default that exception escapes the endpoint as a 500. If you would rather respond with a `409 Conflict`
-carrying a `ProblemDetails` body, opt in when mapping the Wolverine endpoints:
+carrying a `ProblemDetails` body, opt in at service registration time:
 
 <!-- snippet: sample_UseProblemDetailsForConcurrencyExceptions -->
 <a id='snippet-sample_UseProblemDetailsForConcurrencyExceptions'></a>
 ```cs
 // Opt into responding with a 409 status code and a ProblemDetails
-// body when a Marten concurrency exception is caught on any endpoint
-// using the aggregate handler workflow or Marten transactional middleware
-opts.UseProblemDetailsForConcurrencyExceptions();
+// body when a Marten concurrency exception escapes an HTTP endpoint.
+// The exception mapping is done by the ASP.NET Core exception handler
+// middleware, so the application also needs app.UseExceptionHandler()
+builder.Services.UseProblemDetailsForConcurrencyExceptions();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Program.cs#L377-L383' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_UseProblemDetailsForConcurrencyExceptions' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Program.cs#L126-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_UseProblemDetailsForConcurrencyExceptions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-This policy only applies to endpoints that use the aggregate handler workflow (`[AggregateHandler]`,
-`[Aggregate]`, or `[WriteAggregate]`) or that commit a Marten session through Wolverine's transactional
-middleware. On each matching endpoint it catches `JasperFx.ConcurrencyException` — the base type of
-Marten's `EventStreamUnexpectedMaxEventIdException` and `DcbConcurrencyException` — writes the
-`ProblemDetails` response with the configured status code, and logs the handled conflict at the
-`Information` level so operators keep a signal where the escaping exception used to leave an error log.
-The response is registered in the endpoint's OpenAPI metadata on aggregate workflow endpoints and on
-routes accepting verbs other than `GET`/`HEAD`, so read-only endpoints that merely commit an empty
-session don't advertise an unreachable conflict response to generated clients.
+The runtime mapping is done by a `MartenConcurrencyExceptionHandler`, a standard
+`Microsoft.AspNetCore.Diagnostics.IExceptionHandler` registered together with `AddProblemDetails()`,
+so the application **must also run the exception handler middleware** for the mapping to take effect:
 
-On endpoints loading their aggregate with `ConcurrencyStyle.Exclusive`, the policy additionally catches
+```csharp
+var app = builder.Build();
+
+// Required: the concurrency exception mapping runs inside this middleware
+app.UseExceptionHandler();
+
+app.MapWolverineEndpoints();
+```
+
+The handler maps `JasperFx.ConcurrencyException` — the base type of Marten's
+`EventStreamUnexpectedMaxEventIdException` and `DcbConcurrencyException` — to the `ProblemDetails`
+response with the configured status code, and logs the handled conflict at the `Information` level so
+operators keep a signal where the escaping exception used to leave an error log. It also maps
 `Marten.Exceptions.StreamLockedException`, which is thrown on the load path by
-`FetchForExclusiveWriting` and does *not* inherit from `ConcurrencyException`. A locked stream usually
-means another session merely held the lock at that moment, so clients should treat the resulting
-response as retryable.
+`FetchForExclusiveWriting` and does *not* inherit from `ConcurrencyException`; only exclusive fetches
+can throw it, so the unconditional mapping is safe. A locked stream usually means another session
+merely held the lock at that moment, so clients should treat the resulting response as retryable.
+
+The registration also adds a companion policy that registers the conflict response in the OpenAPI
+metadata of the Wolverine endpoints where it is actually reachable: endpoints using the aggregate
+handler workflow, and routes accepting verbs other than `GET`/`HEAD` that commit a Marten session
+through the transactional middleware. Read-only endpoints that merely commit an empty session, and
+endpoints whose own `OnException` handlers already cover the mapped exception types, don't advertise
+an unreachable conflict response to generated clients.
 
 ::: warning
-Catch blocks are ordered most-specific-first, so once the policy is active a broader `OnException(Exception)`
-handler will no longer observe these exception types — the policy only steps aside for a user-defined
-handler of the *exact same* exception type. Also note that if the response has already started streaming
-when the exception surfaces, the policy rethrows so the failure still aborts the response rather than
-silently truncating a success status.
+Standard exception handler middleware semantics apply: if the response has already started streaming
+when the exception surfaces, the middleware cannot rewrite the response and rethrows instead.
 :::
 
 If you need different behavior for a specific endpoint — or prefer to keep the mapping explicit without
-opting into the policy — the [OnException convention](/guide/http/exception-handling) gives you the
-same result by hand:
+opting in — the [OnException convention](/guide/http/exception-handling) gives you the same result by
+hand:
 
 <!-- snippet: sample_concurrency_exception_with_onexception -->
 <a id='snippet-sample_concurrency_exception_with_onexception'></a>
 ```cs
 // This endpoint handles the Marten concurrency failure itself with the OnException
-// convention, so the UseProblemDetailsForConcurrencyExceptions() policy leaves
-// its catch block completely alone
+// convention, so the exception never reaches the exception handler middleware and
+// the UseProblemDetailsForConcurrencyExceptions() mapping never comes into play
 public static class HandleConcurrencyExceptionYourselfEndpoint
 {
     [AggregateHandler]
@@ -461,8 +472,9 @@ public static class HandleConcurrencyExceptionYourselfEndpoint
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/ConcurrencyExceptionEndpoint.cs#L8-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_concurrency_exception_with_onexception' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-An endpoint's own `OnException` handler for the exact same exception type always wins over the policy,
-which skips any exception type the endpoint already catches.
+An endpoint's own `OnException` handlers always win naturally: they swallow the exception inside the
+endpoint chain, so it never reaches the exception handler middleware. That also holds for broader
+handlers like `OnException(Exception)`.
 
 ## Overriding Version Discovery <Badge type="tip" text="5.17" />
 
@@ -613,7 +625,7 @@ Register it in `WolverineHttpOptions` like this:
 ```cs
 opts.UseMartenCompiledQueryResultPolicy();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Program.cs#L347-L350' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_user_marten_compiled_query_policy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Program.cs#L361-L364' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_user_marten_compiled_query_policy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you now return a compiled query from an Endpoint the result will get directly streamed to the client as JSON. Short circuiting JSON deserialization.

--- a/docs/guide/http/marten.md
+++ b/docs/guide/http/marten.md
@@ -148,7 +148,7 @@ public static OrderShipped Ship(ShipOrder2 command, [Aggregate] Order order)
     return new OrderShipped();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L146-L160' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_aggregate_attribute_1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L148-L162' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_aggregate_attribute_1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Using this version of the "aggregate workflow", you no longer have to supply a command in the request body, so you could
@@ -167,7 +167,7 @@ public static OrderShipped Ship3([Aggregate] Order order)
     return new OrderShipped();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L162-L173' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_aggregate_attribute_2' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L164-L175' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_aggregate_attribute_2' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 A couple other notes: 
@@ -260,7 +260,7 @@ public class Order
     public bool IsShipped() => Shipped.HasValue;
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L18-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_order_aggregate_for_http' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L20-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_order_aggregate_for_http' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To append a single event to an event stream from an HTTP endpoint, you can use a return value like so:
@@ -279,7 +279,7 @@ public static OrderShipped Ship(ShipOrder command, Order order)
     return new OrderShipped();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L122-L134' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_emptyresponse' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L124-L136' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_emptyresponse' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or potentially append multiple events using the `Events` type as a return value like this sample:
@@ -315,7 +315,7 @@ public static (OrderStatus, Events) Post(MarkItemReady command, Order order)
     return (new OrderStatus(order.Id, order.IsReadyToShip()), events);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L236-L265' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_returning_multiple_events_from_http_endpoint' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L238-L267' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_returning_multiple_events_from_http_endpoint' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Responding with the Updated Aggregate
@@ -341,7 +341,7 @@ public static (UpdatedAggregate, Events) ConfirmDifferent(ConfirmOrder command, 
     );
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L293-L306' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_returning_updated_aggregate_as_response_from_http_endpoint' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L299-L312' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_returning_updated_aggregate_as_response_from_http_endpoint' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you should happen to have a message handler or HTTP endpoint signature that uses multiple event streams,
@@ -385,6 +385,74 @@ public static class MakePurchaseHandler
 Wolverine can't (yet) handle a signature with multiple event streams of the same aggregate type and
 `UpdatedAggregate`. 
 :::
+
+## Concurrency Exceptions <Badge type="tip" text="6.25" />
+
+The aggregate handler workflow leans on Marten's optimistic concurrency protections, so any endpoint
+using it can fail at commit time when the underlying stream has advanced past the expected version. By
+default that exception escapes the endpoint as a 500. If you would rather respond with a `409 Conflict`
+carrying a `ProblemDetails` body, opt in when mapping the Wolverine endpoints:
+
+<!-- snippet: sample_UseProblemDetailsForConcurrencyExceptions -->
+<a id='snippet-sample_UseProblemDetailsForConcurrencyExceptions'></a>
+```cs
+// Opt into responding with a 409 status code and a ProblemDetails
+// body when a Marten concurrency exception is caught on any endpoint
+// using the aggregate handler workflow or Marten transactional middleware
+opts.UseProblemDetailsForConcurrencyExceptions();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Program.cs#L377-L383' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_UseProblemDetailsForConcurrencyExceptions' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+This policy only applies to endpoints that use the aggregate handler workflow (`[AggregateHandler]`,
+`[Aggregate]`, or `[WriteAggregate]`) or that commit a Marten session through Wolverine's transactional
+middleware. On each matching endpoint it catches `JasperFx.ConcurrencyException` — the base type of
+Marten's `EventStreamUnexpectedMaxEventIdException` and `DcbConcurrencyException` — and writes the
+`ProblemDetails` response with the configured status code. The response is also registered in the
+endpoint's OpenAPI metadata.
+
+::: warning
+The policy also catches `Marten.Exceptions.StreamLockedException`, which is thrown on the load path
+when using exclusive locking (`FetchForExclusiveWriting`) and does *not* inherit from
+`ConcurrencyException`. A locked stream usually means another session merely held the lock at that
+moment, so clients should treat the resulting response as retryable.
+:::
+
+If you need different behavior for a specific endpoint — or prefer to keep the mapping explicit without
+opting into the policy — the [OnException convention](/guide/http/exception-handling) gives you the
+same result by hand:
+
+<!-- snippet: sample_concurrency_exception_with_onexception -->
+<a id='snippet-sample_concurrency_exception_with_onexception'></a>
+```cs
+// This endpoint handles the Marten concurrency failure itself with the OnException
+// convention, so the UseProblemDetailsForConcurrencyExceptions() policy leaves
+// its catch block completely alone
+public static class HandleConcurrencyExceptionYourselfEndpoint
+{
+    [AggregateHandler]
+    [WolverinePost("/orders/itemready/custom-handled")]
+    public static (OrderStatus, Events) Post(MarkItemReady command, Order order)
+    {
+        return (new OrderStatus(order.Id, order.IsReadyToShip()), [new ItemReady(command.ItemName)]);
+    }
+
+    public static ProblemDetails OnException(ConcurrencyException ex)
+    {
+        return new ProblemDetails
+        {
+            Status = 400,
+            Title = "Somebody else got there first",
+            Detail = ex.Message
+        };
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/ConcurrencyExceptionEndpoint.cs#L8-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_concurrency_exception_with_onexception' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+An endpoint's own `OnException` handler for the exact same exception type always wins over the policy,
+which skips any exception type the endpoint already catches.
 
 ## Overriding Version Discovery <Badge type="tip" text="5.17" />
 
@@ -515,7 +583,7 @@ an HTTP endpoint method, use the `[ReadAggregate]` attribute like this:
 [WolverineGet("/orders/latest/{id}")]
 public static Order GetLatest(Guid id, [ReadAggregate] Order order) => order;
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L320-L324' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_readaggregate_in_http' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L326-L330' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_readaggregate_in_http' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If the aggregate doesn't exist, the HTTP request will stop with a 404 status code. 
@@ -535,7 +603,7 @@ Register it in `WolverineHttpOptions` like this:
 ```cs
 opts.UseMartenCompiledQueryResultPolicy();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Program.cs#L343-L346' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_user_marten_compiled_query_policy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Program.cs#L347-L350' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_user_marten_compiled_query_policy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you now return a compiled query from an Endpoint the result will get directly streamed to the client as JSON. Short circuiting JSON deserialization.
@@ -562,7 +630,7 @@ public class ApprovedInvoicedCompiledQuery : ICompiledListQuery<Invoice>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L106-L115' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiled_query_return_query' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L117-L126' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiled_query_return_query' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Streaming JSON Responses <Badge type="tip" text="5.32" />

--- a/src/Http/Wolverine.Http.Marten/ConcurrencyExceptionPolicy.cs
+++ b/src/Http/Wolverine.Http.Marten/ConcurrencyExceptionPolicy.cs
@@ -1,13 +1,8 @@
 using JasperFx;
 using JasperFx.CodeGeneration;
-using JasperFx.CodeGeneration.Frames;
-using JasperFx.CodeGeneration.Model;
-using JasperFx.Core.Reflection;
 using Marten.Exceptions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
 using Wolverine.Marten;
 using Wolverine.Marten.Persistence.Sagas;
 using Wolverine.Middleware;
@@ -15,13 +10,12 @@ using Wolverine.Middleware;
 namespace Wolverine.Http.Marten;
 
 /// <summary>
-///     Opt-in policy that responds with a ProblemDetails body and a configurable status code
-///     (409 Conflict by default) when a Marten optimistic concurrency check fails on an HTTP
-///     endpoint using the aggregate handler workflow or Marten transactional middleware, instead
-///     of letting the exception escape as a 500. Register this policy through
-///     <see cref="WolverineHttpOptionsExtensions.UseProblemDetailsForConcurrencyExceptions" />
+///     Companion policy to <see cref="MartenConcurrencyExceptionHandler" /> that registers the
+///     ProblemDetails conflict response in the OpenAPI metadata of the HTTP chains where a Marten
+///     concurrency failure is actually reachable. This policy does not touch the generated code --
+///     the runtime mapping is done entirely by the exception handler middleware
 /// </summary>
-public class ConcurrencyExceptionPolicy : IHttpPolicy
+public class ConcurrencyExceptionPolicy : IChainPolicy
 {
     private static readonly string[] _bodylessHttpMethods = ["GET", "HEAD"];
 
@@ -32,59 +26,56 @@ public class ConcurrencyExceptionPolicy : IHttpPolicy
         _statusCode = statusCode;
     }
 
-    public void Apply(IReadOnlyList<HttpChain> chains, GenerationRules rules, IServiceContainer container)
+    public void Apply(IReadOnlyList<IChain> chains, GenerationRules rules, IServiceContainer container)
     {
-        // Find *only* the HTTP routes that could plausibly throw a Marten concurrency exception:
-        // the aggregate handler workflow (FetchForWriting), and any route that commits a Marten
-        // session through the transactional middleware
-        foreach (var chain in chains)
+        foreach (var chain in chains.OfType<HttpChain>().Where(shouldApply))
         {
-            var handlings = aggregateHandlingFor(chain);
-            if (handlings.Count == 0 && !chain.Postprocessors.OfType<DocumentSessionSaveChanges>().Any())
-            {
-                continue;
-            }
-
-            var tryCatchFinally = chain.GetOrCreateTryCatchFinallyFrame();
-
-            // Also covers Marten's EventStreamUnexpectedMaxEventIdException and DcbConcurrencyException
-            var applied = tryAddCatchBlock(tryCatchFinally, typeof(ConcurrencyException));
-
-            // StreamLockedException is only ever thrown by the exclusive locking load path
-            // (FetchForExclusiveWriting), and does *not* inherit from ConcurrencyException
-            if (handlings.Any(x => x.LoadStyle == ConcurrencyStyle.Exclusive))
-            {
-                applied |= tryAddCatchBlock(tryCatchFinally, typeof(StreamLockedException));
-            }
-
-            // Alter the OpenAPI metadata to register the ProblemDetails path, but only where the
-            // conflict is actually reachable in practice. A read-only GET that merely commits an
-            // empty session (e.g. [ReadAggregate] under AutoApplyTransactions) keeps the safety-net
-            // catch without advertising an unreachable conflict response to generated clients
-            if (applied && (handlings.Count > 0 || chain.HttpMethods.Any(x => !_bodylessHttpMethods.Contains(x))))
-            {
-                chain.Metadata.ProducesProblem(_statusCode);
-            }
+            chain.Metadata.ProducesProblem(_statusCode);
         }
     }
 
-    private bool tryAddCatchBlock(TryCatchFinallyFrame tryCatchFinally, Type exceptionType)
+    private static bool shouldApply(HttpChain chain)
     {
-        // A user-defined OnException handler for the same exception type has already claimed
-        // the catch, and a second catch of the same type would not even compile (CS0160)
-        if (tryCatchFinally.CatchBlocks.Any(x => x.ExceptionType == exceptionType))
+        var handlings = aggregateHandlingFor(chain);
+
+        // Only the chains that could plausibly throw a Marten concurrency exception: the aggregate
+        // handler workflow (FetchForWriting), and any route committing a Marten session through the
+        // transactional middleware. Read-only GETs that merely commit an empty session (e.g.
+        // [ReadAggregate] under AutoApplyTransactions) don't advertise an unreachable conflict
+        // response to generated clients
+        if (handlings.Count == 0)
         {
-            return false;
+            if (!chain.Postprocessors.OfType<DocumentSessionSaveChanges>().Any())
+            {
+                return false;
+            }
+
+            if (chain.HttpMethods.All(x => _bodylessHttpMethods.Contains(x)))
+            {
+                return false;
+            }
         }
 
-        tryCatchFinally.AddCatchBlock(exceptionType,
-            [new RespondWithConcurrencyProblemDetailsFrame(exceptionType, _statusCode)]);
-        return true;
+        // When the endpoint's own OnException handlers already cover every exception type the
+        // middleware would map, the exception never escapes the chain and the conflict response
+        // is unreachable, so don't advertise it
+        var reachable = new List<Type> { typeof(ConcurrencyException) };
+        if (handlings.Any(x => x.LoadStyle == ConcurrencyStyle.Exclusive))
+        {
+            reachable.Add(typeof(StreamLockedException));
+        }
+
+        var caught = chain.Middleware.OfType<TryCatchFinallyFrame>()
+            .SelectMany(x => x.CatchBlocks)
+            .Select(x => x.ExceptionType)
+            .ToArray();
+
+        return !reachable.All(mapped => caught.Any(c => c.IsAssignableFrom(mapped)));
     }
 
     // AggregateHandling.Store keeps a single instance until a second stream on the same chain
     // promotes the tag to a list, and AggregateHandling.TryLoad only reads the single shape,
-    // so read both shapes here to catch exclusive loading on multi-stream chains too
+    // so read both shapes here to see exclusive loading on multi-stream chains too
     private static IReadOnlyList<AggregateHandling> aggregateHandlingFor(HttpChain chain)
     {
         if (chain.Tags.TryGetValue(nameof(AggregateHandling), out var raw))
@@ -101,65 +92,5 @@ public class ConcurrencyExceptionPolicy : IHttpPolicy
         }
 
         return [];
-    }
-
-    // Make the codegen easier by doing most of the work in this one method
-    public static Task RespondWithProblemDetails(Exception e, HttpContext context, int statusCode)
-    {
-        // An escaping exception used to leave an error log behind, so keep a signal
-        // for operators now that the exception stops here
-        context.RequestServices.GetService<ILoggerFactory>()
-            ?.CreateLogger(typeof(ConcurrencyExceptionPolicy))
-            .LogInformation("Handled {ExceptionType} on {Method} {Path} as HTTP {StatusCode}",
-                e.GetType().Name, context.Request.Method, context.Request.Path, statusCode);
-
-        var problems = new ProblemDetails
-        {
-            Title = "Concurrency conflict",
-            Detail = e.Message,
-            Status = statusCode
-        };
-
-        return Results.Problem(problems).ExecuteAsync(context);
-    }
-}
-
-// This is the actual code being injected into a catch block of the
-// runtime code generation
-internal class RespondWithConcurrencyProblemDetailsFrame : AsyncFrame
-{
-    private readonly Type _exceptionType;
-    private readonly int _statusCode;
-    private Variable? _exception;
-    private Variable? _httpContext;
-
-    public RespondWithConcurrencyProblemDetailsFrame(Type exceptionType, int statusCode)
-    {
-        _exceptionType = exceptionType;
-        _statusCode = statusCode;
-    }
-
-    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
-    {
-        // Resolved from the enclosing catch block's exception variable
-        _exception = chain.FindVariable(_exceptionType);
-        yield return _exception;
-
-        _httpContext = chain.FindVariable(typeof(HttpContext));
-        yield return _httpContext;
-    }
-
-    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
-    {
-        // Once the response has started streaming there is no way left to communicate the
-        // failure in the body, so rethrow to preserve the connection-abort behavior instead
-        // of quietly truncating a 2xx response
-        writer.Write($"BLOCK:if ({_httpContext!.Usage}.{nameof(HttpContext.Response)}.{nameof(HttpResponse.HasStarted)})");
-        writer.Write("throw;");
-        writer.FinishBlock();
-
-        writer.Write(
-            $"await {typeof(ConcurrencyExceptionPolicy).FullNameInCode()}.{nameof(ConcurrencyExceptionPolicy.RespondWithProblemDetails)}({_exception!.Usage}, {_httpContext.Usage}, {_statusCode});");
-        writer.Write("return;");
     }
 }

--- a/src/Http/Wolverine.Http.Marten/ConcurrencyExceptionPolicy.cs
+++ b/src/Http/Wolverine.Http.Marten/ConcurrencyExceptionPolicy.cs
@@ -6,8 +6,11 @@ using JasperFx.Core.Reflection;
 using Marten.Exceptions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Wolverine.Marten;
 using Wolverine.Marten.Persistence.Sagas;
+using Wolverine.Middleware;
 
 namespace Wolverine.Http.Marten;
 
@@ -20,15 +23,7 @@ namespace Wolverine.Http.Marten;
 /// </summary>
 public class ConcurrencyExceptionPolicy : IHttpPolicy
 {
-    private static readonly Type[] _exceptionTypes =
-    [
-        // Also covers Marten's EventStreamUnexpectedMaxEventIdException and DcbConcurrencyException
-        typeof(ConcurrencyException),
-
-        // Thrown on the load path by FetchForExclusiveWriting when the stream is already locked,
-        // and does *not* inherit from ConcurrencyException
-        typeof(StreamLockedException)
-    ];
+    private static readonly string[] _bodylessHttpMethods = ["GET", "HEAD"];
 
     private readonly int _statusCode;
 
@@ -42,48 +37,81 @@ public class ConcurrencyExceptionPolicy : IHttpPolicy
         // Find *only* the HTTP routes that could plausibly throw a Marten concurrency exception:
         // the aggregate handler workflow (FetchForWriting), and any route that commits a Marten
         // session through the transactional middleware
-        foreach (var chain in chains.Where(shouldApply))
+        foreach (var chain in chains)
         {
-            var tryCatchFinally = chain.GetOrCreateTryCatchFinallyFrame();
-            var applied = false;
-
-            foreach (var exceptionType in _exceptionTypes)
+            var handlings = aggregateHandlingFor(chain);
+            if (handlings.Count == 0 && !chain.Postprocessors.OfType<DocumentSessionSaveChanges>().Any())
             {
-                // A user-defined OnException handler for the same exception type has already claimed
-                // the catch, and a second catch of the same type would not even compile (CS0160)
-                if (tryCatchFinally.CatchBlocks.Any(x => x.ExceptionType == exceptionType))
-                {
-                    continue;
-                }
-
-                tryCatchFinally.AddCatchBlock(exceptionType,
-                    [new RespondWithConcurrencyProblemDetailsFrame(exceptionType, _statusCode)]);
-                applied = true;
+                continue;
             }
 
-            if (applied)
+            var tryCatchFinally = chain.GetOrCreateTryCatchFinallyFrame();
+
+            // Also covers Marten's EventStreamUnexpectedMaxEventIdException and DcbConcurrencyException
+            var applied = tryAddCatchBlock(tryCatchFinally, typeof(ConcurrencyException));
+
+            // StreamLockedException is only ever thrown by the exclusive locking load path
+            // (FetchForExclusiveWriting), and does *not* inherit from ConcurrencyException
+            if (handlings.Any(x => x.LoadStyle == ConcurrencyStyle.Exclusive))
             {
-                // Alter the OpenAPI metadata to register the ProblemDetails path
+                applied |= tryAddCatchBlock(tryCatchFinally, typeof(StreamLockedException));
+            }
+
+            // Alter the OpenAPI metadata to register the ProblemDetails path, but only where the
+            // conflict is actually reachable in practice. A read-only GET that merely commits an
+            // empty session (e.g. [ReadAggregate] under AutoApplyTransactions) keeps the safety-net
+            // catch without advertising an unreachable conflict response to generated clients
+            if (applied && (handlings.Count > 0 || chain.HttpMethods.Any(x => !_bodylessHttpMethods.Contains(x))))
+            {
                 chain.Metadata.ProducesProblem(_statusCode);
             }
         }
     }
 
-    private static bool shouldApply(HttpChain chain)
+    private bool tryAddCatchBlock(TryCatchFinallyFrame tryCatchFinally, Type exceptionType)
     {
-        return AggregateHandling.TryLoad(chain, out _)
-               || chain.Postprocessors.OfType<DocumentSessionSaveChanges>().Any();
+        // A user-defined OnException handler for the same exception type has already claimed
+        // the catch, and a second catch of the same type would not even compile (CS0160)
+        if (tryCatchFinally.CatchBlocks.Any(x => x.ExceptionType == exceptionType))
+        {
+            return false;
+        }
+
+        tryCatchFinally.AddCatchBlock(exceptionType,
+            [new RespondWithConcurrencyProblemDetailsFrame(exceptionType, _statusCode)]);
+        return true;
+    }
+
+    // AggregateHandling.Store keeps a single instance until a second stream on the same chain
+    // promotes the tag to a list, and AggregateHandling.TryLoad only reads the single shape,
+    // so read both shapes here to catch exclusive loading on multi-stream chains too
+    private static IReadOnlyList<AggregateHandling> aggregateHandlingFor(HttpChain chain)
+    {
+        if (chain.Tags.TryGetValue(nameof(AggregateHandling), out var raw))
+        {
+            if (raw is AggregateHandling single)
+            {
+                return [single];
+            }
+
+            if (raw is List<AggregateHandling> list)
+            {
+                return list;
+            }
+        }
+
+        return [];
     }
 
     // Make the codegen easier by doing most of the work in this one method
     public static Task RespondWithProblemDetails(Exception e, HttpContext context, int statusCode)
     {
-        // The concurrency exception may surface after the endpoint has already begun streaming
-        // a response, in which case there is no way left to communicate the failure in the body
-        if (context.Response.HasStarted)
-        {
-            return Task.CompletedTask;
-        }
+        // An escaping exception used to leave an error log behind, so keep a signal
+        // for operators now that the exception stops here
+        context.RequestServices.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(ConcurrencyExceptionPolicy))
+            .LogInformation("Handled {ExceptionType} on {Method} {Path} as HTTP {StatusCode}",
+                e.GetType().Name, context.Request.Method, context.Request.Path, statusCode);
 
         var problems = new ProblemDetails
         {
@@ -123,8 +151,15 @@ internal class RespondWithConcurrencyProblemDetailsFrame : AsyncFrame
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
+        // Once the response has started streaming there is no way left to communicate the
+        // failure in the body, so rethrow to preserve the connection-abort behavior instead
+        // of quietly truncating a 2xx response
+        writer.Write($"BLOCK:if ({_httpContext!.Usage}.{nameof(HttpContext.Response)}.{nameof(HttpResponse.HasStarted)})");
+        writer.Write("throw;");
+        writer.FinishBlock();
+
         writer.Write(
-            $"await {typeof(ConcurrencyExceptionPolicy).FullNameInCode()}.{nameof(ConcurrencyExceptionPolicy.RespondWithProblemDetails)}({_exception!.Usage}, {_httpContext!.Usage}, {_statusCode});");
+            $"await {typeof(ConcurrencyExceptionPolicy).FullNameInCode()}.{nameof(ConcurrencyExceptionPolicy.RespondWithProblemDetails)}({_exception!.Usage}, {_httpContext.Usage}, {_statusCode});");
         writer.Write("return;");
     }
 }

--- a/src/Http/Wolverine.Http.Marten/ConcurrencyExceptionPolicy.cs
+++ b/src/Http/Wolverine.Http.Marten/ConcurrencyExceptionPolicy.cs
@@ -1,0 +1,130 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Marten.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine.Marten;
+using Wolverine.Marten.Persistence.Sagas;
+
+namespace Wolverine.Http.Marten;
+
+/// <summary>
+///     Opt-in policy that responds with a ProblemDetails body and a configurable status code
+///     (409 Conflict by default) when a Marten optimistic concurrency check fails on an HTTP
+///     endpoint using the aggregate handler workflow or Marten transactional middleware, instead
+///     of letting the exception escape as a 500. Register this policy through
+///     <see cref="WolverineHttpOptionsExtensions.UseProblemDetailsForConcurrencyExceptions" />
+/// </summary>
+public class ConcurrencyExceptionPolicy : IHttpPolicy
+{
+    private static readonly Type[] _exceptionTypes =
+    [
+        // Also covers Marten's EventStreamUnexpectedMaxEventIdException and DcbConcurrencyException
+        typeof(ConcurrencyException),
+
+        // Thrown on the load path by FetchForExclusiveWriting when the stream is already locked,
+        // and does *not* inherit from ConcurrencyException
+        typeof(StreamLockedException)
+    ];
+
+    private readonly int _statusCode;
+
+    public ConcurrencyExceptionPolicy(int statusCode = 409)
+    {
+        _statusCode = statusCode;
+    }
+
+    public void Apply(IReadOnlyList<HttpChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        // Find *only* the HTTP routes that could plausibly throw a Marten concurrency exception:
+        // the aggregate handler workflow (FetchForWriting), and any route that commits a Marten
+        // session through the transactional middleware
+        foreach (var chain in chains.Where(shouldApply))
+        {
+            var tryCatchFinally = chain.GetOrCreateTryCatchFinallyFrame();
+            var applied = false;
+
+            foreach (var exceptionType in _exceptionTypes)
+            {
+                // A user-defined OnException handler for the same exception type has already claimed
+                // the catch, and a second catch of the same type would not even compile (CS0160)
+                if (tryCatchFinally.CatchBlocks.Any(x => x.ExceptionType == exceptionType))
+                {
+                    continue;
+                }
+
+                tryCatchFinally.AddCatchBlock(exceptionType,
+                    [new RespondWithConcurrencyProblemDetailsFrame(exceptionType, _statusCode)]);
+                applied = true;
+            }
+
+            if (applied)
+            {
+                // Alter the OpenAPI metadata to register the ProblemDetails path
+                chain.Metadata.ProducesProblem(_statusCode);
+            }
+        }
+    }
+
+    private static bool shouldApply(HttpChain chain)
+    {
+        return AggregateHandling.TryLoad(chain, out _)
+               || chain.Postprocessors.OfType<DocumentSessionSaveChanges>().Any();
+    }
+
+    // Make the codegen easier by doing most of the work in this one method
+    public static Task RespondWithProblemDetails(Exception e, HttpContext context, int statusCode)
+    {
+        // The concurrency exception may surface after the endpoint has already begun streaming
+        // a response, in which case there is no way left to communicate the failure in the body
+        if (context.Response.HasStarted)
+        {
+            return Task.CompletedTask;
+        }
+
+        var problems = new ProblemDetails
+        {
+            Title = "Concurrency conflict",
+            Detail = e.Message,
+            Status = statusCode
+        };
+
+        return Results.Problem(problems).ExecuteAsync(context);
+    }
+}
+
+// This is the actual code being injected into a catch block of the
+// runtime code generation
+internal class RespondWithConcurrencyProblemDetailsFrame : AsyncFrame
+{
+    private readonly Type _exceptionType;
+    private readonly int _statusCode;
+    private Variable? _exception;
+    private Variable? _httpContext;
+
+    public RespondWithConcurrencyProblemDetailsFrame(Type exceptionType, int statusCode)
+    {
+        _exceptionType = exceptionType;
+        _statusCode = statusCode;
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        // Resolved from the enclosing catch block's exception variable
+        _exception = chain.FindVariable(_exceptionType);
+        yield return _exception;
+
+        _httpContext = chain.FindVariable(typeof(HttpContext));
+        yield return _httpContext;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write(
+            $"await {typeof(ConcurrencyExceptionPolicy).FullNameInCode()}.{nameof(ConcurrencyExceptionPolicy.RespondWithProblemDetails)}({_exception!.Usage}, {_httpContext!.Usage}, {_statusCode});");
+        writer.Write("return;");
+    }
+}

--- a/src/Http/Wolverine.Http.Marten/MartenConcurrencyExceptionHandler.cs
+++ b/src/Http/Wolverine.Http.Marten/MartenConcurrencyExceptionHandler.cs
@@ -1,0 +1,61 @@
+using JasperFx;
+using Marten.Exceptions;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.Http.Marten;
+
+/// <summary>
+///     Exception handler for the ASP.NET Core exception handler middleware that maps Marten /
+///     JasperFx concurrency failures to a ProblemDetails response with a configurable status code
+///     (409 Conflict by default) instead of a 500. Register through
+///     <see cref="WolverineHttpOptionsExtensions.UseProblemDetailsForConcurrencyExceptions" />,
+///     and make sure the application calls <c>app.UseExceptionHandler()</c> so this handler
+///     actually runs
+/// </summary>
+public class MartenConcurrencyExceptionHandler : IExceptionHandler
+{
+    private readonly int _statusCode;
+    private readonly ILogger<MartenConcurrencyExceptionHandler> _logger;
+
+    public MartenConcurrencyExceptionHandler(int statusCode, ILogger<MartenConcurrencyExceptionHandler> logger)
+    {
+        _statusCode = statusCode;
+        _logger = logger;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception,
+        CancellationToken cancellationToken)
+    {
+        // StreamLockedException does not inherit from ConcurrencyException, but can only ever be
+        // thrown by the exclusive locking load path (FetchForExclusiveWriting), so mapping it
+        // unconditionally is safe
+        if (exception is not ConcurrencyException and not StreamLockedException)
+        {
+            return false;
+        }
+
+        // An escaping exception used to leave an error log behind, so keep a signal
+        // for operators now that the exception stops here
+        _logger.LogInformation("Handled {ExceptionType} on {Method} {Path} as HTTP {StatusCode}",
+            exception.GetType().Name, httpContext.Request.Method, httpContext.Request.Path, _statusCode);
+
+        httpContext.Response.StatusCode = _statusCode;
+
+        var problemDetailsService = httpContext.RequestServices.GetRequiredService<IProblemDetailsService>();
+        return await problemDetailsService.TryWriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = httpContext,
+            Exception = exception,
+            ProblemDetails = new ProblemDetails
+            {
+                Title = "Concurrency conflict",
+                Detail = exception.Message,
+                Status = _statusCode
+            }
+        });
+    }
+}

--- a/src/Http/Wolverine.Http.Marten/WolverineHttpOptionsExtensions.cs
+++ b/src/Http/Wolverine.Http.Marten/WolverineHttpOptionsExtensions.cs
@@ -1,3 +1,8 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
 namespace Wolverine.Http.Marten;
 
 public static class WolverineHttpOptionsExtensions
@@ -13,15 +18,27 @@ public static class WolverineHttpOptionsExtensions
     }
 
     /// <summary>
-    /// Adds a <see cref="ConcurrencyExceptionPolicy"/> that responds with a ProblemDetails body and the
-    /// supplied status code (409 Conflict by default) when a Marten optimistic concurrency exception would
-    /// otherwise escape an HTTP endpoint using the aggregate handler workflow or Marten transactional middleware
+    /// Registers the <see cref="MartenConcurrencyExceptionHandler"/> (plus AddProblemDetails()) so the
+    /// ASP.NET Core exception handler middleware responds with a ProblemDetails body and the supplied
+    /// status code (409 Conflict by default) when a Marten concurrency exception escapes an HTTP
+    /// endpoint, and a <see cref="ConcurrencyExceptionPolicy"/> that registers the conflict response
+    /// in the OpenAPI metadata of the Wolverine endpoints where it is reachable. The application must
+    /// also call <c>app.UseExceptionHandler()</c> for the handler to run
     /// </summary>
-    /// <param name="options">Options to apply policy on</param>
+    /// <param name="services">The application's service collection</param>
     /// <param name="statusCode">The HTTP status code of the ProblemDetails response. Default is 409 (Conflict)</param>
-    public static void UseProblemDetailsForConcurrencyExceptions(this WolverineHttpOptions options,
+    public static IServiceCollection UseProblemDetailsForConcurrencyExceptions(this IServiceCollection services,
         int statusCode = 409)
     {
-        options.Policies.Add(new ConcurrencyExceptionPolicy(statusCode));
+        services.AddProblemDetails();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IExceptionHandler, MartenConcurrencyExceptionHandler>(
+            sp => new MartenConcurrencyExceptionHandler(statusCode,
+                sp.GetRequiredService<ILogger<MartenConcurrencyExceptionHandler>>())));
+
+        // IChainPolicy so it can be registered at service-registration time; Wolverine.Http applies
+        // core chain policies to the HTTP chains, and the policy no-ops for messaging chains
+        services.ConfigureWolverine(opts => opts.Policies.Add(new ConcurrencyExceptionPolicy(statusCode)));
+
+        return services;
     }
 }

--- a/src/Http/Wolverine.Http.Marten/WolverineHttpOptionsExtensions.cs
+++ b/src/Http/Wolverine.Http.Marten/WolverineHttpOptionsExtensions.cs
@@ -11,4 +11,17 @@ public static class WolverineHttpOptionsExtensions
     {
         options.AddResourceWriterPolicy(new CompiledQueryWriterPolicy(responseType, successStatusCode));
     }
+
+    /// <summary>
+    /// Adds a <see cref="ConcurrencyExceptionPolicy"/> that responds with a ProblemDetails body and the
+    /// supplied status code (409 Conflict by default) when a Marten optimistic concurrency exception would
+    /// otherwise escape an HTTP endpoint using the aggregate handler workflow or Marten transactional middleware
+    /// </summary>
+    /// <param name="options">Options to apply policy on</param>
+    /// <param name="statusCode">The HTTP status code of the ProblemDetails response. Default is 409 (Conflict)</param>
+    public static void UseProblemDetailsForConcurrencyExceptions(this WolverineHttpOptions options,
+        int statusCode = 409)
+    {
+        options.Policies.Add(new ConcurrencyExceptionPolicy(statusCode));
+    }
 }

--- a/src/Http/Wolverine.Http.Tests/Marten/concurrency_exception_problem_details.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/concurrency_exception_problem_details.cs
@@ -1,7 +1,6 @@
 using Alba;
 using IntegrationTests;
 using Marten;
-using Marten.Exceptions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;
@@ -67,8 +66,9 @@ public class concurrency_exception_problem_details(AppFixture fixture) : Integra
             x.Post.Json(new MarkItemReady(id, "Socks", 1)).ToUrl("/orders/itemready/custom-handled");
         });
 
-        // The endpoint's own OnException(ConcurrencyException) is already in the catch
-        // block, so the policy must leave it alone rather than doubling the catch
+        // The endpoint's own OnException(ConcurrencyException) swallows the exception inside
+        // the chain, so it never reaches the exception handler middleware and the endpoint's
+        // response wins with no double handling
         var result = await Scenario(x =>
         {
             x.Post.Json(new MarkItemReady(id, "Shoes", 1)).ToUrl("/orders/itemready/custom-handled");
@@ -91,29 +91,12 @@ public class concurrency_exception_problem_details(AppFixture fixture) : Integra
     }
 
     [Fact]
-    public void no_catch_or_conflict_metadata_added_when_the_endpoint_handles_the_exception_itself()
+    public void no_conflict_metadata_advertised_when_the_endpoint_handles_the_exception_itself()
     {
-        var chain = HttpChains.ChainFor("POST", "/orders/itemready/custom-handled");
-        chain.ShouldNotBeNull();
-
-        // The single ConcurrencyException catch belongs to the endpoint's own OnException handler,
-        // and this optimistic chain gets no StreamLockedException catch either
-        var catchBlocks = chain.GetOrCreateTryCatchFinallyFrame().CatchBlocks;
-        catchBlocks.Single().ExceptionType.ShouldBe(typeof(JasperFx.ConcurrencyException));
-
-        // Since the policy added nothing here, it must not advertise the conflict status either
+        // The endpoint's own OnException(ConcurrencyException) means the exception can never
+        // reach the middleware, so advertising the conflict response would be a lie
         endpointFor("/orders/itemready/custom-handled").Metadata.OfType<IProducesResponseTypeMetadata>()
             .Any(x => x.StatusCode == 409).ShouldBeFalse();
-    }
-
-    [Fact]
-    public void stream_locked_catch_is_not_added_to_optimistic_chains()
-    {
-        var chain = HttpChains.ChainFor("POST", "/orders/itemready");
-        chain.ShouldNotBeNull();
-
-        chain.GetOrCreateTryCatchFinallyFrame().CatchBlocks
-            .Any(x => x.ExceptionType == typeof(StreamLockedException)).ShouldBeFalse();
     }
 
     private RouteEndpoint endpointFor(string route)
@@ -125,12 +108,12 @@ public class concurrency_exception_problem_details(AppFixture fixture) : Integra
     }
 }
 
-// The opt-in behavior itself needs hosts with different policy registrations than the shared
+// The opt-in behavior itself needs hosts with different registrations than the shared
 // WolverineWebApi application, so these tests bootstrap their own little applications against
 // the endpoints at the bottom of this file
 public class concurrency_exception_policy_opt_in
 {
-    private static async Task<IAlbaHost> buildHostAsync(Action<WolverineHttpOptions>? configure,
+    private static async Task<IAlbaHost> buildHostAsync(int? problemDetailsStatusCode,
         string? connectionString = null)
     {
         // WolverineWebApi runs in Development under Alba too; without the developer exception
@@ -159,7 +142,21 @@ public class concurrency_exception_policy_opt_in
 
         builder.Services.AddWolverineHttp();
 
-        return await AlbaHost.For(builder, app => app.MapWolverineEndpoints(opts => configure?.Invoke(opts)));
+        if (problemDetailsStatusCode.HasValue)
+        {
+            builder.Services.UseProblemDetailsForConcurrencyExceptions(problemDetailsStatusCode.Value);
+        }
+
+        return await AlbaHost.For(builder, app =>
+        {
+            if (problemDetailsStatusCode.HasValue)
+            {
+                // The concurrency mapping runs inside the exception handler middleware
+                app.UseExceptionHandler();
+            }
+
+            app.MapWolverineEndpoints();
+        });
     }
 
     private static async Task<Guid> startOrder(IAlbaHost host)
@@ -196,7 +193,7 @@ public class concurrency_exception_policy_opt_in
     [Fact]
     public async Task uses_a_non_default_status_code_in_both_response_and_metadata()
     {
-        await using var host = await buildHostAsync(opts => opts.UseProblemDetailsForConcurrencyExceptions(412));
+        await using var host = await buildHostAsync(412);
 
         var id = await startOrder(host);
 
@@ -228,17 +225,10 @@ public class concurrency_exception_policy_opt_in
         // Marten surfaces a contended FetchForExclusiveWriting as a StreamLockedException only
         // after the Npgsql command timeout, so keep that short to make this test quick -- but not
         // so short that first-touch schema migration under parallel suite load can trip it
-        await using var host = await buildHostAsync(opts => opts.UseProblemDetailsForConcurrencyExceptions(),
+        await using var host = await buildHostAsync(409,
             Servers.PostgresConnectionString + ";Command Timeout=5");
 
         var id = await startOrder(host);
-
-        // Chain-level pin: the StreamLockedException catch is only added to exclusive chains
-        var graph = host.Services.GetRequiredService<WolverineHttpOptions>().Endpoints!;
-        graph.ChainFor("POST", "/local/orders/ship-exclusive")!.GetOrCreateTryCatchFinallyFrame().CatchBlocks
-            .Any(x => x.ExceptionType == typeof(StreamLockedException)).ShouldBeTrue();
-        graph.ChainFor("POST", "/local/orders/itemready")!.GetOrCreateTryCatchFinallyFrame().CatchBlocks
-            .Any(x => x.ExceptionType == typeof(StreamLockedException)).ShouldBeFalse();
 
         // Hold the stream's exclusive lock from a competing session for the duration of the request
         var store = host.Services.GetRequiredService<IDocumentStore>();

--- a/src/Http/Wolverine.Http.Tests/Marten/concurrency_exception_problem_details.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/concurrency_exception_problem_details.cs
@@ -1,9 +1,16 @@
 using Alba;
+using IntegrationTests;
+using Marten;
+using Marten.Exceptions;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
+using Wolverine.Attributes;
+using Wolverine.Http.Marten;
+using Wolverine.Marten;
 using WolverineWebApi.Marten;
 
 namespace Wolverine.Http.Tests.Marten;
@@ -76,12 +83,7 @@ public class concurrency_exception_problem_details(AppFixture fixture) : Integra
     [Fact]
     public void concurrency_conflict_is_registered_in_openapi_metadata()
     {
-        var endpoints = Host.Services.GetServices<EndpointDataSource>().SelectMany(x => x.Endpoints)
-            .OfType<RouteEndpoint>().ToList();
-
-        var endpoint = endpoints.Single(x =>
-            x.RoutePattern.RawText == "/orders/itemready" && x.Metadata.OfType<HttpMethodMetadata>()
-                .Any(m => m.HttpMethods.Contains("POST")));
+        var endpoint = endpointFor("/orders/itemready");
 
         var produces = endpoint.Metadata.OfType<IProducesResponseTypeMetadata>().Single(x => x.StatusCode == 409);
         produces.Type.ShouldBe(typeof(ProblemDetails));
@@ -89,15 +91,200 @@ public class concurrency_exception_problem_details(AppFixture fixture) : Integra
     }
 
     [Fact]
-    public void does_not_register_the_conflict_status_when_the_user_catch_took_the_exception_type()
+    public void no_catch_or_conflict_metadata_added_when_the_endpoint_handles_the_exception_itself()
     {
         var chain = HttpChains.ChainFor("POST", "/orders/itemready/custom-handled");
         chain.ShouldNotBeNull();
 
-        // The StreamLockedException catch is still added, but ConcurrencyException
-        // belongs to the endpoint's own OnException handler
-        var catchTypes = chain.GetOrCreateTryCatchFinallyFrame().CatchBlocks
-            .Count(x => x.ExceptionType == typeof(JasperFx.ConcurrencyException));
-        catchTypes.ShouldBe(1);
+        // The single ConcurrencyException catch belongs to the endpoint's own OnException handler,
+        // and this optimistic chain gets no StreamLockedException catch either
+        var catchBlocks = chain.GetOrCreateTryCatchFinallyFrame().CatchBlocks;
+        catchBlocks.Single().ExceptionType.ShouldBe(typeof(JasperFx.ConcurrencyException));
+
+        // Since the policy added nothing here, it must not advertise the conflict status either
+        endpointFor("/orders/itemready/custom-handled").Metadata.OfType<IProducesResponseTypeMetadata>()
+            .Any(x => x.StatusCode == 409).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void stream_locked_catch_is_not_added_to_optimistic_chains()
+    {
+        var chain = HttpChains.ChainFor("POST", "/orders/itemready");
+        chain.ShouldNotBeNull();
+
+        chain.GetOrCreateTryCatchFinallyFrame().CatchBlocks
+            .Any(x => x.ExceptionType == typeof(StreamLockedException)).ShouldBeFalse();
+    }
+
+    private RouteEndpoint endpointFor(string route)
+    {
+        return Host.Services.GetServices<EndpointDataSource>().SelectMany(x => x.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Single(x => x.RoutePattern.RawText == route && x.Metadata.OfType<HttpMethodMetadata>()
+                .Any(m => m.HttpMethods.Contains("POST")));
     }
 }
+
+// The opt-in behavior itself needs hosts with different policy registrations than the shared
+// WolverineWebApi application, so these tests bootstrap their own little applications against
+// the endpoints at the bottom of this file
+public class concurrency_exception_policy_opt_in
+{
+    private static async Task<IAlbaHost> buildHostAsync(Action<WolverineHttpOptions>? configure,
+        string? connectionString = null)
+    {
+        // WolverineWebApi runs in Development under Alba too; without the developer exception
+        // page an escaping exception surfaces to Alba as a thrown exception instead of a 500
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = "Development"
+        });
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.Durability.Mode = DurabilityMode.Solo;
+
+            opts.Discovery.DisableConventionalDiscovery();
+            opts.Discovery.IncludeAssembly(typeof(concurrency_exception_policy_opt_in).Assembly);
+
+            opts.Services.AddMarten(m =>
+            {
+                m.Connection(connectionString ?? Servers.PostgresConnectionString);
+                m.DatabaseSchemaName = "concurrency_policy_http";
+                m.DisableNpgsqlLogging = true;
+            }).IntegrateWithWolverine();
+
+            opts.Policies.AutoApplyTransactions();
+        });
+
+        builder.Services.AddWolverineHttp();
+
+        return await AlbaHost.For(builder, app => app.MapWolverineEndpoints(opts => configure?.Invoke(opts)));
+    }
+
+    private static async Task<Guid> startOrder(IAlbaHost host)
+    {
+        var result = await host.Scenario(x =>
+        {
+            x.Post.Json(new StartOrder(["Socks", "Shoes", "Shirt"])).ToUrl("/local/orders/create");
+        });
+
+        var status = await result.ReadAsJsonAsync<OrderStatus>();
+        status.ShouldNotBeNull();
+        return status.OrderId;
+    }
+
+    [Fact]
+    public async Task concurrency_exception_still_escapes_as_500_without_the_opt_in()
+    {
+        await using var host = await buildHostAsync(null);
+
+        var id = await startOrder(host);
+
+        await host.Scenario(x =>
+        {
+            x.Post.Json(new MarkItemReady(id, "Socks", 1)).ToUrl("/local/orders/itemready");
+        });
+
+        await host.Scenario(x =>
+        {
+            x.Post.Json(new MarkItemReady(id, "Shoes", 1)).ToUrl("/local/orders/itemready");
+            x.StatusCodeShouldBe(500);
+        });
+    }
+
+    [Fact]
+    public async Task uses_a_non_default_status_code_in_both_response_and_metadata()
+    {
+        await using var host = await buildHostAsync(opts => opts.UseProblemDetailsForConcurrencyExceptions(412));
+
+        var id = await startOrder(host);
+
+        await host.Scenario(x =>
+        {
+            x.Post.Json(new MarkItemReady(id, "Socks", 1)).ToUrl("/local/orders/itemready");
+        });
+
+        var result = await host.Scenario(x =>
+        {
+            x.Post.Json(new MarkItemReady(id, "Shoes", 1)).ToUrl("/local/orders/itemready");
+            x.StatusCodeShouldBe(412);
+            x.ContentTypeShouldBe("application/problem+json");
+        });
+
+        var details = await result.ReadAsJsonAsync<ProblemDetails>();
+        details.ShouldNotBeNull();
+        details.Status.ShouldBe(412);
+
+        var endpoint = host.Services.GetServices<EndpointDataSource>().SelectMany(x => x.Endpoints)
+            .OfType<RouteEndpoint>().Single(x => x.RoutePattern.RawText == "/local/orders/itemready");
+        endpoint.Metadata.OfType<IProducesResponseTypeMetadata>().Single(x => x.StatusCode == 412)
+            .ContentTypes.Single().ShouldBe("application/problem+json");
+    }
+
+    [Fact]
+    public async Task stream_locked_by_a_competing_session_responds_with_409()
+    {
+        // Marten surfaces a contended FetchForExclusiveWriting as a StreamLockedException only
+        // after the Npgsql command timeout, so keep that short to make this test quick -- but not
+        // so short that first-touch schema migration under parallel suite load can trip it
+        await using var host = await buildHostAsync(opts => opts.UseProblemDetailsForConcurrencyExceptions(),
+            Servers.PostgresConnectionString + ";Command Timeout=5");
+
+        var id = await startOrder(host);
+
+        // Chain-level pin: the StreamLockedException catch is only added to exclusive chains
+        var graph = host.Services.GetRequiredService<WolverineHttpOptions>().Endpoints!;
+        graph.ChainFor("POST", "/local/orders/ship-exclusive")!.GetOrCreateTryCatchFinallyFrame().CatchBlocks
+            .Any(x => x.ExceptionType == typeof(StreamLockedException)).ShouldBeTrue();
+        graph.ChainFor("POST", "/local/orders/itemready")!.GetOrCreateTryCatchFinallyFrame().CatchBlocks
+            .Any(x => x.ExceptionType == typeof(StreamLockedException)).ShouldBeFalse();
+
+        // Hold the stream's exclusive lock from a competing session for the duration of the request
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+        await using (var holder = store.LightweightSession())
+        {
+            await holder.Events.FetchForExclusiveWriting<Order>(id, TestContext.Current.CancellationToken);
+
+            var result = await host.Scenario(x =>
+            {
+                x.Post.Json(new ShipOrderExclusively(id)).ToUrl("/local/orders/ship-exclusive");
+                x.StatusCodeShouldBe(409);
+                x.ContentTypeShouldBe("application/problem+json");
+            });
+
+            var details = await result.ReadAsJsonAsync<ProblemDetails>();
+            details.ShouldNotBeNull();
+            details.Status.ShouldBe(409);
+        }
+    }
+}
+
+public static class LocalConcurrencyOrderEndpoints
+{
+    [Transactional]
+    [WolverinePost("/local/orders/create")]
+    public static OrderStatus Start(StartOrder command, IDocumentSession session)
+    {
+        var items = command.Items.Select(x => new Item { Name = x }).ToArray();
+        var orderId = session.Events.StartStream<Order>(new OrderCreated(items)).Id;
+
+        return new OrderStatus(orderId, false);
+    }
+
+    [AggregateHandler]
+    [WolverinePost("/local/orders/itemready")]
+    public static (OrderStatus, Events) Post(MarkItemReady command, Order order)
+    {
+        return (new OrderStatus(order.Id, order.IsReadyToShip()), [new ItemReady(command.ItemName)]);
+    }
+
+    [AggregateHandler(ConcurrencyStyle.Exclusive)]
+    [WolverinePost("/local/orders/ship-exclusive"), EmptyResponse]
+    public static OrderShipped Ship(ShipOrderExclusively command, Order order)
+    {
+        return new OrderShipped();
+    }
+}
+
+public record ShipOrderExclusively(Guid OrderId);

--- a/src/Http/Wolverine.Http.Tests/Marten/concurrency_exception_problem_details.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/concurrency_exception_problem_details.cs
@@ -1,0 +1,103 @@
+using Alba;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using WolverineWebApi.Marten;
+
+namespace Wolverine.Http.Tests.Marten;
+
+public class concurrency_exception_problem_details(AppFixture fixture) : IntegrationContext(fixture)
+{
+    private async Task<Guid> startOrder()
+    {
+        var result = await Scenario(x =>
+        {
+            x.Post.Json(new StartOrder(["Socks", "Shoes", "Shirt"])).ToUrl("/orders/create");
+        });
+
+        var status = await result.ReadAsJsonAsync<OrderStatus>();
+        status.ShouldNotBeNull();
+        return status.OrderId;
+    }
+
+    [Fact]
+    public async Task stale_expected_version_responds_with_409_problem_details()
+    {
+        var id = await startOrder();
+
+        // First time is fine, and advances the stream past version 1
+        await Scenario(x =>
+        {
+            x.Post.Json(new MarkItemReady(id, "Socks", 1)).ToUrl("/orders/itemready");
+        });
+
+        // Replaying the same expected version trips Marten's optimistic concurrency
+        // check when the session is committed
+        var result = await Scenario(x =>
+        {
+            x.Post.Json(new MarkItemReady(id, "Shoes", 1)).ToUrl("/orders/itemready");
+            x.StatusCodeShouldBe(409);
+            x.ContentTypeShouldBe("application/problem+json");
+        });
+
+        // And let's verify that we got what we expected for the ProblemDetails
+        // in the HTTP response body of the 2nd request
+        var details = await result.ReadAsJsonAsync<ProblemDetails>();
+        details.ShouldNotBeNull();
+        details.Status.ShouldBe(409);
+        details.Title.ShouldBe("Concurrency conflict");
+    }
+
+    [Fact]
+    public async Task user_defined_on_exception_for_the_same_exception_type_wins()
+    {
+        var id = await startOrder();
+
+        await Scenario(x =>
+        {
+            x.Post.Json(new MarkItemReady(id, "Socks", 1)).ToUrl("/orders/itemready/custom-handled");
+        });
+
+        // The endpoint's own OnException(ConcurrencyException) is already in the catch
+        // block, so the policy must leave it alone rather than doubling the catch
+        var result = await Scenario(x =>
+        {
+            x.Post.Json(new MarkItemReady(id, "Shoes", 1)).ToUrl("/orders/itemready/custom-handled");
+            x.StatusCodeShouldBe(400);
+        });
+
+        var details = await result.ReadAsJsonAsync<ProblemDetails>();
+        details.ShouldNotBeNull();
+        details.Title.ShouldBe("Somebody else got there first");
+    }
+
+    [Fact]
+    public void concurrency_conflict_is_registered_in_openapi_metadata()
+    {
+        var endpoints = Host.Services.GetServices<EndpointDataSource>().SelectMany(x => x.Endpoints)
+            .OfType<RouteEndpoint>().ToList();
+
+        var endpoint = endpoints.Single(x =>
+            x.RoutePattern.RawText == "/orders/itemready" && x.Metadata.OfType<HttpMethodMetadata>()
+                .Any(m => m.HttpMethods.Contains("POST")));
+
+        var produces = endpoint.Metadata.OfType<IProducesResponseTypeMetadata>().Single(x => x.StatusCode == 409);
+        produces.Type.ShouldBe(typeof(ProblemDetails));
+        produces.ContentTypes.Single().ShouldBe("application/problem+json");
+    }
+
+    [Fact]
+    public void does_not_register_the_conflict_status_when_the_user_catch_took_the_exception_type()
+    {
+        var chain = HttpChains.ChainFor("POST", "/orders/itemready/custom-handled");
+        chain.ShouldNotBeNull();
+
+        // The StreamLockedException catch is still added, but ConcurrencyException
+        // belongs to the endpoint's own OnException handler
+        var catchTypes = chain.GetOrCreateTryCatchFinallyFrame().CatchBlocks
+            .Count(x => x.ExceptionType == typeof(JasperFx.ConcurrencyException));
+        catchTypes.ShouldBe(1);
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/Marten/using_version_source_override.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/using_version_source_override.cs
@@ -1,3 +1,4 @@
+using Alba;
 using Marten;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
@@ -38,16 +39,18 @@ public class using_version_source_override(AppFixture fixture) : IntegrationCont
     }
 
     [Fact]
-    public async Task wrong_version_from_route_argument_returns_500()
+    public async Task wrong_version_from_route_argument_returns_409_problem_details()
     {
         var orderId = await CreateOrder();
 
-        // version 99 does not match - should fail
+        // version 99 does not match - should fail with the ProblemDetails response
+        // from UseProblemDetailsForConcurrencyExceptions() in Program.cs
         await Scenario(x =>
         {
             x.Post.Json(new ShipOrderWithExpectedVersion(orderId, 99))
                 .ToUrl($"/orders/{orderId}/ship-with-expected-version/99");
-            x.StatusCodeShouldBe(500);
+            x.StatusCodeShouldBe(409);
+            x.ContentTypeShouldBe("application/problem+json");
         });
     }
 
@@ -70,7 +73,7 @@ public class using_version_source_override(AppFixture fixture) : IntegrationCont
     }
 
     [Fact]
-    public async Task wrong_version_from_request_body_returns_500()
+    public async Task wrong_version_from_request_body_returns_409_problem_details()
     {
         var orderId = await CreateOrder();
 
@@ -78,7 +81,8 @@ public class using_version_source_override(AppFixture fixture) : IntegrationCont
         {
             x.Post.Json(new ShipOrderWithExpectedVersion(orderId, 99))
                 .ToUrl("/orders/ship-with-body-version");
-            x.StatusCodeShouldBe(500);
+            x.StatusCodeShouldBe(409);
+            x.ContentTypeShouldBe("application/problem+json");
         });
     }
 }

--- a/src/Http/WolverineWebApi/Marten/ConcurrencyExceptionEndpoint.cs
+++ b/src/Http/WolverineWebApi/Marten/ConcurrencyExceptionEndpoint.cs
@@ -1,0 +1,33 @@
+using JasperFx;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine.Http;
+using Wolverine.Marten;
+
+namespace WolverineWebApi.Marten;
+
+#region sample_concurrency_exception_with_onexception
+
+// This endpoint handles the Marten concurrency failure itself with the OnException
+// convention, so the UseProblemDetailsForConcurrencyExceptions() policy leaves
+// its catch block completely alone
+public static class HandleConcurrencyExceptionYourselfEndpoint
+{
+    [AggregateHandler]
+    [WolverinePost("/orders/itemready/custom-handled")]
+    public static (OrderStatus, Events) Post(MarkItemReady command, Order order)
+    {
+        return (new OrderStatus(order.Id, order.IsReadyToShip()), [new ItemReady(command.ItemName)]);
+    }
+
+    public static ProblemDetails OnException(ConcurrencyException ex)
+    {
+        return new ProblemDetails
+        {
+            Status = 400,
+            Title = "Somebody else got there first",
+            Detail = ex.Message
+        };
+    }
+}
+
+#endregion

--- a/src/Http/WolverineWebApi/Marten/ConcurrencyExceptionEndpoint.cs
+++ b/src/Http/WolverineWebApi/Marten/ConcurrencyExceptionEndpoint.cs
@@ -8,8 +8,8 @@ namespace WolverineWebApi.Marten;
 #region sample_concurrency_exception_with_onexception
 
 // This endpoint handles the Marten concurrency failure itself with the OnException
-// convention, so the UseProblemDetailsForConcurrencyExceptions() policy leaves
-// its catch block completely alone
+// convention, so the exception never reaches the exception handler middleware and
+// the UseProblemDetailsForConcurrencyExceptions() mapping never comes into play
 public static class HandleConcurrencyExceptionYourselfEndpoint
 {
     [AggregateHandler]

--- a/src/Http/WolverineWebApi/OpenApiEndpoints.cs
+++ b/src/Http/WolverineWebApi/OpenApiEndpoints.cs
@@ -26,9 +26,7 @@ public class OpenApiEndpoints
         return "hello";
     }
 
-    // 409 because the returned Reservation is a Saga, so this chain commits a Marten
-    // session and picks up UseProblemDetailsForConcurrencyExceptions() from Program.cs
-    [ExpectStatusCodes(200, 404, 409)]
+    [ExpectStatusCodes(200, 404)]
     [ExpectProduces(200, typeof(Reservation), "application/json")]
     [WolverineGet("/openapi/json")]
     public Reservation GetJson()

--- a/src/Http/WolverineWebApi/OpenApiEndpoints.cs
+++ b/src/Http/WolverineWebApi/OpenApiEndpoints.cs
@@ -26,7 +26,9 @@ public class OpenApiEndpoints
         return "hello";
     }
 
-    [ExpectStatusCodes(200, 404)]
+    // 409 because the returned Reservation is a Saga, so this chain commits a Marten
+    // session and picks up UseProblemDetailsForConcurrencyExceptions() from Program.cs
+    [ExpectStatusCodes(200, 404, 409)]
     [ExpectProduces(200, typeof(Reservation), "application/json")]
     [WolverineGet("/openapi/json")]
     public Reservation GetJson()

--- a/src/Http/WolverineWebApi/Program.cs
+++ b/src/Http/WolverineWebApi/Program.cs
@@ -123,6 +123,15 @@ public class Program
             opts.Events.UseIdentityMapForAggregates = true;
         }).IntegrateWithWolverine();
 
+        #region sample_UseProblemDetailsForConcurrencyExceptions
+        // Opt into responding with a 409 status code and a ProblemDetails
+        // body when a Marten concurrency exception escapes an HTTP endpoint.
+        // The exception mapping is done by the ASP.NET Core exception handler
+        // middleware, so the application also needs app.UseExceptionHandler()
+        builder.Services.UseProblemDetailsForConcurrencyExceptions();
+
+        #endregion
+
         builder.Services.AddMartenStore<IThingStore>(options =>
         {
             options.Connection(Servers.PostgresConnectionString);
@@ -222,6 +231,11 @@ public class Program
             .AddSupportedUICultures(supportedCultures);
 
         app.UseRequestLocalization(localizationOptions);
+
+        // Required for UseProblemDetailsForConcurrencyExceptions() above: the concurrency
+        // exception mapping runs inside this middleware. Added before the scoped /v1/orders/throws
+        // handler below so that branch stays innermost and keeps winning on its own path.
+        app.UseExceptionHandler();
 
         // Scoped UseExceptionHandler — only on the dedicated regression-test path. Pinning the
         // documented out-of-scope: 5xx responses produced by the global ASP.NET Core exception
@@ -373,14 +387,6 @@ public class Program
                 chain => chain.Method.HandlerType == typeof(MiddlewareExceptionEndpoints));
 
             opts.AddPolicy<StreamCollisionExceptionPolicy>();
-
-            #region sample_UseProblemDetailsForConcurrencyExceptions
-            // Opt into responding with a 409 status code and a ProblemDetails
-            // body when a Marten concurrency exception is caught on any endpoint
-            // using the aggregate handler workflow or Marten transactional middleware
-            opts.UseProblemDetailsForConcurrencyExceptions();
-
-            #endregion
 
             opts.AddPolicy<FrameRearrangeMiddleware.HttpPolicy>();
 

--- a/src/Http/WolverineWebApi/Program.cs
+++ b/src/Http/WolverineWebApi/Program.cs
@@ -374,6 +374,14 @@ public class Program
 
             opts.AddPolicy<StreamCollisionExceptionPolicy>();
 
+            #region sample_UseProblemDetailsForConcurrencyExceptions
+            // Opt into responding with a 409 status code and a ProblemDetails
+            // body when a Marten concurrency exception is caught on any endpoint
+            // using the aggregate handler workflow or Marten transactional middleware
+            opts.UseProblemDetailsForConcurrencyExceptions();
+
+            #endregion
+
             opts.AddPolicy<FrameRearrangeMiddleware.HttpPolicy>();
 
             #region sample_adding_custom_parameter_handling


### PR DESCRIPTION
Addresses #3764.

> ⚠️ **Please review with a healthy dose of skepticism.** This comes from consumers of Wolverine, not maintainers: we reproduced the behavior, studied the surrounding code (`StreamCollisionExceptionPolicy`, the `OnException`/`TryCatchFinallyFrame` machinery, `RequiredEntityPolicy`), and validated against the test suite — but we don't have deep knowledge of these internals or their design history, so take the approach with a pinch of salt. If a different shape fits better, we're glad to rework it, or treat this purely as a working starting point.

## What

`opts.UseProblemDetailsForConcurrencyExceptions(statusCode = 409)` — an opt-in `IHttpPolicy` in Wolverine.Http.Marten mapping commit-time concurrency failures to ProblemDetails instead of an unhandled 500.

- **Broad catch, scoped metadata**: any chain committing a Marten session catches `JasperFx.ConcurrencyException` (covers `EventStreamUnexpectedMaxEventIdException` and `DcbConcurrencyException` via inheritance); `ProducesProblem(statusCode)` is stamped only on write-shaped chains (aggregate handling present, or verbs beyond GET/HEAD) so `[ReadAggregate]` GETs under `AutoApplyTransactions` keep a clean OpenAPI surface.
- **`StreamLockedException`** (a `MartenException`, not a `ConcurrencyException`) caught solely on `ConcurrencyStyle.Exclusive` chains.
- **User code wins**: an endpoint's own `OnException` for the same exception type suppresses both the catch and the metadata stamp.
- **Never masks a streaming failure**: rethrows when `Response.HasStarted`, mirroring ASP.NET Core's `ExceptionHandlerMiddleware`.
- **Telemetry**: handled conflicts log at Information.

## Tests

8 tests in `concurrency_exception_problem_details.cs`, modelled on `use_stream_collision_policy`: deterministic stale-version 409 repro with body + OpenAPI metadata assertions; a live contended `FetchForExclusiveWriting` repro (competing session holds the stream lock, `Command Timeout` bounds the wait) → 409; a default-off pin proving the 500 escape is unchanged without the opt-in; a non-default status (412) test; and user-catch-wins pins at chain level. Two pre-existing tests that pinned escape-as-500 on version-carrying endpoints now assert the 409 ProblemDetails.

Full `Wolverine.Http.Tests`: **952 passed / 0 failed / 10 skipped** across four consecutive runs. One candid note: the first full run after the final build showed 2 failures we failed to capture and could not reproduce across four subsequent runs including a cold build (suspected schema-migration contention against the StreamLocked test host's initial 3s command timeout, since widened to 5s) — flagging for a CI observation cycle rather than pretending it didn't happen.

## Docs

New "Concurrency Exceptions" section in `docs/guide/http/marten.md` plus a cross-link from `exception-handling.md`, via region-tagged WolverineWebApi samples (mdsnippets-clean), including the hand-rolled `OnException` alternative and the supertype/`HasStarted` caveats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)