### PR TITLE
Bump to 6.24.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.24.2</Version>
+        <Version>6.24.3</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Patch release with the GH-3744 / GH-3766 / GH-3767 fixes, MQTT durable-send acks, the GH-3748/GH-3750 agent command protocol work, and the JasperFx 2.37.0 / Marten 9.22.2 / Weasel 9.23.0 stack bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eR4GL278688VhyhrGcttJ