### PR TITLE
Never adopt a test-runner assembly as the application assembly (GH-3776)

### DIFF
--- a/src/Testing/CoreTests/Configuration/application_assembly_is_never_a_test_runner.cs
+++ b/src/Testing/CoreTests/Configuration/application_assembly_is_never_a_test_runner.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using JasperFx;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+/// <summary>
+/// GH-3776: the application assembly is resolved by walking the stack for the first frame outside Wolverine
+/// that isn't part of the framework. Under an async test fixture the frames between Wolverine and the test
+/// class belong to the test RUNNER, so xUnit v3's own "xunit.v3.core" was being adopted for handler discovery.
+/// Discovery then scanned an assembly containing none of the suite's handlers, and every InvokeAsync failed
+/// with IndeterminateRoutesException — 43 of 86 tests in one CIPolecat shard, with the run's only visible
+/// symptom being "Could not determine any valid subscribers or local handlers".
+/// </summary>
+public class application_assembly_is_never_a_test_runner
+{
+    [Theory]
+    [InlineData("xunit.v3.core")]
+    [InlineData("xunit.execution.dotnet")]
+    [InlineData("xunit.runner.utility.netcoreapp10")]
+    [InlineData("nunit.framework")]
+    [InlineData("NUnit3.TestAdapter")]
+    [InlineData("TUnit.Engine")]
+    [InlineData("MSTest.TestAdapter")]
+    [InlineData("testhost")]
+    [InlineData("ReSharperTestRunner")]
+    [InlineData("JetBrains.ReSharper.TestRunner.Merged")]
+    public void recognizes_test_runner_assemblies(string assemblyName)
+    {
+        WolverineOptions.IsTestRunnerAssembly(assemblyName).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("CoreTests")]
+    [InlineData("PolecatTests")]
+    [InlineData("Wolverine")]
+    [InlineData("Wolverine.SqlServer")]
+    [InlineData("MyApp.Api")]
+    // "Xenon" and "Nutrition" share a prefix boundary with xunit/nunit only if the check is sloppier
+    // than StartsWith on the full runner token — pin that they are ordinary application assemblies.
+    [InlineData("Xenon.Services")]
+    [InlineData("Nutrition.Domain")]
+    public void does_not_flag_ordinary_application_assemblies(string assemblyName)
+    {
+        WolverineOptions.IsTestRunnerAssembly(assemblyName).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void refuses_a_test_runner_assembly_handed_over_by_jasperfx()
+    {
+        var options = new WolverineOptions();
+
+        // JasperFx does its own stack walk with no test-runner exclusion, so this is exactly what it handed
+        // Wolverine on the failing CI runs.
+        var xunitCore = typeof(FactAttribute).Assembly;
+        WolverineOptions.IsTestRunnerAssembly(xunitCore.GetName().Name!).ShouldBeTrue();
+
+        options.ReadJasperFxOptions(new JasperFxOptions { ApplicationAssembly = xunitCore });
+
+        options.ApplicationAssembly.ShouldNotBeNull();
+        WolverineOptions.IsTestRunnerAssembly(options.ApplicationAssembly!.GetName().Name!).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_host_bootstrapped_from_a_test_assembly_never_adopts_the_runner()
+    {
+        // The end-to-end guard, and the one that would have caught GH-3776: whatever the stack happens to
+        // look like on this platform and runner, the assembly Wolverine scans for handlers must be the test
+        // assembly that registered the host — never the runner hosting it.
+        using var host = await Host.CreateDefaultBuilder().UseWolverine()
+            .StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var options = host.Services.GetRequiredService<WolverineOptions>();
+        var adopted = options.ApplicationAssembly.ShouldNotBeNull();
+
+        WolverineOptions.IsTestRunnerAssembly(adopted.GetName().Name!)
+            .ShouldBeFalse($"handler discovery adopted the test runner assembly '{adopted.GetName().Name}'");
+
+        options.Assemblies.ShouldContain(typeof(application_assembly_is_never_a_test_runner).Assembly);
+    }
+}

--- a/src/Wolverine/WolverineOptions.Assemblies.cs
+++ b/src/Wolverine/WolverineOptions.Assemblies.cs
@@ -98,7 +98,8 @@ public sealed partial class WolverineOptions
                 continue;
             }
 
-            if (assemblyName.StartsWith("System") || assemblyName.StartsWith("Microsoft"))
+            if (assemblyName.StartsWith("System") || assemblyName.StartsWith("Microsoft") ||
+                IsTestRunnerAssembly(assemblyName))
             {
                 continue;
             }
@@ -107,6 +108,28 @@ public sealed partial class WolverineOptions
         }
 
         return Assembly.GetEntryAssembly();
+    }
+
+    // GH-3776: a test-runner assembly is never the application assembly. determineCallingAssembly walks the
+    // stack for the first frame outside Wolverine that isn't System*/Microsoft*, but under an async test
+    // fixture the frames between Wolverine and the test class belong to the RUNNER, not the test assembly —
+    // so xUnit v3's own "xunit.v3.core" was adopted for handler discovery. Discovery then scanned an assembly
+    // with no handlers in it and every conventionally-discovered handler in the test assembly vanished, with
+    // only a downstream IndeterminateRoutesException ("Could not determine any valid subscribers or local
+    // handlers") to show for it. Skipping the runner lets the walk continue out to the test assembly; if
+    // nothing else matches, the Assembly.GetEntryAssembly() fallback is the test assembly anyway.
+    //
+    // Prefix matching is deliberate: it covers xunit.v3.core / xunit.execution.dotnet / nunit.framework and
+    // the runner hosts, without needing to track exact assembly names across runner versions.
+    internal static bool IsTestRunnerAssembly(string assemblyName)
+    {
+        return assemblyName.StartsWith("xunit", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("nunit", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("TUnit", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("MSTest", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("testhost", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("ReSharperTestRunner", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("JetBrains.", StringComparison.OrdinalIgnoreCase);
     }
 
     private void establishApplicationAssembly(string? assemblyName)

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -700,7 +700,18 @@ public sealed partial class WolverineOptions
         
         if (_applicationAssembly == null)
         {
-            ApplicationAssembly = jasperfx.ApplicationAssembly;
+            // GH-3776: JasperFx resolves its own application assembly with the same kind of stack walk and has
+            // no test-runner exclusion, so in a test process it can hand us the RUNNER assembly. Adopting that
+            // silently points handler discovery at an assembly with no handlers in it. Drop it and resolve
+            // locally instead, where determineCallingAssembly's IsTestRunnerAssembly check keeps the walk
+            // honest and ultimately falls back to the entry assembly.
+            var fromJasperFx = jasperfx.ApplicationAssembly;
+            if (fromJasperFx?.GetName().Name is { } pinned && IsTestRunnerAssembly(pinned))
+            {
+                fromJasperFx = null;
+            }
+
+            ApplicationAssembly = fromJasperFx;
 
             if (ApplicationAssembly == null)
             {


### PR DESCRIPTION
Closes #3776.

## What was actually wrong

Handler discovery was scanning **`xunit.v3.core`** instead of the test assembly. With no handler chains, every `InvokeAsync` fell through to `NoHandlerExecutor` and threw `IndeterminateRoutesException`.

The application assembly is resolved by walking the stack for the first frame outside Wolverine that isn't `System*`/`Microsoft*` (`WolverineOptions.Assemblies.cs`, and `JasperFxOptions.DetermineCallingAssembly` at `JasperFxOptions.cs:243`). Under an async test fixture the frames between the framework and the test class belong to the **runner**, so `xunit.v3.core` satisfied the filter and was adopted. `ReSharperTestRunner` is already excluded there — xUnit was simply never added.

## The fix

- `WolverineOptions.IsTestRunnerAssembly` — skip `xunit*`, `nunit*`, `TUnit*`, `MSTest*`, `testhost*`, `ReSharperTestRunner*`, `JetBrains.*` in the stack walk. If nothing else matches, the existing `Assembly.GetEntryAssembly()` fallback is the test assembly anyway.
- `ReadJasperFxOptions` refuses a runner assembly handed over by JasperFx instead of adopting it. JasperFx resolves its own application assembly with the same kind of walk and has no test-runner exclusion, so the bad value arrives from there.

## Evidence

Instrumented CI runs at `1dfdd42a1`, the commit the failure was bisected to:

| run | adopted application assembly | result |
|---|---|---|
| probe, before fix | `xunit.v3.core` on 79 of 82 hosts (0–15 chains) | 43 failed |
| probe + fix | `PolecatTests` on 82 of 82 hosts (141 chains) | **86 passed, 0 retries** |

The 25 tests that "passed on retry" in the original failure were retried alone in fresh processes — all 25 of those processes adopted `PolecatTests`, which is why they passed. The 18 reported failures were never retried at all; `MaxRetriesPerRun = 25` (`build/SupervisedTests.cs:142`) had exhausted the budget.

The failing set maps exactly onto the defect: every class in the shard that builds a Wolverine host, invokes a message, and relies on conventional discovery failed. Every class that pins `ApplicationAssembly`, calls `Discovery.DisableConventionalDiscovery()`, or never invokes a message passed.

## Regression test

`application_assembly_is_never_a_test_runner` — the end-to-end case asserts a host bootstrapped from a test assembly never adopts the runner, which is what would have caught this. Full `wolverine.slnx` builds clean; `CoreTests.Configuration` is 252/252.

## Follow-ups (not in this PR)

- **The durable fix belongs in JasperFx — filed as JasperFx/jasperfx#600.** 2.37.0 has no test-runner exclusion, so Marten and Polecat hosts are exposed to the same failure. This PR defends Wolverine at the boundary; the skip list should be added upstream too.
- **The GH-3521 divergence warning is noisy — filed as JasperFx/jasperfx#601.** The same walk returns intermediate Critter Stack assemblies, so the warning fires on 81 of 82 hosts on a *healthy* run because `RegistrationCallingAssembly` resolves to `Wolverine.SqlServer`.
- **The Wolverine half of that warning is still unfiled.** `WolverineOptions.Assemblies.cs:118-121` adopts `RememberedApplicationAssembly` without calling `CheckForDivergentApplicationAssembly`, so that path never warns at all.
- **`Polecat` is the only floating dependency** in `Directory.Packages.props` (`[5.7.0,6.0.0)`). Not related to this bug, but worth pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eR4GL278688VhyhrGcttJ
