### PR TITLE
Agent commands wait on observed progress, not the clock (GH-3748, GH-3750)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/AgentWorkConfirmationTests.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/AgentWorkConfirmationTests.cs
@@ -1,0 +1,242 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+public class AgentWorkConfirmationTests
+{
+    private static readonly Uri A = new("fake://one");
+    private static readonly Uri B = new("fake://two");
+    private static readonly Uri C = new("fake://three");
+
+    private static Task<Uri[]> awaitCore(Func<Uri[], Task<Uri[]>> queryRunning, Task<Uri[]> workReply,
+        Uri[] requested, AgentPresenceDirection direction, TimeSpan? stallTimeout = null,
+        CancellationToken cancellation = default)
+    {
+#pragma warning disable VSTHRD003
+        return AgentWorkConfirmation.AwaitCoreAsync(queryRunning, workReply, requested, direction,
+            pollInterval: 25.Milliseconds(), stallTimeout ?? 60.Seconds(), NullLogger.Instance, cancellation);
+#pragma warning restore VSTHRD003
+    }
+
+    private static Task<Uri[]> neverQueried(Uri[] _)
+        => throw new InvalidOperationException("The destination should not have been polled");
+
+    [Fact]
+    public async Task the_reply_wins_when_it_arrives_first()
+    {
+        var confirmed = await awaitCore(neverQueried, Task.FromResult(new[] { A, B, C }), [A, B, C],
+            AgentPresenceDirection.Running, cancellation: TestContext.Current.CancellationToken);
+
+        confirmed.ShouldBe([A, B, C], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task a_partial_reply_is_returned_as_is()
+    {
+        var confirmed = await awaitCore(neverQueried, Task.FromResult(new[] { B }), [A, B, C],
+            AgentPresenceDirection.Running, cancellation: TestContext.Current.CancellationToken);
+
+        confirmed.ShouldBe([B]);
+    }
+
+    [Fact]
+    public async Task polls_confirm_the_whole_batch_without_waiting_for_the_reply()
+    {
+        // The reply never arrives -- the batch is fully confirmed by observation alone
+        var reply = new TaskCompletionSource<Uri[]>();
+
+        var polls = 0;
+        var confirmed = await awaitCore(_ =>
+        {
+            polls++;
+            // Progressive convergence: one more agent is running on each poll
+            return Task.FromResult(new[] { A, B, C }.Take(polls).ToArray());
+        }, reply.Task, [A, B, C], AgentPresenceDirection.Running, cancellation: TestContext.Current.CancellationToken);
+
+        confirmed.ShouldBe([A, B, C], ignoreOrder: true);
+        polls.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task a_timed_out_reply_keeps_what_the_polls_observed_after_progress_stalls()
+    {
+        var reply = new TaskCompletionSource<Uri[]>();
+
+        var polls = 0;
+        var confirmed = await awaitCore(_ =>
+        {
+            polls++;
+            if (polls == 2)
+            {
+                // The legacy reply window elapses after the second poll
+                reply.SetException(new TimeoutException());
+            }
+
+            return Task.FromResult(new[] { A });
+        }, reply.Task, [A, B, C], AgentPresenceDirection.Running, stallTimeout: 200.Milliseconds(),
+            cancellation: TestContext.Current.CancellationToken);
+
+        confirmed.ShouldBe([A]);
+    }
+
+    [Fact]
+    public async Task a_timed_out_reply_does_not_cut_short_a_destination_still_making_progress()
+    {
+        // The reply window elapses early, but the destination keeps answering polls and keeps making
+        // progress -- the wait must continue to full confirmation on the polls alone
+        var reply = new TaskCompletionSource<Uri[]>();
+
+        var polls = 0;
+        var confirmed = await awaitCore(_ =>
+        {
+            polls++;
+            if (polls == 1)
+            {
+                reply.SetException(new TimeoutException());
+            }
+
+            return Task.FromResult(new[] { A, B, C }.Take(polls).ToArray());
+        }, reply.Task, [A, B, C], AgentPresenceDirection.Running, stallTimeout: 60.Seconds(),
+            cancellation: TestContext.Current.CancellationToken);
+
+        confirmed.ShouldBe([A, B, C], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task gone_mode_confirms_the_agents_absent_from_the_node()
+    {
+        // Waiting on stops: A is still running (stop not finished), B and C are gone
+        var reply = new TaskCompletionSource<Uri[]>();
+
+        var confirmed = await awaitCore(_ =>
+        {
+            var result = Task.FromResult(new[] { A });
+            reply.SetException(new TimeoutException());
+            return result;
+        }, reply.Task, [A, B, C], AgentPresenceDirection.Gone, stallTimeout: 200.Milliseconds(),
+            cancellation: TestContext.Current.CancellationToken);
+
+        confirmed.ShouldBe([B, C], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task gives_up_after_answered_polls_show_no_progress_for_the_stall_timeout()
+    {
+        var reply = new TaskCompletionSource<Uri[]>();
+
+        var confirmed = await awaitCore(_ => Task.FromResult(Array.Empty<Uri>()), reply.Task, [A, B, C],
+            AgentPresenceDirection.Running, stallTimeout: 150.Milliseconds(), cancellation: TestContext.Current.CancellationToken);
+
+        // Gave up on a wedged destination without waiting for the (never-arriving) reply
+        confirmed.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task progress_resets_the_stall_clock()
+    {
+        var reply = new TaskCompletionSource<Uri[]>();
+
+        // Each agent takes ~100ms to appear -- longer than the 150ms stall timeout would allow if the
+        // clock never reset, but each poll that confirms something new buys more patience
+        var started = DateTimeOffset.UtcNow;
+        var confirmed = await awaitCore(_ =>
+        {
+            var elapsed = DateTimeOffset.UtcNow - started;
+            var running = new[] { A, B, C }.Take((int)(elapsed.TotalMilliseconds / 100)).ToArray();
+            return Task.FromResult(running);
+        }, reply.Task, [A, B, C], AgentPresenceDirection.Running, stallTimeout: 150.Milliseconds(), cancellation: TestContext.Current.CancellationToken);
+
+        confirmed.ShouldBe([A, B, C], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task unanswered_polls_never_trip_the_stall_timeout()
+    {
+        // A destination that cannot answer the presence query -- a pre-upgrade node -- leaves the
+        // reply's own window as the only bound, so a tiny stall timeout must NOT cut the wait short
+        var reply = new TaskCompletionSource<Uri[]>();
+
+        var polls = 0;
+        var confirmed = await awaitCore(_ =>
+        {
+            polls++;
+            if (polls == 10)
+            {
+                // The real reply finally lands long after the stall timeout would have expired
+                reply.SetResult([A, B]);
+            }
+
+            throw new TimeoutException("no such handler on this node");
+        }, reply.Task, [A, B, C], AgentPresenceDirection.Running, stallTimeout: 50.Milliseconds(), cancellation: TestContext.Current.CancellationToken);
+
+        confirmed.ShouldBe([A, B], ignoreOrder: true);
+        polls.ShouldBeGreaterThanOrEqualTo(10);
+    }
+
+    [Fact]
+    public async Task cancellation_returns_whatever_was_confirmed()
+    {
+        var reply = new TaskCompletionSource<Uri[]>();
+        using var cancellation = new CancellationTokenSource();
+
+        var confirmed = await awaitCore(async _ =>
+        {
+            await cancellation.CancelAsync();
+            return [A];
+        }, reply.Task, [A, B, C], AgentPresenceDirection.Running, cancellation: cancellation.Token);
+
+        confirmed.ShouldBe([A]);
+    }
+
+    [Fact]
+    public async Task confirmations_outside_the_requested_set_are_ignored()
+    {
+        var other = new Uri("fake://someone-else");
+        var reply = new TaskCompletionSource<Uri[]>();
+
+        var confirmed = await awaitCore(_ =>
+        {
+            var result = Task.FromResult(new[] { A, other });
+            reply.SetException(new TimeoutException());
+            return result;
+        }, reply.Task, [A, B], AgentPresenceDirection.Running, stallTimeout: 200.Milliseconds(),
+            cancellation: TestContext.Current.CancellationToken);
+
+        confirmed.ShouldBe([A]);
+    }
+}
+
+public class QueryAgentPresenceTests
+{
+    [Fact]
+    public async Task reports_the_intersection_of_requested_and_running()
+    {
+        var runtime = new MockWolverineRuntime();
+        var a = new Uri("fake://one");
+        var b = new Uri("fake://two");
+        var c = new Uri("fake://three");
+
+        runtime.Agents.AllRunningAgentUris().Returns([a, b]);
+
+        var commands = await new QueryAgentPresence([b, c]).ExecuteAsync(runtime, CancellationToken.None);
+
+        commands.Single().ShouldBeOfType<AgentPresenceReport>().Running.ShouldBe([b]);
+    }
+
+    [Fact]
+    public async Task reports_nothing_running_when_nothing_matches()
+    {
+        var runtime = new MockWolverineRuntime();
+        runtime.Agents.AllRunningAgentUris().Returns([new Uri("fake://other")]);
+
+        var commands = await new QueryAgentPresence([new Uri("fake://one")])
+            .ExecuteAsync(runtime, CancellationToken.None);
+
+        commands.Single().ShouldBeOfType<AgentPresenceReport>().Running.ShouldBeEmpty();
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Agents/agent_command_serialization.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/agent_command_serialization.cs
@@ -87,6 +87,29 @@ public class agent_command_serialization
         other.AgentUris.ShouldBeEmpty();
     }
 
+    [Fact]
+    public void QueryAgentPresence()
+    {
+        var command = new QueryAgentPresence([new Uri("fake://one"), new Uri("fake://two")]);
+
+        roundTrip(command).AgentUris.ShouldBe(command.AgentUris);
+    }
+
+    [Fact]
+    public void AgentPresenceReport()
+    {
+        var command = new AgentPresenceReport([new Uri("fake://one"), new Uri("fake://two")]);
+
+        roundTrip(command).Running.ShouldBe(command.Running);
+    }
+
+    [Fact]
+    public void AgentPresenceReport_with_no_agents()
+    {
+        // The ordinary answer early in a batch of slow starts: nothing requested is running yet
+        roundTrip(new AgentPresenceReport([])).Running.ShouldBeEmpty();
+    }
+
     // GH-3733: a comma is a legal URI sub-delimiter (RFC 3986), permitted unescaped in a path segment, and
     // agent URIs embed operator- and tenant-supplied strings -- an event-subscription URI carries the
     // projection name and the tenant id. Joining on a comma shattered any such agent into fragments, and

--- a/src/Testing/SlowTests/Agents/SlowStartingAgents.cs
+++ b/src/Testing/SlowTests/Agents/SlowStartingAgents.cs
@@ -31,6 +31,14 @@ public class AgentStartTelemetry
     public TimeSpan StartDelay { get; }
 
     /// <summary>
+    /// GH-3748/GH-3750: optional per-agent start cost, overriding <see cref="StartDelay" />. The field
+    /// shape is heterogeneous — a shard behind a projection-version bump replays for minutes while its
+    /// neighbors start in seconds — and re-placement churn only shows when nodes finish their chunks at
+    /// different times, so a symmetric universe can hide it.
+    /// </summary>
+    public Func<Uri, TimeSpan>? DelayOverride { get; set; }
+
+    /// <summary>
     /// GH-3753: how long an agent takes to let go when stopped. Zero by default. A projection version
     /// bump puts a stopping shard behind the same side-effect gate as a starting one, and #3749's lane
     /// wedge only appears when the SOURCE of a reassignment answers its stops slowly — a fast-stopping
@@ -91,7 +99,7 @@ public class AgentStartTelemetry
             // Stand-in for a Marten subscription agent's start: a daemon shard spin-up with database
             // round-trips, made much worse by a projection version bump that gates the new version's
             // side effects behind a replay of the prior version's progression.
-            await Task.Delay(StartDelay, token);
+            await Task.Delay(DelayOverride?.Invoke(uri) ?? StartDelay, token);
         }
         finally
         {

--- a/src/Testing/SlowTests/Agents/slow_starts_outrun_reply_windows.cs
+++ b/src/Testing/SlowTests/Agents/slow_starts_outrun_reply_windows.cs
@@ -1,0 +1,311 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace SlowTests.Agents;
+
+/// <summary>
+/// Reproduction harness for GH-3748 / GH-3750: agent starts that take longer than the batch's
+/// request/reply window.
+///
+/// <para>The reported production shape (same cluster as GH-3753): a projection version bump turns every
+/// subscription shard start into a bounded replay measured at 27s p50 / 215s max — so honest, healthy
+/// work outruns every achievable reply window. The old protocol treated the window elapsing as failure:
+/// the leader released the whole chunk, the pending-assignment ledger's TTL expired, and the next
+/// evaluation re-placed agents that were still mid-start onto other nodes. Field measurement: 369 of 902
+/// distinct agents started more than once in twelve minutes, every repeat on a different node, while
+/// thousands of never-placed agents waited.</para>
+///
+/// <para>This test builds that shape in miniature: chunks whose start work (12 agents x 10s at
+/// parallelism 2 = 60s) exceeds their reply window (30s + 12s = 42s). With the GH-3748 fix the leader
+/// races the reply against <c>QueryAgentPresence</c> progress polling and the destination executes the
+/// batch off its serial control lane, so the cluster must converge with every agent started exactly
+/// once. On the old protocol this exact shape churns: chunks time out at 42s, agents re-place onto other
+/// nodes mid-start, and the same agent completes StartAsync on more than one node.</para>
+/// </summary>
+[Collection("agent_scale")]
+public class slow_starts_outrun_reply_windows : IAsyncLifetime
+{
+    private const string SchemaName = "agent_patience";
+
+    private const int NodeCount = 3;
+    private const int AgentCount = 36;
+
+    // 12 agents per chunk at parallelism 2 and 10s per start = 60s of work against a 42s reply window
+    private const int BatchSize = 12;
+    private const int StartParallelism = 2;
+    private static readonly TimeSpan StartDelay = 10.Seconds();
+
+    private readonly ITestOutputHelper _output;
+    private readonly List<IHost> _hosts = new();
+    private readonly AgentStartTelemetry _telemetry = new(AgentCount, StartDelay);
+
+    public slow_starts_outrun_reply_windows(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync(SchemaName);
+        await conn.CloseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var host in _hosts)
+        {
+            host.GetRuntime().Agents.DisableHealthChecks();
+        }
+
+        _hosts.Reverse();
+        foreach (var host in _hosts)
+        {
+            try
+            {
+                await host.StopAsync();
+                host.Dispose();
+            }
+            catch (Exception e)
+            {
+                _output.WriteLine("Error shutting a host down: " + e);
+            }
+        }
+    }
+
+    // Cluster-wide capture of the agent plane's log stream, dumped on failure. The interesting decisions
+    // (retry-due re-emissions, reverts, reassignments, confirmations) are only visible here.
+    private readonly ConcurrentQueue<string> _log = new();
+    private readonly Stopwatch _clock = Stopwatch.StartNew();
+
+    private sealed class CollectingLoggerProvider(ConcurrentQueue<string> sink, Stopwatch clock, int hostIndex)
+        : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new CollectingLogger(sink, clock, hostIndex, categoryName);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class CollectingLogger(ConcurrentQueue<string> sink, Stopwatch clock, int hostIndex, string category)
+            : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug &&
+                (category.Contains("Agent") || category.Contains("Wolverine.Runtime.WolverineRuntime") || category.Contains("NodeAgentController"));
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (!IsEnabled(logLevel))
+                {
+                    return;
+                }
+
+                sink.Enqueue($"{clock.Elapsed.TotalSeconds,7:0.0}s h{hostIndex} [{logLevel.ToString()[0]}] {formatter(state, exception)}{(exception == null ? "" : " EX: " + exception.Message)}");
+            }
+        }
+    }
+
+    private int _hostIndex;
+
+    private Task<IHost> startHostAsync()
+    {
+        var hostIndex = Interlocked.Increment(ref _hostIndex);
+        return Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.AddProvider(new CollectingLoggerProvider(_log, _clock, hostIndex)))
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Balanced;
+
+                // Let the whole cluster register before the first evaluation so the leader distributes
+                // against the full topology once — the reported scenario is a stable, healthy cluster.
+                opts.Durability.FirstHealthCheckExecution = 20.Seconds();
+                opts.Durability.HealthCheckPollingTime = 2.Seconds();
+                opts.Durability.CheckAssignmentPeriod = 5.Seconds();
+
+                opts.Durability.AgentStartBatchSize = BatchSize;
+                opts.Durability.MaxAgentStartParallelism = StartParallelism;
+
+                // Tight enough that the polls, not the reply window, are what carries the wait
+                opts.Durability.AgentProgressPollInterval = 5.Seconds();
+
+                opts.Services.AddSingleton<IAgentFamily>(new SlowStartAgentFamily(_telemetry, opts));
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, SchemaName);
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task chunks_slower_than_the_reply_window_converge_without_duplicate_starts()
+    {
+        // Heterogeneous start costs, the field shape: a third of the universe starts in 6s, a third in
+        // 12s, a third in 18s, so the nodes finish their chunks at very different times (36s / 72s /
+        // 108s of work against a 42s reply window) and the leader has to keep waiting on nodes that are
+        // slow but demonstrably progressing.
+        _telemetry.DelayOverride = uri =>
+        {
+            var index = int.Parse(uri.AbsolutePath.TrimStart('/').Split('/').Last());
+            return (6 * (1 + index / 12)).Seconds();
+        };
+
+        var hosts = await Task.WhenAll(Enumerable.Range(0, NodeCount).Select(_ => startHostAsync()));
+        _hosts.AddRange(hosts);
+
+        var samples = new List<Sample>();
+        var stopwatch = Stopwatch.StartNew();
+        var hardTimeout = 5.Minutes();
+        TimeSpan? convergedAt = null;
+
+        while (stopwatch.Elapsed < hardTimeout)
+        {
+            await Task.Delay(2.Seconds(), TestContext.Current.CancellationToken);
+
+            var sample = await takeSampleAsync(stopwatch.Elapsed);
+            samples.Add(sample);
+
+            if (sample.TotalAssigned >= AgentCount)
+            {
+                convergedAt = stopwatch.Elapsed;
+                break;
+            }
+        }
+
+        writeReport(samples, convergedAt);
+
+        foreach (var line in await churnFromNodeRecordsAsync())
+        {
+            _output.WriteLine(line);
+        }
+
+        _output.WriteLine("");
+        _output.WriteLine("--- captured agent-plane log ---");
+        foreach (var line in _log)
+        {
+            _output.WriteLine(line);
+        }
+
+        // The whole universe is placed even though every chunk's work outran its reply window. On the
+        // old protocol the timeout was treated as failure and this converges late or never.
+        convergedAt.ShouldNotBeNull();
+
+        // ~20s registration + 60s for one chunk's work per node (all three concurrently) + control
+        // round-trips. Generous so only real churn — restarted work — can spend it.
+        convergedAt.Value.ShouldBeLessThan(3.Minutes());
+
+        // THE GH-3750 churn metric, straight from the field report: no agent may complete a start more
+        // than once anywhere in the cluster. A re-placed mid-start agent completes StartAsync twice, on
+        // two different nodes.
+        var totalCompletedStarts = _telemetry.StartsPerNode.Values.Sum();
+        totalCompletedStarts.ShouldBe(AgentCount);
+
+        // And the distribution actually used the whole cluster
+        var final = samples.Last();
+        foreach (var pair in final.AssignedPerNode)
+        {
+            pair.Value.ShouldBeGreaterThan(0);
+        }
+    }
+
+    private record Sample(TimeSpan Elapsed, Dictionary<int, int> AssignedPerNode, int RegisteredNodes)
+    {
+        public int TotalAssigned => AssignedPerNode.Values.Sum();
+    }
+
+    private async Task<Sample> takeSampleAsync(TimeSpan elapsed)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        var perNode = new Dictionary<int, int>();
+
+        await using (var cmd = conn.CreateCommand($@"
+select n.node_number, count(a.id)
+from {SchemaName}.wolverine_nodes n
+left join {SchemaName}.wolverine_node_assignments a
+    on a.node_id = n.id and a.id like '{SlowStartAgentFamily.SchemeName}://%'
+group by n.node_number
+order by n.node_number"))
+        {
+            await using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                perNode[reader.GetInt32(0)] = (int)reader.GetInt64(1);
+            }
+        }
+
+        await conn.CloseAsync();
+
+        return new Sample(elapsed, perNode, perNode.Count);
+    }
+
+    // The reporter's own churn query from GH-3750: agents started more than once, and whether the
+    // repeats landed on more than one node.
+    private async Task<List<string>> churnFromNodeRecordsAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        var lines = new List<string>();
+        await using (var cmd = conn.CreateCommand($@"
+with s as (
+  select description as agent, count(*) as n, count(distinct node_number) as nodes
+  from {SchemaName}.wolverine_node_records
+  where event_name = 'AgentStarted' and description like '{SlowStartAgentFamily.SchemeName}://%'
+  group by 1)
+select n as times_started, count(*) as agents, sum((nodes > 1)::int) as on_multiple_nodes
+from s group by 1 order by 1 desc"))
+        {
+            await using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                lines.Add(
+                    $"started {reader.GetInt64(0)}x: {reader.GetInt64(1)} agents ({reader.GetInt64(2)} on multiple nodes)");
+            }
+        }
+
+        await conn.CloseAsync();
+        return lines;
+    }
+
+    private void writeReport(List<Sample> samples, TimeSpan? convergedAt)
+    {
+        _output.WriteLine(
+            $"{AgentCount} agents, {NodeCount} nodes, 6s/12s/18s per agent start by index, batch size {BatchSize}, start parallelism {StartParallelism}");
+        // The reply window for a chunk of 12 is 30s + 12 x 1s (AgentBatchTimeouts.ReplyWindowFor)
+        _output.WriteLine($"Reply window per chunk: {30 + BatchSize}s; work per chunk: 36s/72s/108s by index block");
+        _output.WriteLine("");
+        _output.WriteLine("elapsed | nodes | assigned per node          | total");
+        _output.WriteLine("--------+-------+---------------------------+------");
+
+        foreach (var sample in samples)
+        {
+            var per = sample.AssignedPerNode.OrderBy(x => x.Key)
+                .Select(x => $"{x.Key}:{x.Value,3}").Join("  ");
+            _output.WriteLine($"{sample.Elapsed.TotalSeconds,6:0}s | {sample.RegisteredNodes,5} | {per,-25} | {sample.TotalAssigned,4}");
+        }
+
+        _output.WriteLine("");
+        _output.WriteLine($"Converged at:            {(convergedAt.HasValue ? $"{convergedAt.Value.TotalSeconds:0.0}s" : "NEVER")}");
+        _output.WriteLine($"Completed starts:        {_telemetry.StartsPerNode.Values.Sum()} (agent universe is {AgentCount}; any excess is a duplicate start)");
+        _output.WriteLine($"Starts per node:         {_telemetry.StartsPerNode.OrderBy(x => x.Key).Select(x => $"{x.Key}:{x.Value}").Join("  ")}");
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -304,6 +304,26 @@ public class DurabilitySettings : IDescribeMyself
     public int MaxAgentStopParallelism { get; set; } = 10;
 
     /// <summary>
+    ///     GH-3748: once a batched agent command's initial reply window has elapsed without an answer,
+    ///     the leader stops waiting passively and starts asking the destination node which of the
+    ///     requested agents are actually running (or stopped) at this interval. Each poll is a cheap
+    ///     read of the node's in-memory agent registry, so the interval mostly decides how quickly the
+    ///     leader notices convergence. Default 10 seconds.
+    /// </summary>
+    public TimeSpan AgentProgressPollInterval { get; set; } = 10.Seconds();
+
+    /// <summary>
+    ///     GH-3748 / GH-3750: how long the leader tolerates ZERO observed progress on an in-flight
+    ///     agent batch before giving up on the unconfirmed remainder and letting the next assignment
+    ///     evaluation re-decide it. Any progress — one more agent confirmed running or stopped —
+    ///     resets this clock, so a node that is slow but converging gets unbounded time while a node
+    ///     that is wedged or gone costs a bounded wait. Sized to the slowest legitimate single agent
+    ///     start we know of: a Marten projection shard replaying behind a version bump under the
+    ///     daemon's bounded side-effect gate, which has a five-minute ceiling. Default 5 minutes.
+    /// </summary>
+    public TimeSpan AgentProgressStallTimeout { get; set; } = 5.Minutes();
+
+    /// <summary>
     ///     GH-3519: how many extra times this node immediately re-tries an agent that failed to start,
     ///     before giving up and leaving it to the next assignment reevaluation. A first-assignment start
     ///     races the subsystems the agent depends on — an event-subscription shard evaluated before its

--- a/src/Wolverine/Runtime/Agents/AgentCommandHandler.cs
+++ b/src/Wolverine/Runtime/Agents/AgentCommandHandler.cs
@@ -33,6 +33,41 @@ internal class AgentCommandHandler : MessageHandler
 
         var command = (IAgentCommand)context.Envelope!.Message!;
 
+        // GH-3748: a remotely-received batch of agent starts or stops executes off the control lane.
+        // The database control endpoint is strictly serial, so running a slow batch inline here starved
+        // every other control message to this node — stops queued behind it, and the leader had no way
+        // to learn the batch was even progressing. The runner sends the correlated typed reply itself
+        // when the work finishes; this handler is done the moment the work is accepted.
+        //
+        // Local inline invocations keep executing synchronously below — their caller reads the reply
+        // from the in-context cascade, and they already run outside the control lane. They are detected
+        // by ResponseType, which only the in-process Executor.InvokeAsync<T> path sets; ReplyUri alone
+        // cannot tell the two apart because the local path stamps the loopback replies URI too.
+        if (command is IDeferredAgentWork
+            && context.Envelope.ResponseType == null
+            && context.Envelope.ReplyUri != null
+            && context.Envelope.ReplyRequested.IsNotEmpty()
+            && _runtime.NodeController?.DeferredWork is { } deferredWork)
+        {
+            var conversationId = context.Envelope.ConversationId == Guid.Empty
+                ? context.Envelope.Id
+                : context.Envelope.ConversationId;
+
+            if (deferredWork.TryEnqueue(command, context.Envelope.ReplyRequested!, context.Envelope.ReplyUri,
+                    conversationId))
+            {
+                // The executor would otherwise see a reply-requested envelope whose handler produced no
+                // response and IMMEDIATELY send a "no response was created" FailureAcknowledgement —
+                // faulting the requester's InvokeAsync<T> the instant the work was accepted. The reply
+                // obligation now belongs to the deferred runner.
+                context.Envelope.ReplyRequested = null;
+                return;
+            }
+
+            // The runner is shutting down; fall through to the inline path rather than dropping the
+            // command on the floor.
+        }
+
         try
         {
             var results = await command.ExecuteAsync(_runtime, cancellation);

--- a/src/Wolverine/Runtime/Agents/AgentPresence.cs
+++ b/src/Wolverine/Runtime/Agents/AgentPresence.cs
@@ -1,0 +1,70 @@
+namespace Wolverine.Runtime.Agents;
+
+/// <summary>
+///     GH-3748 / GH-3750: asks a node which of the named agents are actually running there right now.
+///
+///     <para>This is the leader's progress probe for an in-flight batched agent command. The old protocol
+///     gave the leader exactly one bit of information — the final <see cref="AgentsStarted" /> /
+///     <see cref="AgentsStopped" /> reply — and when slow agent work outran the reply window, the leader
+///     had to treat the whole chunk as failed and re-place agents that were mid-start on the very node it
+///     gave up on. Answering this query costs the destination a read of its in-memory agent registry, so
+///     the leader can wait on <i>observed progress</i> instead of a clock.</para>
+///
+///     <para>The report names the requested agents that are currently running. The complement is
+///     deliberately direction-agnostic: a leader waiting on starts reads the running set as confirmation,
+///     and a leader waiting on stops reads the missing set as confirmation — an agent this node has never
+///     seen is exactly as stopped as one it just stopped.</para>
+/// </summary>
+internal record QueryAgentPresence(Uri[] AgentUris) : IAgentCommand, ISerializable
+{
+    public Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
+    {
+        var running = new HashSet<Uri>(runtime.Agents.AllRunningAgentUris());
+        var present = AgentUris.Where(running.Contains).ToArray();
+
+        return Task.FromResult<AgentCommands>([new AgentPresenceReport(present)]);
+    }
+
+    // See AgentUriSet: value equality over the agents, independent of their order.
+    public virtual bool Equals(QueryAgentPresence? other)
+        => other is not null && AgentUriSet.AreEquivalent(AgentUris, other.AgentUris);
+
+    public override int GetHashCode() => AgentUriSet.HashOf(AgentUris);
+
+    public byte[] Write()
+    {
+        return AgentUriList.Write(AgentUris);
+    }
+
+    public static object Read(byte[] bytes)
+    {
+        return new QueryAgentPresence(AgentUriList.Read(bytes));
+    }
+}
+
+/// <summary>
+///     The answer to <see cref="QueryAgentPresence" />: which of the queried agents are running on the
+///     answering node. See that type for the protocol.
+/// </summary>
+internal record AgentPresenceReport(Uri[] Running) : IAgentCommand, ISerializable
+{
+    public Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(AgentCommands.Empty);
+    }
+
+    public virtual bool Equals(AgentPresenceReport? other)
+        => other is not null && AgentUriSet.AreEquivalent(Running, other.Running);
+
+    public override int GetHashCode() => AgentUriSet.HashOf(Running);
+
+    public byte[] Write()
+    {
+        return AgentUriList.Write(Running);
+    }
+
+    public static object Read(byte[] bytes)
+    {
+        return new AgentPresenceReport(AgentUriList.Read(bytes));
+    }
+}

--- a/src/Wolverine/Runtime/Agents/AgentWorkConfirmation.cs
+++ b/src/Wolverine/Runtime/Agents/AgentWorkConfirmation.cs
@@ -1,0 +1,212 @@
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.Runtime.Agents;
+
+/// <summary>
+///     Which direction a batched agent command is trying to move its agents, and therefore what counts
+///     as confirmation in an <see cref="AgentPresenceReport" />: an agent <i>running</i> on the node
+///     confirms a start, an agent <i>absent</i> from the node confirms a stop.
+/// </summary>
+internal enum AgentPresenceDirection
+{
+    Running,
+    Gone
+}
+
+/// <summary>
+///     GH-3748 / GH-3750: waits for a batched agent command's outcome on <b>observed progress</b> instead
+///     of a clock.
+///
+///     <para>The typed reply (<see cref="AgentsStarted" /> / <see cref="AgentsStopped" />) only arrives
+///     when the whole batch has been worked through, and the old protocol made its reply window carry two
+///     jobs at once: how long the work may take, and how long until the leader declares the node failed.
+///     No window survives both — a Marten projection shard replaying behind a version bump was measured
+///     at 27s p50 / 215s max per shard, so honest work outran every reasonable window, the leader treated
+///     the timeout as failure, and agents still mid-start were re-placed onto other nodes (369 of 902
+///     agents started more than once in the GH-3750 field data).</para>
+///
+///     <para>Here the reply is <b>raced</b> against a poll loop asking the destination which of the
+///     requested agents are actually running (<see cref="QueryAgentPresence" />). The reply still wins
+///     whenever it arrives — including from a pre-upgrade node that has never heard of the query, whose
+///     polls simply go unanswered and whose reply window is unchanged. The polls add the piece the
+///     protocol never had: progress. As long as one more agent turns up confirmed within
+///     <see cref="DurabilitySettings.AgentProgressStallTimeout" />, the leader keeps waiting, so a slow
+///     node that is converging gets unbounded time while a wedged one costs a bounded wait — and every
+///     agent the leader is waiting on stays held by the dispatcher and the pending-assignment ledger,
+///     which is what stops the re-placement churn.</para>
+/// </summary>
+internal static class AgentWorkConfirmation
+{
+    public static Task<Uri[]> AwaitAsync(IWolverineRuntime runtime, NodeDestination destination,
+        Uri[] requested, Task<Uri[]> workReply, AgentPresenceDirection direction,
+        CancellationToken cancellation)
+    {
+#pragma warning disable VSTHRD003
+        return AwaitCoreAsync(
+            async uris =>
+            {
+                var report = await runtime.Agents.InvokeAsync<AgentPresenceReport>(destination,
+                    new QueryAgentPresence(uris));
+                return report?.Running ?? [];
+            },
+            workReply,
+            requested,
+            direction,
+            runtime.Options.Durability.AgentProgressPollInterval,
+            runtime.Options.Durability.AgentProgressStallTimeout,
+            runtime.Logger,
+            cancellation);
+#pragma warning restore VSTHRD003
+    }
+
+    internal static async Task<Uri[]> AwaitCoreAsync(Func<Uri[], Task<Uri[]>> queryRunning,
+        Task<Uri[]> workReply, Uri[] requested, AgentPresenceDirection direction,
+        TimeSpan pollInterval, TimeSpan stallTimeout, ILogger logger, CancellationToken cancellation)
+    {
+        var universe = new HashSet<Uri>(requested);
+        var confirmed = new HashSet<Uri>();
+
+        // Progress is measured from the last poll that confirmed something NEW, and the stall clock only
+        // runs once the destination has answered at least one poll. A destination that never answers —
+        // a pre-GH-3748 node, or one that is gone — leaves the reply's own window as the only bound,
+        // exactly the pre-existing behavior.
+        var answeredAtLeastOnce = false;
+        var lastProgress = DateTimeOffset.UtcNow;
+
+        // Null once the reply has faulted and been consumed: from then on the polls carry the wait alone,
+        // bounded by the stall clock.
+        var pendingReply = workReply;
+
+        while (true)
+        {
+            if (pendingReply != null)
+            {
+                var delay = Task.Delay(pollInterval, cancellation);
+#pragma warning disable VSTHRD003
+                var finished = await Task.WhenAny(pendingReply, delay);
+#pragma warning restore VSTHRD003
+
+                if (finished == pendingReply)
+                {
+                    try
+                    {
+                        // The reply is the authoritative completion: the batch has been worked through
+                        // and this is exactly what succeeded. Anything a poll confirmed on top of it
+                        // stands — "running on the node" cannot be less true than the reply.
+#pragma warning disable VSTHRD003
+                        var replied = await pendingReply;
+#pragma warning restore VSTHRD003
+                        foreach (var uri in replied)
+                        {
+                            if (universe.Contains(uri))
+                            {
+                                confirmed.Add(uri);
+                            }
+                        }
+
+                        return confirmed.ToArray();
+                    }
+                    catch (Exception failure)
+                    {
+                        // The reply window elapsing — or the request faulting outright — is only the end
+                        // of the story for a destination whose polls go unanswered. One that is answering
+                        // is demonstrably alive and mid-batch, so the wait continues on the polls alone,
+                        // bounded by the stall clock instead of the reply window that slow-but-honest
+                        // work just outran. That double duty — work budget AND failure detector in one
+                        // number — is exactly what GH-3748 reported as impossible to configure.
+                        if (!answeredAtLeastOnce)
+                        {
+                            logger.LogDebug(failure,
+                                "Batched agent command reply was not received and the destination is not answering presence polls; proceeding with {ConfirmedCount} of {RequestedCount} agents confirmed",
+                                confirmed.Count, universe.Count);
+                            return confirmed.ToArray();
+                        }
+
+                        logger.LogDebug(failure,
+                            "Batched agent command reply was not received; continuing on presence polling with {ConfirmedCount} of {RequestedCount} agents confirmed so far",
+                            confirmed.Count, universe.Count);
+                        pendingReply = null;
+                    }
+                }
+            }
+            else
+            {
+                try
+                {
+                    await Task.Delay(pollInterval, cancellation);
+                }
+                catch (OperationCanceledException)
+                {
+                    return confirmed.ToArray();
+                }
+            }
+
+            if (cancellation.IsCancellationRequested)
+            {
+                observe(workReply);
+                return confirmed.ToArray();
+            }
+
+            try
+            {
+                var running = await queryRunning(requested);
+                answeredAtLeastOnce = true;
+
+                var confirming = direction == AgentPresenceDirection.Running
+                    ? (IEnumerable<Uri>)running
+                    : universe.Except(running);
+
+                var progressed = false;
+                foreach (var uri in confirming)
+                {
+                    if (universe.Contains(uri) && confirmed.Add(uri))
+                    {
+                        progressed = true;
+                    }
+                }
+
+                if (progressed)
+                {
+                    lastProgress = DateTimeOffset.UtcNow;
+                }
+
+                if (confirmed.Count == universe.Count)
+                {
+                    // Fully confirmed by observation; no need to hold the lane for the formal reply.
+                    observe(workReply);
+                    return confirmed.ToArray();
+                }
+            }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+            {
+                observe(workReply);
+                return confirmed.ToArray();
+            }
+            catch (Exception e)
+            {
+                // An unanswered poll proves nothing either way — the node may predate the query type, be
+                // briefly unreachable, or be gone. The reply window remains the bound for those.
+                logger.LogDebug(e, "Agent presence poll went unanswered");
+            }
+
+            if (answeredAtLeastOnce && DateTimeOffset.UtcNow - lastProgress >= stallTimeout)
+            {
+                logger.LogWarning(
+                    "Giving up on a batched agent command after no progress for {StallTimeout}: {ConfirmedCount} of {RequestedCount} agents confirmed",
+                    stallTimeout, confirmed.Count, universe.Count);
+                observe(workReply);
+                return confirmed.ToArray();
+            }
+        }
+    }
+
+    // A reply abandoned in favor of poll-observed confirmation may still fault later (most likely its
+    // own TimeoutException). Observe it so it can't surface as an UnobservedTaskException.
+    private static void observe(Task task)
+    {
+        _ = task.ContinueWith(t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+}

--- a/src/Wolverine/Runtime/Agents/AssignAgent.cs
+++ b/src/Wolverine/Runtime/Agents/AssignAgent.cs
@@ -12,24 +12,56 @@ internal record AssignAgent(Uri AgentUri, NodeDestination Destination) : IAgentC
         if (Destination.NodeId == runtime.Options.UniqueNodeId)
         {
             await runtime.Agents.StartLocallyAsync(AgentUri);
+
+            if (runtime is WolverineRuntime localRuntime)
+            {
+                localRuntime.NodeController?.ConfirmDispatched([AgentUri], Destination.NodeId);
+            }
         }
         else
         {
-            try
+            // GH-3748: the acknowledgement only arrives when the start has actually finished, and a
+            // single slow start (a Marten shard replaying behind a version bump was measured at up to
+            // 215s) can never beat the fixed acknowledgement window. Racing it against presence polling
+            // lets a slow-but-happening start be confirmed by observation instead of failed by the clock.
+            var confirmed = await AgentWorkConfirmation.AwaitAsync(runtime, Destination, [AgentUri],
+                startRemotelyAsync(runtime), AgentPresenceDirection.Running, cancellationToken);
+
+            if (confirmed.Length == 0)
             {
-                await runtime.Agents.InvokeAsync(Destination, new StartAgent(AgentUri));
-            }
-            catch (UnknownWolverineNodeException e)
-            {
-                runtime.Logger.LogWarning(e, "Error while trying to assign agent {AgentUri} to {NodeId}", AgentUri,
-                    Destination.NodeId);
+                runtime.Logger.LogWarning(
+                    "Unable to confirm that agent {AgentUri} started on node {NodeId}; the assignment will be re-evaluated",
+                    AgentUri, Destination.NodeId);
                 return AgentCommands.Empty;
+            }
+
+            // GH-3750: see AssignAgents — hold the confirmed placement in the pending ledger until the
+            // persisted assignment row is visible to an evaluation snapshot.
+            if (runtime is WolverineRuntime wolverineRuntime)
+            {
+                wolverineRuntime.NodeController?.ConfirmDispatched([AgentUri], Destination.NodeId);
             }
         }
 
         runtime.Logger.LogInformation("Successfully started agent {AgentUri} on node {NodeId}", AgentUri, runtime.Options.Durability.AssignedNodeNumber);
 
         return AgentCommands.Empty;
+    }
+
+    private async Task<Uri[]> startRemotelyAsync(IWolverineRuntime runtime)
+    {
+        try
+        {
+            await runtime.Agents.InvokeAsync(Destination, new StartAgent(AgentUri));
+        }
+        catch (UnknownWolverineNodeException e)
+        {
+            runtime.Logger.LogWarning(e, "Error while trying to assign agent {AgentUri} to {NodeId}", AgentUri,
+                Destination.NodeId);
+            return [];
+        }
+
+        return [AgentUri];
     }
 
     public virtual bool Equals(AssignAgent? other)

--- a/src/Wolverine/Runtime/Agents/DeferredAgentCommandRunner.cs
+++ b/src/Wolverine/Runtime/Agents/DeferredAgentCommandRunner.cs
@@ -1,0 +1,155 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using Wolverine.Util;
+
+namespace Wolverine.Runtime.Agents;
+
+/// <summary>
+///     Marks a batched agent command whose <b>remote</b> execution is taken off the receiving node's
+///     control lane. See <see cref="DeferredAgentCommandRunner" />.
+/// </summary>
+internal interface IDeferredAgentWork : IAgentCommand
+{
+}
+
+/// <summary>
+///     GH-3748: executes remotely-received batched agent commands (<see cref="StartAgents" /> /
+///     <see cref="StopAgents" />) on a background queue instead of inline on the control endpoint's
+///     message lane, then sends the correlated typed reply when the work actually finishes.
+///
+///     <para>The database control endpoint is deliberately serial (<c>MaxDegreeOfParallelism = 1</c>), so
+///     before this a chunk of slow agent starts — a Marten projection shard replaying behind a version
+///     bump was measured at 27s p50 / 215s max <i>per shard</i> — monopolized the node's entire control
+///     lane for however long the batch took. Every other control message to that node sat behind it:
+///     stops, reassignment stops, and any request that could have told the leader the node was making
+///     progress. The command is accepted here and the lane is free in microseconds.</para>
+///
+///     <para>The reply is not sent early: it still goes out only when the batch has genuinely finished,
+///     carrying exactly the confirmed agents, and it is correlated to the original request's conversation
+///     so a leader blocked in <c>InvokeAsync&lt;AgentsStarted&gt;</c> — including a pre-GH-3748 leader
+///     during a rolling upgrade — completes exactly as if the work had run inline. What changes is only
+///     <i>where</i> the work runs, which is what lets the leader ask <see cref="QueryAgentPresence" />
+///     for progress while the batch is still going.</para>
+///
+///     <para>Work items run strictly one at a time in arrival order, preserving the ordering the serial
+///     control lane used to give consecutive batched commands, and capping a node's agent-start
+///     parallelism at one batch's worth (<c>MaxAgentStartParallelism</c>) no matter how many chunks are
+///     queued.</para>
+/// </summary>
+internal class DeferredAgentCommandRunner : IAsyncDisposable
+{
+    private readonly record struct Item(IAgentCommand Command, string ReplyRequested, Uri ReplyUri, Guid ConversationId, long Sequence);
+
+    private readonly WolverineRuntime _runtime;
+    private readonly NodeAgentController _controller;
+    private readonly CancellationToken _cancellation;
+    private readonly Task _worker;
+
+    private readonly Channel<Item> _channel =
+        Channel.CreateUnbounded<Item>(new UnboundedChannelOptions { SingleReader = true });
+
+    public DeferredAgentCommandRunner(WolverineRuntime runtime, NodeAgentController controller,
+        CancellationToken cancellation)
+    {
+        _runtime = runtime;
+        _controller = controller;
+        _cancellation = cancellation;
+
+        _worker = Task.Run(runAsync, CancellationToken.None);
+    }
+
+    /// <summary>
+    ///     Accept a remotely-received batched command for background execution. False only when the
+    ///     runner is shutting down, in which case the caller should fall back to inline execution.
+    /// </summary>
+    public bool TryEnqueue(IAgentCommand command, string replyRequested, Uri replyUri, Guid conversationId)
+    {
+        // The sequence is captured at ACCEPTANCE, not execution: a stop command that arrives while this
+        // batch is still queued must revoke the batch's starts for its agent, exactly as it would have
+        // executed after them on the old serial lane. See NodeAgentController.StartAgentGuardedAsync.
+        var item = new Item(command, replyRequested, replyUri, conversationId, _controller.CurrentCommandSequence);
+
+        return _channel.Writer.TryWrite(item);
+    }
+
+    private async Task runAsync()
+    {
+        while (!_cancellation.IsCancellationRequested)
+        {
+            Item item;
+            try
+            {
+                item = await _channel.Reader.ReadAsync(_cancellation);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (ChannelClosedException)
+            {
+                return;
+            }
+
+            try
+            {
+                var results = await executeAsync(item);
+
+                foreach (var result in results)
+                {
+                    if (result.GetType().ToMessageTypeName() == item.ReplyRequested)
+                    {
+                        await _runtime.SendAgentCommandReplyAsync(item.ReplyUri, item.ConversationId, result);
+                    }
+                    else
+                    {
+                        // Nothing produces these today; surfaced rather than silently dropped in case a
+                        // future command type does.
+                        _runtime.Logger.LogInformation(
+                            "Discarding cascaded agent command {Command} from deferred execution of {Original}",
+                            result, item.Command);
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception e)
+            {
+                // Cost this one batch only. The requester's reply window or progress polling decides
+                // what to do about the silence.
+                _runtime.Logger.LogError(e, "Error executing deferred agent command {Command}", item.Command);
+            }
+        }
+    }
+
+    private async Task<AgentCommands> executeAsync(Item item)
+    {
+        // Starts go through the revocation guard; a plain ExecuteAsync would race stop commands that
+        // the freed-up control lane can now deliver while this batch is queued or running.
+        if (item.Command is StartAgents starts)
+        {
+            var successful = await StartAgents.StartBatchAsync(_runtime, starts.AgentUris,
+                uri => _controller.StartAgentGuardedAsync(uri, item.Sequence), _cancellation);
+
+            return [new AgentsStarted(successful)];
+        }
+
+        return await item.Command.ExecuteAsync(_runtime, _cancellation);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _channel.Writer.TryComplete();
+
+        try
+        {
+            var worker = _worker;
+            await worker;
+        }
+        catch (Exception)
+        {
+            // Shutting down; a worker that faulted on the way out is not interesting.
+        }
+    }
+}

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.EvaluateAssignments.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.EvaluateAssignments.cs
@@ -20,9 +20,44 @@ public partial class NodeAgentController
     // The ledger is projected onto the grid as Agent.PendingNode so that placement decisions and the commands
     // built from them account for the in-flight copy directly, rather than being filtered afterwards. It is
     // leader-only and in-memory: a new leader starts empty and safely re-drives everything.
+    // Guards _pendingAssignments. The evaluation path is serialized by the health-check loop, but
+    // GH-3750's ConfirmDispatched is called from the dispatcher's lane threads as commands resolve.
+    private readonly object _pendingLock = new();
+
     private readonly Dictionary<Uri, PendingAssignment> _pendingAssignments = new();
 
     private readonly record struct PendingAssignment(Guid NodeId, DateTimeOffset SentAt);
+
+    /// <summary>
+    ///     GH-3750: refresh the pending-assignment ledger for agents a resolving batch command just
+    ///     confirmed. The dispatcher's in-flight hold ends the moment the command resolves, but the
+    ///     ledger entry still carries the SentAt from when the batch was DISPATCHED — for a batch of
+    ///     slow starts that is minutes ago, so the TTL is instantly expired and the next evaluation
+    ///     whose node-state snapshot predates the last assignment rows re-decides an agent that just
+    ///     confirmed, emitting a stop at the very node that started it. Stamping confirmation time here
+    ///     keeps the agent held on its node for the one snapshot cycle it takes the persisted row to
+    ///     become visible, after which reconcilePendingAssignments retires the entry normally.
+    /// </summary>
+    internal void ConfirmDispatched(Uri[] agentUris, Guid nodeId)
+    {
+        if (agentUris.Length == 0)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+
+        lock (_pendingLock)
+        {
+            foreach (var uri in agentUris)
+            {
+                if (_pendingAssignments.TryGetValue(uri, out var pending) && pending.NodeId == nodeId)
+                {
+                    _pendingAssignments[uri] = new PendingAssignment(nodeId, now);
+                }
+            }
+        }
+    }
 
     /// <summary>
     ///     GH-3698. Asks the command dispatcher whether a start for an agent is still queued or executing.
@@ -171,6 +206,14 @@ public partial class NodeAgentController
     // and fabricating one here would make every pending entry instantly self-confirming.
     private void applyPendingAssignments(AssignmentGrid grid)
     {
+        lock (_pendingLock)
+        {
+            applyPendingAssignmentsLocked(grid);
+        }
+    }
+
+    private void applyPendingAssignmentsLocked(AssignmentGrid grid)
+    {
         if (_pendingAssignments.Count == 0)
         {
             return;
@@ -238,6 +281,14 @@ public partial class NodeAgentController
     // Bring the pending-assignment ledger up to date with what this evaluation observed and decided. See
     // _pendingAssignments.
     private void reconcilePendingAssignments(AssignmentGrid grid, AgentCommands commands)
+    {
+        lock (_pendingLock)
+        {
+            reconcilePendingAssignmentsLocked(grid, commands);
+        }
+    }
+
+    private void reconcilePendingAssignmentsLocked(AssignmentGrid grid, AgentCommands commands)
     {
         var now = DateTimeOffset.UtcNow;
 

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.cs
@@ -114,6 +114,52 @@ public partial class NodeAgentController
 
     public ConcurrentDictionary<Uri, IAgent> Agents { get; } = new();
 
+    // GH-3748: background executor for remotely-received batched agent commands, created by
+    // WolverineRuntime for Balanced-mode nodes. See DeferredAgentCommandRunner.
+    internal DeferredAgentCommandRunner? DeferredWork { get; set; }
+
+    // GH-3748: the serial control lane used to guarantee that a stop command arriving after a batch of
+    // starts also EXECUTED after those starts. With batch execution deferred off the lane, that ordering
+    // is kept per agent instead: every stop stamps a monotonic sequence for its agent, and a deferred
+    // start skips (or immediately reverts) any agent whose stop is newer than the batch's acceptance.
+    private long _commandSequence;
+    private readonly ConcurrentDictionary<Uri, long> _stopRevocations = new();
+
+    internal long CurrentCommandSequence => Volatile.Read(ref _commandSequence);
+
+    private bool isRevokedSince(Uri agentUri, long sequence)
+        => _stopRevocations.TryGetValue(agentUri, out var revokedAt) && revokedAt > sequence;
+
+    /// <summary>
+    ///     GH-3748: start one agent from a deferred batch, honoring any stop command that arrived after
+    ///     the batch was accepted. Returns whether the agent is genuinely running here afterward.
+    /// </summary>
+    internal async Task<bool> StartAgentGuardedAsync(Uri agentUri, long asOfSequence)
+    {
+        if (isRevokedSince(agentUri, asOfSequence))
+        {
+            _logger.LogInformation(
+                "Skipping deferred start of agent {AgentUri} on node {NodeNumber}: a stop command arrived after the batch was accepted",
+                agentUri, _runtime.Options.Durability.AssignedNodeNumber);
+            return false;
+        }
+
+        await StartAgentAsync(agentUri);
+
+        // A stop that landed while this start was in flight found nothing to stop — its no-op must not
+        // stand while the agent it aimed at comes up right behind it.
+        if (isRevokedSince(agentUri, asOfSequence))
+        {
+            _logger.LogInformation(
+                "Reverting deferred start of agent {AgentUri} on node {NodeNumber}: a stop command arrived while the start was in flight",
+                agentUri, _runtime.Options.Durability.AssignedNodeNumber);
+            await StopAgentAsync(agentUri);
+            return false;
+        }
+
+        return true;
+    }
+
     public bool HasStartedInSoloMode { get; private set; }
 
     internal void AddHandlers(WolverineRuntime runtime)
@@ -126,6 +172,8 @@ public partial class NodeAgentController
         handlers.RegisterMessageType(typeof(AgentsStopped));
         handlers.RegisterMessageType(typeof(StopAgent));
         handlers.RegisterMessageType(typeof(StopAgents));
+        handlers.RegisterMessageType(typeof(QueryAgentPresence));
+        handlers.RegisterMessageType(typeof(AgentPresenceReport));
     }
 
     public async Task StopAsync(IMessageBus messageBus)
@@ -352,6 +400,10 @@ public partial class NodeAgentController
 
     public async Task StopAgentAsync(Uri agentUri)
     {
+        // GH-3748: stamped before the attempt, so even a stop that finds nothing running revokes any
+        // deferred start still queued or in flight for this agent. See StartAgentGuardedAsync.
+        _stopRevocations[agentUri] = Interlocked.Increment(ref _commandSequence);
+
         if (Agents.TryGetValue(agentUri, out var agent))
         {
             try

--- a/src/Wolverine/Runtime/Agents/ReassignAgent.cs
+++ b/src/Wolverine/Runtime/Agents/ReassignAgent.cs
@@ -17,6 +17,31 @@ internal record ReassignAgent(Uri AgentUri, NodeDestination OriginalNode, NodeDe
 
     public async Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
     {
+        // GH-3748: the stop acknowledgement is raced against presence polling — a stop slower than the
+        // acknowledgement window (a projection shard mid-replay letting go of its work) used to be
+        // indistinguishable from a dead node, so the reassignment was dropped and re-decided forever.
+        // The single-copy invariant holds either way: the start below is only cascaded once the agent is
+        // confirmed GONE from the source, by acknowledgement or by observation.
+        var confirmed = await AgentWorkConfirmation.AwaitAsync(runtime, OriginalNode, [AgentUri],
+            stopAtSourceAsync(runtime), AgentPresenceDirection.Gone, cancellationToken);
+
+        if (confirmed.Length == 0)
+        {
+            runtime.Logger.LogWarning(
+                "Unable to confirm that agent {AgentUri} stopped on node {CurrentNodeId}; its reassignment to {NewNodeId} will be re-evaluated",
+                AgentUri, OriginalNode.NodeId, ActiveNode.NodeId);
+            return AgentCommands.Empty;
+        }
+
+        runtime.Logger.LogInformation("Successfully stopped agent {Agent} on node {OriginalNode}", AgentUri,
+            OriginalNode.NodeId);
+
+        // Do this in separate steps
+        return [new AssignAgent(AgentUri, ActiveNode)];
+    }
+
+    private async Task<Uri[]> stopAtSourceAsync(IWolverineRuntime runtime)
+    {
         try
         {
             await runtime.Agents.InvokeAsync(OriginalNode, new StopAgent(AgentUri));
@@ -26,14 +51,10 @@ internal record ReassignAgent(Uri AgentUri, NodeDestination OriginalNode, NodeDe
             runtime.Logger.LogWarning(e,
                 "Error trying to reassign a running agent {AgentUri} from {CurrentNodeId} to {NewNodeId}", AgentUri,
                 OriginalNode, ActiveNode);
-            return AgentCommands.Empty;
+            return [];
         }
 
-        runtime.Logger.LogInformation("Successfully stopped agent {Agent} on node {OriginalNode}", AgentUri,
-            OriginalNode.NodeId);
-
-        // Do this in separate steps
-        return [new AssignAgent(AgentUri, ActiveNode)];
+        return [AgentUri];
     }
 }
 
@@ -55,15 +76,15 @@ internal record ReassignAgents(NodeDestination OriginalNode, NodeDestination Act
     public async Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
     {
         var timeout = AgentBatchTimeouts.ReplyWindowFor(AgentUris.Length);
-        var response =
-            await runtime.Agents.InvokeAsync<AgentsStopped>(OriginalNode, new StopAgents(AgentUris), timeout);
 
-        if (response == null)
-        {
-            return AgentCommands.Empty;
-        }
+        // GH-3748: raced against presence polling on the SOURCE — an agent absent from the source is a
+        // confirmed stop, whether the acknowledgement said so or a poll observed it. See
+        // AgentWorkConfirmation. The single-copy invariant below is unchanged: only confirmed-gone
+        // agents cascade into a start on the destination.
+        var replyTask = invokeStopsAsync(runtime, timeout);
+        var confirmed = await AgentWorkConfirmation.AwaitAsync(runtime, OriginalNode, AgentUris, replyTask,
+            AgentPresenceDirection.Gone, cancellationToken);
 
-        var confirmed = response.AgentUris ?? [];
         var unconfirmed = AgentUriSet.Missing(AgentUris, confirmed);
 
         if (unconfirmed.Length > 0)
@@ -83,6 +104,13 @@ internal record ReassignAgents(NodeDestination OriginalNode, NodeDestination Act
         }
 
         return [new AssignAgents(ActiveNode, confirmed)];
+    }
+
+    private async Task<Uri[]> invokeStopsAsync(IWolverineRuntime runtime, TimeSpan timeout)
+    {
+        var response =
+            await runtime.Agents.InvokeAsync<AgentsStopped>(OriginalNode, new StopAgents(AgentUris), timeout);
+        return response?.AgentUris ?? [];
     }
 
     // See AgentUriSet: value equality over the agents, independent of their order, so the dispatcher can

--- a/src/Wolverine/Runtime/Agents/StartAgents.cs
+++ b/src/Wolverine/Runtime/Agents/StartAgents.cs
@@ -187,20 +187,28 @@ internal record AssignAgents(NodeDestination Destination, Uri[] AgentIds) : IAge
         // but a large chunk of slow daemon-agent starts must not be cut off by the reply window. See
         // AgentBatchTimeouts for why big chunks get a much larger per-agent allowance.
         var timeout = AgentBatchTimeouts.ReplyWindowFor(AgentIds.Length);
-        var response = await runtime.Agents.InvokeAsync<AgentsStarted>(Destination, startAgents, timeout);
 
-        if (response == null)
+        // GH-3748 / GH-3750: the reply is raced against presence polling, so slow work is distinguished
+        // from a wedged or dead node by observed progress rather than by this window alone — and every
+        // agent stays held (dispatcher in-flight + pending-assignment ledger) for as long as this command
+        // is waiting, which is what keeps a mid-start agent from being re-placed onto another node.
+        var replyTask = invokeStartsAsync(runtime, startAgents, timeout);
+        var confirmed = await AgentWorkConfirmation.AwaitAsync(runtime, Destination, AgentIds, replyTask,
+            AgentPresenceDirection.Running, cancellationToken);
+
+        // GH-3750: refresh the pending-assignment ledger BEFORE the dispatcher's in-flight hold drops,
+        // so an evaluation running against a node-state snapshot that predates the last assignment rows
+        // can't re-decide an agent this command just confirmed.
+        if (runtime is WolverineRuntime wolverineRuntime)
         {
-            return AgentCommands.Empty;
+            wolverineRuntime.NodeController?.ConfirmDispatched(confirmed, Destination.NodeId);
         }
 
-        // GH-3750: the reply is the set of agents that actually reached a started state — StartAgents only
-        // bags an agent once StartLocallyAsync has returned — so a PARTIAL reply is the normal case whenever
-        // starts are slow (the blue/green side-effect gate's warm-up replay is the field example, measured at
-        // 27s p50 / 82s p95 per shard). This used to log the REQUESTED set as "Successfully started"
-        // unconditionally, so a chunk that half-started was indistinguishable in the logs from one that fully
-        // started, and the operator's only clue was the assignment never converging.
-        var confirmed = response.AgentUris ?? [];
+        // GH-3750: a PARTIAL confirmation is the normal case whenever starts are slow (the blue/green
+        // side-effect gate's warm-up replay is the field example, measured at 27s p50 / 82s p95 per
+        // shard). This used to log the REQUESTED set as "Successfully started" unconditionally, so a
+        // chunk that half-started was indistinguishable in the logs from one that fully started, and the
+        // operator's only clue was the assignment never converging.
         var unconfirmed = AgentUriSet.Missing(AgentIds, confirmed);
 
         if (unconfirmed.Length == 0)
@@ -210,12 +218,18 @@ internal record AssignAgents(NodeDestination Destination, Uri[] AgentIds) : IAge
         else
         {
             runtime.Logger.LogWarning(
-                "Node {NodeNumber} confirmed {ConfirmedCount} of {RequestedCount} requested agents; {UnconfirmedCount} did not report started within {Timeout} and remain unconfirmed: {UnconfirmedAgents}",
+                "Node {NodeNumber} confirmed {ConfirmedCount} of {RequestedCount} requested agents; {UnconfirmedCount} did not report started and remain unconfirmed: {UnconfirmedAgents}",
                 runtime.Options.Durability.AssignedNodeNumber, confirmed.Length, AgentIds.Length,
-                unconfirmed.Length, timeout, unconfirmed);
+                unconfirmed.Length, unconfirmed);
         }
 
         return AgentCommands.Empty;
+    }
+
+    private async Task<Uri[]> invokeStartsAsync(IWolverineRuntime runtime, StartAgents startAgents, TimeSpan timeout)
+    {
+        var response = await runtime.Agents.InvokeAsync<AgentsStarted>(Destination, startAgents, timeout);
+        return response?.AgentUris ?? [];
     }
 
     // See AgentUriSet: value equality over the agents, independent of their order.
@@ -233,15 +247,32 @@ internal record StopRemoteAgents(NodeDestination Destination, Uri[] AgentIds) : 
     public async Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime,
         CancellationToken cancellationToken)
     {
-        var startAgents = new StopAgents(AgentIds);
+        var stopAgents = new StopAgents(AgentIds);
 
         // GH-3748: this used to ride the flat default reply window no matter how many agents were in the
         // batch, and a stop can be as slow as a start (a projection shard mid-replay has to let go of its
-        // work). Same scaled backstop as AssignAgents.
+        // work). Same scaled backstop as AssignAgents, and the same presence-polling race — an agent
+        // absent from the node is a confirmed stop.
         var timeout = AgentBatchTimeouts.ReplyWindowFor(AgentIds.Length);
-        await runtime.Agents.InvokeAsync<AgentsStopped>(Destination, startAgents, timeout);
+        var replyTask = invokeStopsAsync(runtime, stopAgents, timeout);
+        var confirmed = await AgentWorkConfirmation.AwaitAsync(runtime, Destination, AgentIds, replyTask,
+            AgentPresenceDirection.Gone, cancellationToken);
+
+        var unconfirmed = AgentUriSet.Missing(AgentIds, confirmed);
+        if (unconfirmed.Length > 0)
+        {
+            runtime.Logger.LogWarning(
+                "Node {NodeId} confirmed stopping {ConfirmedCount} of {RequestedCount} requested agents; {UnconfirmedCount} remain unconfirmed: {UnconfirmedAgents}",
+                Destination.NodeId, confirmed.Length, AgentIds.Length, unconfirmed.Length, unconfirmed);
+        }
 
         return AgentCommands.Empty;
+    }
+
+    private async Task<Uri[]> invokeStopsAsync(IWolverineRuntime runtime, StopAgents stopAgents, TimeSpan timeout)
+    {
+        var response = await runtime.Agents.InvokeAsync<AgentsStopped>(Destination, stopAgents, timeout);
+        return response?.AgentUris ?? [];
     }
 
     // See AgentUriSet: value equality over the agents, independent of their order.
@@ -252,14 +283,32 @@ internal record StopRemoteAgents(NodeDestination Destination, Uri[] AgentIds) : 
     public override int GetHashCode() => HashCode.Combine(Destination, AgentUriSet.HashOf(AgentIds));
 }
 
-internal record StartAgents(Uri[] AgentUris) : IAgentCommand, ISerializable
+internal record StartAgents(Uri[] AgentUris) : IDeferredAgentWork, ISerializable
 {
     public async Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
     {
-        // GH-3604 / D3: start the batch with bounded parallelism instead of serially. Daemon-agent starts are
-        // I/O bound (database round-trips per shard), so a 50-agent chunk started one-at-a-time was seconds of
-        // dead wall-clock that blew the reply window; a bounded fan-out lets the whole chunk converge quickly
-        // without swamping the node.
+        var successful = await StartBatchAsync(runtime, AgentUris,
+            async uri =>
+            {
+                await runtime.Agents.StartLocallyAsync(uri);
+                return true;
+            }, cancellationToken);
+
+        return [new AgentsStarted(successful)];
+    }
+
+    // GH-3604 / D3: start the batch with bounded parallelism instead of serially. Daemon-agent starts are
+    // I/O bound (database round-trips per shard), so a 50-agent chunk started one-at-a-time was seconds of
+    // dead wall-clock that blew the reply window; a bounded fan-out lets the whole chunk converge quickly
+    // without swamping the node.
+    //
+    // The one-agent start is a delegate because the two callers guard differently: inline (local)
+    // execution starts directly, while DeferredAgentCommandRunner routes each start through the GH-3748
+    // stop-revocation guard. The delegate answers whether the agent is genuinely running here afterward —
+    // a start the guard skipped (or immediately reverted) must not be confirmed to the leader.
+    internal static async Task<Uri[]> StartBatchAsync(IWolverineRuntime runtime, Uri[] agentUris,
+        Func<Uri, Task<bool>> startAgent, CancellationToken cancellationToken)
+    {
         var successful = new System.Collections.Concurrent.ConcurrentBag<Uri>();
 
         var dop = Math.Max(1, runtime.Options.Durability.MaxAgentStartParallelism);
@@ -269,12 +318,14 @@ internal record StartAgents(Uri[] AgentUris) : IAgentCommand, ISerializable
             CancellationToken = cancellationToken
         };
 
-        await Parallel.ForEachAsync(AgentUris, options, async (agentUri, token) =>
+        await Parallel.ForEachAsync(agentUris, options, async (agentUri, _) =>
         {
             try
             {
-                await runtime.Agents.StartLocallyAsync(agentUri);
-                successful.Add(agentUri);
+                if (await startAgent(agentUri))
+                {
+                    successful.Add(agentUri);
+                }
             }
             catch (Exception e)
             {
@@ -282,7 +333,7 @@ internal record StartAgents(Uri[] AgentUris) : IAgentCommand, ISerializable
             }
         });
 
-        return [new AgentsStarted(successful.ToArray())];
+        return successful.ToArray();
     }
 
     public virtual bool Equals(StartAgents? other)
@@ -329,7 +380,7 @@ internal record AgentsStopped(Uri[] AgentUris) : IAgentCommand, ISerializable
     }
 }
 
-internal record StopAgents(Uri[] AgentUris) : IAgentCommand, ISerializable
+internal record StopAgents(Uri[] AgentUris) : IDeferredAgentWork, ISerializable
 {
     public async Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime,
         CancellationToken cancellationToken)

--- a/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
@@ -275,6 +275,32 @@ public partial class WolverineRuntime : IAgentRuntime
             LoggerFactory.CreateLogger<NodeAgentController>(), _agentCancellation.Token);
 
         NodeController.AddHandlers(this);
+
+        // GH-3748: only a Balanced node receives batched agent commands over the wire; Solo executes
+        // everything locally and inline.
+        if (Options.Durability.Mode == DurabilityMode.Balanced)
+        {
+            NodeController.DeferredWork = new DeferredAgentCommandRunner(this, NodeController, _agentCancellation.Token);
+        }
+    }
+
+    /// <summary>
+    ///     GH-3748: send the typed reply for an agent command whose execution was deferred off the
+    ///     control lane, correlated to the original request so the requester's pending
+    ///     <c>InvokeAsync&lt;T&gt;</c> completes exactly as if the command had run inline. See
+    ///     <see cref="DeferredAgentCommandRunner" />.
+    /// </summary>
+    internal async Task SendAgentCommandReplyAsync(Uri replyUri, Guid conversationId, object reply)
+    {
+        var envelope = RoutingFor(reply.GetType()).RouteToDestination(reply, replyUri, null);
+
+        // What ReplyTracker.Complete matches on — see MessageContext.TrackEnvelopeCorrelation, which
+        // stamps the same thing for an inline cascaded reply.
+        envelope.ConversationId = conversationId;
+        envelope.IsResponse = true;
+        envelope.Source = Options.ServiceName;
+
+        await envelope.StoreAndForwardAsync();
     }
 
     private async Task startNodeAgentWorkflowAsync()
@@ -397,6 +423,14 @@ public partial class WolverineRuntime : IAgentRuntime
 
         if (NodeController != null) NodeController.PendingDispatches = null;
 
+        if (NodeController?.DeferredWork != null)
+        {
+            // Safe to await: _agentCancellation is cancelled before teardown, so an in-flight batch
+            // lets go at its next cancellation check rather than running to completion.
+            await NodeController.DeferredWork.DisposeAsync();
+            NodeController.DeferredWork = null;
+        }
+
         if (NodeController != null)
         {
             var bus = new MessageBus(this);
@@ -421,6 +455,12 @@ public partial class WolverineRuntime : IAgentRuntime
         }
 
         if (NodeController != null) NodeController.PendingDispatches = null;
+
+        if (NodeController?.DeferredWork != null)
+        {
+            await NodeController.DeferredWork.DisposeAsync();
+            NodeController.DeferredWork = null;
+        }
 
         if (NodeController != null)
         {


### PR DESCRIPTION
Closes #3748. Closes #3750. Part of the #3753 campaign, building on #3757's reply-window mitigation.

## The defect pair

Both issues are one protocol flaw seen from two sides: **the batched agent command reply window did double duty as a work budget and a failure detector**, and no number can be both.

- **#3748**: acknowledgements only arrive when the agent work finishes, so a start or stop slower than the window (a Marten shard behind a projection version bump: 27s p50 / 215s max, measured) *always* times out — 43 lane timeouts and zero successful stops in seven minutes on the reporter's leader.
- **#3750**: the timeout is then treated as whole-chunk failure. The dispatcher releases its in-flight hold, the pending-assignment ledger's TTL (seconds) is long expired, and the next evaluation re-places agents that are still mid-start onto other nodes — 369 of 902 distinct agents started more than once in twelve minutes, every repeat on a different node, while ~5,600 never-placed agents waited.

## What changed

**1. A progress probe: `QueryAgentPresence` → `AgentPresenceReport`.** The leader can ask a node which of the named agents are running right now, answered instantly from the in-memory agent registry. Presence confirms a start; absence confirms a stop (an agent the node has never seen is exactly as stopped as one it just stopped).

**2. Remote `StartAgents`/`StopAgents` execute off the control lane (`DeferredAgentCommandRunner`).** The database control endpoint is deliberately serial (`MaxDegreeOfParallelism = 1`), so a slow inline batch used to monopolize the node's entire control plane — stops queued behind it, and nothing could answer the progress probe. Batches now run on a background FIFO (strictly one at a time, preserving inter-batch ordering and the parallelism cap) and the control lane is free in microseconds. **The typed reply still goes out only at true completion**, correlated to the original conversation, so a pre-upgrade leader blocked in `InvokeAsync<AgentsStarted>` completes exactly as before. A per-agent stop-revocation sequence keeps the stop-after-start ordering the serial lane used to guarantee: a stop that lands while its target's start is queued or in flight either suppresses that start or reverts it immediately.

**3. The leader races the reply against presence polling (`AgentWorkConfirmation`).** The reply wins whenever it arrives — including from pre-upgrade nodes whose polls simply go unanswered and for whom the old reply window remains the bound (no rolling-upgrade regression in either direction). The polls add the missing piece: *observed progress*. One more agent confirmed within `Durability.AgentProgressStallTimeout` (default 5 min, the daemon side-effect gate's ceiling) keeps the wait alive, so a slow-but-converging node gets unbounded time while a wedged or mute one costs a bounded wait. Every agent stays held — dispatcher in-flight + pending ledger — for as long as the command is waiting, which is what stops the re-placement churn. On resolution, confirmed agents re-arm the ledger (`ConfirmDispatched`) so the one-snapshot gap before their assignment rows become visible can't re-decide an agent that just started. The reassignment single-copy invariant is unchanged: a start is only cascaded for agents confirmed **gone** from the source, now by acknowledgement *or* observation.

New knobs: `Durability.AgentProgressPollInterval` (10s) and `Durability.AgentProgressStallTimeout` (5 min).

## Evidence

- **New SlowTests harness `slow_starts_outrun_reply_windows`**: 3 nodes, 36 agents at heterogeneous 6/12/18s per start (36s/72s/108s of work per chunk against 42s reply windows). Converges with **every agent started exactly once** and asserts the reporter's own churn metric (no agent completes a start on more than one node). Getting this green caught three real bugs in the initial implementation — it is a sensitive guard.
- 11 new unit tests over the confirmation race (progress resets the stall clock, mute-poll fallback to the legacy window, gone-mode, partial replies, cancellation) plus presence-query serialization/round-trip coverage.
- Full CoreTests (2192), both existing agent scale harnesses (`agent_assignment_at_scale`, `agent_reassignment_at_scale`), and the persistence agent/control-endpoint suites are green locally; full `wolverine.slnx` Release build is clean.

**Honest note on the baseline**: this miniature also passes on current `main` — the GH-3698/#3757 machinery already makes a 3-node/36-agent cluster eventually-convergent, and the field failure needs production scale (thousands of agents, 512 tenant databases, 5-minute gates, rolling pods) to turn "eventually" into "hours". The discriminating evidence for the root fix is the reporters' field data; what this PR removes is the mechanism — the window-as-failure-detector — rather than tuning its numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)