### PR TITLE
GH-3779: a dev-scale reproduction of slow agent starts, and the first flaky-tag burn-down (GH-3763)

### DIFF
--- a/src/Extensions/Wolverine.DataAnnotationsValidation.Tests/Wolverine.DataAnnotationsValidation.Tests.csproj
+++ b/src/Extensions/Wolverine.DataAnnotationsValidation.Tests/Wolverine.DataAnnotationsValidation.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
+++ b/src/Extensions/Wolverine.FluentValidation.Tests/Wolverine.FluentValidation.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Extensions/Wolverine.MemoryPack.Tests/Wolverine.MemoryPack.Tests.csproj
+++ b/src/Extensions/Wolverine.MemoryPack.Tests/Wolverine.MemoryPack.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Extensions/Wolverine.MessagePack.Tests/Wolverine.MessagePack.Tests.csproj
+++ b/src/Extensions/Wolverine.MessagePack.Tests/Wolverine.MessagePack.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Extensions/Wolverine.Protobuf.Tests/Wolverine.Protobuf.Tests.csproj
+++ b/src/Extensions/Wolverine.Protobuf.Tests/Wolverine.Protobuf.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-	    <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/src/Http/Wolverine.Http.AspVersioning.Tests/Wolverine.Http.AspVersioning.Tests.csproj
+++ b/src/Http/Wolverine.Http.AspVersioning.Tests/Wolverine.Http.AspVersioning.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Http/Wolverine.Http.Tests/Wolverine.Http.Tests.csproj
+++ b/src/Http/Wolverine.Http.Tests/Wolverine.Http.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net9.0</TargetFrameworks>

--- a/src/Persistence/CosmosDbTests/CosmosDbTests.csproj
+++ b/src/Persistence/CosmosDbTests/CosmosDbTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/EfCoreTests.MultiTenancy/EfCoreTests.MultiTenancy.csproj
+++ b/src/Persistence/EfCoreTests.MultiTenancy/EfCoreTests.MultiTenancy.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Persistence/EfCoreTests/EfCoreTests.csproj
+++ b/src/Persistence/EfCoreTests/EfCoreTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Persistence/LeaderElection/CosmosDbTests.LeaderElection/CosmosDbTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/CosmosDbTests.LeaderElection/CosmosDbTests.LeaderElection.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Persistence/LeaderElection/MySqlTests.LeaderElection/MySqlTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/MySqlTests.LeaderElection/MySqlTests.LeaderElection.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Persistence/LeaderElection/OracleTests.LeaderElection/OracleTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/OracleTests.LeaderElection/OracleTests.LeaderElection.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Persistence/LeaderElection/PostgresqlTests.LeaderElection/PostgresqlTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/PostgresqlTests.LeaderElection/PostgresqlTests.LeaderElection.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Persistence/LeaderElection/RavenDbTests.LeaderElection/RavenDbTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/RavenDbTests.LeaderElection/RavenDbTests.LeaderElection.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/LeaderElection/SqlServerTests.LeaderElection/SqlServerTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/SqlServerTests.LeaderElection/SqlServerTests.LeaderElection.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Persistence/MartenSubscriptionTests/MartenSubscriptionTests.csproj
+++ b/src/Persistence/MartenSubscriptionTests/MartenSubscriptionTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Persistence/MartenTests/MartenTests.csproj
+++ b/src/Persistence/MartenTests/MartenTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Persistence/MySql/MySqlTests/MySqlTests.csproj
+++ b/src/Persistence/MySql/MySqlTests/MySqlTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Persistence/Oracle/OracleTests/OracleTests.csproj
+++ b/src/Persistence/Oracle/OracleTests/OracleTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Persistence/PersistenceTests/PersistenceTests.csproj
+++ b/src/Persistence/PersistenceTests/PersistenceTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>

--- a/src/Persistence/Polecat/PolecatIncidentService.Tests/PolecatIncidentService.Tests.csproj
+++ b/src/Persistence/Polecat/PolecatIncidentService.Tests/PolecatIncidentService.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net10.0</TargetFrameworks>

--- a/src/Persistence/PolecatTests/PolecatTests.csproj
+++ b/src/Persistence/PolecatTests/PolecatTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Persistence/PostgresqlTests/PostgresqlTests.csproj
+++ b/src/Persistence/PostgresqlTests/PostgresqlTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Persistence/RavenDbTests/RavenDbTests.csproj
+++ b/src/Persistence/RavenDbTests/RavenDbTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/SqlServerTests/SqlServerTests.csproj
+++ b/src/Persistence/SqlServerTests/SqlServerTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Persistence/SqliteTests/SqliteTests.csproj
+++ b/src/Persistence/SqliteTests/SqliteTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <IsPackable>false</IsPackable>
         <OutputType>Exe</OutputType>
     </PropertyGroup>

--- a/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/Wolverine.ClaimCheck.GoogleCloudStorage.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/Wolverine.ClaimCheck.GoogleCloudStorage.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/Wolverine.ClaimCheck.Nats.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/Wolverine.ClaimCheck.Nats.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Persistence/Wolverine.ClaimCheck.Postgresql.Tests/Wolverine.ClaimCheck.Postgresql.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.Postgresql.Tests/Wolverine.ClaimCheck.Postgresql.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Samples/CQRSWithMarten/TeleHealth.Tests/TeleHealth.Tests.csproj
+++ b/src/Samples/CQRSWithMarten/TeleHealth.Tests/TeleHealth.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Samples/Diagnostics/DiagnosticsTests/DiagnosticsTests.csproj
+++ b/src/Samples/Diagnostics/DiagnosticsTests/DiagnosticsTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Samples/EFCoreSample/ItemService.Tests/ItemService.Tests.csproj
+++ b/src/Samples/EFCoreSample/ItemService.Tests/ItemService.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>

--- a/src/Samples/IncidentService/IncidentService.Tests/IncidentService.Tests.csproj
+++ b/src/Samples/IncidentService/IncidentService.Tests/IncidentService.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net9.0</TargetFrameworks>

--- a/src/Samples/Middleware/AppWithMiddleware.Tests/AppWithMiddleware.Tests.csproj
+++ b/src/Samples/Middleware/AppWithMiddleware.Tests/AppWithMiddleware.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Samples/MultiTenantedTodoService/MultiTenantedTodoWebService.Tests/MultiTenantedTodoWebService.Tests.csproj
+++ b/src/Samples/MultiTenantedTodoService/MultiTenantedTodoWebService.Tests/MultiTenantedTodoWebService.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Samples/ProcessManagerViaHandlers/ProcessManagerViaHandlers.Tests/ProcessManagerViaHandlers.Tests.csproj
+++ b/src/Samples/ProcessManagerViaHandlers/ProcessManagerViaHandlers.Tests/ProcessManagerViaHandlers.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net9.0</TargetFrameworks>

--- a/src/Samples/TestHarness/BankingService.Tests/BankingService.Tests.csproj
+++ b/src/Samples/TestHarness/BankingService.Tests/BankingService.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Samples/TodoWebService/TodoWebServiceTests/TodoWebServiceTests.csproj
+++ b/src/Samples/TodoWebService/TodoWebServiceTests/TodoWebServiceTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/BackPressureTests/BackPressureTests.csproj
+++ b/src/Testing/BackPressureTests/BackPressureTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/Testing/CoreTests/CoreTests.csproj
+++ b/src/Testing/CoreTests/CoreTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Testing/CoreTests/Runtime/Agents/slow_agent_start_convergence.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/slow_agent_start_convergence.cs
@@ -1,0 +1,440 @@
+using CoreTests.Transports;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// GH-3779. Every defect in the GH-3753 chain — GH-3748, GH-3749, GH-3750, jasperfx#594, jasperfx#598 —
+/// takes a <b>slow agent start</b> as its precondition, and none of them had a dev-scale reproduction:
+/// <c>FakeAgent.StartAsync</c> returned <c>Task.CompletedTask</c>, which is precisely the assumption the
+/// whole chain violates. The only verification site was a customer's restored-production canary (512 tenant
+/// databases, ~6,500 agents, 5 nodes), so every candidate fix shipped as a pinned prerelease and was measured
+/// by someone else, and three closed defects carried no regression coverage at all.
+///
+/// <para>This drives the leader's real <see cref="NodeAgentController.EvaluateAssignmentsAsync" /> round after
+/// round against a simulated cluster whose agent starts cost <i>time</i>, and asserts the emergent properties
+/// the field reported losing.</para>
+///
+/// <para><b>Time is measured in evaluation rounds, not milliseconds.</b> The field distribution is p50 27s /
+/// p95 82s / a 215s tail against a ~5s health-check cadence, so a wall-clock simulation would take hours and
+/// would trade a deterministic assertion for a timing race. A round is one health-check tick; the costs below
+/// are that distribution divided by it. Everything here is seeded and deterministic — a failure reproduces.</para>
+///
+/// <para><b>What this is not.</b> A simulation is not the canary. The pathologies in GH-3753 are emergent from
+/// real database contention, real node-table timing and real chunk sizes, so this reproduces the
+/// <i>shape</i> of the problem and not its magnitude. Its value is the other direction: a bad fix can be
+/// rejected in milliseconds instead of round-tripping through someone else's production restore.</para>
+/// </summary>
+public class slow_agent_start_convergence
+{
+    /// <summary>
+    /// Start cost in rounds, calibrated against the field distribution behind GH-3753 at a ~5s health-check
+    /// cadence: p50 27s (~5 rounds), p95 82s (~16 rounds), tail 215s (~43 rounds). Deliberately a long tail
+    /// rather than a uniform cost — a uniformly slow family converges late but converges, while it is the
+    /// handful of very slow starts that outlive a reply window and get re-decided.
+    /// </summary>
+    private static Func<Uri, int> fieldStartCost(int seed, IReadOnlyList<Uri> agents)
+    {
+        var random = new Random(seed);
+        var costs = agents.ToDictionary(x => x, _ =>
+        {
+            var roll = random.NextDouble();
+            if (roll < 0.50) return random.Next(1, 6);
+            if (roll < 0.95) return random.Next(6, 17);
+            return random.Next(17, 44);
+        });
+
+        return uri => costs.TryGetValue(uri, out var cost) ? cost : 1;
+    }
+
+    [Fact]
+    public async Task every_agent_converges_despite_a_long_tailed_start_distribution()
+    {
+        var cluster = new SlowStartCluster(nodeCount: 5, agentCount: 603, seed: 3753);
+        cluster.StartCost = fieldStartCost(3753, cluster.AllAgents);
+
+        // The slowest single start is 43 rounds; anything much past that is the leader failing to converge
+        // rather than the cluster merely being slow.
+        var rounds = await cluster.RunUntilConvergedAsync(maxRounds: 60);
+
+        cluster.RunningAgents.Count.ShouldBe(cluster.AllAgents.Length);
+        rounds.ShouldBeLessThan(60);
+    }
+
+    /// <summary>
+    /// GH-3698's failure mode. A dispatched-but-unstarted agent has no persisted assignment row, so it looks
+    /// completely unplaced to the next evaluation; without the pending-assignment ledger the leader re-decides
+    /// its placement from scratch and sends the same agent to a SECOND node with no stop for the copy already
+    /// coming up on the first. Two live copies of a projection agent is the worst outcome in the whole chain.
+    /// </summary>
+    [Fact]
+    public async Task an_agent_is_never_started_on_two_nodes_at_once()
+    {
+        var cluster = new SlowStartCluster(nodeCount: 5, agentCount: 603, seed: 3753);
+        cluster.StartCost = fieldStartCost(3753, cluster.AllAgents);
+
+        await cluster.RunUntilConvergedAsync(maxRounds: 60);
+
+        // The cluster asserts the single-copy invariant on every mutation as it runs; this is the end-state
+        // restatement of it.
+        cluster.DoubleStartReports.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// The other field shape: five nodes holding 799 / 0 / 0 / 0 / 1. A slow wave must not leave the
+    /// distribution lopsided once it has converged.
+    /// </summary>
+    [Fact]
+    public async Task no_node_is_starved_while_another_holds_everything()
+    {
+        var cluster = new SlowStartCluster(nodeCount: 5, agentCount: 603, seed: 3753);
+        cluster.StartCost = fieldStartCost(3753, cluster.AllAgents);
+
+        await cluster.RunUntilConvergedAsync(maxRounds: 60);
+
+        var counts = cluster.RunningCountsByNode;
+
+        // 603 across 5 nodes is 120 with a remainder of 3, so an even spread is 120 or 121 everywhere.
+        counts.Max().ShouldBeLessThanOrEqualTo(counts.Min() + 1);
+    }
+
+    /// <summary>
+    /// A wave of slow starts must not itself generate churn. Once the leader has placed an agent it should
+    /// stay placed: every stop or reassignment emitted during a first-time placement wave against a stable
+    /// cluster is work the leader is undoing, and it is what turned the field's convergence into a livelock.
+    /// </summary>
+    [Fact]
+    public async Task a_first_placement_wave_emits_no_stops_and_no_reassignments()
+    {
+        var cluster = new SlowStartCluster(nodeCount: 5, agentCount: 603, seed: 3753);
+        cluster.StartCost = fieldStartCost(3753, cluster.AllAgents);
+
+        await cluster.RunUntilConvergedAsync(maxRounds: 60);
+
+        cluster.StopsEmitted.ShouldBe(0);
+        cluster.ReassignmentsEmitted.ShouldBe(0);
+
+        // And each agent was asked to start exactly once — no duplicate dispatch of work already in flight.
+        cluster.DispatchCounts.Values.ShouldAllBe(x => x == 1);
+
+        // The clearest signal from the field that something was wrong: over one four-minute window the
+        // cluster's total running-agent count went 2,401 -> 1,885. Against a stable node set that number can
+        // only fall if agents that had come up were stopped, so this is a restatement of the two assertions
+        // above rather than an independent one — it is here because it is the shape an operator actually
+        // sees, and because it is the assertion that still holds if a node-churn scenario is added later.
+        cluster.RunningCountByRound.ShouldBe(cluster.RunningCountByRound.OrderBy(x => x).ToArray());
+    }
+
+    /// <summary>
+    /// GH-3698, sharpened. The pending-assignment ledger has two ways to hold an agent: a TTL backstop of
+    /// <c>2 x CheckAssignmentPeriod</c>, and the dispatcher's own answer to "is this start still outstanding?".
+    /// A start slower than the TTL is the normal field case (27s p50 against a 60s TTL is close; the 215s tail
+    /// is not close at all), so the TTL is squeezed to nothing here and the probe is left as the only thing
+    /// holding the agent. It must be enough on its own.
+    /// </summary>
+    [Fact]
+    public async Task a_start_slower_than_the_ledger_ttl_is_still_held_by_the_outstanding_dispatch()
+    {
+        var cluster = new SlowStartCluster(nodeCount: 3, agentCount: 12, seed: 3698);
+
+        // 1ms period => a 2ms TTL. Every round below sleeps far past it, so nothing is held by the clock.
+        cluster.Options.Durability.CheckAssignmentPeriod = 1.Milliseconds();
+
+        // No start ever lands during this test.
+        cluster.StartCost = _ => 1000;
+
+        var first = await cluster.RunRoundAsync();
+        cluster.AssignedIn(first).Count().ShouldBe(12);
+
+        for (var i = 0; i < 4; i++)
+        {
+            // Comfortably past the 2ms TTL, so a re-emission here can only come from the ledger having
+            // released an agent whose start is still outstanding.
+            await Task.Delay(25.Milliseconds(), TestContext.Current.CancellationToken);
+
+            var round = await cluster.RunRoundAsync();
+            round.ShouldBeEmpty();
+        }
+
+        cluster.DoubleStartReports.ShouldBeEmpty();
+        cluster.DispatchCounts.Values.ShouldAllBe(x => x == 1);
+    }
+
+    /// <summary>
+    /// GH-3750: a PARTIAL confirmation is the normal case whenever starts are slow — <c>StartAgents</c> only
+    /// bags an agent once its start returns, so a chunk of 50 agents whose costs straddle the reply window
+    /// answers with a subset. The remainder must still be driven to completion rather than being counted as
+    /// started and forgotten.
+    /// </summary>
+    [Fact]
+    public async Task the_unconfirmed_remainder_of_a_partially_started_chunk_still_converges()
+    {
+        var cluster = new SlowStartCluster(nodeCount: 2, agentCount: 100, seed: 3750);
+
+        // Half the chunk lands almost immediately, half of it long after any reply window — the straddle
+        // that produces a partial AgentsStarted reply.
+        var slow = cluster.AllAgents.Where((_, i) => i % 2 == 1).ToHashSet();
+        cluster.StartCost = uri => slow.Contains(uri) ? 30 : 1;
+
+        var rounds = await cluster.RunUntilConvergedAsync(maxRounds: 50);
+
+        cluster.RunningAgents.Count.ShouldBe(100);
+        rounds.ShouldBeLessThan(50);
+
+        // The fast half must not have dragged the slow half into being re-placed somewhere else.
+        cluster.DoubleStartReports.ShouldBeEmpty();
+        cluster.StopsEmitted.ShouldBe(0);
+    }
+
+    /// <summary>
+    /// A simulated multi-node cluster driving the leader's real assignment evaluation. One <see cref="RunRoundAsync" />
+    /// is one health-check tick: in-flight starts advance, the leader evaluates, and the commands it emits are
+    /// applied to the cluster's state the way the corresponding agent commands would apply them for real.
+    /// </summary>
+    private sealed class SlowStartCluster
+    {
+        private readonly IWolverineRuntime _runtime;
+        private readonly FakeAgentFamily _family;
+        private readonly NodeAgentController _controller;
+        private readonly List<WolverineNode> _nodes = [];
+        private readonly Dictionary<Uri, InFlightStart> _inFlight = new();
+
+        // Ground truth: where each agent is actually running. Deliberately NOT the same thing as the leader's
+        // view of it — a node persists its assignment row only after the agent is up, and the leader reads
+        // that row on a later snapshot, so there is a window in which an agent is genuinely running and looks
+        // completely unplaced. That window is what GH-3750 is about, and a simulation that closes it
+        // instantly cannot reproduce the field's falling assigned-agent count.
+        private readonly Dictionary<Uri, Guid> _running = new();
+        private readonly Dictionary<Uri, Guid> _awaitingVisibility = new();
+
+        private readonly List<int> _runningCountByRound = [];
+        private readonly List<string> _doubleStartReports = [];
+        private readonly Dictionary<Uri, int> _dispatchCounts = new();
+
+        private record struct InFlightStart(Guid NodeId, int RoundsRemaining);
+
+        public SlowStartCluster(int nodeCount, int agentCount, int seed)
+        {
+            Options = new WolverineOptions { ApplicationAssembly = GetType().Assembly };
+            Options.Transports.NodeControlEndpoint = new FakeEndpoint("fake://self".ToUri(), EndpointRole.System);
+            Options.Durability.DurabilityAgentEnabled = false;
+
+            _runtime = Substitute.For<IWolverineRuntime>();
+            _runtime.Options.Returns(Options);
+            _runtime.DurabilitySettings.Returns(Options.Durability);
+            _runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+
+            _family = new FakeAgentFamily("fake", agentCount);
+            AllAgents = _family.AllAgentUris();
+
+            _controller = new NodeAgentController(_runtime, Substitute.For<INodeAgentPersistence>(), [_family],
+                NullLogger<NodeAgentController>.Instance, CancellationToken.None);
+
+            // The dispatcher holds a command from the moment it is queued until its lane is done with it,
+            // whatever the outcome. An in-flight start here is exactly that hold.
+            _controller.PendingDispatches = (Uri agentUri, out Guid nodeId) =>
+            {
+                if (_inFlight.TryGetValue(agentUri, out var pending))
+                {
+                    nodeId = pending.NodeId;
+                    return true;
+                }
+
+                nodeId = Guid.Empty;
+                return false;
+            };
+
+            // Node 0 is this process — the controller injects self into any node list that omits it, so the
+            // leader has to BE one of the simulated nodes rather than a sixth observer.
+            for (var i = 0; i < nodeCount; i++)
+            {
+                var node = new WolverineNode
+                {
+                    NodeId = i == 0 ? Options.UniqueNodeId : Guid.NewGuid(),
+                    AssignedNodeNumber = i + 1,
+                    ControlUri = new Uri($"fake://node{i}")
+                };
+
+                node.Capabilities.AddRange(AllAgents);
+                _nodes.Add(node);
+            }
+
+            StartCost = _ => 1;
+            Seed = seed;
+        }
+
+        public WolverineOptions Options { get; }
+        public int Seed { get; }
+        public Uri[] AllAgents { get; }
+
+        /// <summary>How many rounds each agent's start takes to complete on its destination node.</summary>
+        public Func<Uri, int> StartCost { get; set; }
+
+        public IReadOnlyList<int> RunningCountByRound => _runningCountByRound;
+        public IReadOnlyList<string> DoubleStartReports => _doubleStartReports;
+        public IReadOnlyDictionary<Uri, int> DispatchCounts => _dispatchCounts;
+        public int StopsEmitted { get; private set; }
+        public int ReassignmentsEmitted { get; private set; }
+
+        public IReadOnlyList<Uri> RunningAgents => _running.Keys.ToList();
+
+        public int[] RunningCountsByNode
+            => _nodes.Select(node => _running.Count(x => x.Value == node.NodeId)).ToArray();
+
+        public IEnumerable<Uri> AssignedIn(AgentCommands commands)
+            => commands.OfType<AssignAgents>().SelectMany(x => x.AgentIds)
+                .Concat(commands.OfType<AssignAgent>().Select(x => x.AgentUri));
+
+        /// <summary>
+        /// One health-check tick: land any starts whose cost has run out, evaluate, and apply the result.
+        /// </summary>
+        public async Task<AgentCommands> RunRoundAsync()
+        {
+            landCompletedStarts();
+
+            var commands = await _controller.EvaluateAssignmentsAsync(_nodes, new AgentRestrictions());
+
+            foreach (var command in commands)
+            {
+                switch (command)
+                {
+                    case AssignAgent assign:
+                        dispatchStart(assign.AgentUri, assign.Destination.NodeId);
+                        break;
+
+                    case AssignAgents assigns:
+                        foreach (var uri in assigns.AgentIds) dispatchStart(uri, assigns.Destination.NodeId);
+                        break;
+
+                    case ReassignAgent reassign:
+                        ReassignmentsEmitted++;
+                        stop(reassign.AgentUri, reassign.OriginalNode.NodeId);
+                        dispatchStart(reassign.AgentUri, reassign.ActiveNode.NodeId);
+                        break;
+
+                    case ReassignAgents reassigns:
+                        ReassignmentsEmitted += reassigns.AgentUris.Length;
+                        foreach (var uri in reassigns.AgentUris)
+                        {
+                            stop(uri, reassigns.OriginalNode.NodeId);
+                            dispatchStart(uri, reassigns.ActiveNode.NodeId);
+                        }
+
+                        break;
+
+                    case StopRemoteAgent stopOne:
+                        StopsEmitted++;
+                        stop(stopOne.AgentUri, stopOne.Destination.NodeId);
+                        break;
+
+                    case StopRemoteAgents stopMany:
+                        StopsEmitted += stopMany.AgentIds.Length;
+                        foreach (var uri in stopMany.AgentIds) stop(uri, stopMany.Destination.NodeId);
+                        break;
+                }
+            }
+
+            _runningCountByRound.Add(_running.Count);
+
+            return commands;
+        }
+
+        /// <summary>Runs rounds until every agent is running and the leader has nothing left to say.</summary>
+        public async Task<int> RunUntilConvergedAsync(int maxRounds)
+        {
+            for (var round = 1; round <= maxRounds; round++)
+            {
+                var commands = await RunRoundAsync();
+
+                if (commands.Count == 0 && _inFlight.Count == 0 && _awaitingVisibility.Count == 0
+                    && _running.Count == AllAgents.Length)
+                {
+                    return round;
+                }
+            }
+
+            return maxRounds;
+        }
+
+        private void landCompletedStarts()
+        {
+            // Agents that came up last round: their assignment row is now visible to the leader's snapshot.
+            foreach (var (uri, nodeId) in _awaitingVisibility.ToArray())
+            {
+                _nodes.Single(x => x.NodeId == nodeId).ActiveAgents.Fill(uri);
+            }
+
+            _awaitingVisibility.Clear();
+
+            foreach (var uri in _inFlight.Keys.ToArray())
+            {
+                var pending = _inFlight[uri];
+                if (pending.RoundsRemaining > 1)
+                {
+                    _inFlight[uri] = pending with { RoundsRemaining = pending.RoundsRemaining - 1 };
+                    continue;
+                }
+
+                _inFlight.Remove(uri);
+
+                // Running now — but invisible to the leader until the promotion above runs next round.
+                _running[uri] = pending.NodeId;
+                _awaitingVisibility[uri] = pending.NodeId;
+
+                // What AssignAgent/AssignAgents do the moment a start confirms, and the reason the agent stays
+                // held for the one snapshot cycle it takes the persisted assignment row to become visible.
+                _controller.ConfirmDispatched([uri], pending.NodeId);
+            }
+        }
+
+        private void dispatchStart(Uri agentUri, Guid nodeId)
+        {
+            _dispatchCounts.TryGetValue(agentUri, out var count);
+            _dispatchCounts[agentUri] = count + 1;
+
+            // The single-copy invariant, asserted at the moment it would be violated rather than inferred from
+            // the end state — a second copy that is later stopped still ran twice.
+            if (_inFlight.TryGetValue(agentUri, out var already) && already.NodeId != nodeId)
+            {
+                _doubleStartReports.Add(
+                    $"{agentUri} dispatched to node {nodeId} while a start was still in flight to node {already.NodeId}");
+            }
+
+            if (_running.TryGetValue(agentUri, out var runningOn) && runningOn != nodeId)
+            {
+                _doubleStartReports.Add(
+                    $"{agentUri} dispatched to node {nodeId} while already running on node {runningOn}");
+            }
+
+            _inFlight[agentUri] = new InFlightStart(nodeId, Math.Max(1, StartCost(agentUri)));
+        }
+
+        private void stop(Uri agentUri, Guid nodeId)
+        {
+            _nodes.Single(x => x.NodeId == nodeId).ActiveAgents.Remove(agentUri);
+
+            if (_running.TryGetValue(agentUri, out var runningOn) && runningOn == nodeId)
+            {
+                _running.Remove(agentUri);
+            }
+
+            if (_awaitingVisibility.TryGetValue(agentUri, out var pendingVisible) && pendingVisible == nodeId)
+            {
+                _awaitingVisibility.Remove(agentUri);
+            }
+
+            if (_inFlight.TryGetValue(agentUri, out var pending) && pending.NodeId == nodeId)
+            {
+                _inFlight.Remove(agentUri);
+            }
+        }
+    }
+}

--- a/src/Testing/MessageRoutingTests/MessageRoutingTests.csproj
+++ b/src/Testing/MessageRoutingTests/MessageRoutingTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/Testing/MetricsTests/MetricsTests.csproj
+++ b/src/Testing/MetricsTests/MetricsTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Testing/PolicyTests/PolicyTests.csproj
+++ b/src/Testing/PolicyTests/PolicyTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Testing/SlowTests/SlowTests.csproj
+++ b/src/Testing/SlowTests/SlowTests.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
-    </PropertyGroup>
-
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Shouldly" />

--- a/src/Testing/Wolverine.Behavioural.FSharpTests/Wolverine.Behavioural.FSharpTests.csproj
+++ b/src/Testing/Wolverine.Behavioural.FSharpTests/Wolverine.Behavioural.FSharpTests.csproj
@@ -9,7 +9,6 @@
     -->
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/Wolverine.ComplianceTests/FakeAgent.cs
+++ b/src/Testing/Wolverine.ComplianceTests/FakeAgent.cs
@@ -12,20 +12,54 @@ public class FakeAgent : IAgent
 
     public bool IsRunning { get; private set; }
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    /// <summary>
+    ///     GH-3779: how long this agent takes to start. Defaults to zero, which is what every test written
+    ///     before the slow-start work assumed. A real daemon agent is nothing like free — a Marten shard
+    ///     replaying behind a projection version bump was measured in the field at p50 27s / p95 82s with a
+    ///     215s tail — and every defect in the GH-3753 chain takes a slow start as its precondition, so a
+    ///     harness that cannot express one cannot reproduce any of them.
+    /// </summary>
+    public TimeSpan StartDelay { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    ///     GH-3779: how long this agent takes to stop. A stop can be as slow as a start — a shard mid-replay
+    ///     has to let go of its work — which is why StopRemoteAgents got the same scaled reply window as
+    ///     AssignAgents in GH-3748.
+    /// </summary>
+    public TimeSpan StopDelay { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    ///     Number of times StartAsync has been entered, whether or not it completed. Distinguishes a start
+    ///     that is merely slow from one the leader has re-driven.
+    /// </summary>
+    public int StartCount => _startCount;
+
+    private int _startCount;
+
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
+        Interlocked.Increment(ref _startCount);
+
+        if (StartDelay > TimeSpan.Zero)
+        {
+            await Task.Delay(StartDelay, cancellationToken);
+        }
+
         IsRunning = true;
         Status = AgentStatus.Running;
-        return Task.CompletedTask;
     }
 
-    public Task StopAsync(CancellationToken cancellationToken)
+    public async Task StopAsync(CancellationToken cancellationToken)
     {
+        if (StopDelay > TimeSpan.Zero)
+        {
+            await Task.Delay(StopDelay, cancellationToken);
+        }
+
         IsRunning = false;
         Status = AgentStatus.Stopped;
-        return Task.CompletedTask;
     }
-    
+
     public AgentStatus Status { get; private set; } = AgentStatus.Running;
 
     public Uri Uri { get; }

--- a/src/Testing/Wolverine.ComplianceTests/FakeAgentFamily.cs
+++ b/src/Testing/Wolverine.ComplianceTests/FakeAgentFamily.cs
@@ -15,6 +15,28 @@ public class FakeAgentFamily : IStaticAgentFamily
         Scheme = scheme;
     }
 
+    /// <summary>
+    ///     GH-3779: a family of an arbitrary size. The twelve hard-coded <see cref="Names" /> are fine for
+    ///     asserting the shape of a distribution, but GH-3753 is about ~6,500 agents across five nodes, and
+    ///     the pathologies there — a node left holding everything while its peers sit at zero, an assigned
+    ///     count that goes backwards — only emerge at a scale where one assignment wave cannot complete
+    ///     inside one evaluation cycle.
+    /// </summary>
+    public FakeAgentFamily(string scheme, int agentCount)
+    {
+        if (agentCount < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(agentCount), agentCount,
+                "An agent family needs at least one agent");
+        }
+
+        Scheme = scheme;
+
+        // Zero-padded so the lexical order matches the numeric one; several assertions read a lot better
+        // against a sorted agent list.
+        AgentNames = Enumerable.Range(0, agentCount).Select(i => $"agent-{i:D5}").ToArray();
+    }
+
     public string Scheme { get; } = "fake";
 
     public static string[] Names =
@@ -33,6 +55,20 @@ public class FakeAgentFamily : IStaticAgentFamily
         "twelve"
     ];
 
+    /// <summary>
+    ///     The agent names this particular family exposes. Defaults to the shared <see cref="Names" /> so that
+    ///     every test predating the count-taking constructor is unaffected.
+    /// </summary>
+    public IReadOnlyList<string> AgentNames { get; } = Names;
+
+    /// <summary>
+    ///     GH-3779: per-agent start cost, so a long TAIL can be simulated rather than a uniform delay. The
+    ///     field distribution that broke GH-3753 was p50 27s / p95 82s / tail 215s, and it is the tail that
+    ///     does the damage — a uniformly slow family converges late but converges, while a handful of very
+    ///     slow starts is what outlives a reply window and gets re-decided.
+    /// </summary>
+    public Func<Uri, TimeSpan>? StartDelayPolicy { get; set; }
+
     public LightweightCache<Uri, FakeAgent> Agents { get; } = new(x => new FakeAgent(x));
 
     public ValueTask EvaluateAssignmentsAsync(AssignmentGrid assignments)
@@ -43,13 +79,20 @@ public class FakeAgentFamily : IStaticAgentFamily
 
     public ValueTask<IReadOnlyList<Uri>> AllKnownAgentsAsync()
     {
-        var agents = Names.Select(x => new Uri($"{Scheme}://{x}")).ToArray();
+        var agents = AllAgentUris();
         return ValueTask.FromResult((IReadOnlyList<Uri>)agents);
     }
 
     public ValueTask<IAgent> BuildAgentAsync(Uri uri, IWolverineRuntime runtime)
     {
-        return new ValueTask<IAgent>(Agents[uri]);
+        var agent = Agents[uri];
+
+        if (StartDelayPolicy != null)
+        {
+            agent.StartDelay = StartDelayPolicy(uri);
+        }
+
+        return new ValueTask<IAgent>(agent);
     }
 
     public ValueTask<IReadOnlyList<Uri>> SupportedAgentsAsync()
@@ -60,6 +103,6 @@ public class FakeAgentFamily : IStaticAgentFamily
 
     public Uri[] AllAgentUris()
     {
-        return Names.Select(x => new Uri($"{Scheme}://{x}")).ToArray();
+        return AgentNames.Select(x => new Uri($"{Scheme}://{x}")).ToArray();
     }
 }

--- a/src/Testing/Wolverine.ComplianceTests/Wolverine.ComplianceTests.csproj
+++ b/src/Testing/Wolverine.ComplianceTests/Wolverine.ComplianceTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <Description>Compliance test harnesses for adding persistence and transport options to Wolverine</Description>
         <PackageId>WolverineFx.ComplianceTests</PackageId>
         <!--

--- a/src/Testing/Wolverine.Core.FSharpTests/Wolverine.Core.FSharpTests.csproj
+++ b/src/Testing/Wolverine.Core.FSharpTests/Wolverine.Core.FSharpTests.csproj
@@ -8,7 +8,6 @@
     -->
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/Wolverine.Cosmos.FSharpTests/Wolverine.Cosmos.FSharpTests.csproj
+++ b/src/Testing/Wolverine.Cosmos.FSharpTests/Wolverine.Cosmos.FSharpTests.csproj
@@ -9,7 +9,6 @@
     -->
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/Wolverine.EfCore.FSharpTests/Wolverine.EfCore.FSharpTests.csproj
+++ b/src/Testing/Wolverine.EfCore.FSharpTests/Wolverine.EfCore.FSharpTests.csproj
@@ -8,7 +8,6 @@
     -->
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/Wolverine.Http.FSharpTests/Wolverine.Http.FSharpTests.csproj
+++ b/src/Testing/Wolverine.Http.FSharpTests/Wolverine.Http.FSharpTests.csproj
@@ -8,7 +8,6 @@
     -->
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/Wolverine.Marten.FSharpTests/Wolverine.Marten.FSharpTests.csproj
+++ b/src/Testing/Wolverine.Marten.FSharpTests/Wolverine.Marten.FSharpTests.csproj
@@ -8,7 +8,6 @@
     -->
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Testing/Wolverine.MartenAggregate.FSharpTests/Wolverine.MartenAggregate.FSharpTests.csproj
+++ b/src/Testing/Wolverine.MartenAggregate.FSharpTests/Wolverine.MartenAggregate.FSharpTests.csproj
@@ -8,7 +8,6 @@
     -->
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Transports/AWS/Wolverine.AmazonSns.Tests/Wolverine.AmazonSns.Tests.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSns.Tests/Wolverine.AmazonSns.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Wolverine.AmazonSqs.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Wolverine.AzureServiceBus.Tests.csproj
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Wolverine.AzureServiceBus.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/Wolverine.Pubsub.Tests.csproj
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/Wolverine.Pubsub.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/Kafka/BatchMessaging/Program.cs
+++ b/src/Transports/Kafka/BatchMessaging/Program.cs
@@ -9,6 +9,13 @@ builder.Services.AddOpenApi();
 
 builder.Host.UseWolverine(opts =>
 {
+    // GH-3763: this app is booted by Wolverine.Kafka.Tests through AlbaHost.For<Program>, and without this
+    // pin Wolverine resolves the application assembly to the *test* assembly instead of this one. Handler
+    // discovery then never sees TestMessagesHandler, so BatchMessagesOf<TestMessage>() below has no
+    // TestMessage[] handler to bind to and every batch fails at runtime with "there is no known handler for
+    // TestMessage[]". Same pin, for the same reason, as WolverineWebApi's Program. See GH-3521.
+    opts.ApplicationAssembly = typeof(Program).Assembly;
+
     opts.UseKafka("localhost:9092")
         .AutoProvision()
         .AutoPurgeOnStartup()
@@ -35,8 +42,6 @@ app.MapPost("/test", async (IMessageBus bus) =>
         var message = new TestMessage();
         await bus.PublishAsync(message);
         await bus.PublishAsync(message);
-        // results in:
-        // No known handler for TestMessage#08dced0c-3834-b4c6-54d7-e075bf020000 from kafka://topic/topic_0
     });
 
 return await app.RunJasperFxCommands(args);

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/batch_processing_with_kafka.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/batch_processing_with_kafka.cs
@@ -5,7 +5,6 @@ using Wolverine.Tracking;
 
 namespace Wolverine.Kafka.Tests;
 
-[Trait("Category", "Flaky")]
 public class batch_processing_with_kafka
 {
     [Fact]
@@ -26,7 +25,14 @@ public class batch_processing_with_kafka
             .Timeout(60.Seconds())
             .ExecuteAndWaitAsync(execute);
 
-        tracked.FindSingleTrackedMessageOfType<TestMessage[]>()
-            .Length.ShouldBe(2);
+        // Both published messages must arrive at the handler in batch (TestMessage[]) form. Deliberately
+        // NOT asserting a single batch of two: BatchingOptions triggers on a full batch OR on TriggerTime
+        // (250ms by default), so whether two messages published back-to-back land in one batch or in two
+        // depends on how the Kafka consumer happens to slice its polls. Asserting the grouping asserts a
+        // race — the contract that actually matters is that every message was delivered, batched.
+        var batched = tracked.Received.MessagesOf<TestMessage[]>().ToArray();
+
+        batched.ShouldNotBeEmpty();
+        batched.Sum(x => x.Length).ShouldBe(2);
     }
 }

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Transports/MQTT/Wolverine.Mqtt5.Tests/Wolverine.Mqtt5.Tests.csproj
+++ b/src/Transports/MQTT/Wolverine.Mqtt5.Tests/Wolverine.Mqtt5.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Transports/NATS/Wolverine.Nats.Tests/Wolverine.Nats.Tests.csproj
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/Wolverine.Nats.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/Wolverine.Pulsar.Tests.csproj
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/Wolverine.Pulsar.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/RabbitMQ/ChaosTesting/ChaosTesting.csproj
+++ b/src/Transports/RabbitMQ/ChaosTesting/ChaosTesting.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakingTests.csproj
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakingTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_189_fails_if_there_are_many_messages_in_queue_on_startup.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_189_fails_if_there_are_many_messages_in_queue_on_startup.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Wolverine.RabbitMQ.Tests.Bugs;
 
-[Trait("Category", "Flaky")]
 public class Bug_189_fails_if_there_are_many_messages_in_queue_on_startup
 {
     [Fact]

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitMqBrokerHealthProbe_tests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitMqBrokerHealthProbe_tests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Wolverine.RabbitMQ.Tests;
 
-[Trait("Category", "Flaky")]
 public class RabbitMqBrokerHealthProbe_tests
 {
     [Fact]

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/cluster_endpoints.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/cluster_endpoints.cs
@@ -191,7 +191,7 @@ public class cluster_endpoints
         tenant.Transport.AmqpTcpEndpoints.Count.ShouldBe(2);
     }
 
-    [Fact, Trait("Category", "Flaky")]
+    [Fact]
     public async Task can_publish_and_receive_through_cluster_code_path()
     {
         var queueName = RabbitTesting.NextQueueName();

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/end_to_end.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/end_to_end.cs
@@ -36,6 +36,15 @@ public static class RabbitTesting
     }
 }
 
+// GH-3763: stays tagged, and the ledger entry now has numbers behind it. Measured 2026-08-02, this class
+// alone against a fresh broker, three consecutive runs: 18/20 pass every time and TWO fail every time.
+//
+//   send_message_to_and_receive_through_rabbitmq_with_routing_key   fails 3 of 3  (deterministic)
+//   use_direct_exchange_with_binding_key / use_fan_out_exchange     one or the other, every run
+//
+// So this is one hard failure plus a genuine flake, not one flaky class. Both fail in under 500ms, which
+// is the exchange/binding-declaration race described in #2618 rather than anything timing out. Needs the
+// deterministic binding-readiness gate that issue calls for before it can come off the list.
 [Trait("Category", "Flaky")]
 public class end_to_end
 {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/endpoint_health_connection_state_3231.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/endpoint_health_connection_state_3231.cs
@@ -23,7 +23,6 @@ public class EndpointHealthConnectionStateHandler
 // GH-3231: EndpointHealthSnapshot must surface the underlying transport channel/agent connection state so external
 // monitors (CritterWatch) can see a dead-but-"Accepting" listener (or a disconnected sender) directly rather than
 // inferring it from staleness.
-[Trait("Category", "Flaky")]
 public class endpoint_health_connection_state_3231
 {
     private static string nextQueue() => "conn_state_" + Guid.NewGuid().ToString("N");

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/force_restart_listener_3232.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/force_restart_listener_3232.cs
@@ -20,7 +20,6 @@ public class ForceRestartMessageHandler
 // GH-3232: an operator/monitor must be able to force-recover a listener that reports Accepting but isn't actually
 // consuming (a stuck transport channel the framework can't self-heal) without a process bounce. Bare StartAsync()
 // is a no-op when Status == Accepting; RestartAsync(force: true) tears down and rebuilds regardless.
-[Trait("Category", "Flaky")]
 public class force_restart_listener_3232
 {
     private static string nextQueue() => "force_restart_" + Guid.NewGuid().ToString("N");

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_tenancy_through_virtual_hosts.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_tenancy_through_virtual_hosts.cs
@@ -144,6 +144,19 @@ public class MultiTenantedRabbitFixture : IAsyncLifetime
     }
 }
 
+// GH-3763: kept tagged, but this is NOT flakiness and the tag should not be read as "sometimes fails".
+// `send_message_to_a_specific_tenant` is DETERMINISTIC in both directions, measured on 2026-08-02:
+//
+//   this class alone                                    7/7 pass, 3 runs
+//   this class alongside the other Rabbit suites        fails every time, 3 runs
+//
+// It fails in ~100ms — far short of its own 15s tracked-session timeout — so nothing is timing out;
+// the send is rejected or misrouted immediately. That is cross-class state on a shared broker, which is
+// the #1 shape called out in #3763, and it needs the interfering suite identified rather than another
+// retry budget. Untagging it would put a guaranteed red in CIRabbitMQ.
+//
+// The other eight Rabbit classes that carried this tag were untagged in the same pass: 5 consecutive
+// clean runs, 41 tests, zero failures.
 [Trait("Category", "Flaky")]
 public class multi_tenancy_through_virtual_hosts : IClassFixture<MultiTenantedRabbitFixture>
 {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/send_by_topics.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/send_by_topics.cs
@@ -22,7 +22,6 @@ namespace Wolverine.RabbitMQ.Tests;
 // races-with-broker-state flake. Skipping in CI via the Flaky filter; revisit
 // once the topic-binding setup is rewritten with a deterministic readiness gate.
 // See #2618.
-[Trait("Category", "Flaky")]
 public class send_by_topics : IAsyncLifetime
 {
     private IHost theGreenReceiver = null!;
@@ -289,7 +288,6 @@ public class send_by_topics : IAsyncLifetime
 // reliably miss the second receiver in CI when this class runs in the full suite.
 // Skip via the same Flaky filter the non-durable sibling uses, pending the
 // deterministic topic-binding readiness gate described in #2618.
-[Trait("Category", "Flaky")]
 public class send_by_topics_durable : IAsyncLifetime
 {
     private IHost theGreenReceiver = null!;

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/sending_raw_messages.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/sending_raw_messages.cs
@@ -17,7 +17,6 @@ namespace Wolverine.RabbitMQ.Tests;
 // to re-declare it without one. Skipping in CI via the Flaky filter; the real
 // fix is to stop sharing fixed queue names like 'messages1' across tests
 // (use Guid-suffixed names) or to delete-then-redeclare in setup. See #2618.
-[Trait("Category", "Flaky")]
 public class sending_raw_messages
 {
     [Fact]

--- a/src/Transports/Redis/Wolverine.Redis.Tests/Wolverine.Redis.Tests.csproj
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/Wolverine.Redis.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Transports/SignalR/Wolverine.SignalR.Tests/Wolverine.SignalR.Tests.csproj
+++ b/src/Transports/SignalR/Wolverine.SignalR.Tests/Wolverine.SignalR.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <!--
           Deliberately TargetFrameworks (plural) even though there is only one TFM, matching

--- a/src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj
+++ b/src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net9.0</TargetFrameworks>

--- a/src/Wolverine.HealthChecks.Tests/Wolverine.HealthChecks.Tests.csproj
+++ b/src/Wolverine.HealthChecks.Tests/Wolverine.HealthChecks.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <!-- GH-3702: xUnit1051 reinstated for this project -->
         <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <TargetFrameworks>net9.0</TargetFrameworks>


### PR DESCRIPTION
Two independent pieces of testing work, both off the open testing/CI issues, plus a leftover from #3725.

## GH-3779 — a fast, deterministic reproduction of slow agent starts

Every defect in the GH-3753 chain — #3748, #3749, #3750, jasperfx#594, jasperfx#598 — takes a **slow agent start** as its precondition, and `FakeAgent.StartAsync` returned `Task.CompletedTask`, which is exactly the assumption the whole chain violates.

**First, a correction to the issue's premise.** `src/Testing/SlowTests/Agents/` already contains a real reproduction — `agent_assignment_at_scale`, `agent_reassignment_at_scale`, `slow_starts_outrun_reply_windows` — built during the #3748/#3749/#3750 work, with real hosts, real delays, telemetry and a universe that grows mid-test. Those are the thorough version and they already assert the monotonicity the issue asks for.

The gap is different from what #3779 describes:

1. **`SlowTests` runs in no CI workflow at all.** Zero jobs in `tests.yml`, no Nuke target. Three well-built regression tests for this chain run nowhere.
2. They take minutes apiece and are wall-clock-sensitive, so they can't be the guard on a normal commit.

This PR adds the **fast tier underneath them** — 0.5s, deterministic, inside a job that already runs on every commit.

### The harness seams the issue asks for

- `FakeAgent` gets a settable `StartDelay`/`StopDelay` and counts entries into `StartAsync`, so a start that is merely slow can be told apart from one the leader has re-driven.
- `FakeAgentFamily` gets an agent count and a `StartDelayPolicy`, so a long **tail** can be simulated rather than a uniform cost. It is the tail that does the damage — a uniformly slow family converges late but converges.

### The simulation

`slow_agent_start_convergence` drives the real `NodeAgentController.EvaluateAssignmentsAsync` round after round against a simulated multi-node cluster (5 nodes / 603 agents) and asserts what the field reported losing:

| Assertion | Field shape it guards |
|---|---|
| every agent converges | the wave that never finished |
| no agent started on two nodes at once | GH-3698's re-decide-from-scratch |
| no node starved while another holds everything | the observed 799 / 0 / 0 / 0 / 1 |
| a first placement wave emits zero stops and zero reassignments | the churn that made convergence a livelock |
| a start slower than the ledger TTL is still held by the outstanding-dispatch probe | GH-3698, with the TTL squeezed to nothing |
| a partially-started chunk's remainder still converges | GH-3750 |

Two design points worth naming:

**Time is measured in evaluation rounds, not milliseconds.** The field distribution is p50 27s / p95 82s / a 215s tail against a ~5s health-check cadence; a wall-clock version would take hours and would trade a deterministic assertion for a timing race. Everything is seeded — a failure reproduces.

**An agent becomes running one round before it becomes visible to the leader.** A node persists its assignment row only after the agent is up, and the leader reads it on a later snapshot — that window is what GH-3750 is about, and a simulation that closes it instantly cannot reproduce the field's falling assigned-agent count.

### These assertions were checked against mutated product code

Not just "they pass". Two mutations were applied and reverted:

- the pending-assignment ledger never projected onto the grid (pre-GH-3698): **6 of 7 assertions fail**
- the pending placement set but not held: **3 fail**

Every assertion in the final file fails under at least one. The one that didn't — the monotonic running-count check — is documented as strictly implied by the zero-churn assertion against a stable node set, and now rides inside that test rather than standing as a test that cannot fail.

## GH-3763 — first entry off the `Category=Flaky` ledger

`batch_processing_with_kafka.end_to_end` was tagged flaky. It is not flaky; it failed on **every** run, in isolation, exactly as #3763 predicted the tag would be hiding.

The cause is application-assembly resolution, not batching. The sample is booted by `Wolverine.Kafka.Tests` through `AlbaHost.For<Program>`, and Wolverine resolved the application assembly to the *test* assembly:

```
APP=Wolverine.Kafka.Tests | DISCOVERY=Wolverine.RuntimeCompilation,Wolverine.Kafka.Tests
```

So discovery never scanned `BatchMessaging`, `TestMessagesHandler` was never found, and `BatchMessagesOf<TestMessage>()` had no `TestMessage[]` chain to bind to. The sample even carried a comment recording the symptom as expected behaviour. This is the GH-3521 class of problem — #3777 stopped the *runner* assembly being adopted, which is a different assembly from this one.

Fixed by pinning `opts.ApplicationAssembly` in the sample, which is the repo's own convention for a sample driven by an Alba test from another assembly (`WolverineWebApi/Program.cs:192` does exactly this).

That exposed a second, real problem: the test asserted a **single** batch of two. `BatchingOptions` triggers on a full batch *or* on `TriggerTime` (250ms), so whether two messages published back-to-back land in one batch or two depends on how the Kafka consumer slices its polls — asserting the grouping asserts a race. It now asserts what the contract promises: every published message arrived at the handler batched.

Untagged; green 5/5 locally.

### Second pass: the RabbitMQ block

Nine Rabbit classes carried the tag. Measured against a fresh broker, `dotnet test` directly so nothing was retried:

**Seven are stale tags — untagged.** `force_restart_listener_3232`, `RabbitMqBrokerHealthProbe_tests`, `sending_raw_messages`, `cluster_endpoints`, `endpoint_health_connection_state_3231`, both `send_by_topics` classes, `Bug_189`: **5 consecutive runs, 41 tests, zero failures.**

**Two are real, and neither is "flaky".** Both keep the tag, now with the measurements in a comment beside it:

- `multi_tenancy_through_virtual_hosts.send_message_to_a_specific_tenant` — deterministic in *both* directions: 7/7 pass with the class alone (3 runs), fails every time alongside the other Rabbit suites (3 runs). Fails in ~100ms against a 15s tracked-session timeout, so nothing is timing out — cross-class state on a shared broker, the #1 shape #3763 names.
- `end_to_end` — one hard failure plus a genuine flake, not one flaky class: `send_message_to_and_receive_through_rabbitmq_with_routing_key` fails 3/3, and one of `use_direct_exchange_with_binding_key` / `use_fan_out_exchange` fails on every run. Both under 500ms: the #2618 binding-declaration race.

`end_to_end` was very nearly untagged with the rest, because it was not in the filter used for the repeat runs — that would have put a guaranteed red into CIRabbitMQ. Verify each class you untag *by name*.

**Ledger: 53 → 44.** (The RabbitMQ commit message says "53 -> 45"; 44 is correct — `send_by_topics` carries two tags in one file. The code is right, only that one number in the message is off, and the branch ruleset blocks the force-push an amend would need.)

## GH-3725 tail — a comment that now says the opposite of the truth

#3725 deleted `<XUnitCancellationTokenEnforced>` from every project along with the `Directory.Build.targets` block that read it, but left `<!-- GH-3702: xUnit1051 reinstated for this project -->` behind in 71 project files. xUnit1051 is not "reinstated for this project" any more — it is enforced for every project by default, which was the point. Pure deletions; `wolverine.slnx` builds clean in Release with 0 warnings.

## Deliberately NOT in this PR: wiring SlowTests into CI

That was the obvious next step for #3779, and it is blocked — but not by the tests. `SlowTests.Agents` **passes on `main`**; what it cannot do is *finish*.

`agent_reassignment_at_scale.a_version_bump_deploy_converges_and_never_marches_backwards` runs all of its assertions green and then **hangs forever in teardown**, so `dotnet test` never reports and the process has to be killed. Reproduced 4/4, including on a completely idle machine.

The controlled pair that isolates it — the only difference is a 20s bound on the teardown stop:

| `DisposeAsync` | Result |
|---|---|
| `await host.StopAsync()` (as committed) | hangs indefinitely; the run never reports |
| `await host.StopAsync().WaitAsync(20.Seconds())` | **passed, 2m18s** |

So the assertions are fine, and a host shutdown is what wedges. Details worth having:

- The host left standing is **node 1** — the first host created, therefore the last one `DisposeAsync` stops after `_hosts.Reverse()`, and the leader. The other two stop cleanly (the assignment table drains 478 → 322 → 192 and then stops moving).
- It is not the simulated slow stop: `DisposeAsync` sets `_telemetry.StopDelay = TimeSpan.Zero` before stopping anything.
- `dotnet-stack report` on the wedged process shows **every managed thread parked** — thread-pool workers idle, main thread blocked in the xUnit entry point, no CPU burn. That rules out a spin or a lock convoy and points at an await that is never completed.
- The node's `health_check` row stops updating ~2 minutes in and the row is never deleted, consistent with the runtime going quiet mid-shutdown.

A product-side shutdown hang in a Balanced-mode host holding a large number of agents, unrelated to anything here — `SlowTests` uses its own `SlowStartAgentFamily` and never touches `FakeAgent`. Written up separately rather than papered over, because bounding the teardown inside the test would hide a real hang.

**Addresses** #3779; deliberately does not close it. Two things it asks for are still outstanding and both sit behind the hang above:

- `SlowTests` wired into a CI job, so the existing scale harness actually runs somewhere;
- the virtual clock, which only pays for itself once those tests are in CI and their wall clock matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116vfBcKwcjWn8msM4ZjkuA
