### PR TITLE
Wait for the ASB emulator's management api, and pin the image

### DIFF
--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -227,28 +227,70 @@ partial class Build
         Log.Warning("LocalStack did not become ready after 60 seconds");
     }
 
+    /// <summary>
+    /// Waits for the Azure Service Bus emulator to be ready for <b>provisioning</b>, not merely accepting
+    /// sockets.
+    ///
+    /// <para>The emulator binds its AMQP listener on 5673 as soon as Kestrel starts, but its MANAGEMENT api
+    /// on 5300 — the one <c>ServiceBusAdministrationClient</c> uses to create queues and topics — answers
+    /// <c>503 "Service is warming up. Please try after some time."</c> for a good while after that. This
+    /// gate used to be a bare TCP connect to 5673, so it announced "up and ready!" while every provisioning
+    /// call still failed. The first test class to provision anything (<c>InlineComplianceFixture</c>) threw
+    /// out of <c>InitializeAsync</c>, which fails every test in its class — all 22 of them — and the
+    /// standing retry policy then reran each one alone in a fresh process, by which time the emulator was
+    /// warm. So the job reported GREEN while burning 22 of its 25-retry budget on every single run, and
+    /// those 22 were 85% of all retries in the entire repository.</para>
+    ///
+    /// <para>It went unnoticed for so long partly because it does not reproduce locally: docker-compose
+    /// pinned these images to <c>:latest</c>, and <c>servicebus-emulator:latest</c> moved from 2.0.0 to
+    /// 2.0.1, which warms up more slowly. CI pulls fresh every run and gets 2.0.1; a developer machine
+    /// keeps whatever it pulled months ago. The images are pinned now for exactly that reason.</para>
+    /// </summary>
     void WaitForAzureServiceBusEmulatorToBeReady()
     {
-        var attempt = 0;
-        while (attempt < 30)
+        using var http = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+
+        // Any management request will do. While warming, the emulator answers 503 to all of them; once warm
+        // it answers something else (200/400/401 depending on auth and api-version), so readiness does not
+        // depend on getting the ATOM api-version right here.
+        const string managementProbe = "http://localhost:5300/$Resources/topics";
+
+        var deadline = DateTime.UtcNow.AddMinutes(3);
+        var lastReason = "no attempt completed";
+
+        while (DateTime.UtcNow < deadline)
         {
             try
             {
-                using var tcpClient = new System.Net.Sockets.TcpClient();
-                tcpClient.Connect("localhost", 5673);
-                Log.Information("Azure Service Bus emulator is up and ready!");
-                return;
+                using (var tcpClient = new System.Net.Sockets.TcpClient())
+                {
+                    tcpClient.Connect("localhost", 5673);
+                }
+
+                var response = http.GetAsync(managementProbe).GetAwaiter().GetResult();
+                if (response.StatusCode != System.Net.HttpStatusCode.ServiceUnavailable)
+                {
+                    Log.Information(
+                        "Azure Service Bus emulator is up and ready for provisioning (management api answered {StatusCode})",
+                        (int)response.StatusCode);
+                    return;
+                }
+
+                lastReason = "the management api on 5300 is still warming up (503)";
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                // ignore connection errors
+                lastReason = e.Message;
             }
 
             Thread.Sleep(2000);
-            attempt++;
         }
 
-        Log.Warning("Azure Service Bus emulator did not become ready after 60 seconds");
+        // Deliberately fatal. This used to log a warning and carry on, so an emulator that never came up at
+        // all still fed the entire suite into a broker that could not serve it — and the resulting failures
+        // read as flaky tests rather than as infrastructure that never started.
+        throw new InvalidOperationException(
+            $"The Azure Service Bus emulator was not ready for provisioning after 3 minutes. Last attempt: {lastReason}");
     }
 
     /// <summary>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,8 +146,15 @@ services:
     volumes:
       - ./docker/oracle:/container-entrypoint-initdb.d
 
+  # These two were on :latest, which is how CI changed behaviour with no commit behind it:
+  # servicebus-emulator:latest moved 2.0.0 -> 2.0.1, 2.0.1 takes longer to warm its management api, and
+  # CIAzureServiceBus started failing a whole test class on every run (retried green, so nobody saw it).
+  # It was also unreproducible locally, because a developer machine keeps whatever it pulled months ago
+  # while CI pulls fresh every run. Pinned so the version moves only when someone moves it.
+  # azure-sql-edge publishes no concrete tag matching its :latest manifest, hence the digest -- it is
+  # byte-for-byte what CI has been running.
   asb-sql:
-    image: "mcr.microsoft.com/azure-sql-edge:latest"
+    image: "mcr.microsoft.com/azure-sql-edge@sha256:902628a8be89e35dfb7895ca31d602974c7bafde4d583a0d0873844feb1c42cf"
     environment:
       - "ACCEPT_EULA=Y"
       - "MSSQL_SA_PASSWORD=Strong_Passw0rd#2025"
@@ -155,7 +162,7 @@ services:
       sb-emulator:
 
   asb-emulator:
-    image: "mcr.microsoft.com/azure-messaging/servicebus-emulator:latest"
+    image: "mcr.microsoft.com/azure-messaging/servicebus-emulator:2.0.1"
     volumes:
       - ./docker/asb/Config.json:/ServiceBus_Emulator/ConfigFiles/Config.json
     ports:
@@ -172,7 +179,7 @@ services:
       sb-emulator:
 
   asb-sql-2:
-    image: "mcr.microsoft.com/azure-sql-edge:latest"
+    image: "mcr.microsoft.com/azure-sql-edge@sha256:902628a8be89e35dfb7895ca31d602974c7bafde4d583a0d0873844feb1c42cf"
     environment:
       - "ACCEPT_EULA=Y"
       - "MSSQL_SA_PASSWORD=Strong_Passw0rd#2025"
@@ -180,7 +187,7 @@ services:
       sb-emulator-2:
 
   asb-emulator-2:
-    image: "mcr.microsoft.com/azure-messaging/servicebus-emulator:latest"
+    image: "mcr.microsoft.com/azure-messaging/servicebus-emulator:2.0.1"
     volumes:
       - ./docker/asb/Config.json:/ServiceBus_Emulator/ConfigFiles/Config.json
     ports:


### PR DESCRIPTION
Follow-up from the #3781 work: while measuring CI to plan the flakiness burn-down, `CIAzureServiceBus` turned out to be **reporting green while burning 22 of its 25-retry budget every run** — 85% of all retries in the repository, all of them one class.

## It was never flaky

| commit | when | retries |
|---|---|---|
| `0bf49b4f8` | 8/1 21:50 | 1 |
| `3ad7986b6` | 8/1 21:53 | 1 |
| `1dfdd42a1` | 8/2 00:08 | **22** |
| `46dd558c2` | 8/2 12:59 | **22** |
| `141d94880` | 8/2 14:14 | **22** |
| `0d95ad0bf` | 8/2 15:11 | **22** |

22/22 identical, four runs running, always `InlineSendingAndReceivingCompliance`.

## The actual failure

Forcing retries off in CI surfaced it:

```
Azure.Messaging.ServiceBus.ServiceBusException :
  Service is warming up. Please try after some time.
Status: 503 (Service Unavailable)   SystemTracker: localhost:$Resources/topics
```

The emulator binds AMQP on **5673** as soon as Kestrel starts, but the **management api on 5300** — the one `ServiceBusAdministrationClient` uses to provision — answers 503 for another **~26 seconds**. `WaitForAzureServiceBusEmulatorToBeReady` was a bare `TcpClient.Connect("localhost", 5673)`, so it printed "up and ready!" in under a second while provisioning still failed.

`InlineComplianceFixture` threw out of `InitializeAsync` → xUnit fails **all 22 tests in the class** → Bobcat reran each alone in a fresh process → warm by then → green.

## No commit caused it

`servicebus-emulator:latest` moved **2.0.0 → 2.0.1**, and 2.0.1 warms more slowly:

| | digest |
|---|---|
| `:latest` today | `sha256:5a96d8…` = 2.0.1 |
| a machine that pulled months ago | `sha256:a00c96…` = 2.0.0 |

CI pulls fresh every run; developer machines don't. That explains the deterministic CI failure, the total non-reproduction locally, and the tidy-looking three-commit window with no plausible commit in it. I ran a two-arm CI probe reverting the only candidate in that window (GH-3774) — **no effect**, exactly as this explanation predicts.

## Changes

- **Gate polls the management endpoint** until it stops returning 503, and **throws** rather than warning and carrying on. The old warn-and-continue meant an emulator that never started still fed the whole suite into a broker that couldn't serve it, and the failures read as flaky tests. Budget 60s → 3 min.
- **Both images pinned.** Emulator → `2.0.1` (what `:latest` is today). `azure-sql-edge` → by digest, since no concrete tag matches its `:latest` manifest; byte-for-byte what CI already runs, so nothing changes except that it can't move.

## Verification

Pulled 2.0.1 locally and removed the containers for a genuine cold start — the first time this machine could reproduce CI's conditions. The gate waits 26s and gets a 200 where it previously returned instantly.

Expected on this PR: `CIAzureServiceBus` reports **0 retries** instead of 22, and drops ~3 minutes (22 fresh-process retries at ~8-9s each) off what is currently the longest job in the matrix.

## Not in this PR

`WaitForPubsubEmulatorToBeReady` and the Kafka gate are the same TCP-only, warn-and-continue shape, and `:latest` is used more widely in the compose file. Neither is currently costing retries, so they're a follow-up sweep rather than scope creep here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116vfBcKwcjWn8msM4ZjkuA