### PR TITLE
CI/testing sweep: compliance assertion scoping, Marten segmentation, dispose leaks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,12 +34,12 @@ jobs:
           - CIGrpc
           - CIKafka
           # MartenTests is one Postgres project sharded three ways by namespace, each shard strictly
-          # sequential against a single database. CIMarten is the "everything else" shard, so a newly
-          # added namespace still runs somewhere. Replaces the worker-lane split that got the runner
-          # OOM-killed. See #3771, #3762, #3350.
+          # sequential against a single database, balanced on MEASURED per-namespace durations. CIMarten
+          # is the "everything else" shard, so a newly added namespace still runs somewhere. Replaces the
+          # worker-lane split that got the runner OOM-killed. See #3771, #3762, #3350.
           - CIMarten
-          - CIMartenWorkflow
-          - CIMartenSagas
+          - CIMartenDistribution
+          - CIMartenTenancy
           - CIMQTT
           - CIMQTT5
           - CIMySql
@@ -70,9 +70,9 @@ jobs:
           # actually dropped and to catch a recurrence with evidence rather than a guess. See #3771.
           - target: CIMarten
             memory_telemetry: true
-          - target: CIMartenWorkflow
+          - target: CIMartenDistribution
             memory_telemetry: true
-          - target: CIMartenSagas
+          - target: CIMartenTenancy
             memory_telemetry: true
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,13 @@ jobs:
           - CIEfCore
           - CIGrpc
           - CIKafka
+          # MartenTests is one Postgres project sharded three ways by namespace, each shard strictly
+          # sequential against a single database. CIMarten is the "everything else" shard, so a newly
+          # added namespace still runs somewhere. Replaces the worker-lane split that got the runner
+          # OOM-killed. See #3771, #3762, #3350.
           - CIMarten
+          - CIMartenWorkflow
+          - CIMartenSagas
           - CIMQTT
           - CIMQTT5
           - CIMySql
@@ -55,6 +61,19 @@ jobs:
           - CISqlServer
           - CICircuitBreaking
           - CIAotSmoke
+        include:
+          # CIMarten was twice killed outright by the runner ~15 minutes in ("The runner has received a
+          # shutdown signal"), on unrelated diffs, at almost exactly the same elapsed time on both
+          # attempts -- the signature of the VM running out of memory rather than of a test failure.
+          # The worker lanes that caused it are gone (the suite is sharded across these three jobs
+          # instead, one database at a time), so this sampler is now here to *confirm* the footprint
+          # actually dropped and to catch a recurrence with evidence rather than a guess. See #3771.
+          - target: CIMarten
+            memory_telemetry: true
+          - target: CIMartenWorkflow
+            memory_telemetry: true
+          - target: CIMartenSagas
+            memory_telemetry: true
 
     steps:
       - name: Checkout
@@ -68,7 +87,27 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Run Tests
-        run: ./build.sh ${{ matrix.target }} --framework net9.0
+        env:
+          MEMORY_TELEMETRY: ${{ matrix.memory_telemetry }}
+        run: |
+          # The sampler has to live inside this step: when the runner is killed, later steps are
+          # skipped, so only what has already been streamed to this step's log survives. See #3771.
+          if [ "${MEMORY_TELEMETRY:-}" = "true" ]; then
+            ./build/ci-memory-sampler.sh &
+            sampler_pid=$!
+            trap 'kill "${sampler_pid}" 2>/dev/null || true' EXIT
+          fi
+          ./build.sh ${{ matrix.target }} --framework net9.0
+
+      # Only reachable when the runner itself survived. If the OOM killer took a *test* process
+      # rather than the runner service, the kill is recorded here and nowhere else.
+      - name: Kernel OOM report
+        if: failure() && matrix.memory_telemetry == true
+        run: |
+          echo "::group::dmesg (OOM / kill events)"
+          sudo dmesg | grep -iE "out of memory|oom-kill|killed process" || echo "no OOM events in dmesg"
+          echo "::endgroup::"
+          free -m
 
       - name: Stop containers
         if: always()

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,25 +2,6 @@
 <Project>
 
     <!--
-      xUnit1051 ("use TestContext.Current.CancellationToken") is new in the xUnit v3 analyzer set.
-      It ships at warning severity, and TreatWarningsAsErrors turns it into a hard build break, so
-      it was suppressed wholesale for the v3 migration (#3699).
-
-      Reinstating it is a per-project job rather than a flag flip: threading the token genuinely
-      changes how a suite cancels, and a suite has to be run, not just compiled, before its
-      conversion counts. A project opts in with
-
-          <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
-
-      in its own PropertyGroup. This lives in .targets rather than .props because the property is
-      set by the project file, which is evaluated after Directory.Build.props. Remove this block
-      once every xUnit project is converted; the remaining ones are tracked in GH-3702.
-    -->
-    <PropertyGroup Condition=" '$(XUnitCancellationTokenEnforced)' != 'true' ">
-        <NoWarn>$(NoWarn);xUnit1051</NoWarn>
-    </PropertyGroup>
-
-    <!--
       Security remediation for GHSA-v5pm-xwqc-g5wc (uncontrolled recursion / stack overflow
       when parsing OpenAPI documents with circular schema references).
 

--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -334,19 +334,33 @@ partial class Build
     // sibling databases some suites create beside the primary (tenant1-3, players, things) are fixed names,
     // and with a single lane per job they have a single owner again, so no lane-scoping sweep is needed.
     //
-    // Balanced by test-CLASS count, not test count: as measured on PolecatTests, most of the wall clock is
-    // per-class fixture cost (Wolverine + Marten host bootstrap and schema application), not test bodies.
-    // Counts below are from an actual `MartenTests --list-tests` (159 classes / 545 tests), so the split is
-    // known to be disjoint and exhaustive — but they are *counts*, not measured durations, so re-check the
-    // balance against the first real CI run. The two named shards are the heavy thematic clusters; a few
-    // small namespaces ride along as ballast.
+    // Balanced by MEASURED per-namespace duration, from `MartenTests --output Detailed` over the full suite
+    // (533 tests, 880s, zero failures). This matters: the first cut of this split was balanced by test-CLASS
+    // count on the PolecatTests precedent, and class count turned out to be very nearly an *inverted*
+    // predictor of cost here. The expensive namespaces are the ones with few, slow tests:
     //
-    //   CIMartenWorkflow    AggregateHandlerWorkflow, Bugs, ScheduledJobs,
-    //                       Requirements                                        54 classes / 162 tests
-    //   CIMartenSagas       Saga, Persistence (incl. Persistence.Sagas),
-    //                       Distribution, MultiTenancy, AncillaryStores, Dcb    60 classes / 205 tests
-    //   CIMarten            everything else (root namespace, TestHelpers,
-    //                       Sample, ...) + MartenSubscriptionTests              46 classes / 190 tests
+    //     Distribution     192.6s / 49 tests    (multi-node agent distribution, real leader election)
+    //     MultiTenancy     148.4s / 53 tests    (creates tenant databases)
+    //     Bugs             126.5s / 53 tests
+    //     AggregateHandlerWorkflow  73.4s / 90 tests   <- most tests, a third of Distribution's cost
+    //
+    // Distribution and MultiTenancy alone are 39% of the suite, and the class-count split had put BOTH in
+    // the same shard — which is why that shard came in at 7m56s against 4m22s and 4m39s for the other two.
+    // The split below is the best of all 3-way assignments, found by brute force over the measured totals:
+    //
+    //   CIMartenDistribution  Distribution, AggregateHandlerWorkflow,
+    //                         AncillaryStores, Requirements, Sample              293.6s
+    //   CIMartenTenancy       MultiTenancy, TestHelpers, ScheduledJobs,
+    //                         Persistence (incl. Persistence.Sagas), Dcb         293.4s
+    //   CIMarten              everything else (root namespace, Bugs, Saga)
+    //                         + MartenSubscriptionTests                          293.5s
+    //
+    // A 0.2s spread on the measured numbers. Local timings on an M-series machine, so CI's absolute values
+    // differ, but the relative costs are what the split keys off.
+    //
+    // The shards are named for what dominates them. Note that `MartenTests.Saga` lands in the catch-all
+    // while `MartenTests.Persistence.Sagas` lands in CIMartenTenancy — the balance does not respect theme,
+    // which is exactly why the names track the dominant namespace rather than pretending otherwise.
     //
     // Defined ONCE below: the two named shards list their namespaces and CIMarten is the *negation* of both,
     // so a brand new namespace lands in CIMarten automatically instead of being silently dropped from CI.
@@ -359,23 +373,23 @@ partial class Build
     AbsolutePath MartenSubscriptionTests =>
         RootDirectory / "src" / "Persistence" / "MartenSubscriptionTests" / "MartenSubscriptionTests.csproj";
 
-    static readonly string[] MartenWorkflowNamespaces =
+    static readonly string[] MartenDistributionNamespaces =
     [
+        "MartenTests.Distribution",
         "MartenTests.AggregateHandlerWorkflow",
-        "MartenTests.Bugs",
-        "MartenTests.ScheduledJobs",
-        "MartenTests.Requirements"
+        "MartenTests.AncillaryStores",
+        "MartenTests.Requirements",
+        "MartenTests.Sample"
     ];
 
     // "MartenTests.Persistence" also claims MartenTests.Persistence.Sagas, which is where most of that
     // subtree's tests live — the prefix match is on "MartenTests.Persistence." so both are covered.
-    static readonly string[] MartenSagaNamespaces =
+    static readonly string[] MartenTenancyNamespaces =
     [
-        "MartenTests.Saga",
-        "MartenTests.Persistence",
-        "MartenTests.Distribution",
         "MartenTests.MultiTenancy",
-        "MartenTests.AncillaryStores",
+        "MartenTests.TestHelpers",
+        "MartenTests.ScheduledJobs",
+        "MartenTests.Persistence",
         "MartenTests.Dcb"
     ];
 
@@ -399,27 +413,30 @@ partial class Build
     }
 
     /// <summary>
-    /// Marten shard 1: the aggregate handler workflow tests and the Bugs regressions.
+    /// Marten shard 1: multi-node agent distribution — the single most expensive namespace in the suite —
+    /// plus the aggregate handler workflow tests and ancillary stores.
     /// </summary>
-    Target CIMartenWorkflow => _ => _
+    Target CIMartenDistribution => _ => _
         .ProceedAfterFailure()
-        .Executes(() => runMartenShard(includeNamespaces(MartenWorkflowNamespaces)));
+        .Executes(() => runMartenShard(includeNamespaces(MartenDistributionNamespaces)));
 
     /// <summary>
-    /// Marten shard 2: sagas, multi-node distribution, multi-tenancy, ancillary stores and DCB.
+    /// Marten shard 2: multi-tenancy (the second most expensive namespace, since it provisions tenant
+    /// databases), the test helpers, scheduled jobs, saga persistence and DCB.
     /// </summary>
-    Target CIMartenSagas => _ => _
+    Target CIMartenTenancy => _ => _
         .ProceedAfterFailure()
-        .Executes(() => runMartenShard(includeNamespaces(MartenSagaNamespaces)));
+        .Executes(() => runMartenShard(includeNamespaces(MartenTenancyNamespaces)));
 
     /// <summary>
-    /// Marten shard 3: everything not claimed by CIMartenWorkflow or CIMartenSagas — including any newly
-    /// added namespace, which lands here by default — plus MartenSubscriptionTests.
+    /// Marten shard 3: everything not claimed by CIMartenDistribution or CIMartenTenancy — the root
+    /// namespace, Bugs, Saga, and any newly added namespace, which lands here by default — plus
+    /// MartenSubscriptionTests.
     /// </summary>
     Target CIMarten => _ => _
         .ProceedAfterFailure()
         .Executes(() => runMartenShard(
-            excludeNamespaces([..MartenWorkflowNamespaces, ..MartenSagaNamespaces]),
+            excludeNamespaces([..MartenDistributionNamespaces, ..MartenTenancyNamespaces]),
             alsoSubscriptions: true));
 
     Target CIMySql => _ => _

--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -321,22 +321,106 @@ partial class Build
             RunTestProject(sqlServerTests, workers: 4, sqlServerDatabasePerLane: true);
         });
 
+    // MartenTests was the 18m long pole of the matrix (#3752). It was first attacked with worker lanes —
+    // four processes, each on its own database via WOLVERINE_POSTGRES — and that halved the wall clock but
+    // did not hold up: the runner itself was killed outright ("The runner has received a shutdown signal")
+    // twice in a row at ~15 minutes on an unrelated diff (#3771), which is the OOM signature, not a test
+    // failure. Several Marten test hosts plus Postgres does not fit a 4-vCPU/16GB hosted runner, and a lane
+    // count that dies to the OOM killer on a busy day is not a stable halving.
+    //
+    // So the wall clock is bought the way CIPolecat buys it (#3350): SEGMENT the suite across parallel CI
+    // JOBS, each running strictly sequentially against exactly ONE database. Concurrency moves off the
+    // runner VM and onto the matrix, where every shard gets its own 16GB. This also closes #3762 — the
+    // sibling databases some suites create beside the primary (tenant1-3, players, things) are fixed names,
+    // and with a single lane per job they have a single owner again, so no lane-scoping sweep is needed.
+    //
+    // Balanced by test-CLASS count, not test count: as measured on PolecatTests, most of the wall clock is
+    // per-class fixture cost (Wolverine + Marten host bootstrap and schema application), not test bodies.
+    // Counts below are from an actual `MartenTests --list-tests` (159 classes / 545 tests), so the split is
+    // known to be disjoint and exhaustive — but they are *counts*, not measured durations, so re-check the
+    // balance against the first real CI run. The two named shards are the heavy thematic clusters; a few
+    // small namespaces ride along as ballast.
+    //
+    //   CIMartenWorkflow    AggregateHandlerWorkflow, Bugs, ScheduledJobs,
+    //                       Requirements                                        54 classes / 162 tests
+    //   CIMartenSagas       Saga, Persistence (incl. Persistence.Sagas),
+    //                       Distribution, MultiTenancy, AncillaryStores, Dcb    60 classes / 205 tests
+    //   CIMarten            everything else (root namespace, TestHelpers,
+    //                       Sample, ...) + MartenSubscriptionTests              46 classes / 190 tests
+    //
+    // Defined ONCE below: the two named shards list their namespaces and CIMarten is the *negation* of both,
+    // so a brand new namespace lands in CIMarten automatically instead of being silently dropped from CI.
+    //
+    // Note the root namespace `MartenTests` cannot be an *include* list entry — every shard's display names
+    // start with it — which is precisely why the catch-all has to be the negation.
+
+    AbsolutePath MartenTests => RootDirectory / "src" / "Persistence" / "MartenTests" / "MartenTests.csproj";
+
+    AbsolutePath MartenSubscriptionTests =>
+        RootDirectory / "src" / "Persistence" / "MartenSubscriptionTests" / "MartenSubscriptionTests.csproj";
+
+    static readonly string[] MartenWorkflowNamespaces =
+    [
+        "MartenTests.AggregateHandlerWorkflow",
+        "MartenTests.Bugs",
+        "MartenTests.ScheduledJobs",
+        "MartenTests.Requirements"
+    ];
+
+    // "MartenTests.Persistence" also claims MartenTests.Persistence.Sagas, which is where most of that
+    // subtree's tests live — the prefix match is on "MartenTests.Persistence." so both are covered.
+    static readonly string[] MartenSagaNamespaces =
+    [
+        "MartenTests.Saga",
+        "MartenTests.Persistence",
+        "MartenTests.Distribution",
+        "MartenTests.MultiTenancy",
+        "MartenTests.AncillaryStores",
+        "MartenTests.Dcb"
+    ];
+
+    /// <param name="testFilter">Which slice of MartenTests this shard owns.</param>
+    /// <param name="alsoSubscriptions">
+    /// MartenSubscriptionTests is a single 12-test class, too small to shard and too small to justify a job
+    /// of its own, so it rides along with the catch-all shard.
+    /// </param>
+    void runMartenShard(Func<WorkerTest, bool> testFilter, bool alsoSubscriptions = false)
+    {
+        AbsolutePath[] projects = alsoSubscriptions
+            ? [MartenTests, MartenSubscriptionTests]
+            : [MartenTests];
+
+        BuildTestProjects(projects);
+        StartDockerServices("postgresql");
+
+        // workers: 1 and no postgresDatabasePerLane, deliberately. One database is active at a time —
+        // that is the whole point of segmenting rather than lane-splitting. See the note above.
+        RunTestProjects(projects.Select(x => x.ToString()).ToArray(), testFilter: testFilter);
+    }
+
+    /// <summary>
+    /// Marten shard 1: the aggregate handler workflow tests and the Bugs regressions.
+    /// </summary>
+    Target CIMartenWorkflow => _ => _
+        .ProceedAfterFailure()
+        .Executes(() => runMartenShard(includeNamespaces(MartenWorkflowNamespaces)));
+
+    /// <summary>
+    /// Marten shard 2: sagas, multi-node distribution, multi-tenancy, ancillary stores and DCB.
+    /// </summary>
+    Target CIMartenSagas => _ => _
+        .ProceedAfterFailure()
+        .Executes(() => runMartenShard(includeNamespaces(MartenSagaNamespaces)));
+
+    /// <summary>
+    /// Marten shard 3: everything not claimed by CIMartenWorkflow or CIMartenSagas — including any newly
+    /// added namespace, which lands here by default — plus MartenSubscriptionTests.
+    /// </summary>
     Target CIMarten => _ => _
         .ProceedAfterFailure()
-        .Executes(() =>
-        {
-            var martenTests = RootDirectory / "src" / "Persistence" / "MartenTests" / "MartenTests.csproj";
-            var martenSubscriptionTests = RootDirectory / "src" / "Persistence" / "MartenSubscriptionTests" / "MartenSubscriptionTests.csproj";
-
-            BuildTestProjects(martenTests, martenSubscriptionTests);
-            StartDockerServices("postgresql");
-
-            // The 18m long pole of the 28-job matrix (#3752). Four workers, each pointed at its
-            // own database via WOLVERINE_POSTGRES — schema names are hard-coded throughout, so
-            // two processes sharing one database collide however the tests are partitioned.
-            RunTestProjects([martenTests, martenSubscriptionTests],
-                workers: 4, postgresDatabasePerLane: true);
-        });
+        .Executes(() => runMartenShard(
+            excludeNamespaces([..MartenWorkflowNamespaces, ..MartenSagaNamespaces]),
+            alsoSubscriptions: true));
 
     Target CIMySql => _ => _
         .ProceedAfterFailure()

--- a/build/ci-memory-sampler.sh
+++ b/build/ci-memory-sampler.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Samples memory pressure to stdout while a CI test target runs.
+#
+# Why stdout and not a file: the failure this exists to diagnose (GH-3771) is the *runner itself*
+# being killed ~15 minutes in. When that happens every later step is skipped -- the observed run had
+# "Stop containers: skipped" -- so an artifact upload or an `if: failure()` dmesg dump never
+# executes. Anything already streamed to the live job log, on the other hand, survives. So the
+# sampler has to run in the background of the step being diagnosed and print as it goes.
+#
+# Each line is prefixed [mem] so the curve can be pulled out of a noisy log with a single grep:
+#
+#   gh run view <id> --log | grep '\[mem\]'
+#
+# Reads as: if MemAvailable trends toward zero and swap fills just before the kill, this is the OOM
+# killer taking the runner service and the fix is footprint (lane count, per-lane hosts). If memory
+# is flat at the moment of death, it is not OOM and lane tuning would be treating the wrong thing.
+
+set -uo pipefail
+
+interval="${MEMORY_SAMPLE_INTERVAL:-15}"
+
+echo "[mem] sampling every ${interval}s -- total/used/free/available in MB, plus the largest RSS consumers"
+
+while true; do
+    # `free -m` line 2 is the physical memory row; column 7 is "available", which is the number that
+    # actually predicts an OOM kill (unlike "free", which excludes reclaimable page cache).
+    read -r _ total used free _ _ available <<<"$(free -m | awk 'NR==2')"
+    swap_used="$(free -m | awk 'NR==3 {print $3}')"
+
+    # Top three processes by RSS, so a spike can be attributed to a test host / Postgres / the runner
+    # rather than just observed in aggregate.
+    top="$(ps -eo rss=,comm= --sort=-rss | head -3 | awk '{printf "%s=%dMB ", $2, $1/1024}')"
+
+    echo "[mem] $(date -u +%H:%M:%S) total=${total} used=${used} free=${free} available=${available} swap_used=${swap_used} | ${top}"
+
+    sleep "${interval}"
+done

--- a/src/Extensions/Wolverine.DataAnnotationsValidation.Tests/Wolverine.DataAnnotationsValidation.Tests.csproj
+++ b/src/Extensions/Wolverine.DataAnnotationsValidation.Tests/Wolverine.DataAnnotationsValidation.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
       <!-- GH-3702: xUnit1051 reinstated for this project -->
-      <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
+++ b/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Extensions/Wolverine.MemoryPack.Tests/Wolverine.MemoryPack.Tests.csproj
+++ b/src/Extensions/Wolverine.MemoryPack.Tests/Wolverine.MemoryPack.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Extensions/Wolverine.MessagePack.Tests/Wolverine.MessagePack.Tests.csproj
+++ b/src/Extensions/Wolverine.MessagePack.Tests/Wolverine.MessagePack.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Extensions/Wolverine.Protobuf.Tests/Wolverine.Protobuf.Tests.csproj
+++ b/src/Extensions/Wolverine.Protobuf.Tests/Wolverine.Protobuf.Tests.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 	    <!-- GH-3702: xUnit1051 reinstated for this project -->
-	    <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/src/Http/Wolverine.Http.AspVersioning.Tests/Wolverine.Http.AspVersioning.Tests.csproj
+++ b/src/Http/Wolverine.Http.AspVersioning.Tests/Wolverine.Http.AspVersioning.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Http/Wolverine.Http.Tests/Wolverine.Http.Tests.csproj
+++ b/src/Http/Wolverine.Http.Tests/Wolverine.Http.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net9.0</TargetFrameworks>

--- a/src/Persistence/CosmosDbTests/CosmosDbTests.csproj
+++ b/src/Persistence/CosmosDbTests/CosmosDbTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/EfCoreTests.MultiTenancy/EfCoreTests.MultiTenancy.csproj
+++ b/src/Persistence/EfCoreTests.MultiTenancy/EfCoreTests.MultiTenancy.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Persistence/EfCoreTests/EfCoreTests.csproj
+++ b/src/Persistence/EfCoreTests/EfCoreTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Persistence/LeaderElection/CosmosDbTests.LeaderElection/CosmosDbTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/CosmosDbTests.LeaderElection/CosmosDbTests.LeaderElection.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Persistence/LeaderElection/MySqlTests.LeaderElection/MySqlTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/MySqlTests.LeaderElection/MySqlTests.LeaderElection.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Persistence/LeaderElection/OracleTests.LeaderElection/OracleTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/OracleTests.LeaderElection/OracleTests.LeaderElection.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Persistence/LeaderElection/PostgresqlTests.LeaderElection/PostgresqlTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/PostgresqlTests.LeaderElection/PostgresqlTests.LeaderElection.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Persistence/LeaderElection/RavenDbTests.LeaderElection/RavenDbTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/RavenDbTests.LeaderElection/RavenDbTests.LeaderElection.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/LeaderElection/SqlServerTests.LeaderElection/SqlServerTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/SqlServerTests.LeaderElection/SqlServerTests.LeaderElection.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Persistence/MartenSubscriptionTests/MartenSubscriptionTests.csproj
+++ b/src/Persistence/MartenSubscriptionTests/MartenSubscriptionTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Persistence/MartenTests/DurableTcpTransportCompliance.cs
+++ b/src/Persistence/MartenTests/DurableTcpTransportCompliance.cs
@@ -47,10 +47,6 @@ public class DurableTcpTransportFixture : TransportComplianceFixture, IAsyncLife
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class DurableTcpTransportCompliance : TransportCompliance<DurableTcpTransportFixture>;

--- a/src/Persistence/MartenTests/MartenTests.csproj
+++ b/src/Persistence/MartenTests/MartenTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Persistence/MySql/MySqlTests/MySqlTests.csproj
+++ b/src/Persistence/MySql/MySqlTests/MySqlTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Persistence/Oracle/OracleTests/OracleTests.csproj
+++ b/src/Persistence/Oracle/OracleTests/OracleTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Persistence/PersistenceTests/PersistenceTests.csproj
+++ b/src/Persistence/PersistenceTests/PersistenceTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>

--- a/src/Persistence/Polecat/PolecatIncidentService.Tests/PolecatIncidentService.Tests.csproj
+++ b/src/Persistence/Polecat/PolecatIncidentService.Tests/PolecatIncidentService.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net10.0</TargetFrameworks>

--- a/src/Persistence/PolecatTests/PolecatTests.csproj
+++ b/src/Persistence/PolecatTests/PolecatTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Persistence/PostgresqlTests/LocalPostgresqlBackedTransportCompliance.cs
+++ b/src/Persistence/PostgresqlTests/LocalPostgresqlBackedTransportCompliance.cs
@@ -21,10 +21,6 @@ public class LocalPostgresqlBackedFixture : TransportComplianceFixture, IAsyncLi
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 [Collection("marten")]

--- a/src/Persistence/PostgresqlTests/PostgresqlTests.csproj
+++ b/src/Persistence/PostgresqlTests/PostgresqlTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Persistence/PostgresqlTests/Transport/compliance_tests.cs
+++ b/src/Persistence/PostgresqlTests/Transport/compliance_tests.cs
@@ -40,10 +40,6 @@ public class PostgresqlTransportDurableFixture : TransportComplianceFixture, IAs
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 [Collection("marten")]
@@ -88,10 +84,6 @@ public class PostgresqlTransportBufferedFixture : TransportComplianceFixture, IA
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 [Collection("sqlserver")]

--- a/src/Persistence/RavenDbTests/RavenDbTests.csproj
+++ b/src/Persistence/RavenDbTests/RavenDbTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/SqlServerTests/SqlServerTests.csproj
+++ b/src/Persistence/SqlServerTests/SqlServerTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Persistence/SqlServerTests/Transport/compliance_tests.cs
+++ b/src/Persistence/SqlServerTests/Transport/compliance_tests.cs
@@ -43,10 +43,6 @@ public class SqlTransportDurableFixture : TransportComplianceFixture, IAsyncLife
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class SqlServerTransport_Durable_Compliance : TransportCompliance<SqlTransportDurableFixture>;
@@ -90,10 +86,6 @@ public class SqlTransportBufferedFixture : TransportComplianceFixture, IAsyncLif
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class SqlServerTransport_Buffered_Compliance : TransportCompliance<SqlTransportBufferedFixture>

--- a/src/Persistence/SqliteTests/LocalSqliteBackedTransportCompliance.cs
+++ b/src/Persistence/SqliteTests/LocalSqliteBackedTransportCompliance.cs
@@ -25,10 +25,12 @@ public class LocalSqliteBackedFixture : TransportComplianceFixture, IAsyncLifeti
         });
     }
 
-    public new async ValueTask DisposeAsync()
+    // AfterDisposeAsync, not a `new DisposeAsync`: TransportCompliance<T> disposes the fixture through
+    // the statically-bound base method, so a hiding override never runs and this database leaked. See #3763.
+    protected override Task AfterDisposeAsync()
     {
-        await base.DisposeAsync();
         _database.Dispose();
+        return Task.CompletedTask;
     }
 }
 

--- a/src/Persistence/SqliteTests/SqliteTests.csproj
+++ b/src/Persistence/SqliteTests/SqliteTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <IsPackable>false</IsPackable>
         <OutputType>Exe</OutputType>
     </PropertyGroup>

--- a/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/Wolverine.ClaimCheck.GoogleCloudStorage.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/Wolverine.ClaimCheck.GoogleCloudStorage.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/Wolverine.ClaimCheck.Nats.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/Wolverine.ClaimCheck.Nats.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/Wolverine.ClaimCheck.Postgresql.Tests/Wolverine.ClaimCheck.Postgresql.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.Postgresql.Tests/Wolverine.ClaimCheck.Postgresql.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Samples/CQRSWithMarten/TeleHealth.Tests/TeleHealth.Tests.csproj
+++ b/src/Samples/CQRSWithMarten/TeleHealth.Tests/TeleHealth.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Samples/Diagnostics/DiagnosticsTests/DiagnosticsTests.csproj
+++ b/src/Samples/Diagnostics/DiagnosticsTests/DiagnosticsTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Samples/EFCoreSample/ItemService.Tests/ItemService.Tests.csproj
+++ b/src/Samples/EFCoreSample/ItemService.Tests/ItemService.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>

--- a/src/Samples/IncidentService/IncidentService.Tests/IncidentService.Tests.csproj
+++ b/src/Samples/IncidentService/IncidentService.Tests/IncidentService.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net9.0</TargetFrameworks>

--- a/src/Samples/Middleware/AppWithMiddleware.Tests/AppWithMiddleware.Tests.csproj
+++ b/src/Samples/Middleware/AppWithMiddleware.Tests/AppWithMiddleware.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Samples/MultiTenantedTodoService/MultiTenantedTodoWebService.Tests/MultiTenantedTodoWebService.Tests.csproj
+++ b/src/Samples/MultiTenantedTodoService/MultiTenantedTodoWebService.Tests/MultiTenantedTodoWebService.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Samples/ProcessManagerViaHandlers/ProcessManagerViaHandlers.Tests/ProcessManagerViaHandlers.Tests.csproj
+++ b/src/Samples/ProcessManagerViaHandlers/ProcessManagerViaHandlers.Tests/ProcessManagerViaHandlers.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net9.0</TargetFrameworks>

--- a/src/Samples/TestHarness/BankingService.Tests/BankingService.Tests.csproj
+++ b/src/Samples/TestHarness/BankingService.Tests/BankingService.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Samples/TodoWebService/TodoWebServiceTests/TodoWebServiceTests.csproj
+++ b/src/Samples/TodoWebService/TodoWebServiceTests/TodoWebServiceTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/BackPressureTests/BackPressureTests.csproj
+++ b/src/Testing/BackPressureTests/BackPressureTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/Testing/CoreTests/CoreTests.csproj
+++ b/src/Testing/CoreTests/CoreTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Testing/MessageRoutingTests/MessageRoutingTests.csproj
+++ b/src/Testing/MessageRoutingTests/MessageRoutingTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/Testing/MetricsTests/MetricsTests.csproj
+++ b/src/Testing/MetricsTests/MetricsTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Testing/PolicyTests/PolicyTests.csproj
+++ b/src/Testing/PolicyTests/PolicyTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Testing/SlowTests/SharedMemory/buffered_compliance.cs
+++ b/src/Testing/SlowTests/SharedMemory/buffered_compliance.cs
@@ -27,9 +27,12 @@ public class BufferedSharedMemoryInlineFixture : TransportComplianceFixture, IAs
         });
     }
 
-    public new async ValueTask DisposeAsync()
+    // AfterDisposeAsync, not a `new DisposeAsync`: TransportCompliance<T> disposes the fixture through
+    // the statically-bound base method, so a hiding override never runs and the queues were never cleared.
+    // See #3763.
+    protected override Task AfterDisposeAsync()
     {
-        await SharedMemoryQueueManager.ClearAllAsync();
+        return SharedMemoryQueueManager.ClearAllAsync();
     }
 }
 

--- a/src/Testing/SlowTests/SharedMemory/inline_compliance.cs
+++ b/src/Testing/SlowTests/SharedMemory/inline_compliance.cs
@@ -27,9 +27,12 @@ public class InlineSharedMemoryInlineFixture : TransportComplianceFixture, IAsyn
         });
     }
 
-    public new async ValueTask DisposeAsync()
+    // AfterDisposeAsync, not a `new DisposeAsync`: TransportCompliance<T> disposes the fixture through
+    // the statically-bound base method, so a hiding override never runs and the queues were never cleared.
+    // See #3763.
+    protected override Task AfterDisposeAsync()
     {
-        await SharedMemoryQueueManager.ClearAllAsync();
+        return SharedMemoryQueueManager.ClearAllAsync();
     }
 }
 

--- a/src/Testing/SlowTests/SlowTests.csproj
+++ b/src/Testing/SlowTests/SlowTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Testing/SlowTests/TcpTransport/LightweightTcpTransportCompliance.cs
+++ b/src/Testing/SlowTests/TcpTransport/LightweightTcpTransportCompliance.cs
@@ -20,10 +20,6 @@ public class LightweightTcpFixture : TransportComplianceFixture, IAsyncLifetime
         await ReceiverIs(opts => { opts.ListenAtPort(OutboundAddress.Port); });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await DisposeAsync();
-    }
 }
 
 [Collection("compliance")]

--- a/src/Testing/Wolverine.Behavioural.FSharpTests/Wolverine.Behavioural.FSharpTests.csproj
+++ b/src/Testing/Wolverine.Behavioural.FSharpTests/Wolverine.Behavioural.FSharpTests.csproj
@@ -10,7 +10,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/Wolverine.ComplianceTests/Compliance/TransportCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/Compliance/TransportCompliance.cs
@@ -46,6 +46,18 @@ public abstract class TransportComplianceFixture : IDisposable, IAsyncDisposable
     /// </summary>
     public DurabilityMode Mode { get; set; } = DurabilityMode.Solo;
 
+    /// <summary>
+    /// Tears down the sender and receiver hosts, then hands off to <see cref="AfterDisposeAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// Do NOT hide this with a <c>public new DisposeAsync()</c> in a derived fixture. It reads like an
+    /// override and is not one: <see cref="TransportCompliance{T}"/> disposes the fixture through a
+    /// <c>T</c>-typed reference, which binds statically to *this* method, so the hiding member is simply
+    /// never called. Thirty-four fixtures had one; seven of those carried real cleanup — a SQLite database,
+    /// shared-memory queues, and four local MQTT brokers — that had never once executed, and four more were
+    /// infinitely self-recursive dead code. Put transport-specific cleanup in <see cref="AfterDisposeAsync"/>,
+    /// which is virtual and actually runs. See #3763.
+    /// </remarks>
     public async ValueTask DisposeAsync()
     {
         if (Sender == null)
@@ -459,9 +471,21 @@ public abstract class TransportCompliance<T> : IAsyncLifetime where T : Transpor
             .DoNotAssertOnExceptionsDetected()
             .SendMessageAndWaitAsync(theMessage);
 
-        return _session.AllRecordsInOrder().Where(x => x.Envelope!.Message is ErrorCausingMessage).LastOrDefault(x =>
-            x.MessageEventType == MessageEventType.MessageSucceeded ||
-            x.MessageEventType == MessageEventType.MovedToErrorQueue)!;
+        return endingRecordFor(_session)!;
+    }
+
+    /// <summary>
+    /// The last ending record for *the message this test sent*. Scoping by message type alone picks up
+    /// stragglers: broker queues are shared across the test methods in a compliance class, and a
+    /// redelivery still in flight when the previous test's session completed lands in this one's.
+    /// </summary>
+    private EnvelopeRecord? endingRecordFor(ITrackedSession session)
+    {
+        return session.AllRecordsInOrder()
+            .Where(x => x.Envelope?.Message is ErrorCausingMessage m && m.Id == theMessage.Id)
+            .LastOrDefault(x =>
+                x.MessageEventType == MessageEventType.MessageSucceeded ||
+                x.MessageEventType == MessageEventType.MovedToErrorQueue);
     }
 
     protected async Task shouldSucceedOnAttempt(int attempt)
@@ -475,10 +499,7 @@ public abstract class TransportCompliance<T> : IAsyncLifetime where T : Transpor
 
         session.AssertCondition("Expected ending activity was not detected", () =>
         {
-            var record = session.AllRecordsInOrder().Where(x => x.Envelope!.Message is ErrorCausingMessage).LastOrDefault(
-                x =>
-                    x.MessageEventType == MessageEventType.MessageSucceeded ||
-                    x.MessageEventType == MessageEventType.MovedToErrorQueue)!;
+            var record = endingRecordFor(session);
 
             if (record is null) return false;
 
@@ -500,10 +521,7 @@ public abstract class TransportCompliance<T> : IAsyncLifetime where T : Transpor
             .Timeout(30.Seconds())
             .SendMessageAndWaitAsync(theMessage);
 
-        var record = session.AllRecordsInOrder().Where(x => x.Envelope!.Message is ErrorCausingMessage).LastOrDefault(
-            x =>
-                x.MessageEventType == MessageEventType.MessageSucceeded ||
-                x.MessageEventType == MessageEventType.MovedToErrorQueue)!;
+        var record = endingRecordFor(session);
 
         if (record == null)
         {

--- a/src/Testing/Wolverine.ComplianceTests/ErrorHandling/ErrorCausingMessage.cs
+++ b/src/Testing/Wolverine.ComplianceTests/ErrorHandling/ErrorCausingMessage.cs
@@ -2,6 +2,14 @@ namespace Wolverine.ComplianceTests.ErrorHandling;
 
 public class ErrorCausingMessage
 {
+    /// <summary>
+    /// Identifies one specific message under test. The transport compliance suites share broker
+    /// queues across test methods, and a redelivery still in flight when one test's tracked session
+    /// completes will show up in the *next* test's session. Assertions have to scope to this id
+    /// rather than to the message type, or a straggler becomes "the ending activity."
+    /// </summary>
+    public Guid Id { get; set; } = Guid.NewGuid();
+
     public Dictionary<int, Exception> Errors { get; set; } = new();
     public bool WasProcessed { get; set; }
     public int LastAttempt { get; set; }

--- a/src/Testing/Wolverine.ComplianceTests/Wolverine.ComplianceTests.csproj
+++ b/src/Testing/Wolverine.ComplianceTests/Wolverine.ComplianceTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <Description>Compliance test harnesses for adding persistence and transport options to Wolverine</Description>
         <PackageId>WolverineFx.ComplianceTests</PackageId>
         <!--

--- a/src/Testing/Wolverine.Core.FSharpTests/Wolverine.Core.FSharpTests.csproj
+++ b/src/Testing/Wolverine.Core.FSharpTests/Wolverine.Core.FSharpTests.csproj
@@ -9,7 +9,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/Wolverine.Cosmos.FSharpTests/Wolverine.Cosmos.FSharpTests.csproj
+++ b/src/Testing/Wolverine.Cosmos.FSharpTests/Wolverine.Cosmos.FSharpTests.csproj
@@ -10,7 +10,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/Wolverine.EfCore.FSharpTests/Wolverine.EfCore.FSharpTests.csproj
+++ b/src/Testing/Wolverine.EfCore.FSharpTests/Wolverine.EfCore.FSharpTests.csproj
@@ -9,7 +9,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/Wolverine.Http.FSharpTests/Wolverine.Http.FSharpTests.csproj
+++ b/src/Testing/Wolverine.Http.FSharpTests/Wolverine.Http.FSharpTests.csproj
@@ -9,7 +9,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/Wolverine.Marten.FSharpTests/Wolverine.Marten.FSharpTests.csproj
+++ b/src/Testing/Wolverine.Marten.FSharpTests/Wolverine.Marten.FSharpTests.csproj
@@ -9,7 +9,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/Wolverine.MartenAggregate.FSharpTests/Wolverine.MartenAggregate.FSharpTests.csproj
+++ b/src/Testing/Wolverine.MartenAggregate.FSharpTests/Wolverine.MartenAggregate.FSharpTests.csproj
@@ -9,7 +9,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/BufferedSendingAndReceivingCompliance.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/BufferedSendingAndReceivingCompliance.cs
@@ -42,10 +42,6 @@ public class BufferedComplianceFixture : TransportComplianceFixture, IAsyncLifet
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class BufferedSendingAndReceivingCompliance : TransportCompliance<BufferedComplianceFixture>

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/InlineSendingAndReceivingCompliance.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/InlineSendingAndReceivingCompliance.cs
@@ -47,10 +47,6 @@ public class InlineComplianceFixture : TransportComplianceFixture, IAsyncLifetim
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class InlineSendingAndReceivingCompliance : TransportCompliance<InlineComplianceFixture>

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/Wolverine.AmazonSns.Tests.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/Wolverine.AmazonSns.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/sending_compliance_with_prefixes.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/sending_compliance_with_prefixes.cs
@@ -55,10 +55,6 @@ public class PrefixedComplianceFixture : TransportComplianceFixture, IAsyncLifet
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class PrefixedSendingAndReceivingCompliance : TransportCompliance<PrefixedComplianceFixture>

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/BufferedSendingAndReceivingCompliance.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/BufferedSendingAndReceivingCompliance.cs
@@ -38,10 +38,6 @@ public class BufferedComplianceFixture : TransportComplianceFixture, IAsyncLifet
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class BufferedSendingAndReceivingCompliance : TransportCompliance<BufferedComplianceFixture>

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/DurableSendingAndReceivingCompliance.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/DurableSendingAndReceivingCompliance.cs
@@ -67,10 +67,6 @@ public class DurableComplianceFixture : TransportComplianceFixture, IAsyncLifeti
         await Receiver.RebuildAllEnvelopeStorageAsync();
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 
     public class DurableSendingAndReceivingCompliance : TransportCompliance<DurableComplianceFixture>
     {

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/InlineSendingAndReceivingCompliance.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/InlineSendingAndReceivingCompliance.cs
@@ -44,10 +44,6 @@ public class InlineComplianceFixture : TransportComplianceFixture, IAsyncLifetim
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class InlineSendingAndReceivingCompliance : TransportCompliance<InlineComplianceFixture>

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/sending_compliance_with_prefixes.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/sending_compliance_with_prefixes.cs
@@ -40,10 +40,6 @@ public class PrefixedComplianceFixture : TransportComplianceFixture, IAsyncLifet
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class PrefixedSendingAndReceivingCompliance : TransportCompliance<PrefixedComplianceFixture>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Wolverine.AzureServiceBus.Tests.csproj
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Wolverine.AzureServiceBus.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/BufferedSendingAndReceivingCompliance.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/BufferedSendingAndReceivingCompliance.cs
@@ -45,10 +45,6 @@ public class BufferedComplianceFixture : TransportComplianceFixture, IAsyncLifet
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await DisposeAsync();
-    }
 }
 
 [Collection("acceptance")]

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/DurableSendingAndReceivingCompliance.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/DurableSendingAndReceivingCompliance.cs
@@ -69,10 +69,6 @@ public class DurableComplianceFixture : TransportComplianceFixture, IAsyncLifeti
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await DisposeAsync();
-    }
 }
 
 [Collection("acceptance")]

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/InlineSendingAndReceivingCompliance.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/InlineSendingAndReceivingCompliance.cs
@@ -49,10 +49,6 @@ public class InlineComplianceFixture : TransportComplianceFixture, IAsyncLifetim
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await DisposeAsync();
-    }
 }
 
 [Collection("acceptance")]

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/Wolverine.Pubsub.Tests.csproj
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/Wolverine.Pubsub.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/sending_compliance_with_prefixes.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/sending_compliance_with_prefixes.cs
@@ -43,10 +43,6 @@ public class PrefixedComplianceFixture : TransportComplianceFixture, IAsyncLifet
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await DisposeAsync();
-    }
 }
 
 [Collection("acceptance")]

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/MosquittoContainerFixture.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/MosquittoContainerFixture.cs
@@ -15,6 +15,18 @@ public static class MosquittoContainerFixture
     [ModuleInitializer]
     internal static void Initialize()
     {
+        // An already-running broker wins. The container start below sits on the critical path of
+        // *every* process launch -- it runs before Main -- so a caller that supplies a warm broker
+        // (a dev, or a CI lane sharing one) skips it entirely. Same shape as Servers.cs.
+        var configured = Environment.GetEnvironmentVariable("WOLVERINE_MQTT");
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            var parts = configured.Trim().Split(':', 2);
+            Host = parts[0];
+            Port = parts.Length > 1 && int.TryParse(parts[1], out var parsed) ? parsed : 1883;
+            return;
+        }
+
         // Testcontainers logs a "Connected to Docker" banner through a default console logger.
         // Under xUnit v3 the test project is an executable that speaks JSON to the runner over
         // stdout, and a [ModuleInitializer] runs BEFORE Main -- so before xUnit has redirected
@@ -34,5 +46,24 @@ public static class MosquittoContainerFixture
 
         Host = _container.Hostname;
         Port = _container.GetMappedPublicPort(1883);
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => shutdown();
+    }
+
+    /// <summary>
+    /// Stop the container on a graceful exit. Testcontainers' Ryuk reaper normally handles this, but
+    /// it is not always running (ryuk.disabled=true is a common local setting) and the leak is *per
+    /// process*: per-class isolation and the flaky-retry harness both spawn extra processes, so a
+    /// single run can strand several containers that then live forever. A kill -9 still needs Ryuk;
+    /// this only covers the common case.
+    /// </summary>
+    private static void shutdown()
+    {
+        var container = Interlocked.Exchange(ref _container, null);
+        if (container == null) return;
+
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+        container.DisposeAsync().AsTask().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
     }
 }

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/buffered_compliance.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/buffered_compliance.cs
@@ -52,7 +52,10 @@ public class BufferedComplianceFixture : TransportComplianceFixture, IAsyncLifet
 
     public LocalMqttBroker Broker { get; private set; } = null!;
 
-    public new async ValueTask DisposeAsync()
+    // AfterDisposeAsync, not a `new DisposeAsync`: TransportCompliance<T> disposes the fixture through
+    // the statically-bound base method, so a hiding override never runs -- meaning this broker was never
+    // stopped and leaked its listening socket for the life of the test process. See #3763.
+    protected override async Task AfterDisposeAsync()
     {
         await Broker.StopAsync();
         await Broker.DisposeAsync();

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/inline_compliance.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/inline_compliance.cs
@@ -52,7 +52,10 @@ public class InlineComplianceFixture : TransportComplianceFixture, IAsyncLifetim
 
     public LocalMqttBroker Broker { get; private set; } = null!;
 
-    public new async ValueTask DisposeAsync()
+    // AfterDisposeAsync, not a `new DisposeAsync`: TransportCompliance<T> disposes the fixture through
+    // the statically-bound base method, so a hiding override never runs -- meaning this broker was never
+    // stopped and leaked its listening socket for the life of the test process. See #3763.
+    protected override async Task AfterDisposeAsync()
     {
         await Broker.StopAsync();
         await Broker.DisposeAsync();

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/mosquitto_compliance.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/mosquitto_compliance.cs
@@ -46,10 +46,6 @@ public class MosquittoBufferedComplianceFixture : TransportComplianceFixture, IA
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        // Nothing extra to dispose; Mosquitto runs in Docker
-    }
 }
 
 [Collection("mosquitto")]

--- a/src/Transports/MQTT/Wolverine.Mqtt5.Tests/MosquittoContainerFixture.cs
+++ b/src/Transports/MQTT/Wolverine.Mqtt5.Tests/MosquittoContainerFixture.cs
@@ -15,6 +15,18 @@ public static class MosquittoContainerFixture
     [ModuleInitializer]
     internal static void Initialize()
     {
+        // An already-running broker wins. The container start below sits on the critical path of
+        // *every* process launch -- it runs before Main -- so a caller that supplies a warm broker
+        // (a dev, or a CI lane sharing one) skips it entirely. Same shape as Servers.cs.
+        var configured = Environment.GetEnvironmentVariable("WOLVERINE_MQTT");
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            var parts = configured.Trim().Split(':', 2);
+            Host = parts[0];
+            Port = parts.Length > 1 && int.TryParse(parts[1], out var parsed) ? parsed : 1883;
+            return;
+        }
+
         // Testcontainers logs a "Connected to Docker" banner through a default console logger.
         // Under xUnit v3 the test project is an executable that speaks JSON to the runner over
         // stdout, and a [ModuleInitializer] runs BEFORE Main -- so before xUnit has redirected
@@ -34,5 +46,24 @@ public static class MosquittoContainerFixture
 
         Host = _container.Hostname;
         Port = _container.GetMappedPublicPort(1883);
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => shutdown();
+    }
+
+    /// <summary>
+    /// Stop the container on a graceful exit. Testcontainers' Ryuk reaper normally handles this, but
+    /// it is not always running (ryuk.disabled=true is a common local setting) and the leak is *per
+    /// process*: per-class isolation and the flaky-retry harness both spawn extra processes, so a
+    /// single run can strand several containers that then live forever. A kill -9 still needs Ryuk;
+    /// this only covers the common case.
+    /// </summary>
+    private static void shutdown()
+    {
+        var container = Interlocked.Exchange(ref _container, null);
+        if (container == null) return;
+
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+        container.DisposeAsync().AsTask().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
     }
 }

--- a/src/Transports/MQTT/Wolverine.Mqtt5.Tests/Wolverine.Mqtt5.Tests.csproj
+++ b/src/Transports/MQTT/Wolverine.Mqtt5.Tests/Wolverine.Mqtt5.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Transports/MQTT/Wolverine.Mqtt5.Tests/buffered_compliance.cs
+++ b/src/Transports/MQTT/Wolverine.Mqtt5.Tests/buffered_compliance.cs
@@ -52,7 +52,10 @@ public class BufferedComplianceFixture : TransportComplianceFixture, IAsyncLifet
 
     public LocalMqttBroker Broker { get; private set; } = null!;
 
-    public new async ValueTask DisposeAsync()
+    // AfterDisposeAsync, not a `new DisposeAsync`: TransportCompliance<T> disposes the fixture through
+    // the statically-bound base method, so a hiding override never runs -- meaning this broker was never
+    // stopped and leaked its listening socket for the life of the test process. See #3763.
+    protected override async Task AfterDisposeAsync()
     {
         await Broker.StopAsync();
         await Broker.DisposeAsync();

--- a/src/Transports/MQTT/Wolverine.Mqtt5.Tests/inline_compliance.cs
+++ b/src/Transports/MQTT/Wolverine.Mqtt5.Tests/inline_compliance.cs
@@ -52,7 +52,10 @@ public class InlineComplianceFixture : TransportComplianceFixture, IAsyncLifetim
 
     public LocalMqttBroker Broker { get; private set; } = null!;
 
-    public new async ValueTask DisposeAsync()
+    // AfterDisposeAsync, not a `new DisposeAsync`: TransportCompliance<T> disposes the fixture through
+    // the statically-bound base method, so a hiding override never runs -- meaning this broker was never
+    // stopped and leaked its listening socket for the life of the test process. See #3763.
+    protected override async Task AfterDisposeAsync()
     {
         await Broker.StopAsync();
         await Broker.DisposeAsync();

--- a/src/Transports/MQTT/Wolverine.Mqtt5.Tests/mosquitto_compliance.cs
+++ b/src/Transports/MQTT/Wolverine.Mqtt5.Tests/mosquitto_compliance.cs
@@ -46,10 +46,6 @@ public class MosquittoBufferedComplianceFixture : TransportComplianceFixture, IA
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        // Nothing extra to dispose; Mosquitto runs in Docker
-    }
 }
 
 [Collection("mosquitto")]

--- a/src/Transports/NATS/Wolverine.Nats.Tests/Wolverine.Nats.Tests.csproj
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/Wolverine.Nats.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/InlinePulsarTransportComplianceTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/InlinePulsarTransportComplianceTests.cs
@@ -31,10 +31,6 @@ public class InlinePulsarTransportFixture : TransportComplianceFixture, IAsyncLi
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 
     public override void BeforeEach()
     {

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarContainerFixture.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarContainerFixture.cs
@@ -15,6 +15,20 @@ public static class PulsarContainerFixture
     [ModuleInitializer]
     internal static void Initialize()
     {
+        // An already-running Pulsar wins. The container start below sits on the critical path of
+        // *every* process launch -- it runs before Main -- and the Pulsar image is a heavy one, so a
+        // caller that supplies a warm broker skips it entirely. Same shape as Servers.cs.
+        var configured = Environment.GetEnvironmentVariable("WOLVERINE_PULSAR");
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            ServiceUrl = new Uri(configured.Trim());
+            HttpServiceUrl = Environment.GetEnvironmentVariable("WOLVERINE_PULSAR_HTTP")?.Trim()
+                is { Length: > 0 } http
+                ? http
+                : $"http://{ServiceUrl.Host}:8080";
+            return;
+        }
+
         // Testcontainers logs a "Connected to Docker" banner through a default console logger.
         // Under xUnit v3 the test project is an executable that speaks JSON to the runner over
         // stdout, and a [ModuleInitializer] runs BEFORE Main -- so before xUnit has redirected
@@ -34,5 +48,24 @@ public static class PulsarContainerFixture
         var host = _container.Hostname;
         var httpPort = _container.GetMappedPublicPort(8080);
         HttpServiceUrl = $"http://{host}:{httpPort}";
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => shutdown();
+    }
+
+    /// <summary>
+    /// Stop the container on a graceful exit. Testcontainers' Ryuk reaper normally handles this, but
+    /// it is not always running (ryuk.disabled=true is a common local setting) and the leak is *per
+    /// process*: per-class isolation and the flaky-retry harness both spawn extra processes, so a
+    /// single run can strand several containers that then live forever. A kill -9 still needs Ryuk;
+    /// this only covers the common case.
+    /// </summary>
+    private static void shutdown()
+    {
+        var container = Interlocked.Exchange(ref _container, null);
+        if (container == null) return;
+
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+        container.DisposeAsync().AsTask().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
     }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/Wolverine.Pulsar.Tests.csproj
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/Wolverine.Pulsar.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/RabbitMQ/ChaosTesting/ChaosTesting.csproj
+++ b/src/Transports/RabbitMQ/ChaosTesting/ChaosTesting.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakingTests.csproj
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakingTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/InlineRabbitMqTransportComplianceTests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/InlineRabbitMqTransportComplianceTests.cs
@@ -34,10 +34,6 @@ public class InlineRabbitMqTransportFixture : TransportComplianceFixture, IAsync
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class InlineRabbitMqTransportComplianceTests : TransportCompliance<InlineRabbitMqTransportFixture>;

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/durable_compliance.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/durable_compliance.cs
@@ -61,10 +61,6 @@ public class RabbitMqTransportFixture : TransportComplianceFixture, IAsyncLifeti
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class durable_compliance : TransportCompliance<RabbitMqTransportFixture>;

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_node_exclusive_listener_recovery.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_node_exclusive_listener_recovery.cs
@@ -300,9 +300,10 @@ public class multi_node_exclusive_listener_recovery : IAsyncLifetime
     /// routinely lands *after* the exclusive listener has already restarted somewhere else. A listener that
     /// swept once at startup would have already looked, seen nothing dormant, and never looked again.
     ///
-    /// Reproduced here without killing a node: the rows start out owned by a node number that is not in the
-    /// cluster (exactly what a dead node's rows look like), so the listener's startup sweep finds nothing,
-    /// and only later are they released to <c>owner_id = 0</c>.
+    /// Reproduced here without killing a node: the rows start out owned by <i>another live node</i>, so the
+    /// listener's startup sweep finds nothing dormant, and only later are they released to <c>owner_id = 0</c>.
+    /// A live owner rather than a fabricated "departed" node number is load-bearing — see GH-3729 and the
+    /// comment in the body.
     /// </summary>
     [Fact]
     public async Task rows_released_after_the_listener_is_already_running_are_still_recovered()
@@ -316,24 +317,35 @@ public class multi_node_exclusive_listener_recovery : IAsyncLifetime
         (await leader.WaitUntilAssumesLeadershipAsync(30.Seconds()))
             .ShouldBeTrue("The first host never assumed leadership");
 
-        var (listener, _) = await waitForSeparatedAgentsAsync(leader, 60.Seconds());
+        var (listener, agentHost) = await waitForSeparatedAgentsAsync(leader, 60.Seconds());
         var listenerNode = nodeNumberOf(listener);
 
         var store = listener.Services.GetRequiredService<IMessageStore>();
 
-        // Owned by a node that is not part of this cluster -- the state a dead node's in-flight batch is in
-        // before the durability agent gets around to releasing it.
+        // Owned by ANOTHER LIVE NODE in this cluster -- not, as this test used to do, by a made-up node number
+        // standing in for a departed one.
         //
-        // GH-3729: these have to be seeded owned by the departed node, not stored as claimable and reassigned
-        // a round-trip later. The listener's recovery loop polls every ScheduledJobPollingTime (250ms here), so
-        // a sweep landing in that window claimed the rows perfectly correctly -- and then the assertion below,
-        // which exists to prove the listener leaves other nodes' rows alone, failed on the test's own setup
-        // rather than on any product behaviour. That was roughly 40% of runs.
-        const int departedNode = 987654;
-        var seeded = await seedDormantMessagesAsync(listener, 5, departedNode);
+        // GH-3729, second cause. A made-up owner is by definition an orphan, and releasing orphans is a job the
+        // product does on purpose: ReleaseOrphanedMessagesOperation runs
+        //
+        //     update wolverine_incoming_envelopes set owner_id = 0
+        //     where owner_id != 0 and owner_id not in (select node_number from wolverine_nodes)
+        //
+        // on the durability agent's schedule. So the rows stopped being "owned by another node" all by
+        // themselves, the listener's 250ms recovery poll then claimed them perfectly correctly, and the
+        // assertion below failed -- on intended behaviour, roughly 40% of runs. Instrumenting the window shows
+        // it directly: globallyOwned flips 0 -> 5 first, and only then does tracked go to 5.
+        //
+        // A live node's rows are not orphans, so nothing is entitled to free them and the assertion becomes a
+        // real statement about the listener. (InboxStaleTime, the other thing that bumps owned rows, is null
+        // unless explicitly configured, and this test does not set it.)
+        var otherLiveNode = nodeNumberOf(agentHost);
+        otherLiveNode.ShouldNotBe(listenerNode);
+
+        var seeded = await seedDormantMessagesAsync(listener, 5, otherLiveNode);
 
         (await store.LoadPageOfGloballyOwnedIncomingAsync(queueUri(), 100))
-            .ShouldBeEmpty("Nothing should be dormant yet -- the rows are still owned by the departed node");
+            .ShouldBeEmpty($"Nothing should be dormant yet -- the rows are still owned by live node {otherLiveNode}");
 
         // Several recovery sweeps go by with nothing to find. This is the window a one-shot recovery would
         // have spent its single look in.
@@ -342,7 +354,9 @@ public class multi_node_exclusive_listener_recovery : IAsyncLifetime
         tracking.Count.ShouldBe(0,
             "The listener must not touch inbox rows that are still owned by another node");
 
-        // Now the durability agent releases the departed node's rows, long after the listener started.
+        // Now the durability agent releases the other node's rows, long after the listener started. This is the
+        // hand-off that really happens when a node dies: whichever node holds the durability agent frees the
+        // rows back to owner_id = 0, routinely well after the exclusive listener has restarted elsewhere.
         await store.ReassignIncomingAsync(TransportConstants.AnyNode, seeded);
 
         var expected = seeded.Select(x => x.Id).ToArray();

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/process_inline_compliance.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/process_inline_compliance.cs
@@ -52,10 +52,6 @@ public class ProcessInlineFixture : TransportComplianceFixture, IAsyncLifetime
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class process_inline_compliance : TransportCompliance<ProcessInlineFixture>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/quorum_queue_compliance.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/quorum_queue_compliance.cs
@@ -49,10 +49,6 @@ public class QuorumQueueFixture : TransportComplianceFixture, IAsyncLifetime
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class quorum_queue_compliance : TransportCompliance<QuorumQueueFixture>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/sending_compliance_with_prefixes.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/sending_compliance_with_prefixes.cs
@@ -36,10 +36,6 @@ public class PrefixedComplianceFixture : TransportComplianceFixture, IAsyncLifet
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class PrefixedSendingAndReceivingCompliance : TransportCompliance<PrefixedComplianceFixture>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/stream_queue_compliance.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/stream_queue_compliance.cs
@@ -44,10 +44,6 @@ public class StreamQueueFixture : TransportComplianceFixture, IAsyncLifetime
         });
     }
 
-    public new async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync();
-    }
 }
 
 public class stream_queue_compliance : TransportCompliance<StreamQueueFixture>

--- a/src/Transports/Redis/Wolverine.Redis.Tests/RedisContainerFixture.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/RedisContainerFixture.cs
@@ -13,6 +13,16 @@ public static class RedisContainerFixture
     [ModuleInitializer]
     internal static void Initialize()
     {
+        // An already-running Redis wins. The container start below sits on the critical path of
+        // *every* process launch -- it runs before Main -- so a caller that supplies a warm broker
+        // (a dev, or a CI lane sharing one) skips it entirely. Same shape as Servers.cs.
+        var configured = Environment.GetEnvironmentVariable("WOLVERINE_REDIS");
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            ConnectionString = configured.Trim();
+            return;
+        }
+
         // Testcontainers logs a "Connected to Docker" banner through a default console logger.
         // Under xUnit v3 the test project is an executable that speaks JSON to the runner over
         // stdout, and a [ModuleInitializer] runs BEFORE Main -- so before xUnit has redirected
@@ -28,5 +38,24 @@ public static class RedisContainerFixture
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
 
         ConnectionString = _container.GetConnectionString();
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => shutdown();
+    }
+
+    /// <summary>
+    /// Stop the container on a graceful exit. Testcontainers' Ryuk reaper normally handles this, but
+    /// it is not always running (ryuk.disabled=true is a common local setting) and the leak is *per
+    /// process*: per-class isolation and the flaky-retry harness both spawn extra processes, so a
+    /// single run can strand several containers that then live forever. A kill -9 still needs Ryuk;
+    /// this only covers the common case.
+    /// </summary>
+    private static void shutdown()
+    {
+        var container = Interlocked.Exchange(ref _container, null);
+        if (container == null) return;
+
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+        container.DisposeAsync().AsTask().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
     }
 }

--- a/src/Transports/Redis/Wolverine.Redis.Tests/Wolverine.Redis.Tests.csproj
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/Wolverine.Redis.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Transports/SignalR/Wolverine.SignalR.Tests/Wolverine.SignalR.Tests.csproj
+++ b/src/Transports/SignalR/Wolverine.SignalR.Tests/Wolverine.SignalR.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <!--
           Deliberately TargetFrameworks (plural) even though there is only one TFM, matching

--- a/src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj
+++ b/src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <!-- GH-3702: xUnit1051 reinstated for this project -->
-        <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net9.0</TargetFrameworks>

--- a/src/Wolverine.HealthChecks.Tests/Wolverine.HealthChecks.Tests.csproj
+++ b/src/Wolverine.HealthChecks.Tests/Wolverine.HealthChecks.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
       <!-- GH-3702: xUnit1051 reinstated for this project -->
-      <XUnitCancellationTokenEnforced>true</XUnitCancellationTokenEnforced>
         <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <TargetFrameworks>net9.0</TargetFrameworks>


### PR DESCRIPTION
Addresses the open testing/CI issues, plus the two red jobs on `main` today. Closes #3726, #3729, #3771, #3762, #3751, #3725; partially addresses #3763.

## The two findings that were not what the issues said

### #3729 — closed as a "genuine 40% flake"; it is a test bug with a traced mechanism

`multi_node_exclusive_listener_recovery.rows_released_after_the_listener_is_already_running_are_still_recovered` seeded its rows owned by a fabricated node number (`987654`) standing in for a departed node. A fabricated owner **is an orphan**, and freeing orphans is a job the product does on purpose:

```sql
-- ReleaseOrphanedMessagesOperation, on the durability agent's schedule
update wolverine_incoming_envelopes set owner_id = 0
where owner_id != 0 and owner_id not in (select node_number from wolverine_nodes)
```

So the rows stopped being "owned by another node" on their own, the exclusive listener's 250ms recovery poll then claimed them perfectly correctly, and

```csharp
tracking.Count.ShouldBe(0,
    "The listener must not touch inbox rows that are still owned by another node");
```

failed on intended behaviour. Instrumenting the 2-second window shows the order directly — on a failing run:

```
DIAG t=800ms  globallyOwned=0  tracked=0
DIAG t=900ms  globallyOwned=5  tracked=0     <- orphan release
DIAG t=1400ms globallyOwned=0  tracked=5     <- listener, correctly
```

`ListenerInboxRecovery` only ever loads `owner_id = 0` rows, so the listener never touched a row owned by anyone. **The product is right; the test's premise was wrong.**

Fixed by seeding from another *live* node — live rows are not orphans, so nothing is entitled to free them, and the assertion becomes a real statement about the listener. (`InboxStaleTime`, the other thing that bumps owned rows, is null unless explicitly configured and this test does not set it.)

Verified: **12/12 consecutive passes against a 3-in-8 baseline** (P(chance) ≈ 0.35%), plus the full class 3×.

### #3726 — the three tests it names are all already resolved

Verified locally: item 1 passes (fixed by merged #3728), item 3 passes (that was #3729), and item 2 was only ever a missing local SQL Server container. A full `CIRabbitMQ --disable-test-retry` run was **435 passed / 1 failed**, and the one failure was #3729 above.

That run surfaced the *current* chronic failure instead — which is what took CI red today.

## `quorum_queue_compliance` — today's red CIRabbitMQ

The transport compliance error-handling helpers picked their "ending activity" by message **type**:

```csharp
session.AllRecordsInOrder()
    .Where(x => x.Envelope!.Message is ErrorCausingMessage)
    .LastOrDefault(... MessageSucceeded or MovedToErrorQueue ...)
```

Broker queues are shared across the test methods in a compliance class, so a redelivery still in flight when one test's tracked session completed lands in the **next** test's session and becomes its ending record. Today's log shows it directly: message `08def019-82b1-43da` arrives at 27ms in one test and 28ms in another — before either had sent anything — under two different node ids, and its `MessageSucceeded` at 3913ms is what both assertions latched onto.

`ErrorCausingMessage` now carries an `Id` and the three helpers scope to it. That is immune to residue by construction; purging cannot help, because an unacked in-flight redelivery is not in the queue to purge.

## #3771 / #3762 — CIMarten runner deaths

CIMarten was killed outright by the runner twice in a row at ~15 minutes on an unrelated diff — the OOM signature, not a test failure. The worker-lane split is the cause: several Marten hosts plus Postgres does not fit a 4-vCPU/16GB hosted runner. The build already recorded that 4 lanes had killed a runner once; the clamp to 2 still died.

**Lanes are gone.** The suite is segmented across three CI jobs the way CIPolecat is (#3350), each strictly sequential against exactly **one** database — concurrency moves off the runner VM and onto the matrix, where every shard gets its own 16GB.

| Job | Namespaces | Size |
|---|---|---|
| `CIMartenWorkflow` | AggregateHandlerWorkflow, Bugs, ScheduledJobs, Requirements | 54 classes / 162 tests |
| `CIMartenSagas` | Saga, Persistence (incl. Persistence.Sagas), Distribution, MultiTenancy, AncillaryStores, Dcb | 60 classes / 205 tests |
| `CIMarten` | everything else + MartenSubscriptionTests | 46 classes / 190 tests |

Verified disjoint and exhaustive against a real `MartenTests --list-tests` (159 classes / 545 tests). The catch-all is the *negation* of the two named shards, so a brand-new namespace lands somewhere instead of being silently dropped. (The root namespace can never be an include-list entry — every display name starts with it — which is exactly why the catch-all has to be the negation.)

**This also closes #3762**: with a single lane per job the sibling databases (`tenant1-3`, `players`, `things`) have one owner again, so no lane-scoping sweep is needed.

A memory sampler stays on the three Marten jobs to confirm the footprint actually dropped. It prints to the live job log on purpose — when the runner dies, later steps are skipped, so an artifact upload would never run.

## #3763 — the `public new DisposeAsync()` shape

34 compliance fixtures declared `public new DisposeAsync()`. It reads like an override and is not one: `TransportCompliance<T>` disposes through a `T`-typed reference, which binds statically to the base. **Every one of them was dead code.**

- 7 carried real cleanup that had therefore never executed — a SQLite database, the shared-memory queues, and four `LocalMqttBroker`s, each leaking a listening socket for the life of the test process. Moved to `AfterDisposeAsync` (virtual, and actually runs).
- 4 were infinitely self-recursive (`await DisposeAsync()` calling itself).
- The rest were redundant and are deleted.

The trap is now documented on the base method. This is the same shape #3758 fixed for Azure Service Bus; that sweep just never covered the other transports.

## #3751 — Testcontainers fixtures leak one container per process

The Redis/MQTT/Mqtt5/Pulsar `[ModuleInitializer]` fixtures never disposed their container, relying entirely on Ryuk. With `ryuk.disabled=true` every test process leaks one permanently, and the process count is rising. Took the small-diff option from the issue — a `ProcessExit` hook that keeps the static-property ergonomics — rather than the invasive `IAsyncLifetime` conversion. Each also honours a `WOLVERINE_*` connection string when set, so a caller can supply a warm broker and skip a start that sits before `Main` on every process launch.

## #3725 — finish the xUnit1051 rollout

TracingTests opted in (clean, no diagnostics), the `Directory.Build.targets` opt-in block deleted, and the now-redundant property dropped from all 72 projects. Full `wolverine.slnx` builds clean with the analyzer enforced everywhere.

## Verification

- Full `wolverine.slnx` builds clean (0 warnings, 0 errors).
- `LightweightTcpTransportCompliance` 22/22 — exercises all four changed error-handling assertions and proves the new message `Id` round-trips through serialize/transport/deserialize.
- All six RabbitMQ compliance classes green (136 tests).
- `CIRabbitMQ --disable-test-retry`: 435/436, the one failure being #3729, now fixed.

**Two things I could not verify locally, called out honestly:**

1. **The quorum poisoning does not reproduce locally** — three baseline runs on `main` passed on a fast machine with a fresh broker. It needs CI's slower, loaded conditions. CIRabbitMQ on this PR is the real verification.
2. **#3725 asks that TracingTests be _run_, not just compiled.** It compiles clean with the analyzer enforced; `CIOtel` here is the outstanding evidence.

Not addressed: the #3763 `Category=Flaky` ledger itself (~50 tests), and #3752/#3761 (CIAzureServiceBus wall clock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eR4GL278688VhyhrGcttJ
