### PR TITLE
Parameterless OrInner<T>() no longer discards its inner-exception match (GH-3766)

### DIFF
--- a/src/Testing/CoreTests/ErrorHandling/FailureRuleCollectionTests.cs
+++ b/src/Testing/CoreTests/ErrorHandling/FailureRuleCollectionTests.cs
@@ -167,11 +167,12 @@ public class FailureRuleCollectionTests
             .ShouldBeOfType<DiscardEnvelope>();
 
         theHandlers.Failures.DetermineExecutionContinuation(new Exception("bad", new CodeException { Code = 1 }),
-            theEnvelope);
+                theEnvelope)
+            .ShouldBeOfType<DiscardEnvelope>();
 
         theHandlers.Failures
             .DetermineExecutionContinuation(new Exception("worse", new CodeException { Code = 2 }), theEnvelope)
-            .ShouldBeOfType<RequeueContinuation>();
+            .ShouldBeOfType<DiscardEnvelope>();
 
         theHandlers.Failures.DetermineExecutionContinuation(new BadImageFormatException(), theEnvelope)
             .ShouldBeOfType<RequeueContinuation>();
@@ -190,7 +191,8 @@ public class FailureRuleCollectionTests
             .ShouldBeOfType<DiscardEnvelope>();
 
         theHandlers.Failures.DetermineExecutionContinuation(new Exception("bad", new CodeException { Code = 1 }),
-            theEnvelope);
+                theEnvelope)
+            .ShouldBeOfType<DiscardEnvelope>();
         theHandlers.Failures
             .DetermineExecutionContinuation(new Exception("worse", new CodeException { Code = 2 }), theEnvelope)
             .ShouldBeOfType<RequeueContinuation>();

--- a/src/Wolverine/ErrorHandling/PolicyExpression.cs
+++ b/src/Wolverine/ErrorHandling/PolicyExpression.cs
@@ -820,7 +820,7 @@ public class PolicyExpression : IFailureActions
     /// <returns>The PolicyBuilder instance, for fluent chaining.</returns>
     public PolicyExpression OrInner<TException>() where TException : Exception
     {
-        _match.Or(new InnerMatch(new TypeMatch<TException>()));
+        _match = _match.Or(new InnerMatch(new TypeMatch<TException>()));
         return this;
     }
 


### PR DESCRIPTION
## Summary

Fixes #3766 — the parameterless `PolicyExpression.OrInner<TException>()` built the combined exception match and then discarded it (`_match` was never reassigned), so the inner-exception match silently never applied. The predicate overload directly below it was already correct.

One subtlety worth noting: `ExceptionMatchExtensions.Or` mutates in place when the receiver is already an `OrMatch`, so the parameterless overload *accidentally* worked when chained after another `.Or()` — but in the common `OnException<T>().OrInner<T>()` shape, `_match` is a `TypeMatch` and the new `OrMatch` was thrown away.

## Impact

As reported: `OnException<NpgsqlException>().OrInner<NpgsqlException>().RetryWithCooldown(...)` never matched `MartenCommandException` wrapping an `NpgsqlException`, so messages failing during a brief Postgres outage skipped the retry ladder and dead-lettered on the first attempt.

## Testing

The existing `or_predicate_on_inner_type` test already exercised the buggy path but was **missing the assertion** on the wrapped-exception call — the continuation was computed and dropped on the floor, which is how this survived. Both it and its predicate twin now assert `DiscardEnvelope` for wrapped inner exceptions. Verified red without the product fix, green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eR4GL278688VhyhrGcttJ