### PR TITLE
Sanitize Azure Service Bus entity names, and stop losing the reason (GH-3786)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,6 +36,9 @@ jobs:
           echo "### Version: $version" >> $GITHUB_STEP_SUMMARY
 
       - name: Test
+        # Names this run in the retry ledger written to the job summary (build/RetryLedger.cs).
+        env:
+          CI_JOB_NAME: dotnet-ci
         run: ./build.sh ci
 
       # The CI target now also runs MessageRoutingTests, which boots a real

--- a/.github/workflows/http.yml
+++ b/.github/workflows/http.yml
@@ -35,11 +35,17 @@ jobs:
       - name: Exercise the openapi command
         run: ./build.sh OpenApiCommand --framework net9.0
 
+      # CI_JOB_NAME names each run in the retry ledger written to the job summary
+      # (build/RetryLedger.cs).
       - name: Run HTTP Tests
+        env:
+          CI_JOB_NAME: CIHttp
         run: ./build.sh CIHttp --framework net9.0
 
       # Asp.Versioning tests are pinned to net10.0
       - name: Run HTTP Asp.Versioning Tests
+        env:
+          CI_JOB_NAME: CIHttpAspVersioning
         run: ./build.sh CIHttpAspVersioning
 
       - name: Stop containers

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -45,6 +45,9 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Run Tests
+        # Names this run in the retry ledger written to the job summary (build/RetryLedger.cs).
+        env:
+          CI_JOB_NAME: CISlowTests
         run: ./build.sh CISlowTests --framework net9.0
 
       - name: Stop containers

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Run Tests
         env:
           MEMORY_TELEMETRY: ${{ matrix.memory_telemetry }}
+          # Names this job in the retry ledger (build/RetryLedger.cs). GITHUB_JOB is the matrix's
+          # job id -- the same string, "test", for all thirty of these -- so it cannot be used.
+          CI_JOB_NAME: ${{ matrix.target }}
         run: |
           # The sampler has to live inside this step: when the runner is killed, later steps are
           # skipped, so only what has already been streamed to this step's log survives. See #3771.
@@ -111,6 +114,65 @@ jobs:
           echo "::endgroup::"
           free -m
 
+      # The per-job half of GH-3787. `if: always()` because a job that FAILED is exactly the one
+      # whose retry count is worth having -- and a job killed by the 20-minute cap uploads nothing
+      # at all, which the roll-up below reports as unmeasured rather than as clean.
+      - name: Upload retry ledger
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-ledger-${{ matrix.target }}
+          path: artifacts/test-ledger/
+          if-no-files-found: ignore
+          retention-days: 30
+
       - name: Stop containers
         if: always()
         run: docker compose down
+
+  # The run-level half of GH-3787. Aggregates every job's ledger into one table on the run summary
+  # and diffs it against the last `main` run that published one.
+  #
+  # This exists because the absolute retry count was never the signal: CIAzureServiceBus sat at 22 of
+  # 25 retries for four consecutive GREEN main runs, and the step from 1 to 22 between two adjacent
+  # runs was the thing worth seeing. Nowhere had that number ever been written down to compare
+  # against. Informational only -- it never fails the run.
+  flakiness:
+    name: Flakiness roll-up
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      # Fails when nothing matches, which is a legitimate state: every test job can have died before
+      # it wrote a ledger. The roll-up reports that as unmeasured, so it must survive to run.
+      - name: Download retry ledgers
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: test-ledger-*
+          path: ledgers
+          merge-multiple: false
+
+      - name: Roll up
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./build/flakiness-report.sh ledgers rollup
+
+      # This run's aggregate becomes the next run's baseline. Only from `main`: a PR's numbers are
+      # measured against main, never the other way round, or one noisy branch would move the bar.
+      - name: Publish this run's baseline
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-ledger-run
+          path: rollup/aggregate.json
+          if-no-files-found: warn
+          retention-days: 90

--- a/build/RetryLedger.cs
+++ b/build/RetryLedger.cs
@@ -1,0 +1,198 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Bobcat.Supervisor;
+using Nuke.Common.IO;
+using Serilog;
+
+// The retry ledger: what every supervised run reports about its OWN flakiness, where somebody will
+// actually see it. See GH-3787.
+//
+// The problem this exists for: CIAzureServiceBus was green for four consecutive main runs while
+// spending 22 of its 25-retry budget on every one of them — the same 22 tests failing on the first
+// attempt and passing alone in a fresh process, because the emulator wasn't warm yet. That was 85%
+// of all flakiness in the repository, and nothing in the GitHub UI distinguishes a job at 22/25
+// retries from one at 0/25. Both render as a green tick.
+//
+// Bobcat already logged all of it. Serilog warnings are not GitHub annotations, though — the
+// annotations endpoint for that job returns an empty list — so reading them meant opening the log
+// of a job that PASSED, which nobody has a reason to do. It was found by accident.
+//
+// Three outputs, deliberately:
+//
+//   - `$GITHUB_STEP_SUMMARY` markdown, so the numbers are on the run page without opening a log.
+//   - a `::warning` workflow command when the count is nonzero, so it reaches the Annotations panel.
+//   - a JSON ledger under artifacts/test-ledger/, uploaded per job and aggregated by the
+//     `flakiness` roll-up job in tests.yml, which diffs the run against the last completed main run.
+//
+// The third is the one that matters most. The absolute count mattered less than the CHANGE in it:
+// the step from 1 to 22 between two adjacent main runs was the real signal, and no baseline existed
+// anywhere to notice it against.
+//
+// Deliberately NOT here: failing the build past a retry threshold. A suite legitimately sitting at
+// 3 today would be one bad day away from a red main, and the value is in visibility, not a cliff.
+partial class Build
+{
+    /// <summary>
+    /// Per-project ledger files, one per project+framework, uploaded as a CI artifact. Under
+    /// artifacts/ because <see cref="Clean"/> empties it at the start of every run, so a ledger can
+    /// never be a stale leftover from a previous invocation.
+    /// </summary>
+    static AbsolutePath LedgerDirectory => RootDirectory / "artifacts" / "test-ledger";
+
+    /// <summary>
+    /// The CI job this run belongs to (e.g. CIAzureServiceBus). Set by tests.yml from the matrix
+    /// target; the Nuke target name isn't reachable from here and GITHUB_JOB reports the matrix's
+    /// job id ("test"), which is the same string for all thirty jobs.
+    /// </summary>
+    static string ledgerJobName => Environment.GetEnvironmentVariable("CI_JOB_NAME") is { Length: > 0 } name
+        ? name
+        : "local";
+
+    void recordLedger(string projectName, string framework, SupervisorResults results)
+    {
+        var entry = new LedgerEntry
+        {
+            Job = ledgerJobName,
+            Project = projectName,
+            Framework = framework,
+            Tests = results.Tests.Count,
+            CleanPasses = results.CleanPasses.Count,
+            PassedOnRetry = results.PassedOnRetry.Count,
+            RetriesPerformed = results.RetriesPerformed,
+            Failed = results.Failed.Count,
+            Indeterminate = results.Indeterminate.Count,
+            WorkerFaults = results.WorkerFaults.Count,
+            AbortReason = results.AbortReason,
+            // Bounded by the budget itself: the point of the list is to name the suspects, not to
+            // reproduce the log.
+            FlakyTests = results.PassedOnRetry.Select(x => x.DisplayName).Take(MaxRetriesPerRun).ToArray()
+        };
+
+        writeLedgerFile(entry);
+        appendStepSummary(entry);
+        annotate(entry);
+    }
+
+    static void writeLedgerFile(LedgerEntry entry)
+    {
+        try
+        {
+            LedgerDirectory.CreateDirectory();
+
+            // One file per project+framework: a target can run several projects, and a project can
+            // run under several TFMs, so neither alone is a unique key.
+            var fileName = $"{entry.Job}.{entry.Project}.{entry.Framework}.json";
+            var path = LedgerDirectory / fileName;
+
+            File.WriteAllText(path, JsonSerializer.Serialize(entry, LedgerJson));
+        }
+        catch (Exception e)
+        {
+            // Reporting about the tests must never be what fails the tests.
+            Log.Warning(e, "Could not write the retry ledger for {Project}", entry.Project);
+        }
+    }
+
+    /// <summary>
+    /// Appends this project's row to the job summary. Every supervised project in the job appends
+    /// to the same file, so the header is written once, on the first append.
+    /// </summary>
+    static void appendStepSummary(LedgerEntry entry)
+    {
+        var summaryFile = Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
+        if (string.IsNullOrEmpty(summaryFile)) return;
+
+        try
+        {
+            var builder = new StringBuilder();
+
+            if (new FileInfo(summaryFile) is { Exists: false } or { Length: 0 })
+            {
+                builder.AppendLine($"### Retry ledger — {entry.Job}");
+                builder.AppendLine();
+                builder.AppendLine("| project | tests | clean | passed on retry | retries | failed | indeterminate |");
+                builder.AppendLine("|---|--:|--:|--:|--:|--:|--:|");
+            }
+
+            builder.AppendLine(
+                $"| {entry.Project} ({entry.Framework}) | {entry.Tests} | {entry.CleanPasses} | " +
+                $"{mark(entry.PassedOnRetry)} | {mark(entry.RetriesPerformed)} | {mark(entry.Failed)} | " +
+                $"{mark(entry.Indeterminate)} |");
+
+            if (entry.AbortReason is not null)
+            {
+                builder.AppendLine();
+                builder.AppendLine($"> **ABORTED** — {entry.AbortReason}");
+            }
+
+            if (entry.FlakyTests.Length > 0)
+            {
+                builder.AppendLine();
+                builder.AppendLine("<details><summary>Tests that only passed on a retry</summary>");
+                builder.AppendLine();
+                foreach (var test in entry.FlakyTests) builder.AppendLine($"- `{test}`");
+                builder.AppendLine();
+                builder.AppendLine("</details>");
+            }
+
+            builder.AppendLine();
+
+            File.AppendAllText(summaryFile, builder.ToString());
+        }
+        catch (Exception e)
+        {
+            Log.Warning(e, "Could not append to $GITHUB_STEP_SUMMARY for {Project}", entry.Project);
+        }
+
+        // Zero reads as zero; anything else is bolded, because the eye is meant to stop on it.
+        static string mark(int count) => count == 0 ? "0" : $"**{count}**";
+    }
+
+    /// <summary>
+    /// Emits the retry count as a GitHub annotation. Serilog's warnings are not annotations — the
+    /// annotations endpoint came back empty for the run that was burning 22 retries — so this has
+    /// to be the literal workflow command on stdout.
+    /// </summary>
+    static void annotate(LedgerEntry entry)
+    {
+        if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != "true") return;
+        if (entry.RetriesPerformed == 0) return;
+
+        var suspects = entry.FlakyTests.Length > 0
+            ? $" First flaky test: {entry.FlakyTests[0]}."
+            : "";
+
+        // Workflow commands are newline-delimited, so the message has to be a single line.
+        Console.WriteLine(
+            $"::warning title={entry.Job}: {entry.RetriesPerformed} retries::" +
+            $"{entry.Project} ({entry.Framework}) spent {entry.RetriesPerformed} of its " +
+            $"{MaxRetriesPerRun}-retry budget; " +
+            $"{entry.PassedOnRetry} test(s) passed only on a retry.{suspects}");
+    }
+
+    static readonly JsonSerializerOptions LedgerJson = new() { WriteIndented = true };
+
+    /// <summary>
+    /// One supervised project run, as the roll-up job consumes it. Property names are the contract
+    /// with build/flakiness-report.sh — rename one and the jq there goes silently null, which is why
+    /// that script asserts on the fields it reads.
+    /// </summary>
+    class LedgerEntry
+    {
+        public string Job { get; init; }
+        public string Project { get; init; }
+        public string Framework { get; init; }
+        public int Tests { get; init; }
+        public int CleanPasses { get; init; }
+        public int PassedOnRetry { get; init; }
+        public int RetriesPerformed { get; init; }
+        public int Failed { get; init; }
+        public int Indeterminate { get; init; }
+        public int WorkerFaults { get; init; }
+        public string AbortReason { get; init; }
+        public string[] FlakyTests { get; init; } = [];
+    }
+}

--- a/build/SupervisedTests.cs
+++ b/build/SupervisedTests.cs
@@ -44,6 +44,13 @@ partial class Build
     [Parameter] readonly bool DisableTestRetry;
 
     /// <summary>
+    /// Retries a whole project run may spend before every remaining failure is reported as failed
+    /// WITHOUT being retried at all. Read the retry ledger (see RetryLedger.cs) against this number:
+    /// a run at the cap is not "N flaky tests", it is N flaky tests plus an unknown tail.
+    /// </summary>
+    const int MaxRetriesPerRun = 25;
+
+    /// <summary>
     /// The standing exclusion every CI target applies: tests tagged [Trait("Category", "Flaky")]
     /// do not run. Same semantics as the old vstest `Category!=Flaky` filter.
     /// </summary>
@@ -139,7 +146,7 @@ partial class Build
             TestFilter = shardFilter is null ? NotFlaky : t => NotFlaky(t) && shardFilter(t),
             RetryBudget = DisableTestRetry
                 ? RetryBudget.None
-                : new RetryBudget { MaxAttemptsPerTest = 3, MaxRetriesPerRun = 25 },
+                : new RetryBudget { MaxAttemptsPerTest = 3, MaxRetriesPerRun = MaxRetriesPerRun },
             // The policy below only ever asks for fresh-process retries, so idle lanes are
             // released before they run: without this, workers+1 test hosts sit resident at once,
             // which OOM-killed 16GB GitHub runners twice — both times during a retry.
@@ -151,7 +158,7 @@ partial class Build
 
         var results = supervisor.Run().GetAwaiter().GetResult();
 
-        return report(projectName, results, shardFilter is not null);
+        return report(projectName, framework, results, shardFilter is not null);
     }
 
     /// <summary>
@@ -175,8 +182,10 @@ partial class Build
         }
     }
 
-    bool report(string projectName, SupervisorResults results, bool hadShardFilter)
+    bool report(string projectName, string framework, SupervisorResults results, bool hadShardFilter)
     {
+        recordLedger(projectName, framework, results);
+
         if (results.AbortReason is not null)
         {
             Log.Error("=== {Project}: run ABORTED — {Reason} ===", projectName, results.AbortReason);

--- a/build/flakiness-report.sh
+++ b/build/flakiness-report.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# The run-level half of the retry ledger (GH-3787). Each test job writes its own ledger JSON (see
+# build/RetryLedger.cs) and uploads it; this aggregates all of them into one table on the run
+# summary and — the part that actually matters — diffs the run against the last `main` run that
+# published a ledger.
+#
+# The ASB story this exists for: 22 of 25 retries burned on four consecutive green main runs. The
+# absolute 22 was not the signal. The step from 1 to 22 between two adjacent runs was, and there was
+# nowhere that number had ever been written down to compare against.
+#
+# Informational by design: this script never fails the run. A retry count is something a human
+# explains, not a gate — a suite legitimately sitting at 3 would otherwise be one bad day from a red
+# main.
+#
+# Usage: flakiness-report.sh <ledger-dir> <output-dir>
+#   ledger-dir  contains the downloaded per-job artifacts (searched recursively for *.json)
+#   output-dir  receives aggregate.json, uploaded as this run's baseline for the next one
+#
+# Expects in the environment: GH_TOKEN, GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_STEP_SUMMARY.
+
+set -uo pipefail
+
+ledger_dir="${1:?usage: flakiness-report.sh <ledger-dir> <output-dir>}"
+output_dir="${2:?usage: flakiness-report.sh <ledger-dir> <output-dir>}"
+
+repo="${GITHUB_REPOSITORY:-JasperFx/wolverine}"
+summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+mkdir -p "${output_dir}"
+
+# ── This run ────────────────────────────────────────────────────────────────
+
+# One object per project run. Several projects can report under one job (CIAWS, CIMQTT), so the job
+# rows are a group-by rather than a rename.
+ledger_files=$(find "${ledger_dir}" -name '*.json' -type f 2>/dev/null | sort)
+if [ -n "${ledger_files}" ]; then
+  # Ledger file names are composed from job/project/framework — no spaces to quote around.
+  # shellcheck disable=SC2086
+  jq -s '.' ${ledger_files} > "${output_dir}/entries.json" || echo '[]' > "${output_dir}/entries.json"
+else
+  echo '[]' > "${output_dir}/entries.json"
+fi
+
+# The field names here are the contract with LedgerEntry in build/RetryLedger.cs. Assert rather than
+# let jq quietly resolve a renamed field to null and report a comforting zero.
+if [ "$(jq 'length' "${output_dir}/entries.json")" != "0" ]; then
+  if [ "$(jq '[.[] | select(.Job == null or .RetriesPerformed == null)] | length' "${output_dir}/entries.json")" != "0" ]; then
+    echo "::error::Ledger entries are missing Job/RetriesPerformed — build/RetryLedger.cs and this script have drifted."
+    jq '.[0]' "${output_dir}/entries.json"
+    exit 0
+  fi
+fi
+
+jq '[group_by(.Job)[] | {
+      job:           .[0].Job,
+      tests:         (map(.Tests)            | add),
+      retries:       (map(.RetriesPerformed) | add),
+      passedOnRetry: (map(.PassedOnRetry)    | add),
+      failed:        (map(.Failed)           | add),
+      indeterminate: (map(.Indeterminate)    | add),
+      flakyTests:    (map(.FlakyTests[])     | unique)
+    }] | sort_by(-.retries, .job)' \
+  "${output_dir}/entries.json" > "${output_dir}/aggregate.json"
+
+total_retries=$(jq '[.[] | .retries] | add // 0' "${output_dir}/aggregate.json")
+total_tests=$(jq '[.[] | .tests] | add // 0' "${output_dir}/aggregate.json")
+reporting_jobs=$(jq 'length' "${output_dir}/aggregate.json")
+
+# ── The baseline ────────────────────────────────────────────────────────────
+#
+# The newest completed main run that actually published an aggregate. Walking a few back rather than
+# taking the immediately previous one: a cancelled or infrastructure-failed run publishes nothing,
+# and "no baseline" is a worse answer than "a slightly older baseline".
+
+baseline_file=""
+baseline_run=""
+
+# An explicit baseline, for exercising the diff path outside of CI.
+if [ -n "${FLAKINESS_BASELINE_FILE:-}" ] && [ -f "${FLAKINESS_BASELINE_FILE}" ]; then
+  baseline_file="${FLAKINESS_BASELINE_FILE}"
+  baseline_run="local"
+else
+  candidates=$(gh api "repos/${repo}/actions/workflows/tests.yml/runs?branch=main&status=completed&per_page=10" \
+    --jq '.workflow_runs[].id' 2>/dev/null | grep -v "^${GITHUB_RUN_ID:-none}$" | head -n 6)
+
+  for candidate in ${candidates}; do
+    if gh run download "${candidate}" --repo "${repo}" -n test-ledger-run -D "${output_dir}/baseline" >/dev/null 2>&1 \
+       && [ -f "${output_dir}/baseline/aggregate.json" ]; then
+      baseline_file="${output_dir}/baseline/aggregate.json"
+      baseline_run="${candidate}"
+      break
+    fi
+    rm -rf "${output_dir}/baseline"
+  done
+fi
+
+baseline_retries=""
+if [ -n "${baseline_file}" ]; then
+  baseline_retries=$(jq '[.[] | .retries] | add // 0' "${baseline_file}")
+fi
+
+# ── Jobs that reported nothing ──────────────────────────────────────────────
+#
+# A job killed by the 20-minute cap produces no ledger at all — Bobcat prints its summary only at the
+# end, so a cap-killed job reports not even a partial count. That silence is itself a finding, and
+# without this it would read as "no flakiness".
+
+missing=""
+# gh api prints the error BODY to stdout on a failed request, so the exit code has to gate this —
+# otherwise a 404 lands in the report as the name of a job that "reported no ledger".
+if gh api "repos/${repo}/actions/runs/${GITHUB_RUN_ID:-0}/jobs?per_page=100" --paginate \
+     --jq '.jobs[] | select(.conclusion != "skipped" and .conclusion != null) | select(.name | startswith("CI")) | .name' \
+     > "${output_dir}/jobs.txt" 2>/dev/null
+then
+  missing=$(sort -u "${output_dir}/jobs.txt" | while read -r job; do
+    if [ "$(jq --arg j "${job}" '[.[] | select(.job == $j)] | length' "${output_dir}/aggregate.json")" = "0" ]; then
+      echo "${job}"
+    fi
+  done)
+fi
+
+# ── The report ──────────────────────────────────────────────────────────────
+
+delta_for() {
+  local current="$1" previous="$2"
+  if [ -z "${previous}" ]; then echo "—"; return; fi
+  local d=$((current - previous))
+  if   [ "${d}" -gt 0 ]; then echo "**+${d}**"
+  elif [ "${d}" -lt 0 ]; then echo "${d}"
+  else echo "·"; fi
+}
+
+{
+  echo "## Flakiness roll-up"
+  echo
+
+  if [ -n "${baseline_retries}" ]; then
+    if [ "${baseline_run}" = "local" ]; then
+      described="a locally supplied baseline"
+    else
+      described="last \`main\` run [#${baseline_run}](https://github.com/${repo}/actions/runs/${baseline_run})"
+    fi
+    echo "**${total_retries} retries** across ${reporting_jobs} reporting job(s), ${total_tests} tests."
+    echo "Baseline — ${described}: **${baseline_retries}**, $(delta_for "${total_retries}" "${baseline_retries}")."
+  else
+    echo "**${total_retries} retries** across ${reporting_jobs} reporting job(s), ${total_tests} tests."
+    echo "No baseline found in the last few completed \`main\` runs — reporting absolute numbers only."
+  fi
+  echo
+
+  echo "A retry means a test failed and then passed alone in a fresh process. Zero is the only number"
+  echo "that needs no explanation; a count that *moved* is the one worth chasing."
+  echo
+
+  if [ -n "${missing}" ]; then
+    echo "> **Reported no ledger at all:** $(echo "${missing}" | paste -sd', ' -)"
+    echo ">"
+    echo "> Bobcat prints its summary only at the end, so a job killed by the 20-minute cap reports"
+    echo "> nothing — not even a partial count. Treat this as unmeasured, not as clean."
+    echo
+  fi
+
+  if [ "${total_retries}" = "0" ] && [ "$(jq '[.[] | select(.failed > 0 or .indeterminate > 0)] | length' "${output_dir}/aggregate.json")" = "0" ]; then
+    echo "No job spent a retry."
+  else
+    echo "| job | retries | baseline | Δ | passed on retry | failed | indeterminate |"
+    echo "|---|--:|--:|:--|--:|--:|--:|"
+
+    jq -r '.[] | select(.retries > 0 or .failed > 0 or .indeterminate > 0)
+           | [.job, .retries, .passedOnRetry, .failed, .indeterminate] | @tsv' \
+      "${output_dir}/aggregate.json" \
+    | while IFS=$'\t' read -r job retries passed_on_retry failed indeterminate; do
+        was=""
+        if [ -n "${baseline_file}" ]; then
+          was=$(jq -r --arg j "${job}" '[.[] | select(.job == $j) | .retries] | first // ""' "${baseline_file}")
+        fi
+        echo "| ${job} | ${retries} | ${was:-—} | $(delta_for "${retries}" "${was}") | ${passed_on_retry} | ${failed} | ${indeterminate} |"
+      done
+  fi
+  echo
+
+  if [ "${total_retries}" != "0" ]; then
+    echo "<details><summary>Tests that only passed on a retry</summary>"
+    echo
+    jq -r '.[] | select(.retries > 0) | "- **\(.job)**", (.flakyTests[] | "  - `\(.)`")' \
+      "${output_dir}/aggregate.json"
+    echo
+    echo "</details>"
+    echo
+  fi
+} >> "${summary}"
+
+# Also on stdout, so the roll-up is greppable from `gh run view --log` the way the per-job lines are.
+echo "=== flakiness roll-up: ${total_retries} retries, baseline ${baseline_retries:-none} (run ${baseline_run:-none}) ==="
+
+exit 0

--- a/build/flakiness-report.sh
+++ b/build/flakiness-report.sh
@@ -106,6 +106,13 @@ fi
 # end, so a cap-killed job reports not even a partial count. That silence is itself a finding, and
 # without this it would read as "no flakiness".
 
+#
+# Jobs that legitimately produce nothing are listed here rather than reported every run: a section
+# that cries wolf on every single run is how a signal channel gets ignored, which is the failure
+# this whole report exists to undo. CIAotSmoke builds and RUNS two AOT smoke apps -- it invokes no
+# test project at all, so it has no retry budget to spend.
+NO_LEDGER_EXPECTED="CIAotSmoke"
+
 missing=""
 # gh api prints the error BODY to stdout on a failed request, so the exit code has to gate this —
 # otherwise a 404 lands in the report as the name of a job that "reported no ledger".
@@ -114,6 +121,9 @@ if gh api "repos/${repo}/actions/runs/${GITHUB_RUN_ID:-0}/jobs?per_page=100" --p
      > "${output_dir}/jobs.txt" 2>/dev/null
 then
   missing=$(sort -u "${output_dir}/jobs.txt" | while read -r job; do
+    # [[ ]] rather than case: bash 3.2 (what macOS ships) mis-parses a case pattern's ")" as the
+    # end of the enclosing $( ) substitution.
+    if [[ " ${NO_LEDGER_EXPECTED} " == *" ${job} "* ]]; then continue; fi
     if [ "$(jq --arg j "${job}" '[.[] | select(.job == $j)] | length' "${output_dir}/aggregate.json")" = "0" ]; then
       echo "${job}"
     fi
@@ -154,7 +164,8 @@ delta_for() {
   echo
 
   if [ -n "${missing}" ]; then
-    echo "> **Reported no ledger at all:** $(echo "${missing}" | paste -sd', ' -)"
+    # `paste -sd', '` would cycle the two delimiters and yield "a,b c,d" -- one delimiter, then sed.
+    echo "> **Reported no ledger at all:** $(echo "${missing}" | paste -sd, - | sed 's/,/, /g')"
     echo ">"
     echo "> Bobcat prints its summary only at the end, so a job killed by the 20-minute cap reports"
     echo "> nothing — not even a partial count. Treat this as unmeasured, not as clean."

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/AzureServiceBusTransportTests.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/AzureServiceBusTransportTests.cs
@@ -112,4 +112,46 @@ public class AzureServiceBusTransportTests
         endpoints.ShouldContain(x => x.QueueName == "two");
         endpoints.ShouldContain(x => x.QueueName == "three");
     }
+
+    // GH-3786. Azure Service Bus rejects an entity name containing anything outside letters, numbers,
+    // '.', '-' and '_' with a 400 at PROVISIONING time, which BrokerTransport then retries twenty
+    // times over two minutes before reporting only "Unable to initialize the Broker asb in time".
+    // Conventional routing derives its names from the message type, so a handler taking an array --
+    // Handle(BatchedItem[] items) -- produced "...batcheditem[]" and took down broker startup for
+    // every conventionally-routed host in the assembly.
+    [Theory]
+    // The array type that actually caused it
+    [InlineData("Wolverine.Bugs.BatchedItem[]", "wolverine.bugs.batcheditem__")]
+    // Generic and nested message types have the same shape
+    [InlineData("Wolverine.Envelope`1[System.String]", "wolverine.envelope_1_system.string_")]
+    [InlineData("Outer+Inner", "outer_inner")]
+    [InlineData("has spaces", "has_spaces")]
+    public void sanitize_illegal_entity_characters(string identifier, string expected)
+    {
+        new AzureServiceBusTransport().SanitizeIdentifier(identifier).ShouldBe(expected);
+    }
+
+    // Substituting rather than stripping is what keeps distinct type names distinct.
+    [Fact]
+    public void sanitizing_does_not_collide_an_array_type_with_its_element_type()
+    {
+        var transport = new AzureServiceBusTransport();
+
+        transport.SanitizeIdentifier("BatchedItem[]")
+            .ShouldNotBe(transport.SanitizeIdentifier("BatchedItem"));
+    }
+
+    // No name that works today may change: a name containing an illegal character could never have
+    // been provisioned in the first place, so this must stay a pure no-op for legal names.
+    [Theory]
+    [InlineData("Wolverine.Bugs.BatchedItem", "wolverine.bugs.batcheditem")]
+    [InlineData("two-dead-letter-queue", "two-dead-letter-queue")]
+    [InlineData("wolverine.retries.MyService", "wolverine.retries.myservice")]
+    // '/' is kept: Azure Service Bus allows hierarchical entity paths, and an application already
+    // addressing "orders/priority" has to keep addressing the same entity.
+    [InlineData("orders/priority", "orders/priority")]
+    public void legal_identifiers_are_only_lowercased(string identifier, string expected)
+    {
+        new AzureServiceBusTransport().SanitizeIdentifier(identifier).ShouldBe(expected);
+    }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Bugs/Bug_1933_multi_tenant_conventional_routing.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Bugs/Bug_1933_multi_tenant_conventional_routing.cs
@@ -16,9 +16,11 @@ public static class Bug1933MessageHandler
     }
 }
 
-// GH-3786: NOT flaky -- 2 of 2 fail, 7.7m, deterministically, on a clean emulator (2.0.1) with the
-// GH-3783 readiness gate. BrokerInitializationException "Unable to initialize the Broker asb in
-// time". Re-tagged with the numbers rather than left bare; untag when GH-3786 is fixed.
+// NOT flaky. Re-measured 2026-08-02 after the entity-name sanitizing fix: now 1 of 2, down from 2 of
+// 2, and 5.5m for the class. The broker starts fine now; the survivor is
+// should_receive_message_when_published_without_tenant_id, which fails as a TrackedSession timeout
+// after 4m28s -- the message is Sent and never Received. That is real multi-tenant routing
+// behaviour, not provisioning. Needs its own issue.
 [Trait("Category", "Flaky")]
 public class Bug_1933_multi_tenant_conventional_routing : IAsyncLifetime
 {

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Bugs/Bug_2307_batching_with_conventional_routing.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Bugs/Bug_2307_batching_with_conventional_routing.cs
@@ -10,9 +10,16 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests.Bugs;
 
-// GH-3786: NOT flaky -- 1 of 1 fails, 0.1m -- NOT the 2m broker timeout, may differ, deterministically, on a clean emulator (2.0.1) with the
-// GH-3783 readiness gate. BrokerInitializationException "Unable to initialize the Broker asb in
-// time". Re-tagged with the numbers rather than left bare; untag when GH-3786 is fixed.
+// NOT flaky. Re-measured 2026-08-02 after the entity-name sanitizing fix: 1 of 1 still fails, but in
+// 5 SECONDS on a plain assertion instead of the 2-minute broker timeout, so the real defect is now
+// readable:
+//
+//   Expected a listener endpoint for queue 'wolverine.azureservicebus.tests.bugs.batcheditem'
+//   but found only: Wolverine.AzureServiceBus.Tests.Bugs.BatchedItem, AzureServiceBusResponses, ...
+//
+// The listener IS created for the batch element type (that much of GH-2307 works) -- its
+// EndpointName is just the raw type name rather than the sanitized queue name. A naming bug in the
+// GH-2307 fix, not a routing or provisioning failure. Needs its own issue.
 [Trait("Category", "Flaky")]
 public class Bug_2307_batching_with_conventional_routing : IAsyncLifetime
 {

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/Broadcasting/end_to_end_with_conventional_routing.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/Broadcasting/end_to_end_with_conventional_routing.cs
@@ -7,10 +7,6 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting.Broadcasting;
 
-// GH-3786: NOT flaky -- 1 of 1 fails, 3.0m, deterministically, on a clean emulator (2.0.1) with the
-// GH-3783 readiness gate. BrokerInitializationException "Unable to initialize the Broker asb in
-// time". Re-tagged with the numbers rather than left bare; untag when GH-3786 is fixed.
-[Trait("Category", "Flaky")]
 public class end_to_end_with_conventional_routing : IAsyncLifetime
 {
     private IHost _receiver = null!;

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/ConventionalRoutingContext.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/ConventionalRoutingContext.cs
@@ -31,13 +31,13 @@ public abstract class ConventionalRoutingContext : IAsyncLifetime
     /// a test's own IncludeTypes call and make conventional_listener_discovery.include_types pass
     /// whether the include filter works or not.
     /// </summary>
-    private static void narrowToTypesUnderTest(AzureServiceBusMessageRoutingConvention convention)
+    internal static void NarrowToTypesUnderTest(AzureServiceBusMessageRoutingConvention convention)
         => convention.ExcludeTypes(isNotUnderTest);
 
     internal async Task<IWolverineRuntime> theRuntime()
     {
         _host ??= await WolverineHost.ForAsync(opts =>
-            opts.UseAzureServiceBusTesting().UseConventionalRouting(narrowToTypesUnderTest).AutoProvision()
+            opts.UseAzureServiceBusTesting().UseConventionalRouting(NarrowToTypesUnderTest).AutoProvision()
                 .AutoPurgeOnStartup());
 
         return _host.Services.GetRequiredService<IWolverineRuntime>();
@@ -62,7 +62,7 @@ public abstract class ConventionalRoutingContext : IAsyncLifetime
             {
                 opts.UseAzureServiceBusTesting().UseConventionalRouting(convention =>
                 {
-                    narrowToTypesUnderTest(convention);
+                    NarrowToTypesUnderTest(convention);
                     configure(convention);
                 }).AutoProvision().AutoPurgeOnStartup();
             }).StartAsync();

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/ConventionalRoutingContext.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/ConventionalRoutingContext.cs
@@ -12,10 +12,33 @@ public abstract class ConventionalRoutingContext : IAsyncLifetime
 {
     private IHost _host = null!;
 
+    /// <summary>
+    /// The only message types these tests actually assert on. Unrestricted conventional routing
+    /// discovers every handled message type in this assembly and asks Azure Service Bus for 28
+    /// queues per host — and the emulator caps a namespace at 50, so two test classes in one process
+    /// hit "SubCode=40300. The maximum number of resources of type Queue has been reached. Actual: 50,
+    /// Max allowed: 50" and everything after that reads as a broker-initialization timeout. It is
+    /// also most of the wall clock: provisioning and purging 28 queues per test ran these classes at
+    /// roughly 100 seconds per test. See GH-3786.
+    /// </summary>
+    private static bool isNotUnderTest(Type type)
+        => type != typeof(RoutedMessage) && type != typeof(Routed2Message) && type != typeof(PublishedMessage);
+
+    /// <summary>
+    /// Narrows the convention to <see cref="isNotUnderTest"/>. Deliberately an EXCLUDE rather than an
+    /// include: excludes are ANDed together (CompositeFilter.Matches requires
+    /// Excludes.DoesNotMatchAny) whereas includes are ORed, so an include here would silently widen
+    /// a test's own IncludeTypes call and make conventional_listener_discovery.include_types pass
+    /// whether the include filter works or not.
+    /// </summary>
+    private static void narrowToTypesUnderTest(AzureServiceBusMessageRoutingConvention convention)
+        => convention.ExcludeTypes(isNotUnderTest);
+
     internal async Task<IWolverineRuntime> theRuntime()
     {
         _host ??= await WolverineHost.ForAsync(opts =>
-            opts.UseAzureServiceBusTesting().UseConventionalRouting().AutoProvision().AutoPurgeOnStartup());
+            opts.UseAzureServiceBusTesting().UseConventionalRouting(narrowToTypesUnderTest).AutoProvision()
+                .AutoPurgeOnStartup());
 
         return _host.Services.GetRequiredService<IWolverineRuntime>();
     }
@@ -37,8 +60,11 @@ public abstract class ConventionalRoutingContext : IAsyncLifetime
         _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.UseAzureServiceBusTesting().UseConventionalRouting(configure).AutoProvision()
-                    .AutoPurgeOnStartup();
+                opts.UseAzureServiceBusTesting().UseConventionalRouting(convention =>
+                {
+                    narrowToTypesUnderTest(convention);
+                    configure(convention);
+                }).AutoProvision().AutoPurgeOnStartup();
             }).StartAsync();
     }
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/ConventionalRoutingFixture.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/ConventionalRoutingFixture.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Routing;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
+
+/// <summary>
+/// One conventionally-routed host, shared by every test in a class via IClassFixture.
+///
+/// Most of these classes assert several things about the SAME host — four facts about one discovered
+/// listener, three about one discovered sender. Building that host per test meant starting Wolverine,
+/// provisioning queues and purging the emulator once per assertion, which was most of what restoring
+/// these tests cost CIAzureServiceBus. Sharing is safe here precisely because the assertions only
+/// read runtime state; classes whose tests each need a DIFFERENT convention (see
+/// <see cref="conventional_listener_discovery"/>) still build a host per test through
+/// <see cref="ConventionalRoutingContext"/>. See GH-3786.
+/// </summary>
+public abstract class ConventionalRoutingFixture : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    /// <summary>
+    /// Applied on top of <see cref="ConventionalRoutingContext.NarrowToTypesUnderTest"/>. The default
+    /// is the plain convention with no overrides.
+    /// </summary>
+    protected virtual void configure(AzureServiceBusMessageRoutingConvention convention)
+    {
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAzureServiceBusTesting().UseConventionalRouting(convention =>
+                {
+                    ConventionalRoutingContext.NarrowToTypesUnderTest(convention);
+                    configure(convention);
+                }).AutoProvision().AutoPurgeOnStartup();
+            }).StartAsync();
+    }
+
+    // Hands the next class a clean namespace: the emulator caps one at 50 queues and reports the
+    // overflow as a broker-initialization timeout that never mentions a cap.
+    public async ValueTask DisposeAsync()
+    {
+        if (_host != null) await _host.StopAsync();
+        _host?.Dispose();
+        await AzureServiceBusTesting.DeleteAllEmulatorObjectsAsync();
+    }
+
+    internal IWolverineRuntime theRuntime() => _host.Services.GetRequiredService<IWolverineRuntime>();
+
+    internal IMessageRouter RoutingFor<T>() => theRuntime().RoutingFor(typeof(T));
+
+    internal IMessageRoute[] PublishingRoutesFor<T>()
+        => RoutingFor<T>().ShouldBeOfType<MessageRouter<T>>().Routes;
+}
+
+/// <summary>The convention with no overrides at all.</summary>
+public class DefaultConventionalRoutingFixture : ConventionalRoutingFixture;
+
+/// <summary>The convention with the listener queue name overridden.</summary>
+public class OverriddenQueueNamingFixture : ConventionalRoutingFixture
+{
+    protected override void configure(AzureServiceBusMessageRoutingConvention convention)
+        => convention.QueueNameForListener(t => t.Name.ToLower() + "2");
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/conventional_listener_discovery.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/conventional_listener_discovery.cs
@@ -10,10 +10,6 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 
-// GH-3786: NOT flaky -- 5 of 6 fail, 12.6m, deterministically, on a clean emulator (2.0.1) with the
-// GH-3783 readiness gate. BrokerInitializationException "Unable to initialize the Broker asb in
-// time". Re-tagged with the numbers rather than left bare; untag when GH-3786 is fixed.
-[Trait("Category", "Flaky")]
 public class conventional_listener_discovery : ConventionalRoutingContext
 {
     [Fact]

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/discover_with_naming_prefix.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/discover_with_naming_prefix.cs
@@ -5,29 +5,35 @@ using Wolverine.Runtime;
 using Xunit;
 namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 
-// GH-3786: NOT flaky -- 1 of 1 fails, 2.4m, deterministically, on a clean emulator (2.0.1) with the
-// GH-3783 readiness gate. BrokerInitializationException "Unable to initialize the Broker asb in
-// time". Re-tagged with the numbers rather than left bare; untag when GH-3786 is fixed.
-[Trait("Category", "Flaky")]
-public class discover_with_naming_prefix : IDisposable
+public class discover_with_naming_prefix : IAsyncLifetime
 {
-    private readonly IHost _host;
-    private readonly ITestOutputHelper _output;
+    private IHost _host = null!;
 
-    public discover_with_naming_prefix(ITestOutputHelper output)
+    public async ValueTask InitializeAsync()
     {
-        _output = output;
-        _host = Host.CreateDefaultBuilder()
+        _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.UseAzureServiceBusTesting().PrefixIdentifiers("zztop").UseConventionalRouting().AutoProvision()
+                opts.UseAzureServiceBusTesting().PrefixIdentifiers("zztop")
+                    // Only the two types this test asserts on. Unrestricted conventional routing asks
+                    // for 28 queues and the emulator caps a namespace at 50 -- see the note on
+                    // ConventionalRoutingContext.isNotUnderTest. GH-3786.
+                    .UseConventionalRouting(x =>
+                        x.ExcludeTypes(t => t != typeof(RoutedMessage) && t != typeof(AsbMessage1)))
+                    .AutoProvision()
                     .AutoPurgeOnStartup();
-            }).Start();
+            }).StartAsync();
     }
 
-    public void Dispose()
+    // This class provisions PREFIXED queues, so its entities collide with no other test's names and
+    // every one of them counts separately against the emulator's namespace cap. It previously only
+    // disposed the host and left all of them behind, which is what pushed the classes running after
+    // it past 50 queues -- reported as a broker-initialization timeout with no mention of a cap.
+    public async ValueTask DisposeAsync()
     {
-        _host.Dispose();
+        if (_host != null) await _host.StopAsync();
+        _host?.Dispose();
+        await AzureServiceBusTesting.DeleteAllEmulatorObjectsAsync();
     }
 
     [Fact]

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/end_to_end_with_conventional_routing.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/end_to_end_with_conventional_routing.cs
@@ -8,10 +8,6 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 
-// GH-3786: NOT flaky -- 1 of 1 fails, 2.7m, deterministically, on a clean emulator (2.0.1) with the
-// GH-3783 readiness gate. BrokerInitializationException "Unable to initialize the Broker asb in
-// time". Re-tagged with the numbers rather than left bare; untag when GH-3786 is fixed.
-[Trait("Category", "Flaky")]
 public class end_to_end_with_conventional_routing : IAsyncLifetime
 {
     private IHost _receiver = null!;
@@ -22,7 +18,9 @@ public class end_to_end_with_conventional_routing : IAsyncLifetime
         _sender = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.UseAzureServiceBusTesting().UseConventionalRouting().AutoProvision().AutoPurgeOnStartup();
+                opts.UseAzureServiceBusTesting()
+                    .UseConventionalRouting(x => x.ExcludeTypes(t => t != typeof(RoutedMessage)))
+                    .AutoProvision().AutoPurgeOnStartup();
                 opts.DisableConventionalDiscovery();
                 opts.ServiceName = "Sender";
 
@@ -32,7 +30,9 @@ public class end_to_end_with_conventional_routing : IAsyncLifetime
         _receiver = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.UseAzureServiceBusTesting().UseConventionalRouting().AutoProvision().AutoPurgeOnStartup();
+                opts.UseAzureServiceBusTesting()
+                    .UseConventionalRouting(x => x.ExcludeTypes(t => t != typeof(RoutedMessage)))
+                    .AutoProvision().AutoPurgeOnStartup();
                 opts.ServiceName = "Receiver";
                 
                 opts.Services.AddResourceSetupOnStartup();

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/end_to_end_with_conventional_routing_with_prefix.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/end_to_end_with_conventional_routing_with_prefix.cs
@@ -7,10 +7,6 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 
-// GH-3786: NOT flaky -- 1 of 1 fails, 2.8m, deterministically, on a clean emulator (2.0.1) with the
-// GH-3783 readiness gate. BrokerInitializationException "Unable to initialize the Broker asb in
-// time". Re-tagged with the numbers rather than left bare; untag when GH-3786 is fixed.
-[Trait("Category", "Flaky")]
 public class end_to_end_with_conventional_routing_with_prefix : IAsyncLifetime
 {
     private IHost _receiver = null!;
@@ -22,7 +18,8 @@ public class end_to_end_with_conventional_routing_with_prefix : IAsyncLifetime
         {
             opts.UseAzureServiceBusTesting()
                 .PrefixIdentifiers("shazaam")
-                .UseConventionalRouting().AutoProvision().AutoPurgeOnStartup();
+                .UseConventionalRouting(x => x.ExcludeTypes(t => t != typeof(RoutedMessage)))
+                .AutoProvision().AutoPurgeOnStartup();
             opts.DisableConventionalDiscovery();
             opts.ServiceName = "Sender";
         });
@@ -31,7 +28,8 @@ public class end_to_end_with_conventional_routing_with_prefix : IAsyncLifetime
         {
             opts.UseAzureServiceBusTesting()
                 .PrefixIdentifiers("shazaam")
-                .UseConventionalRouting().AutoProvision().AutoPurgeOnStartup();
+                .UseConventionalRouting(x => x.ExcludeTypes(t => t != typeof(RoutedMessage)))
+                .AutoProvision().AutoPurgeOnStartup();
             opts.ServiceName = "Receiver";
         });
     }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
@@ -6,35 +6,38 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 
-public class when_discovering_a_listening_endpoint_with_all_defaults : ConventionalRoutingContext
+// All four facts are about the SAME discovered listener, so they share one host rather than starting
+// Wolverine and provisioning the emulator four times over. See ConventionalRoutingFixture, GH-3786.
+public class when_discovering_a_listening_endpoint_with_all_defaults(DefaultConventionalRoutingFixture fixture)
+    : IClassFixture<DefaultConventionalRoutingFixture>
 {
     private readonly Uri theExpectedUri = "asb://queue/routed2".ToUri();
 
+    private AzureServiceBusQueue theQueue()
+        => fixture.theRuntime().Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AzureServiceBusQueue>();
+
     [Fact]
-    public async Task endpoint_should_be_a_listener()
+    public void endpoint_should_be_a_listener()
     {
-        var theQueue = (await theRuntime()).Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AzureServiceBusQueue>();
-        theQueue.IsListener.ShouldBeTrue();
+        theQueue().IsListener.ShouldBeTrue();
     }
 
     [Fact]
-    public async Task endpoint_should_not_be_null()
+    public void endpoint_should_not_be_null()
     {
-        var theQueue = (await theRuntime()).Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AzureServiceBusQueue>();
-        theQueue.ShouldNotBeNull();
+        theQueue().ShouldNotBeNull();
     }
 
     [Fact]
-    public async Task mode_is_buffered_by_default()
+    public void mode_is_buffered_by_default()
     {
-        var theQueue = (await theRuntime()).Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AzureServiceBusQueue>();
-        theQueue.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+        theQueue().Mode.ShouldBe(EndpointMode.BufferedInMemory);
     }
 
     [Fact]
-    public async Task should_be_an_active_listener()
+    public void should_be_an_active_listener()
     {
-        (await theRuntime()).Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
+        fixture.theRuntime().Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
             .ShouldBeTrue();
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
@@ -6,10 +6,6 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 
-// GH-3786: NOT flaky -- 4 of 4 fail, 10.6m, deterministically, on a clean emulator (2.0.1) with the
-// GH-3783 readiness gate. BrokerInitializationException "Unable to initialize the Broker asb in
-// time". Re-tagged with the numbers rather than left bare; untag when GH-3786 is fixed.
-[Trait("Category", "Flaky")]
 public class when_discovering_a_listening_endpoint_with_all_defaults : ConventionalRoutingContext
 {
     private readonly Uri theExpectedUri = "asb://queue/routed2".ToUri();

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
@@ -5,10 +5,6 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 
-// GH-3786: NOT flaky -- 3 of 3 fail, 6.1m, deterministically, on a clean emulator (2.0.1) with the
-// GH-3783 readiness gate. BrokerInitializationException "Unable to initialize the Broker asb in
-// time". Re-tagged with the numbers rather than left bare; untag when GH-3786 is fixed.
-[Trait("Category", "Flaky")]
 public class when_discovering_a_listening_endpoint_with_overridden_queue_naming : ConventionalRoutingContext
 {
     private readonly Uri theExpectedUri = "asb://queue/routedmessage2".ToUri();

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
@@ -5,37 +5,32 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 
-public class when_discovering_a_listening_endpoint_with_overridden_queue_naming : ConventionalRoutingContext
+// One host for all three assertions -- the queue-naming override is the same for every one of them.
+// See ConventionalRoutingFixture, GH-3786.
+public class when_discovering_a_listening_endpoint_with_overridden_queue_naming(OverriddenQueueNamingFixture fixture)
+    : IClassFixture<OverriddenQueueNamingFixture>
 {
     private readonly Uri theExpectedUri = "asb://queue/routedmessage2".ToUri();
-    private AzureServiceBusQueue theQueue = null!;
 
-    public override async ValueTask InitializeAsync()
-    {
-        await base.InitializeAsync();
-        await ConfigureConventions(c => c.QueueNameForListener(t => t.Name.ToLower() + "2"));
-
-        var runtime = await theRuntime();
-        var theRuntimeEndpoints = runtime.Endpoints.ActiveListeners().ToArray();
-        theQueue = runtime.Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AzureServiceBusQueue>();
-    }
+    private AzureServiceBusQueue theQueue()
+        => fixture.theRuntime().Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<AzureServiceBusQueue>();
 
     [Fact]
     public void endpoint_should_be_a_listener()
     {
-        theQueue.IsListener.ShouldBeTrue();
+        theQueue().IsListener.ShouldBeTrue();
     }
 
     [Fact]
     public void endpoint_should_not_be_null()
     {
-        theQueue.ShouldNotBeNull();
+        theQueue().ShouldNotBeNull();
     }
 
     [Fact]
-    public async Task should_be_an_active_listener()
+    public void should_be_an_active_listener()
     {
-        (await theRuntime()).Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
+        fixture.theRuntime().Endpoints.ActiveListeners().Any(x => x.Uri == theExpectedUri)
             .ShouldBeTrue();
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
@@ -7,10 +7,6 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 
-// GH-3786: NOT flaky -- 3 of 3 fail, 7.1m, deterministically, on a clean emulator (2.0.1) with the
-// GH-3783 readiness gate. BrokerInitializationException "Unable to initialize the Broker asb in
-// time". Re-tagged with the numbers rather than left bare; untag when GH-3786 is fixed.
-[Trait("Category", "Flaky")]
 public class when_discovering_a_sender_with_all_defaults : ConventionalRoutingContext
 {
     private MessageRoute theRoute = null!;

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
@@ -7,33 +7,30 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests.ConventionalRouting;
 
-public class when_discovering_a_sender_with_all_defaults : ConventionalRoutingContext
+// One host for all three assertions about the same discovered sender. See
+// ConventionalRoutingFixture, GH-3786.
+public class when_discovering_a_sender_with_all_defaults(DefaultConventionalRoutingFixture fixture)
+    : IClassFixture<DefaultConventionalRoutingFixture>
 {
-    private MessageRoute theRoute = null!;
-
-    public override async ValueTask InitializeAsync()
-    {
-        await base.InitializeAsync();
-        theRoute = (await PublishingRoutesFor<PublishedMessage>()).Single().As<MessageRoute>();
-    }
+    private MessageRoute theRoute() => fixture.PublishingRoutesFor<PublishedMessage>().Single().As<MessageRoute>();
 
     [Fact]
     public void should_have_exactly_one_route()
     {
-        theRoute.ShouldNotBeNull();
+        theRoute().ShouldNotBeNull();
     }
 
     [Fact]
     public void routed_to_azure_service_bus_queue()
     {
-        var endpoint = theRoute.Sender.Endpoint.ShouldBeOfType<AzureServiceBusQueue>();
+        var endpoint = theRoute().Sender.Endpoint.ShouldBeOfType<AzureServiceBusQueue>();
         endpoint.QueueName.ShouldBe("published.message");
     }
 
     [Fact]
     public void endpoint_mode_is_buffered_by_default()
     {
-        var endpoint = theRoute.Sender.Endpoint.ShouldBeOfType<AzureServiceBusQueue>();
+        var endpoint = theRoute().Sender.Endpoint.ShouldBeOfType<AzureServiceBusQueue>();
         endpoint.Mode.ShouldBe(EndpointMode.BufferedInMemory);
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_using_handler_type_naming.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/ConventionalRouting/when_using_handler_type_naming.cs
@@ -56,6 +56,10 @@ public class when_using_handler_type_naming : IAsyncLifetime
     {
         if (_host != null) await _host.StopAsync();
         _host?.Dispose();
+
+        // Every class in this namespace has to hand the next one a clean namespace: the emulator caps
+        // it at 50 queues and reports the overflow as a broker-init timeout. GH-3786.
+        await AzureServiceBusTesting.DeleteAllEmulatorObjectsAsync();
     }
 }
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end.cs
@@ -8,9 +8,13 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests;
 
-// GH-3786: NOT flaky -- 2 of 6 fail, 2.0m, deterministically, on a clean emulator (2.0.1) with the
-// GH-3783 readiness gate. BrokerInitializationException "Unable to initialize the Broker asb in
-// time". Re-tagged with the numbers rather than left bare; untag when GH-3786 is fixed.
+// NOT flaky, and NOT GH-3786: re-measured 2026-08-02 after the entity-name sanitizing fix, on a
+// freshly recreated emulator (2.0.1). Still 2 of 6, still deterministic, but 2.1m for the class and
+// no broker-initialization timeout anywhere in it -- the two failures are
+// send_and_receive_multiple_messages_to_queue_with_session_identifier and
+// split_messages_with_different_sessionids_into_separate_batches, i.e. SESSION handling, which
+// conventional routing never touched. The other 4 pass. Needs its own issue; do not fold it back
+// into GH-3786.
 [Trait("Category", "Flaky")]
 public class end_to_end : IAsyncLifetime
 {

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTopicBroadcastingRoutingConvention.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTopicBroadcastingRoutingConvention.cs
@@ -16,7 +16,15 @@ public class AzureServiceBusTopicBroadcastingRoutingConvention : MessageRoutingC
     {
         var topic = transport.Topics[identifier];
 
-        var subscriptionName = _subscriptionNameSource == null ? identifier : _subscriptionNameSource(messageType);
+        // `identifier` arrived already sanitized -- MessageRoutingConvention runs every listener
+        // identifier through transport.MaybeCorrectName. A caller-supplied _subscriptionNameSource
+        // does not go through that path, so it has to be sanitized here or an illegal character
+        // reaches the management API as a 400 that reads only as a broker-init timeout. GH-3786:
+        // SubscriptionNameForListener(t => t.Name.ToLowerInvariant()) over a Handle(BatchedItem[])
+        // handler produced the subscription name "batcheditem[]" against a correctly-named topic.
+        var subscriptionName = _subscriptionNameSource == null
+            ? identifier
+            : transport.SanitizeIdentifier(_subscriptionNameSource(messageType));
 
         var subscription =
             transport.Subscriptions.FirstOrDefault(x =>
@@ -36,7 +44,11 @@ public class AzureServiceBusTopicBroadcastingRoutingConvention : MessageRoutingC
     {
         var topic = transport.Topics[topicName];
         
-        var subscriptionName = _subscriptionNameSource == null ? transport.MaybeCorrectName(handlerType.FullName!) : _subscriptionNameSource(handlerType);
+        // Same reasoning as FindOrCreateListenerForIdentifier above: MaybeCorrectName already
+        // sanitizes the default, the caller-supplied source does not sanitize itself.
+        var subscriptionName = _subscriptionNameSource == null
+            ? transport.MaybeCorrectName(handlerType.FullName!)
+            : transport.SanitizeIdentifier(_subscriptionNameSource(handlerType));
 
         var subscription =
             transport.Subscriptions.FirstOrDefault(x =>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
@@ -80,10 +80,43 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
         }
     }
 
+    /// <summary>
+    /// Azure Service Bus accepts only letters, numbers, periods, hyphens and underscores in an entity
+    /// name segment (plus '/' as the segment separator for hierarchical paths). Anything else comes
+    /// back from the management API as a 400 with SubCode=40000 at provisioning time, which
+    /// <see cref="BrokerTransport{TEndpoint}.InitializeAsync"/> then retries twenty times over two
+    /// minutes before reporting only "Unable to initialize the Broker asb in time".
+    ///
+    /// That is what GH-3786 was: conventional routing derives its queue name from the message type,
+    /// and a handler taking an ARRAY -- <c>Handle(BatchedItem[] items)</c> -- yields
+    /// "…bugs.batcheditem[]". One such handler anywhere in the assembly took down broker startup for
+    /// every conventionally-routed host in it. Generic and nested message types ('&lt;', '&gt;', ',', '+')
+    /// have the same shape.
+    ///
+    /// Substituting rather than stripping keeps distinct type names distinct: <c>Foo[]</c> becomes
+    /// "foo__" and stays separable from <c>Foo</c>. No name that works today changes -- a name
+    /// containing an illegal character could never have been provisioned in the first place.
+    /// </summary>
     public override string SanitizeIdentifier(string identifier)
     {
-        return identifier.ToLowerInvariant();
+        var lowered = identifier.ToLowerInvariant();
+
+        char[]? corrected = null;
+        for (var i = 0; i < lowered.Length; i++)
+        {
+            if (isLegalEntityCharacter(lowered[i])) continue;
+
+            corrected ??= lowered.ToCharArray();
+            corrected[i] = '_';
+        }
+
+        return corrected is null ? lowered : new string(corrected);
     }
+
+    // '/' is kept because Azure Service Bus allows hierarchical entity PATHS, and an application
+    // already running against a name like "orders/priority" must keep addressing the same entity.
+    private static bool isLegalEntityCharacter(char c)
+        => char.IsAsciiLetterOrDigit(c) || c is '.' or '-' or '_' or '/';
 
     internal LightweightCache<string, AzureServiceBusTenant> Tenants { get; } = new(key => new AzureServiceBusTenant(key));
 

--- a/src/Wolverine/Transports/BrokerTransport.cs
+++ b/src/Wolverine/Transports/BrokerTransport.cs
@@ -86,9 +86,12 @@ public abstract class BrokerTransport<TEndpoint> : TransportBase<TEndpoint>, IBr
 
         await InitializeEndpointsAsync(runtime);
 
-        #pragma warning disable CS0219
-        var attempts = 1;
-        #pragma warning restore CS0219
+        // Whatever actually went wrong, kept so the exception thrown after the last attempt can carry
+        // it. Without this the only thing a caller ever sees is "Unable to initialize the Broker asb
+        // in time", and the cause survives nowhere but a log line inside a two-minute retry loop.
+        // GH-3786 was a flat 400 Bad Request on an illegal entity name -- never going to succeed on
+        // attempt 20 either -- and it read as a timeout for four months.
+        Exception? lastFailure = null;
 
         for (int i = 0; i < 20; i++)
         {
@@ -99,6 +102,7 @@ public abstract class BrokerTransport<TEndpoint> : TransportBase<TEndpoint>, IBr
             }
             catch (Exception e)
             {
+                lastFailure = e;
                 runtime.Logger.LogError(e, "Error trying to start message broker {Broker} on Attempt {Attempt} of 20", Protocol, i + 1);
                 if (i < 19)
                 {
@@ -108,7 +112,7 @@ public abstract class BrokerTransport<TEndpoint> : TransportBase<TEndpoint>, IBr
             }
         }
 
-        throw new BrokerInitializationException(this);
+        throw new BrokerInitializationException(this, lastFailure);
 
     }
 
@@ -161,8 +165,19 @@ public abstract class BrokerTransport<TEndpoint> : TransportBase<TEndpoint>, IBr
 
 public class BrokerInitializationException : Exception
 {
-    public BrokerInitializationException(IBrokerTransport transport) : base($"Unable to initialize the Broker {transport.Protocol} in time")
+    public BrokerInitializationException(IBrokerTransport transport) : this(transport, null)
     {
-        
+
+    }
+
+    /// <param name="innerException">
+    /// The failure from the LAST startup attempt. Always pass it when there was one: the message here
+    /// says only that the broker did not come up in time, which reads as a timing problem even when
+    /// the cause was a flat rejection that all twenty attempts were guaranteed to reproduce.
+    /// </param>
+    public BrokerInitializationException(IBrokerTransport transport, Exception? innerException)
+        : base($"Unable to initialize the Broker {transport.Protocol} in time", innerException)
+    {
+
     }
 }


### PR DESCRIPTION
Closes #3786. Restores 29 tests: `CIAzureServiceBus` goes **271 → 300 passing**.

## The bug

Conventional routing derives broker entity names from the message type. Azure Service Bus accepts
only letters, numbers, `.`, `-` and `_` in an entity segment, so a handler taking an **array** —
`Handle(BatchedItem[] items)` — asked for a queue named `...bugs.batcheditem[]`:

```
400 SubCode=40000. '...batcheditem%5B%5D' contains character(s) that is not allowed by
Service Bus. Entity segments can contain only letters, numbers, periods (.), hyphens (-),
and underscores (_).
```

One such handler **anywhere in an assembly** took down broker startup for every conventionally-routed
host in it. Generic and nested message types (`<`, `>`, `,`, `+`) have the same shape.

That explains the clue in the issue: `when_using_handler_type_naming` passed all along because it
calls `DisableConventionalDiscovery().IncludeType(...)` and therefore never sees `BatchedItem[]`.

The dates confirm it. `Handle(BatchedItem[])` arrived in commit `5aeefe306` on **2026-03-16**; the
bulk *"Tag all ConventionalRouting tests as Flaky"* sweep was **2026-03-20/21**. The sweep was
mis-tagging a hard regression that had landed four days earlier.

## Why it hid for four months

`BrokerTransport.InitializeAsync` retries startup 20 times over two minutes and then throws
`BrokerInitializationException: Unable to initialize the Broker asb in time`. The actual cause went
to a log line — inside a job already dismissed as flaky. A `400 Bad Request` was never going to
succeed on attempt 20.

`BrokerInitializationException` now carries the last attempt's exception. That single change is what
made the rest of this tractable: the two further failures stacked behind the first became readable in
minutes.

## Fixes

1. `AzureServiceBusTransport.SanitizeIdentifier` substitutes illegal characters rather than only
   lowercasing. **Substituting, not stripping**, so `Foo[]` stays separable from `Foo`. No name that
   works today changes — a name containing an illegal character could never have been provisioned.
   `/` is preserved, since ASB allows hierarchical entity paths.
2. `AzureServiceBusTopicBroadcastingRoutingConvention` sanitizes a caller-supplied
   `SubscriptionNameForListener` result. `MessageRoutingConvention` runs every listener *identifier*
   through `MaybeCorrectName`, but the subscription name is computed inside this convention and
   skipped it — so a correctly-named topic got a subscription named `batcheditem[]`. Found only
   because fix #3 made it visible.
3. `BrokerInitializationException` carries the inner exception.

## Test changes

Every conventional-routing host is narrowed to the message types it actually asserts on.
Unrestricted discovery asked for **28 queues per host**, and the emulator caps a namespace at 50 —
so two classes in one process hit `SubCode=40300 ... Actual: 50, Max allowed: 50`, reported (again)
as a broker-init timeout.

The narrowing is an `ExcludeTypes`, **not** an `IncludeTypes`: `CompositeFilter` ANDs excludes and
ORs includes, so an include would have silently widened each test's own filter and made
`conventional_listener_discovery.include_types` pass whether the include filter worked or not.

`discover_with_naming_prefix` and `when_using_handler_type_naming` now purge in teardown. The first
left 28 *prefixed* queues behind, which is what pushed the classes after it over the cap.

Side effect worth having: the `ConventionalRouting` namespace went from **32m38s to 6m3s**.

## Still tagged — with tags corrected to what was measured

These were all labelled "broker timeout". None of them is one any more:

| class | now | cause |
|---|---|---|
| `end_to_end` | 2 of 6 | **session handling** — never related to this issue |
| `Bug_2307` | 1 of 1, in **5s** | plain assertion: `EndpointName` is the raw type name. A naming bug in the GH-2307 fix |
| `Bug_1933` | 2 of 2 → **1 of 2** | `TrackedSession` timeout; message Sent, never Received |

Each needs its own issue. I did not fold them into #3786.

## Verification

- Full `CIAzureServiceBus` locally against a **freshly recreated** emulator: **300 passed, 0 retries**.
- Every class verified **by name in isolation** as well as in the set — running "the set" is what
  produced the wrong conclusion twice on this issue.
- New unit tests cover the sanitizer directly, including the no-op guarantee for legal names and the
  `Foo[]` vs `Foo` non-collision.
- `dotnet build wolverine.slnx -c Release`: 0 warnings, 0 errors.

**Watch on this PR:** local wall clock for the whole suite was 16m26s against the 20-minute cap. CI
timings differ from local, so the `CIAzureServiceBus` duration here is the number to check before
merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116vfBcKwcjWn8msM4ZjkuA