### PR TITLE
Stop Balanced-mode host shutdown paying a full agent reply window (GH-3781)

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -1,0 +1,52 @@
+name: slow tests
+
+# Manual only, on purpose.
+#
+# `SlowTests` holds the only real-host reproductions of the GH-3753 agent assignment chain --
+# three multi-node classes driving a 480-agent universe across real Postgres-backed hosts -- plus
+# the TCP and shared-memory transport compliance batteries. Those tests are wall-clock bound by
+# design: they wait out health checks, assignment evaluations and agent starts, so unlike every
+# other suite there is no amount of sharding or parallelism that makes them cheap. The first CI
+# run of the whole project was still going when the standard 20 minute cap killed it.
+#
+# So it does not belong in the PR path, where it would add ~20+ minutes to every push for a suite
+# whose subject barely changes. It belongs HERE, run deliberately: before a release, after anything
+# that touches agent assignment / node lifecycle / durability, and when triaging a report like
+# #3753 or #3781.
+#
+# Run it from the Actions tab, or: gh workflow run "slow tests" --ref <branch>
+on:
+  workflow_dispatch:
+
+env:
+  config: Release
+  disable_test_parallelization: true
+
+jobs:
+  slow-tests:
+    name: CISlowTests
+    runs-on: ubuntu-latest
+    # Deliberately past the 20 minute cap that tests.yml enforces. That cap is a real signal for the
+    # PR matrix -- a job that needs longer is a job that needs splitting -- but it is the wrong tool
+    # here: this suite is slow because the behaviour it reproduces is slow, and it is not gating a
+    # pull request. Still bounded, so a genuine wedge (see #3781) fails the job instead of burning a
+    # runner for six hours.
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run Tests
+        run: ./build.sh CISlowTests --framework net9.0
+
+      - name: Stop containers
+        if: always()
+        run: docker compose down

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,10 +60,9 @@ jobs:
           - CISqlite
           - CISqlServer
           - CICircuitBreaking
-          # SlowTests had never run in ANY workflow, which is how the Balanced-mode shutdown wedge
-          # (#3781) sat undetected in the only real-host reproduction of the GH-3753 chain. See #3779.
-          - CISlowTests
           - CIAotSmoke
+          # NOTE: CISlowTests is deliberately NOT here. It is wall-clock bound by design and blew
+          # through the 20 minute cap on its first run; it lives in slow-tests.yml as a manual job.
         include:
           # CIMarten was twice killed outright by the runner ~15 minutes in ("The runner has received a
           # shutdown signal"), on unrelated diffs, at almost exactly the same elapsed time on both

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,9 @@ jobs:
           - CISqlite
           - CISqlServer
           - CICircuitBreaking
+          # SlowTests had never run in ANY workflow, which is how the Balanced-mode shutdown wedge
+          # (#3781) sat undetected in the only real-host reproduction of the GH-3753 chain. See #3779.
+          - CISlowTests
           - CIAotSmoke
         include:
           # CIMarten was twice killed outright by the runner ~15 minutes in ("The runner has received a

--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -750,6 +750,36 @@ partial class Build
             RunTestProject(tests);
         });
 
+    /// <summary>
+    /// GH-3779 / GH-3781. <c>SlowTests</c> has never run in <b>any</b> CI workflow — no job, no Nuke
+    /// target — even though it holds the only real-host reproductions of the GH-3753 agent
+    /// assignment chain (<c>SlowTests/Agents</c>: three multi-node classes over a 480-agent universe).
+    /// A reproduction nothing runs is a reproduction that rots, and GH-3781 is exactly what it caught
+    /// the moment anyone did run it: a Balanced-mode host that would not finish <c>StopAsync</c>.
+    ///
+    /// <para>Postgres is the only infrastructure the project needs — the SqlServer and Kafka project
+    /// references are transitive, and nothing here opens either.</para>
+    ///
+    /// <para>This is deliberately one unsharded job to begin with: the point is to <i>measure</i> what
+    /// the suite costs on a hosted runner, against the same 20 minute cap every other job answers to.
+    /// If it does not fit, the answer is to shard it the way CIMarten and CIPolecat were sharded (see
+    /// #3350), balanced on the measured per-class durations this job prints — not to raise the cap.</para>
+    /// </summary>
+    Target CISlowTests => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            var slowTests = RootDirectory / "src" / "Testing" / "SlowTests" / "SlowTests.csproj";
+
+            // The agent scale classes are wall-clock bound, so overlap the container boot with the
+            // compile rather than paying them serially.
+            LaunchDockerServices("postgresql");
+            BuildTestProjects(slowTests);
+            AwaitDockerServices("postgresql");
+
+            RunTestProject(slowTests);
+        });
+
     // ─── AOT Smoke ──────────────────────────────────────────────────────
     //
     // Builds the Wolverine.AotSmoke project, which sets IsAotCompatible=true +

--- a/src/Testing/CoreTests/Runtime/Agents/per_destination_lane_dispatch.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/per_destination_lane_dispatch.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
@@ -276,6 +277,100 @@ public class per_destination_lane_dispatch
         dispatcher.Enqueue(new AssignAgent(agent("one"), destination(NodeA)));
         await Task.Delay(200, TestContext.Current.CancellationToken);
         attempts.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// GH-3781. Completing a channel writer does not throw away what is already buffered, so the old
+    /// DisposeAsync executed every command still queued for a node the cluster was leaving -- each costing
+    /// its own AgentBatchTimeouts reply window (25.5 minutes at AgentStartBatchSize = 50) inside
+    /// IHost.StopAsync.
+    /// </summary>
+    [Fact]
+    public async Task disposal_abandons_the_commands_still_queued()
+    {
+        var log = new ConcurrentQueue<string>();
+        var running = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var dispatcher = dispatcherFor(async (command, token) =>
+        {
+            running.TrySetResult();
+            return await execute(command, token);
+        });
+
+        // Both aimed at the same node, so the second sits in the lane behind the first.
+        dispatcher.Enqueue(new GatedCommand("first", NodeA, gate.Task, log));
+        dispatcher.Enqueue(new GatedCommand("second", NodeA, Task.CompletedTask, log));
+
+        await running.Task.WaitAsync(10.Seconds(), TestContext.Current.CancellationToken);
+
+        // DisposeAsync latches and empties the lane queues synchronously, before its first await, so
+        // releasing the gate afterwards is deterministic rather than a race. Ordered this way the
+        // unfixed code fails this test on the assertion below instead of deadlocking the runner --
+        // which matters for a regression test whose subject is a shutdown that never returns.
+        var disposal = withLaneShutdownTimeout(500.Milliseconds(),
+            async () => await dispatcher.DisposeAsync());
+        gate.SetResult();
+        await disposal.WaitAsync(10.Seconds(), TestContext.Current.CancellationToken);
+
+        // Generous, deliberately: the point is that "second" never runs, not that it is merely late.
+        await Task.Delay(500, TestContext.Current.CancellationToken);
+        log.ShouldContain("exit:first");
+        log.ShouldNotContain("enter:second");
+
+        // And nothing is left claimed, or a later leader would suppress re-issuing this work.
+        dispatcher.InFlightAgents.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// GH-3781, the backstop. The wedge was one lane parked on a reply from a node that had already gone,
+    /// with teardownAgentsAsync -- and so the node's own deregistration -- queued behind it. Disposal has to
+    /// give up on a lane rather than hold IHost.StopAsync() with it, however that lane came to be stuck.
+    /// </summary>
+    [Fact]
+    public async Task disposal_gives_up_on_a_lane_that_ignores_cancellation()
+    {
+        var log = new ConcurrentQueue<string>();
+        var running = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var never = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var dispatcher = dispatcherFor(async (command, token) =>
+        {
+            running.TrySetResult();
+            // Deliberately not token-aware -- this is the shape of an InvokeAsync sitting out a reply window.
+            await never.Task;
+            return AgentCommands.Empty;
+        });
+
+        dispatcher.Enqueue(new GatedCommand("wedged", NodeA, Task.CompletedTask, log));
+        await running.Task.WaitAsync(10.Seconds(), TestContext.Current.CancellationToken);
+
+        var stopwatch = Stopwatch.StartNew();
+
+        // The outer WaitAsync is what keeps the UNFIXED code from wedging this runner the way it wedges
+        // IHost.StopAsync -- it turns the defect into a failed assertion instead of a hung CI job.
+        await withLaneShutdownTimeout(500.Milliseconds(),
+            async () => await dispatcher.DisposeAsync().AsTask()
+                .WaitAsync(10.Seconds(), TestContext.Current.CancellationToken));
+        stopwatch.Stop();
+
+        stopwatch.Elapsed.ShouldBeLessThan(5.Seconds());
+
+        never.SetResult();
+    }
+
+    private static async Task withLaneShutdownTimeout(TimeSpan timeout, Func<Task> action)
+    {
+        var previous = AgentCommandDispatcher.LaneShutdownTimeout;
+        AgentCommandDispatcher.LaneShutdownTimeout = timeout;
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            AgentCommandDispatcher.LaneShutdownTimeout = previous;
+        }
     }
 
     [Fact]

--- a/src/Testing/CoreTests/Runtime/ResponseReply/response_handling.cs
+++ b/src/Testing/CoreTests/Runtime/ResponseReply/response_handling.cs
@@ -91,4 +91,53 @@ public class response_handling : IDisposable
 
         _theListener.HasListener(envelope.Id).ShouldBeFalse();
     }
+
+    /// <summary>
+    /// GH-3781. A caller handing in a token that is ALREADY cancelled has to fail immediately, not sit out
+    /// the reply window. CancellationTokenRegistration runs its callback synchronously for a cancelled
+    /// token, and the listener used to register the caller's token before assigning _completion -- so the
+    /// callback's `_completion?.TrySetException(...)` fired against null and did nothing at all. Every
+    /// shutdown path passes a cancelled token, and for a batched agent command the window it then waited
+    /// out is AgentBatchTimeouts.ReplyWindowFor(chunk): 25.5 minutes at the shipped AgentStartBatchSize of
+    /// 50, paid inside IHost.StopAsync.
+    /// </summary>
+    [Fact]
+    public async Task a_token_that_is_already_cancelled_fails_the_listener_immediately()
+    {
+        var envelope = ObjectMother.Envelope();
+
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        // A window long enough that "waited it out" and "failed fast" cannot be confused.
+        var waiter = _theListener.RegisterListener<Message1>(envelope, cancellation.Token, 30.Seconds());
+
+        waiter.IsCompleted.ShouldBeTrue();
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+        await Should.ThrowAsync<TimeoutException>(() => waiter);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+
+        // ...and it must not be left in the dictionary: it completed before it was ever registered, so
+        // nothing would take it out again.
+        _theListener.HasListener(envelope.Id).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_token_cancelled_after_registration_fails_the_listener()
+    {
+        var envelope = ObjectMother.Envelope();
+
+        using var cancellation = new CancellationTokenSource();
+
+        var waiter = _theListener.RegisterListener<Message1>(envelope, cancellation.Token, 30.Seconds());
+        waiter.Status.ShouldBe(TaskStatus.WaitingForActivation);
+
+        await cancellation.CancelAsync();
+
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+        await Should.ThrowAsync<TimeoutException>(() => waiter);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+
+        _theListener.HasListener(envelope.Id).ShouldBeFalse();
+    }
 }

--- a/src/Wolverine/Runtime/Agents/AgentCommandDispatcher.cs
+++ b/src/Wolverine/Runtime/Agents/AgentCommandDispatcher.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Threading.Channels;
+using JasperFx.Core;
 using Microsoft.Extensions.Logging;
 
 namespace Wolverine.Runtime.Agents;
@@ -50,6 +51,19 @@ internal class AgentCommandDispatcher : IAsyncDisposable
     // out. Same semantics as NodeAgentController's pending-assignment ledger.
     private readonly ConcurrentDictionary<Uri, Guid> _inFlight = new();
 
+    // GH-3781: latched by DisposeAsync so a lane stops picking work up. Completing a channel writer does
+    // NOT discard what is already buffered -- ReadAsync keeps handing it out -- so without this, shutdown
+    // executed every command still queued for a node that had already gone, one reply window at a time.
+    private volatile bool _disposing;
+
+    /// <summary>
+    ///     How long <see cref="DisposeAsync" /> will wait on a single lane before giving up on it. A lane
+    ///     that honours the cancellation token unwinds in microseconds; this only exists so that a future
+    ///     non-cancellable await inside a command can never again wedge <c>IHost.StopAsync()</c>. Settable
+    ///     for tests.
+    /// </summary>
+    internal static TimeSpan LaneShutdownTimeout { get; set; } = 5.Seconds();
+
     internal AgentCommandDispatcher(
         Func<IAgentCommand, CancellationToken, Task<AgentCommands?>> executor,
         ILogger logger,
@@ -86,7 +100,7 @@ internal class AgentCommandDispatcher : IAsyncDisposable
     /// </summary>
     public void Enqueue(IAgentCommand command)
     {
-        if (_cancellation.IsCancellationRequested) return;
+        if (_cancellation.IsCancellationRequested || _disposing) return;
 
         var destination = command.DestinationNodeId ?? SharedLane;
 
@@ -169,7 +183,7 @@ internal class AgentCommandDispatcher : IAsyncDisposable
 
     private async Task runLaneAsync(Lane lane, Guid destination)
     {
-        while (!_cancellation.IsCancellationRequested)
+        while (!_cancellation.IsCancellationRequested && !_disposing)
         {
             IAgentCommand command;
             try
@@ -182,6 +196,15 @@ internal class AgentCommandDispatcher : IAsyncDisposable
             }
             catch (ChannelClosedException)
             {
+                return;
+            }
+
+            // GH-3781: completing the writer wakes this read with whatever is still buffered, so the
+            // shutdown latch has to be re-checked HERE and not only in the loop condition. Anything
+            // still queued when the node is going down is work for a cluster this node is leaving.
+            if (_disposing)
+            {
+                release(command, destination);
                 return;
             }
 
@@ -217,17 +240,36 @@ internal class AgentCommandDispatcher : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        foreach (var lane in _lanes.Values)
+        _disposing = true;
+
+        foreach (var pair in _lanes)
         {
-            lane.Queue.Writer.TryComplete();
+            pair.Value.Queue.Writer.TryComplete();
+
+            // Abandon whatever is still buffered rather than executing it on the way out. Each of these
+            // would otherwise cost its own reply window -- AgentBatchTimeouts.ReplyWindowFor(50) is 25.5
+            // minutes -- and they are aimed at a cluster this node is in the middle of leaving.
+            while (pair.Value.Queue.Reader.TryRead(out var abandoned))
+            {
+                release(abandoned, pair.Key);
+            }
         }
 
-        foreach (var lane in _lanes.Values)
+        foreach (var pair in _lanes)
         {
             try
             {
-                var worker = lane.Worker;
-                if (worker != null) await worker;
+                var worker = pair.Value.Worker;
+                if (worker != null) await worker.WaitAsync(LaneShutdownTimeout);
+            }
+            catch (TimeoutException)
+            {
+                // GH-3781: a lane still holding on past the budget must not hold IHost.StopAsync() with it.
+                // The whole wedge was one lane parked on a reply from a node that had already gone, with
+                // teardownAgentsAsync -- and therefore the node's own deregistration -- queued behind it.
+                _logger.LogWarning(
+                    "Agent command lane for node {NodeId} did not finish within {Timeout} during shutdown; abandoning it",
+                    pair.Key == SharedLane ? null : pair.Key, LaneShutdownTimeout);
             }
             catch (Exception)
             {

--- a/src/Wolverine/Runtime/RemoteInvocation/ReplyListener.cs
+++ b/src/Wolverine/Runtime/RemoteInvocation/ReplyListener.cs
@@ -16,15 +16,23 @@ internal class ReplyListener<T> : IReplyListener
         RequestId = envelope.Id;
         RequestType = envelope.MessageType;
         Parent = parent ?? throw new ArgumentNullException(nameof(parent));
-        cancellationToken.Register(onCancellation);
 
+        // GH-3781: every field onCancellation touches has to be set BEFORE either token is registered.
+        // CancellationTokenRegistration invokes the callback SYNCHRONOUSLY when the token is already
+        // cancelled, so registering the caller's token first meant onCancellation ran against a null
+        // _completion and its `_completion?.TrySetException(...)` silently did nothing -- the listener
+        // then sat out its whole reply window instead of failing fast. Callers pass an already-cancelled
+        // token on every shutdown path, and for a batched agent command that window is
+        // AgentBatchTimeouts.ReplyWindowFor(chunk) -- 25.5 minutes at the shipped AgentStartBatchSize of
+        // 50, paid inside IHost.StopAsync.
         _completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
-        _cancellation = new CancellationTokenSource(timeout);
-
-        _cancellation.Token.Register(onCancellation);
-
         _timeout = timeout;
         _resultTypes = resultTypes;
+
+        _cancellation = new CancellationTokenSource(timeout);
+        _cancellation.Token.Register(onCancellation);
+
+        cancellationToken.Register(onCancellation);
     }
 
     public string? RequestType { get; set; }

--- a/src/Wolverine/Runtime/RemoteInvocation/ResponseHandler.cs
+++ b/src/Wolverine/Runtime/RemoteInvocation/ResponseHandler.cs
@@ -38,6 +38,16 @@ internal class ReplyTracker : IReplyTracker
     {
         envelope.DeliverWithin = timeout; // Make the message expire so it doesn't cruft up the receivers
         var listener = new ReplyListener<T>(envelope, this, timeout, cancellationToken, _resultTypes);
+
+        // GH-3781: an already-cancelled token completes the listener inside its constructor, before it was
+        // ever in this dictionary for Unregister to remove. Registering it anyway would leave an entry
+        // nothing will ever take out again.
+        if (listener.Task.IsCompleted)
+        {
+            listener.SafeDispose();
+            return listener.Task;
+        }
+
         _listeners.AddOrUpdate(envelope.Id, listener, (_, _) => listener);
 
         _logger.LogDebug("Registering a reply listener for message type {MessageType} and conversation id {ConversationId} on Node {NodeNumber}", typeof(T).ToMessageTypeName(), envelope.ConversationId, AssignedNodeNumber);

--- a/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
@@ -309,9 +309,15 @@ public partial class WolverineRuntime : IAgentRuntime
         // that produces them, so a long wave of slow agent starts can never stop assignments being
         // re-evaluated and a lane wedged on a dead node cannot block a healthy one. Built before the loops
         // start so the very first health check has somewhere to put its commands.
+        // GH-3781: the AGENT cancellation, not the runtime-wide one -- matching NodeAgentController and
+        // DeferredAgentCommandRunner above. StopAsync cancels _agentCancellation first and only calls
+        // DurabilitySettings.Cancel() after teardownAgentsAsync has returned, so a dispatcher holding
+        // Cancellation had a live token at exactly the moment teardown was awaiting its lanes: nothing
+        // unwedged a lane mid-command against a peer that had already gone, and IHost.StopAsync sat there
+        // for a full agent-batch reply window per queued command.
         _dispatcher = new AgentCommandDispatcher(
             async (command, token) => await new MessageBus(this).InvokeAsync<AgentCommands>(command, token),
-            Logger, Cancellation);
+            Logger, _agentCancellation.Token);
 
         if (NodeController != null)
         {


### PR DESCRIPTION
Closes #3781.

`IHost.StopAsync()` on a Balanced-mode node holding a large agent load did not return. A dump of the
wedged process (`dotnet-dump collect` + `dumpasync --coalesce` — `dotnet-stack` cannot see this,
because the wedge is an await on the GC heap, not on a thread stack) put it here:

```
Task<AgentPresenceReport>                          <-- pending
 MessageRoute.sendAndAwaitReplyAsync<AgentPresenceReport>
  WolverineRuntime.InvokeAsync<AgentPresenceReport>
   AgentWorkConfirmation.AwaitCoreAsync             (the QueryAgentPresence poll)
    AssignAgents.ExecuteAsync
     AgentCommandDispatcher.runLaneAsync
      AgentCommandDispatcher.DisposeAsync           <-- awaiting the lane worker
       WolverineRuntime.teardownAgentsAsync
        WolverineRuntime.StopAsync -> Host.StopAsync
```

The leader was stuck in `AgentCommandDispatcher.DisposeAsync()`, waiting on a lane worker executing
an `AssignAgents` chunk aimed at a peer that had already shut down.

## It was never a deadlock

I let the wedged repro run out instead of killing it:

| | duration |
|---|---|
| `agent_reassignment_at_scale`, unfixed | **17m 17s**, passed |
| same, with the issue's `.WaitAsync(20.Seconds())` teardown control | 2m 18s |
| **same, on this branch** | **1m 57s** |

~15 minutes inside `StopAsync`, which is exactly `AgentBatchTimeouts.ReplyWindowFor(30)` =
`30s + 30 x 30s` = 930s. So it is **one full agent-batch reply window per queued command, per lane**
— **25.5 minutes** at the shipped `AgentStartBatchSize = 50` — not "hangs forever". Nobody had
waited it out. That distinction is the fix: there is no lock to break, there is a timeout being paid
in full during shutdown because the cancellation that should short-circuit it was dropped.

## Three compounding causes

### 1. `ReplyListener` silently dropped an already-cancelled token

```csharp
cancellationToken.Register(onCancellation);   // <-- _completion is still null here
_completion = new TaskCompletionSource<T>(...);
```

`CancellationTokenRegistration` invokes the callback **synchronously** when the token is already
cancelled, so `onCancellation`'s `_completion?.TrySetException(...)` fired against `null` and did
nothing. The listener then sat out its entire reply window.

**This one is not agent-specific.** Every shutdown path passes an already-cancelled token, so *any*
`InvokeAsync<T>` in Wolverine handed a cancelled token waited its whole window rather than failing
fast. Agent shutdown is just where that window is 25 minutes long. `ReplyTracker` additionally no
longer registers a listener that completed inside its own constructor — nothing would ever have
taken that entry back out.

### 2. The dispatcher held the wrong cancellation token

It was built with the runtime-wide `Cancellation`; `NodeAgentController` and
`DeferredAgentCommandRunner` both take `_agentCancellation.Token`. And `StopAsync` cancels
`_agentCancellation` at the top but only calls `DurabilitySettings.Cancel()` **after**
`teardownAgentsAsync` has returned — so the token that would end the lane loop was cancelled after
the thing awaiting it had already finished awaiting.

### 3. `DisposeAsync` drained its lanes instead of abandoning them

`Writer.TryComplete()` does not discard what is already buffered — `ReadAsync` keeps handing it out
— so shutdown executed every command still queued for a cluster the node was in the middle of
leaving, one reply window each. It now latches `_disposing`, empties the lane queues (releasing
their in-flight claims so a later leader can re-issue the work), and waits each lane against
`LaneShutdownTimeout`, logging the lane it gives up on. That last part is a backstop: the node's own
deregistration sits behind this in `teardownAgentsAsync`, and no future non-cancellable await inside
a command should be able to hold `IHost.StopAsync()` again.

## Tests

Five new tests, all **mutation-tested** — each was confirmed to fail with only its own fix reverted,
not merely observed to pass:

- `response_handling.a_token_that_is_already_cancelled_fails_the_listener_immediately` (+ the
  after-registration twin as the control)
- `per_destination_lane_dispatch.disposal_abandons_the_commands_still_queued`
- `per_destination_lane_dispatch.disposal_gives_up_on_a_lane_that_ignores_cancellation`

Both dispatcher tests are deliberately written so the unfixed code fails them **on an assertion
rather than by hanging** — the first version deadlocked the test runner under mutation, which for a
regression test whose subject is a shutdown that never returns rather defeats the point.

Verified: CoreTests 2230/2230 green; all three `SlowTests.Agents` scale classes green (5m10s);
`dotnet build wolverine.slnx -c Release` clean, 0 warnings.

## Deliberately not done

`WolverineRuntime.StopAsync(CancellationToken)` accepts the host's shutdown token and never uses it,
so `HostOptions.ShutdownTimeout` is inert for every slow teardown path. Threading it through looks
tempting but would cut off `stopAllAgentsAsync`, which GH-3604 deliberately built to use the whole
SIGTERM grace window for thousands of subscription shards — a 30s default would start SIGKILLing
mid-drain, which is the failure that change existed to fix. The bounded lane wait is the safer
backstop. Worth its own issue if we want `ShutdownTimeout` to mean something here.

## Follow-on for #3779

With this in, `agent_reassignment_at_scale.DisposeAsync` needs no timeout guard and `SlowTests` can
go into a CI job. Bounding the teardown in the test alone would have made CI green while hiding a
production shutdown wedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116vfBcKwcjWn8msM4ZjkuA
